### PR TITLE
refactor: centralize CLI approval events

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -26,6 +26,11 @@ import {
   markApprovalDenied,
 } from '@cli/runtime/approvalAdapter';
 import { setCliApiMode } from '@cli/runtime/apiAccessMode';
+import {
+  cliApprovalEventKind,
+  isCliApprovalEvent,
+  type CliApprovalEvent,
+} from '@cli/runtime/approvalEvents';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type {
@@ -55,19 +60,6 @@ type Emit = <K extends ProgressEvent>(
   payload: ProgressEventPayloads[K],
 ) => void;
 
-const APPROVAL_EVENTS = [
-  'showBashPermission',
-  'showPlanApproval',
-  'showAgentProposal',
-  'showRetryRequest',
-  'showExternalInquiry',
-  'showUserQuestion',
-] as const;
-
-type ApprovalEvent = (typeof APPROVAL_EVENTS)[number];
-
-const APPROVAL_EVENT_SET: ReadonlySet<ProgressEvent> = new Set(APPROVAL_EVENTS);
-
 /**
  * Install the typed approval pipeline. Returns an `unbind` callback that
  * restores the original emit + clears the tool-edit handler.
@@ -84,10 +76,10 @@ export function installTuiApprovals(
     // via the legacy stderr prompt — racing the TUI modal for the same
     // resolver. Non-approval events (status, usage, log) keep flowing
     // through the original chain.
-    if (isApprovalEvent(event)) {
+    if (isCliApprovalEvent(event)) {
       routeApproval(
         event,
-        payload as ProgressEventPayloads[ApprovalEvent],
+        payload as ProgressEventPayloads[CliApprovalEvent],
         context,
         host,
       );
@@ -120,13 +112,9 @@ export function installTuiApprovals(
   };
 }
 
-function isApprovalEvent(event: ProgressEvent): event is ApprovalEvent {
-  return APPROVAL_EVENT_SET.has(event);
-}
-
 function routeApproval(
-  event: ApprovalEvent,
-  payload: ProgressEventPayloads[ApprovalEvent],
+  event: CliApprovalEvent,
+  payload: ProgressEventPayloads[CliApprovalEvent],
   context: CliContext,
   host: CliRuntimeHost,
 ): void {
@@ -135,7 +123,7 @@ function routeApproval(
       routeWithPolicy(
         context,
         host,
-        'bash',
+        cliApprovalEventKind(event),
         payload as ProgressEventPayloads['showBashPermission'],
         (bashPayload, decision) => {
           if (
@@ -153,7 +141,7 @@ function routeApproval(
       routeWithPolicy(
         context,
         host,
-        'plan',
+        cliApprovalEventKind(event),
         payload as ProgressEventPayloads['showPlanApproval'],
         dispatchPlan,
       );
@@ -162,7 +150,7 @@ function routeApproval(
       routeWithPolicy(
         context,
         host,
-        'proposal',
+        cliApprovalEventKind(event),
         payload as ProgressEventPayloads['showAgentProposal'],
         dispatchProposal,
       );
@@ -171,7 +159,7 @@ function routeApproval(
       routeWithPolicy(
         context,
         host,
-        'retry',
+        cliApprovalEventKind(event),
         payload as ProgressEventPayloads['showRetryRequest'],
         dispatchRetry,
       );

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -27,6 +27,10 @@ import {
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
 // Local imports - CLI runtime
+import {
+  isCliDecisionApprovalEvent,
+  type CliDecisionApprovalEvent,
+} from './approvalEvents';
 import { type CliContext, type CliPromptRequest } from './cliContext';
 import { askCliQuestion, writeTextStderr } from './logSinks';
 import { parseUserQuestionAnswer } from './userQuestionAnswer';
@@ -36,14 +40,6 @@ import { parseUserQuestionAnswer } from './userQuestionAnswer';
 // single source of truth for the decision vocabulary across hosts. See
 // docs/proposals/tui-extension-sharing.md (Rung 1).
 export type ApprovalDecision = SharedApprovalDecision;
-
-const APPROVAL_EVENTS = [
-  'showBashPermission',
-  'showPlanApproval',
-  'showAgentProposal',
-  'showRetryRequest',
-] as const;
-type ApprovalEvent = (typeof APPROVAL_EVENTS)[number];
 
 const TRUNCATED_DIFF_LINE_MARKER = ' … [line truncated]';
 const TOOL_EDIT_APPROVAL_DIFF_MAX_CHARS = 12_000;
@@ -56,12 +52,6 @@ const AGENT_PROPOSAL_FILE_GROUP_MAX_FILES = 10;
 
 export const CLI_PERSONAL_API_RETRY_HINT =
   'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch to personal API keys.';
-
-function isApprovalEvent(
-  event: keyof ProgressEventPayloads,
-): event is ApprovalEvent {
-  return (APPROVAL_EVENTS as readonly string[]).includes(event);
-}
 
 const deniedApprovalContexts = new WeakSet<CliContext>();
 const cliPromptQueues = new WeakMap<CliContext, Promise<unknown>>();
@@ -146,8 +136,8 @@ export function immediateDecision(
  *  retry panel so the user can switch to personal API keys; non-interactive
  *  and auto-approval modes should not burn the retry budget. */
 function isUnretryableRetryRequest(
-  event: ApprovalEvent,
-  payload: ProgressEventPayloads[ApprovalEvent],
+  event: CliDecisionApprovalEvent,
+  payload: ProgressEventPayloads[CliDecisionApprovalEvent],
 ): boolean {
   if (event !== 'showRetryRequest') return false;
   const details = (payload as ProgressEventPayloads['showRetryRequest'])
@@ -159,8 +149,8 @@ function isUnretryableRetryRequest(
 }
 
 export function immediateDecisionForApproval(
-  event: ApprovalEvent,
-  payload: ProgressEventPayloads[ApprovalEvent],
+  event: CliDecisionApprovalEvent,
+  payload: ProgressEventPayloads[CliDecisionApprovalEvent],
   context: CliContext,
 ): ApprovalDecision | undefined {
   if (isUnretryableRetryRequest(event, payload)) {
@@ -289,7 +279,7 @@ export function formatAgentProposalApprovalSummary(
   ].join('\n');
 }
 
-function summarizeApprovalEvent<K extends ApprovalEvent>(
+function summarizeApprovalEvent<K extends CliDecisionApprovalEvent>(
   event: K,
   payload: ProgressEventPayloads[K],
 ): string {
@@ -327,7 +317,7 @@ export function formatRetryRequestMessage(
   return message;
 }
 
-function dispatchApprovalDecision<K extends ApprovalEvent>(
+function dispatchApprovalDecision<K extends CliDecisionApprovalEvent>(
   event: K,
   payload: ProgressEventPayloads[K],
   decision: ApprovalDecision,
@@ -656,7 +646,7 @@ export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
     return true;
   }
 
-  if (!isApprovalEvent(event)) return false;
+  if (!isCliDecisionApprovalEvent(event)) return false;
 
   const approvalPayload = payload as ProgressEventPayloads[typeof event];
 

--- a/packages/cli/src/runtime/approvalEvents.ts
+++ b/packages/cli/src/runtime/approvalEvents.ts
@@ -1,0 +1,63 @@
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
+
+export const CLI_DECISION_APPROVAL_EVENTS = [
+  'showBashPermission',
+  'showPlanApproval',
+  'showAgentProposal',
+  'showRetryRequest',
+] as const satisfies readonly (keyof ProgressEventPayloads)[];
+
+export const CLI_HUMAN_INPUT_APPROVAL_EVENTS = [
+  'showExternalInquiry',
+  'showUserQuestion',
+] as const satisfies readonly (keyof ProgressEventPayloads)[];
+
+export const CLI_APPROVAL_EVENTS = [
+  ...CLI_DECISION_APPROVAL_EVENTS,
+  ...CLI_HUMAN_INPUT_APPROVAL_EVENTS,
+] as const satisfies readonly (keyof ProgressEventPayloads)[];
+
+export const CLI_APPROVAL_EVENT_KIND = {
+  showBashPermission: 'bash',
+  showPlanApproval: 'plan',
+  showAgentProposal: 'proposal',
+  showRetryRequest: 'retry',
+  showExternalInquiry: 'externalInquiry',
+  showUserQuestion: 'userQuestion',
+} as const satisfies Record<CliApprovalEvent, string>;
+
+export type CliDecisionApprovalEvent =
+  (typeof CLI_DECISION_APPROVAL_EVENTS)[number];
+export type CliHumanInputApprovalEvent =
+  (typeof CLI_HUMAN_INPUT_APPROVAL_EVENTS)[number];
+export type CliApprovalEvent = (typeof CLI_APPROVAL_EVENTS)[number];
+export type CliApprovalEventKind =
+  (typeof CLI_APPROVAL_EVENT_KIND)[CliApprovalEvent];
+
+const CLI_DECISION_APPROVAL_EVENT_SET: ReadonlySet<ProgressEvent> = new Set(
+  CLI_DECISION_APPROVAL_EVENTS,
+);
+const CLI_APPROVAL_EVENT_SET: ReadonlySet<ProgressEvent> = new Set(
+  CLI_APPROVAL_EVENTS,
+);
+
+export function isCliDecisionApprovalEvent(
+  event: ProgressEvent,
+): event is CliDecisionApprovalEvent {
+  return CLI_DECISION_APPROVAL_EVENT_SET.has(event);
+}
+
+export function isCliApprovalEvent(
+  event: ProgressEvent,
+): event is CliApprovalEvent {
+  return CLI_APPROVAL_EVENT_SET.has(event);
+}
+
+export function cliApprovalEventKind<E extends CliApprovalEvent>(
+  event: E,
+): (typeof CLI_APPROVAL_EVENT_KIND)[E] {
+  return CLI_APPROVAL_EVENT_KIND[event];
+}

--- a/packages/cli/src/runtime/approvalEvents.ts
+++ b/packages/cli/src/runtime/approvalEvents.ts
@@ -3,6 +3,9 @@ import type {
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 
+// CLI hosts share the same progress-event names, but not the same handling.
+// Decision approvals can be auto-approved or denied by policy; human-input
+// prompts must be surfaced to the user when an interactive TTY is available.
 export const CLI_DECISION_APPROVAL_EVENTS = [
   'showBashPermission',
   'showPlanApproval',

--- a/src/test-kernel/cli/ApprovalEvents.vitest.mts
+++ b/src/test-kernel/cli/ApprovalEvents.vitest.mts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CLI_APPROVAL_EVENTS,
+  CLI_DECISION_APPROVAL_EVENTS,
+  CLI_HUMAN_INPUT_APPROVAL_EVENTS,
+  cliApprovalEventKind,
+  isCliApprovalEvent,
+  isCliDecisionApprovalEvent,
+} from '@cli/runtime/approvalEvents';
+
+describe('CLI approval event taxonomy', () => {
+  it('keeps decision and human-input approvals as disjoint subsets', () => {
+    expect(CLI_APPROVAL_EVENTS).toEqual([
+      ...CLI_DECISION_APPROVAL_EVENTS,
+      ...CLI_HUMAN_INPUT_APPROVAL_EVENTS,
+    ]);
+
+    const decisionEvents: ReadonlySet<string> = new Set(
+      CLI_DECISION_APPROVAL_EVENTS,
+    );
+    for (const event of CLI_HUMAN_INPUT_APPROVAL_EVENTS) {
+      expect(decisionEvents.has(event)).toBe(false);
+    }
+  });
+
+  it('identifies approval-like progress events', () => {
+    expect(isCliDecisionApprovalEvent('showBashPermission')).toBe(true);
+    expect(isCliDecisionApprovalEvent('showExternalInquiry')).toBe(false);
+
+    expect(isCliApprovalEvent('showExternalInquiry')).toBe(true);
+    expect(isCliApprovalEvent('showUserQuestion')).toBe(true);
+    expect(isCliApprovalEvent('updateStreamStatus')).toBe(false);
+  });
+
+  it('maps progress event names to TUI approval payload kinds', () => {
+    expect(cliApprovalEventKind('showBashPermission')).toBe('bash');
+    expect(cliApprovalEventKind('showPlanApproval')).toBe('plan');
+    expect(cliApprovalEventKind('showAgentProposal')).toBe('proposal');
+    expect(cliApprovalEventKind('showRetryRequest')).toBe('retry');
+    expect(cliApprovalEventKind('showExternalInquiry')).toBe('externalInquiry');
+    expect(cliApprovalEventKind('showUserQuestion')).toBe('userQuestion');
+  });
+});

--- a/src/test-kernel/cli/ApprovalEvents.vitest.mts
+++ b/src/test-kernel/cli/ApprovalEvents.vitest.mts
@@ -12,8 +12,12 @@ import {
 describe('CLI approval event taxonomy', () => {
   it('keeps decision and human-input approvals as disjoint subsets', () => {
     expect(CLI_APPROVAL_EVENTS).toEqual([
-      ...CLI_DECISION_APPROVAL_EVENTS,
-      ...CLI_HUMAN_INPUT_APPROVAL_EVENTS,
+      'showBashPermission',
+      'showPlanApproval',
+      'showAgentProposal',
+      'showRetryRequest',
+      'showExternalInquiry',
+      'showUserQuestion',
     ]);
 
     const decisionEvents: ReadonlySet<string> = new Set(


### PR DESCRIPTION
## Summary
- add a shared CLI approval event taxonomy for decision approvals and human-input prompts
- reuse that taxonomy in the headless approval adapter and TUI approval subscription
- cover the shared event sets and payload-kind mapping with focused tests

## Validation
- corepack pnpm vitest run src/test-kernel/cli/ApprovalEvents.vitest.mts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/ApprovalQueue.vitest.mts
- npm run format
- npm run typecheck
- npm run lint (passes with existing 29 import-order warnings)
- npm run compile:fast

Closes #5400

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only consolidation of constants and types; approval routing behavior should be unchanged aside from shared definitions.
> 
> **Overview**
> Introduces **`approvalEvents.ts`** as the single definition of which progress events count as CLI approvals, split into **policy-driven decision** events (`bash`, `plan`, `proposal`, `retry`) versus **human-input** prompts (`externalInquiry`, `userQuestion`), plus shared guards and a **`cliApprovalEventKind`** map for TUI queue payloads.
> 
> The **TUI approval hook** and **headless `approvalAdapter`** drop their duplicated event lists and local `isApprovalEvent` helpers in favor of **`isCliApprovalEvent`** / **`isCliDecisionApprovalEvent`** and the shared types; TUI routing now derives queue `kind` from **`cliApprovalEventKind(event)`** instead of hard-coded strings.
> 
> Adds **`ApprovalEvents.vitest.mts`** to lock the event union, disjoint subsets, type guards, and kind mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c027bdf85a5719a8c65a10424106c499d2c8974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->