### PR TITLE
fix(cli): show json run progress on stderr

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -41,7 +41,7 @@ export interface RunProgressRendererInit {
 export function shouldRenderRunProgress(
   context: Pick<CliContext, 'outputFormat' | 'quietLogs'>,
 ): boolean {
-  return context.quietLogs !== true && context.outputFormat === 'text';
+  return context.quietLogs !== true && context.outputFormat !== 'ndjson';
 }
 
 export function createRunProgressRenderer(

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -69,6 +69,42 @@ function workflowTaskState(
   };
 }
 
+async function captureStreamWrites(
+  stream: NodeJS.WriteStream,
+  action: () => Promise<void>,
+): Promise<string> {
+  let output = '';
+  const originalWrite = stream.write;
+  stream.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+    output += decodeStreamChunk(chunk, args);
+    const callback = args.find(
+      (arg): arg is (error?: Error | null) => void => typeof arg === 'function',
+    );
+    callback?.();
+    return true;
+  }) as typeof stream.write;
+
+  try {
+    await action();
+  } finally {
+    stream.write = originalWrite;
+  }
+
+  return output;
+}
+
+function decodeStreamChunk(
+  chunk: string | Uint8Array,
+  args: unknown[],
+): string {
+  if (typeof chunk === 'string') return chunk;
+
+  const encoding = args.find(
+    (arg): arg is BufferEncoding => typeof arg === 'string',
+  );
+  return Buffer.from(chunk).toString(encoding);
+}
+
 describe('CLI run progress renderer', () => {
   it('renders a single ANSI status line and clears it on close', () => {
     let now = 0;
@@ -492,7 +528,7 @@ describe('CLI run progress renderer', () => {
     expect(shouldRenderRunProgress(context({ quietLogs: true }))).toBe(false);
     expect(shouldRenderRunProgress(context({ mode: 'headless' }))).toBe(true);
     expect(shouldRenderRunProgress(context({ outputFormat: 'json' }))).toBe(
-      false,
+      true,
     );
     expect(shouldRenderRunProgress(context({ outputFormat: 'ndjson' }))).toBe(
       false,
@@ -501,51 +537,39 @@ describe('CLI run progress renderer', () => {
   });
 
   it('routes progress events even when ordinary CLI logs are quiet', async () => {
-    let output = '';
-    const originalWrite = process.stderr.write;
-    process.stderr.write = ((
-      chunk: string | Uint8Array,
-      ...args: unknown[]
-    ) => {
-      output += String(chunk);
-      const callback = args.find(
-        (arg): arg is (error?: Error | null) => void =>
-          typeof arg === 'function',
-      );
-      callback?.();
-      return true;
-    }) as typeof process.stderr.write;
-
-    try {
+    const output = await captureStreamWrites(process.stderr, async () => {
       const host = createCliRuntimeHost(
         context({ quietLogs: true, renderRunProgress: true }),
       );
       host.emit('setTaskState', workflowTaskState());
       await host.close();
-    } finally {
-      process.stderr.write = originalWrite;
-    }
+    });
 
     expect(output).toContain('polish paper.tex · 0s');
   });
 
-  it('writes subagent progress events to stdout in ndjson mode', async () => {
-    let output = '';
-    const originalWrite = process.stdout.write;
-    process.stdout.write = ((
-      chunk: string | Uint8Array,
-      ...args: unknown[]
-    ) => {
-      output += String(chunk);
-      const callback = args.find(
-        (arg): arg is (error?: Error | null) => void =>
-          typeof arg === 'function',
-      );
-      callback?.();
-      return true;
-    }) as typeof process.stdout.write;
+  it('writes human progress to stderr without polluting json stdout', async () => {
+    let stderr = '';
+    const stdout = await captureStreamWrites(process.stdout, async () => {
+      stderr = await captureStreamWrites(process.stderr, async () => {
+        const host = createCliRuntimeHost(
+          context({
+            outputFormat: 'json',
+            colorEnabled: false,
+            renderRunProgress: true,
+          }),
+        );
+        host.emit('setTaskState', workflowTaskState());
+        await host.close();
+      });
+    });
 
-    try {
+    expect(stderr).toContain('polish paper.tex · 0s');
+    expect(stdout).toBe('');
+  });
+
+  it('writes subagent progress events to stdout in ndjson mode', async () => {
+    const output = await captureStreamWrites(process.stdout, async () => {
       const host = createCliRuntimeHost(
         context({ outputFormat: 'ndjson', renderRunProgress: false }),
       );
@@ -561,9 +585,7 @@ describe('CLI run progress renderer', () => {
         ],
       });
       await host.close();
-    } finally {
-      process.stdout.write = originalWrite;
-    }
+    });
 
     const records = output
       .trim()

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -184,9 +184,9 @@ describe('buildHeadlessRunContext', () => {
     expect(runContext.renderRunProgress).toBe(true);
   });
 
-  it('disables run progress for non-text output formats', () => {
+  it('keeps human run progress for json output', () => {
     const context = makeContext({ outputFormat: 'json' });
     const runContext = buildHeadlessRunContext(context, KNOWN_MODEL);
-    expect(runContext.renderRunProgress).toBe(false);
+    expect(runContext.renderRunProgress).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- show human run progress on stderr for `--output-format json` while preserving final JSON on stdout
- keep `--output-format ndjson` on structured progress records instead of stderr progress
- refactor duplicated stream-capture test setup and cover JSON stdout/stderr separation

Closes #5174.

## Dogfood

- `validate:tui` passed for external inquiry, agent proposal, compact proposal scrolling, bash approval, focused subagent follow-up, stopped-subagent follow-up, and ctrl-c interruption snapshots
- real `multi-agent run mathematician --approval-policy never --output-format json` completed and returned final JSON
- real `multi-agent run mathematician --approval-policy yolo --output-format json` exposed the no-progress gap while writing `solution.tex`

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors; existing unrelated import-order warnings remain)
- `npm run texra-local:build`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output routing and progress gating only; no auth, data, or core execution path changes beyond where status lines are written.
> 
> **Overview**
> **Human run progress now appears for `--output-format json`** while the final JSON result stays on stdout. Progress still renders to **stderr** (unchanged default sink); only **`ndjson`** disables the ANSI/human progress line in favor of structured progress records on stdout.
> 
> `shouldRenderRunProgress` no longer requires `text` output—it treats every format except **`ndjson`** as eligible (so **`json`** is included). Headless runs inherit that via `buildHeadlessRunContext`, which already sets `renderRunProgress` from `shouldRenderRunProgress`.
> 
> Tests add shared stream capture helpers, assert **json** keeps progress off stdout, and update expectations so **json** enables progress while **ndjson** does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e18a7cba4da73fc3ee2bd4636040086e0f2aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->