### PR TITLE
fix(cli): avoid double Shift-Enter newlines

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -417,10 +417,10 @@ export function App(props: AppProps): React.JSX.Element {
 
   // Under the Kitty disambiguate flag (enabled in runChatTui for Shift+Enter),
   // some Enter variants arrive as CSI-u sequences that Ink parses incompletely.
-  // Re-dispatch keypad Enter as plain Enter so submit/confirm still works, and
-  // Shift+Enter as an internal newline token only while the main draft input is
-  // active. While modals/selects own input, leave Shift+Enter alone so the
-  // original parsed key can confirm exactly once.
+  // Re-dispatch keypad Enter as plain Enter so submit/confirm still works.
+  // Batched Shift+Enter sequences are rewritten into an internal newline token
+  // only while the main draft input is active; standalone Shift+Enter is
+  // already parsed by Ink and must not be emitted twice.
   useEffect(() => {
     const emitter = (
       stdin as unknown as { internal_eventEmitter?: InputEventEmitterLike }

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -130,6 +130,14 @@ export function isTextInputNewlineInput(
 const KITTY_KEYPAD_ENTER_INPUTS = [`${ESC}[57414u`, `${ESC}[57414;1u`];
 const KITTY_SHIFT_ENTER_INPUTS = [`${ESC}[13;2u`, `${ESC}[13:2u`];
 
+// Ink already turns a standalone Kitty Shift+Enter sequence into a shifted
+// return key. The raw-event shim only needs to rewrite sequences embedded in a
+// larger input chunk, where the normal key parser cannot represent both the
+// surrounding text and the modified return.
+function isStandaloneKittyShiftEnterInput(data: string): boolean {
+  return KITTY_SHIFT_ENTER_INPUTS.includes(data);
+}
+
 export function rewriteKittyEnterInput(
   data: string,
   options: { readonly shiftEnter: 'newline' | 'preserve' },
@@ -140,6 +148,9 @@ export function rewriteKittyEnterInput(
   }
   if (options.shiftEnter === 'preserve') {
     return rewritten === data ? undefined : rewritten;
+  }
+  if (isStandaloneKittyShiftEnterInput(rewritten)) {
+    return undefined;
   }
   for (const sequence of KITTY_SHIFT_ENTER_INPUTS) {
     rewritten = rewritten.replaceAll(sequence, SYNTHETIC_SHIFT_RETURN_INPUT);

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -65,12 +65,15 @@ describe('CLI TUI text input editing', () => {
     expect(
       rewriteKittyEnterInput(`${ESC}[57414;1u`, { shiftEnter: 'newline' }),
     ).toBe('\r');
+    // Ink already reports standalone Shift+Enter as a shifted return, so the
+    // raw-event shim must not emit a second synthetic newline for that exact
+    // chunk. Embedded sequences still need rewriting; see the batched test.
     expect(
       rewriteKittyEnterInput(`${ESC}[13;2u`, { shiftEnter: 'newline' }),
-    ).toBe(SYNTHETIC_SHIFT_RETURN_INPUT);
+    ).toBeUndefined();
     expect(
       rewriteKittyEnterInput(`${ESC}[13:2u`, { shiftEnter: 'newline' }),
-    ).toBe(SYNTHETIC_SHIFT_RETURN_INPUT);
+    ).toBeUndefined();
     // Main Enter, plain CR, and modified keypad Enter must not match.
     expect(
       rewriteKittyEnterInput('\r', { shiftEnter: 'newline' }),


### PR DESCRIPTION
## Summary

- avoid re-dispatching standalone Kitty Shift+Enter sequences that Ink already parses as shifted return
- keep batched Shift+Enter chunks normalized to the internal newline token
- update focused text-input tests for standalone vs batched Kitty Shift+Enter behavior

Closes #5324.

## Validation

- `npm run format`
- `pnpm exec vitest run src/test-kernel/cli/TextInputEditing.vitest.mts`
- `pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-dogfood-post-format kitty-shift-enter-newline`
- `pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-dogfood orchestrate-relay-model-pick orchestrate-personal-model-pick plain-submit kitty-shift-enter-newline compact-approval-form compact-long-bash-approval external-inquiry-long external-inquiry-copy-question compact-subagent-picker nested-subagent-picker`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal input shim and tests only; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **double newlines** when using Shift+Enter in the CLI chat TUI under Kitty keyboard disambiguation.
> 
> The raw stdin shim in `rewriteKittyEnterInput` now **skips** re-emitting when the input chunk is **only** a Kitty Shift+Enter CSI-u sequence (`ESC[13;2u` / `ESC[13:2u`), because Ink already surfaces that as a shifted return. **Embedded** Shift+Enter sequences inside a larger chunk are still rewritten to the internal synthetic newline token so batched paste/input keeps working. Keypad Enter → plain `\r` behavior is unchanged; modal/disabled-input paths still use `shiftEnter: 'preserve'`.
> 
> Comments in `App.tsx` and unit tests were updated to match standalone vs batched behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f958920799d8c33b0d311be297febf5c72d6563b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->