### PR TITLE
fix(cli): show hidden current agent in picker

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -10,10 +10,12 @@ import { render } from 'ink';
 import React from 'react';
 
 import { getToolUseAgents, getWorkflowAgents, loadAgents } from '@agent/index';
+import { getWorkspaceState } from '@agent/core/stateStore';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { isInFlightStatus } from '@common/constants/streamStatus';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
 import { tryPlatform } from '@platform/platform';
 import {
   AGENT_CATEGORY,
@@ -162,6 +164,10 @@ function parseList(value: string | undefined): string[] {
     .filter((item) => item.length > 0);
 }
 
+const HARNESS_VISIBLE_TOOL_USE_AGENTS = parseList(
+  process.env.HARNESS_VISIBLE_TOOL_USE_AGENTS,
+);
+
 await initLocalCliPlatform({
   apiMode: HARNESS_API_MODE,
   cwd: HARNESS_CWD,
@@ -170,6 +176,12 @@ await initLocalCliPlatform({
   storageRoot: path.join(HARNESS_CWD, '.texra-storage'),
   helperModel: 'harness-model',
 });
+if (process.env.HARNESS_VISIBLE_TOOL_USE_AGENTS !== undefined) {
+  await getWorkspaceState().update(
+    WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+    HARNESS_VISIBLE_TOOL_USE_AGENTS,
+  );
+}
 await loadAgents({ includeRemote: false });
 
 const HARNESS_ORCHESTRATION_ITEMS = buildCliOrchestrationItems({

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -65,6 +65,17 @@ const LONG_BASH_APPROVAL_COMMAND = [
 const LONG_EXTERNAL_INQUIRY_ANSWER =
   'Independent check agrees: there are 22 non-degenerate triples in the displayed list, plus exactly 61 degenerate triples of the form (0,b,b), and the bounded search over integer pairs proves completeness.';
 const ASYNC_FORM_SETTLE_MS = 12000;
+const VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT = [
+  'research',
+  'review',
+  'creator',
+  'latexDiff',
+  'latexFixer',
+  'lean',
+  'numerics',
+  'presenter',
+  'setup',
+].join('||');
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
@@ -363,12 +374,16 @@ const SCENARIOS = [
   },
   {
     name: 'agent-form',
-    env: { HARNESS_ENTRIES: '4' },
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT,
+    },
     keys: ['/agent', '\r'],
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
       'Tool-use agents',
+      'Current: chat (hidden from picker)',
       'texra chat --agent=<name>',
       'Esc close',
     ],
@@ -381,12 +396,16 @@ const SCENARIOS = [
   {
     name: 'agent-form-80-cols',
     cols: 80,
-    env: { HARNESS_ENTRIES: '4' },
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT,
+    },
     keys: ['/agent', '\r'],
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
       'Tool-use agents',
+      'Current: chat (hidden from picker)',
       'texra chat --agent=<name>',
       'Esc close',
     ],
@@ -474,14 +493,18 @@ const SCENARIOS = [
     name: 'compact-agent-form',
     rows: 12,
     cols: 80,
-    env: { HARNESS_ENTRIES: '4' },
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT,
+    },
     keys: ['/agent', '\r'],
     frame: 'tail',
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
+      'Current: chat (hidden from picker)',
       'Tool-use agents',
-      '+2 earlier, +7 more',
+      '+8 more',
       '↑/↓ navigate',
       'Enter close',
       'Esc close',

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '@inkjs/ui';
 
 import { computeAgentOptionsData } from '@agent/index';
 import type { AgentOptionData } from '@shared/schemas';
+import { agentName } from '@shared/schemas/agent';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
@@ -29,6 +30,8 @@ interface AgentGroups {
   readonly workflow: readonly AgentOptionData[];
 }
 
+type AgentIdentity = Pick<AgentOptionData, 'label' | 'value'>;
+
 const AGENT_FORM_MAX_WIDTH = 80;
 
 export function agentFormWidth(columns: number | undefined): number {
@@ -49,12 +52,37 @@ function agentDescription(agent: AgentOptionData): string {
   return agent.description ? `${kind}; ${source}; ${agent.description}` : kind;
 }
 
+export function currentVisibleAgent(
+  agents: readonly AgentIdentity[],
+  currentAgent: string,
+): AgentIdentity | undefined {
+  const current = currentAgent.trim();
+  const currentName = agentName(current);
+  return agents.find(
+    (agent) =>
+      agent.value === current ||
+      agent.label === current ||
+      agent.label === currentName,
+  );
+}
+
+export function hiddenCurrentAgentHint(
+  agents: readonly AgentIdentity[],
+  currentAgent: string,
+): string | undefined {
+  const current = currentAgent.trim();
+  if (!current || currentVisibleAgent(agents, current)) return undefined;
+  return `Current: ${agentName(current)} (hidden from picker)`;
+}
+
 export function agentSelectWindow({
   availableRows,
+  extraRows = 0,
   itemCount,
   workflowCount,
 }: {
   readonly availableRows: number | undefined;
+  readonly extraRows?: number;
   readonly itemCount: number;
   readonly workflowCount: number;
 }): {
@@ -72,18 +100,19 @@ export function agentSelectWindow({
     };
   }
 
+  const chromeRows = 8 + Math.max(0, extraRows);
   // Border, title, description, tool-use heading, and key hints are the fixed
   // chrome for the primary selectable list.
-  const selectRows = Math.max(1, availableRows - 8);
+  const selectRows = Math.max(1, availableRows - chromeRows);
   if (itemCount > selectRows) {
     return {
-      ...computeSelectWindowSize({ availableRows, itemCount, chromeRows: 8 }),
+      ...computeSelectWindowSize({ availableRows, itemCount, chromeRows }),
       maxVisibleWorkflows: 0,
       showWorkflowOverflow: false,
     };
   }
 
-  const remainingRows = availableRows - 8 - itemCount;
+  const remainingRows = availableRows - chromeRows - itemCount;
   if (workflowCount === 0 || remainingRows < 4) {
     return {
       maxVisibleItems: itemCount,
@@ -147,17 +176,19 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   // The current agent may be stored as a canonical key (`source:name`) or a
   // bare name; rows are keyed by bare name, so resolve to the matching label
   // so Select can render the ✓ on the active row.
-  const activeAgent = agents.toolUse.find(
-    (agent) =>
-      agent.value === props.currentAgent || agent.label === props.currentAgent,
-  );
+  const activeAgent = currentVisibleAgent(agents.toolUse, props.currentAgent);
   const activeValue = activeAgent?.label ?? props.currentAgent;
+  const currentAgentHint = hiddenCurrentAgentHint(
+    agents.toolUse,
+    props.currentAgent,
+  );
   const workflowRows = agents.workflow.map((agent) => ({
     name: agent.label,
     description: agentDescription(agent),
   }));
   const selectWindow = agentSelectWindow({
     availableRows: props.availableRows,
+    extraRows: currentAgentHint ? 1 : 0,
     itemCount: items.length,
     workflowCount: workflowRows.length,
   });
@@ -176,6 +207,11 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   if (isCompactFormRows(props.availableRows)) {
     return (
       <FormFrame color="cyan" title="/agent" showCloseHint={false}>
+        {currentAgentHint ? (
+          <Text dimColor wrap="truncate-end">
+            {currentAgentHint}
+          </Text>
+        ) : null}
         <Text bold>Tool-use agents</Text>
         <Select
           items={items.map(({ value, label }) => ({ value, label }))}
@@ -212,6 +248,11 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
           ? 'Choose the root tool-use agent for the first message.'
           : 'Available agents. Start a new chat with texra chat --agent=<name> to choose the root tool-use agent.'}
       </Text>
+      {currentAgentHint ? (
+        <Text dimColor wrap="truncate-end">
+          {currentAgentHint}
+        </Text>
+      ) : null}
       <Box marginTop={1} flexDirection="column">
         <Text bold>Tool-use agents</Text>
         <Select

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -3,13 +3,37 @@ import { describe, expect, it } from 'vitest';
 import {
   agentFormWidth,
   agentSelectWindow,
+  currentVisibleAgent,
+  hiddenCurrentAgentHint,
 } from '@cli/chat/tui/forms/AgentListForm';
 
 describe('CLI AgentListForm row budget', () => {
+  const visibleAgents = [
+    { value: 'builtInToolUse:chat', label: 'chat' },
+    { value: 'remote:lean', label: 'lean' },
+  ];
+
   it('clamps the regular form width to the terminal columns', () => {
     expect(agentFormWidth(120)).toBe(80);
     expect(agentFormWidth(80)).toBe(80);
     expect(agentFormWidth(60)).toBe(60);
+  });
+
+  it('resolves the current visible agent from bare names or canonical keys', () => {
+    expect(currentVisibleAgent(visibleAgents, 'chat')?.label).toBe('chat');
+    expect(currentVisibleAgent(visibleAgents, 'remote:lean')?.label).toBe(
+      'lean',
+    );
+    expect(
+      currentVisibleAgent(visibleAgents, 'builtInToolUse:lean')?.label,
+    ).toBe('lean');
+  });
+
+  it('labels the current agent when it is hidden from the picker', () => {
+    expect(hiddenCurrentAgentHint(visibleAgents, 'builtInToolUse:review')).toBe(
+      'Current: review (hidden from picker)',
+    );
+    expect(hiddenCurrentAgentHint(visibleAgents, 'chat')).toBeUndefined();
   });
 
   it('windows long agent lists inside the available foreground rows', () => {
@@ -21,6 +45,22 @@ describe('CLI AgentListForm row budget', () => {
       }),
     ).toEqual({
       maxVisibleItems: 2,
+      showOverflow: true,
+      maxVisibleWorkflows: 0,
+      showWorkflowOverflow: false,
+    });
+  });
+
+  it('accounts for the hidden-current hint in the row budget', () => {
+    expect(
+      agentSelectWindow({
+        availableRows: 12,
+        extraRows: 1,
+        itemCount: 12,
+        workflowCount: 10,
+      }),
+    ).toEqual({
+      maxVisibleItems: 1,
       showOverflow: true,
       maxVisibleWorkflows: 0,
       showWorkflowOverflow: false,


### PR DESCRIPTION
## Summary
- show a concise `Current: <agent> (hidden from picker)` hint when `/agent` cannot mark the active root agent because workspace visibility hides it
- keep visible-agent checkmarks working for bare names and source-qualified keys
- add a TUI harness visibility seed so hidden-current-agent frames are covered directly

Fixes #5233

## Dogfood evidence
- live `texra chat --api-mode personal --approval-policy never --no-color` started with `agent: chat · model: sonnet46T`
- opening `/agent` listed visible alternatives but no current marker/context for hidden `chat`

## Tests
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/AgentListForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- agent-form agent-form-80-cols compact-agent-form`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --no-build`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with 10 existing import-order warnings outside this patch)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI/TUI display and test-harness wiring only; no auth, data, or runtime behavior changes beyond agent-picker UX.
> 
> **Overview**
> The `/agent` picker now explains when the **active root agent is not in the visible list** (for example workspace-hidden agents): it shows **`Current: <name> (hidden from picker)`** and reserves a row in compact layouts so overflow counts stay correct.
> 
> **Checkmark resolution** for the current agent now matches **bare names** and **source-qualified keys** (`builtInToolUse:chat`, `remote:lean`, etc.) via shared helpers.
> 
> The **TUI harness** can seed **`HARNESS_VISIBLE_TOOL_USE_AGENTS`** into workspace state so **`validate-tui`** scenarios assert the hidden-current-agent UI without a live API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8a143d1872b47848bf2de0c854190d87d00fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->