### PR TITLE
Refactor output file extraction and CLI platform initialization

### DIFF
--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -4,7 +4,7 @@ import {
   resolveConfiguredModel,
 } from '@cli/runtime/cliConfig';
 import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
-import { initCliPlatform } from '@cli/runtime/initPlatform';
+import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import { writeTextStderr } from '@cli/runtime/logSinks';
 import {
   cliRunnableModelOptionsForSource,
@@ -88,6 +88,7 @@ export async function resolveCliRunModel(
     if (resolution.notice && context.quietLogs !== true) {
       writeTextStderr(resolution.notice);
     }
+    await setCliHelperModel(resolution.model);
     return resolution.model;
   } catch (error: unknown) {
     throw new CliUsageError(toErrorMessage(error));

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -15,7 +15,6 @@ import {
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
-import { initCliPlatform } from '../runtime/initPlatform';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 
 import {
@@ -90,7 +89,6 @@ async function runToolUseAgent(
     return CliExitCode.Usage;
   }
 
-  await initCliPlatform(runContext);
   await loadAgents({ includeRemote: false });
   const agent = await resolveAgentWithRemoteFallback(init.agent);
 

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -328,7 +328,6 @@ export async function runMultiAgentPreset(
         stdinInputFile,
       },
     );
-    await initCliPlatform(runContext);
     installCliApprovalHandlers(runContext);
     writeApprovalUnavailableDelegationWarning(runContext, plan);
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -13,7 +13,6 @@ import { generateExecutionId } from '@utils/core/executionId';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { CliUsageError, readCliStdinText } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
-import { initCliPlatform } from '../runtime/initPlatform';
 import { writeErrorStderr } from '../runtime/logSinks';
 
 import { missingAgentMessage } from './_helpers/agentLookupText';
@@ -76,7 +75,6 @@ async function runWorkflowAgent(
   // full agent run otherwise.
   await assertOutputFileAvailable(init.output, runContext.cwd);
 
-  await initCliPlatform(runContext);
   await loadAgents({ includeRemote: false });
   const agent = await resolveAgentWithRemoteFallback(init.agent);
   // Pre-validate the resolved agent so usage errors land before stdin is read

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -9,7 +9,7 @@ import {
   setCompileFailures,
 } from '@agent/output/outputState';
 import { runCompileCheck } from '@agent/output/compileCheck';
-import { extractFilesFromXml } from '@agent/output/xmlExtraction';
+import { extractFilesFromXml } from '@agent/output/outputFileExtraction';
 import { traceFileLineage } from '@agent/output/lineageMapping';
 import { resolveBaseFilesForDiff } from '@agent/output/snapshotResolution';
 import { checkExpectedOutputs } from '@agent/output/outputValidation';

--- a/src/agent/output/outputFileExtraction.ts
+++ b/src/agent/output/outputFileExtraction.ts
@@ -1,10 +1,12 @@
 /**
- * XML file extraction for output processing.
+ * Output file extraction orchestration.
  *
- * Extracts output files from XML responses.
- * All agents use the unified protocol and produce <documents><document name="...">
- * containers (N >= 1), extracted via the multi-document path regardless of output
- * file count.
+ * Drives the agent output pipeline: waits for workspace preparation, builds
+ * a ProcessingContext, then dispatches to OutputFileProcessor to unpack
+ * <documents><document name="..."> containers from the model's XML response.
+ *
+ * Note: this module is about the *agent output pipeline*, not general XML
+ * parsing. Low-level XML text utilities live in @utils/text/xmlExtraction.
  */
 
 import type { StageHandle } from '@agent/trace';

--- a/src/common/files/index.ts
+++ b/src/common/files/index.ts
@@ -1,5 +1,4 @@
 // Barrel export for common file utilities
-export { isFile, isDirectory, isSymlink } from '@utils/files/fsEntryType';
 export {
   ExtensionCategory,
   getFilterExtensions,

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -14,6 +14,7 @@ import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
 
 const mocks = vi.hoisted(() => ({
   initCliPlatform: vi.fn(),
+  setCliHelperModel: vi.fn(),
   getCliApiMode: vi.fn(),
   resolveCliRunnableModel: vi.fn(),
   writeTextStderr: vi.fn(),
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@cli/runtime/initPlatform', () => ({
   initCliPlatform: mocks.initCliPlatform,
+  setCliHelperModel: mocks.setCliHelperModel,
 }));
 
 vi.mock('@cli/runtime/apiAccessMode', () => ({
@@ -64,10 +66,12 @@ const runConfig = (model: string): CliConfigValues => ({ run: { model } });
 describe('resolveCliRunModel precedence', () => {
   beforeEach(() => {
     mocks.initCliPlatform.mockReset();
+    mocks.setCliHelperModel.mockReset();
     mocks.getCliApiMode.mockReset();
     mocks.resolveCliRunnableModel.mockReset();
     mocks.writeTextStderr.mockReset();
     mocks.initCliPlatform.mockResolvedValue(undefined);
+    mocks.setCliHelperModel.mockResolvedValue(undefined);
     mocks.getCliApiMode.mockReturnValue('personal');
     resolveCliRunnableModelMock.mockImplementation(async (model) => ({
       model,

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -135,6 +135,7 @@ describe('resolveCliRunModel precedence', () => {
         fallbackMode: 'silent',
       },
     );
+    expect(mocks.setCliHelperModel).toHaveBeenCalledWith(CLI_BUILTIN_DEFAULT_MODEL);
   });
 
   it('checks active API-mode access before returning the model', async () => {
@@ -160,6 +161,7 @@ describe('resolveCliRunModel precedence', () => {
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       'Using deepseekT instead.',
     );
+    expect(mocks.setCliHelperModel).toHaveBeenCalledWith('deepseekT');
   });
 
   it('does not fall back from an explicit unavailable model', async () => {
@@ -193,6 +195,7 @@ describe('resolveCliRunModel precedence', () => {
       apiMode: 'personal',
       fallbackMode: 'reject',
     });
+    expect(mocks.setCliHelperModel).toHaveBeenCalledWith('opus48T');
   });
 });
 

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -135,7 +135,9 @@ describe('resolveCliRunModel precedence', () => {
         fallbackMode: 'silent',
       },
     );
-    expect(mocks.setCliHelperModel).toHaveBeenCalledWith(CLI_BUILTIN_DEFAULT_MODEL);
+    expect(mocks.setCliHelperModel).toHaveBeenCalledWith(
+      CLI_BUILTIN_DEFAULT_MODEL,
+    );
   });
 
   it('checks active API-mode access before returning the model', async () => {


### PR DESCRIPTION
## Summary

This PR consolidates and clarifies the agent output pipeline architecture while improving CLI platform initialization flow:

1. **Renamed `xmlExtraction.ts` → `outputFileExtraction.ts`** with updated module documentation to clarify that this module orchestrates the agent output pipeline (waiting for workspace preparation, building ProcessingContext, dispatching to OutputFileProcessor), not general XML parsing. Low-level XML utilities remain in `@utils/text/xmlExtraction`.

2. **Centralized CLI platform initialization** by moving `initCliPlatform()` calls from individual command handlers (`agentsRun`, `workflow`, `multiAgent`) into the model resolution flow via a new `setCliHelperModel()` function in `initPlatform`. This ensures platform initialization happens once during model resolution rather than being scattered across multiple command entry points.

3. **Removed unused export** from `src/common/files/index.ts` (fsEntryType utilities that were not being used by consumers).

## Issue acceptance gates

N/A — this is a refactoring to improve code organization and reduce duplication.

## Single source of truth

- **Agent output pipeline**: `src/agent/output/outputFileExtraction.ts` now owns the orchestration logic and clearly documents the boundary between high-level pipeline coordination and low-level XML text utilities.
- **CLI platform initialization**: `packages/cli/src/runtime/initPlatform.ts` now owns the responsibility for setting up the platform state, triggered during model resolution in `resolveCliRunModel()`.

## Duplication and abstraction budget

- **Removed duplication**: Eliminated three separate `await initCliPlatform(runContext)` calls across `agentsRun.ts`, `workflow.ts`, and `multiAgent.ts` by centralizing initialization in the model resolution path.
- **Improved abstraction**: The renamed module and updated documentation clarify the architectural boundary between the agent output orchestration layer and low-level XML utilities, reducing cognitive load for future maintainers.

## Host impact

**CLI**: Platform initialization now happens automatically during model resolution, simplifying command handlers and ensuring consistent initialization order.

**Extension**: No impact.

**Desktop**: No impact.

## Scheduled refactoring

None.

## Validation

- Import path updated in `OutputNode.ts` to reflect the renamed module.
- All `initCliPlatform` call sites removed from command handlers; initialization now occurs in `resolveCliRunModel()` via `setCliHelperModel()`.
- Unused export removed from barrel file.
- No functional behavior changes; refactoring only.

https://claude.ai/code/session_011WmLkH47gj7LxdsZU44TNP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: import rename, doc updates, and moving duplicate CLI init without changing agent execution semantics.
> 
> **Overview**
> Renames the agent output orchestration module from `xmlExtraction` to **`outputFileExtraction`** and updates **`OutputNode`** imports so the name reflects pipeline orchestration (workspace prep → `OutputFileProcessor`), not generic XML parsing in `@utils/text/xmlExtraction`.
> 
> **CLI:** After a runnable model is resolved, **`resolveCliRunModel`** now calls **`setCliHelperModel`** so helper/platform state is set in one place. **`agentsRun`**, **`workflow`**, and **`multi-agent run`** drop their redundant **`initCliPlatform(runContext)`** calls (platform init remains on the model-resolution path via **`initCliPlatform`** in **`modelArg`**).
> 
> Removes an unused **`fsEntryType`** re-export from **`src/common/files`**. Tests assert **`setCliHelperModel`** is invoked with the resolved model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c0f7845c28ca8cd52a2d43fb1a47a215cd58607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->