### PR TITLE
[codex] Centralize CLI child stream status resolution

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -11,7 +11,6 @@ import React from 'react';
 
 import { getToolUseAgents, getWorkflowAgents, loadAgents } from '@agent/index';
 import { getWorkspaceState } from '@agent/core/stateStore';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { isInFlightStatus } from '@common/constants/streamStatus';
@@ -23,7 +22,6 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_STATUS,
-  StreamStatusSchema,
   STREAM_LOG_ENTRY_TYPES,
   TODO_STATUS,
   TOOL_USE_STATUS,
@@ -31,6 +29,7 @@ import {
   type ExternalInquiryThreadId,
   type NormalizedToolUse,
   type RetryPermission,
+  type StreamTabId,
   type UserQuestionPermission,
 } from '@shared/schemas';
 import { buildContinuationText } from '@tools/inquiry/inquiryContinuation';
@@ -62,6 +61,7 @@ import {
   type ApprovalDecision,
 } from '../src/chat/tui/state/approvalQueue';
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
+import { effectiveStreamStatus } from '../src/chat/tui/state/streamStatus';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
 import { parseCliApiMode, type CliApiMode } from '../src/runtime/apiAccessMode';
 import type { CliModelAccess } from '../src/runtime/modelAccess';
@@ -1083,7 +1083,7 @@ function appendHarnessTranscript(
   }));
 }
 
-function harnessActiveChildStreamId(): string | undefined {
+function harnessActiveChildStreamId(): StreamTabId | undefined {
   const activeStreamId = cliState.activeStreamId.get();
   if (!activeStreamId) return undefined;
   return cliState.parentStream.get().has(activeStreamId)
@@ -1091,29 +1091,11 @@ function harnessActiveChildStreamId(): string | undefined {
     : undefined;
 }
 
-function harnessStreamStatuses(streamId: string): readonly string[] {
-  const streams = cliState.streams.get();
-  const parentStreamId = cliState.parentStream.get().get(streamId);
-  const childStreamStatus = parentStreamId
-    ? streams
-        .get(parentStreamId)
-        ?.childStreams.find((child) => child.childStreamId === streamId)?.status
-    : undefined;
-  return [
-    childStreamStatus,
-    streams.get(streamId)?.status,
-    StreamStatusService.get(streamId),
-  ].filter((status): status is string => status !== undefined);
-}
-
 function harnessRejectsFocusedChildSubmit(): boolean {
   const childStreamId = harnessActiveChildStreamId();
   if (!childStreamId) return false;
-  const statuses = harnessStreamStatuses(childStreamId);
-  return statuses.some((status) => {
-    const parsed = StreamStatusSchema.safeParse(status);
-    return !parsed.success || !isInFlightStatus(parsed.data);
-  });
+  const status = effectiveStreamStatus(childStreamId);
+  return status !== undefined && !isInFlightStatus(status);
 }
 
 function findRegisteredSlashCommand(name: string): SlashCommand | undefined {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -89,7 +89,6 @@ import {
   EXECUTION_STATUS,
   LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
-  StreamStatusSchema,
   type StreamStatus,
   type ExecutionId,
   type StreamTabId,
@@ -121,10 +120,9 @@ import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
 import { subscribeStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
 import {
+  effectiveStreamStatus,
   onStreamStatusChange,
-  streamStatusForStream,
-  streamStatusSnapshot,
-} from './state/streamStatusSnapshot';
+} from './state/streamStatus';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
 import { requestCliCompaction } from './state/compactionRequest';
 import {
@@ -422,24 +420,16 @@ function chatTuiActiveChildStreamId(): StreamTabId | undefined {
     : undefined;
 }
 
-function chatTuiStreamStatuses(streamId: StreamTabId): readonly string[] {
-  return streamStatusSnapshot(streamId);
-}
-
-function chatTuiCanAcceptFollowUp(statuses: readonly string[]): boolean {
-  // A focused child normally has at least one status source. Keep the previous
-  // permissive behavior during the brief edge where parent focus arrives first.
-  if (statuses.length === 0) return true;
-  return statuses.every((status) => {
-    const parsed = StreamStatusSchema.safeParse(status);
-    return parsed.success && isInFlightStatus(parsed.data);
-  });
+function chatTuiCanAcceptFollowUp(status: StreamStatus | undefined): boolean {
+  // A focused child normally has a status. Keep the previous permissive
+  // behavior during the brief edge where parent focus arrives first.
+  return status === undefined || isInFlightStatus(status);
 }
 
 export function chatTuiActiveChildFollowUpTarget(): StreamTabId | undefined {
   const activeStreamId = chatTuiActiveChildStreamId();
   if (!activeStreamId) return undefined;
-  return chatTuiCanAcceptFollowUp(chatTuiStreamStatuses(activeStreamId))
+  return chatTuiCanAcceptFollowUp(effectiveStreamStatus(activeStreamId))
     ? activeStreamId
     : undefined;
 }
@@ -448,13 +438,13 @@ export function chatTuiShouldAnnounceQueuedFollowUp(
   targetStreamId: StreamTabId | undefined,
 ): boolean {
   if (!targetStreamId) return true;
-  return !chatTuiStreamStatuses(targetStreamId).includes(STREAM_STATUS.WAITING);
+  return effectiveStreamStatus(targetStreamId) !== STREAM_STATUS.WAITING;
 }
 
 export function chatTuiRejectedChildFollowUpTarget(): StreamTabId | undefined {
   const activeStreamId = chatTuiActiveChildStreamId();
   if (!activeStreamId) return undefined;
-  return chatTuiCanAcceptFollowUp(chatTuiStreamStatuses(activeStreamId))
+  return chatTuiCanAcceptFollowUp(effectiveStreamStatus(activeStreamId))
     ? undefined
     : activeStreamId;
 }
@@ -1164,7 +1154,7 @@ export async function runChat(
   const pendingSkillActivations = new Map<string, string>();
   let pendingSkillActivationClearEpoch = 0;
   const rootStreamStatus = (): StreamStatus | undefined =>
-    session.streamId ? streamStatusForStream(session.streamId) : undefined;
+    session.streamId ? effectiveStreamStatus(session.streamId) : undefined;
   const hasActiveToolUseFlow = (): boolean =>
     Boolean(session.streamId && getToolUseFlowContext(session.streamId));
   const canSelectCurrentModel = (): boolean =>
@@ -1212,7 +1202,7 @@ export async function runChat(
   const resetSessionForClear = (): void => {
     const activeStreamId = session.streamId ?? cliState.activeStreamId.get();
     const activeStatus = activeStreamId
-      ? streamStatusForStream(activeStreamId)
+      ? effectiveStreamStatus(activeStreamId)
       : undefined;
     const isRunPending = Boolean(session.runPromise && !session.runCompleted);
 

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -11,7 +11,10 @@ import { formatDuration } from '@utils/core';
 
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
-import { visibleSubagentRows } from './childStreamMerge';
+import {
+  childWithEffectiveStatus,
+  visibleSubagentRows,
+} from './childStreamMerge';
 import { orderedDescendantsFromTree } from './focusCycle';
 import { transcriptEntryLines } from './transcriptLines';
 import type {
@@ -299,8 +302,11 @@ export function liveChildExecutionElapsedKey(
 
   const liveKeys: string[] = [];
   for (const child of slice.activeSubagents) {
-    if (hasLiveChildElapsed(child)) {
-      liveKeys.push(`${child.executionId}:${child.startedAt}`);
+    const effectiveChild = childWithEffectiveStatus(child);
+    if (hasLiveChildElapsed(effectiveChild)) {
+      liveKeys.push(
+        `${effectiveChild.executionId}:${effectiveChild.startedAt}`,
+      );
     }
   }
   for (const child of slice.activeProcesses) {

--- a/packages/cli/src/chat/tui/state/childStreamMerge.ts
+++ b/packages/cli/src/chat/tui/state/childStreamMerge.ts
@@ -1,6 +1,8 @@
 // Local imports - shared schemas
 import type { ActiveChildInfo } from '@shared/schemas';
 
+import { effectiveStreamStatus } from './streamStatus';
+
 function childKey(child: ActiveChildInfo): string {
   return child.childStreamId ?? child.executionId;
 }
@@ -16,6 +18,14 @@ export function mergeChildStreams(
   return [...byStream.values()];
 }
 
+export function childWithEffectiveStatus(
+  child: ActiveChildInfo,
+): ActiveChildInfo {
+  if (!child.childStreamId) return child;
+  const status = effectiveStreamStatus(child.childStreamId) ?? child.status;
+  return status === child.status ? child : { ...child, status };
+}
+
 /** Active subagents followed by any retained child streams that are no longer
  *  active — so completed/waiting subagent pages stay listed and addressable. */
 export function visibleSubagentRows(slice: {
@@ -26,5 +36,5 @@ export function visibleSubagentRows(slice: {
   return [
     ...slice.activeSubagents,
     ...slice.childStreams.filter((child) => !activeKeys.has(childKey(child))),
-  ];
+  ].map(childWithEffectiveStatus);
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -301,23 +301,6 @@ export function removeStream(streamId: StreamTabId): void {
   if (nextParents) cliState.parentStream.set(nextParents);
 }
 
-export function updateChildStreamStatus(
-  childStreamId: StreamTabId,
-  status: StreamStatus,
-): void {
-  const current = cliState.streams.get();
-  let out: Map<StreamTabId, StreamSlice> | undefined;
-  for (const [streamId, slice] of current) {
-    const next = mapChildStreamReferenceLists(slice, (children) =>
-      updateChildStreamReferenceStatus(children, childStreamId, status),
-    );
-    if (next === slice) continue;
-    out ??= new Map(current);
-    out.set(streamId, next);
-  }
-  if (out) cliState.streams.set(out);
-}
-
 function scrubChildStreamReferences(
   slice: StreamSlice,
   streamId: StreamTabId,
@@ -352,25 +335,6 @@ function removeChildStreamReference(
 ): readonly ActiveChildInfo[] {
   const next = children.filter((child) => child.childStreamId !== streamId);
   return next.length === children.length ? children : next;
-}
-
-function updateChildStreamReferenceStatus(
-  children: readonly ActiveChildInfo[],
-  childStreamId: StreamTabId,
-  status: StreamStatus,
-): readonly ActiveChildInfo[] {
-  let next: ActiveChildInfo[] | undefined;
-  for (const [index, child] of children.entries()) {
-    const updated =
-      child.childStreamId === childStreamId && child.status !== status
-        ? { ...child, status }
-        : child;
-    if (!next && updated !== child) {
-      next = children.slice(0, index);
-    }
-    next?.push(updated);
-  }
-  return next ?? children;
 }
 
 function defaultSessionMeta(): SessionMeta {

--- a/packages/cli/src/chat/tui/state/streamStatus.ts
+++ b/packages/cli/src/chat/tui/state/streamStatus.ts
@@ -8,9 +8,12 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 
-import { cliState, patchStream, updateChildStreamStatus } from './cliState';
+import { cliState, patchStream } from './cliState';
 
 export function applyStreamStatusChange(change: StreamStatusChange): void {
+  // StreamStatusService is the runtime source of truth. The slice status is a
+  // UI mirror used by panes that render one stream directly; child ownership
+  // rows project this value at read time instead of receiving copied updates.
   patchStream(change.streamId, (slice) => {
     if (slice.status === change.status) return slice;
     // Stamp the turn-start clock when entering RUNNING (keeping any prior
@@ -22,33 +25,15 @@ export function applyStreamStatusChange(change: StreamStatusChange): void {
         : undefined;
     return { ...slice, status: change.status, runStartedAt };
   });
-  updateChildStreamStatus(change.streamId, change.status);
 }
 
-export function streamStatusForStream(
+export function effectiveStreamStatus(
   streamId: StreamTabId,
 ): StreamStatus | undefined {
   return (
-    cliState.streams.get().get(streamId)?.status ??
-    StreamStatusService.get(streamId)
+    StreamStatusService.get(streamId) ??
+    cliState.streams.get().get(streamId)?.status
   );
-}
-
-export function streamStatusSnapshot(
-  streamId: StreamTabId,
-): readonly StreamStatus[] {
-  const streams = cliState.streams.get();
-  const parentStreamId = cliState.parentStream.get().get(streamId);
-  const childStreamStatus = parentStreamId
-    ? streams
-        .get(parentStreamId)
-        ?.childStreams.find((child) => child.childStreamId === streamId)?.status
-    : undefined;
-  return [
-    childStreamStatus,
-    streams.get(streamId)?.status,
-    StreamStatusService.get(streamId),
-  ].filter((status): status is StreamStatus => status != null);
 }
 
 export function onStreamStatusChange(

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -1,10 +1,7 @@
 // Mirror `StreamStatusService.onDidChange` into the per-stream status signal.
 
 import { projectStreamTranscriptForStatus } from './transcriptProjection';
-import {
-  applyStreamStatusChange,
-  onStreamStatusChange,
-} from './streamStatusSnapshot';
+import { applyStreamStatusChange, onStreamStatusChange } from './streamStatus';
 
 export function subscribeStreamStatus(): () => void {
   return onStreamStatusChange((change) => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -226,6 +226,7 @@ describe('cliState Phase 4 fields', () => {
 
       const parent = cliState.streams.get().get(root);
       expect(parent?.activeSubagents).toEqual([]);
+      expect(parent?.childStreams[0]?.status).toBe(STREAM_STATUS.RUNNING);
       expect(visibleSubagentRows(parent!)).toMatchObject([
         {
           executionId: 'agent-1',
@@ -1180,7 +1181,7 @@ describe('CLI TUI row allocation', () => {
     expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
   });
 
-  it('rejects follow-ups to a focused stopped child stream', () => {
+  it('ignores stale child row status when routing focused child follow-ups', () => {
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
     patchStream(root, (s) => ({
       ...s,
@@ -1197,11 +1198,11 @@ describe('CLI TUI row allocation', () => {
     setParentStream(child1, root);
 
     cliState.activeStreamId.set(child1);
-    expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
-    expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
+    expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
+    expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
   });
 
-  it('rejects focused children when any known status source is terminal', () => {
+  it('uses child slice status as a fallback for focused child follow-ups', () => {
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
     patchStream(root, (s) => ({
       ...s,
@@ -1220,6 +1221,28 @@ describe('CLI TUI row allocation', () => {
     cliState.activeStreamId.set(child1);
     expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
     expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
+  });
+
+  it('uses StreamStatusService before stale slice status for focused children', () => {
+    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({
+      ...s,
+      childStreams: [
+        {
+          executionId: 'child-exec-1',
+          agentName: 'critic',
+          childStreamId: child1,
+          status: STREAM_STATUS.STOPPED,
+        },
+      ],
+    }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.STOPPED }));
+    StreamStatusService.set(child1, STREAM_STATUS.RUNNING, { emit: false });
+    setParentStream(child1, root);
+
+    cliState.activeStreamId.set(child1);
+    expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
+    expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
   });
 
   it('rejects focused children when only StreamStatusService is terminal', () => {


### PR DESCRIPTION
## Summary

- replace the child-status snapshot aggregation path with a single `effectiveStreamStatus` resolver, using `StreamStatusService` first and `StreamSlice.status` as the startup fallback
- stop copying status updates into parent `activeSubagents` / `activeProcesses` / `childStreams` rows; project effective child status when rows are read
- align the TUI harness follow-up gate with the production resolver and add focused tests for stale child-row status, slice fallback, and service precedence

Closes #5386

## Validation

- corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm prettier --check packages/cli/src/chat/tui/runChatTui.tsx packages/cli/src/chat/tui/state/childControls.ts packages/cli/src/chat/tui/state/childStreamMerge.ts packages/cli/src/chat/tui/state/cliState.ts packages/cli/src/chat/tui/state/streamStatus.ts packages/cli/src/chat/tui/state/subscribeStreamStatus.ts packages/cli/scripts/tui-harness.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- git diff --check
- node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-child-status-single-source subagent-tab-focus-full-frame nested-subagent-picker task-picker-parent-fallback focused-stopped-subagent-submit failed-subagent-status stopped-subagent-picker stopped-task-picker
- npm run compile:fast
- npm run lint (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes follow-up acceptance and subagent picker/status display when parent child rows disagree with runtime status; behavior is intentional but affects interactive TUI routing.
> 
> **Overview**
> **Centralizes CLI stream status** behind `effectiveStreamStatus` in `streamStatus.ts`, preferring `StreamStatusService` and falling back to each stream slice’s mirrored `status`. The old multi-source `streamStatusSnapshot` path and `updateChildStreamStatus` propagation into parent `activeSubagents` / `childStreams` rows are removed.
> 
> **Child rows now resolve status at read time** via `childWithEffectiveStatus` in `visibleSubagentRows` and related UI (elapsed timers, follow-up routing). Production chat, the TUI harness, and `/clear` gating all use the same resolver instead of aggregating conflicting statuses from parent rows, slices, and the service.
> 
> **Follow-up behavior changes** when parent `childStreams` rows are stale: focused child submits are accepted or rejected from the effective status only, so a running child slice is not blocked by a terminal status still stored on the parent row. Tests cover stale row status, slice fallback, and service precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4082aa243a061c91dcbc8b1152cfa1649b7118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->