### PR TITLE
[codex] Simplify SDK error adapters

### DIFF
--- a/src/agent/modelHandlers/support/sdkErrorAdapters.ts
+++ b/src/agent/modelHandlers/support/sdkErrorAdapters.ts
@@ -4,14 +4,6 @@ import {
   APIConnectionTimeoutError as AnthropicAPIConnectionTimeoutError,
   APIError as AnthropicAPIError,
   APIUserAbortError as AnthropicAPIUserAbortError,
-  AuthenticationError as AnthropicAuthenticationError,
-  BadRequestError as AnthropicBadRequestError,
-  ConflictError as AnthropicConflictError,
-  InternalServerError as AnthropicInternalServerError,
-  NotFoundError as AnthropicNotFoundError,
-  PermissionDeniedError as AnthropicPermissionDeniedError,
-  RateLimitError as AnthropicRateLimitError,
-  UnprocessableEntityError as AnthropicUnprocessableEntityError,
 } from '@anthropic-ai/sdk';
 import { ApiError as GoogleApiError } from '@google/genai';
 import { OpenRouterError } from '@openrouter/sdk/models/errors';
@@ -20,14 +12,6 @@ import {
   APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
   APIError as OpenAIAPIError,
   APIUserAbortError as OpenAIAPIUserAbortError,
-  AuthenticationError as OpenAIAuthenticationError,
-  BadRequestError as OpenAIBadRequestError,
-  ConflictError as OpenAIConflictError,
-  InternalServerError as OpenAIInternalServerError,
-  NotFoundError as OpenAINotFoundError,
-  PermissionDeniedError as OpenAIPermissionDeniedError,
-  RateLimitError as OpenAIRateLimitError,
-  UnprocessableEntityError as OpenAIUnprocessableEntityError,
 } from 'openai';
 
 // Local imports - common errors
@@ -42,7 +26,6 @@ type ErrorConstructor = abstract new (...args: any[]) => Error;
 interface SdkErrorClassMapping {
   ctor: ErrorConstructor;
   kind: SdkErrorKind;
-  includeStatusCode?: boolean;
 }
 
 function tagSdkError(
@@ -64,18 +47,15 @@ function matchMappedSdkError(
   mappings: readonly SdkErrorClassMapping[],
   apiErrorCtor?: ErrorConstructor,
 ): void {
-  for (const { ctor, kind, includeStatusCode } of mappings) {
+  for (const { ctor, kind } of mappings) {
     if (err instanceof ctor) {
-      const statusCode = includeStatusCode
-        ? (err as { status?: number }).status
-        : undefined;
-      tagSdkError(err, provider, kind, statusCode);
+      tagSdkError(err, provider, kind);
       return;
     }
   }
 
   if (apiErrorCtor && err instanceof apiErrorCtor) {
-    const statusCode = (err as { status?: number }).status;
+    const statusCode = sdkErrorStatusCode(err);
     tagSdkError(
       err,
       provider,
@@ -85,42 +65,17 @@ function matchMappedSdkError(
   }
 }
 
+function sdkErrorStatusCode(err: unknown): number | undefined {
+  const status = (err as { status?: unknown }).status;
+  return typeof status === 'number' && Number.isFinite(status)
+    ? status
+    : undefined;
+}
+
 const ANTHROPIC_SDK_ERROR_MAPPINGS: readonly SdkErrorClassMapping[] = [
   { ctor: AnthropicAPIConnectionTimeoutError, kind: 'connection_timeout' },
   { ctor: AnthropicAPIConnectionError, kind: 'connection' },
   { ctor: AnthropicAPIUserAbortError, kind: 'user_abort' },
-  {
-    ctor: AnthropicBadRequestError,
-    kind: 'bad_request',
-    includeStatusCode: true,
-  },
-  {
-    ctor: AnthropicAuthenticationError,
-    kind: 'authentication',
-    includeStatusCode: true,
-  },
-  {
-    ctor: AnthropicPermissionDeniedError,
-    kind: 'permission_denied',
-    includeStatusCode: true,
-  },
-  { ctor: AnthropicNotFoundError, kind: 'not_found', includeStatusCode: true },
-  { ctor: AnthropicConflictError, kind: 'conflict', includeStatusCode: true },
-  {
-    ctor: AnthropicUnprocessableEntityError,
-    kind: 'unprocessable_entity',
-    includeStatusCode: true,
-  },
-  {
-    ctor: AnthropicRateLimitError,
-    kind: 'rate_limit',
-    includeStatusCode: true,
-  },
-  {
-    ctor: AnthropicInternalServerError,
-    kind: 'internal_server',
-    includeStatusCode: true,
-  },
 ];
 
 export function tagAnthropicSdkError(
@@ -196,30 +151,6 @@ const OPENAI_SDK_ERROR_MAPPINGS: readonly SdkErrorClassMapping[] = [
   { ctor: OpenAIAPIConnectionTimeoutError, kind: 'connection_timeout' },
   { ctor: OpenAIAPIConnectionError, kind: 'connection' },
   { ctor: OpenAIAPIUserAbortError, kind: 'user_abort' },
-  { ctor: OpenAIBadRequestError, kind: 'bad_request', includeStatusCode: true },
-  {
-    ctor: OpenAIAuthenticationError,
-    kind: 'authentication',
-    includeStatusCode: true,
-  },
-  {
-    ctor: OpenAIPermissionDeniedError,
-    kind: 'permission_denied',
-    includeStatusCode: true,
-  },
-  { ctor: OpenAINotFoundError, kind: 'not_found', includeStatusCode: true },
-  { ctor: OpenAIConflictError, kind: 'conflict', includeStatusCode: true },
-  {
-    ctor: OpenAIUnprocessableEntityError,
-    kind: 'unprocessable_entity',
-    includeStatusCode: true,
-  },
-  { ctor: OpenAIRateLimitError, kind: 'rate_limit', includeStatusCode: true },
-  {
-    ctor: OpenAIInternalServerError,
-    kind: 'internal_server',
-    includeStatusCode: true,
-  },
 ];
 
 export function tagOpenAISdkError(err: unknown, provider = 'openai'): void {

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -416,6 +416,29 @@ describe('formatProviderHttpError', () => {
     expect(formatted.userRetryable).toBe(false);
   });
 
+  it('formats tagged Anthropic HTTP errors with status-derived metadata', () => {
+    const error = new AnthropicAuthenticationError(
+      401,
+      {
+        type: 'error',
+        error: { type: 'authentication_error', message: 'invalid key' },
+      },
+      'invalid key',
+      new Headers([['request-id', 'req_anthropic']]),
+    );
+    tagAnthropicSdkError(error, 'anthropic');
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.statusCode).toBe(401);
+    expect(formatted.statusText).toBe('Unauthorized');
+    expect(formatted.message).toContain('HTTP 401 Unauthorized');
+    expect(formatted.message).toContain('invalid key');
+    expect(formatted.requestId).toBe('req_anthropic');
+    expect(formatted.userRetryable).toBe(false);
+  });
+
   it('formats tagged Google API errors with inferred kind from status', () => {
     const error = new GoogleApiError({
       message: 'quota exceeded',


### PR DESCRIPTION
## Summary

- remove duplicated OpenAI and Anthropic HTTP subclass mapping tables from SDK error adapters
- keep explicit SDK mappings only for non-HTTP errors: connection timeout, connection, and user abort
- derive HTTP error kinds from each SDK base API error status through `sdkErrorKindFromStatusCode()`
- add Anthropic tagged HTTP regression coverage for provider, status, request id, message, and retryability metadata

## Root Cause

The adapters encoded the same HTTP status-to-kind policy that already exists in `@common/errors/sdkErrorUtils`. That made the provider-specific adapter layer wider and created change amplification whenever status mapping semantics change.

## Validation

- `corepack pnpm vitest run src/test-kernel/common/SdkErrorUtils.vitest.mts`
- `corepack pnpm --filter texra typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check`

Closes #5380

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider error classification at SDK boundaries; behavior should be equivalent but misclassification would affect retries and user-facing messages.
> 
> **Overview**
> **Simplifies OpenAI and Anthropic SDK error tagging** by dropping large per-HTTP-subclass mapping tables (401, 429, 400, etc.) and routing those cases through each provider’s base `APIError` plus shared `sdkErrorKindFromStatusCode()`.
> 
> Explicit `SdkErrorClassMapping` entries remain only for **non-HTTP** failures: connection timeout, connection, and user abort. `matchMappedSdkError` no longer supports `includeStatusCode` on class mappings; HTTP status is read via a new `sdkErrorStatusCode()` helper when the error is an instance of the base API error type.
> 
> Adds a Vitest case that **tagged Anthropic HTTP errors** (e.g. `AuthenticationError`) still produce correct provider, status, request id, message, and retryability after formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a1ed22bf70cc27758ea956e8471e726fba4b9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->