### PR TITLE
[codex] Hide approval-gated tools in CLI chat

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -41,6 +41,7 @@ import { isOAuthProvider, type OAuthProvider } from '@auth/sharedConfig';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
 import { formatCliAccountLabelForDisplay } from '@cli/runtime/accountDisplay';
 import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
+import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
 import {
   effectiveCliApiMode,
   formatCliApiMode,
@@ -1262,6 +1263,7 @@ export async function runChat(
     let executionRegistered = false;
     let agentSettled = false;
     session.executionId = executionId;
+    const approvalsUnavailable = approvalPromptsUnavailable(sessionContext);
 
     const runPromise = setCliHelperModel(currentModel)
       .then(() => registerFreshChatExecution(executionId, config))
@@ -1270,6 +1272,7 @@ export async function runChat(
         return executeAgent(registeredConfig, executionId, {
           runtimeHost: wrapped,
           enforceCategory: true,
+          approvalPromptsUnavailable: approvalsUnavailable,
           onStreamResolved: (resolvedStreamId) => {
             session.streamId = resolvedStreamId;
             moveLocalTranscriptToStream(resolvedStreamId);
@@ -1390,9 +1393,14 @@ export async function runChat(
     const wrapped = wrapRuntimeHost(runtimeHost);
     const unbindApprovals = installTuiApprovals(wrapped, sessionContext);
     disposers.push(unbindApprovals);
+    const approvalsUnavailable = approvalPromptsUnavailable(sessionContext);
 
     session.runPromise = setCliHelperModel(currentModel)
-      .then(() => resumeToolUseFromSnapshot(resolution.snapshot, wrapped))
+      .then(() =>
+        resumeToolUseFromSnapshot(resolution.snapshot, wrapped, {
+          approvalPromptsUnavailable: approvalsUnavailable,
+        }),
+      )
       .then(() => {
         // resumeToolUseFromSnapshot resolves void (no result object), so the
         // streamId we already know is the only handle: flush the tail and

--- a/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
+++ b/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
@@ -1,21 +1,14 @@
-export type ApprovalInstructionContext = {
-  readonly approvalPolicy: 'ask' | 'never' | 'yolo';
-  readonly mode: 'headless' | 'interactive';
-};
+import {
+  approvalPromptsUnavailable,
+  type ApprovalInstructionContext,
+} from '@cli/runtime/approvalPolicyAvailability';
+
+export { approvalPromptsUnavailable, type ApprovalInstructionContext };
 
 const PRIVILEGED_ACTION_GUIDANCE =
   'Do not call approval-gated tools such as bash/shell commands, file edits, setup/config updates, user questions, retry/plan approvals, or new subagent delegations; solve from the provided context or state what approval is needed.';
 const CLI_APPROVAL_POLICY_GUIDANCE =
   'Valid CLI approval policies are "ask", "never", and "yolo" only. If suggesting a rerun, use --approval-policy yolo for headless auto-approval or an interactive run with --approval-policy ask; do not invent other approval mode names.';
-
-export function approvalPromptsUnavailable(
-  context: ApprovalInstructionContext,
-): boolean {
-  return (
-    context.approvalPolicy === 'never' ||
-    (context.mode === 'headless' && context.approvalPolicy === 'ask')
-  );
-}
 
 export function formatUnavailableApprovalInstruction(
   context: ApprovalInstructionContext,

--- a/packages/cli/src/runtime/approvalPolicyAvailability.ts
+++ b/packages/cli/src/runtime/approvalPolicyAvailability.ts
@@ -1,0 +1,15 @@
+import type { CliApprovalPolicy } from '../schemas/cliSettings';
+
+export type ApprovalInstructionContext = {
+  readonly approvalPolicy: CliApprovalPolicy;
+  readonly mode: 'headless' | 'interactive';
+};
+
+export function approvalPromptsUnavailable(
+  context: ApprovalInstructionContext,
+): boolean {
+  return (
+    context.approvalPolicy === 'never' ||
+    (context.mode === 'headless' && context.approvalPolicy === 'ask')
+  );
+}

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -57,15 +57,17 @@ async function resumeFromSnapshot(
       streamId,
     });
 
-    await resumeToolUseFromSnapshot(snapshot, runtimeHost, (session) => {
-      const allFollowUps =
-        followUp !== undefined
-          ? [{ text: followUp }, ...queuedFollowUps]
-          : queuedFollowUps;
+    await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
+      setupSession: (session) => {
+        const allFollowUps =
+          followUp !== undefined
+            ? [{ text: followUp }, ...queuedFollowUps]
+            : queuedFollowUps;
 
-      for (const item of allFollowUps) {
-        session.appendFollowUp(item.text, item.mediaFiles, item.displayText);
-      }
+        for (const item of allFollowUps) {
+          session.appendFollowUp(item.text, item.mediaFiles, item.displayText);
+        }
+      },
     });
 
     return { success: true };

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -533,10 +533,16 @@ export async function executeAgent(
   });
 }
 
+export interface ResumeToolUseFromSnapshotOptions {
+  /** Hide tools whose approval prompts cannot be answered in this host mode. */
+  readonly approvalPromptsUnavailable?: boolean;
+  readonly setupSession?: (session: IToolUseSession) => void;
+}
+
 export async function resumeToolUseFromSnapshot(
   snapshot: ToolUseSessionSnapshot,
   runtimeHost: AgentRuntimeHost,
-  setupSession?: (session: IToolUseSession) => void,
+  options: ResumeToolUseFromSnapshotOptions = {},
 ): Promise<void> {
   const ctx = await buildAgentLaunchContext({
     configPayload: snapshot.agentConfig,
@@ -553,6 +559,7 @@ export async function resumeToolUseFromSnapshot(
   ctx.delegationDepth = await computeDelegationDepthFromStorage(
     snapshot.executionId,
   );
+  ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
   const { setting, streamId } = ctx;
 
   await withExecutionRunContext(ctx, async () => {
@@ -583,13 +590,16 @@ export async function resumeToolUseFromSnapshot(
             // would drop subagent-specific instructions (e.g. the shared
             // /memories protocol) that the fresh run had included.
             isSubagent: (ctx.delegationDepth ?? 0) > 0,
+            approvalPromptsUnavailable: options.approvalPromptsUnavailable,
             onFollowUpConsumed: () =>
               ctx.runtimeHost.emit('updateQueuedFollowUps', {
                 streamId: ctx.streamId,
               }),
           },
           undefined,
-          setupSession ? (context) => setupSession(context.session) : undefined,
+          options.setupSession
+            ? (context) => options.setupSession?.(context.session)
+            : undefined,
         );
         return {
           category: 'toolUse' as const,


### PR DESCRIPTION
## Summary
- Share the CLI approval-prompt availability predicate from `runtime/` instead of keeping it command-only.
- Pass `approvalPromptsUnavailable` into fresh interactive `texra chat` runs so `--approval-policy=never` hides approval-gated tools before model invocation.
- Extend `resumeToolUseFromSnapshot` with an options object and pass the same approval-unavailable flag for resumed CLI chats.
- Update the extension resume caller to the options object with unchanged behavior.

Fixes #5354.

## Root Cause
Headless CLI runs already passed `approvalPromptsUnavailable` into agent execution, but the interactive TUI path only rejected approval events after the model had already received tools such as `bash`. This let models repeatedly call tools that were guaranteed to be denied under `--approval-policy=never`.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/MultiAgentInstruction.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/agent/ResponseCycleTools.vitest.mts src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts`
- `npm run compile:safe`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted CLI/runtime wiring and a resume API shape change; behavior aligns interactive chat with existing headless tool filtering.
> 
> **Overview**
> Interactive **`texra chat`** now passes **`approvalPromptsUnavailable`** into agent execution (fresh runs and resumed sessions), matching headless behavior so approval-gated tools are **hidden from the model** when prompts cannot be answered (e.g. **`--approval-policy=never`**), instead of only failing after tool calls.
> 
> The availability predicate and **`ApprovalInstructionContext`** move to **`@cli/runtime/approvalPolicyAvailability`** and are re-exported from the command helper. **`resumeToolUseFromSnapshot`** takes an **options object** (`approvalPromptsUnavailable`, **`setupSession`**) so the VS Code resume path keeps the same follow-up wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc8e13554117942d38156113f8c81e1d4dbb7d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->