### PR TITLE
fix(cli): label approval form escape as cancel

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1043,6 +1043,7 @@ function openHarnessSlashForm(
   if (!Form) return false;
   cliState.activeForm.set({
     commandName: command.name,
+    escapeAction: command.formEscapeAction,
     render: (close, availableRows) => (
       <Form
         availableRows={availableRows}

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -477,6 +477,8 @@ const SCENARIOS = [
       'Never',
       'Auto-approve',
       'Enter select highlighted',
+      'Esc cancel',
+      '[Esc]cancel',
     ],
   },
   {
@@ -576,7 +578,8 @@ const SCENARIOS = [
       'Auto-approve',
       '↑/↓ navigate',
       '1-3/Enter select',
-      'Esc close',
+      'Esc cancel',
+      '[Esc]cancel',
     ],
     unexpect: [
       'Choose when privileged actions prompt or auto-approve.',

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -327,14 +327,17 @@ export function foregroundSurfaceKind({
 }
 
 export function foregroundEscapeAction({
+  activeFormEscapeAction,
   foregroundKind,
   pending,
 }: {
+  readonly activeFormEscapeAction?: string;
   readonly foregroundKind: ForegroundSurfaceKind | undefined;
   readonly pending: PendingApproval | undefined;
 }): string | undefined {
   if (foregroundKind !== 'approval') {
     if (foregroundKind === undefined) return undefined;
+    if (foregroundKind === 'form') return activeFormEscapeAction ?? 'close';
     return foregroundKind === 'childControls' ? 'panel' : 'close';
   }
   const kind = pending?.payload.kind;
@@ -777,6 +780,7 @@ export function App(props: AppProps): React.JSX.Element {
         <StatusBar
           canStopActiveRun={canStopActiveRun}
           foregroundEscapeAction={foregroundEscapeAction({
+            activeFormEscapeAction: activeForm?.escapeAction,
             foregroundKind,
             pending,
           })}

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -274,6 +274,7 @@ export function registerBuiltinSlashCommands(options?: {
     name: 'approval',
     description: 'Switch approval policy',
     formComponent: ApprovalPolicyFormAdapter,
+    formEscapeAction: 'cancel',
   });
   registerSlashCommand({
     name: 'yolo',

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -26,6 +26,11 @@ export interface SlashCommand {
    */
   readonly formComponent?: React.ComponentType<SlashFormProps>;
   /**
+   * Status-bar verb for Escape while `formComponent` owns input. Defaults to
+   * `close`; use `cancel` for forms where Escape discards a pending choice.
+   */
+  readonly formEscapeAction?: string;
+  /**
    * Set for commands that take a free-text inline argument (e.g. `/foo bar`).
    * When true, Enter in the palette *completes* the command into the input
    * (with a trailing space) so the user can type the argument, rather than

--- a/packages/cli/src/chat/tui/forms/ApprovalPolicyForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApprovalPolicyForm.tsx
@@ -56,7 +56,10 @@ export function ApprovalPolicyForm(
           onSelect={props.onSelect}
           onCancel={props.onCancel}
         />
-        <CompactFormKeyHints primary={{ key: '1-3/Enter', action: 'select' }} />
+        <CompactFormKeyHints
+          primary={{ key: '1-3/Enter', action: 'select' }}
+          escapeAction="cancel"
+        />
       </FormFrame>
     );
   }

--- a/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
@@ -43,13 +43,14 @@ export function FormFrame(props: FormFrameProps): React.JSX.Element {
 
 export function CompactFormKeyHints(props: {
   readonly primary: KeyHint;
+  readonly escapeAction?: string;
 }): React.JSX.Element {
   return (
     <KeyHints
       hints={[
         { key: '↑/↓', action: 'navigate' },
         props.primary,
-        { key: 'Esc', action: 'close' },
+        { key: 'Esc', action: props.escapeAction ?? 'close' },
       ]}
       confirmCancel={false}
     />

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -188,6 +188,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         clearDraft();
         cliState.activeForm.set({
           commandName: cmd.name,
+          escapeAction: cmd.formEscapeAction,
           render: (close, availableRows) => (
             <Form
               remainder={remainder.trimStart()}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -694,6 +694,7 @@ export function openRegisteredCliSlashForm(
   if (!Form) return false;
   cliState.activeForm.set({
     commandName: command.name,
+    escapeAction: command.formEscapeAction,
     render: (close, availableRows) => (
       <Form
         availableRows={availableRows}

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -128,6 +128,8 @@ const PARENT_STREAM = signal<ReadonlyMap<StreamTabId, StreamTabId>>(new Map());
 export interface ActiveSlashForm {
   /** The slash command that mounted the form (for the header strip). */
   readonly commandName: string;
+  /** Status-bar verb for Escape while the form owns input. Defaults to close. */
+  readonly escapeAction?: string;
   /** Render the form body. Receives the close callback. */
   readonly render: (
     onDone: () => void,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -765,6 +765,13 @@ describe('CLI TUI row allocation', () => {
     ).toBe('close');
     expect(
       foregroundEscapeAction({
+        activeFormEscapeAction: 'cancel',
+        foregroundKind: 'form',
+        pending: undefined,
+      }),
+    ).toBe('cancel');
+    expect(
+      foregroundEscapeAction({
         foregroundKind: 'approval',
         pending: pending('externalInquiry'),
       }),


### PR DESCRIPTION
## Summary

Fixes #5290.

- Add a form-level Escape action label to slash-command form metadata.
- Thread that metadata through all form mounting paths: typed slash command handling, slash palette selection, and the TUI harness helper.
- Mark `/approval` as `cancel` while keeping other forms on the default `close` label.
- Update compact approval hints and TUI harness expectations so the local footer and global status bar agree.

## Dogfood evidence

Before the fix, `/approval` rendered:

```text
│ ↑/↓ navigate · 1-3 select now · Enter select highlighted · Esc cancel │
...
Use foreground panel shortcuts  [Esc]close  [Ctrl-C]exit
```

After the fix, both regular and compact `/approval` frames render `[Esc]cancel` in the status bar.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-approval-esc-20260604-v4 approval-form compact-approval-form edit-approval narrow-bash-approval`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-form-regression-20260604-v2 agent-form-80-cols model-form api-form approval-form compact-agent-form compact-model-form compact-api-form compact-approval-form tools-form`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and metadata wiring only; no auth, persistence, or approval-policy behavior changes.
> 
> **Overview**
> Adds optional **`formEscapeAction`** on slash commands and **`escapeAction`** on active form state so the global status bar can show the same Escape verb as each form’s key hints.
> 
> **`/approval`** is registered with **`cancel`** (other structured forms keep the default **`close`**). All form mount paths—palette/input, `runChatTui`, and the TUI harness—pass that metadata through to **`foregroundEscapeAction`**. Compact approval hints use **`CompactFormKeyHints`** with **`escapeAction="cancel"`**, and TUI validation expectations now require **`[Esc]cancel`** on approval scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29398d51a605021cb01fb436fa11c009e72441f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->