### PR TITLE
Extract token counting logic into reusable applyTokenCountLimit method

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -10,7 +10,11 @@ import {
 } from 'llm-zoo';
 import { platform } from '@platform/platform';
 import type { AgentTrace } from '@agent/trace';
-import { logWebFetch, logWebSearch } from '@agent/trace';
+import {
+  logWebFetch,
+  logWebSearch,
+  logContextManagementEvent,
+} from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   AgentCategory,
@@ -27,6 +31,10 @@ import { K_SLICE } from '@agent/core/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { MAX_TIER, FREE_TIER } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
+import {
+  getSdkErrorMessage,
+  isContextWindowError,
+} from '@common/errors/sdkErrorUtils';
 
 // Local imports - platform
 
@@ -63,6 +71,7 @@ import {
 import {
   computeReducedMaxTokens,
   TOKEN_SAFETY_BUFFER,
+  TOOL_USE_SAFETY_BUFFER,
   TOOL_USE_MAX_OUTPUT_FACTOR,
 } from './contextManagementConstants';
 
@@ -970,6 +979,106 @@ export abstract class ModelHandler<
       inputTokens,
       utilizationPercent,
     };
+  }
+
+  /**
+   * COUNT + VALIDATE template for handlers with native token counting.
+   *
+   * Wraps the shared {@link validateTokenLimits} in the soft-failure envelope
+   * every provider handler otherwise repeats: gated on
+   * {@link supportsTokenCounting}, it estimates input tokens via the injected
+   * `countTokens` thunk, reduces the requested max-output tokens to fit the
+   * context window, emits the `max_tokens_reduced` event, and applies the
+   * reduction through the provider-specific `applyReduced` setter.
+   *
+   * Token-count API failures are soft (proceed without adjustment) — except
+   * context-window violations, which are re-thrown so they fail fast. The
+   * caller may inject side effects via `onCounted` (e.g. diagnostics) and
+   * override the soft-failure path via `onCountFailure` (e.g. a fallback cap).
+   *
+   * @param params.countTokens Estimates input tokens; closes over built params.
+   * @param params.currentMaxTokens The requested max output tokens.
+   * @param params.contextWindow The effective context window size.
+   * @param params.detailLabel Human-readable `details` for the reduction event.
+   * @param params.applyReduced Writes the reduced max back to provider params.
+   * @param params.tokenBuffer Safety buffer; defaults to the tool-use-aware buffer.
+   * @param params.onCounted Invoked with the counted tokens before validation.
+   * @param params.onCountFailure Replaces the default soft-failure debug log.
+   */
+  protected async applyTokenCountLimit(params: {
+    countTokens: () => Promise<number>;
+    currentMaxTokens: number;
+    contextWindow: number;
+    detailLabel: string;
+    applyReduced: (adjustedMaxTokens: number) => void;
+    tokenBuffer?: number;
+    onCounted?: (inputTokens: number) => void;
+    onCountFailure?: (err: unknown) => void;
+  }): Promise<void> {
+    if (!this.supportsTokenCounting) {
+      return;
+    }
+    const {
+      countTokens,
+      currentMaxTokens,
+      contextWindow,
+      detailLabel,
+      applyReduced,
+      onCounted,
+      onCountFailure,
+    } = params;
+    // Token counting uses soft failure: if it fails we proceed without
+    // adjustment and let the API enforce limits, avoiding retries for a
+    // non-critical operation.
+    try {
+      const inputTokens = await countTokens();
+      onCounted?.(inputTokens);
+
+      // Use a larger safety buffer in tool-use mode unless the caller overrides.
+      const tokenBuffer =
+        params.tokenBuffer ??
+        (this.isToolUseMode() ? TOOL_USE_SAFETY_BUFFER : undefined);
+      // Throws if input alone exceeds the context window.
+      const validation = this.validateTokenLimits(
+        inputTokens,
+        currentMaxTokens,
+        contextWindow,
+        tokenBuffer,
+      );
+
+      if (validation.adjustedMaxTokens !== currentMaxTokens) {
+        logContextManagementEvent(
+          this.logger,
+          `Token count (${inputTokens}) + max output tokens (${currentMaxTokens}) exceeds context window (${contextWindow}). Reducing to ${validation.adjustedMaxTokens}.`,
+          {
+            action: 'max_tokens_reduced',
+            tokensBefore: inputTokens,
+            contextWindow,
+            utilizationBefore:
+              validation.utilizationPercent ??
+              (inputTokens / contextWindow) * 100,
+            originalMaxTokens: currentMaxTokens,
+            reducedMaxTokens: validation.adjustedMaxTokens,
+            details: detailLabel,
+          },
+        );
+        applyReduced(validation.adjustedMaxTokens);
+      }
+    } catch (err) {
+      this.sdkErrorTagger(err, this.config.provider);
+      // Context-window violations are intentional validation errors that must
+      // fail fast rather than be swallowed by soft failure.
+      if (isContextWindowError(err)) {
+        throw err;
+      }
+      if (onCountFailure) {
+        onCountFailure(err);
+      } else {
+        this.logger.debug(
+          `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
+        );
+      }
+    }
   }
 
   /**

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -8,7 +8,7 @@ import {
 } from '@anthropic-ai/sdk';
 
 // Local imports - agent
-import { logContextManagementEvent, logSdkError } from '@agent/trace';
+import { logSdkError } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   type AgentSetting,
@@ -30,7 +30,6 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 import { getConfig } from '@agent/core/config';
 import {
   getSdkErrorMessage,
-  isContextWindowError,
   attachStreamDiagnostics,
   attachPartialText,
   takeTail,
@@ -56,7 +55,6 @@ import {
 import {
   getAnthropicMaxPdfPages,
   DEFAULT_COMPACTION_THRESHOLD_PERCENT,
-  TOOL_USE_SAFETY_BUFFER,
 } from '../contextManagementConstants';
 import { AnthropicStreamHandler } from '../support/AnthropicStreamHandler';
 import { toAnthropicTools } from '../toolConversion';
@@ -526,16 +524,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Phase 2: COUNT - Estimate input tokens using built params
     // Phase 3: VALIDATE - Adjust max_tokens if needed
-    if (this.supportsTokenCounting) {
-      if (documentAnalysis.hasFileSource) {
-        this.logger.debug(
-          'Skipping token counting because Anthropic countTokens does not support file-based document sources.',
-        );
-      } else {
-        // Token counting uses soft failure - if it fails, we proceed without adjustment
-        // and let the API enforce limits. This avoids unnecessary retries for non-critical operations.
-        try {
-          // Reuse built params for token counting (build once principle)
+    if (this.supportsTokenCounting && documentAnalysis.hasFileSource) {
+      this.logger.debug(
+        'Skipping token counting because Anthropic countTokens does not support file-based document sources.',
+      );
+    } else {
+      await this.applyTokenCountLimit({
+        // Reuse built params for token counting (build once principle).
+        countTokens: async () => {
           const inputTokens = await this.estimateTokenCount(messages, {
             client,
             systemPrompt,
@@ -546,65 +542,29 @@ export class ModelHandlerAnthropic extends ModelHandler<
             betas: options.betas,
           });
           measuredInputTokens = inputTokens;
+          return inputTokens;
+        },
+        currentMaxTokens: options.max_tokens,
+        contextWindow: effectiveContextWindow,
+        detailLabel: 'Anthropic: max_tokens reduced to fit context window',
+        applyReduced: (adjusted) => {
+          options.max_tokens = adjusted;
 
-          // Validate and adjust max_tokens if needed (throws if context window exceeded)
-          // Use larger safety buffer for tool-use mode
-          const tokenBuffer = this.isToolUseMode()
-            ? TOOL_USE_SAFETY_BUFFER
-            : undefined;
-          const validation = this.validateTokenLimits(
-            inputTokens,
-            options.max_tokens,
-            effectiveContextWindow,
-            tokenBuffer,
-          );
-
-          if (validation.adjustedMaxTokens !== options.max_tokens) {
-            const originalMaxTokens = options.max_tokens;
-            logContextManagementEvent(
-              this.logger,
-              `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${originalMaxTokens} > ${effectiveContextWindow}. Reducing max tokens to ${validation.adjustedMaxTokens}.`,
-              {
-                action: 'max_tokens_reduced',
-                tokensBefore: inputTokens,
-                contextWindow: effectiveContextWindow,
-                utilizationBefore:
-                  validation.utilizationPercent ??
-                  (inputTokens / effectiveContextWindow) * 100,
-                originalMaxTokens,
-                reducedMaxTokens: validation.adjustedMaxTokens,
-                details: 'Anthropic: max_tokens reduced to fit context window',
-              },
+          // Only adjust thinking budget when using manual mode and it would
+          // violate API constraint (budget_tokens must be < max_tokens).
+          // Adaptive thinking has no budget_tokens to adjust.
+          if (
+            options.thinking?.type === 'enabled' &&
+            options.thinking.budget_tokens >= options.max_tokens
+          ) {
+            const newBudget = Math.max(1024, options.max_tokens - 1024);
+            this.logger.debug(
+              `Adjusted thinking budget from ${options.thinking.budget_tokens} to ${newBudget} due to reduced max_tokens`,
             );
-            options.max_tokens = validation.adjustedMaxTokens;
-
-            // Only adjust thinking budget when using manual mode and it would
-            // violate API constraint (budget_tokens must be < max_tokens).
-            // Adaptive thinking has no budget_tokens to adjust.
-            if (
-              options.thinking?.type === 'enabled' &&
-              options.thinking.budget_tokens >= options.max_tokens
-            ) {
-              const newBudget = Math.max(1024, options.max_tokens - 1024);
-              this.logger.debug(
-                `Adjusted thinking budget from ${options.thinking.budget_tokens} to ${newBudget} due to reduced max_tokens`,
-              );
-              options.thinking.budget_tokens = newBudget;
-            }
+            options.thinking.budget_tokens = newBudget;
           }
-        } catch (err) {
-          tagAnthropicSdkError(err, this.config.provider);
-          // Re-throw context window violations - these are intentional validation errors
-          // that should fail fast, not be swallowed by soft failure
-          if (isContextWindowError(err)) {
-            throw err;
-          }
-          // Soft failure for token counting API errors - proceed without adjustment
-          this.logger.debug(
-            `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
-          );
-        }
-      }
+        },
+      });
     }
 
     if (documentAnalysis.hasBase64Pdf) {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -30,11 +30,7 @@ import {
 
 // Local imports - agent
 import { ReasoningEffort } from 'llm-zoo';
-import {
-  logContextManagementEvent,
-  logSdkError,
-  type AgentTrace,
-} from '@agent/trace';
+import { logSdkError, type AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentSetting, hasEndTag } from '@agent/core/definition/AgentDataclass';
 import {
@@ -48,7 +44,6 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
   getSdkErrorMessage,
-  isContextWindowError,
   attachPartialText,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
@@ -68,7 +63,6 @@ import {
 } from './googleUsage';
 import { prepareExistingOutputContent } from '../utils/fileContentUtils';
 import { tagGoogleSdkError } from '../support/sdkErrorAdapters';
-import { TOOL_USE_SAFETY_BUFFER } from '../contextManagementConstants';
 
 // Local file imports
 import {
@@ -515,61 +509,23 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     // Phase 2: COUNT - Estimate input tokens using built params
     // Phase 3: VALIDATE - Adjust maxOutputTokens if needed
-    if (this.supportsTokenCounting) {
-      try {
-        // Reuse built params for token counting (build once principle)
-        const totalTokens = await this.estimateTokenCount(history, {
+    await this.applyTokenCountLimit({
+      // Reuse built params for token counting (build once principle).
+      countTokens: () =>
+        this.estimateTokenCount(history, {
           client,
           systemPrompt,
           lastMessageParts,
           googleTools,
           signal,
-        });
-
-        // Validate and adjust maxOutputTokens if needed (throws if context window exceeded)
-        // Use larger safety buffer for tool-use mode
-        const originalMaxTokens = generationConfig.maxOutputTokens ?? 8192;
-        const tokenBuffer = this.isToolUseMode()
-          ? TOOL_USE_SAFETY_BUFFER
-          : undefined;
-        const validation = this.validateTokenLimits(
-          totalTokens,
-          originalMaxTokens,
-          this.config.contextWindow,
-          tokenBuffer,
-        );
-
-        if (validation.adjustedMaxTokens !== originalMaxTokens) {
-          logContextManagementEvent(
-            this.logger,
-            `Token count of message plus max tokens exceeds context window: ${totalTokens} + ${originalMaxTokens} > ${this.config.contextWindow}. Reducing max tokens to ${validation.adjustedMaxTokens}.`,
-            {
-              action: 'max_tokens_reduced',
-              tokensBefore: totalTokens,
-              contextWindow: this.config.contextWindow,
-              utilizationBefore:
-                validation.utilizationPercent ??
-                (totalTokens / this.config.contextWindow) * 100,
-              originalMaxTokens,
-              reducedMaxTokens: validation.adjustedMaxTokens,
-              details: 'Google: maxOutputTokens reduced to fit context window',
-            },
-          );
-          generationConfig.maxOutputTokens = validation.adjustedMaxTokens;
-        }
-      } catch (err) {
-        tagGoogleSdkError(err, this.config.provider);
-        // Re-throw context window violations - these are intentional validation errors
-        // that should fail fast, not be swallowed by soft failure
-        if (isContextWindowError(err)) {
-          throw err;
-        }
-        // Soft failure for token counting API errors - proceed without adjustment
-        this.logger.debug(
-          `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
-        );
-      }
-    }
+        }),
+      currentMaxTokens: generationConfig.maxOutputTokens ?? 8192,
+      contextWindow: this.config.contextWindow,
+      detailLabel: 'Google: maxOutputTokens reduced to fit context window',
+      applyReduced: (adjusted) => {
+        generationConfig.maxOutputTokens = adjusted;
+      },
+    });
 
     // Phase 4: EXECUTE - Make the API call
     const useStreaming = this.getStreamingConfig();

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -34,7 +34,6 @@ import { getConfig } from '@agent/core/config';
 import { toOpenAIReasoningEffort } from '@agent/runtime/reasoningEffort';
 import {
   getSdkErrorMessage,
-  isContextWindowError,
   isMissingFinishReasonError,
   attachPartialText,
   takeTail,
@@ -79,7 +78,6 @@ import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
   COMPACTION_SYSTEM_PROMPT,
   DEFAULT_COMPACTION_THRESHOLD_PERCENT,
-  TOOL_USE_SAFETY_BUFFER,
 } from '../contextManagementConstants';
 import type {
   CreateResponseOptions,
@@ -707,63 +705,25 @@ export class ModelHandlerOpenAI<
 
     // Phase 2: COUNT - Estimate input tokens if handler supports it
     // Phase 3: VALIDATE - Adjust max_tokens if needed
-    if (this.supportsTokenCounting) {
-      try {
-        const inputTokens = await this.estimateTokenCount(messages, {
-          client,
-          systemPrompt,
-          signal,
-        });
-
-        // Validate and adjust max_tokens if needed (throws if context window exceeded)
-        // Use larger safety buffer for tool-use mode
-        const maxTokensKey = this.isOReasoningModel
-          ? 'max_completion_tokens'
-          : 'max_tokens';
-        const currentMaxTokens = this.isOReasoningModel
-          ? (baseParams.max_completion_tokens ??
-            this.getEffectiveMaxOutputTokens())
-          : (baseParams.max_tokens ?? this.getEffectiveMaxOutputTokens());
-        const tokenBuffer = this.isToolUseMode()
-          ? TOOL_USE_SAFETY_BUFFER
-          : undefined;
-        const validation = this.validateTokenLimits(
-          inputTokens,
-          currentMaxTokens,
-          this.config.contextWindow,
-          tokenBuffer,
-        );
-
-        if (validation.adjustedMaxTokens !== currentMaxTokens) {
-          logContextManagementEvent(
-            this.logger,
-            `Token count (${inputTokens}) + ${maxTokensKey} (${currentMaxTokens}) exceeds context window (${this.config.contextWindow}). Reducing to ${validation.adjustedMaxTokens}.`,
-            {
-              action: 'max_tokens_reduced',
-              tokensBefore: inputTokens,
-              contextWindow: this.config.contextWindow,
-              utilizationBefore:
-                validation.utilizationPercent ??
-                (inputTokens / this.config.contextWindow) * 100,
-              originalMaxTokens: currentMaxTokens,
-              reducedMaxTokens: validation.adjustedMaxTokens,
-              details: `OpenAI: ${maxTokensKey} reduced to fit context window`,
-            },
-          );
-          if (this.isOReasoningModel) {
-            baseParams.max_completion_tokens = validation.adjustedMaxTokens;
-          } else {
-            baseParams.max_tokens = validation.adjustedMaxTokens;
-          }
+    const maxTokensKey = this.isOReasoningModel
+      ? 'max_completion_tokens'
+      : 'max_tokens';
+    await this.applyTokenCountLimit({
+      countTokens: () =>
+        this.estimateTokenCount(messages, { client, systemPrompt, signal }),
+      currentMaxTokens: this.isOReasoningModel
+        ? (baseParams.max_completion_tokens ?? this.getEffectiveMaxOutputTokens())
+        : (baseParams.max_tokens ?? this.getEffectiveMaxOutputTokens()),
+      contextWindow: this.config.contextWindow,
+      detailLabel: `OpenAI: ${maxTokensKey} reduced to fit context window`,
+      applyReduced: (adjusted) => {
+        if (this.isOReasoningModel) {
+          baseParams.max_completion_tokens = adjusted;
+        } else {
+          baseParams.max_tokens = adjusted;
         }
-      } catch (err) {
-        tagOpenAISdkError(err, this.config.provider);
-        if (isContextWindowError(err)) throw err;
-        this.logger.debug(
-          `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
-        );
-      }
-    }
+      },
+    });
 
     // Phase 4: EXECUTE
     const response = useStreaming

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -712,7 +712,8 @@ export class ModelHandlerOpenAI<
       countTokens: () =>
         this.estimateTokenCount(messages, { client, systemPrompt, signal }),
       currentMaxTokens: this.isOReasoningModel
-        ? (baseParams.max_completion_tokens ?? this.getEffectiveMaxOutputTokens())
+        ? (baseParams.max_completion_tokens ??
+          this.getEffectiveMaxOutputTokens())
         : (baseParams.max_tokens ?? this.getEffectiveMaxOutputTokens()),
       contextWindow: this.config.contextWindow,
       detailLabel: `OpenAI: ${maxTokensKey} reduced to fit context window`,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1234,23 +1234,31 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // NOTE: When previous_response_id is set, the API includes server-side history
     // (per OpenAI docs). However, there may be edge cases where token counting
     // doesn't match actual context usage. See PRD Known Issues for investigation.
-    if (this.supportsTokenCounting) {
-      try {
-        // Reuse built params for token counting (build once principle)
-        // IMPORTANT: Pass tools and systemPrompt for accurate count
-        const inputTokens = await this.estimateTokenCount(baseParams.input, {
+    await this.applyTokenCountLimit({
+      // Reuse built params for token counting (build once principle).
+      // IMPORTANT: Pass tools and systemPrompt for accurate count.
+      countTokens: () =>
+        this.estimateTokenCount(baseParams.input, {
           client,
           signal,
           systemPrompt,
           tools: convertedTools,
-        });
-
-        // DIAGNOSTIC: Log token count details for investigation
-        // Compare pre-flight estimate with cumulative tokens from previous response
+        }),
+      currentMaxTokens: maxOutputTokens,
+      contextWindow: this.config.contextWindow,
+      tokenBuffer: this.getTokenSafetyBuffer(),
+      detailLabel:
+        'OpenAI Response: max_output_tokens reduced to fit context window',
+      applyReduced: (adjusted) => {
+        maxOutputTokens = adjusted;
+      },
+      onCounted: (inputTokens) => {
+        // DIAGNOSTIC: Log token count details for investigation.
+        // Compare pre-flight estimate with cumulative tokens from prev response.
         const prevCumulative = this.conversationState.cumulativeInputTokens;
         const utilizationEstimate =
           (inputTokens / this.config.contextWindow) * 100;
-        this._diagPreFlightTokens = inputTokens; // Store for comparison in finalizeResponse
+        this._diagPreFlightTokens = inputTokens; // Compared in finalizeResponse
         this.logger.debug(
           `[TOKEN_DIAG] Pre-flight count: ${inputTokens} (${utilizationEstimate.toFixed(1)}% of ${this.config.contextWindow})`,
           {
@@ -1268,38 +1276,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
             },
           },
         );
-
-        // Validate and adjust max_output_tokens if needed (throws if context window exceeded)
-        const tokenBuffer = this.getTokenSafetyBuffer();
-        const validation = this.validateTokenLimits(
-          inputTokens,
-          maxOutputTokens,
-          this.config.contextWindow,
-          tokenBuffer,
-        );
-
-        if (validation.adjustedMaxTokens !== maxOutputTokens) {
-          logContextManagementEvent(
-            this.logger,
-            `Token count (${inputTokens}) + max_output_tokens (${maxOutputTokens}) exceeds context window (${this.config.contextWindow}). Reducing to ${validation.adjustedMaxTokens}.`,
-            {
-              action: 'max_tokens_reduced',
-              tokensBefore: inputTokens,
-              contextWindow: this.config.contextWindow,
-              utilizationBefore:
-                validation.utilizationPercent ??
-                (inputTokens / this.config.contextWindow) * 100,
-              originalMaxTokens: maxOutputTokens,
-              reducedMaxTokens: validation.adjustedMaxTokens,
-              details:
-                'OpenAI Response: max_output_tokens reduced to fit context window',
-            },
-          );
-          maxOutputTokens = validation.adjustedMaxTokens;
-        }
-      } catch (err) {
-        tagOpenAISdkError(err, this.config.provider);
-        if (isContextWindowError(err)) throw err;
+      },
+      onCountFailure: (err) => {
         this.logger.debug(
           `Token counting failed: ${getSdkErrorMessage(err)}. Applying fallback cap.`,
         );
@@ -1317,8 +1295,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
             maxOutputTokens = capped;
           }
         }
-      }
-    }
+      },
+    });
 
     // Phase 4: EXECUTE - Build final params and make the API call
     const parallelToolCalls = getConfig<boolean>(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1078,6 +1078,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    *
    * @returns Result containing the response and optionally updated messages if compaction occurred
    */
+  protected override get sdkErrorTagger() {
+    return tagOpenAISdkError;
+  }
+
   override async createResponse(
     options: CreateResponseOptions<ResponseInputItem, OpenAI>,
   ): Promise<CreateResponseResult<Response, ResponseInputItem>> {
@@ -1093,7 +1097,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     this.inFlight = true;
     try {
       return await withSdkErrorTag(
-        tagOpenAISdkError,
+        this.sdkErrorTagger,
         this.config.provider,
         () => this.createResponseImpl(options),
       );


### PR DESCRIPTION
## Summary

Refactors token counting and context window validation logic across multiple model handlers (Anthropic, OpenAI, Google) into a single reusable `applyTokenCountLimit` method in the base `ModelHandler` class. This eliminates ~200 lines of duplicated error handling, validation, and logging code while maintaining identical behavior across all providers.

The new method encapsulates the "COUNT + VALIDATE" pattern: it estimates input tokens via an injected thunk, validates against context window limits, reduces max output tokens if needed, emits diagnostic events, and applies soft-failure semantics (proceeding without adjustment on token-counting API errors, but re-throwing context-window violations).

## Issue acceptance gates

N/A — This is a refactoring to reduce duplication and improve maintainability.

## Single source of truth

The `ModelHandler.applyTokenCountLimit()` method now owns the token counting and context window validation logic. All provider-specific handlers (Anthropic, OpenAI, Google) delegate to this method rather than reimplementing the same pattern.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated ~200 lines of nearly identical token counting + validation + error handling code across 4 files (Anthropic, OpenAI, Google, OpenAIResponse handlers)
- Consolidated soft-failure semantics, context-window error detection, and diagnostic logging into one place

**New abstraction:**
- `applyTokenCountLimit()` owns the invariant: "estimate input tokens, validate against context window, reduce max output if needed, emit events, apply soft failure"
- Parameterized via dependency injection (`countTokens` thunk, `applyReduced` callback) to remain provider-agnostic
- Supports optional overrides (`tokenBuffer`, `onCounted`, `onCountFailure`) for provider-specific customization without code duplication

## Host impact

Extension: No user-facing changes; internal refactoring only.

Desktop: No user-facing changes; internal refactoring only.

CLI: No impact.

## Scheduled refactoring

None.

## Validation

- Existing unit tests for token counting and context window validation continue to pass (no behavior changes)
- All four model handlers (Anthropic, OpenAI, Google, OpenAIResponse) now use the same validation logic, reducing the surface area for bugs
- Error handling paths (soft failure for API errors, fast-fail for context-window violations) remain identical to the original implementations

https://claude.ai/code/session_01S5kGpxhoPumbHhq58HUarq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared context-window and max-output token logic on every major provider path; intended behavior parity, but regressions would affect LLM request sizing and overflow handling.
> 
> **Overview**
> This PR **centralizes pre-flight token counting** in a new base-class helper `ModelHandler.applyTokenCountLimit`, replacing large duplicated COUNT + VALIDATE blocks in the Anthropic, Google, OpenAI chat, and OpenAI Responses handlers.
> 
> The helper runs only when `supportsTokenCounting` is true: it calls an injected `countTokens` thunk, applies `validateTokenLimits` (with tool-use `TOOL_USE_SAFETY_BUFFER` by default unless overridden), logs `max_tokens_reduced` via `logContextManagementEvent`, and writes the reduced cap through `applyReduced`. **Soft failure** on count API errors (debug log and continue) is preserved; **context-window violations** still fail fast via `isContextWindowError`. SDK errors are tagged with `sdkErrorTagger`.
> 
> Provider-specific behavior stays in callbacks: Anthropic still skips counting for file-based document sources and adjusts thinking `budget_tokens` in `applyReduced`; OpenAI Responses keeps diagnostic logging in `onCounted` and the output-token fallback cap in `onCountFailure`, and wires `sdkErrorTagger` to `tagOpenAISdkError` for `withSdkErrorTag`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82d4f4c7ba4dbd8c8b924737cd6481780992ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->