### PR TITLE
fix(cli): keep simplifier out of defaults

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,7 +2,10 @@ import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { CLI_BUILTIN_DEFAULT_MODEL } from '../runtime/cliConfig';
-import { BUILTIN_DEFAULT_CHAT_AGENT } from '../runtime/chatDefaults';
+import {
+  BUILTIN_DEFAULT_CHAT_AGENT,
+  defaultToolUseAgents,
+} from '../runtime/defaultAgents';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
@@ -20,8 +23,22 @@ import {
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import type { CliContext } from '../runtime/cliContext';
 
+interface InitAgentOption {
+  readonly name: string;
+  readonly description?: string;
+}
+
+export function defaultInitAgentOptions(
+  agents: readonly InitAgentOption[],
+): InitAgentOption[] {
+  return defaultToolUseAgents(agents).map((agent) => ({
+    name: agent.name,
+    description: agent.description,
+  }));
+}
+
 async function gatherOptions(apiMode: CliApiMode): Promise<{
-  agents: { name: string; description?: string }[];
+  agents: InitAgentOption[];
   models: {
     value: string;
     label: string;
@@ -30,10 +47,9 @@ async function gatherOptions(apiMode: CliApiMode): Promise<{
   }[];
 }> {
   await loadAgents({ includeRemote: false });
-  const agents = getVisibleAgents(AgentCategory.ToolUse).map((agent) => ({
-    name: agent.name,
-    description: agent.description,
-  }));
+  const agents = defaultInitAgentOptions(
+    getVisibleAgents(AgentCategory.ToolUse),
+  );
   const models = (await getCliModelAccessList({ apiMode })).map((entry) => ({
     value: entry.model.value,
     label: entry.model.label ?? entry.model.value,

--- a/packages/cli/src/init/runInitWizard.tsx
+++ b/packages/cli/src/init/runInitWizard.tsx
@@ -15,6 +15,7 @@ import {
   type CliApprovalPolicy,
   type CliOutputFormat,
 } from '../schemas/cliSettings';
+import { BUILTIN_DEFAULT_CHAT_AGENT } from '../runtime/defaultAgents';
 import type { InitAnswers } from '../runtime/initConfig';
 
 export interface InitWizardAgentOption {
@@ -118,6 +119,13 @@ function firstAvailableIndex(models: readonly InitWizardModelOption[]): number {
   return index >= 0 ? index : 0;
 }
 
+function defaultAgentIndex(agents: readonly InitWizardAgentOption[]): number {
+  const index = agents.findIndex(
+    (agent) => agent.name === BUILTIN_DEFAULT_CHAT_AGENT,
+  );
+  return index >= 0 ? index : 0;
+}
+
 interface WizardAppProps {
   readonly options: InitWizardOptions;
   readonly onResolve: (result: InitWizardResult | undefined) => void;
@@ -175,6 +183,7 @@ function WizardApp(props: WizardAppProps): React.JSX.Element {
       >
         <Select
           key={step}
+          initialIndex={defaultAgentIndex(props.options.agents)}
           items={props.options.agents.map((agent) => ({
             value: agent.name,
             label: agent.name,

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -9,10 +9,14 @@ import {
   resolveConfiguredAgent,
   resolveConfiguredModel,
 } from './cliConfig';
+import {
+  BUILTIN_DEFAULT_CHAT_AGENT,
+  normalizeDefaultToolUseAgent,
+} from './defaultAgents';
 import type { CliModelSelectionSource } from './modelAccess';
 
-export const BUILTIN_DEFAULT_CHAT_AGENT = 'chat';
 export const BUILTIN_DEFAULT_CHAT_MODEL = CLI_BUILTIN_DEFAULT_MODEL;
+export { BUILTIN_DEFAULT_CHAT_AGENT } from './defaultAgents';
 
 export interface ChatDefaults {
   readonly agent: string;
@@ -49,7 +53,10 @@ function pickDefaults(parsed: unknown): PartialDefaults {
   const record = parsed as Record<string, unknown>;
   const out: { -readonly [K in keyof PartialDefaults]: PartialDefaults[K] } =
     {};
-  if (isNonEmptyString(record.agent)) out.agent = record.agent.trim();
+  if (isNonEmptyString(record.agent)) {
+    const agent = normalizeDefaultToolUseAgent(record.agent);
+    if (agent) out.agent = agent;
+  }
   if (isNonEmptyString(record.model)) {
     const model = record.model.trim();
     if (isKnownCliModel(model)) out.model = model;
@@ -60,7 +67,9 @@ function pickDefaults(parsed: unknown): PartialDefaults {
 async function loadWorkspaceDefaults(cwd: string): Promise<PartialDefaults> {
   const loaded = await loadWorkspaceCliConfig(cwd);
   return {
-    agent: resolveConfiguredAgent(loaded.values, 'chat'),
+    agent: normalizeDefaultToolUseAgent(
+      resolveConfiguredAgent(loaded.values, 'chat'),
+    ),
     model: resolveConfiguredModel(loaded.values, 'chat'),
   };
 }

--- a/packages/cli/src/runtime/defaultAgents.ts
+++ b/packages/cli/src/runtime/defaultAgents.ts
@@ -1,0 +1,21 @@
+export const BUILTIN_DEFAULT_CHAT_AGENT = 'chat';
+
+const NON_DEFAULT_TOOL_USE_AGENTS = new Set(['simplifier']);
+
+export function isDefaultToolUseAgentAllowed(agent: string): boolean {
+  return !NON_DEFAULT_TOOL_USE_AGENTS.has(agent.trim().toLowerCase());
+}
+
+export function defaultToolUseAgents<T extends { readonly name: string }>(
+  agents: readonly T[],
+): T[] {
+  return agents.filter((agent) => isDefaultToolUseAgentAllowed(agent.name));
+}
+
+export function normalizeDefaultToolUseAgent(
+  agent: string | undefined,
+): string | undefined {
+  const trimmed = agent?.trim();
+  if (!trimmed || !isDefaultToolUseAgentAllowed(trimmed)) return undefined;
+  return trimmed;
+}

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -8,6 +8,7 @@ import {
   AgentModePresetSchema,
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
+import { defaultToolUseAgents } from './defaultAgents';
 
 export type CliMultiAgentPresetSource = 'built-in' | 'custom';
 
@@ -376,7 +377,8 @@ function selectPresetRootAgent(
     readonly presetSource: CliMultiAgentPresetSource;
   },
 ): AgentEntry | undefined {
-  const delegatingAgents = agents.filter(agentHasDelegationTools);
+  const rootCandidates = defaultToolUseAgents(agents);
+  const delegatingAgents = rootCandidates.filter(agentHasDelegationTools);
   const preferredRoot = findPreferredRootAgent(
     delegatingAgents,
     options.presetSource,
@@ -388,10 +390,10 @@ function selectPresetRootAgent(
     // Built-in teams name specialists as members. If their orchestrator is not
     // available, fall back only to a plain local agent rather than promoting an
     // arbitrary delegation specialist to team root.
-    return agents.find((agent) => !agentHasDelegationTools(agent));
+    return rootCandidates.find((agent) => !agentHasDelegationTools(agent));
   }
 
-  return delegatingAgents[0] ?? agents[0];
+  return delegatingAgents[0] ?? rootCandidates[0];
 }
 
 function findPreferredRootAgent(

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -12,6 +12,7 @@ import {
   BUILTIN_DEFAULT_CHAT_MODEL,
   resolveChatDefaults,
 } from '@cli/runtime/chatDefaults';
+import { GlobalStorageFS } from '@utils/files/storageFS';
 
 vi.mock('@agent/storage', () => ({
   listExecutions: vi.fn(async () => []),
@@ -42,6 +43,8 @@ vi.mock('@utils/files/storageFS', () => ({
     }),
   },
 }));
+
+const mockedReadJson = vi.mocked(GlobalStorageFS.readJson);
 
 describe('CLI chat defaults', () => {
   it('uses chat and DeepSeek as the built-in chat defaults', async () => {
@@ -189,6 +192,51 @@ describe('CLI chat defaults', () => {
       model: 'sonnet46T',
       agentSource: 'builtin',
       modelSource: 'history',
+    });
+  });
+
+  it('ignores simplifier from configured chat default tiers', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'texra-chat-defaults-'));
+    await mkdir(join(workspace, '.texra'), { recursive: true });
+    await writeFile(
+      join(workspace, '.texra', 'config.json'),
+      JSON.stringify({ chat: { agent: 'simplifier', model: 'sonnet46T' } }),
+    );
+
+    await expect(
+      resolveChatDefaults({ cwd: workspace }),
+    ).resolves.toMatchObject({
+      agent: 'chat',
+      model: 'sonnet46T',
+      agentSource: 'builtin',
+      modelSource: 'workspace',
+    });
+
+    mockedReadJson.mockResolvedValueOnce({
+      agent: 'simplifier',
+      model: 'sonnet46T',
+    });
+    await expect(
+      resolveChatDefaults({
+        cwd: '/tmp/no-such-texra-workspace',
+      }),
+    ).resolves.toMatchObject({
+      agent: 'chat',
+      model: 'sonnet46T',
+      agentSource: 'builtin',
+      modelSource: 'user',
+    });
+  });
+
+  it('still honors a TEXRA_AGENT simplifier override', async () => {
+    await expect(
+      resolveChatDefaults({
+        cwd: '/tmp/no-such-texra-workspace',
+        envAgent: 'simplifier',
+      }),
+    ).resolves.toMatchObject({
+      agent: 'simplifier',
+      agentSource: 'env',
     });
   });
 

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultInitAgentOptions } from '@cli/commands/init';
+
+describe('CLI init command', () => {
+  it('does not offer simplifier as a default init agent option', () => {
+    const options = defaultInitAgentOptions([
+      { name: 'chat', description: 'General chat' },
+      { name: 'simplifier', description: 'Code simplification' },
+      { name: 'review', description: 'Code review' },
+    ]);
+
+    expect(options).toEqual([
+      { name: 'chat', description: 'General chat' },
+      { name: 'review', description: 'Code review' },
+    ]);
+  });
+});

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -307,7 +307,7 @@ describe('CLI multi-agent presets', () => {
     expect(cliMultiAgentPlanHasGaps(onlySimplifierPlan)).toBe(true);
   });
 
-  it('allows custom presets to default to their simplifier agent', () => {
+  it('does not allow custom presets to default to their simplifier agent', () => {
     const plan = planCliMultiAgentPresetRun(
       {
         id: 'custom-cleanup',
@@ -326,8 +326,8 @@ describe('CLI multi-agent presets', () => {
       },
     );
 
-    expect(plan.rootAgent?.name).toBe('simplifier');
-    expect(cliMultiAgentPlanHasGaps(plan)).toBe(false);
+    expect(plan.rootAgent).toBeUndefined();
+    expect(cliMultiAgentPlanHasGaps(plan)).toBe(true);
   });
 
   it('reports no gaps when every preset member resolves', () => {

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -261,6 +261,39 @@ describe('CLI orchestration items', () => {
     expect(view.modelItems).toEqual([]);
   });
 
+  it('scopes startup model choices to the active API mode', () => {
+    const items = buildCliOrchestrationItems({
+      presetPlans: [presetPlan({ id: 'physicist', name: 'Physicist' })],
+      history: [historyEntry('aaaaaaaaaaaa', { agent: 'review' })],
+      toolUseAgents: [toolUseAgent('review')],
+    });
+    const models = [
+      modelAccess('sonnet46T', 'included-access', true, 'included'),
+      modelAccess('deepseekT', 'provider-key', true, 'api key set'),
+      modelAccess('gemini31p', 'missing-key', false),
+    ];
+
+    const relayView = orchestrationModelAccessView(items, models, 'included');
+    const personalView = orchestrationModelAccessView(
+      items,
+      models,
+      'personal',
+    );
+
+    expect(relayView.modelItems.map((item) => item.value)).toEqual([
+      'sonnet46T',
+    ]);
+    expect(relayView.modelItems.map((item) => item.description)).toEqual([
+      'relay: included',
+    ]);
+    expect(personalView.modelItems.map((item) => item.value)).toEqual([
+      'deepseekT',
+    ]);
+    expect(personalView.modelItems.map((item) => item.description)).toEqual([
+      'api: api key set',
+    ]);
+  });
+
   it('keeps launcher rows active when model registry state is unknown', () => {
     const view = orchestrationModelAccessView(
       buildCliOrchestrationItems({


### PR DESCRIPTION
## Summary
- keep the shared default-agent policy from selecting `simplifier` as an implicit tool-use default
- apply that policy to chat defaults, `texra init` agent choices, and implicit multi-agent preset roots
- preserve explicit overrides such as `--agent simplifier` and `TEXRA_AGENT=simplifier`
- cover the startup model picker after chat/team/resume selection so relay mode and personal API-key mode expose different runnable model options

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/InitCommand.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-selection and init UX changes only; explicit agent overrides and delegation behavior are unchanged and covered by tests.
> 
> **Overview**
> Introduces a shared **default tool-use agent policy** that treats **`simplifier` as opt-in only**, so it is no longer picked implicitly as the default chat agent, init wizard choice, or multi-agent preset root.
> 
> **`defaultAgents`** centralizes `BUILTIN_DEFAULT_CHAT_AGENT` and helpers to filter or normalize agent names; **`resolveChatDefaults`** drops `simplifier` from workspace and user config tiers (falling back to **`chat`**) while **explicit overrides** (`--agent`, `TEXRA_AGENT`, preset `agentOverride`) still allow it. **`texra init`** omits `simplifier` from selectable defaults and pre-selects **`chat`** in the wizard; **preset root selection** only considers allowed agents unless the user names a root explicitly.
> 
> Tests lock in init options, chat defaults, preset planning, and orchestration model lists scoped by API mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3307199ef0c6fad4c88dd90fca0ed4a662575e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->