### PR TITLE
[codex] Refresh CLI model-form TUI expectation

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -423,12 +423,13 @@ const SCENARIOS = [
     frame: 'tail',
     expect: [
       '/model · personal API keys',
-      'Available models',
-      'texra chat --model=<name>',
+      'Available models. Finish the active response before switching models.',
+      'Enter close',
     ],
     unexpect: [
       'Platform not initialized',
       '/model - error',
+      'texra chat --model=<name>',
       'texra --model=<name>',
     ],
   },


### PR DESCRIPTION
## Summary
- update the `validate:tui` `model-form` scenario to assert the current nonselectable `/model` copy
- reject the stale `texra chat --model=<name>` guidance so future PTY dogfood runs catch regressions in the right direction

Closes #5276.

## Validation
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-cli-scout-next/tui-snapshots orchestrate-launcher agent-form model-form approval-form bash-approval subagents subagent-picker task-picker
- npm run format
- npm run compile:safe
- npm run lint (passes with existing import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only expectation changes in the CLI TUI validator; no runtime behavior changes in this diff.
> 
> **Overview**
> Updates the **`model-form`** PTY scenario in `validate-tui.mjs` so TUI dogfood matches the current **`/model`** panel when model picking is disabled during an active response.
> 
> **Expect** now includes the nonselectable helper line *"Available models. Finish the active response before switching models."* and **Enter close**, and **unexpect** drops the old **`texra chat --model=<name>`** CLI hint so regressions surface if stale copy returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b66f3fbbe154530beaabbbe4392b428bae41736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->