### PR TITLE
fix: clarify CLI resume launcher input label

### DIFF
--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -5,6 +5,7 @@ import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 
 import {
+  formatCliHistoryInputLabel,
   listCliHistoryEntries,
   type CliHistoryEntry,
 } from '@cli/runtime/history';
@@ -33,7 +34,7 @@ export function resumeSelectWindow(args: {
 }
 
 export function resumeEntryDescription(entry: CliHistoryEntry): string {
-  const input = entry.inputBasename === '-' ? 'no input' : entry.inputBasename;
+  const input = formatCliHistoryInputLabel(entry.inputBasename);
   return `${entry.timestamp}; ${entry.agent}; ${entry.status}; ${input}`;
 }
 

--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -5,10 +5,10 @@ import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 
 import {
-  formatCliHistoryInputLabel,
   listCliHistoryEntries,
   type CliHistoryEntry,
 } from '@cli/runtime/history';
+import { formatCliHistoryInputLabel } from '@cli/runtime/historyLabels';
 import type { ExecutionId } from '@shared/schemas';
 
 import { KeyHints } from '../ui/KeyHints';

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -97,10 +97,6 @@ export function parseCliHistoryId(raw: string): ExecutionId | undefined {
     : undefined;
 }
 
-export function formatCliHistoryInputLabel(inputBasename: string): string {
-  return inputBasename === '-' ? 'no input' : inputBasename;
-}
-
 export async function listCliHistoryEntries(): Promise<CliHistoryEntry[]> {
   const entries = await listExecutions();
   const history: CliHistoryEntry[] = [];

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -97,6 +97,10 @@ export function parseCliHistoryId(raw: string): ExecutionId | undefined {
     : undefined;
 }
 
+export function formatCliHistoryInputLabel(inputBasename: string): string {
+  return inputBasename === '-' ? 'no input' : inputBasename;
+}
+
 export async function listCliHistoryEntries(): Promise<CliHistoryEntry[]> {
   const entries = await listExecutions();
   const history: CliHistoryEntry[] = [];

--- a/packages/cli/src/runtime/historyLabels.ts
+++ b/packages/cli/src/runtime/historyLabels.ts
@@ -1,0 +1,3 @@
+export function formatCliHistoryInputLabel(inputBasename: string): string {
+  return inputBasename === '-' ? 'no input' : inputBasename;
+}

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -6,7 +6,7 @@ import {
   formatCliMultiAgentPresetPlanSummary,
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
-import type { CliHistoryEntry } from './history';
+import { formatCliHistoryInputLabel, type CliHistoryEntry } from './history';
 
 export type CliOrchestrationAction =
   | { readonly kind: 'chat'; readonly agent?: string; readonly model?: string }
@@ -66,7 +66,7 @@ function recentResumeItems(
   return history.slice(0, MAX_RECENT_RESUME_ITEMS).map((entry) => ({
     value: { kind: 'resume', id: entry.id },
     label: `Resume ${entry.id}`,
-    description: `${entry.agent}; ${entry.status}; ${entry.inputBasename}`,
+    description: `${entry.agent}; ${entry.status}; ${formatCliHistoryInputLabel(entry.inputBasename)}`,
   }));
 }
 

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -6,7 +6,8 @@ import {
   formatCliMultiAgentPresetPlanSummary,
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
-import { formatCliHistoryInputLabel, type CliHistoryEntry } from './history';
+import { formatCliHistoryInputLabel } from './historyLabels';
+import type { CliHistoryEntry } from './history';
 
 export type CliOrchestrationAction =
   | { readonly kind: 'chat'; readonly agent?: string; readonly model?: string }

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -133,6 +133,23 @@ describe('CLI orchestration items', () => {
       'Chat with orchestrator',
       'Help',
     ]);
+    expect(items[1]?.description).toBe('review; completed; no input');
+    expect(items[2]?.description).toBe('orchestrator; completed; no input');
+  });
+
+  it('uses the input file name in resume launcher rows when present', () => {
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [
+        historyEntry('aaaaaaaaaaaa', {
+          agent: 'review',
+          inputBasename: 'paper.tex',
+        }),
+      ],
+      toolUseAgents: [toolUseAgent('review')],
+    });
+
+    expect(items[1]?.description).toBe('review; completed; paper.tex');
   });
 
   it('filters recent agent entries to known tool-use agents', () => {

--- a/src/test-kernel/cli/ResumeListForm.vitest.mts
+++ b/src/test-kernel/cli/ResumeListForm.vitest.mts
@@ -34,4 +34,17 @@ describe('CLI ResumeListForm labels', () => {
       }),
     ).toBe('2026-05-20T21:00:00.000Z; polish; completed; paper.tex');
   });
+
+  it('uses human wording for sessions without an input file', () => {
+    expect(
+      resumeEntryDescription({
+        id: 'abc',
+        timestamp: '2026-05-20T21:00:00.000Z',
+        agent: 'chat',
+        model: 'deepseekT',
+        status: 'completed',
+        inputBasename: '-',
+      }),
+    ).toBe('2026-05-20T21:00:00.000Z; chat; completed; no input');
+  });
 });


### PR DESCRIPTION
## Summary

Closes #5202.

- Add a shared `formatCliHistoryInputLabel` helper for human-facing history input labels.
- Reuse it in both the startup launcher resume rows and the `/resume` form.
- Keep `CliHistoryEntry.inputBasename` and history list output raw, so machine/stable history contracts do not change.

## Dogfood Evidence

Live TTY launcher before this fix showed no-input sessions as raw `-`:

```text
Resume 80dbbff1922b — simplifier; completed; -
```

After rebuilding the CLI dist from this branch, the same live launcher shows:

```text
Resume 80dbbff1922b — simplifier; completed; no input
```

Additional CLI dogfood in this pass:

- Focused TUI frame capture: `/tmp/texra-tui-dogfood-20260603144827/index.html`
- Validation-stub math run through `multi-agent run mathematician` solved odd squares modulo 8 and kept JSON on stdout with warnings on stderr.
- Rebuilt local CLI dist before checking `multi-agent list`, which confirmed the earlier stale-dist concern was not a current source bug.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `corepack pnpm exec vitest run src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ResumeListForm.vitest.mts src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --snapshot-dir /tmp/texra-tui-resume-dogfood-final-20260603145909 orchestrate-launcher`
- `corepack pnpm --filter @texra-ai/cli run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label formatting in the CLI TUI; history storage and list output contracts are unchanged.
> 
> **Overview**
> Introduces **`formatCliHistoryInputLabel`** so sessions without an input file show **"no input"** instead of the raw **`-`** sentinel in human-facing CLI UI.
> 
> The helper is wired into the **startup orchestration** resume row descriptions and the **`/resume`** list via **`resumeEntryDescription`**, while **`CliHistoryEntry.inputBasename`** and tab-separated history list output stay unchanged for stable machine contracts.
> 
> Tests assert **`no input`** vs real basenames (e.g. **`paper.tex`**) in orchestration and resume form labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ab7d2a57b9de529f6fd707b44d4a2d2851cd5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->