### PR TITLE
fix(cli): explain multi-agent sign-in recovery

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -78,10 +78,25 @@ interface MultiAgentRunInit {
   readonly instructionFile?: string;
 }
 
+interface RemoteAgentPlanReloadResult<T> {
+  readonly value: T;
+  readonly remoteAgentLoadAttempted: boolean;
+}
+
+export interface MultiAgentRunPlanLoadResult {
+  readonly plan: CliMultiAgentPresetRunPlan;
+  readonly remoteAgentLoadAttempted: boolean;
+}
+
+export interface MultiAgentPresetPlansLoadResult {
+  readonly plans: readonly CliMultiAgentPresetRunPlan[];
+  readonly remoteAgentLoadAttempted: boolean;
+}
+
 const MULTI_AGENT_TASK_REQUIRED_MESSAGE =
   'Provide --input, --instruction, or --instruction-file for the team task. Example: texra multi-agent run physicist --instruction "Check this derivation"';
 
-function resolveMultiAgentRunPlan(
+function planCurrentMultiAgentRun(
   init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
 ): CliMultiAgentPresetRunPlan {
   const preset = findCliMultiAgentPreset(
@@ -121,30 +136,54 @@ function planLoadedCliMultiAgentPresets(
 export async function fillMultiAgentRunPlanGaps(
   init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
 ): Promise<CliMultiAgentPresetRunPlan> {
-  let plan = resolveMultiAgentRunPlan(init);
-  if (
-    cliMultiAgentPlanHasGaps(plan) &&
-    (await getCliAuthProvider().isAuthenticated())
-  ) {
-    await loadAgents();
-    plan = resolveMultiAgentRunPlan(init);
-  }
-  return plan;
+  return (await loadCliMultiAgentRunPlan(init)).plan;
+}
+
+export async function loadCliMultiAgentRunPlan(
+  init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
+): Promise<MultiAgentRunPlanLoadResult> {
+  const result = await reloadRemoteAgentsForGaps(
+    planCurrentMultiAgentRun(init),
+    cliMultiAgentPlanHasGaps,
+    () => planCurrentMultiAgentRun(init),
+  );
+  return {
+    plan: result.value,
+    remoteAgentLoadAttempted: result.remoteAgentLoadAttempted,
+  };
+}
+
+export async function loadCliMultiAgentPresetPlanSet(
+  presets: readonly CliMultiAgentPreset[],
+): Promise<MultiAgentPresetPlansLoadResult> {
+  await loadAgents({ includeRemote: false });
+  const result = await reloadRemoteAgentsForGaps(
+    planLoadedCliMultiAgentPresets(presets),
+    (plans) => plans.some(cliMultiAgentPlanHasGaps),
+    () => planLoadedCliMultiAgentPresets(presets),
+  );
+  return {
+    plans: result.value,
+    remoteAgentLoadAttempted: result.remoteAgentLoadAttempted,
+  };
 }
 
 export async function loadCliMultiAgentPresetPlans(
   presets: readonly CliMultiAgentPreset[],
-): Promise<CliMultiAgentPresetRunPlan[]> {
-  await loadAgents({ includeRemote: false });
-  let plans = planLoadedCliMultiAgentPresets(presets);
-  if (
-    plans.some(cliMultiAgentPlanHasGaps) &&
-    (await getCliAuthProvider().isAuthenticated())
-  ) {
+): Promise<readonly CliMultiAgentPresetRunPlan[]> {
+  return (await loadCliMultiAgentPresetPlanSet(presets)).plans;
+}
+
+async function reloadRemoteAgentsForGaps<T>(
+  value: T,
+  hasGaps: (value: T) => boolean,
+  replan: () => T,
+): Promise<RemoteAgentPlanReloadResult<T>> {
+  if (hasGaps(value) && (await getCliAuthProvider().isAuthenticated())) {
     await loadAgents();
-    plans = planLoadedCliMultiAgentPresets(presets);
+    return { value: replan(), remoteAgentLoadAttempted: true };
   }
-  return plans;
+  return { value, remoteAgentLoadAttempted: false };
 }
 
 interface MissingPresetAgentsWarningOptions {
@@ -248,13 +287,16 @@ function writeMultiAgentRunResult(
 async function runMultiAgentList(context: CliContext): Promise<number> {
   await initLocalCliPlatform(context);
   const presets = readCliMultiAgentPresets();
-  const plans = await loadCliMultiAgentPresetPlans(presets);
+  const { plans, remoteAgentLoadAttempted } =
+    await loadCliMultiAgentPresetPlanSet(presets);
   const records = cliMultiAgentPresetListRecords(plans);
 
   emitCliResult(context, {
     json: records,
     ndjson: cliMultiAgentPresetNdjsonRecords(plans),
-    text: formatCliMultiAgentPresetList(plans),
+    text: formatCliMultiAgentPresetList(plans, {
+      includeLoginHint: !remoteAgentLoadAttempted,
+    }),
   });
   return CliExitCode.Success;
 }
@@ -286,14 +328,16 @@ async function runMultiAgentInspect(
   await initCliPlatform({ ...context, quietLogs: true });
   await loadAgents({ includeRemote: false });
 
-  const plan = await fillMultiAgentRunPlanGaps({
+  const { plan, remoteAgentLoadAttempted } = await loadCliMultiAgentRunPlan({
     preset: presetIdOrName,
   });
 
   emitCliResult(context, {
     json: plan,
     ndjson: { kind: 'multi-agent-preset-inspection', plan },
-    text: formatCliMultiAgentPresetInspection(plan),
+    text: formatCliMultiAgentPresetInspection(plan, {
+      includeLoginHint: !remoteAgentLoadAttempted,
+    }),
   });
   return CliExitCode.Success;
 }

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -26,6 +26,10 @@ export interface CliMultiAgentPresetRunPlan {
   readonly missingToolUseAgents: readonly string[];
 }
 
+export interface CliMultiAgentPresetFormatOptions {
+  readonly includeLoginHint?: boolean;
+}
+
 export type CliMultiAgentPlanStatus = 'available' | 'degraded' | 'unavailable';
 
 export interface CliMultiAgentPresetAgentAvailability {
@@ -63,6 +67,10 @@ export const MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION =
   'Root agent for the team run (defaults to the preset orchestrator)';
 export const MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION =
   'Model for the team root agent';
+const MULTI_AGENT_INSPECT_HINT =
+  'Hint: run `texra multi-agent inspect <preset>` to see missing agents for degraded or unavailable presets.';
+const MULTI_AGENT_LOGIN_HINT =
+  'Hint: built-in teams may load additional relay-served agents after `texra login`.';
 
 export function parseCliCustomAgentPresets(raw: unknown): AgentModePreset[] {
   return AgentModePresetSchema.array().catch([]).parse(raw);
@@ -138,6 +146,7 @@ export function formatCliMultiAgentPresetLauncherSummary(
 
 export function formatCliMultiAgentPresetList(
   plans: readonly CliMultiAgentPresetRunPlan[],
+  options: CliMultiAgentPresetFormatOptions = {},
 ): string {
   if (plans.length === 0) return 'No multi-agent presets found.';
 
@@ -150,7 +159,7 @@ export function formatCliMultiAgentPresetList(
     ].join('\t'),
   );
 
-  const hint = cliMultiAgentPresetListHint(plans);
+  const hint = cliMultiAgentPresetListHint(plans, options);
   return hint ? [...rows, '', hint].join('\n') : rows.join('\n');
 }
 
@@ -170,6 +179,7 @@ export function formatCliMultiAgentPresetDetails(
 
 export function formatCliMultiAgentPresetInspection(
   plan: CliMultiAgentPresetRunPlan,
+  options: CliMultiAgentPresetFormatOptions = {},
 ): string {
   const availableWorkflowAgents = availablePresetAgents(
     plan.preset.workflowAgents,
@@ -180,7 +190,7 @@ export function formatCliMultiAgentPresetInspection(
     plan.missingToolUseAgents,
   );
 
-  return [
+  const lines = [
     `${plan.preset.name} (${plan.preset.id})`,
     `Source: ${plan.preset.source}`,
     `Description: ${plan.preset.description}`,
@@ -194,7 +204,11 @@ export function formatCliMultiAgentPresetInspection(
     formatAgentNames(plan.missingWorkflowAgents),
     'Missing tool-use agents:',
     formatAgentNames(plan.missingToolUseAgents),
-  ].join('\n');
+  ];
+  if (shouldIncludeBuiltInLoginHint(plan, options)) {
+    lines.push('', MULTI_AGENT_LOGIN_HINT);
+  }
+  return lines.join('\n');
 }
 
 export function cliMultiAgentPresetNdjsonRecords(
@@ -505,13 +519,29 @@ function formatAgentNames(names: readonly string[]): string {
 
 function cliMultiAgentPresetListHint(
   plans: readonly CliMultiAgentPresetRunPlan[],
+  options: CliMultiAgentPresetFormatOptions,
 ): string | undefined {
   const hasIncompletePreset = plans.some(
     (plan) => cliMultiAgentPlanStatus(plan) !== 'available',
   );
-  return hasIncompletePreset
-    ? 'Hint: run `texra multi-agent inspect <preset>` to see missing agents for degraded or unavailable presets.'
-    : undefined;
+  const hints = [
+    hasIncompletePreset ? MULTI_AGENT_INSPECT_HINT : undefined,
+    plans.some((plan) => shouldIncludeBuiltInLoginHint(plan, options))
+      ? MULTI_AGENT_LOGIN_HINT
+      : undefined,
+  ].filter((hint): hint is string => hint !== undefined);
+  return hints.length > 0 ? hints.join('\n') : undefined;
+}
+
+function shouldIncludeBuiltInLoginHint(
+  plan: CliMultiAgentPresetRunPlan,
+  options: CliMultiAgentPresetFormatOptions,
+): boolean {
+  return (options.includeLoginHint ?? true) && builtInPresetHasGaps(plan);
+}
+
+function builtInPresetHasGaps(plan: CliMultiAgentPresetRunPlan): boolean {
+  return plan.preset.source === 'built-in' && cliMultiAgentPlanHasGaps(plan);
 }
 
 function lookupKey(value: string): string {

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -80,6 +80,30 @@ describe('CLI multi-agent presets', () => {
       'built-in\tlean-project\tLean Project\tworkflow:0\ttool-use:2/7\tdegraded',
     );
     expect(output).toContain('texra multi-agent inspect <preset>');
+    expect(output).toContain(
+      'built-in teams may load additional relay-served agents after `texra login`',
+    );
+  });
+
+  it('omits the login recovery hint after a remote agent load was attempted', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('lean', AgentCategory.ToolUse),
+        agent('latexFixer', AgentCategory.ToolUse),
+      ],
+    });
+
+    const output = formatCliMultiAgentPresetList([plan], {
+      includeLoginHint: false,
+    });
+
+    expect(output).toContain('texra multi-agent inspect <preset>');
+    expect(output).not.toContain('after `texra login`');
   });
 
   it('formats launcher team summaries as reader-facing status text', () => {
@@ -293,8 +317,28 @@ describe('CLI multi-agent presets', () => {
         '  simplifier',
         '  latexFixer',
         '  progressCheck',
+        '',
+        'Hint: built-in teams may load additional relay-served agents after `texra login`.',
       ].join('\n'),
     );
+  });
+
+  it('omits inspection login recovery hint after a remote agent load was attempted', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'physicist',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [agent('review', AgentCategory.ToolUse)],
+    });
+
+    const details = formatCliMultiAgentPresetInspection(plan, {
+      includeLoginHint: false,
+    });
+
+    expect(details).toContain('Missing tool-use agents:');
+    expect(details).not.toContain('after `texra login`');
   });
 
   it('plans a preset run with canonical visibility keys and an orchestrator root', () => {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -11,12 +11,14 @@ const mocks = vi.hoisted(() => {
   return {
     executeCliRequest: vi.fn(),
     expandRunInputs: vi.fn(),
+    cliMultiAgentPlanHasGaps: vi.fn(),
     getToolUseAgents: vi.fn(),
     getWorkflowAgents: vi.fn(),
     initCliPlatform: vi.fn(),
     installCliApprovalHandlers: vi.fn(),
     isAuthenticated: vi.fn(),
     loadAgents: vi.fn(),
+    planCliMultiAgentPresets: vi.fn(),
     planCliMultiAgentPresetRun: vi.fn(),
     stdinInputFile,
     writeTextStderr: vi.fn(),
@@ -70,7 +72,7 @@ vi.mock('@cli/runtime/multiAgentPresets', () => {
       (agent: { tools?: readonly string[] }) =>
         agent.tools?.some((tool) => delegationTools.has(tool)) ?? false,
     ),
-    cliMultiAgentPlanHasGaps: vi.fn(() => false),
+    cliMultiAgentPlanHasGaps: mocks.cliMultiAgentPlanHasGaps,
     cliMultiAgentPresetNdjsonRecords: vi.fn(() => []),
     findCliMultiAgentPreset: vi.fn(() => ({
       id: 'mathematician',
@@ -86,6 +88,7 @@ vi.mock('@cli/runtime/multiAgentPresets', () => {
     MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION:
       'Root agent for the team run (defaults to the preset orchestrator)',
     MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION: 'Model for the team root agent',
+    planCliMultiAgentPresets: mocks.planCliMultiAgentPresets,
     planCliMultiAgentPresetRun: mocks.planCliMultiAgentPresetRun,
     readCliMultiAgentPresets: vi.fn(() => []),
     withCliMultiAgentPresetVisibility: vi.fn(
@@ -147,6 +150,15 @@ describe('CLI multi-agent run command', () => {
       contextFiles: [],
     });
     mocks.getWorkflowAgents.mockReturnValue([]);
+    mocks.cliMultiAgentPlanHasGaps.mockReturnValue(false);
+    mocks.planCliMultiAgentPresets.mockImplementation((presets) =>
+      presets.map((preset: unknown) =>
+        mocks.planCliMultiAgentPresetRun(preset, {
+          workflowAgents: mocks.getWorkflowAgents(),
+          toolUseAgents: mocks.getToolUseAgents(),
+        }),
+      ),
+    );
     mocks.getToolUseAgents.mockReturnValue([
       {
         name: 'orchestrator',
@@ -218,6 +230,63 @@ describe('CLI multi-agent run command', () => {
     expect(request?.config.instruction).toContain('Primary user input files:');
     expect(request?.config.instruction).toContain('- "problem.tex"');
     expect(mocks.stdinInputFile.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks run-plan resolution when authenticated gaps triggered a remote load', async () => {
+    const { loadCliMultiAgentRunPlan } =
+      await import('@cli/commands/multiAgent');
+    mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
+    mocks.isAuthenticated.mockResolvedValueOnce(true);
+
+    const result = await loadCliMultiAgentRunPlan({
+      preset: 'mathematician',
+    });
+
+    expect(result.remoteAgentLoadAttempted).toBe(true);
+    expect(result.plan.rootAgent?.name).toBe('orchestrator');
+    expect(mocks.loadAgents).toHaveBeenCalledWith();
+    expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not mark run-plan resolution when unauthenticated gaps stay local-only', async () => {
+    const { loadCliMultiAgentRunPlan } =
+      await import('@cli/commands/multiAgent');
+    mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
+    mocks.isAuthenticated.mockResolvedValueOnce(false);
+
+    const result = await loadCliMultiAgentRunPlan({
+      preset: 'mathematician',
+    });
+
+    expect(result.remoteAgentLoadAttempted).toBe(false);
+    expect(mocks.loadAgents).not.toHaveBeenCalled();
+    expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks preset-list resolution when authenticated gaps triggered a remote load', async () => {
+    const { loadCliMultiAgentPresetPlanSet } =
+      await import('@cli/commands/multiAgent');
+    mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
+    mocks.isAuthenticated.mockResolvedValueOnce(true);
+
+    const result = await loadCliMultiAgentPresetPlanSet([
+      {
+        id: 'mathematician',
+        name: 'Mathematician',
+        description: 'For math papers.',
+        icon: 'codicon-symbol-operator',
+        workflowAgents: [],
+        toolUseAgents: ['orchestrator'],
+        source: 'built-in',
+      },
+    ]);
+
+    expect(result.remoteAgentLoadAttempted).toBe(true);
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(1, {
+      includeRemote: false,
+    });
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
+    expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(2);
   });
 
   it('warns when approval policy never blocks team delegation', async () => {


### PR DESCRIPTION
## Summary
- add a sign-in recovery hint when built-in multi-agent presets are degraded
- show the hint in both `multi-agent list` and `multi-agent inspect` text output
- keep machine-readable JSON/NDJSON preset records unchanged

## Dogfood Evidence
- `texra-local multi-agent list --quiet` showed every built-in preset degraded while signed out, with only an inspect hint
- `texra-local auth status --quiet --output-format json` returned `authenticated: false`
- comments in the CLI multi-agent path note relay-served team agents load after auth

## Verification
- `npm run test:kernel -- src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `npm run lint`
- `npm run compile:safe`
- `npm run texra-local:build && npm run texra-local:link && texra-local multi-agent list --quiet && texra-local multi-agent inspect mathematician --quiet`

Fixes #5347.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI messaging and plan-load plumbing only; no changes to auth, agent execution, or machine-readable output contracts beyond new internal flags.
> 
> **Overview**
> Adds **sign-in recovery guidance** when built-in multi-agent presets look degraded because relay-served agents are missing locally. Text output for `multi-agent list` and `multi-agent inspect` can now suggest running `texra login` so additional team agents may load after authentication.
> 
> Refactors plan loading so **remote agent reload** is centralized in `reloadRemoteAgentsForGaps`, with loaders returning whether a remote load was actually attempted (`remoteAgentLoadAttempted`). List/inspect pass `includeLoginHint: false` after that attempt so users are not nudged to sign in again when auth did not fix the gaps. **JSON/NDJSON** preset records are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a746b6e3475c35e9fa430b2fc7bf7d3a6892a194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->