### PR TITLE
fix: add no-build mode for tui validation

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -73,10 +73,9 @@ const DEFAULT_HARNESS_RELATIVE_PATH = path.join(
   'bin',
   'tui-harness.js',
 );
-const HARNESS = path.resolve(
-  CLI_ROOT,
-  process.env.TEXRA_TUI_HARNESS ?? DEFAULT_HARNESS_RELATIVE_PATH,
-);
+const HARNESS_PATH_INPUT =
+  process.env.TEXRA_TUI_HARNESS || DEFAULT_HARNESS_RELATIVE_PATH;
+const HARNESS = path.resolve(CLI_ROOT, HARNESS_PATH_INPUT);
 
 // --- scenarios (verified against the committed harness) ------------------
 const SCENARIOS = [

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -73,9 +73,9 @@ const DEFAULT_HARNESS_RELATIVE_PATH = path.join(
   'bin',
   'tui-harness.js',
 );
-const HARNESS_PATH_INPUT =
-  process.env.TEXRA_TUI_HARNESS || DEFAULT_HARNESS_RELATIVE_PATH;
-const HARNESS = path.resolve(CLI_ROOT, HARNESS_PATH_INPUT);
+const HARNESS = process.env.TEXRA_TUI_HARNESS
+  ? path.resolve(process.env.TEXRA_TUI_HARNESS)
+  : path.resolve(CLI_ROOT, DEFAULT_HARNESS_RELATIVE_PATH);
 
 // --- scenarios (verified against the committed harness) ------------------
 const SCENARIOS = [

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -68,9 +68,14 @@ const ASYNC_FORM_SETTLE_MS = 12000;
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
+const DEFAULT_HARNESS_RELATIVE_PATH = path.join(
+  'dist',
+  'bin',
+  'tui-harness.js',
+);
 const HARNESS = path.resolve(
   CLI_ROOT,
-  process.env.TEXRA_TUI_HARNESS ?? path.join('dist', 'bin', 'tui-harness.js'),
+  process.env.TEXRA_TUI_HARNESS ?? DEFAULT_HARNESS_RELATIVE_PATH,
 );
 
 // --- scenarios (verified against the committed harness) ------------------
@@ -1753,7 +1758,7 @@ function formatUsage() {
     '',
     'Options:',
     '  --snapshot-dir DIR  Write per-scenario .txt/.svg frames and an index.html report',
-    '  --no-build          Use the existing dist/bin/tui-harness.js instead of rebuilding it',
+    `  --no-build          Use the existing ${DEFAULT_HARNESS_RELATIVE_PATH} instead of rebuilding it`,
     '  --skip-if-missing-deps  Exit 0 instead of failing when PTY screenshot deps are unavailable',
     '  --list              Print available scenario names and exit',
     '  --list-selected     Print selected scenario names in run order and exit',
@@ -1876,7 +1881,7 @@ if (useExistingHarness) {
         HARNESS,
       );
       console.error(
-        '[validate-tui] run without --no-build once to build dist/bin/tui-harness.js',
+        `[validate-tui] run without --no-build once to build ${DEFAULT_HARNESS_RELATIVE_PATH}`,
       );
     }
     process.exit(1);

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -16,6 +16,7 @@
 // Run:  node scripts/validate-tui.mjs        (from packages/cli)
 //   or: pnpm --filter @texra-ai/cli validate:tui
 //   or: node scripts/validate-tui.mjs --snapshot-dir /tmp/tui-frames slash-palette
+//   or: node scripts/validate-tui.mjs --no-build slash-palette
 //
 // `--snapshot-dir` writes per-scenario `.txt` and `.svg` frames plus an
 // `index.html` report for quick visual review in a browser or GitHub issue.
@@ -1747,10 +1748,11 @@ const SCENARIOS = [
 
 function formatUsage() {
   return [
-    '[validate-tui] usage: node scripts/validate-tui.mjs [--snapshot-dir DIR] [--skip-if-missing-deps] [scenario ...]',
+    '[validate-tui] usage: node scripts/validate-tui.mjs [--snapshot-dir DIR] [--no-build] [--skip-if-missing-deps] [scenario ...]',
     '',
     'Options:',
     '  --snapshot-dir DIR  Write per-scenario .txt/.svg frames and an index.html report',
+    '  --no-build          Use the existing dist/bin/tui-harness.js instead of rebuilding it',
     '  --skip-if-missing-deps  Exit 0 instead of failing when PTY screenshot deps are unavailable',
     '  --list              Print available scenario names and exit',
     '  --list-selected     Print selected scenario names in run order and exit',
@@ -1773,6 +1775,7 @@ function parseArgs(argv) {
   const scenarios = [];
   let snapshotDir;
   let listSelected = false;
+  let noBuild = false;
   let skipIfMissingDeps = false;
   let endOfOptions = false;
   for (let index = 0; index < argv.length; index += 1) {
@@ -1795,6 +1798,10 @@ function parseArgs(argv) {
     }
     if (!endOfOptions && arg === '--list-selected') {
       listSelected = true;
+      continue;
+    }
+    if (!endOfOptions && arg === '--no-build') {
+      noBuild = true;
       continue;
     }
     if (!endOfOptions && arg === '--skip-if-missing-deps') {
@@ -1827,7 +1834,7 @@ function parseArgs(argv) {
     }
     scenarios.push(arg);
   }
-  return { scenarios, snapshotDir, listSelected, skipIfMissingDeps };
+  return { scenarios, snapshotDir, listSelected, noBuild, skipIfMissingDeps };
 }
 
 const args = parseArgs(process.argv.slice(2));
@@ -1855,6 +1862,25 @@ if (args.listSelected) {
   process.exit(0);
 }
 const snapshotDir = args.snapshotDir;
+const useExistingHarness =
+  Boolean(process.env.TEXRA_TUI_HARNESS) || args.noBuild;
+
+if (useExistingHarness) {
+  if (!existsSync(HARNESS)) {
+    if (process.env.TEXRA_TUI_HARNESS) {
+      console.error('[validate-tui] custom harness does not exist:', HARNESS);
+    } else {
+      console.error(
+        '[validate-tui] --no-build requires an existing harness:',
+        HARNESS,
+      );
+      console.error(
+        '[validate-tui] run without --no-build once to build dist/bin/tui-harness.js',
+      );
+    }
+    process.exit(1);
+  }
+}
 
 function ensureNodePtySpawnHelperExecutable() {
   if (process.platform === 'win32') return;
@@ -1899,12 +1925,7 @@ try {
 }
 
 // --- harness bundle ------------------------------------------------------
-if (process.env.TEXRA_TUI_HARNESS) {
-  if (!existsSync(HARNESS)) {
-    console.error('[validate-tui] custom harness does not exist:', HARNESS);
-    process.exit(1);
-  }
-} else {
+if (!useExistingHarness) {
   // Rebuild the committed harness on every run so local TUI source edits are
   // tested against the current tree instead of a stale dist/bin artifact.
   console.error('[validate-tui] building tui-harness bundle…');

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -68,9 +68,10 @@ const ASYNC_FORM_SETTLE_MS = 12000;
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
-const HARNESS =
-  process.env.TEXRA_TUI_HARNESS ||
-  path.join(CLI_ROOT, 'dist', 'bin', 'tui-harness.js');
+const HARNESS = path.resolve(
+  CLI_ROOT,
+  process.env.TEXRA_TUI_HARNESS ?? path.join('dist', 'bin', 'tui-harness.js'),
+);
 
 // --- scenarios (verified against the committed harness) ------------------
 const SCENARIOS = [

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -22,6 +22,7 @@ describe('TUI validator args', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('[validate-tui] usage:');
     expect(result.stdout).toContain('--snapshot-dir DIR');
+    expect(result.stdout).toContain('--no-build');
     expect(result.stdout).toContain('--skip-if-missing-deps');
     expect(result.stdout).toContain('--list');
     expect(result.stdout).toContain('--list-selected');
@@ -77,6 +78,18 @@ describe('TUI validator args', () => {
   it('parses explicit missing-dependency skip mode before selected scenarios', () => {
     const result = runValidator([
       '--skip-if-missing-deps',
+      '--list-selected',
+      'compact-user-question',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('compact-user-question');
+    expect(result.stderr).toBe('');
+  });
+
+  it('parses no-build mode before selected scenarios', () => {
+    const result = runValidator([
+      '--no-build',
       '--list-selected',
       'compact-user-question',
     ]);

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -8,10 +8,14 @@ const VALIDATOR = path.join(
   'packages/cli/scripts/validate-tui.mjs',
 );
 
-function runValidator(args: string[]) {
+function runValidator(
+  args: string[],
+  env: Record<string, string | undefined> = {},
+) {
   return spawnSync(process.execPath, [VALIDATOR, ...args], {
     cwd: process.cwd(),
     encoding: 'utf8',
+    env: { ...process.env, ...env },
   });
 }
 
@@ -97,6 +101,26 @@ describe('TUI validator args', () => {
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('compact-user-question');
     expect(result.stderr).toBe('');
+  });
+
+  it('fails early when no-build selects a missing custom harness', () => {
+    const missingHarness = path.join(
+      'dist',
+      'bin',
+      'definitely-missing-tui-harness.js',
+    );
+    const result = runValidator(['--no-build', 'compact-user-question'], {
+      TEXRA_TUI_HARNESS: missingHarness,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[validate-tui] custom harness does not exist:',
+    );
+    expect(result.stderr).toContain(
+      path.join('packages', 'cli', missingHarness),
+    );
+    expect(result.stderr).not.toContain('building tui-harness bundle');
   });
 
   it('preserves repeated selected scenarios for snapshot order checks', () => {

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -117,9 +117,7 @@ describe('TUI validator args', () => {
     expect(result.stderr).toContain(
       '[validate-tui] custom harness does not exist:',
     );
-    expect(result.stderr).toContain(
-      path.join('packages', 'cli', missingHarness),
-    );
+    expect(result.stderr).toContain(path.resolve(missingHarness));
     expect(result.stderr).not.toContain('building tui-harness bundle');
   });
 


### PR DESCRIPTION
## Summary

Fixes #5182.

- Add a discoverable `--no-build` option to `validate-tui.mjs`.
- Use the existing `dist/bin/tui-harness.js` when `--no-build` is set, while preserving rebuild-by-default for normal source-edit validation.
- Preflight custom/no-build harness paths before PTY dependency loading so missing harness errors stay clear.
- Cover the new flag in existing argument parser tests.

## Dogfood evidence

Reproduced the current mutation during a normal screenshot scenario:

```text
exit:0
before:1780466363
after:1780467394
changed:yes
[validate-tui] building tui-harness bundle…
✓ compact-user-question
```

After this patch, an existing-harness run leaves the bundle untouched:

```text
node packages/cli/scripts/validate-tui.mjs --no-build compact-user-question
exit:0
changed:no
✓ compact-user-question
validate-tui: all 1 scenarios passed
```

Missing harness preflight stays clear even when PTY deps are also unavailable:

```text
exit:1
[validate-tui] --no-build requires an existing harness: .../packages/cli/dist/bin/tui-harness.js
[validate-tui] run without --no-build once to build dist/bin/tui-harness.js
```

The default path still rebuilds:

```text
node packages/cli/scripts/validate-tui.mjs compact-user-question
[validate-tui] building tui-harness bundle…
✓ compact-user-question
```

## Validation

- `npx prettier --write packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --no-build compact-user-question`
- missing-harness preflight shell simulation
- `node packages/cli/scripts/validate-tui.mjs compact-user-question`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

## Notes

A code-simplifier pass found one ordering issue: the missing-harness preflight initially ran after dependency loading. This PR includes that simplification so `--no-build` reports missing harnesses before PTY dependency failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the CLI TUI validation script and its tests; no production runtime, auth, or data paths are affected.
> 
> **Overview**
> Adds a **`--no-build`** option to the CLI TUI validator so runs can reuse an existing **`dist/bin/tui-harness.js`** instead of rebuilding on every invocation—useful for faster iteration and screenshot workflows where the bundle is already built.
> 
> Default behavior is unchanged: normal runs still rebuild the harness so local TUI edits stay covered. **`TEXRA_TUI_HARNESS`** continues to select a custom harness; both that path and **`--no-build`** now **preflight** that the harness file exists **before** loading PTY dependencies, with clearer errors when it is missing. Help/usage and argument-parser tests were extended for the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c513a10a23770a2ad340e8ffab081dffc1790f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->