### PR TITLE
fix: decouple Lean LSP types from protocol package

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "typescript-eslint": "^8.60.1",
     "vite": "^8.0.16",
     "vitest": "^4.1.8",
-    "vscode-languageserver-protocol": "^3.18.0",
     "webpack": "^5.107.2",
     "webpack-cli": "^7.0.3",
     "zod-v3-to-v4": "^1.21.2"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1624,7 +1624,6 @@
     "typescript-eslint": "^8.60.1",
     "vite": "^8.0.16",
     "vitest": "^4.1.8",
-    "vscode-languageserver-protocol": "^3.18.0",
     "webpack": "^5.107.2",
     "webpack-cli": "^7.0.3",
     "zod-v3-to-v4": "^1.21.2"

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -24,6 +24,7 @@ import {
   type LeanFileCommand,
   type LeanProjectCommand,
 } from '@tools/lean/leanConstants';
+import type { LspHover } from '@tools/lean/lspTypes';
 import type {
   LeanDiagnostic,
   LspResult,
@@ -98,8 +99,6 @@ export function clearVscodeLeanServerEntries(): void {
   }
   knownExtensionServers.clear();
 }
-
-type LspHover = import('vscode-languageserver-protocol').Hover;
 
 /**
  * Duck-typed FileUri compatible with the Lean 4 extension's ExtUri.

--- a/packages/extension/src/progressView/persistence/PersistentMapManager.ts
+++ b/packages/extension/src/progressView/persistence/PersistentMapManager.ts
@@ -9,5 +9,5 @@ export interface MementoStorage {
    * Set a key's value, or pass `undefined` to delete the entry. Mirrors
    * `vscode.Memento.update`, which uses `undefined` as the delete sentinel.
    */
-  update<T>(key: string, value: T | undefined): Thenable<void>;
+  update<T>(key: string, value: T | undefined): PromiseLike<void>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,9 +351,6 @@ importers:
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
-      vscode-languageserver-protocol:
-        specifier: ^3.18.0
-        version: 3.18.0
       webpack:
         specifier: ^5.107.2
         version: 5.107.2(esbuild@0.28.0)(postcss@8.5.13)(webpack-cli@7.0.3)
@@ -794,9 +791,6 @@ importers:
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
-      vscode-languageserver-protocol:
-        specifier: ^3.18.0
-        version: 3.18.0
       webpack:
         specifier: ^5.107.2
         version: 5.107.2(esbuild@0.28.0)(postcss@8.5.13)(webpack-cli@7.0.3)
@@ -6425,16 +6419,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vscode-jsonrpc@9.0.0:
-    resolution: {integrity: sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageserver-protocol@3.18.0:
-    resolution: {integrity: sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==}
-
-  vscode-languageserver-types@3.18.0:
-    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -12713,15 +12697,6 @@ snapshots:
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
-
-  vscode-jsonrpc@9.0.0: {}
-
-  vscode-languageserver-protocol@3.18.0:
-    dependencies:
-      vscode-jsonrpc: 9.0.0
-      vscode-languageserver-types: 3.18.0
-
-  vscode-languageserver-types@3.18.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src/test-kernel/tools/lean/LeanHoverTypes.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanHoverTypes.vitest.ts
@@ -1,0 +1,32 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - tools
+import { extractHoverText } from '@tools/lean/leanTypes';
+
+describe('extractHoverText', () => {
+  it('extracts plain string hover contents', () => {
+    expect(extractHoverText('Nat.succ')).toBe('Nat.succ');
+  });
+
+  it('joins marked string hover contents', () => {
+    expect(
+      extractHoverText([
+        { language: 'lean4', value: '#check Nat' },
+        'natural numbers',
+      ]),
+    ).toBe('#check Nat\n\nnatural numbers');
+  });
+
+  it('extracts single marked string hover contents', () => {
+    expect(extractHoverText({ language: 'lean4', value: '#check Nat' })).toBe(
+      '#check Nat',
+    );
+  });
+
+  it('extracts markup content hover values', () => {
+    expect(
+      extractHoverText({ kind: 'markdown', value: '**theorem** foo' }),
+    ).toBe('**theorem** foo');
+  });
+});

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -18,13 +18,13 @@ import { runLakeCommand } from './lakeCommands';
 import { LeanSession } from './leanSession';
 import type { LeanFileCommand, LeanProjectCommand } from '../leanConstants';
 import type { LeanLanguageServices } from '../leanLanguageServices';
+import type { LspHover } from '../lspTypes';
 import type {
   LeanDiagnostic,
   LspResult,
   PlainGoal,
   PlainTermGoal,
 } from '../leanTypes';
-import type { Hover } from 'vscode-languageserver-protocol';
 
 const LOG_CHANNEL = 'lean.direct';
 
@@ -249,8 +249,8 @@ export function createDirectLspLeanAdapter(
       filePath: string,
       line: number,
       column: number,
-    ): Promise<LspResult<Hover>> {
-      return positionRequest<Hover>(filePath, (session) =>
+    ): Promise<LspResult<LspHover>> {
+      return positionRequest<LspHover>(filePath, (session) =>
         session.getHover(filePath, line, column),
       );
     },

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -23,12 +23,12 @@ import {
   updateLeanServer,
 } from '../leanServerRegistry';
 import { JsonRpcConnection } from './jsonRpc';
-import type { LeanDiagnostic, PlainGoal, PlainTermGoal } from '../leanTypes';
 import type {
-  Diagnostic,
-  Hover,
-  PublishDiagnosticsParams,
-} from 'vscode-languageserver-protocol';
+  LspDiagnostic,
+  LspHover,
+  LspPublishDiagnosticsParams,
+} from '../lspTypes';
+import type { LeanDiagnostic, PlainGoal, PlainTermGoal } from '../leanTypes';
 
 const LOG_CHANNEL = 'lean.direct';
 
@@ -199,8 +199,8 @@ export class LeanSession {
     filePath: string,
     line: number,
     column: number,
-  ): Promise<Hover | null> {
-    return this.requestSettled<Hover | null>(
+  ): Promise<LspHover | null> {
+    return this.requestSettled<LspHover | null>(
       filePath,
       line,
       column,
@@ -279,7 +279,7 @@ export class LeanSession {
     const rpc = new JsonRpcConnection(child.stdin, child.stdout);
     this.rpc = rpc;
     rpc.onNotification('textDocument/publishDiagnostics', (params) =>
-      this.handlePublishDiagnostics(params as PublishDiagnosticsParams),
+      this.handlePublishDiagnostics(params as LspPublishDiagnosticsParams),
     );
     rpc.onNotification('window/logMessage', (params) => {
       debug(LOG_CHANNEL, `[${root}] ${JSON.stringify(params)}`);
@@ -395,7 +395,7 @@ export class LeanSession {
     }
   }
 
-  private handlePublishDiagnostics(params: PublishDiagnosticsParams): void {
+  private handlePublishDiagnostics(params: LspPublishDiagnosticsParams): void {
     const uri = params.uri;
     const absolute = fileUriToPath(uri);
     if (!absolute) return;
@@ -421,7 +421,7 @@ export class LeanSession {
   }
 }
 
-function toLeanDiagnostic(d: Diagnostic): LeanDiagnostic {
+function toLeanDiagnostic(d: LspDiagnostic): LeanDiagnostic {
   return {
     // LSP `DiagnosticSeverity` (Error=1) matches the VS Code numeric severity
     // (Error=0) shifted by one — translate to keep formatting consistent with

--- a/src/tools/lean/leanLanguageServices.ts
+++ b/src/tools/lean/leanLanguageServices.ts
@@ -11,9 +11,8 @@
  * LSP requests).
  */
 
-import type { Hover } from 'vscode-languageserver-protocol';
-
 import type { LeanFileCommand, LeanProjectCommand } from './leanConstants';
+import type { LspHover } from './lspTypes';
 import type {
   LeanDiagnostic,
   LspResult,
@@ -40,7 +39,7 @@ export interface LeanLanguageServices {
     filePath: string,
     line: number,
     column: number,
-  ): Promise<LspResult<Hover>>;
+  ): Promise<LspResult<LspHover>>;
   fetchDiagnosticsForFile(file: string): Promise<LeanDiagnostic[] | null>;
   navigateToFirstError(
     filePath: string,

--- a/src/tools/lean/leanTypes.ts
+++ b/src/tools/lean/leanTypes.ts
@@ -4,7 +4,8 @@
  */
 
 import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting';
-import type { Hover } from 'vscode-languageserver-protocol';
+
+import type { LspHover } from './lspTypes';
 
 /** Response from $/lean/plainGoal LSP request */
 export interface PlainGoal {
@@ -32,7 +33,9 @@ export interface LeanDiagnostic extends GenericDiagnostic {
 }
 
 /** Extract text value from hover contents (handles all LSP content formats) */
-export function extractHoverText(contents: Hover['contents']): string | null {
+export function extractHoverText(
+  contents: LspHover['contents'],
+): string | null {
   if (typeof contents === 'string') {
     return contents;
   }

--- a/src/tools/lean/lspTypes.ts
+++ b/src/tools/lean/lspTypes.ts
@@ -1,0 +1,40 @@
+/**
+ * Minimal LSP shapes used by the Lean integrations.
+ *
+ * Keep these structural so Lean tooling is not coupled to the packaging
+ * details of `vscode-languageserver-protocol`.
+ */
+
+export type LspMarkupContent = {
+  kind: 'plaintext' | 'markdown' | string;
+  value: string;
+};
+
+export type LspMarkedString = string | { language: string; value: string };
+
+export interface LspHover {
+  contents: LspMarkedString | LspMarkupContent | LspMarkedString[];
+  range?: LspRange;
+}
+
+export interface LspDiagnostic {
+  range: LspRange;
+  message: string;
+  severity?: number;
+  source?: string;
+}
+
+export interface LspPublishDiagnosticsParams {
+  uri: string;
+  diagnostics: LspDiagnostic[];
+}
+
+export interface LspRange {
+  start: LspPosition;
+  end: LspPosition;
+}
+
+export interface LspPosition {
+  line: number;
+  character: number;
+}


### PR DESCRIPTION
## Summary

- remove the unused `vscode-languageserver-protocol` dev dependency after #5256
- introduce structural Lean LSP hover/diagnostic types owned by the Lean tooling
- replace one unqualified `Thenable` reference with `PromiseLike`

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/lean/LeanHoverTypes.vitest.ts src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts src/test-kernel/tools/lean/LeanExternalToolStatus.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts`
- `npm run compile:safe`
- `npm run lint` (0 errors, existing import-order warnings only)

Closes #5259.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly type and dependency cleanup with new unit tests; Lean LSP request paths are unchanged aside from local type definitions.
> 
> **Overview**
> Removes the **`vscode-languageserver-protocol`** dev dependency from the workspace and extension packages and updates the lockfile so Lean tooling no longer pulls that package in.
> 
> Lean hover and diagnostics are now described by **local structural types** in `lspTypes.ts` (`LspHover`, `LspDiagnostic`, `LspPublishDiagnosticsParams`). The VS Code Lean bridge, direct LSP session/adapter, `LeanLanguageServices`, and `extractHoverText` are switched from protocol-package types to these aliases—behavior should stay the same, with less coupling to LSP package versioning.
> 
> Adds **`LeanHoverTypes.vitest.ts`** to lock in `extractHoverText` for string, marked-string, and markdown hover payloads. **`MementoStorage.update`** is typed as **`PromiseLike<void>`** instead of VS Code’s `Thenable`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbffea3ebee07669c6efcb0dc26f4c216b1be990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->