### PR TITLE
fix(cli): strip TUI styling in no-color mode

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -49,6 +49,7 @@ import {
 } from '../src/chat/tui/state/cliState';
 import { formatCliSessionStatus } from '../src/chat/tui/sessionStatus';
 import { notify } from '../src/chat/tui/notifications/terminalNotifier';
+import { tuiOutputStreamForColor } from '../src/chat/tui/render/noColorOutput';
 import {
   enqueueApproval,
   type ApprovalDecision,
@@ -149,6 +150,11 @@ const HARNESS_CWD_INPUT = process.env.HARNESS_CWD?.trim();
 // Keep platform state writes out of the repository unless a scenario opts in.
 const HARNESS_CWD =
   HARNESS_CWD_INPUT || mkdtempSync(path.join(tmpdir(), 'texra-tui-harness-'));
+const HARNESS_COLOR_ENABLED = process.env.HARNESS_COLOR_ENABLED !== '0';
+const HARNESS_STDOUT = tuiOutputStreamForColor(
+  process.stdout,
+  HARNESS_COLOR_ENABLED,
+);
 if (!HARNESS_CWD_INPUT && process.env.HARNESS_KEEP_CWD !== '1') {
   process.once('exit', () => {
     rmSync(HARNESS_CWD, { recursive: true, force: true });
@@ -279,7 +285,7 @@ if (SHOW_ORCHESTRATION) {
       onResolve={() => undefined}
     />,
     {
-      stdout: process.stdout,
+      stdout: HARNESS_STDOUT,
       stderr: process.stderr,
       stdin: process.stdin,
     },
@@ -1238,11 +1244,12 @@ ink = render(
     onKillExecution={markHarnessExecutionStopped}
     canInterruptActiveRun={() => canInterrupt}
     canStopActiveRun={() => canInterrupt}
+    colorEnabled={HARNESS_COLOR_ENABLED}
     onInterruptActive={markHarnessInterrupted}
     onCtrlC={handleHarnessCtrlC}
   />,
   {
-    stdout: process.stdout,
+    stdout: HARNESS_STDOUT,
     stderr: process.stderr,
     stdin: process.stdin,
     exitOnCtrlC: false,

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -54,6 +54,7 @@ const KITTY_SHIFT_ENTER = ESC + '[13;2u';
 const UP = ESC + '[A';
 const DOWN = ESC + '[B';
 const PAGE_DOWN = ESC + '[6~';
+const ANSI_SGR_PATTERN = new RegExp(`${ESC}\\[[0-?]*[ -/]*m`, 'g');
 const LONG_BASH_APPROVAL_COMMAND = [
   "python3 << 'EOF'",
   'solutions = []',
@@ -463,6 +464,20 @@ const SCENARIOS = [
       'texra chat --model=<name>',
       'texra --model=<name>',
     ],
+  },
+  {
+    name: 'no-color-model-form',
+    colorEnabled: false,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/model', '\r'],
+    frame: 'tail',
+    expect: [
+      '/model · personal API keys',
+      'Available models. Finish the active response before switching models.',
+      'Enter close',
+    ],
+    unexpect: ['Platform not initialized', '/model - error'],
+    rawUnexpectSgr: true,
   },
   {
     name: 'model-form-selectable',
@@ -2409,6 +2424,7 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
   const rows = scenarioRows(scenario);
   let lastData = Date.now();
   let exited = null;
+  let rawOutput = '';
   let writeQueue = Promise.resolve();
   const frameSnapshot = async () => {
     await writeQueue;
@@ -2418,10 +2434,18 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
     ...process.env,
     ...scenario.env,
     TERM: 'xterm-256color',
-    FORCE_COLOR: '3',
     COLUMNS: String(cols),
     LINES: String(rows),
   };
+  if (scenario.colorEnabled === false) {
+    delete childEnv.FORCE_COLOR;
+    childEnv.NO_COLOR = '1';
+    childEnv.HARNESS_COLOR_ENABLED = '0';
+  } else {
+    childEnv.FORCE_COLOR = '3';
+    delete childEnv.NO_COLOR;
+    childEnv.HARNESS_COLOR_ENABLED ??= '1';
+  }
   if (fakeClipboard) {
     childEnv.PATH = `${fakeClipboard.binDir}${path.delimiter}${childEnv.PATH ?? ''}`;
     childEnv.TEXRA_FAKE_CLIPBOARD_FILE = fakeClipboard.textFile;
@@ -2430,7 +2454,6 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
   // markers make Ink choose a non-interactive render mode and hide the live
   // input/status surface this script is meant to inspect.
   delete childEnv.CI;
-  delete childEnv.NO_COLOR;
   const child = ptySpawn(process.execPath, [HARNESS], {
     name: 'xterm-256color',
     cols,
@@ -2441,6 +2464,7 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
   child.onExit((e) => (exited = e));
   child.onData((d) => {
     lastData = Date.now();
+    rawOutput += d;
     writeQueue = writeQueue.then(
       () => new Promise((resolve) => term.write(d, resolve)),
     );
@@ -2564,6 +2588,17 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
       ? ` (exitCode ${exited.exitCode}, signal ${exited.signal || 'none'})`
       : '';
     failures.push(`exit keys did not close the TUI cleanly${exitDetails}`);
+  }
+  if (scenario.rawUnexpectSgr) {
+    const sgrSequences = [...new Set(rawOutput.match(ANSI_SGR_PATTERN) ?? [])];
+    if (sgrSequences.length > 0) {
+      failures.push(
+        `raw output contains SGR escapes: ${sgrSequences
+          .slice(0, 5)
+          .map((sequence) => JSON.stringify(sequence))
+          .join(', ')}`,
+      );
+    }
   }
   if (fakeClipboard) {
     const copiedText = readFileSync(fakeClipboard.textFile, 'utf8');

--- a/packages/cli/src/chat/tui/render/noColorOutput.ts
+++ b/packages/cli/src/chat/tui/render/noColorOutput.ts
@@ -1,0 +1,105 @@
+import { ANSI_ESCAPE_START } from '@cli/runtime/ansiEscapes';
+
+interface SgrStripState {
+  pending: string;
+}
+
+function isCsiFinalCode(code: number): boolean {
+  return code >= 0x40 && code <= 0x7e;
+}
+
+function stripAnsiSgrChunk(text: string, state: SgrStripState): string {
+  const input = `${state.pending}${text}`;
+  state.pending = '';
+
+  let output = '';
+  for (let index = 0; index < input.length; ) {
+    if (input[index] !== ANSI_ESCAPE_START) {
+      output += input[index];
+      index += 1;
+      continue;
+    }
+
+    const next = input[index + 1];
+    if (next === undefined) {
+      state.pending = input.slice(index);
+      break;
+    }
+    if (next !== '[') {
+      output += input.slice(index, index + 2);
+      index += 2;
+      continue;
+    }
+
+    let end = index + 2;
+    while (end < input.length && !isCsiFinalCode(input.charCodeAt(end))) {
+      end += 1;
+    }
+    if (end >= input.length) {
+      state.pending = input.slice(index);
+      break;
+    }
+
+    const sequence = input.slice(index, end + 1);
+    if (input[end] !== 'm') output += sequence;
+    index = end + 1;
+  }
+
+  return output;
+}
+
+export function stripAnsiSgrSequences(text: string): string {
+  const state: SgrStripState = { pending: '' };
+  const output = stripAnsiSgrChunk(text, state);
+  return `${output}${state.pending}`;
+}
+
+function chunkText(chunk: unknown): string | undefined {
+  if (typeof chunk === 'string') return chunk;
+  if (Buffer.isBuffer(chunk)) return chunk.toString('utf8');
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk).toString('utf8');
+  }
+  return undefined;
+}
+
+function writeCallback(args: readonly unknown[]): (() => void) | undefined {
+  const callback = args.at(-1);
+  return typeof callback === 'function' ? (callback as () => void) : undefined;
+}
+
+export function sgrStrippingWriteStream<T extends NodeJS.WriteStream>(
+  stream: T,
+): T {
+  const state: SgrStripState = { pending: '' };
+  const write = stream.write.bind(stream) as (
+    chunk: string | Uint8Array,
+    ...args: unknown[]
+  ) => boolean;
+  return new Proxy(stream, {
+    get(target, prop, receiver) {
+      if (prop === 'write') {
+        return (chunk: unknown, ...args: unknown[]) => {
+          const text = chunkText(chunk);
+          if (text === undefined) return write(chunk as Uint8Array, ...args);
+
+          const output = stripAnsiSgrChunk(text, state);
+          if (output === '') {
+            writeCallback(args)?.();
+            return true;
+          }
+          return write(output, ...args);
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  }) as T;
+}
+
+export function tuiOutputStreamForColor<T extends NodeJS.WriteStream>(
+  stream: T,
+  colorEnabled: boolean,
+): T {
+  return colorEnabled ? stream : sgrStrippingWriteStream(stream);
+}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -111,6 +111,7 @@ import {
 } from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
+import { tuiOutputStreamForColor } from './render/noColorOutput';
 import { formatCliSessionStatus } from './sessionStatus';
 import { clearApprovals } from './state/approvalQueue';
 import { cliState, resetCliState } from './state/cliState';
@@ -1479,12 +1480,13 @@ export async function runChat(
     });
   };
 
+  const stdoutColorEnabled = context.stdoutColorEnabled ?? context.colorEnabled;
   const ink = render(
     <App
       onSubmit={handleSubmit}
       canInterruptActiveRun={canInterruptActiveRun}
       canStopActiveRun={canStopActiveRun}
-      colorEnabled={context.stdoutColorEnabled ?? context.colorEnabled}
+      colorEnabled={stdoutColorEnabled}
       onInterruptActive={interruptActive}
       onCtrlC={() => handleSigint()}
       onKillExecution={(executionId) => {
@@ -1494,7 +1496,7 @@ export async function runChat(
       history={inputHistory}
     />,
     {
-      stdout: process.stdout,
+      stdout: tuiOutputStreamForColor(process.stdout, stdoutColorEnabled),
       stderr: process.stderr,
       stdin: process.stdin,
       // Own Ctrl+C ourselves (App's unified useInput → exit()) instead of via

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -136,7 +136,11 @@ async function runInit(
 
   if (interactive) {
     const { runInitWizard } = await import('../init/runInitWizard');
-    const result = await runInitWizard({ agents, models });
+    const result = await runInitWizard({
+      agents,
+      models,
+      colorEnabled: context.stdoutColorEnabled ?? context.colorEnabled,
+    });
     if (!result) {
       writeTextStderr('Cancelled. No config written.');
       return CliExitCode.Success;

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -129,6 +129,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
     models,
     apiMode,
     allowDefaultModelLaunch,
+    colorEnabled: context.stdoutColorEnabled ?? context.colorEnabled,
   });
 
   switch (action.kind) {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -32,7 +32,7 @@ async function runSetup(context: CliContext): Promise<number> {
 
   await initCliPlatform({ ...context, quietLogs: true });
   const { runCliOnboarding } = await import('../onboarding/runOnboarding');
-  await runCliOnboarding();
+  await runCliOnboarding(context.stdoutColorEnabled ?? context.colorEnabled);
   return CliExitCode.Success;
 }
 

--- a/packages/cli/src/init/runInitWizard.tsx
+++ b/packages/cli/src/init/runInitWizard.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 
 import { KeyHints } from '../chat/tui/ui/KeyHints';
 import { Select, type SelectItem } from '../chat/tui/ui/Select';
+import { tuiOutputStreamForColor } from '../chat/tui/render/noColorOutput';
 import { clearTerminalScrollback } from '../chat/tui/terminalCleanup';
 import {
   CLI_APPROVAL_POLICIES,
@@ -33,6 +34,7 @@ export interface InitWizardModelOption {
 export interface InitWizardOptions {
   readonly agents: readonly InitWizardAgentOption[];
   readonly models: readonly InitWizardModelOption[];
+  readonly colorEnabled?: boolean;
 }
 
 export interface InitWizardResult {
@@ -309,7 +311,10 @@ export async function runInitWizard(
     const instance = render(
       <WizardApp options={options} onResolve={record} />,
       {
-        stdout: process.stdout,
+        stdout: tuiOutputStreamForColor(
+          process.stdout,
+          options.colorEnabled ?? true,
+        ),
         stderr: process.stderr,
         stdin: process.stdin,
       },

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -25,6 +25,7 @@ import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 
 import { assertNever } from '../chat/tui/assertNever';
 import { ApiKeyEntryForm } from '../chat/tui/forms/ApiKeyEntryForm';
+import { tuiOutputStreamForColor } from '../chat/tui/render/noColorOutput';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { Select, type SelectItem } from '../chat/tui/ui/Select';
@@ -59,6 +60,8 @@ export interface OnboardingGateContext {
   readonly mode: 'headless' | 'interactive';
   readonly stdoutIsTty?: boolean;
   readonly termIsDumb?: boolean;
+  readonly stdoutColorEnabled?: boolean;
+  readonly colorEnabled?: boolean;
   readonly apiMode?: CliApiMode;
 }
 
@@ -99,7 +102,11 @@ export async function maybeRunCliOnboarding(
   if (await hasCliCredentialForApiMode(context.apiMode).catch(() => false)) {
     return NO_ONBOARDING_RESULT;
   }
-  return runOnboardingFlow({ firstRun: true, apiMode: context.apiMode });
+  return runOnboardingFlow({
+    firstRun: true,
+    apiMode: context.apiMode,
+    colorEnabled: context.stdoutColorEnabled ?? context.colorEnabled,
+  });
 }
 
 /**
@@ -107,14 +114,17 @@ export async function maybeRunCliOnboarding(
  * has-credentials / declined gate. Still TTY-only — the command rejects
  * headless before calling this.
  */
-export async function runCliOnboarding(): Promise<CliOnboardingResult> {
+export async function runCliOnboarding(
+  colorEnabled = true,
+): Promise<CliOnboardingResult> {
   if (!process.stdout.isTTY) return NO_ONBOARDING_RESULT;
-  return runOnboardingFlow({ firstRun: false });
+  return runOnboardingFlow({ firstRun: false, colorEnabled });
 }
 
 async function runOnboardingFlow(options: {
   readonly firstRun: boolean;
   readonly apiMode?: CliApiMode;
+  readonly colorEnabled?: boolean;
 }): Promise<CliOnboardingResult> {
   const pickerSubtitle = onboardingPickerSubtitle(options);
   const pickerItems = onboardingPickerItems(onboardingSetupPaths(options));
@@ -130,7 +140,10 @@ async function runOnboardingFlow(options: {
         onResolve={record}
       />,
       {
-        stdout: process.stdout,
+        stdout: tuiOutputStreamForColor(
+          process.stdout,
+          options.colorEnabled ?? true,
+        ),
         stderr: process.stderr,
         stdin: process.stdin,
       },

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { Select } from '../chat/tui/ui/Select';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
+import { tuiOutputStreamForColor } from '../chat/tui/render/noColorOutput';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import {
   modelSelectItemsForCliMode,
@@ -202,6 +203,7 @@ export interface RunOrchestrationTuiOptions {
   readonly models: readonly CliModelAccess[];
   readonly apiMode: CliApiMode;
   readonly allowDefaultModelLaunch?: boolean;
+  readonly colorEnabled?: boolean;
 }
 
 export async function runOrchestrationTui(
@@ -224,7 +226,10 @@ export async function runOrchestrationTui(
         onResolve={record}
       />,
       {
-        stdout: process.stdout,
+        stdout: tuiOutputStreamForColor(
+          process.stdout,
+          options.colorEnabled ?? true,
+        ),
         stderr: process.stderr,
         stdin: process.stdin,
       },

--- a/src/test-kernel/cli/TuiNoColorOutput.vitest.mts
+++ b/src/test-kernel/cli/TuiNoColorOutput.vitest.mts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  sgrStrippingWriteStream,
+  stripAnsiSgrSequences,
+} from '@cli/chat/tui/render/noColorOutput';
+
+describe('TUI no-color output', () => {
+  function fakeWriteStream(): { stream: NodeJS.WriteStream; writes: string[] } {
+    const writes: string[] = [];
+    const stream = {
+      write(chunk: string | Uint8Array) {
+        writes.push(
+          typeof chunk === 'string'
+            ? chunk
+            : Buffer.from(chunk).toString('utf8'),
+        );
+        return true;
+      },
+    } as NodeJS.WriteStream;
+    return { stream, writes };
+  }
+
+  it('strips SGR styling while preserving terminal control escapes', () => {
+    const input = '\x1b[2mDim\x1b[22m\x1b[36m cyan\x1b[39m\x1b[2K\x1b[1;1H';
+
+    expect(stripAnsiSgrSequences(input)).toBe('Dim cyan\x1b[2K\x1b[1;1H');
+  });
+
+  it('strips SGR styling from byte chunks passed to write streams', () => {
+    const { stream, writes } = fakeWriteStream();
+
+    sgrStrippingWriteStream(stream).write(
+      Buffer.from('\x1b[31mred\x1b[39m\x1b[2K'),
+    );
+
+    expect(writes).toEqual(['red\x1b[2K']);
+  });
+
+  it('keeps partial SGR sequences from leaking across writes', () => {
+    const { stream, writes } = fakeWriteStream();
+    const stripped = sgrStrippingWriteStream(stream);
+
+    stripped.write('\x1b[');
+    stripped.write('31mred\x1b[3');
+    stripped.write('9m');
+
+    expect(writes).toEqual(['red']);
+  });
+
+  it('preserves split non-SGR terminal control sequences', () => {
+    const { stream, writes } = fakeWriteStream();
+    const stripped = sgrStrippingWriteStream(stream);
+
+    stripped.write('\x1b[');
+    stripped.write('2Kclear');
+
+    expect(writes).toEqual(['\x1b[2Kclear']);
+  });
+});

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -50,6 +50,7 @@ describe('TUI validator args', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout.split('\n')).toContain('transcript');
+    expect(result.stdout.split('\n')).toContain('no-color-model-form');
     expect(result.stdout.split('\n')).toContain('nested-subagent-picker');
     expect(result.stdout).not.toContain('Available scenarios:');
     expect(result.stderr).not.toContain('building tui-harness bundle');


### PR DESCRIPTION
Fixes #5333

## Summary
- add a shared TUI output wrapper that strips only SGR styling when color is disabled while preserving terminal repaint/control escapes
- use the wrapper for chat, orchestration startup, onboarding/setup, init, and the TUI harness
- add raw PTY no-color validator coverage plus focused unit coverage for SGR stripping

## Dogfood evidence
- full current TUI harness passed before this change: `pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-scout-2`
- new `no-color-model-form` scenario failed before the fix with raw SGR sequences (`\x1b[2m`, `\x1b[90m`, `\x1b[36m`)
- after the fix, all 99 scenarios pass: `pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-scout-2-no-color-full`

## Validation
- `pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-scout-2-no-color-full`
- `pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-no-color-final no-color-model-form orchestrate-launcher`
- `pnpm exec vitest run src/test-kernel/cli/TuiNoColorOutput.vitest.mts src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized rendering/output filtering for disabled color; no auth or data paths, with focused unit and PTY regression coverage.
> 
> **Overview**
> When color is off (`NO_COLOR`, `stdoutColorEnabled`, or harness `HARNESS_COLOR_ENABLED=0`), Ink stdout now goes through a shared wrapper that **strips only SGR styling** (`…m` sequences) while leaving cursor/repaint CSI escapes intact, so no-color terminals stay readable without broken layout.
> 
> That wrapper is wired into **chat**, the **orchestration launcher**, **onboarding/setup**, **init**, and the **TUI harness**, using `context.stdoutColorEnabled ?? context.colorEnabled` (and the same for harness env).
> 
> **Validation:** a new PTY scenario `no-color-model-form` asserts the model form still works and raw output has no SGR; unit tests cover chunked writes and partial escape handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4766ed5e19b5422a1476f95ef056bdeeda2a4805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->