### PR TITLE
refactor: centralize CLI child-control targets

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -39,10 +39,9 @@ import {
   rewriteKittyEnterInput,
 } from './input/inputKeys';
 import {
-  hasChildControlItems,
   hasChildExecutionRows,
   numericFocusTargetForActiveStream,
-  resolveChildControlStreamTarget,
+  resolveChildControlDisplayTargets,
   type ChildControlMode,
 } from './state/childControls';
 import { cliState } from './state/cliState';
@@ -499,26 +498,13 @@ export function App(props: AppProps): React.JSX.Element {
         rows,
         tipVisible: tipRowVisible,
       });
-  const subagentControlTarget = resolveChildControlStreamTarget({
+  const childControlTargets = resolveChildControlDisplayTargets({
     activeStreamId,
-    mode: 'subagents',
     parentStream,
     streams,
   });
-  const taskControlTarget = resolveChildControlStreamTarget({
-    activeStreamId,
-    mode: 'tasks',
-    parentStream,
-    streams,
-  });
-  const taskControlsAvailable = hasChildControlItems(
-    taskControlTarget.slice,
-    'tasks',
-  );
-  const subagentControlsAvailable = hasChildControlItems(
-    subagentControlTarget.slice,
-    'subagents',
-  );
+  const taskControlsAvailable = childControlTargets.tasks.hasItems;
+  const subagentControlsAvailable = childControlTargets.subagents.hasItems;
   const hasSubagentPanel =
     !foregroundOpen && hasChildExecutionRows(activeSlice);
   const hasTodosPlanPanel = shouldShowTodosPlanPanel({
@@ -536,16 +522,9 @@ export function App(props: AppProps): React.JSX.Element {
   });
   const childControlTarget =
     childControlMode !== undefined
-      ? resolveChildControlStreamTarget({
-          activeStreamId,
-          mode: childControlMode,
-          parentStream,
-          streams,
-        })
+      ? childControlTargets[childControlMode]
       : undefined;
-  const childControlHasItems =
-    childControlMode !== undefined &&
-    hasChildControlItems(childControlTarget?.slice, childControlMode);
+  const childControlHasItems = childControlTarget?.hasItems ?? false;
   const { foregroundRows, transcriptRows } = allocateMiddleRows({
     foregroundMaxRows:
       foregroundKind === 'childControls'
@@ -612,30 +591,10 @@ export function App(props: AppProps): React.JSX.Element {
         if (!childControlMode) return null;
         const target = childControlTarget;
         if (!target) return null;
-        const targetStreamLabel = target.streamId
-          ? streamScopeDisplayLabel({
-              parentStream,
-              streamId: target.streamId,
-              streams,
-            })
-          : undefined;
-        const fallbackFromStreamLabel = target.fallbackFromStreamId
-          ? streamScopeDisplayLabel({
-              parentStream,
-              streamId: target.fallbackFromStreamId,
-              streams,
-            })
-          : undefined;
-        const streamScopeDetail =
-          targetStreamLabel && fallbackFromStreamLabel
-            ? childControlMode === 'subagents'
-              ? `${fallbackFromStreamLabel} has no subagents`
-              : `${fallbackFromStreamLabel} has no tasks or sub-workflows`
-            : undefined;
         return (
           <ChildControlPicker
             availableColumns={columns}
-            activeStreamLabel={targetStreamLabel}
+            streamLabel={target.streamLabel}
             activeStreamId={target.streamId}
             availableRows={foregroundRows}
             mode={childControlMode}
@@ -646,7 +605,7 @@ export function App(props: AppProps): React.JSX.Element {
             }
             onKillExecution={props.onKillExecution}
             slice={target.slice}
-            streamScopeDetail={streamScopeDetail}
+            streamScopeDetail={target.streamScopeDetail}
             streams={streams}
           />
         );

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -28,7 +28,7 @@ import type { StreamSlice } from '../state/cliState';
 
 export interface ChildControlPickerProps {
   readonly availableColumns?: number;
-  readonly activeStreamLabel: string | undefined;
+  readonly streamLabel: string | undefined;
   readonly activeStreamId: StreamTabId | undefined;
   readonly availableRows?: number;
   readonly mode: ChildControlMode;
@@ -958,7 +958,7 @@ function TaskDetailView({
 
 export function ChildControlPicker({
   availableColumns,
-  activeStreamLabel,
+  streamLabel,
   activeStreamId,
   availableRows,
   mode,
@@ -980,7 +980,7 @@ export function ChildControlPicker({
   const [tailExecutionId, setTailExecutionId] = useState<string | undefined>(
     undefined,
   );
-  const streamScopeLabel = activeStreamLabel ?? activeStreamId;
+  const streamScopeLabel = streamLabel ?? activeStreamId;
   const selectedIndex = clampPickerIndex(highlight, items.length);
   const selectedItem = items[selectedIndex];
   const hasItems = items.length > 0;

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -28,10 +28,7 @@ import {
   type BypassState,
   type StreamSlice,
 } from '../state/cliState';
-import {
-  hasChildControlItems,
-  resolveChildControlStreamTarget,
-} from '../state/childControls';
+import { resolveChildControlDisplayTargets } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
@@ -739,15 +736,8 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     parentStream,
     streams,
   });
-  const subagentControlTarget = resolveChildControlStreamTarget({
+  const childControlTargets = resolveChildControlDisplayTargets({
     activeStreamId,
-    mode: 'subagents',
-    parentStream,
-    streams,
-  });
-  const taskControlTarget = resolveChildControlStreamTarget({
-    activeStreamId,
-    mode: 'tasks',
     parentStream,
     streams,
   });
@@ -772,15 +762,9 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     activeProcesses: statusSlice?.activeProcesses.length ?? 0,
     approvalDepth: approvals.depth,
     approvalKind: approvals.kind,
-    taskControlsAvailable: hasChildControlItems(
-      taskControlTarget.slice,
-      'tasks',
-    ),
+    taskControlsAvailable: childControlTargets.tasks.hasItems,
     agentSelectionAvailable: props.agentSelectionAvailable,
-    subagentControlsAvailable: hasChildControlItems(
-      subagentControlTarget.slice,
-      'subagents',
-    ),
+    subagentControlsAvailable: childControlTargets.subagents.hasItems,
     hasMultipleStreams: streams.size > 1,
     model: sessionMeta.model,
     apiMode: shortCliApiMode(sessionMeta.apiMode),

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -15,6 +15,7 @@ import {
   childWithEffectiveStatus,
   visibleSubagentRows,
 } from './childStreamMerge';
+import { streamScopeDisplayLabel } from './streamLabels';
 import { orderedDescendantsFromTree } from './focusCycle';
 import { transcriptEntryLines } from './transcriptLines';
 import type {
@@ -43,6 +44,17 @@ export interface ChildControlStreamTarget {
   readonly slice: StreamSlice | undefined;
   readonly streamId: StreamTabId | undefined;
 }
+
+export interface ChildControlDisplayTarget extends ChildControlStreamTarget {
+  readonly hasItems: boolean;
+  readonly streamLabel: string | undefined;
+  readonly streamScopeDetail: string | undefined;
+}
+
+export type ChildControlDisplayTargets = Record<
+  ChildControlMode,
+  ChildControlDisplayTarget
+>;
 
 export interface PickerKeyInput {
   readonly input: string;
@@ -293,6 +305,85 @@ export function resolveChildControlStreamTarget({
   }
 
   return { streamId: activeStreamId, slice: activeSlice };
+}
+
+function childControlFallbackDetail(
+  mode: ChildControlMode,
+  fallbackFromStreamLabel: string | undefined,
+  targetStreamLabel: string | undefined,
+): string | undefined {
+  if (!fallbackFromStreamLabel || !targetStreamLabel) return undefined;
+  return mode === 'subagents'
+    ? `${fallbackFromStreamLabel} has no subagents`
+    : `${fallbackFromStreamLabel} has no tasks or sub-workflows`;
+}
+
+export function resolveChildControlDisplayTarget({
+  activeStreamId,
+  mode,
+  parentStream,
+  streams,
+}: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly mode: ChildControlMode;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}): ChildControlDisplayTarget {
+  const target = resolveChildControlStreamTarget({
+    activeStreamId,
+    mode,
+    parentStream,
+    streams,
+  });
+  const streamLabel = target.streamId
+    ? streamScopeDisplayLabel({
+        parentStream,
+        streamId: target.streamId,
+        streams,
+      })
+    : undefined;
+  const fallbackFromStreamLabel = target.fallbackFromStreamId
+    ? streamScopeDisplayLabel({
+        parentStream,
+        streamId: target.fallbackFromStreamId,
+        streams,
+      })
+    : undefined;
+  return {
+    ...target,
+    hasItems: hasChildControlItems(target.slice, mode),
+    streamLabel,
+    streamScopeDetail: childControlFallbackDetail(
+      mode,
+      fallbackFromStreamLabel,
+      streamLabel,
+    ),
+  };
+}
+
+export function resolveChildControlDisplayTargets({
+  activeStreamId,
+  parentStream,
+  streams,
+}: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}): ChildControlDisplayTargets {
+  return {
+    subagents: resolveChildControlDisplayTarget({
+      activeStreamId,
+      mode: 'subagents',
+      parentStream,
+      streams,
+    }),
+    tasks: resolveChildControlDisplayTarget({
+      activeStreamId,
+      mode: 'tasks',
+      parentStream,
+      streams,
+    }),
+  };
 }
 
 export function liveChildExecutionElapsedKey(

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -33,6 +33,7 @@ import {
   liveChildExecutionElapsedKey,
   nextPickerIndex,
   numericFocusTargetForActiveStream,
+  resolveChildControlDisplayTargets,
   resolveChildControlStreamTarget,
 } from '@cli/chat/tui/state/childControls';
 import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
@@ -633,6 +634,45 @@ describe('CLI child execution controls', () => {
         streams,
       }),
     ).toBe('review');
+  });
+
+  it('resolves child-control display targets with labels and availability', () => {
+    const parent = slice({
+      streamId: 'main',
+      activeSubagents: [
+        {
+          executionId: 'agent-1',
+          agentName: 'review',
+          childStreamId: 'review-stream',
+          status: 'running',
+        },
+      ],
+    });
+    const child = slice({ streamId: 'review-stream' });
+    const parentStream = new Map([['review-stream', 'main']] as const);
+    const targets = resolveChildControlDisplayTargets({
+      activeStreamId: 'review-stream',
+      parentStream,
+      streams: new Map([
+        ['main', parent],
+        ['review-stream', child],
+      ] as const),
+    });
+
+    expect(targets.subagents).toMatchObject({
+      streamId: 'main',
+      fallbackFromStreamId: 'review-stream',
+      hasItems: true,
+      streamLabel: 'main',
+      streamScopeDetail: 'review has no subagents',
+    });
+    expect(targets.tasks).toMatchObject({
+      streamId: 'main',
+      fallbackFromStreamId: 'review-stream',
+      hasItems: true,
+      streamLabel: 'main',
+      streamScopeDetail: 'review has no tasks or sub-workflows',
+    });
   });
 
   it('keeps subagent controls on the focused child when it has descendants', () => {


### PR DESCRIPTION
## Summary\n\nCloses #5388.\n\n- adds a single child-control display target model that owns target stream resolution, availability, friendly stream labels, and fallback scope detail\n- updates App and StatusBar to consume that resolved model instead of each rebuilding pieces of the same decision\n- renames the picker prop from activeStreamLabel to streamLabel because fallback pickers can intentionally show a parent stream\n\n## Validation\n\n- pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts\n- npm run format\n- npm run typecheck\n- npm run lint (passes with pre-existing import-order warnings outside this patch)\n- npm run compile:fast\n- corepack pnpm --filter @texra-ai/cli validate:tui nested-subagent-picker nested-task-picker task-picker-parent-fallback subagent-picker\n\n## Design note\n\nThis keeps the fallback walk in the state layer and exposes a deeper display model to the UI. The foreground picker and status footer now read from the same resolved target map, so their child-control availability and stream scope cannot drift independently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of TUI presentation/state wiring with tests; no auth, persistence, or runtime execution path changes.
> 
> **Overview**
> Introduces a **central child-control display model** in `childControls.ts`: `resolveChildControlDisplayTarget(s)` wraps existing stream-target resolution with **`hasItems`**, **`streamLabel`**, and **`streamScopeDetail`** (parent-fallback messaging).
> 
> **App** and **StatusBar** now call **`resolveChildControlDisplayTargets` once** instead of duplicating `resolveChildControlStreamTarget` + `hasChildControlItems` and inline label/detail strings. The foreground **ChildControlPicker** takes **`streamLabel`** / precomputed **`streamScopeDetail`** from that model (renamed from `activeStreamLabel`).
> 
> Adds a unit test for display-target resolution on parent fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c4beae44a1ecd12ad175034c55f981825dc7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->