### PR TITLE
fix(cli): persist interrupted agent loop status

### DIFF
--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -46,6 +46,12 @@ describe('CLI history status formatting', () => {
         hasFlowRecord: true,
       }),
     ).toBe(EXECUTION_STATUS.ERROR);
+    expect(
+      resolveCliHistoryStatus({
+        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+        hasFlowRecord: true,
+      }),
+    ).toBe(EXECUTION_STATUS.INTERRUPTED);
   });
 
   it('uses nullish fallback semantics for persisted terminal status', () => {

--- a/src/test-kernel/tools/CodexLoopStatus.vitest.ts
+++ b/src/test-kernel/tools/CodexLoopStatus.vitest.ts
@@ -90,7 +90,29 @@ describe('finalizeCodexLoopStatus', () => {
   });
 
   it('maps loop failure state to persisted terminal status', () => {
-    expect(agentCliLoopTerminalStatus(false)).toBe('completed');
-    expect(agentCliLoopTerminalStatus(true)).toBe('error');
+    expect(
+      agentCliLoopTerminalStatus({
+        interrupted: false,
+        sawTurnFailure: false,
+      }),
+    ).toBe('completed');
+    expect(
+      agentCliLoopTerminalStatus({
+        interrupted: true,
+        sawTurnFailure: false,
+      }),
+    ).toBe('interrupted');
+    expect(
+      agentCliLoopTerminalStatus({
+        interrupted: false,
+        sawTurnFailure: true,
+      }),
+    ).toBe('error');
+    expect(
+      agentCliLoopTerminalStatus({
+        interrupted: true,
+        sawTurnFailure: true,
+      }),
+    ).toBe('error');
   });
 });

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -35,10 +35,14 @@ export function isLoopOwnedStatus(status: StreamStatus | undefined): boolean {
   return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.RUNNING;
 }
 
-export function agentCliLoopTerminalStatus(
-  sawTurnFailure: boolean,
-): ExecutionStatus {
-  return sawTurnFailure ? EXECUTION_STATUS.ERROR : EXECUTION_STATUS.COMPLETED;
+export function agentCliLoopTerminalStatus(state: {
+  readonly interrupted: boolean;
+  readonly sawTurnFailure: boolean;
+}): ExecutionStatus {
+  if (state.sawTurnFailure) return EXECUTION_STATUS.ERROR;
+  return state.interrupted
+    ? EXECUTION_STATUS.INTERRUPTED
+    : EXECUTION_STATUS.COMPLETED;
 }
 
 export function markAgentCliLoopError(

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -624,7 +624,10 @@ function startClaudeAgentLoop(params: {
       ToolUseFollowUpQueue.release(childStreamId);
       await writeTerminalStatus(
         executionId,
-        agentCliLoopTerminalStatus(sawTurnFailure),
+        agentCliLoopTerminalStatus({
+          interrupted: session.isInterrupted(),
+          sawTurnFailure,
+        }),
       ).catch(() => {});
       untrackExecution(executionId);
       finalizeAgentCliLoopStatus(childStreamId, runtimeHost);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -641,7 +641,10 @@ function startCodexLoop(params: {
       // notifyWaiters, so consumers must see the final status on disk.
       await writeTerminalStatus(
         executionId,
-        agentCliLoopTerminalStatus(sawTurnFailure),
+        agentCliLoopTerminalStatus({
+          interrupted: session.isInterrupted(),
+          sawTurnFailure,
+        }),
       ).catch(() => {});
       untrackExecution(executionId);
 


### PR DESCRIPTION
## Summary

- Persist interrupted terminal status for cleanly stopped Codex and Claude async agent loops
- Keep failed turns as terminal errors, with failure taking precedence over interruption
- Replace the ambiguous boolean helper with a small state object so call sites stay explicit

Closes #5253

## Validation

- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/CodexLoopStatus.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/CodexLoopStatus.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/HistoryStatus.vitest.ts src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/DefaultAgents.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui orchestrate-relay-model-pick orchestrate-personal-model-pick stopped-subagent-picker focused-stopped-subagent
- git diff --check
- npm run format
- npm run compile:safe
- npm run lint (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to terminal status persistence and a shared helper; behavior is covered by unit tests with no auth or data-model changes.
> 
> **Overview**
> Codex and Claude Code async agent loops now **persist `interrupted` as the terminal execution status** when the session ends from a user stop or clean abort, instead of recording **`completed`**.
> 
> **`agentCliLoopTerminalStatus`** takes a small state object (`interrupted`, `sawTurnFailure`): turn failures still map to **`error`**, and failure **overrides** interruption when both apply. Call sites in **`codex.ts`** and **`claudeAgent.ts`** pass **`session.isInterrupted()`** into **`writeTerminalStatus`**. Tests cover the mapping and CLI history treating persisted **`interrupted`** as authoritative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77646015c3a973da8c7f1b8726095ccd568ad5d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->