### PR TITLE
fix(cli): guard chat model after api mode switch

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -54,6 +54,8 @@ import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
   cliRunnableModelOptionsForSource,
+  type CliModelFallbackMode,
+  type CliRunnableModelResolution,
   formatCliNoAvailableModelsRecovery,
   resolveCliRunnableModel,
 } from '@cli/runtime/modelAccess';
@@ -229,6 +231,17 @@ export function clearTuiSessionRunState(
   session.streamId = undefined;
   session.executionId = undefined;
   session.runPromise = undefined;
+  session.runExitCode = CliExitCode.Success;
+  session.runCompleted = false;
+  session.stopRequested = false;
+}
+
+export function markChatTuiRunPending(
+  session: ClearableTuiSessionState,
+  runPromise: Promise<void>,
+): void {
+  session.streamId = undefined;
+  session.runPromise = runPromise;
   session.runExitCode = CliExitCode.Success;
   session.runCompleted = false;
   session.stopRequested = false;
@@ -481,6 +494,25 @@ async function applyCliModelSelection(
   );
 }
 
+function chatApiModeRecoveryMessage(apiMode: CliApiMode): string {
+  return formatCliNoAvailableModelsRecovery(apiMode, {
+    includedModeAction: 'switch to included relay with `/api included`',
+    personalModeAction: 'switch to personal API keys with `/api personal`',
+  });
+}
+
+export async function resolveChatRootModelForApiMode(
+  model: string,
+  apiMode: CliApiMode,
+  fallbackMode: CliModelFallbackMode,
+): Promise<CliRunnableModelResolution> {
+  return resolveCliRunnableModel(model, {
+    fallbackMode,
+    apiMode,
+    noAvailableModelsMessage: chatApiModeRecoveryMessage(apiMode),
+  });
+}
+
 async function reconcileRootModelAfterApiModeChange(
   context: SlashCommandContext | undefined,
   apiMode: CliApiMode,
@@ -488,14 +520,11 @@ async function reconcileRootModelAfterApiModeChange(
   if (!context || !chatTuiCanStartRootRun(context.session)) return undefined;
 
   const currentModel = cliState.sessionMeta.get().model;
-  const resolution = await resolveCliRunnableModel(currentModel, {
-    fallbackMode: 'notice',
+  const resolution = await resolveChatRootModelForApiMode(
+    currentModel,
     apiMode,
-    noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(apiMode, {
-      includedModeAction: 'switch to included relay with `/api included`',
-      personalModeAction: 'switch to personal API keys with `/api personal`',
-    }),
-  });
+    'notice',
+  );
   if (resolution.model === currentModel) return undefined;
 
   await setCliHelperModel(resolution.model);
@@ -1130,12 +1159,6 @@ export async function runChat(
   };
 
   const startAgentRun = (config: AgentConfigPayload): void => {
-    followUpQueue.clear();
-    session.streamId = undefined;
-    session.runCompleted = false;
-    session.stopRequested = false;
-    session.runExitCode = CliExitCode.Success;
-
     const currentModel = config.model;
     const sessionContext = currentSessionContext(currentModel);
     cliState.sessionMeta.set({
@@ -1154,7 +1177,7 @@ export async function runChat(
     let agentSettled = false;
     session.executionId = executionId;
 
-    session.runPromise = setCliHelperModel(currentModel)
+    const runPromise = setCliHelperModel(currentModel)
       .then(() => registerFreshChatExecution(executionId, config))
       .then((registeredConfig) => {
         executionRegistered = true;
@@ -1226,6 +1249,7 @@ export async function runChat(
         session.runCompleted = true;
         void runtimeHost.close();
       });
+    markChatTuiRunPending(session, runPromise);
   };
 
   // Interactive resume: continue a suspended tool-use session by execution id.
@@ -1335,23 +1359,52 @@ export async function runChat(
     },
   });
 
-  const startSession = (
+  const startSession = async (
     instruction: string,
     mediaFiles?: readonly string[],
-  ): void => {
-    const meta = cliState.sessionMeta.get();
-    const currentAgent = meta.agent || agent;
-    const currentModel = meta.model || model;
-    startAgentRun(
-      buildInitialChatAgentConfig({
-        agent: currentAgent,
-        model: currentModel,
-        instruction,
-        mediaFiles,
-        workingDirectory: context.cwd,
-        cliMultiAgentPresetId: init.cliMultiAgentPresetId,
-      }),
-    );
+  ): Promise<void> => {
+    followUpQueue.clear();
+    session.executionId = undefined;
+    // Queue the async startup body after the reservation below so a second
+    // submit cannot pass chatTuiCanStartRootRun during model/auth resolution.
+    const pendingStart = Promise.resolve().then(async (): Promise<void> => {
+      try {
+        const meta = cliState.sessionMeta.get();
+        const currentAgent = meta.agent || agent;
+        const currentModel = meta.model || model;
+        const resolution = await resolveChatRootModelForApiMode(
+          currentModel,
+          meta.apiMode,
+          'reject',
+        );
+        if (session.stopRequested) {
+          session.runCompleted = true;
+          return;
+        }
+
+        startAgentRun(
+          buildInitialChatAgentConfig({
+            agent: currentAgent,
+            model: resolution.model,
+            instruction,
+            mediaFiles,
+            workingDirectory: context.cwd,
+            cliMultiAgentPresetId: init.cliMultiAgentPresetId,
+          }),
+        );
+      } catch (error: unknown) {
+        if (!session.stopRequested) {
+          appendLocalUserTranscript(instruction);
+          appendLocalErrorTranscript(toErrorMessage(error));
+        }
+        session.runExitCode = session.stopRequested
+          ? CliExitCode.Success
+          : CliExitCode.AgentError;
+        session.runCompleted = true;
+      }
+    });
+    markChatTuiRunPending(session, pendingStart);
+    await pendingStart;
   };
 
   const handleSubmit = (line: string, mediaFiles?: readonly string[]): void => {
@@ -1382,7 +1435,7 @@ export async function runChat(
     }
     const childFollowUpTarget = chatTuiActiveChildFollowUpTarget();
     if (!childFollowUpTarget && chatTuiCanStartRootRun(session)) {
-      startSession(line, mediaFiles);
+      await startSession(line, mediaFiles);
       return;
     }
     // PRD success criterion: follow-ups must not be silently dropped when the

--- a/src/test-kernel/cli/ChatApiModeModelResolution.vitest.mts
+++ b/src/test-kernel/cli/ChatApiModeModelResolution.vitest.mts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveChatRootModelForApiMode } from '@cli/chat/tui/runChatTui';
+import { computeModelOptionsData } from '@model/computeModelOptions';
+
+const mocks = vi.hoisted(() => ({
+  authProvider: {
+    isAuthenticated: vi.fn(),
+  },
+}));
+
+vi.mock('@model/computeModelOptions', () => ({
+  computeModelOptionsData: vi.fn(),
+  invalidateModelOptionsCache: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/supabaseAuth', () => ({
+  getCliAuthProvider: () => mocks.authProvider,
+  signInCliSupabase: vi.fn(),
+  signOutCliSupabase: vi.fn(),
+}));
+
+const computeModelOptionsDataMock = vi.mocked(computeModelOptionsData);
+
+describe('CLI chat API-mode model resolution', () => {
+  beforeEach(() => {
+    computeModelOptionsDataMock.mockReset();
+    mocks.authProvider.isAuthenticated.mockReset();
+  });
+
+  it('keeps a personal-key model in personal API mode', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      {
+        value: 'gpt55',
+        label: 'GPT-5.5',
+        availability: 'provider-key',
+        availabilityLabel: 'API key set',
+      },
+    ]);
+
+    await expect(
+      resolveChatRootModelForApiMode('gpt55', 'personal', 'reject'),
+    ).resolves.toEqual({ model: 'gpt55' });
+  });
+
+  it('rejects a personal-key model after switching to signed-out relay mode', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      {
+        value: 'gpt55',
+        label: 'GPT-5.5',
+        availability: 'provider-key',
+        availabilityLabel: 'API key set',
+      },
+    ]);
+    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(false);
+
+    await expect(
+      resolveChatRootModelForApiMode('gpt55', 'included', 'reject'),
+    ).rejects.toThrow(
+      'Run `texra login` for included relay access, or switch to personal API keys with `/api personal` after configuring a provider API key.',
+    );
+  });
+});

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -70,6 +70,7 @@ import {
   chatTuiShouldAnnounceQueuedFollowUp,
   parseChatLoginSlashArgs,
   clearTuiSessionRunState,
+  markChatTuiRunPending,
 } from '@cli/chat/tui/runChatTui';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import {
@@ -838,6 +839,28 @@ describe('CLI TUI row allocation', () => {
         runPromise,
       }),
     ).toBe(true);
+  });
+
+  it('marks a chat root run pending before async startup work resolves', () => {
+    const startupPromise = new Promise<void>(() => {});
+    const session = {
+      streamId: root,
+      executionId: 'exec-old',
+      runPromise: undefined,
+      runExitCode: CliExitCode.AgentError,
+      runCompleted: true,
+      stopRequested: true,
+    };
+
+    markChatTuiRunPending(session, startupPromise);
+
+    expect(session.streamId).toBeUndefined();
+    expect(session.executionId).toBe('exec-old');
+    expect(session.runPromise).toBe(startupPromise);
+    expect(session.runExitCode).toBe(CliExitCode.Success);
+    expect(session.runCompleted).toBe(false);
+    expect(session.stopRequested).toBe(false);
+    expect(chatTuiCanStartRootRun(session)).toBe(false);
   });
 
   it('allows model selection before start or while a tool-use chat is waiting', () => {


### PR DESCRIPTION
## Summary

- Fixes #5320.
- Re-validates the current root chat model against the current TUI API mode before starting a new root turn.
- Shares the same chat-specific recovery message between `/api` reconciliation and submit-time validation.
- Adds a regression test for personal-key models being rejected after switching to signed-out included relay mode.

## Dogfood evidence

Built the CLI and reproduced the bug in the TUI:

```sh
npm run texra-local:build
node packages/cli/dist/bin/texra.js --no-color --api-mode personal --approval-policy never chat --model gpt54 --agent chat
```

Before the fix, selecting `/api` -> `Included relay` while signed out still allowed `Say hi in one sentence.` to complete with `Hi!`, even though `/model` said relay models require sign-in and `/status` showed `api: included relay`.

After the fix, the same flow refuses the turn before execution:

```text
Model "gpt54" is not available in the active API mode (login required). No models are currently available. Run `texra login` for included relay access, or switch to personal API keys with `/api personal` after configuring a provider API key.
```

## Validation

- `pnpm exec vitest run src/test-kernel/cli/ChatApiModeModelResolution.vitest.mts`
- `pnpm exec vitest run src/test-kernel/cli/ChatApiModeModelResolution.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/RunChatConfig.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npm run format`
- `npm run texra-local:build`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 11 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat TUI run lifecycle and model/API-mode gating before agent execution; behavior change is localized but user-visible when API mode and model disagree.
> 
> **Overview**
> Fixes a gap where the chat TUI could still run a turn with a **personal-key model** after switching to **included relay** while signed out (e.g. #5322).
> 
> **Submit-time guard:** Starting a new root turn is now **async** and calls **`resolveChatRootModelForApiMode`** with **`reject`** before **`startAgentRun`**. Invalid models surface in the transcript and the run never starts. **`chatApiModeRecoveryMessage`** shares the same recovery text for **`/api`** reconciliation and submit validation.
> 
> **Concurrency:** **`markChatTuiRunPending`** sets **`runPromise`** / clears **`streamId`** immediately so a second message cannot slip through **`chatTuiCanStartRootRun`** while model/auth resolution is in flight; **`startAgentRun`** uses the same helper for the execution promise.
> 
> **Tests:** API-mode resolution (personal OK, included+signed-out rejects) and pending-run session state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c1a983fa61944b920648f932e6e7d291d06a5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->