### PR TITLE
fix(cli): preserve Shift-Enter draft text

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -33,11 +33,9 @@ import { TipRow } from './panes/TipRow';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './panes/TodosPlanPanel';
 import { currentApproval, type PendingApproval } from './state/approvalQueue';
 import {
-  isKittyKeypadEnter,
-  isKittyShiftEnter,
   metaChordDigit,
   metaChordInput,
-  SYNTHETIC_SHIFT_RETURN_INPUT,
+  rewriteKittyEnterInput,
 } from './input/inputKeys';
 import {
   hasChildControlItems,
@@ -421,20 +419,18 @@ export function App(props: AppProps): React.JSX.Element {
   // some Enter variants arrive as CSI-u sequences that Ink parses incompletely.
   // Re-dispatch keypad Enter as plain Enter so submit/confirm still works, and
   // Shift+Enter as an internal newline token only while the main draft input is
-  // active so modals/selects keep treating Shift+Enter as ordinary confirmation.
+  // active. While modals/selects own input, leave Shift+Enter alone so the
+  // original parsed key can confirm exactly once.
   useEffect(() => {
     const emitter = (
       stdin as unknown as { internal_eventEmitter?: InputEventEmitterLike }
     ).internal_eventEmitter;
     if (!emitter) return;
     const onInput = (data: string): void => {
-      if (isKittyKeypadEnter(data)) {
-        emitter.emit('input', String.fromCharCode(13));
-        return;
-      }
-      if (!inputDisabled && isKittyShiftEnter(data)) {
-        emitter.emit('input', SYNTHETIC_SHIFT_RETURN_INPUT);
-      }
+      const rewritten = rewriteKittyEnterInput(data, {
+        shiftEnter: inputDisabled ? 'preserve' : 'newline',
+      });
+      if (rewritten !== undefined) emitter.emit('input', rewritten);
     };
     emitter.on('input', onInput);
     return () => emitter.off('input', onInput);

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -339,12 +339,13 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
 
   const moveCursor = useCallback(
     (next: number) => {
-      const c = clampCursor(next, value.length);
-      latestStateRef.current = { value, cursor: c };
+      const latest = latestStateRef.current;
+      const c = clampCursor(next, latest.value.length);
+      latestStateRef.current = { value: latest.value, cursor: c };
       if (!isControlled) setInternalCursor(c);
       onCursorChange?.(c);
     },
-    [isControlled, value, onCursorChange],
+    [isControlled, onCursorChange],
   );
 
   const applyEdit = useCallback(
@@ -363,6 +364,14 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     (text: string) => {
       const { value: v, cursor: c } = latestStateRef.current;
       applyEdit(insertText(v, c, text));
+    },
+    [applyEdit],
+  );
+
+  const applyLatestEdit = useCallback(
+    (edit: (value: string, cursor: number) => TextEdit) => {
+      const { value: v, cursor: c } = latestStateRef.current;
+      applyEdit(edit(v, c));
     },
     [applyEdit],
   );
@@ -396,27 +405,27 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
       if (isTextInputNewlineInput(input, key)) {
         // Ctrl-J (universal) or Shift+Enter (Kitty-protocol terminals) →
         // literal newline. Kills the legacy `/multi` ceremony.
-        applyEdit(insertText(value, cursor, '\n'));
+        insertIntoLatestDraft('\n');
         return;
       }
       if (isPlainReturnInput(input, key)) {
-        submitAfterImagePastes(onSubmit, value);
+        submitAfterImagePastes(onSubmit, latestStateRef.current.value);
         return;
       }
       if (key.backspace) {
-        applyEdit(deleteBeforeCursor(value, cursor));
+        applyLatestEdit(deleteBeforeCursor);
         return;
       }
       if (key.delete) {
-        applyEdit(deleteAtCursor(value, cursor));
+        applyLatestEdit(deleteAtCursor);
         return;
       }
       if (key.leftArrow) {
-        moveCursor(cursor - 1);
+        moveCursor(latestStateRef.current.cursor - 1);
         return;
       }
       if (key.rightArrow) {
-        moveCursor(cursor + 1);
+        moveCursor(latestStateRef.current.cursor + 1);
         return;
       }
       if (key.home || isCtrlInput(input, key, 'a')) {
@@ -424,19 +433,19 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         return;
       }
       if (key.end || isCtrlInput(input, key, 'e')) {
-        moveCursor(value.length);
+        moveCursor(latestStateRef.current.value.length);
         return;
       }
       if (isCtrlInput(input, key, 'u')) {
-        applyEdit(deleteToStart(value, cursor));
+        applyLatestEdit(deleteToStart);
         return;
       }
       if (isCtrlInput(input, key, 'k')) {
-        applyEdit(deleteToEnd(value, cursor));
+        applyLatestEdit(deleteToEnd);
         return;
       }
       if (isCtrlInput(input, key, 'w')) {
-        applyEdit(deletePreviousWord(value, cursor));
+        applyLatestEdit(deletePreviousWord);
         return;
       }
       if (isCtrlInput(input, key, 'v') && props.onImagePaste) {
@@ -464,12 +473,14 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
       ) {
         return;
       }
-      const edit = applyTerminalInputChunk(value, cursor, input);
+      const { value: latestValue, cursor: latestCursor } =
+        latestStateRef.current;
+      const edit = applyTerminalInputChunk(latestValue, latestCursor, input);
       if (edit.submit) {
         submitAfterImagePastes(onInputChunkSubmit ?? onSubmit, edit.value);
         return;
       }
-      if (edit.value === value && edit.cursor === cursor) return;
+      if (edit.value === latestValue && edit.cursor === latestCursor) return;
       applyEdit(edit);
     },
     { isActive: focus },

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -7,6 +7,7 @@ export interface ReturnKeyInput {
 }
 
 export const SYNTHETIC_SHIFT_RETURN_INPUT = '\uE000';
+const ESC = String.fromCharCode(27);
 
 const RAW_CONTROL_INPUTS = new Map<number, string>([
   [1, 'a'],
@@ -126,20 +127,22 @@ export function isTextInputNewlineInput(
 // silently stop submitting once the protocol is on. App.tsx re-dispatches this
 // raw sequence as a plain Enter. Matches only the unmodified form (bare, or the
 // explicit "no modifiers" `;1`) so Ctrl/Alt+keypad-Enter pass through untouched.
-const KITTY_KEYPAD_ENTER = new Set([
-  `${String.fromCharCode(27)}[57414u`,
-  `${String.fromCharCode(27)}[57414;1u`,
-]);
+const KITTY_KEYPAD_ENTER_INPUTS = [`${ESC}[57414u`, `${ESC}[57414;1u`];
+const KITTY_SHIFT_ENTER_INPUTS = [`${ESC}[13;2u`, `${ESC}[13:2u`];
 
-const KITTY_SHIFT_ENTER = new Set([
-  `${String.fromCharCode(27)}[13;2u`,
-  `${String.fromCharCode(27)}[13:2u`,
-]);
-
-export function isKittyKeypadEnter(data: string): boolean {
-  return KITTY_KEYPAD_ENTER.has(data);
-}
-
-export function isKittyShiftEnter(data: string): boolean {
-  return KITTY_SHIFT_ENTER.has(data);
+export function rewriteKittyEnterInput(
+  data: string,
+  options: { readonly shiftEnter: 'newline' | 'preserve' },
+): string | undefined {
+  let rewritten = data;
+  for (const sequence of KITTY_KEYPAD_ENTER_INPUTS) {
+    rewritten = rewritten.replaceAll(sequence, '\r');
+  }
+  if (options.shiftEnter === 'preserve') {
+    return rewritten === data ? undefined : rewritten;
+  }
+  for (const sequence of KITTY_SHIFT_ENTER_INPUTS) {
+    rewritten = rewritten.replaceAll(sequence, SYNTHETIC_SHIFT_RETURN_INPUT);
+  }
+  return rewritten === data ? undefined : rewritten;
 }

--- a/packages/cli/src/chat/tui/input/textInputEditing.ts
+++ b/packages/cli/src/chat/tui/input/textInputEditing.ts
@@ -2,6 +2,7 @@ import {
   isEscapeInput,
   isUnhandledControlInput,
   normalizedCtrlInput,
+  SYNTHETIC_SHIFT_RETURN_INPUT,
 } from './inputKeys';
 
 export interface TextEdit {
@@ -92,6 +93,10 @@ export function applyTerminalInputChunk(
   let submit = false;
 
   for (const ch of input) {
+    if (ch === SYNTHETIC_SHIFT_RETURN_INPUT) {
+      edit = insertText(edit.value, edit.cursor, '\n');
+      continue;
+    }
     if (ch === '\r' || ch === '\n') {
       submit = true;
       break;

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -13,14 +13,13 @@ import {
   isCtrlInput,
   isEscapeInput,
   isUnhandledControlInput,
-  isKittyKeypadEnter,
-  isKittyShiftEnter,
   isPlainReturnInput,
   isShiftReturnInput,
   isTextInputNewlineInput,
   metaChordDigit,
   metaChordInput,
   normalizedCtrlInput,
+  rewriteKittyEnterInput,
   SYNTHETIC_SHIFT_RETURN_INPUT,
 } from '@cli/chat/tui/input/inputKeys';
 
@@ -60,15 +59,55 @@ describe('CLI TUI text input editing', () => {
   });
 
   it('recognizes Kitty Enter sequences for raw re-dispatch', () => {
-    expect(isKittyKeypadEnter(`${ESC}[57414u`)).toBe(true);
-    expect(isKittyKeypadEnter(`${ESC}[57414;1u`)).toBe(true);
-    expect(isKittyShiftEnter(`${ESC}[13;2u`)).toBe(true);
-    expect(isKittyShiftEnter(`${ESC}[13:2u`)).toBe(true);
+    expect(
+      rewriteKittyEnterInput(`${ESC}[57414u`, { shiftEnter: 'newline' }),
+    ).toBe('\r');
+    expect(
+      rewriteKittyEnterInput(`${ESC}[57414;1u`, { shiftEnter: 'newline' }),
+    ).toBe('\r');
+    expect(
+      rewriteKittyEnterInput(`${ESC}[13;2u`, { shiftEnter: 'newline' }),
+    ).toBe(SYNTHETIC_SHIFT_RETURN_INPUT);
+    expect(
+      rewriteKittyEnterInput(`${ESC}[13:2u`, { shiftEnter: 'newline' }),
+    ).toBe(SYNTHETIC_SHIFT_RETURN_INPUT);
     // Main Enter, plain CR, and modified keypad Enter must not match.
-    expect(isKittyKeypadEnter('\r')).toBe(false);
-    expect(isKittyKeypadEnter(`${ESC}[13u`)).toBe(false);
-    expect(isKittyKeypadEnter(`${ESC}[57414;5u`)).toBe(false);
-    expect(isKittyShiftEnter(`${ESC}[13;5u`)).toBe(false);
+    expect(
+      rewriteKittyEnterInput('\r', { shiftEnter: 'newline' }),
+    ).toBeUndefined();
+    expect(
+      rewriteKittyEnterInput(`${ESC}[13u`, { shiftEnter: 'newline' }),
+    ).toBeUndefined();
+    expect(
+      rewriteKittyEnterInput(`${ESC}[57414;5u`, { shiftEnter: 'newline' }),
+    ).toBeUndefined();
+    expect(
+      rewriteKittyEnterInput(`${ESC}[13;5u`, { shiftEnter: 'newline' }),
+    ).toBeUndefined();
+  });
+
+  it('rewrites batched Kitty Shift+Enter chunks before text editing', () => {
+    const rewritten = rewriteKittyEnterInput(`alpha${ESC}[13;2ubeta`, {
+      shiftEnter: 'newline',
+    });
+
+    expect(rewritten).toBe(`alpha${SYNTHETIC_SHIFT_RETURN_INPUT}beta`);
+    expect(applyTerminalInputChunk('', 0, rewritten ?? '')).toEqual({
+      value: 'alpha\nbeta',
+      cursor: 10,
+      submit: false,
+    });
+  });
+
+  it('preserves Shift+Enter while still rewriting keypad Enter', () => {
+    expect(
+      rewriteKittyEnterInput(`${ESC}[13:2u`, { shiftEnter: 'preserve' }),
+    ).toBeUndefined();
+    expect(
+      rewriteKittyEnterInput(`pick${ESC}[57414;1u`, {
+        shiftEnter: 'preserve',
+      }),
+    ).toBe('pick\r');
   });
 
   it('recognizes Option/Alt chords from normalized meta and ESC-prefixed input', () => {


### PR DESCRIPTION
## Summary

Fixes #5322.

- normalize Kitty keypad Enter and Shift+Enter raw input through one helper, including when sequences arrive batched with surrounding text
- make `BaseTextInput` apply edits from its latest draft/cursor ref so re-dispatched input cannot overwrite text typed just before React re-renders
- add focused tests for batched Kitty Shift+Enter and Enter rewrites

## Root Cause

The App-level raw-input bridge only handled exact Kitty Enter escape sequences. In a real PTY, the Shift+Enter sequence can arrive adjacent to ordinary typed text. The text input could then process re-dispatched input before React had re-rendered after the previous edit, so it edited from stale `value`/`cursor` props and dropped the preceding draft text.

## Dogfood

Built the local CLI and spawned `texra chat` in a PTY. Before the fix, sending `alpha ESC[13;2u beta` rendered only `beta`. After the fix, the draft rendered:

```text
alpha
beta
```

## Validation

- `pnpm exec vitest run src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ExternalInquiry.vitest.mts`
- `npm run texra-local:build`
- `npm run compile:safe`
- `npm run lint` (passes with the existing 11 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI input-layer changes with added unit tests; no auth, persistence, or network impact.
> 
> **Overview**
> Fixes Kitty-protocol draft input where **Shift+Enter** could wipe text typed just before the key, and where Enter sequences batched with ordinary characters were not handled correctly.
> 
> **Kitty Enter rewriting** replaces separate keypad/shift detectors with `rewriteKittyEnterInput`, which can rewrite sequences **inside** a larger stdin chunk (not only exact matches). The app bridge still maps keypad Enter to `\r` and, when the main draft is active, Shift+Enter to a synthetic newline token; when modals/foreground UI own input, Shift+Enter is left unchanged so confirm still works once.
> 
> **`BaseTextInput`** applies edits from `latestStateRef` (via `applyLatestEdit` / `insertIntoLatestDraft`) so re-dispatched or batched input does not use stale React `value`/`cursor` props. **`applyTerminalInputChunk`** now treats the synthetic Shift+Enter character as a literal newline during chunk processing.
> 
> Tests cover batched Shift+Enter rewrite end-to-end and preserve-mode behavior for modals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d43d689286a02250425efce9e5b6bfcd7976fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->