### PR TITLE
fix(cli): register chat sessions for resume

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -11,7 +11,12 @@ import PQueue from 'p-queue';
 import { flushPendingRunTraces, getDefaultStreamLogStore } from '@transcript';
 import { tryPlatform } from '@platform/platform';
 import { getAgent, loadAgents } from '@agent/index';
-import { type AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import { registerExecution, writeTerminalStatus } from '@agent/storage';
+import {
+  AgentConfigSchema,
+  type AgentConfig,
+  type AgentConfigPayload,
+} from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   interruptActiveChildren,
@@ -78,6 +83,7 @@ import {
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import {
+  EXECUTION_STATUS,
   LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
   StreamStatusSchema,
@@ -176,6 +182,26 @@ export function buildInitialChatAgentConfig({
     ...(mediaFiles?.length ? { mediaFiles: [...mediaFiles] } : {}),
     ...(cliMultiAgentPresetId ? { cliMultiAgentPresetId } : {}),
   };
+}
+
+export async function registerFreshChatExecution(
+  executionId: ExecutionId,
+  configPayload: AgentConfigPayload,
+): Promise<AgentConfig> {
+  const config = AgentConfigSchema.parse(configPayload);
+  await registerExecution(executionId, config, config.agent);
+  return config;
+}
+
+export async function markRegisteredChatExecutionError(
+  executionId: ExecutionId,
+  options: {
+    readonly executionRegistered: boolean;
+    readonly agentSettled: boolean;
+  },
+): Promise<void> {
+  if (!options.executionRegistered || options.agentSettled) return;
+  await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
 }
 
 export interface ClearableTuiSessionState {
@@ -1124,11 +1150,15 @@ export async function runChat(
     disposers.push(unbindApprovals);
     const executionId = generateExecutionId();
     let waitingTurn = 0;
+    let executionRegistered = false;
+    let agentSettled = false;
     session.executionId = executionId;
 
     session.runPromise = setCliHelperModel(currentModel)
-      .then(() =>
-        executeAgent(config, executionId, {
+      .then(() => registerFreshChatExecution(executionId, config))
+      .then((registeredConfig) => {
+        executionRegistered = true;
+        return executeAgent(registeredConfig, executionId, {
           runtimeHost: wrapped,
           enforceCategory: true,
           onStreamResolved: (resolvedStreamId) => {
@@ -1147,9 +1177,10 @@ export async function runChat(
             );
             finalizeAssistantTranscriptEntries(session.streamId);
           },
-        }),
-      )
+        });
+      })
       .then((result) => {
+        agentSettled = true;
         if (session.stopRequested || result.status !== 'error') {
           session.runExitCode = CliExitCode.Success;
         } else if (hasCliApprovalDenied(sessionContext)) {
@@ -1177,7 +1208,11 @@ export async function runChat(
         }
         notify({ kind: 'agentFinished' });
       })
-      .catch((error: unknown) => {
+      .catch(async (error: unknown) => {
+        await markRegisteredChatExecutionError(executionId, {
+          executionRegistered,
+          agentSettled,
+        });
         if (!session.stopRequested) {
           // Ink owns stdout while the TUI is mounted; surface the failure
           // inline so the user sees why the agent stopped.

--- a/src/test-kernel/cli/RunChatRegistration.vitest.mts
+++ b/src/test-kernel/cli/RunChatRegistration.vitest.mts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import {
+  buildInitialChatAgentConfig,
+  markRegisteredChatExecutionError,
+  registerFreshChatExecution,
+} from '@cli/chat/tui/runChatTui';
+import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  registerExecution: vi.fn(),
+  writeTerminalStatus: vi.fn(),
+}));
+
+vi.mock('@agent/storage', async () => {
+  const actual =
+    await vi.importActual<typeof import('@agent/storage')>('@agent/storage');
+  return {
+    ...actual,
+    registerExecution: mocks.registerExecution,
+    writeTerminalStatus: mocks.writeTerminalStatus,
+  };
+});
+
+describe('CLI chat execution registration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.registerExecution.mockResolvedValue(undefined);
+    mocks.writeTerminalStatus.mockResolvedValue(undefined);
+  });
+
+  it('registers fresh chat executions so resume/history can resolve them', async () => {
+    const executionId = 'abc123' as ExecutionId;
+    const config = buildInitialChatAgentConfig({
+      agent: 'chat',
+      model: 'gpt54',
+      instruction: 'Prove a compactness lemma.',
+      workingDirectory: '/tmp/texra-chat',
+    });
+
+    const registered = await registerFreshChatExecution(executionId, config);
+
+    expect(registered).toMatchObject({
+      agent: 'chat',
+      model: 'gpt54',
+      instruction: 'Prove a compactness lemma.',
+      workingDirectory: '/tmp/texra-chat',
+      agentCategory: AgentCategory.ToolUse,
+    });
+    expect(mocks.registerExecution).toHaveBeenCalledWith(
+      executionId,
+      registered,
+      'chat',
+    );
+  });
+
+  it('marks registered chat executions as errored when launch throws', async () => {
+    const executionId = 'registered' as ExecutionId;
+
+    await markRegisteredChatExecutionError(executionId, {
+      executionRegistered: true,
+      agentSettled: false,
+    });
+
+    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
+      executionId,
+      EXECUTION_STATUS.ERROR,
+    );
+  });
+
+  it('does not mark launch errors before registration succeeds', async () => {
+    const executionId = 'unregistered' as ExecutionId;
+
+    await markRegisteredChatExecutionError(executionId, {
+      executionRegistered: false,
+      agentSettled: false,
+    });
+
+    expect(mocks.writeTerminalStatus).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite terminal status after the agent has settled', async () => {
+    const executionId = 'completed' as ExecutionId;
+
+    await markRegisteredChatExecutionError(executionId, {
+      executionRegistered: true,
+      agentSettled: true,
+    });
+
+    expect(mocks.writeTerminalStatus).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- register fresh interactive `texra chat` executions before calling the low-level agent runner
- reuse the parsed registered config for execution so history/resume metadata matches the run
- add a focused kernel test for chat execution registration

## Root Cause

`runChatTui` generated an execution id and invoked `executeAgent` directly. That low-level runner expects its caller to own registration, so the TUI could print a resume hint for a flow/conversation record without `meta.json` or `config.json`. `history show` could preview the orphaned record, but `history list` omitted it and `resume` failed with `Execution not found`.

Closes #5308.

## Dogfood Validation

Started a real built CLI chat in `/tmp/texra-live-resume-registration`, interrupted it, then verified:

- `history list` shows `800f721bff43` as `chat` / `resumable`
- `history show 800f721bff43` reports `Agent: chat`, `Model: gpt54`, and full config JSON
- stored execution now contains `meta.json`, `config.json`, `conversation.json`, and the flow record
- `resume 800f721bff43` opens the TUI and restores the transcript instead of failing

## Checks

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/RunChatRegistration.vitest.mts src/test-kernel/cli/RunChatConfig.vitest.mts src/test-kernel/cli/SessionResumeResolution.vitest.mts src/test-kernel/cli/HistoryStatus.vitest.ts`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/RunChatRegistration.vitest.mts`
- `git diff --check -- packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/RunChatRegistration.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with 11 pre-existing import-order warnings outside this branch)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI launch-path change with explicit registration/error guards and focused tests; no auth or shared runtime contract changes beyond aligning chat with existing executeAgent expectations.
> 
> **Overview**
> Interactive **`texra chat`** now **registers each new execution** (parsed config + `registerExecution`) **before** `executeAgent`, matching callers like the extension setup path that already owned registration. The runner receives the **same parsed `AgentConfig`** persisted to disk so **`history list`**, **`history show`**, and **`resume`** see `meta.json` / `config.json` instead of orphaned flow hints.
> 
> Launch failures after registration but before the agent finishes are marked **`EXECUTION_STATUS.ERROR`** via `markRegisteredChatExecutionError`, without touching unregistered runs or overwriting status once the run has settled.
> 
> Kernel tests cover registration wiring and the error-marking guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1f95beb7f7c4ce9624c05e5ef9bbba104a5d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->