### PR TITLE
fix(cli): hide completed runs from resume pickers

### DIFF
--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '@inkjs/ui';
 
 import {
   listCliHistoryEntries,
+  resumableCliHistoryEntries,
   type CliHistoryEntry,
 } from '@cli/runtime/history';
 import { formatCliHistoryInputLabel } from '@cli/runtime/historyLabels';
@@ -41,7 +42,8 @@ export function resumeEntryDescription(entry: CliHistoryEntry): string {
 export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
   const { data, loading, error } = useAsyncListForm<readonly CliHistoryEntry[]>(
     {
-      load: async () => (await listCliHistoryEntries()).slice(0, 50),
+      load: async () =>
+        resumableCliHistoryEntries(await listCliHistoryEntries()).slice(0, 50),
       onClose: props.onClose,
       isEmpty: (entries) => entries.length === 0,
     },
@@ -67,7 +69,7 @@ export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
   if (entries.length === 0) {
     return (
       <FormFrame color="yellow" title="/resume">
-        <Text>No execution history found.</Text>
+        <Text>No resumable sessions found.</Text>
       </FormFrame>
     );
   }

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -83,6 +83,18 @@ export interface CliHistoryFile {
 
 export const CLI_HISTORY_RESUMABLE_STATUS = 'resumable';
 
+export function isCliHistoryEntryResumable(
+  entry: Pick<CliHistoryEntry, 'status'>,
+): boolean {
+  return entry.status === CLI_HISTORY_RESUMABLE_STATUS;
+}
+
+export function resumableCliHistoryEntries<
+  T extends Pick<CliHistoryEntry, 'status'>,
+>(entries: readonly T[]): T[] {
+  return entries.filter(isCliHistoryEntryResumable);
+}
+
 export type CliHistoryDeleteResult =
   | { readonly deleted: 'all'; readonly count: number }
   | {

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -8,7 +8,7 @@ import {
 } from './multiAgentPresets';
 import { defaultToolUseAgents } from './defaultAgents';
 import { formatCliHistoryInputLabel } from './historyLabels';
-import type { CliHistoryEntry } from './history';
+import { resumableCliHistoryEntries, type CliHistoryEntry } from './history';
 
 export type CliOrchestrationAction =
   | { readonly kind: 'chat'; readonly agent?: string; readonly model?: string }
@@ -65,11 +65,13 @@ export function buildCliOrchestrationItems(
 function recentResumeItems(
   history: readonly CliHistoryEntry[],
 ): CliOrchestrationItem[] {
-  return history.slice(0, MAX_RECENT_RESUME_ITEMS).map((entry) => ({
-    value: { kind: 'resume', id: entry.id },
-    label: `Resume ${entry.id}`,
-    description: `${entry.agent}; ${entry.status}; ${formatCliHistoryInputLabel(entry.inputBasename)}`,
-  }));
+  return resumableCliHistoryEntries(history)
+    .slice(0, MAX_RECENT_RESUME_ITEMS)
+    .map((entry) => ({
+      value: { kind: 'resume', id: entry.id },
+      label: `Resume ${entry.id}`,
+      description: `${entry.agent}; ${entry.status}; ${formatCliHistoryInputLabel(entry.inputBasename)}`,
+    }));
 }
 
 function recentAgentItems(

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -8,6 +8,7 @@ import { flowKey } from '@agent/node/persistedFlow';
 import {
   CLI_HISTORY_RESUMABLE_STATUS,
   formatCliHistoryDetailsText,
+  resumableCliHistoryEntries,
   readCliHistoryDetails,
   resolveCliHistoryStatus,
 } from '@cli/runtime/history';
@@ -60,6 +61,16 @@ describe('CLI history status formatting', () => {
     expect(resolveCliHistoryStatus({ hasFlowRecord: true })).toBe(
       CLI_HISTORY_RESUMABLE_STATUS,
     );
+  });
+
+  it('filters history entries to resumable sessions only', () => {
+    expect(
+      resumableCliHistoryEntries([
+        { id: 'resume-me', status: CLI_HISTORY_RESUMABLE_STATUS },
+        { id: 'done', status: EXECUTION_STATUS.COMPLETED },
+        { id: 'errored', status: EXECUTION_STATUS.ERROR },
+      ]),
+    ).toEqual([{ id: 'resume-me', status: CLI_HISTORY_RESUMABLE_STATUS }]);
   });
 
   it('keeps legacy terminal-status-free entries completed when no flow remains', () => {

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -8,7 +8,10 @@ import {
 } from '@cli/orchestration/runOrchestrationTui';
 import { buildCliOrchestrationItems } from '@cli/runtime/orchestration';
 
-import type { CliHistoryEntry } from '@cli/runtime/history';
+import {
+  CLI_HISTORY_RESUMABLE_STATUS,
+  type CliHistoryEntry,
+} from '@cli/runtime/history';
 import type { CliModelAccess } from '@cli/runtime/modelAccess';
 import {
   planCliMultiAgentPresetRun,
@@ -136,8 +139,14 @@ describe('CLI orchestration items', () => {
     const items = buildCliOrchestrationItems({
       presetPlans: [],
       history: [
-        historyEntry('aaaaaaaaaaaa', { agent: 'review' }),
-        historyEntry('bbbbbbbbbbbb', { agent: 'orchestrator' }),
+        historyEntry('aaaaaaaaaaaa', {
+          agent: 'review',
+          status: CLI_HISTORY_RESUMABLE_STATUS,
+        }),
+        historyEntry('bbbbbbbbbbbb', {
+          agent: 'orchestrator',
+          status: CLI_HISTORY_RESUMABLE_STATUS,
+        }),
       ],
       toolUseAgents: [toolUseAgent('review'), toolUseAgent('orchestrator')],
     });
@@ -150,8 +159,26 @@ describe('CLI orchestration items', () => {
       'Chat with orchestrator',
       'Help',
     ]);
-    expect(items[1]?.description).toBe('review; completed; no input');
-    expect(items[2]?.description).toBe('orchestrator; completed; no input');
+    expect(items[1]?.description).toBe('review; resumable; no input');
+    expect(items[2]?.description).toBe('orchestrator; resumable; no input');
+  });
+
+  it('does not list completed executions as resume launcher rows', () => {
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [
+        historyEntry('aaaaaaaaaaaa', { agent: 'review' }),
+        historyEntry('bbbbbbbbbbbb', { agent: 'orchestrator' }),
+      ],
+      toolUseAgents: [toolUseAgent('review'), toolUseAgent('orchestrator')],
+    });
+
+    expect(items.map((item) => item.label)).toEqual([
+      'New chat',
+      'Chat with review',
+      'Chat with orchestrator',
+      'Help',
+    ]);
   });
 
   it('uses the input file name in resume launcher rows when present', () => {
@@ -160,13 +187,14 @@ describe('CLI orchestration items', () => {
       history: [
         historyEntry('aaaaaaaaaaaa', {
           agent: 'review',
+          status: CLI_HISTORY_RESUMABLE_STATUS,
           inputBasename: 'paper.tex',
         }),
       ],
       toolUseAgents: [toolUseAgent('review')],
     });
 
-    expect(items[1]?.description).toBe('review; completed; paper.tex');
+    expect(items[1]?.description).toBe('review; resumable; paper.tex');
   });
 
   it('filters recent agent entries to known tool-use agents', () => {
@@ -252,7 +280,12 @@ describe('CLI orchestration items', () => {
     const view = orchestrationModelAccessView(
       buildCliOrchestrationItems({
         presetPlans: [presetPlan({ id: 'physicist', name: 'Physicist' })],
-        history: [historyEntry('aaaaaaaaaaaa', { agent: 'review' })],
+        history: [
+          historyEntry('aaaaaaaaaaaa', {
+            agent: 'review',
+            status: CLI_HISTORY_RESUMABLE_STATUS,
+          }),
+        ],
         toolUseAgents: [toolUseAgent('review')],
       }),
       [modelAccess('deepseekT', 'provider-key', false)],

--- a/src/test-kernel/cli/ResumeListForm.vitest.mts
+++ b/src/test-kernel/cli/ResumeListForm.vitest.mts
@@ -4,6 +4,7 @@ import {
   resumeEntryDescription,
   resumeSelectWindow,
 } from '@cli/chat/tui/forms/ResumeListForm';
+import { CLI_HISTORY_RESUMABLE_STATUS } from '@cli/runtime/history';
 
 describe('CLI ResumeListForm row budget', () => {
   it('windows long execution lists inside the available foreground rows', () => {
@@ -29,10 +30,10 @@ describe('CLI ResumeListForm labels', () => {
         timestamp: '2026-05-20T21:00:00.000Z',
         agent: 'polish',
         model: 'deepseekT',
-        status: 'completed',
+        status: CLI_HISTORY_RESUMABLE_STATUS,
         inputBasename: 'paper.tex',
       }),
-    ).toBe('2026-05-20T21:00:00.000Z; polish; completed; paper.tex');
+    ).toBe('2026-05-20T21:00:00.000Z; polish; resumable; paper.tex');
   });
 
   it('uses human wording for sessions without an input file', () => {
@@ -42,9 +43,9 @@ describe('CLI ResumeListForm labels', () => {
         timestamp: '2026-05-20T21:00:00.000Z',
         agent: 'chat',
         model: 'deepseekT',
-        status: 'completed',
+        status: CLI_HISTORY_RESUMABLE_STATUS,
         inputBasename: '-',
       }),
-    ).toBe('2026-05-20T21:00:00.000Z; chat; completed; no input');
+    ).toBe('2026-05-20T21:00:00.000Z; chat; resumable; no input');
   });
 });


### PR DESCRIPTION
## Summary

- add a shared CLI history helper for entries with the `resumable` status
- use that helper in the startup launcher Resume section and in-chat `/resume` picker
- keep completed history available for recent-agent shortcuts, but stop advertising it as a resume target

Fixes #5243.

## Dogfood evidence

Before this change, running the bundled CLI in a PTY showed completed executions as Resume choices:

```
2. Resume 3bbf7515970f — orchestrator; completed; no input
3. Resume 9685a436e4db — orchestrator; completed; no input
4. Resume 80dbbff1922b — simplifier; completed; no input
```

Selecting one exited with:

```
Execution 3bbf7515970f has no resumable session state (it completed or was cleared).
```

After rebuilding the CLI bundle from this branch and running:

```
TERM=xterm-256color node packages/cli/dist/bin/texra.js --no-color
```

the completed Resume rows were gone; the launcher showed New chat, team presets, and Help.

## Verification

- `npm run format`
- `git diff --check`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/HistoryStatus.vitest.ts src/test-kernel/cli/ResumeListForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --snapshot-dir /tmp/texra-tui-resume-filter-20260604 orchestrate-launcher`
- `corepack pnpm --filter @texra-ai/cli run build`
- `npm run compile:safe`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering of history lists; no auth, persistence, or resume execution logic changes beyond what users see in pickers.
> 
> **Overview**
> Adds shared helpers **`isCliHistoryEntryResumable`** and **`resumableCliHistoryEntries`** so only history rows with status **`resumable`** appear as resume targets.
> 
> The **startup launcher** resume section and the in-chat **`/resume`** picker now load history through that filter (still capped at 50 in the form). The empty **`/resume`** message reads **"No resumable sessions found."** **Recent "Chat with …"** shortcuts still use the full history list—completed runs are no longer advertised as resume choices, which avoids picking a run that then fails with no session state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c489f28951a5d809178b3103c22cccbc4c31f245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->