### PR TITLE
fix: polish CLI access and tool labels

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -443,7 +443,7 @@ const SCENARIOS = [
       '/tools',
       'Toggle available external integrations',
       'always on ·',
-      'enabled · detected · available',
+      'enabled · detected · Ready',
     ],
     unexpect: ['[TeXRA]', 'toolUtils', 'enabled -', 'TeXRA CLI'],
     maxBlankLinesBetween: [
@@ -1457,8 +1457,8 @@ const SCENARIOS = [
     bootExpect: 'TeXRA',
     keys: [ESC + 's'], // Esc/Alt-s
     frame: 'tail',
-    expect: ['◆ running 75s api 3 sub'],
-    unexpect: ['◆running', 'api3', '3 sub 1 proc'],
+    expect: ['◆ running 75s keys 3 sub'],
+    unexpect: ['◆running', 'keys3', '3 sub 1 proc'],
   },
   {
     name: 'tiny-task-subworkflow-detail',
@@ -1747,7 +1747,7 @@ const SCENARIOS = [
     expect: [
       'Harness interrupt requested.',
       '[main](stopped)',
-      '◆ stopped api',
+      '◆ stopped keys',
     ],
   },
 ];

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -41,7 +41,7 @@ const RELAY_STATUS_BY_AVAILABILITY = {
   'provider-key': 'relay: unavailable; api key set',
   'openrouter-key': 'relay: unavailable; openrouter key set',
   'missing-key': 'relay: unavailable; missing api key',
-} satisfies Partial<Record<ModelAvailabilityKind, string>>;
+} satisfies Record<ModelAvailabilityKind, string>;
 
 const EMPTY_MODEL_LIST_MESSAGES = {
   includedLoginRequired:
@@ -59,11 +59,8 @@ export function formatModelStatusForCliMode(
   if (apiMode === 'personal') return `api: ${model.status}`;
 
   const availability = model.model.availability;
-  const relayStatus =
-    availability == null
-      ? undefined
-      : RELAY_STATUS_BY_AVAILABILITY[availability];
-  return relayStatus ?? `relay: ${model.status}`;
+  if (availability == null) return `relay: ${model.status}`;
+  return RELAY_STATUS_BY_AVAILABILITY[availability];
 }
 
 export function modelSelectWindow(args: {

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -12,6 +12,7 @@ import {
   type CliModelAccess,
 } from '@cli/runtime/modelAccess';
 import { formatCliApiMode, type CliApiMode } from '@cli/runtime/apiAccessMode';
+import type { ModelAvailabilityKind } from '@shared/schemas';
 import { Select, type SelectItem } from '../ui/Select';
 import { KeyHints } from '../ui/KeyHints';
 import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
@@ -32,30 +33,37 @@ export interface ModelListFormProps {
   readonly onClose: () => void;
 }
 
+const RELAY_STATUS_BY_AVAILABILITY = {
+  'included-access': 'relay: included',
+  'not-included': 'relay: not included',
+  'included-login-required': 'relay: login required',
+  'relay-quota-exhausted': 'relay: quota exhausted',
+  'provider-key': 'relay: unavailable; api key set',
+  'openrouter-key': 'relay: unavailable; openrouter key set',
+  'missing-key': 'relay: unavailable; missing api key',
+} satisfies Partial<Record<ModelAvailabilityKind, string>>;
+
+const EMPTY_MODEL_LIST_MESSAGES = {
+  includedLoginRequired:
+    'Included relay models require sign-in. Run /login or switch with /api personal.',
+  included:
+    'No included relay models are runnable. Switch with /api personal or try again later.',
+  personal:
+    'No personal API-key models are runnable. Configure a provider key or switch with /api included.',
+} satisfies Record<CliApiMode | 'includedLoginRequired', string>;
+
 export function formatModelStatusForCliMode(
   model: CliModelAccess,
   apiMode: CliApiMode,
 ): string {
   if (apiMode === 'personal') return `api: ${model.status}`;
 
-  switch (model.model.availability) {
-    case 'included-access':
-      return 'relay: included';
-    case 'not-included':
-      return 'relay: not included';
-    case 'included-login-required':
-      return 'relay: login required';
-    case 'relay-quota-exhausted':
-      return 'relay: quota exhausted';
-    case 'provider-key':
-      return 'relay: unavailable; api key set';
-    case 'openrouter-key':
-      return 'relay: unavailable; openrouter key set';
-    case 'missing-key':
-      return 'relay: unavailable; missing api key';
-    default:
-      return `relay: ${model.status}`;
-  }
+  const availability = model.model.availability;
+  const relayStatus =
+    availability == null
+      ? undefined
+      : RELAY_STATUS_BY_AVAILABILITY[availability];
+  return relayStatus ?? `relay: ${model.status}`;
 }
 
 export function modelSelectWindow(args: {
@@ -87,14 +95,10 @@ export function emptyModelListMessageForCliMode(
       (model) => model.model.availability === 'included-login-required',
     )
   ) {
-    return 'Included relay models require sign-in. Run /login or switch with /api personal.';
+    return EMPTY_MODEL_LIST_MESSAGES.includedLoginRequired;
   }
 
-  if (apiMode === 'included') {
-    return 'No included relay models are runnable. Switch with /api personal or try again later.';
-  }
-
-  return 'No personal API-key models are runnable. Configure a provider key or switch with /api included.';
+  return EMPTY_MODEL_LIST_MESSAGES[apiMode];
 }
 
 function EmptyModelListState(props: {

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -9,6 +9,7 @@ import {
   setCliToolEnabled,
   type CliToolStatusRecord,
 } from '@cli/runtime/tools';
+import { toolStatusLabel } from '@shared/tools/toolStatusLabels';
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
 import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
@@ -40,7 +41,7 @@ function formatToolDetectionForTui(
 
 function formatToolStatusForTui(tool: CliToolStatusRecord): string {
   if (tool.comingSoon) return 'not yet usable';
-  return tool.statusLabel ?? tool.status;
+  return toolStatusLabel(tool.status, tool.statusLabel);
 }
 
 export function formatToolDescriptionForTui(tool: CliToolStatusRecord): string {

--- a/packages/cli/src/runtime/apiAccessMode.ts
+++ b/packages/cli/src/runtime/apiAccessMode.ts
@@ -33,7 +33,7 @@ export function formatCliApiMode(mode: CliApiMode): string {
 }
 
 export function shortCliApiMode(mode: CliApiMode): string {
-  return mode === 'included' ? 'relay' : 'api';
+  return mode === 'included' ? 'relay' : 'keys';
 }
 
 export function parseCliApiMode(input: string): CliApiMode | undefined {

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -52,10 +52,10 @@ export interface CliModelAccessListOptions {
   readonly apiMode?: CliApiMode;
 }
 
-const PERSONAL_API_AVAILABILITY: ReadonlySet<ModelAvailabilityKind> = new Set([
-  'provider-key',
-  'openrouter-key',
-]);
+const CLI_MODEL_AVAILABILITY_BY_API_MODE = {
+  included: new Set<ModelAvailabilityKind>(['included-access']),
+  personal: new Set<ModelAvailabilityKind>(['provider-key', 'openrouter-key']),
+} satisfies Record<CliApiMode, ReadonlySet<ModelAvailabilityKind>>;
 
 function isCliModelOptionBasicallyAvailable(model: ModelOptionData): boolean {
   return model.disabled !== true && model.requiresKey !== true;
@@ -65,14 +65,13 @@ function isCliModelOptionAllowedInMode(
   model: ModelOptionData,
   apiMode?: CliApiMode,
 ): boolean {
-  if (apiMode === 'included') {
-    return model.availability === 'included-access';
-  }
-  if (apiMode === 'personal') {
-    const availability = model.availability;
-    return availability != null && PERSONAL_API_AVAILABILITY.has(availability);
-  }
-  return true;
+  if (apiMode == null) return true;
+
+  const availability = model.availability;
+  return (
+    availability != null &&
+    CLI_MODEL_AVAILABILITY_BY_API_MODE[apiMode].has(availability)
+  );
 }
 
 function isCliModelOptionRunnableInMode(

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -17,6 +17,7 @@ import type {
   ToolCommandKind,
   ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
+import { toolStatusLabel } from '@shared/tools/toolStatusLabels';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 @customElement('tool-card')
@@ -246,31 +247,27 @@ export class ToolCard extends LitElement {
     ToolDashboardItem['status'],
     {
       icon: string;
-      label: string;
       variant: 'brand' | 'neutral' | 'success' | 'warning' | 'danger';
     }
   > = {
-    available: { icon: 'check', label: 'Ready', variant: 'success' },
+    available: { icon: 'check', variant: 'success' },
     'not-found': {
       icon: 'warning',
-      label: 'Needs setup',
       variant: 'danger',
     },
     unknown: {
       icon: 'question',
-      label: 'Not checked',
       variant: 'neutral',
     },
     'coming-soon': {
       icon: 'clock',
-      label: 'Coming soon',
       variant: 'neutral',
     },
   };
 
   private renderAvailableStatusIcon(): TemplateResult {
     const config = ToolCard.STATUS_CONFIG.available;
-    const label = this.item.statusLabel ?? config.label;
+    const label = toolStatusLabel(this.item.status, this.item.statusLabel);
 
     return html`
       <span
@@ -288,7 +285,7 @@ export class ToolCard extends LitElement {
     const { status } = this.item;
     const config =
       ToolCard.STATUS_CONFIG[status] ?? ToolCard.STATUS_CONFIG.unknown;
-    const label = this.item.statusLabel ?? config.label;
+    const label = toolStatusLabel(status, this.item.statusLabel);
 
     return html`
       <wa-tag

--- a/src/shared/tools/toolStatusLabels.ts
+++ b/src/shared/tools/toolStatusLabels.ts
@@ -1,0 +1,22 @@
+import type { ToolStatus } from '@shared/schemas/settingsViewMessages';
+
+const TOOL_STATUS_FALLBACK_LABELS = {
+  available: 'Ready',
+  'not-found': 'Needs setup',
+  unknown: 'Not checked',
+  'coming-soon': 'Coming soon',
+} satisfies Record<ToolStatus, string>;
+
+export function toolStatusFallbackLabel(status: string): string {
+  if (Object.hasOwn(TOOL_STATUS_FALLBACK_LABELS, status)) {
+    return TOOL_STATUS_FALLBACK_LABELS[status as ToolStatus];
+  }
+  return status;
+}
+
+export function toolStatusLabel(
+  status: string,
+  statusLabel: string | undefined,
+): string {
+  return statusLabel ?? toolStatusFallbackLabel(status);
+}

--- a/src/test-kernel/cli/CliTools.vitest.mts
+++ b/src/test-kernel/cli/CliTools.vitest.mts
@@ -66,7 +66,7 @@ describe('CLI tools runtime', () => {
           status: 'available',
         }),
       ),
-    ).toBe('always on · detected · available');
+    ).toBe('always on · detected · Ready');
 
     expect(
       formatToolDescriptionForTui(
@@ -74,10 +74,19 @@ describe('CLI tools runtime', () => {
           enabled: true,
           detected: false,
           status: 'not-found',
-          statusLabel: 'Needs setup',
         }),
       ),
     ).toBe('enabled · not detected · Needs setup');
+
+    expect(
+      formatToolDescriptionForTui(
+        record({
+          enabled: true,
+          detected: null,
+          status: 'unknown',
+        }),
+      ),
+    ).toBe('enabled · detection unknown · Not checked');
 
     expect(
       formatToolDescriptionForTui(

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -13,6 +13,8 @@ import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import { STREAM_STATUS } from '@shared/schemas';
 
+const PERSONAL_API_MODE_LABEL = shortCliApiMode('personal');
+
 describe('CLI StatusBar display model', () => {
   it('previews queued follow-up messages without duplicating the count', () => {
     expect(queuedFollowUpsSummary([])).toBeUndefined();
@@ -68,14 +70,14 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
     });
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
-      'api',
+      PERSONAL_API_MODE_LABEL,
       'queued 1',
     ]);
     expect(display.left.at(-1)).toMatchObject({ color: 'yellow' });
@@ -97,14 +99,14 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
     });
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'idle',
-      'api',
+      PERSONAL_API_MODE_LABEL,
     ]);
     expect(display.right).toBeUndefined();
     expect(display.bindings).toContain('[/api]api');
@@ -196,7 +198,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       shiftEnterNewline: true,
     });
@@ -265,7 +267,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: true,
       hasMultipleStreams: true,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
       width: 60,
@@ -293,7 +295,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: true,
       hasMultipleStreams: true,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Option',
       ctrlCAction: 'stop',
       width: 44,
@@ -319,7 +321,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: true,
       hasMultipleStreams: true,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
       width: 30,
@@ -330,11 +332,11 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'running',
       '75s',
-      'api',
+      PERSONAL_API_MODE_LABEL,
       '3 sub',
     ]);
     expect(display.left.map(statusBarSegmentText).join(' ')).not.toContain(
-      'api3',
+      `${PERSONAL_API_MODE_LABEL}3`,
     );
   });
 
@@ -354,7 +356,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
       width: 30,
@@ -364,7 +366,7 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'running',
       '75s',
-      'api',
+      PERSONAL_API_MODE_LABEL,
     ]);
   });
 
@@ -384,7 +386,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
       width: 16,
@@ -393,7 +395,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
-      'api',
+      PERSONAL_API_MODE_LABEL,
     ]);
   });
 
@@ -413,7 +415,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
       width: 30,
@@ -423,7 +425,7 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'running',
       '75s',
-      'api',
+      PERSONAL_API_MODE_LABEL,
     ]);
     expect(display.right).toBeUndefined();
   });
@@ -444,7 +446,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
       width: 80,
@@ -493,7 +495,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: true,
       hasMultipleStreams: true,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop root',
     });
@@ -501,7 +503,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'stopped',
-      'api',
+      PERSONAL_API_MODE_LABEL,
     ]);
     expect(display.bindings).toContain('[Ctrl-C]stop root');
   });
@@ -609,7 +611,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       width: 50,
     });
@@ -634,7 +636,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: true,
       hasMultipleStreams: true,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
       shortcutsActive: false,
@@ -665,7 +667,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       shortcutsActive: false,
     });
@@ -689,7 +691,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: true,
       hasMultipleStreams: true,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
       shortcutsActive: false,
@@ -714,7 +716,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: true,
       hasMultipleStreams: true,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
       shortcutsActive: false,
@@ -740,7 +742,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
     };
     const running = buildStatusBarDisplay(runningInput);
@@ -749,7 +751,7 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'running',
       '110s',
-      'api',
+      PERSONAL_API_MODE_LABEL,
     ]);
 
     const justStarted = buildStatusBarDisplay({
@@ -760,7 +762,7 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'running',
       '0s',
-      'api',
+      PERSONAL_API_MODE_LABEL,
     ]);
 
     // The same elapsed reading is suppressed once the turn is no longer running.
@@ -779,11 +781,15 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
     });
 
-    expect(idle.left.map(statusBarSegmentText)).toEqual(['◆', 'idle', 'api']);
+    expect(idle.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'idle',
+      PERSONAL_API_MODE_LABEL,
+    ]);
   });
 
   it('preserves distinct YOLO and auto-approval badges', () => {
@@ -801,14 +807,14 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
     });
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
-      'api',
+      PERSONAL_API_MODE_LABEL,
       'YOLO',
       'AUTO-BASH',
       'AUTO-APPROVE',
@@ -842,12 +848,12 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
-      width: 60,
+      width: 80,
     });
 
-    expect(display.right).toBe('Keep the pr…');
+    expect(display.right).toBe('Keep the proof under one page.');
     expect(display.bindings).toContain('[Ctrl-C]exit');
   });
 
@@ -866,14 +872,14 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
     });
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'Press Ctrl-C again to exit',
-      'api',
+      PERSONAL_API_MODE_LABEL,
     ]);
     expect(display.bindings).toBe(
       'Resume this session with: texra --resume abc123',
@@ -895,7 +901,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: false,
       hasMultipleStreams: false,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       width: 29,
     });
@@ -924,7 +930,7 @@ describe('CLI StatusBar display model', () => {
       subagentControlsAvailable: true,
       hasMultipleStreams: true,
       model: 'deepseekT',
-      apiMode: 'api',
+      apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: defaultShortcutModifierLabel('darwin'),
     });
 

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -9,6 +9,7 @@ import {
   statusBarDisplaySlice,
   statusBarSegmentText,
 } from '@cli/chat/tui/panes/StatusBar';
+import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import { STREAM_STATUS } from '@shared/schemas';
 
@@ -45,6 +46,11 @@ describe('CLI StatusBar display model', () => {
     expect(queuedFollowUpsSummary(['請補充一個單調有界證明。'], 20)).toBe(
       '請補充一個單調有界…',
     );
+  });
+
+  it('uses clear compact labels for API access mode', () => {
+    expect(shortCliApiMode('included')).toBe('relay');
+    expect(shortCliApiMode('personal')).toBe('keys');
   });
 
   it('keeps queued follow-up counts in the durable left status segments', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -850,10 +850,10 @@ describe('CLI StatusBar display model', () => {
       model: 'deepseekT',
       apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
-      width: 80,
+      width: 61,
     });
 
-    expect(display.right).toBe('Keep the proof under one page.');
+    expect(display.right).toBe('Keep the pr…');
     expect(display.bindings).toContain('[Ctrl-C]exit');
   });
 


### PR DESCRIPTION
## Summary
- show personal API-key mode as `keys` in compact CLI status surfaces instead of the vague `api` label
- share tool status fallback labels so CLI `/tools` and the settings tool card render human labels like `Ready`, `Needs setup`, and `Not checked`
- DRY the CLI model availability/status/empty-message mappings used by startup and `/model` selection

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/CliTools.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings outside this patch)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly display strings and shared label helpers; model filtering logic is reorganized but should behave the same.
> 
> **Overview**
> This PR tightens **CLI and settings copy** so compact surfaces read clearly, and centralizes a few label mappings.
> 
> **Personal API mode** now shows as **`keys`** (not `api`) in the status bar and related TUI harness expectations, while **`relay`** stays for included access.
> 
> **Tool status text** is unified via `toolStatusLabel` in `@shared/tools/toolStatusLabels`, so CLI `/tools` and the settings **tool card** use the same human fallbacks (**Ready**, **Needs setup**, **Not checked**, etc.) instead of raw status strings.
> 
> **Model list / access** refactors relay status strings, empty-list messages, and per-mode availability into shared tables in `ModelListForm` and `modelAccess`, without changing the underlying selection rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe12d43f02ce10f3abe5907904c39dcc6195595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->