### PR TITLE
[codex] fix: cap free relay request bodies

### DIFF
--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -1,0 +1,83 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { describe, it } from 'vitest';
+
+// Local imports - Supabase relay
+import {
+  FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
+  checkRequestBodySizeLimit,
+  formatRequestBytes,
+  readRequestBodyWithinSizeLimit,
+} from '../../../supabase/functions/relay/requestLimits';
+
+function byteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+describe('relay free-tier request size limits', () => {
+  it('rejects free-tier request bodies over the byte cap', () => {
+    assert.deepEqual(checkRequestBodySizeLimit('abc', 3), {
+      allowed: true,
+      limitBytes: 3,
+      requestBytes: 3,
+    });
+    assert.deepEqual(checkRequestBodySizeLimit('abcd', 3), {
+      allowed: false,
+      limitBytes: 3,
+      requestBytes: 4,
+    });
+  });
+
+  it('counts UTF-8 bytes rather than JavaScript string length', () => {
+    const result = checkRequestBodySizeLimit('€', 2);
+
+    assert.equal(result.allowed, false);
+    assert.equal(result.requestBytes, 3);
+  });
+
+  it('uses existing byte lengths for binary request bodies', () => {
+    const result = checkRequestBodySizeLimit(new Uint8Array([0, 255, 1]), 2);
+
+    assert.equal(result.allowed, false);
+    assert.equal(result.requestBytes, 3);
+  });
+
+  it('reads accepted request streams without changing bytes', async () => {
+    const result = await readRequestBodyWithinSizeLimit(
+      byteStream([new Uint8Array([0, 255]), new Uint8Array([1])]),
+      3,
+    );
+
+    if (!result.allowed) assert.fail('expected body under the cap');
+    assert.deepEqual([...result.body], [0, 255, 1]);
+    assert.equal(result.requestBytes, 3);
+  });
+
+  it('stops reading request streams after the cap is exceeded', async () => {
+    const result = await readRequestBodyWithinSizeLimit(
+      byteStream([new Uint8Array([0, 1]), new Uint8Array([2, 3])]),
+      3,
+    );
+
+    assert.equal(result.allowed, false);
+    assert.equal(result.body, null);
+    assert.equal(result.requestBytes, 4);
+  });
+
+  it('uses a loose default limit for normal research requests', () => {
+    assert.equal(FREE_TIER_REQUEST_BODY_LIMIT_BYTES, 2 * 1024 * 1024);
+    assert.equal(
+      formatRequestBytes(FREE_TIER_REQUEST_BODY_LIMIT_BYTES),
+      '2 MiB',
+    );
+  });
+});

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -79,6 +79,10 @@ import {
   isJsonRecord,
   type ReasoningEffortCap,
 } from './reasoning.ts';
+import {
+  formatRequestBytes,
+  readRequestBodyWithinSizeLimit,
+} from './requestLimits.ts';
 
 // =============================================================================
 // Constants
@@ -633,12 +637,36 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     (prefix) => apiPath === prefix || apiPath.startsWith(prefix + '/'),
   );
 
-  let requestBody: string | null = null;
+  let requestBody: string | Uint8Array | null = null;
   let requestBodyJson: unknown = null;
   let modelName: string | null = null;
 
+  // Free relay users share one body-size boundary for all non-GET routes,
+  // including upload endpoints that skip model validation.
+  if (userTier === FREE_TIER && c.req.method !== 'GET') {
+    const requestSize = await readRequestBodyWithinSizeLimit(c.req.raw.body);
+    if (!requestSize.allowed) {
+      return jsonError(
+        `Free tier relay requests are limited to ${formatRequestBytes(requestSize.limitBytes)}. ` +
+          `The relay stopped reading after ${formatRequestBytes(requestSize.requestBytes)}. ` +
+          'Switch to your own API keys for larger requests.',
+        413,
+        {
+          requestTooLarge: true,
+          limitBytes: requestSize.limitBytes,
+          requestBytes: requestSize.requestBytes,
+        },
+      );
+    }
+    requestBody = requestSize.body;
+  }
+
   if (userTier !== ULTRA_TIER && c.req.method !== 'GET' && !isModelFreePath) {
-    requestBody = await c.req.text();
+    if (requestBody === null) {
+      requestBody = await c.req.text();
+    } else if (requestBody instanceof Uint8Array) {
+      requestBody = new TextDecoder().decode(requestBody);
+    }
 
     try {
       requestBodyJson = JSON.parse(requestBody);

--- a/supabase/functions/relay/requestLimits.ts
+++ b/supabase/functions/relay/requestLimits.ts
@@ -1,0 +1,106 @@
+const BYTES_PER_KIB = 1024;
+const BYTES_PER_MIB = BYTES_PER_KIB * 1024;
+
+/**
+ * Deliberately loose cap: blocks runaway free-tier contexts without policing
+ * normal research requests.
+ */
+export const FREE_TIER_REQUEST_BODY_LIMIT_BYTES = 2 * BYTES_PER_MIB;
+
+const textEncoder = new TextEncoder();
+
+export interface RequestBodySizeCheck {
+  allowed: boolean;
+  limitBytes: number;
+  requestBytes: number;
+}
+
+export type RequestBodyReadResult =
+  | (RequestBodySizeCheck & { allowed: true; body: Uint8Array })
+  | (RequestBodySizeCheck & { allowed: false; body: null });
+
+export type RequestBodyForSizeCheck =
+  | string
+  | ArrayBuffer
+  | ArrayBufferView
+  | null;
+
+function requestBodyByteLength(body: RequestBodyForSizeCheck): number {
+  if (body == null) return 0;
+  if (typeof body === 'string') return textEncoder.encode(body).byteLength;
+  return body.byteLength;
+}
+
+export function checkRequestBodySizeLimit(
+  body: RequestBodyForSizeCheck,
+  limitBytes: number = FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
+): RequestBodySizeCheck {
+  const requestBytes = requestBodyByteLength(body);
+
+  return {
+    allowed: requestBytes <= limitBytes,
+    limitBytes,
+    requestBytes,
+  };
+}
+
+function concatChunks(chunks: Uint8Array[], byteLength: number): Uint8Array {
+  const body = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+export async function readRequestBodyWithinSizeLimit(
+  body: ReadableStream<Uint8Array> | null,
+  limitBytes: number = FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
+): Promise<RequestBodyReadResult> {
+  if (body === null) {
+    return {
+      allowed: true,
+      body: new Uint8Array(),
+      limitBytes,
+      requestBytes: 0,
+    };
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let requestBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      requestBytes += value.byteLength;
+      if (requestBytes > limitBytes) {
+        await reader.cancel();
+        return { allowed: false, body: null, limitBytes, requestBytes };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return {
+    allowed: true,
+    body: concatChunks(chunks, requestBytes),
+    limitBytes,
+    requestBytes,
+  };
+}
+
+export function formatRequestBytes(bytes: number): string {
+  if (bytes >= BYTES_PER_MIB && bytes % BYTES_PER_MIB === 0) {
+    return `${bytes / BYTES_PER_MIB} MiB`;
+  }
+  if (bytes >= BYTES_PER_KIB && bytes % BYTES_PER_KIB === 0) {
+    return `${bytes / BYTES_PER_KIB} KiB`;
+  }
+  return `${bytes} bytes`;
+}


### PR DESCRIPTION
## Summary
- Add a deliberately loose 2 MiB body cap for every free-tier relay non-GET request, including model-free upload routes.
- Read free-tier request streams incrementally and stop once the cap is exceeded, then reuse accepted bytes for downstream model validation or forwarding.
- Keep paid tiers uncapped by this guard and add focused tests for byte counting, binary bodies, stream accept/reject behavior, and the default limit display.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/supabase/RelayRequestLimits.vitest.ts src/test-kernel/supabase/RelayReasoningCaps.vitest.ts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with pre-existing import-order warnings outside this change)
- `git diff --check`

Closes #5141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the free-tier relay request ingestion path (including uploads); mis-sizing or double-read bugs could break legitimate traffic, though scope is tier-gated and covered by new tests.
> 
> **Overview**
> Free-tier relay traffic now enforces a **2 MiB** cap on every **non-GET** request body, including upload routes that skip model checks. A new `requestLimits` helper counts **UTF-8 bytes** (not string length), reads the incoming stream incrementally, **cancels** once over the cap, and returns **413** with human-readable sizes and `requestTooLarge` metadata when blocked.
> 
> Accepted bodies are buffered once and **reused** for downstream JSON model validation and upstream forwarding (including decoding to text where needed). **Ultra/Max** tiers are unchanged. Vitest coverage exercises sync checks, binary bodies, stream accept/reject, and the default limit display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e24f5f89397c9a112b25f30425555b644ade385e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->