### PR TITLE
fix(cli): show active root from stopped subagent focus

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1784,7 +1784,12 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     keys: [ESC + 'p', 'k', ESC + 's', DOWN, DOWN, 'f'],
     frame: 'tail',
-    expect: ['[3:strategy](stopped)', '◆ stopped', '[Ctrl-C]stop root'],
+    expect: [
+      '[3:strategy](stopped)',
+      '◆ stopped',
+      'root active',
+      '[Ctrl-C]stop root',
+    ],
     unexpect: ['◆ running', '2 sub 1 proc'],
   },
   {
@@ -1810,6 +1815,7 @@ const SCENARIOS = [
     expect: [
       '[3:strategy](stopped)',
       '◆ stopped',
+      'root active',
       'The selected subagent is no longer accepting follow-ups.',
     ],
     unexpect: [

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -166,6 +166,7 @@ const STATUS_BAR_COMPACT_PRIORITY = {
   usage: 40,
   queuedFollowUp: 50,
   approvalDepth: 60,
+  rootActive: 65,
   elapsed: 70,
 } as const;
 
@@ -493,12 +494,23 @@ export function ctrlCActionForFocus({
     : 'stop';
 }
 
-function statusBarCanStopStatus(status: StreamStatus | undefined): boolean {
+function statusBarCanStopStatus(status: string | undefined): boolean {
   return (
     status === STREAM_STATUS.INITIALIZING ||
     status === STREAM_STATUS.RUNNING ||
     status === STREAM_STATUS.RESUMING
   );
+}
+
+function rootActiveSegment(input: StatusBarDisplayInput) {
+  return input.ctrlCAction === 'stop root' &&
+    !statusBarCanStopStatus(input.status)
+    ? {
+        text: 'root active',
+        color: 'yellow' as const,
+        compactPriority: STATUS_BAR_COMPACT_PRIORITY.rootActive,
+      }
+    : undefined;
 }
 
 function statusBarCanRepresentLiveAncestor(
@@ -602,6 +614,9 @@ export function buildStatusBarDisplay(
       });
     }
   }
+
+  const rootActive = rootActiveSegment(input);
+  if (rootActive) left.push(rootActive);
 
   left.push({ text: input.apiMode, color: 'dim' });
 

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -481,7 +481,7 @@ describe('CLI StatusBar display model', () => {
       }),
     ).toBe('exit');
 
-    const display = buildStatusBarDisplay({
+    const baseDisplayInput = {
       status: STREAM_STATUS.STOPPED,
       pendingExitHint: false,
       pendingExitResumeId: undefined,
@@ -498,14 +498,32 @@ describe('CLI StatusBar display model', () => {
       apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop root',
-    });
+    } as const;
+    const display = buildStatusBarDisplay(baseDisplayInput);
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'stopped',
+      'root active',
       PERSONAL_API_MODE_LABEL,
     ]);
     expect(display.bindings).toContain('[Ctrl-C]stop root');
+
+    const liveChildDisplay = buildStatusBarDisplay({
+      ...baseDisplayInput,
+      status: STREAM_STATUS.RUNNING,
+    });
+    expect(liveChildDisplay.left.map(statusBarSegmentText)).not.toContain(
+      'root active',
+    );
+
+    const stoppedRootDisplay = buildStatusBarDisplay({
+      ...baseDisplayInput,
+      ctrlCAction: 'stop',
+    });
+    expect(stoppedRootDisplay.left.map(statusBarSegmentText)).not.toContain(
+      'root active',
+    );
   });
 
   it('treats visible live stream status as stoppable', () => {


### PR DESCRIPTION
## Summary

- add a compact `root active` status-bar segment when focused on a stopped child stream while Ctrl-C targets the active root run
- keep the focused stream status visible as `stopped` and leave Ctrl-C behavior unchanged
- cover the focused stopped-subagent TUI scenarios and display-model negative cases

Closes #5326

## Validation

- `pnpm exec vitest run src/test-kernel/cli/StatusBar.vitest.mts`
- `pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-root-active focused-stopped-subagent focused-stopped-subagent-submit`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only status bar and test expectation updates; no changes to interrupt handling or security-sensitive paths.
> 
> **Overview**
> When you focus a **stopped** child stream but **Ctrl-C** still targets the parent run (`stop root`), the status bar now adds a compact yellow **`root active`** segment next to the focused stream’s **`stopped`** label so it’s obvious the root is still live.
> 
> **Ctrl-C** behavior is unchanged; narrow layouts can drop **`root active`** via a new compact-priority slot. TUI harness scenarios and **`StatusBar`** unit tests cover the positive and negative cases (running child, root-focused stop).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0c26f2da53c45a956629f62dfe6eb374979cb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->