### PR TITLE
fix: mark failed CLI child rows as errors

### DIFF
--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -1,7 +1,9 @@
+import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
+
 export function childStatusColor(status: string | undefined): string {
   if (!status) return 'green';
   if (status === 'waiting' || status === 'idle') return 'yellow';
-  if (status === 'error' || status === 'stopped') return 'red';
+  if (isChildExecutionErrorStatus(status)) return 'red';
   return 'green';
 }
 

--- a/packages/cli/src/chat/tui/state/childExecutionStatus.ts
+++ b/packages/cli/src/chat/tui/state/childExecutionStatus.ts
@@ -1,0 +1,24 @@
+const ERROR_STATUSES = new Set(['error', 'failed', 'stopped']);
+const IN_FLIGHT_STATUSES = new Set([
+  'initializing',
+  'resuming',
+  'running',
+  'waiting',
+]);
+
+export function isChildExecutionErrorStatus(
+  status: string | undefined,
+): boolean {
+  const normalized = status?.trim().toLowerCase();
+  if (!normalized) return false;
+  if (ERROR_STATUSES.has(normalized)) return true;
+  return /exit(?:ed)?(?:\s+with)?(?:\s+code)?\s+[1-9]\d*/.test(normalized);
+}
+
+export function completedChildExecutionStatus(
+  status: string | undefined,
+): string {
+  const normalized = status?.trim().toLowerCase();
+  if (!normalized || IN_FLIGHT_STATUSES.has(normalized)) return 'completed';
+  return status ?? 'completed';
+}

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -1,6 +1,10 @@
 import { getDefaultStreamLogStore } from '@transcript';
 import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 
+import {
+  completedChildExecutionStatus,
+  isChildExecutionErrorStatus,
+} from './childExecutionStatus';
 import type {
   CompletedProcessTranscript,
   ConversationEntry,
@@ -14,25 +18,8 @@ function processTitle(info: ActiveChildInfo): string {
   return info.agentName || info.toolName || info.executionId;
 }
 
-const ERROR_STATUSES = new Set(['error', 'failed', 'stopped']);
-const IN_FLIGHT_STATUSES = new Set([
-  'initializing',
-  'resuming',
-  'running',
-  'waiting',
-]);
-
 export function isCompletedProcessError(status: string | undefined): boolean {
-  const normalized = status?.trim().toLowerCase();
-  if (!normalized) return false;
-  if (ERROR_STATUSES.has(normalized)) return true;
-  return /exit(?:ed)?(?:\s+with)?(?:\s+code)?\s+[1-9]\d*/.test(normalized);
-}
-
-function completedProcessStatus(status: string | undefined): string {
-  const normalized = status?.trim().toLowerCase();
-  if (!normalized || IN_FLIGHT_STATUSES.has(normalized)) return 'completed';
-  return status ?? 'completed';
+  return isChildExecutionErrorStatus(status);
 }
 
 export function completedProcessTailLines(
@@ -50,7 +37,7 @@ export function buildCompletedProcessTranscript(
   info: ActiveChildInfo,
   tail: ProcessOutputTail | undefined,
 ): CompletedProcessTranscript {
-  const status = completedProcessStatus(info.status);
+  const status = completedChildExecutionStatus(info.status);
   return {
     executionId: info.executionId,
     title: processTitle(info),

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -22,6 +22,8 @@ describe('CLI SubagentList display model', () => {
     expect(childStatusColor('running')).toBe('green');
     expect(childStatusColor('waiting')).toBe('yellow');
     expect(childStatusColor('error')).toBe('red');
+    expect(childStatusColor('failed')).toBe('red');
+    expect(childStatusColor('exit 2')).toBe('red');
     expect(childStatusColor('stopped')).toBe('red');
   });
 


### PR DESCRIPTION
## Summary

- Add a shared CLI child execution status helper for error/terminal status classification.
- Reuse that helper for completed process transcript rows and live subagent/process row markers.
- Render `failed` and non-zero exit statuses like `exit 2` as red/error child rows instead of healthy green rows.

Closes #5210.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-model-api-20260603165141 orchestrate-launcher orchestrate-relay-model-pick orchestrate-personal-model-pick model-form api-form subagents subagent-picker task-picker approval-form bash-approval ctrl-c-interrupt-active`
- Built CLI PTY probe: `texra orchestrate --api-mode personal --no-color` opened the model picker with GPT-5.5/GPT-5.4 API-key models only and no relay entries.
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only status coloring and transcript labeling; no auth, data, or execution path changes beyond display classification.
> 
> **Overview**
> Centralizes CLI child execution status rules in `childExecutionStatus.ts` and wires both **completed process transcripts** and **live subagent/process row colors** through the same helpers.
> 
> **Live rows** now treat `failed` and non-zero exit strings (e.g. `exit 2`) as errors (red), not only `error` / `stopped`. **Completed rows** reuse the same error detection and terminal-status normalization, so transcript error flags stay aligned with the list UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3cb58f7609f1133a23724cf0457d138b1d5864d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->