### PR TITLE
fix(cli): open registered slash forms in chat

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -94,7 +94,11 @@ import { MemoryListForm } from './forms/MemoryListForm';
 import { ModelListForm } from './forms/ModelListForm';
 import { ResumeListForm } from './forms/ResumeListForm';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
-import { listSlashCommands, parseSlashInput } from './commands/slashRegistry';
+import {
+  listSlashCommands,
+  parseSlashInput,
+  type SlashCommand,
+} from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
 import { formatCliSessionStatus } from './sessionStatus';
@@ -743,6 +747,25 @@ function openCliMemoryListForm(): void {
   });
 }
 
+export function openRegisteredCliSlashForm(
+  command: SlashCommand,
+  remainder: string,
+): boolean {
+  const Form = command.formComponent;
+  if (!Form) return false;
+  cliState.activeForm.set({
+    commandName: command.name,
+    render: (close, availableRows) => (
+      <Form
+        availableRows={availableRows}
+        remainder={remainder.trimStart()}
+        onDone={() => close()}
+      />
+    ),
+  });
+  return true;
+}
+
 async function handleTuiSlashCommand(
   line: string,
   context: SlashCommandContext,
@@ -896,6 +919,9 @@ async function handleTuiSlashCommand(
             true,
       );
       if (registered) {
+        if (openRegisteredCliSlashForm(registered, parsed.remainder)) {
+          return true;
+        }
         appendLocalAssistantTranscript(
           `/${parsed.name} is registered but is not available in this CLI view yet.`,
         );

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -11,9 +11,12 @@ import {
   unregisterSlashCommand,
 } from '@cli/chat/tui/commands/slashRegistry';
 import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
+import { openRegisteredCliSlashForm } from '@cli/chat/tui/runChatTui';
+import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
+  resetCliState();
 });
 
 describe('slashRegistry', () => {
@@ -32,6 +35,7 @@ describe('slashRegistry', () => {
         'status',
         'resume',
         'memory',
+        'tools',
         'compact',
       ]),
     );
@@ -64,11 +68,27 @@ describe('slashRegistry', () => {
         formComponent: expect.any(Function),
       }),
     );
+    expect(listSlashCommands().find((cmd) => cmd.name === 'tools')).toEqual(
+      expect.objectContaining({
+        description: 'List or toggle external integrations',
+        formComponent: expect.any(Function),
+      }),
+    );
     expect(listSlashCommands().find((cmd) => cmd.name === 'compact')).toEqual(
       expect.objectContaining({
         description: 'Request context compaction',
       }),
     );
+  });
+
+  it('opens registered structured forms through the shared form opener', () => {
+    registerBuiltinSlashCommands();
+    const tools = listSlashCommands().find((cmd) => cmd.name === 'tools');
+
+    if (!tools) throw new Error('Expected /tools to be registered');
+
+    expect(openRegisteredCliSlashForm(tools, '')).toBe(true);
+    expect(cliState.activeForm.get()?.commandName).toBe('tools');
   });
 
   it('matches by name prefix case-insensitively', () => {


### PR DESCRIPTION
Closes #5154

## Summary

- Adds a shared fallback in the real `texra chat` slash-command handler that opens registered structured forms before reporting a registered command as unavailable.
- Covers `/tools` in the slash registry expectations and verifies registered form commands can be opened through the chat fallback path.

## Validation

- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SlashRegistry.vitest.mts --reporter=verbose`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-tools-fallback tools-form compact-tools-form`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI slash-command routing and form mounting; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes registered slash commands with structured TUI forms (notably **`/tools`**) incorrectly showing as unavailable in **`texra chat`**.
> 
> Adds **`openRegisteredCliSlashForm`**, which mounts a command’s **`formComponent`** on **`cliState.activeForm`** (with optional remainder text). The slash handler’s **default** branch now tries that opener for any registered command before falling back to the “not available in this CLI view yet” message.
> 
> Tests expect **`/tools`** in builtins and verify the shared opener sets **`activeForm.commandName`** to **`tools`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848b4628bd68233431b30402bc25809002401e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->