### PR TITLE
fix(cli): reject missing file flag values

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -100,6 +100,17 @@ function assertSuccess(result, label) {
   );
 }
 
+function assertUsageError(result, label, expectedText) {
+  assert(
+    result.status === 2,
+    `${label} should fail with usage exit 2, got ${result.status}${result.signal ? ` signal ${result.signal}` : ''}${result.error ? ` error ${result.error}` : ''}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assert(
+    `${result.stdout}\n${result.stderr}`.includes(expectedText),
+    `${label} should include ${JSON.stringify(expectedText)}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+}
+
 function parseNdjson(stdout, label) {
   const lines = stdout
     .split('\n')
@@ -144,6 +155,56 @@ function validateBinarySmoke() {
       (record) => record.kind === 'agent',
     ),
     'agents list NDJSON records should have kind=agent',
+  );
+}
+
+function validateFileFlagMissingValues() {
+  assertUsageError(
+    run(process.execPath, [binaryPath, 'run', 'polish', '--input', '--print']),
+    'texra run missing --input value',
+    'Missing value for --input',
+  );
+  assertUsageError(
+    run(process.execPath, [binaryPath, 'run', 'polish', '-i', '-p']),
+    'texra run missing -i value',
+    'Missing value for -i',
+  );
+  assertUsageError(
+    run(process.execPath, [
+      binaryPath,
+      'run',
+      'polish',
+      '--input',
+      'paper.tex',
+      '--output',
+      '--print',
+    ]),
+    'texra run missing --output value',
+    'Missing value for --output',
+  );
+  assertUsageError(
+    run(process.execPath, [
+      binaryPath,
+      'agents',
+      'run',
+      'review',
+      '--instruction-file',
+      '--print',
+    ]),
+    'texra agents run missing --instruction-file value',
+    'Missing value for --instruction-file',
+  );
+  assertUsageError(
+    run(process.execPath, [
+      binaryPath,
+      'multi-agent',
+      'run',
+      'mathematician',
+      '--input',
+      '--print',
+    ]),
+    'texra multi-agent run missing --input value',
+    'Missing value for --input',
   );
 }
 
@@ -1029,6 +1090,7 @@ async function validateCliRunArtifacts() {
   });
   assertSuccess(buildResult, 'pnpm run build');
   validateBinarySmoke();
+  validateFileFlagMissingValues();
   await validateOrchestratePreservesScrollback();
   validateRunCommand();
   validateToolUseAgentRunCommand();

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -154,6 +154,57 @@ export function rejectHeadlessOnlyFlags(
   );
 }
 
+function requireInlineStringFlagValue(flag: string, value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new CliUsageError(`Missing value for ${flag}`);
+  }
+  return trimmed;
+}
+
+function requireSeparateStringFlagValue(
+  flag: string,
+  value: string | undefined,
+): string {
+  if (
+    value === undefined ||
+    value === '--' ||
+    (value !== '-' && value.startsWith('-'))
+  ) {
+    throw new CliUsageError(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+export function optionalStringFlagValue(
+  rawArgs: readonly string[],
+  longName: string,
+): string | undefined {
+  const longFlag = `--${longName}`;
+  const inlineLongPrefix = `${longFlag}=`;
+  let value: string | undefined;
+
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (arg === undefined || arg === '--') break;
+
+    if (arg.startsWith(inlineLongPrefix)) {
+      value = requireInlineStringFlagValue(
+        longFlag,
+        arg.slice(inlineLongPrefix.length),
+      );
+      continue;
+    }
+
+    if (arg === longFlag) {
+      value = requireSeparateStringFlagValue(longFlag, rawArgs[i + 1]);
+      i += 1;
+    }
+  }
+
+  return value;
+}
+
 export function collectStringFlagValues(
   rawArgs: readonly string[],
   longName: string,
@@ -169,17 +220,17 @@ export function collectStringFlagValues(
     if (arg === undefined || arg === '--') break;
 
     if (arg.startsWith(inlineLongPrefix)) {
-      const value = arg.slice(inlineLongPrefix.length).trim();
-      if (value) values.push(value);
+      values.push(
+        requireInlineStringFlagValue(
+          longFlag,
+          arg.slice(inlineLongPrefix.length),
+        ),
+      );
       continue;
     }
 
     if (arg === longFlag || arg === shortFlag) {
-      const value = rawArgs[i + 1];
-      if (value === undefined) {
-        throw new CliUsageError(`Missing value for ${arg}`);
-      }
-      values.push(value);
+      values.push(requireSeparateStringFlagValue(arg, rawArgs[i + 1]));
       i += 1;
     }
   }

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -26,6 +26,7 @@ import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
   GLOBAL_ARGS,
   collectStringFlagValues,
+  optionalStringFlagValue,
   optString,
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
@@ -231,6 +232,6 @@ export const agentsRunCommand = defineCliCommand({
       contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
       model: optString(ctx.args.model),
       instruction: optString(ctx.args.instruction) ?? '',
-      instructionFile: optString(ctx.args['instruction-file']),
+      instructionFile: optionalStringFlagValue(ctx.rawArgs, 'instruction-file'),
     }),
 });

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -42,6 +42,7 @@ import { emitCliResult } from './_helpers/output';
 import {
   GLOBAL_ARGS,
   collectStringFlagValues,
+  optionalStringFlagValue,
   optString,
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
@@ -432,7 +433,7 @@ const multiAgentRunCommand = defineCliCommand({
       agent: optString(ctx.args.agent),
       model: optString(ctx.args.model),
       instruction: optString(ctx.args.instruction) ?? '',
-      instructionFile: optString(ctx.args['instruction-file']),
+      instructionFile: optionalStringFlagValue(ctx.rawArgs, 'instruction-file'),
     }),
 });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -26,6 +26,7 @@ import { emitCliResult } from './_helpers/output';
 import {
   GLOBAL_ARGS,
   collectStringFlagValues,
+  optionalStringFlagValue,
   optString,
 } from './_helpers/globalArgs';
 import { resolveAgentWithRemoteFallback } from './_helpers/remoteAgents';
@@ -229,8 +230,8 @@ export const runWorkflowCommand = defineCliCommand({
       agent: ctx.args.agent,
       inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
       contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
-      output: optString(ctx.args.output),
-      outputDir: optString(ctx.args['output-dir']),
+      output: optionalStringFlagValue(ctx.rawArgs, 'output'),
+      outputDir: optionalStringFlagValue(ctx.rawArgs, 'output-dir'),
       model: optString(ctx.args.model),
       instruction: optString(ctx.args.instruction) ?? '',
     }),

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -27,6 +27,7 @@ import {
 } from '@cli/commands/_helpers/fetchSilencer';
 import {
   collectStringFlagValues,
+  optionalStringFlagValue,
   rejectHeadlessOnlyFlags,
 } from '@cli/commands/_helpers/globalArgs';
 import {
@@ -363,6 +364,55 @@ describe('CLI root argument routing', () => {
         'i',
       ),
     ).toEqual(['Draft0.tex', 'appendices.tex']);
+  });
+
+  it('rejects file flags when the next token is another option', () => {
+    expect(() =>
+      collectStringFlagValues(
+        ['firstread', '--input', '--print'],
+        'input',
+        'i',
+      ),
+    ).toThrow('Missing value for --input');
+    expect(() =>
+      collectStringFlagValues(['firstread', '-i', '-p'], 'input', 'i'),
+    ).toThrow('Missing value for -i');
+  });
+
+  it('rejects file flags with empty inline values', () => {
+    expect(() =>
+      collectStringFlagValues(['firstread', '--input='], 'input', 'i'),
+    ).toThrow('Missing value for --input');
+  });
+
+  it('preserves bare dash as a file flag stdin value', () => {
+    expect(
+      collectStringFlagValues(['firstread', '--input', '-'], 'input', 'i'),
+    ).toEqual(['-']);
+  });
+
+  it('reads optional file flags from raw args with the same value guard', () => {
+    expect(
+      optionalStringFlagValue(['firstread', '--output', 'out.tex'], 'output'),
+    ).toBe('out.tex');
+    expect(
+      optionalStringFlagValue(
+        ['review', '--instruction-file=prompt.md'],
+        'instruction-file',
+      ),
+    ).toBe('prompt.md');
+    expect(
+      optionalStringFlagValue(['firstread', '--output', '-'], 'output'),
+    ).toBe('-');
+    expect(() =>
+      optionalStringFlagValue(
+        ['review', '--instruction-file', '--print'],
+        'instruction-file',
+      ),
+    ).toThrow('Missing value for --instruction-file');
+    expect(() =>
+      optionalStringFlagValue(['firstread', '--output='], 'output'),
+    ).toThrow('Missing value for --output');
   });
 
   it('rejects headless-only flags on interactive command bodies', () => {


### PR DESCRIPTION
Closes #5160.

## Summary

- add a shared raw-argv string flag guard for file-taking CLI options
- reject missing separate values when the next token is another option, while preserving bare `-` as a valid stdin/file sentinel
- route `--input`/`--context`, `--instruction-file`, `--output`, and `--output-dir` through the shared behavior
- add parser unit coverage and built-CLI `validate:run` regressions

## Dogfood evidence before fix

On `origin/main` at `bfe78ecd3`:

```console
$ node packages/cli/dist/bin/texra.js run polish --input --print
--input: file not found: --print

$ node packages/cli/dist/bin/texra.js multi-agent run mathematician --input --print
--input: file not found: --print

$ node packages/cli/dist/bin/texra.js agents run review --instruction-file --print
--instruction-file: file not found: --print

$ node packages/cli/dist/bin/texra.js run polish -i -p
--input: file not found: -p
```

After fix, the same commands return usage exit 2 with `Missing value for ...`.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts --reporter=verbose`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI argument parsing and validation only; improves error handling without touching auth, data, or runtime execution paths.
> 
> **Overview**
> **File-taking CLI flags** now fail fast with usage exit **2** and `Missing value for …` when a value is absent, empty (`--input=`), or the next token looks like another option (e.g. `--input --print` or `-i -p`). A bare **`-`** is still accepted as the stdin sentinel.
> 
> Shared parsing in `globalArgs` (`requireInlineStringFlagValue`, `requireSeparateStringFlagValue`, `optionalStringFlagValue`) backs **`collectStringFlagValues`** and optional flags on **`texra run`**, **`agents run`**, and **`multi-agent run`** (`--input`/`--context`, `--instruction-file`, `--output`, `--output-dir`). **`validate:run`** adds end-to-end checks for those cases; **`CliRootArgs.vitest.mts`** covers the parser behavior.
> 
> This replaces the old behavior where the following flag was treated as a filename (e.g. `file not found: --print`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 387f051165f5bfc00e036feaf4cf86e32a54c4d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->