### PR TITLE
fix(cli): preserve TUI snapshot scenario order

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1750,6 +1750,7 @@ function formatUsage() {
     'Options:',
     '  --snapshot-dir DIR  Write per-scenario .txt/.svg frames and an index.html report',
     '  --list              Print available scenario names and exit',
+    '  --list-selected     Print selected scenario names in run order and exit',
     '  -h, --help          Show this help',
     '',
     'Available scenarios:',
@@ -1768,6 +1769,7 @@ function printScenarioList() {
 function parseArgs(argv) {
   const scenarios = [];
   let snapshotDir;
+  let listSelected = false;
   let endOfOptions = false;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -1786,6 +1788,10 @@ function parseArgs(argv) {
     if (!endOfOptions && arg === '--list') {
       printScenarioList();
       process.exit(0);
+    }
+    if (!endOfOptions && arg === '--list-selected') {
+      listSelected = true;
+      continue;
     }
     if (!endOfOptions && arg === '--snapshot-dir') {
       const value = argv[index + 1];
@@ -1813,14 +1819,16 @@ function parseArgs(argv) {
     }
     scenarios.push(arg);
   }
-  return { scenarios, snapshotDir };
+  return { scenarios, snapshotDir, listSelected };
 }
 
 const args = parseArgs(process.argv.slice(2));
 const only = args.scenarios;
-const scenarioNames = new Set(SCENARIOS.map((s) => s.name));
+const scenarioByName = new Map(
+  SCENARIOS.map((scenario) => [scenario.name, scenario]),
+);
 const unknownScenarios = [
-  ...new Set(only.filter((name) => !scenarioNames.has(name))),
+  ...new Set(only.filter((name) => !scenarioByName.has(name))),
 ];
 if (unknownScenarios.length > 0) {
   console.error(
@@ -1832,8 +1840,12 @@ if (unknownScenarios.length > 0) {
   process.exit(1);
 }
 const scenarios = only.length
-  ? SCENARIOS.filter((s) => only.includes(s.name))
+  ? only.map((name) => scenarioByName.get(name))
   : SCENARIOS;
+if (args.listSelected) {
+  console.log(scenarios.map((scenario) => scenario.name).join('\n'));
+  process.exit(0);
+}
 const snapshotDir = args.snapshotDir;
 
 function ensureNodePtySpawnHelperExecutable() {

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -23,6 +23,7 @@ describe('TUI validator args', () => {
     expect(result.stdout).toContain('[validate-tui] usage:');
     expect(result.stdout).toContain('--snapshot-dir DIR');
     expect(result.stdout).toContain('--list');
+    expect(result.stdout).toContain('--list-selected');
     expect(result.stdout).toContain('Available scenarios:');
     expect(result.stdout).toContain('nested-subagent-picker');
     expect(result.stderr).not.toContain('building tui-harness bundle');
@@ -52,6 +53,56 @@ describe('TUI validator args', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout.split('\n')).toContain('transcript');
+    expect(result.stderr).toBe('');
+  });
+
+  it('prints selected scenarios in requested order without building the harness', () => {
+    const result = runValidator([
+      '--list-selected',
+      'compact-user-question',
+      'plan-approval-odyssey',
+      'slash-palette',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim().split('\n')).toEqual([
+      'compact-user-question',
+      'plan-approval-odyssey',
+      'slash-palette',
+    ]);
+    expect(result.stderr).not.toContain('building tui-harness bundle');
+  });
+
+  it('preserves repeated selected scenarios for snapshot order checks', () => {
+    const result = runValidator([
+      '--list-selected',
+      'slash-palette',
+      'compact-user-question',
+      'slash-palette',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim().split('\n')).toEqual([
+      'slash-palette',
+      'compact-user-question',
+      'slash-palette',
+    ]);
+    expect(result.stderr).toBe('');
+  });
+
+  it('treats a leading package-manager separator as transparent for selected scenarios', () => {
+    const result = runValidator([
+      '--',
+      '--list-selected',
+      'plan-approval-odyssey',
+      'compact-user-question',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim().split('\n')).toEqual([
+      'plan-approval-odyssey',
+      'compact-user-question',
+    ]);
     expect(result.stderr).toBe('');
   });
 });


### PR DESCRIPTION
Fixes #5172.

## Summary

- Preserve user-provided scenario order when running named `validate:tui` scenarios.
- Add `--list-selected` so validator selection order can be checked without building or launching the TUI harness.
- Cover requested order, repeated scenario names, and leading package-manager `--` handling in the validator-args tests.

## Dogfood Evidence

I found this while capturing CLI TUI screenshots for compact user questions, plan approval, long bash approval, slash palette, and nested subagent/task views. The frames passed visually, but the snapshot files were numbered in registry order rather than the command-line order, making reports harder to audit.

Before:

```text
01-slash-palette-ctrl-u-clears-raw-control.txt
02-compact-long-bash-approval-scroll.txt
03-compact-user-question.txt
04-plan-approval-odyssey.txt
```

After:

```text
01-compact-user-question.txt
02-plan-approval-odyssey.txt
03-slash-palette.txt
```

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-order-check-final-vCK4t8 compact-user-question plan-approval-odyssey slash-palette`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only validator script and argument tests; no production CLI or auth paths.
> 
> **Overview**
> **Named `validate:tui` runs now follow CLI argument order** instead of the internal scenario registry order, so `--snapshot-dir` frame numbering and reports match the order you pass on the command line (including duplicate scenario names).
> 
> Adds **`--list-selected`** to print the resolved run list and exit without building the TUI harness—useful for quick order checks. Help documents the flag; **`TuiValidatorArgs`** tests cover requested order, repeated names, and a leading `pnpm` `--` before options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e856db82d0d29f4bf7f9f0f5467f32783e146a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->