### PR TITLE
refactor: centralize CLI default config parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 ### Improvements
 
 - **Better defaults and guidance when starting a run** — multi-agent launches show a task example to guide what to type, the simplifier agent is no longer offered as a default team root, buffered menu hotkeys are handled correctly on startup, and setup/auth errors point you to `texra auth status`.
+- **Consistent user chat defaults** — CLI user `config.json` chat defaults now honor the same `chat` section and `texra.*` keys as workspace `.texra/config.json` files.
 - **User turns stand out in chat** — your messages now render as a full-width reverse-video band that adapts to your terminal's light/dark theme and reflows on resize, making them easy to pick out from the assistant's output when scrolling back.
 - **Clearer `texra doctor` diagnostics** — Node.js version reporting and the supported-version check are aligned and consistent across messages.
 - **Quieter, more predictable model selection** — the CLI no longer prints noise when it implicitly falls back to a default model, and personal-account model recovery hints are clearer when a configured model isn't available.

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,13 +1,14 @@
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { isNonEmptyString } from '@utils/core/stringCore';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
-  isKnownCliModel,
+  CLI_CONFIG_FILE,
   loadWorkspaceCliConfig,
+  parseCliConfigValues,
   resolveConfiguredAgent,
   resolveConfiguredModel,
+  type CliConfigValues,
 } from './cliConfig';
 import {
   BUILTIN_DEFAULT_CHAT_AGENT,
@@ -46,37 +47,25 @@ interface PartialDefaults {
   readonly model?: string;
 }
 
-const CONFIG_FILE = 'config.json';
-
-function pickDefaults(parsed: unknown): PartialDefaults {
-  if (typeof parsed !== 'object' || parsed === null) return {};
-  const record = parsed as Record<string, unknown>;
-  const out: { -readonly [K in keyof PartialDefaults]: PartialDefaults[K] } =
-    {};
-  if (isNonEmptyString(record.agent)) {
-    const agent = resolveImplicitToolUseAgentDefault(record.agent);
-    if (agent) out.agent = agent;
-  }
-  if (isNonEmptyString(record.model)) {
-    const model = record.model.trim();
-    if (isKnownCliModel(model)) out.model = model;
-  }
-  return out;
+function defaultsFromConfigValues(values: CliConfigValues): PartialDefaults {
+  return {
+    agent: resolveImplicitToolUseAgentDefault(
+      resolveConfiguredAgent(values, 'chat'),
+    ),
+    model: resolveConfiguredModel(values, 'chat'),
+  };
 }
 
 async function loadWorkspaceDefaults(cwd: string): Promise<PartialDefaults> {
   const loaded = await loadWorkspaceCliConfig(cwd);
-  return {
-    agent: resolveImplicitToolUseAgentDefault(
-      resolveConfiguredAgent(loaded.values, 'chat'),
-    ),
-    model: resolveConfiguredModel(loaded.values, 'chat'),
-  };
+  return defaultsFromConfigValues(loaded.values);
 }
 
 async function loadUserDefaults(): Promise<PartialDefaults> {
   try {
-    return pickDefaults(await GlobalStorageFS.readJson(CONFIG_FILE));
+    return defaultsFromConfigValues(
+      parseCliConfigValues(await GlobalStorageFS.readJson(CLI_CONFIG_FILE)),
+    );
   } catch {
     return {};
   }
@@ -99,9 +88,12 @@ async function loadHistoryDefaults(): Promise<PartialDefaults> {
       );
     const mostRecent = candidates[0];
     if (!mostRecent?.agentConfig) return {};
-    return pickDefaults({
-      model: mostRecent.agentConfig.model,
-    });
+    return {
+      model: resolveConfiguredModel(
+        parseCliConfigValues({ model: mostRecent.agentConfig.model }),
+        'chat',
+      ),
+    };
   } catch {
     return {};
   }

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -188,6 +188,10 @@ function pickConfigValues(record: Record<string, unknown>): CliConfigValues {
   };
 }
 
+export function parseCliConfigValues(value: unknown): CliConfigValues {
+  return isPlainRecord(value) ? pickConfigValues(value) : {};
+}
+
 export function workspaceCliConfigPath(cwd: string): string {
   return path.join(cwd, CLI_CONFIG_DIR, CLI_CONFIG_FILE);
 }
@@ -224,7 +228,7 @@ export async function loadWorkspaceCliConfig(
 
   return {
     path: filePath,
-    values: pickConfigValues(parsed),
+    values: parseCliConfigValues(parsed),
     warnings: collectValidationWarnings(filePath, parsed),
   };
 }

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -273,4 +273,24 @@ describe('CLI chat defaults', () => {
       source: 'workspace',
     });
   });
+
+  it('uses the shared config parser for prefixed user chat defaults', async () => {
+    mockedReadJson.mockResolvedValueOnce({
+      'texra.agent': 'generic',
+      'texra.model': 'gpt55',
+      'texra.chat': { agent: 'chat', model: 'deepseekT' },
+    });
+
+    await expect(
+      resolveChatDefaults({
+        cwd: '/tmp/no-such-texra-workspace',
+      }),
+    ).resolves.toMatchObject({
+      agent: 'chat',
+      model: 'deepseekT',
+      source: 'user',
+      agentSource: 'user',
+      modelSource: 'user',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- export `parseCliConfigValues` so CLI config parsing has one owner
- route user chat defaults through the same parser as workspace config
- preserve history defaults as model-only while using the shared model resolver

Closes #5396

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/CliContext.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts`
- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor to chat default resolution with a new regression test; no auth or runtime execution path changes beyond how user config is interpreted.
> 
> **Overview**
> **User chat defaults now use the same config path as workspace `.texra/config.json`.** Global `config.json` is parsed through exported `parseCliConfigValues` and the existing `resolveConfiguredAgent` / `resolveConfiguredModel` helpers, so nested `chat` / `run` sections and `texra.*` prefixed keys behave consistently instead of only reading top-level `agent` / `model`.
> 
> The ad-hoc `pickDefaults` logic in `chatDefaults.ts` is removed in favor of `defaultsFromConfigValues`; history-derived defaults stay **model-only** but resolve the model through the shared parser. `loadWorkspaceCliConfig` also routes parsed JSON through `parseCliConfigValues` for a single parsing owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c679c2614bbc95b1d5ab66e7861c2cf41388ba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->