### PR TITLE
fix(extension): surface media in interactive mode + warn when model lacks vision

### DIFF
--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1661,8 +1661,15 @@ export class MainApp extends MainAppBase {
     const isToolUse = this.sessionType.get() === SESSION_TYPES.TOOL_USE;
     const fileSelectionClasses = classMap({
       'file-selection-group': true,
-      'file-selection-group--disabled': isToolUse,
     });
+    // Tool-use (interactive) agents read input/context via their own tools, so
+    // only the Media group (pasted/added images the agent can view) is relevant
+    // to them; workflow agents get the full set. Surfacing Media here lets an
+    // interactive user see/confirm/remove a pasted figure instead of it being
+    // attached invisibly.
+    const visibleFileConfigs = isToolUse
+      ? FILE_SELECT_CONFIGS.filter((config) => config.type === 'media')
+      : FILE_SELECT_CONFIGS;
 
     const akb = this.apiKeyBanner.get();
     const acb = this.agentConfigBanner.get();
@@ -1776,58 +1783,55 @@ export class MainApp extends MainAppBase {
               .handleComponentDismissGettingStarted}
           ></banner-group>
 
-          ${isToolUse
-            ? nothing
-            : html`
-                <div class="section-separator" role="presentation"></div>
-                <wa-details
-                  class="file-selection-details"
-                  ?open=${this.fileSelectionOpen.get()}
-                  @wa-show=${(event: Event) => {
-                    // Filter by event source: child wa-dropdown components
-                    // inside the panel also emit wa-show/wa-hide which bubble
-                    // up. Without this guard, opening any dropdown inside
-                    // the Files panel re-flips fileSelectionOpen on the next
-                    // dropdown close (see webawesome#1540).
-                    if (event.target === event.currentTarget) {
-                      this.fileSelectionOpen.set(true);
-                    }
-                  }}
-                  @wa-hide=${(event: Event) => {
-                    if (event.target === event.currentTarget) {
-                      this.fileSelectionOpen.set(false);
-                    }
-                  }}
-                >
-                  <span slot="summary" class="file-selection-summary">
-                    <wa-icon
-                      library=${TEXRA_ICON_LIBRARY}
-                      name="folder-tree"
-                      variant="solid"
-                    ></wa-icon>
-                    Files
-                  </span>
-                  <div class=${fileSelectionClasses}>
-                    ${repeat(
-                      FILE_SELECT_CONFIGS,
-                      (config) => config.type,
-                      (config) => html`
-                        <file-select-group
-                          .config=${config}
-                          @add-opened-files=${this
-                            .handleComponentAddOpenedFiles}
-                          @empty-files=${this.handleComponentEmptyFiles}
-                          @select-multiple-files=${this
-                            .handleComponentSelectMultipleFiles}
-                          @remove-file=${this.handleComponentRemoveFile}
-                          @files-reordered=${this.handleComponentFilesReordered}
-                          @checkbox-change=${this.handleComponentCheckboxChange}
-                        ></file-select-group>
-                      `,
-                    )}
-                  </div>
-                </wa-details>
-              `}
+          ${html`
+            <div class="section-separator" role="presentation"></div>
+            <wa-details
+              class="file-selection-details"
+              ?open=${this.fileSelectionOpen.get()}
+              @wa-show=${(event: Event) => {
+                // Filter by event source: child wa-dropdown components
+                // inside the panel also emit wa-show/wa-hide which bubble
+                // up. Without this guard, opening any dropdown inside
+                // the Files panel re-flips fileSelectionOpen on the next
+                // dropdown close (see webawesome#1540).
+                if (event.target === event.currentTarget) {
+                  this.fileSelectionOpen.set(true);
+                }
+              }}
+              @wa-hide=${(event: Event) => {
+                if (event.target === event.currentTarget) {
+                  this.fileSelectionOpen.set(false);
+                }
+              }}
+            >
+              <span slot="summary" class="file-selection-summary">
+                <wa-icon
+                  library=${TEXRA_ICON_LIBRARY}
+                  name="folder-tree"
+                  variant="solid"
+                ></wa-icon>
+                Files
+              </span>
+              <div class=${fileSelectionClasses}>
+                ${repeat(
+                  visibleFileConfigs,
+                  (config) => config.type,
+                  (config) => html`
+                    <file-select-group
+                      .config=${config}
+                      @add-opened-files=${this.handleComponentAddOpenedFiles}
+                      @empty-files=${this.handleComponentEmptyFiles}
+                      @select-multiple-files=${this
+                        .handleComponentSelectMultipleFiles}
+                      @remove-file=${this.handleComponentRemoveFile}
+                      @files-reordered=${this.handleComponentFilesReordered}
+                      @checkbox-change=${this.handleComponentCheckboxChange}
+                    ></file-select-group>
+                  `,
+                )}
+              </div>
+            </wa-details>
+          `}
         </div>
 
         ${this.isDesktopHost

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -191,6 +191,17 @@ export class ToolUseWaitNode<C> extends Node<
     // to the freshly-appended user message, reusing the same shared media path
     // as the reflection flow. No-ops when empty or the model lacks vision.
     if (execRes.mediaFiles?.length) {
+      if (
+        !modelHandler.capabilities.supportsVision &&
+        !modelHandler.capabilities.supportsNativeAudio
+      ) {
+        const n = execRes.mediaFiles.length;
+        logger.warn(
+          `Model has no vision support — ${n} pasted ` +
+            `${n === 1 ? 'image is' : 'images are'} not sent to the model. ` +
+            `Switch to a vision-capable model to use ${n === 1 ? 'it' : 'them'}.`,
+        );
+      }
       await modelHandler.addMediaToUserMessage(
         shared.messages,
         execRes.mediaFiles.map((p) => fileService.createLocation(p)),

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -2,6 +2,11 @@ import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { listIdleContinuationProviders } from '@agent/runtime/idleContinuation';
+import {
+  countMediaFilesNeedingVision,
+  formatMediaNeedsVisionWarning,
+  shouldWarnMediaNeedsVision,
+} from '@agent/runtime/mediaVisionWarning';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS } from '@shared/schemas';
 
@@ -191,16 +196,14 @@ export class ToolUseWaitNode<C> extends Node<
     // to the freshly-appended user message, reusing the same shared media path
     // as the reflection flow. No-ops when empty or the model lacks vision.
     if (execRes.mediaFiles?.length) {
+      const visionMediaCount = countMediaFilesNeedingVision(execRes.mediaFiles);
       if (
-        !modelHandler.capabilities.supportsVision &&
-        !modelHandler.capabilities.supportsNativeAudio
+        shouldWarnMediaNeedsVision(
+          execRes.mediaFiles,
+          modelHandler.capabilities,
+        )
       ) {
-        const n = execRes.mediaFiles.length;
-        logger.warn(
-          `Model has no vision support — ${n} pasted ` +
-            `${n === 1 ? 'image is' : 'images are'} not sent to the model. ` +
-            `Switch to a vision-capable model to use ${n === 1 ? 'it' : 'them'}.`,
-        );
+        logger.warn(formatMediaNeedsVisionWarning(visionMediaCount, 'pasted'));
       }
       await modelHandler.addMediaToUserMessage(
         shared.messages,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -45,6 +45,11 @@ import {
   withRunContext,
   type RunCoordinators,
 } from './RunContext';
+import {
+  countMediaFilesNeedingVision,
+  formatMediaNeedsVisionWarning,
+  shouldWarnMediaNeedsVision,
+} from './mediaVisionWarning';
 import { retainRunCoordinatorsForStream } from './runCoordinators';
 import { getStreamTabId } from './streamTab';
 import { StreamStatusService } from './StreamStatusService';
@@ -252,20 +257,19 @@ async function assembleAgentLaunchContext(
     ? normalizeRunId(parentStage.id)
     : (executionId as StorageKey);
 
-  // Tell the user when attached media will be dropped because the chosen model
-  // can consume neither vision nor native audio (e.g. a pasted figure on a
-  // non-vision model like DeepSeek). The downstream initializeMessages /
-  // addMediaToUserMessage guards drop it silently otherwise.
+  // Tell the user when attached images will be dropped because the chosen model
+  // lacks vision. The downstream initializeMessages/addMediaToUserMessage guards
+  // drop them silently otherwise.
+  const visionMediaCount = countMediaFilesNeedingVision(config.mediaFiles);
   if (
-    config.mediaFiles.length > 0 &&
-    !modelHandler.capabilities.supportsVision &&
-    !modelHandler.capabilities.supportsNativeAudio
+    shouldWarnMediaNeedsVision(config.mediaFiles, modelHandler.capabilities)
   ) {
-    const n = config.mediaFiles.length;
     agentLogger.warn(
-      `Model "${fullConfig.model}" has no vision support — ${n} attached ` +
-        `${n === 1 ? 'image is' : 'images are'} not sent to the model. ` +
-        `Switch to a vision-capable model to use ${n === 1 ? 'it' : 'them'}.`,
+      formatMediaNeedsVisionWarning(
+        visionMediaCount,
+        'attached',
+        fullConfig.model,
+      ),
     );
   }
 

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -252,6 +252,23 @@ async function assembleAgentLaunchContext(
     ? normalizeRunId(parentStage.id)
     : (executionId as StorageKey);
 
+  // Tell the user when attached media will be dropped because the chosen model
+  // can consume neither vision nor native audio (e.g. a pasted figure on a
+  // non-vision model like DeepSeek). The downstream initializeMessages /
+  // addMediaToUserMessage guards drop it silently otherwise.
+  if (
+    config.mediaFiles.length > 0 &&
+    !modelHandler.capabilities.supportsVision &&
+    !modelHandler.capabilities.supportsNativeAudio
+  ) {
+    const n = config.mediaFiles.length;
+    agentLogger.warn(
+      `Model "${fullConfig.model}" has no vision support — ${n} attached ` +
+        `${n === 1 ? 'image is' : 'images are'} not sent to the model. ` +
+        `Switch to a vision-capable model to use ${n === 1 ? 'it' : 'them'}.`,
+    );
+  }
+
   const agentPath = path.dirname(resolution.definitionPath);
   const buildVars = () =>
     buildUserVars(

--- a/src/agent/runtime/mediaVisionWarning.ts
+++ b/src/agent/runtime/mediaVisionWarning.ts
@@ -1,0 +1,36 @@
+import { getMimeType } from '@utils/files';
+import type { ModelCapabilities } from 'llm-zoo';
+
+type MediaVisionWarningKind = 'attached' | 'pasted';
+
+function needsVision(filePath: string): boolean {
+  return !getMimeType(filePath)?.startsWith('audio/');
+}
+
+export function countMediaFilesNeedingVision(
+  mediaFiles: readonly string[] | undefined,
+): number {
+  return mediaFiles?.filter(needsVision).length ?? 0;
+}
+
+export function shouldWarnMediaNeedsVision(
+  mediaFiles: readonly string[] | undefined,
+  capabilities: Pick<ModelCapabilities, 'supportsVision'>,
+): boolean {
+  return (
+    countMediaFilesNeedingVision(mediaFiles) > 0 && !capabilities.supportsVision
+  );
+}
+
+export function formatMediaNeedsVisionWarning(
+  count: number,
+  kind: MediaVisionWarningKind,
+  modelName?: string,
+): string {
+  const subject = modelName ? `Model "${modelName}"` : 'Model';
+  return (
+    `${subject} has no vision support — ${count} ${kind} ` +
+    `${count === 1 ? 'media file is' : 'media files are'} not sent to the model. ` +
+    `Switch to a vision-capable model to use ${count === 1 ? 'it' : 'them'}.`
+  );
+}

--- a/src/test-kernel/agent/runtime/mediaVisionWarning.vitest.ts
+++ b/src/test-kernel/agent/runtime/mediaVisionWarning.vitest.ts
@@ -1,0 +1,56 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import {
+  countMediaFilesNeedingVision,
+  formatMediaNeedsVisionWarning,
+  shouldWarnMediaNeedsVision,
+} from '@agent/runtime/mediaVisionWarning';
+
+describe('media vision warnings', () => {
+  it('warns for attached media when native audio is supported but vision is not', () => {
+    const capabilities = {
+      supportsNativeAudio: true,
+      supportsVision: false,
+    };
+
+    expect(shouldWarnMediaNeedsVision(['figure.png'], capabilities)).toBe(true);
+  });
+
+  it('does not warn for audio-only media on non-vision models', () => {
+    expect(
+      shouldWarnMediaNeedsVision(['voice.mp3'], {
+        supportsVision: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('counts only media files that need vision', () => {
+    expect(
+      countMediaFilesNeedingVision(['figure.png', 'voice.mp3', 'document.pdf']),
+    ).toBe(2);
+  });
+
+  it('does not warn when there are no media files or vision is supported', () => {
+    expect(
+      shouldWarnMediaNeedsVision([], {
+        supportsVision: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldWarnMediaNeedsVision(['figure.png'], {
+        supportsVision: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('formats startup and follow-up warnings consistently', () => {
+    expect(formatMediaNeedsVisionWarning(1, 'attached', 'deepseek-chat')).toBe(
+      'Model "deepseek-chat" has no vision support — 1 attached media file is not sent to the model. Switch to a vision-capable model to use it.',
+    );
+    expect(formatMediaNeedsVisionWarning(2, 'pasted')).toBe(
+      'Model has no vision support — 2 pasted media files are not sent to the model. Switch to a vision-capable model to use them.',
+    );
+  });
+});

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -135,4 +135,54 @@ describe('ToolUseWaitNode', () => {
     expect(transition).toBe(FlowTransition.COMPLETE);
     expect(shared.deliveredToOrchestrator).toBe(true);
   });
+
+  it('warns when follow-up media cannot be attached to a non-vision model', async () => {
+    const shared: ToolUseRunShared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const warn = vi.fn();
+    const addMediaToUserMessage = vi.fn(async () => {});
+
+    const services = {
+      checkInterruption: () => false,
+      fileService: {
+        createLocation: (filePath: string) => ({ absolutePath: filePath }),
+      },
+      logger: { info: vi.fn(), warn },
+      modelHandler: {
+        addMediaToUserMessage,
+        capabilities: {
+          supportsNativeAudio: true,
+          supportsVision: false,
+        },
+        createUserFollowUpMessages: vi.fn(async () => []),
+      },
+      runtimeHost: { emit: vi.fn() },
+      streamId: 'test-stream',
+    } as unknown as ToolUseServices;
+
+    const node = new ToolUseWaitNode().setServices(services);
+    const transition = await node.post(
+      shared,
+      {
+        afterError: false,
+        lastResponse: undefined,
+        previouslyDeliveredToOrchestrator: false,
+        touchedFiles: [],
+      },
+      {
+        followUp: 'please inspect this figure',
+        kind: 'continue',
+        mediaFiles: ['/tmp/figure.png'],
+      },
+    );
+
+    expect(transition).toBe(FlowTransition.CONTINUE);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Model has no vision support'),
+    );
+    expect(addMediaToUserMessage).toHaveBeenCalledOnce();
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #5217. Fixes two gaps surfaced while testing image paste with the **interactive / tool-use** agent in the extension, where a pasted figure appeared not to reach the model.

## Root cause (diagnosed)

The data path is intact — interactive runs already carry `mediaFiles` into the tool-use config (`ToolUsePrepareNode`). The user-visible failure was the intersection of:

1. **No UI confirmation in interactive mode** — the whole Files section was gated `isToolUse ? nothing`, so a pasted image was attached *invisibly*; the user only saw the `[pasted_…png]` token and couldn't confirm/remove it.
2. **Silent drop on non-vision models** — `initializeMessages` / `addMediaToUserMessage` drop media when the model lacks vision, with zero feedback.

(The specific repro that prompted this — Kimi K2.6, which *is* vision-capable — was a **stale extension build** predating #5217; rebuilding from latest main makes it work.)

## Changes

**(B) Surface a Media group in interactive mode** — `MainApp.ts`. Render a Media-only `file-select-group` when `isToolUse` (input/context/output stay workflow-only), so an interactive user can see/confirm/remove a pasted image. Render-only; no data-path change.

**(C) Warn when attached media will be dropped** — detect "media present but model can consume neither vision nor native audio" and `agentLogger.warn` at the two seams where media is attached:
- `AgentLaunchContext.ts` — initial-message media (covers CLI, extension, workflow).
- `ToolUseWaitNode.ts` — follow-up (mid-conversation) media.

The condition mirrors the actual drop guard (`!supportsVision && !supportsNativeAudio`), so vision/audio-capable models never warn.

## Testing

- Full workspace `typecheck` green; ESLint clean (one pre-existing import-order warning in `MainApp.ts`, untouched); extension `compile:fast` green.
- Verified `kimi26T`/`gemini31p` are `supportsVision: true` and base `kimi`/`kimi2`/`deepseek` are not, so the warning fires on exactly the right models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI visibility and user-facing warnings only; media attach behavior is unchanged aside from logging.
> 
> **Overview**
> **Interactive mode** no longer hides the entire Files panel: tool-use sessions still show a **Media-only** file group so pasted images can be seen, confirmed, or removed instead of attaching invisibly. Workflow mode is unchanged (full file groups).
> 
> **Non-vision models** now log a clear warning when image/PDF media would be dropped at **run launch** (`AgentLaunchContext`) and on **tool-use follow-ups** (`ToolUseWaitNode`), via shared helpers in `mediaVisionWarning.ts` (audio-only files are excluded from the count). Unit tests cover the helper and the wait-node warning path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb0d6f54f815b151c8c0b900446388a46b86d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->