### PR TITLE
fix: add no-build mode for run validation

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -59,6 +59,7 @@ const { collectTexraThreads } = require(
 const validationEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER';
 const validationFlagEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG';
 const validationFlagContent = 'texra-cli-run-validation\n';
+const validationBundleMarker = validationFlagContent.trim();
 const ESC = String.fromCharCode(27);
 const validationProviderApiKeyEnv = [
   'OPENAI_API_KEY',
@@ -121,6 +122,68 @@ function assertUsageError(result, label, expectedText) {
     `${result.stdout}\n${result.stderr}`.includes(expectedText),
     `${label} should include ${JSON.stringify(expectedText)}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
   );
+}
+
+function formatUsage() {
+  return [
+    '[validate-run] usage: node scripts/validate-run.mjs [--no-build]',
+    '',
+    'Options:',
+    '  --no-build  Reuse the existing dist/bin/texra.js validation bundle instead of rebuilding it',
+    '  -h, --help  Show this help',
+  ].join('\n');
+}
+
+function printUsage(stream = console.log) {
+  stream(formatUsage());
+}
+
+function parseArgs(argv) {
+  let noBuild = false;
+  let endOfOptions = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!endOfOptions && arg === '--') {
+      if (index === 0 && argv[1]?.startsWith('-')) continue;
+      endOfOptions = true;
+      continue;
+    }
+    if (!endOfOptions && (arg === '--help' || arg === '-h')) {
+      printUsage();
+      process.exit(0);
+    }
+    if (!endOfOptions && arg === '--no-build') {
+      noBuild = true;
+      continue;
+    }
+    console.error(`[validate-run] unknown argument: ${arg}`);
+    printUsage(console.error);
+    process.exit(2);
+  }
+  return { noBuild };
+}
+
+function preflightExistingValidationBundle() {
+  if (!existsSync(binaryPath)) {
+    console.error(
+      `[validate-run] --no-build requires an existing CLI bundle: ${binaryPath}`,
+    );
+    console.error(
+      '[validate-run] omit --no-build once to build the validation bundle.',
+    );
+    process.exit(1);
+  }
+
+  const bundle = readFileSync(binaryPath, 'utf8');
+  if (!bundle.includes(validationBundleMarker)) {
+    console.error(
+      `[validate-run] --no-build requires ${binaryPath} to include the internal validation model.`,
+    );
+    console.error(
+      '[validate-run] omit --no-build once, or run `TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL=1 pnpm --filter @texra-ai/cli run build`.',
+    );
+    process.exit(1);
+  }
 }
 
 function parseNdjson(stdout, label) {
@@ -1359,12 +1422,16 @@ ${JSON.stringify({
   }
 }
 
-async function validateCliRunArtifacts() {
-  const buildResult = run('pnpm', ['run', 'build'], {
-    cwd: cliRoot,
-    env: { TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL: '1' },
-  });
-  assertSuccess(buildResult, 'pnpm run build');
+async function validateCliRunArtifacts(options = {}) {
+  if (options.noBuild) {
+    preflightExistingValidationBundle();
+  } else {
+    const buildResult = run('pnpm', ['run', 'build'], {
+      cwd: cliRoot,
+      env: { TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL: '1' },
+    });
+    assertSuccess(buildResult, 'pnpm run build');
+  }
   validateBinarySmoke();
   validateMultiAgentListAvailability();
   validateFileFlagMissingValues();
@@ -1385,8 +1452,12 @@ function rebuildCliWithoutInternalValidationModel() {
   assertSuccess(rebuildResult, 'pnpm run build after validation');
 }
 
+const args = parseArgs(process.argv.slice(2));
+
 try {
-  await validateCliRunArtifacts();
+  await validateCliRunArtifacts(args);
 } finally {
-  rebuildCliWithoutInternalValidationModel();
+  if (!args.noBuild) {
+    rebuildCliWithoutInternalValidationModel();
+  }
 }

--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -144,6 +144,9 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (!endOfOptions && arg === '--') {
+      // pnpm can forward a leading separator to scripts (`pnpm run x -- --flag`).
+      // Treat that package-manager separator as transparent when it precedes a
+      // script option; later `--` still follows normal end-of-options behavior.
       if (index === 0 && argv[1]?.startsWith('-')) continue;
       endOfOptions = true;
       continue;

--- a/src/test-kernel/cli/RunValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/RunValidatorArgs.vitest.mts
@@ -1,0 +1,37 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const VALIDATOR = path.join(
+  process.cwd(),
+  'packages/cli/scripts/validate-run.mjs',
+);
+
+function runValidator(args: string[]) {
+  return spawnSync(process.execPath, [VALIDATOR, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+}
+
+describe('CLI run validator args', () => {
+  it('prints help without building the CLI bundle', () => {
+    const result = runValidator(['--help']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('[validate-run] usage:');
+    expect(result.stdout).toContain('--no-build');
+    expect(result.stderr).not.toContain('building');
+  });
+
+  it('rejects unknown options before running validation', () => {
+    const result = runValidator(['--definitely-missing']);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain(
+      '[validate-run] unknown argument: --definitely-missing',
+    );
+    expect(result.stderr).toContain('[validate-run] usage:');
+  });
+});

--- a/src/test-kernel/cli/RunValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/RunValidatorArgs.vitest.mts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -7,6 +8,11 @@ const VALIDATOR = path.join(
   process.cwd(),
   'packages/cli/scripts/validate-run.mjs',
 );
+const BINARY = path.join(process.cwd(), 'packages/cli/dist/bin/texra.js');
+
+function binaryMtime() {
+  return existsSync(BINARY) ? statSync(BINARY).mtimeMs : undefined;
+}
 
 function runValidator(args: string[]) {
   return spawnSync(process.execPath, [VALIDATOR, ...args], {
@@ -17,21 +23,26 @@ function runValidator(args: string[]) {
 
 describe('CLI run validator args', () => {
   it('prints help without building the CLI bundle', () => {
+    const before = binaryMtime();
     const result = runValidator(['--help']);
+    const after = binaryMtime();
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('[validate-run] usage:');
     expect(result.stdout).toContain('--no-build');
-    expect(result.stderr).not.toContain('building');
+    expect(after).toBe(before);
   });
 
   it('rejects unknown options before running validation', () => {
+    const before = binaryMtime();
     const result = runValidator(['--definitely-missing']);
+    const after = binaryMtime();
 
     expect(result.status).toBe(2);
     expect(result.stderr).toContain(
       '[validate-run] unknown argument: --definitely-missing',
     );
     expect(result.stderr).toContain('[validate-run] usage:');
+    expect(after).toBe(before);
   });
 });


### PR DESCRIPTION
## Summary

- add `validate-run.mjs --no-build` to reuse an existing validation-capable CLI bundle
- preflight `dist/bin/texra.js` for the internal validation marker before running dogfood checks
- skip both validation-build and cleanup rebuild only in explicit no-build mode
- cover help and unknown-argument behavior for the run validator

Closes #5184.

## Dogfood evidence

Startup model-selection harness still passes for distinct API modes:

```bash
node packages/cli/scripts/validate-tui.mjs   orchestrate-relay-model-pick   orchestrate-personal-model-pick   model-form   model-form-included-empty   api-form
```

Result: all 5 scenarios passed.

Original rebuild churn repro:

```
CLI run validation passed
status:0
before:1780465101
after:1780469683
changed:yes
elapsed:33s
```

New no-build path after one validation build:

```
marker:yes
CLI run validation passed
status:0
before:1780469841
after:1780469841
changed:no
elapsed:22s
```

Production bundle restored afterward:

```
marker:no
```

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/RunValidatorArgs.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)
- `node packages/cli/scripts/validate-run.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the CLI validation harness and its tests; no runtime product behavior or auth/data paths.
> 
> **Overview**
> Adds **`--no-build`** to `validate-run.mjs` so dogfood checks can run against an already-built `dist/bin/texra.js` instead of always running **`pnpm run build`** before validation and a cleanup rebuild afterward.
> 
> The script now parses **`-h` / `--help`**, **`--no-build`**, and unknown flags (exit **2**), with a leading **`--`** ignored when pnpm forwards it. In no-build mode it **preflights** that the bundle exists and contains the internal validation marker (`texra-cli-run-validation`); otherwise it still builds with **`TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL=1`** and restores a production bundle in **`finally`** only when build ran.
> 
> New **`RunValidatorArgs.vitest.mts`** asserts help and bad flags exit without changing the CLI binary’s mtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4c1ad101f92a6eb9de7432e2b413f356239800a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->