### PR TITLE
fix: clarify personal model recovery hints

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -48,6 +48,7 @@ import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
   cliRunnableModelOptionsForSource,
+  formatCliNoAvailableModelsRecovery,
   resolveCliRunnableModel,
 } from '@cli/runtime/modelAccess';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
@@ -435,10 +436,10 @@ async function reconcileRootModelAfterApiModeChange(
   const resolution = await resolveCliRunnableModel(currentModel, {
     fallbackMode: 'notice',
     apiMode,
-    noAvailableModelsMessage:
-      apiMode === 'included'
-        ? 'Run `texra login` for included relay access, or switch to personal API keys with `/api personal` after configuring a provider API key.'
-        : undefined,
+    noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(apiMode, {
+      includedModeAction: 'switch to included relay with `/api included`',
+      personalModeAction: 'switch to personal API keys with `/api personal`',
+    }),
   });
   if (resolution.model === currentModel) return undefined;
 
@@ -1001,14 +1002,10 @@ export async function runChat(
       defaults.model,
       cliRunnableModelOptionsForSource(defaults.modelSource, {
         apiMode,
-        noAvailableModelsMessage:
-          apiMode === 'included'
-            ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
-            : undefined,
-        noAvailableModelsHint:
-          apiMode === 'included'
-            ? undefined
-            : 'Run `texra chat --api-mode included` to try included relay access',
+        noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(apiMode, {
+          includedModeAction: 'retry with `texra chat --api-mode included`',
+          personalModeAction: 'retry with `texra chat --api-mode personal`',
+        }),
       }),
     );
   } catch (error: unknown) {

--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -83,10 +83,6 @@ export async function resolveCliRunModel(
       candidate.model,
       cliRunnableModelOptionsForSource(candidate.source, {
         apiMode,
-        noAvailableModelsMessage:
-          apiMode === 'included'
-            ? 'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.'
-            : undefined,
       }),
     );
     if (resolution.notice && context.quietLogs !== true) {

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -7,6 +7,7 @@ import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 import { effectiveCliApiMode } from '../runtime/apiAccessMode';
 import {
+  formatCliNoAvailableModelsRecovery,
   getCliModelAccessList,
   runnableCliModelAccessEntries,
 } from '../runtime/modelAccess';
@@ -49,19 +50,15 @@ export function formatNoListableModelsMessage(
   apiMode: CliContext['apiMode'],
   options: { readonly includeUnavailable?: boolean } = {},
 ): string {
-  const accessHint =
-    apiMode === 'personal'
-      ? 'Retry with `--api-mode included` to try included relay access, run `texra login`, or configure a provider API key.'
-      : apiMode === 'included'
-        ? 'Run `texra login`, or retry with `--api-mode personal` after configuring a provider API key.'
-        : 'Run `texra login` for included relay access, retry with `--api-mode included`, or configure a provider API key.';
   const statusHint =
     options.includeUnavailable === true
       ? 'No model records were returned for this installation.'
       : 'Run `texra models list --all` to see unavailable models and access status.';
-  return ['No models are currently available.', statusHint, accessHint].join(
-    '\n',
-  );
+  return [
+    'No models are currently available.',
+    statusHint,
+    formatCliNoAvailableModelsRecovery(apiMode),
+  ].join('\n');
 }
 
 async function loadModelAccessList(context: CliContext): Promise<

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -25,7 +25,6 @@ export type CliModelFallbackMode = 'reject' | 'notice' | 'silent';
 export interface CliRunnableModelOptions {
   readonly fallbackMode: CliModelFallbackMode;
   readonly apiMode?: CliApiMode;
-  readonly noAvailableModelsHint?: string;
   readonly noAvailableModelsMessage?: string;
 }
 
@@ -50,6 +49,11 @@ const CLI_MODEL_FALLBACK_MODE_BY_SOURCE = {
 
 export interface CliModelAccessListOptions {
   readonly apiMode?: CliApiMode;
+}
+
+export interface CliNoAvailableModelsRecoveryOptions {
+  readonly includedModeAction?: string;
+  readonly personalModeAction?: string;
 }
 
 const CLI_MODEL_AVAILABILITY_BY_API_MODE = {
@@ -118,6 +122,24 @@ export function cliRunnableModelOptionsForSource(
     ...options,
     fallbackMode: cliModelFallbackModeForSource(source),
   };
+}
+
+export function formatCliNoAvailableModelsRecovery(
+  apiMode?: CliApiMode,
+  options: CliNoAvailableModelsRecoveryOptions = {},
+): string {
+  const includedModeAction =
+    options.includedModeAction ?? 'retry with `--api-mode included`';
+  const personalModeAction =
+    options.personalModeAction ?? 'retry with `--api-mode personal`';
+
+  if (apiMode === 'personal') {
+    return `Configure a provider API key for personal mode, or ${includedModeAction} and run \`texra login\` for included relay access.`;
+  }
+  if (apiMode === 'included') {
+    return `Run \`texra login\` for included relay access, or ${personalModeAction} after configuring a provider API key.`;
+  }
+  return `Run \`texra login\` for included relay access, ${includedModeAction}, or configure a provider API key.`;
 }
 
 function toCliModelAccess(
@@ -203,17 +225,14 @@ function formatAvailableModels(
   ids: readonly string[],
   options: Pick<
     CliRunnableModelOptions,
-    'noAvailableModelsHint' | 'noAvailableModelsMessage'
+    'apiMode' | 'noAvailableModelsMessage'
   >,
 ): string {
   if (ids.length > 0) return `Available models: ${ids.join(', ')}.`;
-  if (options.noAvailableModelsMessage) {
-    return `No models are currently available. ${options.noAvailableModelsMessage}`;
-  }
-  const modeHint =
-    options.noAvailableModelsHint ??
-    'Retry with `--api-mode included` to try included relay access';
-  return `No models are currently available. ${modeHint}, run \`texra login\`, or configure a provider API key.`;
+  const recoveryMessage =
+    options.noAvailableModelsMessage ??
+    formatCliNoAvailableModelsRecovery(options.apiMode);
+  return `No models are currently available. ${recoveryMessage}`;
 }
 
 function formatUnavailableModelMessage(
@@ -222,7 +241,7 @@ function formatUnavailableModelMessage(
   availableIds: readonly string[],
   options: Pick<
     CliRunnableModelOptions,
-    'noAvailableModelsHint' | 'noAvailableModelsMessage'
+    'apiMode' | 'noAvailableModelsMessage'
   >,
 ): string {
   const status = entry ? ` (${entry.status})` : '';

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   cliModelFallbackModeForSource,
+  formatCliNoAvailableModelsRecovery,
   getCliModelAccessList,
   runnableCliModelAccessEntries,
   resolveCliRunnableModel,
@@ -285,7 +286,32 @@ describe('CLI model access resolution', () => {
         { fallbackMode: 'notice' },
       ),
     ).toThrow(
-      'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Retry with `--api-mode included` to try included relay access, run `texra login`, or configure a provider API key.',
+      'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Run `texra login` for included relay access, retry with `--api-mode included`, or configure a provider API key.',
+    );
+  });
+
+  it('keeps personal-mode recovery scoped to provider keys or included mode', () => {
+    expect(formatCliNoAvailableModelsRecovery('personal')).toBe(
+      'Configure a provider API key for personal mode, or retry with `--api-mode included` and run `texra login` for included relay access.',
+    );
+    expect(() =>
+      resolveCliRunnableModelFromAccessList(
+        [
+          model('gemini31p', {
+            available: false,
+            status: 'missing api key',
+            model: modelOption('gemini31p', {
+              availability: 'missing-key',
+              disabled: true,
+              requiresKey: true,
+            }),
+          }),
+        ],
+        'gemini31p',
+        { fallbackMode: 'notice', apiMode: 'personal' },
+      ),
+    ).toThrow(
+      'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Configure a provider API key for personal mode, or retry with `--api-mode included` and run `texra login` for included relay access.',
     );
   });
 

--- a/src/test-kernel/cli/ModelsRecord.vitest.mts
+++ b/src/test-kernel/cli/ModelsRecord.vitest.mts
@@ -181,14 +181,14 @@ describe('CLI model list empty-state text', () => {
       [
         'No models are currently available.',
         'Run `texra models list --all` to see unavailable models and access status.',
-        'Retry with `--api-mode included` to try included relay access, run `texra login`, or configure a provider API key.',
+        'Configure a provider API key for personal mode, or retry with `--api-mode included` and run `texra login` for included relay access.',
       ].join('\n'),
     );
   });
 
   it('points included-mode users at login or personal API key setup', () => {
     expect(formatNoListableModelsMessage('included')).toContain(
-      'Run `texra login`, or retry with `--api-mode personal` after configuring a provider API key.',
+      'Run `texra login` for included relay access, or retry with `--api-mode personal` after configuring a provider API key.',
     );
   });
 

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -129,7 +129,6 @@ describe('resolveCliRunModel precedence', () => {
       {
         apiMode: 'personal',
         fallbackMode: 'silent',
-        noAvailableModelsMessage: undefined,
       },
     );
   });
@@ -175,7 +174,6 @@ describe('resolveCliRunModel precedence', () => {
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
       apiMode: 'personal',
       fallbackMode: 'reject',
-      noAvailableModelsMessage: undefined,
     });
   });
 
@@ -190,7 +188,6 @@ describe('resolveCliRunModel precedence', () => {
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
       apiMode: 'personal',
       fallbackMode: 'reject',
-      noAvailableModelsMessage: undefined,
     });
   });
 });


### PR DESCRIPTION
Closes #5206.

## Summary

- centralize no-available-model recovery copy by active API mode
- stop composing partial model-access hints with a generic `texra login` fallback
- make personal mode tell users to configure a provider key, or switch to included mode and then log in
- keep chat/TUI call sites command-specific by passing full recovery sentences from the shared helper

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelsRecord.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `corepack pnpm --filter @texra-ai/cli run build`
- credential-less personal-mode model list repro now says: `Configure a provider API key for personal mode, or retry with --api-mode included and run texra login for included relay access.`
- credential-less personal-mode run/model-resolution repro now emits the same scoped recovery text

## Dogfood Context

Found by the CLI dogfood scout after a full TUI validation pass and headless help/list command sweep. The issue was reproducible in isolated HOME/XDG paths with all provider API key env vars cleared.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error and empty-list copy only; model resolution behavior is unchanged aside from messaging.
> 
> **Overview**
> Centralizes **no models available** recovery text in `formatCliNoAvailableModelsRecovery`, keyed by active API mode (`personal`, `included`, or unset).
> 
> **Personal mode** now tells users to configure a provider key first, or switch to included relay and run `texra login`—instead of mixing generic login/`--api-mode` hints that were easy to misread. **Included** and **unset** modes get parallel, mode-appropriate wording. Chat/TUI and model resolution still pass **command-specific** actions (e.g. `/api` slash commands vs `texra chat --api-mode`) via optional `includedModeAction` / `personalModeAction` overrides.
> 
> Removes the separate `noAvailableModelsHint` option; empty-model errors default through the shared helper using `apiMode`. Headless `resolveCliRunModel` drops ad hoc included-only messages and relies on the same defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3228a4a78e6a2dd85a9bf36a53ff1fd87082b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->