### PR TITLE
[codex] Advertise CLI root agent setup

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -143,6 +143,7 @@ const AGENT_PROPOSAL_INSTRUCTION =
     '6. Include a short independent enumeration so the orchestrator can compare results.',
   ].join('\n');
 const CAN_DELEGATE = process.env.HARNESS_CAN_DELEGATE === '1';
+const CAN_SELECT_AGENT = process.env.HARNESS_CAN_SELECT_AGENT === '1';
 const CAN_SELECT_MODEL = process.env.HARNESS_CAN_SELECT_MODEL === '1';
 const DISABLED_MODEL_SWITCHES = new Set(
   parseList(process.env.HARNESS_DISABLED_MODEL_SWITCHES),
@@ -1327,7 +1328,7 @@ function handleHarnessSlashCommand(line: string): boolean {
 }
 
 registerBuiltinSlashCommands({
-  canSelectAgent: () => false,
+  canSelectAgent: () => CAN_SELECT_AGENT,
   canSelectModel: () => CAN_SELECT_MODEL,
   getModelSwitchDisabledReason: getHarnessModelSwitchDisabledReason,
   getApprovalPolicy: () => harnessApprovalPolicy,
@@ -1361,6 +1362,7 @@ registerBuiltinSlashCommands({
     );
   },
 });
+cliState.rootRunStartAvailable.set(CAN_SELECT_AGENT);
 
 const inkRef: { current?: ReturnType<typeof render> } = {};
 function repaintHarnessTranscriptViewport(

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -407,6 +407,7 @@ export function App(props: AppProps): React.JSX.Element {
   const slashPaletteOpen = useSignal(cliState.slashPaletteOpen);
   const reverseSearchOpen = useSignal(cliState.reverseSearchOpen);
   const transcriptViewerStreamId = useSignal(cliState.transcriptViewerStreamId);
+  const rootRunStartAvailable = useSignal(cliState.rootRunStartAvailable);
   const transcriptViewerOpen = transcriptViewerStreamId !== undefined;
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
@@ -415,6 +416,7 @@ export function App(props: AppProps): React.JSX.Element {
   >(undefined);
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
+  const agentSelectionAvailable = rootRunStartAvailable;
 
   const stdin = useStdin();
   const foregroundOpen =
@@ -790,7 +792,9 @@ export function App(props: AppProps): React.JSX.Element {
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>
         ) : null}
-        {tipRowVisible ? <TipRow /> : null}
+        {tipRowVisible ? (
+          <TipRow agentSelectionAvailable={agentSelectionAvailable} />
+        ) : null}
         {queuedFollowUpPanelVisible ? (
           <QueuedFollowUpsPanel
             maxRows={queuedFollowUpPanelRows}
@@ -806,6 +810,7 @@ export function App(props: AppProps): React.JSX.Element {
         />
         <StreamTabsStrip items={streamTabItems} width={columns} />
         <StatusBar
+          agentSelectionAvailable={agentSelectionAvailable}
           canStopActiveRun={canStopActiveRun}
           foregroundEscapeAction={foregroundEscapeAction({
             activeFormEscapeAction: activeForm?.escapeAction,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -64,6 +64,7 @@ export interface StatusBarDisplayInput {
   readonly approvalDepth: number;
   readonly approvalKind?: ApprovalQueueStatusKind;
   readonly taskControlsAvailable?: boolean;
+  readonly agentSelectionAvailable?: boolean;
   readonly subagentControlsAvailable: boolean;
   /** True when more than the root stream exists, i.e. a subagent or
    *  child stream is live. Gates the stream-navigation hints, which are
@@ -363,6 +364,7 @@ function metaShortcutLabel(modifierLabel: string, key: string): string {
 
 export function statusBarBindingsText(
   taskControlsAvailable = true,
+  agentSelectionAvailable = false,
   subagentControlsAvailable: boolean,
   hasMultipleStreams: boolean,
   modifierLabel = defaultShortcutModifierLabel(),
@@ -379,6 +381,7 @@ export function statusBarBindingsText(
     ...(hasMultipleStreams ? ['[Tab]streams', `${focusBinding}focus`] : []),
     ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
     '[/status]details',
+    ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
     '[/model]models',
     '[/api]api',
     shiftEnterNewline ? '[Shift-Enter]newline' : '[Ctrl-J]newline',
@@ -395,10 +398,22 @@ export function statusBarBindingsText(
   const fullBindings = joinStatusBindings(bindings);
   if (fitsStatusBindings(fullBindings, maxColumns)) return fullBindings;
 
+  if (agentSelectionAvailable) {
+    const setupBindings = joinStatusBindings([
+      '[/agent]agents',
+      '[/model]models',
+      '[/api]api',
+      shiftEnterNewline ? '[Shift-Enter]newline' : '[Ctrl-J]newline',
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(setupBindings, maxColumns)) return setupBindings;
+  }
+
   const compactBindings = joinStatusBindings([
     ...(hasMultipleStreams ? ['[Tab]streams'] : []),
     ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
     ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
+    ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
     '[/status]details',
     `[Ctrl-C]${ctrlCAction}`,
   ]);
@@ -408,6 +423,7 @@ export function statusBarBindingsText(
     ...(hasMultipleStreams ? ['[Tab]streams'] : []),
     ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
     ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
+    ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
     `[Ctrl-C]${ctrlCAction}`,
   ]);
   if (fitsStatusBindings(minimalBindings, maxColumns)) return minimalBindings;
@@ -686,6 +702,7 @@ export function buildStatusBarDisplay(
             )
           : statusBarBindingsText(
               input.taskControlsAvailable ?? true,
+              input.agentSelectionAvailable ?? false,
               input.subagentControlsAvailable,
               input.hasMultipleStreams,
               input.shortcutModifierLabel,
@@ -699,6 +716,7 @@ export function buildStatusBarDisplay(
 }
 
 export interface StatusBarProps {
+  readonly agentSelectionAvailable?: boolean;
   readonly canStopActiveRun?: () => boolean;
   readonly foregroundEscapeAction?: string;
   readonly queuedFollowUpPreview?: boolean;
@@ -758,6 +776,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
       taskControlTarget.slice,
       'tasks',
     ),
+    agentSelectionAvailable: props.agentSelectionAvailable,
     subagentControlsAvailable: hasChildControlItems(
       subagentControlTarget.slice,
       'subagents',

--- a/packages/cli/src/chat/tui/panes/TipRow.tsx
+++ b/packages/cli/src/chat/tui/panes/TipRow.tsx
@@ -1,23 +1,42 @@
 import { Box, Text } from 'ink';
 
-const TIPS = [
+const BASE_TIPS = [
   'Use /help to see available commands',
   'Press /model to switch models',
-  'Press /agent to switch agents',
   'Ctrl-C exits idle chats; stops active responses',
   'Use /clear to start fresh',
   'Press /status to see session details',
   'Press /api to view or change API mode',
 ] as const;
 
-export function TipRow(): React.JSX.Element {
+const AGENT_SELECTION_TIP = 'Press /agent to choose the root agent';
+
+export function tipRowText({
+  agentSelectionAvailable = false,
+  hour = new Date().getHours(),
+}: {
+  readonly agentSelectionAvailable?: boolean;
+  readonly hour?: number;
+} = {}): string {
+  const tips = agentSelectionAvailable
+    ? [BASE_TIPS[0], BASE_TIPS[1], AGENT_SELECTION_TIP, ...BASE_TIPS.slice(2)]
+    : BASE_TIPS;
+  const index = ((hour % tips.length) + tips.length) % tips.length;
+  return tips[index]!;
+}
+
+export function TipRow(props: {
+  readonly agentSelectionAvailable?: boolean;
+}): React.JSX.Element {
   // Pick a deterministic tip based on the current hour so it rotates
   // naturally without timers or extra state.
-  const index = new Date().getHours() % TIPS.length;
+  const tip = tipRowText({
+    agentSelectionAvailable: props.agentSelectionAvailable,
+  });
 
   return (
     <Box paddingX={1}>
-      <Text dimColor>Tip: {TIPS[index]}</Text>
+      <Text dimColor>Tip: {tip}</Text>
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -299,6 +299,7 @@ export function clearTuiSessionRunState(
   session.runExitCode = CliExitCode.Success;
   session.runCompleted = false;
   session.stopRequested = false;
+  publishRootRunStartAvailability(session);
 }
 
 export function markChatTuiRunPending(
@@ -310,6 +311,7 @@ export function markChatTuiRunPending(
   session.runExitCode = CliExitCode.Success;
   session.runCompleted = false;
   session.stopRequested = false;
+  publishRootRunStartAvailability(session);
 }
 
 export function chatTuiCanInterruptActiveRun(
@@ -343,6 +345,17 @@ export function chatTuiCanStartRootRun(
   session: PendingTuiRunSessionState,
 ): boolean {
   return !session.runPromise || session.runCompleted;
+}
+
+function publishRootRunStartAvailability(
+  session: PendingTuiRunSessionState,
+): void {
+  cliState.rootRunStartAvailable.set(chatTuiCanStartRootRun(session));
+}
+
+function markChatTuiRunCompleted(session: PendingTuiRunSessionState): void {
+  session.runCompleted = true;
+  publishRootRunStartAvailability(session);
 }
 
 export function chatTuiCanSelectModel(input: {
@@ -1328,7 +1341,7 @@ export async function runChat(
           : CliExitCode.AgentError;
       })
       .finally(() => {
-        session.runCompleted = true;
+        markChatTuiRunCompleted(session);
         void runtimeHost.close();
       });
     markChatTuiRunPending(session, runPromise);
@@ -1359,6 +1372,7 @@ export async function runChat(
     clearLocalTranscript();
     followUpQueue.clear();
     session.runCompleted = false;
+    publishRootRunStartAvailability(session);
     session.stopRequested = false;
     session.runExitCode = CliExitCode.Success;
     session.streamId = resolution.streamId;
@@ -1413,9 +1427,10 @@ export async function runChat(
           : CliExitCode.AgentError;
       })
       .finally(() => {
-        session.runCompleted = true;
+        markChatTuiRunCompleted(session);
         void runtimeHost.close();
       });
+    publishRootRunStartAvailability(session);
     // Don't await session.runPromise here: a resumed session that suspends at
     // the WAIT node leaves runPromise unresolved (mirrors startAgentRun's
     // fire-and-forget). The exit `finally` handles the dangling-promise case.
@@ -1468,7 +1483,7 @@ export async function runChat(
           'reject',
         );
         if (session.stopRequested) {
-          session.runCompleted = true;
+          markChatTuiRunCompleted(session);
           return;
         }
 
@@ -1492,7 +1507,7 @@ export async function runChat(
         session.runExitCode = session.stopRequested
           ? CliExitCode.Success
           : CliExitCode.AgentError;
-        session.runCompleted = true;
+        markChatTuiRunCompleted(session);
       }
     });
     markChatTuiRunPending(session, pendingStart);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -117,6 +117,7 @@ const SESSION_META = signal<SessionMeta>(EMPTY_SESSION_META);
 const ACTIVE_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 
 const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
+const ROOT_RUN_START_AVAILABLE = signal<boolean>(true);
 
 /** child -> parent map populated from `setParentStream`. The focus cycle
  *  (Ctrl-A / Ctrl-B) walks this when stepping back to the parent. */
@@ -162,6 +163,7 @@ export const cliState = {
   sessionMeta: SESSION_META as Signal.State<SessionMeta>,
   activeStreamId: ACTIVE_STREAM_ID as Signal.State<StreamTabId | undefined>,
   streams: STREAMS as Signal.State<ReadonlyMap<StreamTabId, StreamSlice>>,
+  rootRunStartAvailable: ROOT_RUN_START_AVAILABLE as Signal.State<boolean>,
   parentStream: PARENT_STREAM as Signal.State<
     ReadonlyMap<StreamTabId, StreamTabId>
   >,
@@ -344,6 +346,7 @@ export function resetCliState(sessionMeta = defaultSessionMeta()): void {
   cliState.sessionMeta.set(sessionMeta);
   cliState.activeStreamId.set(undefined);
   cliState.streams.set(new Map());
+  cliState.rootRunStartAvailable.set(true);
   cliState.parentStream.set(new Map());
   cliState.activeForm.set(undefined);
   cliState.slashPaletteOpen.set(false);

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -111,6 +111,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.right).toBeUndefined();
     expect(display.bindings).toContain('[/api]api');
     expect(display.bindings).toContain('[/model]models');
+    expect(display.bindings).not.toContain('[/agent]agents');
     // [Ctrl-J]newline must be visible — the binding exists in BaseTextInput
     // (see #4399) but used to be discoverable only via source diving.
     expect(display.bindings).toContain('[Ctrl-J]newline');
@@ -122,6 +123,59 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).not.toContain('[Tab]streams');
     expect(display.bindings).not.toContain('[Alt-1..9]focus');
     expect(display.left.map(statusBarSegmentText)).not.toContain('deepseekT');
+  });
+
+  it('advertises root agent selection while setup can still change it', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      agentSelectionAvailable: true,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'gpt54',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+      width: 80,
+    });
+
+    expect(display.bindings).toBe(
+      '[/agent]agents  [/model]models  [/api]api  [Ctrl-J]newline  [Ctrl-C]exit',
+    );
+  });
+
+  it('keeps root agent selection visible when setup bindings get narrow', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      agentSelectionAvailable: true,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'gpt54',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+      width: 50,
+    });
+
+    expect(display.bindings).toContain('[/agent]agents');
+    expect(display.bindings).toContain('[Ctrl-C]exit');
+    expect(display.bindings).not.toContain('[/model]models');
+    expect(display.bindings).not.toContain('[/api]api');
   });
 
   it('hides task shortcuts when no task rows exist', () => {

--- a/src/test-kernel/cli/TipRow.vitest.mts
+++ b/src/test-kernel/cli/TipRow.vitest.mts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { tipRowText } from '@cli/chat/tui/panes/TipRow';
+
+describe('CLI TipRow', () => {
+  it('keeps root agent tips hidden after agent selection closes', () => {
+    expect(
+      tipRowText({ agentSelectionAvailable: false, hour: 2 }),
+    ).not.toContain('/agent');
+  });
+
+  it('shows root agent selection as an up-front setup action', () => {
+    expect(tipRowText({ agentSelectionAvailable: true, hour: 2 })).toBe(
+      'Press /agent to choose the root agent',
+    );
+  });
+});

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -862,6 +862,25 @@ describe('CLI TUI row allocation', () => {
     expect(session.runCompleted).toBe(false);
     expect(session.stopRequested).toBe(false);
     expect(chatTuiCanStartRootRun(session)).toBe(false);
+    expect(cliState.rootRunStartAvailable.get()).toBe(false);
+  });
+
+  it('restores root run availability when clearing session run state', () => {
+    const startupPromise = new Promise<void>(() => {});
+    const session = {
+      streamId: root,
+      executionId: 'exec-old',
+      runPromise: startupPromise,
+      runExitCode: CliExitCode.AgentError,
+      runCompleted: false,
+      stopRequested: true,
+    };
+    markChatTuiRunPending(session, startupPromise);
+
+    clearTuiSessionRunState(session);
+
+    expect(chatTuiCanStartRootRun(session)).toBe(true);
+    expect(cliState.rootRunStartAvailable.get()).toBe(true);
   });
 
   it('allows model selection before start or while a tool-use chat is waiting', () => {


### PR DESCRIPTION
## Summary

Fixes #5376.

- Thread the chat TUI's root-run-start capability into the app chrome through `cliState`, so `/agent` visibility updates on the same lifecycle transitions as the session.
- Show `/agent` in the idle footer only while the root run can still be started/changed.
- Change the rotating `/agent` tip to describe choosing the root agent, and hide that tip when selection is unavailable.
- Keep the TUI harness explicit with `HARNESS_CAN_SELECT_AGENT`, so existing harness scenarios do not inherit setup-only chrome.

## Root Cause

The `/agent` command already had a `canSelectAgent` guard, but `TipRow` and `StatusBar` were static. The first implementation passed a boolean snapshot through `App`; review correctly pointed out that this could lag until another render. The updated version publishes root-run-start availability as a `cliState` signal from the existing run lifecycle helpers and has `App` subscribe directly.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TipRow.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs` (108 scenarios)
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings outside this patch)
- `npm run compile:fast`
- `npm run texra-local:build`
- `npm run texra-local:link`
- Live TTY dogfood: `texra-local` startup picker shows built-in teams as `no runnable team root`; new personal-key chat shows `[/agent]agents ...` before the first message; `/agent` opens the root-agent picker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only discoverability changes gated on existing root-run-start logic; no auth, persistence, or agent execution behavior changes.
> 
> **Overview**
> Fixes **#5376** by advertising root **`/agent`** setup in the chat TUI only while the session still allows changing the root agent—aligned with the existing `canSelectAgent` / `chatTuiCanStartRootRun` guard.
> 
> **`cliState.rootRunStartAvailable`** is a new signal updated from the run lifecycle (`clearTuiSessionRunState`, `markChatTuiRunPending`, `markChatTuiRunCompleted`, resume paths) so chrome stays in sync without stale props. **`App`** subscribes and drives **`StatusBar`** and **`TipRow`**.
> 
> The status bar adds **`[/agent]agents`** when selection is available (including a setup-focused binding tier on narrow terminals). **`TipRow`** injects *“Press /agent to choose the root agent”* only in that window. The TUI harness gates the same behavior behind **`HARNESS_CAN_SELECT_AGENT`** so default harness runs do not show setup-only hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8e5d1abb369b7924102ac270d86857482df57b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->