### PR TITLE
fix(cli): wrap text input at word boundaries

### DIFF
--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -75,6 +75,15 @@ function isSoftBreakChar(char: string): boolean {
   return char !== '\n' && /\s/u.test(char);
 }
 
+function shouldWrapAtPreviousSoftBreak(
+  width: number,
+  column: number,
+  lastSoftBreakColumn: number | undefined,
+): boolean {
+  if (lastSoftBreakColumn === undefined) return false;
+  return column - lastSoftBreakColumn <= Math.max(8, Math.floor(width / 4));
+}
+
 function textInputDisplayRows(
   value: string,
   width: number,
@@ -83,6 +92,7 @@ function textInputDisplayRows(
   let rowStart = 0;
   let column = 0;
   let lastSoftBreakIndex: number | undefined;
+  let lastSoftBreakColumn: number | undefined;
 
   let index = 0;
   while (index < value.length) {
@@ -95,6 +105,7 @@ function textInputDisplayRows(
       index = point.nextIndex;
       column = 0;
       lastSoftBreakIndex = undefined;
+      lastSoftBreakColumn = undefined;
       continue;
     }
 
@@ -105,7 +116,8 @@ function textInputDisplayRows(
         wrapIndex = point.nextIndex;
       } else if (
         lastSoftBreakIndex !== undefined &&
-        lastSoftBreakIndex > rowStart
+        lastSoftBreakIndex > rowStart &&
+        shouldWrapAtPreviousSoftBreak(width, column, lastSoftBreakColumn)
       ) {
         wrapIndex = lastSoftBreakIndex;
       }
@@ -114,12 +126,14 @@ function textInputDisplayRows(
       index = wrapIndex;
       column = 0;
       lastSoftBreakIndex = undefined;
+      lastSoftBreakColumn = undefined;
       continue;
     }
 
     column += charWidth;
     if (isSoftBreakChar(point.char)) {
       lastSoftBreakIndex = point.nextIndex;
+      lastSoftBreakColumn = column;
     }
     index = point.nextIndex;
   }

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -61,6 +61,11 @@ interface TextInputDisplayRow {
   readonly breakKind: 'soft' | 'hard' | 'end';
 }
 
+interface LeadingEllipsisDisplay {
+  readonly text: string;
+  readonly removedPrefixCodeUnits: number;
+}
+
 function codePointAtIndex(
   value: string,
   index: number,
@@ -92,6 +97,16 @@ function softBreakRunEnd(value: string, start: number): number {
     index = point.nextIndex;
   }
   return index;
+}
+
+function appendSoftDisplayRow(
+  rows: TextInputDisplayRow[],
+  value: string,
+  start: number,
+  end: number,
+): void {
+  if (value.slice(start, end).trimEnd().length === 0) return;
+  rows.push({ start, end, breakKind: 'soft' });
 }
 
 function textInputDisplayRows(
@@ -131,7 +146,7 @@ function textInputDisplayRows(
       ) {
         wrapIndex = lastSoftBreakIndex;
       }
-      rows.push({ start: rowStart, end: wrapIndex, breakKind: 'soft' });
+      appendSoftDisplayRow(rows, value, rowStart, wrapIndex);
       rowStart = wrapIndex;
       index = wrapIndex;
       column = 0;
@@ -148,7 +163,9 @@ function textInputDisplayRows(
     index = point.nextIndex;
   }
 
-  rows.push({ start: rowStart, end: value.length, breakKind: 'end' });
+  if (rowStart < value.length || rows.at(-1)?.breakKind !== 'soft') {
+    rows.push({ start: rowStart, end: value.length, breakKind: 'end' });
+  }
   return rows;
 }
 
@@ -177,12 +194,25 @@ function cursorDisplayRowIndex(
 function leadingEllipsisDisplay(
   text: string,
   width: number,
-): { readonly text: string; readonly replacesFirstColumn: boolean } {
-  const replacesFirstColumn = textDisplayWidth(text) >= width;
-  if (width <= 1) return { text: '…', replacesFirstColumn };
+): LeadingEllipsisDisplay {
+  if (width <= 1) {
+    return { text: '…', removedPrefixCodeUnits: text.length };
+  }
+  if (textDisplayWidth(text) < width) {
+    return { text: `…${text}`, removedPrefixCodeUnits: 0 };
+  }
+
+  let suffix = '';
+  const chars = [...text];
+  for (let index = chars.length - 1; index >= 0; index--) {
+    const char = chars[index] ?? '';
+    const candidate = `${char}${suffix}`;
+    if (textDisplayWidth(candidate) > width - textDisplayWidth('…')) break;
+    suffix = candidate;
+  }
   return {
-    text: replacesFirstColumn ? `…${text.slice(1)}` : `…${text}`,
-    replacesFirstColumn,
+    text: `…${suffix}`,
+    removedPrefixCodeUnits: text.length - suffix.length,
   };
 }
 
@@ -222,10 +252,10 @@ export function textInputDisplayWindow({
   );
   const displayCursorRow = Math.max(0, cursorRowIndex - startRow);
   const cursorRowTextLength = rowTexts[displayCursorRow]?.length ?? 0;
-  let firstRowEllipsisReplacesFirstColumn = false;
+  let firstRowEllipsisRemovedPrefixCodeUnits = 0;
   if (clipped && startRow > 0) {
     const firstRow = leadingEllipsisDisplay(rowTexts[0] ?? '', columnCount);
-    firstRowEllipsisReplacesFirstColumn = firstRow.replacesFirstColumn;
+    firstRowEllipsisRemovedPrefixCodeUnits = firstRow.removedPrefixCodeUnits;
     rowTexts[0] = firstRow.text;
   }
   const displayValue = rowTexts.join('\n');
@@ -236,8 +266,8 @@ export function textInputDisplayWindow({
       : clampCursor(sourceCursor - cursorRow.start, cursorRowTextLength);
   const ellipsisCursorColumn =
     clipped && startRow > 0 && displayCursorRow === 0
-      ? firstRowEllipsisReplacesFirstColumn
-        ? Math.max(1, cursorColumn)
+      ? firstRowEllipsisRemovedPrefixCodeUnits > 0
+        ? Math.max(1, cursorColumn - firstRowEllipsisRemovedPrefixCodeUnits + 1)
         : cursorColumn + 1
       : cursorColumn;
   const cursorPrefixLength = rowTexts

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -84,6 +84,16 @@ function shouldWrapAtPreviousSoftBreak(
   return column - lastSoftBreakColumn <= Math.max(8, Math.floor(width / 4));
 }
 
+function softBreakRunEnd(value: string, start: number): number {
+  let index = start;
+  while (index < value.length) {
+    const point = codePointAtIndex(value, index);
+    if (point === undefined || !isSoftBreakChar(point.char)) break;
+    index = point.nextIndex;
+  }
+  return index;
+}
+
 function textInputDisplayRows(
   value: string,
   width: number,
@@ -113,7 +123,7 @@ function textInputDisplayRows(
     if (column + charWidth > width && column > 0) {
       let wrapIndex = index;
       if (isSoftBreakChar(point.char)) {
-        wrapIndex = point.nextIndex;
+        wrapIndex = softBreakRunEnd(value, index);
       } else if (
         lastSoftBreakIndex !== undefined &&
         lastSoftBreakIndex > rowStart &&
@@ -164,9 +174,16 @@ function cursorDisplayRowIndex(
   return rowIndex < 0 ? Math.max(0, rows.length - 1) : rowIndex;
 }
 
-function leadingEllipsisText(text: string, width: number): string {
-  if (width <= 1) return '…';
-  return text.length >= width ? `…${text.slice(1)}` : `…${text}`;
+function leadingEllipsisDisplay(
+  text: string,
+  width: number,
+): { readonly text: string; readonly replacesFirstColumn: boolean } {
+  const replacesFirstColumn = text.length >= width;
+  if (width <= 1) return { text: '…', replacesFirstColumn };
+  return {
+    text: replacesFirstColumn ? `…${text.slice(1)}` : `…${text}`,
+    replacesFirstColumn,
+  };
 }
 
 export function textInputDisplayWindow({
@@ -200,29 +217,26 @@ export function textInputDisplayWindow({
   const startRow = rows.length <= rowCount ? 0 : Math.max(0, endRow - rowCount);
   const visibleRows = rows.slice(startRow, endRow);
   const clipped = startRow > 0 || endRow < rows.length;
-  const firstRowOriginalLength =
-    visibleRows[0] === undefined
-      ? 0
-      : visibleRows[0].end - visibleRows[0].start;
   const rowTexts = visibleRows.map((row) =>
     textInputDisplayRowValue(value, row),
   );
+  const displayCursorRow = Math.max(0, cursorRowIndex - startRow);
+  const cursorRowTextLength = rowTexts[displayCursorRow]?.length ?? 0;
+  let firstRowEllipsisReplacesFirstColumn = false;
   if (clipped && startRow > 0) {
-    rowTexts[0] = leadingEllipsisText(rowTexts[0] ?? '', columnCount);
+    const firstRow = leadingEllipsisDisplay(rowTexts[0] ?? '', columnCount);
+    firstRowEllipsisReplacesFirstColumn = firstRow.replacesFirstColumn;
+    rowTexts[0] = firstRow.text;
   }
   const displayValue = rowTexts.join('\n');
-  const displayCursorRow = Math.max(0, cursorRowIndex - startRow);
   const cursorRow = visibleRows[displayCursorRow] ?? visibleRows.at(-1);
   const cursorColumn =
     cursorRow === undefined
       ? 0
-      : clampCursor(
-          sourceCursor - cursorRow.start,
-          rowTexts[displayCursorRow]?.length ?? 0,
-        );
+      : clampCursor(sourceCursor - cursorRow.start, cursorRowTextLength);
   const ellipsisCursorColumn =
     clipped && startRow > 0 && displayCursorRow === 0
-      ? firstRowOriginalLength >= columnCount
+      ? firstRowEllipsisReplacesFirstColumn
         ? Math.max(1, cursorColumn)
         : cursorColumn + 1
       : cursorColumn;

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -100,10 +100,15 @@ function textInputDisplayRows(
 
     const charWidth = textDisplayWidth(point.char);
     if (column + charWidth > width && column > 0) {
-      const wrapIndex =
-        lastSoftBreakIndex !== undefined && lastSoftBreakIndex > rowStart
-          ? lastSoftBreakIndex
-          : index;
+      let wrapIndex = index;
+      if (isSoftBreakChar(point.char)) {
+        wrapIndex = point.nextIndex;
+      } else if (
+        lastSoftBreakIndex !== undefined &&
+        lastSoftBreakIndex > rowStart
+      ) {
+        wrapIndex = lastSoftBreakIndex;
+      }
       rows.push({ start: rowStart, end: wrapIndex, breakKind: 'soft' });
       rowStart = wrapIndex;
       index = wrapIndex;
@@ -121,6 +126,14 @@ function textInputDisplayRows(
 
   rows.push({ start: rowStart, end: value.length, breakKind: 'end' });
   return rows;
+}
+
+function textInputDisplayRowValue(
+  value: string,
+  row: TextInputDisplayRow,
+): string {
+  const text = value.slice(row.start, row.end);
+  return row.breakKind === 'soft' ? text.trimEnd() : text;
 }
 
 function cursorDisplayRowIndex(
@@ -177,7 +190,9 @@ export function textInputDisplayWindow({
     visibleRows[0] === undefined
       ? 0
       : visibleRows[0].end - visibleRows[0].start;
-  const rowTexts = visibleRows.map((row) => value.slice(row.start, row.end));
+  const rowTexts = visibleRows.map((row) =>
+    textInputDisplayRowValue(value, row),
+  );
   if (clipped && startRow > 0) {
     rowTexts[0] = leadingEllipsisText(rowTexts[0] ?? '', columnCount);
   }

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -178,7 +178,7 @@ function leadingEllipsisDisplay(
   text: string,
   width: number,
 ): { readonly text: string; readonly replacesFirstColumn: boolean } {
-  const replacesFirstColumn = text.length >= width;
+  const replacesFirstColumn = textDisplayWidth(text) >= width;
   if (width <= 1) return { text: '…', replacesFirstColumn };
   return {
     text: replacesFirstColumn ? `…${text.slice(1)}` : `…${text}`,

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -27,6 +27,7 @@ import {
   isUnhandledControlInput,
   metaChordInput,
 } from './inputKeys';
+import { textDisplayWidth } from '../render/terminalText';
 
 export interface BaseTextInputProps {
   readonly value: string;
@@ -60,6 +61,20 @@ interface TextInputDisplayRow {
   readonly breakKind: 'soft' | 'hard' | 'end';
 }
 
+function codePointAtIndex(
+  value: string,
+  index: number,
+): { readonly char: string; readonly nextIndex: number } | undefined {
+  const codePoint = value.codePointAt(index);
+  if (codePoint === undefined) return undefined;
+  const char = String.fromCodePoint(codePoint);
+  return { char, nextIndex: index + char.length };
+}
+
+function isSoftBreakChar(char: string): boolean {
+  return char !== '\n' && /\s/u.test(char);
+}
+
 function textInputDisplayRows(
   value: string,
   width: number,
@@ -67,21 +82,41 @@ function textInputDisplayRows(
   const rows: TextInputDisplayRow[] = [];
   let rowStart = 0;
   let column = 0;
+  let lastSoftBreakIndex: number | undefined;
 
-  for (let index = 0; index < value.length; index += 1) {
-    const ch = value[index];
-    if (ch === '\n') {
+  let index = 0;
+  while (index < value.length) {
+    const point = codePointAtIndex(value, index);
+    if (point === undefined) break;
+
+    if (point.char === '\n') {
       rows.push({ start: rowStart, end: index, breakKind: 'hard' });
-      rowStart = index + 1;
+      rowStart = point.nextIndex;
+      index = point.nextIndex;
       column = 0;
+      lastSoftBreakIndex = undefined;
       continue;
     }
-    if (column === width) {
-      rows.push({ start: rowStart, end: index, breakKind: 'soft' });
-      rowStart = index;
+
+    const charWidth = textDisplayWidth(point.char);
+    if (column + charWidth > width && column > 0) {
+      const wrapIndex =
+        lastSoftBreakIndex !== undefined && lastSoftBreakIndex > rowStart
+          ? lastSoftBreakIndex
+          : index;
+      rows.push({ start: rowStart, end: wrapIndex, breakKind: 'soft' });
+      rowStart = wrapIndex;
+      index = wrapIndex;
       column = 0;
+      lastSoftBreakIndex = undefined;
+      continue;
     }
-    column += 1;
+
+    column += charWidth;
+    if (isSoftBreakChar(point.char)) {
+      lastSoftBreakIndex = point.nextIndex;
+    }
+    index = point.nextIndex;
   }
 
   rows.push({ start: rowStart, end: value.length, breakKind: 'end' });

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -8,6 +8,7 @@ import {
 } from '@cli/chat/tui/modals/ExternalInquiry';
 import { KEY_HINT_SEPARATOR } from '@cli/chat/tui/ui/KeyHints';
 import { textInputDisplayWindow } from '@cli/chat/tui/input/BaseTextInput';
+import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
 
 describe('CLI external inquiry modal', () => {
   function hintText(
@@ -171,6 +172,31 @@ describe('CLI external inquiry modal', () => {
     expect(display.value.startsWith('…')).toBe(true);
     expect(display.cursor).toBeGreaterThan(0);
     expect(display.cursor).toBeLessThanOrEqual(display.value.length);
+  });
+
+  it('wraps long answers at word boundaries when there is a nearby break', () => {
+    const value =
+      'Independent check agrees: there are 22 non-degenerate triples in the displayed list, plus exactly 61 degenerate triples.';
+    const display = textInputDisplayWindow({
+      cursor: value.length,
+      maxDisplayRows: 3,
+      value,
+      width: 72,
+    });
+
+    expect(display.value).toContain('\ndisplayed list');
+    expect(display.value).not.toContain('dis\nplayed');
+  });
+
+  it('uses terminal display width when wrapping wide answer text', () => {
+    const display = textInputDisplayWindow({
+      cursor: '１２３４５'.length,
+      maxDisplayRows: 4,
+      value: '１２３４５',
+      width: 6,
+    });
+
+    expect(display.value.split('\n').map(textDisplayWidth)).toEqual([6, 4]);
   });
 
   it('keeps Esc skip readable when scroll hints make the footer tight', () => {

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -212,6 +212,31 @@ describe('CLI external inquiry modal', () => {
     expect(display.value).toBe('hell\nworld');
   });
 
+  it('does not render a blank row for trailing wrapped whitespace', () => {
+    const value = 'hello ';
+    const display = textInputDisplayWindow({
+      cursor: value.length,
+      maxDisplayRows: 3,
+      value,
+      width: 5,
+    });
+
+    expect(display.value).toBe('hello');
+    expect(display.cursor).toBe(display.value.length);
+  });
+
+  it('skips space-only soft-wrap rows', () => {
+    const display = textInputDisplayWindow({
+      cursor: '   word'.length,
+      maxDisplayRows: 4,
+      value: '   word',
+      width: 2,
+    });
+
+    expect(display.value.split('\n')).not.toContain('');
+    expect(display.value).toBe('wo\nrd');
+  });
+
   it('keeps the cursor aligned when clipped ellipsis precedes trimmed text', () => {
     const value = 'aaaaa hell  world';
     const display = textInputDisplayWindow({

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -225,6 +225,19 @@ describe('CLI external inquiry modal', () => {
     expect(display.cursor).toBe(display.value.length);
   });
 
+  it('uses display width for clipped ellipsis cursor alignment', () => {
+    const value = 'abcdef １２３';
+    const display = textInputDisplayWindow({
+      cursor: 'abcdef １'.length,
+      maxDisplayRows: 1,
+      value,
+      width: 6,
+    });
+
+    expect(display.value).toBe('…２３');
+    expect(display.cursor).toBe(1);
+  });
+
   it('does not wrap back to distant whitespace before a long token', () => {
     const value = `a ${'x'.repeat(80)}`;
     const display = textInputDisplayWindow({

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -200,6 +200,31 @@ describe('CLI external inquiry modal', () => {
     expect(display.value).toBe('hello\nworld');
   });
 
+  it('does not render a blank row from consecutive soft-break spaces', () => {
+    const value = 'hell  world';
+    const display = textInputDisplayWindow({
+      cursor: value.length,
+      maxDisplayRows: 3,
+      value,
+      width: 5,
+    });
+
+    expect(display.value).toBe('hell\nworld');
+  });
+
+  it('keeps the cursor aligned when clipped ellipsis precedes trimmed text', () => {
+    const value = 'aaaaa hell  world';
+    const display = textInputDisplayWindow({
+      cursor: 'aaaaa hell'.length,
+      maxDisplayRows: 1,
+      value,
+      width: 5,
+    });
+
+    expect(display.value).toBe('…hell');
+    expect(display.cursor).toBe(display.value.length);
+  });
+
   it('does not wrap back to distant whitespace before a long token', () => {
     const value = `a ${'x'.repeat(80)}`;
     const display = textInputDisplayWindow({

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -188,6 +188,18 @@ describe('CLI external inquiry modal', () => {
     expect(display.value).not.toContain('dis\nplayed');
   });
 
+  it('does not render a whitespace-only row after an exact-width word', () => {
+    const value = 'hello world';
+    const display = textInputDisplayWindow({
+      cursor: value.length,
+      maxDisplayRows: 3,
+      value,
+      width: 5,
+    });
+
+    expect(display.value).toBe('hello\nworld');
+  });
+
   it('uses terminal display width when wrapping wide answer text', () => {
     const display = textInputDisplayWindow({
       cursor: '１２３４５'.length,

--- a/src/test-kernel/cli/ExternalInquiry.vitest.mts
+++ b/src/test-kernel/cli/ExternalInquiry.vitest.mts
@@ -200,6 +200,18 @@ describe('CLI external inquiry modal', () => {
     expect(display.value).toBe('hello\nworld');
   });
 
+  it('does not wrap back to distant whitespace before a long token', () => {
+    const value = `a ${'x'.repeat(80)}`;
+    const display = textInputDisplayWindow({
+      cursor: value.length,
+      maxDisplayRows: 3,
+      value,
+      width: 80,
+    });
+
+    expect(display.value.split('\n')).toEqual([`a ${'x'.repeat(78)}`, 'xx']);
+  });
+
   it('uses terminal display width when wrapping wide answer text', () => {
     const display = textInputDisplayWindow({
       cursor: '１２３４５'.length,


### PR DESCRIPTION
Fixes #5150.

## Summary
- Wrap shared CLI text input rows at nearby whitespace instead of splitting words when possible.
- Reuse terminal display width measurement so full-width glyphs count correctly.
- Add regression coverage for the external inquiry answer and wide terminal text.

## Verification
- npm run format
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ExternalInquiry.vitest.mts --reporter=verbose
- corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-frames-wordwrap external-inquiry-long-80-cols
- npm run compile:safe
- npm run lint

Harness evidence: `/tmp/texra-tui-frames-wordwrap/01-external-inquiry-long-80-cols.txt` now keeps `displayed list` together on the second answer row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to TUI display/wrapping and caret mapping for shared text input, with no auth, data, or API impact.
> 
> **Overview**
> Improves how the shared CLI **text input** draws multi-line, width-limited text: wrapping now prefers **nearby whitespace** instead of breaking words, counts columns with **terminal display width** (wide glyphs), and avoids **blank or space-only rows** after soft wraps.
> 
> **Clipped** first rows use a display-width-aware leading ellipsis, with **caret position** adjusted for trimmed prefixes and removed ellipsis text. Regression tests cover external-inquiry answer wrapping, ellipsis/cursor cases, and full-width characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b608118f8fd8f2dd4321d32bb5e8b2aa0aae68b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->