### PR TITLE
test(cli): wait for settled api form snapshot

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -415,8 +415,9 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/api', '\r'],
     frame: 'tail',
-    expect: ['/api', 'Personal API keys', 'Included relay'],
-    unexpect: ['ServerSideKeyService not initialized'],
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: ['/api', 'api:', 'auth:', 'Personal API keys', 'Included relay'],
+    unexpect: ['loading API status...', 'ServerSideKeyService not initialized'],
   },
   {
     name: 'approval-form',


### PR DESCRIPTION
## Summary

- wait for `/api` form async status loading before capturing the TUI snapshot
- assert the settled `api:` and `auth:` status lines are visible
- reject the transient `loading API status...` placeholder in the final frame

Closes #5195.

## Validation

- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --snapshot-dir /private/tmp/texra-api-form-settled-frames-20260603 api-form`
- settled frame verified at `/private/tmp/texra-api-form-settled-frames-20260603/01-api-form.txt`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with 10 existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to `validate-tui.mjs`; no production CLI or API behavior is modified.
> 
> **Overview**
> The **`api-form`** TUI harness scenario now waits **`ASYNC_FORM_SETTLE_MS`** (12s) after opening `/api` so the snapshot captures the form **after** async API status finishes loading, not while the placeholder is still on screen.
> 
> Assertions now require settled **`api:`** and **`auth:`** lines alongside the existing mode labels, and **fail** if **`loading API status...`** appears in the final frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b4a95bb489093e846d6b61b0fdb4ac17327f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->