### PR TITLE
test(cli): harden implicit default agent policy

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,7 +4,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { CLI_BUILTIN_DEFAULT_MODEL } from '../runtime/cliConfig';
 import {
   BUILTIN_DEFAULT_CHAT_AGENT,
-  defaultToolUseAgents,
+  implicitDefaultToolUseAgents,
 } from '../runtime/defaultAgents';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
@@ -32,7 +32,7 @@ interface InitAgentOption {
 export function defaultInitAgentOptions(
   agents: readonly InitAgentOption[],
 ): InitAgentOption[] {
-  return defaultToolUseAgents(agents).map((agent) => ({
+  return implicitDefaultToolUseAgents(agents).map((agent) => ({
     name: agent.name,
     description: agent.description,
   }));

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -11,7 +11,7 @@ import {
 } from './cliConfig';
 import {
   BUILTIN_DEFAULT_CHAT_AGENT,
-  normalizeDefaultToolUseAgent,
+  resolveImplicitToolUseAgentDefault,
 } from './defaultAgents';
 import type { CliModelSelectionSource } from './modelAccess';
 
@@ -54,7 +54,7 @@ function pickDefaults(parsed: unknown): PartialDefaults {
   const out: { -readonly [K in keyof PartialDefaults]: PartialDefaults[K] } =
     {};
   if (isNonEmptyString(record.agent)) {
-    const agent = normalizeDefaultToolUseAgent(record.agent);
+    const agent = resolveImplicitToolUseAgentDefault(record.agent);
     if (agent) out.agent = agent;
   }
   if (isNonEmptyString(record.model)) {
@@ -67,7 +67,7 @@ function pickDefaults(parsed: unknown): PartialDefaults {
 async function loadWorkspaceDefaults(cwd: string): Promise<PartialDefaults> {
   const loaded = await loadWorkspaceCliConfig(cwd);
   return {
-    agent: normalizeDefaultToolUseAgent(
+    agent: resolveImplicitToolUseAgentDefault(
       resolveConfiguredAgent(loaded.values, 'chat'),
     ),
     model: resolveConfiguredModel(loaded.values, 'chat'),
@@ -161,7 +161,7 @@ export async function resolveChatDefaults(
 ): Promise<ChatDefaults> {
   const overrideAgent = init.agentOverride?.trim();
   const overrideModel = init.modelOverride?.trim();
-  const envAgent = normalizeDefaultToolUseAgent(init.envAgent);
+  const envAgent = resolveImplicitToolUseAgentDefault(init.envAgent);
   const envModel = init.envModel?.trim();
   let agent = overrideAgent || envAgent;
   let model = overrideModel || envModel;

--- a/packages/cli/src/runtime/defaultAgents.ts
+++ b/packages/cli/src/runtime/defaultAgents.ts
@@ -1,21 +1,29 @@
+import { agentName } from '@shared/schemas';
+
 export const BUILTIN_DEFAULT_CHAT_AGENT = 'chat';
 
-const NON_DEFAULT_TOOL_USE_AGENTS = new Set(['simplifier']);
+const NON_IMPLICIT_DEFAULT_TOOL_USE_AGENTS = new Set(['simplifier']);
 
-export function isDefaultToolUseAgentAllowed(agent: string): boolean {
-  return !NON_DEFAULT_TOOL_USE_AGENTS.has(agent.trim().toLowerCase());
+export function isImplicitDefaultToolUseAgentAllowed(agent: string): boolean {
+  return !NON_IMPLICIT_DEFAULT_TOOL_USE_AGENTS.has(
+    agentName(agent.trim()).toLowerCase(),
+  );
 }
 
-export function defaultToolUseAgents<T extends { readonly name: string }>(
-  agents: readonly T[],
-): T[] {
-  return agents.filter((agent) => isDefaultToolUseAgentAllowed(agent.name));
+export function implicitDefaultToolUseAgents<
+  T extends { readonly name: string },
+>(agents: readonly T[]): T[] {
+  return agents.filter((agent) =>
+    isImplicitDefaultToolUseAgentAllowed(agent.name),
+  );
 }
 
-export function normalizeDefaultToolUseAgent(
+export function resolveImplicitToolUseAgentDefault(
   agent: string | undefined,
 ): string | undefined {
   const trimmed = agent?.trim();
-  if (!trimmed || !isDefaultToolUseAgentAllowed(trimmed)) return undefined;
+  if (!trimmed || !isImplicitDefaultToolUseAgentAllowed(trimmed)) {
+    return undefined;
+  }
   return trimmed;
 }

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -8,7 +8,7 @@ import {
   AgentModePresetSchema,
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
-import { defaultToolUseAgents } from './defaultAgents';
+import { implicitDefaultToolUseAgents } from './defaultAgents';
 
 export type CliMultiAgentPresetSource = 'built-in' | 'custom';
 
@@ -374,7 +374,7 @@ function selectPresetRootAgent(
     readonly presetSource: CliMultiAgentPresetSource;
   },
 ): AgentEntry | undefined {
-  const rootCandidates = defaultToolUseAgents(agents);
+  const rootCandidates = implicitDefaultToolUseAgents(agents);
   const delegatingAgents = rootCandidates.filter(agentHasDelegationTools);
   const preferredRoot = findPreferredRootAgent(
     delegatingAgents,

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -6,7 +6,7 @@ import {
   formatCliMultiAgentPresetPlanSummary,
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
-import { defaultToolUseAgents } from './defaultAgents';
+import { implicitDefaultToolUseAgents } from './defaultAgents';
 import { formatCliHistoryInputLabel } from './historyLabels';
 import { resumableCliHistoryEntries, type CliHistoryEntry } from './history';
 
@@ -79,7 +79,7 @@ function recentAgentItems(
   toolUseAgents: readonly AgentEntry[],
 ): CliOrchestrationItem[] {
   const toolUseNames = new Set(
-    defaultToolUseAgents(toolUseAgents).map((agent) => agent.name),
+    implicitDefaultToolUseAgents(toolUseAgents).map((agent) => agent.name),
   );
   const seen = new Set<string>();
   const items: CliOrchestrationItem[] = [];

--- a/src/test-kernel/cli/DefaultAgents.vitest.mts
+++ b/src/test-kernel/cli/DefaultAgents.vitest.mts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BUILTIN_DEFAULT_CHAT_AGENT,
+  implicitDefaultToolUseAgents,
+  isImplicitDefaultToolUseAgentAllowed,
+  resolveImplicitToolUseAgentDefault,
+} from '@cli/runtime/defaultAgents';
+
+describe('CLI implicit default agent policy', () => {
+  it('keeps chat as the built-in default chat agent', () => {
+    expect(BUILTIN_DEFAULT_CHAT_AGENT).toBe('chat');
+  });
+
+  it('does not allow simplifier to become an implicit default', () => {
+    expect(isImplicitDefaultToolUseAgentAllowed('chat')).toBe(true);
+    expect(isImplicitDefaultToolUseAgentAllowed(' simplifier ')).toBe(false);
+    expect(isImplicitDefaultToolUseAgentAllowed('SIMPLIFIER')).toBe(false);
+    expect(
+      isImplicitDefaultToolUseAgentAllowed('builtInToolUse:simplifier'),
+    ).toBe(false);
+  });
+
+  it('filters implicit default candidates without mutating explicit options', () => {
+    const candidates = [
+      { name: 'simplifier', source: 'built-in' },
+      { name: 'builtInToolUse:simplifier', source: 'built-in' },
+      { name: 'chat', source: 'built-in' },
+      { name: 'review', source: 'built-in' },
+    ] as const;
+
+    expect(implicitDefaultToolUseAgents(candidates)).toEqual([
+      { name: 'chat', source: 'built-in' },
+      { name: 'review', source: 'built-in' },
+    ]);
+  });
+
+  it('normalizes only allowed implicit default values', () => {
+    expect(resolveImplicitToolUseAgentDefault(' review ')).toBe('review');
+    expect(resolveImplicitToolUseAgentDefault('simplifier')).toBeUndefined();
+    expect(resolveImplicitToolUseAgentDefault('   ')).toBeUndefined();
+    expect(resolveImplicitToolUseAgentDefault(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- rename CLI default-agent helpers so implicit default selection is explicit at each call site
- keep explicit agent overrides separate from startup/init/history defaults
- add direct coverage that `simplifier` cannot become an implicit default while `chat` remains the built-in default

## Verification
- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/DefaultAgents.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/InitCommand.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with 10 existing import-order warnings)
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-dogfood-20260604-default-agent-refactor orchestrate-launcher orchestrate-relay-model-pick orchestrate-personal-model-pick agent-form`
- `corepack pnpm --filter @texra-ai/cli run build`

## Notes
- This preserves explicit `--agent simplifier`, explicit multi-agent root overrides, and resume behavior. The guard only applies to implicit startup/init/history/default paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to implicit startup/init/config/history defaults and naming; explicit agent overrides and resume paths are unchanged per PR notes.
> 
> **Overview**
> Renames CLI helpers from “default tool-use agent” to **implicit default** naming (`implicitDefaultToolUseAgents`, `resolveImplicitToolUseAgentDefault`, etc.) and wires that vocabulary through `init`, chat default resolution, multi-agent root selection, and the orchestration launcher so call sites clearly mean “auto-picked defaults,” not explicit `--agent` overrides.
> 
> **Policy hardening:** blocked implicit defaults now normalize agent ids via `agentName` before comparing to the denylist, so values like `builtInToolUse:simplifier` cannot slip through as implicit defaults while `chat` stays the built-in chat default. New `DefaultAgents` tests lock in that `simplifier` is excluded from implicit paths and filtering/normalization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3510e60b86562152e93ec5cd85574e6520ca002a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->