### PR TITLE
fix(cli): show focused stopped stream status

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1637,12 +1637,8 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     keys: [ESC + 'p', 'k', ESC + 's', DOWN, DOWN, 'f'],
     frame: 'tail',
-    expect: [
-      '[3:strategy](stopped)',
-      '◆ running',
-      '2 sub 1 proc',
-      '[Ctrl-C]stop root',
-    ],
+    expect: ['[3:strategy](stopped)', '◆ stopped', '[Ctrl-C]stop root'],
+    unexpect: ['◆ running', '2 sub 1 proc'],
   },
   {
     name: 'focused-stopped-subagent-submit',
@@ -1666,10 +1662,14 @@ const SCENARIOS = [
     frame: 'tail',
     expect: [
       '[3:strategy](stopped)',
-      '◆ running',
+      '◆ stopped',
       'The selected subagent is no longer accepting follow-ups.',
     ],
-    unexpect: ['Harness received: can you still receive this?'],
+    unexpect: [
+      'Harness received: can you still receive this?',
+      '◆ running',
+      '2 sub 1 proc',
+    ],
   },
   {
     name: 'empty-task-shortcut-hidden',

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -496,18 +496,6 @@ function statusBarCanStopStatus(status: StreamStatus | undefined): boolean {
   );
 }
 
-function statusBarCanRepresentFocusedSlice(
-  status: StreamStatus | undefined,
-): boolean {
-  return (
-    status === undefined ||
-    status === STREAM_STATUS.INITIALIZING ||
-    status === STREAM_STATUS.RUNNING ||
-    status === STREAM_STATUS.RESUMING ||
-    status === STREAM_STATUS.WAITING
-  );
-}
-
 function statusBarCanRepresentLiveAncestor(
   status: StreamStatus | undefined,
 ): boolean {
@@ -580,18 +568,13 @@ export function statusBarDisplaySlice({
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): StreamSlice | undefined {
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  if (activeSlice && statusBarCanRepresentFocusedSlice(activeSlice.status)) {
-    return activeSlice;
-  }
-  return (
-    statusBarFindAncestorStream({
-      activeStreamId,
-      parentStream,
-      streams,
-      canUseStream: (stream) =>
-        statusBarCanRepresentLiveAncestor(stream.status),
-    }) ?? activeSlice
-  );
+  if (activeSlice) return activeSlice;
+  return statusBarFindAncestorStream({
+    activeStreamId,
+    parentStream,
+    streams,
+    canUseStream: (stream) => statusBarCanRepresentLiveAncestor(stream.status),
+  });
 }
 
 export function buildStatusBarDisplay(

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -557,7 +557,7 @@ describe('CLI StatusBar display model', () => {
     ).toBe(false);
   });
 
-  it('uses live ancestor status when a stopped child stream is focused', () => {
+  it('uses focused stream status when a stopped child stream is focused', () => {
     const rootSlice = {
       status: STREAM_STATUS.RUNNING,
     } as StreamSlice;
@@ -579,7 +579,7 @@ describe('CLI StatusBar display model', () => {
         parentStream: new Map([['child', 'root']]),
         streams,
       }),
-    ).toBe(rootSlice);
+    ).toBe(childSlice);
     expect(
       statusBarDisplaySlice({
         activeStreamId: 'waiting-child',


### PR DESCRIPTION
## Summary
- make the CLI status bar describe the focused stream when that stream exists
- keep root-stop affordances separate from status display so stopped child streams no longer appear as running
- update stopped-subagent TUI regression scenarios to require `◆ stopped` and reject `◆ running`

Closes #5214.

## Validation
- corepack pnpm --filter @texra-ai/cli run validate:tui -- focused-stopped-subagent focused-stopped-subagent-submit stopped-subagent-picker stopped-task-picker stopped-task-subworkflow-detail
- corepack pnpm exec prettier --write packages/cli/src/chat/tui/panes/StatusBar.tsx packages/cli/scripts/validate-tui.mjs
- npm run compile:safe
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI status-display logic and regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> The CLI **status bar** now reflects the **focused stream’s** state instead of inheriting a parent’s **running** label when you focus a **stopped** (or otherwise non-live) child subagent.
> 
> `statusBarDisplaySlice` always uses the active stream slice when present; ancestor lookup only runs when that slice is missing. The old `statusBarCanRepresentFocusedSlice` path that substituted a live ancestor for display is removed. **TUI harness** scenarios and a **StatusBar** unit test are updated so focused stopped subagents show **`◆ stopped`** and no longer show **`◆ running`** or parent sub/proc counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172481fbe98b60e76fb21c451eab26690ba2aae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->