### PR TITLE
fix(cli): show doctor account labels plainly

### DIFF
--- a/packages/cli/src/runtime/accountDisplay.ts
+++ b/packages/cli/src/runtime/accountDisplay.ts
@@ -1,29 +1,3 @@
-const EMAIL_LIKE_ACCOUNT_PATTERN =
-  /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
-
-function maskIdentifierPart(part: string): string {
-  return part ? `${part.at(0)}***` : '***';
-}
-
 export function formatCliAccountLabelForDisplay(accountLabel: string): string {
   return accountLabel.trim();
-}
-
-function redactEmailAccountLabel(accountLabel: string): string {
-  const atIndex = accountLabel.indexOf('@');
-  const localPart = accountLabel.slice(0, atIndex);
-  const domain = accountLabel.slice(atIndex + 1);
-  const domainParts = domain.split('.');
-  const suffix = domainParts.length > 1 ? domainParts.at(-1) : undefined;
-  const domainName = suffix ? domainParts.slice(0, -1).join('.') : domain;
-  const maskedDomain = suffix
-    ? `${maskIdentifierPart(domainName)}.${suffix}`
-    : maskIdentifierPart(domainName);
-  return `${maskIdentifierPart(localPart)}@${maskedDomain}`;
-}
-
-export function redactEmailAccountLabelsForDisplay(text: string): string {
-  return text.replaceAll(EMAIL_LIKE_ACCOUNT_PATTERN, (accountLabel) =>
-    redactEmailAccountLabel(accountLabel),
-  );
 }

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -17,7 +17,7 @@ import {
 import { extractErrorMessage } from '@utils/core';
 
 // Local imports - CLI runtime
-import { redactEmailAccountLabelsForDisplay } from './accountDisplay';
+import { formatCliAccountLabelForDisplay } from './accountDisplay';
 import { workspaceCliConfigPath } from './cliConfig';
 import { CliExitCode } from './exitCodes';
 import {
@@ -70,10 +70,42 @@ interface DoctorDependencies {
 
 type ResolvedDoctorDependencies = Required<DoctorDependencies>;
 
+const EMAIL_LIKE_DIAGNOSTIC_PATTERN =
+  /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+
 function isSupportedNodeVersion(version: string): boolean {
   return semverSatisfies(version, TEXRA_CLI_SUPPORTED_NODE_RANGE, {
     loose: true,
   });
+}
+
+function maskIdentifierPart(part: string): string {
+  return part ? `${part.at(0)}***` : '***';
+}
+
+function redactEmailDiagnosticValue(value: string): string {
+  const atIndex = value.indexOf('@');
+  const localPart = value.slice(0, atIndex);
+  const domain = value.slice(atIndex + 1);
+  const domainParts = domain.split('.');
+  const suffix = domainParts.length > 1 ? domainParts.at(-1) : undefined;
+  const domainName = suffix ? domainParts.slice(0, -1).join('.') : domain;
+  const maskedDomain = suffix
+    ? `${maskIdentifierPart(domainName)}.${suffix}`
+    : maskIdentifierPart(domainName);
+  return `${maskIdentifierPart(localPart)}@${maskedDomain}`;
+}
+
+function redactEmailDiagnostics(text: string): string {
+  return text.replaceAll(EMAIL_LIKE_DIAGNOSTIC_PATTERN, (value) =>
+    redactEmailDiagnosticValue(value),
+  );
+}
+
+function formatDoctorMessage(check: DoctorCheck): string {
+  return check.id === 'auth'
+    ? check.message
+    : redactEmailDiagnostics(check.message);
 }
 
 function check(
@@ -168,10 +200,13 @@ async function checkAuth(
     const profile = await deps.authProfile();
     if (profile.authenticated) {
       const tier = profile.tier ? `, ${profile.tier}` : '';
+      const accountLabel = profile.accountLabel
+        ? formatCliAccountLabelForDisplay(profile.accountLabel)
+        : 'unknown';
       return pass(
         'auth',
         'Included access',
-        `Stored sign-in found for ${profile.accountLabel ?? 'unknown'}${tier}.`,
+        `Stored sign-in found for ${accountLabel}${tier}.`,
       );
     }
     return warn(
@@ -340,10 +375,9 @@ export function formatDoctorText(
   };
   return report.checks
     .map((check) => {
-      const message = redactEmailAccountLabelsForDisplay(check.message);
-      const head = `${marker[check.status]} ${check.name}: ${message}`;
+      const head = `${marker[check.status]} ${check.name}: ${formatDoctorMessage(check)}`;
       return check.hint
-        ? `${head}\n     ${style.muted(redactEmailAccountLabelsForDisplay(check.hint))}`
+        ? `${head}\n     ${style.muted(redactEmailDiagnostics(check.hint))}`
         : head;
     })
     .join('\n');

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -202,7 +202,7 @@ describe('CLI doctor', () => {
     expect(formatDoctorText(report)).toContain('Ignoring invalid model.');
   });
 
-  it('redacts email account labels in text output', async () => {
+  it('shows email account labels plainly in text output', async () => {
     const report = await buildDoctorReport(context, {
       nodeVersion: '24.15.0',
       authProfile: async () => ({
@@ -231,12 +231,48 @@ describe('CLI doctor', () => {
     const records = doctorNdjsonRecords(report, '2026-05-18T00:00:00.000Z');
 
     expect(authCheck?.message).toContain('user@example.edu');
-    expect(text).toContain('Stored sign-in found for u***@e***.edu, Max.');
-    expect(text).not.toContain('user@example.edu');
+    expect(text).toContain('Stored sign-in found for user@example.edu, Max.');
     expect(records).toContainEqual(
       expect.objectContaining({
         id: 'auth',
         message: 'Stored sign-in found for user@example.edu, Max.',
+      }),
+    );
+  });
+
+  it('redacts email-like values outside the auth account message', () => {
+    const report: DoctorReport = {
+      ok: false,
+      checks: [
+        {
+          id: 'auth',
+          name: 'Included access',
+          status: 'pass',
+          message: 'Stored sign-in found for user@example.edu.',
+        },
+        {
+          id: 'config',
+          name: 'Config',
+          status: 'warn',
+          message: 'Workspace config references owner@example.edu.',
+          hint: 'Ask admin@example.edu to update it.',
+        },
+      ],
+    };
+
+    const text = formatDoctorText(report);
+    const records = doctorNdjsonRecords(report, '2026-05-18T00:00:00.000Z');
+
+    expect(text).toContain('Stored sign-in found for user@example.edu.');
+    expect(text).toContain('Workspace config references o***@e***.edu.');
+    expect(text).toContain('Ask a***@e***.edu to update it.');
+    expect(text).not.toContain('owner@example.edu');
+    expect(text).not.toContain('admin@example.edu');
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        id: 'config',
+        message: 'Workspace config references owner@example.edu.',
+        hint: 'Ask admin@example.edu to update it.',
       }),
     );
   });


### PR DESCRIPTION
## Summary

- make `texra doctor` text output show signed-in account labels as-is, matching `texra auth status`
- remove the now-unused email-redaction helper from CLI account display
- update doctor coverage for email account labels

Closes #5297.

## Verification

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/Doctor.vitest.mts src/test-kernel/cli/ApiStatus.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and privacy-scoping for doctor output only; no changes to authentication or credential handling.
> 
> **Overview**
> **`texra doctor` text output** now shows the signed-in account label in plain text (trimmed via `formatCliAccountLabelForDisplay`), aligned with **`texra auth status`**. Global email redaction was removed from `accountDisplay.ts`.
> 
> Redaction for email-like strings is **scoped to doctor formatting**: the **`auth`** check message is left as-is; other checks’ messages and hints still mask emails in human-readable text. **NDJSON** records keep full, unredacted messages.
> 
> Tests were updated for plain auth labels and for redaction on non-auth diagnostic lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ed88243ffbfe2cdeb14799f515a28bba5009ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->