### PR TITLE
Repair compile-failed workflow rounds

### DIFF
--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -841,6 +841,14 @@ export class LaTeXTab extends LitElement {
         currentValue: cv.workflowAutoOpenPdf,
       })}
       ${this.renderBooleanSetting({
+        field: 'workflowRejectOnCompileFailure',
+        label: 'Reject rounds when compile fails',
+        description:
+          'When a LaTeX compile check fails, use the next planned round to repair the output with the compile log.',
+        defaultValue: LATEX_CONFIG_DEFAULTS.workflowRejectOnCompileFailure,
+        currentValue: cv.workflowRejectOnCompileFailure,
+      })}
+      ${this.renderBooleanSetting({
         field: 'latexdiffBetweenRounds',
         label: 'Generate diffs between consecutive rounds',
         description:
@@ -898,6 +906,7 @@ export class LaTeXTab extends LitElement {
     field:
       | 'workflowAutoCompile'
       | 'workflowAutoOpenPdf'
+      | 'workflowRejectOnCompileFailure'
       | 'latexdiffBetweenRounds'
       | 'latexdiffChangesOnly';
     label: string;

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -10,6 +10,7 @@ import { AgentWorkspaceStateSnapshotSchema } from '@agent/core/execution/AgentWo
 import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessage';
 import {
   AgentFileLocationSchema,
+  CompileResultSchema,
   RetryErrorInfoSchema,
   RoundOutputSchema,
 } from '@shared/schemas';
@@ -41,6 +42,12 @@ export const ReflectionFlowStateSchema = z.object({
 
   /** Distinguishes failure from cancellation during resume. */
   lastError: RetryErrorInfoSchema.optional(),
+
+  /** Final LaTeX compile status for the last completed round, when checked. */
+  lastCompileResult: CompileResultSchema.optional(),
+
+  /** One-shot repair context injected into the next round's user request. */
+  compileFailureContext: z.string().optional(),
 });
 
 export type ReflectionFlowState = z.infer<typeof ReflectionFlowStateSchema>;

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -18,11 +18,19 @@ import {
   getRoundOutput,
   type RoundSummary,
 } from '@agent/output/roundSummary';
+import {
+  formatCompileFailureRoundContext,
+  shouldUseCompileFailureRepairContext,
+} from '@agent/output/compileFailureRoundContext';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { getWorkspaceState } from '@agent/core/stateStore';
 import { toErrorMessage } from '@common/errors';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
-import type { CompileFailure, RoundOutput } from '@shared/schemas';
+import type {
+  CompileFailure,
+  CompileResult,
+  RoundOutput,
+} from '@shared/schemas';
 import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import type { AgentFileLocation, FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
@@ -43,6 +51,7 @@ interface OutputExecResult {
   roundOutput: RoundOutput;
   summary: RoundSummary;
   compileFailures: CompileFailure[];
+  compileResult?: CompileResult;
   compiledArtifacts: CompiledPdfArtifact[];
   emitCompileFailures: boolean;
 }
@@ -93,6 +102,7 @@ export class OutputNode<C = unknown> extends Node<
 
     let mapping: RoundFileMapping | undefined;
     let compileFailures: CompileFailure[] = [];
+    let compileRoundResult: CompileResult | undefined;
     const compiledArtifacts: CompiledPdfArtifact[] = [];
     let emitCompileFailures = false;
 
@@ -152,6 +162,7 @@ export class OutputNode<C = unknown> extends Node<
               currentRound,
             );
             compileFailures = compileResult.failures;
+            compileRoundResult = compileResult.compileResult;
             compiledArtifacts.push(...compileResult.artifacts);
             setCompileFailures(outputState, currentRound, compileFailures);
             emitCompileFailures =
@@ -188,6 +199,7 @@ export class OutputNode<C = unknown> extends Node<
       roundOutput,
       summary,
       compileFailures,
+      compileResult: compileRoundResult,
       compiledArtifacts,
       emitCompileFailures,
     };
@@ -237,6 +249,7 @@ export class OutputNode<C = unknown> extends Node<
       },
       summary,
       compileFailures: [],
+      compileResult: undefined,
       compiledArtifacts: [],
       emitCompileFailures: false,
     };
@@ -318,6 +331,23 @@ export class OutputNode<C = unknown> extends Node<
 
     // Store round output
     shared.roundOutputs[currentRound] = roundOutput;
+    if (execRes.compileResult) {
+      shared.lastCompileResult = execRes.compileResult;
+      const compileFailureContext = shouldUseCompileFailureRepairContext(
+        execRes.compileResult,
+        shouldRejectOnCompileFailure(),
+      )
+        ? formatCompileFailureRoundContext(execRes.compileResult)
+        : undefined;
+      if (compileFailureContext) {
+        shared.compileFailureContext = compileFailureContext;
+      } else {
+        delete shared.compileFailureContext;
+      }
+    } else {
+      delete shared.lastCompileResult;
+      delete shared.compileFailureContext;
+    }
 
     return FlowTransition.DEFAULT;
   }
@@ -346,5 +376,12 @@ function shouldAutoOpenPdfOrLog(): boolean {
   return getWorkspaceState().get<boolean>(
     WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
     LATEX_CONFIG_DEFAULTS.workflowAutoOpenPdf,
+  );
+}
+
+function shouldRejectOnCompileFailure(): boolean {
+  return getWorkspaceState().get<boolean>(
+    WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
+    LATEX_CONFIG_DEFAULTS.workflowRejectOnCompileFailure,
   );
 }

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -2,6 +2,7 @@ import { Node } from '@agent/node';
 import { ConversationRoundStateSnapshotSchema } from '@agent/core/execution/AgentState';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { appendCompileFailureRoundContext } from '@agent/output/compileFailureRoundContext';
 
 import type {
   ReflectionFlowShared,
@@ -15,6 +16,7 @@ import type {
 interface PrepInput {
   currentRound: number;
   conversation: ProviderMessage[];
+  compileFailureContext?: string;
 }
 
 export class PrepareContextNode<C = unknown> extends Node<
@@ -26,12 +28,13 @@ export class PrepareContextNode<C = unknown> extends Node<
     return {
       currentRound: shared.currentRound,
       conversation: shared.conversation,
+      compileFailureContext: shared.compileFailureContext,
     };
   }
 
   async exec(prepRes: PrepInput): Promise<RoundContext> {
     const { promptBuilder, modelHandler, logger } = this.services;
-    const { currentRound, conversation } = prepRes;
+    const { currentRound, conversation, compileFailureContext } = prepRes;
 
     const stateRound = ConversationRoundStateSnapshotSchema.parse({
       roundIndex: currentRound,
@@ -50,9 +53,13 @@ export class PrepareContextNode<C = unknown> extends Node<
         systemPrompt,
       );
     } else {
+      const userRequest = appendCompileFailureRoundContext(
+        await promptBuilder.buildUserRequest(currentRound),
+        compileFailureContext,
+      );
       messages = await modelHandler.createRoundMessages(
         conversation,
-        await promptBuilder.buildUserRequest(currentRound),
+        userRequest,
         undefined,
       );
     }
@@ -84,6 +91,7 @@ export class PrepareContextNode<C = unknown> extends Node<
     context: RoundContext,
   ): Promise<string | undefined> {
     shared.context = context;
+    delete shared.compileFailureContext;
     return FlowTransition.DEFAULT;
   }
 }

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -6,12 +6,15 @@ import { toErrorMessage } from '@common/errors';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
 import { hasLatexCompiler } from '@latex/latexToolchain';
 import { compileLatex2Pdf } from '@latex/texTools';
-import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
+import type {
+  CompileFailure,
+  CompileResult,
+  OutputFileInfo,
+} from '@shared/schemas';
 import {
   LATEX_CONFIG_DEFAULTS,
   LATEX_CONFIG_RANGES,
 } from '@shared/constants/latex';
-import { hasExtension } from '@utils/core/pathCore';
 import {
   createRunStorageLocation,
   flexibleFS,
@@ -19,6 +22,7 @@ import {
   pathToLocation,
   type TaskRunFileService,
 } from '@utils/files';
+import { hasExtension } from '@utils/core/pathCore';
 
 import {
   publishCompiledPdfArtifact,
@@ -34,11 +38,13 @@ export interface CompileCheckContext {
 }
 
 const LOG_TAIL_LINES = 200;
+const COMPILE_LOG_EXCERPT_CHAR_LIMIT = 12000;
 const MIN_TIMEOUT_MS = LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min;
 
 export interface CompileCheckResult {
   failures: CompileFailure[];
   artifacts: CompiledPdfArtifact[];
+  compileResult?: CompileResult;
 }
 
 /**
@@ -110,6 +116,7 @@ export async function runCompileCheck(
   // the build succeeded.
   const compileRoot = path.join(runDirectory, 'compile');
   const failures: CompileFailure[] = [];
+  const failureLogExcerpts: string[] = [];
   const artifacts: CompiledPdfArtifact[] = [];
 
   for (const outputFile of texOutputs) {
@@ -126,7 +133,10 @@ export async function runCompileCheck(
           timeoutMs,
         },
       );
-      if (result.failure) failures.push(result.failure);
+      if (result.failure) {
+        failures.push(result.failure);
+        failureLogExcerpts.push(result.failureLogExcerpt);
+      }
       if (result.artifact) artifacts.push(result.artifact);
     } catch (err) {
       ctx.logger.warn(
@@ -135,7 +145,20 @@ export async function runCompileCheck(
     }
   }
 
-  return { failures, artifacts };
+  const compileResult: CompileResult =
+    failures.length > 0
+      ? {
+          status: 'failed',
+          round: currentRound,
+          failures,
+          logExcerpt: combineFailureLogExcerpts(failureLogExcerpts),
+        }
+      : {
+          status: 'ok',
+          round: currentRound,
+        };
+
+  return { failures, artifacts, compileResult };
 }
 
 interface PerFileOptions {
@@ -152,6 +175,7 @@ async function compileOne(
   opts: PerFileOptions,
 ): Promise<{
   failure: CompileFailure | null;
+  failureLogExcerpt: string;
   artifact: CompiledPdfArtifact | null;
 }> {
   // compiledBasename is the actual on-disk filename LaTeX engines use when
@@ -189,7 +213,7 @@ async function compileOne(
     ctx.logger.debug(
       `Compile check: ${displayName} has no \\documentclass, skipping`,
     );
-    return { failure: null, artifact: null };
+    return { failure: null, failureLogExcerpt: '', artifact: null };
   }
 
   // execa's timeout option kills the child process on expiry, so we don't
@@ -223,15 +247,13 @@ async function compileOne(
         `Compile check: ${displayName} PDF persisted at ${artifact.latestPdf.relativePath}`,
       );
     }
-    return { failure: null, artifact };
+    return { failure: null, failureLogExcerpt: '', artifact };
   }
 
   const tail = await readLogTail(buildDir, compiledBasename);
+  const failureLogExcerpt = `Compile check failed for ${displayName}\nBuild directory: ${buildDir}\n\n${tail}`;
   await flexibleFS.ensureDir(pathToLocation(opts.compileRoot));
-  await flexibleFS.write(
-    logDest,
-    `Compile check failed for ${displayName}\nBuild directory: ${buildDir}\n\n${tail}\n`,
-  );
+  await flexibleFS.write(logDest, `${failureLogExcerpt}\n`);
   ctx.logger.warn(
     `Compile check: ${displayName} failed — wrote ${path.relative(opts.runDirectory, logDest.absolutePath)}`,
   );
@@ -251,8 +273,19 @@ async function compileOne(
       log: logLocation,
       logRelativePath,
     },
+    failureLogExcerpt,
     artifact: null,
   };
+}
+
+function combineFailureLogExcerpts(excerpts: string[]): string {
+  const combined = excerpts.filter(Boolean).join('\n\n');
+  if (combined.length <= COMPILE_LOG_EXCERPT_CHAR_LIMIT) return combined;
+
+  return [
+    `[truncated to last ${COMPILE_LOG_EXCERPT_CHAR_LIMIT} characters]`,
+    combined.slice(-COMPILE_LOG_EXCERPT_CHAR_LIMIT),
+  ].join('\n');
 }
 
 async function readLogTail(

--- a/src/agent/output/compileFailureRoundContext.ts
+++ b/src/agent/output/compileFailureRoundContext.ts
@@ -1,0 +1,42 @@
+import type { CompileResult } from '@shared/schemas';
+
+export function formatCompileFailureRoundContext(
+  result: CompileResult | undefined,
+): string | undefined {
+  if (result?.status !== 'failed') return undefined;
+
+  const failedOutputs = result.failures
+    .map((failure) => `- ${failure.displayName} (${failure.logRelativePath})`)
+    .join('\n');
+
+  return [
+    '<compile_failure_context>',
+    'The previous workflow round was rejected because LaTeX compilation failed.',
+    'Use the log excerpt below to repair the next output.',
+    '',
+    'Failed outputs:',
+    failedOutputs,
+    '',
+    'Log excerpt:',
+    result.logExcerpt.trim(),
+    '</compile_failure_context>',
+  ].join('\n');
+}
+
+export function appendCompileFailureRoundContext(
+  userRequest: string,
+  compileFailureContext: string | undefined,
+): string {
+  if (!compileFailureContext) return userRequest;
+  const trimmedRequest = userRequest.trimEnd();
+  return trimmedRequest
+    ? [trimmedRequest, compileFailureContext].join('\n\n')
+    : compileFailureContext;
+}
+
+export function shouldUseCompileFailureRepairContext(
+  result: CompileResult | undefined,
+  enabled: boolean,
+): boolean {
+  return enabled && result?.status === 'failed';
+}

--- a/src/common/state/stateKeys.ts
+++ b/src/common/state/stateKeys.ts
@@ -61,6 +61,7 @@ export enum WorkspaceStateKey {
   WORKFLOW_AUTO_COMPILE = 'texra.workflow.autoCompileAfterOutput',
   WORKFLOW_AUTO_COMPILE_TIMEOUT_MS = 'texra.workflow.autoCompileTimeoutMs',
   WORKFLOW_AUTO_OPEN_PDF = 'texra.workflow.autoOpenPdf',
+  WORKFLOW_REJECT_ON_COMPILE_FAILURE = 'texra.workflow.rejectOnCompileFailure',
   LATEXDIFF_BETWEEN_ROUNDS = 'texra.latexdiff.generateBetweenRoundDiffs',
   LATEXDIFF_TIMEOUT_MS = 'texra.latexdiff.timeoutMs',
   LATEXDIFF_MATH_MARKUP = 'texra.latexdiff.mathMarkup',

--- a/src/shared/constants/latex.ts
+++ b/src/shared/constants/latex.ts
@@ -452,6 +452,7 @@ export const LATEX_CONFIG_DEFAULTS = {
   workflowAutoCompile: true,
   workflowAutoCompileTimeoutMs: 120000,
   workflowAutoOpenPdf: true,
+  workflowRejectOnCompileFailure: true,
   latexdiffBetweenRounds: false,
   latexdiffTimeoutMs: 10000,
   latexdiffMathMarkup: 'coarse' as LatexdiffMathMarkupValue,
@@ -475,6 +476,8 @@ export const LATEX_FIELD_TO_KEY = {
   workflowAutoCompileTimeoutMs:
     WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
   workflowAutoOpenPdf: WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
+  workflowRejectOnCompileFailure:
+    WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
   latexdiffBetweenRounds: WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
   latexdiffTimeoutMs: WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS,
   latexdiffMathMarkup: WorkspaceStateKey.LATEXDIFF_MATH_MARKUP,

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -74,6 +74,20 @@ export type FileLineage = z.infer<typeof FileLineageSchema>;
 export type OutputFileInfo = z.infer<typeof OutputFileInfoSchema>;
 export type CompileFailure = z.infer<typeof CompileFailureSchema>;
 
+export const CompileResultSchema = z.discriminatedUnion('status', [
+  z.strictObject({
+    status: z.literal('ok'),
+    round: z.number(),
+  }),
+  z.strictObject({
+    status: z.literal('failed'),
+    round: z.number(),
+    failures: z.array(CompileFailureSchema),
+    logExcerpt: z.string(),
+  }),
+]);
+export type CompileResult = z.infer<typeof CompileResultSchema>;
+
 export const OutputXmlSummarySchema = z.strictObject({
   tagContents: z
     .record(z.string(), z.union([z.string(), z.array(z.string())]))

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -566,6 +566,7 @@ export const LatexConfigValuesSchema = z.object({
     .min(LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min)
     .optional(),
   workflowAutoOpenPdf: z.boolean().optional(),
+  workflowRejectOnCompileFailure: z.boolean().optional(),
   latexdiffBetweenRounds: z.boolean().optional(),
   latexdiffTimeoutMs: z
     .int()

--- a/src/test-kernel/agent/output/CompileFailureRoundContext.vitest.ts
+++ b/src/test-kernel/agent/output/CompileFailureRoundContext.vitest.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendCompileFailureRoundContext,
+  formatCompileFailureRoundContext,
+  shouldUseCompileFailureRepairContext,
+} from '@agent/output/compileFailureRoundContext';
+import type { CompileFailure, CompileResult } from '@shared/schemas';
+
+const outputLocation = {
+  kind: 'workspace',
+  absolutePath: '/workspace/main.tex',
+  relativePath: 'main.tex',
+} as const;
+const logLocation = {
+  kind: 'runStorage',
+  absolutePath: '/run/compile/r0_main.tex.log',
+  relativePath: 'compile/r0_main.tex.log',
+  executionId: '00000000-0000-4000-8000-000000000001',
+} as const;
+
+const failure: CompileFailure = {
+  round: 0,
+  displayName: 'main.tex',
+  output: outputLocation,
+  log: logLocation,
+  logRelativePath: 'compile/r0_main.tex.log',
+};
+
+const failedResult: CompileResult = {
+  status: 'failed',
+  round: 0,
+  failures: [failure],
+  logExcerpt: '! Undefined control sequence.',
+};
+
+describe('compile failure round context', () => {
+  it('formats failed compile results for the next round prompt', () => {
+    const context = formatCompileFailureRoundContext(failedResult);
+
+    expect(context).toContain('previous workflow round was rejected');
+    expect(context).toContain('main.tex (compile/r0_main.tex.log)');
+    expect(context).toContain('! Undefined control sequence.');
+  });
+
+  it('does not format successful compile results', () => {
+    expect(
+      formatCompileFailureRoundContext({ status: 'ok', round: 0 }),
+    ).toBeUndefined();
+  });
+
+  it('appends compile context to the existing user request', () => {
+    expect(
+      appendCompileFailureRoundContext('Revise the document.\n', 'log tail'),
+    ).toBe('Revise the document.\n\nlog tail');
+  });
+
+  it('uses compile failure repair context only when enabled', () => {
+    expect(shouldUseCompileFailureRepairContext(failedResult, true)).toBe(true);
+    expect(shouldUseCompileFailureRepairContext(failedResult, false)).toBe(
+      false,
+    );
+    expect(
+      shouldUseCompileFailureRepairContext({ status: 'ok', round: 0 }, true),
+    ).toBe(false);
+  });
+});

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -1,10 +1,11 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { OutputNode } from '@agent/implementations/flows/reflection/nodes/OutputNode';
+import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
 import { createOutputState, type RoundData } from '@agent/output/outputState';
 import {
@@ -13,8 +14,11 @@ import {
 } from '@agent/output/OutputFileProcessor';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import { normalizeRunId } from '@common/constants/runIds';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
 import type {
   AgentFileLocation,
+  CompileFailure,
+  CompileResult,
   FileLocation,
   OutputFileInfo,
   OutputXmlSummary,
@@ -37,7 +41,63 @@ const emptyXmlSummary: OutputXmlSummary = {
   sourceLocation: null,
 };
 
+function createCompileFailureFixture() {
+  const outputLocation = createAgentLocation('/tmp/output.xml');
+  const texLocation = createLocation('/tmp/rendered.tex');
+  const logLocation = createLocation('/tmp/compile.log');
+  const compileFailure: CompileFailure = {
+    round: 0,
+    displayName: 'rendered.tex',
+    output: texLocation,
+    log: logLocation,
+    logRelativePath: 'compile/r0_rendered.tex.log',
+  };
+  const compileResult: CompileResult = {
+    status: 'failed',
+    round: 0,
+    failures: [compileFailure],
+    logExcerpt: '! Missing $ inserted.',
+  };
+  const roundOutput: RoundOutput = {
+    round: 0,
+    rawOutput: outputLocation,
+    outputs: [],
+    compileFailures: [compileFailure],
+    xmlSummary: emptyXmlSummary,
+  };
+  const summary = {
+    storageKey: normalizeRunId('run:compile-context'),
+    currRound: 0,
+    fileInfos: [],
+    filesToOpen: [],
+    outputFile: outputLocation,
+    endTurn: false,
+  };
+
+  return {
+    outputLocation,
+    compileFailure,
+    compileResult,
+    roundOutput,
+    summary,
+  };
+}
+
+async function initFakePlatform(
+  workspaceState: Record<string, unknown> = {},
+): Promise<void> {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(createFakePlatform({ workspaceState }));
+}
+
 describe('output progress events', () => {
+  beforeEach(async () => {
+    await initFakePlatform();
+  });
+
   it('publishes reflection output-node events through the runtime host', async () => {
     const { events, host } = createRecordingHost();
     const outputNode = new OutputNode().setServices({
@@ -100,6 +160,131 @@ describe('output progress events', () => {
         payload: { location: openedLocation, preserveFocus: true },
       },
     ]);
+  });
+
+  it('stores compile failure context for the next reflection round', async () => {
+    const { host } = createRecordingHost();
+    const outputNode = new OutputNode().setServices({
+      streamId: 'stream:compile-context',
+      logger: { warn: () => {} },
+      outputState: createOutputState(),
+      runtimeHost: host,
+    } as unknown as ReflectionServices);
+    const {
+      outputLocation,
+      compileFailure,
+      compileResult,
+      roundOutput,
+      summary,
+    } = createCompileFailureFixture();
+    const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
+
+    await outputNode.post(
+      shared,
+      {
+        outputLocation,
+        currentRound: 0,
+        endTurn: false,
+      },
+      {
+        roundOutput,
+        summary,
+        compileFailures: [compileFailure],
+        compileResult,
+        compiledArtifacts: [],
+        emitCompileFailures: false,
+      },
+    );
+
+    expect(shared.lastCompileResult).toEqual(compileResult);
+    expect(shared.compileFailureContext).toContain(
+      'previous workflow round was rejected',
+    );
+    expect(shared.compileFailureContext).toContain('! Missing $ inserted.');
+  });
+
+  it('honors disabled compile-failure repair context setting', async () => {
+    await initFakePlatform({
+      [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: false,
+    });
+    const { host } = createRecordingHost();
+    const outputNode = new OutputNode().setServices({
+      streamId: 'stream:compile-context-disabled',
+      logger: { warn: () => {} },
+      outputState: createOutputState(),
+      runtimeHost: host,
+    } as unknown as ReflectionServices);
+    const {
+      outputLocation,
+      compileFailure,
+      compileResult,
+      roundOutput,
+      summary,
+    } = createCompileFailureFixture();
+    const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
+
+    await outputNode.post(
+      shared,
+      {
+        outputLocation,
+        currentRound: 0,
+        endTurn: false,
+      },
+      {
+        roundOutput,
+        summary,
+        compileFailures: [compileFailure],
+        compileResult,
+        compiledArtifacts: [],
+        emitCompileFailures: false,
+      },
+    );
+
+    expect(shared.lastCompileResult).toEqual(compileResult);
+    expect(shared.compileFailureContext).toBeUndefined();
+  });
+
+  it('clears stale compile failure context after a successful compile result', async () => {
+    const { host } = createRecordingHost();
+    const outputNode = new OutputNode().setServices({
+      streamId: 'stream:compile-context-ok',
+      logger: { warn: () => {} },
+      outputState: createOutputState(),
+      runtimeHost: host,
+    } as unknown as ReflectionServices);
+    const { outputLocation, roundOutput, summary } =
+      createCompileFailureFixture();
+    const compileResult: CompileResult = { status: 'ok', round: 1 };
+    const shared = {
+      roundOutputs: [],
+      compileFailureContext: 'old context',
+      lastCompileResult: {
+        status: 'failed',
+        round: 0,
+        failures: [],
+        logExcerpt: 'old log',
+      },
+    } as unknown as ReflectionFlowShared;
+
+    await outputNode.post(
+      shared,
+      {
+        outputLocation,
+        currentRound: 1,
+        endTurn: false,
+      },
+      {
+        roundOutput: { ...roundOutput, round: 1, compileFailures: [] },
+        summary: { ...summary, currRound: 1 },
+        compileFailures: [],
+        compileResult,
+        compiledArtifacts: [],
+        emitCompileFailures: false,
+      },
+    );
+
+    expect(shared.lastCompileResult).toEqual(compileResult);
+    expect(shared.compileFailureContext).toBeUndefined();
   });
 
   it('publishes missing-output processing events through the runtime host', async () => {


### PR DESCRIPTION
## Summary
- persist per-round LaTeX compile results and carry failed compile log excerpts into the next reflection round
- let the round loop spend the next planned round through a generic forced-continuation callback
- add a workspace-backed setting, `workflowRejectOnCompileFailure`, exposed in the LaTeX settings tab and defaulting on

Refs #3234.

## Validation
- npm run format
- npm run test:kernel -- src/test-kernel/agent/output/CompileFailureRoundContext.vitest.ts src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
- npm run lint
- npm run compile:safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reflection-round prompting and compile-check outputs in the agent workflow path; misconfiguration or bad log excerpts could steer repair rounds, but behavior is toggleable and scoped to compile failures.
> 
> **Overview**
> Adds an optional **compile-failure repair loop** for reflection workflows: when post-round LaTeX compile checks fail, the next round’s user prompt can include a structured `<compile_failure_context>` block with failed file names and a truncated log excerpt so the agent can fix the `.tex` output.
> 
> **Compile check** now returns a typed `CompileResult` (`ok` / `failed`) with combined, length-capped log excerpts in addition to existing failure records and artifacts. **Reflection flow state** persists `lastCompileResult` and a one-shot `compileFailureContext`; **OutputNode** sets or clears these based on the latest check, gated by a new workspace setting **`workflowRejectOnCompileFailure`** (default **on**). **PrepareContextNode** appends that context to non-initial round requests and clears it after use.
> 
> The setting is wired through shared LaTeX config/state keys and exposed in the LaTeX settings tab as “Reject rounds when compile fails.” Unit tests cover context formatting and OutputNode behavior when the toggle is on, off, or after a successful compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acbc22af8b1efc3a2c9cd26a4631a51d495d6046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->