### PR TITLE
fix(cli): route setup headless flag errors

### DIFF
--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -518,7 +518,9 @@ async function commandFlagSpecs(
   const commandName = resolved.commandPath.at(-1);
   if (
     resolved.commandPath.length === 2 &&
-    (commandName === 'chat' || commandName === 'orchestrate')
+    (commandName === 'chat' ||
+      commandName === 'orchestrate' ||
+      commandName === 'setup')
   ) {
     // Keep the existing explicit "interactive command" usage error for these
     // known headless-only global flags instead of downgrading it to "unknown".

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -142,8 +142,10 @@ export function rejectHeadlessOnlyFlags(
   const headlessOnly = rawArgs.some(
     (arg) =>
       arg === '--print' ||
+      arg.startsWith('--print=') ||
       arg === '-p' ||
       arg === '--no-input' ||
+      arg.startsWith('--no-input=') ||
       arg === '--output-format' ||
       arg.startsWith('--output-format='),
   );

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -278,6 +278,9 @@ describe('CLI root argument routing', () => {
       detectUnknownCliFlag(['run', 'polish', '-mdeepseekT', '--no-color']),
     ).resolves.toBeUndefined();
     await expect(
+      detectUnknownCliFlag(['setup', '--no-input']),
+    ).resolves.toBeUndefined();
+    await expect(
       detectUnknownCliFlag([
         'multi-agent',
         'run',
@@ -423,6 +426,12 @@ describe('CLI root argument routing', () => {
       rejectHeadlessOnlyFlags(['--output-format=json'], 'orchestrate'),
     ).toThrow('texra orchestrate is interactive');
     expect(() => rejectHeadlessOnlyFlags(['--no-input'], 'chat')).toThrow(
+      'texra chat is interactive',
+    );
+    expect(() => rejectHeadlessOnlyFlags(['--no-input=true'], 'chat')).toThrow(
+      'texra chat is interactive',
+    );
+    expect(() => rejectHeadlessOnlyFlags(['--print=true'], 'chat')).toThrow(
       'texra chat is interactive',
     );
     expect(() =>
@@ -1089,6 +1098,20 @@ describe('runCli usage output stream routing', () => {
     const result = await runCli(['chat', '--print']);
     expect(result.exitCode).toBe(2);
     expect(stderr).toContain('texra chat is interactive');
+    expect(stderr).not.toContain('Unknown option');
+    expect(stdout).toBe('');
+
+    stderr = '';
+    const setupResult = await runCli(['setup', '--no-input']);
+    expect(setupResult.exitCode).toBe(2);
+    expect(stderr).toContain('texra setup is interactive');
+    expect(stderr).not.toContain('Unknown option');
+    expect(stdout).toBe('');
+
+    stderr = '';
+    const inlineSetupResult = await runCli(['setup', '--no-input=true']);
+    expect(inlineSetupResult.exitCode).toBe(2);
+    expect(stderr).toContain('texra setup is interactive');
     expect(stderr).not.toContain('Unknown option');
     expect(stdout).toBe('');
   });


### PR DESCRIPTION
## Summary
- include `setup` in the interactive-command flag recognition path for headless-only global flags
- preserve the tailored interactive-command error for `texra setup --no-input` instead of reporting an unknown option
- add CLI argument routing regression coverage

Fixes #5225

## Root cause
The unknown-flag detector treated `--no-input` as known for `chat` and `orchestrate`, letting those commands reach `rejectHeadlessOnlyFlags`. `setup` also called `rejectHeadlessOnlyFlags`, but the detector did not whitelist setup first, so the command exited earlier with `Unknown option`.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint`
- `corepack pnpm --filter @texra-ai/cli run build`
- rebuilt binary smoke: `node packages/cli/dist/bin/texra.js setup --no-input --no-color` now prints the tailored interactive-command error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only argument parsing and error-message routing; no auth, data, or runtime behavior changes beyond clearer validation for `setup` and inline flag spellings.
> 
> **Overview**
> **`setup` is now treated like other interactive commands** (`chat`, `orchestrate`) when the CLI validates global flags, so headless-only options such as `--no-input` are recognized instead of failing early with *Unknown option*.
> 
> **Headless-only rejection** also covers **inline boolean forms** (`--no-input=true`, `--print=true`), keeping the tailored *interactive command* usage error for `chat`/`setup`/`orchestrate`.
> 
> Regression tests cover unknown-flag detection for `setup --no-input` and end-to-end CLI exit messages for `setup` with `--no-input` and `--no-input=true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28645148b7703b6a0daa106edfa9ee97276e9b7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->