### PR TITLE
[codex] Keep CLI child stream ownership in sync

### DIFF
--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -267,10 +267,7 @@ export function resolveChildControlStreamTarget({
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): ChildControlStreamTarget {
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  const activeHasRows =
-    mode === 'subagents'
-      ? hasVisibleSubagents(activeSlice)
-      : hasVisibleTasks(activeSlice);
+  const activeHasRows = hasChildControlItems(activeSlice, mode);
   if (!activeStreamId || activeHasRows) {
     return { streamId: activeStreamId, slice: activeSlice };
   }
@@ -280,10 +277,7 @@ export function resolveChildControlStreamTarget({
   while (parentStreamId && !visited.has(parentStreamId)) {
     visited.add(parentStreamId);
     const parentSlice = streams.get(parentStreamId);
-    const parentHasRows =
-      mode === 'subagents'
-        ? hasVisibleSubagents(parentSlice)
-        : hasVisibleTasks(parentSlice);
+    const parentHasRows = hasChildControlItems(parentSlice, mode);
     if (!parentHasRows) {
       parentStreamId = parentStream.get(parentStreamId);
       continue;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -119,8 +119,10 @@ const ACTIVE_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
 const ROOT_RUN_START_AVAILABLE = signal<boolean>(true);
 
-/** child -> parent map populated from `setParentStream`. The focus cycle
- *  (Ctrl-A / Ctrl-B) walks this when stepping back to the parent. */
+/** child -> parent map populated from child stream ownership events. The focus
+ *  cycle (Ctrl-A / Ctrl-B) walks this when stepping back to the parent, and
+ *  transcript rendering uses it to keep child streams scoped to their own
+ *  history. */
 const PARENT_STREAM = signal<ReadonlyMap<StreamTabId, StreamTabId>>(new Map());
 
 /** Active inline slash form, or `undefined` when the chat input owns the
@@ -220,23 +222,57 @@ export function patchStream(
   cliState.streams.set(out);
 }
 
+interface ParentStreamEdgeUpdate {
+  readonly childStreamId?: StreamTabId;
+  readonly parentStreamId: StreamTabId | null | undefined;
+}
+
+function parentStreamMapUpdate(
+  current: ReadonlyMap<StreamTabId, StreamTabId>,
+  updates: readonly ParentStreamEdgeUpdate[],
+): Map<StreamTabId, StreamTabId> | undefined {
+  let out: Map<StreamTabId, StreamTabId> | undefined;
+  for (const { childStreamId, parentStreamId } of updates) {
+    if (!childStreamId) continue;
+    const readable = out ?? current;
+    if (parentStreamId == null || childStreamId === parentStreamId) {
+      if (!readable.has(childStreamId)) continue;
+      out ??= new Map(current);
+      out.delete(childStreamId);
+      continue;
+    }
+    if (readable.get(childStreamId) === parentStreamId) continue;
+    out ??= new Map(current);
+    out.set(childStreamId, parentStreamId);
+  }
+  return out;
+}
+
+function commitParentStreamEdges(
+  updates: readonly ParentStreamEdgeUpdate[],
+): void {
+  const next = parentStreamMapUpdate(cliState.parentStream.get(), updates);
+  if (next) cliState.parentStream.set(next);
+}
+
 export function setParentStream(
   childStreamId: StreamTabId,
   parentStreamId: StreamTabId | null | undefined,
 ): void {
-  const current = cliState.parentStream.get();
   // A null parent means the runtime promoted this child to a top-level stream.
-  if (parentStreamId == null || childStreamId === parentStreamId) {
-    if (!current.has(childStreamId)) return;
-    const out = new Map(current);
-    out.delete(childStreamId);
-    cliState.parentStream.set(out);
-    return;
-  }
-  if (current.get(childStreamId) === parentStreamId) return;
-  const out = new Map(current);
-  out.set(childStreamId, parentStreamId);
-  cliState.parentStream.set(out);
+  commitParentStreamEdges([{ childStreamId, parentStreamId }]);
+}
+
+export function registerChildStreams(
+  parentStreamId: StreamTabId,
+  children: readonly ActiveChildInfo[],
+): void {
+  commitParentStreamEdges(
+    children.map((child) => ({
+      childStreamId: child.childStreamId,
+      parentStreamId,
+    })),
+  );
 }
 
 export function removeStream(streamId: StreamTabId): void {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -13,6 +13,7 @@ import { appendTail } from '@utils/strings/appendTail';
 import {
   cliState,
   patchStream,
+  registerChildStreams,
   removeStream,
   setParentStream,
   type ProcessOutputTail,
@@ -125,6 +126,7 @@ function applyToState<K extends ProgressEvent>(
     }
     case 'updateActiveSubagents': {
       const p = payload as ProgressEventPayloads['updateActiveSubagents'];
+      registerChildStreams(p.parentStreamId, p.children);
       patchStream(p.parentStreamId, (s) => ({
         ...s,
         activeSubagents: p.children,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -44,6 +44,7 @@ import {
   finalizeSettledPrefix,
   syncStreamLog,
 } from '@cli/chat/tui/state/subscribeStreamLog';
+import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMode';
 import { projectStreamTranscript } from '@cli/chat/tui/state/transcriptProjection';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
 import { wrapRuntimeHost } from '@cli/chat/tui/state/subscribeRuntimeHost';
@@ -244,6 +245,40 @@ describe('cliState Phase 4 fields', () => {
     setParentStream(child1, null);
 
     expect(cliState.parentStream.get().has(child1)).toBe(false);
+  });
+
+  it('registers subagent parent edges when active child rows arrive', () => {
+    const wrapped = wrapRuntimeHost({
+      emit: () => undefined,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+
+    cliState.activeStreamId.set(root);
+    patchStream(child1, (s) => ({
+      ...s,
+      status: STREAM_STATUS.RUNNING,
+    }));
+
+    wrapped.emit('updateActiveSubagents', {
+      parentStreamId: root,
+      children: [
+        {
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: child1,
+          status: STREAM_STATUS.RUNNING,
+        },
+      ],
+    });
+
+    expect(cliState.parentStream.get().get(child1)).toBe(root);
+    expect(nextFocusForward()).toBe(child1);
+    expect(
+      transcriptViewportKey({
+        activeStreamId: child1,
+        parentStream: cliState.parentStream.get(),
+      }),
+    ).toBe(`scoped:${child1}`);
   });
 });
 


### PR DESCRIPTION
## Summary

- register child stream parent edges when active subagent rows arrive, before those rows become focusable
- route explicit parent updates and child-row registration through one parent-edge helper
- centralize child-control row availability checks for subagent/task fallback resolution

Closes #5382

## Validation

- corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/SubagentScopedViewer.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm prettier --check packages/cli/src/chat/tui/state/cliState.ts packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts packages/cli/src/chat/tui/state/childControls.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- git diff --check
- node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-child-ownership subagent-tab-focus-full-frame subagent-focus-return-root-scrollback-deduped
- npm run compile:fast
- npm run lint (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TUI state wiring for parent/child streams (focus, transcript scoping); behavior change is localized but user-visible if edges are wrong.
> 
> **Overview**
> Keeps the CLI TUI **child→parent stream map** aligned with active subagent rows so focus cycling (Ctrl-A/B), scoped transcripts, and child-control fallbacks work as soon as children appear—not only after explicit `setParentStream` events.
> 
> **`updateActiveSubagents`** now calls **`registerChildStreams`** before patching the parent slice, so each child’s `childStreamId` is linked to its parent when the row list updates. **`setParentStream`** and batch registration share **`commitParentStreamEdges`** / **`parentStreamMapUpdate`** for consistent add/remove/promotion (null parent) behavior.
> 
> **`resolveChildControlStreamTarget`** uses **`hasChildControlItems`** instead of duplicated subagent/task visibility checks when walking up to a parent with rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f952d0794a0d75373f12950ba6fbd017e694c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->