### PR TITLE
[codex] Centralize CLI model access display

### DIFF
--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -8,12 +8,10 @@ import { Spinner } from '@inkjs/ui';
 
 import {
   getCliModelAccessList,
-  runnableCliModelAccessEntries,
   type CliModelAccess,
 } from '@cli/runtime/modelAccess';
 import { formatCliApiMode, type CliApiMode } from '@cli/runtime/apiAccessMode';
-import type { ModelAvailabilityKind } from '@shared/schemas';
-import { Select, type SelectItem } from '../ui/Select';
+import { Select } from '../ui/Select';
 import { KeyHints } from '../ui/KeyHints';
 import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
 import {
@@ -23,6 +21,10 @@ import {
 } from './_shared/selectWindow';
 import { useAsyncListForm } from './_shared/useAsyncListForm';
 import { isPlainReturnInput } from '../input/inputKeys';
+import {
+  emptyModelListMessageForCliMode,
+  modelSelectItemsForCliMode,
+} from '../modelAccessDisplay';
 
 export interface ModelListFormProps {
   readonly currentModel: string;
@@ -34,85 +36,12 @@ export interface ModelListFormProps {
   readonly onClose: () => void;
 }
 
-const RELAY_STATUS_BY_AVAILABILITY = {
-  'included-access': 'relay: included',
-  'not-included': 'relay: not included',
-  'included-login-required': 'relay: login required',
-  'relay-quota-exhausted': 'relay: quota exhausted',
-  'provider-key': 'relay: unavailable; api key set',
-  'openrouter-key': 'relay: unavailable; openrouter key set',
-  'missing-key': 'relay: unavailable; missing api key',
-} satisfies Record<ModelAvailabilityKind, string>;
-
-const EMPTY_MODEL_LIST_MESSAGES = {
-  includedLoginRequired:
-    'Included relay models require sign-in. Run /login or switch with /api personal.',
-  included:
-    'No included relay models are runnable. Switch with /api personal or try again later.',
-  personal:
-    'No personal API-key models are runnable. Configure a provider key or switch with /api included.',
-} satisfies Record<CliApiMode | 'includedLoginRequired', string>;
-
-export type NoRunnableModelAccessReason = CliApiMode | 'includedLoginRequired';
-
-export function noRunnableModelAccessReason(
-  models: readonly CliModelAccess[],
-  apiMode: CliApiMode,
-): NoRunnableModelAccessReason {
-  if (
-    apiMode === 'included' &&
-    models.some(
-      (model) => model.model.availability === 'included-login-required',
-    )
-  ) {
-    return 'includedLoginRequired';
-  }
-  return apiMode;
-}
-
-export function formatModelStatusForCliMode(
-  model: CliModelAccess,
-  apiMode: CliApiMode,
-): string {
-  if (apiMode === 'personal') return `api: ${model.status}`;
-
-  const availability = model.model.availability;
-  if (availability == null) return `relay: ${model.status}`;
-  return RELAY_STATUS_BY_AVAILABILITY[availability];
-}
-
 export function modelSelectWindow(args: {
   readonly availableRows: number | undefined;
   readonly itemCount: number;
 }): SelectWindowSize {
   // Border, title, description, and key hints are the irreducible chrome.
   return computeSelectWindowSize({ ...args, chromeRows: 5 });
-}
-
-export function modelSelectItemsForCliMode(
-  models: readonly CliModelAccess[],
-  apiMode: CliApiMode,
-  getModelSwitchDisabledReason?: (model: string) => string | undefined,
-): ReadonlyArray<SelectItem<string>> {
-  return runnableCliModelAccessEntries(models, apiMode).map((m) => {
-    const disabledReason = getModelSwitchDisabledReason?.(m.model.value);
-    const status = formatModelStatusForCliMode(m, apiMode);
-    return {
-      value: m.model.value,
-      label: m.model.label || m.model.value,
-      description: disabledReason ? `${status}; ${disabledReason}` : status,
-      disabled: disabledReason != null,
-    };
-  });
-}
-
-export function emptyModelListMessageForCliMode(
-  models: readonly CliModelAccess[],
-  apiMode: CliApiMode,
-): string {
-  return EMPTY_MODEL_LIST_MESSAGES[
-    noRunnableModelAccessReason(models, apiMode)
-  ];
 }
 
 function EmptyModelListState(props: {

--- a/packages/cli/src/chat/tui/modelAccessDisplay.ts
+++ b/packages/cli/src/chat/tui/modelAccessDisplay.ts
@@ -1,0 +1,98 @@
+import type { CliApiMode } from '@cli/runtime/apiAccessMode';
+import {
+  runnableCliModelAccessEntries,
+  type CliModelAccess,
+} from '@cli/runtime/modelAccess';
+import type { ModelAvailabilityKind } from '@shared/schemas';
+
+import type { SelectItem } from './ui/Select';
+
+const RELAY_STATUS_BY_AVAILABILITY = {
+  'included-access': 'relay: included',
+  'not-included': 'relay: not included',
+  'included-login-required': 'relay: login required',
+  'relay-quota-exhausted': 'relay: quota exhausted',
+  'provider-key': 'relay: unavailable; api key set',
+  'openrouter-key': 'relay: unavailable; openrouter key set',
+  'missing-key': 'relay: unavailable; missing api key',
+} satisfies Record<ModelAvailabilityKind, string>;
+
+const EMPTY_MODEL_LIST_SUMMARIES = {
+  includedLoginRequired: 'Included relay models require sign-in.',
+  included: 'No included relay models are runnable.',
+  personal: 'No personal API-key models are runnable.',
+} satisfies Record<NoRunnableModelAccessReason, string>;
+
+const MODEL_ACCESS_LAUNCH_BLOCK_DESCRIPTIONS = {
+  includedLoginRequired: 'Sign in with texra login for included relay models',
+  included: 'No included relay models are runnable',
+  personal: 'No personal API-key models are runnable',
+} satisfies Record<NoRunnableModelAccessReason, string>;
+
+const EMPTY_MODEL_LIST_RECOVERY = {
+  includedLoginRequired: 'Run /login or switch with /api personal.',
+  included: 'Switch with /api personal or try again later.',
+  personal: 'Configure a provider key or switch with /api included.',
+} satisfies Record<NoRunnableModelAccessReason, string>;
+
+export type NoRunnableModelAccessReason = CliApiMode | 'includedLoginRequired';
+
+export function noRunnableModelAccessReason(
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+): NoRunnableModelAccessReason {
+  if (
+    apiMode === 'included' &&
+    models.some(
+      (model) => model.model.availability === 'included-login-required',
+    )
+  ) {
+    return 'includedLoginRequired';
+  }
+  return apiMode;
+}
+
+export function formatModelStatusForCliMode(
+  model: CliModelAccess,
+  apiMode: CliApiMode,
+): string {
+  if (apiMode === 'personal') return `api: ${model.status}`;
+
+  const availability = model.model.availability;
+  if (availability == null) return `relay: ${model.status}`;
+  return RELAY_STATUS_BY_AVAILABILITY[availability];
+}
+
+export function modelSelectItemsForCliMode(
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+  getModelSwitchDisabledReason?: (model: string) => string | undefined,
+): ReadonlyArray<SelectItem<string>> {
+  return runnableCliModelAccessEntries(models, apiMode).map((model) => {
+    const disabledReason = getModelSwitchDisabledReason?.(model.model.value);
+    const status = formatModelStatusForCliMode(model, apiMode);
+    return {
+      value: model.model.value,
+      label: model.model.label || model.model.value,
+      description: disabledReason ? `${status}; ${disabledReason}` : status,
+      disabled: disabledReason != null,
+    };
+  });
+}
+
+export function modelAccessLaunchBlockDescriptionForCliMode(
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+): string {
+  return MODEL_ACCESS_LAUNCH_BLOCK_DESCRIPTIONS[
+    noRunnableModelAccessReason(models, apiMode)
+  ];
+}
+
+export function emptyModelListMessageForCliMode(
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+): string {
+  const reason = noRunnableModelAccessReason(models, apiMode);
+  return `${EMPTY_MODEL_LIST_SUMMARIES[reason]} ${EMPTY_MODEL_LIST_RECOVERY[reason]}`;
+}

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -6,9 +6,9 @@ import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { tuiOutputStreamForColor } from '../chat/tui/render/noColorOutput';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import {
+  modelAccessLaunchBlockDescriptionForCliMode,
   modelSelectItemsForCliMode,
-  noRunnableModelAccessReason,
-} from '../chat/tui/forms/ModelListForm';
+} from '../chat/tui/modelAccessDisplay';
 import { formatCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
 import type { CliModelAccess } from '../runtime/modelAccess';
 import type {
@@ -26,23 +26,6 @@ function isModelPickAction(
   action: CliOrchestrationAction,
 ): action is ModelPickAction {
   return action.kind === 'chat' || action.kind === 'preset';
-}
-
-function noRunnableModelLaunchDescription(
-  models: readonly CliModelAccess[],
-  apiMode: CliApiMode,
-): string {
-  const reason = noRunnableModelAccessReason(models, apiMode);
-  switch (reason) {
-    case 'includedLoginRequired':
-      return 'Sign in with texra login for included relay models';
-    case 'included':
-      return 'No included relay models are runnable';
-    case 'personal':
-      return 'No personal API-key models are runnable';
-  }
-  const exhaustive: never = reason;
-  return exhaustive;
 }
 
 export function orchestrationModelAccessView(
@@ -65,7 +48,10 @@ export function orchestrationModelAccessView(
     return { items, modelItems };
   }
 
-  const description = noRunnableModelLaunchDescription(models, apiMode);
+  const description = modelAccessLaunchBlockDescriptionForCliMode(
+    models,
+    apiMode,
+  );
   return {
     modelItems,
     items: items.map((item) =>

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -4,9 +4,9 @@ import {
   emptyModelListMessageForCliMode,
   formatModelStatusForCliMode,
   modelSelectItemsForCliMode,
-  modelSelectWindow,
   noRunnableModelAccessReason,
-} from '@cli/chat/tui/forms/ModelListForm';
+} from '@cli/chat/tui/modelAccessDisplay';
+import { modelSelectWindow } from '@cli/chat/tui/forms/ModelListForm';
 import { shouldCloseAsyncListFormOnInput } from '@cli/chat/tui/forms/_shared/useAsyncListForm';
 import {
   COMPACT_FORM_MAX_ROWS,
@@ -324,21 +324,18 @@ describe('CLI ModelListForm empty state', () => {
   });
 
   it('explains that included relay models require sign-in', () => {
-    expect(
-      emptyModelListMessageForCliMode(
-        [
-          access(
-            {
-              availability: 'included-login-required',
-              disabled: true,
-            },
-            'login required',
-            false,
-          ),
-        ],
-        'included',
+    const models = [
+      access(
+        {
+          availability: 'included-login-required',
+          disabled: true,
+        },
+        'login required',
+        false,
       ),
-    ).toBe(
+    ];
+
+    expect(emptyModelListMessageForCliMode(models, 'included')).toBe(
       'Included relay models require sign-in. Run /login or switch with /api personal.',
     );
   });


### PR DESCRIPTION
Fixes #5374

## Summary
- Move pure CLI model-access presentation helpers into `modelAccessDisplay`.
- Reuse the same API-mode model row projection from both `/model` and the startup orchestration picker.
- Keep `ModelListForm` focused on loading/rendering while preserving existing launcher descriptions and form copy.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs orchestrate-relay-model-pick orchestrate-personal-model-pick orchestrate-no-runnable-models model-form model-form-selectable model-form-included-empty`
- `npm run typecheck`
- `npm run lint` (0 errors; 29 pre-existing import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of TUI copy and select-item mapping with no runtime or security behavior changes; existing tests cover the strings and projections.
> 
> **Overview**
> Moves CLI model-access **presentation** (status labels, select rows, empty-state copy, and “no runnable models” reasons) out of `ModelListForm` into shared `modelAccessDisplay`, so `/model` and the startup orchestration picker use the same helpers.
> 
> `ModelListForm` keeps loading/rendering and `modelSelectWindow`; orchestration drops its local `noRunnableModelLaunchDescription` switch in favor of `modelAccessLaunchBlockDescriptionForCliMode`. Empty-list messaging is built from summary + recovery strings (user-visible text unchanged). Tests import the moved symbols from `modelAccessDisplay`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e08e45314e3dc99aa183284887f0572aeb5809bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->