### PR TITLE
fix(cli): clarify mixed agent picker label

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -382,7 +382,7 @@ const SCENARIOS = [
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
-      'Tool-use agents',
+      'Tool-use and orchestrator agents',
       'Current: chat (hidden from picker)',
       'texra chat --agent=<name>',
       'Esc close',
@@ -404,7 +404,7 @@ const SCENARIOS = [
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
-      'Tool-use agents',
+      'Tool-use and orchestrator agents',
       'Current: chat (hidden from picker)',
       'texra chat --agent=<name>',
       'Esc close',
@@ -503,7 +503,7 @@ const SCENARIOS = [
     expect: [
       '/agent',
       'Current: chat (hidden from picker)',
-      'Tool-use agents',
+      'Tool-use and orchestrator agents',
       '+8 more',
       '↑/↓ navigate',
       'Enter close',

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -31,6 +31,7 @@ interface AgentGroups {
 }
 
 type AgentIdentity = Pick<AgentOptionData, 'label' | 'value'>;
+type AgentOrchestrationFlag = Pick<AgentOptionData, 'isOrchestrator'>;
 
 const AGENT_FORM_MAX_WIDTH = 80;
 
@@ -48,8 +49,26 @@ function agentDescription(agent: AgentOptionData): string {
     : agent.isCustom
       ? 'custom'
       : 'built-in';
-  const kind = agent.isOrchestrator ? 'orchestrator' : 'tool-use';
+  const kind = isOrchestratorAgent(agent) ? 'orchestrator' : 'tool-use';
   return agent.description ? `${kind}; ${source}; ${agent.description}` : kind;
+}
+
+function isOrchestratorAgent(agent: AgentOrchestrationFlag): boolean {
+  return agent.isOrchestrator === true;
+}
+
+export function agentPickerPrimarySectionTitle(
+  agents: readonly AgentOrchestrationFlag[],
+): string {
+  const hasOrchestrators = agents.some(isOrchestratorAgent);
+  const hasToolUseSpecialists = agents.some(
+    (agent) => !isOrchestratorAgent(agent),
+  );
+
+  if (hasOrchestrators && hasToolUseSpecialists) {
+    return 'Tool-use and orchestrator agents';
+  }
+  return hasOrchestrators ? 'Orchestrator agents' : 'Tool-use agents';
 }
 
 export function currentVisibleAgent(
@@ -168,6 +187,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
 
   const agents: AgentGroups = data ?? { toolUse: [], workflow: [] };
   const selectable = props.selectable === true;
+  const primarySectionTitle = agentPickerPrimarySectionTitle(agents.toolUse);
   const items = agents.toolUse.map((agent) => ({
     value: agent.label,
     label: agent.label,
@@ -212,7 +232,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
             {currentAgentHint}
           </Text>
         ) : null}
-        <Text bold>Tool-use agents</Text>
+        <Text bold>{primarySectionTitle}</Text>
         <Select
           items={items.map(({ value, label }) => ({ value, label }))}
           activeValue={activeValue}
@@ -245,8 +265,8 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
       </Text>
       <Text dimColor wrap="truncate-end">
         {selectable
-          ? 'Choose the root tool-use agent for the first message.'
-          : 'Available agents. Start a new chat with texra chat --agent=<name> to choose the root tool-use agent.'}
+          ? 'Choose the root agent for the first message.'
+          : 'Available agents. Start a new chat with texra chat --agent=<name> to choose the root agent.'}
       </Text>
       {currentAgentHint ? (
         <Text dimColor wrap="truncate-end">
@@ -254,7 +274,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
         </Text>
       ) : null}
       <Box marginTop={1} flexDirection="column">
-        <Text bold>Tool-use agents</Text>
+        <Text bold>{primarySectionTitle}</Text>
         <Select
           items={items}
           activeValue={activeValue}

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   agentFormWidth,
+  agentPickerPrimarySectionTitle,
   agentSelectWindow,
   currentVisibleAgent,
   hiddenCurrentAgentHint,
@@ -34,6 +35,25 @@ describe('CLI AgentListForm row budget', () => {
       'Current: review (hidden from picker)',
     );
     expect(hiddenCurrentAgentHint(visibleAgents, 'chat')).toBeUndefined();
+  });
+
+  it('labels the primary agent section from the visible row kinds', () => {
+    expect(agentPickerPrimarySectionTitle([])).toBe('Tool-use agents');
+    expect(agentPickerPrimarySectionTitle([{ isOrchestrator: false }])).toBe(
+      'Tool-use agents',
+    );
+    expect(
+      agentPickerPrimarySectionTitle([{ isOrchestrator: undefined }]),
+    ).toBe('Tool-use agents');
+    expect(agentPickerPrimarySectionTitle([{ isOrchestrator: true }])).toBe(
+      'Orchestrator agents',
+    );
+    expect(
+      agentPickerPrimarySectionTitle([
+        { isOrchestrator: false },
+        { isOrchestrator: true },
+      ]),
+    ).toBe('Tool-use and orchestrator agents');
   });
 
   it('windows long agent lists inside the available foreground rows', () => {


### PR DESCRIPTION
## Summary

- derive the `/agent` primary section title from the visible row kinds
- show `Tool-use and orchestrator agents` when the picker mixes regular tool-use agents with orchestrator-capable root agents
- avoid saying only `root tool-use agent` in the form description
- update the PTY harness expectations for the corrected label

Fixes #5263.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/AgentListForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-snapshots-5263-final agent-form agent-form-80-cols compact-agent-form`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with the existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and label logic only in the CLI agent list form and tests; no auth, data, or agent-selection behavior changes.
> 
> **Overview**
> The `/agent` picker no longer always labels its main list **Tool-use agents**. It derives the section heading from visible rows: **Orchestrator agents**, **Tool-use agents**, or **Tool-use and orchestrator agents** when both kinds appear.
> 
> Help copy now says **root agent** instead of **root tool-use agent**, matching orchestrator-capable roots. TUI harness expectations and unit tests cover the new titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fdd3d51d29875e2056b73fca2c3494eb4724863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->