### PR TITLE
fix(cli): soften TUI snapshot reports

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2231,6 +2231,19 @@ function escapeHtml(value) {
     .replaceAll('"', '&quot;');
 }
 
+const SNAPSHOT_THEME = {
+  colorScheme: 'light',
+  pageBackground: '#f6f4ee',
+  text: '#24211c',
+  muted: '#6e675c',
+  cardBackground: '#fffdf8',
+  border: '#d8d0c3',
+  headerBorder: '#e4ddd2',
+  failedBorder: '#b55d54',
+  link: '#1b5e8f',
+  failureText: '#9b3d35',
+};
+
 function snapshotSvgDocument(name, frame) {
   const lines = frame.split('\n');
   const charWidth = 8.4;
@@ -2250,8 +2263,8 @@ function snapshotSvgDocument(name, frame) {
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="title">
   <title id="title">${escapeHtml(name)} TUI snapshot</title>
-  <rect width="100%" height="100%" fill="#101216"/>
-  <text fill="#e8e4d8" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="${fontSize}" xml:space="preserve">
+  <rect width="100%" height="100%" fill="${SNAPSHOT_THEME.cardBackground}"/>
+  <text fill="${SNAPSHOT_THEME.text}" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="${fontSize}" xml:space="preserve">
     ${tspans}
   </text>
 </svg>
@@ -2299,35 +2312,35 @@ function snapshotHtmlDocument(results) {
   <meta charset="utf-8">
   <title>TeXRA TUI snapshots</title>
   <style>
-    :root { color-scheme: dark; }
+    :root { color-scheme: ${SNAPSHOT_THEME.colorScheme}; }
     body {
       margin: 0;
-      background: #101216;
-      color: #e8e4d8;
+      background: ${SNAPSHOT_THEME.pageBackground};
+      color: ${SNAPSHOT_THEME.text};
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     }
     main { max-width: 1280px; margin: 0 auto; padding: 24px; }
     h1 { font-size: 20px; margin: 0 0 6px; }
-    .meta { color: #a8a293; margin: 0 0 24px; }
+    .meta { color: ${SNAPSHOT_THEME.muted}; margin: 0 0 24px; }
     .scenario {
-      border: 1px solid #3d424d;
+      border: 1px solid ${SNAPSHOT_THEME.border};
       border-radius: 8px;
       margin: 0 0 24px;
       overflow: hidden;
-      background: #171a20;
+      background: ${SNAPSHOT_THEME.cardBackground};
     }
-    .scenario.failed { border-color: #a95b5b; }
+    .scenario.failed { border-color: ${SNAPSHOT_THEME.failedBorder}; }
     header {
       align-items: center;
-      border-bottom: 1px solid #303540;
+      border-bottom: 1px solid ${SNAPSHOT_THEME.headerBorder};
       display: flex;
       justify-content: space-between;
       padding: 10px 14px;
     }
     h2 { font-size: 14px; margin: 0; }
     nav { display: flex; gap: 14px; }
-    a { color: #8cc8ff; text-decoration: none; }
-    ul { color: #ffb4a8; margin: 12px 14px 0; }
+    a { color: ${SNAPSHOT_THEME.link}; text-decoration: none; }
+    ul { color: ${SNAPSHOT_THEME.failureText}; margin: 12px 14px 0; }
     pre {
       line-height: 1.22;
       margin: 0;


### PR DESCRIPTION
## Summary

- switch generated CLI TUI snapshot reports from a high-contrast dark theme to a softer light report theme
- centralize SVG and HTML snapshot colors in one `SNAPSHOT_THEME` object
- keep the runtime TUI rendering unchanged; this only affects artifacts produced by `validate-tui --snapshot-dir`

Closes #5314.

## Dogfood

Ran a focused approval/inquiry/subagent snapshot pass before the change and inspected the generated frames:

```bash
cd packages/cli
node scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-dogfood-frames \
  long-bash-approval compact-long-bash-approval external-inquiry-long-80-cols \
  external-inquiry-copy-question agent-proposal-long compact-agent-proposal-scroll \
  plan-approval subagent-picker task-subworkflow-detail-long-output
```

Then regenerated a focused set after the change and verified the SVG/HTML artifacts now use the light palette:

```bash
cd packages/cli
node scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-light-frames \
  external-inquiry-long-80-cols long-bash-approval subagent-picker
```

## Validation

- `node scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-light-frames external-inquiry-long-80-cols long-bash-approval subagent-picker`
- `corepack pnpm exec prettier --check packages/cli/scripts/validate-tui.mjs`
- `node --check packages/cli/scripts/validate-tui.mjs`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (passes with 11 existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic-only changes to validator snapshot HTML/SVG styling in validate-tui.mjs; no runtime CLI or auth paths touched.
> 
> **Overview**
> Generated CLI TUI snapshot artifacts from `validate-tui --snapshot-dir` now use a **soft light report palette** instead of the previous high-contrast dark styling.
> 
> Colors for **SVG frames** and the **`index.html` report** are centralized in a single `SNAPSHOT_THEME` object (page, cards, borders, links, failure accents). **Runtime TUI rendering is unchanged**—only snapshot/report output is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef30ad1da15cfde1ec149baca25bd33e153a612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->