### PR TITLE
fix: keep CLI subagent history out of root scrollback

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -8,6 +8,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
   LIVE_ELAPSED_STREAM_STATUSES,
   type StreamStatus,
+  type StreamTabId,
 } from '@shared/schemas';
 
 import { assertNever } from './assertNever';
@@ -247,6 +248,20 @@ export function staticTranscriptRowBudget({
   return Math.max(0, optionalRows - liveTranscriptReserveRows);
 }
 
+export function staticScrollbackStreamId({
+  activeStreamId,
+  rootStreamId,
+}: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly rootStreamId: StreamTabId | undefined;
+}): StreamTabId | undefined {
+  if (rootStreamId) return rootStreamId;
+  // Before a root run resolves, local helper output and harness-built root
+  // streams still need static scrollback. Once `rootStreamId` is set, focused
+  // children can no longer redirect this owner.
+  return activeStreamId;
+}
+
 export function shouldShowTipRow({
   foregroundOpen,
   hasQueuedFollowUps = false,
@@ -400,6 +415,7 @@ export function App(props: AppProps): React.JSX.Element {
   // off the same read and InputBar can stay mounted but disabled.
   const pending = useSignal(currentApproval);
   const activeStreamId = useSignal(cliState.activeStreamId);
+  const rootStreamId = useSignal(cliState.rootStreamId);
   const streams = useSignal(cliState.streams);
   const parentStream = useSignal(cliState.parentStream);
   const activeForm = useSignal(cliState.activeForm);
@@ -427,6 +443,10 @@ export function App(props: AppProps): React.JSX.Element {
   const inputBarVisible = !foregroundOpen;
   const viewportKey = transcriptViewportKey({ activeStreamId, parentStream });
   const scopedTranscript = isScopedTranscriptViewport(viewportKey);
+  const scrollbackStreamId = staticScrollbackStreamId({
+    activeStreamId,
+    rootStreamId,
+  });
   const previousViewportKey = useRef<string | undefined>(undefined);
   const onTranscriptViewportChange = props.onTranscriptViewportChange;
 
@@ -715,6 +735,7 @@ export function App(props: AppProps): React.JSX.Element {
         <StaticConversationTranscript
           colorEnabled={props.colorEnabled}
           maxRows={staticTranscriptRows}
+          scrollbackStreamId={scrollbackStreamId}
           width={transcriptWidth}
         />
       )}

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -128,18 +128,18 @@ function staticTranscriptItemRowCount(
 }
 
 export function appendStaticTranscriptItems({
-  activeStreamId,
   currentItems,
   streams,
   meta,
   maxRows,
+  scrollbackStreamId,
   width,
 }: {
-  readonly activeStreamId: StreamTabId | undefined;
   readonly currentItems: readonly StaticTranscriptItem[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly meta: SessionMeta;
   readonly maxRows?: number;
+  readonly scrollbackStreamId: StreamTabId | undefined;
   readonly width?: number;
 }): readonly StaticTranscriptItem[] {
   const seen = new Set(currentItems.map((item) => item.id));
@@ -165,13 +165,12 @@ export function appendStaticTranscriptItems({
     }
   }
 
-  // Only the active stream feeds the shared `<Static>` scrollback. Dumping
-  // every stream here floods the main transcript with each subagent's tool
-  // calls and file reads, interleaving them with the live side panel.
-  // Subagent activity is surfaced in the live region when its tab is
-  // focused instead.
-  if (!activeStreamId) return nextItems;
-  const slice = streams.get(activeStreamId);
+  // Only the root scrollback owner feeds shared `<Static>` output. Dumping
+  // focused child streams here floods the main transcript with each subagent's
+  // tool calls and file reads. Subagent activity is rendered by its scoped
+  // conversation pane or transcript viewer.
+  if (!scrollbackStreamId) return nextItems;
+  const slice = streams.get(scrollbackStreamId);
   for (const entry of slice?.entries ?? []) {
     if (!entry.finalized) continue;
     if (seen.has(entry.id)) continue;
@@ -187,22 +186,23 @@ export function appendStaticTranscriptItems({
 export function StaticConversationTranscript({
   colorEnabled,
   maxRows,
+  scrollbackStreamId,
   width,
 }: {
   readonly colorEnabled?: boolean;
   readonly maxRows?: number;
+  readonly scrollbackStreamId: StreamTabId | undefined;
   readonly width?: number;
 }): React.JSX.Element {
-  const activeStreamId = useSignal(cliState.activeStreamId);
   const streams = useSignal(cliState.streams);
   const sessionMeta = useSignal(cliState.sessionMeta);
   const [items, setItems] = useState<readonly StaticTranscriptItem[]>(() =>
     appendStaticTranscriptItems({
-      activeStreamId,
       currentItems: [],
       streams,
       meta: sessionMeta,
       maxRows,
+      scrollbackStreamId,
       width,
     }),
   );
@@ -212,18 +212,18 @@ export function StaticConversationTranscript({
     // items list from scratch so the header is the first thing the user
     // sees after the scrollback was wiped. Focused child streams do not
     // mount this static scrollback; they render their own bounded history.
-    const isHardReset = streams.size === 0 && activeStreamId === undefined;
+    const isHardReset = streams.size === 0 && scrollbackStreamId === undefined;
     setItems((currentItems) =>
       appendStaticTranscriptItems({
-        activeStreamId,
         currentItems: isHardReset ? [] : currentItems,
         streams,
         meta: sessionMeta,
         maxRows,
+        scrollbackStreamId,
         width,
       }),
     );
-  }, [activeStreamId, maxRows, sessionMeta, streams, width]);
+  }, [maxRows, scrollbackStreamId, sessionMeta, streams, width]);
 
   return (
     // Remount <Static> on a width change so Ink regenerates `fullStaticOutput`

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1269,6 +1269,7 @@ export async function runChat(
           approvalPromptsUnavailable: approvalsUnavailable,
           onStreamResolved: (resolvedStreamId) => {
             session.streamId = resolvedStreamId;
+            cliState.rootStreamId.set(resolvedStreamId);
             moveLocalTranscriptToStream(resolvedStreamId);
             cliState.activeStreamId.set(resolvedStreamId);
             if (session.stopRequested) interruptActive();
@@ -1367,6 +1368,7 @@ export async function runChat(
     session.runExitCode = CliExitCode.Success;
     session.streamId = resolution.streamId;
     session.executionId = resolution.snapshot.executionId;
+    cliState.rootStreamId.set(resolution.streamId);
 
     const currentModel = resolution.config.model;
     const sessionContext = currentSessionContext(currentModel);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -115,6 +115,7 @@ const EMPTY_SESSION_META: SessionMeta = {
 const SESSION_META = signal<SessionMeta>(EMPTY_SESSION_META);
 
 const ACTIVE_STREAM_ID = signal<StreamTabId | undefined>(undefined);
+const ROOT_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 
 const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
 const ROOT_RUN_START_AVAILABLE = signal<boolean>(true);
@@ -164,6 +165,7 @@ const RESET_HOOKS = new Set<() => void>();
 export const cliState = {
   sessionMeta: SESSION_META as Signal.State<SessionMeta>,
   activeStreamId: ACTIVE_STREAM_ID as Signal.State<StreamTabId | undefined>,
+  rootStreamId: ROOT_STREAM_ID as Signal.State<StreamTabId | undefined>,
   streams: STREAMS as Signal.State<ReadonlyMap<StreamTabId, StreamSlice>>,
   rootRunStartAvailable: ROOT_RUN_START_AVAILABLE as Signal.State<boolean>,
   parentStream: PARENT_STREAM as Signal.State<
@@ -345,6 +347,7 @@ function defaultSessionMeta(): SessionMeta {
 export function resetCliState(sessionMeta = defaultSessionMeta()): void {
   cliState.sessionMeta.set(sessionMeta);
   cliState.activeStreamId.set(undefined);
+  cliState.rootStreamId.set(undefined);
   cliState.streams.set(new Map());
   cliState.rootRunStartAvailable.set(true);
   cliState.parentStream.set(new Map());

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -11,6 +11,7 @@ import {
   appendStaticTranscriptItems,
   sessionHeaderIdentityLine,
 } from '@cli/chat/tui/panes/StaticConversationTranscript';
+import { staticScrollbackStreamId } from '@cli/chat/tui/App';
 import {
   transcriptViewportChange,
   transcriptViewportKey,
@@ -29,7 +30,10 @@ import {
   type StreamSlice,
 } from '@cli/chat/tui/state/cliState';
 import { transcriptToLines } from '@cli/chat/tui/state/transcriptLines';
-import { finalizeAssistantTranscriptEntries } from '@cli/chat/tui/state/transcript';
+import {
+  CLI_LOCAL_STREAM_ID,
+  finalizeAssistantTranscriptEntries,
+} from '@cli/chat/tui/state/transcript';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
 import {
   STREAM_STATUS,
@@ -335,7 +339,7 @@ describe('CLI conversation transcript splitting', () => {
     const assistant = entry('a1', 'assistant', 'A decomposition.', false);
 
     const first = appendStaticTranscriptItems({
-      activeStreamId: STREAM_ID,
+      scrollbackStreamId: STREAM_ID,
       currentItems: [],
       streams: streamsFromEntries(STREAM_ID, [user, assistant]),
       meta: SESSION_META,
@@ -345,7 +349,7 @@ describe('CLI conversation transcript splitting', () => {
     expect(first.slice(1).map((item) => item.id)).toEqual(['u1']);
 
     const second = appendStaticTranscriptItems({
-      activeStreamId: STREAM_ID,
+      scrollbackStreamId: STREAM_ID,
       currentItems: first,
       streams: streamsFromEntries(STREAM_ID, [
         user,
@@ -359,7 +363,7 @@ describe('CLI conversation transcript splitting', () => {
 
   it('shows the session header exactly once', () => {
     const first = appendStaticTranscriptItems({
-      activeStreamId: undefined,
+      scrollbackStreamId: undefined,
       currentItems: [],
       streams: new Map(),
       meta: SESSION_META,
@@ -367,7 +371,7 @@ describe('CLI conversation transcript splitting', () => {
     expect(first).toHaveLength(1);
 
     const again = appendStaticTranscriptItems({
-      activeStreamId: undefined,
+      scrollbackStreamId: undefined,
       currentItems: first,
       streams: new Map(),
       meta: { ...SESSION_META, model: 'sonnet' },
@@ -380,7 +384,7 @@ describe('CLI conversation transcript splitting', () => {
     const assistant = entry('a1', 'assistant', 'A decomposition.', true);
 
     const compact = appendStaticTranscriptItems({
-      activeStreamId: STREAM_ID,
+      scrollbackStreamId: STREAM_ID,
       currentItems: [],
       streams: streamsFromEntries(STREAM_ID, [user, assistant]),
       meta: SESSION_META,
@@ -398,7 +402,7 @@ describe('CLI conversation transcript splitting', () => {
 
     expect(
       appendStaticTranscriptItems({
-        activeStreamId: STREAM_ID,
+        scrollbackStreamId: STREAM_ID,
         currentItems: [],
         streams: streamsFromEntries(STREAM_ID, [user, assistant]),
         meta: SESSION_META,
@@ -414,7 +418,7 @@ describe('CLI conversation transcript splitting', () => {
     const later = entry('u2', 'user', 'later', true);
 
     const compact = appendStaticTranscriptItems({
-      activeStreamId: STREAM_ID,
+      scrollbackStreamId: STREAM_ID,
       currentItems: [],
       streams: streamsFromEntries(STREAM_ID, [first, large, later]),
       meta: SESSION_META,
@@ -443,7 +447,7 @@ describe('CLI conversation transcript splitting', () => {
     );
   });
 
-  it('only feeds the active stream into scrollback, not background subagents', () => {
+  it('only feeds the root scrollback stream, not background subagents', () => {
     const rootUser = entry('u1', 'user', 'do x', true);
     const childAssistant = entry('a1', 'assistant', 'done', true);
     const ROOT = 'root-stream' as StreamTabId;
@@ -454,13 +458,53 @@ describe('CLI conversation transcript splitting', () => {
     ]);
 
     const items = appendStaticTranscriptItems({
-      activeStreamId: ROOT,
+      scrollbackStreamId: ROOT,
       currentItems: [],
       streams,
       meta: SESSION_META,
     });
 
     expect(items.slice(1).map((item) => item.id)).toEqual(['u1']);
+  });
+
+  it('keeps child focus from changing the static scrollback owner', () => {
+    const rootUser = entry('u1', 'user', 'root prompt', true);
+    const childAssistant = entry('a1', 'assistant', 'child detail', true);
+    const ROOT = 'root-stream' as StreamTabId;
+    const CHILD = 'claude@agent-sdk#1' as StreamTabId;
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [ROOT, sliceWithEntries(ROOT, [rootUser])],
+      [CHILD, sliceWithEntries(CHILD, [childAssistant])],
+    ]);
+
+    const scrollbackStreamId = staticScrollbackStreamId({
+      activeStreamId: CHILD,
+      rootStreamId: ROOT,
+    });
+    const items = appendStaticTranscriptItems({
+      scrollbackStreamId,
+      currentItems: [],
+      streams,
+      meta: SESSION_META,
+    });
+
+    expect(scrollbackStreamId).toBe(ROOT);
+    expect(items.slice(1).map((item) => item.id)).toEqual(['u1']);
+  });
+
+  it('falls back to active stream only before the root owner resolves', () => {
+    expect(
+      staticScrollbackStreamId({
+        activeStreamId: STREAM_ID,
+        rootStreamId: undefined,
+      }),
+    ).toBe(STREAM_ID);
+    expect(
+      staticScrollbackStreamId({
+        activeStreamId: CLI_LOCAL_STREAM_ID,
+        rootStreamId: undefined,
+      }),
+    ).toBe(CLI_LOCAL_STREAM_ID);
   });
 
   it('separates root scrollback from scoped child transcript viewports', () => {


### PR DESCRIPTION
## Summary

Fixes #5390.

This makes the CLI TUI static transcript owner explicit instead of deriving it from the active focused stream. The root chat stream now owns shared Ink `<Static>` scrollback, while subagent streams render through the scoped conversation pane or transcript viewer.

Architecture after this change:

```text
root stream resolution / resume
  -> cliState.rootStreamId
  -> App.staticScrollbackStreamId(...)
  -> StaticConversationTranscript(scrollbackStreamId)
  -> root-only finalized rows in terminal scrollback

child stream focus
  -> cliState.activeStreamId
  -> scoped ConversationPane / TranscriptViewer
  -> child-only history, no Static append
```

The bootstrap fallback remains for local pre-run messages and harness-built root streams before a real root id exists. Once `rootStreamId` is assigned, focused children cannot redirect static scrollback.

## Validation

- `pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `pnpm vitest run src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui nested-subagent-picker subagent-picker`
- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI TUI rendering change with unit tests; no auth, persistence, or agent execution logic beyond setting/clearing `rootStreamId`.
> 
> **Overview**
> Fixes subagent transcript pollution in the main terminal scrollback by **decoupling Ink `<Static>` scrollback from tab focus**.
> 
> The TUI now tracks **`cliState.rootStreamId`** (set when a root run resolves or on resume, cleared on reset) and derives **`scrollbackStreamId`** via `staticScrollbackStreamId`: **root wins once known**; until then it falls back to `activeStreamId` for local pre-run / harness output. **`StaticConversationTranscript`** and **`appendStaticTranscriptItems`** take `scrollbackStreamId` instead of the focused stream, so **focusing a child no longer appends subagent tool/file noise to shared scrollback**—children stay in the scoped conversation pane or transcript viewer.
> 
> Tests in **`ConversationPane.vitest.mts`** cover root-only static feed, focus-invariant scrollback owner, and pre-root fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e835e92a64aa40daba3ab49dd7bc49f0c440c112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->