### PR TITLE
fix: clarify CLI run terminal progress

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -662,6 +662,14 @@ function validateRunCommand() {
       text.stdout.trim() === copiedOutputPath,
       'text run output should print the filesystem copy path when --output is used',
     );
+    assert(
+      text.stderr.includes(' · done ·'),
+      `text run progress should end with a neutral done label\nstderr:\n${text.stderr}`,
+    );
+    assert(
+      !text.stderr.includes(' · stopped ·'),
+      `text run progress should not leak the internal stopped stream status\nstderr:\n${text.stderr}`,
+    );
 
     const json = run(
       process.execPath,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -57,7 +57,10 @@ import {
   signInCliSupabase,
   signOutCliSupabase,
 } from '@cli/runtime/supabaseAuth';
-import { dumbTerminalMessage } from '@cli/runtime/terminalRequirements';
+import {
+  formatInteractiveTerminalFailure,
+  interactiveTerminalFailure,
+} from '@cli/runtime/terminalRequirements';
 import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
@@ -954,19 +957,18 @@ export async function runChat(
   // (see cliContext.cliMode); stdout must also be a TTY for Ink to render,
   // and `TERM=dumb` strips the cursor controls Ink depends on (Ink would
   // mount and emit garbled output instead of a usable session).
-  const isHeadless =
-    context.mode === 'headless' || context.stdoutIsTty !== true;
-  const dumbTerm = context.termIsDumb === true;
+  const terminalFailure = interactiveTerminalFailure(context);
   const clearItermProgress = process.env.TERM_PROGRAM === 'iTerm.app';
-  if (isHeadless || dumbTerm) {
+  if (terminalFailure) {
     // Headless precedence: in CI (headless + TERM=dumb often co-occur) the
     // actionable advice is "use `texra run`", not "fix your TERM".
     writeTextStderr(
-      isHeadless
-        ? 'texra chat requires an interactive terminal (TTY stdin and stdout). For scripting or piped input, use `texra run`.'
-        : dumbTerminalMessage('chat', {
-            nonInteractiveFallback: '`texra run`',
-          }),
+      formatInteractiveTerminalFailure(terminalFailure, {
+        headlessMessage:
+          'texra chat requires an interactive terminal (TTY stdin and stdout). For scripting or piped input, use `texra run`.',
+        dumbTerminalCommand: 'chat',
+        dumbTerminalOptions: { nonInteractiveFallback: '`texra run`' },
+      }),
     );
     return { exitCode: CliExitCode.Usage };
   }

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -7,7 +7,10 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { listCliHistoryEntries } from '../runtime/history';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
-import { dumbTerminalMessage } from '../runtime/terminalRequirements';
+import {
+  formatInteractiveTerminalFailure,
+  interactiveTerminalFailure,
+} from '../runtime/terminalRequirements';
 import {
   readCliMultiAgentPresets,
   withCliMultiAgentPresetVisibility,
@@ -36,14 +39,14 @@ import { runResumeExecution } from './resume';
 import type { CliContext } from '../runtime/cliContext';
 
 async function runOrchestration(context: CliContext): Promise<number> {
-  const isHeadless =
-    context.mode === 'headless' || context.stdoutIsTty !== true;
-  const dumbTerm = context.termIsDumb === true;
-  if (isHeadless || dumbTerm) {
+  const terminalFailure = interactiveTerminalFailure(context);
+  if (terminalFailure) {
     writeTextStderr(
-      isHeadless
-        ? 'texra orchestrate requires an interactive terminal (TTY stdin and stdout). For scripting, use `texra run` or a concrete subcommand.'
-        : dumbTerminalMessage('orchestrate'),
+      formatInteractiveTerminalFailure(terminalFailure, {
+        headlessMessage:
+          'texra orchestrate requires an interactive terminal (TTY stdin and stdout). For scripting, use `texra run` or a concrete subcommand.',
+        dumbTerminalCommand: 'orchestrate',
+      }),
     );
     return CliExitCode.Usage;
   }

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -8,6 +8,10 @@ import {
   explainNonResumable,
   resolveCliResumeSnapshot,
 } from '../runtime/sessionResume';
+import {
+  formatInteractiveTerminalFailure,
+  interactiveTerminalFailure,
+} from '../runtime/terminalRequirements';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
@@ -28,6 +32,22 @@ export async function runResumeExecution(
   context: CliContext,
   id: ExecutionId,
 ): Promise<number> {
+  const terminalFailure = interactiveTerminalFailure(context);
+  if (terminalFailure) {
+    // A resumed tool-use session goes back to WAITING for the next message;
+    // headless has no input channel to provide one, so continuing here would
+    // block forever. Reject before platform/snapshot work; no terminal means no
+    // interactive resume regardless of whether the id is otherwise resumable.
+    writeTextStderr(
+      formatInteractiveTerminalFailure(terminalFailure, {
+        headlessMessage: `Resuming continues an interactive chat session — run \`texra --resume ${id}\` in a terminal. For scripting, use \`texra run\`.`,
+        dumbTerminalCommand: 'resume',
+        dumbTerminalOptions: { nonInteractiveFallback: '`texra run`' },
+      }),
+    );
+    return CliExitCode.Usage;
+  }
+
   await initCliPlatform({ ...context, quietLogs: true });
 
   // Resolve the stored session up front so we (a) fail fast with a clear
@@ -38,17 +58,6 @@ export async function runResumeExecution(
   const resolution = await resolveCliResumeSnapshot(id);
   if (resolution.kind !== 'toolUse') {
     writeTextStderr(explainNonResumable(resolution, id));
-    return CliExitCode.Usage;
-  }
-
-  const headless = context.mode === 'headless' || context.stdoutIsTty !== true;
-  if (headless) {
-    // A resumed tool-use session goes back to WAITING for the next message;
-    // headless has no input channel to provide one, so continuing here would
-    // block forever. Mirror runChat's non-TTY guidance instead of hanging.
-    writeTextStderr(
-      `Resuming continues an interactive chat session — run \`texra --resume ${id}\` in a terminal. For scripting, use \`texra run\`.`,
-    );
     return CliExitCode.Usage;
   }
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -3,7 +3,10 @@ import { defineCommand } from 'citty';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
-import { dumbTerminalMessage } from '../runtime/terminalRequirements';
+import {
+  formatInteractiveTerminalFailure,
+  interactiveTerminalFailure,
+} from '../runtime/terminalRequirements';
 
 import { contextFromArgs } from './_helpers/context';
 import { withUsageSections } from './_helpers/dispatch';
@@ -15,14 +18,14 @@ import {
 import type { CliContext } from '../runtime/cliContext';
 
 async function runSetup(context: CliContext): Promise<number> {
-  const isHeadless =
-    context.mode === 'headless' || context.stdoutIsTty !== true;
-  const dumbTerm = context.termIsDumb === true;
-  if (isHeadless || dumbTerm) {
+  const terminalFailure = interactiveTerminalFailure(context);
+  if (terminalFailure) {
     writeTextStderr(
-      isHeadless
-        ? 'texra setup requires an interactive terminal (TTY stdin and stdout). For scripting, set a provider API key env var (e.g. ANTHROPIC_API_KEY) or run `texra login`.'
-        : dumbTerminalMessage('setup'),
+      formatInteractiveTerminalFailure(terminalFailure, {
+        headlessMessage:
+          'texra setup requires an interactive terminal (TTY stdin and stdout). For scripting, set a provider API key env var (e.g. ANTHROPIC_API_KEY) or run `texra login`.',
+        dumbTerminalCommand: 'setup',
+      }),
     );
     return CliExitCode.Usage;
   }

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -33,6 +33,7 @@ import { type CliApiMode } from '../runtime/apiAccessMode';
 import { hasCliCredentialForApiMode } from '../runtime/credentialStatus';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
 import { signInCliSupabase } from '../runtime/supabaseAuth';
+import { interactiveTerminalFailure } from '../runtime/terminalRequirements';
 
 import { saveProviderApiKey } from './applyOnboardingResult';
 import {
@@ -79,12 +80,7 @@ export async function maybeRunCliOnboarding(
   // `process.stdout.isTTY` is the authoritative "Ink can actually mount here"
   // check at the call site (same guard runCliOnboarding uses for the
   // context-less `texra setup` path). Defense-in-depth before we render.
-  if (
-    context.mode === 'headless' ||
-    context.stdoutIsTty !== true ||
-    context.termIsDumb === true ||
-    !process.stdout.isTTY
-  ) {
+  if (interactiveTerminalFailure(context) || !process.stdout.isTTY) {
     return { configured: false, declined: false };
   }
   if (getOnboardingDeclined(platform().globalState)) {

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -4,7 +4,12 @@ import path from 'node:path';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local imports - shared schemas
-import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+import {
+  EXECUTION_STATUS,
+  STREAM_STATUS,
+  type ExecutionStatus,
+  type StreamStatus,
+} from '@shared/schemas';
 
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
@@ -118,15 +123,14 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         this.render(true);
         return true;
       case 'updateStreamStatus':
-        if (
-          this.isRootStream(
-            (payload as ProgressEventPayloads['updateStreamStatus']).streamId,
-          )
-        ) {
-          const status = (
-            payload as ProgressEventPayloads['updateStreamStatus']
-          ).status;
-          this.state.phase = String(status);
+        {
+          const data = payload as ProgressEventPayloads['updateStreamStatus'];
+          if (!this.isRootStream(data.streamId)) return true;
+          const { status } = data;
+          this.state.phase = formatRunProgressStatus(
+            status,
+            data.terminalStatus,
+          );
           this.rootStreamTerminal = isTerminalStreamStatus(status);
           if (this.rootStreamTerminal) {
             this.state.activeProcesses = undefined;
@@ -298,6 +302,16 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
 function isTerminalStreamStatus(status: StreamStatus): boolean {
   return status === STREAM_STATUS.STOPPED || status === STREAM_STATUS.ERROR;
+}
+
+function formatRunProgressStatus(
+  status: StreamStatus,
+  terminalStatus?: ExecutionStatus,
+): string {
+  if (status !== STREAM_STATUS.STOPPED) return status;
+  if (terminalStatus === EXECUTION_STATUS.COMPLETED) return 'done';
+  if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) return 'interrupted';
+  return status;
 }
 
 function safeBasename(file: string | undefined): string | undefined {

--- a/packages/cli/src/runtime/terminalRequirements.ts
+++ b/packages/cli/src/runtime/terminalRequirements.ts
@@ -1,3 +1,17 @@
+import type { CliContext } from './cliContext';
+
+export type InteractiveTerminalFailureReason = 'headless' | 'dumb-terminal';
+
+export function interactiveTerminalFailure(
+  context: Pick<CliContext, 'mode' | 'stdoutIsTty' | 'termIsDumb'>,
+): InteractiveTerminalFailureReason | undefined {
+  if (context.mode === 'headless' || context.stdoutIsTty !== true) {
+    return 'headless';
+  }
+  if (context.termIsDumb === true) return 'dumb-terminal';
+  return undefined;
+}
+
 export function dumbTerminalMessage(
   command: string,
   options: { nonInteractiveFallback?: string } = {},
@@ -7,4 +21,19 @@ export function dumbTerminalMessage(
       ? ''
       : ` For non-interactive runs, use ${options.nonInteractiveFallback}.`;
   return `texra ${command} needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with \`TERM=xterm-256color\`.${fallback}`;
+}
+
+export function formatInteractiveTerminalFailure(
+  reason: InteractiveTerminalFailureReason,
+  options: {
+    readonly headlessMessage: string;
+    readonly dumbTerminalCommand: string;
+    readonly dumbTerminalOptions?: { readonly nonInteractiveFallback?: string };
+  },
+): string {
+  if (reason === 'headless') return options.headlessMessage;
+  return dumbTerminalMessage(
+    options.dumbTerminalCommand,
+    options.dumbTerminalOptions,
+  );
 }

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -5,6 +5,7 @@ import {
 } from '@common/constants/streamStatus';
 import {
   STREAM_STATUS,
+  type ExecutionStatus,
   type StreamTabId,
   type StreamStatus,
 } from '@shared/schemas';
@@ -16,16 +17,19 @@ export interface StreamStatusChange {
   streamId: StreamTabId;
   status: StreamStatus;
   previousStatus: StreamStatus;
+  terminalStatus?: ExecutionStatus;
 }
 
 interface EmitSetOptions {
   emit?: true;
   runtimeHost: AgentRuntimeHost;
+  terminalStatus?: ExecutionStatus;
 }
 
 interface SilentSetOptions {
   emit: false;
   runtimeHost?: AgentRuntimeHost;
+  terminalStatus?: ExecutionStatus;
 }
 
 type SetOptions = EmitSetOptions | SilentSetOptions;
@@ -63,6 +67,9 @@ export const StreamStatusService = {
         streamId: stream,
         status,
         previousStatus,
+        ...(options.terminalStatus
+          ? { terminalStatus: options.terminalStatus }
+          : {}),
       };
       options.runtimeHost.emit('updateStreamStatus', change);
       for (const listener of statusListeners) {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -192,12 +192,11 @@ async function runFlowWithLifecycle(
   try {
     const result = await runner();
     await options?.onCompleted?.(result);
-    await writeTerminalStatus(
-      ctx.executionId,
+    const terminalStatus =
       result.status === END_GROUP_STATUS.ERROR
         ? EXECUTION_STATUS.ERROR
-        : EXECUTION_STATUS.COMPLETED,
-    ).catch(() => {});
+        : EXECUTION_STATUS.COMPLETED;
+    await writeTerminalStatus(ctx.executionId, terminalStatus).catch(() => {});
 
     untrackExecution(ctx.executionId);
     ctx.parentStage.end(result.status);
@@ -207,6 +206,7 @@ async function runFlowWithLifecycle(
         result.status === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED;
       StreamStatusService.set(streamId, status, {
         runtimeHost: ctx.runtimeHost,
+        terminalStatus,
       });
     }
     logger.debug(`Task completed with status: ${result.status}`);
@@ -235,6 +235,7 @@ async function runFlowWithLifecycle(
     ctx.parentStage.end(status);
     StreamStatusService.set(streamId, streamStatus, {
       runtimeHost: ctx.runtimeHost,
+      terminalStatus,
     });
 
     // Subagents propagate errors to the orchestrator via FollowUpQueue —

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -16,6 +16,7 @@ import type {
   PlanApprovalPermission,
   RetryPermission,
   StorageKey,
+  ExecutionStatus,
   StreamStatus,
   StreamTabId,
   TokenUsageStats,
@@ -82,6 +83,8 @@ export interface ProgressEventPayloads {
     status: StreamStatus;
     /** Previous status before this update, for detecting transitions */
     previousStatus: StreamStatus;
+    /** Terminal execution outcome when the stream ended, if known. */
+    terminalStatus?: ExecutionStatus;
   };
   addOutputFiles: StreamScopedPayload & {
     filesByRound: { [key: number]: OutputFileInfo[] };

--- a/src/test-kernel/cli/ResumeCommand.vitest.mts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.mts
@@ -92,12 +92,29 @@ describe('runResumeExecution', () => {
       runResumeExecution(cliContext({ stdoutIsTty: false }), EXECUTION_ID),
     ).resolves.toBe(2);
 
+    expect(mocks.initCliPlatform).not.toHaveBeenCalled();
+    expect(mocks.resolveCliResumeSnapshot).not.toHaveBeenCalled();
     expect(mocks.runChat).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       expect.stringContaining(`texra --resume ${EXECUTION_ID}`),
     );
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       expect.stringContaining('For scripting, use `texra run`.'),
+    );
+  });
+
+  it('rejects resume in dumb terminals before falling through to chat', async () => {
+    const { runResumeExecution } = await import('@cli/commands/resume');
+
+    await expect(
+      runResumeExecution(cliContext({ termIsDumb: true }), EXECUTION_ID),
+    ).resolves.toBe(2);
+
+    expect(mocks.initCliPlatform).not.toHaveBeenCalled();
+    expect(mocks.resolveCliResumeSnapshot).not.toHaveBeenCalled();
+    expect(mocks.runChat).not.toHaveBeenCalled();
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'texra resume needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with `TERM=xterm-256color`. For non-interactive runs, use `texra run`.',
     );
   });
 });

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -8,7 +8,7 @@ import {
 } from '@cli/runtime/runProgressRenderer';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { CliContext } from '@cli/runtime/cliContext';
-import { STREAM_STATUS } from '@shared/schemas';
+import { EXECUTION_STATUS, STREAM_STATUS } from '@shared/schemas';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
   return {
@@ -442,7 +442,7 @@ describe('CLI run progress renderer', () => {
     );
   });
 
-  it('does not overwrite a terminal status with late root descriptions', () => {
+  it('shows completed terminal stream stops as done', () => {
     let now = 0;
     let output = '';
     const renderer = createRunProgressRenderer(
@@ -481,6 +481,7 @@ describe('CLI run progress renderer', () => {
       streamId: 'root-stream',
       status: STREAM_STATUS.STOPPED,
       previousStatus: STREAM_STATUS.RUNNING,
+      terminalStatus: EXECUTION_STATUS.COMPLETED,
     });
     renderer?.handle('updateStreamDescription', {
       streamId: 'root-stream',
@@ -508,8 +509,40 @@ describe('CLI run progress renderer', () => {
     expect(output).toBe(
       'orchestrator · 0s\n' +
         'orchestrator · tool: Bash · 0s\n' +
-        'orchestrator · stopped · 11s\n',
+        'orchestrator · done · 11s\n',
     );
+  });
+
+  it('keeps interrupted terminal stream stops distinct from completion', () => {
+    let output = '';
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: (text) => {
+          output += text;
+        },
+        minIntervalMs: 0,
+        nowMs: () => 0,
+      },
+    );
+
+    renderer?.handle(
+      'setTaskState',
+      workflowTaskState({
+        streamId: 'root-stream',
+        agent: 'orchestrator',
+        inputFiles: [],
+      }),
+    );
+    renderer?.handle('updateStreamStatus', {
+      streamId: 'root-stream',
+      status: STREAM_STATUS.STOPPED,
+      previousStatus: STREAM_STATUS.RUNNING,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+    });
+
+    expect(output).toBe('orchestrator · 0s\norchestrator · interrupted · 0s\n');
   });
 
   it('uses a separate render flag from platform log suppression', () => {

--- a/src/test-kernel/cli/TerminalRequirements.vitest.mts
+++ b/src/test-kernel/cli/TerminalRequirements.vitest.mts
@@ -1,8 +1,43 @@
 import { describe, expect, it } from 'vitest';
 
-import { dumbTerminalMessage } from '@cli/runtime/terminalRequirements';
+import {
+  dumbTerminalMessage,
+  formatInteractiveTerminalFailure,
+  interactiveTerminalFailure,
+} from '@cli/runtime/terminalRequirements';
 
 describe('terminal requirement diagnostics', () => {
+  it('classifies interactive terminal failures once for CLI entry points', () => {
+    expect(
+      interactiveTerminalFailure({
+        mode: 'headless',
+        stdoutIsTty: true,
+        termIsDumb: false,
+      }),
+    ).toBe('headless');
+    expect(
+      interactiveTerminalFailure({
+        mode: 'interactive',
+        stdoutIsTty: false,
+        termIsDumb: false,
+      }),
+    ).toBe('headless');
+    expect(
+      interactiveTerminalFailure({
+        mode: 'interactive',
+        stdoutIsTty: true,
+        termIsDumb: true,
+      }),
+    ).toBe('dumb-terminal');
+    expect(
+      interactiveTerminalFailure({
+        mode: 'interactive',
+        stdoutIsTty: true,
+        termIsDumb: false,
+      }),
+    ).toBeUndefined();
+  });
+
   it('gives interactive PTY users an exact TERM recovery hint', () => {
     expect(dumbTerminalMessage('chat')).toBe(
       'texra chat needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with `TERM=xterm-256color`.',
@@ -12,6 +47,24 @@ describe('terminal requirement diagnostics', () => {
   it('keeps the non-interactive fallback when one applies', () => {
     expect(
       dumbTerminalMessage('chat', { nonInteractiveFallback: '`texra run`' }),
+    ).toBe(
+      'texra chat needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with `TERM=xterm-256color`. For non-interactive runs, use `texra run`.',
+    );
+  });
+
+  it('formats the classified failure without repeating the predicate', () => {
+    expect(
+      formatInteractiveTerminalFailure('headless', {
+        headlessMessage: 'headless copy',
+        dumbTerminalCommand: 'chat',
+      }),
+    ).toBe('headless copy');
+    expect(
+      formatInteractiveTerminalFailure('dumb-terminal', {
+        headlessMessage: 'headless copy',
+        dumbTerminalCommand: 'chat',
+        dumbTerminalOptions: { nonInteractiveFallback: '`texra run`' },
+      }),
     ).toBe(
       'texra chat needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with `TERM=xterm-256color`. For non-interactive runs, use `texra run`.',
     );


### PR DESCRIPTION
## Summary

- Map the CLI run progress renderer's neutral terminal stream state from internal `stopped` to user-facing `done`.
- Add `validate-run` coverage so successful text runs must show `done` and must not leak `stopped`.
- Centralize interactive terminal preflight into `terminalRequirements.ts` and reuse it across chat, orchestrate, setup, resume, and onboarding.
- Reject `texra resume` in dumb/non-interactive terminals before platform init or snapshot resolution, instead of falling through to chat.

Closes #5208.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/TerminalRequirements.vitest.mts src/test-kernel/cli/ResumeCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:run`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-status-20260603161937 orchestrate-launcher orchestrate-relay-model-pick orchestrate-personal-model-pick model-form api-form approval-form subagents subagent-picker task-picker ctrl-c-interrupt-active`
- Direct validation-model run: stderr ended with `[r2] · polish paper.tex · done · 1m 23s` and no `stopped` matches.
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and CLI messaging changes with small event-payload extensions; no auth, payment, or data-model changes.
> 
> **Overview**
> **`texra run` progress** now shows user-facing **`done`** or **`interrupted`** when a run finishes, instead of leaking the internal stream status **`stopped`**. The agent runtime attaches **`terminalStatus`** on stream stop events; the CLI progress renderer maps that to the label on stderr. **`validate-run`** asserts successful text runs end with **`done`** and never **`stopped`**.
> 
> **Interactive commands** (`chat`, `orchestrate`, `setup`, `resume`, onboarding) share **`interactiveTerminalFailure`** / **`formatInteractiveTerminalFailure`** in **`terminalRequirements.ts`**, so headless vs **`TERM=dumb`** messaging is consistent. **`texra resume`** fails fast on non-interactive or dumb terminals **before** platform init or snapshot lookup, with the same dumb-terminal guidance as chat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88e565820008ae2b382abdebe356a2da5bf7fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->