### PR TITLE
fix: handle colon Shift-Enter in CLI input

### DIFF
--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -129,14 +129,20 @@ export function isTextInputNewlineInput(
 // raw sequence as a plain Enter. Matches only the unmodified form (bare, or the
 // explicit "no modifiers" `;1`) so Ctrl/Alt+keypad-Enter pass through untouched.
 const KITTY_KEYPAD_ENTER_INPUTS = [`${ESC}[57414u`, `${ESC}[57414;1u`];
-const KITTY_SHIFT_ENTER_INPUTS = [`${ESC}[13;2u`, `${ESC}[13:2u`];
 
-// Ink already turns a standalone Kitty Shift+Enter sequence into a shifted
-// return key. The raw-event shim only needs to rewrite sequences embedded in a
-// larger input chunk, where the normal key parser cannot represent both the
-// surrounding text and the modified return.
-function isStandaloneKittyShiftEnterInput(data: string): boolean {
-  return KITTY_SHIFT_ENTER_INPUTS.includes(data);
+// Ink only parses the semicolon CSI-u form as a shifted Return key when it is
+// the whole input event. The colon form can still be emitted by terminals, but
+// Ink surfaces it as an unhandled raw sequence, so TeXRA must synthesize the
+// newline token for that spelling itself.
+const INK_PARSED_KITTY_SHIFT_ENTER_INPUTS = [`${ESC}[13;2u`];
+const RAW_KITTY_SHIFT_ENTER_INPUTS = [`${ESC}[13:2u`];
+const KITTY_SHIFT_ENTER_INPUTS = [
+  ...INK_PARSED_KITTY_SHIFT_ENTER_INPUTS,
+  ...RAW_KITTY_SHIFT_ENTER_INPUTS,
+];
+
+function isInkParsedStandaloneShiftEnterInput(data: string): boolean {
+  return INK_PARSED_KITTY_SHIFT_ENTER_INPUTS.includes(data);
 }
 
 export function rewriteKittyEnterInput(
@@ -150,7 +156,7 @@ export function rewriteKittyEnterInput(
   if (options.shiftEnter === 'preserve') {
     return rewritten === data ? undefined : rewritten;
   }
-  if (isStandaloneKittyShiftEnterInput(rewritten)) {
+  if (isInkParsedStandaloneShiftEnterInput(rewritten)) {
     return undefined;
   }
   for (const sequence of KITTY_SHIFT_ENTER_INPUTS) {

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -65,15 +65,16 @@ describe('CLI TUI text input editing', () => {
     expect(
       rewriteKittyEnterInput(`${ESC}[57414;1u`, { shiftEnter: 'newline' }),
     ).toBe('\r');
-    // Ink already reports standalone Shift+Enter as a shifted return, so the
-    // raw-event shim must not emit a second synthetic newline for that exact
-    // chunk. Embedded sequences still need rewriting; see the batched test.
+    // Ink reports the semicolon CSI-u spelling as shifted Return, so the raw
+    // shim must not emit a second synthetic newline for that exact chunk.
     expect(
       rewriteKittyEnterInput(`${ESC}[13;2u`, { shiftEnter: 'newline' }),
     ).toBeUndefined();
+    // The colon spelling is not parsed by Ink; normalize it at the raw-event
+    // layer so Shift+Enter still inserts a newline.
     expect(
       rewriteKittyEnterInput(`${ESC}[13:2u`, { shiftEnter: 'newline' }),
-    ).toBeUndefined();
+    ).toBe(SYNTHETIC_SHIFT_RETURN_INPUT);
     // Main Enter, plain CR, and modified keypad Enter must not match.
     expect(
       rewriteKittyEnterInput('\r', { shiftEnter: 'newline' }),
@@ -96,6 +97,17 @@ describe('CLI TUI text input editing', () => {
 
     expect(rewritten).toBe(`alpha${SYNTHETIC_SHIFT_RETURN_INPUT}beta`);
     expect(applyTerminalInputChunk('', 0, rewritten ?? '')).toEqual({
+      value: 'alpha\nbeta',
+      cursor: 10,
+      submit: false,
+    });
+
+    const colonRewritten = rewriteKittyEnterInput(`alpha${ESC}[13:2ubeta`, {
+      shiftEnter: 'newline',
+    });
+
+    expect(colonRewritten).toBe(`alpha${SYNTHETIC_SHIFT_RETURN_INPUT}beta`);
+    expect(applyTerminalInputChunk('', 0, colonRewritten ?? '')).toEqual({
       value: 'alpha\nbeta',
       cursor: 10,
       submit: false,


### PR DESCRIPTION
## Summary
- distinguish Kitty Shift+Enter sequences Ink parses from raw spellings TeXRA must normalize
- rewrite standalone colon CSI-u Shift+Enter into the internal newline token
- add regression coverage for standalone and batched semicolon/colon Shift+Enter input

Closes #5402.

## Validation
- corepack pnpm vitest run src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/InputBar.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- kitty-shift-enter-newline ctrl-j-newline
- npm run format
- npm run typecheck
- npm run lint
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI keyboard normalization with added unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **Shift+Enter** in the CLI text input when the terminal sends the Kitty CSI-u **colon** spelling (`ESC[13:2u`), which Ink leaves as a raw sequence instead of a shifted Return.
> 
> `rewriteKittyEnterInput` now treats **semicolon** (`;2u`) and **colon** (`:2u`) forms differently: standalone semicolon input is still left alone so Ink’s parsed Shift+Return is not doubled, while colon sequences (standalone or embedded in a chunk) are rewritten to the internal `SYNTHETIC_SHIFT_RETURN_INPUT` newline token like batched semicolon input already was. Regression tests cover standalone colon Shift+Enter and batched colon chunks through `applyTerminalInputChunk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31e7ed468165de5d67cfa96cd41d91a33b06eca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->