### PR TITLE
fix(cli): persist model switches for resume

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -11,10 +11,6 @@ import {
   type ResultMeta,
 } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { isToolUseTaskState } from '@agent/core/execution/TaskState';
-import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
-import { getStreamTabId } from '@agent/runtime/streamTab';
-import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { isFileNotFoundError } from '@common/errors';
 import {
   EXECUTION_STATUS,
@@ -24,6 +20,8 @@ import {
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
+
+import { readCliToolUseResumeData } from './toolUseResumeData';
 
 const HISTORY_FILE_SCAN_DEPTH = 2;
 const CONVERSATION_PREVIEW_MESSAGE_LIMIT = 3;
@@ -61,6 +59,7 @@ export interface CliHistoryDetails {
   readonly conversationPreview: CliHistoryConversationPreview | null;
   readonly files: readonly CliHistoryFile[];
   readonly hasFlowRecord: boolean;
+  readonly currentModel?: string;
 }
 
 export interface CliHistoryConversationPreview {
@@ -139,7 +138,9 @@ export async function readCliHistoryDetails(
     store.readWorkspaceFiles(),
     listGeneratedFiles(id),
   ]);
-  const hasFlowRecord = await hasResumableCliFlowRecord(id, config);
+  const resumeData = config
+    ? await readCliToolUseResumeData(id, config)
+    : undefined;
   const conversationPreview = createConversationPreview(conversation);
   const workspaceFiles = await listWorkspaceToolFiles(
     config,
@@ -148,12 +149,12 @@ export async function readCliHistoryDetails(
   );
   const files = mergeHistoryFiles(generatedFiles, workspaceFiles);
 
-  if (!meta && !config && !conversationPreview && !hasFlowRecord) return null;
+  if (!meta && !config && !conversationPreview && !resumeData) return null;
   return {
     id,
     status: resolveCliHistoryStatus({
       terminalStatus: meta?.terminalStatus,
-      hasFlowRecord,
+      hasFlowRecord: !!resumeData,
     }),
     meta,
     config,
@@ -161,7 +162,8 @@ export async function readCliHistoryDetails(
     report,
     conversationPreview,
     files,
-    hasFlowRecord,
+    hasFlowRecord: !!resumeData,
+    currentModel: resumeData?.snapshot.agentConfig.model,
   };
 }
 
@@ -252,14 +254,22 @@ export function formatCliHistoryDetailsText(
   details: CliHistoryDetails,
 ): string {
   const { config, meta } = details;
+  const model = details.currentModel ?? config?.model;
   const lines = [
     `Execution: ${details.id}`,
     `Status: ${details.status}`,
     `Timestamp: ${meta?.timestamp ?? 'unknown'}`,
     `Agent: ${config?.agent ?? 'unknown'}`,
-    `Model: ${config?.model ?? 'unknown'}`,
+    `Model: ${model ?? 'unknown'}`,
   ];
 
+  if (
+    details.currentModel &&
+    config?.model &&
+    details.currentModel !== config.model
+  ) {
+    lines.push(`Startup model: ${config.model}`);
+  }
   if (config?.agentCategory) lines.push(`Category: ${config.agentCategory}`);
   if (meta?.parentExecutionId) lines.push(`Parent: ${meta.parentExecutionId}`);
   if (meta?.description) lines.push(`Description: ${meta.description}`);
@@ -286,40 +296,23 @@ async function toCliHistoryEntry(
   entry: ExecutionListingEntry,
 ): Promise<CliHistoryEntry> {
   const inputBasename = firstInputBasename(entry.agentConfig);
-  const hasFlowRecord =
-    entry.terminalStatus === undefined
-      ? await hasResumableCliFlowRecord(entry.id, entry.agentConfig)
-      : false;
+  const resumeData =
+    entry.terminalStatus === undefined && entry.agentConfig
+      ? await readCliToolUseResumeData(entry.id, entry.agentConfig)
+      : null;
   return {
     id: entry.id,
     timestamp: entry.timestamp,
     agent: entry.agent,
-    model: entry.model,
+    model: resumeData?.snapshot.agentConfig.model ?? entry.model,
     status: resolveCliHistoryStatus({
       terminalStatus: entry.terminalStatus,
-      hasFlowRecord,
+      hasFlowRecord: !!resumeData,
     }),
     inputBasename,
     category: entry.category,
     description: entry.description,
   };
-}
-
-async function hasResumableCliFlowRecord(
-  id: ExecutionId,
-  config?: AgentConfig | null,
-): Promise<boolean> {
-  const agentConfig = config ?? (await readCliHistoryConfig(id));
-  if (!agentConfig) return false;
-
-  const taskState = agentConfigToTaskState(agentConfig);
-  if (!isToolUseTaskState(taskState)) return false;
-
-  const streamId = getStreamTabId(agentConfig.agent, agentConfig.model, {
-    executionId: id,
-  });
-  const resume = await retrieveSessionResumeData(streamId, id, taskState);
-  return resume?.type === 'toolUse';
 }
 
 function firstInputBasename(config: AgentConfig | null): string {

--- a/packages/cli/src/runtime/sessionResume.ts
+++ b/packages/cli/src/runtime/sessionResume.ts
@@ -9,12 +9,11 @@
 import { isToolUseTaskState } from '@agent/core/execution/TaskState';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse';
-import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
-import { getStreamTabId } from '@agent/runtime/streamTab';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import { readCliHistoryConfig } from './history';
+import { readCliToolUseResumeData } from './toolUseResumeData';
 
 export type CliResumeResolution =
   | {
@@ -39,15 +38,15 @@ export async function resolveCliResumeSnapshot(
   const taskState = agentConfigToTaskState(config);
   if (!isToolUseTaskState(taskState)) return { kind: 'workflow' };
 
-  // The original run derived its streamId deterministically from agent+model+id,
-  // so re-deriving it here reuses the same stream/transcript on resume.
-  const streamId = getStreamTabId(config.agent, config.model, {
-    executionId: id,
-  });
-  const resume = await retrieveSessionResumeData(streamId, id, taskState);
-  if (resume?.type !== 'toolUse') return { kind: 'no-snapshot' };
+  const resume = await readCliToolUseResumeData(id, config);
+  if (!resume) return { kind: 'no-snapshot' };
 
-  return { kind: 'toolUse', snapshot: resume.snapshot, streamId, config };
+  return {
+    kind: 'toolUse',
+    snapshot: resume.snapshot,
+    streamId: resume.streamId,
+    config: resume.config,
+  };
 }
 
 /** A user-facing line explaining why a non-tool-use resolution can't continue. */

--- a/packages/cli/src/runtime/toolUseResumeData.ts
+++ b/packages/cli/src/runtime/toolUseResumeData.ts
@@ -1,0 +1,32 @@
+import { isToolUseTaskState } from '@agent/core/execution/TaskState';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse';
+import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { getStreamTabId } from '@agent/runtime/streamTab';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+export interface CliToolUseResumeData {
+  readonly snapshot: ToolUseSessionSnapshot;
+  readonly streamId: StreamTabId;
+  readonly config: AgentConfig;
+}
+
+export async function readCliToolUseResumeData(
+  id: ExecutionId,
+  config: AgentConfig,
+): Promise<CliToolUseResumeData | null> {
+  const taskState = agentConfigToTaskState(config);
+  if (!isToolUseTaskState(taskState)) return null;
+
+  const streamId = getStreamTabId(config.agent, config.model, {
+    executionId: id,
+  });
+  const resume = await retrieveSessionResumeData(streamId, id, taskState);
+  if (resume?.type !== 'toolUse') return null;
+  return {
+    snapshot: resume.snapshot,
+    streamId,
+    config: resume.snapshot.agentConfig,
+  };
+}

--- a/src/agent/implementations/flows/tooluse/modelSwitchState.ts
+++ b/src/agent/implementations/flows/tooluse/modelSwitchState.ts
@@ -13,22 +13,20 @@ export function currentModelFromUserChannels(
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
-export function withToolUseSharedModel(
+export function setToolUseSharedModel(
   shared: ToolUseRunShared,
   model: string,
-): ToolUseRunShared | null {
-  if (!shared.stateSlices) return null;
-  return {
-    ...shared,
-    stateSlices: {
-      ...shared.stateSlices,
-      userChannels: {
-        input: shared.stateSlices.userChannels.input,
-        transient: {
-          ...shared.stateSlices.userChannels.transient,
-          [MODEL_USER_VARIABLE]: model,
-        },
+): boolean {
+  if (!shared.stateSlices) return false;
+  shared.stateSlices = {
+    ...shared.stateSlices,
+    userChannels: {
+      input: shared.stateSlices.userChannels.input,
+      transient: {
+        ...shared.stateSlices.userChannels.transient,
+        [MODEL_USER_VARIABLE]: model,
       },
     },
   };
+  return true;
 }

--- a/src/agent/implementations/flows/tooluse/modelSwitchState.ts
+++ b/src/agent/implementations/flows/tooluse/modelSwitchState.ts
@@ -1,0 +1,34 @@
+import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
+
+import type { ToolUseRunShared } from './nodes/types';
+
+const MODEL_USER_VARIABLE = 'MODEL';
+
+export function currentModelFromUserChannels(
+  channels: UserVariableChannels,
+): string | undefined {
+  const value =
+    channels.transient[MODEL_USER_VARIABLE] ??
+    channels.input[MODEL_USER_VARIABLE];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+export function withToolUseSharedModel(
+  shared: ToolUseRunShared,
+  model: string,
+): ToolUseRunShared | null {
+  if (!shared.stateSlices) return null;
+  return {
+    ...shared,
+    stateSlices: {
+      ...shared.stateSlices,
+      userChannels: {
+        input: shared.stateSlices.userChannels.input,
+        transient: {
+          ...shared.stateSlices.userChannels.transient,
+          [MODEL_USER_VARIABLE]: model,
+        },
+      },
+    },
+  };
+}

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -41,7 +41,7 @@ import {
   migrateSharedState,
   type ToolUseRunShared,
 } from './nodes/types';
-import { withToolUseSharedModel } from './modelSwitchState';
+import { setToolUseSharedModel } from './modelSwitchState';
 import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 import type { ToolUseServices } from './ToolUseServices';
@@ -91,6 +91,12 @@ export interface ToolUseFlowContext {
 
 export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
 
+type ToolUsePersistedFlow<C> = PersistedFlow<
+  ToolUseRunShared,
+  Record<string, unknown>,
+  ToolUseServices<C>
+>;
+
 const IMMEDIATE_COMPACTION_FOLLOW_UP =
   'The user requested immediate context compaction. Do not start a new task; continue only far enough for the runtime to process any available context compaction, and do not claim that compaction has completed.';
 
@@ -134,21 +140,17 @@ export async function runToolUseFlow<C = unknown>(
     delegationTrimmed,
   };
   const switchedHandlers = new Set<ToolUseServices<C>['modelHandler']>();
+  let activePersistedFlow: ToolUsePersistedFlow<C> | undefined;
 
   const persistModelSwitch = async (model: string): Promise<void> => {
-    const key = flowKey(executionId);
-    const flowRecord = await kv.read<FlowRecord>(key);
-    const migrationResult = migrateSharedState(flowRecord?.shared);
-    const updatedShared = migrationResult
-      ? withToolUseSharedModel(migrationResult.data, model)
-      : null;
-    if (!flowRecord || !updatedShared) {
+    const flow = activePersistedFlow;
+    const liveShared = await flow?.getShared();
+    if (!flow || !liveShared || !setToolUseSharedModel(liveShared, model)) {
       throw new Error(
         'Cannot save the model switch because the resumable session state is unavailable.',
       );
     }
-    flowRecord.shared = updatedShared;
-    await kv.write(key, flowRecord);
+    await flow.setShared(liveShared);
   };
 
   const switchModel = async (model: string): Promise<void> => {
@@ -254,11 +256,8 @@ export async function runToolUseFlow<C = unknown>(
     prepareNode.next(cycleNode);
     cycleNode.next(waitNode);
     waitNode.on(FlowTransition.CONTINUE, cycleNode);
-    const pf = new PersistedFlow<
-      ToolUseRunShared,
-      Record<string, unknown>,
-      ToolUseServices<C>
-    >(prepareNode, kv);
+    const pf: ToolUsePersistedFlow<C> = new PersistedFlow(prepareNode, kv);
+    activePersistedFlow = pf;
     pf.setServices(services);
     pf.setProjection(async (s, store) => {
       const todos = s.stateSlices?.workspaceSnapshot?.workPlan?.todos;
@@ -304,6 +303,7 @@ export async function runToolUseFlow<C = unknown>(
         : undefined;
     }
   } finally {
+    activePersistedFlow = undefined;
     if (shared.userCancelledRetry) {
       logger.debug('Flow record preserved for resume after retry cancellation');
     } else {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -41,6 +41,7 @@ import {
   migrateSharedState,
   type ToolUseRunShared,
 } from './nodes/types';
+import { withToolUseSharedModel } from './modelSwitchState';
 import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 import type { ToolUseServices } from './ToolUseServices';
@@ -134,6 +135,22 @@ export async function runToolUseFlow<C = unknown>(
   };
   const switchedHandlers = new Set<ToolUseServices<C>['modelHandler']>();
 
+  const persistModelSwitch = async (model: string): Promise<void> => {
+    const key = flowKey(executionId);
+    const flowRecord = await kv.read<FlowRecord>(key);
+    const migrationResult = migrateSharedState(flowRecord?.shared);
+    const updatedShared = migrationResult
+      ? withToolUseSharedModel(migrationResult.data, model)
+      : null;
+    if (!flowRecord || !updatedShared) {
+      throw new Error(
+        'Cannot save the model switch because the resumable session state is unavailable.',
+      );
+    }
+    flowRecord.shared = updatedShared;
+    await kv.write(key, flowRecord);
+  };
+
   const switchModel = async (model: string): Promise<void> => {
     const nextConfig = MODEL_CONFIGS[model];
     if (!nextConfig) {
@@ -150,6 +167,12 @@ export async function runToolUseFlow<C = unknown>(
       throw new Error(
         'Cannot switch this conversation to a model with a different conversation format. Start a new chat to use that model.',
       );
+    }
+    try {
+      await persistModelSwitch(model);
+    } catch (error) {
+      nextHandler.dispose();
+      throw error;
     }
     nextHandler.setAgentCategory(setting.agentCategory);
     nextHandler.setLogger(logger);

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -22,6 +22,7 @@ import {
   TOOL_USE_SNAPSHOT_VERSION,
   ToolUseSessionSnapshotSchema,
 } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
+import { currentModelFromUserChannels } from '@agent/implementations/flows/tooluse/modelSwitchState';
 import {
   isToolUseTaskState,
   isWorkflowTaskState,
@@ -174,6 +175,12 @@ async function retrieveToolUseResumeData(
     }
 
     const { messages, stateSlices } = parseResult.data;
+    const agentConfig = {
+      ...taskState.agentConfig,
+      model:
+        currentModelFromUserChannels(stateSlices.userChannels) ??
+        taskState.agentConfig.model,
+    };
 
     // Construct and validate the complete snapshot.
     // Validation provides defense-in-depth: even if flow record is valid,
@@ -182,7 +189,7 @@ async function retrieveToolUseResumeData(
       version: TOOL_USE_SNAPSHOT_VERSION,
       executionId,
       streamId,
-      agentConfig: taskState.agentConfig,
+      agentConfig,
       messages,
       run: stateSlices.runStateSnapshot,
       workspace: stateSlices.workspaceSnapshot,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { getExecutionStore } from '@agent/storage';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { AgentRunStateSnapshotSchema } from '@agent/core/execution/AgentState';
+import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
+import { flowKey } from '@agent/node/persistedFlow';
+import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+const CONFIG: AgentConfig = {
+  inputFiles: [],
+  contextFiles: [],
+  mediaFiles: [],
+  outputFiles: [],
+  editedFile: null,
+  agent: 'chat',
+  model: 'gpt54',
+  instruction: 'Continue.',
+  agentCategory: AgentCategory.ToolUse,
+  editedFiles: [],
+  toolConfig: DEFAULT_TOOL_CONFIG,
+  memories: [],
+  workingDirectory: '/workspace',
+  cliOutputFile: null,
+  cliMultiAgentPresetId: null,
+};
+
+beforeEach(async () => {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(createFakePlatform({ workspacePath: '/workspace' }));
+});
+
+describe('retrieveSessionResumeData', () => {
+  it('uses the persisted current model while preserving the original stream id', async () => {
+    const executionId = 'abc123' as ExecutionId;
+    const streamId = 'chat@gpt54#abc123' as StreamTabId;
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        messages: [],
+        shouldSkipCycle: false,
+        stateSlices: {
+          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+          userChannels: {
+            input: Object.freeze({ MODEL: 'gpt54' }),
+            transient: { MODEL: 'gpt55' },
+          },
+        },
+      },
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+
+    const resume = await retrieveSessionResumeData(
+      streamId,
+      executionId,
+      agentConfigToTaskState(CONFIG),
+    );
+
+    expect(resume?.type).toBe('toolUse');
+    if (resume?.type !== 'toolUse') return;
+    expect(resume.snapshot.streamId).toBe(streamId);
+    expect(resume.snapshot.agentConfig.model).toBe('gpt55');
+  });
+});

--- a/src/test-kernel/agent/toolUse/ModelSwitchState.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ModelSwitchState.vitest.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   currentModelFromUserChannels,
-  withToolUseSharedModel,
+  setToolUseSharedModel,
 } from '@agent/implementations/flows/tooluse/modelSwitchState';
 import type { ToolUseRunShared } from '@agent/implementations/flows/tooluse/nodes/types';
 
@@ -28,18 +28,19 @@ describe('tool-use model switch state helpers', () => {
       },
     } as unknown as ToolUseRunShared;
 
-    const updated = withToolUseSharedModel(shared, 'gpt55');
+    const updated = setToolUseSharedModel(shared, 'gpt55');
 
-    expect(updated?.stateSlices?.userChannels.input).toBe(input);
-    expect(updated?.stateSlices?.userChannels.transient.MODEL).toBe('gpt55');
+    expect(updated).toBe(true);
+    expect(shared.stateSlices?.userChannels.input).toBe(input);
+    expect(shared.stateSlices?.userChannels.transient.MODEL).toBe('gpt55');
   });
 
-  it('returns null when the flow has not reached resumable state', () => {
+  it('returns false when the flow has not reached resumable state', () => {
     expect(
-      withToolUseSharedModel(
+      setToolUseSharedModel(
         { messages: [], shouldSkipCycle: false, stateSlices: null },
         'gpt55',
       ),
-    ).toBeNull();
+    ).toBe(false);
   });
 });

--- a/src/test-kernel/agent/toolUse/ModelSwitchState.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ModelSwitchState.vitest.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  currentModelFromUserChannels,
+  withToolUseSharedModel,
+} from '@agent/implementations/flows/tooluse/modelSwitchState';
+import type { ToolUseRunShared } from '@agent/implementations/flows/tooluse/nodes/types';
+
+describe('tool-use model switch state helpers', () => {
+  it('prefers the transient model over the launch model', () => {
+    expect(
+      currentModelFromUserChannels({
+        input: Object.freeze({ MODEL: 'gpt54' }),
+        transient: { MODEL: 'gpt55' },
+      }),
+    ).toBe('gpt55');
+  });
+
+  it('updates the persisted transient model without rewriting input variables', () => {
+    const input = Object.freeze({ MODEL: 'gpt54' });
+    const shared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: {
+        runStateSnapshot: {},
+        workspaceSnapshot: {},
+        userChannels: { input, transient: { MODEL: 'gpt54' } },
+      },
+    } as unknown as ToolUseRunShared;
+
+    const updated = withToolUseSharedModel(shared, 'gpt55');
+
+    expect(updated?.stateSlices?.userChannels.input).toBe(input);
+    expect(updated?.stateSlices?.userChannels.transient.MODEL).toBe('gpt55');
+  });
+
+  it('returns null when the flow has not reached resumable state', () => {
+    expect(
+      withToolUseSharedModel(
+        { messages: [], shouldSkipCycle: false, stateSlices: null },
+        'gpt55',
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   listExecutions: vi.fn(),
   deleteExecution: vi.fn(),
   deleteAllExecutions: vi.fn(),
+  readCliToolUseResumeData: vi.fn(),
 }));
 
 vi.mock('@agent/storage', async () => {
@@ -44,6 +45,10 @@ vi.mock('@agent/storage', async () => {
 
 vi.mock('@utils/files/taskRunStorage', () => ({
   resolveStoragePath: vi.fn(async () => undefined),
+}));
+
+vi.mock('@cli/runtime/toolUseResumeData', () => ({
+  readCliToolUseResumeData: mocks.readCliToolUseResumeData,
 }));
 
 // Imported after vi.mock so the mocked dependencies are in place.
@@ -91,6 +96,7 @@ describe('CLI history runtime', () => {
     mocks.readResultMeta.mockResolvedValue(null);
     mocks.readReport.mockResolvedValue(null);
     mocks.exists.mockResolvedValue(false);
+    mocks.readCliToolUseResumeData.mockResolvedValue(null);
   });
 
   it('formats history list rows with the stable tab-separated text shape', async () => {
@@ -135,6 +141,28 @@ describe('CLI history runtime', () => {
     await expect(readCliHistoryConfig('a1' as ExecutionId)).resolves.toEqual(
       config,
     );
+  });
+
+  it('shows the current resumable model without losing the startup model', async () => {
+    const toolUseConfig = {
+      ...config,
+      agent: 'chat',
+      model: 'gpt54',
+      agentCategory: 'toolUse',
+    } as AgentConfig;
+    mocks.readConfig.mockResolvedValue(toolUseConfig);
+    mocks.readCliToolUseResumeData.mockResolvedValue({
+      streamId: 'chat@gpt54#a1',
+      config: toolUseConfig,
+      snapshot: { agentConfig: { ...toolUseConfig, model: 'gpt55' } },
+    });
+
+    const details = await readCliHistoryDetails('a1' as ExecutionId);
+    const text = formatCliHistoryDetailsText(details!);
+
+    expect(details?.currentModel).toBe('gpt55');
+    expect(text).toContain('Model: gpt55');
+    expect(text).toContain('Startup model: gpt54');
   });
 
   it('shows a bounded final assistant preview when no report is stored', async () => {

--- a/src/test-kernel/cli/SessionResumeResolution.vitest.mts
+++ b/src/test-kernel/cli/SessionResumeResolution.vitest.mts
@@ -81,8 +81,12 @@ describe('resolveCliResumeSnapshot', () => {
   });
 
   it('returns toolUse with snapshot + streamId when a flow record exists', async () => {
-    const snapshot = { executionId: EXECUTION_ID, streamId: STREAM_ID };
     const config = toolUseConfig();
+    const snapshot = {
+      executionId: EXECUTION_ID,
+      streamId: STREAM_ID,
+      agentConfig: { ...config, model: 'gpt-5.5' },
+    };
     mocks.readCliHistoryConfig.mockResolvedValue(config);
     mocks.retrieveSessionResumeData.mockResolvedValue({
       type: 'toolUse',
@@ -95,7 +99,7 @@ describe('resolveCliResumeSnapshot', () => {
       kind: 'toolUse',
       snapshot,
       streamId: STREAM_ID,
-      config,
+      config: snapshot.agentConfig,
     });
     // The stream id is re-derived from agent + model + execution id so resume
     // reuses the original stream/transcript.


### PR DESCRIPTION
## Summary

Fixes #5316.

- Persist `/model` switches into the active idle tool-use flow state, so exiting before another turn or continuing in the same TUI no longer loses the selected model.
- Keep the original launch config/model as the stable stream-log locator, while rebuilding the resumable snapshot with the current selected model.
- Share the CLI tool-use resume lookup between `history` and `resume`, so both surfaces read the same snapshot state.
- Show `Startup model:` in `history show` when it differs from the current resumable model.

## Verification

- `pnpm exec vitest run src/test-kernel/agent/toolUse/ModelSwitchState.vitest.ts src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/cli/History.vitest.mts src/test-kernel/cli/SessionResumeResolution.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 11 import-order warnings)
- `npm run texra-local:build`
- Live CLI dogfood, idle-exit path:
  - started `texra chat --model gpt54`
  - asked a short binomial theorem prompt
  - switched `/model` to `gpt55` while idle
  - exited without sending another turn
  - `history show 597b266c6140` reported `Model: gpt55` and `Startup model: gpt54`
  - `texra resume 597b266c6140` reopened with `agent: chat · model: gpt55`
- Live CLI dogfood, switch-then-follow-up path from bot review:
  - started `texra chat --model gpt54`
  - asked `2+2`, switched `/model` to `gpt55`, sent another turn in the same TUI, then exited
  - `history show f160ad255759` reported `Model: gpt55` and `Startup model: gpt54`
  - flow JSON kept `input.MODEL=gpt54`, `transient.MODEL=gpt55`, and 6 persisted messages after the second turn
