### PR TITLE
[codex] Fix raw Escape close for CLI list forms

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -33,6 +33,7 @@ import { TipRow } from './panes/TipRow';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './panes/TodosPlanPanel';
 import { currentApproval, type PendingApproval } from './state/approvalQueue';
 import {
+  isEscapeInput,
   metaChordDigit,
   metaChordInput,
   rewriteKittyEnterInput,
@@ -708,7 +709,7 @@ export function App(props: AppProps): React.JSX.Element {
 
     // Escape interrupts an active run.
     if (
-      key.escape &&
+      isEscapeInput(input, key) &&
       appEscapeInterruptActive({
         inputDisabled,
         reverseSearchOpen,

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -9,7 +9,7 @@ import {
   type SlashCommand,
   type SlashPickIntent,
 } from './slashRegistry';
-import { isPlainReturnInput } from '../input/inputKeys';
+import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 
 export interface SlashPaletteProps {
@@ -144,7 +144,7 @@ export function SlashPalette(
 
   useInput(
     (input, key) => {
-      if (key.escape) {
+      if (isEscapeInput(input, key)) {
         props.onCancel();
         return;
       }

--- a/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
@@ -6,6 +6,11 @@
 import { useInput } from 'ink';
 import { useEffect, useState } from 'react';
 
+import {
+  isEscapeInput,
+  type ReturnKeyInput,
+} from '@cli/chat/tui/input/inputKeys';
+
 export interface AsyncListFormState<T> {
   readonly data: T | undefined;
   readonly loading: boolean;
@@ -30,6 +35,19 @@ export interface UseAsyncListFormOptions<T> {
   readonly isEmpty?: (data: T) => boolean;
 }
 
+export function shouldCloseAsyncListFormOnInput(args: {
+  readonly input: string;
+  readonly key: Pick<ReturnKeyInput, 'escape'>;
+  readonly loading: boolean;
+  readonly error: string | undefined;
+  readonly empty: boolean;
+}): boolean {
+  return (
+    (args.loading || args.error !== undefined || args.empty) &&
+    isEscapeInput(args.input, args.key)
+  );
+}
+
 /**
  * Run the form's loader on mount, expose `loading` / `error` / `data`, and wire
  * `Esc` to close while the panel is loading, errored, or empty. Matches the
@@ -47,7 +65,15 @@ export function useAsyncListForm<T>(
     data !== undefined && options.isEmpty ? options.isEmpty(data) : false;
 
   useInput((_input, key) => {
-    if ((loading || error !== undefined || empty) && key.escape) {
+    if (
+      shouldCloseAsyncListFormOnInput({
+        input: _input,
+        key,
+        loading,
+        error,
+        empty,
+      })
+    ) {
       options.onClose();
     }
   });

--- a/packages/cli/src/chat/tui/input/ReverseSearch.tsx
+++ b/packages/cli/src/chat/tui/input/ReverseSearch.tsx
@@ -9,7 +9,7 @@ import { Box, Text, useInput } from 'ink';
 
 import { KeyHints } from '../ui/KeyHints';
 import { BaseTextInput } from './BaseTextInput';
-import { isCtrlInput } from './inputKeys';
+import { isCtrlInput, isEscapeInput } from './inputKeys';
 import type { InputHistory } from '../history/inputHistory';
 
 export interface ReverseSearchProps {
@@ -30,7 +30,7 @@ export function ReverseSearch(props: ReverseSearchProps): React.JSX.Element {
   const match = props.history.reverseFind(query, cursor);
 
   useInput((input, key) => {
-    if (key.escape || isCtrlInput(input, key, 'g')) {
+    if (isEscapeInput(input, key) || isCtrlInput(input, key, 'g')) {
       props.onCancel();
       return;
     }

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -11,6 +11,7 @@ import {
   confirmCardKeyHintsForWidth,
 } from './ConfirmCardState';
 import { BaseTextInput } from '../input/BaseTextInput';
+import { isEscapeInput } from '../input/inputKeys';
 import { KEY_HINT_SEPARATOR, KeyHints } from '../ui/KeyHints';
 import type {
   ApprovalBypassKind,
@@ -74,7 +75,7 @@ export function ConfirmCard({
   useInput(
     (input, key) => {
       if (feedbackMode) {
-        if (key.escape) {
+        if (isEscapeInput(input, key)) {
           setFeedbackActive(false);
           updateFeedback('');
         }

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -1,4 +1,5 @@
 import { KEY_HINT_SEPARATOR } from '../ui/KeyHints';
+import { isEscapeInput } from '../input/inputKeys';
 
 export type ConfirmCardKeyAction =
   | 'approve'
@@ -34,7 +35,7 @@ export function confirmCardKeyAction(
   key: ConfirmCardKey,
   allowAlways: boolean,
 ): ConfirmCardKeyAction {
-  if (key.escape) return 'reject';
+  if (isEscapeInput(input, key)) return 'reject';
   if (key.ctrl || key.meta) return 'ignore';
   switch (input.toLowerCase()) {
     case 'y':

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -6,6 +6,7 @@ import type { ExternalInquiryPermission } from '@shared/schemas';
 
 import { CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import { BaseTextInput } from '../input/BaseTextInput';
+import { isEscapeInput } from '../input/inputKeys';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import {
   maxScrollableRowOffset,
@@ -304,7 +305,7 @@ export function ExternalInquiry(
   }, [maxQuestionOffset]);
 
   useInput((input, key) => {
-    if (key.escape) {
+    if (isEscapeInput(input, key)) {
       props.onDecide({
         accepted: false,
         userMessage: 'External inquiry skipped by user.',

--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Box, Text, useInput } from 'ink';
 
+import { isEscapeInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 import { transcriptToLines } from '../state/transcriptLines';
 import type { StreamSlice } from '../state/cliState';
@@ -80,7 +81,8 @@ export function TranscriptViewer({
   }, [maxOffset]);
 
   useInput((input, key) => {
-    if (key.escape || (key.ctrl && input.toLowerCase() === 't')) onClose();
+    if (isEscapeInput(input, key) || (key.ctrl && input.toLowerCase() === 't'))
+      onClose();
     else if (key.downArrow) scrollTo((current) => current + 1);
     else if (key.upArrow) scrollTo((current) => current - 1);
     else if (key.pageDown) scrollTo((current) => current + viewRows);

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -16,7 +16,7 @@ import {
 } from './UserQuestionState';
 import { CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import { BaseTextInput } from '../input/BaseTextInput';
-import { isPlainReturnInput } from '../input/inputKeys';
+import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { clipToWidth, textDisplayWidth } from '../render/terminalText';
 import {
@@ -351,7 +351,7 @@ function MultiSelectQuestion(
 
   useInput((input, key) => {
     // Esc cancels; Ctrl+C is owned by the App's unified handler (exits the app).
-    if (key.escape) {
+    if (isEscapeInput(input, key)) {
       props.onCancel();
       return;
     }
@@ -466,9 +466,9 @@ function FreeTextQuestion(props: FreeTextQuestionProps): React.JSX.Element {
     showOverflow: false,
     visibleItemCount: visibleOptions.length,
   });
-  useInput((_input, key) => {
+  useInput((input, key) => {
     // Esc cancels; Ctrl+C is owned by the App's unified handler (exits the app).
-    if (key.escape) {
+    if (isEscapeInput(input, key)) {
       props.onCancel();
     }
   });

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -10,7 +10,7 @@ import {
 import { formatDuration } from '@utils/core';
 
 // Local imports - CLI state
-import { isPlainReturnInput } from '../input/inputKeys';
+import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { visibleSubagentRows } from './childStreamMerge';
 import { orderedDescendantsFromTree } from './focusCycle';
 import { transcriptEntryLines } from './transcriptLines';
@@ -384,7 +384,7 @@ export function subagentPickerSelection(
 }
 
 export function childPickerKeyAction(key: PickerKeyInput): PickerKeyAction {
-  if (key.escape) return { kind: 'close' };
+  if (isEscapeInput(key.input, key)) return { kind: 'close' };
   if (key.upArrow) return { kind: 'up' };
   if (key.downArrow) return { kind: 'down' };
   if (isPlainReturnInput(key.input, key)) return { kind: 'select' };

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -11,7 +11,7 @@
 import { Box, Text, useInput } from 'ink';
 import { useEffect, useState } from 'react';
 
-import { isPlainReturnInput } from '../input/inputKeys';
+import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 
 export const SELECT_LABEL_MAX_COLS = 24;
 
@@ -232,7 +232,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   });
 
   useInput((input, key) => {
-    if (key.escape) {
+    if (isEscapeInput(input, key)) {
       props.onCancel();
       return;
     }

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -846,6 +846,12 @@ describe('CLI child execution controls', () => {
     expect(childPickerKeyAction({ input: '', escape: true })).toEqual({
       kind: 'close',
     });
+    expect(childPickerKeyAction({ input: '\u001B' })).toEqual({
+      kind: 'close',
+    });
+    expect(childPickerKeyAction({ input: '\u001Bp' })).toEqual({
+      kind: 'ignore',
+    });
     expect(childPickerKeyAction({ input: '', return: true })).toEqual({
       kind: 'select',
     });

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -13,6 +13,8 @@ describe('CLI confirm-card key handling', () => {
     expect(confirmCardKeyAction('Y', {}, false)).toBe('approve');
     expect(confirmCardKeyAction('n', {}, false)).toBe('reject');
     expect(confirmCardKeyAction('', { escape: true }, false)).toBe('reject');
+    expect(confirmCardKeyAction('\u001B', {}, false)).toBe('reject');
+    expect(confirmCardKeyAction('\u001Bn', {}, false)).toBe('ignore');
   });
 
   it('enters feedback mode with e', () => {

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -7,6 +7,7 @@ import {
   modelSelectWindow,
   noRunnableModelAccessReason,
 } from '@cli/chat/tui/forms/ModelListForm';
+import { shouldCloseAsyncListFormOnInput } from '@cli/chat/tui/forms/_shared/useAsyncListForm';
 import {
   COMPACT_FORM_MAX_ROWS,
   isCompactFormRows,
@@ -380,6 +381,50 @@ describe('CLI ModelListForm empty state', () => {
     ).toBe(
       'No personal API-key models are runnable. Configure a provider key or switch with /api included.',
     );
+  });
+});
+
+describe('CLI async list form close input', () => {
+  it('treats normalized and raw Escape as close in non-actionable states', () => {
+    expect(
+      shouldCloseAsyncListFormOnInput({
+        input: '',
+        key: { escape: true },
+        loading: true,
+        error: undefined,
+        empty: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCloseAsyncListFormOnInput({
+        input: '\u001B',
+        key: {},
+        loading: false,
+        error: 'failed',
+        empty: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCloseAsyncListFormOnInput({
+        input: '\u001B',
+        key: {},
+        loading: false,
+        error: undefined,
+        empty: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not let Escape close an actionable list form', () => {
+    expect(
+      shouldCloseAsyncListFormOnInput({
+        input: '\u001B',
+        key: {},
+        loading: false,
+        error: undefined,
+        empty: false,
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- route CLI foreground Escape handling through the shared `isEscapeInput` helper so raw `\u001B` closes list forms, selectors, palettes, approvals, inquiry/question modals, transcript viewer, reverse search, and active-run interrupts consistently
- keep the fix DRY by using the existing key helper directly instead of adding per-form fallbacks or pass-through wrappers
- add regression coverage for raw Escape and Alt/meta-prefixed Escape sequences in pure key-action helpers

## Validation
- `npm run format`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ConfirmCardState.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/TextInputEditing.vitest.mts`
- `npm run compile:safe`
- `npm run lint` (0 errors; existing import-order warnings outside this patch)
- `npm run texra-local:build && npm run texra-local:link`
- live TTY: `texra-local chat --approval-policy never --no-color`, opened `/`, sent raw Escape, verified palette closed
- live TTY: opened `/model`, sent raw Escape, verified selector closed
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-cli-dogfood-round2-snapshots-escape-sweep --skip-if-missing-deps` (106 scenarios passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized input-normalization change with existing helper and added tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Escape handling** in the Ink TUI now goes through **`isEscapeInput`**, which treats both Ink’s `key.escape` and a raw **`\u001B`** byte as Escape. That fixes cases where PTYs deliver Escape without setting the escape flag—especially **dismissing slash list forms** (`/model`, etc.) from empty, loading, or error states and **canceling loaded `Select` lists**.
> 
> The change is applied across **app interrupt**, **slash palette**, **reverse search**, **shared async list forms** (via new **`shouldCloseAsyncListFormOnInput`**), **Select**, **child pickers**, and **approval / question modals**. Kernel tests cover normalized escape, raw `\u001B`, and that Escape does **not** close actionable list forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a293920c2a0ac2a71868cce6bb1533a314ec921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->