### PR TITLE
[codex] Prefer local CLI skill sources

### DIFF
--- a/src/skills/skillSources.ts
+++ b/src/skills/skillSources.ts
@@ -59,36 +59,7 @@ export function defaultSkillSources(
   options: SkillSourceOptions = {},
 ): SkillSource[] {
   const home = os.homedir();
-  const sources: SkillSource[] = [
-    ...bundledSkillSources(context.resourcesPath),
-    {
-      scope: 'user',
-      path: path.join(home, '.texra', 'skills'),
-      label: 'user',
-    },
-    {
-      scope: 'project',
-      path: path.join(context.cwd, '.texra', 'skills'),
-      label: 'project',
-    },
-  ];
-
-  if (options.includeInterop === true) {
-    for (const dir of INTEROP_SKILL_DIRS) {
-      sources.push(
-        {
-          scope: 'interop',
-          path: path.join(home, dir, 'skills'),
-          label: `${dir} user`,
-        },
-        {
-          scope: 'interop',
-          path: path.join(context.cwd, dir, 'skills'),
-          label: `${dir} project`,
-        },
-      );
-    }
-  }
+  const sources: SkillSource[] = [];
 
   for (const candidate of options.additionalPaths ?? []) {
     sources.push({
@@ -98,6 +69,40 @@ export function defaultSkillSources(
       required: true,
     });
   }
+
+  sources.push({
+    scope: 'project',
+    path: path.join(context.cwd, '.texra', 'skills'),
+    label: 'project',
+  });
+
+  if (options.includeInterop === true) {
+    for (const dir of INTEROP_SKILL_DIRS) {
+      sources.push({
+        scope: 'interop',
+        path: path.join(context.cwd, dir, 'skills'),
+        label: `${dir} project`,
+      });
+    }
+  }
+
+  sources.push({
+    scope: 'user',
+    path: path.join(home, '.texra', 'skills'),
+    label: 'user',
+  });
+
+  if (options.includeInterop === true) {
+    for (const dir of INTEROP_SKILL_DIRS) {
+      sources.push({
+        scope: 'interop',
+        path: path.join(home, dir, 'skills'),
+        label: `${dir} user`,
+      });
+    }
+  }
+
+  sources.push(...bundledSkillSources(context.resourcesPath));
 
   return uniqueSources(sources);
 }

--- a/src/test-kernel/cli/CliSkills.vitest.mts
+++ b/src/test-kernel/cli/CliSkills.vitest.mts
@@ -48,10 +48,13 @@ afterEach(async () => {
 
 describe('CLI skills runtime', () => {
   it('resolves default, interop, and custom skill sources in precedence order', () => {
+    const cwd = '/tmp/project';
+    const resourcesPath = '/tmp/resources';
+    const bundledSourcePath = path.resolve(resourcesPath, '../../..', 'skills');
     const sources = defaultSkillSources(
       {
-        cwd: '/tmp/project',
-        resourcesPath: '/tmp/resources',
+        cwd,
+        resourcesPath,
       },
       {
         includeInterop: true,
@@ -59,26 +62,73 @@ describe('CLI skills runtime', () => {
       },
     );
 
-    expect(sources.map((source) => source.path)).toEqual(
-      expect.arrayContaining([
-        '/tmp/resources/skills',
-        path.join(os.homedir(), '.texra', 'skills'),
-        '/tmp/project/.texra/skills',
-        path.join(os.homedir(), '.claude', 'skills'),
-        '/tmp/project/.claude/skills',
-        path.join(os.homedir(), '.codex', 'skills'),
-        '/tmp/project/.codex/skills',
-        path.join(os.homedir(), '.gemini', 'skills'),
-        '/tmp/project/.gemini/skills',
-        '/tmp/project/vendor/skills',
-      ]),
-    );
+    expect(sources.map((source) => source.path)).toEqual([
+      '/tmp/project/vendor/skills',
+      '/tmp/project/.texra/skills',
+      '/tmp/project/.claude/skills',
+      '/tmp/project/.codex/skills',
+      '/tmp/project/.gemini/skills',
+      path.join(os.homedir(), '.texra', 'skills'),
+      path.join(os.homedir(), '.claude', 'skills'),
+      path.join(os.homedir(), '.codex', 'skills'),
+      path.join(os.homedir(), '.gemini', 'skills'),
+      '/tmp/resources/skills',
+      bundledSourcePath,
+    ]);
+    expect(sources.map((source) => source.scope)).toEqual([
+      'custom',
+      'project',
+      'interop',
+      'interop',
+      'interop',
+      'user',
+      'interop',
+      'interop',
+      'interop',
+      'bundled',
+      'bundled',
+    ]);
+    expect(sources.map((source) => source.label)).toEqual([
+      'custom',
+      'project',
+      '.claude project',
+      '.codex project',
+      '.gemini project',
+      'user',
+      '.claude user',
+      '.codex user',
+      '.gemini user',
+      'bundled',
+      'bundled source',
+    ]);
     expect(
       sources.find((source) => source.path === '/tmp/project/vendor/skills'),
     ).toMatchObject({ required: true, scope: 'custom' });
   });
 
-  it('lists bundled skills before custom duplicate names', async () => {
+  it('deduplicates repeated source paths while preserving required custom roots', () => {
+    const sources = defaultSkillSources(
+      {
+        cwd: '/tmp/project',
+        resourcesPath: '/tmp/resources',
+      },
+      {
+        additionalPaths: ['.texra/skills'],
+      },
+    );
+
+    expect(
+      sources.filter((source) => source.path === '/tmp/project/.texra/skills'),
+    ).toEqual([
+      expect.objectContaining({
+        scope: 'custom',
+        label: 'custom',
+        required: true,
+      }),
+    ]);
+  });
+
+  it('lists custom duplicate names before bundled skills', async () => {
     const resources = await createTempRoot();
     const custom = await createTempRoot();
     await fs.mkdir(path.join(resources, 'skills'));
@@ -102,17 +152,64 @@ describe('CLI skills runtime', () => {
 
     expect(result.skills.map(skillListRecord)).toMatchObject([
       {
-        name: 'shared-skill',
-        description: 'The bundled skill.',
-        scope: 'bundled',
-      },
-      {
         name: 'custom-only',
         description: 'The custom-only skill.',
         scope: 'custom',
       },
+      {
+        name: 'shared-skill',
+        description: 'The custom skill.',
+        scope: 'custom',
+      },
     ]);
     expect(formatCliSkillList(result.skills)).toContain(
+      'custom\tshared-skill\tThe custom skill.',
+    );
+    expect(formatCliSkillList(result.skills)).not.toContain(
+      'bundled\tshared-skill\tThe bundled skill.',
+    );
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        code: 'duplicate_name',
+        name: 'shared-skill',
+      }),
+    );
+  });
+
+  it('lists project duplicate names before bundled skills', async () => {
+    const project = await createTempRoot();
+    const resources = await createTempRoot();
+    await fs.mkdir(path.join(project, '.texra', 'skills'), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(resources, 'skills'));
+    await writeSkill(
+      path.join(resources, 'skills'),
+      'shared-skill',
+      'The bundled skill.',
+    );
+    await writeSkill(
+      path.join(project, '.texra', 'skills'),
+      'shared-skill',
+      'The project skill.',
+    );
+
+    const result = await readCliSkills({
+      cwd: project,
+      resourcesPath: resources,
+    });
+
+    expect(result.skills.map(skillListRecord)).toMatchObject([
+      {
+        name: 'shared-skill',
+        description: 'The project skill.',
+        scope: 'project',
+      },
+    ]);
+    expect(formatCliSkillList(result.skills)).toContain(
+      'project\tshared-skill\tThe project skill.',
+    );
+    expect(formatCliSkillList(result.skills)).not.toContain(
       'bundled\tshared-skill\tThe bundled skill.',
     );
     expect(result.errors).toContainEqual(


### PR DESCRIPTION
## Summary
- Search explicit, project, and user skill roots before bundled skills in the CLI runtime catalog.
- Keep project skills visible at the top of `/skills` and allow local skills to shadow bundled names.
- Add focused CLI skills coverage for source precedence, deduplication, and duplicate-name behavior.

## Root Cause
The TUI harness seeded a project skill (`proof-audit`), but `/skills` listed bundled skills first because `defaultSkillSources` searched bundled roots before local roots. Since skill discovery keeps the first skill name it sees, local skills were hidden below bundled entries and could not override bundled names.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/CliSkills.vitest.mts src/test-kernel/skills/LoadSkills.vitest.mts src/test-kernel/skills/RuntimeSkills.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-dogfood-snapshots-20260605-skills-fix skills-form skills-form-select-submit`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-dogfood-snapshots-20260605-2 transcript plain-submit kitty-shift-enter-newline ctrl-j-newline model-form no-color-model-form model-form-selectable model-switch-compatible-only orchestrate-relay-model-pick orchestrate-personal-model-pick approval-form bash-approval external-inquiry-copy-question subagent-picker task-picker skills-form skills-form-select-submit`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes skill catalog precedence for all CLI users; behavior is intentional but affects which skill content runs when names collide.
> 
> **Overview**
> **Reorders CLI skill source discovery** so `defaultSkillSources` walks **custom → project → interop (project) → user → interop (user) → bundled** instead of leading with bundled paths. Because the catalog keeps the **first** occurrence of each skill name, project and explicit custom skills now appear in `/skills` and can **override** bundled names that used to win.
> 
> **Tests** now assert the full source path/scope/label ordering, deduplication when a custom path overlaps `.texra/skills`, and that duplicate-name listings prefer **custom** or **project** over **bundled** (with `duplicate_name` warnings unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a3b477a9f62a3528074973317b4e4549075245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->