### PR TITLE
fix(cli): show slash palette escape hint

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -330,7 +330,13 @@ const SCENARIOS = [
     name: 'slash-palette',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/mo'],
-    expect: ['/model', 'List available models', 'navigate', 'Tab complete'],
+    expect: [
+      '/model',
+      'List available models',
+      'navigate',
+      'Esc close',
+      'Tab complete',
+    ],
   },
   {
     name: 'narrow-slash-palette-command-names',
@@ -610,6 +616,7 @@ const SCENARIOS = [
       'Show session details',
       '/exit',
       'Exit the CLI session',
+      'Esc close',
     ],
   },
   {

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -228,6 +228,7 @@ export function SlashPalette(
               key: 'Enter',
               action: slashPaletteEnterHintAction(highlightedCommand),
             },
+            { key: 'Esc', action: 'close' },
             { key: 'Tab', action: 'complete' },
           ]}
           confirmCancel={false}


### PR DESCRIPTION
## Summary

- add `Esc close` to the slash command palette footer
- keep the hint before `Tab complete` so close remains visible in narrower palette layouts
- update TUI validator expectations for the slash palette frames

Fixes #5288

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/SlashPalette.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-slash-esc slash-palette narrow-slash-palette-command-names slash-palette-overflow slash-palette-ctrl-u-clears-raw-control`
- `npm run compile:safe`
- `npm run lint` (passes with existing 11 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only footer hint and test expectation updates; Esc dismissal behavior was already implemented.
> 
> **Overview**
> The slash command palette footer now shows **`Esc close`**, placed before **`Tab complete`** so the dismiss hint stays visible on narrow terminals. **`validate-tui`** expectations for slash-palette scenarios were updated to match the new footer text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f8bc1f883228c21d6490f9f70be4b3fa7d5648e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->