### PR TITLE
Route CLI model traffic to usage log with version tracking

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -9,6 +9,7 @@ import { render } from 'ink';
 import PQueue from 'p-queue';
 
 import { flushPendingRunTraces, getDefaultStreamLogStore } from '@transcript';
+import { tryPlatform } from '@platform/platform';
 import { getAgent, loadAgents } from '@agent/index';
 import { type AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -1399,6 +1400,13 @@ export async function runChat(
     flushPendingRunTraces();
     return getDefaultStreamLogStore().flush();
   };
+  // These TUI exit paths call process.exit() directly, so bin/texra.ts's
+  // `finally` (which runs platform shutdown) never fires. Run it here too so
+  // shutdown handlers — notably UsageLogService.dispose(), which flushes any
+  // queued usage entries — execute before the process dies. runShutdown is
+  // idempotent, so the normal return path can still rely on bin/texra.ts.
+  const runPlatformShutdown = (): Promise<void> =>
+    tryPlatform()?.lifecycle.runShutdown() ?? Promise.resolve();
   const exitNow = (exitCode: number): void => {
     exiting = true;
     removeProcessHandlers();
@@ -1412,11 +1420,13 @@ export async function runChat(
     cleanupTerminalModes({ clearItermProgress });
     // Synchronous signal exits (SIGINT double-tap / SIGTERM / SIGHUP) own the
     // whole teardown here (the finally skips when `exiting`), so drain
-    // persistence before exiting. `.catch` keeps a flush failure from becoming
-    // an unhandled rejection under --unhandled-rejections=strict.
-    void drainPersistence()
-      .catch(() => {})
-      .finally(() => process.exit(exitCode));
+    // persistence and run platform shutdown before exiting. allSettled never
+    // rejects, so a flush failure can't become an unhandled rejection under
+    // --unhandled-rejections=strict.
+    void Promise.allSettled([
+      drainPersistence(),
+      runPlatformShutdown(),
+    ]).finally(() => process.exit(exitCode));
   };
   const armExit = (): void => {
     exitArmed = true;
@@ -1541,7 +1551,9 @@ export async function runChat(
         // The dangling runPromise keeps the event loop alive, so a normal return
         // would never let the process exit. Force-exit here, AFTER persistence
         // is flushed and the resume hint is printed, preserving the suspended
-        // flow record on disk for `texra --resume`.
+        // flow record on disk for `texra --resume`. Run platform shutdown first
+        // so queued usage logs flush — bin/texra.ts's finally won't on exit().
+        await runPlatformShutdown();
         process.exit(session.runExitCode);
       }
     }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -24,6 +24,9 @@ import { GlobalStateKey } from '@common/state/stateKeys';
 // Local imports - logger
 import { setOutputChannelFactory } from '@logger/logUtils';
 
+// Local imports - telemetry
+import { UsageLogService } from '@telemetry/UsageLogService';
+
 // Local imports - tool integrations
 import { setTexraCliEntrypointChecker } from '@tools/externalToolDefs';
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
@@ -53,7 +56,7 @@ type CliShutdownSignal = 'SIGINT' | 'SIGTERM';
 
 type CliPlatformInitOptions = Pick<
   CliContext,
-  'apiMode' | 'cwd' | 'resourcesPath' | 'helperModel'
+  'apiMode' | 'cwd' | 'resourcesPath' | 'helperModel' | 'version'
 > & {
   readonly bestEffortIncludedModelAccess?: boolean;
   readonly installSignalHandlers?: boolean;
@@ -190,6 +193,16 @@ export async function initCliPlatform(
     // Attribute agent-authored commits to the TeXRA identity by default;
     // configurable via `.texra/config.json` `texra.git.markCommits`.
     applyCliGitAuthorConfig(config);
+
+    // Route CLI model traffic to the same Supabase usage log the extension
+    // writes to, tagged with editorType 'cli' and the CLI version so relay
+    // pricing stays version-aware. dispose() flushes any queued entries; it
+    // runs on normal exit (bin/texra.ts finally) and on signals, both of
+    // which call lifecycle.runShutdown().
+    UsageLogService.initialize({}, context.version, 'cli');
+    lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+      UsageLogService.dispose(),
+    );
   }
 
   if (!serverSideKeysInitialized) {

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -201,6 +201,10 @@ class UsageLogServiceImpl {
     this.flushTimer = setInterval(() => {
       void this.flush();
     }, this.config.flushIntervalMs);
+    // Don't let the periodic flush keep a short-lived host (the CLI) alive: an
+    // active run keeps the loop running so the interval still fires, but at exit
+    // dispose() flushes and clears it rather than the timer blocking shutdown.
+    this.flushTimer.unref?.();
   }
 
   private stopFlushTimer(): void {

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -49,6 +49,10 @@ vi.mock('@tools/externalToolDefs', () => ({
   setTexraCliEntrypointChecker: vi.fn(),
 }));
 
+vi.mock('@telemetry/UsageLogService', () => ({
+  UsageLogService: { initialize: vi.fn(), dispose: vi.fn() },
+}));
+
 function cliContext(
   overrides: Partial<CliContext> & {
     bestEffortIncludedModelAccess?: boolean;

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { initCliPlatform } from '@cli/runtime/initPlatform';
+import { UsageLogService } from '@telemetry/UsageLogService';
 import type { CliContext } from '@cli/runtime/cliContext';
 
 const mocks = vi.hoisted(() => ({
@@ -15,6 +16,10 @@ const mocks = vi.hoisted(() => ({
   },
   setRuntimeSkillSources: vi.fn(),
   tryPlatform: vi.fn(),
+  // Collects callbacks registered via the (mocked) lifecycle host's onShutdown
+  // so a test can run them and assert the usage-log dispose was wired.
+  shutdownHandlers: [] as Array<() => unknown>,
+  leanAdapter: { dispose: vi.fn() },
 }));
 
 vi.mock('@agent/index/platformAgentDirectories', () => ({
@@ -53,14 +58,61 @@ vi.mock('@telemetry/UsageLogService', () => ({
   UsageLogService: { initialize: vi.fn(), dispose: vi.fn() },
 }));
 
+// First-init dependencies: only exercised when tryPlatform() returns undefined.
+// The existing auth-probe tests keep tryPlatform truthy and skip this block, so
+// these stubs are inert there and only drive the "first init" test below.
+vi.mock('@platform/defaults/lifecycleHost', () => ({
+  createLifecycleHost: () => ({
+    onShutdown: (_phase: unknown, callback: () => unknown) => {
+      mocks.shutdownHandlers.push(callback);
+      return { dispose: vi.fn() };
+    },
+    runShutdown: vi.fn(),
+  }),
+}));
+
+vi.mock('@platform/defaults/jsonStore', () => ({
+  JsonStore: { open: vi.fn().mockResolvedValue({}) },
+}));
+
+vi.mock('@platform/defaults/jsonConfigProvider', () => ({
+  JsonConfigProvider: vi.fn(),
+}));
+
+vi.mock('@platform/defaults/nodeFilesystem', () => ({ nodeFilesystem: {} }));
+
+vi.mock('@platform/defaults/nodeWorkspace', () => ({
+  createNodeWorkspace: vi.fn(() => ({})),
+}));
+
+vi.mock('@cli/runtime/cliStateStores', () => ({
+  createCliStateStores: vi.fn().mockResolvedValue({
+    globalState: { update: vi.fn() },
+    workspaceState: {},
+    storage: {},
+  }),
+}));
+
+vi.mock('@cli/runtime/gitAuthor', () => ({ applyCliGitAuthorConfig: vi.fn() }));
+
+vi.mock('@tools/lean/direct/directLspAdapter', () => ({
+  createDirectLspLeanAdapter: () => mocks.leanAdapter,
+}));
+
+vi.mock('@tools/lean/leanLanguageServices', () => ({
+  setLeanLanguageServices: vi.fn(),
+}));
+
 function cliContext(
   overrides: Partial<CliContext> & {
     bestEffortIncludedModelAccess?: boolean;
+    installSignalHandlers?: boolean;
   } = {},
 ): Parameters<typeof initCliPlatform>[0] {
   return {
     cwd: '/tmp/project',
     resourcesPath: '/tmp/resources',
+    version: '0.0.0-test',
     quietLogs: true,
     ...overrides,
   };
@@ -69,6 +121,7 @@ function cliContext(
 describe('CLI platform init', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.shutdownHandlers.length = 0;
     mocks.tryPlatform.mockReturnValue({
       globalState: {
         update: vi.fn(),
@@ -78,6 +131,27 @@ describe('CLI platform init', () => {
     mocks.serverSideKeyService.setUseIncludedModelAccess.mockResolvedValue(
       undefined,
     );
+  });
+
+  it('wires usage logging on first platform init', async () => {
+    // tryPlatform() === undefined drives the once-per-process first-init block.
+    mocks.tryPlatform.mockReturnValue(undefined);
+    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+
+    await initCliPlatform(
+      cliContext({ version: '1.2.3', installSignalHandlers: false }),
+    );
+
+    expect(vi.mocked(UsageLogService.initialize)).toHaveBeenCalledWith(
+      {},
+      '1.2.3',
+      'cli',
+    );
+
+    // The dispose handler must be registered on shutdown so queued entries flush.
+    expect(vi.mocked(UsageLogService.dispose)).not.toHaveBeenCalled();
+    for (const handler of mocks.shutdownHandlers) await handler();
+    expect(vi.mocked(UsageLogService.dispose)).toHaveBeenCalled();
   });
 
   it('surfaces included-access auth probe failures by default', async () => {


### PR DESCRIPTION
## Summary

Integrate the CLI with the telemetry usage log service to track model traffic alongside the VS Code extension. This ensures CLI usage is properly attributed with version information for relay pricing awareness and consistent telemetry across all TeXRA hosts.

## Issue acceptance gates

Not specified in diff context.

## Single source of truth

`UsageLogService` in `@telemetry/UsageLogService` now owns the initialization and lifecycle management of usage logging for both the extension and CLI hosts. The CLI passes its version and `'cli'` editor type identifier during initialization.

## Duplication and abstraction budget

No duplication removed. `UsageLogService` is reused across hosts (extension and CLI) rather than duplicating telemetry logic, leveraging the existing abstraction.

## Host impact

**Extension:** No changes.

**Desktop:** No changes.

**CLI:** Now initializes `UsageLogService` during platform initialization with the CLI version and editor type identifier. Usage log entries are flushed on shutdown via the lifecycle manager.

## Scheduled refactoring

None.

## Validation

- Added mock for `UsageLogService` in CLI test suite (`CliInitPlatform.vitest.mts`)
- Existing test infrastructure covers initialization path
- No new test cases needed; mocking ensures the service is properly called during platform init

https://claude.ai/code/session_01HFyyAGnFmW5Htm6EiH1sQs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and shutdown wiring only; no auth or model-call logic changes beyond flushing queued usage on exit paths already handling persistence.
> 
> **Overview**
> The CLI now **initializes `UsageLogService`** on first platform boot with the CLI **version** and `editorType: 'cli'`, matching the extension’s Supabase usage log and tagging relay traffic for version-aware pricing. **`UsageLogService.dispose()`** is registered on the platform lifecycle **before** shutdown so queued entries flush on normal exit and signal handlers.
> 
> **Interactive chat TUI** exits that call **`process.exit()`** directly (signals, resumable-idle) previously skipped `bin/texra.ts`’s `finally`, so they now also invoke **`lifecycle.runShutdown()`** alongside stream-log persistence—so usage logs flush on those paths too.
> 
> The usage log’s periodic flush timer is **`unref()`’d** so it does not keep a short-lived CLI process alive after the main work finishes.
> 
> Tests assert first-init wires **`initialize({}, version, 'cli')`** and that shutdown handlers call **`dispose()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189500768b3059296f13728d815362fb1ac729e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->