### PR TITLE
Remove @agent/core/config re-export, use @utils/config/configUtils directly

### DIFF
--- a/src/agent/core/config.ts
+++ b/src/agent/core/config.ts
@@ -1,8 +1,0 @@
-/**
- * Configuration facade for the agent layer.
- *
- * `getConfig` is a thin wrapper over `platform().config`; the single
- * implementation lives in `@utils/config`. This module re-exports it so agent
- * code can keep importing from `@agent/core/config`.
- */
-export { getConfig } from '@utils/config/configUtils';

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -6,7 +6,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { type RetryResult } from '@agent/runtime/RetryRequestCoordinator';
 import { waitForRetry } from '@agent/runtime/runCoordinators';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   ensureError,

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -27,7 +27,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - common
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import {
   getSdkErrorMessage,
   attachStreamDiagnostics,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -30,7 +30,7 @@ import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@agent/core/constants';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { toOpenAIReasoningEffort } from '@agent/runtime/reasoningEffort';
 import {
   getSdkErrorMessage,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -18,7 +18,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { K_SLICE } from '@agent/core/constants';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { toOpenAIReasoningEffort } from '@agent/runtime/reasoningEffort';
 import {
   getSdkErrorMessage,

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -10,7 +10,7 @@ import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Local imports - tools and utils

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -1,5 +1,5 @@
 import { ModelProvider } from 'llm-zoo';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
 import {

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -3,7 +3,7 @@ import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { getGlobalState } from '@agent/core/stateStore';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { GlobalStateKey } from '@common/state/stateKeys';
 import * as logger from '@logger/logUtils';
 import { getUseOpenRouter } from '@utils/config/providerConfig';

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import type { AgentTrace } from '@agent/trace';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceFS, StorageFS } from '@utils/files';

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -9,7 +9,7 @@ import {
   AgentPrompt,
   AgentCategory,
 } from '@agent/core/definition/AgentDataclass';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import type { FileListEntry } from '@shared/schemas';
 import { parseFrontmatter } from '@tools/memory/memoryMeta';
 import { displayToStoragePath } from '@tools/memory/memoryUtils';

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 
 // Local imports - log
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import * as logger from '@logger/logUtils';
 import { renderPrompt } from '@utils/prompt';
 import {

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 
 import { sync as globSync } from 'glob';
 
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { isFileNotFoundError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -1,5 +1,5 @@
 // Local imports - log
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { runToolWithCheck } from '@utils/system';

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -2,7 +2,7 @@
 import type { ExecResult } from '@agent/types/ResultTypes';
 
 // Internal imports
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { getWorkspaceState } from '@agent/core/stateStore';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
 import * as logger from '@logger/logUtils';

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 
 // Local imports - common
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import {
   LaTeXCompileOptionsSchema,

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -5,7 +5,7 @@
 // Local imports - common
 
 // Local imports - log
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -83,7 +83,7 @@ async function loadApprovalModules(workspacePath = '/workspace') {
       relativePath: filePath,
     };
   };
-  vi.doMock('@agent/core/config', () => ({
+  vi.doMock('@utils/config/configUtils', () => ({
     getConfig: vi.fn(() => 'sameDirectory'),
   }));
   vi.doMock('@agent/runtime/RunContext', async () => {
@@ -150,7 +150,7 @@ async function loadApprovalModules(workspacePath = '/workspace') {
 
 describe('desktop tool edit approval', () => {
   afterEach(() => {
-    vi.doUnmock('@agent/core/config');
+    vi.doUnmock('@utils/config/configUtils');
     vi.doUnmock('@agent/runtime/RunContext');
     vi.doUnmock('@utils/files');
     vi.restoreAllMocks();

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -33,7 +33,7 @@ vi.mock('@agent/core/stateStore', () => ({
   }),
 }));
 
-vi.mock('@agent/core/config', () => ({
+vi.mock('@utils/config/configUtils', () => ({
   getConfig: <T>(_key: string, fallback: T) => fallback,
 }));
 

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
 
 // Local imports - agent state
-import * as agentConfig from '@agent/core/config';
+import * as agentConfig from '@utils/config/configUtils';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 
 // Local imports - model handlers

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
@@ -10,7 +10,7 @@ import {
 
 // Local imports - agent
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import * as configModule from '@agent/core/config';
+import * as configModule from '@utils/config/configUtils';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 
 class UnsupportedBackgroundHandler extends ModelHandlerOpenAIResponse {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { requireRuntimeHost } from '@tools/contextHelpers';
 import { type ToolResult } from '@tools/result';

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import { sync as globSync } from 'glob';
 
 import { platform } from '@platform/platform';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import { TEMP_EXTENSIONS } from '@housekeeping/constants';
 import { LaTeXdiffService } from '@latex/latexdiff';

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import {
   LineChangesSchema,

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import {
   extractBibliographyContext,
   loadBibliographyEntries,

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -11,7 +11,7 @@
 import axios from 'axios';
 
 // Local imports - core
-import { getConfig } from '@agent/core/config';
+import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import { ToolError } from '@tools/result';
 import { isTimeoutErrorCode } from '@tools/timeouts';


### PR DESCRIPTION
## Summary

Remove the `@agent/core/config` module which was a thin re-export wrapper around `@utils/config/configUtils`. Update all 24 import sites across the codebase to import `getConfig` directly from `@utils/config/configUtils`, eliminating an unnecessary indirection layer.

## Issue acceptance gates

N/A — This is a cleanup refactor with no functional changes.

## Single source of truth

`@utils/config/configUtils` is now the single canonical location for the `getConfig` export. The removed `@agent/core/config` module was purely a pass-through re-export that added no value.

## Duplication and abstraction budget

**Removed:** One unnecessary pass-through module (`src/agent/core/config.ts`) that served only to re-export from `@utils/config/configUtils`.

**Benefit:** Eliminates an indirection layer and reduces cognitive overhead—callers now import directly from the actual implementation location rather than through an intermediate facade.

## Host impact

Extension: No impact — import paths updated, behavior unchanged.

Desktop: No impact — import paths updated, behavior unchanged.

CLI: No impact — import paths updated, behavior unchanged.

## Scheduled refactoring

None.

## Validation

- All 24 import sites updated consistently (agent core flows, model handlers, tools, LaTeX utilities, test files)
- Mock paths in test files updated to match new import locations
- No functional changes—purely a module reorganization
- Existing tests continue to pass with updated mock paths

https://claude.ai/code/session_01UHap1NSdkzxBt5mbihMkeC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with no logic changes; low risk aside from ensuring all mock paths were updated consistently in tests.
> 
> **Overview**
> Removes the **`@agent/core/config`** pass-through module and points every caller at **`getConfig`** from **`@utils/config/configUtils`** instead.
> 
> **Production code** across agent flows, model handlers, runtime, LaTeX utilities, replacement engine, and tools (approvals, bash, Zotero, bibliography) now imports the canonical helper directly. **Tests** update **`vi.mock` / `vi.doUnmock`** paths to match.
> 
> No behavior change—only import path consolidation so configuration has one obvious source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97bb085ceafdb48db48e5e423fd719543de7d35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->