### PR TITLE
fix(cli): wait longer for async TUI forms

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -63,6 +63,7 @@ const LONG_BASH_APPROVAL_COMMAND = [
 ].join('\n');
 const LONG_EXTERNAL_INQUIRY_ANSWER =
   'Independent check agrees: there are 22 non-degenerate triples in the displayed list, plus exactly 61 degenerate triples of the form (0,b,b), and the bounded search over integer pairs proves completeness.';
+const ASYNC_FORM_SETTLE_MS = 12000;
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
@@ -323,6 +324,7 @@ const SCENARIOS = [
     name: 'agent-form',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/agent', '\r'],
+    settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
       'Tool-use agents',
@@ -340,6 +342,7 @@ const SCENARIOS = [
     cols: 80,
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/agent', '\r'],
+    settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
       'Tool-use agents',
@@ -413,6 +416,7 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/tools', '\r'],
     frame: 'tail',
+    settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/tools',
       'Toggle available external integrations',
@@ -431,6 +435,7 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/agent', '\r'],
     frame: 'tail',
+    settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
       'Tool-use agents',
@@ -504,6 +509,7 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/tools', '\r'],
     frame: 'tail',
+    settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/tools',
       'Toggle available external integrations',
@@ -2175,7 +2181,7 @@ async function runScenario(scenario) {
   // which used to snapshot partial lines such as a task detail output row
   // ending at `Ple`. Prefer a frame where the scenario's expected visible text
   // is present, but still time out with the best frame if the UI regresses.
-  const settleDeadline = Date.now() + 4000;
+  const settleDeadline = Date.now() + Number(scenario.settleMs ?? 4000);
   let fullFrame = await frameSnapshot();
   let frame = scenarioFrame(scenario, fullFrame, rows);
   while (Date.now() < settleDeadline) {


### PR DESCRIPTION
Closes #5164.

## Summary
- Add a per-scenario settle budget to the TUI validator.
- Apply a longer settle window only to async `/agent` and `/tools` form scenarios.
- Keep the default 4s settle window for the rest of the TUI suite.

## Evidence
On `origin/main` (`4e612761c`), the full TUI validation run captured these forms before async loading finished:

- `tools-form`: spinner `Checking tool integrations...` instead of tool rows
- `compact-agent-form`: spinner `Loading agent registry...` instead of agent rows
- `compact-tools-form`: spinner `Checking tool integrations...` instead of compact tool rows

Running the same three scenarios alone passed, so this was a full-suite timing flake rather than a content regression.

## Validation
- `npm run format`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-dogfood-next-HloBs3/tui-frames-after` (all 91 scenarios passed)
- `npm run compile:safe`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness timing only; no production CLI or auth behavior changes.
> 
> **Overview**
> The TUI validator in `validate-tui.mjs` now supports a **per-scenario post-keystroke settle window** instead of a fixed 4s wait for every scenario. A shared **`ASYNC_FORM_SETTLE_MS` (12s)** is applied only to scenarios that open **`/agent`** or **`/tools`** forms (including compact and 80-column variants), so the harness can finish async loading (agent registry, tool integrations) before frame assertions run under a full 91-scenario suite.
> 
> All other scenarios still use the default **4s** settle unless they set `settleMs` explicitly. This targets full-suite timing flakes where snapshots captured loading spinners instead of the final form content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77e5d7c9f41795ba9d713dbaf473a06f5ff78b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->