### PR TITLE
[codex] Avoid specialist team roots

### DIFF
--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -420,8 +420,9 @@ function selectPresetRootAgent(
     readonly presetSource: CliMultiAgentPresetSource;
   },
 ): AgentEntry | undefined {
-  const rootCandidates = implicitDefaultToolUseAgents(agents);
-  const delegatingAgents = rootCandidates.filter(agentHasDelegationTools);
+  const delegatingAgents = implicitDefaultToolUseAgents(agents).filter(
+    agentHasDelegationTools,
+  );
   const preferredRoot = findPreferredRootAgent(
     delegatingAgents,
     options.presetSource,
@@ -435,7 +436,7 @@ function selectPresetRootAgent(
     return undefined;
   }
 
-  return delegatingAgents[0] ?? rootCandidates[0];
+  return delegatingAgents[0];
 }
 
 function findPreferredRootAgent(

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -433,6 +433,25 @@ describe('CLI multi-agent presets', () => {
     expect(cliMultiAgentPlanHasGaps(onlySimplifierPlan)).toBe(true);
   });
 
+  it('keeps delegating built-in specialists as members instead of roots', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('lean', AgentCategory.ToolUse, ['delegate_agent']),
+        agent('latexFixer', AgentCategory.ToolUse),
+      ],
+    });
+
+    expect(plan.rootAgent).toBeUndefined();
+    expect(formatCliMultiAgentPresetLauncherSummary(plan)).toBe(
+      'unavailable; no runnable team root; 2/7 tool-use agents',
+    );
+  });
+
   it('allows custom presets to default to a delegating member root', () => {
     const plan = planCliMultiAgentPresetRun(
       {
@@ -454,6 +473,27 @@ describe('CLI multi-agent presets', () => {
 
     expect(plan.rootAgent?.name).toBe('review');
     expect(cliMultiAgentPlanHasGaps(plan)).toBe(false);
+  });
+
+  it('does not infer a non-delegating root for custom presets', () => {
+    const plan = planCliMultiAgentPresetRun(
+      {
+        id: 'custom-review',
+        name: 'Custom review',
+        description: 'User-authored review team.',
+        icon: 'codicon-symbol-method',
+        source: 'custom',
+        workflowAgents: [],
+        toolUseAgents: ['review'],
+      },
+      {
+        workflowAgents: [],
+        toolUseAgents: [agent('review', AgentCategory.ToolUse)],
+      },
+    );
+
+    expect(plan.rootAgent).toBeUndefined();
+    expect(cliMultiAgentPlanHasGaps(plan)).toBe(true);
   });
 
   it('does not allow custom presets to default to their simplifier agent', () => {


### PR DESCRIPTION
## Summary

- stop inferred multi-agent team roots from falling back to non-delegating tool-use agents
- keep built-in specialists such as `lean`, `research`, and `numerics` as team members when the dedicated root is unavailable
- add regression coverage for the launcher summary and custom preset root inference

## Root Cause

The planner could return a non-delegating implicit root when no preferred team root was available. In stale or partially loaded CLI registries that made built-in teams surface confusing rows such as `root lean cannot delegate`, even though `lean` is a specialist member rather than the team root.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm --filter @texra-ai/cli validate:tui orchestrate-launcher`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `node packages/cli/dist/bin/texra.js multi-agent list`
- `node packages/cli/dist/bin/texra.js multi-agent inspect lean-project`
- `node packages/cli/dist/bin/texra.js multi-agent inspect physicist`

Closes #5378

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CLI preset root inference and launcher availability messaging; explicit `agentOverride` and preferred orchestrator selection are unchanged.
> 
> **Overview**
> **Tightens inferred multi-agent team root selection** in `selectPresetRootAgent` so planners no longer promote arbitrary implicit tool-use agents when no preferred orchestrator root exists.
> 
> For **built-in** presets, behavior is unchanged when dedicated roots (`orchestrator`, `leanOrchestrator`) are missing: the root stays **undefined** instead of falling back to specialists like `lean` that happen to delegate—avoiding misleading launcher text such as `root lean cannot delegate`.
> 
> For **custom** presets, the fallback is now **only** the first delegating implicit-default agent (`delegatingAgents[0]`). The removed `?? rootCandidates[0]` path means non-delegating members (e.g. `review` without `delegate_agent`) are never auto-selected as team roots.
> 
> Regression tests cover `lean-project` with a delegating `lean` member (unavailable / no runnable team root) and custom presets with only non-delegating tool-use agents (gaps flagged, no inferred root).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678b141b9f9e853e635ef98e3ad91f74cb310fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->