### PR TITLE
[codex] Clear CLI scrollback when focusing subagents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,15 +326,16 @@ reinvent them.
   a **full repaint** — `ansiEscapes.clearTerminal` then reprint
   `fullStaticOutput` (header + finalized root history, reflowed), with the live
   region drawn below — debounced so a drag-storm collapses into one redraw.
-  Returning from a scoped child viewport to root uses the same known-origin
-  pattern (`transcriptViewportChange().enteredRootScrollback`) before reprinting
-  root `<Static>` history; entering or switching child viewports uses
-  viewport-only clearing. Line-count erasing of the live region can't survive
-  reflow, because the emulator owns the reflow/scroll geometry and a write-only
-  stdout can't observe it, so any fixed erase count either strands residue or
-  walks up and eats the static header. Don't "fix" this back to line-count
-  erasing; the no-repaint rule applies to steady-state root rendering, not
-  resize or scoped-return repaint.
+  Any transcript viewport switch (`root` ↔ scoped child, or child ↔ child) uses
+  the same known-origin pattern: clear scrollback, drop cached static output,
+  then repaint the new viewport. Root viewports reprint root `<Static>` history;
+  scoped child viewports paint only the focused child's bounded transcript.
+  Line-count erasing of the live region can't survive reflow, because the
+  emulator owns the reflow/scroll geometry and a write-only stdout can't observe
+  it, so any fixed erase count either strands residue or walks up and eats the
+  static header. Don't "fix" this back to line-count erasing; the no-repaint
+  rule applies to steady-state rendering, not resize or transcript viewport
+  switches.
 
 ### CLI design (clig.dev)
 

--- a/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
+++ b/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
@@ -2,6 +2,13 @@ import type { StreamTabId } from '@shared/schemas';
 
 export const ROOT_SCROLLBACK_VIEWPORT_KEY = 'root-scrollback';
 
+/**
+ * The root stream owns ordinary terminal scrollback through Ink `<Static>`.
+ * Focused child streams own a scoped, self-contained transcript surface.
+ * Moving between those viewports must redraw from a clean primary buffer so
+ * a child page cannot appear under stale root scrollback, and returning to the
+ * root can reprint the root static transcript as the active owner.
+ */
 export function transcriptViewportKey({
   activeStreamId,
   parentStream,
@@ -21,7 +28,6 @@ export function isScopedTranscriptViewport(viewportKey: string): boolean {
 export interface TranscriptViewportChange {
   readonly previousViewportKey: string;
   readonly nextViewportKey: string;
-  readonly enteredRootScrollback: boolean;
 }
 
 export interface TranscriptViewportRepaintOptions {
@@ -38,20 +44,14 @@ export function transcriptViewportChange({
 }): TranscriptViewportChange | undefined {
   if (previousViewportKey === undefined) return undefined;
   if (previousViewportKey === nextViewportKey) return undefined;
-  return {
-    previousViewportKey,
-    nextViewportKey,
-    enteredRootScrollback:
-      isScopedTranscriptViewport(previousViewportKey) &&
-      !isScopedTranscriptViewport(nextViewportKey),
-  };
+  return { previousViewportKey, nextViewportKey };
 }
 
 export function transcriptViewportRepaintOptions(
-  change: TranscriptViewportChange,
+  _change: TranscriptViewportChange,
 ): TranscriptViewportRepaintOptions {
   return {
-    clearScrollback: change.enteredRootScrollback,
+    clearScrollback: true,
     preserveStatic: false,
   };
 }

--- a/patches/ink@7.0.5.patch
+++ b/patches/ink@7.0.5.patch
@@ -97,7 +97,7 @@ index b8fd45cc990adbc080eff28fc37463cd91337dff..7ec06768f5316b86e3c826d3c2de08df
 +        this.options.onRender?.({ renderTime: performance.now() - startTime });
 +        const hasStaticOutput = staticOutput && staticOutput !== '\n';
 +        // ansi-escapes@7.3.0 exposes clearViewport for visible-screen-only
-+        // repaints; keep it here so scoped transcript switches preserve scrollback.
++        // repaint callers; transcript switches request clearScrollback.
 +        const clearSequence = options.clearScrollback === true
 +            ? ansiEscapes.clearTerminal
 +            : ansiEscapes.clearViewport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.0.5: 50cbf6db969e687ac7d63f0b6bc5e37d9764e450f87645ab7ac53a37b4f7a833
+  ink@7.0.5: b41fb48a0ebb5005f770353111ec6b9c777f975899420a7e0e6098d5ef2a6f81
 
 importers:
 
@@ -377,7 +377,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@inkjs/ui':
         specifier: ^2.0.0
-        version: 2.0.0(ink@7.0.5(patch_hash=50cbf6db969e687ac7d63f0b6bc5e37d9764e450f87645ab7ac53a37b4f7a833)(@types/react@19.2.16)(react@19.2.7))
+        version: 2.0.0(ink@7.0.5(patch_hash=b41fb48a0ebb5005f770353111ec6b9c777f975899420a7e0e6098d5ef2a6f81)(@types/react@19.2.16)(react@19.2.7))
       '@lit-labs/signals':
         specifier: ^0.3.0
         version: 0.3.0
@@ -416,7 +416,7 @@ importers:
         version: 0.28.0
       ink:
         specifier: ^7.0.5
-        version: 7.0.5(patch_hash=50cbf6db969e687ac7d63f0b6bc5e37d9764e450f87645ab7ac53a37b4f7a833)(@types/react@19.2.16)(react@19.2.7)
+        version: 7.0.5(patch_hash=b41fb48a0ebb5005f770353111ec6b9c777f975899420a7e0e6098d5ef2a6f81)(@types/react@19.2.16)(react@19.2.7)
       markdown-it:
         specifier: ^14.2.0
         version: 14.2.0
@@ -7449,13 +7449,13 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inkjs/ui@2.0.0(ink@7.0.5(patch_hash=50cbf6db969e687ac7d63f0b6bc5e37d9764e450f87645ab7ac53a37b4f7a833)(@types/react@19.2.16)(react@19.2.7))':
+  '@inkjs/ui@2.0.0(ink@7.0.5(patch_hash=b41fb48a0ebb5005f770353111ec6b9c777f975899420a7e0e6098d5ef2a6f81)(@types/react@19.2.16)(react@19.2.7))':
     dependencies:
       chalk: 5.6.2
       cli-spinners: 3.4.0
       deepmerge: 4.3.1
       figures: 6.1.0
-      ink: 7.0.5(patch_hash=50cbf6db969e687ac7d63f0b6bc5e37d9764e450f87645ab7ac53a37b4f7a833)(@types/react@19.2.16)(react@19.2.7)
+      ink: 7.0.5(patch_hash=b41fb48a0ebb5005f770353111ec6b9c777f975899420a7e0e6098d5ef2a6f81)(@types/react@19.2.16)(react@19.2.7)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -10608,7 +10608,7 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  ink@7.0.5(patch_hash=50cbf6db969e687ac7d63f0b6bc5e37d9764e450f87645ab7ac53a37b4f7a833)(@types/react@19.2.16)(react@19.2.7):
+  ink@7.0.5(patch_hash=b41fb48a0ebb5005f770353111ec6b9c777f975899420a7e0e6098d5ef2a6f81)(@types/react@19.2.16)(react@19.2.7):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.3.0
       ansi-escapes: 7.3.0

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -483,16 +483,22 @@ describe('CLI conversation transcript splitting', () => {
         previousViewportKey: rootViewportKey,
         nextViewportKey: childViewportKey,
       }),
-    ).toMatchObject({ enteredRootScrollback: false });
+    ).toMatchObject({
+      previousViewportKey: rootViewportKey,
+      nextViewportKey: childViewportKey,
+    });
     expect(
       transcriptViewportChange({
         previousViewportKey: childViewportKey,
         nextViewportKey: rootViewportKey,
       }),
-    ).toMatchObject({ enteredRootScrollback: true });
+    ).toMatchObject({
+      previousViewportKey: childViewportKey,
+      nextViewportKey: rootViewportKey,
+    });
   });
 
-  it('repaints viewport switches without preserving stale Static output', () => {
+  it('repaints viewport switches from a clean scrollback owner', () => {
     const rootToChild = transcriptViewportChange({
       previousViewportKey: 'root-scrollback',
       nextViewportKey: 'scoped:child',
@@ -501,14 +507,23 @@ describe('CLI conversation transcript splitting', () => {
       previousViewportKey: 'scoped:child',
       nextViewportKey: 'root-scrollback',
     });
+    const childToChild = transcriptViewportChange({
+      previousViewportKey: 'scoped:child',
+      nextViewportKey: 'scoped:other-child',
+    });
 
     expect(rootToChild).toBeDefined();
     expect(childToRoot).toBeDefined();
+    expect(childToChild).toBeDefined();
     expect(transcriptViewportRepaintOptions(rootToChild!)).toEqual({
-      clearScrollback: false,
+      clearScrollback: true,
       preserveStatic: false,
     });
     expect(transcriptViewportRepaintOptions(childToRoot!)).toEqual({
+      clearScrollback: true,
+      preserveStatic: false,
+    });
+    expect(transcriptViewportRepaintOptions(childToChild!)).toEqual({
       clearScrollback: true,
       preserveStatic: false,
     });


### PR DESCRIPTION
## Summary

- Treat CLI transcript viewport switches as scrollback ownership changes.
- Clear the primary buffer on root-to-child, child-to-root, and child-to-child transcript switches while dropping cached Ink static output.
- Update the conversation-pane tests to cover the new repaint contract.

## Root cause

Root streams render finalized transcript rows through Ink `<Static>`, which puts them in ordinary terminal scrollback. Focused subagents intentionally render their own scoped history in the live region instead of mounting the root static transcript. The previous repaint policy only cleared scrollback when returning from a child to the root, so switching from root to a child could leave root/orchestrator static output above the focused child pane in real terminal scrollback.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/InkResizePatch.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs`
- `npm run lint` (0 errors, existing import-order warnings)
- `npm run typecheck`
- `npm run compile:fast`

Fixes #5370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TUI terminal repaint behavior for subagent focus and viewport switching; incorrect handling could affect scrollback or transcript display, but scope is limited to interactive Ink TUI paths.
> 
> **Overview**
> Fixes stale root transcript scrollback appearing above focused subagent panes when switching CLI transcript viewports.
> 
> **Viewport repaint contract** — `transcriptViewportRepaintOptions` now always requests a full primary-buffer reset (`clearScrollback: true`, `preserveStatic: false`) for every transcript viewport change (root ↔ scoped child, or child ↔ child), not only when returning to root. `enteredRootScrollback` is removed from `transcriptViewportChange` because direction no longer matters.
> 
> **Ink patch / docs** — The vendored `ink` repaint comment is aligned with callers that pass `clearScrollback` on transcript switches; lockfile patch hash updates. `CLAUDE.md` documents the unified “known-origin” redraw for all viewport switches. Tests in `ConversationPane.vitest.mts` cover child-to-child switches and the new repaint options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1561ab2a2e452b76c5533f7a1e352b2fdd15c205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->