### PR TITLE
fix(cli): harden clipboard text writes

### DIFF
--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -5,9 +5,19 @@ export type ClipboardTextWriteResult =
   | { readonly ok: true }
   | { readonly ok: false; readonly reason: string };
 
+const DEFAULT_CLIPBOARD_WRITE_TIMEOUT_MS = 5_000;
+
 interface ClipboardCommand {
   readonly command: string;
   readonly args: readonly string[];
+}
+
+type SpawnCommand = typeof spawn;
+
+interface ClipboardTextWriteOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly spawnCommand?: SpawnCommand;
+  readonly timeoutMs?: number;
 }
 
 function normalizeClipboardText(text: string, platform = osPlatform()): string {
@@ -33,6 +43,7 @@ function clipboardCommandsForPlatform(
           command: 'powershell.exe',
           args: [
             '-NoProfile',
+            '-NonInteractive',
             '-Command',
             '[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false); Set-Clipboard -Value ([Console]::In.ReadToEnd())',
           ],
@@ -53,20 +64,58 @@ function missingClipboardToolsMessage(platform = osPlatform()): string {
 function writeWithCommand(
   candidate: ClipboardCommand,
   text: string,
+  {
+    spawnCommand = spawn,
+    timeoutMs = DEFAULT_CLIPBOARD_WRITE_TIMEOUT_MS,
+  }: Pick<ClipboardTextWriteOptions, 'spawnCommand' | 'timeoutMs'> = {},
 ): Promise<ClipboardTextWriteResult> {
   return new Promise((resolve) => {
     let settled = false;
     let stderr = '';
+    const deadlineMs = Math.max(1, Math.floor(timeoutMs));
+
+    let child: ReturnType<SpawnCommand>;
+    try {
+      child = spawnCommand(candidate.command, [...candidate.args], {
+        stdio: ['pipe', 'ignore', 'pipe'],
+        windowsHide: true,
+      });
+    } catch (error) {
+      resolve({
+        ok: false,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    const stdin = child.stdin;
+    if (!stdin) {
+      resolve({
+        ok: false,
+        reason: `${candidate.command} did not open stdin`,
+      });
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // Best effort only; the result still needs to unblock the UI.
+      }
+      finish({
+        ok: false,
+        reason: `${candidate.command} timed out after ${deadlineMs}ms`,
+      });
+    }, deadlineMs);
     const finish = (result: ClipboardTextWriteResult): void => {
       if (settled) return;
       settled = true;
+      clearTimeout(timeout);
       resolve(result);
     };
 
-    const child = spawn(candidate.command, [...candidate.args], {
-      stdio: ['pipe', 'ignore', 'pipe'],
-    });
-    child.stdin.on('error', () => undefined);
+    stdin.on('error', () => undefined);
     child.stderr?.on('data', (chunk) => {
       stderr += String(chunk);
     });
@@ -89,14 +138,15 @@ function writeWithCommand(
       });
     });
 
-    child.stdin.end(text);
+    stdin.end(text, 'utf8');
   });
 }
 
 export async function writeClipboardText(
   text: string,
+  options: ClipboardTextWriteOptions = {},
 ): Promise<ClipboardTextWriteResult> {
-  const platform = osPlatform();
+  const platform = options.platform ?? osPlatform();
   const normalized = normalizeClipboardText(text, platform);
   const candidates = clipboardCommandsForPlatform(platform);
   if (candidates.length === 0) {
@@ -105,7 +155,7 @@ export async function writeClipboardText(
 
   let lastFailure = missingClipboardToolsMessage(platform);
   for (const candidate of candidates) {
-    const result = await writeWithCommand(candidate, normalized);
+    const result = await writeWithCommand(candidate, normalized, options);
     if (result.ok) return result;
     lastFailure = result.reason;
   }

--- a/src/test-kernel/cli/ClipboardText.vitest.mts
+++ b/src/test-kernel/cli/ClipboardText.vitest.mts
@@ -1,0 +1,137 @@
+import { EventEmitter } from 'node:events';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { writeClipboardText } from '@cli/runtime/clipboardText';
+import type { spawn } from 'node:child_process';
+
+type SpawnCommand = typeof spawn;
+
+interface ChildScenario {
+  readonly closeCode?: number;
+  readonly hang?: boolean;
+  readonly stderr?: string;
+}
+
+class FakeClipboardChild extends EventEmitter {
+  readonly stderr = new EventEmitter();
+  readonly stdin: EventEmitter & {
+    end: (chunk?: string | Buffer, encoding?: BufferEncoding) => void;
+  };
+  readonly kill = vi.fn(() => true);
+  input = '';
+  inputEncoding: BufferEncoding | undefined;
+
+  constructor(private readonly scenario: ChildScenario) {
+    super();
+    const stdin = new EventEmitter() as FakeClipboardChild['stdin'];
+    stdin.end = (chunk, encoding): void => {
+      this.input += Buffer.isBuffer(chunk)
+        ? chunk.toString('utf8')
+        : (chunk ?? '');
+      this.inputEncoding = encoding;
+      if (this.scenario.hang) return;
+      queueMicrotask(() => {
+        if (this.scenario.stderr) {
+          this.stderr.emit('data', this.scenario.stderr);
+        }
+        this.emit('close', this.scenario.closeCode ?? 0);
+      });
+    };
+    this.stdin = stdin;
+  }
+}
+
+interface SpawnCall {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly options: unknown;
+  readonly child: FakeClipboardChild;
+}
+
+function spawnStub(scenarios: readonly ChildScenario[]): {
+  readonly calls: readonly SpawnCall[];
+  readonly spawnCommand: SpawnCommand;
+} {
+  const calls: SpawnCall[] = [];
+  const spawnMock = vi.fn(
+    (command: string, args: readonly string[], options) => {
+      const child = new FakeClipboardChild(scenarios[calls.length] ?? {});
+      calls.push({ command, args, options, child });
+      return child;
+    },
+  );
+  return {
+    calls,
+    spawnCommand: spawnMock as unknown as SpawnCommand,
+  };
+}
+
+describe('CLI clipboard text writer', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses a Unicode-safe PowerShell command for Windows text copies', async () => {
+    const { calls, spawnCommand } = spawnStub([{ closeCode: 0 }]);
+
+    const result = await writeClipboardText('alpha π\nbeta 🚀', {
+      platform: 'win32',
+      spawnCommand,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe('powershell.exe');
+    expect(calls[0]?.command).not.toBe('clip.exe');
+    expect(calls[0]?.args).toEqual(
+      expect.arrayContaining(['-NoProfile', '-NonInteractive', '-Command']),
+    );
+    expect(calls[0]?.args.join(' ')).toContain('InputEncoding');
+    expect(calls[0]?.args.join(' ')).toContain('Set-Clipboard');
+    expect(calls[0]?.child.input).toBe('alpha π\r\nbeta 🚀');
+    expect(calls[0]?.child.inputEncoding).toBe('utf8');
+  });
+
+  it('kills a hung command and falls back to the next Linux clipboard tool', async () => {
+    vi.useFakeTimers();
+    const { calls, spawnCommand } = spawnStub([
+      { hang: true },
+      { closeCode: 0 },
+    ]);
+
+    const resultPromise = writeClipboardText('question', {
+      platform: 'linux',
+      spawnCommand,
+      timeoutMs: 25,
+    });
+
+    expect(calls.map((call) => call.command)).toEqual(['wl-copy']);
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(resultPromise).resolves.toEqual({ ok: true });
+    expect(calls.map((call) => call.command)).toEqual(['wl-copy', 'xclip']);
+    expect(calls[0]?.child.kill).toHaveBeenCalledTimes(1);
+    expect(calls[1]?.child.kill).not.toHaveBeenCalled();
+  });
+
+  it('reports timeout failure when the platform clipboard command hangs', async () => {
+    vi.useFakeTimers();
+    const { calls, spawnCommand } = spawnStub([{ hang: true }]);
+
+    const resultPromise = writeClipboardText('question', {
+      platform: 'darwin',
+      spawnCommand,
+      timeoutMs: 10,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      reason: 'pbcopy timed out after 10ms',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.child.kill).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- add a per-command timeout for CLI text clipboard writes so hung tools unblock and fall through
- keep Windows text copies on PowerShell with UTF-8 stdin instead of codepage-sensitive clip.exe behavior
- cover Windows Unicode writes, Linux timeout fallback, and final timeout failure

Fixes #5282
Fixes #5283

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ClipboardText.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing 11 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI subprocess/clipboard utility changes with no auth, security, or persistent data impact; behavior is easier to reason about via new tests.
> 
> **Overview**
> Hardens CLI **text clipboard** writes so hung external tools no longer block the TUI indefinitely.
> 
> Each platform command now runs under a **default 5s timeout** that kills the child and returns a failure reason, which lets Linux try the next tool (`wl-copy` → `xclip` → `xsel`) instead of stalling on the first hung binary. **Windows** copies stay on `powershell.exe` with `-NonInteractive`, UTF-8 stdin, and `Set-Clipboard` (avoiding codepage-sensitive `clip.exe` behavior). Spawn handling is tightened (`windowsHide`, sync spawn errors, missing stdin checks), and `writeClipboardText` accepts injectable **platform / spawn / timeout** options for tests.
> 
> New Vitest coverage exercises Unicode Windows copies, Linux timeout fallback, and a single-tool timeout failure on macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5dbff880ddc9e92f960e14cca8db597379bd1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->