### PR TITLE
[codex] Show descriptions for CLI resume rows

### DIFF
--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -9,7 +9,7 @@ import {
   resumableCliHistoryEntries,
   type CliHistoryEntry,
 } from '@cli/runtime/history';
-import { formatCliHistoryInputLabel } from '@cli/runtime/historyLabels';
+import { formatCliHistoryResumeInputLabel } from '@cli/runtime/historyLabels';
 import type { ExecutionId } from '@shared/schemas';
 
 import { KeyHints } from '../ui/KeyHints';
@@ -35,7 +35,7 @@ export function resumeSelectWindow(args: {
 }
 
 export function resumeEntryDescription(entry: CliHistoryEntry): string {
-  const input = formatCliHistoryInputLabel(entry.inputBasename);
+  const input = formatCliHistoryResumeInputLabel(entry);
   return `${entry.timestamp}; ${entry.agent}; ${entry.status}; ${input}`;
 }
 

--- a/packages/cli/src/runtime/historyLabels.ts
+++ b/packages/cli/src/runtime/historyLabels.ts
@@ -1,3 +1,14 @@
-export function formatCliHistoryInputLabel(inputBasename: string): string {
+import type { CliHistoryEntry } from './history';
+
+function formatCliHistoryInputLabel(inputBasename: string): string {
   return inputBasename === '-' ? 'no input' : inputBasename;
+}
+
+export function formatCliHistoryResumeInputLabel(
+  entry: Pick<CliHistoryEntry, 'description' | 'inputBasename'>,
+): string {
+  if (entry.inputBasename !== '-') {
+    return formatCliHistoryInputLabel(entry.inputBasename);
+  }
+  return entry.description?.trim() || 'no input';
 }

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -7,7 +7,7 @@ import {
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
 import { implicitDefaultToolUseAgents } from './defaultAgents';
-import { formatCliHistoryInputLabel } from './historyLabels';
+import { formatCliHistoryResumeInputLabel } from './historyLabels';
 import { resumableCliHistoryEntries, type CliHistoryEntry } from './history';
 
 export type CliOrchestrationAction =
@@ -70,7 +70,7 @@ function recentResumeItems(
     .map((entry) => ({
       value: { kind: 'resume', id: entry.id },
       label: `Resume ${entry.id}`,
-      description: `${entry.agent}; ${entry.status}; ${formatCliHistoryInputLabel(entry.inputBasename)}`,
+      description: `${entry.agent}; ${entry.status}; ${formatCliHistoryResumeInputLabel(entry)}`,
     }));
 }
 

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -197,6 +197,25 @@ describe('CLI orchestration items', () => {
     expect(items[1]?.description).toBe('review; resumable; paper.tex');
   });
 
+  it('uses the history description for resume launcher rows without input files', () => {
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [
+        historyEntry('aaaaaaaaaaaa', {
+          agent: 'chat',
+          status: CLI_HISTORY_RESUMABLE_STATUS,
+          inputBasename: '-',
+          description: 'Sketching inductive Lean proof of Nat.add_comm.',
+        }),
+      ],
+      toolUseAgents: [toolUseAgent('chat')],
+    });
+
+    expect(items[1]?.description).toBe(
+      'chat; resumable; Sketching inductive Lean proof of Nat.add_comm.',
+    );
+  });
+
   it('filters recent agent entries to known tool-use agents', () => {
     const items = buildCliOrchestrationItems({
       presetPlans: [],

--- a/src/test-kernel/cli/ResumeListForm.vitest.mts
+++ b/src/test-kernel/cli/ResumeListForm.vitest.mts
@@ -48,4 +48,34 @@ describe('CLI ResumeListForm labels', () => {
       }),
     ).toBe('2026-05-20T21:00:00.000Z; chat; resumable; no input');
   });
+
+  it('uses the history description for sessions without an input file', () => {
+    expect(
+      resumeEntryDescription({
+        id: 'abc',
+        timestamp: '2026-05-20T21:00:00.000Z',
+        agent: 'chat',
+        model: 'deepseekT',
+        status: CLI_HISTORY_RESUMABLE_STATUS,
+        inputBasename: '-',
+        description: 'Sketching inductive Lean proof of Nat.add_comm.',
+      }),
+    ).toBe(
+      '2026-05-20T21:00:00.000Z; chat; resumable; Sketching inductive Lean proof of Nat.add_comm.',
+    );
+  });
+
+  it('keeps input file names ahead of history descriptions', () => {
+    expect(
+      resumeEntryDescription({
+        id: 'abc',
+        timestamp: '2026-05-20T21:00:00.000Z',
+        agent: 'polish',
+        model: 'deepseekT',
+        status: CLI_HISTORY_RESUMABLE_STATUS,
+        inputBasename: 'paper.tex',
+        description: 'Rewrite the introduction.',
+      }),
+    ).toBe('2026-05-20T21:00:00.000Z; polish; resumable; paper.tex');
+  });
 });


### PR DESCRIPTION
## Summary
- Use a shared CLI history-label helper for human-facing resume rows.
- Show the stored history description when a resumable chat has no input file.
- Apply the same label in the startup orchestration launcher and the `/resume` form, while preserving file-name labels when an input file exists.

Fixes #5355.

## Root Cause
The launcher and `/resume` form both formatted `inputBasename === "-"` as `no input`, even though chat history entries can carry a useful generated description for the session.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ResumeListForm.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-resume-description-snapshots orchestrate-launcher`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label logic in CLI resume/orchestration UI with no auth, data, or execution-path changes.
> 
> **Overview**
> Resume rows in the **startup orchestration launcher** and **`/resume`** form now share `formatCliHistoryResumeInputLabel`, which still shows the input file basename when one exists, but falls back to the stored history **description** (trimmed) when `inputBasename` is `-`, instead of always showing **no input**.
> 
> The previous basename-only helper is kept internal to `historyLabels.ts`; call sites switch to the new resume-specific formatter. Vitest covers description fallback and file-name precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df543804c44530bd2ef5698146778316b990889b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->