### PR TITLE
[codex] Allow live CLI model switching

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -34,8 +34,10 @@ import { TodosPlanPanel, todosPlanPanelRowCount } from './panes/TodosPlanPanel';
 import { currentApproval, type PendingApproval } from './state/approvalQueue';
 import {
   isKittyKeypadEnter,
+  isKittyShiftEnter,
   metaChordDigit,
   metaChordInput,
+  SYNTHETIC_SHIFT_RETURN_INPUT,
 } from './input/inputKeys';
 import {
   hasChildControlItems,
@@ -386,14 +388,20 @@ export function App(props: AppProps): React.JSX.Element {
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
 
-  // Under the Kitty disambiguate flag (enabled in runChatTui for Shift+Enter),
-  // keypad Enter becomes its own key (codepoint 57414) that Ink parses but
-  // exposes no `useInput` field for — so it would silently stop submitting.
-  // Re-dispatch it on Ink's own input channel as a plain Enter (CR) so every
-  // submit/confirm path that keys off `key.return` keeps working. Inert when the
-  // protocol is off — the sequence never arrives. (Ctrl+C needs no such bridge:
-  // Ink decodes its CSI-u form to a normal ctrl+c key, handled in useInput below.)
   const stdin = useStdin();
+  const foregroundOpen =
+    pending !== undefined ||
+    activeForm !== undefined ||
+    childControlMode !== undefined ||
+    transcriptViewerOpen;
+  const inputDisabled = props.inputDisabled === true || foregroundOpen;
+  const inputBarVisible = !foregroundOpen;
+
+  // Under the Kitty disambiguate flag (enabled in runChatTui for Shift+Enter),
+  // some Enter variants arrive as CSI-u sequences that Ink parses incompletely.
+  // Re-dispatch keypad Enter as plain Enter so submit/confirm still works, and
+  // Shift+Enter as an internal newline token only while the main draft input is
+  // active so modals/selects keep treating Shift+Enter as ordinary confirmation.
   useEffect(() => {
     const emitter = (
       stdin as unknown as { internal_eventEmitter?: InputEventEmitterLike }
@@ -402,18 +410,15 @@ export function App(props: AppProps): React.JSX.Element {
     const onInput = (data: string): void => {
       if (isKittyKeypadEnter(data)) {
         emitter.emit('input', String.fromCharCode(13));
+        return;
+      }
+      if (!inputDisabled && isKittyShiftEnter(data)) {
+        emitter.emit('input', SYNTHETIC_SHIFT_RETURN_INPUT);
       }
     };
     emitter.on('input', onInput);
     return () => emitter.off('input', onInput);
-  }, [stdin]);
-  const foregroundOpen =
-    pending !== undefined ||
-    activeForm !== undefined ||
-    childControlMode !== undefined ||
-    transcriptViewerOpen;
-  const inputDisabled = props.inputDisabled === true || foregroundOpen;
-  const inputBarVisible = !foregroundOpen;
+  }, [inputDisabled, stdin]);
 
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const queuedFollowUpMessages = activeSlice?.queuedFollowUpMessages ?? [];

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -1,7 +1,7 @@
 // `/model` form. It loads the same registry used by `texra models list`, then
 // shows only the entries that can run in the active API mode. Before the first
-// message it can choose the root model; after that it is read-only because an
-// active conversation owns a concrete model handler.
+// message it chooses the root model; once a tool-use chat is waiting, it can
+// switch the live conversation to a compatible model for future turns.
 
 import { Box, Text, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
@@ -199,8 +199,8 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
       </Text>
       <Text dimColor>
         {selectable
-          ? 'Choose the root model for the first message.'
-          : 'Available models. Start a new chat with texra chat --model=<name> to choose the root model.'}
+          ? 'Choose the model for future turns.'
+          : 'Available models. Finish the active response before switching models.'}
       </Text>
       {items.length === 0 ? (
         <EmptyModelListState

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -6,6 +6,8 @@ export interface ReturnKeyInput {
   readonly escape?: boolean;
 }
 
+export const SYNTHETIC_SHIFT_RETURN_INPUT = '\uE000';
+
 const RAW_CONTROL_INPUTS = new Map<number, string>([
   [1, 'a'],
   [5, 'e'],
@@ -96,6 +98,7 @@ export function isShiftReturnInput(
   input: string,
   key: ReturnKeyInput,
 ): boolean {
+  if (input === SYNTHETIC_SHIFT_RETURN_INPUT) return true;
   if (key.ctrl || key.meta || key.shift !== true) return false;
   return key.return === true || input === '\r' || input === '\n';
 }
@@ -111,6 +114,15 @@ const KITTY_KEYPAD_ENTER = new Set([
   `${String.fromCharCode(27)}[57414;1u`,
 ]);
 
+const KITTY_SHIFT_ENTER = new Set([
+  `${String.fromCharCode(27)}[13;2u`,
+  `${String.fromCharCode(27)}[13:2u`,
+]);
+
 export function isKittyKeypadEnter(data: string): boolean {
   return KITTY_KEYPAD_ENTER.has(data);
+}
+
+export function isKittyShiftEnter(data: string): boolean {
+  return KITTY_SHIFT_ENTER.has(data);
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -241,6 +241,22 @@ export function chatTuiCanStartRootRun(
   return !session.runPromise || session.runCompleted;
 }
 
+export function chatTuiCanSelectModel(input: {
+  readonly canStartRootRun: boolean;
+  readonly streamId: StreamTabId | undefined;
+  readonly status: StreamStatus | undefined;
+  readonly hasActiveToolUseFlow: boolean;
+}): boolean {
+  return (
+    input.canStartRootRun ||
+    Boolean(
+      input.streamId &&
+      input.status === STREAM_STATUS.WAITING &&
+      input.hasActiveToolUseFlow,
+    )
+  );
+}
+
 export type ChatTuiSigintAction =
   | 'clean-exit'
   | 'force-exit'
@@ -345,6 +361,7 @@ interface SlashCommandContext {
   readonly requestInputExit: () => void;
   readonly getApprovalPolicy: () => CliApprovalPolicy;
   readonly setApprovalPolicy: (policy: CliApprovalPolicy) => void;
+  readonly canSelectModel: () => boolean;
   readonly resetSession: () => void;
   readonly resumeExecution: (id: ExecutionId) => Promise<void>;
 }
@@ -377,24 +394,52 @@ function applyInitialCliAgentSelection(
   appendLocalAssistantTranscript(`Root agent set to ${nextAgent}.`);
 }
 
-async function applyInitialCliModelSelection(
+async function applyCliModelSelection(
   model: string,
   context: SlashCommandContext,
 ): Promise<void> {
-  if (!chatTuiCanStartRootRun(context.session)) {
+  const nextModel = model.trim();
+  if (chatTuiCanStartRootRun(context.session)) {
+    try {
+      await setCliHelperModel(nextModel);
+      cliState.sessionMeta.set({
+        ...cliState.sessionMeta.get(),
+        model: nextModel,
+      });
+      appendLocalAssistantTranscript(`Root model set to ${nextModel}.`);
+    } catch (error: unknown) {
+      appendLocalAssistantTranscript(toErrorMessage(error));
+    }
+    return;
+  }
+
+  if (!context.canSelectModel()) {
     appendLocalAssistantTranscript(
-      'Model changes are only available before the first message. Start a new chat with texra chat --model=<name> to choose a different root model.',
+      'Finish the active response before switching models.',
     );
     return;
   }
-  const nextModel = model.trim();
+
+  const activeFlow = context.session.streamId
+    ? getToolUseFlowContext(context.session.streamId)
+    : undefined;
+  if (!activeFlow) {
+    appendLocalAssistantTranscript(
+      'Model switching is only available for an active tool-use chat. Start a new chat with texra chat --model=<name> to choose a different root model.',
+    );
+    return;
+  }
+
   try {
+    await activeFlow.switchModel(nextModel);
     await setCliHelperModel(nextModel);
     cliState.sessionMeta.set({
       ...cliState.sessionMeta.get(),
       model: nextModel,
     });
-    appendLocalAssistantTranscript(`Root model set to ${nextModel}.`);
+    appendLocalAssistantTranscript(
+      `Model switched to ${nextModel}. Future turns will use it.`,
+    );
   } catch (error: unknown) {
     appendLocalAssistantTranscript(toErrorMessage(error));
   }
@@ -926,6 +971,7 @@ export async function runChat(
     requestInputExit,
     getApprovalPolicy,
     setApprovalPolicy,
+    canSelectModel: canSelectCurrentModel,
     resetSession: resetSessionForClear,
     resumeExecution: resumeAgentRun,
   });
@@ -987,6 +1033,15 @@ export async function runChat(
       ? (cliState.streams.get().get(session.streamId)?.status ??
         StreamStatusService.get(session.streamId))
       : undefined;
+  const hasActiveToolUseFlow = (): boolean =>
+    Boolean(session.streamId && getToolUseFlowContext(session.streamId));
+  const canSelectCurrentModel = (): boolean =>
+    chatTuiCanSelectModel({
+      canStartRootRun: chatTuiCanStartRootRun(session),
+      streamId: session.streamId,
+      status: rootStreamStatus(),
+      hasActiveToolUseFlow: hasActiveToolUseFlow(),
+    });
   const canInterruptActiveRun = (): boolean =>
     chatTuiCanInterruptActiveRun(session);
   const canStopActiveRun = (): boolean =>
@@ -1222,9 +1277,9 @@ export async function runChat(
         `Approval mode set to ${formatApprovalPolicy(policy)}.`,
       );
     },
-    canSelectModel: () => chatTuiCanStartRootRun(session),
+    canSelectModel: canSelectCurrentModel,
     onModelSelect: (nextModel) =>
-      applyInitialCliModelSelection(nextModel, slashCommandContext()),
+      applyCliModelSelection(nextModel, slashCommandContext()),
     onApiModeSelect: (nextMode) =>
       applyCliApiModeSelection(nextMode, slashCommandContext()),
     onMemorySelect: showCliMemoryPreview,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -432,17 +432,27 @@ async function applyCliModelSelection(
 
   try {
     await activeFlow.switchModel(nextModel);
-    await setCliHelperModel(nextModel);
     cliState.sessionMeta.set({
       ...cliState.sessionMeta.get(),
       model: nextModel,
     });
-    appendLocalAssistantTranscript(
-      `Model switched to ${nextModel}. Future turns will use it.`,
-    );
   } catch (error: unknown) {
     appendLocalAssistantTranscript(toErrorMessage(error));
+    return;
   }
+
+  try {
+    await setCliHelperModel(nextModel);
+  } catch (error: unknown) {
+    appendLocalAssistantTranscript(
+      `Model switched to ${nextModel}. Could not persist it as the default helper model: ${toErrorMessage(error)}`,
+    );
+    return;
+  }
+
+  appendLocalAssistantTranscript(
+    `Model switched to ${nextModel}. Future turns will use it.`,
+  );
 }
 
 async function reconcileRootModelAfterApiModeChange(

--- a/packages/cli/src/runtime/accountDisplay.ts
+++ b/packages/cli/src/runtime/accountDisplay.ts
@@ -1,22 +1,18 @@
 const EMAIL_LIKE_ACCOUNT_PATTERN =
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
-const EMAIL_LIKE_ACCOUNT_EXACT_PATTERN =
-  /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 
 function maskIdentifierPart(part: string): string {
   return part ? `${part.at(0)}***` : '***';
 }
 
 export function formatCliAccountLabelForDisplay(accountLabel: string): string {
-  const trimmed = accountLabel.trim();
-  if (!EMAIL_LIKE_ACCOUNT_EXACT_PATTERN.test(trimmed)) {
-    return trimmed;
-  }
+  return accountLabel.trim();
+}
 
-  const atIndex = trimmed.indexOf('@');
-
-  const localPart = trimmed.slice(0, atIndex);
-  const domain = trimmed.slice(atIndex + 1);
+function redactEmailAccountLabel(accountLabel: string): string {
+  const atIndex = accountLabel.indexOf('@');
+  const localPart = accountLabel.slice(0, atIndex);
+  const domain = accountLabel.slice(atIndex + 1);
   const domainParts = domain.split('.');
   const suffix = domainParts.length > 1 ? domainParts.at(-1) : undefined;
   const domainName = suffix ? domainParts.slice(0, -1).join('.') : domain;
@@ -28,6 +24,6 @@ export function formatCliAccountLabelForDisplay(accountLabel: string): string {
 
 export function redactEmailAccountLabelsForDisplay(text: string): string {
   return text.replaceAll(EMAIL_LIKE_ACCOUNT_PATTERN, (accountLabel) =>
-    formatCliAccountLabelForDisplay(accountLabel),
+    redactEmailAccountLabel(accountLabel),
   );
 }

--- a/src/test-kernel/cli/ApiStatus.vitest.mts
+++ b/src/test-kernel/cli/ApiStatus.vitest.mts
@@ -32,16 +32,16 @@ describe('CLI API status text', () => {
     );
   });
 
-  it('redacts email account labels before showing auth status in the TUI', () => {
+  it('shows account labels plainly in auth status', () => {
     expect(formatCliAccountLabelForDisplay('sirui.lu.phys@gmail.com')).toBe(
-      's***@g***.com',
+      'sirui.lu.phys@gmail.com',
     );
     expect(
       formatCliAuthStatusLine({
         authenticated: true,
         accountLabel: 'user@example.edu',
       }),
-    ).toBe('auth: signed in as u***@e***.edu');
+    ).toBe('auth: signed in as user@example.edu');
   });
 
   it('keeps non-email account labels readable', () => {

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -171,6 +171,32 @@ describe('slashRegistry', () => {
     expect(cliState.activeForm.get()?.commandName).toBe('agent');
   });
 
+  it('keeps the model picker selectable after root agent selection is closed', () => {
+    resetCliState({
+      agent: 'chat',
+      model: 'deepseekT',
+      cwd: '/tmp/workspace',
+      apiMode: 'included',
+      canDelegate: false,
+      version: 'test',
+    });
+    registerBuiltinSlashCommands({
+      canSelectAgent: () => false,
+      canSelectModel: () => true,
+    });
+    const model = listSlashCommands().find((cmd) => cmd.name === 'model');
+
+    if (!model) throw new Error('Expected /model to be registered');
+
+    expect(openRegisteredCliSlashForm(model, '')).toBe(true);
+
+    const modelNode = renderFormAdapter<{
+      selectable?: boolean;
+    }>(cliState.activeForm.get()?.render(() => {}, 20));
+
+    expect(modelNode.props).toMatchObject({ selectable: true });
+  });
+
   it('routes API picker selection failures to the shared error handler', async () => {
     resetCliState({
       agent: 'chat',

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -14,11 +14,13 @@ import {
   isEscapeInput,
   isUnhandledControlInput,
   isKittyKeypadEnter,
+  isKittyShiftEnter,
   isPlainReturnInput,
   isShiftReturnInput,
   metaChordDigit,
   metaChordInput,
   normalizedCtrlInput,
+  SYNTHETIC_SHIFT_RETURN_INPUT,
 } from '@cli/chat/tui/input/inputKeys';
 
 const ESC = String.fromCharCode(27);
@@ -38,19 +40,23 @@ describe('CLI TUI text input editing', () => {
 
   it('treats Shift+Enter as a newline, distinct from plain Enter and Ctrl-J', () => {
     expect(isShiftReturnInput('', { return: true, shift: true })).toBe(true);
+    expect(isShiftReturnInput(SYNTHETIC_SHIFT_RETURN_INPUT, {})).toBe(true);
     // Plain Enter, Ctrl-J, and Option+Enter are not Shift+Enter.
     expect(isShiftReturnInput('', { return: true })).toBe(false);
     expect(isShiftReturnInput('j', { ctrl: true })).toBe(false);
     expect(isShiftReturnInput('', { return: true, meta: true })).toBe(false);
   });
 
-  it('recognizes the Kitty keypad-Enter sequence for re-dispatch as Enter', () => {
+  it('recognizes Kitty Enter sequences for raw re-dispatch', () => {
     expect(isKittyKeypadEnter(`${ESC}[57414u`)).toBe(true);
     expect(isKittyKeypadEnter(`${ESC}[57414;1u`)).toBe(true);
+    expect(isKittyShiftEnter(`${ESC}[13;2u`)).toBe(true);
+    expect(isKittyShiftEnter(`${ESC}[13:2u`)).toBe(true);
     // Main Enter, plain CR, and modified keypad Enter must not match.
     expect(isKittyKeypadEnter('\r')).toBe(false);
     expect(isKittyKeypadEnter(`${ESC}[13u`)).toBe(false);
     expect(isKittyKeypadEnter(`${ESC}[57414;5u`)).toBe(false);
+    expect(isKittyShiftEnter(`${ESC}[13;5u`)).toBe(false);
   });
 
   it('recognizes Option/Alt chords from normalized meta and ESC-prefixed input', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -61,6 +61,7 @@ import {
   chatTuiCanStopActiveRun,
   chatTuiCanStopVisibleRun,
   chatTuiCanStartRootRun,
+  chatTuiCanSelectModel,
   chatTuiSigintAction,
   chatTuiActiveChildFollowUpTarget,
   chatTuiRejectedChildFollowUpTarget,
@@ -796,6 +797,41 @@ describe('CLI TUI row allocation', () => {
         runPromise,
       }),
     ).toBe(true);
+  });
+
+  it('allows model selection before start or while a tool-use chat is waiting', () => {
+    expect(
+      chatTuiCanSelectModel({
+        canStartRootRun: true,
+        streamId: undefined,
+        status: undefined,
+        hasActiveToolUseFlow: false,
+      }),
+    ).toBe(true);
+    expect(
+      chatTuiCanSelectModel({
+        canStartRootRun: false,
+        streamId: root,
+        status: STREAM_STATUS.WAITING,
+        hasActiveToolUseFlow: true,
+      }),
+    ).toBe(true);
+    expect(
+      chatTuiCanSelectModel({
+        canStartRootRun: false,
+        streamId: root,
+        status: STREAM_STATUS.RUNNING,
+        hasActiveToolUseFlow: true,
+      }),
+    ).toBe(false);
+    expect(
+      chatTuiCanSelectModel({
+        canStartRootRun: false,
+        streamId: root,
+        status: STREAM_STATUS.WAITING,
+        hasActiveToolUseFlow: false,
+      }),
+    ).toBe(false);
   });
 
   it('only reports Ctrl-C stoppable while the root stream is actively responding', () => {


### PR DESCRIPTION
## Summary
- let the CLI /model picker switch compatible models for a waiting live tool-use chat instead of becoming read-only after the first message
- preserve the flow-level conversation-format safety check and show its error inline for incompatible switches
- show auth account labels plainly in /auth and sign-in status while keeping doctor text redaction
- bridge raw Kitty Shift+Enter sequences to a draft-input newline so multiline input works when Ink does not expose key.shift

## Validation
- corepack pnpm install
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ApiStatus.vitest.mts src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/Doctor.vitest.mts
- npm run format
- npm run compile:safe
- npm run lint (passes with existing import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Live model switching mutates an active tool-use conversation via `switchModel`, which is security- and reliability-sensitive though gated to WAITING state; Kitty stdin bridging could affect input if mis-scoped.
> 
> **Overview**
> The CLI **`/model`** flow is no longer limited to “before the first message.” **`chatTuiCanSelectModel`** allows picking a model when the root run hasn’t started, or when the root stream is **`WAITING`** and an active tool-use flow exists. **`applyCliModelSelection`** calls **`activeFlow.switchModel`** for live chats (with inline errors), still sets the default helper model when possible, and updates **`ModelListForm`** copy accordingly.
> 
> **Kitty keyboard:** raw **Shift+Enter** CSI sequences are re-dispatched as **`SYNTHETIC_SHIFT_RETURN_INPUT`** only while the main draft input is enabled, so multiline typing works without breaking modal **Enter** behavior; keypad Enter bridging is unchanged.
> 
> **Auth display:** **`formatCliAccountLabelForDisplay`** shows account labels plainly in **`/auth`** and sign-in status; email masking remains on **`redactEmailAccountLabelsForDisplay`** for doctor-style text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e86ffe7f9a35cf531514a014e3ee00c65118c3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->