### PR TITLE
fix: show user question selection shortcuts

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -849,6 +849,8 @@ const SCENARIOS = [
       'previous rows',
       'Which proof direction',
       '+2 more',
+      '↑/↓ navigate',
+      '1-3 select now',
       'Enter select',
       'Esc skip',
       '1 question',

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -83,6 +83,19 @@ function userQuestionInlineClipIndicator({
   };
 }
 
+function userQuestionChoiceHints({
+  optionCount,
+  shortcutAction,
+}: {
+  readonly optionCount: number;
+  readonly shortcutAction: string;
+}): KeyHint[] {
+  return [
+    { key: '↑/↓', action: 'navigate' },
+    { key: `1-${optionCount}`, action: shortcutAction },
+  ];
+}
+
 export function isCompactUserQuestionRows(
   availableRows: number | undefined,
 ): boolean {
@@ -406,6 +419,10 @@ function MultiSelectQuestion(
       question={props.question}
       index={props.index}
       hints={[
+        ...userQuestionChoiceHints({
+          optionCount: options.length,
+          shortcutAction: 'toggle',
+        }),
         { key: 'Space', action: 'toggle' },
         { key: 'Enter', action: 'submit' },
         { key: 'Esc', action: 'skip' },
@@ -551,6 +568,10 @@ function SingleSelectQuestion(
       question={props.question}
       index={props.index}
       hints={[
+        ...userQuestionChoiceHints({
+          optionCount: props.question.options.length,
+          shortcutAction: 'select now',
+        }),
         { key: 'Enter', action: 'select' },
         { key: 'Esc', action: 'skip' },
       ]}


### PR DESCRIPTION
## Summary

Fixes #5178.

- Add arrow-navigation and direct number shortcut hints to CLI user-question choice prompts.
- Keep the hint construction shared between single-select and multi-select prompts.
- Extend the compact user-question PTY validator scenario so the rendered frame proves the shortcuts are visible.

## Dogfood evidence

The issue came from exercising the bundled CLI/TUI harness with captured frames:

```bash
corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-snapshots-next approval-form compact-user-question bash-approval orchestrate-relay-model-pick orchestrate-personal-model-pick subagent-followup-summary
```

The compact user-question frame previously only showed `Enter select · Esc skip` even though arrow navigation and `1-3` direct selection worked. After the fix, the focused frame shows:

```
↑/↓ navigate · 1-3 select now · Enter select · Esc skip
```

I also launched the real bundled chat TUI with:

```bash
TERM=xterm-256color node packages/cli/dist/bin/texra.js chat --cwd /tmp/texra-real-chat-dogfood --api-mode personal --approval-policy ask --no-color
```

and verified `/help` plus clean `/exit` behavior.

## Validation

- `npx prettier --write packages/cli/src/chat/tui/modals/UserQuestion.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/UserQuestion.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/UserQuestion.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-snapshots-question-hints compact-user-question`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

## Notes

I ran a small code-simplifier pass on this patch and removed the unnecessary public helper/test surface it flagged; the rendered PTY scenario now owns the visible footer assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Footer copy and a TUI validator expectation only; no change to approval or input handling logic.
> 
> **Overview**
> Surfaces **arrow** and **number-key** shortcuts in the CLI **Agent asks** choice prompts so the footer matches behavior that already worked but was not labeled (fixes #5178).
> 
> A shared `userQuestionChoiceHints` helper prepends **↑/↓ navigate** and **`1-N`** hints to `KeyHints` on both **single-select** and **multi-select** flows (`select now` vs `toggle`). The **compact-user-question** PTY scenario now asserts those strings appear in the captured frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5555fa9c9307db84144a32329ce00ae15434e897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->