### PR TITLE
fix(cli): align foreground escape hints

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -871,6 +871,7 @@ const SCENARIOS = [
     unexpect: [
       '└─Degenerate triples',
       '[/model]models',
+      '[Esc]panel',
       'Esc sk…',
       '1 approval',
     ],
@@ -896,6 +897,7 @@ const SCENARIOS = [
     unexpect: [
       '└─Degenerate triples',
       '[/model]models',
+      '[Esc]panel',
       'Esc sk…',
       '1 approval',
     ],
@@ -920,6 +922,7 @@ const SCENARIOS = [
     ],
     unexpect: [
       '[/model]models',
+      '[Esc]panel',
       'Context detail: the candidate proof',
       '1 approval',
     ],

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -326,6 +326,23 @@ export function foregroundSurfaceKind({
   return undefined;
 }
 
+export function foregroundEscapeAction({
+  foregroundKind,
+  pending,
+}: {
+  readonly foregroundKind: ForegroundSurfaceKind | undefined;
+  readonly pending: PendingApproval | undefined;
+}): string | undefined {
+  if (foregroundKind !== 'approval') {
+    if (foregroundKind === undefined) return undefined;
+    return foregroundKind === 'childControls' ? 'panel' : 'close';
+  }
+  const kind = pending?.payload.kind;
+  return kind === 'externalInquiry' || kind === 'userQuestion'
+    ? 'skip'
+    : 'cancel';
+}
+
 export function childControlForegroundMaxRows({
   hasItems,
 }: {
@@ -759,6 +776,10 @@ export function App(props: AppProps): React.JSX.Element {
         <StreamTabsStrip items={streamTabItems} width={columns} />
         <StatusBar
           canStopActiveRun={canStopActiveRun}
+          foregroundEscapeAction={foregroundEscapeAction({
+            foregroundKind,
+            pending,
+          })}
           queuedFollowUpPreview={!queuedFollowUpPanelVisible}
           shortcutsActive={focusShortcutsActive}
         />

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -83,6 +83,9 @@ export interface StatusBarDisplayInput {
    *  slash palette, or reverse search) owns input and global chat shortcuts are
    *  intentionally inactive. */
   readonly shortcutsActive?: boolean;
+  /** Label for the foreground surface's Escape action while shortcutsActive is
+   *  false. */
+  readonly foregroundEscapeAction?: string;
 }
 
 export interface StatusBarDisplay {
@@ -462,9 +465,10 @@ function fitsStatusBindings(text: string, maxColumns: number | undefined) {
 function foregroundBindingsText(
   ctrlCAction: CtrlCAction,
   maxColumns?: number,
+  escapeAction = 'close',
 ): string {
   const ctrlCBinding = `[Ctrl-C]${ctrlCAction}`;
-  const escBinding = '[Esc]panel';
+  const escBinding = `[Esc]${escapeAction}`;
   const full = `Use foreground panel shortcuts  ${escBinding}  ${ctrlCBinding}`;
   if (fitsStatusBindings(full, maxColumns)) return full;
 
@@ -663,6 +667,7 @@ export function buildStatusBarDisplay(
               input.width === undefined
                 ? undefined
                 : Math.max(0, input.width - STATUS_BAR_HORIZONTAL_PADDING),
+              input.foregroundEscapeAction,
             )
           : statusBarBindingsText(
               input.taskControlsAvailable ?? true,
@@ -680,6 +685,7 @@ export function buildStatusBarDisplay(
 
 export interface StatusBarProps {
   readonly canStopActiveRun?: () => boolean;
+  readonly foregroundEscapeAction?: string;
   readonly queuedFollowUpPreview?: boolean;
   readonly shortcutsActive?: boolean;
 }
@@ -758,6 +764,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
         }),
       parentStream,
     }),
+    foregroundEscapeAction: props.foregroundEscapeAction,
     shortcutsActive: props.shortcutsActive,
   });
 

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -644,7 +644,7 @@ describe('CLI StatusBar display model', () => {
 
     expect(display.left.map(statusBarSegmentText)).toContain('1 approval');
     expect(display.bindings).toBe(
-      'Use foreground panel shortcuts  [Esc]panel  [Ctrl-C]stop',
+      'Use foreground panel shortcuts  [Esc]close  [Ctrl-C]stop',
     );
     expect(display.bindings).not.toContain('[Tab]streams');
     expect(display.bindings).not.toContain('[Alt-p]tasks');
@@ -669,11 +669,37 @@ describe('CLI StatusBar display model', () => {
       model: 'deepseekT',
       apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
+      foregroundEscapeAction: 'skip',
       shortcutsActive: false,
     });
 
     expect(display.left.map(statusBarSegmentText)).toContain('1 question');
     expect(display.left.map(statusBarSegmentText)).not.toContain('1 approval');
+    expect(display.bindings).toContain('[Esc]skip');
+  });
+
+  it('shows cancel for non-question approval foregrounds', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 1,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+      foregroundEscapeAction: 'cancel',
+      shortcutsActive: false,
+    });
+
+    expect(display.bindings).toContain('[Esc]cancel');
   });
 
   it('keeps escape and Ctrl-C actions visible in narrow foreground panels', () => {
@@ -698,7 +724,7 @@ describe('CLI StatusBar display model', () => {
       width: 40,
     });
 
-    expect(display.bindings).toBe('[Esc]panel  [Ctrl-C]stop');
+    expect(display.bindings).toBe('[Esc]close  [Ctrl-C]stop');
   });
 
   it('falls back to the bare Ctrl-C action in tiny foreground panels', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -24,11 +24,13 @@ import {
   appFocusShortcutsActive,
   approvalForegroundMaxRows,
   childControlForegroundMaxRows,
+  foregroundEscapeAction,
   foregroundSurfaceKind,
   shouldShowTipRow,
   shouldShowTodosPlanPanel,
   staticTranscriptRowBudget,
 } from '@cli/chat/tui/App';
+import type { PendingApproval } from '@cli/chat/tui/state/approvalQueue';
 import {
   nextFocusBack,
   nextFocusForward,
@@ -741,6 +743,38 @@ describe('CLI TUI row allocation', () => {
         transcriptViewerOpen: false,
       }),
     ).toBeUndefined();
+  });
+
+  it('labels foreground escape actions from the owning surface', () => {
+    const pending = (
+      kind: PendingApproval['payload']['kind'],
+    ): PendingApproval =>
+      ({
+        payload: { kind } as PendingApproval['payload'],
+        decide: () => undefined,
+      }) satisfies PendingApproval;
+
+    expect(
+      foregroundEscapeAction({
+        foregroundKind: 'childControls',
+        pending: undefined,
+      }),
+    ).toBe('panel');
+    expect(
+      foregroundEscapeAction({ foregroundKind: 'form', pending: undefined }),
+    ).toBe('close');
+    expect(
+      foregroundEscapeAction({
+        foregroundKind: 'approval',
+        pending: pending('externalInquiry'),
+      }),
+    ).toBe('skip');
+    expect(
+      foregroundEscapeAction({
+        foregroundKind: 'approval',
+        pending: pending('bash'),
+      }),
+    ).toBe('cancel');
   });
 
   it('only reports a chat run interruptible after stream resolution', () => {


### PR DESCRIPTION
## Summary

- make the CLI status bar show `[Esc]skip` while user-question and external-inquiry modals own input
- keep child-control panels on the generic `[Esc]panel` footer because nested task/detail screens may mean either close or back
- keep known close/cancel surfaces wired through one foreground escape-action helper
- add a TUI validator guard so inquiry snapshots fail if `[Esc]panel` reappears under question modals

Fixes #5286

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-esc-footer-2 external-inquiry-long external-inquiry-long-80-cols compact-user-question task-picker tiny-task-subworkflow-detail tiny-task-process-detail tiny-task-subworkflow-detail-controls tiny-task-process-detail-controls`
- `npm run compile:safe`
- `npm run lint` (passes with existing 11 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only status bar copy and test guards; no changes to auth, data, or approval handling logic.
> 
> **Overview**
> The CLI status bar no longer shows a generic **`[Esc]panel`** hint whenever a foreground surface owns input. A shared **`foregroundEscapeAction`** helper maps the active surface (and approval type) to the label shown in the footer: **`skip`** for user questions and external inquiries, **`cancel`** for other approval modals, **`close`** for forms and the transcript viewer, and **`panel`** for child-control pickers and task detail screens.
> 
> **`App`** passes that label into **`StatusBar`**, which parameterizes **`foregroundBindingsText`** instead of hardcoding Escape text. Unit tests cover the mapping and footer strings; the TUI harness now fails inquiry/question snapshots if **`[Esc]panel`** reappears under those modals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf5ee03015c78f287173cf89104bc0a11473a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->