### PR TITLE
fix(cli): make Ctrl-J insert TUI newlines

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -49,6 +49,7 @@ const DC2 = String.fromCharCode(18); // Ctrl-R
 const DC4 = String.fromCharCode(20); // Ctrl-T
 const NAK = String.fromCharCode(21); // Ctrl-U
 const EM = String.fromCharCode(25); // Ctrl-Y
+const LF = String.fromCharCode(10); // Ctrl-J
 const KITTY_SHIFT_ENTER = ESC + '[13;2u';
 const UP = ESC + '[A';
 const DOWN = ESC + '[B';
@@ -392,6 +393,15 @@ const SCENARIOS = [
     frame: 'tail',
     expect: ['Harness received: first line\nsecond line'],
     unexpect: ['first linesecond line', '13;2u', '[13', 'ERROR'],
+  },
+  {
+    name: 'ctrl-j-newline',
+    cols: 120,
+    env: { HARNESS_ENTRIES: '2' },
+    keys: ['first line', LF, 'second line', '\r'],
+    frame: 'tail',
+    expect: ['Harness received: first line\nsecond line'],
+    unexpect: ['first linesecond line', 'ERROR'],
   },
   {
     name: 'agent-form',

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -21,9 +21,9 @@ import {
 } from './textInputEditing';
 import {
   isPlainReturnInput,
-  isShiftReturnInput,
   isCtrlInput,
   isEscapeInput,
+  isTextInputNewlineInput,
   isUnhandledControlInput,
   metaChordInput,
 } from './inputKeys';
@@ -393,7 +393,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         return;
       }
 
-      if (isCtrlInput(input, key, 'j') || isShiftReturnInput(input, key)) {
+      if (isTextInputNewlineInput(input, key)) {
         // Ctrl-J (universal) or Shift+Enter (Kitty-protocol terminals) →
         // literal newline. Kills the legacy `/multi` ceremony.
         applyEdit(insertText(value, cursor, '\n'));

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -79,7 +79,7 @@ export function metaChordDigit(
 // Deliberately shift-agnostic: in modals, Select, and the child-control picker
 // Shift+Enter has no newline meaning and must still confirm. The text editor is
 // the only place Shift+Enter differs (→ newline), and it discriminates by
-// testing `isShiftReturnInput` *before* this — so accepting shift here can't
+// testing `isTextInputNewlineInput` *before* this — so accepting shift here can't
 // make Shift+Enter also submit in the editor.
 export function isPlainReturnInput(
   input: string,
@@ -101,6 +101,23 @@ export function isShiftReturnInput(
   if (input === SYNTHETIC_SHIFT_RETURN_INPUT) return true;
   if (key.ctrl || key.meta || key.shift !== true) return false;
   return key.return === true || input === '\r' || input === '\n';
+}
+
+/**
+ * Text inputs treat Ctrl-J and Shift+Enter as literal newline insertion before
+ * the shared Return handler can submit. Raw Ctrl-J arrives from Ink as bare LF
+ * with no ctrl flag, while Kitty-capable terminals may surface either Ctrl+J as
+ * a ctrl chord or Shift+Enter as a modified return/synthetic token.
+ */
+export function isTextInputNewlineInput(
+  input: string,
+  key: ReturnKeyInput,
+): boolean {
+  return (
+    (input === '\n' && !key.meta) ||
+    isCtrlInput(input, key, 'j') ||
+    isShiftReturnInput(input, key)
+  );
 }
 
 // Under the Kitty disambiguate flag, terminals report keypad Enter as its own

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -17,6 +17,7 @@ import {
   isKittyShiftEnter,
   isPlainReturnInput,
   isShiftReturnInput,
+  isTextInputNewlineInput,
   metaChordDigit,
   metaChordInput,
   normalizedCtrlInput,
@@ -45,6 +46,17 @@ describe('CLI TUI text input editing', () => {
     expect(isShiftReturnInput('', { return: true })).toBe(false);
     expect(isShiftReturnInput('j', { ctrl: true })).toBe(false);
     expect(isShiftReturnInput('', { return: true, meta: true })).toBe(false);
+  });
+
+  it('treats Ctrl-J and Shift+Enter as literal newlines in text input', () => {
+    expect(isTextInputNewlineInput('\n', {})).toBe(true);
+    expect(isTextInputNewlineInput('j', { ctrl: true })).toBe(true);
+    expect(isTextInputNewlineInput(SYNTHETIC_SHIFT_RETURN_INPUT, {})).toBe(
+      true,
+    );
+    expect(isTextInputNewlineInput('\n', { meta: true })).toBe(false);
+    expect(isTextInputNewlineInput('\r', {})).toBe(false);
+    expect(isTextInputNewlineInput('', { return: true })).toBe(false);
   });
 
   it('recognizes Kitty Enter sequences for raw re-dispatch', () => {


### PR DESCRIPTION
## Summary

- fix the CLI draft input so raw Ctrl-J inserts a literal newline before the shared Enter-submit path runs
- keep Enter confirmation behavior unchanged for selectors, modals, and slash-command UI
- add PTY frame coverage for the advertised `[Ctrl-J]newline` fallback next to the existing Kitty Shift+Enter scenario

## Root cause

Ink parses raw LF from Ctrl-J as an enter-like key, but `BaseTextInput` only checked `key.ctrl + j` and Kitty Shift+Enter before falling through to `isPlainReturnInput()`. In a real PTY run, Ctrl-J submitted `first line` and then submitted `second line` as a separate draft.

Closes #5312.

## Validation

- `node scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-ctrl-j-frames kitty-shift-enter-newline ctrl-j-newline`
- `node scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-regression-frames orchestrate-relay-model-pick orchestrate-personal-model-pick kitty-shift-enter-newline ctrl-j-newline external-inquiry-copy-question model-form-selectable-submit subagent-focused-submit`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/input/inputKeys.ts packages/cli/src/chat/tui/input/BaseTextInput.tsx src/test-kernel/cli/TextInputEditing.vitest.mts packages/cli/scripts/validate-tui.mjs`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with 11 existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to draft text-input key handling and tests; modals and other Enter paths still use plain return detection unchanged.
> 
> **Overview**
> Fixes the CLI draft input so **Ctrl-J inserts a literal newline** instead of submitting early. Ink often delivers Ctrl-J as a bare **LF** with no `ctrl` flag, so the editor previously fell through to plain Enter handling and split multi-line drafts into separate submissions.
> 
> The change centralizes newline detection in **`isTextInputNewlineInput`**, which treats bare LF (without meta), Ctrl+J chords, and Shift+Enter / Kitty synthetic tokens as newline insertion **before** submit. **`BaseTextInput`** uses that helper instead of checking Ctrl+J and Shift+Enter separately. Unit tests and a **`ctrl-j-newline`** PTY scenario mirror the existing Kitty Shift+Enter coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ff88e2a7005685c46067d1740175d59ef5c8792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->