### PR TITLE
test(cli): exercise inquiry copy shortcut

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -28,13 +28,17 @@
 import {
   chmodSync,
   existsSync,
+  mkdtempSync,
   mkdirSync,
+  readFileSync,
   readdirSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
@@ -44,6 +48,7 @@ const ETX = String.fromCharCode(3); // Ctrl-C
 const DC2 = String.fromCharCode(18); // Ctrl-R
 const DC4 = String.fromCharCode(20); // Ctrl-T
 const NAK = String.fromCharCode(21); // Ctrl-U
+const EM = String.fromCharCode(25); // Ctrl-Y
 const UP = ESC + '[A';
 const DOWN = ESC + '[B';
 const PAGE_DOWN = ESC + '[6~';
@@ -911,6 +916,23 @@ const SCENARIOS = [
       'Esc sk…',
       '1 approval',
     ],
+  },
+  {
+    name: 'external-inquiry-copy-question',
+    rows: 24,
+    cols: 80,
+    env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
+    bootExpect: '[Ctrl-C]',
+    keys: [EM],
+    frame: 'tail',
+    fakeClipboard: {
+      expectIncludes: [
+        'Problem: Find all integer triples',
+        'whose perimeter is at most 120',
+      ],
+    },
+    expect: ['Agent asks: copied to clipboard', 'Ctrl-Y copy', '1 question'],
+    unexpect: ['copy failed', '[/model]models', '1 approval'],
   },
   {
     name: 'compact-user-question',
@@ -2062,6 +2084,36 @@ function expectedFrameTextVisible(scenario, frame) {
   return (scenario.expect ?? []).every((text) => frame.includes(text));
 }
 
+const FAKE_CLIPBOARD_COMMANDS = [
+  'pbcopy',
+  'wl-copy',
+  'xclip',
+  'xsel',
+  'powershell.exe',
+];
+
+function makeFakeClipboard() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'texra-tui-clipboard-'));
+  const binDir = path.join(dir, 'bin');
+  const textFile = path.join(dir, 'clipboard.txt');
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(textFile, '');
+
+  const script = [
+    '#!/usr/bin/env sh',
+    'set -eu',
+    'cat > "$TEXRA_FAKE_CLIPBOARD_FILE"',
+    '',
+  ].join('\n');
+  for (const command of FAKE_CLIPBOARD_COMMANDS) {
+    const commandPath = path.join(binDir, command);
+    writeFileSync(commandPath, script);
+    chmodSync(commandPath, 0o755);
+  }
+
+  return { binDir, dir, textFile };
+}
+
 function blankLinesBetween(frame, from, to) {
   const lines = frame.split('\n');
   const toIndex = lines.findLastIndex((line) => line.includes(to));
@@ -2248,6 +2300,7 @@ async function runScenario(scenario) {
   const term = makeTerm(scenario);
   const cols = scenarioCols(scenario);
   const rows = scenarioRows(scenario);
+  const fakeClipboard = scenario.fakeClipboard ? makeFakeClipboard() : null;
   let lastData = Date.now();
   let exited = null;
   let writeQueue = Promise.resolve();
@@ -2263,6 +2316,10 @@ async function runScenario(scenario) {
     COLUMNS: String(cols),
     LINES: String(rows),
   };
+  if (fakeClipboard) {
+    childEnv.PATH = `${fakeClipboard.binDir}${path.delimiter}${childEnv.PATH ?? ''}`;
+    childEnv.TEXRA_FAKE_CLIPBOARD_FILE = fakeClipboard.textFile;
+  }
   // The validator intentionally exercises an interactive TTY. Inherited CI
   // markers make Ink choose a non-interactive render mode and hide the live
   // input/status surface this script is meant to inspect.
@@ -2401,6 +2458,17 @@ async function runScenario(scenario) {
       ? ` (exitCode ${exited.exitCode}, signal ${exited.signal || 'none'})`
       : '';
     failures.push(`exit keys did not close the TUI cleanly${exitDetails}`);
+  }
+  if (fakeClipboard) {
+    const copiedText = readFileSync(fakeClipboard.textFile, 'utf8');
+    for (const text of scenario.fakeClipboard.expectIncludes ?? []) {
+      if (!copiedText.includes(text)) {
+        failures.push(
+          `fake clipboard missing expected text: ${JSON.stringify(text)}`,
+        );
+      }
+    }
+    rmSync(fakeClipboard.dir, { recursive: true, force: true });
   }
 
   return {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2084,15 +2084,19 @@ function expectedFrameTextVisible(scenario, frame) {
   return (scenario.expect ?? []).every((text) => frame.includes(text));
 }
 
-const FAKE_CLIPBOARD_COMMANDS = [
-  'pbcopy',
-  'wl-copy',
-  'xclip',
-  'xsel',
-  'powershell.exe',
-];
+const FAKE_CLIPBOARD_COMMANDS_BY_PLATFORM = {
+  darwin: ['pbcopy'],
+  linux: ['wl-copy', 'xclip', 'xsel'],
+};
 
-function makeFakeClipboard() {
+function fakeClipboardCommandsForPlatform(platform = process.platform) {
+  return FAKE_CLIPBOARD_COMMANDS_BY_PLATFORM[platform] ?? [];
+}
+
+function makeFakeClipboard(platform = process.platform) {
+  const commands = fakeClipboardCommandsForPlatform(platform);
+  if (commands.length === 0) return null;
+
   const dir = mkdtempSync(path.join(tmpdir(), 'texra-tui-clipboard-'));
   const binDir = path.join(dir, 'bin');
   const textFile = path.join(dir, 'clipboard.txt');
@@ -2105,7 +2109,7 @@ function makeFakeClipboard() {
     'cat > "$TEXRA_FAKE_CLIPBOARD_FILE"',
     '',
   ].join('\n');
-  for (const command of FAKE_CLIPBOARD_COMMANDS) {
+  for (const command of commands) {
     const commandPath = path.join(binDir, command);
     writeFileSync(commandPath, script);
     chmodSync(commandPath, 0o755);
@@ -2298,6 +2302,19 @@ function writeSnapshotReport(results) {
 
 async function runScenario(scenario) {
   const fakeClipboard = scenario.fakeClipboard ? makeFakeClipboard() : null;
+  if (scenario.fakeClipboard && !fakeClipboard) {
+    const skipReason = `fake clipboard is not supported on ${process.platform}`;
+    return {
+      name: scenario.name,
+      ok: true,
+      skipped: true,
+      skipReason,
+      failures: [],
+      frame: skipReason,
+      fullFrame: skipReason,
+      rows: scenarioRows(scenario),
+    };
+  }
   try {
     return await runScenarioWithResources(scenario, fakeClipboard);
   } finally {
@@ -2486,6 +2503,7 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
   return {
     name: scenario.name,
     ok: failures.length === 0,
+    skipped: false,
     failures,
     frame,
     fullFrame,
@@ -2496,13 +2514,17 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
 if (snapshotDir) resetSnapshotDir(snapshotDir);
 
 let failed = 0;
+let skipped = 0;
 const results = [];
 for (const [index, scenario] of scenarios.entries()) {
   // eslint-disable-next-line no-await-in-loop
   const result = await runScenario(scenario);
   results.push(result);
   writeSnapshot(index, result.name, result.fullFrame, result.rows);
-  if (result.ok) {
+  if (result.skipped) {
+    skipped += 1;
+    console.log(`- ${result.name} (skipped: ${result.skipReason})`);
+  } else if (result.ok) {
     console.log(`✓ ${result.name}`);
   } else {
     failed += 1;
@@ -2522,7 +2544,7 @@ writeSnapshotReport(results);
 console.log('');
 console.log(
   failed === 0
-    ? `validate-tui: all ${scenarios.length} scenarios passed`
+    ? `validate-tui: all ${scenarios.length - skipped} scenario(s) passed${skipped ? `, ${skipped} skipped` : ''}`
     : `validate-tui: ${failed}/${scenarios.length} scenario(s) FAILED`,
 );
 if (snapshotDir) {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2297,10 +2297,23 @@ function writeSnapshotReport(results) {
 }
 
 async function runScenario(scenario) {
+  const fakeClipboard = scenario.fakeClipboard ? makeFakeClipboard() : null;
+  try {
+    return await runScenarioWithResources(scenario, fakeClipboard);
+  } finally {
+    cleanupFakeClipboard(fakeClipboard);
+  }
+}
+
+function cleanupFakeClipboard(fakeClipboard) {
+  if (!fakeClipboard) return;
+  rmSync(fakeClipboard.dir, { recursive: true, force: true });
+}
+
+async function runScenarioWithResources(scenario, fakeClipboard) {
   const term = makeTerm(scenario);
   const cols = scenarioCols(scenario);
   const rows = scenarioRows(scenario);
-  const fakeClipboard = scenario.fakeClipboard ? makeFakeClipboard() : null;
   let lastData = Date.now();
   let exited = null;
   let writeQueue = Promise.resolve();
@@ -2468,7 +2481,6 @@ async function runScenario(scenario) {
         );
       }
     }
-    rmSync(fakeClipboard.dir, { recursive: true, force: true });
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes #5293.

- Add a safe fake clipboard to the TUI validator for opt-in scenarios.
- Add `external-inquiry-copy-question`, which presses `Ctrl-Y` in the external-inquiry modal.
- Assert the visible `copied to clipboard` status and verify the fake clipboard received the math inquiry text.

## Dogfood evidence

The new snapshot shows the Pythagorean-triples inquiry modal after pressing `Ctrl-Y`:

```text
│ Agent asks: copied to clipboard                                              │
│ I need an independent verification of an enumeration of Pythagorean triples. │
...
│ PgUp/PgDn scroll · Ctrl-Y copy · Enter submit · Ctrl-R reject · Esc skip     │
```

The scenario also checks the fake clipboard content includes:

- `Problem: Find all integer triples`
- `whose perimeter is at most 120`

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui --list | rg "external-inquiry"`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ExternalInquiry.vitest.mts src/test-kernel/cli/ClipboardText.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-inquiry-copy-suite-20260604 external-inquiry-long external-inquiry-long-80-cols external-inquiry-copy-question compact-user-question`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the TUI validation script and a new harness scenario; no production runtime or auth paths are modified.
> 
> **Overview**
> Extends the CLI **TUI PTY validator** with an opt-in **fake clipboard**: temporary `pbcopy` / `xclip`-style shims on `PATH` write copied text to a file keyed by `TEXRA_FAKE_CLIPBOARD_FILE`, and scenarios can assert substrings in that file. Unsupported platforms **skip** those scenarios instead of failing.
> 
> Adds **`external-inquiry-copy-question`**, which opens the external-inquiry modal, sends **Ctrl-Y**, checks the frame for **copied to clipboard** (and related UI), and verifies the clipboard file contains the Pythagorean-triples inquiry text. Run output now reports **skipped** scenarios separately from passes/failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e868e61b6f7f8875e3aa598f2cec750d266d6926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->