### PR TITLE
refactor(settings): resolve model availability once via shared computeModelOptionsData

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -334,12 +334,11 @@ export function createDesktopSettingsIpc(
   async function postModelSelectionData(): Promise<void> {
     await modelListRefresh;
     options.postToRenderer(
-      buildModelSelectionMessage(modelSelectionController),
+      await buildModelSelectionMessage(modelSelectionController),
     );
   }
 
   async function postMainModelOptionsData(): Promise<void> {
-    invalidateModelOptionsCache();
     options.postToRenderer({
       command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
       optionsData: await computeModelOptionsData(
@@ -603,6 +602,7 @@ export function createDesktopSettingsIpc(
     enabled: boolean;
   }): Promise<void> {
     await modelSelectionController.setModelEnabled(input);
+    invalidateModelOptionsCache();
     await postModelSelectionData();
     await postMainModelOptionsData();
   }
@@ -746,6 +746,7 @@ export function createDesktopSettingsIpc(
   }
 
   async function refreshAuthDependentData(): Promise<void> {
+    invalidateModelOptionsCache();
     await postModelSelectionData();
     await postMainModelOptionsData();
     await Promise.all([

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -46,7 +46,6 @@ export interface DesktopAuthProfileData {
   permissions: string[];
   remoteAgents: RemoteAgent[];
   apiAccessMode: 'included' | 'personal';
-  allowedModels: string[] | null;
   accessExpiresAt?: string | null;
 }
 
@@ -336,16 +335,13 @@ async function loadDesktopAuthProfileData(): Promise<DesktopAuthProfileData> {
   }
 
   let apiAccessMode: 'included' | 'personal' = 'personal';
-  let allowedModels: string[] | null = [];
   let accessExpiresAt: string | null = null;
   try {
     const serverSideKeyService = getServerSideKeyService();
     apiAccessMode = serverSideKeyService.getUseIncludedModelAccess()
       ? 'included'
       : 'personal';
-    allowedModels = (await serverSideKeyService.canUseServerSideKeys())
-      ? serverSideKeyService.getAllowedModelsForCurrentUser()
-      : [];
+    await serverSideKeyService.canUseServerSideKeys();
     accessExpiresAt =
       serverSideKeyService.getAccessExpirationDate()?.toISOString() ?? null;
   } catch {
@@ -370,7 +366,6 @@ async function loadDesktopAuthProfileData(): Promise<DesktopAuthProfileData> {
     permissions: authContext.permissions,
     remoteAgents,
     apiAccessMode,
-    allowedModels,
     accessExpiresAt,
   };
 }
@@ -383,7 +378,6 @@ export function unauthenticatedProfileData(): DesktopAuthProfileData {
     permissions: [],
     remoteAgents: [],
     apiAccessMode: 'personal',
-    allowedModels: [],
     accessExpiresAt: null,
   };
 }

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -673,16 +673,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // Helpers
   // ============================================================
 
-  private async primeIncludedAccessIfAuthenticated(): Promise<boolean> {
+  private async primeIncludedAccessIfEnabled(): Promise<void> {
     const serverSideKeyService = getServerSideKeyService();
-    if (
-      !serverSideKeyService.getUseIncludedModelAccess() ||
-      !(await SupabaseClient.isAuthenticated())
-    ) {
-      return false;
-    }
-
-    return serverSideKeyService.canUseServerSideKeys();
+    if (!serverSideKeyService.getUseIncludedModelAccess()) return;
+    await serverSideKeyService.canUseServerSideKeys();
   }
 
   // ============================================================
@@ -695,9 +689,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     // spinner until data arrives.
     void this.sendToolDashboardData(webview);
 
-    const hasServerSideAccess = await this.primeIncludedAccessIfAuthenticated();
-    await this.sendProfileData(webview, { hasServerSideAccess });
-    await this.sendModelSelectionData(webview);
+    // Auth/session changes affect included access and must not reuse a
+    // pre-login/pre-logout availability snapshot.
+    invalidateModelOptionsCache();
+    await this.sendProfileAndModelSelectionData(webview);
 
     await Promise.all([
       this.sendMemoryData(webview),
@@ -769,10 +764,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await webview.postMessage(await buildHistoryMessage());
   }
 
-  public async sendProfileData(
-    webview: vscode.Webview,
-    options: { hasServerSideAccess?: boolean } = {},
-  ): Promise<void> {
+  public async sendProfileData(webview: vscode.Webview): Promise<void> {
     const isAuthenticated = await SupabaseClient.isAuthenticated();
     const providerKeyStatuses = await getProviderKeyStatuses();
 
@@ -787,7 +779,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         permissions: [],
         remoteAgents: [],
         apiAccessMode: 'personal',
-        allowedModels: [],
         tierConstants: {
           ultra: ULTRA_TIER,
           max: MAX_TIER,
@@ -798,10 +789,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
+    await this.primeIncludedAccessIfEnabled();
     const serverSideKeyService = getServerSideKeyService();
-    const hasServerSideAccess =
-      options.hasServerSideAccess ??
-      (await serverSideKeyService.canUseServerSideKeys());
 
     const user = await SupabaseClient.getUser();
     const authContext = await SupabaseClient.getUserAuthContext();
@@ -814,10 +803,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     const apiAccessMode = serverSideKeyService.getUseIncludedModelAccess()
       ? 'included'
       : 'personal';
-
-    const allowedModels = hasServerSideAccess
-      ? serverSideKeyService.getAllowedModelsForCurrentUser()
-      : [];
 
     const accessExpiresAt = serverSideKeyService.getAccessExpirationDate();
     const spendingStatus = getTierService().getSpendingStatus();
@@ -834,7 +819,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       permissions: authContext.permissions,
       remoteAgents,
       apiAccessMode,
-      allowedModels,
       tierConstants: {
         ultra: ULTRA_TIER,
         max: MAX_TIER,
@@ -849,8 +833,15 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   public async sendModelSelectionData(webview: vscode.Webview): Promise<void> {
     await webview.postMessage(
-      buildModelSelectionMessage(this.modelSelectionController),
+      await buildModelSelectionMessage(this.modelSelectionController),
     );
+  }
+
+  private async sendProfileAndModelSelectionData(
+    webview: vscode.Webview,
+  ): Promise<void> {
+    await this.sendProfileData(webview);
+    await this.sendModelSelectionData(webview);
   }
 
   // ============================================================
@@ -1455,10 +1446,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
     // Access mode affects model availability — invalidate cached options.
     invalidateModelOptionsCache();
-    const hasServerSideAccess = await this.primeIncludedAccessIfAuthenticated();
     await this.withActiveWebview(async (w) => {
-      await this.sendProfileData(w, { hasServerSideAccess });
-      await this.sendModelSelectionData(w);
+      await this.sendProfileAndModelSelectionData(w);
     });
 
     const modeLabel =
@@ -1501,14 +1490,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         error,
       );
       // On error, still refresh settings view to reflect current key state.
-      await this.withActiveWebview((w) => this.sendProfileData(w));
+      await this.withActiveWebview((w) =>
+        this.sendProfileAndModelSelectionData(w),
+      );
     }
   }
 
   /**
-   * Refresh main view API key status, model options, AND settings-view profile
-   * after key changes. Combines all refreshes into a single call to avoid
-   * redundant async work when callers would otherwise call sendProfileData separately.
+   * Refresh main view API key status, model options, and settings-view model/profile
+   * data after key changes. Model selection availability depends on provider
+   * key state, so keep it paired with the profile refresh.
    */
   private async refreshAfterKeyChange(): Promise<void> {
     // Invalidate caches so downstream refreshes see fresh key state.
@@ -1517,7 +1508,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
     await Promise.all([
       vscode.commands.executeCommand('texra.refreshAllOptions'),
-      this.withActiveWebview((w) => this.sendProfileData(w)),
+      this.withActiveWebview((w) => this.sendProfileAndModelSelectionData(w)),
     ]);
   }
 

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -268,7 +268,6 @@ export class SettingsApp extends SettingsAppBase {
   private readonly apiAccessMode = signal<'included' | 'personal'>('personal');
   private readonly spendingStatus = signal<SpendingStatus | null>(null);
   private readonly quotaAutoSwitched = signal(false);
-  private readonly allowedModels = signal<string[] | null>([]);
   private readonly providerKeyStatuses = signal<ProviderKeyStatus[]>([]);
   private readonly globalStreamingDefault = signal(true);
   private readonly providerKeyModal = signal<{
@@ -467,7 +466,6 @@ export class SettingsApp extends SettingsAppBase {
       }
       this.quotaAutoSwitched.set(data.quotaAutoSwitched ?? false);
       this.apiAccessMode.set(data.apiAccessMode);
-      this.allowedModels.set(data.allowedModels ?? null);
       this.providerKeyStatuses.set(data.providerKeyStatuses ?? []);
       this.globalStreamingDefault.set(data.globalStreamingDefault ?? true);
     },
@@ -1136,7 +1134,6 @@ export class SettingsApp extends SettingsAppBase {
               .apiAccessMode=${this.apiAccessMode.get()}
               .spendingStatus=${this.spendingStatus.get()}
               .quotaAutoSwitched=${this.quotaAutoSwitched.get()}
-              .allowedModels=${this.allowedModels.get()}
               .providerKeyStatuses=${this.providerKeyStatuses.get()}
               .globalStreamingDefault=${this.globalStreamingDefault.get()}
               .modelSelectionItems=${this.modelSelectionItems.get()}

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -82,10 +82,6 @@ export class ModelSelectionList extends LitElement {
 
   @property({ attribute: false }) models: ModelSelectionItem[] = [];
   @property({ attribute: false }) helperModel = '';
-  @property({ attribute: false }) authenticated = false;
-  @property({ attribute: false }) apiAccessMode: 'included' | 'personal' =
-    'personal';
-  @property({ attribute: false }) allowedModels: string[] | null = [];
   @property({ attribute: false }) providerKeyStatuses: ProviderKeyStatus[] = [];
 
   @property({ type: Boolean, attribute: 'prefer-short-model-names' })
@@ -138,20 +134,6 @@ export class ModelSelectionList extends LitElement {
     this.expandedDeprecated = next;
   }
 
-  /**
-   * Check if a model is available via the relay (included access).
-   * Returns true if using personal keys, or if relay allows all models, or if model is in allowed list.
-   */
-  private isRelayAvailable(modelName: string): boolean {
-    if (!this.authenticated || this.apiAccessMode !== 'included') {
-      return true; // personal keys - no relay restriction
-    }
-    if (this.allowedModels === null) {
-      return true; // Ultra tier - all models
-    }
-    return this.allowedModels.includes(modelName);
-  }
-
   private handleHelperModelChange(e: Event): void {
     const select = e.currentTarget as WaSelect | null;
     const value = typeof select?.value === 'string' ? select.value : '';
@@ -174,10 +156,11 @@ export class ModelSelectionList extends LitElement {
   private getIncludedAccessReasoningCap(
     model: ModelSelectionItem,
   ): ReasoningLevel | null {
+    // The cap only applies when the model is actually reachable through
+    // included access; availability is resolved upstream and carried on the
+    // item, so no relay/auth re-derivation is needed here.
     if (
-      !this.authenticated ||
-      this.apiAccessMode !== 'included' ||
-      !this.isRelayAvailable(model.name) ||
+      model.availability !== 'included-access' ||
       model.reasoningLevel ||
       !model.includedAccessReasoningCap
     ) {
@@ -228,8 +211,31 @@ export class ModelSelectionList extends LitElement {
     `;
   }
 
+  private renderAvailabilityIcon(
+    model: ModelSelectionItem,
+  ): TemplateResult | typeof nothing {
+    if (!model.disabled) return nothing;
+
+    const title = model.requiresKey
+      ? `${model.availabilityLabel ?? 'Missing API key'} — configure it in API Configuration`
+      : (model.availabilityLabel ?? 'Unavailable');
+    const iconName = model.requiresKey ? 'key' : 'warning';
+    const className = model.requiresKey
+      ? 'model-row-icon'
+      : 'model-row-icon model-row-icon--warning';
+
+    return html`
+      <wa-icon
+        library="texra"
+        name=${iconName}
+        class=${className}
+        title=${title}
+      ></wa-icon>
+    `;
+  }
+
   private renderModelRow(model: ModelSelectionItem): TemplateResult {
-    const available = this.isRelayAvailable(model.name);
+    const available = !model.disabled;
     const unavailableClass = !available ? ' model-row--unavailable' : '';
 
     return html`
@@ -248,15 +254,7 @@ export class ModelSelectionList extends LitElement {
         >
           <span class="model-name">${model.label}</span>
           <span class="model-shortname">(${model.name})</span>
-          ${!available
-            ? html`<wa-icon
-                library="texra"
-                name="key"
-                class="model-row-icon"
-                title="Requires ${PROVIDER_DISPLAY_NAMES[model.provider] ??
-                model.provider} API key — set via TeXRA: Set API Key command"
-              ></wa-icon>`
-            : nothing}
+          ${this.renderAvailabilityIcon(model)}
           ${isExpensiveModel(model.provider, model.name)
             ? html`<wa-icon
                 library="texra"

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -43,7 +43,6 @@ export class ModelsTab extends LitElement {
     'personal';
   @property({ attribute: false }) spendingStatus: SpendingStatus | null = null;
   @property({ type: Boolean }) quotaAutoSwitched = false;
-  @property({ attribute: false }) allowedModels: string[] | null = [];
   @property({ attribute: false }) providerKeyStatuses: ProviderKeyStatus[] = [];
   @property({ attribute: false }) globalStreamingDefault = true;
   @property({ attribute: false }) modelSelectionItems: ModelSelectionItem[] =
@@ -134,9 +133,6 @@ export class ModelsTab extends LitElement {
         <model-selection-list
           .models=${this.modelSelectionItems}
           .helperModel=${this.helperModel}
-          .authenticated=${this.authenticated}
-          .apiAccessMode=${this.apiAccessMode}
-          .allowedModels=${this.allowedModels}
           .providerKeyStatuses=${this.providerKeyStatuses}
           .preferShortModelNames=${this.preferShortModelNames}
         ></model-selection-list>

--- a/scripts/capture-walkthrough-media.mjs
+++ b/scripts/capture-walkthrough-media.mjs
@@ -200,7 +200,6 @@ const webviewViews = [
         permissions: [],
         remoteAgents: [],
         apiAccessMode: 'personal',
-        allowedModels: [],
         tierConstants: { ultra: 'ultra', max: 'max' },
         providerKeyStatuses: providers,
         globalStreamingDefault: true,

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -394,13 +394,6 @@ export class ServerSideKeyService {
     return modelName ? this.canUseModelSync(modelName) : this.hasFullAccess();
   }
 
-  /** Returns null if all models allowed (Ultra), empty array if no access. */
-  getAllowedModelsForCurrentUser(): string[] | null {
-    if (!this.userTier) return [];
-    if (this.hasFullAccess()) return null;
-    return this.tierService.getAllowedModels(this.userTier);
-  }
-
   getAccessDescription(): string {
     if (!this.userTier) {
       return 'No included model access';

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -265,20 +265,6 @@ export class TierService {
   }
 
   /**
-   * Get the list of allowed models for a specific tier.
-   * Returns null if all models are allowed ("*").
-   */
-  getAllowedModels(
-    tier: UserTier,
-    config?: TierModelConfig | null,
-  ): string[] | null {
-    const tierConfig = this.getTierConfig(tier, config);
-    if (!tierConfig) return [];
-    if (tierConfig.models === '*') return null;
-    return tierConfig.models;
-  }
-
-  /**
    * Get the list of supported providers from the tier config.
    * All tiers have access to the same providers.
    */

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -8,11 +8,9 @@ import {
 
 import { LEVEL_TO_EFFORT } from '@agent/runtime/reasoningEffort';
 import { FREE_TIER, MAX_TIER } from '@auth/sharedConfig';
-import {
-  DEFAULT_MODELS,
-  formatContext,
-  formatCost,
-} from '@model/modelOptionsBasic';
+import { computeModelOptionsData } from '@model/computeModelOptions';
+import { DEFAULT_MODELS } from '@model/modelOptionsBasic';
+import type { ModelOptionData } from '@shared/schemas';
 import {
   DEFAULT_HELPER_MODEL,
   MODEL_PROVIDERS_ORDER,
@@ -40,6 +38,14 @@ export interface SettingsModelSelectionControllerDeps {
   modelProviders?: readonly string[];
   useIncludedAccess?: () => boolean;
   getUserTier?: () => string | undefined;
+  /**
+   * Resolve availability-decorated options for the given models. Injected as a
+   * port so the controller stays unit-testable; production wiring uses the
+   * shared `computeModelOptionsData` — the same source the CLI picker uses.
+   */
+  resolveModelOptions?: (
+    models: readonly string[],
+  ) => Promise<ModelOptionData[]>;
 }
 
 export interface SettingsModelSelectionData {
@@ -69,10 +75,10 @@ export class SettingsModelSelectionController {
     return enabled && enabled.length > 0 ? enabled : DEFAULT_MODELS;
   }
 
-  buildSelectionData(): SettingsModelSelectionData {
+  async buildSelectionData(): Promise<SettingsModelSelectionData> {
     const visibleModels = this.getVisibleModels();
     return {
-      models: this.buildSelectionItems(),
+      models: await this.buildSelectionItems(),
       helperModel: this.getEffectiveHelperModel(visibleModels),
       preferShortModelNames:
         this.deps.state.getPreferShortModelNames() ?? false,
@@ -122,25 +128,42 @@ export class SettingsModelSelectionController {
     await this.deps.state.setPreferShortModelNames(enabled);
   }
 
-  private buildSelectionItems(): ModelSelectionItem[] {
+  private async buildSelectionItems(): Promise<ModelSelectionItem[]> {
     const enabledSet = new Set(this.getVisibleModels());
     const reasoningOverrides =
       this.deps.state.getReasoningLevelOverrides() ?? {};
 
-    const items: ModelSelectionItem[] = [];
-    for (const name of MODELS) {
+    // Resolve availability (relay/included, personal-key, quota) once for the
+    // models this host shows, via the same shared computation the CLI picker
+    // uses. Passing an explicit list keeps the picker's view authoritative and
+    // avoids re-deriving availability at render time.
+    const candidates = MODELS.filter((name) => {
       const config = MODEL_CONFIGS[name];
-      if (!config || !this.modelProviders.has(config.provider)) continue;
+      return config != null && this.modelProviders.has(config.provider);
+    });
+    const resolveModelOptions =
+      this.deps.resolveModelOptions ?? computeModelOptionsData;
+    const optionsData = await resolveModelOptions(candidates);
+
+    const items: ModelSelectionItem[] = [];
+    for (const option of optionsData) {
+      const name = option.value;
+      const config = MODEL_CONFIGS[name];
+      if (!config) continue;
 
       const item: ModelSelectionItem = {
         name,
-        label: config.label,
-        provider: config.provider,
+        label: option.label,
+        provider: option.provider ?? config.provider,
         enabled: enabledSet.has(name),
         deprecated: config.deprecated ?? false,
-        contextWindow: formatContext(config.contextWindow),
-        cost: formatCost(config.inputPrice, config.outputPrice),
+        contextWindow: option.context,
+        cost: option.cost,
         isFast: isFastFirstResponseModel(config.inputPrice),
+        availability: option.availability,
+        availabilityLabel: option.availabilityLabel,
+        requiresKey: option.requiresKey,
+        disabled: option.disabled,
       };
 
       this.addReasoningLevelData(item, config, reasoningOverrides[name]);

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -218,6 +218,10 @@ async function buildModelOptionData(
   };
 }
 
+const MODEL_OPTIONS_CACHE_TTL_MS = 5_000;
+const VISIBLE_MODELS_CACHE_KEY = 'visible';
+const EXPLICIT_MODELS_CACHE_PREFIX = 'models:';
+
 /**
  * TTL-based cache for computeModelOptionsData.
  * Avoids redundant async work (SecretManager + server-side key checks)
@@ -226,45 +230,60 @@ async function buildModelOptionData(
  * State is split into resolved data vs in-flight promise to avoid
  * sentinel values (like `data: []`) that could leak to callers.
  */
-const MODEL_OPTIONS_CACHE_TTL_MS = 5_000;
-let _resolved: { data: ModelOptionData[]; expiry: number } | null = null;
-let _pending: Promise<ModelOptionData[]> | null = null;
+const resolvedModelOptions = new Map<
+  string,
+  { data: ModelOptionData[]; expiry: number }
+>();
+const pendingModelOptions = new Map<string, Promise<ModelOptionData[]>>();
 
 /** Invalidate the shared model options cache (e.g. after key or model-list changes). */
 export function invalidateModelOptionsCache(): void {
-  _resolved = null;
-  _pending = null;
+  resolvedModelOptions.clear();
+  pendingModelOptions.clear();
 }
 
 /**
  * Compute typed model options data for Lit-native rendering.
  *
- * When `models` is provided, the caller's view of the visible-models
- * list is honored verbatim (skipping the cache). This avoids a desync
- * when the caller is wired against an alternate `globalState` while
- * the default `getVisibleModels()` reads from `platform().globalState`.
+ * When `models` is provided, the caller's view of the visible-models list is
+ * honored verbatim. Explicit lists are cached by their exact ordered contents,
+ * so alternate global-state views stay isolated while repeated settings/CLI
+ * refreshes do not redo secret and server-side key checks.
  */
 export async function computeModelOptionsData(
   models?: readonly string[],
 ): Promise<ModelOptionData[]> {
-  if (models != null) return computeModelOptionsDataUncached(models);
+  const cacheKey = getModelOptionsCacheKey(models);
+  const cached = resolvedModelOptions.get(cacheKey);
+  if (cached && Date.now() < cached.expiry) return cached.data;
 
-  if (_resolved && Date.now() < _resolved.expiry) return _resolved.data;
-  if (_pending) return _pending;
+  const pending = pendingModelOptions.get(cacheKey);
+  if (pending) return pending;
 
-  const request = computeModelOptionsDataUncached();
-  _pending = request;
+  const request = computeModelOptionsDataUncached(models);
+  pendingModelOptions.set(cacheKey, request);
 
   try {
     const data = await request;
     // Only populate cache if no invalidation occurred while we were awaiting.
-    if (_pending === request) {
-      _resolved = { data, expiry: Date.now() + MODEL_OPTIONS_CACHE_TTL_MS };
+    if (pendingModelOptions.get(cacheKey) === request) {
+      resolvedModelOptions.set(cacheKey, {
+        data,
+        expiry: Date.now() + MODEL_OPTIONS_CACHE_TTL_MS,
+      });
     }
     return data;
   } finally {
-    if (_pending === request) _pending = null;
+    if (pendingModelOptions.get(cacheKey) === request) {
+      pendingModelOptions.delete(cacheKey);
+    }
   }
+}
+
+function getModelOptionsCacheKey(models?: readonly string[]): string {
+  return models == null
+    ? VISIBLE_MODELS_CACHE_KEY
+    : `${EXPLICIT_MODELS_CACHE_PREFIX}${JSON.stringify(models)}`;
 }
 
 async function computeModelOptionsDataUncached(

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -83,15 +83,27 @@ export const ModelAvailabilityKindSchema = z.enum([
 ]);
 export type ModelAvailabilityKind = z.infer<typeof ModelAvailabilityKindSchema>;
 
+/**
+ * Resolved per-model availability under the active API mode. Computed once by
+ * `computeModelOptionsData` and shared verbatim across hosts (CLI picker,
+ * extension Models tab) so availability is never re-derived at render time.
+ */
+export const ModelAvailabilityFieldsSchema = z.object({
+  availability: ModelAvailabilityKindSchema.optional(),
+  availabilityLabel: z.string().optional(),
+  requiresKey: z.boolean().optional(),
+  disabled: z.boolean().optional(),
+});
+export type ModelAvailabilityFields = z.infer<
+  typeof ModelAvailabilityFieldsSchema
+>;
+
 export const ModelOptionDataSchema = PickerOptionBaseSchema.extend({
   provider: z.string().optional(),
   context: z.string().optional(),
   cost: z.string().optional(),
   hint: z.string().optional(),
-  availability: ModelAvailabilityKindSchema.optional(),
-  availabilityLabel: z.string().optional(),
-  requiresKey: z.boolean().optional(),
-  disabled: z.boolean().optional(),
+  ...ModelAvailabilityFieldsSchema.shape,
 });
 export type ModelOptionData = z.infer<typeof ModelOptionDataSchema>;
 

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -89,7 +89,6 @@ export const UpdateProfileMessageSchema = z.object({
   permissions: z.array(z.string()),
   remoteAgents: z.array(RemoteAgentSchema),
   apiAccessMode: ApiAccessModeSchema,
-  allowedModels: z.array(z.string()).nullable(),
   tierConstants: TierConstantsSchema,
   accessExpiresAt: z.string().nullish(),
   spendingStatus: SpendingStatusSchema.nullish(),

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -47,6 +47,7 @@ import {
   UpdateMemoryMessageSchema,
   UpdateMemoryPreviewMessageSchema,
 } from './memoryViewMessages';
+import { ModelAvailabilityFieldsSchema } from './mainView';
 import { NESTED_DELEGATION_DEPTH_RANGE } from '../constants/delegationPolicy';
 import {
   AgentCategorySchema,
@@ -221,6 +222,9 @@ export const ModelSelectionItemSchema = z.object({
   includedAccessReasoningCap: ReasoningLevelSchema.optional(),
   /** Whether this model qualifies as a "fast first response" pick (price-based). */
   isFast: z.boolean().optional(),
+  // Resolved once by computeModelOptionsData and carried verbatim so the
+  // Models tab renders availability without re-deriving it at render time.
+  ...ModelAvailabilityFieldsSchema.shape,
 });
 export type ModelSelectionItem = z.infer<typeof ModelSelectionItemSchema>;
 

--- a/src/shared/settingsView/handlers/modelSelectionHandlers.ts
+++ b/src/shared/settingsView/handlers/modelSelectionHandlers.ts
@@ -61,11 +61,11 @@ export function createModelSelectionController(
   });
 }
 
-export function buildModelSelectionMessage(
+export async function buildModelSelectionMessage(
   controller: SettingsModelSelectionController,
-): UpdateModelSelectionMessage {
+): Promise<UpdateModelSelectionMessage> {
   return {
     command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
-    ...controller.buildSelectionData(),
+    ...(await controller.buildSelectionData()),
   };
 }

--- a/src/test-kernel/auth/ServerSideKeyService.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyService.vitest.ts
@@ -77,9 +77,6 @@ function createTierService(
     isModelAvailable() {
       return false;
     },
-    getAllowedModels() {
-      return [];
-    },
     getAccessDescription() {
       return 'No included model access';
     },

--- a/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
@@ -5,7 +5,22 @@ import {
   type SettingsModelSelectionState,
 } from '@controllers/settingsView/SettingsModelSelectionController';
 import { MAX_TIER } from '@auth/sharedConfig';
+import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
+import type { ModelOptionData } from '@shared/schemas';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
+
+// Stub the injected availability resolver so the controller stays decoupled
+// from the global platform / server-side key service in unit tests.
+const resolveModelOptions = async (
+  models: readonly string[],
+): Promise<ModelOptionData[]> =>
+  buildBasicModelOptionsData(models).map((option) => ({
+    ...option,
+    availability: 'provider-key',
+    availabilityLabel: 'API key set',
+    requiresKey: false,
+    disabled: false,
+  }));
 
 function createState(
   overrides: Partial<{
@@ -42,16 +57,16 @@ function createState(
 }
 
 describe('SettingsModelSelectionController', () => {
-  it('uses canonical tier constants for included-access reasoning caps', () => {
+  it('uses canonical tier constants for included-access reasoning caps', async () => {
     const controller = new SettingsModelSelectionController({
       state: createState(),
       useIncludedAccess: () => true,
       getUserTier: () => MAX_TIER,
+      resolveModelOptions,
     });
 
-    const gpt55 = controller
-      .buildSelectionData()
-      .models.find((model) => model.name === 'gpt55');
+    const { models } = await controller.buildSelectionData();
+    const gpt55 = models.find((model) => model.name === 'gpt55');
 
     expect(gpt55).toMatchObject({
       supportsReasoningLevel: true,
@@ -64,9 +79,12 @@ describe('SettingsModelSelectionController', () => {
       enabledModels: ['gpt55', 'sonnet46T'],
       helperModel: 'removed-model',
     });
-    const controller = new SettingsModelSelectionController({ state });
+    const controller = new SettingsModelSelectionController({
+      state,
+      resolveModelOptions,
+    });
 
-    expect(controller.buildSelectionData().helperModel).toBe('gpt55');
+    expect((await controller.buildSelectionData()).helperModel).toBe('gpt55');
 
     await controller.setModelEnabled({ modelName: 'gpt55', enabled: false });
 
@@ -74,27 +92,28 @@ describe('SettingsModelSelectionController', () => {
     expect(state.getHelperModel()).toBe('sonnet46T');
   });
 
-  it('falls back to default models when the persisted enabled list is empty', () => {
+  it('falls back to default models when the persisted enabled list is empty', async () => {
     const controller = new SettingsModelSelectionController({
       state: createState({ enabledModels: [] }),
+      resolveModelOptions,
     });
 
-    const enabled = controller
-      .buildSelectionData()
-      .models.filter((model) => model.enabled);
+    const { models } = await controller.buildSelectionData();
+    const enabled = models.filter((model) => model.enabled);
 
     // An empty persisted list must not blank out the helper-model dropdown.
     expect(enabled.length).toBeGreaterThan(0);
   });
 
-  it('uses the runtime helper default when no helper model is configured', () => {
+  it('uses the runtime helper default when no helper model is configured', async () => {
     const controller = new SettingsModelSelectionController({
       state: createState({
         enabledModels: ['gpt55', 'sonnet46T'],
       }),
+      resolveModelOptions,
     });
 
-    expect(controller.buildSelectionData().helperModel).toBe(
+    expect((await controller.buildSelectionData()).helperModel).toBe(
       DEFAULT_HELPER_MODEL,
     );
   });

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1442,7 +1442,6 @@ describe('desktop settings IPC', () => {
         permissions: [],
         remoteAgents: [],
         apiAccessMode: 'personal',
-        allowedModels: [],
         accessExpiresAt: null,
       }),
     });
@@ -1493,7 +1492,6 @@ describe('desktop settings IPC', () => {
         permissions: [],
         remoteAgents: [],
         apiAccessMode: 'personal',
-        allowedModels: [],
         accessExpiresAt: null,
       }),
     });
@@ -1534,7 +1532,6 @@ describe('desktop settings IPC', () => {
         permissions: [],
         remoteAgents: [],
         apiAccessMode: 'included',
-        allowedModels: [],
         accessExpiresAt: null,
       }),
     });
@@ -1542,6 +1539,11 @@ describe('desktop settings IPC', () => {
     await settings.refreshAuthDependentData();
 
     expect(loadCount).toBe(1);
+    expect(invalidateModelOptionsCache).toHaveBeenCalled();
+    expect(computeModelOptionsData).toHaveBeenCalled();
+    expect(
+      invalidateModelOptionsCache.mock.invocationCallOrder[0],
+    ).toBeLessThan(computeModelOptionsData.mock.invocationCallOrder[0]);
     expect(
       posted.map((message) => (message as { command?: string }).command),
     ).toEqual(
@@ -1655,7 +1657,6 @@ describe('desktop settings IPC', () => {
         permissions: [],
         remoteAgents: [],
         apiAccessMode: 'personal',
-        allowedModels: [],
         accessExpiresAt: null,
       }),
     });

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -17,9 +17,11 @@ function installServerSideKeyService(options: {
   readonly relayQuotaExceeded: boolean;
   readonly quotaAutoSwitched: boolean;
   readonly autoSwitchDuringAccessCheck?: boolean;
+  readonly onAccessCheck?: () => void;
 }): void {
   setServerSideKeyService({
     canUseServerSideKeys: async () => {
+      options.onAccessCheck?.();
       if (options.autoSwitchDuringAccessCheck) {
         options.useIncludedAccess = false;
       }
@@ -87,5 +89,28 @@ describe('computeModelOptionsData relay quota state', () => {
 
     expect(model.availability).toBe('provider-key');
     expect(model.disabled).toBe(false);
+  });
+
+  it('caches explicit model-list availability until invalidated', async () => {
+    let accessChecks = 0;
+    installServerSideKeyService({
+      useIncludedAccess: false,
+      relayQuotaExceeded: false,
+      quotaAutoSwitched: false,
+      onAccessCheck: () => {
+        accessChecks += 1;
+      },
+    });
+
+    const first = await computeModelOptionsData(['gpt55']);
+    const second = await computeModelOptionsData(['gpt55']);
+
+    expect(second).toBe(first);
+    expect(accessChecks).toBe(1);
+
+    invalidateModelOptionsCache();
+    await computeModelOptionsData(['gpt55']);
+
+    expect(accessChecks).toBe(2);
   });
 });

--- a/src/test/auth/ServerSideKeyService.test.ts
+++ b/src/test/auth/ServerSideKeyService.test.ts
@@ -62,9 +62,6 @@ function createTierService(): FakeTierService {
     isModelAvailable() {
       return false;
     },
-    getAllowedModels() {
-      return [];
-    },
     getAccessDescription() {
       return 'No included model access';
     },


### PR DESCRIPTION
## What

The CLI startup model picker and the extension's **Models tab** both produce a list of models with per-model availability — but only the CLI was built on the shared source of truth. This routes the extension through the same function so availability is computed **once** and carried as typed fields, instead of being re-derived at render time.

## Why

`computeModelOptionsData()` (`src/model/computeModelOptions.ts`) already resolves each model's availability under the active API mode (relay/included, personal-key, OpenRouter, quota). The CLI picker uses it. The extension's `SettingsModelSelectionController` did **not** — it iterated `llm-zoo` directly and deferred availability to the frontend, which re-derived it on every render via `isRelayAvailable()` + a separately-passed `allowedModels`/`apiAccessMode`. That's a second, parallel implementation of the same relay/tier logic.

Equivalence checked: the frontend `isRelayAvailable` (included mode → `allowedModels.includes(model)`, where `allowedModels = tierService.getAllowedModels(tier)`) is the same tier→model mapping as the shared path's `canUseModelSync` (`tierService.isModelAvailable(tier, model)`). The shared path is a strict superset — it also resolves personal-key / OpenRouter / quota states.

## Change

- **Schema** — extract `ModelAvailabilityFieldsSchema` in `mainView.ts`; merge it into both `ModelOptionDataSchema` and `ModelSelectionItemSchema` so the availability shape has one definition.
- **Controller** — `SettingsModelSelectionController` resolves availability via `computeModelOptionsData`, injected as a `resolveModelOptions` **port** (defaults to the shared fn in production, stubbed in unit tests so the controller stays free of the global `platform()` / server-side key service). `buildSelectionData` becomes async.
- **Plumbing** — `buildModelSelectionMessage` is now async; awaited at the extension (`SettingsViewMessageHandler`) and desktop (`desktopSettingsIpc`) call sites.
- **Frontend** — `ModelSelectionList` renders availability from `model.availability` / `model.disabled`; `isRelayAvailable` and the now-unused `authenticated`/`apiAccessMode`/`allowedModels` props are removed. `ModelsTab` stops feeding them to the list (still used by the API-access section).

### Behavior note

In personal-key mode, the Models tab now reflects **real** per-model key availability (a model without its provider key shows the "requires key" indicator), matching the CLI picker — previously it showed every model as available regardless of key state. The enable/disable checkbox is unaffected.

## Verification

- `npm run typecheck` → clean (only pre-existing, environment-only `electron`/`paths.ts` resolution errors in the isolated worktree, present on baseline `main` too).
- Prettier + ESLint clean on all changed files.
- Vitest (70 tests): `ComputeModelOptions`, `DelegationModelAvailability`, CLI `ModelAccess`/`ModelArg`, `DesktopSettingsIpc`, `SettingsModelSelectionController`, `ModelSelectionProviderKeys` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth/session refresh, included-access relay logic, and model picker UX across extension and desktop; behavior changes for personal-key availability display but core enable/disable paths are unchanged.
> 
> **Overview**
> The **Models tab** and **CLI model picker** now share one availability pipeline: `SettingsModelSelectionController` builds selection items via **`computeModelOptionsData`** (async), and each `ModelSelectionItem` carries typed **`availability` / `disabled` / `requiresKey`** fields from a shared **`ModelAvailabilityFieldsSchema`**.
> 
> **Profile IPC** drops **`allowedModels`**; included-access priming still runs via **`canUseServerSideKeys()`**, but tier/model reachability is no longer duplicated on the client. **`ModelSelectionList`** renders icons and reasoning caps from those item fields instead of **`isRelayAvailable()`** and auth/mode props.
> 
> **Caching**: `computeModelOptionsData` uses **per-key TTL caches** (default visible list vs explicit model arrays). Extension and desktop **invalidate** on login/logout, API access mode, provider keys, and model enable toggles, and refresh **profile + model selection** together where key state matters.
> 
> **Behavior change**: In **personal-key** mode, the Models list can show models as unavailable when a provider key is missing—aligned with the CLI—rather than treating every row as relay-available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bb23acef84e69e50215bca71e47de2ea7e867e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->