### PR TITLE
refactor: add filterNotNull/filterNotNullish helpers, replace 16 inline type-guard filters

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -17,11 +17,11 @@ import { AgentSource } from '@shared/schemas/agent';
 import { agentKey as createKey, agentName } from '@shared/schemas/agent';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { AbsoluteFS } from '@utils/files';
+import { filterNotNull } from '@utils/core';
 import {
   getAgentDirectories,
   type AgentDirectories,
 } from './agentDirectoriesRegistry';
-import { filterNotNull } from '@utils/core';
 
 const CHANNEL = 'agentRegistry';
 logger.initialize(CHANNEL);
@@ -394,7 +394,7 @@ async function scanDirectory(
       }),
     );
 
-    const result = filterNotNull(entries);
+    const result = entries.filter(filterNotNull);
     logger.debug(CHANNEL, `Scanned ${result.length} agents from ${source}`);
     return result;
   } catch (err) {

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -21,6 +21,7 @@ import {
   getAgentDirectories,
   type AgentDirectories,
 } from './agentDirectoriesRegistry';
+import { filterNotNull } from '@utils/core';
 
 const CHANNEL = 'agentRegistry';
 logger.initialize(CHANNEL);
@@ -393,7 +394,7 @@ async function scanDirectory(
       }),
     );
 
-    const result = entries.filter((e): e is AgentEntry => e !== null);
+    const result = filterNotNull(entries);
     logger.debug(CHANNEL, `Scanned ${result.length} agents from ${source}`);
     return result;
   } catch (err) {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -33,7 +33,7 @@ import {
 import type { ToolFileAttachment } from '@tools/result';
 
 // Local imports - utils
-import { delay } from '@utils/core';
+import { delay, filterNotNullish } from '@utils/core';
 import {
   getWebSocketEnabled,
   getUseOpenRouter,
@@ -2417,7 +2417,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (Array.isArray(message.content)) {
       const texts = message.content
         .map((part) => extractTextContentPart(part))
-        .filter((text): text is string => text !== undefined);
+        .filter(filterNotNullish);
       return texts.length > 0 ? texts.join('') : undefined;
     }
 

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -18,13 +18,13 @@ import { ensureError, toErrorMessage } from '@common/errors/errorMessage';
 import * as logger from '@logger/logUtils';
 import { resolveToolDefinitions } from '@tools/registry';
 
+import { filterNotNull } from '@utils/core';
 import {
   RemoteAgentListItemSchema,
   EdgeFunctionResponseSchema,
   type RemoteAgentListItem,
   type RemoteAgentConfig,
 } from './types';
-import { filterNotNull } from '@utils/core';
 
 const CHANNEL = 'RemoteAgentLoader';
 logger.initialize(CHANNEL);

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -176,9 +176,7 @@ export class RemoteAgentLoader {
         return [];
       }
 
-      return (data ?? [])
-        .map(parseListItemRow)
-        .filter(filterNotNull);
+      return (data ?? []).map(parseListItemRow).filter(filterNotNull);
     } catch (error) {
       logger.debug(
         CHANNEL,

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -24,6 +24,7 @@ import {
   type RemoteAgentListItem,
   type RemoteAgentConfig,
 } from './types';
+import { filterNotNull } from '@utils/core';
 
 const CHANNEL = 'RemoteAgentLoader';
 logger.initialize(CHANNEL);
@@ -177,7 +178,7 @@ export class RemoteAgentLoader {
 
       return (data ?? [])
         .map(parseListItemRow)
-        .filter((item): item is RemoteAgentListItem => item !== null);
+        .filter(filterNotNull);
     } catch (error) {
       logger.debug(
         CHANNEL,

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -16,6 +16,7 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { KVStore } from '@common/storage/KVStore';
 import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
+import { filterNotNull } from '@utils/core';
 
 // ============================================================================
 // Key constants (implementation detail — not exported)
@@ -217,7 +218,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
         return result.success ? { id, ...result.data } : null;
       }),
     );
-    return entries.filter((e): e is ChildRecord => e !== null);
+    return filterNotNull(entries);
   }
 
   async readResultMeta(): Promise<ResultMeta | null> {

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -218,7 +218,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
         return result.success ? { id, ...result.data } : null;
       }),
     );
-    return filterNotNull(entries);
+    return entries.filter(filterNotNull);
   }
 
   async readResultMeta(): Promise<ResultMeta | null> {

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -8,6 +8,7 @@
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { getExecutionStore } from './ExecutionKVStore';
+import { filterNotNull } from '@utils/core';
 
 /**
  * Check if a single stream has a valid, resumable flow record.
@@ -52,5 +53,5 @@ export async function detectWaitingStreams(
     (await hasPersistedFlowRecord(executionId)) ? streamId : null,
   );
   const results = await Promise.all(checks);
-  return new Set(results.filter((id): id is StreamTabId => id !== null));
+  return new Set(filterNotNull(results));
 }

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -7,8 +7,8 @@
 
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import { getExecutionStore } from './ExecutionKVStore';
 import { filterNotNull } from '@utils/core';
+import { getExecutionStore } from './ExecutionKVStore';
 
 /**
  * Check if a single stream has a valid, resumable flow record.
@@ -53,5 +53,5 @@ export async function detectWaitingStreams(
     (await hasPersistedFlowRecord(executionId)) ? streamId : null,
   );
   const results = await Promise.all(checks);
-  return new Set(filterNotNull(results));
+  return new Set(results.filter(filterNotNull));
 }

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -28,6 +28,7 @@ import {
   EXECUTIONS_DIR,
   getExecutionStore,
 } from './ExecutionKVStore';
+import { filterNotNull } from '@utils/core';
 
 const CHANNEL = 'ExecutionListing';
 const INDEX_PATH = 'executions/index.json';
@@ -152,7 +153,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
   );
 
   const listing = results
-    .filter((e): e is ExecutionListingEntry => e !== null)
+    .filter(filterNotNull)
     .sort(
       (a, b) =>
         new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -21,6 +21,7 @@ import { toErrorMessage } from '@common/errors/errorMessage';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 import { StorageFS, WorkspaceFS } from '@utils/files';
+import { filterNotNull } from '@utils/core';
 import { isDirectory } from '@utils/files/fsEntryType';
 
 import {
@@ -28,7 +29,6 @@ import {
   EXECUTIONS_DIR,
   getExecutionStore,
 } from './ExecutionKVStore';
-import { filterNotNull } from '@utils/core';
 
 const CHANNEL = 'ExecutionListing';
 const INDEX_PATH = 'executions/index.json';

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -19,13 +19,13 @@ import {
   getPromptFileName,
   getXmlFormatFromReadableFiles,
 } from '@utils/prompt';
+import { filterNotNull } from '@utils/core';
 import {
   listExternalRoots,
   type ExternalRootKind,
 } from '@utils/files/externalRoots';
 import { setVarFromFile } from '@utils/files/varsUtils';
 import { StorageFS } from '@utils/files/storageFS';
-import { filterNotNull } from '@utils/core';
 
 /** Relative path from an agent directory to the shared LaTeX style rules file. */
 const SHARED_LATEX_RULES_REL = '../shared/latex_style_rules.txt';
@@ -460,7 +460,7 @@ async function getAttachedMemories(
     }),
   );
 
-  const parts = filterNotNull(results);
+  const parts = results.filter(filterNotNull);
   if (parts.length === 0) return null;
   return `<attached_memories>\n${parts.join('\n')}\n</attached_memories>`;
 }

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -25,6 +25,7 @@ import {
 } from '@utils/files/externalRoots';
 import { setVarFromFile } from '@utils/files/varsUtils';
 import { StorageFS } from '@utils/files/storageFS';
+import { filterNotNull } from '@utils/core';
 
 /** Relative path from an agent directory to the shared LaTeX style rules file. */
 const SHARED_LATEX_RULES_REL = '../shared/latex_style_rules.txt';
@@ -459,7 +460,7 @@ async function getAttachedMemories(
     }),
   );
 
-  const parts = results.filter((p): p is string => p !== null);
+  const parts = filterNotNull(results);
   if (parts.length === 0) return null;
   return `<attached_memories>\n${parts.join('\n')}\n</attached_memories>`;
 }

--- a/src/controllers/mainView/MainViewExecutionController.ts
+++ b/src/controllers/mainView/MainViewExecutionController.ts
@@ -15,12 +15,12 @@ import {
 } from '@shared/schemas/toolConfig';
 
 // Local imports - utilities
+import { filterNotNull } from '@utils/core';
 import {
   getPastedImageFullPath,
   isPastedImage,
 } from '@utils/files/pastedImageUtils';
 import type { z } from 'zod';
-import { filterNotNull } from '@utils/core';
 
 /**
  * Message shape from the main view for agent execution.

--- a/src/controllers/mainView/MainViewExecutionController.ts
+++ b/src/controllers/mainView/MainViewExecutionController.ts
@@ -20,6 +20,7 @@ import {
   isPastedImage,
 } from '@utils/files/pastedImageUtils';
 import type { z } from 'zod';
+import { filterNotNull } from '@utils/core';
 
 /**
  * Message shape from the main view for agent execution.
@@ -84,7 +85,7 @@ export function prepareMainViewExecutionRequest(
       toolConfig: { ...toolConfigResult.data, attachDiagnostics: false },
       mediaFiles: (message.mediaFiles ?? [])
         .map(mapMediaFile)
-        .filter((file: string | null): file is string => file !== null),
+        .filter(filterNotNull),
       editedFile: null,
     },
   });

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -163,9 +163,7 @@ async function getIndividualCounts(
     }),
   );
 
-  const outputs = results
-    .map((result) => result.output)
-    .filter(filterNotNull);
+  const outputs = results.map((result) => result.output).filter(filterNotNull);
   const errors = results.flatMap((result) => result.errors);
 
   return { outputs, errors };

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -7,6 +7,7 @@ import { flexibleFS, pathToLocation } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';
 import { hasExtension } from '@utils/core/pathCore';
+import { filterNotNull } from '@utils/core';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
@@ -164,7 +165,7 @@ async function getIndividualCounts(
 
   const outputs = results
     .map((result) => result.output)
-    .filter((output): output is string => output !== null);
+    .filter(filterNotNull);
   const errors = results.flatMap((result) => result.errors);
 
   return { outputs, errors };

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -6,8 +6,8 @@ import * as logger from '@logger/logUtils';
 import { flexibleFS, pathToLocation } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';
-import { hasExtension } from '@utils/core/pathCore';
 import { filterNotNull } from '@utils/core';
+import { hasExtension } from '@utils/core/pathCore';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/test-kernel/utils/TypeGuards.vitest.ts
+++ b/src/test-kernel/utils/TypeGuards.vitest.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterNotNull, filterNotNullish } from '@utils/core';
+
+describe('core type guard predicates', () => {
+  it('filters null values as an Array.filter predicate', () => {
+    const values: Array<string | null> = ['alpha', null, 'beta'];
+
+    expect(values.filter(filterNotNull)).toEqual(['alpha', 'beta']);
+  });
+
+  it('filters nullish values as an Array.filter predicate', () => {
+    const values: Array<string | null | undefined> = [
+      'alpha',
+      null,
+      undefined,
+      'beta',
+    ];
+
+    expect(values.filter(filterNotNullish)).toEqual(['alpha', 'beta']);
+  });
+});

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -50,6 +50,7 @@ import {
   resolveStoragePath,
 } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
+import { filterNotNull } from '@utils/core';
 
 // ============================================================================
 // Schema
@@ -410,6 +411,6 @@ Optional:
       }),
     );
 
-    return results.filter((f): f is string => f !== null);
+    return filterNotNull(results);
   }
 }

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -45,12 +45,12 @@ import {
   createRunStorageLocation,
   createWorkspaceLocation,
 } from '@utils/files';
+import { filterNotNull } from '@utils/core';
 import {
   getOriginalSnapshotPath,
   resolveStoragePath,
 } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
-import { filterNotNull } from '@utils/core';
 
 // ============================================================================
 // Schema
@@ -411,6 +411,6 @@ Optional:
       }),
     );
 
-    return filterNotNull(results);
+    return results.filter(filterNotNull);
   }
 }

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { splitContentLines } from '@utils/text/stringUtils';
 import { toPosixPath } from '@utils/core/pathCore';
+import { filterNotNull } from '@utils/core';
 import { safeHomedir } from '@utils/system/platformPaths';
 
 // Local file imports
@@ -170,7 +171,7 @@ async function loadGitignoreMatcher(): Promise<GitignoreMatcher> {
       ...globalSources,
       workspaceGlobalSource,
       workspaceSource,
-    ].filter((source): source is GitignoreSource => source !== null);
+    ].filter(filterNotNull);
 
     const rules = sources.flatMap((source) => source.rules);
     if (rules.length === 0) {

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -3,9 +3,9 @@ import * as path from 'path';
 
 // Local imports - utils
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
+import { filterNotNull } from '@utils/core';
 import { splitContentLines } from '@utils/text/stringUtils';
 import { toPosixPath } from '@utils/core/pathCore';
-import { filterNotNull } from '@utils/core';
 import { safeHomedir } from '@utils/system/platformPaths';
 
 // Local file imports

--- a/src/tools/odyssey/odysseyStore.ts
+++ b/src/tools/odyssey/odysseyStore.ts
@@ -9,6 +9,7 @@ import type { StreamTabId } from '@shared/schemas/identifiers';
 
 import type { Plan } from '@shared/schemas/plan';
 
+import { filterNotNull } from '@utils/core';
 import {
   ODYSSEY_DEFAULT_MAX_CONTINUATIONS,
   ODYSSEY_HISTORY_LIMIT,
@@ -19,7 +20,6 @@ import {
   type OdysseyEventKind,
   type OdysseyStatus,
 } from './odysseyMeta';
-import { filterNotNull } from '@utils/core';
 
 const STREAM_KEY_PREFIX = 'odysseys:byStream:';
 const INDEX_KEY = 'odysseys:index';

--- a/src/tools/odyssey/odysseyStore.ts
+++ b/src/tools/odyssey/odysseyStore.ts
@@ -19,6 +19,7 @@ import {
   type OdysseyEventKind,
   type OdysseyStatus,
 } from './odysseyMeta';
+import { filterNotNull } from '@utils/core';
 
 const STREAM_KEY_PREFIX = 'odysseys:byStream:';
 const INDEX_KEY = 'odysseys:index';
@@ -149,7 +150,7 @@ export const OdysseyStore = {
   list(): Odyssey[] {
     return readIndex()
       .map((id) => readRaw(id))
-      .filter((o): o is Odyssey => o !== null);
+      .filter(filterNotNull);
   },
 
   /**

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -43,6 +43,7 @@ import {
 import { ToolError, type ToolResult } from '@tools/result';
 import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
+import { filterNotNull } from '@utils/core';
 
 const logger = createChannelTrace('PlanTool');
 
@@ -80,7 +81,7 @@ function formatOdysseyView(odyssey: Odyssey): string {
     `Time elapsed: ${formatOdysseyTime(odysseyElapsedMs(odyssey))}`,
     odyssey.completedReason ? `Reason: ${odyssey.completedReason}` : null,
   ]
-    .filter((v): v is string => v !== null)
+    .filter(filterNotNull)
     .join('\n');
 }
 

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -22,6 +22,7 @@ import {
   type BbtCollection,
   type BbtLibrary,
 } from './bbtClient';
+import { filterNotNull } from '@utils/core';
 
 const ZoteroCollectionsInputSchema = z.strictObject({
   query: z
@@ -133,7 +134,7 @@ function filterTree(nodes: CollectionNode[], query: string): FilterResult {
     const nameMatches = node.name.toLowerCase().includes(lowerQuery);
     const filteredChildren = node.children
       .map((child) => visit(child))
-      .filter((c): c is CollectionNode => c !== null);
+      .filter(filterNotNull);
 
     if (nameMatches) matchCount++;
 
@@ -145,7 +146,7 @@ function filterTree(nodes: CollectionNode[], query: string): FilterResult {
 
   const tree = nodes
     .map((n) => visit(n))
-    .filter((n): n is CollectionNode => n !== null);
+    .filter(filterNotNull);
 
   return { tree, matchCount };
 }

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -144,9 +144,7 @@ function filterTree(nodes: CollectionNode[], query: string): FilterResult {
     return null;
   }
 
-  const tree = nodes
-    .map((n) => visit(n))
-    .filter(filterNotNull);
+  const tree = nodes.map((n) => visit(n)).filter(filterNotNull);
 
   return { tree, matchCount };
 }

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -16,13 +16,13 @@ import { z } from 'zod';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - zotero
+import { filterNotNull } from '@utils/core';
 import {
   callBetterBibTeX,
   getZoteroPort,
   type BbtCollection,
   type BbtLibrary,
 } from './bbtClient';
-import { filterNotNull } from '@utils/core';
 
 const ZoteroCollectionsInputSchema = z.strictObject({
   query: z

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -11,7 +11,7 @@ import {
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
-import { isFiniteNumber, isObject } from '@utils/core';
+import { filterNotNull, isFiniteNumber, isObject } from '@utils/core';
 
 import {
   isRunningGroupEntry,
@@ -391,7 +391,7 @@ export class StreamLogStore {
       );
 
       const sortedResults = results
-        .filter((result): result is StreamLoadResult => result !== null)
+        .filter(filterNotNull)
         .sort(
           (a, b) =>
             (a.summary.firstTimestamp ?? Number.POSITIVE_INFINITY) -

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -14,5 +14,5 @@ export {
   serializeError,
   type SerializedError,
 } from './stringCore';
-export { isObject, isFiniteNumber } from './typeGuards';
+export { isObject, isFiniteNumber, filterNotNull, filterNotNullish } from './typeGuards';
 export { debounce, delay } from './async';

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -14,5 +14,10 @@ export {
   serializeError,
   type SerializedError,
 } from './stringCore';
-export { isObject, isFiniteNumber, filterNotNull, filterNotNullish } from './typeGuards';
+export {
+  isObject,
+  isFiniteNumber,
+  filterNotNull,
+  filterNotNullish,
+} from './typeGuards';
 export { debounce, delay } from './async';

--- a/src/utils/core/typeGuards.ts
+++ b/src/utils/core/typeGuards.ts
@@ -12,12 +12,12 @@ export function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
-/** Filter null values from an array, narrowing the element type. */
-export function filterNotNull<T>(items: (T | null)[]): T[] {
-  return items.filter((item): item is T => item !== null);
+/** Predicate for filtering null values from arrays while narrowing the element type. */
+export function filterNotNull<T>(item: T | null): item is T {
+  return item !== null;
 }
 
-/** Filter null and undefined values from an array, narrowing the element type. */
-export function filterNotNullish<T>(items: (T | null | undefined)[]): T[] {
-  return items.filter((item): item is T => item != null);
+/** Predicate for filtering null and undefined values from arrays while narrowing the element type. */
+export function filterNotNullish<T>(item: T | null | undefined): item is T {
+  return item != null;
 }

--- a/src/utils/core/typeGuards.ts
+++ b/src/utils/core/typeGuards.ts
@@ -11,3 +11,13 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 export function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
+
+/** Filter null values from an array, narrowing the element type. */
+export function filterNotNull<T>(items: (T | null)[]): T[] {
+  return items.filter((item): item is T => item !== null);
+}
+
+/** Filter null and undefined values from an array, narrowing the element type. */
+export function filterNotNullish<T>(items: (T | null | undefined)[]): T[] {
+  return items.filter((item): item is T => item != null);
+}


### PR DESCRIPTION
## Summary

- Adds `filterNotNull<T>` and `filterNotNullish<T>` to `src/utils/core/typeGuards.ts` and exports them from the `@utils/core` barrel
- Replaces 16 identical inline `.filter((e): e is T => e !== null)` patterns across 15 files with the new helpers
- One `filter((t): t is string => t !== undefined)` in `modelHandlerOpenAIResponse.ts` replaced with `filterNotNullish`

The codebase scan found this as the one meaningful consolidation opportunity — all other utility patterns (path normalization, error formatting, async helpers, polling base classes) were already well-centralized.

## Files changed

| File | Change |
|------|--------|
| `src/utils/core/typeGuards.ts` | +`filterNotNull`, +`filterNotNullish` |
| `src/utils/core/index.ts` | exports both new helpers |
| 15 call-site files | import + use `filterNotNull` / `filterNotNullish` |

## Test plan

- [x] `npm run compile:fast` passes cleanly (build output verified)
- [x] No new TypeScript errors introduced (pre-existing `@types/mocha/node/vscode` missing-lib errors are environment-only, unrelated to this change)
- [ ] Spot-check: `agentRegistry.ts`, `detectWaitingStreams.ts`, `ZoteroCollectionsTool.ts` — confirm filter results are identical to the removed inline predicates

https://claude.ai/code/session_01KfjAsvnCxXuTKdr6ar5rDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfjAsvnCxXuTKdr6ar5rDT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with equivalent filter semantics; low risk aside from verifying the single `filterNotNullish` site matches prior `undefined`-only behavior if any callers relied on keeping `null`.
> 
> **Overview**
> Introduces shared **`filterNotNull`** and **`filterNotNullish`** predicates in `src/utils/core/typeGuards.ts` and re-exports them from `@utils/core`, then replaces repeated inline `.filter((x): x is T => x !== null)` (and one `!== undefined`) pattern across **15 call sites** spanning agent registry/remote loading, execution storage and listing, stream detection, main-view execution prep, LaTeX texcount, tools (accept run files, gitignore, plan, Zotero collections, odyssey store), and transcript loading.
> 
> The OpenAI Responses handler uses **`filterNotNullish`** when joining assistant message text parts so both `null` and `undefined` are dropped. Adds **`TypeGuards.vitest.ts`** to lock predicate behavior. No functional API or product behavior is intended to change—this is deduplication for readability and consistent narrowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4675dd928d58467ce48cd7e2ac7687edea117c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->