### PR TITLE
refactor(cli/tui): simplify TUI subsystem — inline helpers, drop dead code

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -165,6 +165,13 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     0,
     selectWindow.maxVisibleWorkflows,
   );
+  const handleSelectItem = (value: string): void => {
+    if (selectable) {
+      props.onSelect?.(value);
+      return;
+    }
+    props.onClose();
+  };
 
   if (isCompactFormRows(props.availableRows)) {
     return (
@@ -175,13 +182,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
           activeValue={activeValue}
           maxVisibleItems={1}
           showOverflow={false}
-          onSelect={(value) => {
-            if (selectable) {
-              props.onSelect?.(value);
-              return;
-            }
-            props.onClose();
-          }}
+          onSelect={handleSelectItem}
           onCancel={props.onClose}
         />
         <CompactFormKeyHints
@@ -218,13 +219,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
           activeValue={activeValue}
           maxVisibleItems={selectWindow.maxVisibleItems}
           showOverflow={selectWindow.showOverflow}
-          onSelect={(value) => {
-            if (selectable) {
-              props.onSelect?.(value);
-              return;
-            }
-            props.onClose();
-          }}
+          onSelect={handleSelectItem}
           onCancel={props.onClose}
         />
       </Box>

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -109,16 +109,17 @@ export function ConfirmCard({
     { isActive: true },
   );
 
+  const mappedExtraActions = extraActions.map((action) => ({
+    key: action.key,
+    action: action.label,
+  }));
   const hints = feedbackMode
     ? confirmCardFeedbackHints()
     : confirmCardKeyHintsForWidth({
         approveLabel,
         rejectLabel,
         alwaysAllowLabel: alwaysAllow?.label,
-        extraActions: extraActions.map((action) => ({
-          key: action.key,
-          action: action.label,
-        })),
+        extraActions: mappedExtraActions,
         maxColumns: Math.max(
           0,
           columns -
@@ -133,10 +134,7 @@ export function ConfirmCard({
         approveLabel,
         rejectLabel,
         alwaysAllowLabel: alwaysAllow?.label,
-        extraActions: extraActions.map((action) => ({
-          key: action.key,
-          action: action.label,
-        })),
+        extraActions: mappedExtraActions,
         maxColumns: columns,
       });
   const stackCompactHints =

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -117,9 +117,8 @@ export function externalInquiryQuestionRowsBudget({
   return Math.max(0, availableRows - EXTERNAL_INQUIRY_FIXED_ROWS - answerRows);
 }
 
-function overflowText(kind: 'previous' | 'more' | 'hidden', count: number) {
+function overflowText(kind: 'previous' | 'more', count: number) {
   if (kind === 'previous') return `... ${count} previous rows`;
-  if (kind === 'hidden') return `... ${count} rows hidden`;
   return `... ${count} more rows`;
 }
 

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -181,32 +181,6 @@ export function userQuestionFreeTextSuggestionLine({
   return clipToWidth(`${prefix}${suffix}`, width);
 }
 
-export function userQuestionPromptLines({
-  context,
-  question,
-  width,
-}: {
-  readonly context?: string | null;
-  readonly question: string;
-  readonly width: number;
-}): readonly UserQuestionPromptLine[] {
-  const wrapWidth = Math.max(MIN_USER_QUESTION_CONTENT_WIDTH, width);
-  return [
-    ...(context
-      ? wrappedUserQuestionPromptLines({
-          kind: 'context',
-          text: context,
-          width: wrapWidth,
-        })
-      : []),
-    ...wrappedUserQuestionPromptLines({
-      kind: 'question',
-      text: question,
-      width: wrapWidth,
-    }),
-  ];
-}
-
 export function boundedUserQuestionPromptLines({
   context,
   maxDisplayLines,

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -127,21 +127,6 @@ function staticTranscriptItemRowCount(
     .length;
 }
 
-function canAppendStaticTranscriptItem({
-  currentRows,
-  item,
-  maxRows,
-  width,
-}: {
-  readonly currentRows: number;
-  readonly item: StaticTranscriptItem;
-  readonly maxRows?: number;
-  readonly width?: number;
-}): boolean {
-  if (maxRows === undefined) return true;
-  return currentRows + staticTranscriptItemRowCount(item, width) <= maxRows;
-}
-
 export function appendStaticTranscriptItems({
   activeStreamId,
   currentItems,
@@ -172,12 +157,7 @@ export function appendStaticTranscriptItems({
     };
     if (
       maxRows === undefined ||
-      canAppendStaticTranscriptItem({
-        currentRows,
-        item: header,
-        maxRows,
-        width,
-      })
+      currentRows + staticTranscriptItemRowCount(header, width) <= maxRows
     ) {
       nextItems.push(header);
       currentRows += staticTranscriptItemRowCount(header, width);

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -65,7 +65,9 @@ function orderedStreamTree(init: {
   if (init.streams.has(init.root)) out.push({ id: init.root });
   for (const [index, id] of ordered.entries()) {
     if (!init.streams.has(id)) continue;
-    out.push({ id, shortcutIndex: streamTabShortcutIndex(index + 1) });
+    const position = index + 1;
+    const shortcutIndex = position <= 0 || position > 9 ? undefined : position;
+    out.push({ id, shortcutIndex });
   }
   return out;
 }
@@ -102,14 +104,12 @@ export interface StreamTabLineSegment {
   readonly text: string;
 }
 
-function ellipsisTabItem(): StreamTabDisplayItem {
-  return {
-    id: 'ellipsis',
-    label: '…',
-    active: false,
-    running: false,
-  };
-}
+const ELLIPSIS_TAB_ITEM: StreamTabDisplayItem = {
+  id: 'ellipsis',
+  label: '…',
+  active: false,
+  running: false,
+};
 
 function activeAnchoredItems(
   items: readonly StreamTabDisplayItem[],
@@ -121,11 +121,11 @@ function activeAnchoredItems(
   const out: StreamTabDisplayItem[] = [];
   if (activeIndex > 0) {
     out.push(items[0]);
-    if (activeIndex > 1) out.push(ellipsisTabItem());
+    if (activeIndex > 1) out.push(ELLIPSIS_TAB_ITEM);
   }
   out.push(activeItem);
   if (lastItem && activeIndex < items.length - 1) {
-    if (activeIndex < items.length - 2) out.push(ellipsisTabItem());
+    if (activeIndex < items.length - 2) out.push(ELLIPSIS_TAB_ITEM);
     out.push(lastItem);
   }
   return out;
@@ -220,7 +220,7 @@ function collapseMiddle(
     const item = items[i];
     if (keep.has(i)) {
       if (elided) {
-        out.push(ellipsisTabItem());
+        out.push(ELLIPSIS_TAB_ITEM);
         elided = false;
       }
       out.push(item);
@@ -229,11 +229,6 @@ function collapseMiddle(
     }
   }
   return out;
-}
-
-function streamTabShortcutIndex(position: number): number | undefined {
-  if (position <= 0 || position > 9) return undefined;
-  return position;
 }
 
 export function streamTabsDisplayItems(init: {

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -51,7 +51,7 @@ export function compactChildRowText({
     elapsed,
     tailSummary,
   ]
-    .filter((part): part is string => Boolean(part))
+    .filter(Boolean)
     .join(' · ');
 }
 

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -497,23 +497,6 @@ export function UniversalToolRow({
   );
 }
 
-function BashToolRow({
-  toolUse,
-}: {
-  readonly toolUse: NormalizedToolUse;
-}): React.JSX.Element {
-  return (
-    <ToolRow
-      toolUse={toolUse}
-      fallbackName="bash"
-      previewColor="cyan"
-      showOutput={true}
-      showExitCode={true}
-      preferInputPreview={true}
-    />
-  );
-}
-
 function isBashTool(toolUse: NormalizedToolUse): boolean {
   return lastSegmentToolName(toolUse.toolName).toLowerCase() === 'bash';
 }
@@ -533,7 +516,16 @@ const editRenderer: ToolRenderer = {
 const bashRenderer: ToolRenderer = {
   key: 'bash',
   matches: isBashTool,
-  render: (toolUse) => <BashToolRow toolUse={toolUse} />,
+  render: (toolUse) => (
+    <ToolRow
+      toolUse={toolUse}
+      fallbackName="bash"
+      previewColor="cyan"
+      showOutput={true}
+      showExitCode={true}
+      preferInputPreview={true}
+    />
+  ),
   displayLines: (toolUse, options) =>
     bashToolUseDisplayLines(toolUse, { elide: options?.elide }),
 };

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -84,7 +84,6 @@ export function selectPendingEntriesForViewport(
   let usedRows = 0;
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index];
-    if (!entry) continue;
     const entryRows = estimatePendingEntryRows(entry, width);
     if (usedRows + entryRows > maxRows) {
       if (

--- a/packages/cli/src/chat/tui/render/ansiWrap.ts
+++ b/packages/cli/src/chat/tui/render/ansiWrap.ts
@@ -8,11 +8,6 @@ import {
 
 const MIN_WRAP_WIDTH = 1;
 
-function normalizedWidth(width: number | undefined): number | undefined {
-  if (width == null || !Number.isFinite(width)) return undefined;
-  return Math.max(MIN_WRAP_WIDTH, Math.floor(width));
-}
-
 function splitRawAtVisiblePrefix(
   line: string,
   visiblePrefixLength: number,
@@ -103,7 +98,10 @@ export function wrapAnsiToWidth(
   width?: number,
   preserveMarkdownPrefix = false,
 ): string {
-  const columns = normalizedWidth(width);
+  const columns =
+    width == null || !Number.isFinite(width)
+      ? undefined
+      : Math.max(MIN_WRAP_WIDTH, Math.floor(width));
   if (columns == null) return text;
 
   return text

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -14,10 +14,6 @@ import type {
 
 export const COMPLETED_PROCESS_TAIL_LINES = 20;
 
-function processTitle(info: ActiveChildInfo): string {
-  return info.agentName || info.toolName || info.executionId;
-}
-
 export function isCompletedProcessError(status: string | undefined): boolean {
   return isChildExecutionErrorStatus(status);
 }
@@ -40,7 +36,7 @@ export function buildCompletedProcessTranscript(
   const status = completedChildExecutionStatus(info.status);
   return {
     executionId: info.executionId,
-    title: processTitle(info),
+    title: info.agentName || info.toolName || info.executionId,
     status,
     elapsed: info.elapsed,
     isError: isCompletedProcessError(status),


### PR DESCRIPTION
## Summary

Behavior-preserving simplification of the **`texra` CLI TUI** subsystem (`packages/cli/src/chat/tui/`). Produced by a scout → code-simplify pass over **16 disjoint clusters** covering 73 files. **8 clusters** yielded changes — **11 files, net −73 lines**.

This is a focused follow-up to #5228 (which simplified recently-changed code repo-wide). The 7 TUI files already touched by #5228 are **excluded here**, so this PR is conflict-free and can merge in any order relative to it.

No feature, rendering, or behavior changes. The agents ran under the CLAUDE.md *Terminal UI (Ink) discipline*: the `<Static>`/live-region split, **dedup-by-id**, key derivation, signal-vs-local state, emit order, capability-gating, and **headless parity** are all preserved and were explicitly verified untouched.

## What changed

- **Inline single-use private wrappers** — `StaticConversationTranscript.canAppendStaticTranscriptItem` (the `maxRows === undefined ||` short-circuit is preserved; dedup logic untouched), `toolRenderers.BashToolRow`, `ansiWrap.normalizedWidth`, `completedProcessTranscript.processTitle`, `StreamTabsStrip.streamTabShortcutIndex`.
- **Remove dead code** — the exported `userQuestionPromptLines` (zero consumers repo-wide, incl. test-kernel), an unreachable `'hidden'` branch in `ExternalInquiry.overflowText`, and a dead `if (!entry) continue` in `selectPendingEntriesForViewport` (the loop index is always in-bounds and `noUncheckedIndexedAccess` is off).
- **Drop a trivial identity factory** — `ellipsisTabItem()` → a shared `ELLIPSIS_TAB_ITEM` const (only reference-compared against `activeItem`, which an ellipsis never is; never mutated).
- **Hoist duplicated handlers / maps** — `AgentListForm` `onSelect`, `ConfirmCard` `extraActions` map.
- **Idiomatic filter** — `.filter((p): p is string => Boolean(p))` → `.filter(Boolean)` in `SubagentList` (identical truthiness test; narrows to `string[]`).

## Safety

8 of 16 clusters made **no changes** — the simplifiers correctly declined to touch load-bearing render/key/order logic, exported helpers with test-kernel consumers, and capability-gated paths, and skipped cosmetic-only churn (e.g. a nested ternary in `Select.nextSelectHighlightIndex` left alone to avoid risking wrap-around behavior). No exported symbol was removed without confirming zero external consumers.

## Verification

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean (only pre-existing `import/order` warnings, none in touched files)
- ✅ `npm run test:kernel` — **1806 passing**; the one failure is the same `AgentsCommand` dynamic-`import` 5 s timeout under full parallel load that passes 7/7 in isolation, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors and dead-code removal in presentation-layer TUI code with no auth, data, or API surface changes.
> 
> **Overview**
> Behavior-preserving cleanup in **`packages/cli/src/chat/tui/`** (~73 lines removed). The PR **deduplicates** shared handlers (`AgentListForm` select, `ConfirmCard` extra-action hints), **inlines** one-off helpers (bash `ToolRow`, static transcript row budget, ANSI wrap width, process titles, stream tab shortcuts), and **replaces** the ellipsis tab factory with a shared **`ELLIPSIS_TAB_ITEM`** constant.
> 
> **Dead code is removed**: exported **`userQuestionPromptLines`**, an unused **`overflowText('hidden')`** branch in external inquiry, and a redundant bounds check in pending transcript viewport selection. **`SubagentList`** uses **`.filter(Boolean)`** instead of a redundant type guard.
> 
> No intended changes to Ink rendering, keys, `<Static>` dedup, or headless parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0ef81be666924025f6ecc4c0ef912b206e8353a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->