### PR TITLE
feat(cli,extension): paste images + collapse large text pastes

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -355,7 +355,7 @@ export function approvalForegroundMaxRows(
 }
 
 export interface AppProps {
-  readonly onSubmit: (line: string) => void;
+  readonly onSubmit: (line: string, mediaFiles?: readonly string[]) => void;
   readonly onKillExecution: (executionId: string) => void;
   readonly canInterruptActiveRun: () => boolean;
   readonly canStopActiveRun?: () => boolean;

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -403,7 +403,10 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
 
   useInput(
     (input, key) => {
-      if (isEscapeInput(input, key)) return;
+      if (isEscapeInput(input, key)) {
+        pendingSubmitRef.current = null;
+        return;
+      }
       if (pendingSubmitRef.current) {
         // A visible Enter already committed this draft. Ignore later keystrokes
         // until clipboard probes settle so the deferred submit is neither

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -51,6 +51,7 @@ export interface BaseTextInputProps {
   /** Ctrl-V handler: probe the OS clipboard for an image. Resolves to the chip
    *  text to insert (e.g. `[Image #1]`) or null when there is no image. */
   readonly onImagePaste?: () => Promise<string | null>;
+  readonly onImagePasteError?: (error: unknown) => void;
   /** Render the value as bullets (secret entry, e.g. an API key). Display-only:
    *  the captured value, edits, and paste are unaffected. */
   readonly masked?: boolean;
@@ -404,11 +405,14 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         // Insert the chip at whatever the caret is when the async probe
         // resolves (read from a ref, not a keypress-time snapshot) so typing
         // during the probe isn't clobbered.
-        void props.onImagePaste().then((chip) => {
-          if (!chip) return;
-          const { value: v, cursor: c } = latestStateRef.current;
-          applyEdit(insertText(v, c, chip));
-        });
+        void props
+          .onImagePaste()
+          .then((chip) => {
+            if (!chip) return;
+            const { value: v, cursor: c } = latestStateRef.current;
+            applyEdit(insertText(v, c, chip));
+          })
+          .catch((err: unknown) => props.onImagePasteError?.(err));
         return;
       }
       // Drop unhandled control/meta combos; pass printable input through.

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -355,6 +355,14 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     [isControlled, onChange, onCursorChange],
   );
 
+  const insertIntoLatestDraft = useCallback(
+    (text: string) => {
+      const { value: v, cursor: c } = latestStateRef.current;
+      applyEdit(insertText(v, c, text));
+    },
+    [applyEdit],
+  );
+
   const flushPendingSubmit = useCallback(() => {
     if (pendingImagePastesRef.current.size > 0) return;
     const submit = pendingSubmitRef.current;
@@ -379,6 +387,12 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   useInput(
     (input, key) => {
       if (isEscapeInput(input, key)) return;
+      if (pendingSubmitRef.current) {
+        // A visible Enter already committed this draft. Ignore later keystrokes
+        // until clipboard probes settle so the deferred submit is neither
+        // overwritten nor allowed to clear a newer draft.
+        return;
+      }
 
       if (isCtrlInput(input, key, 'j') || isShiftReturnInput(input, key)) {
         // Ctrl-J (universal) or Shift+Enter (Kitty-protocol terminals) →
@@ -434,8 +448,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
           .onImagePaste()
           .then((chip) => {
             if (!chip) return;
-            const { value: v, cursor: c } = latestStateRef.current;
-            applyEdit(insertText(v, c, chip));
+            insertIntoLatestDraft(chip);
           })
           .catch((err: unknown) => props.onImagePasteError?.(err));
         pendingImagePastesRef.current.add(paste);
@@ -472,9 +485,9 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   // otherwise the paste is inserted verbatim.
   usePaste(
     (text) => {
+      if (pendingSubmitRef.current) return;
       const toInsert = props.transformPaste?.(text) ?? text;
-      const { value: v, cursor: c } = latestStateRef.current;
-      applyEdit(insertText(v, c, toInsert));
+      insertIntoLatestDraft(toInsert);
     },
     { isActive: focus },
   );

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -371,7 +371,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
       // Enter commits the draft that was visible at keypress time. Pending
       // image probes may still insert chips into the UI, but they should not
       // silently change what this submit sends.
-      pendingSubmitRef.current = () => handler(submitted);
+      pendingSubmitRef.current ??= () => handler(submitted);
     },
     [],
   );
@@ -473,7 +473,8 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   usePaste(
     (text) => {
       const toInsert = props.transformPaste?.(text) ?? text;
-      applyEdit(insertText(value, cursor, toInsert));
+      const { value: v, cursor: c } = latestStateRef.current;
+      applyEdit(insertText(v, c, toInsert));
     },
     { isActive: focus },
   );

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -311,6 +311,12 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     value.length,
   );
 
+  // Mirror the latest value/cursor for async handlers (image paste): a
+  // clipboard probe that resolves after the user keeps typing must insert at
+  // the current caret, not a stale keypress-time snapshot.
+  const latestStateRef = useRef({ value, cursor });
+  latestStateRef.current = { value, cursor };
+
   // Track the last value we ourselves emitted via onChange. If the prop's
   // `value` diverges from this, the parent swapped the text out from under
   // us (slash-palette accept, reverse-search recall, programmatic clear) —
@@ -395,13 +401,13 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         return;
       }
       if (isCtrlInput(input, key, 'v') && props.onImagePaste) {
-        // Async clipboard probe; insert the resulting chip at the caret. Uses
-        // the caret captured at keypress — a deliberate ctrl-v isn't raced by
-        // typing in the few ms the probe takes.
-        const atValue = value;
-        const atCursor = cursor;
+        // Insert the chip at whatever the caret is when the async probe
+        // resolves (read from a ref, not a keypress-time snapshot) so typing
+        // during the probe isn't clobbered.
         void props.onImagePaste().then((chip) => {
-          if (chip) applyEdit(insertText(atValue, atCursor, chip));
+          if (!chip) return;
+          const { value: v, cursor: c } = latestStateRef.current;
+          applyEdit(insertText(v, c, chip));
         });
         return;
       }

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -27,9 +27,8 @@ import {
   isUnhandledControlInput,
   metaChordInput,
 } from './inputKeys';
+import { ImagePasteQueue, withImagePasteTimeout } from './imagePasteQueue';
 import { textDisplayWidth } from '../render/terminalText';
-
-const IMAGE_PASTE_TIMEOUT_MS = 15_000;
 
 export interface BaseTextInputProps {
   readonly value: string;
@@ -54,6 +53,7 @@ export interface BaseTextInputProps {
    *  text to insert (e.g. `[Image #1]`) or null when there is no image. */
   readonly onImagePaste?: () => Promise<string | null>;
   readonly onImagePasteError?: (error: unknown) => void;
+  readonly imagePasteQueue?: ImagePasteQueue;
   /** Render the value as bullets (secret entry, e.g. an API key). Display-only:
    *  the captured value, edits, and paste are unaffected. */
   readonly masked?: boolean;
@@ -74,19 +74,6 @@ interface TextInputDisplayRow {
 interface LeadingEllipsisDisplay {
   readonly text: string;
   readonly removedPrefixCodeUnits: number;
-}
-
-function withImagePasteTimeout<T>(promise: Promise<T>): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timeout = setTimeout(
-      () => reject(new Error('Image paste timed out.')),
-      IMAGE_PASTE_TIMEOUT_MS,
-    );
-  });
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeout) clearTimeout(timeout);
-  });
 }
 
 function codePointAtIndex(
@@ -332,8 +319,10 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   // the current caret, not a stale keypress-time snapshot.
   const latestStateRef = useRef({ value, cursor });
   latestStateRef.current = { value, cursor };
-  const pendingImagePastesRef = useRef(new Set<Promise<void>>());
-  const pendingSubmitRef = useRef<(() => void) | null>(null);
+  const ownedImagePasteQueueRef = useRef<ImagePasteQueue | null>(null);
+  ownedImagePasteQueueRef.current ??= new ImagePasteQueue();
+  const imagePasteQueue =
+    props.imagePasteQueue ?? ownedImagePasteQueueRef.current;
 
   // Track the last value we ourselves emitted via onChange. If the prop's
   // `value` diverges from this, the parent swapped the text out from under
@@ -378,36 +367,26 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     [applyEdit],
   );
 
-  const flushPendingSubmit = useCallback(() => {
-    if (pendingImagePastesRef.current.size > 0) return;
-    const submit = pendingSubmitRef.current;
-    pendingSubmitRef.current = null;
-    submit?.();
-  }, []);
-
   const submitAfterImagePastes = useCallback(
     (handler: (value: string) => void, submitted: string): void => {
-      if (pendingImagePastesRef.current.size === 0) {
+      if (
+        !imagePasteQueue.deferUntilIdle(() =>
+          handler(latestStateRef.current.value),
+        )
+      ) {
         handler(submitted);
-        return;
       }
-      // Enter commits this draft and locks further input until clipboard probes
-      // settle. The flushed submit should include chips produced by those
-      // already-started probes, but not later user edits. Freeze the handler
-      // from this Enter press so a later parent rerender cannot redirect the
-      // committed submit.
-      pendingSubmitRef.current ??= () => handler(latestStateRef.current.value);
     },
-    [],
+    [imagePasteQueue],
   );
 
   useInput(
     (input, key) => {
       if (isEscapeInput(input, key)) {
-        pendingSubmitRef.current = null;
+        imagePasteQueue.cancelDeferredAction();
         return;
       }
-      if (pendingSubmitRef.current) {
+      if (imagePasteQueue.hasDeferredAction) {
         // A visible Enter already committed this draft. Ignore later keystrokes
         // until clipboard probes settle so the deferred submit is neither
         // overwritten nor allowed to clear a newer draft.
@@ -472,11 +451,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
             insertIntoLatestDraft(chip);
           })
           .catch((err: unknown) => props.onImagePasteError?.(err));
-        pendingImagePastesRef.current.add(paste);
-        void paste.finally(() => {
-          pendingImagePastesRef.current.delete(paste);
-          flushPendingSubmit();
-        });
+        imagePasteQueue.track(paste);
         return;
       }
       // Drop unhandled control/meta combos; pass printable input through.
@@ -506,7 +481,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   // otherwise the paste is inserted verbatim.
   usePaste(
     (text) => {
-      if (pendingSubmitRef.current) return;
+      if (imagePasteQueue.hasDeferredAction) return;
       const toInsert = props.transformPaste?.(text) ?? text;
       insertIntoLatestDraft(toInsert);
     },

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -44,6 +44,13 @@ export interface BaseTextInputProps {
   readonly onSubmit: (value: string) => void;
   readonly onInputChunkSubmit?: (value: string) => void;
   readonly onChange: (value: string) => void;
+  /** Optionally transform pasted text before it is inserted — e.g. collapse a
+   *  large paste into a `[Pasted text #N +M lines]` chip and stash the content
+   *  elsewhere. Defaults to inserting the paste verbatim. */
+  readonly transformPaste?: (text: string) => string;
+  /** Ctrl-V handler: probe the OS clipboard for an image. Resolves to the chip
+   *  text to insert (e.g. `[Image #1]`) or null when there is no image. */
+  readonly onImagePaste?: () => Promise<string | null>;
   /** Render the value as bullets (secret entry, e.g. an API key). Display-only:
    *  the captured value, edits, and paste are unaffected. */
   readonly masked?: boolean;
@@ -387,6 +394,17 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         applyEdit(deletePreviousWord(value, cursor));
         return;
       }
+      if (isCtrlInput(input, key, 'v') && props.onImagePaste) {
+        // Async clipboard probe; insert the resulting chip at the caret. Uses
+        // the caret captured at keypress — a deliberate ctrl-v isn't raced by
+        // typing in the few ms the probe takes.
+        const atValue = value;
+        const atCursor = cursor;
+        void props.onImagePaste().then((chip) => {
+          if (chip) applyEdit(insertText(atValue, atCursor, chip));
+        });
+        return;
+      }
       // Drop unhandled control/meta combos; pass printable input through.
       if (
         key.meta ||
@@ -410,9 +428,12 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
 
   // Bracketed paste arrives as ONE string and is not forwarded to useInput,
   // so newlines in the paste are preserved literally instead of firing Enter.
+  // `transformPaste` (when supplied) may collapse a large paste into a chip;
+  // otherwise the paste is inserted verbatim.
   usePaste(
     (text) => {
-      applyEdit(insertText(value, cursor, text));
+      const toInsert = props.transformPaste?.(text) ?? text;
+      applyEdit(insertText(value, cursor, toInsert));
     },
     { isActive: focus },
   );

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -29,6 +29,8 @@ import {
 } from './inputKeys';
 import { textDisplayWidth } from '../render/terminalText';
 
+const IMAGE_PASTE_TIMEOUT_MS = 15_000;
+
 export interface BaseTextInputProps {
   readonly value: string;
   readonly placeholder?: string;
@@ -72,6 +74,19 @@ interface TextInputDisplayRow {
 interface LeadingEllipsisDisplay {
   readonly text: string;
   readonly removedPrefixCodeUnits: number;
+}
+
+function withImagePasteTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error('Image paste timed out.')),
+      IMAGE_PASTE_TIMEOUT_MS,
+    );
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
 }
 
 function codePointAtIndex(
@@ -378,7 +393,9 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
       }
       // Enter commits this draft and locks further input until clipboard probes
       // settle. The flushed submit should include chips produced by those
-      // already-started probes, but not later user edits.
+      // already-started probes, but not later user edits. Freeze the handler
+      // from this Enter press so a later parent rerender cannot redirect the
+      // committed submit.
       pendingSubmitRef.current ??= () => handler(latestStateRef.current.value);
     },
     [],
@@ -444,8 +461,9 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         // Insert the chip at whatever the caret is when the async probe
         // resolves (read from a ref, not a keypress-time snapshot) so typing
         // during the probe isn't clobbered.
-        const paste = props
-          .onImagePaste()
+        const paste = withImagePasteTimeout(
+          Promise.resolve().then(() => props.onImagePaste?.() ?? null),
+        )
           .then((chip) => {
             if (!chip) return;
             insertIntoLatestDraft(chip);

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -376,10 +376,10 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         handler(submitted);
         return;
       }
-      // Enter commits the draft that was visible at keypress time. Pending
-      // image probes may still insert chips into the UI, but they should not
-      // silently change what this submit sends.
-      pendingSubmitRef.current ??= () => handler(submitted);
+      // Enter commits this draft and locks further input until clipboard probes
+      // settle. The flushed submit should include chips produced by those
+      // already-started probes, but not later user edits.
+      pendingSubmitRef.current ??= () => handler(latestStateRef.current.value);
     },
     [],
   );

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -368,7 +368,10 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         handler(submitted);
         return;
       }
-      pendingSubmitRef.current = () => handler(latestStateRef.current.value);
+      // Enter commits the draft that was visible at keypress time. Pending
+      // image probes may still insert chips into the UI, but they should not
+      // silently change what this submit sends.
+      pendingSubmitRef.current = () => handler(submitted);
     },
     [],
   );

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -317,6 +317,8 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   // the current caret, not a stale keypress-time snapshot.
   const latestStateRef = useRef({ value, cursor });
   latestStateRef.current = { value, cursor };
+  const pendingImagePastesRef = useRef(new Set<Promise<void>>());
+  const pendingSubmitRef = useRef<(() => void) | null>(null);
 
   // Track the last value we ourselves emitted via onChange. If the prop's
   // `value` diverges from this, the parent swapped the text out from under
@@ -334,21 +336,41 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   const moveCursor = useCallback(
     (next: number) => {
       const c = clampCursor(next, value.length);
+      latestStateRef.current = { value, cursor: c };
       if (!isControlled) setInternalCursor(c);
       onCursorChange?.(c);
     },
-    [isControlled, value.length, onCursorChange],
+    [isControlled, value, onCursorChange],
   );
 
   const applyEdit = useCallback(
     (edit: TextEdit) => {
       const c = clampCursor(edit.cursor, edit.value.length);
+      latestStateRef.current = { value: edit.value, cursor: c };
       lastEmittedValueRef.current = edit.value;
       onChange(edit.value);
       if (!isControlled) setInternalCursor(c);
       onCursorChange?.(c);
     },
     [isControlled, onChange, onCursorChange],
+  );
+
+  const flushPendingSubmit = useCallback(() => {
+    if (pendingImagePastesRef.current.size > 0) return;
+    const submit = pendingSubmitRef.current;
+    pendingSubmitRef.current = null;
+    submit?.();
+  }, []);
+
+  const submitAfterImagePastes = useCallback(
+    (handler: (value: string) => void, submitted: string): void => {
+      if (pendingImagePastesRef.current.size === 0) {
+        handler(submitted);
+        return;
+      }
+      pendingSubmitRef.current = () => handler(latestStateRef.current.value);
+    },
+    [],
   );
 
   useInput(
@@ -362,7 +384,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         return;
       }
       if (isPlainReturnInput(input, key)) {
-        onSubmit(value);
+        submitAfterImagePastes(onSubmit, value);
         return;
       }
       if (key.backspace) {
@@ -405,7 +427,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         // Insert the chip at whatever the caret is when the async probe
         // resolves (read from a ref, not a keypress-time snapshot) so typing
         // during the probe isn't clobbered.
-        void props
+        const paste = props
           .onImagePaste()
           .then((chip) => {
             if (!chip) return;
@@ -413,6 +435,11 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
             applyEdit(insertText(v, c, chip));
           })
           .catch((err: unknown) => props.onImagePasteError?.(err));
+        pendingImagePastesRef.current.add(paste);
+        void paste.finally(() => {
+          pendingImagePastesRef.current.delete(paste);
+          flushPendingSubmit();
+        });
         return;
       }
       // Drop unhandled control/meta combos; pass printable input through.
@@ -427,7 +454,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
       }
       const edit = applyTerminalInputChunk(value, cursor, input);
       if (edit.submit) {
-        (onInputChunkSubmit ?? onSubmit)(edit.value);
+        submitAfterImagePastes(onInputChunkSubmit ?? onSubmit, edit.value);
         return;
       }
       if (edit.value === value && edit.cursor === cursor) return;

--- a/packages/cli/src/chat/tui/input/draftAttachments.ts
+++ b/packages/cli/src/chat/tui/input/draftAttachments.ts
@@ -80,6 +80,18 @@ function matchChips(input: string): ChipMatch[] {
   return matches;
 }
 
+function isInlineWhitespace(char: string | undefined): boolean {
+  return char === ' ' || char === '\t';
+}
+
+function removeChipRange(input: string, start: number, end: number): string {
+  const removeFollowingSpace =
+    isInlineWhitespace(input[start - 1]) && isInlineWhitespace(input[end]);
+  return (
+    input.slice(0, start) + input.slice(removeFollowingSpace ? end + 1 : end)
+  );
+}
+
 export class DraftAttachmentStore {
   private readonly entries = new Map<number, DraftAttachment>();
   private nextId = 1;
@@ -121,6 +133,23 @@ export class DraftAttachmentStore {
       const entry = this.entries.get(match.id);
       if (entry?.kind !== 'text') continue;
       out = out.slice(0, match.start) + entry.content + out.slice(match.end);
+    }
+    return out;
+  }
+
+  /**
+   * Text to persist in input history. Pasted text is useful on recall, but
+   * image chips are not: once submitted, their media entries are cleared and a
+   * recalled `[Image #N]` would be a bare token with no file attached.
+   */
+  expandTextForHistory(input: string): string {
+    let out = this.expandText(input);
+    const matches = matchChips(out);
+    for (let i = matches.length - 1; i >= 0; i--) {
+      const match = matches[i];
+      const entry = this.entries.get(match.id);
+      if (entry?.kind !== 'image') continue;
+      out = removeChipRange(out, match.start, match.end);
     }
     return out;
   }

--- a/packages/cli/src/chat/tui/input/draftAttachments.ts
+++ b/packages/cli/src/chat/tui/input/draftAttachments.ts
@@ -87,6 +87,12 @@ function isInlineWhitespace(char: string | undefined): boolean {
 function removeChipRange(input: string, start: number, end: number): string {
   const removeFollowingSpace =
     isInlineWhitespace(input[start - 1]) && isInlineWhitespace(input[end]);
+  const removePrecedingSpace =
+    isInlineWhitespace(input[start - 1]) &&
+    (input[end] === undefined || input[end] === '\n' || input[end] === '\r');
+  if (removePrecedingSpace) {
+    return input.slice(0, start - 1) + input.slice(end);
+  }
   return (
     input.slice(0, start) + input.slice(removeFollowingSpace ? end + 1 : end)
   );
@@ -143,15 +149,15 @@ export class DraftAttachmentStore {
    * recalled `[Image #N]` would be a bare token with no file attached.
    */
   expandTextForHistory(input: string): string {
-    let out = this.expandText(input);
-    const matches = matchChips(out);
+    let out = input;
+    const matches = matchChips(input);
     for (let i = matches.length - 1; i >= 0; i--) {
       const match = matches[i];
       const entry = this.entries.get(match.id);
       if (entry?.kind !== 'image') continue;
       out = removeChipRange(out, match.start, match.end);
     }
-    return out;
+    return this.expandText(out);
   }
 
   /**

--- a/packages/cli/src/chat/tui/input/draftAttachments.ts
+++ b/packages/cli/src/chat/tui/input/draftAttachments.ts
@@ -1,0 +1,142 @@
+// Draft attachment store for the chat InputBar.
+//
+// Collapsing large pastes and pasted images into compact
+// `[Pasted text #N +M lines]` / `[Image #N]` chips keeps the draft readable.
+// The full content lives here, keyed by a per-draft id, and is spliced back in
+// at submit time. Text and image chips share one `#N` id space so the counter
+// never collides (mirrors Claude Code).
+//
+// This store is InputBar-local (held in a ref) — it never leaks into the
+// headless (`texra run` / `--print`) path, which has no InputBar and therefore
+// never creates a placeholder. Expansion happens only at the interactive submit
+// boundary, so the piped/non-TTY output stays byte-identical.
+
+/** Collapse a paste into a chip when it exceeds either bound. */
+const PASTE_CHAR_THRESHOLD = 800;
+const PASTE_MAX_INLINE_LINES = 2;
+
+export interface PastedTextEntry {
+  readonly id: number;
+  readonly kind: 'text';
+  readonly content: string;
+}
+
+export interface PastedImageEntry {
+  readonly id: number;
+  readonly kind: 'image';
+  /** Absolute path to the on-disk image (under the run/chat storage dir). */
+  readonly path: string;
+  readonly mediaType: string;
+  readonly displayName: string;
+}
+
+export type DraftAttachment = PastedTextEntry | PastedImageEntry;
+
+/** Count newline sequences, matching the chip's "+M lines" suffix. */
+export function pastedNewlineCount(text: string): number {
+  return (text.match(/\r\n|\r|\n/g) ?? []).length;
+}
+
+/** Whether a paste is large enough to collapse into a chip. */
+export function shouldCollapsePaste(text: string): boolean {
+  return (
+    text.length > PASTE_CHAR_THRESHOLD ||
+    pastedNewlineCount(text) > PASTE_MAX_INLINE_LINES
+  );
+}
+
+export function formatPastedTextChip(id: number, numLines: number): string {
+  return numLines === 0
+    ? `[Pasted text #${id}]`
+    : `[Pasted text #${id} +${numLines} lines]`;
+}
+
+export function formatImageChip(id: number): string {
+  return `[Image #${id}]`;
+}
+
+/**
+ * Matches the chips the input collapses pastes/attachments into. The optional
+ * `+M lines` is non-capturing — only the id matters for lookup.
+ */
+const CHIP_RE = /\[(?:Pasted text|Image) #(\d+)(?: \+\d+ lines)?\]/g;
+
+interface ChipMatch {
+  readonly id: number;
+  readonly start: number;
+  readonly end: number;
+}
+
+function matchChips(input: string): ChipMatch[] {
+  const matches: ChipMatch[] = [];
+  for (const m of input.matchAll(CHIP_RE)) {
+    if (m.index === undefined) continue;
+    matches.push({
+      id: Number(m[1]),
+      start: m.index,
+      end: m.index + m[0].length,
+    });
+  }
+  return matches;
+}
+
+export class DraftAttachmentStore {
+  private readonly entries = new Map<number, DraftAttachment>();
+  private nextId = 1;
+
+  /** Store pasted text; returns the chip to insert in the draft. */
+  addPastedText(content: string): string {
+    const id = this.nextId++;
+    this.entries.set(id, { id, kind: 'text', content });
+    return formatPastedTextChip(id, pastedNewlineCount(content));
+  }
+
+  /** Store a pasted image; returns the chip to insert in the draft. */
+  addPastedImage(image: Omit<PastedImageEntry, 'id' | 'kind'>): string {
+    const id = this.nextId++;
+    this.entries.set(id, { id, kind: 'image', ...image });
+    return formatImageChip(id);
+  }
+
+  isEmpty(): boolean {
+    return this.entries.size === 0;
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.nextId = 1;
+  }
+
+  /**
+   * Expand text chips back to their stored content (reverse-offset splice so
+   * earlier replacements don't shift later match indices, and any chip-like
+   * text *inside* pasted content is never re-matched). Image chips are left in
+   * place — the image bytes ride along as media files (see {@link resolveMedia}).
+   */
+  expandText(input: string): string {
+    let out = input;
+    const matches = matchChips(input);
+    for (let i = matches.length - 1; i >= 0; i--) {
+      const match = matches[i];
+      const entry = this.entries.get(match.id);
+      if (entry?.kind !== 'text') continue;
+      out = out.slice(0, match.start) + entry.content + out.slice(match.end);
+    }
+    return out;
+  }
+
+  /**
+   * Absolute paths of image attachments whose `[Image #N]` chip still survives
+   * in the submitted draft. Orphaned chips (deleted from the text) are dropped,
+   * matching Claude Code's orphan gate.
+   */
+  resolveMedia(input: string): string[] {
+    const present = new Set(matchChips(input).map((m) => m.id));
+    const paths: string[] = [];
+    for (const id of present) {
+      const entry = this.entries.get(id);
+      if (entry?.kind === 'image') paths.push(entry.path);
+    }
+    return paths;
+  }
+}

--- a/packages/cli/src/chat/tui/input/imagePasteQueue.ts
+++ b/packages/cli/src/chat/tui/input/imagePasteQueue.ts
@@ -1,0 +1,59 @@
+export const IMAGE_PASTE_TIMEOUT_MS = 15_000;
+
+export function withImagePasteTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error('Image paste timed out.')),
+      IMAGE_PASTE_TIMEOUT_MS,
+    );
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
+}
+
+export class ImagePasteQueue {
+  private readonly pending = new Set<Promise<void>>();
+  private deferredAction: (() => void) | null = null;
+
+  get hasPending(): boolean {
+    return this.pending.size > 0;
+  }
+
+  get hasDeferredAction(): boolean {
+    return this.deferredAction !== null;
+  }
+
+  track(work: Promise<void>): void {
+    this.pending.add(work);
+    void work
+      .finally(() => {
+        this.pending.delete(work);
+        this.flush();
+      })
+      .catch(() => undefined);
+  }
+
+  runWhenIdle(action: () => void): void {
+    if (!this.deferUntilIdle(action)) action();
+  }
+
+  /** First submit wins while an image paste is pending. */
+  deferUntilIdle(action: () => void): boolean {
+    if (!this.hasPending) return false;
+    this.deferredAction ??= action;
+    return true;
+  }
+
+  cancelDeferredAction(): void {
+    this.deferredAction = null;
+  }
+
+  private flush(): void {
+    if (this.hasPending) return;
+    const action = this.deferredAction;
+    this.deferredAction = null;
+    action?.();
+  }
+}

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from 'ink';
 
 import { writeTextStderr } from '@cli/runtime/logSinks';
 import { attachClipboardImage } from '@cli/runtime/clipboardImage';
+import { toErrorMessage } from '@common/errors/errorMessage';
 import { BaseTextInput } from '../input/BaseTextInput';
 import {
   DraftAttachmentStore,
@@ -52,16 +53,21 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
     return attachmentsRef.current.addPastedText(text);
   }, []);
   const onImagePaste = useCallback(async (): Promise<string | null> => {
-    const result = await attachClipboardImage();
-    if (!result.ok) {
-      setAttachNotice(result.reason);
+    try {
+      const result = await attachClipboardImage();
+      if (!result.ok) {
+        setAttachNotice(result.reason);
+        return null;
+      }
+      return attachmentsRef.current.addPastedImage({
+        path: result.path,
+        mediaType: result.mediaType,
+        displayName: result.displayName,
+      });
+    } catch (error) {
+      setAttachNotice(`Image paste failed: ${toErrorMessage(error)}`);
       return null;
     }
-    return attachmentsRef.current.addPastedImage({
-      path: result.path,
-      mediaType: result.mediaType,
-      displayName: result.displayName,
-    });
   }, []);
 
   // Clear the transient paste notice a few seconds after it appears.
@@ -87,7 +93,11 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       // Expand `[Pasted text #N …]` chips back to their full content, and
       // collect any pasted-image attachments still referenced in the draft.
       const trimmed = store.expandText(submitted).trim();
-      if (trimmed.length === 0) return;
+      if (trimmed.length === 0) {
+        setValue('');
+        store.clear();
+        return;
+      }
       const mediaFiles = store.resolveMedia(submitted);
       setValue('');
       store.clear();
@@ -221,6 +231,9 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           onChange={setValue}
           transformPaste={transformPaste}
           onImagePaste={onImagePaste}
+          onImagePasteError={(error) =>
+            setAttachNotice(`Image paste failed: ${toErrorMessage(error)}`)
+          }
           onInputChunkSubmit={handleInputChunkSubmit}
           onSubmit={showPalette ? () => undefined : handleSubmit}
         />

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -9,6 +9,7 @@ import {
   DraftAttachmentStore,
   shouldCollapsePaste,
 } from '../input/draftAttachments';
+import { ImagePasteQueue } from '../input/imagePasteQueue';
 import { ReverseSearch } from '../input/ReverseSearch';
 import { isCtrlInput } from '../input/inputKeys';
 import { SlashPalette } from '../commands/SlashPalette';
@@ -40,21 +41,56 @@ function slashSubmitText(
   current: string,
   commandName: string,
   fallbackRemainder: string,
+  typedName?: string,
 ): string {
-  const parsed = parseSlashInput(current);
-  if (!parsed) {
+  const parsedName = parseSlashInput(current)?.name;
+  const nameToReplace =
+    typedName && current.startsWith(`/${typedName}`) ? typedName : parsedName;
+  if (!nameToReplace) {
     return `/${commandName}${fallbackRemainder ? ` ${fallbackRemainder.trimStart()}` : ''}`;
   }
-  return `/${commandName}${current.slice(parsed.name.length + 1)}`;
+  const suffix = current.slice(nameToReplace.length + 1);
+  const separator = suffix.length > 0 && !/^\s/.test(suffix) ? ' ' : '';
+  return `/${commandName}${separator}${suffix}`;
+}
+
+export function submitSlashCommandWhenReady({
+  commandName,
+  fallbackRemainder,
+  handleSubmit,
+  imagePasteQueue,
+  readDraft,
+  typedName,
+}: {
+  readonly commandName: string;
+  readonly fallbackRemainder: string;
+  readonly handleSubmit: (value: string) => void;
+  readonly imagePasteQueue: ImagePasteQueue;
+  readonly readDraft: () => string;
+  readonly typedName?: string;
+}): void {
+  imagePasteQueue.runWhenIdle(() => {
+    handleSubmit(
+      slashSubmitText(readDraft(), commandName, fallbackRemainder, typedName),
+    );
+  });
 }
 
 export function InputBar(props: InputBarProps): React.JSX.Element {
   const { disabled, history, onSubmit, prompt } = props;
-  const [value, setValue] = useState('');
+  const [value, setValueState] = useState('');
   const [reverseSearchOpen, setReverseSearchOpen] = useState(false);
   const [attachNotice, setAttachNotice] = useState<string | null>(null);
+  const draftValueRef = useRef(value);
+  const setValue = useCallback((next: string) => {
+    draftValueRef.current = next;
+    setValueState(next);
+  }, []);
   const historyRef = useRef(history);
   historyRef.current = history;
+  const imagePasteQueueRef = useRef<ImagePasteQueue | null>(null);
+  imagePasteQueueRef.current ??= new ImagePasteQueue();
+  const imagePasteQueue = imagePasteQueueRef.current;
 
   // Collapsed pastes (and, in the image slice, pasted images) live here keyed
   // by chip id and are expanded back into the submitted text at handleSubmit.
@@ -126,11 +162,16 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       });
       onSubmit(trimmed, mediaFiles.length > 0 ? mediaFiles : undefined);
     },
-    [onSubmit],
+    [onSubmit, setValue],
   );
 
   const acceptSlashCommand = useCallback(
-    (cmd: SlashCommand, intent: SlashPickIntent, remainder: string): void => {
+    (
+      cmd: SlashCommand,
+      intent: SlashPickIntent,
+      typedName: string,
+      remainder: string,
+    ): void => {
       if (cmd.formComponent) {
         // Structured forms own the screen — clear the input and let
         // the active-form signal mount the component (see App.tsx).
@@ -149,12 +190,19 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         return;
       }
       if (intent === 'submit') {
-        handleSubmit(slashSubmitText(value, cmd.name, remainder));
+        submitSlashCommandWhenReady({
+          commandName: cmd.name,
+          fallbackRemainder: remainder,
+          handleSubmit,
+          imagePasteQueue,
+          readDraft: () => draftValueRef.current,
+          typedName,
+        });
         return;
       }
       setValue(`/${cmd.name}${remainder ? ` ${remainder.trimStart()}` : ' '}`);
     },
-    [handleSubmit, value],
+    [handleSubmit, imagePasteQueue, setValue],
   );
 
   const handleInputChunkSubmit = useCallback(
@@ -166,6 +214,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           acceptSlashCommand(
             chosen,
             slashPickIntent(chosen, 'enter'),
+            slash.name,
             slash.remainder,
           );
           return;
@@ -216,7 +265,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         <SlashPalette
           query={parsed.name}
           onPick={(cmd, intent) => {
-            acceptSlashCommand(cmd, intent, parsed.remainder);
+            acceptSlashCommand(cmd, intent, parsed.name, parsed.remainder);
           }}
           onCancel={() => {
             /* Esc clears the slash — caller can re-open by typing again. */
@@ -241,6 +290,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           value={value}
           focus={!disabled && !reverseSearchOpen}
           onChange={setValue}
+          imagePasteQueue={imagePasteQueue}
           transformPaste={transformPaste}
           onImagePaste={onImagePaste}
           onImagePasteError={(error) =>

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -99,12 +99,14 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         return;
       }
       const mediaFiles = store.resolveMedia(submitted);
+      const historyText = store.expandTextForHistory(submitted).trim();
       setValue('');
       store.clear();
       // Persisting history is best-effort — a disk failure (read-only fs,
       // ENOSPC) must not block the submit. Surface the failure through the
       // shared log sink so it isn't completely silent.
-      const historyPersist = historyRef.current?.push(trimmed);
+      const historyPersist =
+        historyText.length > 0 ? historyRef.current?.push(historyText) : null;
       historyPersist?.catch((err: unknown) => {
         writeTextStderr(
           `texra: failed to persist input history: ${String(err)}`,

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -96,6 +96,17 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   // by chip id and are expanded back into the submitted text at handleSubmit.
   // Ref-held so the store survives re-renders and never triggers one itself.
   const attachmentsRef = useRef(new DraftAttachmentStore());
+  const clearDraft = useCallback(() => {
+    setValue('');
+    attachmentsRef.current.clear();
+  }, [setValue]);
+  const replaceDraft = useCallback(
+    (next: string) => {
+      setValue(next);
+      attachmentsRef.current.clear();
+    },
+    [setValue],
+  );
   const transformPaste = useCallback((text: string): string => {
     if (!shouldCollapsePaste(text)) return text;
     return attachmentsRef.current.addPastedText(text);
@@ -142,14 +153,12 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       // collect any pasted-image attachments still referenced in the draft.
       const trimmed = store.expandText(submitted).trim();
       if (trimmed.length === 0) {
-        setValue('');
-        store.clear();
+        clearDraft();
         return;
       }
       const mediaFiles = store.resolveMedia(submitted);
       const historyText = store.expandTextForHistory(submitted).trim();
-      setValue('');
-      store.clear();
+      clearDraft();
       // Persisting history is best-effort — a disk failure (read-only fs,
       // ENOSPC) must not block the submit. Surface the failure through the
       // shared log sink so it isn't completely silent.
@@ -162,7 +171,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       });
       onSubmit(trimmed, mediaFiles.length > 0 ? mediaFiles : undefined);
     },
-    [onSubmit, setValue],
+    [clearDraft, onSubmit],
   );
 
   const acceptSlashCommand = useCallback(
@@ -176,7 +185,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         // Structured forms own the screen — clear the input and let
         // the active-form signal mount the component (see App.tsx).
         const Form = cmd.formComponent;
-        setValue('');
+        clearDraft();
         cliState.activeForm.set({
           commandName: cmd.name,
           render: (close, availableRows) => (
@@ -200,9 +209,11 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         });
         return;
       }
-      setValue(`/${cmd.name}${remainder ? ` ${remainder.trimStart()}` : ' '}`);
+      replaceDraft(
+        `/${cmd.name}${remainder ? ` ${remainder.trimStart()}` : ' '}`,
+      );
     },
-    [handleSubmit, imagePasteQueue, setValue],
+    [clearDraft, handleSubmit, imagePasteQueue, replaceDraft],
   );
 
   const handleInputChunkSubmit = useCallback(
@@ -269,7 +280,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           }}
           onCancel={() => {
             /* Esc clears the slash — caller can re-open by typing again. */
-            setValue('');
+            clearDraft();
           }}
         />
       ) : null}
@@ -277,7 +288,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         <ReverseSearch
           history={historyRef.current}
           onCommit={(line) => {
-            setValue(line);
+            replaceDraft(line);
             setReverseSearchOpen(false);
           }}
           onCancel={() => setReverseSearchOpen(false)}

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 
 import { writeTextStderr } from '@cli/runtime/logSinks';
+import { attachClipboardImage } from '@cli/runtime/clipboardImage';
 import { BaseTextInput } from '../input/BaseTextInput';
+import {
+  DraftAttachmentStore,
+  shouldCollapsePaste,
+} from '../input/draftAttachments';
 import { ReverseSearch } from '../input/ReverseSearch';
 import { isCtrlInput } from '../input/inputKeys';
 import { SlashPalette } from '../commands/SlashPalette';
@@ -17,8 +22,9 @@ import { cliState } from '../state/cliState';
 import type { InputHistory } from '../history/inputHistory';
 
 export interface InputBarProps {
-  /** Forwarded to BaseTextInput; called only on real (non-paste) Enter. */
-  readonly onSubmit: (value: string) => void;
+  /** Forwarded to BaseTextInput; called only on real (non-paste) Enter.
+   *  `mediaFiles` carries absolute paths of any pasted-image attachments. */
+  readonly onSubmit: (value: string, mediaFiles?: readonly string[]) => void;
   /** Disable the input while an approval modal is owning the screen. */
   readonly disabled?: boolean;
   /** Preserve component state while giving foreground panels the input rows. */
@@ -33,8 +39,37 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   const { disabled, history, onSubmit, prompt } = props;
   const [value, setValue] = useState('');
   const [reverseSearchOpen, setReverseSearchOpen] = useState(false);
+  const [attachNotice, setAttachNotice] = useState<string | null>(null);
   const historyRef = useRef(history);
   historyRef.current = history;
+
+  // Collapsed pastes (and, in the image slice, pasted images) live here keyed
+  // by chip id and are expanded back into the submitted text at handleSubmit.
+  // Ref-held so the store survives re-renders and never triggers one itself.
+  const attachmentsRef = useRef(new DraftAttachmentStore());
+  const transformPaste = useCallback((text: string): string => {
+    if (!shouldCollapsePaste(text)) return text;
+    return attachmentsRef.current.addPastedText(text);
+  }, []);
+  const onImagePaste = useCallback(async (): Promise<string | null> => {
+    const result = await attachClipboardImage();
+    if (!result.ok) {
+      setAttachNotice(result.reason);
+      return null;
+    }
+    return attachmentsRef.current.addPastedImage({
+      path: result.path,
+      mediaType: result.mediaType,
+      displayName: result.displayName,
+    });
+  }, []);
+
+  // Clear the transient paste notice a few seconds after it appears.
+  useEffect(() => {
+    if (attachNotice === null) return;
+    const timer = setTimeout(() => setAttachNotice(null), 4000);
+    return () => clearTimeout(timer);
+  }, [attachNotice]);
 
   // Listen for Ctrl-R *outside* the text input — Ink emits the keystroke
   // to every `useInput` consumer, and BaseTextInput drops unhandled ctrl
@@ -48,9 +83,14 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
 
   const handleSubmit = useCallback(
     (submitted: string) => {
-      const trimmed = submitted.trim();
+      const store = attachmentsRef.current;
+      // Expand `[Pasted text #N …]` chips back to their full content, and
+      // collect any pasted-image attachments still referenced in the draft.
+      const trimmed = store.expandText(submitted).trim();
       if (trimmed.length === 0) return;
+      const mediaFiles = store.resolveMedia(submitted);
       setValue('');
+      store.clear();
       // Persisting history is best-effort — a disk failure (read-only fs,
       // ENOSPC) must not block the submit. Surface the failure through the
       // shared log sink so it isn't completely silent.
@@ -60,7 +100,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           `texra: failed to persist input history: ${String(err)}`,
         );
       });
-      onSubmit(trimmed);
+      onSubmit(trimmed, mediaFiles.length > 0 ? mediaFiles : undefined);
     },
     [onSubmit],
   );
@@ -172,12 +212,15 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           onCancel={() => setReverseSearchOpen(false)}
         />
       ) : null}
+      {attachNotice ? <Text dimColor>{attachNotice}</Text> : null}
       <Box borderStyle="round" borderColor="gray" paddingX={1}>
         <Text color="cyan">{prompt ?? '›'} </Text>
         <BaseTextInput
           value={value}
           focus={!disabled && !reverseSearchOpen}
           onChange={setValue}
+          transformPaste={transformPaste}
+          onImagePaste={onImagePaste}
           onInputChunkSubmit={handleInputChunkSubmit}
           onSubmit={showPalette ? () => undefined : handleSubmit}
         />

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -36,6 +36,18 @@ export interface InputBarProps {
   readonly history?: InputHistory;
 }
 
+function slashSubmitText(
+  current: string,
+  commandName: string,
+  fallbackRemainder: string,
+): string {
+  const parsed = parseSlashInput(current);
+  if (!parsed) {
+    return `/${commandName}${fallbackRemainder ? ` ${fallbackRemainder.trimStart()}` : ''}`;
+  }
+  return `/${commandName}${current.slice(parsed.name.length + 1)}`;
+}
+
 export function InputBar(props: InputBarProps): React.JSX.Element {
   const { disabled, history, onSubmit, prompt } = props;
   const [value, setValue] = useState('');
@@ -137,14 +149,12 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         return;
       }
       if (intent === 'submit') {
-        handleSubmit(
-          `/${cmd.name}${remainder ? ` ${remainder.trimStart()}` : ''}`,
-        );
+        handleSubmit(slashSubmitText(value, cmd.name, remainder));
         return;
       }
       setValue(`/${cmd.name}${remainder ? ` ${remainder.trimStart()}` : ' '}`);
     },
-    [handleSubmit],
+    [handleSubmit, value],
   );
 
   const handleInputChunkSubmit = useCallback(

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -153,6 +153,7 @@ export interface BuildInitialChatAgentConfigInput {
   readonly model: string;
   readonly instruction: string;
   readonly workingDirectory: string;
+  readonly mediaFiles?: readonly string[];
   readonly cliMultiAgentPresetId?: string;
 }
 
@@ -161,6 +162,7 @@ export function buildInitialChatAgentConfig({
   model,
   instruction,
   workingDirectory,
+  mediaFiles,
   cliMultiAgentPresetId,
 }: BuildInitialChatAgentConfigInput): AgentConfigPayload {
   return {
@@ -169,6 +171,7 @@ export function buildInitialChatAgentConfig({
     instruction,
     agentCategory: AgentCategory.ToolUse,
     workingDirectory,
+    ...(mediaFiles?.length ? { mediaFiles: [...mediaFiles] } : {}),
     ...(cliMultiAgentPresetId ? { cliMultiAgentPresetId } : {}),
   };
 }
@@ -1364,7 +1367,10 @@ export async function runChat(
     },
   });
 
-  const startSession = (instruction: string): void => {
+  const startSession = (
+    instruction: string,
+    mediaFiles?: readonly string[],
+  ): void => {
     const meta = cliState.sessionMeta.get();
     const currentAgent = meta.agent || agent;
     const currentModel = meta.model || model;
@@ -1373,24 +1379,31 @@ export async function runChat(
         agent: currentAgent,
         model: currentModel,
         instruction,
+        mediaFiles,
         workingDirectory: context.cwd,
         cliMultiAgentPresetId: init.cliMultiAgentPresetId,
       }),
     );
   };
 
-  const handleSubmit = (line: string): void => {
-    void handleSubmittedLine(line);
+  const handleSubmit = (line: string, mediaFiles?: readonly string[]): void => {
+    void handleSubmittedLine(line, mediaFiles);
   };
 
-  const handleSubmittedLine = async (line: string): Promise<void> => {
+  const handleSubmittedLine = async (
+    line: string,
+    mediaFiles?: readonly string[],
+  ): Promise<void> => {
     if (await handleTuiSlashCommand(line, slashCommandContext())) {
       return;
     }
-    await submitChatMessage(line);
+    await submitChatMessage(line, mediaFiles);
   };
 
-  const submitChatMessage = async (line: string): Promise<void> => {
+  const submitChatMessage = async (
+    line: string,
+    mediaFiles?: readonly string[],
+  ): Promise<void> => {
     const rejectedChildFollowUpTarget = chatTuiRejectedChildFollowUpTarget();
     if (rejectedChildFollowUpTarget) {
       appendLocalAssistantTranscript(
@@ -1401,7 +1414,7 @@ export async function runChat(
     }
     const childFollowUpTarget = chatTuiActiveChildFollowUpTarget();
     if (!childFollowUpTarget && chatTuiCanStartRootRun(session)) {
-      startSession(line);
+      startSession(line, mediaFiles);
       return;
     }
     // PRD success criterion: follow-ups must not be silently dropped when the
@@ -1426,7 +1439,7 @@ export async function runChat(
         followUpTarget = session.streamId;
       }
       if (!followUpTarget || session.stopRequested) return;
-      const result = await sendFollowUp(followUpTarget, line);
+      const result = await sendFollowUp(followUpTarget, line, mediaFiles);
       if (result.status === 'no_session') {
         // Child stream ids are keys in parentStream; the root session id is not.
         if (followUpTarget === session.streamId) {

--- a/packages/cli/src/runtime/clipboardImage.ts
+++ b/packages/cli/src/runtime/clipboardImage.ts
@@ -12,7 +12,7 @@
 // code is duplicated.
 
 import { execFile } from 'node:child_process';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { platform as osPlatform, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -37,7 +37,22 @@ export type ClipboardAttachResult =
   | { readonly ok: false; readonly reason: string };
 
 /** Per-platform read result: PNG bytes, no image present, or unsupported. */
-type ClipboardRead = Buffer | 'none' | 'unsupported';
+type ClipboardRead = Buffer | 'none' | 'unsupported' | 'too-large';
+
+async function readPngFileWithinLimit(outFile: string): Promise<ClipboardRead> {
+  const { size } = await stat(outFile);
+  if (size > MAX_IMAGE_BYTES) return 'too-large';
+  return readFile(outFile);
+}
+
+function isMaxBufferError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    err.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
+  );
+}
 
 async function readClipboardPngMac(outFile: string): Promise<ClipboardRead> {
   try {
@@ -56,7 +71,7 @@ async function readClipboardPngMac(outFile: string): Promise<ClipboardRead> {
   } catch {
     return 'none';
   }
-  return readFile(outFile);
+  return readPngFileWithinLimit(outFile);
 }
 
 async function readClipboardPngLinux(): Promise<ClipboardRead> {
@@ -77,6 +92,7 @@ async function readClipboardPngLinux(): Promise<ClipboardRead> {
       const buf = stdout as unknown as Buffer;
       if (buf.length > 0) return buf;
     } catch (err) {
+      if (isMaxBufferError(err)) return 'too-large';
       if (isFileNotFoundError(err)) continue; // tool not installed → try next
       toolFound = true; // tool ran but the clipboard had no image
     }
@@ -101,7 +117,7 @@ async function readClipboardPngWindows(
   } catch {
     return 'none';
   }
-  return readFile(outFile);
+  return readPngFileWithinLimit(outFile);
 }
 
 /**
@@ -135,6 +151,12 @@ export async function attachClipboardImage(): Promise<ClipboardAttachResult> {
     }
     if (read === 'none') {
       return { ok: false, reason: 'No image found on the clipboard.' };
+    }
+    if (read === 'too-large') {
+      return {
+        ok: false,
+        reason: 'Clipboard image is too large to attach.',
+      };
     }
 
     const fileName = generatePastedImageName('png');

--- a/packages/cli/src/runtime/clipboardImage.ts
+++ b/packages/cli/src/runtime/clipboardImage.ts
@@ -1,0 +1,146 @@
+// Clipboard image adapter for the chat TUI.
+//
+// Terminals do not forward binary clipboard data through bracketed paste, so
+// image attachment is an explicit action (ctrl+v) that probes the OS clipboard
+// out-of-band, mirroring Claude Code's approach with built-in tooling only (no
+// extra installs on macOS/Windows):
+//   - macOS:   osascript `«class PNGf»` → temp PNG
+//   - Linux:   wl-paste (Wayland) / xclip (X11) image/png
+//   - Windows: PowerShell Get-Clipboard -Format Image → PNG
+// The saved file flows through the same shared `pasted/` storage dir +
+// MediaAttachmentProcessor path as the extension webview, so no model-layer
+// code is duplicated.
+
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { platform as osPlatform, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { isFileNotFoundError } from '@common/errors';
+import {
+  generatePastedImageName,
+  savePastedImageBuffer,
+} from '@utils/files/pastedImageUtils';
+
+const execFileAsync = promisify(execFile);
+const MAX_IMAGE_BYTES = 64 * 1024 * 1024;
+
+export type ClipboardAttachResult =
+  | {
+      readonly ok: true;
+      /** Absolute path to the saved image under the shared `pasted/` dir. */
+      readonly path: string;
+      readonly mediaType: string;
+      readonly displayName: string;
+    }
+  | { readonly ok: false; readonly reason: string };
+
+/** Per-platform read result: PNG bytes, no image present, or unsupported. */
+type ClipboardRead = Buffer | 'none' | 'unsupported';
+
+async function readClipboardPngMac(outFile: string): Promise<ClipboardRead> {
+  try {
+    // osascript ships with macOS — no external dependency. The first statement
+    // throws when the clipboard holds no image, which lands us in the catch.
+    await execFileAsync('osascript', [
+      '-e',
+      'set png_data to (the clipboard as «class PNGf»)',
+      '-e',
+      `set fp to open for access POSIX file "${outFile}" with write permission`,
+      '-e',
+      'write png_data to fp',
+      '-e',
+      'close access fp',
+    ]);
+  } catch {
+    return 'none';
+  }
+  return readFile(outFile);
+}
+
+async function readClipboardPngLinux(): Promise<ClipboardRead> {
+  // Prefer Wayland (wl-paste) then X11 (xclip). Both are optional; if neither
+  // is installed we report unsupported rather than "no image".
+  const attempts: ReadonlyArray<readonly [string, readonly string[]]> = [
+    ['wl-paste', ['--type', 'image/png']],
+    ['xclip', ['-selection', 'clipboard', '-t', 'image/png', '-o']],
+  ];
+  let toolFound = false;
+  for (const [cmd, args] of attempts) {
+    try {
+      const { stdout } = await execFileAsync(cmd, [...args], {
+        encoding: 'buffer',
+        maxBuffer: MAX_IMAGE_BYTES,
+      });
+      toolFound = true;
+      const buf = stdout as unknown as Buffer;
+      if (buf.length > 0) return buf;
+    } catch (err) {
+      if (isFileNotFoundError(err)) continue; // tool not installed → try next
+      toolFound = true; // tool ran but the clipboard had no image
+    }
+  }
+  return toolFound ? 'none' : 'unsupported';
+}
+
+async function readClipboardPngWindows(
+  outFile: string,
+): Promise<ClipboardRead> {
+  const script = `$img = Get-Clipboard -Format Image; if ($img) { Add-Type -AssemblyName System.Drawing; $img.Save('${outFile.replaceAll(
+    '\\',
+    '\\\\',
+  )}', [System.Drawing.Imaging.ImageFormat]::Png) } else { Write-Output 'NO_IMAGE' }`;
+  try {
+    const { stdout } = await execFileAsync('powershell', [
+      '-NoProfile',
+      '-Command',
+      script,
+    ]);
+    if (String(stdout).includes('NO_IMAGE')) return 'none';
+  } catch {
+    return 'none';
+  }
+  return readFile(outFile);
+}
+
+/**
+ * Read an image from the OS clipboard, persist it to the shared `pasted/`
+ * storage dir, and return its location. Returns `{ ok: false, reason }` when
+ * the clipboard holds no image or the platform/tooling is unsupported — callers
+ * surface `reason` and leave the text draft untouched.
+ */
+export async function attachClipboardImage(): Promise<ClipboardAttachResult> {
+  const plat = osPlatform();
+  if (plat !== 'darwin' && plat !== 'linux' && plat !== 'win32') {
+    return { ok: false, reason: `Image paste is not supported on ${plat}.` };
+  }
+
+  const dir = await mkdtemp(join(tmpdir(), 'texra-clip-'));
+  const tmpFile = join(dir, 'clipboard.png');
+  try {
+    const read =
+      plat === 'darwin'
+        ? await readClipboardPngMac(tmpFile)
+        : plat === 'linux'
+          ? await readClipboardPngLinux()
+          : await readClipboardPngWindows(tmpFile);
+
+    if (read === 'unsupported') {
+      return {
+        ok: false,
+        reason:
+          'Image paste on Linux needs wl-clipboard (Wayland) or xclip (X11).',
+      };
+    }
+    if (read === 'none') {
+      return { ok: false, reason: 'No image found on the clipboard.' };
+    }
+
+    const fileName = generatePastedImageName('png');
+    const path = await savePastedImageBuffer(read, fileName);
+    return { ok: true, path, mediaType: 'image/png', displayName: fileName };
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/packages/cli/src/runtime/clipboardImage.ts
+++ b/packages/cli/src/runtime/clipboardImage.ts
@@ -103,10 +103,8 @@ async function readClipboardPngLinux(): Promise<ClipboardRead> {
 async function readClipboardPngWindows(
   outFile: string,
 ): Promise<ClipboardRead> {
-  const script = `$img = Get-Clipboard -Format Image; if ($img) { Add-Type -AssemblyName System.Drawing; $img.Save('${outFile.replaceAll(
-    '\\',
-    '\\\\',
-  )}', [System.Drawing.Imaging.ImageFormat]::Png) } else { Write-Output 'NO_IMAGE' }`;
+  const quotedOutFile = outFile.replaceAll("'", "''");
+  const script = `$img = Get-Clipboard -Format Image; if ($img) { Add-Type -AssemblyName System.Drawing; $img.Save('${quotedOutFile}', [System.Drawing.Imaging.ImageFormat]::Png) } else { Write-Output 'NO_IMAGE' }`;
   try {
     const { stdout } = await execFileAsync('powershell', [
       '-NoProfile',

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -106,12 +106,16 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
   registerCommands(context, [
     {
       id: 'texra.sendFollowUp',
-      handler: async (payload: { stream: StreamTabId; text: string }) => {
-        const { stream: streamId, text } = payload;
+      handler: async (payload: {
+        stream: StreamTabId;
+        text: string;
+        mediaFiles?: string[];
+      }) => {
+        const { stream: streamId, text, mediaFiles } = payload;
 
         await lazyDetectWaitingStatus(streamId);
 
-        const result = await sendFollowUp(streamId, text);
+        const result = await sendFollowUp(streamId, text, mediaFiles);
         await handleFollowUpResult(result, streamId);
       },
     },

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -46,9 +46,12 @@ async function resumeFromSnapshot(
     runtimeHost,
   });
 
-  let queuedFollowUps: string[] = [];
+  let queuedFollowUps: Array<{
+    text: string;
+    mediaFiles?: readonly string[];
+  }> = [];
   try {
-    queuedFollowUps = ToolUseFollowUpQueue.drain(streamId);
+    queuedFollowUps = ToolUseFollowUpQueue.drainItems(streamId);
     runtimeHost.emit('updateQueuedFollowUps', {
       streamId,
     });
@@ -56,11 +59,11 @@ async function resumeFromSnapshot(
     await resumeToolUseFromSnapshot(snapshot, runtimeHost, (session) => {
       const allFollowUps =
         followUp !== undefined
-          ? [followUp, ...queuedFollowUps]
+          ? [{ text: followUp }, ...queuedFollowUps]
           : queuedFollowUps;
 
-      for (const text of allFollowUps) {
-        session.appendFollowUp(text);
+      for (const item of allFollowUps) {
+        session.appendFollowUp(item.text, item.mediaFiles);
       }
     });
 
@@ -69,7 +72,7 @@ async function resumeFromSnapshot(
     const lostFollowUps =
       queuedFollowUps.length > 0
         ? queuedFollowUps
-        : ToolUseFollowUpQueue.drain(streamId);
+        : ToolUseFollowUpQueue.drainItems(streamId);
     const lostCount = lostFollowUps.length;
 
     const baseMessage = logErrorMessage(

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -56,6 +56,7 @@ import {
   pathToLocation,
   WorkspaceFS,
 } from '@utils/files';
+import { savePastedImageBase64 } from '@utils/files/pastedImageUtils';
 import {
   buildFileContextFromTaskState,
   polishTextWithAI,
@@ -213,9 +214,23 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         }
       },
       [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]: async (data) => {
+        // Persist any pasted follow-up images to the shared `pasted/` dir (the
+        // same path the main webview uses) and forward their file paths so they
+        // reach the model on this follow-up turn via addMediaToUserMessage.
+        const mediaFiles: string[] = [];
+        for (const img of data.images ?? []) {
+          try {
+            mediaFiles.push(
+              await savePastedImageBase64(img.base64, img.fileName),
+            );
+          } catch {
+            // Best-effort: a failed image save must not block the text.
+          }
+        }
         await vscode.commands.executeCommand('texra.sendFollowUp', {
           stream: data.stream,
           text: data.text,
+          ...(mediaFiles.length > 0 ? { mediaFiles } : {}),
         });
       },
       [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]: (data) =>

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -223,8 +223,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             mediaFiles.push(
               await savePastedImageBase64(img.base64, img.fileName),
             );
-          } catch {
-            // Best-effort: a failed image save must not block the text.
+          } catch (err) {
+            // Best-effort: a failed image save must not block the text, but log
+            // it so a missing attachment is diagnosable.
+            this.logger.warn(
+              this.channel,
+              `Failed to save pasted follow-up image: ${toErrorMessage(err)}`,
+            );
           }
         }
         await vscode.commands.executeCommand('texra.sendFollowUp', {

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -661,8 +661,8 @@ export class ProgressApp extends ProgressAppBase {
   private onFollowUpChange = (e: CustomEvent): void =>
     handleFollowUpChange(e, this.getEventHandlerContext());
 
-  private onFollowUpSend = (): void =>
-    handleFollowUpSend(this.getEventHandlerContext());
+  private onFollowUpSend = (e: CustomEvent): void =>
+    handleFollowUpSend(this.getEventHandlerContext(), e.detail?.images ?? []);
 
   private onFollowUpPolish = (): void =>
     handleFollowUpPolish(this.getEventHandlerContext());

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -123,6 +123,8 @@ export class FollowUpInput extends LitElement {
 
   /** Images pasted into the follow-up box; attached to the message on send. */
   private pendingImages: ExtractedClipboardImage[] = [];
+  private readonly pendingImagePastes = new Set<Promise<void>>();
+  private sendAfterImagePastes = false;
 
   @query(`#${ELEMENT_IDS.FOLLOW_UP_INPUT}`)
   declare private textAreaEl: HTMLElement | null;
@@ -197,7 +199,12 @@ export class FollowUpInput extends LitElement {
     if (files.length === 0) return;
     // Suppress the default paste synchronously, before the async read below.
     event.preventDefault();
-    void this.attachPastedImages(event, files);
+    const paste = this.attachPastedImages(event, files);
+    this.pendingImagePastes.add(paste);
+    void paste.finally(() => {
+      this.pendingImagePastes.delete(paste);
+      this.flushPendingImagePasteSend();
+    });
   }
 
   private async attachPastedImages(
@@ -324,10 +331,22 @@ export class FollowUpInput extends LitElement {
   }
 
   private emitSend(): void {
+    if (this.pendingImagePastes.size > 0) {
+      this.sendAfterImagePastes = true;
+      return;
+    }
     this.dispatchEvent(
       ProgressEvents.followupSend({ images: this.pendingImages }),
     );
     this.pendingImages = [];
+    this.sendAfterImagePastes = false;
+  }
+
+  private flushPendingImagePasteSend(): void {
+    if (!this.sendAfterImagePastes || this.pendingImagePastes.size > 0) {
+      return;
+    }
+    this.emitSend();
   }
 
   private emitPolish(): void {
@@ -340,6 +359,7 @@ export class FollowUpInput extends LitElement {
 
   private emitClear(): void {
     this.pendingImages = [];
+    this.sendAfterImagePastes = false;
     this.dispatchEvent(ProgressEvents.followupClear());
   }
 

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -16,6 +16,13 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { RecordingButtonController } from '@shared/controllers';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { getTextareaValue, insertTextAtCursor } from '@shared/utils/textarea';
+import {
+  clipboardImageFiles,
+  generatePastedImageName,
+  getExtensionFromMimeType,
+  readFileAsBase64,
+  type ExtractedClipboardImage,
+} from '@shared/utils/clipboardImages';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
@@ -114,6 +121,9 @@ export class FollowUpInput extends LitElement {
 
   @state() private polishing = false;
 
+  /** Images pasted into the follow-up box; attached to the message on send. */
+  private pendingImages: ExtractedClipboardImage[] = [];
+
   @query(`#${ELEMENT_IDS.FOLLOW_UP_INPUT}`)
   declare private textAreaEl: HTMLElement | null;
 
@@ -179,6 +189,45 @@ export class FollowUpInput extends LitElement {
     }
   }
 
+  /** Pasting an image stashes its bytes and inserts a `[fileName]` token; the
+   *  bytes ride along to the model when the follow-up is sent. Non-image
+   *  pastes fall through to the textarea's default text handling. */
+  private handlePaste(event: ClipboardEvent): void {
+    const files = clipboardImageFiles(event);
+    if (files.length === 0) return;
+    // Suppress the default paste synchronously, before the async read below.
+    event.preventDefault();
+    void this.attachPastedImages(event, files);
+  }
+
+  private async attachPastedImages(
+    event: ClipboardEvent,
+    files: Array<{ file: File; type: string }>,
+  ): Promise<void> {
+    const target = this.textAreaEl;
+    if (!target) return;
+    let insertText = event.clipboardData?.getData('text/plain') || '';
+    const added: ExtractedClipboardImage[] = [];
+    for (const { file, type } of files) {
+      const base64 = await readFileAsBase64(file);
+      if (!base64) continue;
+      const fileName = generatePastedImageName(getExtensionFromMimeType(type));
+      added.push({ fileName, base64, mediaType: type });
+      if (
+        insertText &&
+        !insertText.endsWith(' ') &&
+        !insertText.endsWith('\n')
+      ) {
+        insertText += ' ';
+      }
+      insertText += `[${fileName}]`;
+    }
+    if (added.length === 0) return;
+    this.pendingImages = [...this.pendingImages, ...added];
+    insertTextAtCursor(target, insertText);
+    this.updateValue(getTextareaValue(target));
+  }
+
   override render(): TemplateResult | typeof nothing {
     return html`
       <wa-details class="panel-collapsible" summary="Follow-up Input">
@@ -196,6 +245,7 @@ export class FollowUpInput extends LitElement {
               .value=${live(this.value)}
               @input=${this.handleInput}
               @keydown=${this.handleKeydown}
+              @paste=${this.handlePaste}
             ></wa-textarea>
 
             <div class="follow-up-actions">
@@ -266,7 +316,10 @@ export class FollowUpInput extends LitElement {
   }
 
   private emitSend(): void {
-    this.dispatchEvent(ProgressEvents.followupSend());
+    this.dispatchEvent(
+      ProgressEvents.followupSend({ images: this.pendingImages }),
+    );
+    this.pendingImages = [];
   }
 
   private emitPolish(): void {
@@ -278,6 +331,7 @@ export class FollowUpInput extends LitElement {
   }
 
   private emitClear(): void {
+    this.pendingImages = [];
     this.dispatchEvent(ProgressEvents.followupClear());
   }
 

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -124,6 +124,7 @@ export class FollowUpInput extends LitElement {
   /** Images pasted into the follow-up box; attached to the message on send. */
   private pendingImages: ExtractedClipboardImage[] = [];
   private readonly pendingImagePastes = new Set<Promise<void>>();
+  private imagePasteRevision = 0;
   private sendAfterImagePastes = false;
 
   @query(`#${ELEMENT_IDS.FOLLOW_UP_INPUT}`)
@@ -199,7 +200,11 @@ export class FollowUpInput extends LitElement {
     if (files.length === 0) return;
     // Suppress the default paste synchronously, before the async read below.
     event.preventDefault();
-    const paste = this.attachPastedImages(event, files);
+    const paste = this.attachPastedImages(
+      event,
+      files,
+      this.imagePasteRevision,
+    );
     this.pendingImagePastes.add(paste);
     void paste.finally(() => {
       this.pendingImagePastes.delete(paste);
@@ -210,6 +215,7 @@ export class FollowUpInput extends LitElement {
   private async attachPastedImages(
     event: ClipboardEvent,
     files: Array<{ file: File; type: string }>,
+    pasteRevision: number,
   ): Promise<void> {
     const target = this.textAreaEl;
     if (!target) return;
@@ -232,6 +238,7 @@ export class FollowUpInput extends LitElement {
         ),
       )
     ).filter((image): image is ExtractedClipboardImage => image !== undefined);
+    if (pasteRevision !== this.imagePasteRevision) return;
     if (added.length === 0) return;
     const chipText = added.map(({ fileName }) => `[${fileName}]`).join(' ');
     if (insertText && !insertText.endsWith(' ') && !insertText.endsWith('\n')) {
@@ -358,6 +365,7 @@ export class FollowUpInput extends LitElement {
   }
 
   private emitClear(): void {
+    this.imagePasteRevision += 1;
     this.pendingImages = [];
     this.sendAfterImagePastes = false;
     this.dispatchEvent(ProgressEvents.followupClear());

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -207,22 +207,30 @@ export class FollowUpInput extends LitElement {
     const target = this.textAreaEl;
     if (!target) return;
     let insertText = event.clipboardData?.getData('text/plain') || '';
-    const added: ExtractedClipboardImage[] = [];
-    for (const { file, type } of files) {
-      const base64 = await readFileAsBase64(file);
-      if (!base64) continue;
-      const fileName = generatePastedImageName(getExtensionFromMimeType(type));
-      added.push({ fileName, base64, mediaType: type });
-      if (
-        insertText &&
-        !insertText.endsWith(' ') &&
-        !insertText.endsWith('\n')
-      ) {
-        insertText += ' ';
-      }
-      insertText += `[${fileName}]`;
-    }
+    const added = (
+      await Promise.all(
+        files.map(
+          async ({
+            file,
+            type,
+          }): Promise<ExtractedClipboardImage | undefined> => {
+            const base64 = await readFileAsBase64(file);
+            if (!base64) return undefined;
+            return {
+              fileName: generatePastedImageName(getExtensionFromMimeType(type)),
+              base64,
+              mediaType: type,
+            };
+          },
+        ),
+      )
+    ).filter((image): image is ExtractedClipboardImage => image !== undefined);
     if (added.length === 0) return;
+    const chipText = added.map(({ fileName }) => `[${fileName}]`).join(' ');
+    if (insertText && !insertText.endsWith(' ') && !insertText.endsWith('\n')) {
+      insertText += ' ';
+    }
+    insertText += chipText;
     this.pendingImages = [...this.pendingImages, ...added];
     insertTextAtCursor(target, insertText);
     this.updateValue(getTextareaValue(target));

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -5,6 +5,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import type { StreamTabId } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
 
 // Local imports - progress view
 import {
@@ -164,13 +165,23 @@ function getActiveFollowUpText(
   return { streamId, text };
 }
 
-export function handleFollowUpSend(ctx: FrontendEventHandlerContext): void {
+export function handleFollowUpSend(
+  ctx: FrontendEventHandlerContext,
+  images: readonly ExtractedClipboardImage[] = [],
+): void {
   const result = getActiveFollowUpText(ctx);
   if (!result) return;
+
+  // Orphan gate: only attach images whose [fileName] token survives in the
+  // submitted text (the user may have deleted a pasted chip before sending).
+  const attached = images.filter((img) =>
+    result.text.includes(`[${img.fileName}]`),
+  );
 
   postMessage(PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP, {
     stream: result.streamId,
     text: result.text,
+    ...(attached.length > 0 ? { images: attached } : {}),
   });
   updateToolUseState(ctx, result.streamId, (prev) =>
     create(prev, (draft) => {

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -6,6 +6,7 @@
 import type { StringValueDetail } from '@shared/schemas';
 import type { UserQuestionAnswers } from '@shared/schemas';
 import { createEvent } from '@shared/utils/events';
+import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
 
 import type { PermissionState } from './components/PermissionCard';
 import type { StreamFilter } from './store';
@@ -28,6 +29,11 @@ export interface ToolbarCommandDetail {
 
 /** Alias for semantic clarity - uses shared StringValueDetail */
 export type FollowUpChangeDetail = StringValueDetail;
+
+/** Images pasted into the follow-up box, carried with the send event. */
+export interface FollowUpSendDetail {
+  readonly images: readonly ExtractedClipboardImage[];
+}
 
 export interface WorkflowFollowupFormData {
   agent: string;
@@ -87,7 +93,8 @@ export const ProgressEvents = {
   followupChange: (detail: FollowUpChangeDetail) =>
     createEvent('followup-change', detail),
 
-  followupSend: () => createEvent('followup-send', undefined),
+  followupSend: (detail: FollowUpSendDetail) =>
+    createEvent('followup-send', detail),
 
   followupPolish: () => createEvent('followup-polish', undefined),
 

--- a/packages/extension/src/webview/frontend/pasteHandler.ts
+++ b/packages/extension/src/webview/frontend/pasteHandler.ts
@@ -1,131 +1,45 @@
-// Third-party imports
-import { nanoid } from 'nanoid';
-
 // Local imports - shared utilities
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import { insertTextAtCursor } from '@shared/utils/textarea';
-import { PASTED_PREFIX } from '@shared/files/pastedImageConstants';
-
-const IMAGE_MIME_TYPES: Record<string, string> = {
-  'image/jpeg': 'jpg',
-  'image/jpg': 'jpg',
-  'image/png': 'png',
-  'image/gif': 'gif',
-  'image/webp': 'webp',
-  'image/bmp': 'bmp',
-  'image/svg+xml': 'svg',
-  'image/tiff': 'tiff',
-  'image/tif': 'tiff',
-  'image/x-icon': 'ico',
-  'image/vnd.microsoft.icon': 'ico',
-  'image/heic': 'heic',
-  'image/heif': 'heif',
-  'image/avif': 'avif',
-  'image/pjpeg': 'jpg',
-  'image/x-png': 'png',
-  'image/x-jng': 'jng',
-  'image/x-mng': 'mng',
-  'image/vnd.adobe.photoshop': 'psd',
-  'image/x-photoshop': 'psd',
-  'image/x-psd': 'psd',
-};
-
-function generatePastedImageName(extension: string): string {
-  const timestamp = Date.now();
-  const random = nanoid(6);
-  return `${PASTED_PREFIX}${timestamp}_${random}.${extension}`;
-}
-
-function getExtensionFromMimeType(mimeType: string): string {
-  return IMAGE_MIME_TYPES[mimeType] || mimeType.split('/')[1] || 'png';
-}
-
-async function processClipboardImage(
-  file: File,
-  mimeType: string,
-): Promise<string | null> {
-  return new Promise((resolve) => {
-    const extension = getExtensionFromMimeType(mimeType);
-    const fileName = generatePastedImageName(extension);
-    const reader = new FileReader();
-
-    reader.onload = () => {
-      const result = reader.result;
-      if (typeof result === 'string') {
-        const base64 = result.split(',')[1];
-        if (base64) {
-          postMessage(MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE, {
-            base64,
-            mediaType: mimeType,
-            fileName,
-          });
-          resolve(fileName);
-          return;
-        }
-      }
-      resolve(null);
-    };
-
-    reader.onerror = () => {
-      console.error(`Failed to read file: ${fileName}`);
-      postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
-        text: `Failed to process pasted image: ${fileName}`,
-      });
-      resolve(null);
-    };
-
-    try {
-      reader.readAsDataURL(file);
-    } catch (error) {
-      console.error(`Error reading file: ${String(error)}`);
-      resolve(null);
-    }
-  });
-}
+import {
+  clipboardImageFiles,
+  generatePastedImageName,
+  getExtensionFromMimeType,
+  readFileAsBase64,
+} from '@shared/utils/clipboardImages';
 
 export async function handleImagePaste(
   event: ClipboardEvent,
   target: HTMLElement,
 ): Promise<boolean> {
-  /* eslint-disable unicorn/prefer-spread -- DataTransferItemList lacks iterator typing. */
-  const items = event.clipboardData
-    ? Array.from(event.clipboardData.items)
-    : [];
-  /* eslint-enable unicorn/prefer-spread */
-  const images: Array<{ file: File; type: string }> = [];
-
-  for (const item of items) {
-    if (item.type.startsWith('image/')) {
-      const file = item.getAsFile();
-      if (file) {
-        images.push({ file, type: item.type });
-      }
-    }
-  }
-
+  const images = clipboardImageFiles(event);
   if (images.length === 0) {
     return false;
   }
 
+  // Must run synchronously, before any await, to suppress the default paste.
   event.preventDefault();
 
   let insertText = event.clipboardData?.getData('text/plain') || '';
-  const fileNames = await Promise.all(
-    images.map(({ file, type }) => processClipboardImage(file, type)),
-  );
-
-  for (const fileName of fileNames) {
-    if (fileName) {
-      if (
-        insertText &&
-        !insertText.endsWith(' ') &&
-        !insertText.endsWith('\n')
-      ) {
-        insertText += ' ';
-      }
-      insertText += `[${fileName}]`;
+  for (const { file, type } of images) {
+    const fileName = generatePastedImageName(getExtensionFromMimeType(type));
+    const base64 = await readFileAsBase64(file);
+    if (!base64) {
+      postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
+        text: `Failed to process pasted image: ${fileName}`,
+      });
+      continue;
     }
+    postMessage(MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE, {
+      base64,
+      mediaType: type,
+      fileName,
+    });
+    if (insertText && !insertText.endsWith(' ') && !insertText.endsWith('\n')) {
+      insertText += ' ';
+    }
+    insertText += `[${fileName}]`;
   }
 
   if (insertText) {

--- a/packages/extension/src/webview/frontend/pasteHandler.ts
+++ b/packages/extension/src/webview/frontend/pasteHandler.ts
@@ -21,25 +21,32 @@ export async function handleImagePaste(
   // Must run synchronously, before any await, to suppress the default paste.
   event.preventDefault();
 
-  let insertText = event.clipboardData?.getData('text/plain') || '';
-  for (const { file, type } of images) {
-    const fileName = generatePastedImageName(getExtensionFromMimeType(type));
-    const base64 = await readFileAsBase64(file);
-    if (!base64) {
-      postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
-        text: `Failed to process pasted image: ${fileName}`,
+  const pastedImageText = await Promise.all(
+    images.map(async ({ file, type }) => {
+      const fileName = generatePastedImageName(getExtensionFromMimeType(type));
+      const base64 = await readFileAsBase64(file);
+      if (!base64) {
+        postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
+          text: `Failed to process pasted image: ${fileName}`,
+        });
+        return '';
+      }
+      postMessage(MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE, {
+        base64,
+        mediaType: type,
+        fileName,
       });
-      continue;
-    }
-    postMessage(MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE, {
-      base64,
-      mediaType: type,
-      fileName,
-    });
+      return `[${fileName}]`;
+    }),
+  );
+
+  const imageChips = pastedImageText.filter(Boolean).join(' ');
+  let insertText = event.clipboardData?.getData('text/plain') || '';
+  if (imageChips) {
     if (insertText && !insertText.endsWith(' ') && !insertText.endsWith('\n')) {
       insertText += ' ';
     }
-    insertText += `[${fileName}]`;
+    insertText += imageChips;
   }
 
   if (insertText) {

--- a/packages/extension/src/webview/managers/InstructionManager.ts
+++ b/packages/extension/src/webview/managers/InstructionManager.ts
@@ -1,5 +1,3 @@
-import * as path from 'path';
-
 import * as vscode from 'vscode';
 
 import { toErrorMessage } from '@common/errors';
@@ -8,7 +6,10 @@ import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import type { MainViewInboundMessage } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
 import { THREE_DAYS_MS } from '@utils/config';
-import { PASTED_DIR } from '@utils/files/pastedImageUtils';
+import {
+  PASTED_DIR,
+  savePastedImageBase64,
+} from '@utils/files/pastedImageUtils';
 import {
   polishTextWithAI,
   FileContext,
@@ -114,10 +115,7 @@ export class InstructionManager extends BaseWebviewManager {
       if (!base64 || !mediaType || !fileName) {
         return;
       }
-      await StorageFS.ensureDir(PASTED_DIR);
-      const relativePath = path.join(PASTED_DIR, fileName);
-      await StorageFS.write(relativePath, Buffer.from(base64, 'base64'));
-      await StorageFS.cleanupOldFiles(PASTED_DIR, THREE_DAYS_MS);
+      await savePastedImageBase64(base64, fileName);
       this.postMessage({
         command: MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE,
         file: fileName,

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -3,6 +3,7 @@ import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
+import type { TaskRunFileService } from '@utils/files';
 import type {
   BaseFlowContextInit,
   FlowParams,
@@ -13,6 +14,8 @@ import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly setting: AgentToolUseSetting;
   readonly session: IToolUseSession;
+  /** Run-storage-aware file locator; used to attach follow-up media files. */
+  readonly fileService: TaskRunFileService;
   readonly resolvedTools: ToolDefinition[];
   readonly toolRegistry: IToolRegistry;
   readonly snapshot: ToolUseSessionSnapshot | null;

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -3,7 +3,7 @@ import type { FollowUpQueueBatch } from '@agent/toolUse/FollowUpQueue';
 import type { StreamTabId } from '@shared/schemas';
 
 export interface IToolUseSession {
-  appendFollowUp(text: string): void;
+  appendFollowUp(text: string, mediaFiles?: readonly string[]): void;
   appendSyntheticFollowUp(text: string): void;
   hasQueuedFollowUp(): boolean;
   /** Wait for the next follow-up items. Returns null if interrupted. */
@@ -18,8 +18,8 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
 
   constructor(private readonly streamTabId: StreamTabId) {}
 
-  appendFollowUp(text: string): void {
-    this.followUps.enqueue(text);
+  appendFollowUp(text: string, mediaFiles?: readonly string[]): void {
+    this.followUps.enqueue(text, mediaFiles);
   }
 
   appendSyntheticFollowUp(text: string): void {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -21,7 +21,8 @@ export class ToolUsePrepareNode<C> extends Node<
   async exec(
     _prepRes: void,
   ): Promise<{ kind: 'success'; result: PrepareResult }> {
-    const { userVarChannels, logger, snapshot } = this.services;
+    const { userVarChannels, logger, snapshot, config, fileService } =
+      this.services;
     const resolvedToolNames = this.services.resolvedTools.map((t) => t.name);
     const hasDelegationTools = this.services.resolvedTools.some((t) =>
       DELEGATION_TOOLS.has(t.name),
@@ -83,10 +84,16 @@ export class ToolUsePrepareNode<C> extends Node<
     const systemMessage = systemPrompt
       ? `${systemPrompt}\n${instructionSuffix}`
       : instructionSuffix;
+    // Attach any media files (CLI `--media`, an image pasted on the first
+    // message) to the initial user message via the shared media slot. No-ops
+    // when empty or the model lacks vision.
+    const mediaFiles = config.mediaFiles.length
+      ? config.mediaFiles.map((p) => fileService.createLocation(p))
+      : undefined;
     const messages = await this.services.modelHandler.initializeMessages(
       userPrefix,
       userRequest,
-      undefined,
+      mediaFiles,
       systemMessage,
     );
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -127,6 +127,7 @@ export class ToolUseWaitNode<C> extends Node<
       kind: 'continue',
       followUp: batch.items.join('\n\n'),
       synthetic: batch.synthetic,
+      mediaFiles: batch.mediaFiles,
     };
   }
 
@@ -143,8 +144,14 @@ export class ToolUseWaitNode<C> extends Node<
     prepRes: WaitPrepResult,
     execRes: WaitExecResult,
   ): Promise<string | undefined> {
-    const { onFollowUpConsumed, streamId, logger, modelHandler, runtimeHost } =
-      this.services;
+    const {
+      onFollowUpConsumed,
+      streamId,
+      logger,
+      modelHandler,
+      runtimeHost,
+      fileService,
+    } = this.services;
 
     if (execRes.kind === 'stop') {
       if (prepRes.deliveredToOrchestrator) {
@@ -179,6 +186,16 @@ export class ToolUseWaitNode<C> extends Node<
       shared.messages,
       execRes.followUp,
     );
+
+    // Attach any media (e.g. pasted images) the user sent with this follow-up
+    // to the freshly-appended user message, reusing the same shared media path
+    // as the reflection flow. No-ops when empty or the model lacks vision.
+    if (execRes.mediaFiles?.length) {
+      await modelHandler.addMediaToUserMessage(
+        shared.messages,
+        execRes.mediaFiles.map((p) => fileService.createLocation(p)),
+      );
+    }
 
     return FlowTransition.CONTINUE;
   }

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -57,6 +57,12 @@ export type WaitExecResult =
        * continuations don't emit a spurious updateQueuedFollowUps event.
        */
       synthetic?: boolean;
+      /**
+       * Media file paths attached to this follow-up (from the user queue).
+       * Converted to FileLocation[] and attached to the new user message via
+       * `addMediaToUserMessage` in post(). Empty for synthetic continuations.
+       */
+      mediaFiles?: string[];
     }
   | { kind: 'stop' };
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -31,6 +31,7 @@ import type { SubagentProgressUpdate } from '@shared/schemas';
 import { evaluateDelegationGate } from '@shared/constants/delegationPolicy';
 
 import { getDefaultToolRegistry } from '@tools/registry';
+import { TaskRunFileService } from '@utils/files';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
 import { ToolUseWaitNode } from './nodes/ToolUseWaitNode';
@@ -126,6 +127,7 @@ export async function runToolUseFlow<C = unknown>(
     snapshot: input.resumeSnapshot ?? null,
     onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
     persistTodos: (todos) => kv.writeTodos(todos),
+    fileService: new TaskRunFileService(executionId),
     delegationDepth,
     delegationConfig,
     delegationTrimmed,

--- a/src/agent/toolUse/FollowUpQueue.ts
+++ b/src/agent/toolUse/FollowUpQueue.ts
@@ -8,19 +8,23 @@
 interface FollowUpQueueItem {
   readonly text: string;
   readonly synthetic: boolean;
+  /** Media file paths (e.g. pasted images) attached to this user follow-up. */
+  readonly mediaFiles?: readonly string[];
 }
 
 export interface FollowUpQueueBatch {
   readonly items: string[];
   readonly synthetic: boolean;
+  /** Media file paths from the user follow-ups in this batch, flattened. */
+  readonly mediaFiles: string[];
 }
 
 export class FollowUpQueue {
   private readonly queued: FollowUpQueueItem[] = [];
   private resolver: ((value: FollowUpQueueItem | null) => void) | null = null;
 
-  enqueue(value: string): void {
-    this.enqueueItem({ text: value, synthetic: false });
+  enqueue(value: string, mediaFiles?: readonly string[]): void {
+    this.enqueueItem({ text: value, synthetic: false, mediaFiles });
   }
 
   enqueueSynthetic(value: string): void {
@@ -75,16 +79,19 @@ export class FollowUpQueue {
     const first = await this.waitForNext(checkInterruption);
     if (first === null) return null;
     if (first.synthetic) {
-      return { items: [first.text], synthetic: true };
+      return { items: [first.text], synthetic: true, mediaFiles: [] };
     }
 
     const items = [first.text];
+    const mediaFiles: string[] = [...(first.mediaFiles ?? [])];
     while (true) {
       const next = this.queued[0];
       if (!next || next.synthetic) break;
-      items.push(this.queued.shift()!.text);
+      const item = this.queued.shift()!;
+      items.push(item.text);
+      if (item.mediaFiles?.length) mediaFiles.push(...item.mediaFiles);
     }
-    return { items, synthetic: false };
+    return { items, synthetic: false, mediaFiles };
   }
 
   cancelWait(): void {

--- a/src/agent/toolUse/FollowUpQueue.ts
+++ b/src/agent/toolUse/FollowUpQueue.ts
@@ -52,6 +52,18 @@ export class FollowUpQueue {
       .map((item) => item.text);
   }
 
+  /**
+   * Drain queued visible follow-ups together with their media file paths.
+   * Used by resume to replay queued user input without losing pasted images;
+   * the text-only {@link drain} stays for display/back-compat.
+   */
+  drainItems(): Array<{ text: string; mediaFiles?: readonly string[] }> {
+    return this.queued
+      .splice(0)
+      .filter((item) => !item.synthetic)
+      .map((item) => ({ text: item.text, mediaFiles: item.mediaFiles }));
+  }
+
   waitForNext(
     checkInterruption: () => boolean,
   ): Promise<FollowUpQueueItem | null> {

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -71,6 +71,7 @@ export function notifyFollowUpSent(
 export async function sendFollowUp(
   streamId: StreamTabId,
   text: string,
+  mediaFiles?: readonly string[],
 ): Promise<SendFollowUpResult> {
   const status = StreamStatusService.get(streamId);
   const activeChildren = getActiveChildren(streamId);
@@ -78,7 +79,7 @@ export async function sendFollowUp(
     activeChildren.subagents.length > 0 || activeChildren.processes.length > 0;
   if (status !== undefined && !isInFlightStatus(status)) {
     if (hasActiveChildren) {
-      ToolUseFollowUpQueue.enqueue(streamId, text, { force: true });
+      ToolUseFollowUpQueue.enqueue(streamId, text, { force: true, mediaFiles });
       return { status: 'queued', reason: 'children_running' };
     }
     logger.warn(
@@ -90,20 +91,20 @@ export async function sendFollowUp(
   // Try active flow context first
   const flowContext = getToolUseFlowContext(streamId);
   if (flowContext) {
-    flowContext.session.appendFollowUp(text);
+    flowContext.session.appendFollowUp(text, mediaFiles);
     notifyFollowUpSent(streamId, flowContext.runtimeHost);
     return { status: 'sent' };
   }
 
   // Queue if session is resuming
   if (ToolUseFollowUpQueue.isResuming(streamId)) {
-    ToolUseFollowUpQueue.enqueue(streamId, text);
+    ToolUseFollowUpQueue.enqueue(streamId, text, { mediaFiles });
     return { status: 'queued', reason: 'resuming' };
   }
 
   // Queue if session is waiting (paused, can be resumed)
   if (status === STREAM_STATUS.WAITING) {
-    ToolUseFollowUpQueue.enqueue(streamId, text);
+    ToolUseFollowUpQueue.enqueue(streamId, text, { mediaFiles });
     return { status: 'queued', reason: 'waiting' };
   }
 
@@ -111,7 +112,7 @@ export async function sendFollowUp(
     // force:true reopens a queue sealed by sessionLifecycle disposal — the
     // caller must auto-resume the parent or re-release, or late child
     // deliveries will leak into the next run on this stream.
-    ToolUseFollowUpQueue.enqueue(streamId, text, { force: true });
+    ToolUseFollowUpQueue.enqueue(streamId, text, { force: true, mediaFiles });
     return { status: 'queued', reason: 'children_running' };
   }
 

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -91,7 +91,7 @@ export class ToolUseFollowUpQueue {
   static enqueue(
     streamId: StreamTabId,
     followUp: string,
-    options?: { force?: boolean },
+    options?: { force?: boolean; mediaFiles?: readonly string[] },
   ): boolean {
     if (this.released.has(streamId) && !options?.force) {
       logger.debug(
@@ -100,7 +100,7 @@ export class ToolUseFollowUpQueue {
       return false;
     }
     const queue = this.acquire(streamId);
-    queue.enqueue(followUp);
+    queue.enqueue(followUp, options?.mediaFiles);
     logger.debug(`Queued follow-up for stream ${streamId}.`);
     return true;
   }

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -109,6 +109,13 @@ export class ToolUseFollowUpQueue {
     return this.queues.get(streamId)?.drain() ?? [];
   }
 
+  /** Drain queued follow-ups with their media file paths (resume replay). */
+  static drainItems(
+    streamId: StreamTabId,
+  ): Array<{ text: string; mediaFiles?: readonly string[] }> {
+    return this.queues.get(streamId)?.drainItems() ?? [];
+  }
+
   /** Get all queued follow-up messages for a stream without consuming them. */
   static getAll(streamId: StreamTabId): string[] {
     return this.queues.get(streamId)?.getAll() ?? [];

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -642,6 +642,16 @@ const SendFollowUpMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP),
   stream: StreamTabIdSchema,
   text: TrimmedStringSchema,
+  /** Pasted images (base64) to attach to this follow-up turn. */
+  images: z
+    .array(
+      z.object({
+        base64: z.string(),
+        mediaType: z.string(),
+        fileName: z.string(),
+      }),
+    )
+    .optional(),
 });
 
 const PolishFollowUpMessageSchema = z.object({

--- a/src/shared/utils/clipboardImages.ts
+++ b/src/shared/utils/clipboardImages.ts
@@ -1,0 +1,74 @@
+// Shared clipboard-image extraction for webview paste handlers (main view +
+// progress-view follow-up). Browser-only — relies on FileReader/DataTransfer
+// and has no Node imports, so it is safe in both webview bundles.
+
+import { nanoid } from 'nanoid';
+
+import { PASTED_PREFIX } from '@shared/files/pastedImageConstants';
+
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/bmp': 'bmp',
+  'image/svg+xml': 'svg',
+  'image/tiff': 'tiff',
+  'image/tif': 'tiff',
+  'image/x-icon': 'ico',
+  'image/vnd.microsoft.icon': 'ico',
+  'image/heic': 'heic',
+  'image/heif': 'heif',
+  'image/avif': 'avif',
+  'image/pjpeg': 'jpg',
+  'image/x-png': 'png',
+};
+
+export function getExtensionFromMimeType(mimeType: string): string {
+  return IMAGE_MIME_TYPES[mimeType] || mimeType.split('/')[1] || 'png';
+}
+
+export function generatePastedImageName(extension: string): string {
+  return `${PASTED_PREFIX}${Date.now()}_${nanoid(6)}.${extension}`;
+}
+
+export interface ExtractedClipboardImage {
+  readonly fileName: string;
+  readonly base64: string;
+  readonly mediaType: string;
+}
+
+/** Image files present on a paste event, paired with their MIME type. */
+export function clipboardImageFiles(
+  event: ClipboardEvent,
+): Array<{ file: File; type: string }> {
+  const list = event.clipboardData?.items;
+  const images: Array<{ file: File; type: string }> = [];
+  for (let i = 0; i < (list?.length ?? 0); i++) {
+    const item = list?.[i];
+    if (!item || !item.type.startsWith('image/')) continue;
+    const file = item.getAsFile();
+    if (file) images.push({ file, type: item.type });
+  }
+  return images;
+}
+
+/** Read a File to base64 (no data-URL prefix), or null on failure. */
+export function readFileAsBase64(file: File): Promise<string | null> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      resolve(
+        typeof result === 'string' ? (result.split(',')[1] ?? null) : null,
+      );
+    };
+    reader.onerror = () => resolve(null);
+    try {
+      reader.readAsDataURL(file);
+    } catch {
+      resolve(null);
+    }
+  });
+}

--- a/src/shared/utils/clipboardImages.ts
+++ b/src/shared/utils/clipboardImages.ts
@@ -23,6 +23,11 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
   'image/avif': 'avif',
   'image/pjpeg': 'jpg',
   'image/x-png': 'png',
+  'image/x-jng': 'jng',
+  'image/x-mng': 'mng',
+  'image/vnd.adobe.photoshop': 'psd',
+  'image/x-photoshop': 'psd',
+  'image/x-psd': 'psd',
 };
 
 export function getExtensionFromMimeType(mimeType: string): string {

--- a/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
@@ -16,6 +16,7 @@ describe('FollowUpQueue', () => {
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
       items: ['first', 'second'],
       synthetic: false,
+      mediaFiles: [],
     });
   });
 
@@ -30,10 +31,25 @@ describe('FollowUpQueue', () => {
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
       items: ['compact now'],
       synthetic: true,
+      mediaFiles: [],
     });
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
       items: ['user text'],
       synthetic: false,
+      mediaFiles: [],
+    });
+  });
+
+  it('carries media file paths and flattens them across a visible batch', async () => {
+    const queue = new FollowUpQueue();
+
+    queue.enqueue('look at this', ['/tmp/pasted/a.png']);
+    queue.enqueue('and this', ['/tmp/pasted/b.png']);
+
+    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
+      items: ['look at this', 'and this'],
+      synthetic: false,
+      mediaFiles: ['/tmp/pasted/a.png', '/tmp/pasted/b.png'],
     });
   });
 
@@ -49,6 +65,7 @@ describe('FollowUpQueue', () => {
       await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
         items: ['compact now'],
         synthetic: true,
+        mediaFiles: [],
       });
       expect(session.hasQueuedFollowUp()).toBe(false);
     } finally {
@@ -69,6 +86,25 @@ describe('FollowUpQueue', () => {
       await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
         items: ['compact after interrupt'],
         synthetic: true,
+        mediaFiles: [],
+      });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('attaches media to a session follow-up', async () => {
+    const session = new ToolUseSessionLifecycle(
+      'stream:media-followup' as StreamTabId,
+    );
+
+    try {
+      session.appendFollowUp('describe the figure', ['/tmp/pasted/fig.png']);
+
+      await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
+        items: ['describe the figure'],
+        synthetic: false,
+        mediaFiles: ['/tmp/pasted/fig.png'],
       });
     } finally {
       session.dispose();

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -45,7 +45,7 @@ describe('tool-use follow-up progress events', () => {
     const result = await sendFollowUp(streamId, 'please continue');
 
     expect(result).toEqual({ status: 'sent' });
-    expect(appendFollowUp).toHaveBeenCalledWith('please continue');
+    expect(appendFollowUp).toHaveBeenCalledWith('please continue', undefined);
     expect(events).toEqual([
       {
         event: 'followUpSent',

--- a/src/test-kernel/cli/DraftAttachments.vitest.mts
+++ b/src/test-kernel/cli/DraftAttachments.vitest.mts
@@ -75,6 +75,15 @@ describe('DraftAttachmentStore', () => {
     ]);
   });
 
+  it('does not strip chip-like text from pasted text history', () => {
+    const store = new DraftAttachmentStore();
+    const text = store.addPastedText('literal [Image #2]');
+    const image = store.addPastedImage(img('a.png'));
+    expect(store.expandTextForHistory(`${text} ${image}`)).toBe(
+      'literal [Image #2]',
+    );
+  });
+
   it('resolves only image chips still present in the draft (orphan gate)', () => {
     const store = new DraftAttachmentStore();
     const kept = store.addPastedImage(img('a.png'));

--- a/src/test-kernel/cli/DraftAttachments.vitest.mts
+++ b/src/test-kernel/cli/DraftAttachments.vitest.mts
@@ -63,6 +63,18 @@ describe('DraftAttachmentStore', () => {
     expect(store.expandText(`look ${chip}`)).toBe(`look ${chip}`);
   });
 
+  it('drops backed image chips from history text after expanding pasted text', () => {
+    const store = new DraftAttachmentStore();
+    const text = store.addPastedText('A\nB\nC\nD');
+    const image = store.addPastedImage(img('a.png'));
+    expect(store.expandTextForHistory(`look ${text} ${image} done`)).toBe(
+      'look A\nB\nC\nD done',
+    );
+    expect(store.resolveMedia(`look ${text} ${image} done`)).toEqual([
+      '/p/a.png',
+    ]);
+  });
+
   it('resolves only image chips still present in the draft (orphan gate)', () => {
     const store = new DraftAttachmentStore();
     const kept = store.addPastedImage(img('a.png'));

--- a/src/test-kernel/cli/DraftAttachments.vitest.mts
+++ b/src/test-kernel/cli/DraftAttachments.vitest.mts
@@ -1,0 +1,81 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import {
+  DraftAttachmentStore,
+  shouldCollapsePaste,
+} from '@cli/chat/tui/input/draftAttachments';
+
+const img = (name: string) => ({
+  path: `/p/${name}`,
+  mediaType: 'image/png',
+  displayName: name,
+});
+
+describe('shouldCollapsePaste', () => {
+  it('keeps short single-line pastes inline', () => {
+    expect(shouldCollapsePaste('a short paste')).toBe(false);
+  });
+
+  it('collapses pastes longer than the char threshold', () => {
+    expect(shouldCollapsePaste('x'.repeat(801))).toBe(true);
+  });
+
+  it('collapses pastes with more than two newlines but not fewer', () => {
+    expect(shouldCollapsePaste('a\nb\nc\nd')).toBe(true); // 3 newlines
+    expect(shouldCollapsePaste('a\nb')).toBe(false); // 1 newline
+  });
+});
+
+describe('DraftAttachmentStore', () => {
+  it('formats a text chip with the newline count and expands it back', () => {
+    const store = new DraftAttachmentStore();
+    const content = 'line1\nline2\nline3\nline4'; // 3 newlines
+    const chip = store.addPastedText(content);
+    expect(chip).toBe('[Pasted text #1 +3 lines]');
+    expect(store.expandText(`see ${chip} ok`)).toBe(`see ${content} ok`);
+  });
+
+  it('omits the line count for a single-line paste', () => {
+    const store = new DraftAttachmentStore();
+    expect(store.addPastedText('x'.repeat(801))).toBe('[Pasted text #1]');
+  });
+
+  it('shares one id space between text and image chips', () => {
+    const store = new DraftAttachmentStore();
+    expect(store.addPastedText('a\nb\nc\nd')).toBe('[Pasted text #1 +3 lines]');
+    expect(store.addPastedImage(img('a.png'))).toBe('[Image #2]');
+  });
+
+  it('expands multiple text chips with no spurious re-match', () => {
+    const store = new DraftAttachmentStore();
+    const c1 = store.addPastedText('A\nA\nA\nA');
+    const c2 = store.addPastedText('B\nB\nB\nB');
+    expect(store.expandText(`${c1} mid ${c2}`)).toBe(
+      'A\nA\nA\nA mid B\nB\nB\nB',
+    );
+  });
+
+  it('leaves image chips untouched when expanding text', () => {
+    const store = new DraftAttachmentStore();
+    const chip = store.addPastedImage(img('a.png'));
+    expect(store.expandText(`look ${chip}`)).toBe(`look ${chip}`);
+  });
+
+  it('resolves only image chips still present in the draft (orphan gate)', () => {
+    const store = new DraftAttachmentStore();
+    const kept = store.addPastedImage(img('a.png'));
+    store.addPastedImage(img('b.png')); // orphaned — chip removed from draft
+    expect(store.resolveMedia(`keep ${kept}`)).toEqual(['/p/a.png']);
+  });
+
+  it('clears entries and resets the id counter', () => {
+    const store = new DraftAttachmentStore();
+    store.addPastedText('a\nb\nc\nd');
+    expect(store.isEmpty()).toBe(false);
+    store.clear();
+    expect(store.isEmpty()).toBe(true);
+    expect(store.addPastedText('x\ny\nz\nw')).toBe('[Pasted text #1 +3 lines]');
+  });
+});

--- a/src/test-kernel/cli/InputBar.vitest.mts
+++ b/src/test-kernel/cli/InputBar.vitest.mts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { ImagePasteQueue } from '@cli/chat/tui/input/imagePasteQueue';
+import { submitSlashCommandWhenReady } from '@cli/chat/tui/panes/InputBar';
+
+function deferred(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function flushPromiseQueue(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('InputBar slash submit', () => {
+  it('waits for pending image pastes and submits the latest draft', async () => {
+    const imagePasteQueue = new ImagePasteQueue();
+    const paste = deferred();
+    const submitted: string[] = [];
+    let draft = '/h';
+
+    imagePasteQueue.track(
+      paste.promise.then(() => {
+        draft = '/h [Image #1]';
+      }),
+    );
+
+    submitSlashCommandWhenReady({
+      commandName: 'help',
+      fallbackRemainder: '',
+      handleSubmit: (value) => submitted.push(value),
+      imagePasteQueue,
+      readDraft: () => draft,
+      typedName: 'h',
+    });
+
+    expect(submitted).toEqual([]);
+
+    paste.resolve();
+    await paste.promise;
+    await flushPromiseQueue();
+
+    expect(submitted).toEqual(['/help [Image #1]']);
+  });
+
+  it('keeps an image chip attached to the typed slash prefix', async () => {
+    const imagePasteQueue = new ImagePasteQueue();
+    const paste = deferred();
+    const submitted: string[] = [];
+    let draft = '/h';
+
+    imagePasteQueue.track(
+      paste.promise.then(() => {
+        draft = '/h[Image #1]';
+      }),
+    );
+
+    submitSlashCommandWhenReady({
+      commandName: 'help',
+      fallbackRemainder: '',
+      handleSubmit: (value) => submitted.push(value),
+      imagePasteQueue,
+      readDraft: () => draft,
+      typedName: 'h',
+    });
+
+    paste.resolve();
+    await paste.promise;
+    await flushPromiseQueue();
+
+    expect(submitted).toEqual(['/help [Image #1]']);
+  });
+});

--- a/src/test-kernel/files/PastedImageUtils.vitest.ts
+++ b/src/test-kernel/files/PastedImageUtils.vitest.ts
@@ -1,0 +1,27 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { pastedImageFileName } from '@utils/files/pastedImageUtils';
+
+describe('pastedImageFileName', () => {
+  it('accepts generated pasted image basenames', () => {
+    expect(pastedImageFileName('pasted_1234_abcd.png')).toBe(
+      'pasted_1234_abcd.png',
+    );
+  });
+
+  it('rejects paths and non-pasted names from webview input', () => {
+    for (const name of [
+      '../pasted_1234_abcd.png',
+      '/tmp/pasted_1234_abcd.png',
+      'C:\\tmp\\pasted_1234_abcd.png',
+      'avatar.png',
+      '',
+    ]) {
+      expect(() => pastedImageFileName(name)).toThrow(
+        'Invalid pasted image filename.',
+      );
+    }
+  });
+});

--- a/src/test-kernel/shared/ClipboardImages.vitest.ts
+++ b/src/test-kernel/shared/ClipboardImages.vitest.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { getExtensionFromMimeType } from '@shared/utils/clipboardImages';
+
+describe('clipboard image helpers', () => {
+  it('keeps legacy pasted-image MIME aliases', () => {
+    expect(getExtensionFromMimeType('image/x-jng')).toBe('jng');
+    expect(getExtensionFromMimeType('image/x-mng')).toBe('mng');
+    expect(getExtensionFromMimeType('image/vnd.adobe.photoshop')).toBe('psd');
+    expect(getExtensionFromMimeType('image/x-photoshop')).toBe('psd');
+    expect(getExtensionFromMimeType('image/x-psd')).toBe('psd');
+  });
+});

--- a/src/utils/files/pastedImageUtils.ts
+++ b/src/utils/files/pastedImageUtils.ts
@@ -41,8 +41,12 @@ export async function savePastedImageBuffer(
   data: Buffer,
   fileName: string,
 ): Promise<string> {
+  // Defensive: a pasted filename can arrive from a webview message, so strip
+  // any directory components to keep the write inside PASTED_DIR — no `../`
+  // traversal or absolute-path escape.
+  const safeName = path.basename(fileName);
   await StorageFS.ensureDir(PASTED_DIR);
-  const relativePath = path.join(PASTED_DIR, fileName);
+  const relativePath = path.join(PASTED_DIR, safeName);
   await StorageFS.write(relativePath, data);
   await StorageFS.cleanupOldFiles(PASTED_DIR, THREE_DAYS_MS);
   return StorageFS.fullPath(relativePath);

--- a/src/utils/files/pastedImageUtils.ts
+++ b/src/utils/files/pastedImageUtils.ts
@@ -20,7 +20,9 @@ export function isPastedImage(filename: string): boolean {
  * Get the full filesystem path for a pasted image
  */
 export function getPastedImageFullPath(filename: string): string {
-  return StorageFS.fullPath(path.join(PASTED_DIR, filename));
+  return StorageFS.fullPath(
+    path.join(PASTED_DIR, pastedImageFileName(filename)),
+  );
 }
 
 /**
@@ -29,6 +31,26 @@ export function getPastedImageFullPath(filename: string): string {
  */
 export function generatePastedImageName(ext: string): string {
   return `${PASTED_PREFIX}${Date.now()}_${randomBytes(4).toString('hex')}.${ext}`;
+}
+
+/**
+ * Validate a pasted-image filename received at a trust boundary. Webviews send
+ * filenames over IPC, so reject path separators, absolute paths, empty names,
+ * and non-TeXRA pasted-image names instead of silently normalizing them.
+ */
+export function pastedImageFileName(fileName: string): string {
+  if (
+    !fileName ||
+    fileName.includes('\0') ||
+    path.isAbsolute(fileName) ||
+    path.win32.isAbsolute(fileName) ||
+    path.posix.basename(fileName) !== fileName ||
+    path.win32.basename(fileName) !== fileName ||
+    !isPastedImage(fileName)
+  ) {
+    throw new Error('Invalid pasted image filename.');
+  }
+  return fileName;
 }
 
 /**
@@ -41,10 +63,7 @@ export async function savePastedImageBuffer(
   data: Buffer,
   fileName: string,
 ): Promise<string> {
-  // Defensive: a pasted filename can arrive from a webview message, so strip
-  // any directory components to keep the write inside PASTED_DIR — no `../`
-  // traversal or absolute-path escape.
-  const safeName = path.basename(fileName);
+  const safeName = pastedImageFileName(fileName);
   await StorageFS.ensureDir(PASTED_DIR);
   const relativePath = path.join(PASTED_DIR, safeName);
   await StorageFS.write(relativePath, data);

--- a/src/utils/files/pastedImageUtils.ts
+++ b/src/utils/files/pastedImageUtils.ts
@@ -1,8 +1,10 @@
 // Standard library imports
+import { randomBytes } from 'node:crypto';
 import * as path from 'path';
 
 // Local imports
 import { PASTED_PREFIX } from '@shared/files/pastedImageConstants';
+import { THREE_DAYS_MS } from '@utils/config/constants';
 import { StorageFS } from './storageFS';
 
 export const PASTED_DIR = 'pasted';
@@ -19,4 +21,38 @@ export function isPastedImage(filename: string): boolean {
  */
 export function getPastedImageFullPath(filename: string): string {
   return StorageFS.fullPath(path.join(PASTED_DIR, filename));
+}
+
+/**
+ * Generate a pasted-image filename: `pasted_<timestamp>_<rand>.<ext>`. The
+ * `PASTED_PREFIX` lets {@link isPastedImage} recognize it later.
+ */
+export function generatePastedImageName(ext: string): string {
+  return `${PASTED_PREFIX}${Date.now()}_${randomBytes(4).toString('hex')}.${ext}`;
+}
+
+/**
+ * Persist pasted image bytes into the shared `pasted/` storage dir and return
+ * the absolute path. Shared by the extension webview host and the CLI so both
+ * produce identical on-disk media files that flow through the same
+ * MediaAttachmentProcessor path — no duplicated encoding.
+ */
+export async function savePastedImageBuffer(
+  data: Buffer,
+  fileName: string,
+): Promise<string> {
+  await StorageFS.ensureDir(PASTED_DIR);
+  const relativePath = path.join(PASTED_DIR, fileName);
+  await StorageFS.write(relativePath, data);
+  await StorageFS.cleanupOldFiles(PASTED_DIR, THREE_DAYS_MS);
+  return StorageFS.fullPath(relativePath);
+}
+
+/** base64 convenience wrapper around {@link savePastedImageBuffer} — used by
+ *  the extension webview path, which receives base64 from the browser. */
+export function savePastedImageBase64(
+  base64: string,
+  fileName: string,
+): Promise<string> {
+  return savePastedImageBuffer(Buffer.from(base64, 'base64'), fileName);
 }


### PR DESCRIPTION
## Summary

Adds **image paste** and **large-text-paste collapsing** to the paste/follow-up paths, for both the CLI TUI and the VS Code extension. The headline capability is **inserting images mid-conversation** into a tool-use agent — not just on the first prompt.

Everything funnels through the **existing shared media-file path** (`MediaAttachmentProcessor` → `addMediaToUserMessage`, the same call the reflection flow already uses), so there is **no new provider/model-layer code** and no second image pipeline.

## What's included

**① Core — tool-use follow-ups carry media (mid-conversation, both hosts)**
- `FollowUpQueue` items/batch gain optional media file paths, threaded through `ToolUseSessionLifecycle.appendFollowUp` → `sendFollowUp` → `ToolUseFollowUpQueueManager` → `WaitExecResult`.
- `ToolUseWaitNode.post()` attaches them to the freshly-appended user message via `addMediaToUserMessage`. `ToolUseServices` gains a `fileService` for the `path → FileLocation` conversion.
- `ToolUsePrepareNode` now passes `config.mediaFiles` into `initializeMessages`' media slot, so tool-use agents also get images on the **first** message (previously `undefined`).

**② CLI image paste (cross-platform, no extra installs)**
- `ctrl+v` probes the OS clipboard with built-in tooling — macOS `osascript «class PNGf»`, Linux `wl-paste`/`xclip`, Windows PowerShell `Get-Clipboard` — saving into the shared `pasted/` dir. **No `pngpaste` dependency** (matches Claude Code).
- Inserts an `[Image #N]` chip; resolved to media-file paths at submit and sent through ①.

**③ CLI large-text-paste collapsing (CLI-only)**
- A paste over ~800 chars or >2 newlines collapses to `[Pasted text #N +M lines]` (via a `transformPaste` prop on `BaseTextInput` + `DraftAttachmentStore`), expanded back to full content at the submit boundary. Text and image chips share one id space.
- **Headless parity preserved**: `InputBar` is TTY-only, so `texra run` / `--print` / `--output-format json|ndjson` never see placeholders.

**④ Extension follow-up image paste**
- Pasting an image into the progress-view follow-up box reaches the model mid-conversation: `SEND_FOLLOW_UP` carries the images, the host saves them via `savePastedImageBase64` and forwards paths to `texra.sendFollowUp(stream, text, mediaFiles)` → ①.
- Clipboard extraction is factored into `src/shared/utils/clipboardImages.ts` and **reused by the main webview `pasteHandler`** (DRY).

## Testing

- Full workspace `typecheck`, ESLint, CLI esbuild bundle, extension `compile:fast` — all green.
- Vitest: extended `FollowUpQueue.vitest.ts` (media carried through the batch) + new `DraftAttachments.vitest.mts` (collapse threshold, reverse-offset expansion, orphan gate, shared id space).
- **Live-verified** via a tmux PTY on macOS: multi-line paste → `[Pasted text #1 +4 lines]`; short paste stays inline; `ctrl+v` → `[Image #1]` chip with the bytes written byte-identically into `pasted/`.

## Notes

- Scoped strictly to the paste/attachment feature; unrelated in-flight working-tree changes (docs, `doctor.ts`, lockfile pin, etc.) are intentionally **not** in this branch.
- Known follow-ups (not blocking): non-vision models silently drop images (`addMediaToUserMessage` guards `supportsVision`) — could warn; chips aren't atomic-delete tokens; Linux/Windows clipboard paths are implemented but only macOS is verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches follow-up queuing, resume replay, and cross-platform clipboard/exec paths; failures are mostly localized to paste UX, but incorrect media path handling could affect user message content.
> 
> **Overview**
> Adds **image and large-text paste** across the CLI TUI and VS Code extension, wired so pasted images reach the model on **first messages and mid-conversation follow-ups** via the existing `addMediaToUserMessage` / `MediaAttachmentProcessor` path (no new model layer).
> 
> **Agent / IPC:** `FollowUpQueue`, `sendFollowUp`, resume drain, and `ToolUseWaitNode` now carry optional `mediaFiles`; `ToolUsePrepareNode` passes `config.mediaFiles` into the initial user message. Extension progress-view and main webview follow-ups save pasted images through shared `pastedImageUtils` and forward paths on `texra.sendFollowUp`.
> 
> **CLI TUI:** Large pastes collapse to `[Pasted text #N …]` chips (`DraftAttachmentStore`, expanded at submit); **Ctrl+V** reads the OS clipboard (`clipboardImage.ts`), inserts `[Image #N]`, and defers submit while async paste probes finish (`ImagePasteQueue`). `onSubmit` gains optional `mediaFiles`.
> 
> **Shared:** `clipboardImages.ts` DRYs webview paste handling; `pastedImageFileName` / `savePastedImageBuffer` harden the paste storage boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d4f568d7439ea5f4c8b157190b968400803800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->