### PR TITLE
fix(cli): recognize raw Ctrl-V for image paste

### DIFF
--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -16,6 +16,7 @@ const RAW_CONTROL_INPUTS = new Map<number, string>([
   [11, 'k'],
   [18, 'r'],
   [21, 'u'],
+  [22, 'v'],
   [23, 'w'],
 ]);
 

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -132,6 +132,9 @@ describe('CLI TUI text input editing', () => {
     expect(isCtrlInput('\u0015', {}, 'u')).toBe(true);
     expect(isCtrlInput('u', { ctrl: true }, 'u')).toBe(true);
     expect(isCtrlInput('\u0015', { meta: true }, 'u')).toBe(false);
+    expect(normalizedCtrlInput('\u0016', {})).toBe('v');
+    expect(isCtrlInput('\u0016', {}, 'v')).toBe(true);
+    expect(isCtrlInput('\u0016', { meta: true }, 'v')).toBe(false);
     expect(isEscapeInput('\u001B', {})).toBe(true);
     expect(isUnhandledControlInput('\u0006')).toBe(true);
     expect(isUnhandledControlInput('\t')).toBe(false);


### PR DESCRIPTION
## Summary

- Normalize raw terminal Ctrl-V (`\u0016`) to `v` in the shared CLI TUI control-key helper.
- Add focused coverage proving raw Ctrl-V reaches `isCtrlInput(..., 'v')` while meta/Option still suppresses it.

Closes #5335.

## Why

`BaseTextInput` already routes image paste through `isCtrlInput(input, key, 'v')`, but Ink can surface Ctrl-V as the raw control byte with no `key.ctrl` flag. Without this mapping, the byte is treated as an unhandled control input and the image-paste shortcut is silently dropped.

## Verification

- `npm run test:kernel -- src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/InputBar.vitest.mts`
- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny input-normalization change with unit tests; no auth, data, or API surface impact.
> 
> **Overview**
> Fixes **image paste** in the CLI TUI when the terminal delivers **Ctrl-V** as the raw control byte (`\u0016`) instead of a normal `v` key with `key.ctrl`.
> 
> The shared `RAW_CONTROL_INPUTS` map in `inputKeys.ts` now treats that byte like other readline-style shortcuts, so `isCtrlInput(..., 'v')` matches and `BaseTextInput` can run the existing paste handler instead of dropping the key as an unhandled control input. Tests mirror the existing Ctrl-U coverage for raw vs meta-suppressed input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c83c94573c4e0458eb35bb38d47d93c308ea4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->