### PR TITLE
[codex] Centralize CLI stream status snapshots

### DIFF
--- a/docs/architecture/cli-runtime-round-trips.md
+++ b/docs/architecture/cli-runtime-round-trips.md
@@ -1,0 +1,236 @@
+# CLI Runtime Round Trips
+
+This note maps the current CLI startup, model/team selection, and chat TUI
+rendering paths. The goal is to make ownership and repeated work visible before
+refactoring the CLI further.
+
+## Startup And Selection
+
+```mermaid
+flowchart TD
+  user[User runs texra / texra orchestrate]
+  orch[commands/orchestrate.ts runOrchestration]
+  platform[runtime/initPlatform initCliPlatform]
+  onboarding[onboarding maybeRunCliOnboarding]
+  history[runtime/history listCliHistoryEntries]
+  presets[runtime/multiAgentPresets readCliMultiAgentPresets]
+  plans[commands/multiAgent loadCliMultiAgentPresetPlans]
+  agentsLocal[agentRegistry loadAgents includeRemote false]
+  auth[supabaseAuth isAuthenticated]
+  agentsRemote[agentRegistry loadAgents includeRemote true]
+  replan[planCliMultiAgentPresets replan]
+  items[runtime/orchestration buildCliOrchestrationItems]
+  modelList[runtime/modelAccess getCliModelAccessList]
+  defaultModel[resolveChatDefaults + resolveCliRunnableModelWithAccessList]
+  picker[orchestration/runOrchestrationTui]
+  chat[chat/tui/runChatTui runChat]
+  presetRun[commands/multiAgent fillMultiAgentRunPlanGaps]
+
+  user --> orch
+  orch --> platform
+  platform --> onboarding
+  onboarding --> history
+  onboarding --> presets
+  presets --> plans
+  plans --> agentsLocal
+  agentsLocal --> auth
+  auth -->|if authenticated and gaps exist| agentsRemote
+  agentsRemote --> replan
+  auth -->|otherwise| replan
+  replan --> items
+  history --> items
+  orch --> modelList
+  modelList --> defaultModel
+  items --> picker
+  defaultModel --> picker
+  picker -->|chat action| chat
+  picker -->|team action| presetRun
+  presetRun --> chat
+```
+
+Current ownership:
+
+- Terminal interactivity:
+  `commands/orchestrate.ts` and `chat/tui/runChatTui.tsx`.
+  Both entry points enforce TTY before mounting Ink.
+- First-run auth onboarding:
+  `commands/orchestrate.ts` and `chat/tui/runChatTui.tsx`.
+  The launcher can run onboarding, then a selected chat runs the same gate again.
+- Team availability:
+  `commands/multiAgent.ts` plus `runtime/multiAgentPresets.ts`.
+  List, inspect, and run all use the same planner, but launch replans after selection.
+- Agent registry load scope:
+  `agentRegistry.loadAgents()` call sites.
+  Local-only for list/display, remote reload only when authenticated and gaps exist.
+- API mode:
+  `runtime/apiAccessMode.ts`.
+  One persisted key-mode flag, with command/env override through `CliContext`.
+- Model availability:
+  `runtime/modelAccess.ts`.
+  The launcher, `/model`, and chat startup share this module, but can each load the model list.
+- Initial root agent/model defaults:
+  `runtime/chatDefaults.ts`.
+  Resolves workspace, user, history, then built-in defaults.
+
+## Chat TUI Runtime
+
+```mermaid
+flowchart LR
+  runtime[executeAgent / tool-use runtime]
+  host[runtimeHost + wrapRuntimeHost]
+  streamLog[StreamLogStore]
+  statusService[StreamStatusService]
+  cliState[chat/tui/state/cliState signals]
+  statusSub[subscribeStreamStatus]
+  logSub[subscribeStreamLog]
+  projection[transcriptProjection]
+  app[chat/tui/App]
+  viewport[transcriptViewportMode]
+  staticPane[StaticConversationTranscript]
+  livePane[ConversationPane]
+  statusBar[StatusBar / StreamTabsStrip / side panels]
+
+  runtime --> host
+  runtime --> streamLog
+  runtime --> statusService
+  host --> cliState
+  streamLog --> logSub --> cliState
+  statusService --> statusSub --> cliState
+  statusSub --> projection --> cliState
+  cliState --> app
+  app --> viewport
+  viewport -->|root scrollback| staticPane
+  viewport -->|root live tail| livePane
+  viewport -->|focused child scoped history| livePane
+  cliState --> statusBar
+```
+
+The transcript path intentionally has two render modes:
+
+- Root stream:
+  Finalized active-root entries print once through `<Static>`.
+  Pending root entries render in bounded live-tail mode.
+- Child stream:
+  `<StaticConversationTranscript>` is not mounted.
+  The child stream renders in scoped-history mode, using only that child slice.
+
+That means a focused-child tab should not read parent entries through
+`ConversationPane`. If parent output remains visible after focus changes, the
+likely root is terminal scrollback/static repaint behavior, not direct parent
+slice selection.
+
+## Model Selection Round Trips
+
+```mermaid
+sequenceDiagram
+  participant O as orchestrate
+  participant MA as modelAccess
+  participant UI as orchestration TUI
+  participant C as runChat
+  participant F as /model form
+  participant Flow as active tool-use flow
+
+  O->>MA: getCliModelAccessList(apiMode)
+  O->>MA: resolve default model against same list
+  O->>UI: pass model list for second-step picker
+  UI-->>C: chosen model or no override
+  C->>MA: resolveCliRunnableModel(default/override, apiMode)
+  C->>C: persist helper model + write cliState.sessionMeta
+  F->>MA: getCliModelAccessList(apiMode)
+  F-->>C: selected model
+  C->>Flow: switchModel(model), if a waiting flow exists
+  C->>C: persist helper model + write cliState.sessionMeta
+```
+
+The model filter itself is shared, which is good. The repeated work is around
+loading/reconciling the same `apiMode + selected model` pair at launcher,
+chat-start, submit-time, and `/model` form time.
+
+## Team Planning Round Trips
+
+```mermaid
+sequenceDiagram
+  participant L as multi-agent list / launcher
+  participant P as multiAgentPresets planner
+  participant A as agentRegistry
+  participant R as remote agent loader
+  participant Run as team run
+
+  L->>A: loadAgents({ includeRemote: false })
+  L->>P: plan presets with local agents
+  P-->>L: plans, gaps, local fallback roots
+  L->>R: maybe load remote agents if authenticated and gaps exist
+  R-->>P: replan with remote agents
+  L-->>Run: selected preset id
+  Run->>P: plan current preset again
+  Run->>R: maybe load remote agents again if gaps exist
+  Run->>P: replan current preset
+```
+
+The local CLI currently shows built-in teams as unavailable without relay-served
+agents. For example, `texra-local multi-agent inspect physicist` resolves
+`research` as a local root but still blocks team launch because that root cannot
+delegate and required specialists are missing. That behavior is internally
+consistent, but it is a UX pressure point because list output exposes a root
+agent while run output correctly says the team cannot launch.
+
+## Skills Protocol Implication
+
+Current public SKILL.md conventions treat a skill package as a `SKILL.md` file
+plus optional supporting files, with full instructions loaded only when the
+agent needs that workflow. TeXRA's CLI should keep the startup path metadata-only:
+
+```mermaid
+flowchart LR
+  discover[Discover skill metadata]
+  list[Show /skills or slash form]
+  activate[User or agent activates skill]
+  loadBody[Load SKILL.md and supporting references]
+  prompt[Inject activation into next tool-use prompt]
+
+  discover --> list
+  list --> activate
+  activate --> loadBody --> prompt
+```
+
+This argues against routing skill bodies through launcher, model selection, or
+team planning. Startup should need only names, descriptions, and availability.
+
+## Refactor Targets
+
+- Launcher-to-chat preflight:
+  `orchestrate` and `runChat` both run platform/onboarding/model checks.
+  Introduce a small `CliInteractivePreflight` result that standalone chat can compute
+  and launcher can pass through.
+- Team plan reload:
+  Listing builds a plan set, then selected team launch replans by preset id.
+  Return a `CliMultiAgentPlanSnapshot` from the planner and let launch validate or
+  reuse it unless registry/auth state changed.
+- Model selection ownership:
+  Startup, submit-time, and `/model` each reconcile model availability and persistence.
+  Add a `CliRootModelSelection` helper that owns `apiMode`, current model, runnable
+  list loading, and persistence.
+- Stream status lookup:
+  UI helpers read child status from parent slice, child slice, and `StreamStatusService`.
+  Normalize once in the subscriber and make UI read `StreamSlice` only. Keep the
+  service as an input source, not a UI fallback.
+- Transcript viewport repaint:
+  `App` detects root/scoped changes and calls back into `runChatTui` to repaint Ink.
+  Move viewport repaint ownership into a small TUI viewport controller so render mode
+  and terminal clear policy live together.
+- Slash command dispatch:
+  Built-in commands are registered, but `handleTuiSlashCommand` still owns a large
+  switch with special cases. Move command handlers into the registry incrementally,
+  keeping `runChatTui` as dispatcher plus session lifecycle owner.
+- Skills startup:
+  Skills should be discoverable without injecting bodies into every tool-use prompt.
+  Keep discovery metadata cached; load `SKILL.md` only on activation for the next message.
+
+## Suggested Order
+
+1. Normalize stream status ownership first. It is small and directly helps
+   subagent display/debuggability.
+2. Extract model selection ownership next. It addresses startup model selection,
+   `/model`, API-mode switching, and future relay/personal divergence.
+3. Consolidate team planning after that. It is higher blast radius because it
+   touches local/remote agent loading and multi-agent launch semantics.

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -26,7 +26,6 @@ import {
   executeAgent,
   resumeToolUseFromSnapshot,
 } from '@agent/runtime/executeAgent';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   notifyFollowUpSent,
   sendFollowUp,
@@ -98,7 +97,6 @@ import {
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { escapeText } from '@shared/utils/xmlEscape';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
-import { filterNotNullish } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { truncateSummary } from '@utils/text/stringUtils';
 
@@ -122,6 +120,11 @@ import { installTuiApprovals } from './state/subscribeApprovals';
 import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
 import { subscribeStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
+import {
+  onStreamStatusChange,
+  streamStatusForStream,
+  streamStatusSnapshot,
+} from './state/streamStatusSnapshot';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
 import { requestCliCompaction } from './state/compactionRequest';
 import {
@@ -407,18 +410,7 @@ function chatTuiActiveChildStreamId(): StreamTabId | undefined {
 }
 
 function chatTuiStreamStatuses(streamId: StreamTabId): readonly string[] {
-  const streams = cliState.streams.get();
-  const parentStreamId = cliState.parentStream.get().get(streamId);
-  const childStreamStatus = parentStreamId
-    ? streams
-        .get(parentStreamId)
-        ?.childStreams.find((child) => child.childStreamId === streamId)?.status
-    : undefined;
-  return [
-    childStreamStatus,
-    streams.get(streamId)?.status,
-    StreamStatusService.get(streamId),
-  ].filter(filterNotNullish);
+  return streamStatusSnapshot(streamId);
 }
 
 function chatTuiCanAcceptFollowUp(statuses: readonly string[]): boolean {
@@ -1159,10 +1151,7 @@ export async function runChat(
   const pendingSkillActivations = new Map<string, string>();
   let pendingSkillActivationClearEpoch = 0;
   const rootStreamStatus = (): StreamStatus | undefined =>
-    session.streamId
-      ? (cliState.streams.get().get(session.streamId)?.status ??
-        StreamStatusService.get(session.streamId))
-      : undefined;
+    session.streamId ? streamStatusForStream(session.streamId) : undefined;
   const hasActiveToolUseFlow = (): boolean =>
     Boolean(session.streamId && getToolUseFlowContext(session.streamId));
   const canSelectCurrentModel = (): boolean =>
@@ -1210,8 +1199,7 @@ export async function runChat(
   const resetSessionForClear = (): void => {
     const activeStreamId = session.streamId ?? cliState.activeStreamId.get();
     const activeStatus = activeStreamId
-      ? (cliState.streams.get().get(activeStreamId)?.status ??
-        StreamStatusService.get(activeStreamId))
+      ? streamStatusForStream(activeStreamId)
       : undefined;
     const isRunPending = Boolean(session.runPromise && !session.runCompleted);
 
@@ -1801,7 +1789,7 @@ export async function runChat(
   // signals "your turn." Combined with the StatusBar pill, this replaces
   // the legacy reader.prompt() ergonomics.
   disposers.push(
-    StreamStatusService.onDidChange((change) => {
+    onStreamStatusChange((change) => {
       if (
         change.streamId === session.streamId &&
         change.status === STREAM_STATUS.WAITING &&

--- a/packages/cli/src/chat/tui/state/streamStatusSnapshot.ts
+++ b/packages/cli/src/chat/tui/state/streamStatusSnapshot.ts
@@ -13,6 +13,9 @@ import { cliState, patchStream, updateChildStreamStatus } from './cliState';
 export function applyStreamStatusChange(change: StreamStatusChange): void {
   patchStream(change.streamId, (slice) => {
     if (slice.status === change.status) return slice;
+    // Stamp the turn-start clock when entering RUNNING (keeping any prior
+    // stamp if we re-enter without leaving), and clear it otherwise so the
+    // StatusBar's elapsed segment only ticks during an active turn.
     const runStartedAt =
       change.status === STREAM_STATUS.RUNNING
         ? (slice.runStartedAt ?? Date.now())

--- a/packages/cli/src/chat/tui/state/streamStatusSnapshot.ts
+++ b/packages/cli/src/chat/tui/state/streamStatusSnapshot.ts
@@ -1,0 +1,55 @@
+import {
+  StreamStatusService,
+  type StreamStatusChange,
+} from '@agent/runtime/StreamStatusService';
+import {
+  STREAM_STATUS,
+  type StreamStatus,
+  type StreamTabId,
+} from '@shared/schemas';
+
+import { cliState, patchStream, updateChildStreamStatus } from './cliState';
+
+export function applyStreamStatusChange(change: StreamStatusChange): void {
+  patchStream(change.streamId, (slice) => {
+    if (slice.status === change.status) return slice;
+    const runStartedAt =
+      change.status === STREAM_STATUS.RUNNING
+        ? (slice.runStartedAt ?? Date.now())
+        : undefined;
+    return { ...slice, status: change.status, runStartedAt };
+  });
+  updateChildStreamStatus(change.streamId, change.status);
+}
+
+export function streamStatusForStream(
+  streamId: StreamTabId,
+): StreamStatus | undefined {
+  return (
+    cliState.streams.get().get(streamId)?.status ??
+    StreamStatusService.get(streamId)
+  );
+}
+
+export function streamStatusSnapshot(
+  streamId: StreamTabId,
+): readonly StreamStatus[] {
+  const streams = cliState.streams.get();
+  const parentStreamId = cliState.parentStream.get().get(streamId);
+  const childStreamStatus = parentStreamId
+    ? streams
+        .get(parentStreamId)
+        ?.childStreams.find((child) => child.childStreamId === streamId)?.status
+    : undefined;
+  return [
+    childStreamStatus,
+    streams.get(streamId)?.status,
+    StreamStatusService.get(streamId),
+  ].filter((status): status is StreamStatus => status != null);
+}
+
+export function onStreamStatusChange(
+  listener: (change: StreamStatusChange) => void,
+): () => void {
+  return StreamStatusService.onDidChange(listener);
+}

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -1,30 +1,19 @@
 // Mirror `StreamStatusService.onDidChange` into the per-stream status signal.
 
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { STREAM_STATUS } from '@shared/schemas';
-
-import { patchStream, updateChildStreamStatus } from './cliState';
 import { projectStreamTranscriptForStatus } from './transcriptProjection';
+import {
+  applyStreamStatusChange,
+  onStreamStatusChange,
+} from './streamStatusSnapshot';
 
 export function subscribeStreamStatus(): () => void {
-  return StreamStatusService.onDidChange((change) => {
+  return onStreamStatusChange((change) => {
     // Patch status BEFORE projection so the transcript projector derives
     // `finalizeDeferred` from the current status. A reused stream still
     // carrying `WAITING` from the previous turn would otherwise finalize
     // the next run's first chunks early, shoving partial text into
     // `<Static>` before it finished streaming.
-    patchStream(change.streamId, (slice) => {
-      if (slice.status === change.status) return slice;
-      // Stamp the turn-start clock when entering RUNNING (keeping any prior
-      // stamp if we re-enter without leaving), and clear it otherwise so the
-      // StatusBar's elapsed segment only ticks during an active turn.
-      const runStartedAt =
-        change.status === STREAM_STATUS.RUNNING
-          ? (slice.runStartedAt ?? Date.now())
-          : undefined;
-      return { ...slice, status: change.status, runStartedAt };
-    });
-    updateChildStreamStatus(change.streamId, change.status);
+    applyStreamStatusChange(change);
     projectStreamTranscriptForStatus(change.streamId, change.status);
   });
 }


### PR DESCRIPTION
## Summary

- Add a CLI runtime architecture note with Mermaid diagrams for startup selection, model/team planning, chat TUI rendering, and skill activation boundaries.
- Centralize TUI stream status fallback/patch logic in `streamStatusSnapshot.ts` so `runChatTui` no longer assembles parent, child, and `StreamStatusService` status sources inline.
- Keep `subscribeStreamStatus` focused on ordering: patch status first, then project transcripts.

## Why

The CLI path has accumulated repeated model/team/status resolution work. The architecture note makes those round trips explicit, and the small refactor takes the first low-risk cleanup step by moving status-source reconciliation into the TUI state layer.

## Validation

- `corepack pnpm exec prettier --check docs/architecture/cli-runtime-round-trips.md packages/cli/src/chat/tui/runChatTui.tsx packages/cli/src/chat/tui/state/subscribeStreamStatus.ts packages/cli/src/chat/tui/state/streamStatusSnapshot.ts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli`
- `npm run typecheck`
- `npm run lint` (0 errors; 29 pre-existing import-order warnings outside this diff)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of status reconciliation with documentation only outside the TUI state layer; touches subagent follow-up and session-clear paths but logic is moved, not rewritten.
> 
> **Overview**
> Adds **`docs/architecture/cli-runtime-round-trips.md`** with Mermaid diagrams for CLI startup, chat TUI data flow, model/team round trips, skills boundaries, and a prioritized refactor backlog (stream status first).
> 
> **Centralizes TUI stream status handling** in new `streamStatusSnapshot.ts`: `applyStreamStatusChange` (patch `cliState` + child status + `runStartedAt`), `streamStatusForStream` / `streamStatusSnapshot` (reconcile parent child slice, stream slice, and `StreamStatusService`), and `onStreamStatusChange` as the subscription entry point.
> 
> `runChatTui.tsx` drops inline status assembly and direct `StreamStatusService` imports for follow-ups, root status, `/clear` guards, and WAITING notifications. `subscribeStreamStatus.ts` delegates patching to `applyStreamStatusChange` and keeps **patch-before-project** ordering for transcript projection only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a98ade36525ab4ae4df08e16e4963e5eef6bf6cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->