### PR TITLE
fix: centralize CLI model empty states

### DIFF
--- a/packages/cli/src/chat/tui/modelAccessDisplay.ts
+++ b/packages/cli/src/chat/tui/modelAccessDisplay.ts
@@ -1,8 +1,10 @@
-import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import {
+  noRunnableModelAccessReason,
   runnableCliModelAccessEntries,
   type CliModelAccess,
+  type NoRunnableModelAccessReason,
 } from '@cli/runtime/modelAccess';
+import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { ModelAvailabilityKind } from '@shared/schemas';
 
 import type { SelectItem } from './ui/Select';
@@ -34,23 +36,6 @@ const EMPTY_MODEL_LIST_RECOVERY = {
   included: 'Switch with /api personal or try again later.',
   personal: 'Configure a provider key or switch with /api included.',
 } satisfies Record<NoRunnableModelAccessReason, string>;
-
-export type NoRunnableModelAccessReason = CliApiMode | 'includedLoginRequired';
-
-export function noRunnableModelAccessReason(
-  models: readonly CliModelAccess[],
-  apiMode: CliApiMode,
-): NoRunnableModelAccessReason {
-  if (
-    apiMode === 'included' &&
-    models.some(
-      (model) => model.model.availability === 'included-login-required',
-    )
-  ) {
-    return 'includedLoginRequired';
-  }
-  return apiMode;
-}
 
 export function formatModelStatusForCliMode(
   model: CliModelAccess,

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -56,6 +56,8 @@ export interface CliNoAvailableModelsRecoveryOptions {
   readonly personalModeAction?: string;
 }
 
+export type NoRunnableModelAccessReason = CliApiMode | 'includedLoginRequired';
+
 const CLI_MODEL_AVAILABILITY_BY_API_MODE = {
   included: new Set<ModelAvailabilityKind>(['included-access']),
   personal: new Set<ModelAvailabilityKind>(['provider-key', 'openrouter-key']),
@@ -96,6 +98,21 @@ export function runnableCliModelAccessEntries(
     (entry) =>
       entry.available && isCliModelOptionAllowedInMode(entry.model, apiMode),
   );
+}
+
+export function noRunnableModelAccessReason(
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+): NoRunnableModelAccessReason {
+  if (
+    apiMode === 'included' &&
+    models.some(
+      (model) => model.model.availability === 'included-login-required',
+    )
+  ) {
+    return 'includedLoginRequired';
+  }
+  return apiMode;
 }
 
 function formatModelAccessStatus(model: ModelOptionData): string {

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -4,6 +4,7 @@ import {
   cliModelFallbackModeForSource,
   formatCliNoAvailableModelsRecovery,
   getCliModelAccessList,
+  noRunnableModelAccessReason,
   runnableCliModelAccessEntries,
   resolveCliRunnableModel,
   resolveCliRunnableModelFromAccessList,
@@ -215,6 +216,57 @@ describe('CLI model access resolution', () => {
         (entry) => entry.model.value,
       ),
     ).toEqual(['deepseekT', 'openrouterOnlyT']);
+  });
+
+  it('classifies signed-out included access separately from other included outages', () => {
+    expect(
+      noRunnableModelAccessReason(
+        [
+          model('sonnet46T', {
+            available: false,
+            status: 'login required',
+            model: modelOption('sonnet46T', {
+              availability: 'included-login-required',
+              disabled: true,
+            }),
+          }),
+        ],
+        'included',
+      ),
+    ).toBe('includedLoginRequired');
+  });
+
+  it('classifies personal and non-login included empty states by API mode', () => {
+    expect(
+      noRunnableModelAccessReason(
+        [
+          model('gemini31p', {
+            available: false,
+            status: 'missing api key',
+            model: modelOption('gemini31p', {
+              availability: 'missing-key',
+              requiresKey: true,
+            }),
+          }),
+        ],
+        'personal',
+      ),
+    ).toBe('personal');
+    expect(
+      noRunnableModelAccessReason(
+        [
+          model('deepseekT', {
+            available: false,
+            status: 'relay quota exhausted',
+            model: modelOption('deepseekT', {
+              availability: 'relay-quota-exhausted',
+              disabled: true,
+            }),
+          }),
+        ],
+        'included',
+      ),
+    ).toBe('included');
   });
 
   it('rejects personal-key models in included relay mode', () => {

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -4,7 +4,6 @@ import {
   emptyModelListMessageForCliMode,
   formatModelStatusForCliMode,
   modelSelectItemsForCliMode,
-  noRunnableModelAccessReason,
 } from '@cli/chat/tui/modelAccessDisplay';
 import { modelSelectWindow } from '@cli/chat/tui/forms/ModelListForm';
 import { shouldCloseAsyncListFormOnInput } from '@cli/chat/tui/forms/_shared/useAsyncListForm';
@@ -272,57 +271,6 @@ describe('CLI ModelListForm model visibility', () => {
 });
 
 describe('CLI ModelListForm empty state', () => {
-  it('classifies signed-out included access separately from other included outages', () => {
-    expect(
-      noRunnableModelAccessReason(
-        [
-          access(
-            {
-              availability: 'included-login-required',
-              disabled: true,
-            },
-            'login required',
-            false,
-          ),
-        ],
-        'included',
-      ),
-    ).toBe('includedLoginRequired');
-  });
-
-  it('classifies personal and non-login included empty states by API mode', () => {
-    expect(
-      noRunnableModelAccessReason(
-        [
-          access(
-            {
-              availability: 'missing-key',
-              requiresKey: true,
-            },
-            'missing api key',
-            false,
-          ),
-        ],
-        'personal',
-      ),
-    ).toBe('personal');
-    expect(
-      noRunnableModelAccessReason(
-        [
-          access(
-            {
-              availability: 'relay-quota-exhausted',
-              disabled: true,
-            },
-            'relay quota exhausted',
-            false,
-          ),
-        ],
-        'included',
-      ),
-    ).toBe('included');
-  });
-
   it('explains that included relay models require sign-in', () => {
     const models = [
       access(

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -185,6 +185,54 @@ describe('CLI multi-agent presets', () => {
     );
   });
 
+  it('keeps built-in teams unavailable until their orchestrator root is present', () => {
+    const plans = planCliMultiAgentPresets(cliMultiAgentPresets(undefined), {
+      workflowAgents: [
+        agent('correct', AgentCategory.Workflow),
+        agent('polish', AgentCategory.Workflow),
+      ],
+      toolUseAgents: [
+        agent('lean', AgentCategory.ToolUse),
+        agent('research', AgentCategory.ToolUse),
+        agent('numerics', AgentCategory.ToolUse),
+        agent('review', AgentCategory.ToolUse),
+        agent('search', AgentCategory.ToolUse),
+        agent('latexFixer', AgentCategory.ToolUse),
+      ],
+    });
+
+    const summaries = new Map(
+      plans.map((plan) => [
+        plan.preset.id,
+        formatCliMultiAgentPresetLauncherSummary(plan),
+      ]),
+    );
+
+    expect(summaries).toEqual(
+      new Map([
+        [
+          'lean-project',
+          'unavailable; no runnable team root; 2/7 tool-use agents',
+        ],
+        [
+          'physicist',
+          'unavailable; no runnable team root; 5/9 tool-use agents; 0/4 workflow agents',
+        ],
+        [
+          'mathematician',
+          'unavailable; no runnable team root; 4/7 tool-use agents; 2/5 workflow agents',
+        ],
+        [
+          'cs-ml',
+          'unavailable; no runnable team root; 4/8 tool-use agents; 1/5 workflow agents',
+        ],
+      ]),
+    );
+    for (const summary of summaries.values()) {
+      expect(summary).not.toContain('cannot delegate');
+    }
+  });
+
   it('serializes planned availability for machine-readable list output', () => {
     const preset = findCliMultiAgentPreset(
       cliMultiAgentPresets(undefined),


### PR DESCRIPTION
## Summary

- Move no-runnable-model classification from the Ink display helper into `packages/cli/src/runtime/modelAccess.ts` so API-mode model availability decisions live with the runtime model access source of truth.
- Keep TUI-specific empty-state and launch-block copy in `modelAccessDisplay.ts`.
- Add a built-in team launcher regression so local specialists are not reported as non-delegating roots when remote orchestrator roots are missing.

Closes #5392.

## Notes

The reported `root lean cannot delegate` launcher text reproduces with the older globally installed `texra` 0.38.5 on this machine, while the current repo-local `texra-local` 0.38.6 reports those teams as unavailable with `no runnable team root`. This PR keeps that intended behavior pinned in tests.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`
- `corepack pnpm vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui orchestrate-launcher`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor plus test moves with no auth or data-path changes; behavior is guarded by existing and new unit tests.
> 
> **Overview**
> Moves **`noRunnableModelAccessReason`** and **`NoRunnableModelAccessReason`** from the Ink TUI helper (`modelAccessDisplay.ts`) into **`packages/cli/src/runtime/modelAccess.ts`**, so “why is the model list empty?” logic lives with the rest of CLI model access. The display layer still owns TUI copy (empty-list messages, recovery hints, launch-block text) and imports the classifier from runtime.
> 
> Tests for that classification move from **`ModelListForm.vitest.mts`** to **`ModelAccess.vitest.mts`**.
> 
> Adds a **`MultiAgentPresets`** regression: when built-in teams only have local specialists and no orchestrator root, launcher summaries stay **`unavailable; no runnable team root`** and must not show misleading **`cannot delegate`** wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa12f4d6f190baf2967b5a999fd164e3b3ab2986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->