### PR TITLE
test(cli): cover Shift-Enter newline input

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -390,8 +390,8 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '2' },
     keys: ['first line', KITTY_SHIFT_ENTER, 'second line', '\r'],
     frame: 'tail',
-    expect: ['Harness received: first line', 'second line'],
-    unexpect: ['13;2u', '[13', 'ERROR'],
+    expect: ['Harness received: first line\nsecond line'],
+    unexpect: ['first linesecond line', '13;2u', '[13', 'ERROR'],
   },
   {
     name: 'agent-form',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -49,6 +49,7 @@ const DC2 = String.fromCharCode(18); // Ctrl-R
 const DC4 = String.fromCharCode(20); // Ctrl-T
 const NAK = String.fromCharCode(21); // Ctrl-U
 const EM = String.fromCharCode(25); // Ctrl-Y
+const KITTY_SHIFT_ENTER = ESC + '[13;2u';
 const UP = ESC + '[A';
 const DOWN = ESC + '[B';
 const PAGE_DOWN = ESC + '[6~';
@@ -382,6 +383,15 @@ const SCENARIOS = [
     frame: 'tail',
     expect: ['Harness received: prove the bounded case for n <= 20'],
     unexpect: ['signal read during notification phase', 'ERROR'],
+  },
+  {
+    name: 'kitty-shift-enter-newline',
+    cols: 120,
+    env: { HARNESS_ENTRIES: '2' },
+    keys: ['first line', KITTY_SHIFT_ENTER, 'second line', '\r'],
+    frame: 'tail',
+    expect: ['Harness received: first line', 'second line'],
+    unexpect: ['13;2u', '[13', 'ERROR'],
   },
   {
     name: 'agent-form',


### PR DESCRIPTION
## Summary

- add a CLI TUI validator scenario for raw Kitty Shift-Enter (`ESC[13;2u`) in the chat input
- assert the prompt is submitted only after a later plain Enter and no CSI-u bytes leak into the rendered transcript

Closes #5295.

## Verification

- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build kitty-shift-enter-newline`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build --snapshot-dir /tmp/texra-tui-shift-enter-20260604 kitty-shift-enter-newline`
- `corepack pnpm --filter @texra-ai/cli validate:tui --list | rg "kitty-shift-enter|plain-submit"`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to the CLI TUI validator script; no production runtime paths modified.
> 
> **Overview**
> Adds **PTY TUI validation** for Kitty **Shift+Enter** in chat input: a `KITTY_SHIFT_ENTER` constant (`ESC[13;2u`) and a **`kitty-shift-enter-newline`** scenario next to **`plain-submit`**.
> 
> The harness types two lines with Shift+Enter, submits with plain Enter, and checks the harness sees **`first line` + newline + `second line`**, while rejecting merged text, leaked CSI-u bytes (`13;2u`, `[13`), and errors.
> 
> This is **regression coverage** for existing Kitty newline handling in the CLI TUI, not a behavior change in application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96791550b042f3bc9220fe21dd3450f4b33d911e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->