### PR TITLE
fix(cli): avoid simplifier as default team root

### DIFF
--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -57,6 +57,12 @@ export interface CliMultiAgentPresetListRecord extends CliMultiAgentPreset {
   readonly availability: CliMultiAgentPresetAvailability;
 }
 
+const NON_DEFAULT_ROOT_TOOL_USE_AGENTS_BY_PRESET_SOURCE: Partial<
+  Record<CliMultiAgentPresetSource, ReadonlySet<string>>
+> = {
+  'built-in': new Set(['simplifier']),
+};
+
 export function parseCliCustomAgentPresets(raw: unknown): AgentModePreset[] {
   return AgentModePresetSchema.array().catch([]).parse(raw);
 }
@@ -281,7 +287,10 @@ export function planCliMultiAgentPresetRun(
   );
   const rootAgent =
     override.agent ??
-    selectPresetRootAgent(toolUse.resolved, preset.toolUseAgents);
+    selectPresetRootAgent(toolUse.resolved, {
+      presetOrder: preset.toolUseAgents,
+      presetSource: preset.source,
+    });
   const toolUseAgents = rootAgent
     ? includeAgent(toolUse.resolved, rootAgent)
     : toolUse.resolved;
@@ -368,16 +377,31 @@ function resolveAgentOverride(
 
 function selectPresetRootAgent(
   agents: readonly AgentEntry[],
-  presetOrder: readonly string[],
+  options: {
+    readonly presetOrder: readonly string[];
+    readonly presetSource: CliMultiAgentPresetSource;
+  },
 ): AgentEntry | undefined {
-  const delegatingAgents = agents.filter(agentHasDelegationTools);
+  const rootCandidates = agents.filter((agent) =>
+    isPresetRootCandidate(agent, options.presetSource),
+  );
+  const delegatingAgents = rootCandidates.filter(agentHasDelegationTools);
   if (delegatingAgents.length > 0) {
     return (
-      findPreferredRootAgent(delegatingAgents, presetOrder) ??
+      findPreferredRootAgent(delegatingAgents, options.presetOrder) ??
       delegatingAgents[0]
     );
   }
-  return agents[0];
+  return rootCandidates[0];
+}
+
+function isPresetRootCandidate(
+  agent: AgentEntry,
+  presetSource: CliMultiAgentPresetSource,
+): boolean {
+  return !NON_DEFAULT_ROOT_TOOL_USE_AGENTS_BY_PRESET_SOURCE[presetSource]?.has(
+    agent.name,
+  );
 }
 
 function findPreferredRootAgent(

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -283,6 +283,53 @@ describe('CLI multi-agent presets', () => {
     expect(cliMultiAgentPlanHasGaps(plan)).toBe(true);
   });
 
+  it('does not select simplifier as an implicit preset root', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'physicist',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('review', AgentCategory.ToolUse),
+        agent('simplifier', AgentCategory.ToolUse, ['delegate_agent']),
+      ],
+    });
+    const onlySimplifierPlan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('simplifier', AgentCategory.ToolUse, ['delegate_agent']),
+      ],
+    });
+
+    expect(plan.rootAgent?.name).toBe('review');
+    expect(onlySimplifierPlan.rootAgent).toBeUndefined();
+    expect(cliMultiAgentPlanHasGaps(onlySimplifierPlan)).toBe(true);
+  });
+
+  it('allows custom presets to default to their simplifier agent', () => {
+    const plan = planCliMultiAgentPresetRun(
+      {
+        id: 'custom-cleanup',
+        name: 'Custom cleanup',
+        description: 'User-authored cleanup team.',
+        icon: 'codicon-symbol-method',
+        source: 'custom',
+        workflowAgents: [],
+        toolUseAgents: ['simplifier'],
+      },
+      {
+        workflowAgents: [],
+        toolUseAgents: [
+          agent('simplifier', AgentCategory.ToolUse, ['delegate_agent']),
+        ],
+      },
+    );
+
+    expect(plan.rootAgent?.name).toBe('simplifier');
+    expect(cliMultiAgentPlanHasGaps(plan)).toBe(false);
+  });
+
   it('reports no gaps when every preset member resolves', () => {
     const preset = findCliMultiAgentPreset(
       cliMultiAgentPresets(undefined),
@@ -344,6 +391,24 @@ describe('CLI multi-agent presets', () => {
     expect(plan.toolUseAgentKeys).toContain('builtInToolUse:review');
     expect(sourceQualifiedPlan.missingAgentOverride).toBeUndefined();
     expect(sourceQualifiedPlan.rootAgent?.name).toBe('review');
+  });
+
+  it('allows simplifier when explicitly requested as the preset root', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'physicist',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('review', AgentCategory.ToolUse),
+        agent('simplifier', AgentCategory.ToolUse, ['delegate_agent']),
+      ],
+      agentOverride: 'simplifier',
+    });
+
+    expect(plan.rootAgent?.name).toBe('simplifier');
+    expect(plan.toolUseAgentKeys).toContain('builtInToolUse:simplifier');
   });
 
   it('tracks a missing root override as a plan gap', () => {


### PR DESCRIPTION
## Summary

- exclude simplifier from implicit multi-agent preset root selection
- keep explicit --agent simplifier overrides working
- add planner coverage for both default and explicit paths

Closes #5218.

## Validation

- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentPresets.vitest.mts
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
- npm run compile:safe
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI preset root-selection logic only; no auth, data, or API surface changes beyond multi-agent planning behavior.
> 
> **Overview**
> **Built-in** multi-agent presets no longer pick **`simplifier`** as the implicit tool-use root when it is the only delegating agent available; another agent (e.g. **`review`**) is preferred, and a simplifier-only registry leaves **no root** and marks the plan as having gaps.
> 
> **Custom** presets are unchanged: **`simplifier`** can still be the default root when it is the preset’s tool-use agent. **`--agent simplifier`** (or an equivalent override) still forces simplifier as root for built-in presets.
> 
> Planner tests cover implicit exclusion, custom-default behavior, and explicit override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 048d9c734ecd87b9ced563e9fb383fd2658190e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->