### PR TITLE
[codex] Refactor CLI transcript projection

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -120,19 +120,18 @@ import { cliState, resetCliState } from './state/cliState';
 import { collectResumeTargets, formatResumeHint } from './state/resumeHint';
 import { installTuiApprovals } from './state/subscribeApprovals';
 import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
-import { subscribeStreamLog, syncStreamLog } from './state/subscribeStreamLog';
+import { subscribeStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
 import { requestCliCompaction } from './state/compactionRequest';
 import {
-  appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
   appendLocalErrorTranscript,
   appendLocalUserTranscript,
   clearLocalTranscript,
-  finalizeAssistantTranscriptEntries,
   moveLocalTranscriptToStream,
 } from './state/transcript';
+import { projectStreamTranscript } from './state/transcriptProjection';
 import {
   cleanupTerminalModes,
   clearTerminalScrollback,
@@ -1233,8 +1232,8 @@ export async function runChat(
     pendingSkillActivations.clear();
     clearTuiSessionRunState(session);
     // StreamLogStore entries outlive resetCliState (which only clears the
-    // React/signal view). Drop them so syncStreamLog can't replay the
-    // cleared conversation into the fresh `<Static>` scrollback.
+    // React/signal view). Drop them so transcript projection can't replay
+    // the cleared conversation into the fresh `<Static>` scrollback.
     const store = getDefaultStreamLogStore();
     for (const streamId of cliState.streams.get().keys()) {
       store.delete(streamId).catch(() => {
@@ -1282,13 +1281,13 @@ export async function runChat(
           },
           onBeforeWaiting: (lastResponse) => {
             if (!session.streamId) return;
-            syncStreamLog(session.streamId);
-            appendAssistantTranscriptIfMissing(
-              session.streamId,
-              lastResponse,
-              `waiting:${executionId}:${waitingTurn++}`,
-            );
-            finalizeAssistantTranscriptEntries(session.streamId);
+            projectStreamTranscript(session.streamId, {
+              fallbackAssistant: {
+                text: lastResponse,
+                idPrefix: `waiting:${executionId}:${waitingTurn++}`,
+              },
+              finalize: true,
+            });
           },
         });
       })
@@ -1306,18 +1305,20 @@ export async function runChat(
         // this, a reply that finalized between sync ticks would never
         // hit the transcript.
         if (result.streamId) {
-          syncStreamLog(result.streamId);
-          // The run is definitively done — promote any still-deferred
-          // assistant/tool rows into `<Static>` even if the status-change
-          // path didn't fire its own finalize.
-          finalizeAssistantTranscriptEntries(result.streamId);
-        }
-        if (result.category === AgentCategory.ToolUse) {
-          appendAssistantTranscriptIfMissing(
-            result.streamId,
-            result.lastResponse,
-            `final:${result.executionId}`,
-          );
+          // The run is definitively done. Pull any final log chunks into
+          // cliState, add the result text only if the log did not render it,
+          // and promote deferred assistant/tool rows into `<Static>`.
+          projectStreamTranscript(result.streamId, {
+            finalize: true,
+            ...(result.category === AgentCategory.ToolUse
+              ? {
+                  fallbackAssistant: {
+                    text: result.lastResponse,
+                    idPrefix: `final:${result.executionId}`,
+                  },
+                }
+              : {}),
+          });
         }
         notify({ kind: 'agentFinished' });
       })
@@ -1383,11 +1384,11 @@ export async function runChat(
 
     // Rehydrate the prior transcript so the user sees the conversation they're
     // continuing. ensureLoaded pulls the persisted entries off disk into the
-    // store; syncStreamLog promotes them into `<Static>` scrollback. An older
-    // run with no persisted entries simply shows whatever exists (possibly
-    // nothing) — the continued turn streams in regardless.
+    // store; projection promotes already-final rows into `<Static>` scrollback.
+    // An older run with no persisted entries simply shows whatever exists
+    // (possibly nothing) — the continued turn streams in regardless.
     await getDefaultStreamLogStore().ensureLoaded(resolution.streamId);
-    syncStreamLog(resolution.streamId);
+    projectStreamTranscript(resolution.streamId);
     cliState.activeStreamId.set(resolution.streamId);
 
     const runtimeHost = createCliRuntimeHost(sessionContext);
@@ -1407,8 +1408,7 @@ export async function runChat(
         // streamId we already know is the only handle: flush the tail and
         // promote any deferred assistant/tool rows into `<Static>`.
         if (session.streamId) {
-          syncStreamLog(session.streamId);
-          finalizeAssistantTranscriptEntries(session.streamId);
+          projectStreamTranscript(session.streamId, { finalize: true });
         }
         session.runExitCode = CliExitCode.Success;
         notify({ kind: 'agentFinished' });

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -4,15 +4,11 @@ import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS } from '@shared/schemas';
 
 import { patchStream, updateChildStreamStatus } from './cliState';
-import { syncStreamLog } from './subscribeStreamLog';
-import {
-  finalizeAssistantTranscriptEntries,
-  isFinalTranscriptStatus,
-} from './transcript';
+import { projectStreamTranscriptForStatus } from './transcriptProjection';
 
 export function subscribeStreamStatus(): () => void {
   return StreamStatusService.onDidChange((change) => {
-    // Patch status BEFORE syncing so `syncStreamLog` derives
+    // Patch status BEFORE projection so the transcript projector derives
     // `finalizeDeferred` from the current status. A reused stream still
     // carrying `WAITING` from the previous turn would otherwise finalize
     // the next run's first chunks early, shoving partial text into
@@ -29,9 +25,6 @@ export function subscribeStreamStatus(): () => void {
       return { ...slice, status: change.status, runStartedAt };
     });
     updateChildStreamStatus(change.streamId, change.status);
-    syncStreamLog(change.streamId);
-    if (isFinalTranscriptStatus(change.status)) {
-      finalizeAssistantTranscriptEntries(change.streamId);
-    }
+    projectStreamTranscriptForStatus(change.streamId, change.status);
   });
 }

--- a/packages/cli/src/chat/tui/state/transcriptProjection.ts
+++ b/packages/cli/src/chat/tui/state/transcriptProjection.ts
@@ -1,0 +1,57 @@
+import type { StreamStatus, StreamTabId } from '@shared/schemas';
+
+import { syncStreamLog } from './subscribeStreamLog';
+import {
+  appendAssistantTranscriptIfMissing,
+  finalizeAssistantTranscriptEntries,
+  isFinalTranscriptStatus,
+} from './transcript';
+
+export interface TranscriptFallbackAssistant {
+  readonly text: string | undefined;
+  readonly idPrefix: string;
+}
+
+export interface ProjectStreamTranscriptOptions {
+  /**
+   * Fallback text from the agent result when the stream log did not already
+   * materialize the final assistant block.
+   */
+  readonly fallbackAssistant?: TranscriptFallbackAssistant;
+  /** Promote all deferred assistant/tool rows into static scrollback. */
+  readonly finalize?: boolean;
+}
+
+/**
+ * Single projection edge from StreamLogStore into cliState.
+ *
+ * Callers that know a stream reached a turn boundary should project through
+ * this helper instead of open-coding sync + fallback + finalization. That keeps
+ * transcript ordering and dedupe rules owned by one path.
+ */
+export function projectStreamTranscript(
+  streamId: StreamTabId,
+  options: ProjectStreamTranscriptOptions = {},
+): void {
+  syncStreamLog(streamId);
+  if (options.fallbackAssistant) {
+    appendAssistantTranscriptIfMissing(
+      streamId,
+      options.fallbackAssistant.text,
+      options.fallbackAssistant.idPrefix,
+    );
+  }
+  if (options.finalize) {
+    finalizeAssistantTranscriptEntries(streamId);
+  }
+}
+
+/** Project a stream after a status transition. Final statuses promote rows. */
+export function projectStreamTranscriptForStatus(
+  streamId: StreamTabId,
+  status: StreamStatus,
+): void {
+  projectStreamTranscript(streamId, {
+    finalize: isFinalTranscriptStatus(status),
+  });
+}

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -44,6 +44,7 @@ import {
   finalizeSettledPrefix,
   syncStreamLog,
 } from '@cli/chat/tui/state/subscribeStreamLog';
+import { projectStreamTranscript } from '@cli/chat/tui/state/transcriptProjection';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
 import { wrapRuntimeHost } from '@cli/chat/tui/state/subscribeRuntimeHost';
 import {
@@ -1455,6 +1456,37 @@ describe('CLI transcript state', () => {
       const entries = cliState.streams.get().get(root)?.entries ?? [];
       expect(entries.map((entry) => entry.text)).toEqual(['Done.']);
       expect(entries[0]?.synthetic).toBeUndefined();
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('projects a turn boundary without duplicating fallback assistant text', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info('What is 1 + 1?', {
+        messageType: MESSAGE_TYPES.USER_MESSAGE,
+      });
+      logger.info('2', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+
+      projectStreamTranscript(root, {
+        fallbackAssistant: { text: '2', idPrefix: 'final:turn' },
+        finalize: true,
+      });
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        'What is 1 + 1?',
+        '2',
+      ]);
+      expect(entries.map((entry) => entry.finalized)).toEqual([true, true]);
+      expect(entries.some((entry) => entry.id === 'final:turn:root')).toBe(
+        false,
+      );
     } finally {
       setDefaultStreamLogStore(previousStore);
     }


### PR DESCRIPTION
## Summary

- add a small CLI TUI transcript projection module that owns stream-log sync, fallback assistant text, and finalization at turn boundaries
- route status transitions, waiting boundaries, normal completion, and resume completion through that single projection helper
- add a regression test proving projection does not duplicate final fallback text when the stream log already contains the assistant response

## Why

The CLI TUI had several call sites open-coding `syncStreamLog` plus deferred-row finalization, with fallback assistant insertion handled separately. That made transcript ownership harder to reason about after the architecture pass: status changes, wait transitions, completion, and resume were all partial projection edges. This PR keeps the behavior the same but gives those turn-boundary paths one narrow API.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli`
- `npm run lint` (0 errors; existing import-order warnings outside this diff)
- `npm run typecheck`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only consolidation of existing transcript sync/finalize behavior with a targeted dedupe regression test; no new auth or data paths.
> 
> **Overview**
> Introduces **`transcriptProjection`** as the single path from `StreamLogStore` into `cliState`: sync, optional fallback assistant text, and deferred-row finalization at turn boundaries.
> 
> **`runChatTui`** and **`subscribeStreamStatus`** no longer open-code `syncStreamLog` plus `appendAssistantTranscriptIfMissing` / `finalizeAssistantTranscriptEntries`; they call `projectStreamTranscript` (or `projectStreamTranscriptForStatus` on status changes, which finalizes when the status is terminal). Waiting hooks, normal completion, resume rehydration, and resume completion all go through the same helper.
> 
> Adds a regression test that **`projectStreamTranscript`** does not insert a synthetic fallback when the stream log already contains the assistant reply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af93545aa9ea940353487457735c43a6af3c9de0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->