### PR TITLE
fix(cli): reuse slash forms for startup model picks

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1208,17 +1208,12 @@ registerBuiltinSlashCommands({
       `Harness memory selected: ${storagePath}.`,
     );
   },
-  onMemoryError: (error) => {
-    appendHarnessAssistantTranscript(
-      `Memory command failed: ${formatHarnessError(error)}`,
-    );
-  },
   onResumeSelect: (id) => {
     appendHarnessAssistantTranscript(`Harness resume selected: ${id}.`);
   },
-  onResumeError: (error) => {
+  onError: (error) => {
     appendHarnessAssistantTranscript(
-      `Resume command failed: ${formatHarnessError(error)}`,
+      `Slash command failed: ${formatHarnessError(error)}`,
     );
   },
 });

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -23,6 +23,7 @@ type ApiModeSelectHandler = (value: CliApiMode) => void | Promise<void>;
 type MemorySelectHandler = (storagePath: string) => void | Promise<void>;
 type ResumeSelectHandler = (id: ExecutionId) => void | Promise<void>;
 type ErrorHandler = (error: unknown) => void | Promise<void>;
+type SelectionCompletion = 'afterAction' | 'beforeAction';
 
 function patchSessionMeta<K extends 'agent' | 'model' | 'apiMode'>(
   key: K,
@@ -31,17 +32,39 @@ function patchSessionMeta<K extends 'agent' | 'model' | 'apiMode'>(
   cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), [key]: value });
 }
 
-/** Run a select handler (sync or async) and close the form with the selected
- *  value once it settles, routing any rejection to `onError` first. */
-function settleThenDone<T>(
-  result: void | Promise<void>,
-  value: T,
-  onDone: (value: T) => void,
-  onError?: ErrorHandler,
-): void {
-  void Promise.resolve(result)
+/** Run a form selection handler with consistent completion and error routing. */
+function runFormSelection<T>({
+  action,
+  value,
+  onDone,
+  onError,
+  completion = 'afterAction',
+}: {
+  readonly action: () => void | Promise<void>;
+  readonly value: T;
+  readonly onDone: (value: T) => void;
+  readonly onError?: ErrorHandler;
+  readonly completion?: SelectionCompletion;
+}): void {
+  const runAction = (): Promise<void> => {
+    try {
+      return Promise.resolve(action());
+    } catch (error: unknown) {
+      return Promise.reject(error);
+    }
+  };
+
+  if (completion === 'beforeAction') {
+    onDone(value);
+  }
+
+  void runAction()
     .catch((error: unknown) => onError?.(error))
-    .finally(() => onDone(value));
+    .finally(() => {
+      if (completion === 'afterAction') {
+        onDone(value);
+      }
+    });
 }
 
 export function registerBuiltinSlashCommands(options?: {
@@ -53,9 +76,8 @@ export function registerBuiltinSlashCommands(options?: {
   canSelectModel?: () => boolean;
   onApiModeSelect?: ApiModeSelectHandler;
   onMemorySelect?: MemorySelectHandler;
-  onMemoryError?: ErrorHandler;
   onResumeSelect?: ResumeSelectHandler;
-  onResumeError?: ErrorHandler;
+  onError?: ErrorHandler;
 }): void {
   const onAgentSelect: AgentSelectHandler =
     options?.onAgentSelect ?? ((value) => patchSessionMeta('agent', value));
@@ -95,11 +117,13 @@ export function registerBuiltinSlashCommands(options?: {
           // agree on what "model selection available" means; otherwise close.
           const advanceToModel =
             selectable && (options?.canSelectModel?.() ?? true);
-          settleThenDone(
-            onAgentSelect(value),
+          runFormSelection({
+            action: () => onAgentSelect(value),
             value,
-            advanceToModel ? () => openModelSelectionForm() : props.onDone,
-          );
+            onDone: advanceToModel
+              ? () => openModelSelectionForm()
+              : props.onDone,
+          });
         }}
         onClose={() => props.onDone(undefined)}
       />
@@ -113,7 +137,12 @@ export function registerBuiltinSlashCommands(options?: {
         currentMode={current}
         availableRows={props.availableRows}
         onSelect={(value) =>
-          settleThenDone(onApiModeSelect(value), value, props.onDone)
+          runFormSelection({
+            action: () => onApiModeSelect(value),
+            value,
+            onDone: props.onDone,
+            onError: options?.onError,
+          })
         }
         onCancel={() => props.onDone(undefined)}
       />
@@ -127,11 +156,11 @@ export function registerBuiltinSlashCommands(options?: {
         availableRows={props.availableRows}
         currentPolicy={current}
         onSelect={(value) =>
-          settleThenDone(
-            options?.onApprovalPolicySelect?.(value),
+          runFormSelection({
+            action: () => options?.onApprovalPolicySelect?.(value),
             value,
-            props.onDone,
-          )
+            onDone: props.onDone,
+          })
         }
         onCancel={() => props.onDone(undefined)}
       />
@@ -148,7 +177,11 @@ export function registerBuiltinSlashCommands(options?: {
         availableRows={props.availableRows}
         selectable={selectable}
         onSelect={(value) =>
-          settleThenDone(onModelSelect(value), value, props.onDone)
+          runFormSelection({
+            action: () => onModelSelect(value),
+            value,
+            onDone: props.onDone,
+          })
         }
         onClose={() => props.onDone(undefined)}
       />
@@ -160,12 +193,13 @@ export function registerBuiltinSlashCommands(options?: {
       <MemoryListForm
         availableRows={props.availableRows}
         onSelect={(value) =>
-          settleThenDone(
-            options?.onMemorySelect?.(value),
+          runFormSelection({
+            action: () => options?.onMemorySelect?.(value),
             value,
-            props.onDone,
-            options?.onMemoryError,
-          )
+            onDone: props.onDone,
+            onError: options?.onError,
+            completion: 'beforeAction',
+          })
         }
         onClose={() => props.onDone(undefined)}
       />
@@ -177,12 +211,13 @@ export function registerBuiltinSlashCommands(options?: {
       <ResumeListForm
         availableRows={props.availableRows}
         onSelect={(id) =>
-          settleThenDone(
-            options?.onResumeSelect?.(id),
-            id,
-            props.onDone,
-            options?.onResumeError,
-          )
+          runFormSelection({
+            action: () => options?.onResumeSelect?.(id),
+            value: id,
+            onDone: props.onDone,
+            onError: options?.onError,
+            completion: 'beforeAction',
+          })
         }
         onClose={() => props.onDone(undefined)}
       />

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -92,15 +92,7 @@ import { truncateSummary } from '@utils/text/stringUtils';
 
 import { App } from './App';
 import { assertNever } from './assertNever';
-import { AgentListForm } from './forms/AgentListForm';
-import { ApiModeForm } from './forms/ApiModeForm';
-import {
-  ApprovalPolicyForm,
-  formatApprovalPolicyForCli as formatApprovalPolicy,
-} from './forms/ApprovalPolicyForm';
-import { MemoryListForm } from './forms/MemoryListForm';
-import { ModelListForm } from './forms/ModelListForm';
-import { ResumeListForm } from './forms/ResumeListForm';
+import { formatApprovalPolicyForCli as formatApprovalPolicy } from './forms/ApprovalPolicyForm';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
 import {
   listSlashCommands,
@@ -384,25 +376,6 @@ function applyInitialCliAgentSelection(
   appendLocalAssistantTranscript(`Root agent set to ${nextAgent}.`);
 }
 
-function openCliAgentListForm(context: SlashCommandContext): void {
-  const selectable = chatTuiCanStartRootRun(context.session);
-  cliState.activeForm.set({
-    commandName: 'agent',
-    render: (close, availableRows) => (
-      <AgentListForm
-        currentAgent={cliState.sessionMeta.get().agent}
-        availableRows={availableRows}
-        selectable={selectable}
-        onSelect={(value) => {
-          applyInitialCliAgentSelection(value, context);
-          close();
-        }}
-        onClose={close}
-      />
-    ),
-  });
-}
-
 async function applyInitialCliModelSelection(
   model: string,
   context: SlashCommandContext,
@@ -451,25 +424,6 @@ async function reconcileRootModelAfterApiModeChange(
   return resolution.notice;
 }
 
-function openCliModelListForm(context: SlashCommandContext): void {
-  const selectable = chatTuiCanStartRootRun(context.session);
-  cliState.activeForm.set({
-    commandName: 'model',
-    render: (close, availableRows) => (
-      <ModelListForm
-        currentModel={cliState.sessionMeta.get().model}
-        apiMode={cliState.sessionMeta.get().apiMode}
-        availableRows={availableRows}
-        selectable={selectable}
-        onSelect={(value) => {
-          void applyInitialCliModelSelection(value, context).finally(close);
-        }}
-        onClose={close}
-      />
-    ),
-  });
-}
-
 async function applyCliApiModeSelection(
   mode: string | CliApiMode,
   context?: SlashCommandContext,
@@ -510,34 +464,6 @@ async function applyCliApiModeSelection(
   }
 
   appendLocalAssistantTranscript('Usage: /api personal | /api included');
-}
-
-function openCliApiModeForm(
-  onSelect: (mode: CliApiMode) => void | Promise<void>,
-): void {
-  cliState.activeForm.set({
-    commandName: 'api',
-    render: (close) => {
-      const current = cliState.sessionMeta.get().apiMode;
-      return (
-        <ApiModeForm
-          currentMode={current}
-          onSelect={(value) => {
-            void (async () => {
-              try {
-                await onSelect(value);
-              } catch (error: unknown) {
-                appendLocalAssistantTranscript(toErrorMessage(error));
-              } finally {
-                close();
-              }
-            })();
-          }}
-          onCancel={close}
-        />
-      );
-    },
-  });
 }
 
 async function showCliAuthStatus(): Promise<void> {
@@ -673,26 +599,6 @@ function parseApprovalPolicy(input: string): CliApprovalPolicy | undefined {
 
 const YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
 
-function openCliApprovalPolicyForm(context: SlashCommandContext): void {
-  cliState.activeForm.set({
-    commandName: 'approval',
-    render: (close, availableRows) => (
-      <ApprovalPolicyForm
-        availableRows={availableRows}
-        currentPolicy={context.getApprovalPolicy()}
-        onSelect={(policy) => {
-          context.setApprovalPolicy(policy);
-          appendLocalAssistantTranscript(
-            `Approval mode set to ${formatApprovalPolicy(policy)}.`,
-          );
-          close();
-        }}
-        onCancel={close}
-      />
-    ),
-  });
-}
-
 function applyCliApprovalPolicySelection(
   input: string,
   context: SlashCommandContext,
@@ -700,7 +606,7 @@ function applyCliApprovalPolicySelection(
 ): void {
   const normalized = input.trim().toLowerCase();
   if (!normalized || normalized === 'status') {
-    openCliApprovalPolicyForm(context);
+    openRegisteredCliSlashCommandForm('approval', '');
     return;
   }
 
@@ -716,48 +622,12 @@ function applyCliApprovalPolicySelection(
   );
 }
 
-function openCliResumeListForm(context: SlashCommandContext): void {
-  cliState.activeForm.set({
-    commandName: 'resume',
-    render: (close, availableRows) => (
-      <ResumeListForm
-        availableRows={availableRows}
-        onSelect={(id) => {
-          close();
-          void context.resumeExecution(id).catch((error: unknown) => {
-            appendLocalAssistantTranscript(toErrorMessage(error));
-          });
-        }}
-        onClose={close}
-      />
-    ),
-  });
-}
-
 async function showCliMemoryList(): Promise<void> {
   appendLocalAssistantTranscript(formatCliMemoryList(await loadMemoryItems()));
 }
 
 async function showCliMemoryPreview(inputPath: string): Promise<void> {
   appendLocalAssistantTranscript(await formatCliMemoryPreview(inputPath));
-}
-
-function openCliMemoryListForm(): void {
-  cliState.activeForm.set({
-    commandName: 'memory',
-    render: (close, availableRows) => (
-      <MemoryListForm
-        availableRows={availableRows}
-        onSelect={(storagePath) => {
-          close();
-          void showCliMemoryPreview(storagePath).catch((error: unknown) => {
-            appendLocalAssistantTranscript(toErrorMessage(error));
-          });
-        }}
-        onClose={close}
-      />
-    ),
-  });
 }
 
 export function openRegisteredCliSlashForm(
@@ -777,6 +647,25 @@ export function openRegisteredCliSlashForm(
     ),
   });
   return true;
+}
+
+function findRegisteredCliSlashCommand(
+  commandName: string,
+): SlashCommand | undefined {
+  const lower = commandName.toLowerCase();
+  return listSlashCommands().find(
+    (cmd) =>
+      cmd.name.toLowerCase() === lower ||
+      cmd.aliases?.some((alias) => alias.toLowerCase() === lower) === true,
+  );
+}
+
+function openRegisteredCliSlashCommandForm(
+  commandName: string,
+  remainder: string,
+): boolean {
+  const registered = findRegisteredCliSlashCommand(commandName);
+  return registered ? openRegisteredCliSlashForm(registered, remainder) : false;
 }
 
 async function handleTuiSlashCommand(
@@ -823,16 +712,16 @@ async function handleTuiSlashCommand(
       } else if (rest) {
         applyInitialCliAgentSelection(rest, context);
       } else {
-        openCliAgentListForm(context);
+        openRegisteredCliSlashCommandForm('agent', rest);
       }
       return true;
     case 'model':
     case 'models':
-      openCliModelListForm(context);
+      openRegisteredCliSlashCommandForm('model', rest);
       return true;
     case 'api':
       if (!rest) {
-        openCliApiModeForm((mode) => applyCliApiModeSelection(mode, context));
+        openRegisteredCliSlashCommandForm('api', rest);
         return true;
       }
       try {
@@ -858,7 +747,7 @@ async function handleTuiSlashCommand(
       if (rest) {
         applyCliApprovalPolicySelection(rest, context);
       } else {
-        openCliApprovalPolicyForm(context);
+        openRegisteredCliSlashCommandForm('approval', rest);
       }
       return true;
     case 'yolo':
@@ -891,7 +780,7 @@ async function handleTuiSlashCommand(
     }
     case 'resume': {
       if (!rest) {
-        openCliResumeListForm(context);
+        openRegisteredCliSlashCommandForm('resume', rest);
         return true;
       }
       const id = parseCliHistoryId(rest);
@@ -905,7 +794,7 @@ async function handleTuiSlashCommand(
     case 'memory': {
       try {
         if (!rest) {
-          openCliMemoryListForm();
+          openRegisteredCliSlashCommandForm('memory', rest);
         } else if (rest.toLowerCase() === 'list') {
           await showCliMemoryList();
         } else {
@@ -925,12 +814,7 @@ async function handleTuiSlashCommand(
       });
       return true;
     default: {
-      const registered = listSlashCommands().find(
-        (cmd) =>
-          cmd.name.toLowerCase() === command ||
-          cmd.aliases?.some((alias) => alias.toLowerCase() === command) ===
-            true,
-      );
+      const registered = findRegisteredCliSlashCommand(command);
       if (registered) {
         if (openRegisteredCliSlashForm(registered, parsed.remainder)) {
           return true;
@@ -1343,11 +1227,8 @@ export async function runChat(
     onApiModeSelect: (nextMode) =>
       applyCliApiModeSelection(nextMode, slashCommandContext()),
     onMemorySelect: showCliMemoryPreview,
-    onMemoryError: (error) => {
-      appendLocalAssistantTranscript(toErrorMessage(error));
-    },
     onResumeSelect: resumeAgentRun,
-    onResumeError: (error) => {
+    onError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));
     },
   });

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -13,6 +13,7 @@ import {
 import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
 import { openRegisteredCliSlashForm } from '@cli/chat/tui/runChatTui';
 import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
+import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
@@ -20,6 +21,23 @@ afterEach(() => {
 });
 
 describe('slashRegistry', () => {
+  function renderFormAdapter<TProps>(node: unknown): { props?: TProps } {
+    const element = node as {
+      type?: (props: unknown) => unknown;
+      props?: unknown;
+    };
+    if (typeof element.type !== 'function') {
+      throw new TypeError('Expected registered slash form adapter element');
+    }
+    return element.type(element.props) as { props?: TProps };
+  }
+
+  async function settleFormSelection(): Promise<void> {
+    for (let index = 0; index < 4; index += 1) {
+      await Promise.resolve();
+    }
+  }
+
   it('keeps the CLI session control commands registered', () => {
     registerBuiltinSlashCommands();
     expect(listSlashCommands().map((cmd) => cmd.name)).toEqual(
@@ -89,6 +107,135 @@ describe('slashRegistry', () => {
 
     expect(openRegisteredCliSlashForm(tools, '')).toBe(true);
     expect(cliState.activeForm.get()?.commandName).toBe('tools');
+  });
+
+  it('chains selectable agent picks into the API-mode-aware model picker', async () => {
+    resetCliState({
+      agent: 'chat',
+      model: 'deepseekT',
+      cwd: '/tmp/workspace',
+      apiMode: 'included',
+      canDelegate: false,
+      version: 'test',
+    });
+    registerBuiltinSlashCommands();
+    const agent = listSlashCommands().find((cmd) => cmd.name === 'agent');
+
+    if (!agent) throw new Error('Expected /agent to be registered');
+
+    expect(openRegisteredCliSlashForm(agent, '')).toBe(true);
+
+    const agentNode = renderFormAdapter<{
+      onSelect?: (value: string) => void;
+    }>(cliState.activeForm.get()?.render(() => {}, 20));
+    agentNode.props?.onSelect?.('review');
+    await settleFormSelection();
+
+    expect(cliState.sessionMeta.get().agent).toBe('review');
+    expect(cliState.activeForm.get()?.commandName).toBe('model');
+
+    const modelNode = renderFormAdapter<{
+      apiMode?: string;
+      selectable?: boolean;
+    }>(cliState.activeForm.get()?.render(() => {}, 20));
+    expect(modelNode.props).toMatchObject({
+      apiMode: 'included',
+      selectable: true,
+    });
+  });
+
+  it('marks the agent picker read-only when root selection is closed', () => {
+    resetCliState({
+      agent: 'chat',
+      model: 'deepseekT',
+      cwd: '/tmp/workspace',
+      apiMode: 'included',
+      canDelegate: false,
+      version: 'test',
+    });
+    registerBuiltinSlashCommands({
+      canSelectAgent: () => false,
+      canSelectModel: () => true,
+    });
+    const agent = listSlashCommands().find((cmd) => cmd.name === 'agent');
+
+    if (!agent) throw new Error('Expected /agent to be registered');
+
+    expect(openRegisteredCliSlashForm(agent, '')).toBe(true);
+
+    const agentNode = renderFormAdapter<{
+      selectable?: boolean;
+    }>(cliState.activeForm.get()?.render(() => {}, 20));
+
+    expect(agentNode.props).toMatchObject({ selectable: false });
+    expect(cliState.activeForm.get()?.commandName).toBe('agent');
+  });
+
+  it('routes API picker selection failures to the shared error handler', async () => {
+    resetCliState({
+      agent: 'chat',
+      model: 'deepseekT',
+      cwd: '/tmp/workspace',
+      apiMode: 'included',
+      canDelegate: false,
+      version: 'test',
+    });
+    const errors: string[] = [];
+    registerBuiltinSlashCommands({
+      onApiModeSelect: async () => {
+        throw new Error('api mode failed');
+      },
+      onError: (error) => {
+        errors.push(error instanceof Error ? error.message : String(error));
+      },
+    });
+    const api = listSlashCommands().find((cmd) => cmd.name === 'api');
+    let closed = false;
+
+    if (!api) throw new Error('Expected /api to be registered');
+
+    expect(openRegisteredCliSlashForm(api, '')).toBe(true);
+
+    const apiNode = renderFormAdapter<{
+      onSelect?: (value: CliApiMode) => void;
+    }>(
+      cliState.activeForm.get()?.render(() => {
+        closed = true;
+      }, 20),
+    );
+    apiNode.props?.onSelect?.('personal');
+    await settleFormSelection();
+
+    expect(errors).toEqual(['api mode failed']);
+    expect(closed).toBe(true);
+  });
+
+  it('closes the resume picker before running the resume action', async () => {
+    let closed = false;
+    let sawClosedBeforeResume = false;
+    registerBuiltinSlashCommands({
+      onResumeSelect: async () => {
+        sawClosedBeforeResume = closed;
+      },
+    });
+    const resume = listSlashCommands().find((cmd) => cmd.name === 'resume');
+
+    if (!resume) throw new Error('Expected /resume to be registered');
+
+    expect(openRegisteredCliSlashForm(resume, '')).toBe(true);
+
+    const resumeNode = renderFormAdapter<{
+      onSelect?: (id: string) => void;
+    }>(
+      cliState.activeForm.get()?.render(() => {
+        closed = true;
+      }, 20),
+    );
+    resumeNode.props?.onSelect?.('previous-session');
+    await settleFormSelection();
+
+    expect(closed).toBe(true);
+    expect(sawClosedBeforeResume).toBe(true);
   });
 
   it('matches by name prefix case-insensitively', () => {


### PR DESCRIPTION
Closes #5251.

## Summary

- Route no-argument CLI slash commands through the registered slash form adapters instead of duplicating one-off form openers in runChatTui.
- Let the real /agent form path share the existing agent-to-model chain, so selecting a root agent before the first message advances into the API-mode-aware /model picker.
- Add regression coverage for the selectable /agent -> /model flow and the read-only agent picker state.

## Validation

- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/DefaultAgents.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts
- node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-model-auth-20260604-after orchestrate-relay-model-pick orchestrate-personal-model-pick agent-form model-form api-form approval-form
- git diff --check
- npm run format
- npm run compile:safe
- npm run lint (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors CLI TUI slash-form wiring and selection timing without touching auth, payments, or server APIs; behavior is covered by new SlashRegistry tests and existing CLI validation.
> 
> **Overview**
> **No-argument slash commands** (`/agent`, `/model`, `/api`, `/approval`, `/resume`, `/memory`) now open forms through the **registered slash adapters** in `registerBuiltins` instead of duplicate one-off openers removed from `runChatTui`.
> 
> **Startup flow:** Choosing a root agent before the first message still **chains into the API-mode-aware `/model` picker** via the shared `/agent` form path, with `canSelectAgent` / `canSelectModel` gating read-only vs selectable pickers.
> 
> **Form completion:** `settleThenDone` is replaced by **`runFormSelection`**, which can close the form **before** async work (`memory`, `resume`) or **after** (`api`, default). **`onMemoryError` / `onResumeError`** are merged into a single **`onError`** (harness + chat).
> 
> **Tests** cover agent→model chaining, read-only agent list, API error routing, and resume closing before the resume handler runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd4bdbe8ec7d1a507d75d4188c4b37a53066bb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->