### PR TITLE
fix(cli): disable unavailable init models

### DIFF
--- a/packages/cli/src/init/runInitWizard.tsx
+++ b/packages/cli/src/init/runInitWizard.tsx
@@ -7,7 +7,7 @@ import { render, Box, Text, useApp } from 'ink';
 import { useState } from 'react';
 
 import { KeyHints } from '../chat/tui/ui/KeyHints';
-import { Select } from '../chat/tui/ui/Select';
+import { Select, type SelectItem } from '../chat/tui/ui/Select';
 import { clearTerminalScrollback } from '../chat/tui/terminalCleanup';
 import {
   CLI_APPROVAL_POLICIES,
@@ -119,6 +119,20 @@ function firstAvailableIndex(models: readonly InitWizardModelOption[]): number {
   return index >= 0 ? index : 0;
 }
 
+export function initWizardModelSelectItems(
+  models: readonly InitWizardModelOption[],
+): ReadonlyArray<SelectItem<string>> {
+  const hasAvailableModel = models.some((model) => model.available);
+  return models.map((model) => ({
+    value: model.value,
+    label: model.label,
+    description: model.available
+      ? model.status
+      : `${model.status} (unavailable now)`,
+    disabled: hasAvailableModel && !model.available,
+  }));
+}
+
 function defaultAgentIndex(agents: readonly InitWizardAgentOption[]): number {
   const index = agents.findIndex(
     (agent) => agent.name === BUILTIN_DEFAULT_CHAT_AGENT,
@@ -206,13 +220,7 @@ function WizardApp(props: WizardAppProps): React.JSX.Element {
         <Select
           key={step}
           initialIndex={firstAvailableIndex(props.options.models)}
-          items={props.options.models.map((model) => ({
-            value: model.value,
-            label: model.label,
-            description: model.available
-              ? model.status
-              : `${model.status} (unavailable now)`,
-          }))}
+          items={initWizardModelSelectItems(props.options.models)}
           onSelect={(model) => commit({ model })}
           onCancel={cancel}
         />

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { defaultInitAgentOptions, initCommand } from '@cli/commands/init';
+import { initWizardModelSelectItems } from '@cli/init/runInitWizard';
 
 describe('CLI init command', () => {
   it('accepts global CLI flags while keeping init-specific cwd help', () => {
@@ -34,6 +35,70 @@ describe('CLI init command', () => {
     expect(options).toEqual([
       { name: 'chat', description: 'General chat' },
       { name: 'review', description: 'Code review' },
+    ]);
+  });
+
+  it('disables init model rows unavailable in the active API mode', () => {
+    expect(
+      initWizardModelSelectItems([
+        {
+          value: 'sonnet46T',
+          label: 'Sonnet',
+          available: true,
+          status: 'included access',
+        },
+        {
+          value: 'deepseekT',
+          label: 'DeepSeek',
+          available: false,
+          status: 'api key set',
+        },
+      ]),
+    ).toEqual([
+      {
+        value: 'sonnet46T',
+        label: 'Sonnet',
+        description: 'included access',
+        disabled: false,
+      },
+      {
+        value: 'deepseekT',
+        label: 'DeepSeek',
+        description: 'api key set (unavailable now)',
+        disabled: true,
+      },
+    ]);
+  });
+
+  it('keeps all-unavailable init model rows selectable as a fallback', () => {
+    expect(
+      initWizardModelSelectItems([
+        {
+          value: 'sonnet46T',
+          label: 'Sonnet',
+          available: false,
+          status: 'login required',
+        },
+        {
+          value: 'deepseekT',
+          label: 'DeepSeek',
+          available: false,
+          status: 'missing key',
+        },
+      ]),
+    ).toEqual([
+      {
+        value: 'sonnet46T',
+        label: 'Sonnet',
+        description: 'login required (unavailable now)',
+        disabled: false,
+      },
+      {
+        value: 'deepseekT',
+        label: 'DeepSeek',
+        description: 'missing key (unavailable now)',
+        disabled: false,
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- disables unavailable `texra init` model rows using the existing shared
  `Select.disabled` support
- keeps access-mode status text visible while preventing relay/API-mode
  mismatches from being selected during interactive init
- adds a focused CLI init test for the model row projection

Closes #5261.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/InitCommand.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with 10 pre-existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX guard in the init TUI with unit tests; no auth, persistence, or runtime API changes beyond choice filtering.
> 
> **Overview**
> Interactive **`texra init`** model selection now maps wizard model options through **`initWizardModelSelectItems`**, which sets **`Select`** `disabled` on models that are unavailable in the current API mode while still showing their access status (with an “unavailable now” suffix when needed).
> 
> When at least one model is available, unavailable rows cannot be chosen, avoiding relay/API-mode mismatches during init; if every model is unavailable, rows stay selectable as a fallback. CLI init tests cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cefa41ce923bb63088abda936695275e9fc9c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->