### PR TITLE
fix(cli): clarify explicit multi-agent root warning

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -144,8 +144,13 @@ export async function loadCliMultiAgentPresetPlans(
   return plans;
 }
 
+interface MissingPresetAgentsWarningOptions {
+  readonly requestedRootAgent?: string;
+}
+
 export function writeMissingPresetAgents(
   plan: CliMultiAgentPresetRunPlan,
+  options: MissingPresetAgentsWarningOptions = {},
 ): void {
   const missing = [
     ...plan.missingWorkflowAgents.map((agent) => `workflow:${agent}`),
@@ -166,7 +171,7 @@ export function writeMissingPresetAgents(
   );
   if (!agentHasDelegationTools(plan.rootAgent)) {
     writeTextStderr(
-      `WARN team delegation unavailable for preset ${plan.preset.id}; running only root agent ${plan.rootAgent.name}. Enable a delegating team root or pass --agent to choose one.`,
+      `WARN team delegation unavailable for preset ${plan.preset.id}; running only root agent ${plan.rootAgent.name}. ${nonDelegatingRootAdvice(options)}`,
     );
     return;
   }
@@ -184,6 +189,14 @@ export function writeMissingPresetAgents(
   writeTextStderr(
     `WARN preset ${plan.preset.id} is degraded; running root agent ${plan.rootAgent.name} with ${availableText}.`,
   );
+}
+
+function nonDelegatingRootAdvice(
+  options: MissingPresetAgentsWarningOptions,
+): string {
+  return options.requestedRootAgent
+    ? 'The selected --agent root cannot delegate; choose a delegating root to run this as a team.'
+    : 'Enable a delegating team root or pass --agent to choose one.';
 }
 
 function writeApprovalUnavailableDelegationWarning(
@@ -307,7 +320,9 @@ export async function runMultiAgentPreset(
     );
     return CliExitCode.Usage;
   }
-  writeMissingPresetAgents(plan);
+  writeMissingPresetAgents(plan, {
+    requestedRootAgent: init.agent?.trim() || undefined,
+  });
 
   // A team run drives a tool-use orchestrator, so it follows the `chat`
   // (tool-use) model config rather than `run` (workflow agents). Resolve the

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -412,6 +412,84 @@ describe('CLI multi-agent run command', () => {
     );
   });
 
+  it('does not suggest --agent again when the explicit root cannot delegate', async () => {
+    mocks.planCliMultiAgentPresetRun.mockReturnValue({
+      preset: {
+        id: 'mathematician',
+        name: 'Mathematician',
+        source: 'built-in',
+      },
+      rootAgent: {
+        name: 'review',
+        category: 'toolUse',
+        source: 'builtInToolUse',
+        path: '/agents/review.yaml',
+        tools: [],
+      },
+      missingWorkflowAgents: ['generic', 'devise', 'apply'],
+      missingToolUseAgents: ['simplifier', 'progressCheck', 'orchestrator'],
+      workflowAgentKeys: [],
+      toolUseAgentKeys: ['builtInToolUse:review'],
+    });
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(cliContext(), {
+      preset: 'mathematician',
+      inputFiles: [],
+      contextFiles: [],
+      agent: 'review',
+      model: 'deepseekT',
+      instruction: 'Solve a short math problem.',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'WARN team delegation unavailable for preset mathematician; running only root agent review. The selected --agent root cannot delegate; choose a delegating root to run this as a team.',
+    );
+    expect(mocks.writeTextStderr).not.toHaveBeenCalledWith(
+      expect.stringContaining('pass --agent to choose one'),
+    );
+  });
+
+  it('does not treat whitespace-only --agent as an explicit root choice', async () => {
+    mocks.planCliMultiAgentPresetRun.mockReturnValue({
+      preset: {
+        id: 'mathematician',
+        name: 'Mathematician',
+        source: 'built-in',
+      },
+      rootAgent: {
+        name: 'lean',
+        category: 'toolUse',
+        source: 'builtInToolUse',
+        path: '/agents/lean.yaml',
+        tools: [],
+      },
+      missingWorkflowAgents: ['generic', 'devise', 'apply'],
+      missingToolUseAgents: ['simplifier', 'progressCheck', 'orchestrator'],
+      workflowAgentKeys: [],
+      toolUseAgentKeys: ['builtInToolUse:lean'],
+    });
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(cliContext(), {
+      preset: 'mathematician',
+      inputFiles: [],
+      contextFiles: [],
+      agent: '   ',
+      model: 'deepseekT',
+      instruction: 'Solve a short math problem.',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'WARN team delegation unavailable for preset mathematician; running only root agent lean. Enable a delegating team root or pass --agent to choose one.',
+    );
+    expect(mocks.writeTextStderr).not.toHaveBeenCalledWith(
+      expect.stringContaining('The selected --agent root cannot delegate'),
+    );
+  });
+
   it('keeps degraded-team wording when the root can delegate', async () => {
     mocks.planCliMultiAgentPresetRun.mockReturnValue({
       preset: {


### PR DESCRIPTION
## Summary

- Makes degraded multi-agent warnings context-aware when the user explicitly passes `--agent`.
- Keeps the existing fallback advice for default root selection and orchestrated launcher runs.
- Adds focused CLI command coverage for the explicit non-delegating root case.

## Root Cause

`writeMissingPresetAgents` always printed the same non-delegating-root advice, even when `multi-agent run` was already using an explicit `--agent` override. In that case, telling the user to “pass --agent” is stale advice; the selected root simply cannot delegate.

Closes #5304.

## Validation

- Live dogfood command:
  `node packages/cli/dist/bin/texra.js --no-color --no-input --api-mode personal --approval-policy never multi-agent run mathematician --agent review --model gpt54 --instruction "..."`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `git diff --check`
- `npm run compile:safe`
- `corepack pnpm --filter @texra-ai/cli run build`
- `npm run lint` (passes with the existing 11 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing warning text and unit tests only; no change to preset planning or execution behavior.
> 
> **Overview**
> **Degraded multi-agent preset warnings** now depend on whether the user explicitly chose a root with `--agent`.
> 
> When `multi-agent run` falls back to a **non-delegating** root, stderr no longer always says to “pass `--agent`”. If a real `--agent` was provided (after trim), the message explains that **the selected root cannot delegate** and to pick a delegating root for a team run. Whitespace-only `--agent` is ignored so the original fallback advice still applies.
> 
> `runMultiAgentPreset` passes the trimmed `--agent` into `writeMissingPresetAgents` via a small options type and `nonDelegatingRootAdvice`. **CLI tests** cover the explicit non-delegating root case and whitespace-only `--agent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732688a4756d23de2a0211adc0f3d66e89fda8c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->