### PR TITLE
fix(cli): define dirname in ESM bundles

### DIFF
--- a/packages/cli/scripts/build-bundle.mjs
+++ b/packages/cli/scripts/build-bundle.mjs
@@ -4,6 +4,7 @@ import { chmod } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { build } from 'esbuild';
 
+import { esmCjsGlobalsBanner } from './esm-cjs-globals-banner.mjs';
 import { reactCompilerPlugin } from './reactCompilerPlugin.mjs';
 
 const reactDevtoolsStub = fileURLToPath(
@@ -71,12 +72,7 @@ await build({
   // JSX needs to be transformed for ink (which uses React's JSX runtime).
   jsx: 'automatic',
   banner: {
-    js:
-      '#!/usr/bin/env node\n' +
-      'import { createRequire as __texraCreateRequire } from "node:module";\n' +
-      'import { fileURLToPath as __texraFileURLToPath } from "node:url";\n' +
-      'const require = __texraCreateRequire(import.meta.url);\n' +
-      'const __filename = __texraFileURLToPath(import.meta.url);',
+    js: `#!/usr/bin/env node\n${esmCjsGlobalsBanner}`,
   },
 });
 

--- a/packages/cli/scripts/build-harness.mjs
+++ b/packages/cli/scripts/build-harness.mjs
@@ -3,6 +3,7 @@
 import { chmod } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { build } from 'esbuild';
+import { esmCjsGlobalsBanner } from './esm-cjs-globals-banner.mjs';
 import { reactCompilerPlugin } from './reactCompilerPlugin.mjs';
 
 const reactDevtoolsStub = fileURLToPath(
@@ -23,12 +24,7 @@ await build({
   alias: { 'react-devtools-core': reactDevtoolsStub },
   outfile,
   banner: {
-    js: [
-      `import { createRequire as __cr } from 'node:module';`,
-      `import { fileURLToPath as __texraFileURLToPath } from 'node:url';`,
-      `const require = __cr(import.meta.url);`,
-      `const __filename = __texraFileURLToPath(import.meta.url);`,
-    ].join('\n'),
+    js: esmCjsGlobalsBanner,
   },
   plugins: [reactCompilerPlugin()],
   logLevel: 'info',

--- a/packages/cli/scripts/esm-cjs-globals-banner.mjs
+++ b/packages/cli/scripts/esm-cjs-globals-banner.mjs
@@ -1,0 +1,8 @@
+export const esmCjsGlobalsBanner = [
+  'import { createRequire as __texraCreateRequire } from "node:module";',
+  'import { dirname as __texraDirname } from "node:path";',
+  'import { fileURLToPath as __texraFileURLToPath } from "node:url";',
+  'const require = __texraCreateRequire(import.meta.url);',
+  'const __filename = __texraFileURLToPath(import.meta.url);',
+  'const __dirname = __texraDirname(__filename);',
+].join('\n');

--- a/src/test-kernel/cli/CliBundleBanner.vitest.mts
+++ b/src/test-kernel/cli/CliBundleBanner.vitest.mts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf8');
+}
+
+describe('CLI ESM bundle banner', () => {
+  it('defines CommonJS globals for bundled dependencies', () => {
+    const banner = readRepoFile(
+      'packages/cli/scripts/esm-cjs-globals-banner.mjs',
+    );
+
+    expect(banner).toContain('__texraCreateRequire');
+    expect(banner).toContain('const require = __texraCreateRequire');
+    expect(banner).toContain('const __filename = __texraFileURLToPath');
+    expect(banner).toContain('const __dirname = __texraDirname(__filename)');
+  });
+
+  it('uses the shared banner for both CLI ESM bundles', () => {
+    expect(readRepoFile('packages/cli/scripts/build-bundle.mjs')).toContain(
+      'esmCjsGlobalsBanner',
+    );
+    expect(readRepoFile('packages/cli/scripts/build-harness.mjs')).toContain(
+      'esmCjsGlobalsBanner',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared CLI ESM banner that defines `require`, `__filename`, and `__dirname`
- use that banner for both the shipping CLI bundle and the TUI harness bundle
- add regression coverage so both bundle scripts keep using the shared CommonJS-global banner

Fixes #5241.

## Dogfood evidence
Before this change, the built ESM CLI bundle contained a bare `__dirname` reference in the external-agent binary resolver path:

```js
RFr(jQ.join(__dirname,".."), t)
```

That can produce the observed `__dirname is not defined` failure when CLI subagent tools like `codex` or `claude_code` try to resolve their native binaries.

After this change, rebuilt bundle headers define the CommonJS globals explicitly:

```js
const __filename = __texraFileURLToPath(import.meta.url);
const __dirname = __texraDirname(__filename);
```

and the rebuilt CLI detects both external agent integrations in this environment.

## Validation
- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliBundleBanner.vitest.mts src/test-kernel/cli/CliTools.vitest.mts src/test-kernel/tools/CodexLoopStatus.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli run build`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- inspected `packages/cli/dist/bin/texra.js` and `packages/cli/dist/bin/tui-harness.js` headers
- `node packages/cli/dist/bin/texra.js tools list --no-color --output-format json`
- `node packages/cli/dist/bin/texra.js tools show codex --no-color --output-format json`
- `node packages/cli/dist/bin/texra.js tools show claude-agent --no-color --output-format json`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with 10 existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time banner injection only; no runtime auth or data-path changes, with small regression tests on the banner module and build scripts.
> 
> **Overview**
> Fixes ESM CLI bundles that could throw **`__dirname is not defined`** when bundled code (e.g. external-agent binary resolution) still expects CommonJS globals.
> 
> A shared **`esmCjsGlobalsBanner`** now prepends **`require`**, **`__filename`**, and **`__dirname`** (new) to both **`texra.js`** and **`tui-harness.js`** esbuild outputs, replacing duplicated inline banner strings in the two build scripts. Vitest asserts the banner contents and that both bundle scripts import the shared module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 338007a7cfecdfd1d39058c95164bd92fdc08d62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->