### PR TITLE
fix(cli): harden startup defaults

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -86,6 +86,8 @@ const SHOW_LONG_CHILD_OUTPUT = process.env.HARNESS_LONG_CHILD_OUTPUT === '1';
 const SHOW_WIDE_FIRST_CHILD_LINE =
   process.env.HARNESS_WIDE_FIRST_CHILD_LINE === '1';
 const SHOW_ORCHESTRATION = process.env.HARNESS_ORCHESTRATION === '1';
+const SHOW_NO_RUNNABLE_ORCHESTRATION_MODELS =
+  process.env.HARNESS_NO_RUNNABLE_MODELS === '1';
 const HARNESS_API_MODE_FROM_ENV = parseCliApiMode(
   process.env.HARNESS_API_MODE ?? '',
 );
@@ -237,9 +239,16 @@ function harnessModel(
 function harnessOrchestrationModels(
   apiMode: CliApiMode,
 ): readonly CliModelAccess[] {
-  return HARNESS_ORCHESTRATION_MODEL_FIXTURES.map((fixture) =>
+  const models = HARNESS_ORCHESTRATION_MODEL_FIXTURES.map((fixture) =>
     harnessModel(fixture, apiMode),
   );
+  return SHOW_NO_RUNNABLE_ORCHESTRATION_MODELS
+    ? models.map((model) => ({
+        ...model,
+        available: false,
+        status: 'missing key',
+      }))
+    : models;
 }
 
 if (SHOW_ORCHESTRATION) {
@@ -252,6 +261,7 @@ if (SHOW_ORCHESTRATION) {
           : []
       }
       apiMode={HARNESS_API_MODE}
+      allowDefaultModelLaunch={false}
       onResolve={() => undefined}
     />,
     {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -296,6 +296,26 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'orchestrate-no-runnable-models',
+    env: {
+      HARNESS_ORCHESTRATION: '1',
+      HARNESS_API_MODE: 'personal',
+      HARNESS_NO_RUNNABLE_MODELS: '1',
+    },
+    bootExpect: 'Choose how to start this CLI session.',
+    keys: ['1'],
+    exitKeys: [ESC],
+    expectExit: true,
+    expect: [
+      'Choose how to start this CLI session.',
+      'New chat',
+      'No personal API-key models are runnable',
+      'Help',
+      'Esc exit',
+    ],
+    unexpect: ['Model · personal API keys', 'DeepSeek V4 Flash'],
+  },
+  {
     name: 'slash-palette',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/mo'],

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -52,6 +52,23 @@ const EMPTY_MODEL_LIST_MESSAGES = {
     'No personal API-key models are runnable. Configure a provider key or switch with /api included.',
 } satisfies Record<CliApiMode | 'includedLoginRequired', string>;
 
+export type NoRunnableModelAccessReason = CliApiMode | 'includedLoginRequired';
+
+export function noRunnableModelAccessReason(
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+): NoRunnableModelAccessReason {
+  if (
+    apiMode === 'included' &&
+    models.some(
+      (model) => model.model.availability === 'included-login-required',
+    )
+  ) {
+    return 'includedLoginRequired';
+  }
+  return apiMode;
+}
+
 export function formatModelStatusForCliMode(
   model: CliModelAccess,
   apiMode: CliApiMode,
@@ -86,16 +103,9 @@ export function emptyModelListMessageForCliMode(
   models: readonly CliModelAccess[],
   apiMode: CliApiMode,
 ): string {
-  if (
-    apiMode === 'included' &&
-    models.some(
-      (model) => model.model.availability === 'included-login-required',
-    )
-  ) {
-    return EMPTY_MODEL_LIST_MESSAGES.includedLoginRequired;
-  }
-
-  return EMPTY_MODEL_LIST_MESSAGES[apiMode];
+  return EMPTY_MODEL_LIST_MESSAGES[
+    noRunnableModelAccessReason(models, apiMode)
+  ];
 }
 
 function EmptyModelListState(props: {

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -17,11 +17,15 @@ import {
 } from '../runtime/multiAgentPresets';
 import { buildCliOrchestrationItems } from '../runtime/orchestration';
 import {
+  cliRunnableModelOptionsForSource,
   getCliModelAccessList,
+  resolveCliRunnableModelWithAccessList,
+  runnableCliModelAccessEntries,
   type CliModelAccess,
 } from '../runtime/modelAccess';
 import { effectiveCliApiMode } from '../runtime/apiAccessMode';
 import { notifyCliUpdate } from '../runtime/updateChecker';
+import { resolveChatDefaults } from '../runtime/chatDefaults';
 
 import { contextFromArgs } from './_helpers/context';
 import { withUsageSections } from './_helpers/dispatch';
@@ -37,6 +41,35 @@ import {
 } from './multiAgent';
 import { runResumeExecution } from './resume';
 import type { CliContext } from '../runtime/cliContext';
+
+async function canLaunchWithDefaultModel(
+  context: CliContext,
+  models: readonly CliModelAccess[],
+  apiMode: ReturnType<typeof effectiveCliApiMode>,
+): Promise<boolean> {
+  if (
+    models.length === 0 ||
+    runnableCliModelAccessEntries(models, apiMode).length > 0
+  ) {
+    return true;
+  }
+
+  const defaults = await resolveChatDefaults({
+    cwd: context.cwd,
+    envAgent: context.envAgent,
+    envModel: context.envModel,
+  });
+  try {
+    await resolveCliRunnableModelWithAccessList(
+      models,
+      defaults.model,
+      cliRunnableModelOptionsForSource(defaults.modelSource, { apiMode }),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 async function runOrchestration(context: CliContext): Promise<number> {
   const terminalFailure = interactiveTerminalFailure(context);
@@ -85,9 +118,18 @@ async function runOrchestration(context: CliContext): Promise<number> {
   const models: readonly CliModelAccess[] = await getCliModelAccessList({
     apiMode,
   }).catch(() => []);
+  const allowDefaultModelLaunch = await canLaunchWithDefaultModel(
+    context,
+    models,
+    apiMode,
+  );
   const { runOrchestrationTui } =
     await import('../orchestration/runOrchestrationTui');
-  const action = await runOrchestrationTui(items, { models, apiMode });
+  const action = await runOrchestrationTui(items, {
+    models,
+    apiMode,
+    allowDefaultModelLaunch,
+  });
 
   switch (action.kind) {
     case 'chat': {

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -4,7 +4,10 @@ import { useState } from 'react';
 import { Select } from '../chat/tui/ui/Select';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
-import { modelSelectItemsForCliMode } from '../chat/tui/forms/ModelListForm';
+import {
+  modelSelectItemsForCliMode,
+  noRunnableModelAccessReason,
+} from '../chat/tui/forms/ModelListForm';
 import { formatCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
 import type { CliModelAccess } from '../runtime/modelAccess';
 import type {
@@ -24,12 +27,62 @@ function isModelPickAction(
   return action.kind === 'chat' || action.kind === 'preset';
 }
 
+function noRunnableModelLaunchDescription(
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+): string {
+  const reason = noRunnableModelAccessReason(models, apiMode);
+  switch (reason) {
+    case 'includedLoginRequired':
+      return 'Sign in with texra login for included relay models';
+    case 'included':
+      return 'No included relay models are runnable';
+    case 'personal':
+      return 'No personal API-key models are runnable';
+  }
+  const exhaustive: never = reason;
+  return exhaustive;
+}
+
+export function orchestrationModelAccessView(
+  items: readonly CliOrchestrationItem[],
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+  options: {
+    readonly allowDefaultModelLaunch?: boolean;
+  } = {},
+): {
+  readonly items: readonly CliOrchestrationItem[];
+  readonly modelItems: ReturnType<typeof modelSelectItemsForCliMode>;
+} {
+  const modelItems = modelSelectItemsForCliMode(models, apiMode);
+  if (
+    models.length === 0 ||
+    modelItems.length > 0 ||
+    options.allowDefaultModelLaunch === true
+  ) {
+    return { items, modelItems };
+  }
+
+  const description = noRunnableModelLaunchDescription(models, apiMode);
+  return {
+    modelItems,
+    items: items.map((item) =>
+      isModelPickAction(item.value)
+        ? { ...item, description, disabled: true }
+        : item,
+    ),
+  };
+}
+
 export interface OrchestrationAppProps {
   readonly items: readonly CliOrchestrationItem[];
-  /** Model access list for the second step; if no entries are runnable in the
-   *  active API mode, the launcher skips the model pick. */
+  /** Model access list for the second step. An empty list means unknown
+   *  registry state, so the launcher still starts chats with runtime defaults;
+   *  a known list with no runnable model disables chat/team starts. */
   readonly models: readonly CliModelAccess[];
   readonly apiMode: CliApiMode;
+  readonly allowDefaultModelLaunch?: boolean;
   readonly onResolve: (action: CliOrchestrationAction) => void;
 }
 
@@ -55,7 +108,12 @@ export function OrchestrationApp(
   const app = useApp();
   const { rows } = useWindowSize();
   const maxVisibleItems = Math.max(4, rows - 8);
-  const modelItems = modelSelectItemsForCliMode(props.models, props.apiMode);
+  const { items, modelItems } = orchestrationModelAccessView(
+    props.items,
+    props.models,
+    props.apiMode,
+    { allowDefaultModelLaunch: props.allowDefaultModelLaunch },
+  );
   // When set, the launcher is on its second step: choosing the model for this
   // chat/team. Esc returns to the item list rather than exiting.
   const [pending, setPending] = useState<ModelPickAction | undefined>(
@@ -122,9 +180,9 @@ export function OrchestrationApp(
       <Text dimColor>Choose how to start this CLI session.</Text>
       <Box marginTop={1}>
         <Select
-          items={props.items}
+          items={items}
           maxVisibleItems={maxVisibleItems}
-          showOverflow={props.items.length > maxVisibleItems}
+          showOverflow={items.length > maxVisibleItems}
           onSelect={onItemSelect}
           onCancel={() => finish({ kind: 'exit' })}
         />
@@ -137,10 +195,13 @@ export function OrchestrationApp(
 }
 
 export interface RunOrchestrationTuiOptions {
-  /** Available models for the second step; the launcher filters to runnable
-   *  ones. Empty or all-unavailable skips the model pick. */
+  /** Available models for the second step; an empty list means registry
+   *  unavailable/unknown, while a non-empty all-unavailable list disables
+   *  model-dependent launch rows unless runtime defaults can still resolve a
+   *  hidden configured model. */
   readonly models: readonly CliModelAccess[];
   readonly apiMode: CliApiMode;
+  readonly allowDefaultModelLaunch?: boolean;
 }
 
 export async function runOrchestrationTui(
@@ -159,6 +220,7 @@ export async function runOrchestrationTui(
         items={items}
         models={options.models}
         apiMode={options.apiMode}
+        allowDefaultModelLaunch={options.allowDefaultModelLaunch}
         onResolve={record}
       />,
       {

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,4 +1,3 @@
-import { getAgent, loadAgents } from '@agent/index';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { isNonEmptyString } from '@utils/core/stringCore';
@@ -74,20 +73,8 @@ async function loadUserDefaults(): Promise<PartialDefaults> {
   }
 }
 
-function isResolvableToolUseAgent(name: string | undefined): boolean {
-  if (!name) return false;
-  const entry = getAgent(name);
-  return entry?.category === AgentCategory.ToolUse;
-}
-
 async function loadHistoryDefaults(): Promise<PartialDefaults> {
   try {
-    // Ensure the local registry is populated before validating history names —
-    // otherwise stale rows that name an agent missing from the current install
-    // (e.g. a `bash` row persisted from a process-tracking run) would still
-    // win this tier and the chat session would crash on first submit with
-    // "Could not find agent: <name>".
-    await loadAgents({ includeRemote: false });
     const entries = await listExecutions();
     const candidates = entries
       .filter(
@@ -101,12 +88,9 @@ async function loadHistoryDefaults(): Promise<PartialDefaults> {
         (a, b) =>
           new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
       );
-    const mostRecent = candidates.find((entry) =>
-      isResolvableToolUseAgent(entry.agentConfig?.agent),
-    );
+    const mostRecent = candidates[0];
     if (!mostRecent?.agentConfig) return {};
     return pickDefaults({
-      agent: mostRecent.agentConfig.agent,
       model: mostRecent.agentConfig.model,
     });
   } catch {
@@ -159,8 +143,9 @@ export interface ResolveChatDefaultsInit {
 /**
  * Four-tier lookup per `docs/prd/cli-tui-ink/10-architecture.md#entrypoint-default`:
  * workspace `.texra/config.json` → user `<global-storage>/config.json` →
- * last toolUse execution → built-in. Per-field independence: a workspace that
- * only sets `agent` still falls through to user/history for `model`.
+ * last single-agent toolUse execution's model → built-in. Per-field
+ * independence: a workspace that only sets `agent` still falls through to
+ * user/history for `model`, but history never changes the single-chat agent.
  */
 export async function resolveChatDefaults(
   init: ResolveChatDefaultsInit,

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -286,6 +286,14 @@ export async function resolveCliRunnableModel(
   options: CliRunnableModelOptions,
 ): Promise<CliRunnableModelResolution> {
   const models = await getCliModelAccessList({ apiMode: options.apiMode });
+  return resolveCliRunnableModelWithAccessList(models, model, options);
+}
+
+export async function resolveCliRunnableModelWithAccessList(
+  models: readonly CliModelAccess[],
+  model: string,
+  options: CliRunnableModelOptions,
+): Promise<CliRunnableModelResolution> {
   const trimmed = model.trim();
   const hiddenModelId =
     trimmed && !findModelAccess(models, trimmed)

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -57,12 +57,6 @@ export interface CliMultiAgentPresetListRecord extends CliMultiAgentPreset {
   readonly availability: CliMultiAgentPresetAvailability;
 }
 
-const NON_DEFAULT_ROOT_TOOL_USE_AGENTS_BY_PRESET_SOURCE: Partial<
-  Record<CliMultiAgentPresetSource, ReadonlySet<string>>
-> = {
-  'built-in': new Set(['simplifier']),
-};
-
 export function parseCliCustomAgentPresets(raw: unknown): AgentModePreset[] {
   return AgentModePresetSchema.array().catch([]).parse(raw);
 }
@@ -382,33 +376,33 @@ function selectPresetRootAgent(
     readonly presetSource: CliMultiAgentPresetSource;
   },
 ): AgentEntry | undefined {
-  const rootCandidates = agents.filter((agent) =>
-    isPresetRootCandidate(agent, options.presetSource),
+  const delegatingAgents = agents.filter(agentHasDelegationTools);
+  const preferredRoot = findPreferredRootAgent(
+    delegatingAgents,
+    options.presetSource,
+    options.presetOrder,
   );
-  const delegatingAgents = rootCandidates.filter(agentHasDelegationTools);
-  if (delegatingAgents.length > 0) {
-    return (
-      findPreferredRootAgent(delegatingAgents, options.presetOrder) ??
-      delegatingAgents[0]
-    );
-  }
-  return rootCandidates[0];
-}
+  if (preferredRoot) return preferredRoot;
 
-function isPresetRootCandidate(
-  agent: AgentEntry,
-  presetSource: CliMultiAgentPresetSource,
-): boolean {
-  return !NON_DEFAULT_ROOT_TOOL_USE_AGENTS_BY_PRESET_SOURCE[presetSource]?.has(
-    agent.name,
-  );
+  if (options.presetSource === 'built-in') {
+    // Built-in teams name specialists as members. If their orchestrator is not
+    // available, fall back only to a plain local agent rather than promoting an
+    // arbitrary delegation specialist to team root.
+    return agents.find((agent) => !agentHasDelegationTools(agent));
+  }
+
+  return delegatingAgents[0] ?? agents[0];
 }
 
 function findPreferredRootAgent(
   agents: readonly AgentEntry[],
+  presetSource: CliMultiAgentPresetSource,
   presetOrder: readonly string[],
 ): AgentEntry | undefined {
-  const searchOrder = ['orchestrator', 'leanOrchestrator', ...presetOrder];
+  const searchOrder =
+    presetSource === 'built-in'
+      ? ['orchestrator', 'leanOrchestrator']
+      : ['orchestrator', 'leanOrchestrator', ...presetOrder];
   for (const name of searchOrder) {
     const entry = agents.find((agent) => agent.name === name);
     if (entry) return entry;

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -8,33 +8,13 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
+  BUILTIN_DEFAULT_CHAT_AGENT,
   BUILTIN_DEFAULT_CHAT_MODEL,
   resolveChatDefaults,
 } from '@cli/runtime/chatDefaults';
 
 vi.mock('@agent/storage', () => ({
   listExecutions: vi.fn(async () => []),
-}));
-
-// Stub the agent registry so chat-defaults validation is hermetic — the real
-// `loadAgents()` reads from disk paths that aren't reliably populated in the
-// test kernel, so we treat a small allowlist of names as "real tool-use
-// agents" and everything else (including the stale `bash` row from #4397) as
-// unresolvable.
-const TOOL_USE_AGENT_FIXTURES = new Set([
-  'research',
-  'review',
-  'chat',
-  'orchestrator',
-  'leanOrchestrator',
-]);
-vi.mock('@agent/index', () => ({
-  loadAgents: vi.fn(async () => {}),
-  getAgent: vi.fn((name: string) =>
-    TOOL_USE_AGENT_FIXTURES.has(name)
-      ? { name, category: 'toolUse' as const }
-      : undefined,
-  ),
 }));
 
 const mockedListExecutions = vi.mocked(listExecutions);
@@ -64,7 +44,8 @@ vi.mock('@utils/files/storageFS', () => ({
 }));
 
 describe('CLI chat defaults', () => {
-  it('uses DeepSeek as the built-in chat model', async () => {
+  it('uses chat and DeepSeek as the built-in chat defaults', async () => {
+    expect(BUILTIN_DEFAULT_CHAT_AGENT).toBe('chat');
     expect(BUILTIN_DEFAULT_CHAT_MODEL).toBe('deepseekT');
     expect(MODEL_CONFIGS[BUILTIN_DEFAULT_CHAT_MODEL]).toBeDefined();
 
@@ -121,18 +102,24 @@ describe('CLI chat defaults', () => {
     });
   });
 
-  it('inherits the agent from the most recent single-agent tool-use execution', async () => {
+  it('inherits only the model from recent single-agent tool-use history', async () => {
     mockedListExecutions.mockResolvedValueOnce([historyEntry('research')]);
 
     await expect(
       resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
-    ).resolves.toMatchObject({ agent: 'research', source: 'history' });
+    ).resolves.toMatchObject({
+      agent: 'chat',
+      model: 'sonnet46T',
+      source: 'mixed',
+      agentSource: 'builtin',
+      modelSource: 'history',
+    });
   });
 
-  it('does not inherit the orchestrator from a multi-agent team run', async () => {
+  it('does not inherit the model from a multi-agent team run', async () => {
     // A `texra multi-agent run physicist` is stored as a tool-use execution
-    // whose root is the team orchestrator. It must not become the default
-    // agent for a plain `texra chat` — fall back to the built-in instead.
+    // whose root is the team orchestrator. It must not affect plain
+    // `texra chat` defaults — fall back to the built-ins instead.
     mockedListExecutions.mockResolvedValueOnce([
       historyEntry('leanOrchestrator', {
         cliMultiAgentPresetId: 'lean-project',
@@ -141,13 +128,17 @@ describe('CLI chat defaults', () => {
 
     await expect(
       resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
-    ).resolves.toMatchObject({ agent: 'chat', source: 'builtin' });
+    ).resolves.toMatchObject({
+      agent: 'chat',
+      model: 'deepseekT',
+      source: 'builtin',
+    });
   });
 
-  it('skips a history row whose agent is not in the tool-use registry', async () => {
-    // A stale `bash` row (or any other name not resolved by `getAgent()`)
-    // used to win this tier and the chat session would then crash on first
-    // submit with "Could not find agent: bash" — see #4397.
+  it('does not inherit stale history agent names', async () => {
+    // A stale `bash` row used to win the agent tier and crash on first submit
+    // with "Could not find agent: bash" — see #4397. History is now model-only,
+    // so the single-chat agent stays on the built-in `chat` default.
     mockedListExecutions.mockResolvedValueOnce([
       historyEntry('bash', {}, '2026-05-21T08:02:00.000Z'),
       historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
@@ -155,10 +146,15 @@ describe('CLI chat defaults', () => {
 
     await expect(
       resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
-    ).resolves.toMatchObject({ agent: 'research', source: 'history' });
+    ).resolves.toMatchObject({
+      agent: 'chat',
+      model: 'sonnet46T',
+      agentSource: 'builtin',
+      modelSource: 'history',
+    });
   });
 
-  it('skips a team run to reach an earlier single-agent execution', async () => {
+  it('skips a team run to reach an earlier single-agent model', async () => {
     mockedListExecutions.mockResolvedValueOnce([
       historyEntry(
         'orchestrator',
@@ -172,7 +168,41 @@ describe('CLI chat defaults', () => {
 
     await expect(
       resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
-    ).resolves.toMatchObject({ agent: 'research', source: 'history' });
+    ).resolves.toMatchObject({
+      agent: 'chat',
+      model: 'sonnet46T',
+      agentSource: 'builtin',
+      modelSource: 'history',
+    });
+  });
+
+  it('does not inherit simplifier as the default single-chat agent', async () => {
+    mockedListExecutions.mockResolvedValueOnce([
+      historyEntry('simplifier', {}, '2026-05-21T08:02:00.000Z'),
+      historyEntry('research', {}, '2026-05-21T08:01:00.000Z'),
+    ]);
+
+    await expect(
+      resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
+    ).resolves.toMatchObject({
+      agent: 'chat',
+      model: 'sonnet46T',
+      agentSource: 'builtin',
+      modelSource: 'history',
+    });
+  });
+
+  it('still honors an explicit simplifier agent override', async () => {
+    await expect(
+      resolveChatDefaults({
+        cwd: '/tmp/no-such-texra-workspace',
+        agentOverride: 'simplifier',
+        modelOverride: 'deepseekT',
+      }),
+    ).resolves.toMatchObject({
+      agent: 'simplifier',
+      agentSource: 'override',
+    });
   });
 
   it('uses prefixed command-specific workspace defaults', async () => {

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -7,6 +7,7 @@ import {
   runnableCliModelAccessEntries,
   resolveCliRunnableModel,
   resolveCliRunnableModelFromAccessList,
+  resolveCliRunnableModelWithAccessList,
   type CliModelAccess,
   type CliModelFallbackMode,
   type CliModelSelectionSource,
@@ -491,6 +492,39 @@ describe('CLI model access resolution', () => {
       }),
     ).resolves.toEqual({ model: 'hiddenFixtureModel' });
     expect(computeModelOptionsDataMock).toHaveBeenNthCalledWith(2, [
+      'hiddenFixtureModel',
+    ]);
+  });
+
+  it('checks hidden model access against a supplied visible model list', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('hiddenFixtureModel', {
+        availability: 'provider-key',
+        availabilityLabel: 'API key set',
+      }),
+    ]);
+
+    await expect(
+      resolveCliRunnableModelWithAccessList(
+        [
+          model('deepseekT', {
+            available: false,
+            status: 'missing api key',
+            model: modelOption('deepseekT', {
+              availability: 'missing-key',
+              disabled: true,
+              requiresKey: true,
+            }),
+          }),
+        ],
+        'hiddenFixtureModel',
+        {
+          fallbackMode: 'reject',
+          apiMode: 'personal',
+        },
+      ),
+    ).resolves.toEqual({ model: 'hiddenFixtureModel' });
+    expect(computeModelOptionsDataMock).toHaveBeenCalledWith([
       'hiddenFixtureModel',
     ]);
   });

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -5,6 +5,7 @@ import {
   formatModelStatusForCliMode,
   modelSelectItemsForCliMode,
   modelSelectWindow,
+  noRunnableModelAccessReason,
 } from '@cli/chat/tui/forms/ModelListForm';
 import {
   COMPACT_FORM_MAX_ROWS,
@@ -232,6 +233,57 @@ describe('CLI ModelListForm model visibility', () => {
 });
 
 describe('CLI ModelListForm empty state', () => {
+  it('classifies signed-out included access separately from other included outages', () => {
+    expect(
+      noRunnableModelAccessReason(
+        [
+          access(
+            {
+              availability: 'included-login-required',
+              disabled: true,
+            },
+            'login required',
+            false,
+          ),
+        ],
+        'included',
+      ),
+    ).toBe('includedLoginRequired');
+  });
+
+  it('classifies personal and non-login included empty states by API mode', () => {
+    expect(
+      noRunnableModelAccessReason(
+        [
+          access(
+            {
+              availability: 'missing-key',
+              requiresKey: true,
+            },
+            'missing api key',
+            false,
+          ),
+        ],
+        'personal',
+      ),
+    ).toBe('personal');
+    expect(
+      noRunnableModelAccessReason(
+        [
+          access(
+            {
+              availability: 'relay-quota-exhausted',
+              disabled: true,
+            },
+            'relay quota exhausted',
+            false,
+          ),
+        ],
+        'included',
+      ),
+    ).toBe('included');
+  });
+
   it('explains that included relay models require sign-in', () => {
     expect(
       emptyModelListMessageForCliMode(

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -2,10 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { orchestrationKeyHints } from '@cli/orchestration/runOrchestrationTui';
+import {
+  orchestrationKeyHints,
+  orchestrationModelAccessView,
+} from '@cli/orchestration/runOrchestrationTui';
 import { buildCliOrchestrationItems } from '@cli/runtime/orchestration';
 
 import type { CliHistoryEntry } from '@cli/runtime/history';
+import type { CliModelAccess } from '@cli/runtime/modelAccess';
 import {
   planCliMultiAgentPresetRun,
   type CliMultiAgentPreset,
@@ -51,6 +55,19 @@ function toolUseAgent(name: string, tools: string[] = []): AgentEntry {
 
 function workflowAgent(name: string): AgentEntry {
   return agent(name, AgentCategory.Workflow);
+}
+
+function modelAccess(
+  value: string,
+  availability: CliModelAccess['model']['availability'],
+  available: boolean,
+  status = available ? 'available' : 'missing key',
+): CliModelAccess {
+  return {
+    model: { value, label: value, availability },
+    available,
+    status,
+  };
 }
 
 function preset(overrides: Partial<CliMultiAgentPreset>): CliMultiAgentPreset {
@@ -212,6 +229,82 @@ describe('CLI orchestration items', () => {
     ).toEqual({
       kind: 'preset',
       preset: 'physicist',
+    });
+  });
+
+  it('disables model-dependent launcher rows when no personal model can run', () => {
+    const view = orchestrationModelAccessView(
+      buildCliOrchestrationItems({
+        presetPlans: [presetPlan({ id: 'physicist', name: 'Physicist' })],
+        history: [historyEntry('aaaaaaaaaaaa', { agent: 'review' })],
+        toolUseAgents: [toolUseAgent('review')],
+      }),
+      [modelAccess('deepseekT', 'provider-key', false)],
+      'personal',
+    );
+
+    const disabledLabels = view.items
+      .filter((item) => item.disabled)
+      .map((item) => item.label);
+    expect(disabledLabels).toEqual([
+      'New chat',
+      'Chat with review',
+      'Team Physicist',
+    ]);
+    expect(
+      view.items.find((item) => item.label === 'Resume aaaaaaaaaaaa'),
+    ).not.toHaveProperty('disabled');
+    expect(view.items.at(-1)).toMatchObject({ label: 'Help' });
+    expect(view.items[0]?.description).toBe(
+      'No personal API-key models are runnable',
+    );
+    expect(view.modelItems).toEqual([]);
+  });
+
+  it('keeps launcher rows active when model registry state is unknown', () => {
+    const view = orchestrationModelAccessView(
+      buildCliOrchestrationItems({
+        presetPlans: [presetPlan({ id: 'physicist', name: 'Physicist' })],
+        history: [],
+        toolUseAgents: [],
+      }),
+      [],
+      'personal',
+    );
+
+    expect(view.items.some((item) => item.disabled)).toBe(false);
+  });
+
+  it('keeps launcher rows active when a hidden runtime default can launch', () => {
+    const view = orchestrationModelAccessView(
+      buildCliOrchestrationItems({
+        presetPlans: [presetPlan({ id: 'physicist', name: 'Physicist' })],
+        history: [],
+        toolUseAgents: [],
+      }),
+      [modelAccess('deepseekT', 'provider-key', false)],
+      'personal',
+      { allowDefaultModelLaunch: true },
+    );
+
+    expect(view.items.some((item) => item.disabled)).toBe(false);
+    expect(view.modelItems).toEqual([]);
+  });
+
+  it('uses relay-specific disabled text when included access needs login', () => {
+    const view = orchestrationModelAccessView(
+      buildCliOrchestrationItems({
+        presetPlans: [],
+        history: [],
+        toolUseAgents: [],
+      }),
+      [modelAccess('sonnet46T', 'included-login-required', false)],
+      'included',
+    );
+
+    expect(view.items[0]).toMatchObject({
+      disabled: true,
+      description: 'Sign in with texra login for included relay models',
     });
   });
 });


### PR DESCRIPTION
## Summary

- keep `simplifier` out of implicit/default CLI tool-use agent selection while preserving explicit `--agent simplifier` and custom preset behavior
- disable launcher chat/team rows when model access is known but no model can run in the active API mode
- share no-runnable-model classification between `/model` and the startup launcher so relay vs personal behavior stays aligned

Fixes #5221.

## Verification

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- orchestrate-no-runnable-models orchestrate-personal-model-pick orchestrate-relay-model-pick orchestrate-launcher`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect default agent/model selection and launcher UX only; no auth, billing, or data-path changes.
> 
> **Overview**
> Hardens **CLI startup defaults and the orchestration launcher** when model access is missing or misleading.
> 
> **Chat defaults** no longer pull the **agent** from execution history—only the **model** (still skipping multi-agent team runs). Plain `texra chat` keeps the built-in `chat` agent unless workspace/user/env overrides apply, which avoids stale or specialist agents (e.g. `bash`, `simplifier`) becoming the implicit default.
> 
> **Orchestration / bare `texra` launcher**: when the model registry is loaded and **nothing is runnable** in the active API mode, **New chat** and team rows are **disabled** with the same “no runnable models” messaging as `/model` (including sign-in vs personal-key cases). If the registry is unknown (empty list) or a **hidden configured default** can still resolve, launch stays allowed. **`orchestrate`** computes `allowDefaultModelLaunch` via `resolveChatDefaults` + hidden-model resolution.
> 
> **Multi-agent presets**: built-in team **root** selection prefers orchestrators and avoids promoting arbitrary delegation specialists when the orchestrator is missing.
> 
> Adds unit tests and a TUI scenario (`orchestrate-no-runnable-models`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fcd0fc0e3fe7f336786a2c9f56c936eea7d6dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->