### PR TITLE
refactor(latex): simplify LaTeX-processing helpers — inline wrappers, drop dead code

### DIFF
--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -14,6 +14,7 @@ import {
   pathToLocation,
   type FileLocation,
 } from '@utils/files';
+import { filterNotNullish } from '@utils/core';
 import { isFile } from '@utils/files/fsEntryType';
 import { getExtensionLowercase, hasExtension } from '@utils/core/pathCore';
 
@@ -153,10 +154,8 @@ export class LatexMediaManager {
       { concurrency: LATEX_CONCURRENCY, stopOnError: false },
     );
 
-    for (const result of compileResults) {
-      if (result) {
-        workspaceState.media.addMediaFiles([result]);
-      }
+    for (const result of compileResults.filter(filterNotNullish)) {
+      workspaceState.media.addMediaFiles([result]);
     }
   }
 

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -1,16 +1,11 @@
 // Standard library imports
 import * as path from 'path';
 
-// Local imports - log
-import * as logger from '@logger/logUtils';
 import { flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { joinLatexPath } from '@utils/core/pathCore';
 
 import { findExistingLatexPath, resolveLatexDir } from './latexParsingUtils';
-
-const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 const FIGURE_EXTENSIONS = ['.pdf', '.png', '.jpg', '.jpeg'];
 

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -236,20 +236,19 @@ export class LaTeXdiffService {
       const results = { success: [] as string[], failed: [] as string[] };
 
       for (const inputLocation of inputLocations) {
+        const inputFile = inputLocation.absolutePath;
         try {
           const result = await this.runDiffVc(
             inputLocation,
             commitHash,
             mathMarkup,
           );
-          const inputFile = inputLocation.absolutePath;
           if (result.success) {
             results.success.push(inputFile);
           } else {
             results.failed.push(inputFile);
           }
         } catch (err) {
-          const inputFile = inputLocation.absolutePath;
           results.failed.push(inputFile);
           logger.error(
             this.channel,

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -94,30 +94,18 @@ export class DiffFileProcessor {
         return [];
       }
 
-      return this.formatLine(line);
+      const result: string[] = [];
+      if (PACKAGES_NEEDING_NEWLINE.some((pkg) => line.includes(pkg))) {
+        result.push('');
+      }
+      result.push(line);
+      if (line.includes('\\RequirePackage{color}')) {
+        result.push('');
+      }
+      return result;
     });
 
     return processedLines.join('\n') + '\n';
-  }
-
-  private formatLine(line: string): string[] {
-    const result: string[] = [];
-
-    if (this.needsNewlineBefore(line)) {
-      result.push('');
-    }
-
-    result.push(line);
-
-    if (line.includes('\\RequirePackage{color}')) {
-      result.push('');
-    }
-
-    return result;
-  }
-
-  private needsNewlineBefore(line: string): boolean {
-    return PACKAGES_NEEDING_NEWLINE.some((pkg) => line.includes(pkg));
   }
 
   private async processTikzPictureEndings(


### PR DESCRIPTION
## Summary

Behavior-preserving simplification of the **`src/latex/`** LaTeX-processing subsystem (formatting, latexdiff, TikZ/figures, bibliography, texcount, arxiv). Produced by a scout → code-simplify pass over **7 disjoint clusters** covering all 23 files. **4 clusters** yielded changes — **4 files, net −19 lines**.

A third follow-up to #5228 / #5229 (both merged), in a fresh area with no overlap. The agents ran under hard "LaTeX exactness" constraints: **no regular expression, shell/argv construction, file I/O path/encoding, temp-file naming, LaTeX/TikZ output string, error handling, or accumulation order was changed** — purely structural dedup. `src/latex/` is a VS Code-free zone; no `vscode` import was introduced.

## What changed

- **`extractFigure.ts`** — remove the unused `@logger` import, the dead `CHANNEL` constant, and the redundant module-level `logger.initialize()` call. The file never logs, and the `'LaTeXCommands'` channel is already initialized (idempotently) by sibling latex modules (`texcount`, `latexdiff`, `TikzPictureManager`, …).
- **`LatexMediaManager.ts`** — replace a `for` loop + inner `if (result)` null guard with `.filter(filterNotNullish)` from `@utils/core`. Elements are media-file objects or nullish, so the truthiness test is equivalent; per-item `addMediaFiles([result])` and iteration order are preserved.
- **`latexdiff.ts`** — hoist the duplicated `const inputFile = inputLocation.absolutePath` (a side-effect-free string property read) to the top of the loop body, shared by the success and `catch` paths.
- **`diffFileProcessor.ts`** — inline the single-use private `formatLine()` / `needsNewlineBefore()` wrappers into `processLineByLine`'s `flatMap` callback, preserving the exact push order (optional leading blank → line → optional trailing blank).

## Safety

3 of 7 clusters made **no changes** (`arxiv-bib`, `parsing-count`, `text-target`) — the simplifiers correctly declined to touch command construction, regexes, and self-documenting twice-used predicates, and kept exported helpers with external consumers.

One change the agents proposed was **caught in review and reverted**: rewriting `Boolean(result && result.success)` → `result?.success ?? false` in the two formatter helpers. It is runtime-equivalent but **fails typecheck** — `result` is typed `false | ExecResult`, and optional chaining only narrows `null`/`undefined`, not the literal `false`, so `.success` errors on the `false` arm (the original `&&` narrows correctly). Both formatter files are reverted to their exact originals; they are not part of this PR.

## Verification

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — clean (10 pre-existing `import/order` warnings, **none in touched files**; the one warning my new import introduced was auto-fixed)
- ✅ `npm run test:kernel` — **1829 passing**; the lone failure is the same `AgentsCommand` dynamic-`import` 5 s timeout under parallel load that passes 7/7 in isolation, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural-only edits with no changes to LaTeX strings, I/O paths, regexes, or command execution; compile and diff behavior stay the same.
> 
> **Overview**
> **Behavior-preserving cleanup** in four LaTeX helpers: dead logging setup removed from figure extraction, compile-result handling simplified in media management, a duplicated path variable hoisted in VC diff batching, and diff post-processing line formatting inlined.
> 
> `extractFigure.ts` drops unused `@logger` wiring (`CHANNEL`, `initialize`) because the module never logs.
> 
> `LatexMediaManager` registers successful PDF compiles with `compileResults.filter(filterNotNullish)` instead of a manual null check loop—same order and per-file `addMediaFiles` calls.
> 
> `latexdiff.ts` defines `inputFile` once per iteration in `runDiffVcMultiple` for success, failure, and error logging.
> 
> `diffFileProcessor.ts` folds `formatLine` / `needsNewlineBefore` into the `flatMap` callback so blank-line rules around specific package lines are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c959c829b00118c21e8ba0601fc06e826a19f20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->