### PR TITLE
refactor: centralize CLI model lookup

### DIFF
--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -7,6 +7,7 @@ import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 import { effectiveCliApiMode } from '../runtime/apiAccessMode';
 import {
+  findCliModelAccessEntry,
   formatCliNoAvailableModelsRecovery,
   getCliModelAccessList,
   runnableCliModelAccessEntries,
@@ -22,7 +23,6 @@ import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
 
 type ModelAccessList = Awaited<ReturnType<typeof getCliModelAccessList>>;
-type ModelAccessEntry = ModelAccessList[number];
 
 /**
  * Output projection for JSON/NDJSON: prefix the model record with `id` so the
@@ -110,17 +110,7 @@ async function listModels(
   return CliExitCode.Success;
 }
 
-function findModelById(
-  list: ModelAccessList,
-  id: string,
-): ModelAccessEntry | undefined {
-  const direct = list.find((entry) => entry.model.value === id);
-  if (direct) return direct;
-  const lower = id.toLowerCase();
-  return list.find((entry) => entry.model.value.toLowerCase() === lower);
-}
-
-function formatModelDetails(entry: ModelAccessEntry): string {
+function formatModelDetails(entry: ModelAccessList[number]): string {
   const { model, status } = entry;
   const lines: string[] = [];
   lines.push(`id: ${model.value}`);
@@ -145,7 +135,7 @@ async function showModel(context: CliContext, id: string): Promise<number> {
     return CliExitCode.ModelOrNetworkError;
   }
 
-  const entry = findModelById(result.models, id);
+  const entry = findCliModelAccessEntry(result.models, id);
   if (!entry) {
     writeTextStderr(`Model not found: ${id}`);
     return CliExitCode.Usage;

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -208,7 +208,7 @@ export async function getCliModelAccessList(
   return access;
 }
 
-function findModelAccess(
+export function findCliModelAccessEntry(
   models: readonly CliModelAccess[],
   model: string,
 ): CliModelAccess | undefined {
@@ -227,7 +227,9 @@ function withModelAccess(
   models: readonly CliModelAccess[],
   entry: CliModelAccess | undefined,
 ): readonly CliModelAccess[] {
-  if (!entry || findModelAccess(models, entry.model.value)) return models;
+  if (!entry || findCliModelAccessEntry(models, entry.model.value)) {
+    return models;
+  }
   return [...models, entry];
 }
 
@@ -275,8 +277,8 @@ export function resolveCliRunnableModelFromAccessList(
     models,
     options.apiMode,
   );
-  const entry = findModelAccess(models, trimmed);
-  const runnableEntry = findModelAccess(runnableEntries, trimmed);
+  const entry = findCliModelAccessEntry(models, trimmed);
+  const runnableEntry = findCliModelAccessEntry(runnableEntries, trimmed);
   if (runnableEntry) return { model: runnableEntry.model.value };
 
   const availableIds = modelIds(runnableEntries);
@@ -313,7 +315,7 @@ export async function resolveCliRunnableModelWithAccessList(
 ): Promise<CliRunnableModelResolution> {
   const trimmed = model.trim();
   const hiddenModelId =
-    trimmed && !findModelAccess(models, trimmed)
+    trimmed && !findCliModelAccessEntry(models, trimmed)
       ? getCanonicalModelConfigId(trimmed)
       : undefined;
   let hiddenModel: CliModelAccess | undefined;

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   cliModelFallbackModeForSource,
+  findCliModelAccessEntry,
   formatCliNoAvailableModelsRecovery,
   getCliModelAccessList,
   noRunnableModelAccessReason,
@@ -185,6 +186,15 @@ describe('CLI model access resolution', () => {
     expect(
       runnableCliModelAccessEntries(entries).map((entry) => entry.model.value),
     ).toEqual(['sonnet46T']);
+  });
+
+  it('finds model access entries by id case-insensitively', () => {
+    const entries = [model('sonnet46T'), model('deepseekT')];
+
+    expect(findCliModelAccessEntry(entries, 'DEEPSEEKT')?.model.value).toBe(
+      'deepseekT',
+    );
+    expect(findCliModelAccessEntry(entries, 'missing')).toBeUndefined();
   });
 
   it('filters runnable models by active API mode when requested', () => {


### PR DESCRIPTION
## Summary
- export the runtime CLI model-access lookup helper as the single case-insensitive lookup path
- route `texra models show` through runtime model access instead of a duplicate command helper
- add focused coverage for case-insensitive lookup

Closes #5394.

## Validation
- npm run format
- npm run typecheck
- npm run lint (passes with existing unrelated import-order warnings)
- npm run compile:fast
- corepack pnpm vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelsRecord.vitest.mts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with behavior preserved; `models show` and runnable-model resolution share one lookup implementation, with added unit coverage.
> 
> **Overview**
> **Centralizes CLI model ID lookup** by exporting `findCliModelAccessEntry` from runtime `modelAccess` as the single case-insensitive lookup path, and wiring `texra models show` to use it instead of a duplicate command-local helper.
> 
> Runtime model resolution (`withModelAccess`, `resolveCliRunnableModelFromAccessList`, hidden-model handling) now calls the same exported helper. A focused test covers case-insensitive lookup and missing IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14bfd265cb2eb0281970c3be513290c0e68b6de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->