### PR TITLE
fix(cli): gate included launcher on relay sign-in

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -60,6 +60,18 @@ const validationEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER';
 const validationFlagEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG';
 const validationFlagContent = 'texra-cli-run-validation\n';
 const ESC = String.fromCharCode(27);
+const validationProviderApiKeyEnv = [
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
+  'GOOGLE_API_KEY',
+  'XAI_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'MOONSHOT_API_KEY',
+  'DASHSCOPE_API_KEY',
+  'MINIMAX_API_KEY',
+  'GLM_API_KEY',
+];
 
 function run(command, args, options = {}) {
   const env = {
@@ -228,82 +240,147 @@ function ensureNodePtySpawnHelperExecutable() {
   }
 }
 
-async function validateOrchestratePreservesScrollback() {
-  ensureNodePtySpawnHelperExecutable();
-  const ptyMod = await import('node-pty');
-  const ptySpawn = ptyMod.spawn ?? ptyMod.default?.spawn;
-  assert(
-    typeof ptySpawn === 'function',
-    'node-pty should expose spawn for orchestration validation',
-  );
-
+function createInteractivePtyEnv(overrides = {}) {
   const env = {
     ...process.env,
     TERM: 'xterm-256color',
     FORCE_COLOR: '3',
     TEXRA_NO_UPDATE_CHECK: '1',
+    ...overrides,
   };
   // Exercise the same interactive path a real terminal uses. CI markers make
-  // Ink switch render modes, which hides the behavior this PTY check covers.
+  // Ink switch render modes, which hides the behavior these PTY checks cover.
   delete env.CI;
   delete env.NO_COLOR;
+  return env;
+}
 
-  const result = await new Promise((resolve, reject) => {
+async function loadPtySpawn(label) {
+  ensureNodePtySpawnHelperExecutable();
+  const ptyMod = await import('node-pty');
+  const ptySpawn = ptyMod.spawn ?? ptyMod.default?.spawn;
+  assert(
+    typeof ptySpawn === 'function',
+    `node-pty should expose spawn for ${label}`,
+  );
+  return ptySpawn;
+}
+
+async function runTexraPty(args, options = {}) {
+  const label = options.label ?? `texra ${args.join(' ')}`;
+  const ptySpawn = await loadPtySpawn(label);
+  const env = createInteractivePtyEnv(options.env);
+
+  return await new Promise((resolve, reject) => {
     let output = '';
-    let exitSent = false;
     let exited = false;
-    let fallbackExitTimer;
-    let promptExitTimer;
+    let settled = false;
+    const timers = new Set();
 
-    const child = ptySpawn(process.execPath, [binaryPath, 'orchestrate'], {
+    const clearTimers = () => {
+      for (const timer of timers) clearTimeout(timer);
+      timers.clear();
+    };
+    const settle = (callback) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      callback();
+    };
+    const setTimer = (callback, delayMs) => {
+      const timer = setTimeout(() => {
+        timers.delete(timer);
+        if (!settled) callback();
+      }, delayMs);
+      timers.add(timer);
+      return timer;
+    };
+
+    const child = ptySpawn(process.execPath, [binaryPath, ...args], {
       name: 'xterm-256color',
-      cols: 100,
-      rows: 30,
-      cwd: cliRoot,
+      cols: options.cols ?? 100,
+      rows: options.rows ?? 30,
+      cwd: options.cwd ?? cliRoot,
       env,
     });
 
-    const sendExit = () => {
-      if (exitSent || exited) return;
-      exitSent = true;
-      try {
-        child.write(ESC);
-      } catch (err) {
-        if (!exited) reject(err);
-      }
-    };
-
-    const timeout = setTimeout(() => {
+    const rejectWithKill = (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
       if (!exited) {
         try {
           child.kill();
         } catch {}
       }
-      clearTimeout(fallbackExitTimer);
-      clearTimeout(promptExitTimer);
-      reject(new Error(`texra orchestrate did not exit\noutput:\n${output}`));
-    }, 12_000);
+      reject(err);
+    };
+
+    const controller = {
+      get output() {
+        return output;
+      },
+      write(data) {
+        if (exited || settled) return;
+        try {
+          child.write(data);
+        } catch (err) {
+          if (!exited) rejectWithKill(err);
+        }
+      },
+      setTimer,
+    };
+
+    setTimer(() => {
+      rejectWithKill(new Error(`${label} did not exit\noutput:\n${output}`));
+    }, options.timeoutMs ?? 12_000);
 
     child.onData((data) => {
       output += data;
-      if (
-        !exitSent &&
-        promptExitTimer == null &&
-        output.includes('Choose how to start this CLI session')
-      ) {
-        promptExitTimer = setTimeout(sendExit, 100);
+      try {
+        options.onData?.(data, controller);
+      } catch (err) {
+        rejectWithKill(err);
       }
     });
 
-    fallbackExitTimer = setTimeout(sendExit, 4_000);
-
     child.onExit((exit) => {
       exited = true;
-      clearTimeout(timeout);
-      clearTimeout(fallbackExitTimer);
-      clearTimeout(promptExitTimer);
-      resolve({ output, exit });
+      settle(() => resolve({ output, exit }));
     });
+
+    try {
+      options.onStart?.(controller);
+    } catch (err) {
+      rejectWithKill(err);
+    }
+  });
+}
+
+async function validateOrchestratePreservesScrollback() {
+  let exitSent = false;
+  let promptExitTimer;
+  const sendExit = (pty) => {
+    if (exitSent) return;
+    exitSent = true;
+    pty.write(ESC);
+  };
+
+  const result = await runTexraPty(['orchestrate'], {
+    label: 'texra orchestrate',
+    cwd: cliRoot,
+    onStart: (pty) => {
+      pty.setTimer(() => sendExit(pty), 4_000);
+    },
+    onData: (_data, pty) => {
+      if (
+        !exitSent &&
+        promptExitTimer == null &&
+        pty.output.includes('Choose how to start this CLI session')
+      ) {
+        promptExitTimer = pty.setTimer(() => sendExit(pty), 100);
+      }
+    },
   });
 
   assert(
@@ -318,6 +395,117 @@ async function validateOrchestratePreservesScrollback() {
     !result.output.includes(`${ESC}[3J`),
     'texra orchestrate should not erase terminal scrollback on exit',
   );
+}
+
+async function validateOrchestrateApiModeOnboardingPicker(options) {
+  const root = mkdtempSync(path.join(tmpdir(), 'texra-cli-api-mode-setup-'));
+  try {
+    const home = path.join(root, 'home');
+    const env = Object.fromEntries(
+      validationProviderApiKeyEnv.map((name) => [name, '']),
+    );
+    let exitSent = false;
+    let welcomeExitTimer;
+    const sendEsc = (pty) => {
+      if (exitSent) return;
+      exitSent = true;
+      pty.write(ESC);
+    };
+
+    const result = await runTexraPty(
+      ['orchestrate', '--api-mode', options.apiMode],
+      {
+        label: `texra orchestrate ${options.apiMode}-mode onboarding`,
+        cwd: repoRoot,
+        env: {
+          HOME: home,
+          XDG_CONFIG_HOME: path.join(home, '.config'),
+          XDG_DATA_HOME: path.join(home, '.local/share'),
+          XDG_STATE_HOME: path.join(home, '.local/state'),
+          ...env,
+          ...options.env,
+        },
+        onData: (_data, pty) => {
+          if (
+            !exitSent &&
+            welcomeExitTimer == null &&
+            pty.output.includes('Welcome to TeXRA')
+          ) {
+            welcomeExitTimer = pty.setTimer(() => sendEsc(pty), 100);
+          }
+          if (
+            !exitSent &&
+            pty.output.includes('Choose how to start this CLI session')
+          ) {
+            exitSent = true;
+            pty.write('\r');
+          }
+        },
+      },
+    );
+
+    assert(
+      result.exit.exitCode === 0 && !result.exit.signal,
+      `${options.apiMode}-mode onboarding should exit cleanly after Esc (exit ${result.exit.exitCode}, signal ${result.exit.signal || 'none'})\noutput:\n${result.output}`,
+    );
+    assert(
+      result.output.includes('Welcome to TeXRA'),
+      `${options.apiMode} mode should show onboarding`,
+    );
+    assert(
+      !result.output.includes('Choose how to start this CLI session'),
+      `${options.apiMode} mode should not show launcher actions before onboarding`,
+    );
+    assert(
+      !result.output.includes('New chat'),
+      `${options.apiMode} mode should not offer New chat before onboarding`,
+    );
+    assert(
+      !result.output.includes('Model "deepseekT" is not available'),
+      `${options.apiMode} mode should not fall through to model resolution`,
+    );
+    for (const text of options.expected) {
+      assert(
+        result.output.includes(text),
+        `${options.apiMode} mode should show ${JSON.stringify(text)}`,
+      );
+    }
+    for (const text of options.forbidden) {
+      assert(
+        !result.output.includes(text),
+        `${options.apiMode} mode should not show ${JSON.stringify(text)}`,
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function validateOrchestrateApiModeOnboardingPickers() {
+  await validateOrchestrateApiModeOnboardingPicker({
+    apiMode: 'included',
+    env: { ANTHROPIC_API_KEY: 'texra-validation-fake-key' },
+    expected: [
+      'Included relay access needs sign-in for this run:',
+      'opens your browser, no API key needed',
+    ],
+    forbidden: [
+      'Use my own provider API key',
+      'paste an Anthropic / OpenAI / Google key',
+    ],
+  });
+  await validateOrchestrateApiModeOnboardingPicker({
+    apiMode: 'personal',
+    env: {},
+    expected: [
+      'Personal API-key mode needs a provider key for this run:',
+      'paste an Anthropic / OpenAI / Google key',
+    ],
+    forbidden: [
+      'Sign in for included relay access',
+      'opens your browser, no API key needed',
+    ],
+  });
 }
 
 function validateRunCommand() {
@@ -1092,6 +1280,7 @@ async function validateCliRunArtifacts() {
   validateBinarySmoke();
   validateFileFlagMissingValues();
   await validateOrchestratePreservesScrollback();
+  await validateOrchestrateApiModeOnboardingPickers();
   validateRunCommand();
   validateToolUseAgentRunCommand();
   validateMultiAgentRunCommand();

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -3,10 +3,10 @@
 // Replaces today's dead-end (a launcher full of "login required" models that
 // errors out when the user picks chat) with a 2-choice picker, modeled on
 // Claude Code / Gemini CLI / aider: the no-key included-relay login is the
-// recommended default, bring-your-own provider key is second, and skip is
-// explicit. After credentials are set the caller re-reads availability in the
-// SAME process (the relay/key paths invalidate the relevant caches), so the
-// launcher/chat continues with real models — no restart.
+// recommended default when both modes are viable, bring-your-own provider key is
+// second, and skip is explicit. After credentials are set the caller re-reads
+// availability in the SAME process (the relay/key paths invalidate the relevant
+// caches), so the launcher/chat continues with real models — no restart.
 //
 // TTY-only: the gate returns immediately in headless / non-TTY / dumb-terminal
 // runs, and both entry points already reject those before calling it, so
@@ -27,9 +27,10 @@ import { assertNever } from '../chat/tui/assertNever';
 import { ApiKeyEntryForm } from '../chat/tui/forms/ApiKeyEntryForm';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
-import { Select } from '../chat/tui/ui/Select';
+import { Select, type SelectItem } from '../chat/tui/ui/Select';
 import { formatCliAccountLabelForDisplay } from '../runtime/accountDisplay';
-import { hasAnyCliCredential } from '../runtime/credentialStatus';
+import { type CliApiMode } from '../runtime/apiAccessMode';
+import { hasCliCredentialForApiMode } from '../runtime/credentialStatus';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
 import { signInCliSupabase } from '../runtime/supabaseAuth';
 
@@ -53,6 +54,7 @@ export interface OnboardingGateContext {
   readonly mode: 'headless' | 'interactive';
   readonly stdoutIsTty?: boolean;
   readonly termIsDumb?: boolean;
+  readonly apiMode?: CliApiMode;
 }
 
 const SKIP_SUMMARY =
@@ -85,13 +87,13 @@ export async function maybeRunCliOnboarding(
   ) {
     return { configured: false, declined: false };
   }
-  if (await hasAnyCliCredential().catch(() => false)) {
-    return { configured: false, declined: false };
-  }
   if (getOnboardingDeclined(platform().globalState)) {
     return { configured: false, declined: false };
   }
-  return runOnboardingFlow({ firstRun: true });
+  if (await hasCliCredentialForApiMode(context.apiMode).catch(() => false)) {
+    return { configured: false, declined: false };
+  }
+  return runOnboardingFlow({ firstRun: true, apiMode: context.apiMode });
 }
 
 /**
@@ -106,14 +108,21 @@ export async function runCliOnboarding(): Promise<CliOnboardingResult> {
 
 async function runOnboardingFlow(options: {
   readonly firstRun: boolean;
+  readonly apiMode?: CliApiMode;
 }): Promise<CliOnboardingResult> {
+  const pickerSubtitle = onboardingPickerSubtitle(options);
+  const pickerItems = onboardingPickerItems(onboardingSetupPaths(options));
   const resolution = await new Promise<OnboardingResolution>((resolve) => {
     let chosen: OnboardingResolution = { configured: false, declined: false };
     const record = (next: OnboardingResolution): void => {
       chosen = next;
     };
     const instance = render(
-      <OnboardingApp firstRun={options.firstRun} onResolve={record} />,
+      <OnboardingApp
+        pickerSubtitle={pickerSubtitle}
+        pickerItems={pickerItems}
+        onResolve={record}
+      />,
       {
         stdout: process.stdout,
         stderr: process.stderr,
@@ -158,9 +167,8 @@ type Screen =
   | 'key-entry';
 
 interface OnboardingAppProps {
-  /** First-run gate vs. an explicit `texra setup` re-configuration — only the
-   *  picker subtitle differs (the latter may already have credentials). */
-  readonly firstRun: boolean;
+  readonly pickerSubtitle: string;
+  readonly pickerItems: readonly OnboardingPickerItem[];
   readonly onResolve: (resolution: OnboardingResolution) => void;
 }
 
@@ -185,7 +193,8 @@ function OnboardingApp(props: OnboardingAppProps): React.JSX.Element {
   if (screen === 'picker') {
     return (
       <PickerStep
-        firstRun={props.firstRun}
+        subtitle={props.pickerSubtitle}
+        items={props.pickerItems}
         onRelay={() => {
           setError(undefined);
           setScreen('relay-provider');
@@ -316,8 +325,68 @@ function OnboardingFrame(props: {
   );
 }
 
-function PickerStep(props: {
+function onboardingPickerSubtitle(props: {
   readonly firstRun: boolean;
+  readonly apiMode?: CliApiMode;
+}): string {
+  if (!props.firstRun) {
+    return 'Choose how to power model calls — sign in, or add a provider API key:';
+  }
+  if (props.apiMode === 'included') {
+    return 'Included relay access needs sign-in for this run:';
+  }
+  if (props.apiMode === 'personal') {
+    return 'Personal API-key mode needs a provider key for this run:';
+  }
+  return 'Not signed in, and no provider API key is configured. Choose how to power model calls:';
+}
+
+type OnboardingChoice = 'relay' | 'key' | 'skip';
+type OnboardingSetupPath = Exclude<OnboardingChoice, 'skip'>;
+type OnboardingPickerItem = SelectItem<OnboardingChoice>;
+
+const RELAY_PICKER_ITEM: OnboardingPickerItem = {
+  value: 'relay',
+  label: 'Sign in for included relay access (recommended)',
+  description: 'opens your browser, no API key needed',
+};
+
+const KEY_PICKER_ITEM: OnboardingPickerItem = {
+  value: 'key',
+  label: 'Use my own provider API key',
+  description: 'paste an Anthropic / OpenAI / Google key',
+};
+
+const SKIP_PICKER_ITEM: OnboardingPickerItem = {
+  value: 'skip',
+  label: 'Skip for now',
+  description: 'set up later: texra login / texra setup',
+};
+
+function onboardingSetupPaths(props: {
+  readonly firstRun: boolean;
+  readonly apiMode?: CliApiMode;
+}): readonly OnboardingSetupPath[] {
+  if (!props.firstRun) return ['relay', 'key'];
+  if (props.apiMode === 'included') return ['relay'];
+  if (props.apiMode === 'personal') return ['key'];
+  return ['relay', 'key'];
+}
+
+function onboardingPickerItems(
+  setupPaths: readonly OnboardingSetupPath[],
+): readonly OnboardingPickerItem[] {
+  return [
+    ...setupPaths.map((path) =>
+      path === 'relay' ? RELAY_PICKER_ITEM : KEY_PICKER_ITEM,
+    ),
+    SKIP_PICKER_ITEM,
+  ];
+}
+
+function PickerStep(props: {
+  readonly subtitle: string;
+  readonly items: readonly OnboardingPickerItem[];
   readonly onRelay: () => void;
   readonly onKey: () => void;
   readonly onSkip: () => void;
@@ -325,35 +394,15 @@ function PickerStep(props: {
   return (
     <OnboardingFrame
       title="Welcome to TeXRA"
-      subtitle={
-        props.firstRun
-          ? 'Not signed in, and no provider API key is configured. Choose how to power model calls:'
-          : 'Choose how to power model calls — sign in, or add a provider API key:'
-      }
+      subtitle={props.subtitle}
       hints={[
         { key: '↑/↓', action: 'navigate' },
-        { key: '1-3/Enter', action: 'select' },
+        { key: `1-${props.items.length}/Enter`, action: 'select' },
         { key: 'Esc', action: 'skip' },
       ]}
     >
-      <Select<'relay' | 'key' | 'skip'>
-        items={[
-          {
-            value: 'relay',
-            label: 'Sign in for included relay access (recommended)',
-            description: 'opens your browser, no API key needed',
-          },
-          {
-            value: 'key',
-            label: 'Use my own provider API key',
-            description: 'paste an Anthropic / OpenAI / Google key',
-          },
-          {
-            value: 'skip',
-            label: 'Skip for now',
-            description: 'set up later: texra login / texra setup',
-          },
-        ]}
+      <Select<OnboardingChoice>
+        items={props.items}
         onSelect={(value) => {
           if (value === 'relay') props.onRelay();
           else if (value === 'key') props.onKey();

--- a/packages/cli/src/runtime/credentialStatus.ts
+++ b/packages/cli/src/runtime/credentialStatus.ts
@@ -1,32 +1,40 @@
-// "Does the user have any usable credential path?" — the single signal the
-// first-run onboarding gate keys off.
+// Credential checks used by the interactive first-run onboarding gate.
 //
-// Deliberately mode-independent: the orchestrate launcher boots the platform
-// with included-access probing skipped (initLocalCliPlatform forces personal
-// mode), so an api-mode-derived model list (getCliModelAccessList) is
-// unreliable there and would mis-flag a signed-in returning user as
-// credential-less. Checking the two real credential sources directly — a stored
-// TeXRA sign-in (included relay) and any resolvable provider key (secret OR
-// env) — is correct in both entry points.
+// The default check remains mode-independent for launchers that have not pinned
+// an API mode. When a command explicitly asks for included relay or personal
+// keys, use the credential source that can actually satisfy that mode so a
+// provider key does not suppress included-relay sign-in setup, and vice versa.
 
 import { platform } from '@platform/platform';
 import { API_PROVIDERS, apiKeyExists } from '@model/apiProviders';
 
 import { getCliAuthProvider } from './supabaseAuth';
+import type { CliApiMode } from './apiAccessMode';
 
-export async function hasAnyCliCredential(): Promise<boolean> {
-  const signedIn = await getCliAuthProvider()
+async function hasIncludedRelaySignIn(): Promise<boolean> {
+  return await getCliAuthProvider()
     .isAuthenticated()
     .catch(() => false);
-  if (signedIn) return true;
+}
 
-  // Short-circuit on the first provider key found rather than scanning all
-  // providers up front — avoids touching unrelated provider secrets once a
-  // usable key is present.
+async function hasProviderApiKey(): Promise<boolean> {
   const secrets = platform().secrets;
   for (const provider of API_PROVIDERS) {
     // Sequential by design: stop at the first key found.
     if (await apiKeyExists(secrets, provider)) return true;
   }
   return false;
+}
+
+export async function hasCliCredentialForApiMode(
+  apiMode: CliApiMode | undefined,
+): Promise<boolean> {
+  switch (apiMode) {
+    case 'included':
+      return hasIncludedRelaySignIn();
+    case 'personal':
+      return hasProviderApiKey();
+    default:
+      return (await hasIncludedRelaySignIn()) || (await hasProviderApiKey());
+  }
 }

--- a/src/test-kernel/cli/CredentialStatus.vitest.mts
+++ b/src/test-kernel/cli/CredentialStatus.vitest.mts
@@ -18,9 +18,10 @@ vi.mock('@model/apiProviders', async (importOriginal) => {
   return { ...actual, apiKeyExists: mocks.apiKeyExists };
 });
 
-const { hasAnyCliCredential } = await import('@cli/runtime/credentialStatus');
+const { hasCliCredentialForApiMode } =
+  await import('@cli/runtime/credentialStatus');
 
-describe('hasAnyCliCredential', () => {
+describe('CLI credential status', () => {
   beforeEach(() => {
     mocks.isAuthenticated.mockReset();
     mocks.apiKeyExists.mockReset();
@@ -28,7 +29,7 @@ describe('hasAnyCliCredential', () => {
 
   it('is true when signed in, without checking any provider key', async () => {
     mocks.isAuthenticated.mockResolvedValue(true);
-    await expect(hasAnyCliCredential()).resolves.toBe(true);
+    await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(true);
     expect(mocks.apiKeyExists).not.toHaveBeenCalled();
   });
 
@@ -36,18 +37,44 @@ describe('hasAnyCliCredential', () => {
     mocks.isAuthenticated.mockResolvedValue(false);
     mocks.apiKeyExists.mockResolvedValue(false);
     mocks.apiKeyExists.mockResolvedValueOnce(true);
-    await expect(hasAnyCliCredential()).resolves.toBe(true);
+    await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(true);
+  });
+
+  it('does not count provider keys as included-relay credentials', async () => {
+    mocks.isAuthenticated.mockResolvedValue(false);
+    mocks.apiKeyExists.mockRejectedValue(
+      new Error('provider keys must not be checked'),
+    );
+    await expect(hasCliCredentialForApiMode('included')).resolves.toBe(false);
+    expect(mocks.apiKeyExists).not.toHaveBeenCalled();
+  });
+
+  it('does not count relay sign-in as a personal API-key credential', async () => {
+    mocks.isAuthenticated.mockRejectedValue(
+      new Error('relay sign-in must not be checked'),
+    );
+    mocks.apiKeyExists.mockResolvedValue(false);
+    await expect(hasCliCredentialForApiMode('personal')).resolves.toBe(false);
+    expect(mocks.isAuthenticated).not.toHaveBeenCalled();
+    expect(mocks.apiKeyExists).toHaveBeenCalled();
+  });
+
+  it('counts provider keys as personal API-key credentials', async () => {
+    mocks.isAuthenticated.mockResolvedValue(false);
+    mocks.apiKeyExists.mockResolvedValue(false);
+    mocks.apiKeyExists.mockResolvedValueOnce(true);
+    await expect(hasCliCredentialForApiMode('personal')).resolves.toBe(true);
   });
 
   it('is false when signed out and no provider key resolves', async () => {
     mocks.isAuthenticated.mockResolvedValue(false);
     mocks.apiKeyExists.mockResolvedValue(false);
-    await expect(hasAnyCliCredential()).resolves.toBe(false);
+    await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(false);
   });
 
   it('treats an auth-check failure as not signed in', async () => {
     mocks.isAuthenticated.mockRejectedValue(new Error('offline'));
     mocks.apiKeyExists.mockResolvedValue(false);
-    await expect(hasAnyCliCredential()).resolves.toBe(false);
+    await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(false);
   });
 });

--- a/src/test-kernel/cli/OnboardingGate.vitest.mts
+++ b/src/test-kernel/cli/OnboardingGate.vitest.mts
@@ -6,12 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // branches we stub stdout.isTTY = true and mock the gate's collaborators.
 
 const mocks = vi.hoisted(() => ({
-  hasAnyCliCredential: vi.fn(),
+  hasCliCredentialForApiMode: vi.fn(),
   declined: false,
 }));
 
 vi.mock('@cli/runtime/credentialStatus', () => ({
-  hasAnyCliCredential: mocks.hasAnyCliCredential,
+  hasCliCredentialForApiMode: mocks.hasCliCredentialForApiMode,
 }));
 
 vi.mock('@platform/platform', () => ({
@@ -36,7 +36,7 @@ describe('maybeRunCliOnboarding gate', () => {
   let originalIsTty: unknown;
 
   beforeEach(() => {
-    mocks.hasAnyCliCredential.mockReset().mockResolvedValue(false);
+    mocks.hasCliCredentialForApiMode.mockReset().mockResolvedValue(false);
     mocks.declined = false;
     originalIsTty = process.stdout.isTTY;
     Object.defineProperty(process.stdout, 'isTTY', {
@@ -53,12 +53,23 @@ describe('maybeRunCliOnboarding gate', () => {
   });
 
   it('skips (configured:false) when the user already has a credential', async () => {
-    mocks.hasAnyCliCredential.mockResolvedValue(true);
+    mocks.hasCliCredentialForApiMode.mockResolvedValue(true);
     await expect(maybeRunCliOnboarding(INTERACTIVE)).resolves.toEqual({
       configured: false,
       declined: false,
     });
-    expect(mocks.hasAnyCliCredential).toHaveBeenCalledOnce();
+    expect(mocks.hasCliCredentialForApiMode).toHaveBeenCalledWith(undefined);
+  });
+
+  it('checks credentials for the explicitly requested API mode', async () => {
+    mocks.hasCliCredentialForApiMode.mockResolvedValue(true);
+    await expect(
+      maybeRunCliOnboarding({ ...INTERACTIVE, apiMode: 'included' }),
+    ).resolves.toEqual({
+      configured: false,
+      declined: false,
+    });
+    expect(mocks.hasCliCredentialForApiMode).toHaveBeenCalledWith('included');
   });
 
   it('skips when onboarding was previously declined', async () => {
@@ -67,6 +78,7 @@ describe('maybeRunCliOnboarding gate', () => {
       configured: false,
       declined: false,
     });
+    expect(mocks.hasCliCredentialForApiMode).not.toHaveBeenCalled();
   });
 
   it('skips on a dumb terminal before checking credentials', async () => {
@@ -77,7 +89,7 @@ describe('maybeRunCliOnboarding gate', () => {
         termIsDumb: true,
       }),
     ).resolves.toEqual({ configured: false, declined: false });
-    expect(mocks.hasAnyCliCredential).not.toHaveBeenCalled();
+    expect(mocks.hasCliCredentialForApiMode).not.toHaveBeenCalled();
   });
 
   it('skips in headless mode before checking credentials', async () => {
@@ -88,6 +100,6 @@ describe('maybeRunCliOnboarding gate', () => {
         termIsDumb: false,
       }),
     ).resolves.toEqual({ configured: false, declined: false });
-    expect(mocks.hasAnyCliCredential).not.toHaveBeenCalled();
+    expect(mocks.hasCliCredentialForApiMode).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #5162.

## Summary
- Make the CLI onboarding credential gate respect the requested API mode: included mode requires a relay sign-in, while personal mode requires a provider API key.
- Keep the mode-independent launcher path as the legacy "relay sign-in or provider key" check.
- Pass a precomputed onboarding picker subtitle into the Ink UI instead of threading API mode through React only for text.
- Add a built-CLI PTY regression for `texra orchestrate --api-mode included` with only a provider key configured, sharing the PTY harness with the existing scrollback check.

## Evidence
Before the fix, a PTY run with isolated CLI state and only `ANTHROPIC_API_KEY` set showed the launcher, offered `New chat`, then exited with `Model "deepseekT" is not available in the active API mode (login required).`

After the fix, the same setup opens `Welcome to TeXRA` onboarding directly and does not show the launcher or model-resolution error.

## Validation
- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CredentialStatus.vitest.mts src/test-kernel/cli/OnboardingGate.vitest.mts src/test-kernel/cli/OnboardingState.vitest.mts --reporter=verbose`
- `npm run compile:safe`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run lint` (passes with the existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run auth gating and credential detection for interactive orchestrate; behavior is well covered by unit and PTY tests but affects the sign-in/setup path users hit on launch.
> 
> **Overview**
> **API-mode-aware onboarding** stops `texra orchestrate --api-mode included|personal` from treating a mismatched credential (e.g. only a provider key in included mode) as “ready,” which previously skipped setup and surfaced the launcher / model errors.
> 
> `hasCliCredentialForApiMode` replaces the mode-agnostic check: **included** requires relay sign-in, **personal** requires a provider key, and unpinned launchers still accept either. The first-run gate passes `apiMode` through and shows a **mode-specific welcome picker** (relay-only vs key-only options and subtitles); `texra setup` still offers both paths.
> 
> CLI validation refactors PTY spawning into a shared harness and adds **PTY regressions** for included and personal onboarding in isolated home dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa10f49ae2c0bf0e89b18ad2823f70bc71d8f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->