### PR TITLE
fix(cli): handle buffered menu hotkeys

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -523,6 +523,16 @@ const SCENARIOS = [
     unexpect: ['ServerSideKeyService not initialized'],
   },
   {
+    name: 'api-form-buffered-hotkey',
+    rows: 12,
+    cols: 80,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/api', '\r', '21'],
+    frame: 'tail',
+    expect: ['API mode set to included.'],
+    unexpect: ['ServerSideKeyService not initialized'],
+  },
+  {
     name: 'compact-approval-form',
     rows: 10,
     cols: 60,

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -195,6 +195,15 @@ export function selectIndexForHotkey(input: string): number | undefined {
   return undefined;
 }
 
+/**
+ * Ink can deliver rapid key presses as one input chunk. Menus should still
+ * honor the first shortcut instead of silently dropping the whole chunk.
+ */
+export function selectIndexForHotkeyInput(input: string): number | undefined {
+  const first = input.at(0);
+  return first == null ? undefined : selectIndexForHotkey(first);
+}
+
 export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   const initial = selectInitialHighlightIndex({
     activeValue: props.activeValue,
@@ -257,7 +266,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
     // we render with exitOnCtrlC: false, so Ink no longer mutes it), and
     // Ctrl/Alt+<letter> were never meant as row hotkeys.
     if (!key.ctrl && !key.meta) {
-      const idx = selectIndexForHotkey(input);
+      const idx = selectIndexForHotkeyInput(input);
       if (idx != null && idx < props.items.length) {
         const choice = props.items[idx];
         if (choice && !choice.disabled) {

--- a/src/test-kernel/cli/SelectHotkeys.vitest.mts
+++ b/src/test-kernel/cli/SelectHotkeys.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   selectHotkeyForIndex,
   selectIndexForHotkey,
+  selectIndexForHotkeyInput,
 } from '@cli/chat/tui/ui/Select';
 
 describe('Select hotkeys', () => {
@@ -32,5 +33,12 @@ describe('Select hotkeys', () => {
     expect(selectIndexForHotkey('0')).toBeUndefined();
     expect(selectIndexForHotkey('')).toBeUndefined();
     expect(selectIndexForHotkey('ab')).toBeUndefined();
+  });
+
+  it('uses the first shortcut from buffered terminal input', () => {
+    expect(selectIndexForHotkeyInput('21')).toBe(1);
+    expect(selectIndexForHotkeyInput('A1')).toBe(9);
+    expect(selectIndexForHotkeyInput('0a')).toBeUndefined();
+    expect(selectIndexForHotkeyInput('')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- handle Ink input chunks such as `21` by consuming the first valid `Select` hotkey instead of dropping the chunk
- add focused hotkey unit coverage for buffered terminal input
- add a raw-PTY `validate-tui` scenario that sends `/api`, Enter, then `21` as one write

Fixes #5223

## Root cause
The shared CLI `Select` primitive only mapped single-character input through `selectIndexForHotkey`. When a terminal delivered rapid keypresses as one chunk, e.g. `21`, the picker treated it as non-shortcut input and gave no feedback.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SelectHotkeys.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- api-form-buffered-hotkey`
- real PTY smoke: rebuilt `packages/cli/dist/bin/texra.js`, ran `texra setup` with isolated HOME/XDG/TMP dirs, sent `21` as one write, and confirmed it moved to the Provider API key provider picker
- `git diff --check`
- `npm run compile:safe`
- `npm run lint`
- `corepack pnpm --filter @texra-ai/cli run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI input handling and test-only harness changes; no auth, data, or API surface impact.
> 
> **Overview**
> Fixes **buffered terminal hotkeys** in the shared CLI **`Select`** menu: when Ink delivers multiple keys in one chunk (e.g. `21`), the picker now treats the **first character** as the row shortcut instead of ignoring the whole chunk.
> 
> Adds **`selectIndexForHotkeyInput`**, wires it into **`Select`**’s input handler, unit tests in **`SelectHotkeys.vitest.mts`**, and a **`validate-tui`** PTY scenario (`api-form-buffered-hotkey`) that opens `/api` and sends `21` in one write, expecting included API mode to apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530dfeec6be111e41a723164cc5982d84b310513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->