### PR TITLE
refactor: centralize CLI agent detail lookup

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,7 +1,6 @@
 import { defineCommand } from 'citty';
 
 import {
-  getAgent,
   getToolUseAgents,
   getVisibleAgents,
   getWorkflowAgents,
@@ -161,7 +160,7 @@ export async function showAgent(
   await initLocalCliPlatform(context);
   await loadAgents({ includeRemote: false });
 
-  const entry = getAgent(name) ?? (await resolveAgentWithRemoteFallback(name));
+  const entry = await resolveAgentWithRemoteFallback(name);
   if (!entry) {
     writeTextStderr(missingAgentMessage(name));
     return CliExitCode.Usage;

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -207,7 +207,7 @@ describe('CLI agents command', () => {
     );
   });
 
-  it('uses the local registry match for agent details before remote fallback', async () => {
+  it('uses the remote fallback resolver for agent details', async () => {
     const localAgent = {
       name: 'lean',
       source: 'builtInToolUse',
@@ -216,7 +216,7 @@ describe('CLI agents command', () => {
       description: 'Lean 4 proof assistant.',
       tools: ['lean_diagnostics'],
     };
-    mocks.getAgent.mockReturnValue(localAgent);
+    mocks.resolveAgentWithRemoteFallback.mockResolvedValue(localAgent);
     const { showAgent } = await import('@cli/commands/agents');
 
     const exitCode = await showAgent(cliContext(), 'lean');
@@ -224,12 +224,37 @@ describe('CLI agents command', () => {
     expect(exitCode).toBe(0);
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledTimes(1);
     expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
-    expect(mocks.getAgent).toHaveBeenCalledWith('lean');
-    expect(mocks.resolveAgentWithRemoteFallback).not.toHaveBeenCalled();
+    expect(mocks.getAgent).not.toHaveBeenCalled();
+    expect(mocks.resolveAgentWithRemoteFallback).toHaveBeenCalledWith('lean');
     expect(mocks.emitCliResult).toHaveBeenCalledWith(expect.anything(), {
       json: localAgent,
       ndjson: { kind: 'agent', agent: localAgent },
       text: expect.stringContaining('source: builtInToolUse'),
+    });
+  });
+
+  it('renders the agent returned by the resolver regardless of source', async () => {
+    const remoteAgent = {
+      name: 'lean',
+      source: 'remote',
+      path: '',
+      category: AgentCategory.ToolUse,
+      description: 'Relay-served Lean assistant.',
+      tools: ['delegate_agent', 'lean_diagnostics'],
+      visibility: ['public'],
+    };
+    mocks.resolveAgentWithRemoteFallback.mockResolvedValue(remoteAgent);
+    const { showAgent } = await import('@cli/commands/agents');
+
+    const exitCode = await showAgent(cliContext(), 'lean');
+
+    expect(exitCode).toBe(0);
+    expect(mocks.getAgent).not.toHaveBeenCalled();
+    expect(mocks.resolveAgentWithRemoteFallback).toHaveBeenCalledWith('lean');
+    expect(mocks.emitCliResult).toHaveBeenCalledWith(expect.anything(), {
+      json: remoteAgent,
+      ndjson: { kind: 'agent', agent: remoteAgent },
+      text: expect.stringContaining('source: remote'),
     });
   });
 
@@ -243,7 +268,6 @@ describe('CLI agents command', () => {
       tools: ['delegate_agent', 'delegate_workflow'],
       visibility: ['public'],
     };
-    mocks.getAgent.mockReturnValue(undefined);
     mocks.resolveAgentWithRemoteFallback.mockResolvedValue(remoteAgent);
     const { showAgent } = await import('@cli/commands/agents');
 
@@ -263,7 +287,6 @@ describe('CLI agents command', () => {
   });
 
   it('reports missing agents after the remote fallback is exhausted', async () => {
-    mocks.getAgent.mockReturnValue(undefined);
     mocks.resolveAgentWithRemoteFallback.mockResolvedValue(undefined);
     const { showAgent } = await import('@cli/commands/agents');
 


### PR DESCRIPTION
## Summary
- route `texra agents show` through `resolveAgentWithRemoteFallback` for all detail lookups
- remove the local `getAgent()` short-circuit that bypassed remote-priority ownership
- update unit coverage for resolver-owned local and remote-priority results

Closes #5398

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/AgentsCommand.vitest.mts`
- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-path refactor with behavior change limited to which agent record wins when local and remote definitions conflict; tests cover the new contract.
> 
> **Overview**
> **`texra agents show`** now resolves agent details only through **`resolveAgentWithRemoteFallback`**, dropping the **`getAgent()`** fast path that could return a local entry before remote-priority rules applied.
> 
> Unit tests assert **`getAgent`** is never called from **`showAgent`**, cover resolver-owned local and remote results, and trim redundant **`getAgent`** mocks from missing-agent cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf8d05049dc901c16bdf26eab83f87e1e988d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->