### PR TITLE
fix(cli): accept tui scenario list alias

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1897,7 +1897,8 @@ function formatUsage() {
     '  --snapshot-dir DIR  Write per-scenario .txt/.svg frames and an index.html report',
     `  --no-build          Use the existing ${DEFAULT_HARNESS_RELATIVE_PATH} instead of rebuilding it`,
     '  --skip-if-missing-deps  Exit 0 instead of failing when PTY screenshot deps are unavailable',
-    '  --list              Print available scenario names and exit',
+    '  --list, --list-scenarios',
+    '                      Print available scenario names and exit',
     '  --list-selected     Print selected scenario names in run order and exit',
     '  -h, --help          Show this help',
     '',
@@ -1935,7 +1936,7 @@ function parseArgs(argv) {
       printUsage();
       process.exit(0);
     }
-    if (!endOfOptions && arg === '--list') {
+    if (!endOfOptions && (arg === '--list' || arg === '--list-scenarios')) {
       printScenarioList();
       process.exit(0);
     }

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -29,6 +29,7 @@ describe('TUI validator args', () => {
     expect(result.stdout).toContain('--no-build');
     expect(result.stdout).toContain('--skip-if-missing-deps');
     expect(result.stdout).toContain('--list');
+    expect(result.stdout).toContain('--list-scenarios');
     expect(result.stdout).toContain('--list-selected');
     expect(result.stdout).toContain('Available scenarios:');
     expect(result.stdout).toContain('nested-subagent-picker');
@@ -52,6 +53,16 @@ describe('TUI validator args', () => {
     expect(result.stdout.split('\n')).toContain('nested-subagent-picker');
     expect(result.stdout).not.toContain('Available scenarios:');
     expect(result.stderr).not.toContain('building tui-harness bundle');
+  });
+
+  it('treats list-scenarios as a scenario list alias', () => {
+    const result = runValidator(['--list-scenarios']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.split('\n')).toContain('transcript');
+    expect(result.stdout.split('\n')).toContain('nested-subagent-picker');
+    expect(result.stdout).not.toContain('Available scenarios:');
+    expect(result.stderr).toBe('');
   });
 
   it('treats a leading package-manager separator as transparent for list', () => {


### PR DESCRIPTION
Closes #5306.\n\n## Summary\n- add `--list-scenarios` as an alias for `validate:tui -- --list`\n- document the alias in the validator help\n- cover the alias in `TuiValidatorArgs`\n\n## Dogfood\n- ran live `texra chat` with `--approval-policy ask` in a temp workspace, requested a harmless bash command, rejected it, and verified the CLI rendered a single rejected bash tool result and the model returned to idle\n- ran approval harness snapshots for bash approval, narrow bash approval, compact long command scroll, external inquiry copy question, and plan approval Odyssey\n\n## Validation\n- `corepack pnpm --filter @texra-ai/cli run validate:tui -- --list-scenarios`\n- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`\n- `corepack pnpm exec prettier --check packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/TuiValidatorArgs.vitest.mts`\n- `git diff --check`\n- `npm run compile:safe`\n- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only flag alias and test updates; no runtime product or security behavior changes.
> 
> **Overview**
> Adds **`--list-scenarios`** as an alias for the TUI validator’s existing **`--list`** flag so `validate:tui` can print scenario names without remembering the shorter flag (e.g. after `pnpm run … --`).
> 
> **`validate-tui.mjs`** documents both flags in help and treats **`--list`** and **`--list-scenarios`** identically in argument parsing (same exit path as before: scenario names only, no harness build).
> 
> **`TuiValidatorArgs.vitest.mts`** asserts help mentions the new alias and that **`--list-scenarios`** output matches **`--list`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ef445e9ff0cf350b99572d30d31a23e079d7b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->