### PR TITLE
refactor: use shared utilities instead of inline reimplementations (v2, from latest main)

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -15,6 +15,7 @@ import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { isInFlightStatus } from '@common/constants/streamStatus';
+import { toErrorMessage } from '@common/errors';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
 import { tryPlatform } from '@platform/platform';
 import {
@@ -1076,10 +1077,6 @@ function applyHarnessApprovalPolicySelection(
   setHarnessApprovalPolicy(policy);
 }
 
-function formatHarnessError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function markHarnessExecutionStopped(executionId: string): void {
   const parentSlice = cliState.streams.get().get(STREAM_ID);
   if (!parentSlice) return;
@@ -1213,7 +1210,7 @@ registerBuiltinSlashCommands({
   },
   onError: (error) => {
     appendHarnessAssistantTranscript(
-      `Slash command failed: ${formatHarnessError(error)}`,
+      `Slash command failed: ${toErrorMessage(error)}`,
     );
   },
 });

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -123,12 +123,7 @@ function failFromError(
   message: string,
   error: unknown,
 ): DoctorCheck {
-  return fail(
-    id,
-    name,
-    message,
-    extractErrorMessage(error),
-  );
+  return fail(id, name, message, extractErrorMessage(error));
 }
 
 function checkNode(version: string): DoctorCheck {

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -14,6 +14,7 @@ import {
   TEXRA_CLI_SUPPORTED_NODE_RANGE,
   TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY,
 } from '@shared/constants/cliRuntime';
+import { extractErrorMessage } from '@utils/core';
 
 // Local imports - CLI runtime
 import { redactEmailAccountLabelsForDisplay } from './accountDisplay';
@@ -126,7 +127,7 @@ function failFromError(
     id,
     name,
     message,
-    error instanceof Error ? error.message : undefined,
+    extractErrorMessage(error),
   );
 }
 

--- a/packages/cli/src/runtime/memory.ts
+++ b/packages/cli/src/runtime/memory.ts
@@ -8,6 +8,7 @@ import {
   resolveMemoryStoragePath,
   toDisplayPath,
 } from '@tools/memory/memoryUtils';
+import { filterNotNullish } from '@utils/core';
 import { truncateSummary } from '@utils/text/stringUtils';
 
 export const CLI_MEMORY_LIST_LIMIT = 50;
@@ -30,7 +31,7 @@ export function cliMemoryItemDescription(item: MemoryViewItem): string {
     formatSize(item.size),
     formatModifiedDate(item.mtime),
     item.modifiedBy ? `by ${item.modifiedBy}` : undefined,
-  ].filter((part): part is string => part != null);
+  ].filter(filterNotNullish);
   return truncateSummary(parts.join('; '), MEMORY_DESCRIPTION_MAX);
 }
 

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -1,3 +1,4 @@
+import { filterNotNullish } from '@utils/core';
 import { installDesktopHostBridge } from './hostBridge.js';
 import { createDesktopExecutionIpc } from './desktopExecutionIpc.js';
 import {
@@ -98,7 +99,7 @@ export function installDesktopMainViewIpc(
     logs,
     shell,
     execution,
-  ].filter((handler): handler is DesktopMessageHandler => handler != null);
+  ].filter(filterNotNullish);
 
   const dispose = () => {
     if (disposed) return;

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -17,6 +17,7 @@ import {
   type DesktopCommandActions,
   type DesktopCommandMenuEntry,
 } from '../desktopCommandSurface';
+import { filterNotNullish } from '@utils/core';
 import { getDefaultPlatform, getRendererPlatform } from './rendererPlatform';
 
 export interface DesktopCommandPaletteOptions {
@@ -97,7 +98,7 @@ export function getDesktopCommandPaletteEntries({
 } = {}): CommandPaletteEntry[] {
   const desktopEntries = getDesktopCommandMenuEntries(undefined, platform)
     .map(toPaletteEntry)
-    .filter((entry): entry is CommandPaletteEntry => entry != null);
+    .filter(filterNotNullish);
   return [...desktopEntries, ...streams.map(toStreamPaletteEntry)];
 }
 

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -11,13 +11,13 @@ import {
   type CommandPaletteEntry,
 } from '@shared/wa/commandPalette';
 
+import { filterNotNullish } from '@utils/core';
 import {
   dispatchDesktopCommand,
   getDesktopCommandMenuEntries,
   type DesktopCommandActions,
   type DesktopCommandMenuEntry,
 } from '../desktopCommandSurface';
-import { filterNotNullish } from '@utils/core';
 import { getDefaultPlatform, getRendererPlatform } from './rendererPlatform';
 
 export interface DesktopCommandPaletteOptions {

--- a/packages/extension/src/commands/history/chatExportFormatter.ts
+++ b/packages/extension/src/commands/history/chatExportFormatter.ts
@@ -12,7 +12,6 @@
  * This module is VS Code-free — all platform wiring lives in the caller.
  */
 
-import { filterNotNullish } from '@utils/core';
 import { z } from 'zod';
 import {
   isAssistantMessage,
@@ -20,6 +19,7 @@ import {
 } from 'openai/lib/chatCompletionUtils';
 import { assertToolCallsAreChatCompletionFunctionToolCalls } from 'openai/lib/parser';
 import latexPreamble from '@resources/templates/chatExport.tex';
+import { filterNotNullish } from '@utils/core';
 import type { Part } from '@google/genai';
 import type {
   ChatCompletionMessageParam,

--- a/packages/extension/src/commands/history/chatExportFormatter.ts
+++ b/packages/extension/src/commands/history/chatExportFormatter.ts
@@ -12,6 +12,7 @@
  * This module is VS Code-free — all platform wiring lives in the caller.
  */
 
+import { filterNotNullish } from '@utils/core';
 import { z } from 'zod';
 import {
   isAssistantMessage,
@@ -665,7 +666,7 @@ const MD_NODES: NodeRenderers = {
       content ? `\n\`\`\`\n${content}\n\`\`\`` : undefined,
       '',
     ]
-      .filter((l): l is string => l !== undefined)
+      .filter(filterNotNullish)
       .join('\n'),
 };
 
@@ -770,7 +771,7 @@ const TEX_NODES: NodeRenderers = {
       '\\end{websearchbox}',
       '',
     ]
-      .filter((l): l is string => l !== undefined)
+      .filter(filterNotNullish)
       .join('\n'),
 };
 

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -13,7 +13,7 @@ import { runLatexFormatter } from '@latex/texFormatter';
 import { getTeXCount, type TexcountMode } from '@latex/texcount';
 import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
-import { delay } from '@utils/core';
+import { delay, filterNotNull } from '@utils/core';
 
 import { getIndentTeXNotification } from './latexHousekeepingNotifications';
 
@@ -211,7 +211,7 @@ export async function handleGetTeXCount(): Promise<void> {
                   ? { label: template.replace('$1', match[1]) }
                   : null;
               })
-              .filter((item): item is { label: string } => item !== null);
+              .filter(filterNotNull);
 
             await vscode.window.showQuickPick(stats, {
               placeHolder: 'TeXCount Results (press Esc to dismiss)',

--- a/packages/extension/src/progressView/streamInfoUtils.ts
+++ b/packages/extension/src/progressView/streamInfoUtils.ts
@@ -5,6 +5,7 @@ import {
 } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentCategoryFilter, StreamTabInfo } from '@shared/schemas';
+import { filterNotNull } from '@utils/core';
 import { compareByNewestCreationTime } from './streamOrdering';
 import type { ProgressViewState } from './state/ProgressViewState';
 
@@ -91,7 +92,7 @@ export function buildStreamInfos(
   const infos = state.streamLogs
     .keys()
     .map((id) => buildStreamInfo(state, id, filter))
-    .filter((info): info is StreamTabInfo => info !== null);
+    .filter(filterNotNull);
 
   return infos.sort(compareByNewestCreationTime);
 }

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -44,6 +44,7 @@ import {
 } from '@shared/constants/latex';
 
 // Local imports - shared utilities
+import { filterNotNullish } from '@utils/core';
 import { copyTextToClipboard } from '@shared/utils/clipboard';
 import { createEvent } from '@shared/utils/events';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
@@ -475,7 +476,7 @@ export class LaTeXTab extends LitElement {
     if (!dep.pathKeys) return [];
     return dep.pathKeys
       .map((k) => this.settings[k])
-      .filter((v): v is string => v !== null && v !== undefined);
+      .filter(filterNotNullish);
   }
 
   private renderDependencyCard(dep: DependencyInfo): TemplateResult {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -474,9 +474,7 @@ export class LaTeXTab extends LitElement {
   /** Collect detected tool paths for a dependency. */
   private getDetectedPaths(dep: DependencyInfo): string[] {
     if (!dep.pathKeys) return [];
-    return dep.pathKeys
-      .map((k) => this.settings[k])
-      .filter(filterNotNullish);
+    return dep.pathKeys.map((k) => this.settings[k]).filter(filterNotNullish);
   }
 
   private renderDependencyCard(dep: DependencyInfo): TemplateResult {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -44,9 +44,9 @@ import {
 } from '@shared/constants/latex';
 
 // Local imports - shared utilities
-import { filterNotNullish } from '@utils/core';
 import { copyTextToClipboard } from '@shared/utils/clipboard';
 import { createEvent } from '@shared/utils/events';
+import { filterNotNullish } from '@utils/core';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -763,7 +763,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
           }
         } catch (err) {
           options.logger.debug(
-            `Skipping inaccessible media file: ${attachment.path} (${err instanceof Error ? err.message : 'unknown error'})`,
+            `Skipping inaccessible media file: ${attachment.path} (${toErrorMessage(err)})`,
           );
         }
       }

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -19,7 +19,7 @@ import {
   getPromptFileName,
   getXmlFormatFromReadableFiles,
 } from '@utils/prompt';
-import { filterNotNull } from '@utils/core';
+import { filterNotNull, isNonEmptyString } from '@utils/core';
 import {
   listExternalRoots,
   type ExternalRootKind,
@@ -225,7 +225,7 @@ function getCategoryFiles(config: AgentConfig, category: string): string[] {
   if (!cat) return [];
   const list = (config[cat.multiple] as string[] | undefined) ?? [];
   const single = cat.single ? (config[cat.single] as string | null) : null;
-  return [...new Set([single, ...list].filter((f): f is string => Boolean(f)))];
+  return [...new Set([single, ...list].filter(isNonEmptyString))];
 }
 
 /** Categories used for building file vars (excludes MEDIA which is display-only) */

--- a/src/shared/utils/clipboard.ts
+++ b/src/shared/utils/clipboard.ts
@@ -1,3 +1,5 @@
+import { normalizeLineEndings } from '@utils/text/stringUtils';
+
 export const COPY_RESET_DELAY_MS = 2000;
 
 /**
@@ -9,7 +11,7 @@ export async function copyTextToClipboard(text: string): Promise<boolean> {
   }
 
   try {
-    await navigator.clipboard.writeText(text.replaceAll(/\r?\n/g, '\n'));
+    await navigator.clipboard.writeText(normalizeLineEndings(text));
     return true;
   } catch {
     return false;

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -7,6 +7,7 @@
  * paths (PR / repo / issue).
  */
 
+import { isNonEmptyString } from '@utils/core';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
 import type { GhIssueComment } from './prTypes';
 
@@ -59,7 +60,7 @@ export function sections(
   ...parts: ReadonlyArray<string | null | undefined | false>
 ): string {
   return parts
-    .filter((s): s is string => typeof s === 'string' && s.length > 0)
+    .filter(isNonEmptyString)
     .join('\n\n');
 }
 

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -59,9 +59,7 @@ export function authorOf(user: { login: string } | null | undefined): string {
 export function sections(
   ...parts: ReadonlyArray<string | null | undefined | false>
 ): string {
-  return parts
-    .filter(isNonEmptyString)
-    .join('\n\n');
+  return parts.filter(isNonEmptyString).join('\n\n');
 }
 
 export function truncate(s: string | null | undefined, max: number): string {


### PR DESCRIPTION
## Summary

Two commits on top of latest main, each addressing a separate pass of consolidation findings. All changes are pure refactors — identical or strictly-better runtime behavior, typecheck clean.

---

### Commit 1 — First pass (9 files)

Replaces the most widespread inline patterns with their existing shared utilities:

| Pattern replaced | Utility used | Files |
|---|---|---|
| `.filter((x): x is T => x != null)` | `filterNotNull` / `filterNotNullish` from `@utils/core` | 7 files |
| `err instanceof Error ? err.message : 'unknown error'` | `toErrorMessage()` (already imported) | `ToolUseCycleFlow.ts` |
| `text.replaceAll(/\r?\n/g, '\n')` | `normalizeLineEndings()` from `@utils/text/stringUtils` | `clipboard.ts` |

---

### Commit 2 — Deeper pass (4 files)

Found in a second scan of the updated main, targeting patterns the first pass didn't cover:

**`tui-harness.tsx`** — Deletes the local `formatHarnessError(error)` function whose body was byte-for-byte identical to `toErrorMessage()`; imports and calls `toErrorMessage()` directly at the one call site.

**`doctor.ts`** — Replaces `error instanceof Error ? error.message : undefined` with `extractErrorMessage(error)` from `@utils/core`. `extractErrorMessage` is the canonical utility for this exact signature (returns `string | undefined`).

**`formatUtils.ts`** — Replaces verbose `.filter((s): s is string => typeof s === 'string' && s.length > 0)` with `.filter(isNonEmptyString)`. Also slightly stricter: whitespace-only section strings (which produce empty output anyway) are now filtered.

**`userVars.ts`** — Replaces `.filter((f): f is string => Boolean(f))` with `.filter(isNonEmptyString)`. `Boolean(f)` was used as a type-cast workaround; `isNonEmptyString` is the proper type predicate.

---

## What was NOT changed (notable non-findings)

- **Logger `initialize()` calls** — 76 files call `logger.initialize(CHANNEL)` at module load. These are technically redundant (every log function lazily calls `ensureChannel`), but removing them alone without introducing a bound `createLogger()` pattern would save one line per file at the cost of leaving `const CHANNEL` orphaned. A `createLogger` migration is worthwhile but scope-exceeds a cleanup PR.
- **Custom fallback error messages** — `supabaseAuthBrowser.ts`, `remoteAgentUtils.ts`, `TexraDiffView.ts` all use `error instanceof Error ? error.message : 'Custom fallback'`. These are intentional UX choices, not accidental reimplementations.
- **`[...new Set(...)]` patterns** — 23 occurrences across the codebase; varied enough in context that a single `uniqueArray()` wrapper wouldn't simplify most of them.

## Test plan

- [x] `npm run typecheck` — passes with no errors on both commits
- [ ] Smoke test clipboard copy (line-ending normalization)
- [ ] Smoke test CLI slash-command error path (`tui-harness.tsx` change)
- [ ] Smoke test doctor check failure path (`doctor.ts` change)

https://claude.ai/code/session_01H8ooXwuxpy81V4yvqrRW42

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8ooXwuxpy81V4yvqrRW42)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors with typecheck coverage; only minor semantic tightening from `isNonEmptyString` on optional GitHub sections and file lists.
> 
> **Overview**
> This PR **replaces duplicated inline helpers** with shared utilities from `@utils/core`, `@common/errors`, and `@utils/text/stringUtils` across CLI, desktop, extension, agent, and tools code—no intended behavior change except where noted below.
> 
> **Null filtering:** Inline `.filter((x): x is T => …)` calls now use **`filterNotNull`** or **`filterNotNullish`** in memory listing, desktop IPC/palette, chat export formatters, LaTeX TeXCount stats, progress stream tabs, and LaTeX settings path lists.
> 
> **Errors:** The TUI harness drops local `formatHarnessError` in favor of **`toErrorMessage`**. `doctor` failure hints use **`extractErrorMessage`**. Tool-use media skip logging uses **`toErrorMessage`** instead of a one-off `instanceof Error` check.
> 
> **Strings:** Clipboard copy uses **`normalizeLineEndings`** instead of an inline regex. GitHub **`sections()`** and agent **`getCategoryFiles`** use **`isNonEmptyString`**, which is slightly stricter than the old truthy/`length > 0` checks (whitespace-only strings are dropped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be58cf38d97b34892aab0116ba72c074144e252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->