### PR TITLE
fix(cli): resume TUI sessions from snapshots

### DIFF
--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -1,5 +1,5 @@
-// `/resume` form. It lists recent execution configurations that can be
-// restarted in the current chat TUI.
+// `/resume` form. It lists recent executions that can be continued from the
+// current chat TUI.
 
 import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
@@ -91,7 +91,7 @@ export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
       <Text bold color="cyan">
         /resume
       </Text>
-      <Text dimColor>Choose a stored execution configuration.</Text>
+      <Text dimColor>Choose a previous session to continue.</Text>
       <Box marginTop={1}>
         <Select
           items={items}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -61,7 +61,7 @@ import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
 } from '@cli/schemas/cliSettings';
-import { parseCliHistoryId, readCliHistoryConfig } from '@cli/runtime/history';
+import { parseCliHistoryId } from '@cli/runtime/history';
 import {
   explainNonResumable,
   resolveCliResumeSnapshot,
@@ -119,6 +119,7 @@ import {
   appendLocalAssistantTranscript,
   appendLocalErrorTranscript,
   appendLocalUserTranscript,
+  clearLocalTranscript,
   finalizeAssistantTranscriptEntries,
   moveLocalTranscriptToStream,
 } from './state/transcript';
@@ -351,7 +352,7 @@ interface SlashCommandContext {
   readonly getApprovalPolicy: () => CliApprovalPolicy;
   readonly setApprovalPolicy: (policy: CliApprovalPolicy) => void;
   readonly resetSession: () => void;
-  readonly startStoredExecution: (config: AgentConfigPayload) => void;
+  readonly resumeExecution: (id: ExecutionId) => Promise<void>;
 }
 
 function agentSupportsDelegation(agentName: string): boolean {
@@ -714,25 +715,6 @@ function applyCliApprovalPolicySelection(
   );
 }
 
-async function resumeStoredExecution(
-  id: ExecutionId,
-  context: SlashCommandContext,
-): Promise<void> {
-  if (!chatTuiCanStartRootRun(context.session)) {
-    appendLocalAssistantTranscript(
-      'Finish the active chat before resuming a stored execution.',
-    );
-    return;
-  }
-  const config = await readCliHistoryConfig(id);
-  if (!config) {
-    appendLocalAssistantTranscript(`Execution not found: ${id}`);
-    return;
-  }
-  context.startStoredExecution(config);
-  appendLocalAssistantTranscript(`Resuming execution ${id}.`);
-}
-
 function openCliResumeListForm(context: SlashCommandContext): void {
   cliState.activeForm.set({
     commandName: 'resume',
@@ -741,7 +723,7 @@ function openCliResumeListForm(context: SlashCommandContext): void {
         availableRows={availableRows}
         onSelect={(id) => {
           close();
-          void resumeStoredExecution(id, context).catch((error: unknown) => {
+          void context.resumeExecution(id).catch((error: unknown) => {
             appendLocalAssistantTranscript(toErrorMessage(error));
           });
         }}
@@ -916,7 +898,7 @@ async function handleTuiSlashCommand(
         appendLocalAssistantTranscript(`Invalid execution id: ${rest}`);
         return true;
       }
-      await resumeStoredExecution(id, context);
+      await context.resumeExecution(id);
       return true;
     }
     case 'memory': {
@@ -1054,7 +1036,7 @@ export async function runChat(
   };
   // The slash-command context is identical at every call site; build it once
   // lazily so the closures it captures (interruptActive, resetSessionForClear,
-  // startAgentRun) are all defined before the first use.
+  // resumeAgentRun) are all defined before the first use.
   const slashCommandContext = (): SlashCommandContext => ({
     session,
     initialAgent: agent,
@@ -1064,7 +1046,7 @@ export async function runChat(
     getApprovalPolicy,
     setApprovalPolicy,
     resetSession: resetSessionForClear,
-    startStoredExecution: startAgentRun,
+    resumeExecution: resumeAgentRun,
   });
   await loadAgents();
   cliState.sessionMeta.set({
@@ -1264,13 +1246,20 @@ export async function runChat(
       });
   };
 
-  // Interactive `texra --resume <id>`: continue a suspended tool-use session.
+  // Interactive resume: continue a suspended tool-use session by execution id.
   // Mirrors startAgentRun's runtimeHost/approvals/runPromise lifecycle, but
   // (a) resolves a persisted snapshot instead of building a fresh config, and
   // (b) the streamId is already known (re-derived from the prior run), so we
   // set session.streamId up front and rehydrate that stream's transcript so
   // the user sees the prior conversation before the continued turn streams in.
   const resumeAgentRun = async (id: ExecutionId): Promise<void> => {
+    if (!chatTuiCanStartRootRun(session)) {
+      appendLocalAssistantTranscript(
+        'Finish the active chat before resuming a previous session.',
+      );
+      return;
+    }
+
     const resolution = await resolveCliResumeSnapshot(id);
     if (resolution.kind !== 'toolUse') {
       // Workflows / missing / already-completed sessions can't continue here —
@@ -1279,6 +1268,7 @@ export async function runChat(
       return;
     }
 
+    clearLocalTranscript();
     followUpQueue.clear();
     session.runCompleted = false;
     session.stopRequested = false;
@@ -1360,7 +1350,7 @@ export async function runChat(
     onMemoryError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));
     },
-    onResumeSelect: (id) => resumeStoredExecution(id, slashCommandContext()),
+    onResumeSelect: resumeAgentRun,
     onResumeError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));
     },

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -132,6 +132,10 @@ export function moveLocalTranscriptToStream(streamId: StreamTabId): void {
   removeStream(CLI_LOCAL_STREAM_ID);
 }
 
+export function clearLocalTranscript(): void {
+  removeStream(CLI_LOCAL_STREAM_ID);
+}
+
 /** Finalizes any entries that defer finalization to end-of-stream
  *  (assistant text and tool rows). Tool rows are included so that a
  *  fast-completing tool doesn't jump ahead of still-streaming assistant

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -73,6 +73,7 @@ import {
   appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
   appendLocalErrorTranscript,
+  clearLocalTranscript,
   CLI_LOCAL_STREAM_ID,
   moveLocalTranscriptToStream,
 } from '@cli/chat/tui/state/transcript';
@@ -1619,6 +1620,20 @@ describe('CLI transcript state', () => {
         .get(root)
         ?.entries.map((entry) => entry.text),
     ).toEqual(['Available commands: /help']);
+  });
+
+  it('can discard pre-resume local slash-command output', () => {
+    appendLocalAssistantTranscript('/resume exec-1');
+
+    expect(cliState.activeStreamId.get()).toBe(CLI_LOCAL_STREAM_ID);
+    expect(
+      cliState.streams.get().get(CLI_LOCAL_STREAM_ID)?.entries,
+    ).toHaveLength(1);
+
+    clearLocalTranscript();
+
+    expect(cliState.streams.get().has(CLI_LOCAL_STREAM_ID)).toBe(false);
+    expect(cliState.activeStreamId.get()).toBeUndefined();
   });
 
   it('preserves synthetic final responses across later log syncs', () => {


### PR DESCRIPTION
## Summary
- route in-chat `/resume` selections and `/resume <id>` through the existing snapshot resume lifecycle
- remove the duplicate history-config rerun path from the TUI slash command flow
- update the `/resume` picker copy so it describes continuing a previous session, not restarting a config

Closes #5197.

## Verification
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with the repo's existing 10 import-order warnings)
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --snapshot-dir /private/tmp/texra-resume-slash-smoke-20260603-2 slash-palette`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `/resume` continues sessions (snapshot vs config rerun) in the interactive TUI; behavior should match `--resume` but affects session continuity and transcript display.
> 
> **Overview**
> In-chat **`/resume`** (picker and **`/resume <id>`**) now continues sessions through the same **snapshot-based** path as **`texra --resume`**, instead of reloading stored history config and starting a **new** agent run.
> 
> The duplicate **`readCliHistoryConfig` → `startAgentRun`** flow is removed; slash commands call **`resumeAgentRun`**, which resolves **`resolveCliResumeSnapshot`**, rehydrates the prior stream log, and runs **`resumeToolUseFromSnapshot`**. Before resume, **`clearLocalTranscript`** drops ephemeral local slash output so it does not appear in the continued session. The “finish the active chat first” guard lives on **`resumeAgentRun`**. **`/resume`** picker copy now says continuing a **previous session**, not choosing a stored execution configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f60a869b076b3e5e0904f07d0bd5d2ffe94a69d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->