### PR TITLE
fix(webview): preserve text on mixed image paste

### DIFF
--- a/packages/extension/src/webview/frontend/pasteHandler.ts
+++ b/packages/extension/src/webview/frontend/pasteHandler.ts
@@ -20,6 +20,9 @@ export async function handleImagePaste(
 
   // Must run synchronously, before any await, to suppress the default paste.
   event.preventDefault();
+  // Chromium webviews move clipboard data into protected mode after the first
+  // async yield, so read plain text before the file reads below.
+  const pastedText = event.clipboardData?.getData('text/plain') || '';
 
   const pastedImageText = await Promise.all(
     images.map(async ({ file, type }) => {
@@ -41,7 +44,7 @@ export async function handleImagePaste(
   );
 
   const imageChips = pastedImageText.filter(Boolean).join(' ');
-  let insertText = event.clipboardData?.getData('text/plain') || '';
+  let insertText = pastedText;
   if (imageChips) {
     if (insertText && !insertText.endsWith(' ') && !insertText.endsWith('\n')) {
       insertText += ' ';

--- a/src/test-kernel/webview/PasteHandler.vitest.ts
+++ b/src/test-kernel/webview/PasteHandler.vitest.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  asyncReadStarted: false,
+  clipboardImageFiles: vi.fn(),
+  generatePastedImageName: vi.fn(),
+  getExtensionFromMimeType: vi.fn(),
+  insertTextAtCursor: vi.fn(),
+  postMessage: vi.fn(),
+  readFileAsBase64: vi.fn(),
+}));
+
+vi.mock('@shared/hostBridge', () => ({
+  postMessage: mocks.postMessage,
+}));
+
+vi.mock('@shared/utils/clipboardImages', () => ({
+  clipboardImageFiles: mocks.clipboardImageFiles,
+  generatePastedImageName: mocks.generatePastedImageName,
+  getExtensionFromMimeType: mocks.getExtensionFromMimeType,
+  readFileAsBase64: mocks.readFileAsBase64,
+}));
+
+vi.mock('@shared/utils/textarea', () => ({
+  insertTextAtCursor: mocks.insertTextAtCursor,
+}));
+
+describe('handleImagePaste', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.asyncReadStarted = false;
+    mocks.clipboardImageFiles.mockReturnValue([
+      { file: {} as File, type: 'image/png' },
+    ]);
+    mocks.generatePastedImageName.mockReturnValue('pasted_test.png');
+    mocks.getExtensionFromMimeType.mockReturnValue('png');
+    mocks.readFileAsBase64.mockImplementation(async () => {
+      mocks.asyncReadStarted = true;
+      return 'encoded-image';
+    });
+  });
+
+  it('preserves mixed text and image paste text before async clipboard protection', async () => {
+    const { handleImagePaste } = await import('@webview/frontend/pasteHandler');
+    const target = {} as HTMLElement;
+    const getData = vi.fn((type: string) =>
+      type === 'text/plain' && !mocks.asyncReadStarted ? 'describe this' : '',
+    );
+    const event = {
+      clipboardData: { getData },
+      preventDefault: vi.fn(),
+    } as unknown as ClipboardEvent;
+
+    await expect(handleImagePaste(event, target)).resolves.toBe(true);
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(getData).toHaveBeenCalledWith('text/plain');
+    expect(getData).toHaveBeenCalledTimes(1);
+    expect(mocks.insertTextAtCursor).toHaveBeenCalledWith(
+      target,
+      'describe this [pasted_test.png]',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- capture plain text synchronously before async image reads in the main webview paste handler
- add a regression test for mixed text+image paste when clipboard data becomes protected after async work starts

Closes #5230.

## Validation
- npm run format
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/webview/PasteHandler.vitest.ts
- npm run compile:safe
- npm run lint (passes with existing import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized paste-handler ordering change plus a unit test; no auth, data, or API surface impact.
> 
> **Overview**
> Fixes **mixed text + image paste** in the main webview instruction area: plain text from the clipboard was dropped when images were also present because `getData('text/plain')` ran only after async image encoding.
> 
> `handleImagePaste` now reads **`text/plain` synchronously** right after `preventDefault`, before `readFileAsBase64`, so Chromium’s post-await clipboard protection cannot strip the text. The composed insert string still appends image chips as before.
> 
> Adds a **Vitest regression** that simulates clipboard text becoming unavailable after the first async yield and asserts the final cursor insert is `describe this [pasted_test.png]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fd82060badc7c2239147bffc7930256613b1fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->