### PR TITLE
fix: fail tui validation when deps are missing

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -20,9 +20,9 @@
 // `--snapshot-dir` writes per-scenario `.txt` and `.svg` frames plus an
 // `index.html` report for quick visual review in a browser or GitHub issue.
 //
-// Deps: node-pty (PTY; optional — native) and @xterm/headless (pure JS). If
-// node-pty is unavailable (e.g. CI without build tools), the validator prints a
-// notice and exits 0 so it never breaks installs that opt out of the native dep.
+// Deps: node-pty (PTY; native) and @xterm/headless (pure JS). Missing deps fail
+// by default so validation cannot look green without exercising any frames.
+// Pass --skip-if-missing-deps only in environments that intentionally opt out.
 
 import {
   chmodSync,
@@ -1751,6 +1751,7 @@ function formatUsage() {
     '',
     'Options:',
     '  --snapshot-dir DIR  Write per-scenario .txt/.svg frames and an index.html report',
+    '  --skip-if-missing-deps  Exit 0 instead of failing when PTY screenshot deps are unavailable',
     '  --list              Print available scenario names and exit',
     '  --list-selected     Print selected scenario names in run order and exit',
     '  -h, --help          Show this help',
@@ -1772,6 +1773,7 @@ function parseArgs(argv) {
   const scenarios = [];
   let snapshotDir;
   let listSelected = false;
+  let skipIfMissingDeps = false;
   let endOfOptions = false;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -1793,6 +1795,10 @@ function parseArgs(argv) {
     }
     if (!endOfOptions && arg === '--list-selected') {
       listSelected = true;
+      continue;
+    }
+    if (!endOfOptions && arg === '--skip-if-missing-deps') {
+      skipIfMissingDeps = true;
       continue;
     }
     if (!endOfOptions && arg === '--snapshot-dir') {
@@ -1821,7 +1827,7 @@ function parseArgs(argv) {
     }
     scenarios.push(arg);
   }
-  return { scenarios, snapshotDir, listSelected };
+  return { scenarios, snapshotDir, listSelected, skipIfMissingDeps };
 }
 
 const args = parseArgs(process.argv.slice(2));
@@ -1885,11 +1891,11 @@ try {
   }
 } catch (err) {
   console.error(
-    '[validate-tui] skipped — install the TUI dev deps to run this validator:\n' +
+    `[validate-tui] ${args.skipIfMissingDeps ? 'skipped' : 'failed'} — install the TUI dev deps to run this validator:\n` +
       '  pnpm --filter @texra-ai/cli add -D node-pty @xterm/headless\n' +
       `  (${err instanceof Error ? err.message : String(err)})`,
   );
-  process.exit(0);
+  process.exit(args.skipIfMissingDeps ? 0 : 1);
 }
 
 // --- harness bundle ------------------------------------------------------

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1747,7 +1747,7 @@ const SCENARIOS = [
 
 function formatUsage() {
   return [
-    '[validate-tui] usage: node scripts/validate-tui.mjs [--snapshot-dir DIR] [scenario ...]',
+    '[validate-tui] usage: node scripts/validate-tui.mjs [--snapshot-dir DIR] [--skip-if-missing-deps] [scenario ...]',
     '',
     'Options:',
     '  --snapshot-dir DIR  Write per-scenario .txt/.svg frames and an index.html report',

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -22,6 +22,7 @@ describe('TUI validator args', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('[validate-tui] usage:');
     expect(result.stdout).toContain('--snapshot-dir DIR');
+    expect(result.stdout).toContain('--skip-if-missing-deps');
     expect(result.stdout).toContain('--list');
     expect(result.stdout).toContain('--list-selected');
     expect(result.stdout).toContain('Available scenarios:');
@@ -71,6 +72,18 @@ describe('TUI validator args', () => {
       'slash-palette',
     ]);
     expect(result.stderr).not.toContain('building tui-harness bundle');
+  });
+
+  it('parses explicit missing-dependency skip mode before selected scenarios', () => {
+    const result = runValidator([
+      '--skip-if-missing-deps',
+      '--list-selected',
+      'compact-user-question',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('compact-user-question');
+    expect(result.stderr).toBe('');
   });
 
   it('preserves repeated selected scenarios for snapshot order checks', () => {


### PR DESCRIPTION
## Summary

Fixes #5180.

- Make `validate-tui.mjs` fail by default when `node-pty` or `@xterm/headless` cannot be loaded.
- Add `--skip-if-missing-deps` for environments that intentionally opt out of native PTY screenshot validation.
- Document the new flag in validator help and cover parser acceptance in the existing argument tests.

## Dogfood evidence

Reproduced the current false-green behavior in a clean worktree without dependencies:

```bash
node packages/cli/scripts/validate-tui.mjs compact-user-question; printf 'exit:%s\n' 0
```

Before this patch it printed a skip message and exited `0`, even though no TUI frames were rendered.

After this patch, I simulated missing `node-pty` in the dependency-installed worktree by temporarily moving `packages/cli/node_modules/node-pty` under a shell trap:

```text
default_exit:1
skip_exit:0
--- default ---
[validate-tui] failed — install the TUI dev deps to run this validator:
  pnpm --filter @texra-ai/cli add -D node-pty @xterm/headless
--- skip ---
[validate-tui] skipped — install the TUI dev deps to run this validator:
  pnpm --filter @texra-ai/cli add -D node-pty @xterm/headless
```

The normal validator path still runs and writes snapshots when dependencies are present.

## Validation

- `npx prettier --write packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-snapshots-validator-deps compact-user-question`
- missing-dependency shell simulation: default exit `1`, `--skip-if-missing-deps` exit `0`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

## Notes

A code-simplifier pass found no simplification needed in the validator logic; I renamed the parser test so it does not overstate dependency-path coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling and test-only CLI validator behavior; no production runtime or auth paths.
> 
> **Overview**
> The TUI validator (`validate-tui.mjs`) no longer exits **0** when `node-pty` or `@xterm/headless` cannot load—it **fails** so CI and local runs cannot look green without rendering frames. **`--skip-if-missing-deps`** restores the old opt-out behavior (exit 0 with a skip message). Help text and header comments document the new default; **`TuiValidatorArgs.vitest.mts`** asserts the flag appears in help and parses correctly with `--list-selected`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ac127ae3f375a3e10e9956fd8539d48c4056c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->