### PR TITLE
[codex] Disable incompatible CLI model switches

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -140,6 +140,12 @@ const AGENT_PROPOSAL_INSTRUCTION =
   ].join('\n');
 const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
 const CAN_SELECT_MODEL = process.env.HARNESS_CAN_SELECT_MODEL === '1';
+const DISABLED_MODEL_SWITCHES = new Set(
+  parseList(process.env.HARNESS_DISABLED_MODEL_SWITCHES),
+);
+const DISABLED_MODEL_SWITCH_REASON =
+  process.env.HARNESS_DISABLED_MODEL_SWITCH_REASON ??
+  'different conversation format; start new chat';
 const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_NESTED_CHILDREN = process.env.HARNESS_NESTED_CHILDREN === '1';
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
@@ -1151,6 +1157,14 @@ function setHarnessApprovalPolicy(policy: CliApprovalPolicy): void {
   );
 }
 
+function getHarnessModelSwitchDisabledReason(
+  model: string,
+): string | undefined {
+  return DISABLED_MODEL_SWITCHES.has(model)
+    ? DISABLED_MODEL_SWITCH_REASON
+    : undefined;
+}
+
 function openHarnessSlashForm(
   command: SlashCommand,
   remainder: string,
@@ -1311,6 +1325,7 @@ function handleHarnessSlashCommand(line: string): boolean {
 registerBuiltinSlashCommands({
   canSelectAgent: () => false,
   canSelectModel: () => CAN_SELECT_MODEL,
+  getModelSwitchDisabledReason: getHarnessModelSwitchDisabledReason,
   getApprovalPolicy: () => harnessApprovalPolicy,
   onApprovalPolicySelect: setHarnessApprovalPolicy,
   onModelSelect: (model) => {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -501,6 +501,32 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'model-switch-compatible-only',
+    env: {
+      ANTHROPIC_API_KEY: 'harness-anthropic-key',
+      HARNESS_CAN_SELECT_MODEL: '1',
+      HARNESS_DISABLED_MODEL_SWITCHES: 'sonnet46T||opus48T',
+      HARNESS_ENTRIES: '4',
+      OPENAI_API_KEY: 'harness-openai-key',
+    },
+    keys: ['/model', '\r'],
+    frame: 'tail',
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: [
+      '/model · personal API keys',
+      'Choose the model for future turns.',
+      'Sonnet 4.6',
+      'different conversation format',
+      'GPT-5.5',
+    ],
+    unexpect: [
+      'Harness model selected.',
+      'Finish the active response before switching models.',
+      'Platform not initialized',
+      '/model - error',
+    ],
+  },
+  {
     name: 'model-form-selectable-submit',
     env: {
       HARNESS_CAN_SELECT_MODEL: '1',

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -75,6 +75,7 @@ export function registerBuiltinSlashCommands(options?: {
   onApprovalPolicySelect?: ApprovalPolicySelectHandler;
   onModelSelect?: ModelSelectHandler;
   canSelectModel?: () => boolean;
+  getModelSwitchDisabledReason?: (model: string) => string | undefined;
   onApiModeSelect?: ApiModeSelectHandler;
   onMemorySelect?: MemorySelectHandler;
   onResumeSelect?: ResumeSelectHandler;
@@ -177,6 +178,7 @@ export function registerBuiltinSlashCommands(options?: {
         apiMode={cliState.sessionMeta.get().apiMode}
         availableRows={props.availableRows}
         selectable={selectable}
+        getModelSwitchDisabledReason={options?.getModelSwitchDisabledReason}
         onSelect={(value) =>
           runFormSelection({
             action: () => onModelSelect(value),

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -29,6 +29,7 @@ export interface ModelListFormProps {
   readonly apiMode: CliApiMode;
   readonly availableRows?: number;
   readonly selectable?: boolean;
+  readonly getModelSwitchDisabledReason?: (model: string) => string | undefined;
   readonly onSelect?: (value: string) => void;
   readonly onClose: () => void;
 }
@@ -91,12 +92,18 @@ export function modelSelectWindow(args: {
 export function modelSelectItemsForCliMode(
   models: readonly CliModelAccess[],
   apiMode: CliApiMode,
+  getModelSwitchDisabledReason?: (model: string) => string | undefined,
 ): ReadonlyArray<SelectItem<string>> {
-  return runnableCliModelAccessEntries(models, apiMode).map((m) => ({
-    value: m.model.value,
-    label: m.model.label || m.model.value,
-    description: formatModelStatusForCliMode(m, apiMode),
-  }));
+  return runnableCliModelAccessEntries(models, apiMode).map((m) => {
+    const disabledReason = getModelSwitchDisabledReason?.(m.model.value);
+    const status = formatModelStatusForCliMode(m, apiMode);
+    return {
+      value: m.model.value,
+      label: m.model.label || m.model.value,
+      description: disabledReason ? `${status}; ${disabledReason}` : status,
+      disabled: disabledReason != null,
+    };
+  });
 }
 
 export function emptyModelListMessageForCliMode(
@@ -145,7 +152,11 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
   }
 
   const models = data ?? [];
-  const items = modelSelectItemsForCliMode(models, props.apiMode);
+  const items = modelSelectItemsForCliMode(
+    models,
+    props.apiMode,
+    props.getModelSwitchDisabledReason,
+  );
   const selectable = props.selectable === true;
   const selectWindow = modelSelectWindow({
     availableRows: props.availableRows,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1110,6 +1110,17 @@ export async function runChat(
       status: rootStreamStatus(),
       hasActiveToolUseFlow: hasActiveToolUseFlow(),
     });
+  const getModelSwitchDisabledReason = (
+    candidateModel: string,
+  ): string | undefined => {
+    if (chatTuiCanStartRootRun(session) || !canSelectCurrentModel()) {
+      return undefined;
+    }
+    const activeFlow = session.streamId
+      ? getToolUseFlowContext(session.streamId)
+      : undefined;
+    return activeFlow?.modelSwitchDisabledReason(candidateModel);
+  };
   const canInterruptActiveRun = (): boolean =>
     chatTuiCanInterruptActiveRun(session);
   const canStopActiveRun = (): boolean =>
@@ -1350,6 +1361,7 @@ export async function runChat(
       );
     },
     canSelectModel: canSelectCurrentModel,
+    getModelSwitchDisabledReason,
     onModelSelect: (nextModel) =>
       applyCliModelSelection(nextModel, slashCommandContext()),
     onApiModeSelect: (nextMode) =>

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -1,7 +1,11 @@
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { getExecutionStore } from '@agent/storage';
-import { createModelHandler } from '@agent/runtime/ModelFactory';
+import {
+  activeModelHandlerCompatibilityKey,
+  createModelHandler,
+  modelHandlerCompatibilityKey,
+} from '@agent/runtime/ModelFactory';
 import {
   registerInterruptible,
   unregisterInterruptible,
@@ -86,6 +90,7 @@ export interface ToolUseFlowContext {
   readonly model: string;
   interrupt(): void;
   requestImmediateCompaction(): void;
+  modelSwitchDisabledReason(model: string): string | undefined;
   switchModel(model: string): Promise<void>;
 }
 
@@ -99,6 +104,10 @@ type ToolUsePersistedFlow<C> = PersistedFlow<
 
 const IMMEDIATE_COMPACTION_FOLLOW_UP =
   'The user requested immediate context compaction. Do not start a new task; continue only far enough for the runtime to process any available context compaction, and do not claim that compaction has completed.';
+const MODEL_SWITCH_DIFFERENT_FORMAT_ERROR =
+  'Cannot switch this conversation to a model with a different conversation format. Start a new chat to use that model.';
+const MODEL_SWITCH_DIFFERENT_FORMAT_REASON =
+  'different conversation format; start new chat';
 
 export async function runToolUseFlow<C = unknown>(
   input: RunToolUseFlowInput<C>,
@@ -153,6 +162,25 @@ export async function runToolUseFlow<C = unknown>(
     await flow.setShared(liveShared);
   };
 
+  const modelSwitchDisabledReason = (model: string): string | undefined => {
+    if (services.config.model === model) return undefined;
+
+    const nextConfig = MODEL_CONFIGS[model];
+    if (!nextConfig) return `Model ${model} not found in MODEL_CONFIGS`;
+
+    const activeKey = activeModelHandlerCompatibilityKey(services.modelHandler);
+    if (!activeKey) {
+      // Non-factory handlers still reach switchModel's constructor-reference
+      // check. Keep the UI permissive rather than guessing their format here.
+      return undefined;
+    }
+    const nextKey = modelHandlerCompatibilityKey(nextConfig);
+    if (!nextKey) return `Unsupported model provider: ${nextConfig.provider}`;
+    return activeKey === nextKey
+      ? undefined
+      : MODEL_SWITCH_DIFFERENT_FORMAT_REASON;
+  };
+
   const switchModel = async (model: string): Promise<void> => {
     const nextConfig = MODEL_CONFIGS[model];
     if (!nextConfig) {
@@ -160,15 +188,24 @@ export async function runToolUseFlow<C = unknown>(
     }
     if (services.config.model === model) return;
 
+    const disabledReason = modelSwitchDisabledReason(model);
+    if (disabledReason) {
+      throw new Error(
+        disabledReason === MODEL_SWITCH_DIFFERENT_FORMAT_REASON
+          ? MODEL_SWITCH_DIFFERENT_FORMAT_ERROR
+          : disabledReason,
+      );
+    }
+
     const previousHandler = services.modelHandler;
     const nextHandler = (await createModelHandler(
       nextConfig,
     )) as ToolUseServices<C>['modelHandler'];
+    // Backstop for untagged/custom handlers and future route drift. This is a
+    // constructor-reference comparison, so CLI minification cannot affect it.
     if (nextHandler.constructor !== previousHandler.constructor) {
       nextHandler.dispose();
-      throw new Error(
-        'Cannot switch this conversation to a model with a different conversation format. Start a new chat to use that model.',
-      );
+      throw new Error(MODEL_SWITCH_DIFFERENT_FORMAT_ERROR);
     }
     try {
       await persistModelSwitch(model);
@@ -214,6 +251,7 @@ export async function runToolUseFlow<C = unknown>(
         );
       }
     },
+    modelSwitchDisabledReason,
     switchModel,
   };
 

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 
@@ -17,6 +20,33 @@ type ModelHandlerConstructor = new (
 ) => ModelHandler<ProviderMessage>;
 
 type ProviderHandlerLoader = () => Promise<ModelHandlerConstructor>;
+export type ModelHandlerCompatibilityKey =
+  | 'ModelHandlerValidation'
+  | 'ModelHandlerOpenAIResponse'
+  | 'ModelHandlerOpenRouterNative'
+  | 'ModelHandlerAnthropic'
+  | 'ModelHandlerOpenAI'
+  | 'ModelHandlerGoogleGenAI'
+  | 'ModelHandlerDeepSeek'
+  | 'ModelHandlerXAI'
+  | 'ModelHandlerKimi'
+  | 'ModelHandlerDashScope'
+  | 'ModelHandlerMiniMax'
+  | 'ModelHandlerGLM';
+
+interface ProviderHandlerRoute {
+  readonly load: ProviderHandlerLoader | null;
+  readonly compatibilityKey: ModelHandlerCompatibilityKey | null;
+}
+
+const MODEL_HANDLER_COMPATIBILITY_PROPERTY =
+  '__texraModelHandlerCompatibilityKey';
+
+type ModelHandlerCompatibilityTagged = object & {
+  readonly [MODEL_HANDLER_COMPATIBILITY_PROPERTY]?:
+    | ModelHandlerCompatibilityKey
+    | undefined;
+};
 
 const INCLUDE_INTERNAL_VALIDATION_MODEL_HANDLER =
   process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL === '1';
@@ -29,40 +59,73 @@ const INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_CONTENT =
 
 // Record (not Map) so TypeScript enforces exhaustiveness over ModelProvider.
 // A new enum value in llm-zoo without an entry here will fail typecheck.
-// `null` marks providers that have no direct handler (routed elsewhere or unsupported).
-const PROVIDER_HANDLERS: Record<ModelProvider, ProviderHandlerLoader | null> = {
-  [ModelProvider.ANTHROPIC]: async () =>
-    (await import('@agent/modelHandlers/anthropic/modelHandlerAnthropic'))
-      .ModelHandlerAnthropic,
-  [ModelProvider.OPENAI]: async () =>
-    (await import('@agent/modelHandlers/openai/modelHandlerOpenAI'))
-      .ModelHandlerOpenAI,
-  [ModelProvider.GOOGLE]: async () =>
-    (await import('@agent/modelHandlers/google/modelHandlerGoogleGenAI'))
-      .ModelHandlerGoogleGenAI,
-  [ModelProvider.DEEPSEEK]: async () =>
-    (await import('@agent/modelHandlers/openai/modelHandlerDeepSeek'))
-      .ModelHandlerDeepSeek,
-  [ModelProvider.XAI]: async () =>
-    (await import('@agent/modelHandlers/openai/modelHandlerXAI'))
-      .ModelHandlerXAI,
-  [ModelProvider.MOONSHOT]: async () =>
-    (await import('@agent/modelHandlers/openai/modelHandlerKimi'))
-      .ModelHandlerKimi,
-  [ModelProvider.DASHSCOPE]: async () =>
-    (await import('@agent/modelHandlers/openai/modelHandlerDashScope'))
-      .ModelHandlerDashScope,
-  [ModelProvider.MINIMAX]: async () =>
-    (await import('@agent/modelHandlers/openai/modelHandlerMiniMax'))
-      .ModelHandlerMiniMax,
-  [ModelProvider.GLM]: async () =>
-    (await import('@agent/modelHandlers/openai/modelHandlerGLM'))
-      .ModelHandlerGLM,
-  [ModelProvider.OTHERS]: async () =>
-    (
-      await import('@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative')
-    ).ModelHandlerOpenRouterNative,
-  [ModelProvider.COPILOT]: null,
+// `null` route fields mark providers that have no direct handler.
+const PROVIDER_HANDLER_ROUTES: Record<ModelProvider, ProviderHandlerRoute> = {
+  [ModelProvider.ANTHROPIC]: {
+    load: async () =>
+      (await import('@agent/modelHandlers/anthropic/modelHandlerAnthropic'))
+        .ModelHandlerAnthropic,
+    compatibilityKey: 'ModelHandlerAnthropic',
+  },
+  [ModelProvider.OPENAI]: {
+    load: async () =>
+      (await import('@agent/modelHandlers/openai/modelHandlerOpenAI'))
+        .ModelHandlerOpenAI,
+    compatibilityKey: 'ModelHandlerOpenAI',
+  },
+  [ModelProvider.GOOGLE]: {
+    load: async () =>
+      (await import('@agent/modelHandlers/google/modelHandlerGoogleGenAI'))
+        .ModelHandlerGoogleGenAI,
+    compatibilityKey: 'ModelHandlerGoogleGenAI',
+  },
+  [ModelProvider.DEEPSEEK]: {
+    load: async () =>
+      (await import('@agent/modelHandlers/openai/modelHandlerDeepSeek'))
+        .ModelHandlerDeepSeek,
+    compatibilityKey: 'ModelHandlerDeepSeek',
+  },
+  [ModelProvider.XAI]: {
+    load: async () =>
+      (await import('@agent/modelHandlers/openai/modelHandlerXAI'))
+        .ModelHandlerXAI,
+    compatibilityKey: 'ModelHandlerXAI',
+  },
+  [ModelProvider.MOONSHOT]: {
+    load: async () =>
+      (await import('@agent/modelHandlers/openai/modelHandlerKimi'))
+        .ModelHandlerKimi,
+    compatibilityKey: 'ModelHandlerKimi',
+  },
+  [ModelProvider.DASHSCOPE]: {
+    load: async () =>
+      (await import('@agent/modelHandlers/openai/modelHandlerDashScope'))
+        .ModelHandlerDashScope,
+    compatibilityKey: 'ModelHandlerDashScope',
+  },
+  [ModelProvider.MINIMAX]: {
+    load: async () =>
+      (await import('@agent/modelHandlers/openai/modelHandlerMiniMax'))
+        .ModelHandlerMiniMax,
+    compatibilityKey: 'ModelHandlerMiniMax',
+  },
+  [ModelProvider.GLM]: {
+    load: async () =>
+      (await import('@agent/modelHandlers/openai/modelHandlerGLM'))
+        .ModelHandlerGLM,
+    compatibilityKey: 'ModelHandlerGLM',
+  },
+  [ModelProvider.OTHERS]: {
+    load: async () =>
+      (
+        await import('@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative')
+      ).ModelHandlerOpenRouterNative,
+    compatibilityKey: 'ModelHandlerOpenRouterNative',
+  },
+  [ModelProvider.COPILOT]: {
+    load: null,
+    compatibilityKey: null,
+  },
 };
 
 /**
@@ -127,41 +190,22 @@ export function shouldUseResponsesAPI(
   );
 }
 
-/**
- * Apply the user's "prefer short model names" setting.
- * When enabled, uses the model's shortName (e.g. "gpt-5.5") instead of the
- * date-pinned fullName (e.g. "gpt-5.5-2026-04-15"). Useful for proxies/gateways
- * that only accept unpinned model identifiers.
- */
-function withShortModelName(config: ModelConfig): ModelConfig {
-  if (
-    !getGlobalState().get<boolean>(
-      GlobalStateKey.PREFER_SHORT_MODEL_NAMES,
-      false,
-    )
-  ) {
-    return config;
-  }
+function applyShortModelNamePreference(
+  config: ModelConfig,
+  preferShortModelNames: boolean,
+): ModelConfig {
+  if (!preferShortModelNames) return config;
   const short = config.shortName;
   if (!short || short === config.fullName) return config;
-
-  logger.debug(
-    CHANNEL,
-    `Using short model name for ${config.name}: ${config.fullName} → ${short}`,
-  );
   return { ...config, fullName: short };
 }
 
-async function shouldUseInternalValidationModelHandler(): Promise<boolean> {
+function shouldUseInternalValidationModelHandler(): boolean {
   if (process.env[INTERNAL_VALIDATION_MODEL_HANDLER_ENV] !== '1') {
     return false;
   }
 
   const flagPath = process.env[INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV];
-  const [{ readFileSync }, path] = await Promise.all([
-    import('node:fs'),
-    import('node:path'),
-  ]);
   if (process.env.CI !== '1' || !flagPath || !path.isAbsolute(flagPath)) {
     throw new Error(
       `${INTERNAL_VALIDATION_MODEL_HANDLER_ENV}=1 is restricted to package validation with CI=1 and an absolute ${INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV} path.`,
@@ -187,6 +231,77 @@ async function shouldUseInternalValidationModelHandler(): Promise<boolean> {
   return true;
 }
 
+/** Returns the conversation-history format used by the handler for this model. */
+export function modelHandlerCompatibilityKey(
+  originalConfig: ModelConfig,
+  useOpenRouter = getUseOpenRouter(),
+  preferShortModelNames = getGlobalState().get<boolean>(
+    GlobalStateKey.PREFER_SHORT_MODEL_NAMES,
+    false,
+  ),
+): ModelHandlerCompatibilityKey | undefined {
+  if (
+    INCLUDE_INTERNAL_VALIDATION_MODEL_HANDLER &&
+    shouldUseInternalValidationModelHandler()
+  ) {
+    return 'ModelHandlerValidation';
+  }
+
+  const config = applyShortModelNamePreference(
+    originalConfig,
+    preferShortModelNames,
+  );
+  if (shouldUseResponsesAPI(config, useOpenRouter)) {
+    return 'ModelHandlerOpenAIResponse';
+  }
+  if (config.openRouterOnly || useOpenRouter) {
+    return 'ModelHandlerOpenRouterNative';
+  }
+  return PROVIDER_HANDLER_ROUTES[config.provider].compatibilityKey ?? undefined;
+}
+
+export function activeModelHandlerCompatibilityKey(
+  handler: object,
+): ModelHandlerCompatibilityKey | undefined {
+  return (handler as ModelHandlerCompatibilityTagged)[
+    MODEL_HANDLER_COMPATIBILITY_PROPERTY
+  ];
+}
+
+function withModelHandlerCompatibilityKey<T extends ModelHandler>(
+  handler: T,
+  compatibilityKey: ModelHandlerCompatibilityKey,
+): T {
+  Object.defineProperty(handler, MODEL_HANDLER_COMPATIBILITY_PROPERTY, {
+    value: compatibilityKey,
+    enumerable: false,
+  });
+  return handler;
+}
+
+/**
+ * Apply the user's "prefer short model names" setting.
+ * When enabled, uses the model's shortName (e.g. "gpt-5.5") instead of the
+ * date-pinned fullName (e.g. "gpt-5.5-2026-04-15"). Useful for proxies/gateways
+ * that only accept unpinned model identifiers.
+ */
+function withShortModelName(config: ModelConfig): ModelConfig {
+  const resolved = applyShortModelNamePreference(
+    config,
+    getGlobalState().get<boolean>(
+      GlobalStateKey.PREFER_SHORT_MODEL_NAMES,
+      false,
+    ),
+  );
+  if (resolved === config) return config;
+
+  logger.debug(
+    CHANNEL,
+    `Using short model name for ${config.name}: ${config.fullName} → ${resolved.fullName}`,
+  );
+  return resolved;
+}
+
 /**
  * Creates a model handler instance based on provider and routing configuration.
  * Applies short model name preference and reasoning level overrides.
@@ -198,7 +313,7 @@ export async function createModelHandler(
 
   if (
     INCLUDE_INTERNAL_VALIDATION_MODEL_HANDLER &&
-    (await shouldUseInternalValidationModelHandler())
+    shouldUseInternalValidationModelHandler()
   ) {
     // Package validation still enters the real CLI and executeAgent path.
     // Only the provider boundary is deterministic, so this must not become
@@ -209,7 +324,10 @@ export async function createModelHandler(
     );
     const { ModelHandlerValidation } =
       await import('@agent/modelHandlers/modelHandlerValidation');
-    return new ModelHandlerValidation(config);
+    return withModelHandlerCompatibilityKey(
+      new ModelHandlerValidation(config),
+      'ModelHandlerValidation',
+    );
   }
 
   const useOpenRouter = getUseOpenRouter();
@@ -219,7 +337,10 @@ export async function createModelHandler(
     logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
     const { ModelHandlerOpenAIResponse } =
       await import('@agent/modelHandlers/openai/modelHandlerOpenAIResponse');
-    return withReasoningOverride(new ModelHandlerOpenAIResponse(config));
+    return withModelHandlerCompatibilityKey(
+      withReasoningOverride(new ModelHandlerOpenAIResponse(config)),
+      'ModelHandlerOpenAIResponse',
+    );
   }
 
   // Route through OpenRouter if configured
@@ -228,17 +349,23 @@ export async function createModelHandler(
       config.openrouterFullName ?? `${config.provider}/${config.fullName}`;
     const { ModelHandlerOpenRouterNative } =
       await import('@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative');
-    return withReasoningOverride(
-      new ModelHandlerOpenRouterNative({ ...config, openrouterFullName }),
+    return withModelHandlerCompatibilityKey(
+      withReasoningOverride(
+        new ModelHandlerOpenRouterNative({ ...config, openrouterFullName }),
+      ),
+      'ModelHandlerOpenRouterNative',
     );
   }
 
   // Direct provider handler
-  const loadHandler = PROVIDER_HANDLERS[config.provider];
-  if (!loadHandler) {
+  const route = PROVIDER_HANDLER_ROUTES[config.provider];
+  if (!route.load || !route.compatibilityKey) {
     throw new Error(`Unsupported model provider: ${config.provider}`);
   }
-  const HandlerClass = await loadHandler();
+  const HandlerClass = await route.load();
   logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
-  return withReasoningOverride(new HandlerClass(config));
+  return withModelHandlerCompatibilityKey(
+    withReasoningOverride(new HandlerClass(config)),
+    route.compatibilityKey,
+  );
 }

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_MODEL_CAPABILITIES,
   MODEL_CONFIGS,
@@ -6,13 +10,18 @@ import {
   type ModelConfig,
 } from 'llm-zoo';
 
-import { shouldUseResponsesAPI } from '@agent/runtime/ModelFactory';
 import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative';
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/google/modelHandlerGoogleGenAI';
 import { ModelHandlerDeepSeek } from '@agent/modelHandlers/openai/modelHandlerDeepSeek';
 import { ModelHandlerKimi } from '@agent/modelHandlers/openai/modelHandlerKimi';
 import { ModelHandlerMiniMax } from '@agent/modelHandlers/openai/modelHandlerMiniMax';
+import {
+  activeModelHandlerCompatibilityKey,
+  createModelHandler,
+  modelHandlerCompatibilityKey,
+  shouldUseResponsesAPI,
+} from '@agent/runtime/ModelFactory';
 
 function modelConfig(
   provider: ModelProvider,
@@ -34,6 +43,10 @@ function modelConfig(
 }
 
 describe('OpenAI model handler routing', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('routes current GPT reasoning tool-use models to Responses by default', () => {
     expect(shouldUseResponsesAPI(MODEL_CONFIGS.gpt54, false)).toBe(true);
     expect(shouldUseResponsesAPI(MODEL_CONFIGS.gpt55, false)).toBe(true);
@@ -71,6 +84,107 @@ describe('OpenAI model handler routing', () => {
         false,
       ),
     ).toBe(false);
+  });
+
+  it('exposes the same compatibility key for switchable response models', () => {
+    expect(
+      modelHandlerCompatibilityKey(MODEL_CONFIGS.gpt54, false, false),
+    ).toBe('ModelHandlerOpenAIResponse');
+    expect(
+      modelHandlerCompatibilityKey(MODEL_CONFIGS.gpt55, false, false),
+    ).toBe('ModelHandlerOpenAIResponse');
+    expect(
+      modelHandlerCompatibilityKey(MODEL_CONFIGS.sonnet46T, false, false),
+    ).toBe('ModelHandlerAnthropic');
+  });
+
+  it('uses the OpenRouter compatibility key when models are proxied', () => {
+    expect(modelHandlerCompatibilityKey(MODEL_CONFIGS.gpt54, true, false)).toBe(
+      'ModelHandlerOpenRouterNative',
+    );
+    expect(
+      modelHandlerCompatibilityKey(MODEL_CONFIGS.deepseekT, true, false),
+    ).toBe('ModelHandlerOpenRouterNative');
+  });
+
+  it('uses short-name routing when computing compatibility keys', () => {
+    expect(
+      modelHandlerCompatibilityKey(
+        {
+          ...modelConfig(ModelProvider.OPENAI, {
+            supportsFunctionCalling: true,
+            supportsReasoningEffort: true,
+          }),
+          fullName: 'gpt-5-compatible-test',
+          shortName: 'legacy-chat-test',
+        },
+        false,
+        true,
+      ),
+    ).toBe('ModelHandlerOpenAI');
+  });
+
+  it('tags created handlers with a minifier-safe compatibility key', async () => {
+    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+      import('@platform/platform'),
+      import('@test/support/FakePlatform'),
+    ]);
+    initPlatform(createFakePlatform());
+
+    const handler = await createModelHandler(MODEL_CONFIGS.gpt54);
+    try {
+      expect(activeModelHandlerCompatibilityKey(handler)).toBe(
+        'ModelHandlerOpenAIResponse',
+      );
+    } finally {
+      handler.dispose();
+    }
+  });
+
+  it('uses the validation compatibility key only after the validation gate passes', async () => {
+    const flagRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'texra-validation-handler-'),
+    );
+    const flagPath = path.join(flagRoot, 'flag');
+    await fs.writeFile(flagPath, 'texra-cli-run-validation\n');
+
+    vi.stubEnv('TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL', '1');
+    vi.stubEnv(
+      'TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_ENV',
+      'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER',
+    );
+    vi.stubEnv(
+      'TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV',
+      'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG',
+    );
+    vi.stubEnv(
+      'TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_CONTENT',
+      'texra-cli-run-validation',
+    );
+    vi.stubEnv('TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER', '1');
+    vi.stubEnv('TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG', flagPath);
+    vi.stubEnv('CI', '1');
+
+    vi.resetModules();
+    const passingFactory = await import('@agent/runtime/ModelFactory');
+    expect(
+      passingFactory.modelHandlerCompatibilityKey(
+        MODEL_CONFIGS.gpt54,
+        false,
+        false,
+      ),
+    ).toBe('ModelHandlerValidation');
+
+    vi.stubEnv('TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG', '');
+    vi.resetModules();
+    const failingFactory = await import('@agent/runtime/ModelFactory');
+    expect(() =>
+      failingFactory.modelHandlerCompatibilityKey(
+        MODEL_CONFIGS.gpt54,
+        false,
+        false,
+      ),
+    ).toThrow(/restricted to package validation/);
   });
 });
 

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -198,6 +198,44 @@ describe('CLI ModelListForm model visibility', () => {
     ]);
   });
 
+  it('marks API-mode-runnable models disabled when the live chat cannot switch formats', () => {
+    const items = modelSelectItemsForCliMode(
+      [
+        access({
+          value: 'sonnet46T',
+          label: 'Sonnet',
+          availability: 'provider-key',
+        }),
+        access({
+          value: 'gpt55',
+          label: 'GPT-5.5',
+          availability: 'provider-key',
+        }),
+      ],
+      'personal',
+      (model) =>
+        model === 'sonnet46T'
+          ? 'different conversation format; start new chat'
+          : undefined,
+    );
+
+    expect(items).toEqual([
+      {
+        value: 'sonnet46T',
+        label: 'Sonnet',
+        description:
+          'api: api key set; different conversation format; start new chat',
+        disabled: true,
+      },
+      {
+        value: 'gpt55',
+        label: 'GPT-5.5',
+        description: 'api: api key set',
+        disabled: false,
+      },
+    ]);
+  });
+
   it('treats filtered-empty lists as non-actionable', () => {
     expect(
       modelSelectItemsForCliMode(

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -205,6 +205,40 @@ describe('slashRegistry', () => {
     expect(modelNode.props).toMatchObject({ selectable: true });
   });
 
+  it('passes live model-switch disabled reasons into the model picker', () => {
+    resetCliState({
+      agent: 'chat',
+      model: 'gpt54',
+      cwd: '/tmp/workspace',
+      apiMode: 'personal',
+      canDelegate: false,
+      version: 'test',
+    });
+    registerBuiltinSlashCommands({
+      canSelectModel: () => true,
+      getModelSwitchDisabledReason: (model) =>
+        model === 'sonnet46T'
+          ? 'different conversation format; start new chat'
+          : undefined,
+    });
+    const model = listSlashCommands().find((cmd) => cmd.name === 'model');
+
+    if (!model) throw new Error('Expected /model to be registered');
+
+    expect(openRegisteredCliSlashForm(model, '')).toBe(true);
+
+    const modelNode = renderFormAdapter<{
+      getModelSwitchDisabledReason?: (model: string) => string | undefined;
+    }>(cliState.activeForm.get()?.render(() => {}, 20));
+
+    expect(modelNode.props?.getModelSwitchDisabledReason?.('sonnet46T')).toBe(
+      'different conversation format; start new chat',
+    );
+    expect(modelNode.props?.getModelSwitchDisabledReason?.('gpt55')).toBe(
+      undefined,
+    );
+  });
+
   it('routes API picker selection failures to the shared error handler', async () => {
     resetCliState({
       agent: 'chat',


### PR DESCRIPTION
## Summary
- add model-handler compatibility keys at the model factory route boundary
- disable `/model` rows that cannot switch into the active conversation format
- add unit and TUI harness coverage for post-history compatible model switching

Fixes #5350

## Validation
- `npm run test:kernel -- src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/TuiValidatorArgs.vitest.mts src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-model-switch-compat-20260605-114339 model-switch-compatible-only`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings outside this PR)
- `npm run texra-local:build && npm run texra-local:link`
- `texra-local --version`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model routing and live session model switching; mistakes could block valid switches or allow incompatible history formats, but scope is bounded with tests and UI pre-checks.
> 
> **Overview**
> Adds **model-handler compatibility keys** at `ModelFactory` routing (including tags on created handlers) and uses them in **tool-use flow** to decide whether mid-chat model switches are allowed, with the existing constructor check kept as a backstop.
> 
> The **`/model`** picker now accepts a per-model disabled reason: incompatible rows show **“different conversation format; start new chat”** and cannot be selected during an active conversation. The TUI harness and **validate-tui** scenario **`model-switch-compatible-only`** exercise this; unit tests cover factory keys and form wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c917163fdfc1fb786a498a769e4fd0b2d08f997b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->