### PR TITLE
docs: fix stale claude-code-with-provider reference in verification.md

### DIFF
--- a/docs/dev/verification.md
+++ b/docs/dev/verification.md
@@ -47,12 +47,14 @@ review jobs. One special case needs an explicit rule: a pull request may edit
 the review workflow, its local action, or its review prompts. In that case the
 review job must not run untrusted automation from the pull request itself.
 
-The repository handles this by running the pull request through the trusted
-automation from the base branch. The `Claude Code Review` workflow checks out
-the base branch into `.trusted-actions` and runs the review action and prompt
-files from that directory. This means changes to `.github/workflows/claude-code-review.yml`,
-`.github/actions/claude-code-with-provider/`, or `.github/prompts/` are still
-reviewed, but the changed automation only takes effect after the PR is merged.
+The repository handles this by running the pull request through trusted
+automation. The provider wrapper is an external, version-pinned action
+(`LionSR/agent-ci-actions@v1`), so a pull request cannot alter it. The in-repo
+prompts can still be edited by a pull request, so the `Claude Code Review`
+workflow checks out the base branch into `.trusted-actions` and runs with the
+prompt files from that directory. This means changes to
+`.github/workflows/claude-code-review.yml` or `.github/prompts/` are still
+reviewed, but the changed prompts only take effect after the PR is merged.
 
 If GitHub refuses to run a self-editing workflow, or if the provider-side review
 service is unavailable, do not treat the missing review as silently acceptable.

--- a/docs/dev/verification.md
+++ b/docs/dev/verification.md
@@ -44,15 +44,16 @@ corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-
 
 Every pull request should keep the required checks green, including the Claude
 review jobs. One special case needs an explicit rule: a pull request may edit
-the review workflow, its local action, or its review prompts. In that case the
+the review workflow or its review prompts. In that case the
 review job must not run untrusted automation from the pull request itself.
 
 The repository handles this by running the pull request through trusted
-automation. The provider wrapper is an external, version-pinned action
-(`LionSR/agent-ci-actions@v1`), so a pull request cannot alter it. The in-repo
-prompts can still be edited by a pull request, so the `Claude Code Review`
-workflow checks out the base branch into `.trusted-actions` and runs with the
-prompt files from that directory. This means changes to
+automation. The provider wrapper is external to this repository
+(`LionSR/agent-ci-actions@v1`), so a pull request cannot alter its
+implementation in this tree. The in-repo prompts can still be edited by a pull
+request, so the `Claude Code Review` workflow checks out the base branch into
+`.trusted-actions` and runs with the prompt files from that directory. This
+means changes to
 `.github/workflows/claude-code-review.yml` or `.github/prompts/` are still
 reviewed, but the changed prompts only take effect after the PR is merged.
 


### PR DESCRIPTION
The provider wrapper was extracted to an external, version-pinned action (`LionSR/agent-ci-actions@v1`); the in-repo `.github/actions/claude-code-with-provider/` no longer exists.

`docs/dev/verification.md` still described it as an in-repo action and claimed the base-branch checkout protects that action. Updated the PR-review automation section to match reality: the action is external and pinned (a PR can't alter it), and the `.trusted-actions` base-branch checkout now protects the in-repo **prompts**.

Docs-only; no behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or CI behavior impact.
> 
> **Overview**
> Updates the **PR review automation** section in `docs/dev/verification.md` so it matches how CI actually works after the provider wrapper moved out of the repo.
> 
> The doc no longer treats `.github/actions/claude-code-with-provider/` as in-tree or as something the base-branch checkout protects. It now states that **`LionSR/agent-ci-actions@v1`** is external and pinned (PRs cannot change that implementation here), while the **`.trusted-actions`** checkout still applies to in-repo **workflow and prompt** paths (`.github/workflows/claude-code-review.yml`, `.github/prompts/`), which only take effect after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 270b421d0b45f30a13c17b0e885022b3d7ad6d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->