### PR TITLE
fix(cli): mark failed async agents as errored

### DIFF
--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -21,6 +21,7 @@ describe('CLI SubagentList display model', () => {
     expect(childStatusColor(undefined)).toBe('green');
     expect(childStatusColor('running')).toBe('green');
     expect(childStatusColor('waiting')).toBe('yellow');
+    expect(childStatusColor('error')).toBe('red');
     expect(childStatusColor('stopped')).toBe('red');
   });
 

--- a/src/test-kernel/tools/CodexLoopStatus.vitest.ts
+++ b/src/test-kernel/tools/CodexLoopStatus.vitest.ts
@@ -9,12 +9,17 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 // Local imports - tools
+import {
+  agentCliLoopTerminalStatus,
+  markAgentCliLoopError,
+} from '@tools/agentCliShared';
 import { finalizeCodexLoopStatus } from '@tools/codex';
 
 const streamIds = [
   'stream:codex-loop-running',
   'stream:codex-loop-waiting',
   'stream:codex-loop-stopped',
+  'stream:codex-loop-error',
 ] as const satisfies readonly StreamTabId[];
 
 const runtimeHost = { emit: () => {} } satisfies AgentRuntimeHost;
@@ -55,5 +60,37 @@ describe('finalizeCodexLoopStatus', () => {
     finalizeCodexLoopStatus(streamId, runtimeHost);
 
     expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+  });
+
+  it('preserves error statuses set by failed turns', () => {
+    const streamId = streamIds[3];
+    StreamStatusService.set(streamId, STREAM_STATUS.ERROR, { emit: false });
+
+    finalizeCodexLoopStatus(streamId, runtimeHost);
+
+    expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.ERROR);
+  });
+
+  it('marks loop-owned child streams as errored after a failed turn', () => {
+    const streamId = streamIds[0];
+    StreamStatusService.set(streamId, STREAM_STATUS.WAITING, { emit: false });
+
+    markAgentCliLoopError(streamId, runtimeHost);
+
+    expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.ERROR);
+  });
+
+  it('does not overwrite explicit user stops with failed-turn errors', () => {
+    const streamId = streamIds[2];
+    StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, { emit: false });
+
+    markAgentCliLoopError(streamId, runtimeHost);
+
+    expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+  });
+
+  it('maps loop failure state to persisted terminal status', () => {
+    expect(agentCliLoopTerminalStatus(false)).toBe('completed');
+    expect(agentCliLoopTerminalStatus(true)).toBe('error');
   });
 });

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -1,8 +1,16 @@
 // Shared helpers for the agent-CLI tool modules (codex.ts, claudeAgent.ts).
-// Host-agnostic, VS Code-free: pure predicates and a turn-summary logger.
+// Host-agnostic, VS Code-free.
 
 import { type AgentTrace } from '@agent/trace';
-import { StreamStatus, STREAM_STATUS } from '@shared/schemas';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  EXECUTION_STATUS,
+  type ExecutionStatus,
+  type StreamStatus,
+  STREAM_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
 import { formatDuration } from '@utils/core';
 
 /** True for an AbortController-style cancellation error. */
@@ -25,6 +33,34 @@ export function isCleanInterruption(
 /** Transient statuses owned by a running agent loop. */
 export function isLoopOwnedStatus(status: StreamStatus | undefined): boolean {
   return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.RUNNING;
+}
+
+export function agentCliLoopTerminalStatus(
+  sawTurnFailure: boolean,
+): ExecutionStatus {
+  return sawTurnFailure ? EXECUTION_STATUS.ERROR : EXECUTION_STATUS.COMPLETED;
+}
+
+export function markAgentCliLoopError(
+  childStreamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
+): void {
+  if (StreamStatusService.get(childStreamId) !== STREAM_STATUS.STOPPED) {
+    StreamStatusService.set(childStreamId, STREAM_STATUS.ERROR, {
+      runtimeHost,
+    });
+  }
+}
+
+export function finalizeAgentCliLoopStatus(
+  childStreamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
+): void {
+  if (isLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
+    StreamStatusService.set(childStreamId, STREAM_STATUS.READY, {
+      runtimeHost,
+    });
+  }
 }
 
 /** Log a turn summary (duration + token usage) to the child stream. */

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -77,9 +77,11 @@ import {
 } from './claudeAgentImport';
 import { createChildStream } from './childStream';
 import {
+  agentCliLoopTerminalStatus,
+  finalizeAgentCliLoopStatus,
   isCleanInterruption,
-  isLoopOwnedStatus,
   logTurnSummary,
+  markAgentCliLoopError,
 } from './agentCliShared';
 import {
   buildClaudeToolUseLog,
@@ -205,11 +207,7 @@ function finalizeClaudeAgentLoopStatus(
   childStreamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
 ): void {
-  if (isLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
-    StreamStatusService.set(childStreamId, STREAM_STATUS.READY, {
-      runtimeHost,
-    });
-  }
+  finalizeAgentCliLoopStatus(childStreamId, runtimeHost);
 }
 
 // ============================================================================
@@ -537,6 +535,7 @@ function startClaudeAgentLoop(params: {
   let resumeSessionId: string | undefined;
   const storedSessionIds = new Set<string>();
 
+  let sawTurnFailure = false;
   void (async () => {
     try {
       while (!session.isInterrupted()) {
@@ -583,7 +582,12 @@ function startClaudeAgentLoop(params: {
         }
 
         const wallTimeMs = Date.now() - startedAt;
-        if (turn?.sessionId && !sessionRegistry.has(turn.sessionId)) {
+        const turnFailed = err != null || turn?.isError === true;
+        if (
+          !turnFailed &&
+          turn?.sessionId &&
+          !sessionRegistry.has(turn.sessionId)
+        ) {
           storeSession(turn.sessionId, {
             childStreamId,
             parentStreamId,
@@ -607,15 +611,25 @@ function startClaudeAgentLoop(params: {
         }
 
         const msg =
-          turn && !err
+          turn && !turnFailed
             ? formatClaudeDelivery(executionId, prompt, wallTimeMs, turn)
-            : formatClaudeError(executionId, prompt, err);
+            : formatClaudeError(
+                executionId,
+                prompt,
+                err ?? turn?.errorMessage ?? turn?.finalResponse,
+              );
         try {
           await getExecutionStore(executionId).writeReport(msg);
         } catch {
           // Best-effort; delivery must not block on storage.
         }
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
+
+        if (turnFailed) {
+          sawTurnFailure = true;
+          markAgentCliLoopError(childStreamId, runtimeHost);
+          break;
+        }
 
         if (!session.isInterrupted()) {
           StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
@@ -624,13 +638,16 @@ function startClaudeAgentLoop(params: {
         }
       }
     } finally {
-      sessionStage.end('stopped');
+      sessionStage.end(sawTurnFailure ? 'error' : 'stopped');
       for (const sessionId of storedSessionIds) {
         sessionRegistry.delete(sessionId);
       }
       unregisterInterruptible(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
-      await writeTerminalStatus(executionId, 'completed').catch(() => {});
+      await writeTerminalStatus(
+        executionId,
+        agentCliLoopTerminalStatus(sawTurnFailure),
+      ).catch(() => {});
       untrackExecution(executionId);
       finalizeClaudeAgentLoopStatus(childStreamId, runtimeHost);
       disposeTrace();

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -72,9 +72,11 @@ import { defineTool } from './core/define';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { createChildStream } from './childStream';
 import {
+  agentCliLoopTerminalStatus,
+  finalizeAgentCliLoopStatus,
   isCleanInterruption,
-  isLoopOwnedStatus,
   logTurnSummary,
+  markAgentCliLoopError,
 } from './agentCliShared';
 import {
   buildCodexCommandToolLog,
@@ -227,11 +229,7 @@ export function finalizeCodexLoopStatus(
   childStreamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
 ): void {
-  if (isLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
-    StreamStatusService.set(childStreamId, STREAM_STATUS.READY, {
-      runtimeHost,
-    });
-  }
+  finalizeAgentCliLoopStatus(childStreamId, runtimeHost);
 }
 
 // ============================================================================
@@ -547,6 +545,7 @@ function startCodexLoop(params: {
     runtimeHost,
   });
 
+  let sawTurnFailure = false;
   void (async () => {
     try {
       while (!session.isInterrupted()) {
@@ -583,8 +582,9 @@ function startCodexLoop(params: {
         }
 
         const wallTimeMs = Date.now() - startedAt;
+        const turnFailed = err != null;
         const threadId = thread.id;
-        if (threadId && !threadRegistry.has(threadId)) {
+        if (!turnFailed && threadId && !threadRegistry.has(threadId)) {
           storeThread(threadId, {
             thread,
             childStreamId,
@@ -603,7 +603,7 @@ function startCodexLoop(params: {
         }
 
         const msg =
-          turn && !err
+          turn && !turnFailed
             ? formatCodexDelivery(
                 executionId,
                 prompt,
@@ -619,6 +619,12 @@ function startCodexLoop(params: {
         }
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
 
+        if (turnFailed) {
+          sawTurnFailure = true;
+          markAgentCliLoopError(childStreamId, runtimeHost);
+          break;
+        }
+
         if (!session.isInterrupted()) {
           StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
             runtimeHost,
@@ -626,14 +632,17 @@ function startCodexLoop(params: {
         }
       }
     } finally {
-      sessionStage.end('stopped');
+      sessionStage.end(sawTurnFailure ? 'error' : 'stopped');
       unregisterInterruptible(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
       const threadId = thread.id;
       if (threadId) threadRegistry.delete(threadId);
       // Persist terminal status before untracking — untrackExecution fires
       // notifyWaiters, so consumers must see the final status on disk.
-      await writeTerminalStatus(executionId, 'completed').catch(() => {});
+      await writeTerminalStatus(
+        executionId,
+        agentCliLoopTerminalStatus(sawTurnFailure),
+      ).catch(() => {});
       untrackExecution(executionId);
 
       finalizeCodexLoopStatus(childStreamId, runtimeHost);


### PR DESCRIPTION
Fixes #5170.

## Summary
- centralize async agent loop status handling in `agentCliShared`
- mark Codex/Claude child streams, trace groups, and terminal status as `error` after failed turns
- avoid registering failed Codex/Claude sessions as healthy resumable child sessions
- keep user-initiated `stopped` status preserved

## Dogfooding evidence
- ran focused CLI TUI snapshot validation for transcript, slash palette, bash approval, subagents, subagent picker, task picker, and compact controls
- ran startup model-picker scenarios for relay vs personal API mode
- ran a real bundled CLI validation-model multi-agent math prompt for odd squares mod 8
- confirmed `--no-color` keeps text, JSON, help, and warning-bearing JSON output free of ANSI escapes

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/tools/CodexLoopStatus.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 10 unrelated import-order warnings)
- `npm run texra-local:build`
- `corepack pnpm --filter @texra-ai/cli validate:tui stopped-subagent-picker stopped-task-picker focused-stopped-subagent subagent-picker`
- `corepack pnpm --filter @texra-ai/cli validate:run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async agent lifecycle (stream status, terminal execution status, session registry) for Codex and Claude; behavior is well-tested but affects how orchestrators and the TUI interpret child agent outcomes.
> 
> **Overview**
> Failed Codex and Claude Code async child agents are now surfaced as **errored** instead of looking healthy or **completed** after a bad turn.
> 
> Shared helpers in `agentCliShared` set child stream status to `ERROR` on turn failure (without clobbering user **stopped**), map persisted execution status to `error` vs `completed`, and reuse the same finalize logic both tools used locally. Codex and Claude loops track turn failure, exit the loop, end the session trace stage as `error`, and skip registering resumable thread/session IDs when a turn fails. Claude also treats SDK-reported turn errors like thrown failures for delivery and status.
> 
> Tests cover preserved `ERROR`/`STOPPED` stream status, failed-turn marking, terminal status mapping, and red CLI subagent display for `error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ccb3348213cb5180f0537a531fe86edda76674b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->