### PR TITLE
fix(cli): silence implicit default model fallback

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -46,7 +46,10 @@ import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
-import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
+import {
+  cliRunnableModelOptionsForSource,
+  resolveCliRunnableModel,
+} from '@cli/runtime/modelAccess';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { writeTextStderr, writeTextStdout } from '@cli/runtime/logSinks';
 import {
@@ -429,7 +432,7 @@ async function reconcileRootModelAfterApiModeChange(
 
   const currentModel = cliState.sessionMeta.get().model;
   const resolution = await resolveCliRunnableModel(currentModel, {
-    allowFallback: true,
+    fallbackMode: 'notice',
     apiMode,
     noAvailableModelsMessage:
       apiMode === 'included'
@@ -1006,27 +1009,26 @@ export async function runChat(
     envAgent: context.envAgent,
     envModel: context.envModel,
   });
-  const explicitModelRequested = Boolean(
-    init.modelOverride?.trim() || context.envModel?.trim(),
-  );
   // One API mode for the whole session: an explicit --api-mode/env override
   // wins, otherwise the persisted account default. Model resolution, the
   // no-models hints, and the header/status all read this same value so they can
   // never disagree.
   let modelResolution: Awaited<ReturnType<typeof resolveCliRunnableModel>>;
   try {
-    modelResolution = await resolveCliRunnableModel(defaults.model, {
-      allowFallback: !explicitModelRequested,
-      apiMode,
-      noAvailableModelsMessage:
-        apiMode === 'included'
-          ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
-          : undefined,
-      noAvailableModelsHint:
-        apiMode === 'included'
-          ? undefined
-          : 'Run `texra chat --api-mode included` to try included relay access',
-    });
+    modelResolution = await resolveCliRunnableModel(
+      defaults.model,
+      cliRunnableModelOptionsForSource(defaults.modelSource, {
+        apiMode,
+        noAvailableModelsMessage:
+          apiMode === 'included'
+            ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
+            : undefined,
+        noAvailableModelsHint:
+          apiMode === 'included'
+            ? undefined
+            : 'Run `texra chat --api-mode included` to try included relay access',
+      }),
+    );
   } catch (error: unknown) {
     writeTextStderr(toErrorMessage(error));
     return { exitCode: CliExitCode.Usage };

--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -6,10 +6,24 @@ import {
 import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
 import { initCliPlatform } from '@cli/runtime/initPlatform';
 import { writeTextStderr } from '@cli/runtime/logSinks';
-import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
+import {
+  cliRunnableModelOptionsForSource,
+  resolveCliRunnableModel,
+  type CliModelSelectionSource,
+} from '@cli/runtime/modelAccess';
 import { shouldRenderRunProgress } from '@cli/runtime/runProgressRenderer';
 import { effectiveCliApiMode } from '@cli/runtime/apiAccessMode';
 import { toErrorMessage } from '@common/errors/errorMessage';
+
+type CliRunModelCandidateSource = Extract<
+  CliModelSelectionSource,
+  'override' | 'env' | 'config' | 'builtin'
+>;
+
+interface CliRunModelCandidate {
+  readonly model: string;
+  readonly source: CliRunModelCandidateSource;
+}
 
 /** Trim `-m`; throw a Usage error for unknown ids; undefined when absent. */
 export function assertExplicitModelKnown(
@@ -25,6 +39,21 @@ export function assertExplicitModelKnown(
   return trimmed;
 }
 
+function resolveCliRunModelCandidateDetails(
+  context: CliContext,
+  modelOverride: string | undefined,
+  role: 'chat' | 'run',
+): CliRunModelCandidate {
+  const explicit = assertExplicitModelKnown(modelOverride);
+  if (explicit) return { model: explicit, source: 'override' };
+  if (context.envModel) return { model: context.envModel, source: 'env' };
+
+  const configured = resolveConfiguredModel(context.cliConfig, role);
+  if (configured) return { model: configured, source: 'config' };
+
+  return { model: CLI_BUILTIN_DEFAULT_MODEL, source: 'builtin' };
+}
+
 /**
  * Resolve the model for a headless runner with the shared precedence:
  * explicit `-m` > `TEXRA_MODEL` env > configured `chat`/`run` model > builtin.
@@ -34,13 +63,7 @@ export function resolveCliRunModelCandidate(
   modelOverride: string | undefined,
   role: 'chat' | 'run',
 ): string {
-  const explicit = assertExplicitModelKnown(modelOverride);
-  return (
-    explicit ||
-    context.envModel ||
-    resolveConfiguredModel(context.cliConfig, role) ||
-    CLI_BUILTIN_DEFAULT_MODEL
-  );
+  return resolveCliRunModelCandidateDetails(context, modelOverride, role).model;
 }
 
 export async function resolveCliRunModel(
@@ -48,21 +71,24 @@ export async function resolveCliRunModel(
   modelOverride: string | undefined,
   role: 'chat' | 'run',
 ): Promise<string> {
-  const model = resolveCliRunModelCandidate(context, modelOverride, role);
-  const explicitModelRequested = Boolean(
-    modelOverride?.trim() || context.envModel?.trim(),
+  const candidate = resolveCliRunModelCandidateDetails(
+    context,
+    modelOverride,
+    role,
   );
   await initCliPlatform({ ...context, quietLogs: true });
   const apiMode = effectiveCliApiMode(context);
   try {
-    const resolution = await resolveCliRunnableModel(model, {
-      allowFallback: !explicitModelRequested,
-      apiMode,
-      noAvailableModelsMessage:
-        apiMode === 'included'
-          ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
-          : undefined,
-    });
+    const resolution = await resolveCliRunnableModel(
+      candidate.model,
+      cliRunnableModelOptionsForSource(candidate.source, {
+        apiMode,
+        noAvailableModelsMessage:
+          apiMode === 'included'
+            ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
+            : undefined,
+      }),
+    );
     if (resolution.notice && context.quietLogs !== true) {
       writeTextStderr(resolution.notice);
     }

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -10,6 +10,7 @@ import {
   resolveConfiguredAgent,
   resolveConfiguredModel,
 } from './cliConfig';
+import type { CliModelSelectionSource } from './modelAccess';
 
 export const BUILTIN_DEFAULT_CHAT_AGENT = 'chat';
 export const BUILTIN_DEFAULT_CHAT_MODEL = CLI_BUILTIN_DEFAULT_MODEL;
@@ -18,6 +19,8 @@ export interface ChatDefaults {
   readonly agent: string;
   readonly model: string;
   readonly source: ChatDefaultSource;
+  readonly agentSource: ChatDefaultValueSource;
+  readonly modelSource: ChatDefaultValueSource;
 }
 
 export type ChatDefaultSource =
@@ -26,6 +29,14 @@ export type ChatDefaultSource =
   | 'history'
   | 'builtin'
   | 'mixed';
+
+export type ChatDefaultValueSource =
+  | 'override'
+  | 'env'
+  | Extract<
+      CliModelSelectionSource,
+      'workspace' | 'user' | 'history' | 'builtin'
+    >;
 
 interface PartialDefaults {
   readonly agent?: string;
@@ -103,12 +114,38 @@ async function loadHistoryDefaults(): Promise<PartialDefaults> {
   }
 }
 
-function deriveSource(picked: {
-  agent?: ChatDefaultSource;
-  model?: ChatDefaultSource;
+function deriveSource(sources: {
+  readonly agent: ChatDefaultValueSource;
+  readonly model: ChatDefaultValueSource;
 }): ChatDefaultSource {
-  const sources = [picked.agent ?? 'builtin', picked.model ?? 'builtin'];
-  return sources[0] === sources[1] ? sources[0] : 'mixed';
+  const source = sources.agent === sources.model ? sources.agent : 'mixed';
+  return source === 'override' || source === 'env' ? 'mixed' : source;
+}
+
+function sourceForOverride(
+  override: string | undefined,
+  env: string | undefined,
+): ChatDefaultValueSource | undefined {
+  if (override) return 'override';
+  if (env) return 'env';
+  return undefined;
+}
+
+function buildChatDefaults(init: {
+  readonly agent: string | undefined;
+  readonly model: string | undefined;
+  readonly agentSource: ChatDefaultValueSource | undefined;
+  readonly modelSource: ChatDefaultValueSource | undefined;
+}): ChatDefaults {
+  const agentSource = init.agentSource ?? 'builtin';
+  const modelSource = init.modelSource ?? 'builtin';
+  return {
+    agent: init.agent ?? BUILTIN_DEFAULT_CHAT_AGENT,
+    model: init.model ?? BUILTIN_DEFAULT_CHAT_MODEL,
+    source: deriveSource({ agent: agentSource, model: modelSource }),
+    agentSource,
+    modelSource,
+  };
 }
 
 export interface ResolveChatDefaultsInit {
@@ -132,16 +169,13 @@ export async function resolveChatDefaults(
   const overrideModel = init.modelOverride?.trim();
   const envAgent = init.envAgent?.trim();
   const envModel = init.envModel?.trim();
+  let agent = overrideAgent || envAgent;
+  let model = overrideModel || envModel;
+  let agentSource = sourceForOverride(overrideAgent, envAgent);
+  let modelSource = sourceForOverride(overrideModel, envModel);
 
-  if (overrideAgent && overrideModel) {
-    return { agent: overrideAgent, model: overrideModel, source: 'mixed' };
-  }
-  if ((overrideAgent || envAgent) && (overrideModel || envModel)) {
-    return {
-      agent: overrideAgent || envAgent || BUILTIN_DEFAULT_CHAT_AGENT,
-      model: overrideModel || envModel || BUILTIN_DEFAULT_CHAT_MODEL,
-      source: 'mixed',
-    };
+  if (agent && model) {
+    return buildChatDefaults({ agent, model, agentSource, modelSource });
   }
 
   // Tiers are independent I/O — fan out in parallel.
@@ -152,34 +186,25 @@ export async function resolveChatDefaults(
     loadUserDefaults(),
     loadHistoryDefaults(),
   ]);
-  const tiers: ReadonlyArray<readonly [ChatDefaultSource, PartialDefaults]> = [
+  const tiers: ReadonlyArray<
+    readonly [ChatDefaultValueSource, PartialDefaults]
+  > = [
     ['workspace', workspace],
     ['user', user],
     ['history', history],
   ];
 
-  const pickedSources: {
-    agent?: ChatDefaultSource;
-    model?: ChatDefaultSource;
-  } = {};
-  let agent = overrideAgent || envAgent;
-  let model = overrideModel || envModel;
-
   for (const [source, defaults] of tiers) {
     if (!agent && defaults.agent) {
       agent = defaults.agent;
-      pickedSources.agent = source;
+      agentSource = source;
     }
     if (!model && defaults.model) {
       model = defaults.model;
-      pickedSources.model = source;
+      modelSource = source;
     }
     if (agent && model) break;
   }
 
-  return {
-    agent: agent ?? BUILTIN_DEFAULT_CHAT_AGENT,
-    model: model ?? BUILTIN_DEFAULT_CHAT_MODEL,
-    source: deriveSource(pickedSources),
-  };
+  return buildChatDefaults({ agent, model, agentSource, modelSource });
 }

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -20,12 +20,23 @@ export interface CliRunnableModelResolution {
   readonly notice?: string;
 }
 
+export type CliModelFallbackMode = 'reject' | 'notice' | 'silent';
+
 export interface CliRunnableModelOptions {
-  readonly allowFallback: boolean;
+  readonly fallbackMode: CliModelFallbackMode;
   readonly apiMode?: CliApiMode;
   readonly noAvailableModelsHint?: string;
   readonly noAvailableModelsMessage?: string;
 }
+
+export type CliModelSelectionSource =
+  | 'override'
+  | 'env'
+  | 'config'
+  | 'workspace'
+  | 'user'
+  | 'history'
+  | 'builtin';
 
 export interface CliModelAccessListOptions {
   readonly apiMode?: CliApiMode;
@@ -82,6 +93,25 @@ function formatModelAccessStatus(model: ModelOptionData): string {
     return `missing ${provider}key`;
   }
   return 'unavailable';
+}
+
+export function cliModelFallbackModeForSource(
+  source: CliModelSelectionSource,
+): CliModelFallbackMode {
+  if (source === 'override' || source === 'env') {
+    return 'reject';
+  }
+  return source === 'builtin' ? 'silent' : 'notice';
+}
+
+export function cliRunnableModelOptionsForSource(
+  source: CliModelSelectionSource,
+  options: Omit<CliRunnableModelOptions, 'fallbackMode'> = {},
+): CliRunnableModelOptions {
+  return {
+    ...options,
+    fallbackMode: cliModelFallbackModeForSource(source),
+  };
 }
 
 function toCliModelAccess(
@@ -214,11 +244,12 @@ export function resolveCliRunnableModelFromAccessList(
     availableIds,
     options,
   );
-  if (!options.allowFallback || availableIds.length === 0) {
+  if (options.fallbackMode === 'reject' || availableIds.length === 0) {
     throw new Error(unavailableMessage);
   }
 
   const fallback = availableIds[0]!;
+  if (options.fallbackMode === 'silent') return { model: fallback };
   return {
     model: fallback,
     notice: `${unavailableMessage} Using "${fallback}" instead.`,

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -38,6 +38,16 @@ export type CliModelSelectionSource =
   | 'history'
   | 'builtin';
 
+const CLI_MODEL_FALLBACK_MODE_BY_SOURCE = {
+  override: 'reject',
+  env: 'reject',
+  config: 'notice',
+  workspace: 'notice',
+  user: 'notice',
+  history: 'notice',
+  builtin: 'silent',
+} satisfies Record<CliModelSelectionSource, CliModelFallbackMode>;
+
 export interface CliModelAccessListOptions {
   readonly apiMode?: CliApiMode;
 }
@@ -98,10 +108,7 @@ function formatModelAccessStatus(model: ModelOptionData): string {
 export function cliModelFallbackModeForSource(
   source: CliModelSelectionSource,
 ): CliModelFallbackMode {
-  if (source === 'override' || source === 'env') {
-    return 'reject';
-  }
-  return source === 'builtin' ? 'silent' : 'notice';
+  return CLI_MODEL_FALLBACK_MODE_BY_SOURCE[source];
 }
 
 export function cliRunnableModelOptionsForSource(

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -74,6 +74,8 @@ describe('CLI chat defaults', () => {
       agent: 'chat',
       model: 'deepseekT',
       source: 'builtin',
+      agentSource: 'builtin',
+      modelSource: 'builtin',
     });
   });
 
@@ -91,6 +93,8 @@ describe('CLI chat defaults', () => {
       agent: 'chat',
       model: 'deepseekT',
       source: 'mixed',
+      agentSource: 'workspace',
+      modelSource: 'builtin',
     });
   });
 
@@ -112,6 +116,8 @@ describe('CLI chat defaults', () => {
       agent: 'chat',
       model: 'sonnet46T',
       source: 'mixed',
+      agentSource: 'workspace',
+      modelSource: 'env',
     });
   });
 

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  cliModelFallbackModeForSource,
   getCliModelAccessList,
   runnableCliModelAccessEntries,
   resolveCliRunnableModel,
@@ -56,9 +57,16 @@ describe('CLI model access resolution', () => {
       resolveCliRunnableModelFromAccessList(
         [model('sonnet46T'), model('opus48T')],
         'opus48T',
-        { allowFallback: false },
+        { fallbackMode: 'reject' },
       ),
     ).toEqual({ model: 'opus48T' });
+  });
+
+  it('centralizes fallback policy by model source', () => {
+    expect(cliModelFallbackModeForSource('override')).toBe('reject');
+    expect(cliModelFallbackModeForSource('env')).toBe('reject');
+    expect(cliModelFallbackModeForSource('workspace')).toBe('notice');
+    expect(cliModelFallbackModeForSource('builtin')).toBe('silent');
   });
 
   it('rejects an explicit model that is unavailable in the active API mode', () => {
@@ -76,7 +84,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'opus48T',
-        { allowFallback: false },
+        { fallbackMode: 'reject' },
       ),
     ).toThrow(
       'Model "opus48T" is not available in the active API mode (not included). Available models: sonnet46T.',
@@ -99,13 +107,34 @@ describe('CLI model access resolution', () => {
           model('sonnet46T'),
         ],
         'opus48T',
-        { allowFallback: true },
+        { fallbackMode: 'notice' },
       ),
     ).toEqual({
       model: 'deepseekT',
       notice:
         'Model "opus48T" is not available in the active API mode (not included). Available models: deepseekT, sonnet46T. Using "deepseekT" instead.',
     });
+  });
+
+  it('can fall back silently from an implicit default', () => {
+    expect(
+      resolveCliRunnableModelFromAccessList(
+        [
+          model('deepseekT', {
+            available: false,
+            status: 'missing api key',
+            model: modelOption('deepseekT', {
+              availability: 'missing-key',
+              disabled: true,
+              requiresKey: true,
+            }),
+          }),
+          model('gpt55'),
+        ],
+        'deepseekT',
+        { fallbackMode: 'silent' },
+      ),
+    ).toEqual({ model: 'gpt55' });
   });
 
   it('filters runnable models by access-list availability', () => {
@@ -191,7 +220,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'deepseekT',
-        { allowFallback: false, apiMode: 'included' },
+        { fallbackMode: 'reject', apiMode: 'included' },
       ),
     ).toThrow(
       'Model "deepseekT" is not available in the active API mode (api key set). Available models: sonnet46T.',
@@ -216,7 +245,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'sonnet46T',
-        { allowFallback: true, apiMode: 'personal' },
+        { fallbackMode: 'notice', apiMode: 'personal' },
       ),
     ).toEqual({
       model: 'deepseekT',
@@ -240,7 +269,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'gemini31p',
-        { allowFallback: true },
+        { fallbackMode: 'notice' },
       ),
     ).toThrow(
       'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Retry with `--api-mode included` to try included relay access, run `texra login`, or configure a provider API key.',
@@ -263,7 +292,7 @@ describe('CLI model access resolution', () => {
         ],
         'gemini31p',
         {
-          allowFallback: true,
+          fallbackMode: 'notice',
           noAvailableModelsMessage:
             'Run `texra login` for included relay access.',
         },
@@ -418,7 +447,9 @@ describe('CLI model access resolution', () => {
       ]);
 
     await expect(
-      resolveCliRunnableModel('HIDDENFIXTUREMODEL', { allowFallback: false }),
+      resolveCliRunnableModel('HIDDENFIXTUREMODEL', {
+        fallbackMode: 'reject',
+      }),
     ).resolves.toEqual({ model: 'hiddenFixtureModel' });
     expect(computeModelOptionsDataMock).toHaveBeenNthCalledWith(2, [
       'hiddenFixtureModel',
@@ -433,7 +464,9 @@ describe('CLI model access resolution', () => {
       .mockResolvedValueOnce([]);
 
     await expect(
-      resolveCliRunnableModel('hiddenFixtureModel', { allowFallback: false }),
+      resolveCliRunnableModel('hiddenFixtureModel', {
+        fallbackMode: 'reject',
+      }),
     ).rejects.toThrow(
       'Model "hiddenFixtureModel" is configured but has no option data.',
     );

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -7,6 +7,8 @@ import {
   resolveCliRunnableModel,
   resolveCliRunnableModelFromAccessList,
   type CliModelAccess,
+  type CliModelFallbackMode,
+  type CliModelSelectionSource,
 } from '@cli/runtime/modelAccess';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { ModelOptionData } from '@shared/schemas';
@@ -63,10 +65,21 @@ describe('CLI model access resolution', () => {
   });
 
   it('centralizes fallback policy by model source', () => {
-    expect(cliModelFallbackModeForSource('override')).toBe('reject');
-    expect(cliModelFallbackModeForSource('env')).toBe('reject');
-    expect(cliModelFallbackModeForSource('workspace')).toBe('notice');
-    expect(cliModelFallbackModeForSource('builtin')).toBe('silent');
+    const expectedModes = {
+      override: 'reject',
+      env: 'reject',
+      config: 'notice',
+      workspace: 'notice',
+      user: 'notice',
+      history: 'notice',
+      builtin: 'silent',
+    } satisfies Record<CliModelSelectionSource, CliModelFallbackMode>;
+
+    for (const [source, mode] of Object.entries(expectedModes)) {
+      expect(
+        cliModelFallbackModeForSource(source as CliModelSelectionSource),
+      ).toBe(mode);
+    }
   });
 
   it('rejects an explicit model that is unavailable in the active API mode', () => {

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -29,9 +29,14 @@ vi.mock('@cli/runtime/apiAccessMode', () => ({
   getCliApiMode: mocks.getCliApiMode,
 }));
 
-vi.mock('@cli/runtime/modelAccess', () => ({
-  resolveCliRunnableModel: mocks.resolveCliRunnableModel,
-}));
+vi.mock('@cli/runtime/modelAccess', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@cli/runtime/modelAccess')>();
+  return {
+    ...actual,
+    resolveCliRunnableModel: mocks.resolveCliRunnableModel,
+  };
+});
 
 vi.mock('@cli/runtime/logSinks', () => ({
   writeTextStderr: mocks.writeTextStderr,
@@ -114,6 +119,21 @@ describe('resolveCliRunModel precedence', () => {
     );
   });
 
+  it('suppresses fallback notices for the implicit builtin default', async () => {
+    const context = makeContext();
+
+    await resolveCliRunModel(context, undefined, 'run');
+
+    expect(resolveCliRunnableModelMock).toHaveBeenCalledWith(
+      CLI_BUILTIN_DEFAULT_MODEL,
+      {
+        apiMode: 'personal',
+        fallbackMode: 'silent',
+        noAvailableModelsMessage: undefined,
+      },
+    );
+  });
+
   it('checks active API-mode access before returning the model', async () => {
     const context = makeContext({
       cliConfig: runConfig('staleConfiguredModel'),
@@ -128,7 +148,7 @@ describe('resolveCliRunModel precedence', () => {
     );
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith(
       'staleConfiguredModel',
-      expect.objectContaining({ allowFallback: true }),
+      expect.objectContaining({ fallbackMode: 'notice' }),
     );
     expect(mocks.initCliPlatform).toHaveBeenCalledWith({
       ...context,
@@ -153,8 +173,8 @@ describe('resolveCliRunModel precedence', () => {
       CliUsageError,
     );
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
-      allowFallback: false,
       apiMode: 'personal',
+      fallbackMode: 'reject',
       noAvailableModelsMessage: undefined,
     });
   });
@@ -168,8 +188,8 @@ describe('resolveCliRunModel precedence', () => {
     await resolveCliRunModel(context, undefined, 'run');
 
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
-      allowFallback: false,
       apiMode: 'personal',
+      fallbackMode: 'reject',
       noAvailableModelsMessage: undefined,
     });
   });


### PR DESCRIPTION
## Summary

- track the source of chat startup agent/model defaults per field
- replace boolean fallback flags with a single `fallbackMode` (`reject`, `notice`, `silent`)
- silently fall back from only the implicit built-in model default, so OpenAI-only personal API users start direct chat on a runnable model without an unavailable DeepSeek warning

Closes #5191.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:run`
- real PTY repro: `texra chat --api-mode personal` in a clean HOME with only `OPENAI_API_KEY` set starts on `gpt55` and does not include `Model "deepseekT" is not available`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --snapshot-dir /private/tmp/texra-cli-openai-default-frames-20260603` (`all 91 scenarios passed`)
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with 10 existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to CLI model resolution and default metadata; explicit model requests are unchanged (still reject), with added tests covering fallback modes.
> 
> **Overview**
> Replaces the CLI’s boolean **allow fallback** flag with **`fallbackMode`** (`reject`, `notice`, `silent`) and ties it to **where the model was chosen** (override/env/config/workspace/user/history/builtin).
> 
> **Chat defaults** now expose per-field **`agentSource`** and **`modelSource`** so startup and headless runs can pick the right fallback behavior without duplicating “was this explicit?” checks.
> 
> **User-visible effect:** when the only implicit default is the built-in model (e.g. DeepSeek) and it isn’t runnable in the active API mode, the CLI **silently** switches to the first available model—fixing noisy warnings for personal-API-only setups (e.g. OpenAI key → starts on `gpt55` without a DeepSeek unavailable message). **`-m`**, **`TEXRA_MODEL`**, and configured defaults still **reject** or **show a notice** when fallback happens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9ed4c58a939a08a42cfd6035f7b00df7f6d65b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->