### PR TITLE
fix(cli): enforce api mode in model choices

### DIFF
--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -70,7 +70,7 @@ export function modelSelectItemsForCliMode(
   models: readonly CliModelAccess[],
   apiMode: CliApiMode,
 ): ReadonlyArray<SelectItem<string>> {
-  return runnableCliModelAccessEntries(models).map((m) => ({
+  return runnableCliModelAccessEntries(models, apiMode).map((m) => ({
     value: m.model.value,
     label: m.model.label || m.model.value,
     description: formatModelStatusForCliMode(m, apiMode),

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -144,13 +144,8 @@ function findModelAccess(
   return models.find((entry) => entry.model.value.toLowerCase() === lower);
 }
 
-function availableModelIds(
-  models: readonly CliModelAccess[],
-  apiMode?: CliApiMode,
-): string[] {
-  return runnableCliModelAccessEntries(models, apiMode).map(
-    (entry) => entry.model.value,
-  );
+function modelIds(models: readonly CliModelAccess[]): string[] {
+  return models.map((entry) => entry.model.value);
 }
 
 function withModelAccess(
@@ -204,15 +199,15 @@ export function resolveCliRunnableModelFromAccessList(
   options: CliRunnableModelOptions,
 ): CliRunnableModelResolution {
   const trimmed = model.trim();
+  const runnableEntries = runnableCliModelAccessEntries(
+    models,
+    options.apiMode,
+  );
   const entry = findModelAccess(models, trimmed);
-  if (
-    entry?.available &&
-    isCliModelOptionAllowedInMode(entry.model, options.apiMode)
-  ) {
-    return { model: entry.model.value };
-  }
+  const runnableEntry = findModelAccess(runnableEntries, trimmed);
+  if (runnableEntry) return { model: runnableEntry.model.value };
 
-  const availableIds = availableModelIds(models, options.apiMode);
+  const availableIds = modelIds(runnableEntries);
   const unavailableMessage = formatUnavailableModelMessage(
     trimmed,
     entry,

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -66,8 +66,12 @@ function isCliModelOptionRunnableInMode(
 
 export function runnableCliModelAccessEntries(
   models: readonly CliModelAccess[],
+  apiMode?: CliApiMode,
 ): CliModelAccess[] {
-  return models.filter((entry) => entry.available);
+  return models.filter(
+    (entry) =>
+      entry.available && isCliModelOptionAllowedInMode(entry.model, apiMode),
+  );
 }
 
 function formatModelAccessStatus(model: ModelOptionData): string {
@@ -140,8 +144,11 @@ function findModelAccess(
   return models.find((entry) => entry.model.value.toLowerCase() === lower);
 }
 
-function availableModelIds(models: readonly CliModelAccess[]): string[] {
-  return runnableCliModelAccessEntries(models).map(
+function availableModelIds(
+  models: readonly CliModelAccess[],
+  apiMode?: CliApiMode,
+): string[] {
+  return runnableCliModelAccessEntries(models, apiMode).map(
     (entry) => entry.model.value,
   );
 }
@@ -198,9 +205,14 @@ export function resolveCliRunnableModelFromAccessList(
 ): CliRunnableModelResolution {
   const trimmed = model.trim();
   const entry = findModelAccess(models, trimmed);
-  if (entry?.available) return { model: entry.model.value };
+  if (
+    entry?.available &&
+    isCliModelOptionAllowedInMode(entry.model, options.apiMode)
+  ) {
+    return { model: entry.model.value };
+  }
 
-  const availableIds = availableModelIds(models);
+  const availableIds = availableModelIds(models, options.apiMode);
   const unavailableMessage = formatUnavailableModelMessage(
     trimmed,
     entry,

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -142,6 +142,37 @@ describe('CLI model access resolution', () => {
     ).toEqual(['sonnet46T']);
   });
 
+  it('filters runnable models by active API mode when requested', () => {
+    const entries = [
+      model('sonnet46T', {
+        model: modelOption('sonnet46T', {
+          availability: 'included-access',
+        }),
+      }),
+      model('deepseekT', {
+        model: modelOption('deepseekT', {
+          availability: 'provider-key',
+        }),
+      }),
+      model('openrouterOnlyT', {
+        model: modelOption('openrouterOnlyT', {
+          availability: 'openrouter-key',
+        }),
+      }),
+    ];
+
+    expect(
+      runnableCliModelAccessEntries(entries, 'included').map(
+        (entry) => entry.model.value,
+      ),
+    ).toEqual(['sonnet46T']);
+    expect(
+      runnableCliModelAccessEntries(entries, 'personal').map(
+        (entry) => entry.model.value,
+      ),
+    ).toEqual(['deepseekT', 'openrouterOnlyT']);
+  });
+
   it('rejects personal-key models in included relay mode', () => {
     expect(() =>
       resolveCliRunnableModelFromAccessList(
@@ -153,7 +184,6 @@ describe('CLI model access resolution', () => {
             status: 'included access',
           }),
           model('deepseekT', {
-            available: false,
             model: modelOption('deepseekT', {
               availability: 'provider-key',
             }),
@@ -173,7 +203,6 @@ describe('CLI model access resolution', () => {
       resolveCliRunnableModelFromAccessList(
         [
           model('sonnet46T', {
-            available: false,
             model: modelOption('sonnet46T', {
               availability: 'included-access',
             }),
@@ -373,7 +402,7 @@ describe('CLI model access resolution', () => {
       { model: { value: 'deepseekT' }, available: false },
     ]);
     expect(
-      runnableCliModelAccessEntries(includedModeEntries).map(
+      runnableCliModelAccessEntries(includedModeEntries, 'included').map(
         (entry) => entry.model.value,
       ),
     ).toEqual(['sonnet46T']);

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -113,7 +113,6 @@ describe('CLI ModelListForm model visibility', () => {
             availability: 'provider-key',
           },
           'api key set',
-          false,
         ),
         access(
           {
@@ -122,7 +121,6 @@ describe('CLI ModelListForm model visibility', () => {
             availability: 'openrouter-key',
           },
           'openrouter key',
-          false,
         ),
         access(
           {
@@ -159,8 +157,7 @@ describe('CLI ModelListForm model visibility', () => {
             label: 'Sonnet',
             availability: 'included-access',
           },
-          'api key set',
-          false,
+          'included access',
         ),
         access({
           value: 'deepseekT',


### PR DESCRIPTION
Fixes #5152.

## Summary
- Make the shared runnable model helper enforce the active CLI API mode.
- Use that helper from the `/model` and startup model picker path so relay and personal API users get distinct choices.
- Strengthen tests with mixed available model lists to catch pass-through regressions.

## Verification
- npm run format
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts --reporter=verbose
- corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-frames-model-modes orchestrate-relay-model-pick orchestrate-personal-model-pick
- npm run compile:safe
- npm run lint

Harness evidence: `/tmp/texra-tui-frames-model-modes/01-orchestrate-relay-model-pick.txt` shows only included relay models; `/tmp/texra-tui-frames-model-modes/02-orchestrate-personal-model-pick.txt` shows only personal API-key models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which models users can select or fall back to at chat startup and in `/model`; incorrect filtering could block valid models or suggest invalid ones, but logic reuses existing mode rules and is well covered by tests.
> 
> **Overview**
> **CLI model pickers and resolution now honor the active API mode** (`included` relay vs `personal` keys), not just the generic `available` flag on each registry entry.
> 
> `runnableCliModelAccessEntries` takes an optional `apiMode` and keeps entries only when they are both marked runnable **and** allowed for that mode. The `/model` TUI (`modelSelectItemsForCliMode`) passes the current mode into that helper so relay users do not see personal-key models and vice versa. `resolveCliRunnableModelFromAccessList` uses the same filtered list to accept a requested model, build error/fallback “available models” lists, and choose fallbacks—fixing cases where a model looked “available” globally but was wrong for the active mode.
> 
> Tests cover per-mode filtering, rejection/fallback across mixed lists, and updated form expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bac6e14d9bd03c9c0fd2522dd5255346f5cabf3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->