### PR TITLE
fix(docs): unfreeze texra.ai + forbid stray root docs via pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,14 @@ repos:
         args: ['run', 'format']
         language: system
         pass_filenames: false
+      # Forbid a stray internal doc at the docs root from being published to
+      # texra.ai. The boundary lives in docs/.vitepress/publicDocs.js; this
+      # dependency-free Node gate fails the commit if a root-level doc/dir is
+      # neither public nor excluded. (The docs-deploy.yml allowlist remains the
+      # server-side backstop.) Scoped to docs/ so it only runs when relevant.
+      - id: docs-root-boundary
+        name: docs root public/internal boundary
+        entry: node docs/scripts/check-root-docs.mjs
+        language: system
+        files: ^docs/
+        pass_filenames: false

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -217,6 +217,7 @@ const baseConfig = {
     'README.md',
     'agent-sdk-readiness-audit.md',
     'analysis-subagent-updates.md',
+    'tui-performance-audit.md',
     'desktop-signing-ci.md',
     'electron-migration-plan.md',
     'relay-tier-config.md',

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,5 +1,6 @@
 // .vitepress/config.js
 import { withMermaid } from 'vitepress-plugin-mermaid';
+import { srcExclude } from './publicDocs.js';
 
 const base = '/';
 
@@ -208,34 +209,9 @@ const baseConfig = {
       };
     },
   },
-  // Public site allowlist: only index.md, launch.md, terms.md, providers.md,
-  // and everything under guide/ except the desktop pages, which stay internal
-  // while the desktop app is in beta. Every other markdown file in this
-  // directory is internal and must NOT be published to texra.ai. Static assets
-  // under public/ are served as-is and are fine to expose.
-  srcExclude: [
-    'README.md',
-    'agent-sdk-readiness-audit.md',
-    'analysis-subagent-updates.md',
-    'tui-performance-audit.md',
-    'desktop-signing-ci.md',
-    'electron-migration-plan.md',
-    'relay-tier-config.md',
-    'guide/desktop.md',
-    'guide/desktop-migration.md',
-    'blog/**',
-    'design/**',
-    'dev/**',
-    'architecture/**',
-    'pocketflow/**',
-    'prd/**',
-    'proposals/**',
-    'reference/**',
-    'skills/**',
-    'supabase/**',
-    'toolCalls/**',
-    'node_modules/**',
-  ],
+  // The public/internal docs boundary lives in ./publicDocs.js (single source
+  // of truth, shared with the scripts/check-root-docs.mjs CI gate).
+  srcExclude,
   vite: {
     vue: {
       template: {

--- a/docs/.vitepress/publicDocs.js
+++ b/docs/.vitepress/publicDocs.js
@@ -5,10 +5,11 @@
 // unclassified root-level doc). Keep this file dependency-free — no imports —
 // so the gate can run with bare Node, without installing the docs sub-project.
 //
-// Public site allowlist: only the files in `publicRootDocs` and the dirs in
-// `publicRootDirs` are published to texra.ai. Every other markdown file in this
-// directory is internal and must NOT be published. Static assets under public/
-// are served as-is and are fine to expose.
+// Intended public root surface for texra.ai. VitePress is opt-out: it publishes
+// root markdown files and content directories unless `srcExclude` blocks them.
+// The boundary gate treats `publicRootDocs` / `publicRootDirs` as the explicit
+// public surface and `srcExclude` as internal. Static assets under public/ are
+// served as-is and are fine to expose.
 
 // Root-level markdown intentionally published to texra.ai. `changelog.md` and
 // `terms.md` are generated into the docs root at build time by the

--- a/docs/.vitepress/publicDocs.js
+++ b/docs/.vitepress/publicDocs.js
@@ -10,8 +10,18 @@
 // directory is internal and must NOT be published. Static assets under public/
 // are served as-is and are fine to expose.
 
-// Root-level markdown intentionally published to texra.ai.
-export const publicRootDocs = ['index.md', 'launch.md', 'providers.md'];
+// Root-level markdown intentionally published to texra.ai. `changelog.md` and
+// `terms.md` are generated into the docs root at build time by the
+// `sync-content` script (from repo-root CHANGELOG.md / TERMS_OF_SERVICE.md) and
+// are .gitignored; they are listed here so the boundary gate does not flag them
+// as unclassified in a checkout where the build has run.
+export const publicRootDocs = [
+  'index.md',
+  'launch.md',
+  'providers.md',
+  'changelog.md',
+  'terms.md',
+];
 
 // Root-level directories whose contents are published (minus any per-page
 // exclusions in `srcExclude`, e.g. the guide/desktop* beta pages).

--- a/docs/.vitepress/publicDocs.js
+++ b/docs/.vitepress/publicDocs.js
@@ -1,0 +1,44 @@
+// Single source of truth for the docs publishing boundary.
+//
+// This is imported by `.vitepress/config.js` (as VitePress `srcExclude`) and by
+// `../scripts/check-root-docs.mjs` (the CI gate that fails a PR introducing an
+// unclassified root-level doc). Keep this file dependency-free — no imports —
+// so the gate can run with bare Node, without installing the docs sub-project.
+//
+// Public site allowlist: only the files in `publicRootDocs` and the dirs in
+// `publicRootDirs` are published to texra.ai. Every other markdown file in this
+// directory is internal and must NOT be published. Static assets under public/
+// are served as-is and are fine to expose.
+
+// Root-level markdown intentionally published to texra.ai.
+export const publicRootDocs = ['index.md', 'launch.md', 'providers.md'];
+
+// Root-level directories whose contents are published (minus any per-page
+// exclusions in `srcExclude`, e.g. the guide/desktop* beta pages).
+export const publicRootDirs = ['guide'];
+
+// Sources excluded from the public build. Root-level *.md entries are internal
+// docs; `name/**` entries exclude whole internal directories.
+export const srcExclude = [
+  'README.md',
+  'agent-sdk-readiness-audit.md',
+  'analysis-subagent-updates.md',
+  'tui-performance-audit.md',
+  'desktop-signing-ci.md',
+  'electron-migration-plan.md',
+  'relay-tier-config.md',
+  'guide/desktop.md',
+  'guide/desktop-migration.md',
+  'blog/**',
+  'design/**',
+  'dev/**',
+  'architecture/**',
+  'pocketflow/**',
+  'prd/**',
+  'proposals/**',
+  'reference/**',
+  'skills/**',
+  'supabase/**',
+  'toolCalls/**',
+  'node_modules/**',
+];

--- a/docs/scripts/check-root-docs.mjs
+++ b/docs/scripts/check-root-docs.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// CI gate: forbid an unclassified root-level doc from reaching the public site.
+//
+// VitePress publishes every root-level *.md (and content directory) to texra.ai
+// unless it is listed in `srcExclude`. The deploy workflow has an allowlist that
+// catches a stray internal doc, but only at deploy time on main — which fails
+// the whole Deploy Docs run and silently freezes the site. This gate moves that
+// check to PR time: a doc added without being classified as public or internal
+// fails the author's PR, loudly, before merge.
+//
+// It is intentionally dependency-free (bare Node, only the local publicDocs.js
+// import) so it runs without installing the docs sub-project.
+
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  publicRootDocs,
+  publicRootDirs,
+  srcExclude,
+} from '../.vitepress/publicDocs.js';
+
+const docsDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Build/system entries that are never publishable content and need no
+// classification (VitePress internals, static-asset dir, deps, this script's
+// own folder).
+const SYSTEM_ENTRIES = new Set([
+  '.vitepress',
+  'public',
+  'node_modules',
+  'scripts',
+]);
+
+const publicDocs = new Set(publicRootDocs);
+const publicDirs = new Set(publicRootDirs);
+// Root-level entries named directly in srcExclude, with any `/**` glob suffix
+// stripped so a directory matches its `name/**` exclusion.
+const excluded = new Set(srcExclude.map((e) => e.replace(/\/\*\*$/, '')));
+
+const entries = readdirSync(docsDir, { withFileTypes: true });
+const unclassified = [];
+
+for (const entry of entries) {
+  const { name } = entry;
+  if (SYSTEM_ENTRIES.has(name)) continue;
+
+  if (entry.isDirectory()) {
+    // A content directory must be published (publicRootDirs) or excluded.
+    if (publicDirs.has(name) || excluded.has(name)) continue;
+    unclassified.push(`${name}/ (directory)`);
+    continue;
+  }
+
+  // Only markdown is rendered into the public site; other root files
+  // (package.json, lockfiles, …) are not published.
+  if (!name.endsWith('.md')) continue;
+  if (publicDocs.has(name) || excluded.has(name)) continue;
+  unclassified.push(name);
+}
+
+if (unclassified.length > 0) {
+  const ghError = process.env.GITHUB_ACTIONS === 'true' ? '::error::' : '';
+  console.error(
+    `${ghError}Unclassified root-level docs entries (neither public nor internal):`,
+  );
+  for (const name of unclassified) console.error(`${ghError}  docs/${name}`);
+  console.error('');
+  console.error('Each must be classified in docs/.vitepress/publicDocs.js:');
+  console.error(
+    '  - publish to texra.ai -> add to publicRootDocs / publicRootDirs',
+  );
+  console.error('  - keep internal      -> add to srcExclude');
+  process.exit(1);
+}
+
+console.log(
+  `docs boundary OK: every root-level entry is classified ` +
+    `(${publicDocs.size} public docs, ${publicDirs.size} public dirs).`,
+);


### PR DESCRIPTION
## Why
Every `Deploy Docs` run on 2026-06-02 failed at the allowlist guard:
```
##[error]Unexpected entry in build output: tui-performance-audit.html
```
The internal doc `docs/tui-performance-audit.md` was committed at the docs root. The docs boundary is **opt-out** — any root-level `.md` defaults to public unless listed in `srcExclude` — so VitePress published it, tripping the deploy guard. Because the guard runs before the publish step, the deploy aborted and **texra.ai silently froze** at the last good deploy.

## What this does
1. **Fix** — adds `tui-performance-audit.md` to `srcExclude`, unblocking the deploy.
2. **Forbid recurrence (pre-commit, no CI cost)** — moves the public/internal boundary into a single source of truth (`docs/.vitepress/publicDocs.js`, shared by the VitePress config and a dependency-free gate `docs/scripts/check-root-docs.mjs`) and enforces it as a **pre-commit hook** scoped to `docs/` changes. A doc added without being classified as public (`publicRootDocs`/`publicRootDirs`) or internal (`srcExclude`) fails the commit **locally** — no CI minutes spent. The existing `docs-deploy.yml` allowlist remains the server-side backstop.

## Verification
- Pre-commit hook passes on this tree; fails on a planted stray root doc (exit 1).
- `config.js` resolves with all 21 `srcExclude` entries via the shared module.
- No CI workflow changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs publishing configuration and a local validation hook only; no runtime product, auth, or data-path changes.
> 
> **Overview**
> Unblocks **texra.ai** docs deploys by classifying `tui-performance-audit.md` as internal in the shared exclude list, so VitePress no longer emits that page and the deploy allowlist can pass again.
> 
> The public vs internal docs boundary moves from an inline `srcExclude` block in VitePress config into **`docs/.vitepress/publicDocs.js`** (`publicRootDocs`, `publicRootDirs`, `srcExclude`). Config imports that module only.
> 
> A **pre-commit** hook runs **`docs/scripts/check-root-docs.mjs`** on `docs/` changes: bare Node scans the docs root and fails if any root `.md` or content directory is neither public nor excluded—catching stray internal docs before merge instead of only at deploy. Deploy workflow allowlist is unchanged as a backstop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269a6e46d916a9c730af316c8e2872a685543420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->