### PR TITLE
refactor: consolidate ensureArray utility and replace inline delay patterns

### DIFF
--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -13,13 +13,13 @@ import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Type imports
 import { ensureArray } from '@utils/core';
-import { getExtensionLowercase } from '@utils/core/pathCore';
 import {
   AbsoluteFS,
   getMimeType,
   getShortDisplayPath,
   type FileLocation,
 } from '@utils/files';
+import { getExtensionLowercase } from '@utils/core/pathCore';
 import {
   countPdfPages,
   getBase64EncodedMedia,

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -12,6 +12,7 @@ import { toErrorMessage } from '@common/errors';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Type imports
+import { ensureArray } from '@utils/core';
 import { getExtensionLowercase } from '@utils/core/pathCore';
 import {
   AbsoluteFS,
@@ -185,7 +186,7 @@ export class MediaAttachmentProcessor {
         results.push(result);
 
         if (entry) {
-          const entryList = Array.isArray(entry) ? entry : [entry];
+          const entryList = ensureArray(entry);
           entries.push(...entryList);
         }
       } else {
@@ -374,7 +375,7 @@ export class MediaAttachmentProcessor {
 
   /** Normalize data to array for consistent processing */
   private normalizeToArray(data: string | string[]): string[] {
-    return Array.isArray(data) ? data : [data];
+    return ensureArray(data);
   }
 
   /** Get the first data item (for single-item scenarios) */

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -11,7 +11,7 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 import { toErrorMessage } from '@common/errors';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
-// Type imports
+// Local imports - utils
 import { ensureArray } from '@utils/core';
 import {
   AbsoluteFS,

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -6,7 +6,7 @@ import * as logger from '@logger/logUtils';
 import { flexibleFS, pathToLocation } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';
-import { filterNotNull } from '@utils/core';
+import { filterNotNull, ensureArray } from '@utils/core';
 import { hasExtension } from '@utils/core/pathCore';
 
 const CHANNEL = 'LaTeXCommands';
@@ -237,7 +237,7 @@ export async function getTeXCount(
   const resolvedChannel = channel ?? CHANNEL;
 
   try {
-    const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
+    const paths = ensureArray(filePaths);
     const trimmedPaths = paths
       .map((filePath) => filePath.trim())
       .filter((filePath) => filePath.length > 0);

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -4,6 +4,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
+import { delay } from '@utils/core/async';
 
 import { UsageLogResponseSchema } from './UsageLogTypes';
 import type {
@@ -220,7 +221,7 @@ class UsageLogServiceImpl {
 
     const deadline = Date.now() + 5000;
     while (this.activeFlush && Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await delay(50);
     }
 
     if (this.activeFlush) {

--- a/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
+++ b/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
@@ -21,7 +21,6 @@ import type { StreamTabId } from '@shared/schemas';
 
 const tmpDirs: string[] = [];
 
-
 function createRuntimeHost(): {
   host: AgentRuntimeHost;
   events: Array<{ event: string; payload: unknown }>;

--- a/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
+++ b/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
+import { delay } from '@utils/core/async';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { ProcessExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import {
@@ -20,9 +21,6 @@ import type { StreamTabId } from '@shared/schemas';
 
 const tmpDirs: string[] = [];
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 function createRuntimeHost(): {
   host: AgentRuntimeHost;

--- a/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
+++ b/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
-import { delay } from '@utils/core/async';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { ProcessExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import {
@@ -18,6 +17,7 @@ import {
 
 // Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
+import { delay } from '@utils/core/async';
 
 const tmpDirs: string[] = [];
 

--- a/src/test-kernel/auth/ServerSideKeyService.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyService.vitest.ts
@@ -1,8 +1,6 @@
 // Third-party imports
 import { describe, expect, it } from 'vitest';
 
-// Local imports - utils
-
 // Local imports - auth
 import { FREE_TIER, ULTRA_TIER, type UserTier } from '@auth/config';
 import {

--- a/src/test-kernel/auth/ServerSideKeyService.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyService.vitest.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { describe, expect, it } from 'vitest';
 
+// Local imports - utils
+import { delay } from '@utils/core/async';
+
 // Local imports - auth
 import { FREE_TIER, ULTRA_TIER, type UserTier } from '@auth/config';
 import {
@@ -126,7 +129,7 @@ describe('ServerSideKeyService quota fallback', () => {
     service.initialize({ state });
 
     expect(await service.canUseServerSideKeys()).toBe(false);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await delay(0);
     expect(service.getUseIncludedModelAccess()).toBe(false);
     expect(service.wasQuotaAutoSwitched()).toBe(true);
     expect(service.isRelayQuotaExceeded()).toBe(true);

--- a/src/test-kernel/auth/ServerSideKeyService.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyService.vitest.ts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - utils
-import { delay } from '@utils/core/async';
 
 // Local imports - auth
 import { FREE_TIER, ULTRA_TIER, type UserTier } from '@auth/config';
@@ -12,6 +11,7 @@ import {
   type ServerSideKeyState,
 } from '@auth/serverKeys/ServerSideKeyService';
 import type { TierService } from '@auth/tier/TierService';
+import { delay } from '@utils/core/async';
 
 const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
 

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -20,6 +20,7 @@ import { createRequire } from 'node:module';
 
 import { describe, expect, it } from 'vitest';
 
+import { delay } from '@utils/core/async';
 import { fillRows } from '@cli/chat/tui/render/terminalText';
 
 const cliRequire = createRequire(
@@ -76,7 +77,7 @@ async function waitFor(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (predicate()) return true;
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await delay(25);
   }
   return predicate();
 }

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -20,8 +20,8 @@ import { createRequire } from 'node:module';
 
 import { describe, expect, it } from 'vitest';
 
-import { delay } from '@utils/core/async';
 import { fillRows } from '@cli/chat/tui/render/terminalText';
+import { delay } from '@utils/core/async';
 
 const cliRequire = createRequire(
   new URL('../../../packages/cli/package.json', import.meta.url),

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -2,11 +2,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - utils
-import { delay } from '@utils/core/async';
 
 // Local imports - shared schemas
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
+import { delay } from '@utils/core/async';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+// Local imports - utils
+import { delay } from '@utils/core/async';
+
 // Local imports - shared schemas
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
@@ -80,7 +83,7 @@ async function loadDesktopCommandPalette(): Promise<DesktopCommandPaletteModule>
 // those promise/timer callbacks resolve in jsdom (which has no real raf).
 async function flushDialogTicks(times = 5): Promise<void> {
   for (let i = 0; i < times; i += 1) {
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await delay(0);
   }
 }
 

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -1,8 +1,6 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
-// Local imports - utils
-
 // Local imports - shared schemas
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { delay } from '@utils/core/async';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type {
   ProgressEventBusLike,
@@ -57,7 +58,7 @@ async function pathExists(filePath: string): Promise<boolean> {
 async function waitForEmptyDir(dir: string): Promise<void> {
   for (let attempt = 0; attempt < 20; attempt++) {
     if ((await readdir(dir)).length === 0) return;
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await delay(10);
   }
 }
 

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -4,7 +4,6 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { delay } from '@utils/core/async';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type {
   ProgressEventBusLike,
@@ -16,6 +15,7 @@ import type {
   DiffSource,
   DiffViewHost,
 } from '@hosts/diffViewHost';
+import { delay } from '@utils/core/async';
 
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 

--- a/src/test-kernel/progressView/StreamTabStorageConcurrency.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabStorageConcurrency.vitest.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { delay } from '@utils/core/async';
 import {
   mapStreamTabStorage,
   STREAM_TAB_IO_CONCURRENCY,
@@ -51,7 +52,7 @@ describe('mapStreamTabStorage', () => {
 async function waitFor(predicate: () => boolean): Promise<void> {
   for (let i = 0; i < 50; i++) {
     if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await delay(0);
   }
   throw new Error('Timed out waiting for condition');
 }

--- a/src/test-kernel/progressView/StreamTabStorageConcurrency.vitest.ts
+++ b/src/test-kernel/progressView/StreamTabStorageConcurrency.vitest.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { delay } from '@utils/core/async';
 import {
   mapStreamTabStorage,
   STREAM_TAB_IO_CONCURRENCY,
 } from '@progressView/persistence/StreamTabStore';
 import type { StreamTabId } from '@shared/schemas';
+import { delay } from '@utils/core/async';
 
 describe('mapStreamTabStorage', () => {
   it('bounds concurrent per-stream storage work', async () => {

--- a/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
+++ b/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
@@ -13,6 +13,7 @@ import { FileType, type FileStat } from '@platform/interfaces/filesystem';
 import { walkMemoryDirectory } from '@tools/memory/memoryFileSystem';
 import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
 import { StorageFS } from '@utils/files';
+import { delay } from '@utils/core/async';
 
 const MEMORY_LISTING_CONCURRENCY = 8;
 const FILE_COUNT_PER_DIRECTORY = 12;
@@ -80,7 +81,7 @@ describe('memory filesystem listing', () => {
         activeMetadataReads,
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 5));
+      await delay(5);
       activeMetadataReads -= 1;
       return testFileStat();
     });

--- a/src/test-kernel/settings/ProviderKeyModal.vitest.ts
+++ b/src/test-kernel/settings/ProviderKeyModal.vitest.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { delay } from '@utils/core/async';
 import { useLitComponentTestDom } from './litComponentTestUtils';
 
 type ProviderKeyModalElement = HTMLElement & {
@@ -15,7 +16,7 @@ type WaDialogElement = HTMLElement & { open: boolean };
 // those promise/timer callbacks resolve in jsdom (which has no real raf).
 async function flushDialogTicks(times = 5): Promise<void> {
   for (let i = 0; i < times; i += 1) {
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await delay(0);
   }
 }
 

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { delay } from '@utils/core/async';
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
 import { fileUriToPath, LeanSession } from '@tools/lean/direct/leanSession';
 
@@ -161,7 +162,7 @@ describe('createDirectLspLeanAdapter', () => {
     await session.ensureReady();
 
     const pendingDiagnostics = session.fetchDiagnostics(filePath);
-    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    await delay(100);
     await session.dispose();
 
     await expect(

--- a/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
+++ b/src/test-kernel/tools/lean/DirectLspAdapter.vitest.ts
@@ -11,9 +11,9 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { delay } from '@utils/core/async';
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
 import { fileUriToPath, LeanSession } from '@tools/lean/direct/leanSession';
+import { delay } from '@utils/core/async';
 
 const FAKE_LAKE = `#!/usr/bin/env node
 const fs = require('node:fs');

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -4,6 +4,9 @@ import * as path from 'node:path';
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+// Local imports
+import { delay } from '@utils/core/async';
+
 // Platform imports
 import { FileType, type FileStat } from '@platform/interfaces/filesystem';
 
@@ -187,7 +190,7 @@ async function waitForCondition(
 ): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     if (condition()) return;
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await delay(0);
   }
   throw new Error(message);
 }

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -5,7 +5,6 @@ import * as path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import { delay } from '@utils/core/async';
 
 // Platform imports
 import { FileType, type FileStat } from '@platform/interfaces/filesystem';
@@ -18,6 +17,7 @@ import {
   type StreamLogEntry,
 } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
+import { delay } from '@utils/core/async';
 
 const STREAM_LOGS_DIR = 'streamLogs';
 const STREAM_LOG_SUMMARIES_DIR = 'streamLogSummaries';

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -4,8 +4,6 @@ import * as path from 'node:path';
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-// Local imports
-
 // Platform imports
 import { FileType, type FileStat } from '@platform/interfaces/filesystem';
 

--- a/src/test-kernel/utils/TypeGuards.vitest.ts
+++ b/src/test-kernel/utils/TypeGuards.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { filterNotNull, filterNotNullish } from '@utils/core';
+import { ensureArray, filterNotNull, filterNotNullish } from '@utils/core';
 
 describe('core type guard predicates', () => {
   it('filters null values as an Array.filter predicate', () => {
@@ -18,5 +18,15 @@ describe('core type guard predicates', () => {
     ];
 
     expect(values.filter(filterNotNullish)).toEqual(['alpha', 'beta']);
+  });
+
+  it('returns array values unchanged', () => {
+    const values = ['alpha', 'beta'];
+
+    expect(ensureArray(values)).toBe(values);
+  });
+
+  it('wraps scalar values in an array', () => {
+    expect(ensureArray('alpha')).toEqual(['alpha']);
   });
 });

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -11,6 +11,7 @@ import { toErrorMessage } from '@common/errors';
 import { ToolResult } from '@tools/result';
 import { isTimeoutErrorCode } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
+import { ensureArray } from '@utils/core';
 
 const LOOGLE_TIMEOUT_MS = 10_000; // 10 s
 
@@ -201,7 +202,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
 
   protected async execute(input: LeanLoogleInput): Promise<ToolResult> {
     const { query, limit } = input;
-    const queries = Array.isArray(query) ? query : [query];
+    const queries = ensureArray(query);
 
     // Single query: return directly (backward-compatible format)
     if (queries.length === 1) {

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { getTeXCount } from '@latex/texcount';
 import { ToolError, type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
+import { ensureArray } from '@utils/core';
 
 const TexcountInputSchema = z.strictObject({
   files: z
@@ -24,7 +25,7 @@ const TexcountInputSchema = z.strictObject({
 type TexcountInput = z.infer<typeof TexcountInputSchema>;
 
 function toFileArray(files: TexcountInput['files']): string[] {
-  return Array.isArray(files) ? files : [files];
+  return ensureArray(files);
 }
 
 function formatOutput(output: string, format: TexcountInput['format']): string {

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -2,6 +2,7 @@
 import { tryPlatform } from '@platform/platform';
 import type { ConfigTarget } from '@platform/interfaces/config';
 import type { Disposable } from '@platform/interfaces/disposable';
+import { ensureArray } from '@utils/core';
 
 interface ConfigSubscriptionContext {
   subscriptions: Disposable[];
@@ -96,7 +97,7 @@ export function watchConfig(
   keys: string | string[],
   callback: () => void,
 ): Disposable {
-  const keyArray = Array.isArray(keys) ? keys : [keys];
+  const keyArray = ensureArray(keys);
   const provider = configProvider();
   const disposable = provider?.watch(keyArray, callback) ?? {
     dispose: () => {},

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -1,8 +1,8 @@
 // Local imports
 import { tryPlatform } from '@platform/platform';
+import { ensureArray } from '@utils/core';
 import type { ConfigTarget } from '@platform/interfaces/config';
 import type { Disposable } from '@platform/interfaces/disposable';
-import { ensureArray } from '@utils/core';
 
 interface ConfigSubscriptionContext {
   subscriptions: Disposable[];

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -19,5 +19,6 @@ export {
   isFiniteNumber,
   filterNotNull,
   filterNotNullish,
+  ensureArray,
 } from './typeGuards';
 export { debounce, delay } from './async';

--- a/src/utils/core/typeGuards.ts
+++ b/src/utils/core/typeGuards.ts
@@ -21,3 +21,8 @@ export function filterNotNull<T>(item: T | null): item is T {
 export function filterNotNullish<T>(item: T | null | undefined): item is T {
   return item != null;
 }
+
+/** Wrap a single value in an array, or return the array unchanged. */
+export function ensureArray<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value];
+}


### PR DESCRIPTION
## Summary

Two targeted consolidations identified by a codebase-wide audit:

### 1. `ensureArray<T>()` utility (6 call sites)

The pattern `Array.isArray(x) ? x : [x]` appeared in six separate production files with no shared abstraction. A new `ensureArray<T>(value: T | T[]): T[]` helper is added to `src/utils/core/typeGuards.ts` and exported from the `@utils/core` barrel.

**Call sites updated:**
- `src/utils/config/configUtils.ts` — `watchConfig` key normalisation
- `src/tools/lean/LoogleTool.ts` — query coercion in `execute()`
- `src/tools/texcount/TexcountTool.ts` — body of `toFileArray()` helper
- `src/latex/texcount.ts` — file-path coercion in `getTeXCount()`
- `src/agent/modelHandlers/support/MediaAttachmentProcessor.ts` — inline coercion (×1) and body of `normalizeToArray()` (×1)

### 2. `delay()` from `@utils/core/async` (11 call sites)

`@utils/core/async` already re-exports the `delay` package as the codebase's canonical async-sleep helper. Eleven files ignored this and reinvented the wheel with `new Promise((resolve) => setTimeout(resolve, ms))`. One file (`ProcessOutputPoller.vitest.ts`) had defined its own private `delay()` function, which is removed entirely.

**Files updated:** `UsageLogService.ts` (production) + 10 test-kernel files across agent, auth, cli, desktop, progressView, settings, tools, and transcript suites.

## Test plan

- [x] `npm run compile:fast` — builds cleanly with no errors
- [ ] `npm run typecheck` — requires full dev-dep install (blocked in sandbox); changes are type-safe by inspection (`ensureArray<T>` preserves the generic and `delay` signature is identical to `setTimeout`-based pattern)

https://claude.ai/code/session_01CAgjxMhVbyqi5tZXfvNyct

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAgjxMhVbyqi5tZXfvNyct)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical, behavior-preserving refactors with no API or security changes; only `UsageLogService.dispose` uses `delay` in production code.
> 
> **Overview**
> Introduces shared **`ensureArray<T>`** in `@utils/core` (`typeGuards.ts`, barrel export) and replaces repeated `Array.isArray(x) ? x : [x]` at production call sites: config `watchConfig` keys, Loogle/texcount tools and `getTeXCount`, and media attachment loading/normalization.
> 
> Standardizes async sleeps on the existing **`delay`** helper from `@utils/core/async` instead of ad-hoc `new Promise(setTimeout)` (including `UsageLogService.dispose` polling) and across multiple test-kernel suites; removes a duplicate local `delay` in `ProcessOutputPoller.vitest.ts`. Adds unit coverage for `ensureArray` identity vs wrap behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbfd3fe7981b912a9202177f21d3c08ea73ee176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->