### PR TITLE
test(cli): cover failed subagent status rows

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -143,6 +143,7 @@ const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_NESTED_CHILDREN = process.env.HARNESS_NESTED_CHILDREN === '1';
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
 const SHOW_IDLE_TODOS = process.env.HARNESS_TODOS_IDLE === '1';
+const FAILED_CHILD_AGENT = process.env.HARNESS_FAILED_CHILD?.trim();
 const TEAM_NAME = process.env.HARNESS_TEAM_NAME?.trim() || undefined;
 let canInterrupt = process.env.HARNESS_CAN_INTERRUPT === '1';
 let harnessApprovalPolicy: CliApprovalPolicy = 'ask';
@@ -769,12 +770,24 @@ if (SHOW_CHILDREN) {
       status: STREAM_STATUS.RUNNING,
       startedAt: startedAt + 12_000,
     },
-  ];
+  ].map((child) =>
+    child.agentName === FAILED_CHILD_AGENT
+      ? {
+          ...child,
+          status: STREAM_STATUS.ERROR,
+          startedAt: undefined,
+          elapsed: null,
+        }
+      : child,
+  );
+  const activeSubagents = childStreams.filter(
+    (child) => child.status !== STREAM_STATUS.ERROR,
+  );
   patchStream(STREAM_ID, (slice) => ({
     ...slice,
     status: STREAM_STATUS.RUNNING,
     runStartedAt: startedAt,
-    activeSubagents: childStreams,
+    activeSubagents,
     childStreams,
     activeProcesses: [
       {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1202,6 +1202,25 @@ const SCENARIOS = [
     unexpect: ['[Option-p]tasks', '[Option-s]subagents'],
   },
   {
+    name: 'failed-subagent-status',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_FAILED_CHILD: 'reviewer',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    expect: [
+      'strategy running',
+      'leanSolver waiting',
+      'reviewer error',
+      '2 sub',
+      '[Tab]streams',
+      ']tasks',
+    ],
+    unexpect: ['reviewer running', '3 sub'],
+  },
+  {
     name: 'subagents-with-todos-compact',
     rows: 14,
     cols: 80,


### PR DESCRIPTION
## Summary

- add a CLI TUI harness knob that marks one child stream as failed while keeping the row visible
- keep failed child streams out of the active subagent count in that harness frame
- add a validate:tui scenario that asserts the failed child renders as error, not running

Fixes #5341.
References #5170, #5210, and #5214.

## Verification

- npm run format
- npm run compile:safe
- npm run lint (0 errors, existing 11 import-order warnings)
- pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-failed-child failed-subagent-status

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness and validator-only changes with no production CLI behavior modified in the diff.
> 
> **Overview**
> Adds **test-only** coverage for failed subagent rows in the CLI TUI harness and snapshot validator.
> 
> The harness reads **`HARNESS_FAILED_CHILD`** to force a named child (e.g. `reviewer`) to **`error`** while keeping it in **`childStreams`**, and seeds **`activeSubagents`** without failed children so the status bar shows **`2 sub`** instead of three. A new **`failed-subagent-status`** `validate:tui` scenario asserts labels like **`reviewer error`**, **`strategy running`**, and **`leanSolver waiting`**, and rejects **`reviewer running`** / **`3 sub`**.
> 
> No production TUI rendering logic changes in this diff—only deterministic fixtures and regression checks (fixes #5341).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f38d3ef9e670923a6190782ac6e95ee815a70e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->