### PR TITLE
test(cli): cover selectable model switching in TUI

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -132,6 +132,7 @@ const AGENT_PROPOSAL_INSTRUCTION =
     '6. Include a short independent enumeration so the orchestrator can compare results.',
   ].join('\n');
 const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
+const CAN_SELECT_MODEL = process.env.HARNESS_CAN_SELECT_MODEL === '1';
 const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_NESTED_CHILDREN = process.env.HARNESS_NESTED_CHILDREN === '1';
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
@@ -1194,9 +1195,15 @@ function handleHarnessSlashCommand(line: string): boolean {
 
 registerBuiltinSlashCommands({
   canSelectAgent: () => false,
-  canSelectModel: () => false,
+  canSelectModel: () => CAN_SELECT_MODEL,
   getApprovalPolicy: () => harnessApprovalPolicy,
   onApprovalPolicySelect: setHarnessApprovalPolicy,
+  onModelSelect: (model) => {
+    cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), model });
+    appendHarnessAssistantTranscript(
+      `Harness model selected. Future turns: ${model}.`,
+    );
+  },
   onApiModeSelect: (apiMode) => {
     cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), apiMode });
     appendHarnessAssistantTranscript(`API mode set to ${apiMode}.`);

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -455,6 +455,42 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'model-form-selectable',
+    env: {
+      HARNESS_CAN_SELECT_MODEL: '1',
+      HARNESS_ENTRIES: '4',
+    },
+    keys: ['/model', '\r'],
+    frame: 'tail',
+    expect: [
+      '/model · personal API keys',
+      'Choose the model for future turns.',
+      '1-9/a-z',
+      'select',
+    ],
+    unexpect: [
+      'Finish the active response before switching models.',
+      'Enter close',
+      'Platform not initialized',
+      '/model - error',
+    ],
+  },
+  {
+    name: 'model-form-selectable-submit',
+    env: {
+      HARNESS_CAN_SELECT_MODEL: '1',
+      HARNESS_ENTRIES: '4',
+    },
+    keys: ['/model', '\r', '\r'],
+    frame: 'tail',
+    expect: ['Harness model selected. Future turns:'],
+    unexpect: [
+      'Finish the active response before switching models.',
+      'Platform not initialized',
+      '/model - error',
+    ],
+  },
+  {
     name: 'model-form-included-empty',
     env: {
       HARNESS_AUTHENTICATED: '1',


### PR DESCRIPTION
## Summary

Closes #5299.

This extends the CLI PTY dogfood harness so it can opt into the selectable `/model` path. The existing `model-form` scenario still covers the disabled/read-only state; the new scenarios cover the waiting-chat style state where model rows should be selectable and selecting the highlighted row should visibly apply.

## Changes

- Add `HARNESS_CAN_SELECT_MODEL=1` to let the harness register selectable model commands.
- Wire harness model selection to update `cliState.sessionMeta` and append a visible confirmation.
- Add PTY validator scenarios for selectable `/model` copy and Enter-to-select behavior.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --snapshot-dir /tmp/texra-model-switch-scout model-form model-form-selectable model-form-selectable-submit`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness and validator-only changes; no production chat runtime behavior beyond the harness script.
> 
> **Overview**
> The TUI dogfood harness can now opt into **selectable** `/model` behavior via `HARNESS_CAN_SELECT_MODEL=1`, while the existing `model-form` scenario still covers the read-only “finish the active response” path.
> 
> When enabled, builtin slash registration treats model rows as selectable; choosing a model updates `cliState.sessionMeta` and appends a harness transcript line (`Harness model selected. Future turns: …`). **PTY validator** scenarios `model-form-selectable` and `model-form-selectable-submit` assert the interactive copy and Enter-to-apply flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273a162d2f611bf5a9032230601c793f5f057210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->