### PR TITLE
[codex] test: backfill LaTeX processing helper coverage

### DIFF
--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -1,0 +1,165 @@
+// Standard library imports
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - platform
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+
+// Local imports - test support
+import { createFakePlatform } from '@test/support/FakePlatform';
+
+// Local imports - agent
+import type { AgentTrace } from '@agent/trace';
+import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
+
+// Local imports - latex
+import { LatexMediaManager } from '@latex/LatexMediaManager';
+import { DiffFileProcessor } from '@latex/latexdiff/diffFileProcessor';
+import type { ToolConfig } from '@shared/schemas/toolConfig';
+import { createExternalLocation, type FileLocation } from '@utils/files';
+
+const mocks = vi.hoisted(() => ({
+  compileLatex2Pdf: vi.fn(),
+}));
+
+vi.mock('@latex/texTools', () => ({
+  compileLatex2Pdf: mocks.compileLatex2Pdf,
+}));
+
+type DiffFileProcessorInternals = {
+  processLineByLine(content: string): string;
+};
+
+const compilePdfConfig: ToolConfig = {
+  autoExtractFigure: false,
+  autoExtractTikzFigure: false,
+  attachTeXCount: false,
+  attachDiagnostics: false,
+  autoCompileInputPdf: true,
+};
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as AgentTrace;
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+async function installPlatform(workspaceDir: string): Promise<void> {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(
+    createFakePlatform({ workspacePath: workspaceDir }, { fs: nodeFilesystem }),
+  );
+}
+
+function processLineByLine(content: string): string {
+  return (
+    new DiffFileProcessor('test') as unknown as DiffFileProcessorInternals
+  ).processLineByLine(content);
+}
+
+describe('DiffFileProcessor line formatting', () => {
+  it('preserves package blank-line insertion order', () => {
+    const processed = processLineByLine(
+      [
+        '% !TEX root = main.tex',
+        'Here is preamble text from latexdiff',
+        '\\documentclass{article}',
+        '\\usepackage{tikz}',
+        '\\usepackage{pgfplots}',
+        '\\providecommand{\\DIFaddbegin}{}',
+        '\\RequirePackage[normalem]{ulem}',
+        '\\usetikzlibrary{calc}',
+        '\\RequirePackage{color}',
+        'body',
+      ].join('\n'),
+    );
+
+    expect(processed).toBe(
+      [
+        '\\documentclass{article}',
+        '',
+        '\\usepackage{tikz}',
+        '',
+        '\\usepackage{pgfplots}',
+        '',
+        '\\providecommand{\\DIFaddbegin}{}',
+        '',
+        '\\RequirePackage[normalem]{ulem}',
+        '',
+        '\\usetikzlibrary{calc}',
+        '',
+        '\\RequirePackage{color}',
+        '',
+        'body',
+        '',
+      ].join('\n'),
+    );
+  });
+});
+
+describe('LatexMediaManager PDF compilation', () => {
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('filters nullish compile results before adding media files', async () => {
+    const workspaceDir = await makeTempDir('texra-latex-media-');
+    await installPlatform(workspaceDir);
+
+    const inputPaths = [
+      path.join(workspaceDir, 'compiled.tex'),
+      path.join(workspaceDir, 'missing-result.tex'),
+    ];
+    await Promise.all(
+      inputPaths.map(async (filePath) => {
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, '\\documentclass{article}\n');
+      }),
+    );
+
+    const compiledPdfPath = path.join(workspaceDir, 'build', 'compiled.pdf');
+    mocks.compileLatex2Pdf.mockImplementation(
+      async (file: FileLocation, options: { outputDirectory?: string }) => {
+        if (path.basename(file.absolutePath) === 'missing-result.tex') {
+          return undefined;
+        }
+        const outputDirectory = options.outputDirectory!;
+        await mkdir(outputDirectory, { recursive: true });
+        await writeFile(compiledPdfPath, 'compiled pdf');
+        return true;
+      },
+    );
+
+    const workspaceState = AgentWorkspaceState.create();
+    const manager = new LatexMediaManager(logger);
+    await manager.processInputFiles(
+      inputPaths.map(createExternalLocation),
+      workspaceState,
+      compilePdfConfig,
+      true,
+    );
+
+    expect(mocks.compileLatex2Pdf).toHaveBeenCalledTimes(2);
+    expect(workspaceState.media.files.map((file) => file.absolutePath)).toEqual(
+      [compiledPdfPath],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused Vitest coverage for `DiffFileProcessor.processLineByLine` package newline formatting.
- Add `LatexMediaManager` coverage proving undefined PDF compile results are filtered before media attachment.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/latex/LatexProcessingHelpers.vitest.ts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with pre-existing import-order warnings outside this change)
- `git diff --check`

Closes #5236

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modifications.
> 
> **Overview**
> Adds **`LatexProcessingHelpers.vitest.ts`** with kernel tests only—no production code changes.
> 
> **`DiffFileProcessor`:** Exercises private **`processLineByLine`** (via a narrow cast) to lock in behavior that strips latexdiff preamble noise and inserts blank lines between preamble commands in a fixed order.
> 
> **`LatexMediaManager`:** Mocks **`compileLatex2Pdf`** so one `.tex` succeeds and one returns **`undefined`**, then asserts **`processInputFiles`** still compiles both inputs but only attaches the successful PDF to workspace media.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276591e57486d3b2257452a00520dc152f949947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->