### PR TITLE
[codex] Keep built-in team roots explicit

### DIFF
--- a/docs/architecture/cli-runtime-round-trips.md
+++ b/docs/architecture/cli-runtime-round-trips.md
@@ -158,7 +158,7 @@ sequenceDiagram
 
   L->>A: loadAgents({ includeRemote: false })
   L->>P: plan presets with local agents
-  P-->>L: plans, gaps, local fallback roots
+  P-->>L: plans, gaps, explicit root availability
   L->>R: maybe load remote agents if authenticated and gaps exist
   R-->>P: replan with remote agents
   L-->>Run: selected preset id
@@ -167,12 +167,11 @@ sequenceDiagram
   Run->>P: replan current preset
 ```
 
-The local CLI currently shows built-in teams as unavailable without relay-served
-agents. For example, `texra-local multi-agent inspect physicist` resolves
-`research` as a local root but still blocks team launch because that root cannot
-delegate and required specialists are missing. That behavior is internally
-consistent, but it is a UX pressure point because list output exposes a root
-agent while run output correctly says the team cannot launch.
+The local CLI shows built-in teams as unavailable without relay-served
+orchestrators. Local specialists such as `lean`, `research`, and `numerics`
+remain visible as available members, but they are not promoted to team roots.
+That keeps list, launcher, and run output aligned: a built-in team either has a
+delegating orchestrator root or reports that no runnable team root is available.
 
 ## Skills Protocol Implication
 

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -231,7 +231,7 @@ const SCENARIOS = [
       'Team Lean Project',
       '2/7 tool-use agents',
       'unavailable',
-      'root lean cannot delegate',
+      'no runnable team root',
       'Team Physicist',
       'Team Computer Scientist…',
       'Help',

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -127,10 +127,11 @@ function planLoadedCliMultiAgentPresets(
  * Resolve a preset plan, then — when it still has gaps and the user is
  * authenticated — perform a remote load and replan. Relay-served premium agents
  * (the team orchestrator and delegation specialists most presets name) are only
- * visible after a remote load, so a local-only resolve silently degrades the
- * team (e.g. falling back to the first plain tool-use agent as root). Both the
- * headless `multi-agent run` path and the interactive `orchestrate` menu route
- * through here so they can't drift apart again.
+ * visible after a remote load. Until then, built-in presets report no runnable
+ * root instead of promoting a local specialist; custom presets can still use
+ * their own delegating member root. Both the headless `multi-agent run` path and
+ * the interactive `orchestrate` menu route through here so they can't drift
+ * apart again.
  *
  * Assumes local agents are already loaded by the caller.
  */

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -67,6 +67,7 @@ export const MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION =
   'Root agent for the team run (defaults to the preset orchestrator)';
 export const MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION =
   'Model for the team root agent';
+const BUILT_IN_TEAM_ROOT_AGENT_NAMES = ['orchestrator', 'leanOrchestrator'];
 const MULTI_AGENT_INSPECT_HINT =
   'Hint: run `texra multi-agent inspect <preset>` to see missing agents for degraded or unavailable presets.';
 const MULTI_AGENT_LOGIN_HINT =
@@ -429,10 +430,9 @@ function selectPresetRootAgent(
   if (preferredRoot) return preferredRoot;
 
   if (options.presetSource === 'built-in') {
-    // Built-in teams name specialists as members. If their orchestrator is not
-    // available, fall back only to a plain local agent rather than promoting an
-    // arbitrary delegation specialist to team root.
-    return rootCandidates.find((agent) => !agentHasDelegationTools(agent));
+    // Built-in teams have dedicated orchestrator roots. Local specialists such
+    // as `lean`, `research`, or `numerics` are members, not safe root fallbacks.
+    return undefined;
   }
 
   return delegatingAgents[0] ?? rootCandidates[0];
@@ -445,8 +445,8 @@ function findPreferredRootAgent(
 ): AgentEntry | undefined {
   const searchOrder =
     presetSource === 'built-in'
-      ? ['orchestrator', 'leanOrchestrator']
-      : ['orchestrator', 'leanOrchestrator', ...presetOrder];
+      ? BUILT_IN_TEAM_ROOT_AGENT_NAMES
+      : [...BUILT_IN_TEAM_ROOT_AGENT_NAMES, ...presetOrder];
   for (const name of searchOrder) {
     const entry = agents.find((agent) => agent.name === name);
     if (entry) return entry;

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -123,7 +123,7 @@ describe('CLI multi-agent presets', () => {
     });
 
     expect(formatCliMultiAgentPresetLauncherSummary(plan)).toBe(
-      'unavailable; root lean cannot delegate; 2/7 tool-use agents',
+      'unavailable; no runnable team root; 2/7 tool-use agents',
     );
     expect(cliMultiAgentPresetCanLaunchTeam(plan)).toBe(false);
   });
@@ -221,12 +221,8 @@ describe('CLI multi-agent presets', () => {
         ],
         label: '2/7',
       },
-      rootAgent: {
-        key: 'builtInToolUse:lean',
-        name: 'lean',
-        source: 'builtInToolUse',
-      },
     });
+    expect(record.availability.rootAgent).toBeUndefined();
   });
 
   it('includes planned availability in ndjson preset records', () => {
@@ -396,24 +392,24 @@ describe('CLI multi-agent presets', () => {
     expect(plan.missingToolUseAgents).toContain('research');
   });
 
-  it('flags a gap when the preset has a root but missing members', () => {
+  it('flags a gap when a built-in preset has members but no root', () => {
     const preset = findCliMultiAgentPreset(
       cliMultiAgentPresets(undefined),
       'physicist',
     )!;
-    // A local-only registry: `review` can serve as root, but the orchestrator
-    // and the rest of the team are absent. The run should still be treated as
-    // having gaps so an authenticated user triggers a remote load.
+    // A local-only registry can expose team members before relay-served
+    // orchestrators are available. The members should still count as available,
+    // but they should not be promoted to the built-in team root.
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [agent('review', AgentCategory.ToolUse)],
     });
 
-    expect(plan.rootAgent?.name).toBe('review');
+    expect(plan.rootAgent).toBeUndefined();
     expect(cliMultiAgentPlanHasGaps(plan)).toBe(true);
   });
 
-  it('does not select simplifier as an implicit preset root', () => {
+  it('does not select built-in team specialists as implicit roots', () => {
     const preset = findCliMultiAgentPreset(
       cliMultiAgentPresets(undefined),
       'physicist',
@@ -432,9 +428,32 @@ describe('CLI multi-agent presets', () => {
       ],
     });
 
-    expect(plan.rootAgent?.name).toBe('review');
+    expect(plan.rootAgent).toBeUndefined();
     expect(onlySimplifierPlan.rootAgent).toBeUndefined();
     expect(cliMultiAgentPlanHasGaps(onlySimplifierPlan)).toBe(true);
+  });
+
+  it('allows custom presets to default to a delegating member root', () => {
+    const plan = planCliMultiAgentPresetRun(
+      {
+        id: 'custom-review',
+        name: 'Custom review',
+        description: 'User-authored review team.',
+        icon: 'codicon-symbol-method',
+        source: 'custom',
+        workflowAgents: [],
+        toolUseAgents: ['review'],
+      },
+      {
+        workflowAgents: [],
+        toolUseAgents: [
+          agent('review', AgentCategory.ToolUse, ['delegate_agent']),
+        ],
+      },
+    );
+
+    expect(plan.rootAgent?.name).toBe('review');
+    expect(cliMultiAgentPlanHasGaps(plan)).toBe(false);
   });
 
   it('does not allow custom presets to default to their simplifier agent', () => {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -453,9 +453,9 @@ describe('CLI multi-agent run command', () => {
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
   });
 
-  it('refuses signed-out preset fallback to one root agent', async () => {
+  it('refuses built-in presets without a runnable root agent', async () => {
     mocks.cliMultiAgentPresetTeamLaunchBlockReason.mockReturnValueOnce(
-      'root lean cannot delegate',
+      'no runnable team root',
     );
     mocks.planCliMultiAgentPresetRun.mockReturnValue({
       preset: {
@@ -463,13 +463,7 @@ describe('CLI multi-agent run command', () => {
         name: 'Mathematician',
         source: 'built-in',
       },
-      rootAgent: {
-        name: 'lean',
-        category: 'toolUse',
-        source: 'builtInToolUse',
-        path: '/agents/lean.yaml',
-        tools: [],
-      },
+      rootAgent: undefined,
       missingWorkflowAgents: ['generic', 'devise', 'apply'],
       missingToolUseAgents: ['simplifier', 'progressCheck', 'orchestrator'],
       workflowAgentKeys: [],
@@ -488,7 +482,7 @@ describe('CLI multi-agent run command', () => {
     expect(exitCode).toBe(2);
     expect(mocks.executeCliRequest).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'Multi-agent preset "mathematician" cannot start as a team: root lean cannot delegate. Run `texra multi-agent inspect mathematician` to see missing agents. Start a single-agent chat with `texra chat --agent lean` if that is what you want.',
+      'Multi-agent preset "mathematician" cannot start as a team: no runnable team root. Run `texra multi-agent inspect mathematician` to see missing agents. Install or sign in for a runnable team root before launching this preset.',
     );
     expect(mocks.writeTextStderr).not.toHaveBeenCalledWith(
       expect.stringContaining('WARN team delegation unavailable'),

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -285,7 +285,7 @@ describe('CLI orchestration items', () => {
     );
   });
 
-  it('disables team presets that would launch only a fallback root', () => {
+  it('does not promote built-in team members to fallback roots', () => {
     const items = buildCliOrchestrationItems({
       presetPlans: [
         presetPlan(
@@ -307,8 +307,7 @@ describe('CLI orchestration items', () => {
     expect(items.find((item) => item.label === 'Team Lean Project')).toEqual(
       expect.objectContaining({
         disabled: true,
-        description:
-          'unavailable; root lean cannot delegate; 1/2 tool-use agents',
+        description: 'unavailable; no runnable team root; 1/2 tool-use agents',
       }),
     );
   });
@@ -394,8 +393,7 @@ describe('CLI orchestration items', () => {
       view.items.find((item) => item.label === 'Team Lean Project'),
     ).toMatchObject({
       disabled: true,
-      description:
-        'unavailable; root lean cannot delegate; 1/2 tool-use agents',
+      description: 'unavailable; no runnable team root; 1/2 tool-use agents',
     });
   });
 


### PR DESCRIPTION
## Summary

- Stop built-in multi-agent presets from promoting visible local specialists (`lean`, `research`, `numerics`, etc.) to team roots when the relay-served orchestrator is absent.
- Keep those local agents counted as available team members, while reporting no runnable team root until `orchestrator` or `leanOrchestrator` is loaded.
- Update CLI architecture notes and regression tests for launcher, list/inspect serialization, and headless run errors.

## Root Cause

The preset planner selected the first implicit local tool-use member as a fallback root for built-in teams when the preferred orchestrator was unavailable. The launcher then correctly rejected that root because it could not delegate, producing misleading rows such as `root lean cannot delegate`.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js multi-agent list`
- `node packages/cli/dist/bin/texra.js multi-agent inspect physicist`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli`
- `npm run typecheck`
- `npm run lint` (passes with 29 pre-existing import-order warnings outside this diff)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-agent launch and root-selection semantics across list, launcher, and run paths; behavior is well covered by tests but affects how users start built-in teams offline.
> 
> **Overview**
> Built-in multi-agent presets **no longer promote** local specialists (`lean`, `research`, `numerics`, etc.) to team root when `orchestrator` / `leanOrchestrator` is missing. Those agents still count as available members, but availability and launch now surface **`no runnable team root`** instead of picking a root that fails with `root X cannot delegate`.
> 
> **Custom** presets can still default to a delegating member root; built-in presets only accept dedicated orchestrator roots or stay unlaunchable until relay agents load after login.
> 
> List, inspect, orchestration launcher, headless `multi-agent run`, architecture notes, and TUI validation expectations are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f506abc143509e0ab77dff3c94571b1899a3375d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->