### PR TITLE
fix(cli): honor no-color in help

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiWrap.ts
+++ b/packages/cli/src/chat/tui/render/ansiWrap.ts
@@ -1,43 +1,16 @@
 import wrapAnsi from 'wrap-ansi';
 
+import {
+  ANSI_ESCAPE_START,
+  ansiEscapeEnd,
+  stripAnsiSequences,
+} from '@cli/runtime/ansiEscapes';
+
 const MIN_WRAP_WIDTH = 1;
-const ESC = String.fromCharCode(27);
-const BEL = String.fromCharCode(7);
 
 function normalizedWidth(width: number | undefined): number | undefined {
   if (width == null || !Number.isFinite(width)) return undefined;
   return Math.max(MIN_WRAP_WIDTH, Math.floor(width));
-}
-
-function ansiEscapeEnd(text: string, index: number): number {
-  if (text[index] !== ESC) return index;
-  const next = text[index + 1];
-  if (next === '[') {
-    let end = index + 2;
-    while (end < text.length && !/[@-~]/.test(text[end] ?? '')) end += 1;
-    return Math.min(end + 1, text.length);
-  }
-  if (next === ']') {
-    const belEnd = text.indexOf(BEL, index + 2);
-    const stEnd = text.indexOf(`${ESC}\\`, index + 2);
-    if (belEnd === -1 && stEnd === -1) return text.length;
-    if (belEnd !== -1 && (stEnd === -1 || belEnd < stEnd)) return belEnd + 1;
-    return stEnd + 2;
-  }
-  return Math.min(index + 2, text.length);
-}
-
-function stripAnsiForPrefix(text: string): string {
-  let plain = '';
-  for (let i = 0; i < text.length; ) {
-    if (text[i] === ESC) {
-      i = ansiEscapeEnd(text, i);
-    } else {
-      plain += text[i];
-      i += 1;
-    }
-  }
-  return plain;
 }
 
 function splitRawAtVisiblePrefix(
@@ -47,14 +20,16 @@ function splitRawAtVisiblePrefix(
   let visible = 0;
   let index = 0;
   while (index < line.length && visible < visiblePrefixLength) {
-    if (line[index] === ESC) {
+    if (line[index] === ANSI_ESCAPE_START) {
       index = ansiEscapeEnd(line, index);
     } else {
       visible += 1;
       index += 1;
     }
   }
-  while (line[index] === ESC) index = ansiEscapeEnd(line, index);
+  while (line[index] === ANSI_ESCAPE_START) {
+    index = ansiEscapeEnd(line, index);
+  }
   return {
     prefix: line.slice(0, index),
     rest: line.slice(index),
@@ -69,7 +44,7 @@ function markdownContinuationPrefix(line: string):
       width: number;
     }
   | undefined {
-  const plain = stripAnsiForPrefix(line);
+  const plain = stripAnsiSequences(line);
   const list = plain.match(/^((?:│ )*)( {2}(?:•|\d+[.)]) )/);
   if (list) {
     const quote = list[1] ?? '';

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -8,6 +8,7 @@ import {
 
 import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
 import { readCliAmbientState } from '@cli/runtime/cliContext';
+import { stripAnsiSequences } from '@cli/runtime/ansiEscapes';
 
 import { GLOBAL_BOOL_FLAGS, GLOBAL_VALUE_FLAGS } from './globalArgs';
 
@@ -138,8 +139,6 @@ export interface UsageSection {
 }
 
 const usageSections = new WeakMap<AnyCommand, readonly UsageSection[]>();
-const ESC = String.fromCharCode(27);
-const BEL = String.fromCharCode(7);
 
 let usageColorOverride: boolean | undefined;
 
@@ -191,35 +190,6 @@ async function renderUsageWithSections(
 interface UsageRenderContext {
   readonly parentPath?: readonly string[];
   readonly rootCommand?: AnyCommand;
-}
-
-function stripAnsiSequences(text: string): string {
-  let stripped = '';
-  for (let index = 0; index < text.length; index += 1) {
-    if (text[index] !== ESC) {
-      stripped += text[index];
-      continue;
-    }
-    index = ansiEscapeEnd(text, index);
-  }
-  return stripped;
-}
-
-function ansiEscapeEnd(text: string, start: number): number {
-  const marker = text[start + 1];
-  if (marker === '[') {
-    for (let index = start + 2; index < text.length; index += 1) {
-      const code = text.charCodeAt(index);
-      if (code >= 0x40 && code <= 0x7e) return index;
-    }
-  }
-  if (marker === ']') {
-    for (let index = start + 2; index < text.length; index += 1) {
-      if (text[index] === BEL) return index;
-      if (text[index] === ESC && text[index + 1] === '\\') return index + 1;
-    }
-  }
-  return start + 1;
 }
 
 function usageColorEnabled(stream: 'stdout' | 'stderr'): boolean | undefined {

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -142,10 +142,22 @@ const usageSections = new WeakMap<AnyCommand, readonly UsageSection[]>();
 
 let usageColorOverride: boolean | undefined;
 
+export function hasUsageNoColorFlag(rawArgs: readonly string[]): boolean {
+  for (let index = 0; index < rawArgs.length; ) {
+    const arg = rawArgs[index];
+    if (arg === undefined || arg === '--') return false;
+    if (arg === '--no-color') return true;
+
+    const tokenCount = knownGlobalFlagTokenCount(rawArgs, index);
+    index += tokenCount ?? 1;
+  }
+  return false;
+}
+
 export function setUsageColorOverrideFromRawArgs(
   rawArgs: readonly string[],
 ): void {
-  usageColorOverride = rawArgs.includes('--no-color') ? false : undefined;
+  usageColorOverride = hasUsageNoColorFlag(rawArgs) ? false : undefined;
 }
 
 export function withUsageSections<T extends AnyCommand>(

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -5,7 +5,6 @@ import {
   type CommandDef,
   type CommandMeta,
 } from 'citty';
-import stripAnsi from 'strip-ansi';
 
 import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
 import { readCliAmbientState } from '@cli/runtime/cliContext';
@@ -139,6 +138,16 @@ export interface UsageSection {
 }
 
 const usageSections = new WeakMap<AnyCommand, readonly UsageSection[]>();
+const ESC = String.fromCharCode(27);
+const BEL = String.fromCharCode(7);
+
+let usageColorOverride: boolean | undefined;
+
+export function setUsageColorOverrideFromRawArgs(
+  rawArgs: readonly string[],
+): void {
+  usageColorOverride = rawArgs.includes('--no-color') ? false : undefined;
+}
 
 export function withUsageSections<T extends AnyCommand>(
   command: T,
@@ -174,24 +183,47 @@ async function renderUsageWithSections(
   const usageWithSections = sections?.length
     ? `${usage}\n${sections.map(formatUsageSection).join('\n\n')}`
     : usage;
-  return usageColorEnabled(context, stream) === false
-    ? stripAnsi(usageWithSections)
+  return usageColorEnabled(stream) === false
+    ? stripAnsiSequences(usageWithSections)
     : usageWithSections;
 }
 
 interface UsageRenderContext {
   readonly parentPath?: readonly string[];
   readonly rootCommand?: AnyCommand;
-  readonly rawArgs?: readonly string[];
 }
 
-function usageColorEnabled(
-  context: UsageRenderContext | undefined,
-  stream: 'stdout' | 'stderr',
-): boolean | undefined {
-  const rawArgs = context?.rawArgs;
-  if (rawArgs == null) return undefined;
-  if (rawArgs.includes('--no-color')) return false;
+function stripAnsiSequences(text: string): string {
+  let stripped = '';
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] !== ESC) {
+      stripped += text[index];
+      continue;
+    }
+    index = ansiEscapeEnd(text, index);
+  }
+  return stripped;
+}
+
+function ansiEscapeEnd(text: string, start: number): number {
+  const marker = text[start + 1];
+  if (marker === '[') {
+    for (let index = start + 2; index < text.length; index += 1) {
+      const code = text.charCodeAt(index);
+      if (code >= 0x40 && code <= 0x7e) return index;
+    }
+  }
+  if (marker === ']') {
+    for (let index = start + 2; index < text.length; index += 1) {
+      if (text[index] === BEL) return index;
+      if (text[index] === ESC && text[index + 1] === '\\') return index + 1;
+    }
+  }
+  return start + 1;
+}
+
+function usageColorEnabled(stream: 'stdout' | 'stderr'): boolean | undefined {
+  if (usageColorOverride !== undefined) return usageColorOverride;
   const ambient = readCliAmbientState();
   return stream === 'stdout'
     ? ambient.stdoutColorEnabled

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -5,8 +5,10 @@ import {
   type CommandDef,
   type CommandMeta,
 } from 'citty';
+import stripAnsi from 'strip-ansi';
 
 import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
+import { readCliAmbientState } from '@cli/runtime/cliContext';
 
 import { GLOBAL_BOOL_FLAGS, GLOBAL_VALUE_FLAGS } from './globalArgs';
 
@@ -162,19 +164,38 @@ async function renderUsageWithSections(
   cmd: AnyCommand,
   parent?: AnyCommand,
   context?: UsageRenderContext,
+  stream: 'stdout' | 'stderr' = 'stdout',
 ): Promise<string> {
   const usage = await renderUsage(
     cmd,
     await usageParentWithFullPath(parent, context),
   );
   const sections = usageSections.get(cmd);
-  if (!sections?.length) return usage;
-  return `${usage}\n${sections.map(formatUsageSection).join('\n\n')}`;
+  const usageWithSections = sections?.length
+    ? `${usage}\n${sections.map(formatUsageSection).join('\n\n')}`
+    : usage;
+  return usageColorEnabled(context, stream) === false
+    ? stripAnsi(usageWithSections)
+    : usageWithSections;
 }
 
 interface UsageRenderContext {
   readonly parentPath?: readonly string[];
   readonly rootCommand?: AnyCommand;
+  readonly rawArgs?: readonly string[];
+}
+
+function usageColorEnabled(
+  context: UsageRenderContext | undefined,
+  stream: 'stdout' | 'stderr',
+): boolean | undefined {
+  const rawArgs = context?.rawArgs;
+  if (rawArgs == null) return undefined;
+  if (rawArgs.includes('--no-color')) return false;
+  const ambient = readCliAmbientState();
+  return stream === 'stdout'
+    ? ambient.stdoutColorEnabled
+    : ambient.stderrColorEnabled;
 }
 
 async function resolveCommandMeta(cmd: AnyCommand): Promise<CommandMeta> {
@@ -585,7 +606,9 @@ export async function showUsageStderr(
   parent?: AnyCommand,
   context?: UsageRenderContext,
 ): Promise<void> {
-  writeRawStderr(`${await renderUsageWithSections(cmd, parent, context)}\n`);
+  writeRawStderr(
+    `${await renderUsageWithSections(cmd, parent, context, 'stderr')}\n`,
+  );
 }
 
 export async function showUsage(

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -14,7 +14,9 @@ export const helpCommand = defineCommand({
   async run(ctx) {
     const { rootCommand } = await import('./root');
     if (ctx.rawArgs.length === 0) {
-      await showUsage(rootCommand);
+      await showUsage(rootCommand, undefined, {
+        rawArgs: ctx.rawArgs,
+      });
       return;
     }
 
@@ -27,6 +29,9 @@ export const helpCommand = defineCommand({
     }
 
     const resolved = await resolveDeepestSubCommand(rootCommand, ctx.rawArgs);
-    await showUsage(resolved.command, resolved.parent, resolved);
+    await showUsage(resolved.command, resolved.parent, {
+      ...resolved,
+      rawArgs: ctx.rawArgs,
+    });
   },
 });

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -14,9 +14,7 @@ export const helpCommand = defineCommand({
   async run(ctx) {
     const { rootCommand } = await import('./root');
     if (ctx.rawArgs.length === 0) {
-      await showUsage(rootCommand, undefined, {
-        rawArgs: ctx.rawArgs,
-      });
+      await showUsage(rootCommand);
       return;
     }
 
@@ -29,9 +27,6 @@ export const helpCommand = defineCommand({
     }
 
     const resolved = await resolveDeepestSubCommand(rootCommand, ctx.rawArgs);
-    await showUsage(resolved.command, resolved.parent, {
-      ...resolved,
-      rawArgs: ctx.rawArgs,
-    });
+    await showUsage(resolved.command, resolved.parent, resolved);
   },
 });

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -18,6 +18,7 @@ import {
   normalizeRootShortcuts,
   reorderGlobalFlags,
   resolveDeepestSubCommand,
+  setUsageColorOverrideFromRawArgs,
   showUsage,
   showUsageStderr,
   withUsageSections,
@@ -137,16 +138,14 @@ export async function runCli(
   const rawArgs = reorderGlobalFlags(
     normalizeRootShortcuts(argv ? [...argv] : readCliArgv()),
   );
+  setUsageColorOverrideFromRawArgs(rawArgs);
 
   // `--help` / `-h` anywhere prints usage for the deepest matched subcommand
   // (e.g. `texra agents list --help` → list-level usage), mirroring citty's
   // own `runMain` behavior without inheriting its `exit(1)` for usage errors.
   if (rawArgs.some((arg) => arg === '--help' || arg === '-h')) {
     const resolved = await resolveDeepestSubCommand(rootCommand, rawArgs);
-    await showUsage(resolved.command, resolved.parent, {
-      ...resolved,
-      rawArgs,
-    });
+    await showUsage(resolved.command, resolved.parent, resolved);
     return { exitCode: CliExitCode.Success };
   }
 
@@ -175,10 +174,7 @@ export async function runCli(
       // machine-parseable under `--output-format json|ndjson`. The explicit
       // `--help` path above keeps using STDOUT (`showUsage`) per Unix
       // convention.
-      await showUsageStderr(resolved.command, resolved.parent, {
-        ...resolved,
-        rawArgs,
-      });
+      await showUsageStderr(resolved.command, resolved.parent, resolved);
       writeTextStderr(error.message);
       return { exitCode: CliExitCode.Usage };
     }

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -143,7 +143,10 @@ export async function runCli(
   // own `runMain` behavior without inheriting its `exit(1)` for usage errors.
   if (rawArgs.some((arg) => arg === '--help' || arg === '-h')) {
     const resolved = await resolveDeepestSubCommand(rootCommand, rawArgs);
-    await showUsage(resolved.command, resolved.parent, resolved);
+    await showUsage(resolved.command, resolved.parent, {
+      ...resolved,
+      rawArgs,
+    });
     return { exitCode: CliExitCode.Success };
   }
 
@@ -172,7 +175,10 @@ export async function runCli(
       // machine-parseable under `--output-format json|ndjson`. The explicit
       // `--help` path above keeps using STDOUT (`showUsage`) per Unix
       // convention.
-      await showUsageStderr(resolved.command, resolved.parent, resolved);
+      await showUsageStderr(resolved.command, resolved.parent, {
+        ...resolved,
+        rawArgs,
+      });
       writeTextStderr(error.message);
       return { exitCode: CliExitCode.Usage };
     }

--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -1,0 +1,39 @@
+export const ANSI_ESCAPE_START = String.fromCharCode(27);
+
+const ANSI_BEL = String.fromCharCode(7);
+
+export function ansiEscapeEnd(text: string, index: number): number {
+  if (text[index] !== ANSI_ESCAPE_START) return index + 1;
+
+  const next = text[index + 1];
+  if (next === '[') {
+    for (let end = index + 2; end < text.length; end += 1) {
+      const code = text.charCodeAt(end);
+      if (code >= 0x40 && code <= 0x7e) return end + 1;
+    }
+    return text.length;
+  }
+
+  if (next === ']') {
+    const belEnd = text.indexOf(ANSI_BEL, index + 2);
+    const stEnd = text.indexOf(`${ANSI_ESCAPE_START}\\`, index + 2);
+    if (belEnd === -1 && stEnd === -1) return text.length;
+    if (belEnd !== -1 && (stEnd === -1 || belEnd < stEnd)) return belEnd + 1;
+    return stEnd + 2;
+  }
+
+  return Math.min(index + 2, text.length);
+}
+
+export function stripAnsiSequences(text: string): string {
+  let stripped = '';
+  for (let index = 0; index < text.length; ) {
+    if (text[index] === ANSI_ESCAPE_START) {
+      index = ansiEscapeEnd(text, index);
+      continue;
+    }
+    stripped += text[index];
+    index += 1;
+  }
+  return stripped;
+}

--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -3,7 +3,7 @@ export const ANSI_ESCAPE_START = String.fromCharCode(27);
 const ANSI_BEL = String.fromCharCode(7);
 
 export function ansiEscapeEnd(text: string, index: number): number {
-  if (text[index] !== ANSI_ESCAPE_START) return index + 1;
+  if (text[index] !== ANSI_ESCAPE_START) return index;
 
   const next = text[index + 1];
   if (next === '[') {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1106,6 +1106,14 @@ describe('runCli usage output stream routing', () => {
     expect(stderr).toBe('');
   });
 
+  it('honors --no-color in help command output', async () => {
+    const result = await runCli(['--no-color', 'help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('USAGE');
+    expect(stdout).toBe(stripAnsi(stdout));
+    expect(stderr).toBe('');
+  });
+
   it('prints version output when no-op global color flags are present', async () => {
     for (const args of [
       ['--version', '--no-color'],

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import stripAnsi from 'strip-ansi';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -1094,6 +1095,14 @@ describe('runCli usage output stream routing', () => {
     expect(stdout).toContain('texra agents list');
     expect(stdout).toContain('texra doctor');
     expect(stdout).toContain('Learn more: https://texra.ai');
+    expect(stderr).toBe('');
+  });
+
+  it('honors --no-color in explicit help output', async () => {
+    const result = await runCli(['--no-color', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('USAGE');
+    expect(stdout).toBe(stripAnsi(stdout));
     expect(stderr).toBe('');
   });
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -16,6 +16,7 @@ import { doctorPlatformInitContext } from '@cli/commands/doctor';
 import {
   formatUnknownCliCommand,
   formatUnknownCliFlag,
+  hasUsageNoColorFlag,
   normalizeRootShortcuts,
   reorderGlobalFlags,
 } from '@cli/commands/_helpers/dispatch';
@@ -880,6 +881,12 @@ describe('CLI global color/input flags', () => {
     expect(GLOBAL_BOOL_FLAGS.has('--no-color')).toBe(true);
     expect(GLOBAL_BOOL_FLAGS.has('--no-input')).toBe(true);
     expect(GLOBAL_BOOL_FLAGS.has('--input')).toBe(false);
+  });
+
+  it('detects usage --no-color only as a global flag', () => {
+    expect(hasUsageNoColorFlag(['--no-color', '--help'])).toBe(true);
+    expect(hasUsageNoColorFlag(['--cwd', '--no-color', '--help'])).toBe(false);
+    expect(hasUsageNoColorFlag(['--', '--no-color', '--help'])).toBe(false);
   });
 
   it('does not treat command-specific --input as a leading global flag', () => {


### PR DESCRIPTION
## Summary
- strip ANSI from rendered usage when --no-color is present
- route stdout/stderr color policy through the shared usage renderer
- add a CLI root regression test for --no-color --help

## Verification
- npm run format
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts --reporter=verbose
- npm run compile:safe
- npm run lint (passes with existing import-order warnings)
- corepack pnpm --filter @texra-ai/cli bundle
- bundled CLI smoke: texra --no-color --help exits 0 and emits no ANSI escapes

Closes #5148.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation and shared ANSI utilities only; no auth, data, or execution-path changes.
> 
> **Overview**
> **`--no-color` now applies to help and usage text**, not only runtime output. At startup, `runCli` records a leading global `--no-color` (before `--` or non-global positions) and the usage renderer strips ANSI from citty usage when that override is set or when ambient stdout/stderr color is disabled.
> 
> ANSI escape parsing is **centralized** in `@cli/runtime/ansiEscapes` (`ansiEscapeEnd`, `stripAnsiSequences`), and the TUI `ansiWrap` path uses that module instead of local copies.
> 
> **Tests** cover global-only `--no-color` detection and assert `--no-color --help` / `--no-color help` emit plain text without escape sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9e6d6a07afb9ca543fbe66a10404a9ae14e1d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->