### PR TITLE
fix(cli): explain degraded multi-agent presets

### DIFF
--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -133,16 +133,17 @@ export function formatCliMultiAgentPresetList(
 ): string {
   if (plans.length === 0) return 'No multi-agent presets found.';
 
-  return plans
-    .map((plan) =>
-      [
-        plan.preset.source,
-        plan.preset.id,
-        plan.preset.name,
-        ...cliMultiAgentPresetAvailabilityParts(plan),
-      ].join('\t'),
-    )
-    .join('\n');
+  const rows = plans.map((plan) =>
+    [
+      plan.preset.source,
+      plan.preset.id,
+      plan.preset.name,
+      ...cliMultiAgentPresetAvailabilityParts(plan),
+    ].join('\t'),
+  );
+
+  const hint = cliMultiAgentPresetListHint(plans);
+  return hint ? [...rows, '', hint].join('\n') : rows.join('\n');
 }
 
 export function formatCliMultiAgentPresetDetails(
@@ -458,6 +459,17 @@ function presetAgentAvailability(
 function formatAgentNames(names: readonly string[]): string {
   if (names.length === 0) return '  (none)';
   return names.map((name) => `  ${name}`).join('\n');
+}
+
+function cliMultiAgentPresetListHint(
+  plans: readonly CliMultiAgentPresetRunPlan[],
+): string | undefined {
+  const hasIncompletePreset = plans.some(
+    (plan) => cliMultiAgentPlanStatus(plan) !== 'available',
+  );
+  return hasIncompletePreset
+    ? 'Hint: run `texra multi-agent inspect <preset>` to see missing agents for degraded or unavailable presets.'
+    : undefined;
 }
 
 function lookupKey(value: string): string {

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -52,9 +52,12 @@ describe('CLI multi-agent presets', () => {
     });
 
     expect(presets.map((preset) => preset.id)).toContain('physicist');
-    expect(formatCliMultiAgentPresetList(plans)).toContain(
+    const output = formatCliMultiAgentPresetList(plans);
+
+    expect(output).toContain(
       'built-in\tphysicist\tPhysicist\tworkflow:4\ttool-use:9',
     );
+    expect(output).not.toContain('Hint:');
   });
 
   it('lists missing preset members as degraded availability', () => {
@@ -70,9 +73,12 @@ describe('CLI multi-agent presets', () => {
       ],
     });
 
-    expect(formatCliMultiAgentPresetList([plan])).toContain(
+    const output = formatCliMultiAgentPresetList([plan]);
+
+    expect(output).toContain(
       'built-in\tlean-project\tLean Project\tworkflow:0\ttool-use:2/7\tdegraded',
     );
+    expect(output).toContain('texra multi-agent inspect <preset>');
   });
 
   it('serializes planned availability for machine-readable list output', () => {


### PR DESCRIPTION
## Summary

- Adds a text-only hint when `texra multi-agent list` includes degraded or unavailable presets.
- Keeps JSON and NDJSON list records unchanged.
- Covers both the available-list and degraded-list formatter behavior with focused CLI kernel tests.

## Root Cause

The CLI already had `texra multi-agent inspect <preset>` for root/missing-agent diagnostics, but `multi-agent list` did not point users there when it surfaced a degraded preset.

Closes #5302.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `corepack pnpm --filter @texra-ai/cli run build`
- `node packages/cli/dist/bin/texra.js --no-color multi-agent list`
- `npm run lint` (passes with the existing 11 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI text formatting and tests only; no auth, data, or API contract changes beyond optional trailing hint lines.
> 
> **Overview**
> Text output from **`texra multi-agent list`** now appends a short **hint** when any listed preset is **degraded** or **unavailable**, pointing users to **`texra multi-agent inspect <preset>`** for missing-agent details. Fully **available** lists stay unchanged (no extra lines).
> 
> **JSON** and **NDJSON** list payloads are untouched; only the human-readable formatter in `formatCliMultiAgentPresetList` / `cliMultiAgentPresetListHint` changed. Tests assert the hint appears only for incomplete availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271beeb2f8b17173fc745ca169eea406d8e8930a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->