### PR TITLE
fix(claude-agent): prefer OAuth credentials over managed API key

### DIFF
--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -9,6 +9,7 @@ import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 
 let secretStore: Map<string, string>;
 let cleanupDirs: string[];
+let execFileSyncMock: ReturnType<typeof vi.fn>;
 
 async function loadBuildClaudeAgentEnv(): Promise<
   typeof import('@tools/claudeAgentConfig').buildClaudeAgentEnv
@@ -17,9 +18,7 @@ async function loadBuildClaudeAgentEnv(): Promise<
     const actual = await importOriginal<typeof import('child_process')>();
     return {
       ...actual,
-      execFileSync: vi.fn(() => {
-        throw new Error('not found');
-      }),
+      execFileSync: execFileSyncMock,
     };
   });
 
@@ -44,6 +43,9 @@ describe('Claude Code CLI configuration', () => {
   beforeEach(() => {
     secretStore = new Map();
     cleanupDirs = [];
+    execFileSyncMock = vi.fn(() => {
+      throw new Error('not found');
+    });
     vi.resetModules();
     invalidateApiKeyCache();
     // Deterministic baseline: no OAuth credential present. Point the config dir
@@ -88,7 +90,7 @@ describe('Claude Code CLI configuration', () => {
   });
 
   it('strips an inherited ANTHROPIC_API_KEY when an OAuth token is present', async () => {
-    // OAuth must win even over an explicit env API key — otherwise the CLI
+    // OAuth must win even over an explicit env API key; otherwise the CLI
     // prefers ANTHROPIC_API_KEY and ignores the login session.
     vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
     vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'oauth-token');
@@ -106,6 +108,26 @@ describe('Claude Code CLI configuration', () => {
     vi.stubEnv('CLAUDE_CONFIG_DIR', sessionDir);
     vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
     secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
+
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    const env = await buildClaudeAgentEnv();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  it('strips ANTHROPIC_API_KEY when a config-dir keychain OAuth session exists', async () => {
+    const configDir = path.join(os.tmpdir(), 'texra-test-claude-profile');
+    vi.stubEnv('CLAUDE_CONFIG_DIR', configDir);
+    vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
+    secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
+    execFileSyncMock.mockImplementation((_command, args) => {
+      if (
+        Array.isArray(args) &&
+        args.includes(`${path.resolve(configDir)}-access-token`)
+      ) {
+        return Buffer.from('');
+      }
+      throw new Error('not found');
+    });
 
     const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
     const env = await buildClaudeAgentEnv();

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -11,6 +11,16 @@ let secretStore: Map<string, string>;
 async function loadBuildClaudeAgentEnv(): Promise<
   typeof import('@tools/claudeAgentConfig').buildClaudeAgentEnv
 > {
+  vi.doMock('child_process', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('child_process')>();
+    return {
+      ...actual,
+      execFileSync: vi.fn(() => {
+        throw new Error('not found');
+      }),
+    };
+  });
+
   vi.doMock('@platform/platform', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@platform/platform')>();
     return {
@@ -37,6 +47,8 @@ describe('Claude Code CLI configuration', () => {
     // at a path that cannot contain `.credentials.json` and clear the token so
     // tests don't pick up a real `claude login` session on the host.
     vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '');
+    vi.stubEnv('ANTHROPIC_API_KEY', '');
+    delete process.env.ANTHROPIC_API_KEY;
     vi.stubEnv(
       'CLAUDE_CONFIG_DIR',
       path.join(os.tmpdir(), 'texra-test-no-claude-config'),
@@ -44,13 +56,13 @@ describe('Claude Code CLI configuration', () => {
   });
 
   afterEach(() => {
+    vi.doUnmock('child_process');
     vi.doUnmock('@platform/platform');
     invalidateApiKeyCache();
     vi.unstubAllEnvs();
   });
 
   it('injects the managed Anthropic secret when no OAuth credential exists', async () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
     secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
 
     const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
@@ -72,6 +84,7 @@ describe('Claude Code CLI configuration', () => {
 
   it('passes an explicit env ANTHROPIC_API_KEY through untouched', async () => {
     vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
+    secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
 
     const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
     await expect(buildClaudeAgentEnv()).resolves.toMatchObject({

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -7,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 
 let secretStore: Map<string, string>;
+let cleanupDirs: string[];
 
 async function loadBuildClaudeAgentEnv(): Promise<
   typeof import('@tools/claudeAgentConfig').buildClaudeAgentEnv
@@ -41,6 +43,7 @@ async function loadBuildClaudeAgentEnv(): Promise<
 describe('Claude Code CLI configuration', () => {
   beforeEach(() => {
     secretStore = new Map();
+    cleanupDirs = [];
     vi.resetModules();
     invalidateApiKeyCache();
     // Deterministic baseline: no OAuth credential present. Point the config dir
@@ -60,6 +63,7 @@ describe('Claude Code CLI configuration', () => {
     vi.doUnmock('@platform/platform');
     invalidateApiKeyCache();
     vi.unstubAllEnvs();
+    for (const dir of cleanupDirs) rmSync(dir, { recursive: true, force: true });
   });
 
   it('injects the managed Anthropic secret when no OAuth credential exists', async () => {
@@ -82,7 +86,32 @@ describe('Claude Code CLI configuration', () => {
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
   });
 
-  it('passes an explicit env ANTHROPIC_API_KEY through untouched', async () => {
+  it('strips an inherited ANTHROPIC_API_KEY when an OAuth token is present', async () => {
+    // OAuth must win even over an explicit env API key — otherwise the CLI
+    // prefers ANTHROPIC_API_KEY and ignores the login session.
+    vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
+    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'oauth-token');
+
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    const env = await buildClaudeAgentEnv();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
+  });
+
+  it('strips ANTHROPIC_API_KEY when a `claude login` session file exists', async () => {
+    const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'texra-claude-'));
+    writeFileSync(path.join(sessionDir, '.credentials.json'), '{}');
+    cleanupDirs.push(sessionDir);
+    vi.stubEnv('CLAUDE_CONFIG_DIR', sessionDir);
+    vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
+    secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
+
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    const env = await buildClaudeAgentEnv();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  it('passes an explicit env ANTHROPIC_API_KEY through when no OAuth credential exists', async () => {
     vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
     secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
 

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -10,14 +10,7 @@ import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 let secretStore: Map<string, string>;
 let cleanupDirs: string[];
 let execFileSyncMock: ReturnType<typeof vi.fn>;
-let originalProcessPlatform: NodeJS.Platform;
-
-function stubProcessPlatform(platform: NodeJS.Platform): void {
-  Object.defineProperty(process, 'platform', {
-    value: platform,
-    configurable: true,
-  });
-}
+let homedirMock: string;
 
 async function loadBuildClaudeAgentEnv(): Promise<
   typeof import('@tools/claudeAgentConfig').buildClaudeAgentEnv
@@ -27,6 +20,14 @@ async function loadBuildClaudeAgentEnv(): Promise<
     return {
       ...actual,
       execFileSync: execFileSyncMock,
+    };
+  });
+
+  vi.doMock('os', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('os')>();
+    return {
+      ...actual,
+      homedir: () => homedirMock,
     };
   });
 
@@ -49,9 +50,9 @@ async function loadBuildClaudeAgentEnv(): Promise<
 
 describe('Claude Code CLI configuration', () => {
   beforeEach(() => {
-    originalProcessPlatform = process.platform;
     secretStore = new Map();
     cleanupDirs = [];
+    homedirMock = os.homedir();
     execFileSyncMock = vi.fn(() => {
       throw new Error('not found');
     });
@@ -71,10 +72,10 @@ describe('Claude Code CLI configuration', () => {
 
   afterEach(() => {
     vi.doUnmock('child_process');
+    vi.doUnmock('os');
     vi.doUnmock('@platform/platform');
     invalidateApiKeyCache();
     vi.unstubAllEnvs();
-    stubProcessPlatform(originalProcessPlatform);
     for (const dir of cleanupDirs)
       rmSync(dir, { recursive: true, force: true });
   });
@@ -142,8 +143,23 @@ describe('Claude Code CLI configuration', () => {
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
   });
 
+  it('expands a tilde CLAUDE_CONFIG_DIR before checking for a login session file', async () => {
+    const homeDir = mkdtempSync(path.join(os.tmpdir(), 'texra-home-'));
+    const sessionDir = path.join(homeDir, '.claude');
+    mkdirSync(sessionDir);
+    writeFileSync(path.join(sessionDir, '.credentials.json'), '{}');
+    cleanupDirs.push(homeDir);
+    homedirMock = homeDir;
+    vi.stubEnv('CLAUDE_CONFIG_DIR', '~/.claude');
+    vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
+    secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
+
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    const env = await buildClaudeAgentEnv();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
   it('strips ANTHROPIC_API_KEY when a config-dir keychain OAuth session exists', async () => {
-    stubProcessPlatform('darwin');
     const configDir = path.join(os.tmpdir(), 'texra-test-claude-profile');
     vi.stubEnv('CLAUDE_CONFIG_DIR', configDir);
     vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
@@ -159,7 +175,7 @@ describe('Claude Code CLI configuration', () => {
     });
 
     const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
-    const env = await buildClaudeAgentEnv();
+    const env = await buildClaudeAgentEnv({ platform: 'darwin' });
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
   });
 

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -1,4 +1,6 @@
 // Third-party imports
+import * as os from 'os';
+import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - model
@@ -31,6 +33,14 @@ describe('Claude Code CLI configuration', () => {
     secretStore = new Map();
     vi.resetModules();
     invalidateApiKeyCache();
+    // Deterministic baseline: no OAuth credential present. Point the config dir
+    // at a path that cannot contain `.credentials.json` and clear the token so
+    // tests don't pick up a real `claude login` session on the host.
+    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '');
+    vi.stubEnv(
+      'CLAUDE_CONFIG_DIR',
+      path.join(os.tmpdir(), 'texra-test-no-claude-config'),
+    );
   });
 
   afterEach(() => {
@@ -39,13 +49,33 @@ describe('Claude Code CLI configuration', () => {
     vi.unstubAllEnvs();
   });
 
-  it('prefers the managed Anthropic key over the inherited process env', async () => {
+  it('injects the managed Anthropic secret when no OAuth credential exists', async () => {
     vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
     secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
 
     const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
     await expect(buildClaudeAgentEnv()).resolves.toMatchObject({
       ANTHROPIC_API_KEY: 'from-secret',
+    });
+  });
+
+  it('does not override a CLAUDE_CODE_OAUTH_TOKEN session with the managed secret', async () => {
+    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'oauth-token');
+    secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
+
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    const env = await buildClaudeAgentEnv();
+    // The stale Settings key must not shadow the working login session.
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
+  });
+
+  it('passes an explicit env ANTHROPIC_API_KEY through untouched', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
+
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    await expect(buildClaudeAgentEnv()).resolves.toMatchObject({
+      ANTHROPIC_API_KEY: 'from-env',
     });
   });
 });

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -110,12 +110,23 @@ describe('Claude Code CLI configuration', () => {
     // OAuth must win even over an explicit env API key; otherwise the CLI
     // prefers ANTHROPIC_API_KEY and ignores the login session.
     vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
-    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'oauth-token');
+    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', ' oauth-token ');
 
     const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
     const env = await buildClaudeAgentEnv();
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
+  });
+
+  it('ignores a whitespace-only OAuth token when no OAuth credential exists', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
+    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '   ');
+    secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
+
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    const env = await buildClaudeAgentEnv();
+    expect(env.ANTHROPIC_API_KEY).toBe('from-env');
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
   });
 
   it('strips ANTHROPIC_API_KEY when a `claude login` session file exists', async () => {

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -63,7 +63,8 @@ describe('Claude Code CLI configuration', () => {
     vi.doUnmock('@platform/platform');
     invalidateApiKeyCache();
     vi.unstubAllEnvs();
-    for (const dir of cleanupDirs) rmSync(dir, { recursive: true, force: true });
+    for (const dir of cleanupDirs)
+      rmSync(dir, { recursive: true, force: true });
   });
 
   it('injects the managed Anthropic secret when no OAuth credential exists', async () => {

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -179,6 +179,29 @@ describe('Claude Code CLI configuration', () => {
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
   });
 
+  it('ignores the global keychain entry when a custom config dir is active', async () => {
+    const configDir = path.join(os.tmpdir(), 'texra-test-custom-claude');
+    vi.stubEnv('CLAUDE_CONFIG_DIR', configDir);
+    vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
+    secretStore.set(apiKeySecretName('anthropic'), 'from-secret');
+    execFileSyncMock.mockImplementation((_command, args) => {
+      if (Array.isArray(args) && args.includes('Claude Code-credentials')) {
+        return Buffer.from('');
+      }
+      throw new Error('not found');
+    });
+
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    const env = await buildClaudeAgentEnv({ platform: 'darwin' });
+    expect(env.ANTHROPIC_API_KEY).toBe('from-env');
+    expect(
+      execFileSyncMock.mock.calls.some(
+        ([, args]) =>
+          Array.isArray(args) && args.includes('Claude Code-credentials'),
+      ),
+    ).toBe(false);
+  });
+
   it('passes an explicit env ANTHROPIC_API_KEY through when no OAuth credential exists', async () => {
     vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');
     secretStore.set(apiKeySecretName('anthropic'), 'from-secret');

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -10,6 +10,14 @@ import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 let secretStore: Map<string, string>;
 let cleanupDirs: string[];
 let execFileSyncMock: ReturnType<typeof vi.fn>;
+let originalProcessPlatform: NodeJS.Platform;
+
+function stubProcessPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+}
 
 async function loadBuildClaudeAgentEnv(): Promise<
   typeof import('@tools/claudeAgentConfig').buildClaudeAgentEnv
@@ -41,6 +49,7 @@ async function loadBuildClaudeAgentEnv(): Promise<
 
 describe('Claude Code CLI configuration', () => {
   beforeEach(() => {
+    originalProcessPlatform = process.platform;
     secretStore = new Map();
     cleanupDirs = [];
     execFileSyncMock = vi.fn(() => {
@@ -65,6 +74,7 @@ describe('Claude Code CLI configuration', () => {
     vi.doUnmock('@platform/platform');
     invalidateApiKeyCache();
     vi.unstubAllEnvs();
+    stubProcessPlatform(originalProcessPlatform);
     for (const dir of cleanupDirs)
       rmSync(dir, { recursive: true, force: true });
   });
@@ -76,6 +86,13 @@ describe('Claude Code CLI configuration', () => {
     await expect(buildClaudeAgentEnv()).resolves.toMatchObject({
       ANTHROPIC_API_KEY: 'from-secret',
     });
+  });
+
+  it('leaves ANTHROPIC_API_KEY absent when no credential exists', async () => {
+    const buildClaudeAgentEnv = await loadBuildClaudeAgentEnv();
+    const env = await buildClaudeAgentEnv();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CLAUDE_AGENT_SDK_CLIENT_APP).toBe('texra');
   });
 
   it('does not override a CLAUDE_CODE_OAUTH_TOKEN session with the managed secret', async () => {
@@ -115,6 +132,7 @@ describe('Claude Code CLI configuration', () => {
   });
 
   it('strips ANTHROPIC_API_KEY when a config-dir keychain OAuth session exists', async () => {
+    stubProcessPlatform('darwin');
     const configDir = path.join(os.tmpdir(), 'texra-test-claude-profile');
     vi.stubEnv('CLAUDE_CONFIG_DIR', configDir);
     vi.stubEnv('ANTHROPIC_API_KEY', 'from-env');

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -111,14 +111,14 @@ export const getClaudeAgentEffort: () => ClaudeAgentEffort =
  */
 function hasClaudeOauthCredential(
   env: NodeJS.ProcessEnv = process.env,
+  currentPlatform: NodeJS.Platform = process.platform,
 ): boolean {
   if (env.CLAUDE_CODE_OAUTH_TOKEN) return true;
 
-  const configDir =
-    env.CLAUDE_CONFIG_DIR?.trim() || path.join(os.homedir(), '.claude');
+  const configDir = resolveClaudeConfigDir(env.CLAUDE_CONFIG_DIR);
   if (existsSync(path.join(configDir, '.credentials.json'))) return true;
 
-  if (process.platform === 'darwin') {
+  if (currentPlatform === 'darwin') {
     for (const probe of claudeKeychainCredentialProbes(configDir)) {
       try {
         execFileSync('security', probe, { stdio: 'ignore', timeout: 1000 });
@@ -130,6 +130,20 @@ function hasClaudeOauthCredential(
   }
 
   return false;
+}
+
+function resolveClaudeConfigDir(configDirInput: string | undefined): string {
+  const configDir = configDirInput?.trim();
+  if (!configDir) return path.join(os.homedir(), '.claude');
+  return expandHomePath(configDir);
+}
+
+function expandHomePath(filePath: string): string {
+  if (filePath === '~') return os.homedir();
+  if (filePath.startsWith('~/') || filePath.startsWith('~\\')) {
+    return path.join(os.homedir(), filePath.slice(2));
+  }
+  return filePath;
 }
 
 function claudeKeychainCredentialProbes(configDir: string): string[][] {
@@ -177,7 +191,9 @@ function claudeKeychainCredentialProbes(configDir: string): string[][] {
  *
  * The SDK identifies itself in the User-Agent via CLAUDE_AGENT_SDK_CLIENT_APP.
  */
-export async function buildClaudeAgentEnv(): Promise<NodeJS.ProcessEnv> {
+export async function buildClaudeAgentEnv(
+  options: { platform?: NodeJS.Platform } = {},
+): Promise<NodeJS.ProcessEnv> {
   const env: NodeJS.ProcessEnv = { ...process.env };
   env.CLAUDE_AGENT_SDK_CLIENT_APP = 'texra';
   const oauthToken = env.CLAUDE_CODE_OAUTH_TOKEN?.trim();
@@ -191,7 +207,7 @@ export async function buildClaudeAgentEnv(): Promise<NodeJS.ProcessEnv> {
 
   // 1. OAuth wins: drop any inherited API key so it can't out-prioritize the
   //    OAuth credential, and skip injecting the managed secret entirely.
-  if (hasClaudeOauthCredential(env)) {
+  if (hasClaudeOauthCredential(env, options.platform ?? process.platform)) {
     delete env[apiKeyVar];
     return env;
   }

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -11,11 +11,7 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
-import {
-  lookupApiKey,
-  lookupApiKeyOrigin,
-  apiKeyEnvName,
-} from '@model/apiProviders';
+import { lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
 import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
 import { createEnumParser, createEnumStateGetter } from './support/enumConfig';
 import {
@@ -138,38 +134,42 @@ function hasClaudeOauthCredential(): boolean {
 /**
  * Build the env block passed to the Claude Code subprocess.
  *
- * Auth resolution prefers an existing OAuth credential over a TeXRA-managed
- * API key, so a stale key saved in Settings → API Keys can never shadow a
- * working `claude login` session (the cause of spurious "Invalid API key"
- * failures):
- *   1. An explicit `ANTHROPIC_API_KEY` in the environment is already present
- *      in `env` and passes through untouched.
- *   2. A `CLAUDE_CODE_OAUTH_TOKEN` or `claude login` session is left for the
- *      CLI to use; we do NOT override it with the managed key.
- *   3. Only when no OAuth credential exists do we inject the workspace-managed
- *      secret (Settings → API Keys → Anthropic) as `ANTHROPIC_API_KEY`.
+ * Auth precedence is OAuth > env API key > managed secret:
+ *
+ *   1. A `CLAUDE_CODE_OAUTH_TOKEN` or `claude login` session always wins. We
+ *      strip `ANTHROPIC_API_KEY` from the subprocess env so the CLI uses the
+ *      OAuth credential and never inject the managed key — an API key must
+ *      never out-prioritize or shadow OAuth (the cause of spurious "Invalid
+ *      API key" failures).
+ *   2. Otherwise an explicit `ANTHROPIC_API_KEY` inherited from the
+ *      environment passes through untouched.
+ *   3. Otherwise the workspace-managed secret (Settings → API Keys →
+ *      Anthropic) is injected as `ANTHROPIC_API_KEY`.
  *
  * The SDK identifies itself in the User-Agent via CLAUDE_AGENT_SDK_CLIENT_APP.
  */
 export async function buildClaudeAgentEnv(): Promise<NodeJS.ProcessEnv> {
   const env: NodeJS.ProcessEnv = { ...process.env };
   env.CLAUDE_AGENT_SDK_CLIENT_APP = 'texra';
-  const anthropicApiKeyEnv = apiKeyEnvName('anthropic');
 
-  if (env[anthropicApiKeyEnv]) return env;
+  const apiKeyVar = apiKeyEnvName('anthropic');
 
-  const [managed, origin] = await Promise.all([
-    lookupApiKey(platform().secrets, 'anthropic').catch(() => undefined),
-    lookupApiKeyOrigin(platform().secrets, 'anthropic').catch(
-      () => 'none' as const,
-    ),
-  ]);
+  // 1. OAuth wins: drop any inherited API key so it can't out-prioritize the
+  //    OAuth credential, and skip injecting the managed secret entirely.
+  if (hasClaudeOauthCredential()) {
+    delete env[apiKeyVar];
+    return env;
+  }
 
-  // Inject only the Settings-stored secret, and only when no OAuth credential
-  // is available. An `env`-origin key is already in `env`; an OAuth session
-  // takes precedence over the managed key.
-  if (managed && origin === 'secret' && !hasClaudeOauthCredential()) {
-    env[anthropicApiKeyEnv] = managed;
+  // 2. Preserve an explicit env key rather than overriding it with the secret.
+  if (env[apiKeyVar]) return env;
+
+  // 3. Fall back to the Settings-managed secret.
+  const managed = await lookupApiKey(platform().secrets, 'anthropic').catch(
+    () => undefined,
+  );
+  if (managed) {
+    env[apiKeyVar] = managed;
   }
 
   return env;

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -148,13 +148,18 @@ function expandHomePath(filePath: string): string {
 
 function claudeKeychainCredentialProbes(configDir: string): string[][] {
   const normalizedConfigDir = path.resolve(configDir);
+  const usesDefaultConfigDir =
+    normalizedConfigDir === path.resolve(resolveClaudeConfigDir(undefined));
   const configDirHash = createHash('sha256')
     .update(normalizedConfigDir)
     .digest('hex');
   const keychainProfiles = [normalizedConfigDir, configDirHash];
+  const legacyProbes: string[][] = usesDefaultConfigDir
+    ? [['find-generic-password', '-s', 'Claude Code-credentials']]
+    : [];
 
   return [
-    ['find-generic-password', '-s', 'Claude Code-credentials'],
+    ...legacyProbes,
     ...keychainProfiles.flatMap((profile) => [
       [
         'find-generic-password',

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'child_process';
+import { createHash } from 'crypto';
 import { existsSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -104,8 +105,8 @@ export const getClaudeAgentEffort: () => ClaudeAgentEffort =
  *
  * Best-effort and side-effect-free: the login session lives in
  * `${CLAUDE_CONFIG_DIR | ~/.claude}/.credentials.json` on Linux/Windows and in
- * the login keychain on macOS. The macOS probe reads metadata only (no
- * `-w`/`-g`) so it never triggers a keychain access prompt; any failure is
+ * the login keychain on macOS. The macOS probes read metadata only (no
+ * `-w`/`-g`) so they never trigger a keychain access prompt; any failure is
  * swallowed and treated as "no credential."
  */
 function hasClaudeOauthCredential(): boolean {
@@ -116,19 +117,45 @@ function hasClaudeOauthCredential(): boolean {
   if (existsSync(path.join(configDir, '.credentials.json'))) return true;
 
   if (process.platform === 'darwin') {
-    try {
-      execFileSync(
-        'security',
-        ['find-generic-password', '-s', 'Claude Code-credentials'],
-        { stdio: 'ignore', timeout: 2000 },
-      );
-      return true;
-    } catch {
-      // Not found / `security` unavailable — fall through to "no credential."
+    for (const probe of claudeKeychainCredentialProbes(configDir)) {
+      try {
+        execFileSync('security', probe, { stdio: 'ignore', timeout: 1000 });
+        return true;
+      } catch {
+        // Not found / `security` unavailable — try the next known service name.
+      }
     }
   }
 
   return false;
+}
+
+function claudeKeychainCredentialProbes(configDir: string): string[][] {
+  const normalizedConfigDir = path.resolve(configDir);
+  const configDirHash = createHash('sha256')
+    .update(normalizedConfigDir)
+    .digest('hex');
+  const keychainProfiles = [normalizedConfigDir, configDirHash];
+
+  return [
+    ['find-generic-password', '-s', 'Claude Code-credentials'],
+    ...keychainProfiles.flatMap((profile) => [
+      [
+        'find-generic-password',
+        '-a',
+        `${profile}-user`,
+        '-s',
+        `${profile}-access-token`,
+      ],
+      [
+        'find-generic-password',
+        '-a',
+        `${profile}-user`,
+        '-s',
+        `${profile}-refresh-token`,
+      ],
+    ]),
+  ];
 }
 
 /**

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -109,11 +109,13 @@ export const getClaudeAgentEffort: () => ClaudeAgentEffort =
  * `-w`/`-g`) so they never trigger a keychain access prompt; any failure is
  * swallowed and treated as "no credential."
  */
-function hasClaudeOauthCredential(): boolean {
-  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) return true;
+function hasClaudeOauthCredential(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.CLAUDE_CODE_OAUTH_TOKEN) return true;
 
   const configDir =
-    process.env.CLAUDE_CONFIG_DIR?.trim() || path.join(os.homedir(), '.claude');
+    env.CLAUDE_CONFIG_DIR?.trim() || path.join(os.homedir(), '.claude');
   if (existsSync(path.join(configDir, '.credentials.json'))) return true;
 
   if (process.platform === 'darwin') {
@@ -178,12 +180,18 @@ function claudeKeychainCredentialProbes(configDir: string): string[][] {
 export async function buildClaudeAgentEnv(): Promise<NodeJS.ProcessEnv> {
   const env: NodeJS.ProcessEnv = { ...process.env };
   env.CLAUDE_AGENT_SDK_CLIENT_APP = 'texra';
+  const oauthToken = env.CLAUDE_CODE_OAUTH_TOKEN?.trim();
+  if (oauthToken) {
+    env.CLAUDE_CODE_OAUTH_TOKEN = oauthToken;
+  } else {
+    delete env.CLAUDE_CODE_OAUTH_TOKEN;
+  }
 
   const apiKeyVar = apiKeyEnvName('anthropic');
 
   // 1. OAuth wins: drop any inherited API key so it can't out-prioritize the
   //    OAuth credential, and skip injecting the managed secret entirely.
-  if (hasClaudeOauthCredential()) {
+  if (hasClaudeOauthCredential(env)) {
     delete env[apiKeyVar];
     return env;
   }

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -154,6 +154,9 @@ function hasClaudeOauthCredential(): boolean {
 export async function buildClaudeAgentEnv(): Promise<NodeJS.ProcessEnv> {
   const env: NodeJS.ProcessEnv = { ...process.env };
   env.CLAUDE_AGENT_SDK_CLIENT_APP = 'texra';
+  const anthropicApiKeyEnv = apiKeyEnvName('anthropic');
+
+  if (env[anthropicApiKeyEnv]) return env;
 
   const [managed, origin] = await Promise.all([
     lookupApiKey(platform().secrets, 'anthropic').catch(() => undefined),
@@ -166,7 +169,7 @@ export async function buildClaudeAgentEnv(): Promise<NodeJS.ProcessEnv> {
   // is available. An `env`-origin key is already in `env`; an OAuth session
   // takes precedence over the managed key.
   if (managed && origin === 'secret' && !hasClaudeOauthCredential()) {
-    env[apiKeyEnvName('anthropic')] = managed;
+    env[anthropicApiKeyEnv] = managed;
   }
 
   return env;

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -1,3 +1,8 @@
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
 // Local imports - agent config
 import { platform } from '@platform/platform';
 import {
@@ -6,7 +11,11 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
-import { lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
+import {
+  lookupApiKey,
+  lookupApiKeyOrigin,
+  apiKeyEnvName,
+} from '@model/apiProviders';
 import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
 import { createEnumParser, createEnumStateGetter } from './support/enumConfig';
 import {
@@ -93,28 +102,73 @@ export const getClaudeAgentEffort: () => ClaudeAgentEffort =
 // ============================================================================
 
 /**
+ * Detect an existing Claude Code OAuth credential — either the
+ * `CLAUDE_CODE_OAUTH_TOKEN` env var (from `claude setup-token`) or a
+ * `claude login` session (Pro/Max subscription).
+ *
+ * Best-effort and side-effect-free: the login session lives in
+ * `${CLAUDE_CONFIG_DIR | ~/.claude}/.credentials.json` on Linux/Windows and in
+ * the login keychain on macOS. The macOS probe reads metadata only (no
+ * `-w`/`-g`) so it never triggers a keychain access prompt; any failure is
+ * swallowed and treated as "no credential."
+ */
+function hasClaudeOauthCredential(): boolean {
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) return true;
+
+  const configDir =
+    process.env.CLAUDE_CONFIG_DIR?.trim() || path.join(os.homedir(), '.claude');
+  if (existsSync(path.join(configDir, '.credentials.json'))) return true;
+
+  if (process.platform === 'darwin') {
+    try {
+      execFileSync(
+        'security',
+        ['find-generic-password', '-s', 'Claude Code-credentials'],
+        { stdio: 'ignore', timeout: 2000 },
+      );
+      return true;
+    } catch {
+      // Not found / `security` unavailable — fall through to "no credential."
+    }
+  }
+
+  return false;
+}
+
+/**
  * Build the env block passed to the Claude Code subprocess.
  *
- * Resolution order matches user expectations:
- *   1. Workspace-managed secret (Settings → API Keys → Anthropic) wins, so
- *      a key set in TeXRA "just works."
- *   2. Otherwise we leave `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN`
- *      alone — the CLI handles them itself, and if neither is set it falls
- *      back to the `~/.claude/` config produced by `claude login`.
+ * Auth resolution prefers an existing OAuth credential over a TeXRA-managed
+ * API key, so a stale key saved in Settings → API Keys can never shadow a
+ * working `claude login` session (the cause of spurious "Invalid API key"
+ * failures):
+ *   1. An explicit `ANTHROPIC_API_KEY` in the environment is already present
+ *      in `env` and passes through untouched.
+ *   2. A `CLAUDE_CODE_OAUTH_TOKEN` or `claude login` session is left for the
+ *      CLI to use; we do NOT override it with the managed key.
+ *   3. Only when no OAuth credential exists do we inject the workspace-managed
+ *      secret (Settings → API Keys → Anthropic) as `ANTHROPIC_API_KEY`.
  *
  * The SDK identifies itself in the User-Agent via CLAUDE_AGENT_SDK_CLIENT_APP.
  */
 export async function buildClaudeAgentEnv(): Promise<NodeJS.ProcessEnv> {
   const env: NodeJS.ProcessEnv = { ...process.env };
+  env.CLAUDE_AGENT_SDK_CLIENT_APP = 'texra';
 
-  const managed = await lookupApiKey(platform().secrets, 'anthropic').catch(
-    () => undefined,
-  );
-  if (managed) {
+  const [managed, origin] = await Promise.all([
+    lookupApiKey(platform().secrets, 'anthropic').catch(() => undefined),
+    lookupApiKeyOrigin(platform().secrets, 'anthropic').catch(
+      () => 'none' as const,
+    ),
+  ]);
+
+  // Inject only the Settings-stored secret, and only when no OAuth credential
+  // is available. An `env`-origin key is already in `env`; an OAuth session
+  // takes precedence over the managed key.
+  if (managed && origin === 'secret' && !hasClaudeOauthCredential()) {
     env[apiKeyEnvName('anthropic')] = managed;
   }
 
-  env.CLAUDE_AGENT_SDK_CLIENT_APP = 'texra';
   return env;
 }
 


### PR DESCRIPTION
The Claude Code sub-agent injected the TeXRA Settings → API Keys
Anthropic secret as ANTHROPIC_API_KEY unconditionally, which shadowed a
working `claude login` session or CLAUDE_CODE_OAUTH_TOKEN. A stale key in
Settings therefore surfaced as "Invalid API key · Fix external API key"
even when valid OAuth credentials were available.

buildClaudeAgentEnv now injects the managed secret only when no OAuth
credential is present, detected via CLAUDE_CODE_OAUTH_TOKEN, the
`${CLAUDE_CONFIG_DIR | ~/.claude}/.credentials.json` login session, or
(on macOS) a metadata-only keychain probe that never prompts. When no OAuth
credential is present, an explicit env ANTHROPIC_API_KEY passes through
untouched.

https://claude.ai/code/session_0131a31ixNXrVz8FK9ZPecwL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subprocess authentication precedence and adds macOS keychain/filesystem probes; mistakes could break Claude agent auth or leak wrong credential choice.
> 
> **Overview**
> **`buildClaudeAgentEnv`** no longer always injects the TeXRA-managed Anthropic API key. Auth for the Claude Code subprocess is now **OAuth → explicit `ANTHROPIC_API_KEY` → managed secret**, so a stale Settings key cannot override a working login.
> 
> When OAuth is detected, **`ANTHROPIC_API_KEY` is removed** from the child env (including inherited values) and the managed secret is not applied. Detection covers trimmed **`CLAUDE_CODE_OAUTH_TOKEN`**, **`${CLAUDE_CONFIG_DIR | ~/.claude}/.credentials.json`** (with `~` expansion), and on **macOS** metadata-only **`security find-generic-password`** probes scoped to the active config dir (legacy global keychain only for the default dir).
> 
> Vitest coverage adds isolated temp config dirs and mocks for **`child_process`**, **`os.homedir`**, and keychain probes so host login state does not affect CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea819633d16fdbad674158a11b025e96a1e92a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->