### PR TITLE
fix(cli): include team availability in list json

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -177,21 +177,33 @@ function validateMultiAgentListAvailability() {
     const env = Object.fromEntries(
       validationProviderApiKeyEnv.map((name) => [name, '']),
     );
-    const text = run(
-      process.execPath,
-      [binaryPath, 'multi-agent', 'list', '--cwd', cwd, '--no-color'],
-      {
-        cwd: repoRoot,
-        env: {
-          ...env,
-          HOME: home,
-          XDG_CONFIG_HOME: path.join(home, '.config'),
-          XDG_DATA_HOME: path.join(home, '.local/share'),
-          XDG_CACHE_HOME: path.join(home, '.cache'),
-          TEXRA_NO_UPDATE_CHECK: '1',
+    const listEnv = {
+      ...env,
+      HOME: home,
+      XDG_CONFIG_HOME: path.join(home, '.config'),
+      XDG_DATA_HOME: path.join(home, '.local/share'),
+      XDG_CACHE_HOME: path.join(home, '.cache'),
+      TEXRA_NO_UPDATE_CHECK: '1',
+    };
+    const runList = (args = []) =>
+      run(
+        process.execPath,
+        [
+          binaryPath,
+          'multi-agent',
+          'list',
+          '--cwd',
+          cwd,
+          ...args,
+          '--no-color',
+        ],
+        {
+          cwd: repoRoot,
+          env: listEnv,
         },
-      },
-    );
+      );
+
+    const text = runList();
     assertSuccess(text, 'texra multi-agent list');
     const leanProjectLine = text.stdout
       .split('\n')
@@ -207,6 +219,38 @@ function validateMultiAgentListAvailability() {
     assert(
       !leanProjectLine.includes('\ttool-use:7'),
       `lean-project should not claim the full preset is available without auth\nline:\n${leanProjectLine}`,
+    );
+
+    const json = runList(['--output-format', 'json']);
+    assertSuccess(json, 'texra multi-agent list JSON');
+    const jsonRecords = JSON.parse(json.stdout);
+    const leanProjectJson = jsonRecords.find(
+      (record) => record.id === 'lean-project',
+    );
+    const leanProjectAvailability = leanProjectJson?.availability;
+    assert(
+      leanProjectAvailability?.toolUse?.label != null,
+      `multi-agent list JSON should include planned availability\nstdout:\n${json.stdout}`,
+    );
+    assert(
+      leanProjectAvailability?.status === 'degraded' ||
+        leanProjectAvailability?.status === 'unavailable',
+      `lean-project JSON should report degraded or unavailable status\nrecord:\n${JSON.stringify(leanProjectJson, null, 2)}`,
+    );
+    assert(
+      leanProjectAvailability?.toolUse?.label !== '7',
+      `lean-project JSON should not claim full tool-use availability\nrecord:\n${JSON.stringify(leanProjectJson, null, 2)}`,
+    );
+
+    const ndjson = runList(['--output-format', 'ndjson']);
+    assertSuccess(ndjson, 'texra multi-agent list NDJSON');
+    const leanProjectNdjson = parseNdjson(
+      ndjson.stdout,
+      'multi-agent list NDJSON',
+    ).find((record) => record.preset?.id === 'lean-project');
+    assert(
+      leanProjectNdjson?.preset?.availability?.toolUse?.label != null,
+      `multi-agent list NDJSON should include planned availability\nstdout:\n${ndjson.stdout}`,
     );
   } finally {
     rmSync(cwd, { recursive: true, force: true });

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -20,6 +20,7 @@ import {
   agentHasDelegationTools,
   cliMultiAgentPlanHasGaps,
   cliMultiAgentPresetNdjsonRecords,
+  cliMultiAgentPresetListRecords,
   findCliMultiAgentPreset,
   formatCliMultiAgentPresetDetails,
   formatCliMultiAgentPresetInspection,
@@ -229,10 +230,11 @@ async function runMultiAgentList(context: CliContext): Promise<number> {
   await initLocalCliPlatform(context);
   const presets = readCliMultiAgentPresets();
   const plans = await loadCliMultiAgentPresetPlans(presets);
+  const records = cliMultiAgentPresetListRecords(plans);
 
   emitCliResult(context, {
-    json: presets,
-    ndjson: cliMultiAgentPresetNdjsonRecords(presets),
+    json: records,
+    ndjson: cliMultiAgentPresetNdjsonRecords(plans),
     text: formatCliMultiAgentPresetList(plans),
   });
   return CliExitCode.Success;

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -25,7 +25,37 @@ export interface CliMultiAgentPresetRunPlan {
   readonly missingToolUseAgents: readonly string[];
 }
 
-type CliMultiAgentPlanStatus = 'available' | 'degraded' | 'unavailable';
+export type CliMultiAgentPlanStatus = 'available' | 'degraded' | 'unavailable';
+
+export interface CliMultiAgentPresetAgentAvailability {
+  readonly available: number;
+  readonly total: number;
+  readonly missing: readonly string[];
+  readonly label: string;
+}
+
+export interface CliMultiAgentPresetAvailability {
+  readonly status: CliMultiAgentPlanStatus;
+  readonly workflow: CliMultiAgentPresetAgentAvailability;
+  readonly toolUse: CliMultiAgentPresetAgentAvailability;
+  readonly rootAgent?: {
+    readonly key: string;
+    readonly name: string;
+    readonly source: AgentEntry['source'];
+  };
+  readonly missingAgentOverride?: string;
+}
+
+/**
+ * Machine-readable `multi-agent list` record. It preserves the raw preset
+ * fields so existing consumers still see a preset-shaped object, while adding
+ * the planned availability that list output needs. `multi-agent show` continues
+ * to emit the raw `CliMultiAgentPreset` because it is definition-focused and
+ * does not load the agent registry.
+ */
+export interface CliMultiAgentPresetListRecord extends CliMultiAgentPreset {
+  readonly availability: CliMultiAgentPresetAvailability;
+}
 
 export function parseCliCustomAgentPresets(raw: unknown): AgentModePreset[] {
   return AgentModePresetSchema.array().catch([]).parse(raw);
@@ -154,13 +184,13 @@ export function formatCliMultiAgentPresetInspection(
 }
 
 export function cliMultiAgentPresetNdjsonRecords(
-  presets: readonly CliMultiAgentPreset[],
+  plans: readonly CliMultiAgentPresetRunPlan[],
 ): object[] {
   const ts = new Date().toISOString();
-  return presets.map((preset) => ({
+  return plans.map((plan) => ({
     kind: 'multi-agent-preset',
     ts,
-    preset,
+    preset: cliMultiAgentPresetListRecord(plan),
   }));
 }
 
@@ -183,11 +213,50 @@ export function cliMultiAgentPlanHasGaps(
   );
 }
 
-function cliMultiAgentPlanStatus(
+export function cliMultiAgentPlanStatus(
   plan: CliMultiAgentPresetRunPlan,
 ): CliMultiAgentPlanStatus {
   if (!plan.rootAgent) return 'unavailable';
   return cliMultiAgentPlanHasGaps(plan) ? 'degraded' : 'available';
+}
+
+export function cliMultiAgentPresetAvailability(
+  plan: CliMultiAgentPresetRunPlan,
+): CliMultiAgentPresetAvailability {
+  return {
+    status: cliMultiAgentPlanStatus(plan),
+    workflow: presetAgentAvailability(
+      plan.preset.workflowAgents,
+      plan.missingWorkflowAgents,
+    ),
+    toolUse: presetAgentAvailability(
+      plan.preset.toolUseAgents,
+      plan.missingToolUseAgents,
+    ),
+    rootAgent: plan.rootAgent
+      ? {
+          key: toAgentKey(plan.rootAgent),
+          name: plan.rootAgent.name,
+          source: plan.rootAgent.source,
+        }
+      : undefined,
+    missingAgentOverride: plan.missingAgentOverride,
+  };
+}
+
+export function cliMultiAgentPresetListRecord(
+  plan: CliMultiAgentPresetRunPlan,
+): CliMultiAgentPresetListRecord {
+  return {
+    ...plan.preset,
+    availability: cliMultiAgentPresetAvailability(plan),
+  };
+}
+
+export function cliMultiAgentPresetListRecords(
+  plans: readonly CliMultiAgentPresetRunPlan[],
+): CliMultiAgentPresetListRecord[] {
+  return plans.map(cliMultiAgentPresetListRecord);
 }
 
 export function planCliMultiAgentPresetRun(
@@ -352,9 +421,21 @@ function formatAvailablePresetAgentCount(
   presetAgents: readonly string[],
   missingAgents: readonly string[],
 ): string {
+  return presetAgentAvailability(presetAgents, missingAgents).label;
+}
+
+function presetAgentAvailability(
+  presetAgents: readonly string[],
+  missingAgents: readonly string[],
+): CliMultiAgentPresetAgentAvailability {
   const total = presetAgents.length;
   const available = total - missingAgents.length;
-  return missingAgents.length === 0 ? String(total) : `${available}/${total}`;
+  return {
+    available,
+    total,
+    missing: [...missingAgents],
+    label: missingAgents.length === 0 ? String(total) : `${available}/${total}`,
+  };
 }
 
 function formatAgentNames(names: readonly string[]): string {

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -4,6 +4,8 @@ import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   cliMultiAgentPlanHasGaps,
+  cliMultiAgentPresetListRecord,
+  cliMultiAgentPresetNdjsonRecords,
   cliMultiAgentPresets,
   findCliMultiAgentPreset,
   formatCliMultiAgentPresetDetails,
@@ -71,6 +73,79 @@ describe('CLI multi-agent presets', () => {
     expect(formatCliMultiAgentPresetList([plan])).toContain(
       'built-in\tlean-project\tLean Project\tworkflow:0\ttool-use:2/7\tdegraded',
     );
+  });
+
+  it('serializes planned availability for machine-readable list output', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('lean', AgentCategory.ToolUse),
+        agent('latexFixer', AgentCategory.ToolUse),
+      ],
+    });
+    const record = cliMultiAgentPresetListRecord(plan);
+
+    expect(record.id).toBe('lean-project');
+    expect(record.toolUseAgents).toEqual(preset.toolUseAgents);
+    expect(record.availability).toMatchObject({
+      status: 'degraded',
+      workflow: {
+        available: 0,
+        total: 0,
+        missing: [],
+        label: '0',
+      },
+      toolUse: {
+        available: 2,
+        total: 7,
+        missing: [
+          'leanSearch',
+          'leanSimplifier',
+          'leanBlueprint',
+          'progressCheck',
+          'leanOrchestrator',
+        ],
+        label: '2/7',
+      },
+      rootAgent: {
+        key: 'builtInToolUse:lean',
+        name: 'lean',
+        source: 'builtInToolUse',
+      },
+    });
+  });
+
+  it('includes planned availability in ndjson preset records', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [agent('lean', AgentCategory.ToolUse)],
+    });
+
+    expect(cliMultiAgentPresetNdjsonRecords([plan])).toEqual([
+      expect.objectContaining({
+        kind: 'multi-agent-preset',
+        ts: expect.any(String),
+        preset: expect.objectContaining({
+          id: 'lean-project',
+          availability: expect.objectContaining({
+            status: 'degraded',
+            toolUse: expect.objectContaining({
+              available: 1,
+              total: 7,
+              label: '1/7',
+            }),
+          }),
+        }),
+      }),
+    ]);
   });
 
   it('parses valid custom team presets and ignores invalid state', () => {


### PR DESCRIPTION
Closes #5168.

## Summary
- Add an additive `availability` object to `multi-agent list` JSON records while preserving the existing preset fields.
- Emit the same enriched preset record through NDJSON.
- Reuse the planned preset counts/status so text, JSON, and NDJSON cannot drift.

## Evidence
Clean no-auth JSON for `lean-project` now includes planned availability:

```json
{
  "id": "lean-project",
  "source": "built-in",
  "availability": {
    "status": "degraded",
    "workflow": { "available": 0, "total": 0, "missing": [], "label": "0" },
    "toolUse": { "available": 2, "total": 7, "label": "2/7" },
    "rootAgent": {
      "key": "builtInToolUse:lean",
      "name": "lean",
      "source": "builtInToolUse"
    }
  }
}
```

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `npm run texra-local:build`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run format`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with the existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI list output and tests only; no auth, run execution, or breaking removal of preset fields.
> 
> **Overview**
> **`texra multi-agent list`** now returns preset-shaped JSON/NDJSON records with an additive **`availability`** block (status, workflow/tool-use counts, missing agent names, optional root agent), built from the same planned registry resolution as the existing tab-separated text output so formats stay aligned.
> 
> **`multi-agent show`** is unchanged and still emits definition-only preset objects without loading the agent registry. Unit tests and **`validate:run`** cover JSON/NDJSON availability for no-auth **`lean-project`** (e.g. degraded **`tool-use:2/7`**, not full **`7`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152edb11864cfc952d925eeed148aca7663b1400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->