### PR TITLE
[codex] Guard direct subagent tab focus

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -37,7 +37,10 @@ import { buildContinuationText } from '@tools/inquiry/inquiryContinuation';
 import { getDefaultStreamLogStore } from '@transcript';
 
 import { App } from '../src/chat/tui/App';
-import type { TranscriptViewportChange } from '../src/chat/tui/state/transcriptViewportMode';
+import {
+  transcriptViewportRepaintOptions,
+  type TranscriptViewportChange,
+} from '../src/chat/tui/state/transcriptViewportMode';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
 import {
   listSlashCommands,
@@ -1363,10 +1366,7 @@ const inkRef: { current?: ReturnType<typeof render> } = {};
 function repaintHarnessTranscriptViewport(
   change: TranscriptViewportChange,
 ): void {
-  inkRef.current?.repaint({
-    clearScrollback: change.enteredRootScrollback,
-    preserveStatic: false,
-  });
+  inkRef.current?.repaint(transcriptViewportRepaintOptions(change));
 }
 
 function handleHarnessCtrlC(): void {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1361,6 +1361,29 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'subagent-tab-focus-full-frame',
+    cols: 120,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: ['\t'],
+    expect: [
+      'Please handle the harness-child-strategy sub-workflow.',
+      'strategy is checking the harness-child-strategy details',
+      '[1:strategy]*',
+    ],
+    unexpect: [
+      'entry-1 chat history line',
+      'entry-4 chat history line',
+      '[main]*',
+      'signal read during notification phase',
+      'ERROR',
+    ],
+  },
+  {
     name: 'subagent-focus-return-root-scrollback-deduped',
     cols: 120,
     env: {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -136,7 +136,10 @@ import {
   cleanupTerminalModes,
   clearTerminalScrollback,
 } from './terminalCleanup';
-import type { TranscriptViewportChange } from './state/transcriptViewportMode';
+import {
+  transcriptViewportRepaintOptions,
+  type TranscriptViewportChange,
+} from './state/transcriptViewportMode';
 
 export interface ChatResult {
   exitCode: number;
@@ -1616,10 +1619,7 @@ export async function runChat(
   const repaintTranscriptViewport = (
     change: TranscriptViewportChange,
   ): void => {
-    inkRef.current?.repaint({
-      clearScrollback: change.enteredRootScrollback,
-      preserveStatic: false,
-    });
+    inkRef.current?.repaint(transcriptViewportRepaintOptions(change));
   };
   const ink = render(
     <App

--- a/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
+++ b/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
@@ -24,6 +24,11 @@ export interface TranscriptViewportChange {
   readonly enteredRootScrollback: boolean;
 }
 
+export interface TranscriptViewportRepaintOptions {
+  readonly clearScrollback: boolean;
+  readonly preserveStatic: false;
+}
+
 export function transcriptViewportChange({
   nextViewportKey,
   previousViewportKey,
@@ -39,5 +44,14 @@ export function transcriptViewportChange({
     enteredRootScrollback:
       isScopedTranscriptViewport(previousViewportKey) &&
       !isScopedTranscriptViewport(nextViewportKey),
+  };
+}
+
+export function transcriptViewportRepaintOptions(
+  change: TranscriptViewportChange,
+): TranscriptViewportRepaintOptions {
+  return {
+    clearScrollback: change.enteredRootScrollback,
+    preserveStatic: false,
   };
 }

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -14,6 +14,7 @@ import {
 import {
   transcriptViewportChange,
   transcriptViewportKey,
+  transcriptViewportRepaintOptions,
 } from '@cli/chat/tui/state/transcriptViewportMode';
 import {
   estimateLiveTranscriptEntryRows,
@@ -489,6 +490,28 @@ describe('CLI conversation transcript splitting', () => {
         nextViewportKey: rootViewportKey,
       }),
     ).toMatchObject({ enteredRootScrollback: true });
+  });
+
+  it('repaints viewport switches without preserving stale Static output', () => {
+    const rootToChild = transcriptViewportChange({
+      previousViewportKey: 'root-scrollback',
+      nextViewportKey: 'scoped:child',
+    });
+    const childToRoot = transcriptViewportChange({
+      previousViewportKey: 'scoped:child',
+      nextViewportKey: 'root-scrollback',
+    });
+
+    expect(rootToChild).toBeDefined();
+    expect(childToRoot).toBeDefined();
+    expect(transcriptViewportRepaintOptions(rootToChild!)).toEqual({
+      clearScrollback: false,
+      preserveStatic: false,
+    });
+    expect(transcriptViewportRepaintOptions(childToRoot!)).toEqual({
+      clearScrollback: true,
+      preserveStatic: false,
+    });
   });
 
   it('detects generated inquiry continuation rows only', () => {


### PR DESCRIPTION
## Summary

- centralize CLI transcript viewport repaint options beside the viewport key/change helpers
- reuse the same repaint policy from the real CLI and TUI harness
- add a full-frame harness scenario for direct Tab focus into a subagent stream, asserting root history is not visible in the child viewport

## Notes

This pass was prompted by subagent pages appearing to inherit orchestrator output. The existing picker-focus harness path was already clean; the new scenario pins the direct Tab route so future regressions catch full-frame root-history leakage, not only tail output.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui subagent-tab-focus-full-frame`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build subagent-focused-submit subagent-tab-focus-full-frame subagent-focus-return-root-scrollback-deduped subagent-picker-enter-views-subagent`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli`
- `git diff --check`
- `npm run lint` (passes with 29 pre-existing import-order warnings outside this diff)
- `npm run typecheck`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI rendering-only refactor with shared repaint policy and regression harness; no auth, data, or API surface changes.
> 
> **Overview**
> Centralizes **Ink transcript viewport repaint** policy in `transcriptViewportRepaintOptions` next to the existing viewport key/change helpers. The real CLI (`runChatTui`) and TUI harness now call that helper instead of inlining `repaint({ clearScrollback, preserveStatic: false })`.
> 
> On every stream switch, repaints use **`preserveStatic: false`** so stale `<Static>` scrollback is not kept; **`clearScrollback`** is set only when leaving a scoped subagent viewport and returning to root scrollback (`enteredRootScrollback`).
> 
> Adds a **`subagent-tab-focus-full-frame`** PTY harness scenario: Tab into a subagent must show only child transcript lines and `[1:strategy]*`, with root `entry-*` history and `[main]*` absent—guarding the direct Tab focus path against orchestrator output leaking into the child frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b4c48329ba13eb6cf0f75923699332e6a38bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->