### PR TITLE
fix: document tool input schemas

### DIFF
--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -7,6 +7,8 @@ import {
   toOpenAIResponseTools,
 } from '@agent/modelHandlers/toolConversion';
 import type { ToolDefinition } from '@model';
+import { DiagnosticsTool } from '@tools/DiagnosticsTool';
+import { ApplyPathTool } from '@tools/applyPath';
 import { BashTool } from '@tools/bash';
 import { EditFileTool } from '@tools/EditTool';
 import { GlobTool } from '@tools/glob';
@@ -14,10 +16,91 @@ import { GrepTool } from '@tools/grep';
 import { LsTool } from '@tools/ls';
 import { ReadFileTool } from '@tools/ReadTool';
 import { WriteFileTool } from '@tools/WriteTool';
+import { ArxivDownloadTool } from '@tools/arxiv/ArxivDownloadTool';
+import { ArxivMetadataTool } from '@tools/arxiv/ArxivMetadataTool';
+import { ArxivSearchTool } from '@tools/arxiv/ArxivSearchTool';
+import { CrossrefDoiTool } from '@tools/citation/CrossrefDoiTool';
+import { CrossrefSearchTool } from '@tools/citation/CrossrefSearchTool';
+import { TexcountTool } from '@tools/texcount/TexcountTool';
+import { WebFetchTool } from '@tools/web/WebFetchTool';
+import { WebSearchTool } from '@tools/web/WebSearchTool';
 import type { ChatCompletionTool } from 'openai/resources/chat/completions';
 import type { FunctionTool } from 'openai/resources/responses/responses';
 
 type OpenAIFunctionTool = Extract<ChatCompletionTool, { type: 'function' }>;
+type JsonSchemaWithProperties = {
+  description?: unknown;
+  properties?: Record<string, JsonSchemaWithProperties>;
+  anyOf?: JsonSchemaWithProperties[];
+  oneOf?: JsonSchemaWithProperties[];
+  allOf?: JsonSchemaWithProperties[];
+};
+type DescriptionPath = readonly string[];
+type ToolDescriptionCase = {
+  readonly definition: ToolDefinition;
+  readonly fields: readonly string[];
+  readonly nestedFields?: readonly DescriptionPath[];
+};
+
+function propertySchema(
+  schema: JsonSchemaWithProperties | undefined,
+  field: string,
+): JsonSchemaWithProperties | undefined {
+  const directProperty = schema?.properties?.[field];
+  if (directProperty) return directProperty;
+
+  for (const branch of [
+    ...(schema?.anyOf ?? []),
+    ...(schema?.oneOf ?? []),
+    ...(schema?.allOf ?? []),
+  ]) {
+    const nestedProperty = propertySchema(branch, field);
+    if (nestedProperty) return nestedProperty;
+  }
+
+  return undefined;
+}
+
+function schemaAtPath(
+  parameters: unknown,
+  path: DescriptionPath,
+): JsonSchemaWithProperties | undefined {
+  let schema = parameters as JsonSchemaWithProperties | undefined;
+  for (const segment of path) {
+    schema = propertySchema(schema, segment);
+  }
+  return schema;
+}
+
+function expectDescribedParameters(
+  toolName: string,
+  parameters: unknown,
+  paths: readonly DescriptionPath[],
+): void {
+  for (const path of paths) {
+    const field = path.join('.');
+    const description = schemaAtPath(parameters, path)?.description;
+    expect(typeof description, `${toolName}.${field}`).toBe('string');
+    expect(
+      (description as string).length,
+      `${toolName}.${field}`,
+    ).toBeGreaterThan(0);
+  }
+}
+
+function expectDescribedProperties(
+  definition: ToolDefinition,
+  paths: readonly DescriptionPath[],
+): void {
+  expectDescribedParameters(definition.name, definition.parameters, paths);
+}
+
+function descriptionPaths(testCase: ToolDescriptionCase): DescriptionPath[] {
+  return [
+    ...testCase.fields.map((field) => [field] as const),
+    ...(testCase.nestedFields ?? []),
+  ];
+}
 
 describe('OpenAI tool conversion', () => {
   it('flattens discriminated object unions into a single object schema', () => {
@@ -182,6 +265,113 @@ describe('Anthropic tool conversion', () => {
     expect(customTools.map((tool) => tool.name)).toContain('grep');
     for (const tool of customTools) {
       expect(tool.input_schema?.type, tool.name).toBe('object');
+    }
+  });
+});
+
+describe('tool schema descriptions', () => {
+  it('keeps LLM-facing input fields described through provider conversions', () => {
+    const cases: ToolDescriptionCase[] = [
+      { definition: new ApplyPathTool().definition, fields: ['patch'] },
+      {
+        definition: new ArxivDownloadTool().definition,
+        fields: ['id', 'autoIndent', 'destination'],
+      },
+      {
+        definition: new ArxivMetadataTool().definition,
+        fields: ['id', 'includeAbstract', 'maxAuthors'],
+      },
+      {
+        definition: new ArxivSearchTool().definition,
+        fields: [
+          'query',
+          'field',
+          'categories',
+          'maxResults',
+          'start',
+          'sortBy',
+          'sortOrder',
+        ],
+      },
+      { definition: new CrossrefDoiTool().definition, fields: ['doi'] },
+      {
+        definition: new CrossrefSearchTool().definition,
+        fields: ['query', 'rows', 'offset', 'sort', 'order', 'filter'],
+      },
+      {
+        definition: new DiagnosticsTool().definition,
+        fields: ['command', 'path'],
+      },
+      {
+        definition: new EditFileTool().definition,
+        fields: ['path', 'old_str', 'new_str', 'replace_all'],
+      },
+      { definition: new GlobTool().definition, fields: ['pattern', 'path'] },
+      { definition: new LsTool().definition, fields: ['path', 'ignore'] },
+      {
+        definition: new ReadFileTool().definition,
+        fields: ['path', 'range'],
+        nestedFields: [
+          ['range', 'start'],
+          ['range', 'end'],
+        ],
+      },
+      {
+        definition: new TexcountTool().definition,
+        fields: ['files', 'mode', 'format'],
+      },
+      { definition: new WebFetchTool().definition, fields: ['url', 'prompt'] },
+      {
+        definition: new WebSearchTool().definition,
+        fields: ['query', 'max_results'],
+      },
+    ];
+
+    for (const testCase of cases) {
+      expectDescribedProperties(
+        testCase.definition,
+        descriptionPaths(testCase),
+      );
+    }
+
+    const definitions = cases.map(({ definition }) => definition);
+    const anthropicByName = new Map(
+      toAnthropicTools(definitions).flatMap((tool) =>
+        'type' in tool ? [] : [[tool.name, tool.input_schema] as const],
+      ),
+    );
+    const openAiByName = new Map(
+      toOpenAITools(definitions).flatMap((tool) =>
+        tool.type === 'function'
+          ? [[tool.function.name, tool.function.parameters] as const]
+          : [],
+      ),
+    );
+    const openAiResponseByName = new Map(
+      toOpenAIResponseTools(definitions).flatMap((tool) =>
+        tool.type === 'function' ? [[tool.name, tool.parameters] as const] : [],
+      ),
+    );
+
+    for (const testCase of cases) {
+      const { definition } = testCase;
+      const paths = descriptionPaths(testCase);
+
+      expectDescribedParameters(
+        `${definition.name} anthropic`,
+        anthropicByName.get(definition.name),
+        paths,
+      );
+      expectDescribedParameters(
+        `${definition.name} openai`,
+        openAiByName.get(definition.name),
+        paths,
+      );
+      expectDescribedParameters(
+        `${definition.name} openai-response`,
+        openAiResponseByName.get(definition.name),
+        paths,
+      );
     }
   });
 });

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -26,8 +26,12 @@ const CHANNEL = 'DiagnosticsTool';
 logger.initialize(CHANNEL);
 
 export const DiagnosticsInputSchema = z.strictObject({
-  command: z.enum(['list', 'count']),
-  path: z.string(),
+  command: z
+    .enum(['list', 'count'])
+    .describe('Use "list" for full diagnostics or "count" for a summary.'),
+  path: z
+    .string()
+    .describe('Workspace-relative or absolute file path to check.'),
 });
 
 export type DiagnosticsInput = z.infer<typeof DiagnosticsInputSchema>;

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -25,10 +25,21 @@ import { WorkspaceFS } from '@utils/files';
 import { defineTool } from './core/define';
 
 const EditInputSchema = z.strictObject({
-  path: z.string(),
-  old_str: z.string(),
-  new_str: z.string(),
-  replace_all: z.boolean().nullish(),
+  path: z
+    .string()
+    .describe('Workspace-relative or absolute file path to edit.'),
+  old_str: z
+    .string()
+    .describe('Exact literal text to replace, copied from read_file output.'),
+  new_str: z
+    .string()
+    .describe('Replacement text to write in place of old_str.'),
+  replace_all: z
+    .boolean()
+    .nullish()
+    .describe(
+      'Replace every occurrence instead of requiring one unique match.',
+    ),
 });
 
 export type EditInput = z.infer<typeof EditInputSchema>;

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -43,8 +43,12 @@ const RangeSchema = z.preprocess(
   },
   z
     .strictObject({
-      start: z.int().min(1),
-      end: z.int().min(1).nullish(),
+      start: z.int().min(1).describe('First line to read, 1-indexed.'),
+      end: z
+        .int()
+        .min(1)
+        .nullish()
+        .describe('Last line to read, inclusive and 1-indexed.'),
     })
 
     .refine((value) => value.end == null || value.end >= value.start, {
@@ -54,8 +58,12 @@ const RangeSchema = z.preprocess(
 );
 
 const ReadInputSchema = z.strictObject({
-  path: z.string(),
-  range: RangeSchema.nullish(),
+  path: z
+    .string()
+    .describe('Workspace-relative or absolute file path to read.'),
+  range: RangeSchema.nullish().describe(
+    'Optional inclusive line range to read.',
+  ),
 });
 
 export type ReadInput = z.infer<typeof ReadInputSchema>;

--- a/src/tools/applyPath.ts
+++ b/src/tools/applyPath.ts
@@ -9,7 +9,10 @@ import { executeCommand } from '@utils/system/execUtils';
 import { defineTool } from './core/define';
 
 const ApplyPathInputSchema = z.strictObject({
-  patch: z.string().min(1, 'patch content is required'),
+  patch: z
+    .string()
+    .min(1, 'patch content is required')
+    .describe('Unified diff patch content to apply with git apply.'),
 });
 
 export type ApplyPathInput = z.infer<typeof ApplyPathInputSchema>;

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -12,15 +12,17 @@ import { WorkspaceFS } from '@utils/files';
 import { toPosixPath } from '@utils/core/pathCore';
 
 const ArxivDownloadInputSchema = z.strictObject({
-  id: z.string(),
+  id: z.string().describe('arXiv identifier or URL for the source archive.'),
   autoIndent: z
     .boolean()
     .nullish()
-    .transform((v) => v ?? true),
+    .transform((v) => v ?? true)
+    .describe('Auto-indent extracted TeX files after downloading source.'),
   destination: z
     .enum(['root', 'references'])
     .nullish()
-    .transform((v) => v ?? ('references' as const)),
+    .transform((v) => v ?? ('references' as const))
+    .describe('Where to extract the source: workspace root or References/.'),
 });
 
 export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -16,12 +16,18 @@ import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
 
 const ArxivMetadataInputSchema = z.strictObject({
-  id: z.string(),
+  id: z.string().describe('arXiv identifier or URL for the paper.'),
   includeAbstract: z
     .boolean()
     .nullish()
-    .transform((v) => v ?? true),
-  maxAuthors: z.int().positive().max(ARXIV_CONSTANTS.MAX_AUTHORS).nullish(),
+    .transform((v) => v ?? true)
+    .describe('Include the paper abstract in the metadata response.'),
+  maxAuthors: z
+    .int()
+    .positive()
+    .max(ARXIV_CONSTANTS.MAX_AUTHORS)
+    .nullish()
+    .describe('Maximum number of authors to include before truncating.'),
 });
 
 export type ArxivMetadataInput = z.infer<typeof ArxivMetadataInputSchema>;

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -29,26 +29,33 @@ const SortOrderSchema = z.enum(['ascending', 'descending']);
 const SearchFieldSchema = z.enum(['all', 'author', 'title', 'abstract']);
 
 const ArxivSearchInputSchema = z.strictObject({
-  query: z.string(),
+  query: z
+    .string()
+    .describe('Search query terms, title text, or author names.'),
   field: SearchFieldSchema.nullish()
     .transform((v) => v ?? 'all')
     .describe(
       'Search field: "author" for author names, "title" for paper titles, "abstract" for abstracts, "all" (default) for all fields',
     ),
-  categories: z.array(z.string()).nullish(),
+  categories: z
+    .array(z.string())
+    .nullish()
+    .describe('Optional arXiv category filters such as "math.NT" or "cs.AI".'),
   maxResults: z
     .int()
     .positive()
     .max(ARXIV_CONSTANTS.MAX_RESULTS)
     .nullish()
-    .transform((v) => v ?? ARXIV_CONSTANTS.DEFAULT_RESULTS),
+    .transform((v) => v ?? ARXIV_CONSTANTS.DEFAULT_RESULTS)
+    .describe('Maximum number of papers to return.'),
   start: z
     .int()
     .min(0)
     .nullish()
-    .transform((v) => v ?? 0),
-  sortBy: SortBySchema.nullish(),
-  sortOrder: SortOrderSchema.nullish(),
+    .transform((v) => v ?? 0)
+    .describe('Zero-based result offset for pagination.'),
+  sortBy: SortBySchema.nullish().describe('arXiv sort field to use.'),
+  sortOrder: SortOrderSchema.nullish().describe('Sort direction for results.'),
 });
 
 export type ArxivSearchInput = z.infer<typeof ArxivSearchInputSchema>;

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -12,7 +12,7 @@ import { CROSSREF_CONSTANTS, crossrefClient } from './constants';
 import { waitForRateLimit } from './rateLimiter';
 
 const CrossrefDoiInputSchema = z.strictObject({
-  doi: z.string(),
+  doi: z.string().describe('DOI to look up, with or without a DOI URL prefix.'),
 });
 
 export type CrossrefDoiInput = z.infer<typeof CrossrefDoiInputSchema>;

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -18,19 +18,27 @@ import { CROSSREF_CONSTANTS, crossrefClient } from './constants';
 import { waitForRateLimit } from './rateLimiter';
 
 const CrossrefSearchInputSchema = z.strictObject({
-  query: z.string(),
+  query: z.string().describe('Bibliographic search query for Crossref works.'),
   rows: z
     .int()
     .positive()
     .max(CROSSREF_CONSTANTS.MAX_ROWS)
     .nullish()
-    .transform((v) => v ?? CROSSREF_CONSTANTS.DEFAULT_ROWS),
-  offset: z.int().min(0).nullish(),
-  sort: z.string().nullish(),
-  order: z.enum(['asc', 'desc']).nullish(),
+    .transform((v) => v ?? CROSSREF_CONSTANTS.DEFAULT_ROWS)
+    .describe('Maximum number of works to return.'),
+  offset: z
+    .int()
+    .min(0)
+    .nullish()
+    .describe('Zero-based result offset for pagination.'),
+  sort: z.string().nullish().describe('Crossref sort field to apply.'),
+  order: z.enum(['asc', 'desc']).nullish().describe('Crossref sort order.'),
   // Filter as Crossref filter string format (e.g., "from-pub-date:2023,has-orcid:true")
   // Object format removed due to OpenAI JSON Schema limitations with z.record()
-  filter: z.string().nullish(),
+  filter: z
+    .string()
+    .nullish()
+    .describe('Crossref filter string, e.g. "from-pub-date:2023".'),
 });
 
 export type CrossrefSearchInput = z.infer<typeof CrossrefSearchInputSchema>;

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -19,8 +19,14 @@ import { toPosixPath } from '@utils/core/pathCore';
 import { defineTool } from './core/define';
 
 const GlobInputSchema = z.strictObject({
-  pattern: z.string().min(1, 'pattern is required'),
-  path: z.string().nullish(),
+  pattern: z
+    .string()
+    .min(1, 'pattern is required')
+    .describe('Glob pattern to match, such as "**/*.tex" or "src/**/*.ts".'),
+  path: z
+    .string()
+    .nullish()
+    .describe('Directory to search within. Defaults to the workspace root.'),
 });
 
 export type GlobInput = z.infer<typeof GlobInputSchema>;

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -23,8 +23,15 @@ import { toPosixPath } from '@utils/core/pathCore';
 import { defineTool } from './core/define';
 
 const LsInputSchema = z.strictObject({
-  path: z.string(),
-  ignore: z.array(z.string()).prefault([]),
+  path: z
+    .string()
+    .describe(
+      'File or directory path to list, workspace-relative or absolute.',
+    ),
+  ignore: z
+    .array(z.string())
+    .prefault([])
+    .describe('Additional glob patterns or names to hide from the listing.'),
 });
 
 export type LsInput = z.infer<typeof LsInputSchema>;

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -7,12 +7,18 @@ import { ToolError, type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
 const TexcountInputSchema = z.strictObject({
-  files: z.union([z.string(), z.array(z.string()).min(1)]),
+  files: z
+    .union([z.string(), z.array(z.string()).min(1)])
+    .describe('LaTeX file path or non-empty list of LaTeX files to count.'),
   mode: z
     .enum(['separate', 'include', 'sum'])
     .nullish()
-    .transform((v) => v ?? 'separate'),
-  format: z.enum(['raw', 'stats']).nullish(),
+    .transform((v) => v ?? 'separate')
+    .describe('How texcount should combine files: separate, include, or sum.'),
+  format: z
+    .enum(['raw', 'stats'])
+    .nullish()
+    .describe('Return raw texcount output or wrap it as stats.'),
 });
 
 type TexcountInput = z.infer<typeof TexcountInputSchema>;

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -21,8 +21,13 @@ const WebFetchInputSchema = z.strictObject({
     .refine(
       (value) => value.startsWith('http://') || value.startsWith('https://'),
       'URL must use HTTP or HTTPS protocol',
-    ),
-  prompt: z.string().min(1).nullish(),
+    )
+    .describe('Public HTTP or HTTPS URL to fetch.'),
+  prompt: z
+    .string()
+    .min(1)
+    .nullish()
+    .describe('Optional instruction describing what to extract from the page.'),
 });
 
 export type WebFetchInput = z.infer<typeof WebFetchInputSchema>;

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -8,13 +8,16 @@ import { wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 
 const WebSearchInputSchema = z.strictObject({
-  query: z.string(),
+  query: z
+    .string()
+    .describe('Search query to send to the web search provider.'),
   max_results: z
     .number()
     .min(1)
     .max(5)
     .nullish()
-    .transform((v) => v ?? 3),
+    .transform((v) => v ?? 3)
+    .describe('Maximum number of search results to return, up to 5.'),
 });
 
 export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;


### PR DESCRIPTION
## Summary
- add descriptions to LLM-facing fields across core file, search, citation, arXiv, web, diagnostics, texcount, and patch tool schemas
- add a regression test that generated tool definitions keep these descriptions on top-level input properties

Closes #5216

## Validation
- node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-dogfood-20260604-next transcript queued-followups queued-subagent-followup-summary plain-submit subagent-focused-submit task-picker-parent-fallback todos ctrl-c-exit ctrl-c-interrupt-active
- node packages/cli/scripts/validate-run.mjs
- npm run format
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
- git diff --check
- npm run compile:safe
- npm run lint (passes with 10 unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema metadata and test coverage only; tool runtime behavior is unchanged aside from richer LLM-facing parameter descriptions.
> 
> **Overview**
> Adds **`.describe()`** text on LLM-facing **Zod input fields** across file, patch, diagnostics, glob/ls, read/edit, arXiv, Crossref, texcount, and web tools so generated JSON schemas explain each argument (including nested **`read_file`** `range.start` / `range.end`).
> 
> Introduces a **`tool schema descriptions`** regression in `ToolConversion.vitest.ts` that asserts those descriptions stay present on tool definitions and after **Anthropic**, **OpenAI chat**, and **OpenAI Responses** conversions (with helpers that walk nested `anyOf`/`oneOf`/`allOf` property paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba85a5977fa0b49a94fabc9e19d91d363e70110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->