### PR TITLE
[codex] Keep async CLI picker commits input-blocking

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -186,6 +186,7 @@ export function registerBuiltinSlashCommands(options?: {
             action: () => onModelSelect(value),
             value,
             onDone: props.onDone,
+            onError: options?.onError,
           })
         }
         onClose={() => props.onDone(undefined)}

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -38,6 +38,33 @@ describe('slashRegistry', () => {
     }
   }
 
+  function deferredSelection(): {
+    readonly promise: Promise<void>;
+    readonly resolve: () => void;
+  } {
+    let resolveSelection: () => void = () => {};
+    const promise = new Promise<void>((resolve) => {
+      resolveSelection = resolve;
+    });
+    return { promise, resolve: resolveSelection };
+  }
+
+  function renderOpenForm<TProps>(): {
+    readonly props?: TProps;
+    readonly isClosed: () => boolean;
+  } {
+    let closed = false;
+    const node = renderFormAdapter<TProps>(
+      cliState.activeForm.get()?.render(() => {
+        closed = true;
+      }, 20),
+    );
+    return {
+      props: node.props,
+      isClosed: () => closed,
+    };
+  }
+
   it('keeps the CLI session control commands registered', () => {
     registerBuiltinSlashCommands();
     expect(listSlashCommands().map((cmd) => cmd.name)).toEqual(
@@ -239,6 +266,57 @@ describe('slashRegistry', () => {
     );
   });
 
+  it('keeps the model picker open until model selection commits', async () => {
+    const selection = deferredSelection();
+    registerBuiltinSlashCommands({
+      onModelSelect: () => selection.promise,
+    });
+    const model = listSlashCommands().find((cmd) => cmd.name === 'model');
+
+    if (!model) throw new Error('Expected /model to be registered');
+
+    expect(openRegisteredCliSlashForm(model, '')).toBe(true);
+
+    const modelNode = renderOpenForm<{
+      onSelect?: (value: string) => void;
+    }>();
+    modelNode.props?.onSelect?.('gpt55');
+    await settleFormSelection();
+
+    expect(modelNode.isClosed()).toBe(false);
+
+    selection.resolve();
+    await settleFormSelection();
+
+    expect(modelNode.isClosed()).toBe(true);
+  });
+
+  it('routes model picker selection failures to the shared error handler', async () => {
+    const errors: string[] = [];
+    registerBuiltinSlashCommands({
+      onModelSelect: async () => {
+        throw new Error('model failed');
+      },
+      onError: (error) => {
+        errors.push(error instanceof Error ? error.message : String(error));
+      },
+    });
+    const model = listSlashCommands().find((cmd) => cmd.name === 'model');
+
+    if (!model) throw new Error('Expected /model to be registered');
+
+    expect(openRegisteredCliSlashForm(model, '')).toBe(true);
+
+    const modelNode = renderOpenForm<{
+      onSelect?: (value: string) => void;
+    }>();
+    modelNode.props?.onSelect?.('gpt55');
+    await settleFormSelection();
+
+    expect(errors).toEqual(['model failed']);
+    expect(modelNode.isClosed()).toBe(true);
+  });
+
   it('routes API picker selection failures to the shared error handler', async () => {
     resetCliState({
       agent: 'chat',
@@ -258,24 +336,52 @@ describe('slashRegistry', () => {
       },
     });
     const api = listSlashCommands().find((cmd) => cmd.name === 'api');
-    let closed = false;
 
     if (!api) throw new Error('Expected /api to be registered');
 
     expect(openRegisteredCliSlashForm(api, '')).toBe(true);
 
-    const apiNode = renderFormAdapter<{
+    const apiNode = renderOpenForm<{
       onSelect?: (value: CliApiMode) => void;
-    }>(
-      cliState.activeForm.get()?.render(() => {
-        closed = true;
-      }, 20),
-    );
+    }>();
     apiNode.props?.onSelect?.('personal');
     await settleFormSelection();
 
     expect(errors).toEqual(['api mode failed']);
-    expect(closed).toBe(true);
+    expect(apiNode.isClosed()).toBe(true);
+  });
+
+  it('keeps the API picker open until API mode selection commits', async () => {
+    resetCliState({
+      agent: 'chat',
+      model: 'deepseekT',
+      cwd: '/tmp/workspace',
+      apiMode: 'included',
+      canDelegate: false,
+      version: 'test',
+    });
+    const selection = deferredSelection();
+    registerBuiltinSlashCommands({
+      onApiModeSelect: () => selection.promise,
+    });
+    const api = listSlashCommands().find((cmd) => cmd.name === 'api');
+
+    if (!api) throw new Error('Expected /api to be registered');
+
+    expect(openRegisteredCliSlashForm(api, '')).toBe(true);
+
+    const apiNode = renderOpenForm<{
+      onSelect?: (value: CliApiMode) => void;
+    }>();
+    apiNode.props?.onSelect?.('personal');
+    await settleFormSelection();
+
+    expect(apiNode.isClosed()).toBe(false);
+
+    selection.resolve();
+    await settleFormSelection();
+
+    expect(apiNode.isClosed()).toBe(true);
   });
 
   it('closes the resume picker before running the resume action', async () => {


### PR DESCRIPTION
## Summary

- keep `/api` and `/model` foreground forms mounted until their async selection handlers settle, preserving the existing active-form input lock
- route `/model` selection failures through the shared slash-form error handler
- add slash-registry coverage for commit-before-close timing on both API mode and model selection

Closes #5384

## Validation

- corepack pnpm vitest run src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/ChatApiModeModelResolution.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm prettier --check packages/cli/src/chat/tui/commands/registerBuiltins.tsx src/test-kernel/cli/SlashRegistry.vitest.mts
- git diff --check
- node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-close-async-pickers-r2 model-form-selectable-submit model-switch-compatible-only api-form api-form-buffered-hotkey

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI slash-form lifecycle and error-routing only; behavior is covered by new slash-registry tests with no auth or data-path changes.
> 
> **Overview**
> **`/model` picker errors** now go through the same `runFormSelection` **`onError`** hook as **`/api`**, so failed model switches surface via the shared slash-form error handler instead of failing silently.
> 
> **Slash-registry tests** add helpers (`deferredSelection`, `renderOpenForm`) and assert that **`/model`** and **`/api`** foreground forms **stay open while async selection handlers are in flight** and only close after commit, plus model-picker failure routing. Existing API error tests were refactored to use the shared close-tracking helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06bf2c413d8edf6d0aeb4d441cf3ec1697a86f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->