### PR TITLE
fix(cli): improve startup defaults and task guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In the terminal:
 ```sh
 texra chat                                  # interactive tool-use session
 texra run polish --input paper.tex          # one-shot workflow
-texra multi-agent run physicist             # named team
+texra multi-agent run physicist --instruction "Check this derivation"  # named team
 ```
 
 Run history and agent settings are shared between both surfaces.

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -75,6 +75,9 @@ interface MultiAgentRunInit {
   readonly instructionFile?: string;
 }
 
+const MULTI_AGENT_TASK_REQUIRED_MESSAGE =
+  'Provide --input, --instruction, or --instruction-file for the team task. Example: texra multi-agent run physicist --instruction "Check this derivation"';
+
 function resolveMultiAgentRunPlan(
   init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
 ): CliMultiAgentPresetRunPlan {
@@ -286,9 +289,7 @@ export async function runMultiAgentPreset(
   const instruction = await resolveFileBackedInstruction(init, context.cwd);
   const hasInstruction = instruction.trim().length > 0;
   if (init.inputFiles.length === 0 && !hasInstruction) {
-    throw new CliUsageError(
-      'Provide --input, --instruction, or --instruction-file.',
-    );
+    throw new CliUsageError(MULTI_AGENT_TASK_REQUIRED_MESSAGE);
   }
 
   await initCliPlatform({ ...context, quietLogs: true });

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -6,6 +6,7 @@ import {
   formatCliMultiAgentPresetPlanSummary,
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
+import { defaultToolUseAgents } from './defaultAgents';
 import { formatCliHistoryInputLabel } from './historyLabels';
 import type { CliHistoryEntry } from './history';
 
@@ -75,7 +76,9 @@ function recentAgentItems(
   history: readonly CliHistoryEntry[],
   toolUseAgents: readonly AgentEntry[],
 ): CliOrchestrationItem[] {
-  const toolUseNames = new Set(toolUseAgents.map((agent) => agent.name));
+  const toolUseNames = new Set(
+    defaultToolUseAgents(toolUseAgents).map((agent) => agent.name),
+  );
   const seen = new Set<string>();
   const items: CliOrchestrationItem[] = [];
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -368,7 +368,9 @@ describe('CLI multi-agent run command', () => {
         model: 'deepseekT',
         instruction: '',
       }),
-    ).rejects.toThrow(/Provide --input, --instruction, or --instruction-file/);
+    ).rejects.toThrow(
+      /Provide --input, --instruction, or --instruction-file for the team task\. Example: texra multi-agent run physicist --instruction "Check this derivation"/,
+    );
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
   });
 

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -188,6 +188,22 @@ describe('CLI orchestration items', () => {
     expect(items.map((item) => item.label)).not.toContain('Chat with missing');
   });
 
+  it('does not offer simplifier as an inferred startup chat agent', () => {
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [
+        historyEntry('aaaaaaaaaaaa', { agent: 'simplifier' }),
+        historyEntry('bbbbbbbbbbbb', { agent: 'review' }),
+      ],
+      toolUseAgents: [toolUseAgent('simplifier'), toolUseAgent('review')],
+    });
+
+    expect(items.map((item) => item.label)).toContain('Chat with review');
+    expect(items.map((item) => item.label)).not.toContain(
+      'Chat with simplifier',
+    );
+  });
+
   it('lists team presets as runnable orchestration actions', () => {
     const items = buildCliOrchestrationItems({
       presetPlans: [


### PR DESCRIPTION
## Summary
- update the README multi-agent example so it includes the required task input
- replace the terse missing-task error with a copy-pasteable `--instruction` example
- keep inferred startup tool-use defaults from offering `simplifier` by reusing the shared default-agent filter
- add regression coverage for multi-agent task guidance and launcher default filtering

Fixes #5239.

## Dogfood evidence
Current README advertised:

```sh
texra multi-agent run physicist
```

But current CLI behavior was:

```sh
node packages/cli/dist/bin/texra.js multi-agent run physicist --no-input --no-color
# Provide --input, --instruction, or --instruction-file.
```

After this patch, the same dist command reports:

```text
Provide --input, --instruction, or --instruction-file for the team task. Example: texra multi-agent run physicist --instruction "Check this derivation"
```

## Validation
- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/InitCommand.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with 10 existing import-order warnings outside this change)
- `corepack pnpm --filter @texra-ai/cli run build`
- `node packages/cli/dist/bin/texra.js multi-agent run physicist --no-input --no-color`
