### PR TITLE
refactor: simplify recently-changed CLI/agent code

### DIFF
--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -152,6 +152,14 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     itemCount: items.length,
   });
 
+  function handleSelect(value: string): void {
+    if (selectable) {
+      props.onSelect?.(value);
+      return;
+    }
+    props.onClose();
+  }
+
   if (isCompactFormRows(props.availableRows) && items.length > 0) {
     return (
       <FormFrame
@@ -165,13 +173,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
           activeValue={props.currentModel}
           maxVisibleItems={1}
           showOverflow={false}
-          onSelect={(value) => {
-            if (selectable) {
-              props.onSelect?.(value);
-              return;
-            }
-            props.onClose();
-          }}
+          onSelect={handleSelect}
           onCancel={props.onClose}
         />
         <CompactFormKeyHints
@@ -213,13 +215,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
             activeValue={props.currentModel}
             maxVisibleItems={selectWindow.maxVisibleItems}
             showOverflow={selectWindow.showOverflow}
-            onSelect={(value) => {
-              if (selectable) {
-                props.onSelect?.(value);
-                return;
-              }
-              props.onClose();
-            }}
+            onSelect={handleSelect}
             onCancel={props.onClose}
           />
         </Box>

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -98,6 +98,14 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
     disabled: !tool.toggleable || tool.comingSoon,
   }));
 
+  function handleToggle(id: string): void {
+    const tool = tools.find((candidate) => candidate.id === id);
+    if (!tool || tool.enabled == null) return;
+    void setCliToolEnabled(id, !tool.enabled)
+      .then(() => readCliToolStatuses())
+      .then(setTools);
+  }
+
   if (isCompactFormRows(props.availableRows)) {
     return (
       <FormFrame color="cyan" title="/tools" showCloseHint={false}>
@@ -108,13 +116,7 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
           items={items}
           maxVisibleItems={1}
           showOverflow={false}
-          onSelect={(id) => {
-            const tool = tools.find((candidate) => candidate.id === id);
-            if (!tool || tool.enabled == null) return;
-            void setCliToolEnabled(id, !tool.enabled)
-              .then(() => readCliToolStatuses())
-              .then(setTools);
-          }}
+          onSelect={handleToggle}
           onCancel={props.onClose}
         />
         <CompactFormKeyHints
@@ -131,13 +133,7 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
         items={items}
         maxVisibleItems={selectWindow.maxVisibleItems}
         showOverflow={selectWindow.showOverflow}
-        onSelect={(id) => {
-          const tool = tools.find((candidate) => candidate.id === id);
-          if (!tool || tool.enabled == null) return;
-          void setCliToolEnabled(id, !tool.enabled)
-            .then(() => readCliToolStatuses())
-            .then(setTools);
-        }}
+        onSelect={handleToggle}
         onCancel={props.onClose}
       />
       <Box marginTop={1}>

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -585,24 +585,6 @@ function taskDetailScrollContextKey(context: TaskDetailScrollContext): string {
   ].join(':');
 }
 
-function taskDetailScrollStateWithAnchor(
-  state: Omit<TaskDetailScrollState, 'anchor'>,
-  anchor: TaskDetailScrollAnchor | undefined,
-): TaskDetailScrollState {
-  return anchor ? { ...state, anchor } : state;
-}
-
-function taskDetailScrollStateWithoutAnchor(
-  state: TaskDetailScrollState,
-  offset: number,
-): TaskDetailScrollState {
-  return {
-    executionId: state.executionId,
-    followsTail: state.followsTail,
-    offset,
-  };
-}
-
 export function syncTaskDetailScrollState(
   state: TaskDetailScrollState,
   executionId: string,
@@ -615,7 +597,11 @@ export function syncTaskDetailScrollState(
     return { executionId, followsTail: true, offset: clampedFollowOffset };
   }
   if (state.followsTail) {
-    return taskDetailScrollStateWithoutAnchor(state, clampedFollowOffset);
+    return {
+      executionId: state.executionId,
+      followsTail: state.followsTail,
+      offset: clampedFollowOffset,
+    };
   }
   if (context && state.anchor) {
     return {
@@ -673,18 +659,17 @@ export function moveTaskDetailScrollState(
     maxOffset,
     followOffset,
   );
-  return taskDetailScrollStateWithAnchor(
-    {
-      executionId: state.executionId,
-      followsTail,
-      offset: nextOffset,
-    },
-    followsTail
-      ? undefined
-      : context
-        ? taskDetailScrollAnchorFromOffset(context, nextOffset)
-        : state.anchor,
-  );
+  const anchor = followsTail
+    ? undefined
+    : context
+      ? taskDetailScrollAnchorFromOffset(context, nextOffset)
+      : state.anchor;
+  return {
+    executionId: state.executionId,
+    followsTail,
+    offset: nextOffset,
+    ...(anchor ? { anchor } : {}),
+  };
 }
 
 export function computePickerListLayout({

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -13,6 +13,7 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
+import { filterNotNullish } from '@utils/core';
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
 import { formatCliStatusLabel } from '../sessionStatus';
@@ -330,7 +331,7 @@ function fitStatusBarLeftSegments(
     ...new Set(
       compacted
         .map((segment) => segment.compactPriority)
-        .filter((priority): priority is number => priority !== undefined),
+        .filter(filterNotNullish),
     ),
   ].sort((a, b) => a - b);
 

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -7,6 +7,8 @@
 import { Box, Text } from 'ink';
 import { structuredPatch, type StructuredPatchHunk } from 'diff';
 
+import { filterNotNullish, isObject } from '@utils/core';
+
 import { wrapAnsiToWidth } from './ansiWrap';
 import { maxScrollableRowOffset, scrollBoundedRows } from './scrollBounds';
 import { clipToWidth, fillRows, textDisplayWidth } from './terminalText';
@@ -60,10 +62,6 @@ export function statsFromHunks(hunks: readonly Hunk[]): DiffStats {
   return { added, removed, hunks: hunks.length };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 function stringField(
   record: Record<string, unknown>,
   keys: readonly string[],
@@ -85,7 +83,7 @@ function editCandidate(
       readonly newText: string;
     }
   | undefined {
-  if (!isRecord(input)) return undefined;
+  if (!isObject(input)) return undefined;
   const oldText = stringField(input, ['old_string', 'old_str']);
   const newText = stringField(input, ['new_string', 'new_str']);
   if (oldText === undefined || newText === undefined) return undefined;
@@ -99,15 +97,14 @@ function editCandidate(
 export function editPatchGroups(
   input: unknown,
 ): readonly InlinePatchGroup[] | undefined {
-  if (!isRecord(input)) return undefined;
+  if (!isObject(input)) return undefined;
   const fileLabel = stringField(input, ['path', 'file_path']) ?? 'edit';
   const edits = input.edits;
   const candidates = Array.isArray(edits)
     ? edits.map((edit) => editCandidate(edit, fileLabel))
     : [editCandidate(input, fileLabel)];
 
-  const groups = candidates.flatMap((candidate) => {
-    if (!candidate) return [];
+  const groups = candidates.filter(filterNotNullish).flatMap((candidate) => {
     const hunks = buildHunks(
       candidate.fileLabel,
       candidate.oldText,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -86,6 +86,7 @@ import {
 } from '@shared/schemas';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
+import { filterNotNullish } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { truncateSummary } from '@utils/text/stringUtils';
 
@@ -179,13 +180,6 @@ export function buildInitialChatAgentConfig({
     workingDirectory,
     ...(cliMultiAgentPresetId ? { cliMultiAgentPresetId } : {}),
   };
-}
-
-function formatQueuedFollowUpNotice(line: string): string {
-  return `Queued follow-up: ${truncateSummary(
-    line,
-    QUEUED_FOLLOW_UP_NOTICE_LENGTH,
-  )}`;
 }
 
 export interface ClearableTuiSessionState {
@@ -311,7 +305,7 @@ function chatTuiStreamStatuses(streamId: StreamTabId): readonly string[] {
     childStreamStatus,
     streams.get(streamId)?.status,
     StreamStatusService.get(streamId),
-  ].filter((status): status is string => status !== undefined);
+  ].filter(filterNotNullish);
 }
 
 function chatTuiCanAcceptFollowUp(statuses: readonly string[]): boolean {
@@ -1402,7 +1396,10 @@ export async function runChat(
     const initialFollowUpTarget = childFollowUpTarget ?? session.streamId;
     if (chatTuiShouldAnnounceQueuedFollowUp(initialFollowUpTarget)) {
       appendLocalAssistantTranscript(
-        formatQueuedFollowUpNotice(line),
+        `Queued follow-up: ${truncateSummary(
+          line,
+          QUEUED_FOLLOW_UP_NOTICE_LENGTH,
+        )}`,
         initialFollowUpTarget,
       );
     }

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -202,28 +202,21 @@ export function buildChildControlItems(
   > = new Map(),
   nowMs?: number,
 ): readonly ChildControlItem[] {
+  const activeKeys = new Set(slice.activeSubagents.map(childKey));
+  const subagentItems = visibleSubagentRows(slice).map((child) =>
+    buildSubagentItem(
+      child,
+      streamsById,
+      nowMs,
+      activeKeys.has(childKey(child)),
+    ),
+  );
   if (mode === 'subagents') {
-    const activeKeys = new Set(slice.activeSubagents.map(childKey));
-    return visibleSubagentRows(slice).map((child) =>
-      buildSubagentItem(
-        child,
-        streamsById,
-        nowMs,
-        activeKeys.has(childKey(child)),
-      ),
-    );
+    return subagentItems;
   }
 
-  const activeKeys = new Set(slice.activeSubagents.map(childKey));
   return [
-    ...visibleSubagentRows(slice).map((child) =>
-      buildSubagentItem(
-        child,
-        streamsById,
-        nowMs,
-        activeKeys.has(childKey(child)),
-      ),
-    ),
+    ...subagentItems,
     ...slice.activeProcesses.map((child) =>
       buildProcessItem(
         child,

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -135,21 +135,23 @@ export function optString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
+function isHeadlessOnlyFlag(arg: string): boolean {
+  return (
+    arg === '--print' ||
+    arg.startsWith('--print=') ||
+    arg === '-p' ||
+    arg === '--no-input' ||
+    arg.startsWith('--no-input=') ||
+    arg === '--output-format' ||
+    arg.startsWith('--output-format=')
+  );
+}
+
 export function rejectHeadlessOnlyFlags(
   rawArgs: readonly string[],
   commandName: string,
 ): void {
-  const headlessOnly = rawArgs.some(
-    (arg) =>
-      arg === '--print' ||
-      arg.startsWith('--print=') ||
-      arg === '-p' ||
-      arg === '--no-input' ||
-      arg.startsWith('--no-input=') ||
-      arg === '--output-format' ||
-      arg.startsWith('--output-format='),
-  );
-  if (!headlessOnly) return;
+  if (!rawArgs.some(isHeadlessOnlyFlag)) return;
 
   throw new CliUsageError(
     `texra ${commandName} is interactive and does not support --print, --no-input, or --output-format. For scripting, use \`texra run\` or a concrete non-interactive subcommand.`,

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -70,17 +70,6 @@ async function resolveToolUseInstruction(
   return instruction;
 }
 
-function writeToolUseRunResult(
-  context: CliContext,
-  result: CliToolUseRunResult,
-): void {
-  emitCliResult(context, {
-    json: result,
-    ndjson: { kind: 'agent-result', result },
-    text: toolUseResultText(result),
-  });
-}
-
 async function runToolUseAgent(
   context: CliContext,
   init: ToolUseAgentRunInit,
@@ -178,7 +167,11 @@ async function runToolUseAgent(
         workingDirectory: runContext.cwd,
       },
     );
-    writeToolUseRunResult(runContext, displayResult);
+    emitCliResult(runContext, {
+      json: displayResult,
+      ndjson: { kind: 'agent-result', result: displayResult },
+      text: toolUseResultText(displayResult),
+    });
 
     return terminalStatusExitCode(terminalStatus, runContext);
   } finally {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -212,25 +212,6 @@ const authStatusCommand = defineCliCommand({
   },
 });
 
-function writeRelayUsageSummary(
-  context: CliContext,
-  summary: RelayUsageSummary,
-): void {
-  const month = summary.periodStart.slice(0, 7);
-  emitCliResult(context, {
-    json: summary,
-    ndjson: { kind: 'relay-usage', ...summary },
-    text: [
-      `Relay usage for ${month} (${summary.tier})`,
-      `Spend: $${summary.costUsd.toFixed(2)} / $${summary.limitUsd.toFixed(2)} (${summary.usagePercent.toFixed(1)}%)`,
-      `Remaining: $${summary.remainingUsd.toFixed(2)}`,
-      `Streams: ${summary.streamCount}`,
-      `Tokens: ${summary.inputTokens} input (${summary.cachedTokens} cached), ${summary.outputTokens} output, ${summary.reasoningTokens} reasoning`,
-      `Models: ${summary.modelsUsed}; providers: ${summary.providersUsed}`,
-    ].join('\n'),
-  });
-}
-
 const usageCommand = defineCliCommand({
   meta: { name: 'usage', description: 'Show relay usage for this account' },
   args: {
@@ -270,7 +251,19 @@ const usageCommand = defineCliCommand({
       return CliExitCode.ModelOrNetworkError;
     }
 
-    writeRelayUsageSummary(context, summary);
+    const periodMonth = summary.periodStart.slice(0, 7);
+    emitCliResult(context, {
+      json: summary,
+      ndjson: { kind: 'relay-usage', ...summary },
+      text: [
+        `Relay usage for ${periodMonth} (${summary.tier})`,
+        `Spend: $${summary.costUsd.toFixed(2)} / $${summary.limitUsd.toFixed(2)} (${summary.usagePercent.toFixed(1)}%)`,
+        `Remaining: $${summary.remainingUsd.toFixed(2)}`,
+        `Streams: ${summary.streamCount}`,
+        `Tokens: ${summary.inputTokens} input (${summary.cachedTokens} cached), ${summary.outputTokens} output, ${summary.reasoningTokens} reasoning`,
+        `Models: ${summary.modelsUsed}; providers: ${summary.providersUsed}`,
+      ].join('\n'),
+    });
     return CliExitCode.Success;
   },
 });

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -386,7 +386,7 @@ const multiAgentListCommand = defineCliCommand({
   args: {
     ...GLOBAL_ARGS,
   },
-  run: (context) => runMultiAgentList(context),
+  run: runMultiAgentList,
 });
 
 const multiAgentPresetArgs = {

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -61,6 +61,12 @@ export interface OnboardingGateContext {
 const SKIP_SUMMARY =
   "Setup skipped — run `texra login` or `texra setup` when you're ready.";
 
+/** Gate returned without showing the picker (or before any choice is made). */
+const NO_ONBOARDING_RESULT: CliOnboardingResult = {
+  configured: false,
+  declined: false,
+};
+
 interface OnboardingResolution {
   readonly configured: boolean;
   readonly declined: boolean;
@@ -81,13 +87,13 @@ export async function maybeRunCliOnboarding(
   // check at the call site (same guard runCliOnboarding uses for the
   // context-less `texra setup` path). Defense-in-depth before we render.
   if (interactiveTerminalFailure(context) || !process.stdout.isTTY) {
-    return { configured: false, declined: false };
+    return NO_ONBOARDING_RESULT;
   }
   if (getOnboardingDeclined(platform().globalState)) {
-    return { configured: false, declined: false };
+    return NO_ONBOARDING_RESULT;
   }
   if (await hasCliCredentialForApiMode(context.apiMode).catch(() => false)) {
-    return { configured: false, declined: false };
+    return NO_ONBOARDING_RESULT;
   }
   return runOnboardingFlow({ firstRun: true, apiMode: context.apiMode });
 }
@@ -98,7 +104,7 @@ export async function maybeRunCliOnboarding(
  * headless before calling this.
  */
 export async function runCliOnboarding(): Promise<CliOnboardingResult> {
-  if (!process.stdout.isTTY) return { configured: false, declined: false };
+  if (!process.stdout.isTTY) return NO_ONBOARDING_RESULT;
   return runOnboardingFlow({ firstRun: false });
 }
 
@@ -109,7 +115,7 @@ async function runOnboardingFlow(options: {
   const pickerSubtitle = onboardingPickerSubtitle(options);
   const pickerItems = onboardingPickerItems(onboardingSetupPaths(options));
   const resolution = await new Promise<OnboardingResolution>((resolve) => {
-    let chosen: OnboardingResolution = { configured: false, declined: false };
+    let chosen: OnboardingResolution = NO_ONBOARDING_RESULT;
     const record = (next: OnboardingResolution): void => {
       chosen = next;
     };

--- a/packages/cli/src/runtime/completionBash.ts
+++ b/packages/cli/src/runtime/completionBash.ts
@@ -8,10 +8,6 @@ import {
   type CompletionFlag,
 } from './completionCommandTree';
 
-function flagTokens(flags: readonly CompletionFlag[]): string[] {
-  return flags.flatMap(completionFlagTokens);
-}
-
 interface FlagValueTokenEntry {
   readonly flag: CompletionFlag;
   readonly token: string;
@@ -33,10 +29,6 @@ function flagValueTokenEntries(
     }
   }
   return entries;
-}
-
-function flagValueTokens(commands: readonly CompletionCommand[]): string[] {
-  return flagValueTokenEntries(commands).map((entry) => entry.token);
 }
 
 function fixedFlagValueCases(commands: readonly CompletionCommand[]): string {
@@ -65,25 +57,11 @@ const DYNAMIC_VALUE_FLAG_CASES = [
   { tokens: ['--agent'], source: '_texra_agents' },
 ] as const;
 
-function dynamicFlagValueTokens(): Set<string> {
-  return new Set(
-    DYNAMIC_VALUE_FLAG_CASES.flatMap((flagCase) => flagCase.tokens),
-  );
-}
-
 function dynamicFlagValueCases(): string {
   return DYNAMIC_VALUE_FLAG_CASES.map(
     (flagCase) =>
       `${flagCase.tokens.join('|')}) COMPREPLY=( $(compgen -W "$(${flagCase.source})" -- "$cur") ); return ;;`,
   ).join('\n    ');
-}
-
-function isFileValueFlag(flag: CompletionFlag): boolean {
-  return flag.valueKind === 'file' || flag.valueKind === 'path';
-}
-
-function isDirectoryValueFlag(flag: CompletionFlag): boolean {
-  return flag.valueKind === 'directory' || flag.valueKind === 'dir';
 }
 
 function genericFlagValueCases(commands: readonly CompletionCommand[]): string {
@@ -94,16 +72,18 @@ function genericFlagValueCases(commands: readonly CompletionCommand[]): string {
         .flatMap(completionFlagTokens),
     ),
   );
-  const dynamicValueFlags = dynamicFlagValueTokens();
+  const dynamicValueFlags = new Set<string>(
+    DYNAMIC_VALUE_FLAG_CASES.flatMap((flagCase) => flagCase.tokens),
+  );
   const fileFlags: string[] = [];
   const directoryFlags: string[] = [];
   const genericFlags: string[] = [];
 
   for (const { flag, token } of flagValueTokenEntries(commands)) {
     if (fixedValueFlags.has(token) || dynamicValueFlags.has(token)) continue;
-    if (isDirectoryValueFlag(flag)) {
+    if (flag.valueKind === 'directory' || flag.valueKind === 'dir') {
       directoryFlags.push(token);
-    } else if (isFileValueFlag(flag)) {
+    } else if (flag.valueKind === 'file' || flag.valueKind === 'path') {
       fileFlags.push(token);
     } else {
       genericFlags.push(token);
@@ -130,7 +110,7 @@ function genericFlagValueCases(commands: readonly CompletionCommand[]): string {
 function commandCaseBlock(command: CompletionCommand): string {
   const key = commandKey(command.path);
   const commands = command.subcommands.join(' ');
-  const flags = flagTokens(command.flags).join(' ');
+  const flags = command.flags.flatMap(completionFlagTokens).join(' ');
   return `${shellQuote(key)}) subcommands=${shellQuote(commands)}; flags=${shellQuote(flags)} ;;`;
 }
 
@@ -140,7 +120,9 @@ export function bashCompletion(commands: readonly CompletionCommand[]): string {
   const dynamicValueCases = dynamicFlagValueCases();
   const genericValueCases = genericFlagValueCases(commands);
   const valueFlagPattern =
-    flagValueTokens(commands).join('|') || '--_texra_no_value_flags_';
+    flagValueTokenEntries(commands)
+      .map((entry) => entry.token)
+      .join('|') || '--_texra_no_value_flags_';
   const allCommandPaths = commands
     .map((command) => commandKey(command.path))
     .filter((path) => path.length > 0);

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -72,10 +72,14 @@ export function cliMultiAgentPresets(
   customRaw: unknown,
 ): CliMultiAgentPreset[] {
   return [
-    ...AGENT_MODE_PRESETS.map((preset) => withSource(preset, 'built-in')),
-    ...parseCliCustomAgentPresets(customRaw).map((preset) =>
-      withSource(preset, 'custom'),
-    ),
+    ...AGENT_MODE_PRESETS.map((preset) => ({
+      ...preset,
+      source: 'built-in' as const,
+    })),
+    ...parseCliCustomAgentPresets(customRaw).map((preset) => ({
+      ...preset,
+      source: 'custom' as const,
+    })),
   ];
 }
 
@@ -331,13 +335,6 @@ export async function withCliMultiAgentPresetVisibility<T>(
       previousToolUseAgents,
     );
   }
-}
-
-function withSource(
-  preset: AgentModePreset,
-  source: CliMultiAgentPresetSource,
-): CliMultiAgentPreset {
-  return { ...preset, source };
 }
 
 function resolvePresetAgents(

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -203,7 +203,9 @@ export class DesktopProgressBridge {
       openPath: options.openPath,
       openBuildDisplay: options.openBuildDisplay,
       openDiff: options.openDiff,
-      showErrorMessage: (message) => this.options.showErrorMessage?.(message),
+      showErrorMessage: async (message) => {
+        await this.options.showErrorMessage?.(message);
+      },
     });
     this.workflowFileActions = new ProgressWorkflowFileActionsController({
       state: {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -203,7 +203,7 @@ export class DesktopProgressBridge {
       openPath: options.openPath,
       openBuildDisplay: options.openBuildDisplay,
       openDiff: options.openDiff,
-      showErrorMessage: (message) => this.showErrorMessage(message),
+      showErrorMessage: (message) => this.options.showErrorMessage?.(message),
     });
     this.workflowFileActions = new ProgressWorkflowFileActionsController({
       state: {
@@ -229,8 +229,12 @@ export class DesktopProgressBridge {
         },
         openLabel: (label) => this.findAndOpenLabel(label),
         readFile: (file) => readFile(file, 'utf8'),
-        showInfo: (message) => this.showInfoMessage(message),
-        showError: (message) => this.showErrorMessage(message),
+        showInfo: async (message) => {
+          await this.options.showInfoMessage?.(message);
+        },
+        showError: async (message) => {
+          await this.options.showErrorMessage?.(message);
+        },
         logError: (message, error) => {
           this.logger.error(message, {
             data: error instanceof Error ? error : { error },
@@ -1027,7 +1031,7 @@ export class DesktopProgressBridge {
       // memory and reviving the runtime is out of scope (audit item
       // D Phase 2). Surface a clear message rather than silently no-op.
       if (this.restoredStreams.has(streamId)) {
-        await this.showInfoMessage(
+        await this.options.showInfoMessage?.(
           'This run is from a previous session. Live resume is not yet supported — please start a fresh run.',
         );
       }
@@ -1055,7 +1059,7 @@ export class DesktopProgressBridge {
       return;
     }
 
-    await this.showInfoMessage(
+    await this.options.showInfoMessage?.(
       'No active session. Start a new agent task to continue.',
     );
   }
@@ -1069,7 +1073,7 @@ export class DesktopProgressBridge {
       await this.options.openBuildDisplay(toFileLocation(filePath));
       return;
     }
-    await this.showErrorMessage(
+    await this.options.showErrorMessage?.(
       'Desktop LaTeX preview is unavailable. Cannot compile and open this file.',
     );
   }
@@ -1171,7 +1175,7 @@ export class DesktopProgressBridge {
     editedFile: string,
   ): Promise<void> {
     if (!this.options.openDiff) {
-      await this.showErrorMessage(
+      await this.options.showErrorMessage?.(
         'Desktop file comparison is not available in this host yet.',
       );
       return;
@@ -1202,7 +1206,7 @@ export class DesktopProgressBridge {
       },
     });
     if (!validation.valid) {
-      await this.showErrorMessage(`Merge: ${validation.message}`);
+      await this.options.showErrorMessage?.(`Merge: ${validation.message}`);
       return;
     }
     await this.runExecution(validation.request);
@@ -1240,7 +1244,7 @@ export class DesktopProgressBridge {
     }
 
     const operation = isNewFile && !targetExists ? 'created' : 'replaced';
-    await this.showInfoMessage(
+    await this.options.showInfoMessage?.(
       `Successfully ${operation} '${targetFileName}' with content from '${path.basename(editedFile)}'`,
     );
     return true;
@@ -1260,7 +1264,7 @@ export class DesktopProgressBridge {
     );
 
     if (!result.success || !result.diffFileName) {
-      await this.showErrorMessage(
+      await this.options.showErrorMessage?.(
         result.message ?? 'Failed to generate diff file.',
       );
       return;
@@ -1323,14 +1327,6 @@ export class DesktopProgressBridge {
       readDirectory: (directory) =>
         (tryPlatform()?.fs ?? nodeFilesystem).readDirectory(directory),
     });
-  }
-
-  private async showInfoMessage(message: string): Promise<void> {
-    await this.options.showInfoMessage?.(message);
-  }
-
-  private async showErrorMessage(message: string): Promise<void> {
-    await this.options.showErrorMessage?.(message);
   }
 }
 

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -287,10 +287,6 @@ export function createDesktopSettingsIpc(
     });
   }
 
-  function applyAndPostGitAuthorSettings(): void {
-    postGitAuthorSettings(applyCurrentGitAuthorSettings());
-  }
-
   function readLatexConfigValues() {
     return latexConfigPersistenceController.buildConfigValues((key) =>
       workspaceState.get(key),
@@ -576,7 +572,7 @@ export function createDesktopSettingsIpc(
     value: unknown,
   ): Promise<void> {
     await workspaceState.update(key, value);
-    applyAndPostGitAuthorSettings();
+    postGitAuthorSettings(applyCurrentGitAuthorSettings());
   }
 
   async function updateLatexConfigValue(input: {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -341,9 +341,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.withActiveWebview((w) => this.sendMemoryEnabled(w)),
       [SETTINGS_VIEW_COMMANDS.SET_MEMORY_ENABLED]: (data) =>
         this.handleSetMemoryEnabled(data),
-      [SETTINGS_VIEW_COMMANDS.PIN_MEMORY]: (data) => this.handlePinMemory(data),
+      [SETTINGS_VIEW_COMMANDS.PIN_MEMORY]: (data) =>
+        this.setMemoryPinned(data.storagePath, true),
       [SETTINGS_VIEW_COMMANDS.UNPIN_MEMORY]: (data) =>
-        this.handleUnpinMemory(data),
+        this.setMemoryPinned(data.storagePath, false),
 
       // History handlers
       [SETTINGS_VIEW_COMMANDS.GET_HISTORY_DATA]: () =>
@@ -1136,18 +1137,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         await w.postMessage(message);
       });
     }
-  }
-
-  private async handlePinMemory(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.PIN_MEMORY>,
-  ): Promise<void> {
-    await this.setMemoryPinned(data.storagePath, true);
-  }
-
-  private async handleUnpinMemory(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.UNPIN_MEMORY>,
-  ): Promise<void> {
-    await this.setMemoryPinned(data.storagePath, false);
   }
 
   private async setMemoryPinned(

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -91,7 +91,6 @@ import {
   setupContextManagement,
   logContextManagementFromResponse,
   enforceCacheControlLimit,
-  type ContextManagementSetupOptions,
 } from './anthropicContextManagement';
 import {
   extractDocumentBlocks,
@@ -137,7 +136,6 @@ import type {
 } from '@anthropic-ai/sdk/resources/beta/messages';
 import type {
   Base64ImageSource,
-  CacheControlEphemeral,
   MessageParam,
   ContentBlockParam,
   ToolUseBlock,
@@ -162,10 +160,7 @@ function extractPartialTextTail(
 ): string {
   if (!message?.content) return '';
   const text = message.content
-    .filter(
-      (block): block is Extract<BetaContentBlock, { type: 'text' }> =>
-        block.type === 'text',
-    )
+    .filter(isBetaTextBlock)
     .map((block) => block.text)
     .join('');
   return takeTail(text, maxChars);
@@ -180,6 +175,12 @@ const isAnyThinkingBlockParam = (
 /** Type guard for tool use blocks in Beta API responses */
 const isBetaToolUseBlock = (block: BetaContentBlock): block is ToolUseBlock =>
   block.type === 'tool_use';
+
+/** Type guard for text blocks in Beta API responses */
+const isBetaTextBlock = (
+  block: BetaContentBlock,
+): block is Extract<BetaContentBlock, { type: 'text' }> =>
+  block.type === 'text';
 
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
@@ -253,22 +254,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
    */
   protected override get supportsToolResultFileUpload(): boolean {
     return true;
-  }
-
-  /**
-   * Sets up context management configuration for Anthropic's server-side editing.
-   * Must be called before token counting so estimate options match create options.
-   */
-  private setupContextManagement(opts: ContextManagementSetupOptions): void {
-    const consumed = setupContextManagement(
-      opts,
-      this.isToolUseMode(),
-      isCompactionEligibleModel(this.config.fullName),
-      this.compactionRequested,
-    );
-    if (consumed) {
-      this.compactionRequested = false;
-    }
   }
 
   async getClient(): Promise<Anthropic> {
@@ -412,7 +397,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
       ? LONG_CACHE_CONTROL
       : SHORT_CACHE_CONTROL;
 
-    this.enforceCacheControlLimit(messages, reservedCacheSlots, cacheControl);
+    enforceCacheControlLimit(
+      messages,
+      reservedCacheSlots,
+      cacheControl,
+      this.capabilities.supportsPromptCaching,
+    );
 
     const documentAnalysis = analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
@@ -520,11 +510,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
       'texra.model.compactionThresholdPercent',
       DEFAULT_COMPACTION_THRESHOLD_PERCENT,
     );
-    this.setupContextManagement({
-      options,
-      contextWindow: effectiveContextWindow,
-      thresholdPercent: compactionThresholdPercent,
-    });
+    const compactionConsumed = setupContextManagement(
+      {
+        options,
+        contextWindow: effectiveContextWindow,
+        thresholdPercent: compactionThresholdPercent,
+      },
+      this.isToolUseMode(),
+      isCompactionEligibleModel(this.config.fullName),
+      this.compactionRequested,
+    );
+    if (compactionConsumed) {
+      this.compactionRequested = false;
+    }
 
     // Phase 2: COUNT - Estimate input tokens using built params
     // Phase 3: VALIDATE - Adjust max_tokens if needed
@@ -762,19 +760,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     );
 
     return { response };
-  }
-
-  private enforceCacheControlLimit(
-    messages: MessageParam[],
-    reservedSlots: number,
-    cacheControl: CacheControlEphemeral,
-  ): void {
-    enforceCacheControlLimit(
-      messages,
-      reservedSlots,
-      cacheControl,
-      this.capabilities.supportsPromptCaching,
-    );
   }
 
   /** Initializes the message array for Anthropic chat models with user prefix, request, and optional media. */
@@ -1022,10 +1007,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Extract base response
     const stopReason = responseObject.stop_reason;
     let newResponse = responseObject.content
-      .filter(
-        (block): block is Extract<BetaContentBlock, { type: 'text' }> =>
-          block.type === 'text',
-      )
+      .filter(isBetaTextBlock)
       .map((block) => block.text.trim())
       .join('');
 

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -18,7 +18,7 @@ import { ensureError, toErrorMessage } from '@common/errors/errorMessage';
 import * as logger from '@logger/logUtils';
 import { resolveToolDefinitions } from '@tools/registry';
 
-import { filterNotNull } from '@utils/core';
+import { filterNotNull, filterNotNullish } from '@utils/core';
 import {
   RemoteAgentListItemSchema,
   EdgeFunctionResponseSchema,
@@ -60,7 +60,7 @@ export function isMissingRemoteAgentToolsColumnError(
   if (!error) return false;
 
   const text = [error.message, error.details, error.hint]
-    .filter((part): part is string => typeof part === 'string')
+    .filter(filterNotNullish)
     .join(' ')
     .toLowerCase();
   const schemaError =

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -21,12 +21,6 @@ type RuntimeHostProvider = () => AgentRuntimeHost;
 
 export type CoordinatorRuntimeHost = AgentRuntimeHost | RuntimeHostProvider;
 
-function toRuntimeHostProvider(
-  runtimeHost: CoordinatorRuntimeHost,
-): RuntimeHostProvider {
-  return typeof runtimeHost === 'function' ? runtimeHost : () => runtimeHost;
-}
-
 type RequestState<TResult> =
   | {
       status: 'pending';
@@ -52,7 +46,8 @@ export abstract class BasePromiseCoordinator<
   private readonly getRuntimeHost: RuntimeHostProvider;
 
   constructor(runtimeHost: CoordinatorRuntimeHost) {
-    this.getRuntimeHost = toRuntimeHostProvider(runtimeHost);
+    this.getRuntimeHost =
+      typeof runtimeHost === 'function' ? runtimeHost : () => runtimeHost;
   }
 
   protected get runtimeHost(): AgentRuntimeHost {

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -262,13 +262,10 @@ async function getFileVars(
     const primaryFile = readableFiles[0];
 
     // Aliases for custom YAMLs that still reference INPUT_FILE / INPUT_CONTENT.
-    if (primaryFile) {
-      const loaded = await setVarFromFile(primaryFile, prefix, userVars);
-      if (!loaded) {
-        userVars[`${prefix}_FILE`] = null;
-        userVars[`${prefix}_CONTENT`] = null;
-      }
-    } else {
+    const loaded =
+      primaryFile != null &&
+      (await setVarFromFile(primaryFile, prefix, userVars));
+    if (!loaded) {
       userVars[`${prefix}_FILE`] = null;
       userVars[`${prefix}_CONTENT`] = null;
     }

--- a/src/shared/constants/cliRuntime.ts
+++ b/src/shared/constants/cliRuntime.ts
@@ -1,14 +1,10 @@
 export const TEXRA_CLI_SUPPORTED_NODE_RANGE = '>=22.9.0';
 
-export const TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY = formatNodeRangeForDisplay(
-  TEXRA_CLI_SUPPORTED_NODE_RANGE,
-);
-
-function formatNodeRangeForDisplay(range: string): string {
-  const versions = range.split(' || ');
+export const TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY = (() => {
+  const versions = TEXRA_CLI_SUPPORTED_NODE_RANGE.split(' || ');
   const finalVersion = versions.at(-1);
 
   return versions.length > 1 && finalVersion != null
     ? `${versions.slice(0, -1).join(', ')}, or ${finalVersion}`
-    : range;
-}
+    : TEXRA_CLI_SUPPORTED_NODE_RANGE;
+})();

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -54,7 +54,6 @@ import type {
   StreamTabId,
   ExecutionId,
   StorageKey,
-  TokenUsageStats,
   ToolUseLog,
 } from '@shared/schemas';
 import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
@@ -203,13 +202,6 @@ class ClaudeAgentSession implements IInterruptible {
   }
 }
 
-function finalizeClaudeAgentLoopStatus(
-  childStreamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  finalizeAgentCliLoopStatus(childStreamId, runtimeHost);
-}
-
 // ============================================================================
 // Result formatting
 // ============================================================================
@@ -274,20 +266,6 @@ function formatClaudeError(
 type ClaudeToolLogRef = ToolUseCardRef & {
   toolLog: ToolUseLog;
 };
-
-function publishClaudeAgentStreamUsage(
-  childStreamId: StreamTabId,
-  executionId: ExecutionId,
-  usage: TokenUsageStats,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  runtimeHost.emit('updateStreamUsage', {
-    streamId: childStreamId,
-    storageKey: executionId as StorageKey,
-    executionId,
-    usage,
-  });
-}
 
 // ============================================================================
 // SDK type aliases — we keep these loose to avoid pulling the SDK's full type
@@ -602,12 +580,12 @@ function startClaudeAgentLoop(params: {
         }
 
         if (turn?.usage) {
-          publishClaudeAgentStreamUsage(
-            childStreamId,
+          runtimeHost.emit('updateStreamUsage', {
+            streamId: childStreamId,
+            storageKey: executionId as StorageKey,
             executionId,
-            buildClaudeUsageStats(turn.usage),
-            runtimeHost,
-          );
+            usage: buildClaudeUsageStats(turn.usage),
+          });
         }
 
         const msg =
@@ -649,7 +627,7 @@ function startClaudeAgentLoop(params: {
         agentCliLoopTerminalStatus(sawTurnFailure),
       ).catch(() => {});
       untrackExecution(executionId);
-      finalizeClaudeAgentLoopStatus(childStreamId, runtimeHost);
+      finalizeAgentCliLoopStatus(childStreamId, runtimeHost);
       disposeTrace();
     }
   })();

--- a/src/tools/github/formatRepoEvent.ts
+++ b/src/tools/github/formatRepoEvent.ts
@@ -40,19 +40,9 @@ const MAX_BODY = 200;
 
 const truncate = makeTruncator(MAX_BODY);
 
-/** Repo-level events use a single newline + URL footer. */
-const withFooterUrl = (headline: string, url: string): string =>
-  `${headline}\n${url}`;
-
-const reviewCommentLabel = (c: GhReviewComment): string =>
-  c.in_reply_to_id != null ? 'review reply' : 'inline review comment';
-
 export function formatRepoPROpened(slug: string, pr: GhPullsListEntry): string {
   return wrap(
-    withFooterUrl(
-      `New pull request ${prRef(slug, pr.number)} opened by ${authorOf(pr.user)}: "${truncate(pr.title)}"`,
-      pr.html_url,
-    ),
+    `New pull request ${prRef(slug, pr.number)} opened by ${authorOf(pr.user)}: "${truncate(pr.title)}"\n${pr.html_url}`,
   );
 }
 
@@ -70,10 +60,7 @@ export function formatRepoIssueComment(
   c: GhIssueComment,
 ): string {
   return wrap(
-    withFooterUrl(
-      `New comment on ${issueRef(slug, number)} by ${authorOf(c.user)}: "${truncate(c.body)}"`,
-      c.html_url,
-    ),
+    `New comment on ${issueRef(slug, number)} by ${authorOf(c.user)}: "${truncate(c.body)}"\n${c.html_url}`,
   );
 }
 
@@ -83,10 +70,7 @@ export function formatRepoReviewComment(
   c: GhReviewComment,
 ): string {
   return wrap(
-    withFooterUrl(
-      `New ${reviewCommentLabel(c)} on ${prRef(slug, prNumber)} by ${authorOf(c.user)} (${c.path}): "${truncate(c.body)}"`,
-      c.html_url,
-    ),
+    `New ${c.in_reply_to_id != null ? 'review reply' : 'inline review comment'} on ${prRef(slug, prNumber)} by ${authorOf(c.user)} (${c.path}): "${truncate(c.body)}"\n${c.html_url}`,
   );
 }
 

--- a/src/utils/prompt/promptUtils.ts
+++ b/src/utils/prompt/promptUtils.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as nunjucks from 'nunjucks';
 
 import * as logger from '@logger/logUtils';
+import { filterNotNull } from '@utils/core';
 import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'promptUtils';
@@ -74,9 +75,7 @@ export async function getXmlFormatFromReadableFiles(
       }
     }),
   );
-  const readable = xmlContents.filter(
-    (doc): doc is { file: string; xml: string } => doc !== null,
-  );
+  const readable = xmlContents.filter(filterNotNull);
   return {
     xml: readable.length > 0 ? readable.map((doc) => doc.xml).join('\n') : null,
     readableFiles: readable.map((doc) => doc.file),


### PR DESCRIPTION
## Summary

Behavior-preserving simplification of code merged to `main` over the last two days. Produced by a scout → code-simplify pass over **20 disjoint file clusters** (166 recently-changed source files; `supabase/functions/relay/index.ts` deliberately excluded as security-sensitive). **18 clusters** yielded changes — **25 files, net −150 lines**. No feature or behavior changes.

## What changed

- **Inline single-use private wrappers** into their lone call sites — `completionBash` (5), `claudeAgent` (2), `modelHandlerAnthropic` (2), `BasePromiseCoordinator`, `desktopAgentExecution` (10 call sites), `desktopSettingsIpc`, `SettingsViewMessageHandler` (2), `auth` / `agentsRun` / `multiAgent` commands, `formatRepoEvent` (2).
- **Shared type-guard helpers** — replace inline `(x): x is T => x != null` filters with `filterNotNull` / `filterNotNullish` from `@utils/core` (`DiffView`, `StatusBar`, `runChatTui`, `RemoteAgentLoader`, `promptUtils`). Used `filterNotNullish` (not `filterNotNull`) wherever the array elements are `undefined` rather than `null`, preserving the original guard exactly.
- **Remove trivial identity factories** — `multiAgentPresets` `withSource`, `multiAgent` list-command adapter; fold the single-use `formatNodeRangeForDisplay` into an IIFE (`cliRuntime`).
- **Hoist duplicated handlers / literals** — `ModelListForm` / `ToolsListForm` select handlers, `ChildControlPicker` scroll-state wrappers, `childControls` shared mapping, `runOnboarding` `NO_ONBOARDING_RESULT` constant, `globalArgs` headless-flag predicate.
- **Extract `isBetaTextBlock`** in `modelHandlerAnthropic` to dedupe the text-block filter predicate; drop the now-dead `ContextManagementSetupOptions` / `CacheControlEphemeral` type imports.

## Safety

Each simplifier independently verified its scout's findings and **skipped anything unsafe** — it declined to inline `codex.ts` wrappers consumed by test-kernel suites, kept the genuinely 2-call DRY helper in `multiAgentPresets`, and corrected a scout's incorrect "set unconditionally to null" proposal in `userVars.ts` (would have clobbered values `setVarFromFile` sets on success). No exported symbol was renamed or removed without confirming zero external consumers. Two clusters (`model-handlers-openai`, `misc-subsystems`) correctly produced no changes.

The one non-mechanical fix during review: inlining `completionBash`'s `dynamicFlagValueTokens()` dropped its explicit `: Set<string>` return type, so the `as const` literal union (`'--model' | '-m' | '--agent'`) leaked into `.has(token: string)` — restored by typing the inlined `new Set<string>(...)`.

## Verification

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean (only pre-existing `import/order` warnings, all in files this PR does not touch)
- ✅ `npm run test:kernel` — **1806 passing**; the single failure was an `AgentsCommand` dynamic-`import` 5s-timeout under full parallel load that passes 7/7 in isolation (79 ms import), unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication and inlining only; PR description calls out explicit typing fix for bash completion and preserving `userVars` semantics on successful file load.
> 
> **Overview**
> Behavior-preserving cleanup across the **CLI TUI**, **commands**, **desktop host**, **extension settings**, and shared **agent/tools/utils** code—roughly **25 files** with a modest net line reduction.
> 
> **CLI chat TUI:** `/model` and `/tools` forms now share one **`handleSelect` / `handleToggle`** instead of duplicated `Select` callbacks; child-control pickers drop small scroll-state helpers in favor of explicit objects; **`childControls`** builds subagent rows once for both picker modes; status bar and diff parsing use shared **`filterNotNullish` / `isObject`** helpers; queued follow-up copy is inlined in **`runChatTui`**.
> 
> **CLI commands & shell:** Headless-only argv checks use **`isHeadlessOnlyFlag`**; **`agentsRun`**, **`auth usage`**, and **`multiAgent list`** drop one-line emit/list wrappers; onboarding reuses **`NO_ONBOARDING_RESULT`**; bash completion inlines flag-token helpers (with an explicit **`Set<string>`** where needed); multi-agent presets inline **`source`** instead of **`withSource`**.
> 
> **Desktop & extension:** Desktop agent execution calls **`showInfoMessage` / `showErrorMessage` on options** directly; git-author settings post without a tiny wrapper; memory pin/unpin routes straight to **`setMemoryPinned`**.
> 
> **Agent/runtime:** Anthropic handler adds **`isBetaTextBlock`** and calls context-management / cache-limit helpers at the call site; remote loader and prompt utils use shared filters; promise coordinator inlines runtime-host resolution; Claude agent and GitHub event formatters drop single-use private wrappers; **`userVars`** tightens the “file loaded?” branch without clearing vars on successful load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09d4d40cc816832ea3b963e211dd0ebceae8e751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->