### PR TITLE
[codex] Activate CLI skills from /skills picker

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1343,6 +1343,11 @@ registerBuiltinSlashCommands({
       `Harness memory selected: ${storagePath}.`,
     );
   },
+  onSkillSelect: (selection) => {
+    appendHarnessAssistantTranscript(
+      `Harness skill selected: ${selection.name}.`,
+    );
+  },
   onResumeSelect: (id) => {
     appendHarnessAssistantTranscript(`Harness resume selected: ${id}.`);
   },

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -608,10 +608,10 @@ const SCENARIOS = [
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/skills',
-      'Discoverable skills from configured sources.',
+      'Select a skill to activate it.',
       'proof-audit',
       'project · Review mathematical proof steps.',
-      'Enter close',
+      'Enter activate',
       'Esc close',
     ],
     unexpect: [
@@ -621,6 +621,19 @@ const SCENARIOS = [
     ],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: '/skills', max: 8 },
+    ],
+  },
+  {
+    name: 'skills-form-select-submit',
+    env: { HARNESS_ENTRIES: '4', HARNESS_PROJECT_SKILL: '1' },
+    keys: ['/skills', '\r', '\r'],
+    frame: 'tail',
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: ['Harness skill selected: proof-audit.'],
+    unexpect: [
+      'No skills found',
+      '/skills - error',
+      'Platform not initialized',
     ],
   },
   {

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -10,7 +10,7 @@ import { ApprovalPolicyForm } from '../forms/ApprovalPolicyForm';
 import { MemoryListForm } from '../forms/MemoryListForm';
 import { ModelListForm } from '../forms/ModelListForm';
 import { ResumeListForm } from '../forms/ResumeListForm';
-import { SkillsListForm } from '../forms/SkillsListForm';
+import { SkillsListForm, type SkillSelectValue } from '../forms/SkillsListForm';
 import { ToolsListForm } from '../forms/ToolsListForm';
 import { cliState } from '../state/cliState';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
@@ -23,6 +23,7 @@ type ModelSelectHandler = (value: string) => void | Promise<void>;
 type ApiModeSelectHandler = (value: CliApiMode) => void | Promise<void>;
 type MemorySelectHandler = (storagePath: string) => void | Promise<void>;
 type ResumeSelectHandler = (id: ExecutionId) => void | Promise<void>;
+type SkillSelectHandler = (value: SkillSelectValue) => void | Promise<void>;
 type ErrorHandler = (error: unknown) => void | Promise<void>;
 type SelectionCompletion = 'afterAction' | 'beforeAction';
 
@@ -79,6 +80,7 @@ export function registerBuiltinSlashCommands(options?: {
   onApiModeSelect?: ApiModeSelectHandler;
   onMemorySelect?: MemorySelectHandler;
   onResumeSelect?: ResumeSelectHandler;
+  onSkillSelect?: SkillSelectHandler;
   onError?: ErrorHandler;
 }): void {
   const onAgentSelect: AgentSelectHandler =
@@ -240,6 +242,15 @@ export function registerBuiltinSlashCommands(options?: {
     return (
       <SkillsListForm
         availableRows={props.availableRows}
+        onSelect={(value) =>
+          runFormSelection({
+            action: () => options?.onSkillSelect?.(value),
+            value,
+            onDone: props.onDone,
+            onError: options?.onError,
+            completion: 'beforeAction',
+          })
+        }
         onClose={() => props.onDone(undefined)}
       />
     );

--- a/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
@@ -1,10 +1,11 @@
 // `/skills` form. It lists discoverable runtime skills from the same source
-// registry that feeds prompt
-// injection instead of rediscovering paths from the UI layer.
+// registry that feeds prompt injection and builds activation payloads from the
+// shared runtime formatter instead of duplicating skill wiring in the UI layer.
 
 import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 
+import { formatRuntimeSkillActivation } from '@skills/runtimeSkills';
 import { readCliRuntimeSkills, skillListRecord } from '@cli/runtime/skills';
 
 import { KeyHints } from '../ui/KeyHints';
@@ -23,7 +24,13 @@ import type {
 
 export interface SkillsListFormProps {
   readonly availableRows?: number;
+  readonly onSelect: (value: SkillSelectValue) => void;
   readonly onClose: () => void;
+}
+
+export interface SkillSelectValue {
+  readonly name: string;
+  readonly activationPrompt: string;
 }
 
 export function formatSkillDescriptionForTui(skill: SourcedSkill): string {
@@ -31,13 +38,35 @@ export function formatSkillDescriptionForTui(skill: SourcedSkill): string {
   return `${record.sourceLabel} · ${record.description}`;
 }
 
+export function formatSkillActivationPrompt(skill: SourcedSkill): string {
+  const activationInstruction = [
+    `The user selected the ${skill.skill.name} skill.`,
+    'Use these instructions for the next substantive user request.',
+    'Resolve relative file references against the skill_directory.',
+  ].join(' ');
+  return [
+    '<skill_activation>',
+    activationInstruction,
+    formatRuntimeSkillActivation(skill),
+    '</skill_activation>',
+  ].join('\n');
+}
+
+export function skillSelectValueForTui(skill: SourcedSkill): SkillSelectValue {
+  const record = skillListRecord(skill);
+  return {
+    name: record.name,
+    activationPrompt: formatSkillActivationPrompt(skill),
+  };
+}
+
 export function skillSelectItemsForTui(
   skills: readonly SourcedSkill[],
-): SelectItem<string>[] {
+): SelectItem<SkillSelectValue>[] {
   return skills.map((skill) => {
     const record = skillListRecord(skill);
     return {
-      value: record.path,
+      value: skillSelectValueForTui(skill),
       label: record.name,
       description: formatSkillDescriptionForTui(skill),
     };
@@ -105,22 +134,26 @@ export function SkillsListForm(props: SkillsListFormProps): React.JSX.Element {
   });
   const items = skillSelectItemsForTui(skills);
 
+  function handleSelect(value: SkillSelectValue): void {
+    props.onSelect(value);
+  }
+
   if (isCompactFormRows(props.availableRows)) {
     return (
       <FormFrame color="cyan" title="/skills" showCloseHint={false}>
         <Text dimColor wrap="truncate-end">
-          Discoverable skills.
+          Select a skill to activate.
         </Text>
         {issueSummary ? <Text dimColor>{issueSummary}</Text> : null}
         <Select
           items={items}
           maxVisibleItems={1}
           showOverflow={false}
-          onSelect={props.onClose}
+          onSelect={handleSelect}
           onCancel={props.onClose}
         />
         <CompactFormKeyHints
-          primary={{ key: '1-9/a-z/Enter', action: 'close' }}
+          primary={{ key: '1-9/a-z/Enter', action: 'activate' }}
         />
       </FormFrame>
     );
@@ -128,20 +161,20 @@ export function SkillsListForm(props: SkillsListFormProps): React.JSX.Element {
 
   return (
     <FormFrame color="cyan" title="/skills" showCloseHint={false}>
-      <Text dimColor>Discoverable skills from configured sources.</Text>
+      <Text dimColor>Select a skill to activate it.</Text>
       {issueSummary ? <Text dimColor>{issueSummary}</Text> : null}
       <Select
         items={items}
         maxVisibleItems={selectWindow.maxVisibleItems}
         showOverflow={selectWindow.showOverflow}
-        onSelect={props.onClose}
+        onSelect={handleSelect}
         onCancel={props.onClose}
       />
       <Box marginTop={1}>
         <KeyHints
           hints={[
             { key: '↑/↓', action: 'navigate' },
-            { key: 'Enter', action: 'close' },
+            { key: 'Enter', action: 'activate' },
             { key: 'Esc', action: 'close' },
           ]}
           confirmCancel={false}

--- a/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '@inkjs/ui';
 
 import { formatRuntimeSkillActivation } from '@skills/runtimeSkills';
 import { readCliRuntimeSkills, skillListRecord } from '@cli/runtime/skills';
+import { escapeText } from '@shared/utils/xmlEscape';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select, type SelectItem } from '../ui/Select';
@@ -40,7 +41,7 @@ export function formatSkillDescriptionForTui(skill: SourcedSkill): string {
 
 export function formatSkillActivationPrompt(skill: SourcedSkill): string {
   const activationInstruction = [
-    `The user selected the ${skill.skill.name} skill.`,
+    `The user selected the ${escapeText(skill.skill.name)} skill.`,
     'Use these instructions for the next substantive user request.',
     'Resolve relative file references against the skill_directory.',
   ].join(' ');

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -164,6 +164,7 @@ export interface BuildInitialChatAgentConfigInput {
   readonly agent: string;
   readonly model: string;
   readonly instruction: string;
+  readonly displayInstruction?: string;
   readonly workingDirectory: string;
   readonly mediaFiles?: readonly string[];
   readonly cliMultiAgentPresetId?: string;
@@ -173,6 +174,7 @@ export function buildInitialChatAgentConfig({
   agent,
   model,
   instruction,
+  displayInstruction,
   workingDirectory,
   mediaFiles,
   cliMultiAgentPresetId,
@@ -181,11 +183,64 @@ export function buildInitialChatAgentConfig({
     agent,
     model,
     instruction,
+    ...(displayInstruction ? { displayInstruction } : {}),
     agentCategory: AgentCategory.ToolUse,
     workingDirectory,
     ...(mediaFiles?.length ? { mediaFiles: [...mediaFiles] } : {}),
     ...(cliMultiAgentPresetId ? { cliMultiAgentPresetId } : {}),
   };
+}
+
+export interface ReservedSkillActivation {
+  readonly name: string;
+  readonly activationPrompt: string;
+}
+
+export interface PreparedChatInstruction {
+  readonly instruction: string;
+  readonly displayInstruction?: string;
+  readonly reservedSkillActivations: readonly ReservedSkillActivation[];
+}
+
+export function takePendingSkillActivations(
+  pendingSkillActivations: Map<string, string>,
+  line: string,
+): PreparedChatInstruction {
+  if (pendingSkillActivations.size === 0) {
+    return { instruction: line, reservedSkillActivations: [] };
+  }
+
+  const entries = [...pendingSkillActivations.entries()].map(
+    ([name, activationPrompt]) => ({ name, activationPrompt }),
+  );
+  for (const { name } of entries) {
+    pendingSkillActivations.delete(name);
+  }
+
+  const activations = entries
+    .map(({ activationPrompt }) => activationPrompt)
+    .join('\n\n');
+  return {
+    instruction: [
+      activations,
+      '<user_request>',
+      line,
+      '</user_request>',
+    ].join('\n'),
+    displayInstruction: line,
+    reservedSkillActivations: entries,
+  };
+}
+
+export function restorePendingSkillActivations(
+  pendingSkillActivations: Map<string, string>,
+  activations: readonly ReservedSkillActivation[],
+): void {
+  for (const { name, activationPrompt } of activations) {
+    if (!pendingSkillActivations.has(name)) {
+      pendingSkillActivations.set(name, activationPrompt);
+    }
+  }
 }
 
 export async function registerFreshChatExecution(
@@ -1096,6 +1151,7 @@ export async function runChat(
   };
 
   const followUpQueue = new PQueue({ concurrency: 1 });
+  const pendingSkillActivations = new Map<string, string>();
   const rootStreamStatus = (): StreamStatus | undefined =>
     session.streamId
       ? (cliState.streams.get().get(session.streamId)?.status ??
@@ -1120,6 +1176,19 @@ export async function runChat(
       ? getToolUseFlowContext(session.streamId)
       : undefined;
     return activeFlow?.modelSwitchDisabledReason(candidateModel);
+  };
+  const activateSkillForNextMessage = (selection: {
+    readonly name: string;
+    readonly activationPrompt: string;
+  }): void => {
+    const wasPending = pendingSkillActivations.has(selection.name);
+    pendingSkillActivations.set(selection.name, selection.activationPrompt);
+    appendLocalAssistantTranscript(
+      [
+        `Skill ${wasPending ? 'refreshed' : 'activated'}: ${selection.name}.`,
+        'It will be applied to your next message.',
+      ].join(' '),
+    );
   };
   const canInterruptActiveRun = (): boolean =>
     chatTuiCanInterruptActiveRun(session);
@@ -1156,6 +1225,7 @@ export async function runChat(
     if (isRunPending) interruptActive();
     clearApprovals();
     followUpQueue.clear();
+    pendingSkillActivations.clear();
     clearTuiSessionRunState(session);
     // StreamLogStore entries outlive resetCliState (which only clears the
     // React/signal view). Drop them so syncStreamLog can't replay the
@@ -1367,6 +1437,7 @@ export async function runChat(
     onApiModeSelect: (nextMode) =>
       applyCliApiModeSelection(nextMode, slashCommandContext()),
     onMemorySelect: showCliMemoryPreview,
+    onSkillSelect: activateSkillForNextMessage,
     onResumeSelect: resumeAgentRun,
     onError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));
@@ -1376,9 +1447,11 @@ export async function runChat(
   const startSession = async (
     instruction: string,
     mediaFiles?: readonly string[],
-  ): Promise<void> => {
+    displayInstruction?: string,
+  ): Promise<boolean> => {
     followUpQueue.clear();
     session.executionId = undefined;
+    let started = false;
     // Queue the async startup body after the reservation below so a second
     // submit cannot pass chatTuiCanStartRootRun during model/auth resolution.
     const pendingStart = Promise.resolve().then(async (): Promise<void> => {
@@ -1401,14 +1474,16 @@ export async function runChat(
             agent: currentAgent,
             model: resolution.model,
             instruction,
+            displayInstruction,
             mediaFiles,
             workingDirectory: context.cwd,
             cliMultiAgentPresetId: init.cliMultiAgentPresetId,
           }),
         );
+        started = true;
       } catch (error: unknown) {
         if (!session.stopRequested) {
-          appendLocalUserTranscript(instruction);
+          appendLocalUserTranscript(displayInstruction ?? instruction);
           appendLocalErrorTranscript(toErrorMessage(error));
         }
         session.runExitCode = session.stopRequested
@@ -1419,6 +1494,7 @@ export async function runChat(
     });
     markChatTuiRunPending(session, pendingStart);
     await pendingStart;
+    return started;
   };
 
   const handleSubmit = (line: string, mediaFiles?: readonly string[]): void => {
@@ -1448,8 +1524,22 @@ export async function runChat(
       return;
     }
     const childFollowUpTarget = chatTuiActiveChildFollowUpTarget();
+    const prepared = takePendingSkillActivations(
+      pendingSkillActivations,
+      line,
+    );
     if (!childFollowUpTarget && chatTuiCanStartRootRun(session)) {
-      await startSession(line, mediaFiles);
+      const started = await startSession(
+        prepared.instruction,
+        mediaFiles,
+        prepared.displayInstruction,
+      );
+      if (!started) {
+        restorePendingSkillActivations(
+          pendingSkillActivations,
+          prepared.reservedSkillActivations,
+        );
+      }
       return;
     }
     // PRD success criterion: follow-ups must not be silently dropped when the
@@ -1467,25 +1557,41 @@ export async function runChat(
       );
     }
     void followUpQueue.add(async () => {
+      let delivered = false;
       let followUpTarget = childFollowUpTarget;
-      while (
-        !followUpTarget &&
-        !session.stopRequested &&
-        !session.runCompleted
-      ) {
-        await new Promise<void>((resolve) => setTimeout(resolve, 25));
-        followUpTarget = session.streamId;
-      }
-      if (!followUpTarget || session.stopRequested) return;
-      const result = await sendFollowUp(followUpTarget, line, mediaFiles);
-      if (result.status === 'no_session') {
-        // Child stream ids are keys in parentStream; the root session id is not.
-        if (followUpTarget === session.streamId) {
-          session.stopRequested = true;
-        } else {
-          appendLocalAssistantTranscript(
-            'The selected subagent is no longer accepting follow-ups.',
-            followUpTarget,
+      try {
+        while (
+          !followUpTarget &&
+          !session.stopRequested &&
+          !session.runCompleted
+        ) {
+          await new Promise<void>((resolve) => setTimeout(resolve, 25));
+          followUpTarget = session.streamId;
+        }
+        if (!followUpTarget || session.stopRequested) return;
+        const result = await sendFollowUp(
+          followUpTarget,
+          prepared.instruction,
+          mediaFiles,
+          prepared.displayInstruction,
+        );
+        delivered = result.status === 'sent' || result.status === 'queued';
+        if (result.status === 'no_session') {
+          // Child stream ids are keys in parentStream; the root session id is not.
+          if (followUpTarget === session.streamId) {
+            session.stopRequested = true;
+          } else {
+            appendLocalAssistantTranscript(
+              'The selected subagent is no longer accepting follow-ups.',
+              followUpTarget,
+            );
+          }
+        }
+      } finally {
+        if (!delivered) {
+          restorePendingSkillActivations(
+            pendingSkillActivations,
+            prepared.reservedSkillActivations,
           );
         }
       }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -95,6 +95,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { escapeText } from '@shared/utils/xmlEscape';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 import { filterNotNullish } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
@@ -183,7 +184,7 @@ export function buildInitialChatAgentConfig({
     agent,
     model,
     instruction,
-    ...(displayInstruction ? { displayInstruction } : {}),
+    ...(displayInstruction !== undefined ? { displayInstruction } : {}),
     agentCategory: AgentCategory.ToolUse,
     workingDirectory,
     ...(mediaFiles?.length ? { mediaFiles: [...mediaFiles] } : {}),
@@ -224,7 +225,7 @@ export function takePendingSkillActivations(
     instruction: [
       activations,
       '<user_request>',
-      line,
+      escapeText(line),
       '</user_request>',
     ].join('\n'),
     displayInstruction: line,
@@ -1152,6 +1153,7 @@ export async function runChat(
 
   const followUpQueue = new PQueue({ concurrency: 1 });
   const pendingSkillActivations = new Map<string, string>();
+  let pendingSkillActivationClearEpoch = 0;
   const rootStreamStatus = (): StreamStatus | undefined =>
     session.streamId
       ? (cliState.streams.get().get(session.streamId)?.status ??
@@ -1225,6 +1227,7 @@ export async function runChat(
     if (isRunPending) interruptActive();
     clearApprovals();
     followUpQueue.clear();
+    pendingSkillActivationClearEpoch += 1;
     pendingSkillActivations.clear();
     clearTuiSessionRunState(session);
     // StreamLogStore entries outlive resetCliState (which only clears the
@@ -1524,10 +1527,17 @@ export async function runChat(
       return;
     }
     const childFollowUpTarget = chatTuiActiveChildFollowUpTarget();
-    const prepared = takePendingSkillActivations(
-      pendingSkillActivations,
-      line,
-    );
+    const prepared = takePendingSkillActivations(pendingSkillActivations, line);
+    const skillActivationClearEpoch = pendingSkillActivationClearEpoch;
+    const restoreReservedSkillActivations = (): void => {
+      if (skillActivationClearEpoch !== pendingSkillActivationClearEpoch) {
+        return;
+      }
+      restorePendingSkillActivations(
+        pendingSkillActivations,
+        prepared.reservedSkillActivations,
+      );
+    };
     if (!childFollowUpTarget && chatTuiCanStartRootRun(session)) {
       const started = await startSession(
         prepared.instruction,
@@ -1535,10 +1545,7 @@ export async function runChat(
         prepared.displayInstruction,
       );
       if (!started) {
-        restorePendingSkillActivations(
-          pendingSkillActivations,
-          prepared.reservedSkillActivations,
-        );
+        restoreReservedSkillActivations();
       }
       return;
     }
@@ -1589,10 +1596,7 @@ export async function runChat(
         }
       } finally {
         if (!delivered) {
-          restorePendingSkillActivations(
-            pendingSkillActivations,
-            prepared.reservedSkillActivations,
-          );
+          restoreReservedSkillActivations();
         }
       }
     });

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -48,6 +48,7 @@ async function resumeFromSnapshot(
 
   let queuedFollowUps: Array<{
     text: string;
+    displayText?: string;
     mediaFiles?: readonly string[];
   }> = [];
   try {
@@ -63,7 +64,7 @@ async function resumeFromSnapshot(
           : queuedFollowUps;
 
       for (const item of allFollowUps) {
-        session.appendFollowUp(item.text, item.mediaFiles);
+        session.appendFollowUp(item.text, item.mediaFiles, item.displayText);
       }
     });
 

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -16,6 +16,8 @@ const AgentConfigFieldsSchema = NullableFileFieldsSchema.extend({
   agent: z.string().prefault(DEFAULT_AGENT_NAME),
   model: z.string().prefault(DEFAULT_AGENT_MODEL),
   instruction: z.string().prefault(DEFAULT_AGENT_INSTRUCTION),
+  /** Optional user-facing text for logs when instruction contains hidden context. */
+  displayInstruction: z.string().nullish(),
   agentCategory: z.enum(AgentCategory).prefault(AgentCategory.Workflow),
   editedFiles: z.array(z.string()).prefault([]),
   toolConfig: ToolConfigSchema,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -218,12 +218,18 @@ class ToolUsePrepNode<C> extends BaseNode<
   async prep(_shared: ToolUseCycleShared): Promise<{
     interrupted: boolean;
     queuedFollowUp: string | null;
+    queuedFollowUpDisplay: string | null;
     synthetic: boolean;
   }> {
     const interrupted = this.services.checkInterruption();
 
     if (!this.services.session?.hasQueuedFollowUp()) {
-      return { interrupted, queuedFollowUp: null, synthetic: false };
+      return {
+        interrupted,
+        queuedFollowUp: null,
+        queuedFollowUpDisplay: null,
+        synthetic: false,
+      };
     }
 
     // Drain without waiting (we know there's something queued)
@@ -231,6 +237,7 @@ class ToolUsePrepNode<C> extends BaseNode<
     return {
       interrupted,
       queuedFollowUp: batch?.items.join('\n\n') ?? null,
+      queuedFollowUpDisplay: batch?.displayItems.join('\n\n') ?? null,
       synthetic: batch?.synthetic ?? false,
     };
   }
@@ -240,6 +247,7 @@ class ToolUsePrepNode<C> extends BaseNode<
     prepRes: {
       interrupted: boolean;
       queuedFollowUp: string | null;
+      queuedFollowUpDisplay: string | null;
       synthetic: boolean;
     },
   ): Promise<string | undefined> {
@@ -254,7 +262,10 @@ class ToolUsePrepNode<C> extends BaseNode<
     // before the model starts thinking/responding
     if (prepRes.queuedFollowUp) {
       if (!prepRes.synthetic) {
-        logUserMessage(this.services.logger, prepRes.queuedFollowUp);
+        logUserMessage(
+          this.services.logger,
+          prepRes.queuedFollowUpDisplay ?? prepRes.queuedFollowUp,
+        );
       }
       shared.messages =
         await this.services.modelHandler.createUserFollowUpMessages(

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -3,7 +3,11 @@ import type { FollowUpQueueBatch } from '@agent/toolUse/FollowUpQueue';
 import type { StreamTabId } from '@shared/schemas';
 
 export interface IToolUseSession {
-  appendFollowUp(text: string, mediaFiles?: readonly string[]): void;
+  appendFollowUp(
+    text: string,
+    mediaFiles?: readonly string[],
+    displayText?: string,
+  ): void;
   appendSyntheticFollowUp(text: string): void;
   hasQueuedFollowUp(): boolean;
   /** Wait for the next follow-up items. Returns null if interrupted. */
@@ -18,8 +22,12 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
 
   constructor(private readonly streamTabId: StreamTabId) {}
 
-  appendFollowUp(text: string, mediaFiles?: readonly string[]): void {
-    this.followUps.enqueue(text, mediaFiles);
+  appendFollowUp(
+    text: string,
+    mediaFiles?: readonly string[],
+    displayText?: string,
+  ): void {
+    this.followUps.enqueue(text, mediaFiles, displayText);
   }
 
   appendSyntheticFollowUp(text: string): void {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -131,6 +131,7 @@ export class ToolUseWaitNode<C> extends Node<
     return {
       kind: 'continue',
       followUp: batch.items.join('\n\n'),
+      displayFollowUp: batch.displayItems.join('\n\n'),
       synthetic: batch.synthetic,
       mediaFiles: batch.mediaFiles,
     };
@@ -182,7 +183,7 @@ export class ToolUseWaitNode<C> extends Node<
     if (!execRes.synthetic) {
       shared.deliveredToOrchestrator = undefined;
       onFollowUpConsumed?.();
-      logUserMessage(logger, execRes.followUp);
+      logUserMessage(logger, execRes.displayFollowUp ?? execRes.followUp);
     }
     StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
       runtimeHost,

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -50,6 +50,8 @@ export type WaitExecResult =
   | {
       kind: 'continue';
       followUp: string;
+      /** User-facing text for logs when followUp contains injected context. */
+      displayFollowUp?: string;
       /**
        * True when `followUp` was synthesized by an idle-continuation provider
        * instead of being consumed from `session.waitForFollowUp()`. The

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -244,7 +244,9 @@ async function assembleAgentLaunchContext(
   // Log the initial instruction as a user message so both workflow and
   // tool-use tabs display it inline with the stream log (no separate panel).
   const displayInstruction =
-    config.displayInstruction?.trim() || config.instruction?.trim();
+    config.displayInstruction == null
+      ? config.instruction?.trim()
+      : config.displayInstruction.trim();
   const initialInstruction =
     displayInstruction && !input.streamTabIdOverride
       ? displayInstruction

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -243,9 +243,11 @@ async function assembleAgentLaunchContext(
 
   // Log the initial instruction as a user message so both workflow and
   // tool-use tabs display it inline with the stream log (no separate panel).
+  const displayInstruction =
+    config.displayInstruction?.trim() || config.instruction?.trim();
   const initialInstruction =
-    config.instruction?.trim() && !input.streamTabIdOverride
-      ? config.instruction.trim()
+    displayInstruction && !input.streamTabIdOverride
+      ? displayInstruction
       : undefined;
 
   const parentStage = await beginRunStage(

--- a/src/agent/toolUse/FollowUpQueue.ts
+++ b/src/agent/toolUse/FollowUpQueue.ts
@@ -7,13 +7,19 @@
 
 interface FollowUpQueueItem {
   readonly text: string;
+  readonly displayText?: string;
   readonly synthetic: boolean;
   /** Media file paths (e.g. pasted images) attached to this user follow-up. */
   readonly mediaFiles?: readonly string[];
 }
 
+function displayTextForItem(item: FollowUpQueueItem): string {
+  return item.displayText ?? item.text;
+}
+
 export interface FollowUpQueueBatch {
   readonly items: string[];
+  readonly displayItems: string[];
   readonly synthetic: boolean;
   /** Media file paths from the user follow-ups in this batch, flattened. */
   readonly mediaFiles: string[];
@@ -23,8 +29,17 @@ export class FollowUpQueue {
   private readonly queued: FollowUpQueueItem[] = [];
   private resolver: ((value: FollowUpQueueItem | null) => void) | null = null;
 
-  enqueue(value: string, mediaFiles?: readonly string[]): void {
-    this.enqueueItem({ text: value, synthetic: false, mediaFiles });
+  enqueue(
+    value: string,
+    mediaFiles?: readonly string[],
+    displayText?: string,
+  ): void {
+    this.enqueueItem({
+      text: value,
+      displayText,
+      synthetic: false,
+      mediaFiles,
+    });
   }
 
   enqueueSynthetic(value: string): void {
@@ -49,7 +64,7 @@ export class FollowUpQueue {
     return this.queued
       .splice(0)
       .filter((item) => !item.synthetic)
-      .map((item) => item.text);
+      .map(displayTextForItem);
   }
 
   /**
@@ -57,11 +72,19 @@ export class FollowUpQueue {
    * Used by resume to replay queued user input without losing pasted images;
    * the text-only {@link drain} stays for display/back-compat.
    */
-  drainItems(): Array<{ text: string; mediaFiles?: readonly string[] }> {
+  drainItems(): Array<{
+    text: string;
+    displayText?: string;
+    mediaFiles?: readonly string[];
+  }> {
     return this.queued
       .splice(0)
       .filter((item) => !item.synthetic)
-      .map((item) => ({ text: item.text, mediaFiles: item.mediaFiles }));
+      .map((item) => ({
+        text: item.text,
+        displayText: item.displayText,
+        mediaFiles: item.mediaFiles,
+      }));
   }
 
   waitForNext(
@@ -91,19 +114,26 @@ export class FollowUpQueue {
     const first = await this.waitForNext(checkInterruption);
     if (first === null) return null;
     if (first.synthetic) {
-      return { items: [first.text], synthetic: true, mediaFiles: [] };
+      return {
+        items: [first.text],
+        displayItems: [displayTextForItem(first)],
+        synthetic: true,
+        mediaFiles: [],
+      };
     }
 
     const items = [first.text];
+    const displayItems = [displayTextForItem(first)];
     const mediaFiles: string[] = [...(first.mediaFiles ?? [])];
     while (true) {
       const next = this.queued[0];
       if (!next || next.synthetic) break;
       const item = this.queued.shift()!;
       items.push(item.text);
+      displayItems.push(displayTextForItem(item));
       if (item.mediaFiles?.length) mediaFiles.push(...item.mediaFiles);
     }
-    return { items, synthetic: false, mediaFiles };
+    return { items, displayItems, synthetic: false, mediaFiles };
   }
 
   cancelWait(): void {
@@ -121,6 +151,6 @@ export class FollowUpQueue {
   getAll(): string[] {
     return this.queued
       .filter((item) => !item.synthetic)
-      .map((item) => item.text);
+      .map(displayTextForItem);
   }
 }

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -72,14 +72,19 @@ export async function sendFollowUp(
   streamId: StreamTabId,
   text: string,
   mediaFiles?: readonly string[],
+  displayText?: string,
 ): Promise<SendFollowUpResult> {
   const status = StreamStatusService.get(streamId);
   const activeChildren = getActiveChildren(streamId);
   const hasActiveChildren =
     activeChildren.subagents.length > 0 || activeChildren.processes.length > 0;
+  const queueOptions = { mediaFiles, displayText };
   if (status !== undefined && !isInFlightStatus(status)) {
     if (hasActiveChildren) {
-      ToolUseFollowUpQueue.enqueue(streamId, text, { force: true, mediaFiles });
+      ToolUseFollowUpQueue.enqueue(streamId, text, {
+        ...queueOptions,
+        force: true,
+      });
       return { status: 'queued', reason: 'children_running' };
     }
     logger.warn(
@@ -91,20 +96,20 @@ export async function sendFollowUp(
   // Try active flow context first
   const flowContext = getToolUseFlowContext(streamId);
   if (flowContext) {
-    flowContext.session.appendFollowUp(text, mediaFiles);
+    flowContext.session.appendFollowUp(text, mediaFiles, displayText);
     notifyFollowUpSent(streamId, flowContext.runtimeHost);
     return { status: 'sent' };
   }
 
   // Queue if session is resuming
   if (ToolUseFollowUpQueue.isResuming(streamId)) {
-    ToolUseFollowUpQueue.enqueue(streamId, text, { mediaFiles });
+    ToolUseFollowUpQueue.enqueue(streamId, text, queueOptions);
     return { status: 'queued', reason: 'resuming' };
   }
 
   // Queue if session is waiting (paused, can be resumed)
   if (status === STREAM_STATUS.WAITING) {
-    ToolUseFollowUpQueue.enqueue(streamId, text, { mediaFiles });
+    ToolUseFollowUpQueue.enqueue(streamId, text, queueOptions);
     return { status: 'queued', reason: 'waiting' };
   }
 
@@ -112,7 +117,10 @@ export async function sendFollowUp(
     // force:true reopens a queue sealed by sessionLifecycle disposal — the
     // caller must auto-resume the parent or re-release, or late child
     // deliveries will leak into the next run on this stream.
-    ToolUseFollowUpQueue.enqueue(streamId, text, { force: true, mediaFiles });
+    ToolUseFollowUpQueue.enqueue(streamId, text, {
+      ...queueOptions,
+      force: true,
+    });
     return { status: 'queued', reason: 'children_running' };
   }
 

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -91,7 +91,11 @@ export class ToolUseFollowUpQueue {
   static enqueue(
     streamId: StreamTabId,
     followUp: string,
-    options?: { force?: boolean; mediaFiles?: readonly string[] },
+    options?: {
+      force?: boolean;
+      mediaFiles?: readonly string[];
+      displayText?: string;
+    },
   ): boolean {
     if (this.released.has(streamId) && !options?.force) {
       logger.debug(
@@ -100,7 +104,7 @@ export class ToolUseFollowUpQueue {
       return false;
     }
     const queue = this.acquire(streamId);
-    queue.enqueue(followUp, options?.mediaFiles);
+    queue.enqueue(followUp, options?.mediaFiles, options?.displayText);
     logger.debug(`Queued follow-up for stream ${streamId}.`);
     return true;
   }
@@ -110,9 +114,11 @@ export class ToolUseFollowUpQueue {
   }
 
   /** Drain queued follow-ups with their media file paths (resume replay). */
-  static drainItems(
-    streamId: StreamTabId,
-  ): Array<{ text: string; mediaFiles?: readonly string[] }> {
+  static drainItems(streamId: StreamTabId): Array<{
+    text: string;
+    displayText?: string;
+    mediaFiles?: readonly string[];
+  }> {
     return this.queues.get(streamId)?.drainItems() ?? [];
   }
 

--- a/src/skills/runtimeSkills.ts
+++ b/src/skills/runtimeSkills.ts
@@ -1,4 +1,5 @@
 import type { AgentTrace } from '@agent/trace';
+import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 
 import {
   discoverSkillSources,
@@ -36,6 +37,26 @@ export function formatRuntimeSkillCatalog(
       return `- ${skill.name}: ${skill.description}\n  Source: ${sourceLabel}\n  Path: ${skill.path}`;
     })
     .join('\n');
+}
+
+export function formatRuntimeSkillActivation({
+  skill,
+  source,
+}: SourcedSkill): string {
+  const sourceLabel = source.label ?? source.scope;
+  const body = escapeText(
+    skill.body.replaceAll('${TEXRA_SKILL_DIR}', skill.baseDir),
+  );
+  return [
+    `<skill name="${escapeAttr(skill.name)}">`,
+    `<source>${escapeText(sourceLabel)}</source>`,
+    `<path>${escapeText(skill.path)}</path>`,
+    `<skill_directory>${escapeText(skill.baseDir)}</skill_directory>`,
+    '<instructions>',
+    body,
+    '</instructions>',
+    '</skill>',
+  ].join('\n');
 }
 
 export async function loadRuntimeSkillCatalog(

--- a/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
@@ -15,6 +15,7 @@ describe('FollowUpQueue', () => {
 
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
       items: ['first', 'second'],
+      displayItems: ['first', 'second'],
       synthetic: false,
       mediaFiles: [],
     });
@@ -30,11 +31,13 @@ describe('FollowUpQueue', () => {
 
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
       items: ['compact now'],
+      displayItems: ['compact now'],
       synthetic: true,
       mediaFiles: [],
     });
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
       items: ['user text'],
+      displayItems: ['user text'],
       synthetic: false,
       mediaFiles: [],
     });
@@ -48,8 +51,27 @@ describe('FollowUpQueue', () => {
 
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
       items: ['look at this', 'and this'],
+      displayItems: ['look at this', 'and this'],
       synthetic: false,
       mediaFiles: ['/tmp/pasted/a.png', '/tmp/pasted/b.png'],
+    });
+  });
+
+  it('keeps injected text separate from display text', async () => {
+    const queue = new FollowUpQueue();
+
+    queue.enqueue(
+      '<skill_activation>hidden</skill_activation>',
+      undefined,
+      'fix theorem',
+    );
+
+    expect(queue.getAll()).toEqual(['fix theorem']);
+    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
+      items: ['<skill_activation>hidden</skill_activation>'],
+      displayItems: ['fix theorem'],
+      synthetic: false,
+      mediaFiles: [],
     });
   });
 
@@ -64,6 +86,7 @@ describe('FollowUpQueue', () => {
 
       await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
         items: ['compact now'],
+        displayItems: ['compact now'],
         synthetic: true,
         mediaFiles: [],
       });
@@ -85,6 +108,7 @@ describe('FollowUpQueue', () => {
 
       await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
         items: ['compact after interrupt'],
+        displayItems: ['compact after interrupt'],
         synthetic: true,
         mediaFiles: [],
       });
@@ -103,6 +127,7 @@ describe('FollowUpQueue', () => {
 
       await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
         items: ['describe the figure'],
+        displayItems: ['describe the figure'],
         synthetic: false,
         mediaFiles: ['/tmp/pasted/fig.png'],
       });

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -45,7 +45,11 @@ describe('tool-use follow-up progress events', () => {
     const result = await sendFollowUp(streamId, 'please continue');
 
     expect(result).toEqual({ status: 'sent' });
-    expect(appendFollowUp).toHaveBeenCalledWith('please continue', undefined);
+    expect(appendFollowUp).toHaveBeenCalledWith(
+      'please continue',
+      undefined,
+      undefined,
+    );
     expect(events).toEqual([
       {
         event: 'followUpSent',

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -75,7 +75,9 @@ describe('ToolUseWaitNode', () => {
           if (waitCalls === 1) {
             return {
               items: ['synthetic continuation'],
+              displayItems: ['synthetic continuation'],
               synthetic: true,
+              mediaFiles: [],
             };
           }
           interrupted = true;

--- a/src/test-kernel/cli/RunChatConfig.vitest.mts
+++ b/src/test-kernel/cli/RunChatConfig.vitest.mts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { buildInitialChatAgentConfig } from '@cli/chat/tui/runChatTui';
+import {
+  buildInitialChatAgentConfig,
+  restorePendingSkillActivations,
+  takePendingSkillActivations,
+} from '@cli/chat/tui/runChatTui';
 
 describe('CLI chat run config', () => {
   it('tags preset-launched team chats with the multi-agent preset id', () => {
@@ -32,5 +36,72 @@ describe('CLI chat run config', () => {
         workingDirectory: '/tmp/project',
       }),
     ).not.toHaveProperty('cliMultiAgentPresetId');
+  });
+
+  it('preserves display instruction separately from model instruction', () => {
+    expect(
+      buildInitialChatAgentConfig({
+        agent: 'chat',
+        model: 'deepseekT',
+        instruction: '<skill_activation>hidden</skill_activation>',
+        displayInstruction: 'summarize this proof',
+        workingDirectory: '/tmp/project',
+      }),
+    ).toMatchObject({
+      instruction: '<skill_activation>hidden</skill_activation>',
+      displayInstruction: 'summarize this proof',
+    });
+  });
+
+  it('reserves pending skill activations for only one prepared message', () => {
+    const pending = new Map([
+      ['proof-audit', '<skill_activation>proof</skill_activation>'],
+    ]);
+
+    const first = takePendingSkillActivations(pending, 'first request');
+    const second = takePendingSkillActivations(pending, 'second request');
+
+    expect(first).toMatchObject({
+      displayInstruction: 'first request',
+      reservedSkillActivations: [
+        {
+          name: 'proof-audit',
+          activationPrompt: '<skill_activation>proof</skill_activation>',
+        },
+      ],
+    });
+    expect(first.instruction).toContain(
+      '<skill_activation>proof</skill_activation>',
+    );
+    expect(first.instruction).toContain(
+      '<user_request>\nfirst request\n</user_request>',
+    );
+    expect(second).toEqual({
+      instruction: 'second request',
+      reservedSkillActivations: [],
+    });
+  });
+
+  it('restores reserved skill activations without replacing newer selections', () => {
+    const pending = new Map([
+      ['proof-audit', '<skill_activation>old</skill_activation>'],
+    ]);
+    const reserved = takePendingSkillActivations(
+      pending,
+      'first request',
+    ).reservedSkillActivations;
+
+    restorePendingSkillActivations(pending, reserved);
+    expect(pending.get('proof-audit')).toBe(
+      '<skill_activation>old</skill_activation>',
+    );
+
+    pending.clear();
+    pending.set('proof-audit', '<skill_activation>new</skill_activation>');
+    restorePendingSkillActivations(pending, reserved);
+
+    expect(pending.get('proof-audit')).toBe(
+      '<skill_activation>new</skill_activation>',
+    );
   });
 });

--- a/src/test-kernel/cli/RunChatConfig.vitest.mts
+++ b/src/test-kernel/cli/RunChatConfig.vitest.mts
@@ -125,10 +125,7 @@ describe('CLI chat run config', () => {
       ['proof-audit', '<skill_activation>proof</skill_activation>'],
     ]);
 
-    const prepared = takePendingSkillActivations(
-      pending,
-      'compare A < B & C',
-    );
+    const prepared = takePendingSkillActivations(pending, 'compare A < B & C');
 
     expect(prepared.displayInstruction).toBe('compare A < B & C');
     expect(prepared.instruction).toContain(

--- a/src/test-kernel/cli/RunChatConfig.vitest.mts
+++ b/src/test-kernel/cli/RunChatConfig.vitest.mts
@@ -53,6 +53,21 @@ describe('CLI chat run config', () => {
     });
   });
 
+  it('preserves an empty display instruction instead of dropping it', () => {
+    expect(
+      buildInitialChatAgentConfig({
+        agent: 'chat',
+        model: 'deepseekT',
+        instruction: '<skill_activation>hidden</skill_activation>',
+        displayInstruction: '',
+        workingDirectory: '/tmp/project',
+      }),
+    ).toMatchObject({
+      instruction: '<skill_activation>hidden</skill_activation>',
+      displayInstruction: '',
+    });
+  });
+
   it('reserves pending skill activations for only one prepared message', () => {
     const pending = new Map([
       ['proof-audit', '<skill_activation>proof</skill_activation>'],
@@ -102,6 +117,22 @@ describe('CLI chat run config', () => {
 
     expect(pending.get('proof-audit')).toBe(
       '<skill_activation>new</skill_activation>',
+    );
+  });
+
+  it('escapes user request text inside skill activation wrappers', () => {
+    const pending = new Map([
+      ['proof-audit', '<skill_activation>proof</skill_activation>'],
+    ]);
+
+    const prepared = takePendingSkillActivations(
+      pending,
+      'compare A < B & C',
+    );
+
+    expect(prepared.displayInstruction).toBe('compare A < B & C');
+    expect(prepared.instruction).toContain(
+      '<user_request>\ncompare A &lt; B &amp; C\n</user_request>',
     );
   });
 });

--- a/src/test-kernel/cli/SkillsListForm.vitest.mts
+++ b/src/test-kernel/cli/SkillsListForm.vitest.mts
@@ -80,6 +80,20 @@ describe('SkillsListForm helpers', () => {
     expect(prompt).toContain('Use proof-audit.');
   });
 
+  it('escapes skill names in activation prose defensively', () => {
+    const prompt = formatSkillActivationPrompt(
+      sourcedSkill({
+        name: 'proof<audit &',
+        description: 'Review mathematical proof steps.',
+        scope: 'project',
+      }),
+    );
+
+    expect(prompt).toContain(
+      'The user selected the proof&lt;audit &amp; skill.',
+    );
+  });
+
   it('reserves one extra row when import issues are visible', () => {
     expect(
       skillsSelectWindow({

--- a/src/test-kernel/cli/SkillsListForm.vitest.mts
+++ b/src/test-kernel/cli/SkillsListForm.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatSkillActivationPrompt,
   skillSelectItemsForTui,
   skillsSelectWindow,
 } from '@cli/chat/tui/forms/SkillsListForm';
@@ -47,11 +48,36 @@ describe('SkillsListForm helpers', () => {
       ]),
     ).toEqual([
       {
-        value: '/tmp/proof-audit/SKILL.md',
+        value: {
+          name: 'proof-audit',
+          activationPrompt: formatSkillActivationPrompt(
+            sourcedSkill({
+              name: 'proof-audit',
+              description: 'Review mathematical proof steps.',
+              scope: 'project',
+              label: 'project',
+            }),
+          ),
+        },
         label: 'proof-audit',
         description: 'project · Review mathematical proof steps.',
       },
     ]);
+  });
+
+  it('formats the skill activation prompt with the skill body', () => {
+    const prompt = formatSkillActivationPrompt(
+      sourcedSkill({
+        name: 'proof-audit',
+        description: 'Review mathematical proof steps.',
+        scope: 'project',
+      }),
+    );
+
+    expect(prompt).toContain('<skill_activation>');
+    expect(prompt).toContain('<skill name="proof-audit">');
+    expect(prompt).toContain('<path>/tmp/proof-audit/SKILL.md</path>');
+    expect(prompt).toContain('Use proof-audit.');
   });
 
   it('reserves one extra row when import issues are visible', () => {

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -306,6 +306,45 @@ describe('slashRegistry', () => {
     expect(sawClosedBeforeResume).toBe(true);
   });
 
+  it('routes skill picker selections through the shared handler', async () => {
+    const selected: string[] = [];
+    let closed = false;
+    let sawClosedBeforeSkillSelect = false;
+    registerBuiltinSlashCommands({
+      onSkillSelect: (value) => {
+        sawClosedBeforeSkillSelect = closed;
+        selected.push(value.activationPrompt);
+      },
+    });
+    const skills = listSlashCommands().find((cmd) => cmd.name === 'skills');
+
+    if (!skills) throw new Error('Expected /skills to be registered');
+
+    expect(openRegisteredCliSlashForm(skills, '')).toBe(true);
+
+    const skillsNode = renderFormAdapter<{
+      onSelect?: (value: {
+        readonly name: string;
+        readonly activationPrompt: string;
+      }) => void;
+    }>(
+      cliState.activeForm.get()?.render(() => {
+        closed = true;
+      }, 20),
+    );
+    skillsNode.props?.onSelect?.({
+      name: 'proof-audit',
+      activationPrompt: '<skill_activation>proof-audit</skill_activation>',
+    });
+    await settleFormSelection();
+
+    expect(selected).toEqual([
+      '<skill_activation>proof-audit</skill_activation>',
+    ]);
+    expect(closed).toBe(true);
+    expect(sawClosedBeforeSkillSelect).toBe(true);
+  });
+
   it('matches by name prefix case-insensitively', () => {
     registerSlashCommand({ name: 'model', description: 'pick a model' });
     registerSlashCommand({ name: 'agent', description: 'pick an agent' });

--- a/src/test-kernel/skills/RuntimeSkills.vitest.mts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.mts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import {
   clearRuntimeSkillSources,
+  formatRuntimeSkillActivation,
   loadRuntimeSkillCatalog,
   setRuntimeSkillSources,
 } from '@skills/runtimeSkills';
@@ -52,6 +53,33 @@ afterEach(async () => {
 });
 
 describe('runtime skills', () => {
+  it('formats selected skills for activation with skill directory substitution', () => {
+    const activation = formatRuntimeSkillActivation({
+      skill: {
+        name: 'proof-audit',
+        description: 'Review mathematical proof steps.',
+        body: 'Read ${TEXRA_SKILL_DIR}/references/checklist.md first & compare <proof>.',
+        baseDir: '/tmp/proof-audit',
+        path: '/tmp/proof-audit/SKILL.md',
+        frontmatter: {
+          name: 'proof-audit',
+          description: 'Review mathematical proof steps.',
+        },
+      },
+      source: {
+        scope: 'project',
+        path: '/tmp/.texra/skills',
+        label: 'project',
+      },
+    });
+
+    expect(activation).toContain('<skill name="proof-audit">');
+    expect(activation).toContain('<source>project</source>');
+    expect(activation).toContain(
+      'Read /tmp/proof-audit/references/checklist.md first &amp; compare &lt;proof>.',
+    );
+  });
+
   it('formats configured runtime skills for prompt injection', async () => {
     const root = await createTempRoot();
     const skillPath = await writeSkill(


### PR DESCRIPTION
## Summary

- Make the CLI `/skills` TUI picker actionable instead of read-only.
- Align picker activation with the Agent Skills protocol / local skills PRD: selecting a skill stages a `<skill_activation>` payload containing the selected `SKILL.md` body, source, path, and skill directory for the next substantive user message.
- Escape activated skill instructions before embedding them in XML-shaped context, including `${TEXRA_SKILL_DIR}` substitution.
- Keep skill activation context model-facing only: progress logs and queued follow-up previews use the original user text, while the model receives the activation payload plus `<user_request>` wrapper.
- Reserve pending skill activations for exactly one prepared message; failed delivery restores the reservation without overwriting newer same-skill selections.
- Keep the activation payload DRY by formatting the selected skill in `src/skills/runtimeSkills.ts` and threading the typed selection through the shared slash-form helper.
- Close the picker before running the selection handler and remove the unused selected-skill `path` pass-through.

Refs #4064.

## Validation

- npm run test:kernel -- src/test-kernel/cli/SkillsListForm.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/RunChatConfig.vitest.mts src/test-kernel/skills/RuntimeSkills.vitest.mts src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-skills-activation-20260605-r5 skills-form skills-form-select-submit
- npm run compile:safe
- npm run lint (same 7 pre-existing import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent instruction delivery, follow-up queuing, and resume replay; mistakes could leak hidden XML to the UI or drop staged activations, but behavior is covered by kernel and TUI validation tests.
> 
> **Overview**
> The CLI **`/skills`** picker is now **actionable**: choosing a skill stages activation for the **next user message**, with copy and key hints updated from browse-only to **activate**.
> 
> Activation builds a shared **`<skill_activation>`** payload (via `formatRuntimeSkillActivation`) with escaped XML, `${TEXRA_SKILL_DIR}` substitution, and the user text wrapped in **`<user_request>`**. The agent still receives the full **`instruction`**, while logs and queued follow-up previews use optional **`displayInstruction`** / **`displayText`** threaded through agent config, follow-up queues, tool-use wait/cycle nodes, and resume replay.
> 
> Pending activations apply to **one** prepared send; failed start or undelivered follow-ups **restore** reservations without overwriting a newer selection for the same skill. **`/clear`** clears pending skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429e5f314a819ec7a1e780ce4eb877ff846d447d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

