### PR TITLE
fix(cli): tag interactive team chat runs

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -135,6 +135,8 @@ export interface RunChatInit {
   readonly modelOverride?: string;
   /** Visible team identity when chat was launched from a multi-agent preset. */
   readonly teamName?: string;
+  /** Multi-agent preset id when chat was launched from a team preset. */
+  readonly cliMultiAgentPresetId?: string;
   /**
    * Continue (resume) a stored tool-use session by its execution id instead of
    * starting fresh: the interactive `texra --resume <id>` path. Set by the
@@ -145,6 +147,31 @@ export interface RunChatInit {
 }
 
 const QUEUED_FOLLOW_UP_NOTICE_LENGTH = 96;
+
+export interface BuildInitialChatAgentConfigInput {
+  readonly agent: string;
+  readonly model: string;
+  readonly instruction: string;
+  readonly workingDirectory: string;
+  readonly cliMultiAgentPresetId?: string;
+}
+
+export function buildInitialChatAgentConfig({
+  agent,
+  model,
+  instruction,
+  workingDirectory,
+  cliMultiAgentPresetId,
+}: BuildInitialChatAgentConfigInput): AgentConfigPayload {
+  return {
+    agent,
+    model,
+    instruction,
+    agentCategory: AgentCategory.ToolUse,
+    workingDirectory,
+    ...(cliMultiAgentPresetId ? { cliMultiAgentPresetId } : {}),
+  };
+}
 
 function formatQueuedFollowUpNotice(line: string): string {
   return `Queued follow-up: ${truncateSummary(
@@ -1341,13 +1368,15 @@ export async function runChat(
     const meta = cliState.sessionMeta.get();
     const currentAgent = meta.agent || agent;
     const currentModel = meta.model || model;
-    startAgentRun({
-      agent: currentAgent,
-      model: currentModel,
-      instruction,
-      agentCategory: AgentCategory.ToolUse,
-      workingDirectory: context.cwd,
-    });
+    startAgentRun(
+      buildInitialChatAgentConfig({
+        agent: currentAgent,
+        model: currentModel,
+        instruction,
+        workingDirectory: context.cwd,
+        cliMultiAgentPresetId: init.cliMultiAgentPresetId,
+      }),
+    );
   };
 
   const handleSubmit = (line: string): void => {

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -112,6 +112,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
           agentOverride: plan.rootAgent?.name,
           teamName: plan.preset.name,
           modelOverride: action.model,
+          cliMultiAgentPresetId: plan.preset.id,
         }),
       );
       return result.exitCode;

--- a/src/test-kernel/cli/RunChatConfig.vitest.mts
+++ b/src/test-kernel/cli/RunChatConfig.vitest.mts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { buildInitialChatAgentConfig } from '@cli/chat/tui/runChatTui';
+
+describe('CLI chat run config', () => {
+  it('tags preset-launched team chats with the multi-agent preset id', () => {
+    expect(
+      buildInitialChatAgentConfig({
+        agent: 'orchestrator',
+        model: 'deepseekT',
+        instruction: 'prove the bounded case',
+        workingDirectory: '/tmp/project',
+        cliMultiAgentPresetId: 'physicist',
+      }),
+    ).toMatchObject({
+      agent: 'orchestrator',
+      model: 'deepseekT',
+      instruction: 'prove the bounded case',
+      workingDirectory: '/tmp/project',
+      agentCategory: AgentCategory.ToolUse,
+      cliMultiAgentPresetId: 'physicist',
+    });
+  });
+
+  it('does not tag ordinary chats as multi-agent preset runs', () => {
+    expect(
+      buildInitialChatAgentConfig({
+        agent: 'chat',
+        model: 'deepseekT',
+        instruction: 'hello',
+        workingDirectory: '/tmp/project',
+      }),
+    ).not.toHaveProperty('cliMultiAgentPresetId');
+  });
+});


### PR DESCRIPTION
## Summary

- pass the selected multi-agent preset id from interactive `texra orchestrate` team launches into `runChat`
- build the initial chat agent config through one helper so preset tagging stays shared and explicit
- cover tagged team chats and ordinary chats with a focused CLI regression test

Closes #5156.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/RunChatConfig.vitest.mts --reporter=verbose`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI wiring and a small exported helper; behavior change is limited to optional metadata on agent config for preset-launched chats.
> 
> **Overview**
> Interactive team chats launched from **`texra orchestrate`** now carry the selected **multi-agent preset id** on the initial agent run config, matching how headless multi-agent runs are already tagged.
> 
> `RunChatInit` gains **`cliMultiAgentPresetId`**, and **`buildInitialChatAgentConfig`** centralizes building the first **`AgentConfigPayload`** (tool-use category, cwd, optional preset id). **`startSession`** uses that helper instead of inlining the payload. The orchestrate **preset** path passes **`plan.preset.id`** into **`runChat`**.
> 
> A small CLI test asserts preset-launched configs include **`cliMultiAgentPresetId`** and ordinary chats omit it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef0f93ba0e159262acdf42ce8807499517458b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->