### PR TITLE
fix(cli): show resumable history entries

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -11,7 +11,10 @@ import {
   type ResultMeta,
 } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { flowKey } from '@agent/node/persistedFlow';
+import { isToolUseTaskState } from '@agent/core/execution/TaskState';
+import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { getStreamTabId } from '@agent/runtime/streamTab';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { isFileNotFoundError } from '@common/errors';
 import {
   EXECUTION_STATUS,
@@ -50,6 +53,7 @@ export interface CliHistoryEntry {
 
 export interface CliHistoryDetails {
   readonly id: ExecutionId;
+  readonly status: string;
   readonly meta: ExecutionMeta | null;
   readonly config: AgentConfig | null;
   readonly resultMeta: ResultMeta | null;
@@ -77,6 +81,8 @@ export interface CliHistoryFile {
   readonly isDirectory: boolean;
 }
 
+export const CLI_HISTORY_RESUMABLE_STATUS = 'resumable';
+
 export type CliHistoryDeleteResult =
   | { readonly deleted: 'all'; readonly count: number }
   | {
@@ -93,7 +99,11 @@ export function parseCliHistoryId(raw: string): ExecutionId | undefined {
 
 export async function listCliHistoryEntries(): Promise<CliHistoryEntry[]> {
   const entries = await listExecutions();
-  return entries.map(toCliHistoryEntry);
+  const history: CliHistoryEntry[] = [];
+  for (const entry of entries) {
+    history.push(await toCliHistoryEntry(entry));
+  }
+  return history;
 }
 
 export async function readCliHistoryDetails(
@@ -108,7 +118,6 @@ export async function readCliHistoryDetails(
     conversation,
     persistedWorkspaceFilePaths,
     generatedFiles,
-    hasFlowRecord,
   ] = await Promise.all([
     store.readMeta(),
     store.readConfig(),
@@ -117,8 +126,8 @@ export async function readCliHistoryDetails(
     store.readConversation(),
     store.readWorkspaceFiles(),
     listGeneratedFiles(id),
-    store.exists(flowKey(id)),
   ]);
+  const hasFlowRecord = await hasResumableCliFlowRecord(id, config);
   const conversationPreview = createConversationPreview(conversation);
   const workspaceFiles = await listWorkspaceToolFiles(
     config,
@@ -130,6 +139,10 @@ export async function readCliHistoryDetails(
   if (!meta && !config && !conversationPreview && !hasFlowRecord) return null;
   return {
     id,
+    status: resolveCliHistoryStatus({
+      terminalStatus: meta?.terminalStatus,
+      hasFlowRecord,
+    }),
     meta,
     config,
     resultMeta,
@@ -211,13 +224,25 @@ export function cliHistoryNdjsonRecords(
   return entries.map((entry) => ({ kind: 'history-entry', ts, entry }));
 }
 
+export function resolveCliHistoryStatus(input: {
+  readonly terminalStatus?: string;
+  readonly hasFlowRecord?: boolean;
+}): string {
+  return (
+    input.terminalStatus ??
+    (input.hasFlowRecord
+      ? CLI_HISTORY_RESUMABLE_STATUS
+      : EXECUTION_STATUS.COMPLETED)
+  );
+}
+
 export function formatCliHistoryDetailsText(
   details: CliHistoryDetails,
 ): string {
   const { config, meta } = details;
   const lines = [
     `Execution: ${details.id}`,
-    `Status: ${meta?.terminalStatus ?? EXECUTION_STATUS.COMPLETED}`,
+    `Status: ${details.status}`,
     `Timestamp: ${meta?.timestamp ?? 'unknown'}`,
     `Agent: ${config?.agent ?? 'unknown'}`,
     `Model: ${config?.model ?? 'unknown'}`,
@@ -241,22 +266,48 @@ export function formatCliHistoryDetailsText(
       ? details.files.map(formatCliHistoryFile)
       : ['(none)']),
   );
-  if (details.hasFlowRecord) lines.push('', 'Flow record: present');
+  if (details.hasFlowRecord) lines.push('', 'Resumable flow record: present');
   return lines.join('\n');
 }
 
-function toCliHistoryEntry(entry: ExecutionListingEntry): CliHistoryEntry {
+async function toCliHistoryEntry(
+  entry: ExecutionListingEntry,
+): Promise<CliHistoryEntry> {
   const inputBasename = firstInputBasename(entry.agentConfig);
+  const hasFlowRecord =
+    entry.terminalStatus === undefined
+      ? await hasResumableCliFlowRecord(entry.id, entry.agentConfig)
+      : false;
   return {
     id: entry.id,
     timestamp: entry.timestamp,
     agent: entry.agent,
     model: entry.model,
-    status: entry.terminalStatus ?? EXECUTION_STATUS.COMPLETED,
+    status: resolveCliHistoryStatus({
+      terminalStatus: entry.terminalStatus,
+      hasFlowRecord,
+    }),
     inputBasename,
     category: entry.category,
     description: entry.description,
   };
+}
+
+async function hasResumableCliFlowRecord(
+  id: ExecutionId,
+  config?: AgentConfig | null,
+): Promise<boolean> {
+  const agentConfig = config ?? (await readCliHistoryConfig(id));
+  if (!agentConfig) return false;
+
+  const taskState = agentConfigToTaskState(agentConfig);
+  if (!isToolUseTaskState(taskState)) return false;
+
+  const streamId = getStreamTabId(agentConfig.agent, agentConfig.model, {
+    executionId: id,
+  });
+  const resume = await retrieveSessionResumeData(streamId, id, taskState);
+  return resume?.type === 'toolUse';
 }
 
 function firstInputBasename(config: AgentConfig | null): string {

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { registerExecution, getExecutionStore } from '@agent/storage';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { flowKey } from '@agent/node/persistedFlow';
+import {
+  CLI_HISTORY_RESUMABLE_STATUS,
+  formatCliHistoryDetailsText,
+  readCliHistoryDetails,
+  resolveCliHistoryStatus,
+} from '@cli/runtime/history';
+import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+const TOOL_USE_CONFIG: AgentConfig = {
+  inputFiles: [],
+  contextFiles: [],
+  mediaFiles: [],
+  outputFiles: [],
+  editedFile: null,
+  agent: 'orchestrator',
+  model: 'deepseekT',
+  instruction: 'Continue the session.',
+  agentCategory: AgentCategory.ToolUse,
+  editedFiles: [],
+  toolConfig: DEFAULT_TOOL_CONFIG,
+  memories: [],
+  workingDirectory: '/workspace',
+  cliOutputFile: null,
+  cliMultiAgentPresetId: null,
+};
+
+beforeEach(async () => {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(createFakePlatform({ workspacePath: '/workspace' }));
+});
+
+describe('CLI history status formatting', () => {
+  it('keeps terminal statuses authoritative', () => {
+    expect(
+      resolveCliHistoryStatus({
+        terminalStatus: EXECUTION_STATUS.ERROR,
+        hasFlowRecord: true,
+      }),
+    ).toBe(EXECUTION_STATUS.ERROR);
+  });
+
+  it('uses nullish fallback semantics for persisted terminal status', () => {
+    expect(
+      resolveCliHistoryStatus({
+        terminalStatus: '',
+        hasFlowRecord: true,
+      }),
+    ).toBe('');
+  });
+
+  it('marks flow records without terminal status as resumable', () => {
+    expect(resolveCliHistoryStatus({ hasFlowRecord: true })).toBe(
+      CLI_HISTORY_RESUMABLE_STATUS,
+    );
+  });
+
+  it('keeps legacy terminal-status-free entries completed when no flow remains', () => {
+    expect(resolveCliHistoryStatus({ hasFlowRecord: false })).toBe(
+      EXECUTION_STATUS.COMPLETED,
+    );
+  });
+
+  it('prints resumable details instead of inventing completed status', () => {
+    const text = formatCliHistoryDetailsText({
+      id: 'abc123' as ExecutionId,
+      status: CLI_HISTORY_RESUMABLE_STATUS,
+      meta: {
+        timestamp: '2026-06-03T05:03:06.717Z',
+        category: 'toolUse',
+      },
+      config: null,
+      resultMeta: null,
+      report: null,
+      conversationPreview: null,
+      files: [],
+      hasFlowRecord: true,
+    });
+
+    expect(text).toContain('Status: resumable');
+    expect(text).toContain('Resumable flow record: present');
+    expect(text).not.toContain(`Status: ${EXECUTION_STATUS.COMPLETED}`);
+  });
+
+  it('does not mark invalid flow records as resumable', async () => {
+    const id = 'abc123' as ExecutionId;
+    await registerExecution(id, TOOL_USE_CONFIG, 'orchestrator', undefined);
+    await getExecutionStore(id).write(flowKey(id), {
+      flowName: 'test',
+      params: {},
+      shared: null,
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+
+    const details = await readCliHistoryDetails(id);
+
+    expect(details?.hasFlowRecord).toBe(false);
+    expect(details?.status).toBe(EXECUTION_STATUS.COMPLETED);
+    expect(formatCliHistoryDetailsText(details!)).not.toContain(
+      'Resumable flow record: present',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- derive CLI history status from terminal metadata plus persisted flow-record state
- show executions with no terminal status and an active flow record as `resumable` instead of `completed`
- add focused test coverage for terminal, resumable, legacy fallback, and detail formatting behavior

Fixes #5176.

## Validation

- `npx prettier --write packages/cli/src/runtime/history.ts src/test-kernel/cli/HistoryStatus.vitest.ts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/HistoryStatus.vitest.ts`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)
- rebuilt local CLI and verified the dogfood run now shows `resumable` in `history list`, text `history show`, and JSON `history show`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CLI history logic with stricter resume checks; list may be slower when many entries lack terminal status.
> 
> **Overview**
> CLI **history list** and **history show** no longer label runs without a persisted terminal status as **completed** by default. Status now comes from **`resolveCliHistoryStatus`**: stored terminal status wins (including empty string); otherwise entries with a **valid tool-use resume snapshot** show as **`resumable`**, and everything else still falls back to **completed**.
> 
> **Resumable** detection was tightened: instead of only checking that a flow KV file exists, **`hasResumableCliFlowRecord`** mirrors resume logic (tool-use task state + **`retrieveSessionResumeData`**). Details expose a computed **`status`** field and text output says **“Resumable flow record: present”** when applicable. Listing may do extra async work per entry when terminal status is missing.
> 
> Focused tests cover terminal precedence, resumable vs legacy completed, detail formatting, and invalid flow blobs not being marked resumable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c1b96135a89196821c458011fa4ba1eecbd26a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->