### PR TITLE
fix: isolate CLI transcript viewers

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1417,14 +1417,41 @@ const SCENARIOS = [
     },
     bootExpect: '[Tab]streams',
     keys: [ESC + 's', '\r'],
-    frame: 'tail',
     expect: [
       'strategy',
       'Please handle the harness-child-strategy sub-workflow.',
       'strategy is checking the harness-child-strategy details',
       'Esc close',
     ],
-    unexpect: ['Harness received:'],
+    unexpect: [
+      'entry-1 chat history line',
+      'entry-4 chat history line',
+      'Harness received:',
+    ],
+  },
+  {
+    name: 'nested-subagent-picker-enter-views-subagent',
+    cols: 100,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_NESTED_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [ESC + 's', 'f', ESC + 's', '\r'],
+    expect: [
+      'localChecker',
+      'Please handle the nested proof check sub-workflow.',
+      'localChecker is checking the nested proof check details',
+      'Esc close',
+    ],
+    unexpect: [
+      'entry-1 chat history line',
+      'entry-4 chat history line',
+      'Please handle the harness-child-strategy sub-workflow.',
+      'strategy is checking the harness-child-strategy details',
+    ],
   },
   {
     name: 'nested-subagent-picker',

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -125,6 +125,7 @@ export function allocateMiddleRows({
   inputVisible = true,
   queuedFollowUpPanelRows = 0,
   reverseSearchOpen,
+  reserveTranscriptRows = true,
   rows,
   slashPaletteOpen,
   streamTabsVisible = true,
@@ -136,6 +137,7 @@ export function allocateMiddleRows({
   readonly inputVisible?: boolean;
   readonly queuedFollowUpPanelRows?: number;
   readonly reverseSearchOpen: boolean;
+  readonly reserveTranscriptRows?: boolean;
   readonly rows: number;
   readonly slashPaletteOpen: boolean;
   readonly streamTabsVisible?: boolean;
@@ -169,6 +171,7 @@ export function allocateMiddleRows({
   }
 
   const transcriptRows =
+    reserveTranscriptRows &&
     availableRows >= MIN_FOREGROUND_ROWS_WITH_TRANSCRIPT
       ? Math.min(FOREGROUND_TRANSCRIPT_ROWS, availableRows - 1)
       : 0;
@@ -441,7 +444,11 @@ export function App(props: AppProps): React.JSX.Element {
     transcriptViewerOpen;
   const inputDisabled = props.inputDisabled === true || foregroundOpen;
   const inputBarVisible = !foregroundOpen;
-  const viewportKey = transcriptViewportKey({ activeStreamId, parentStream });
+  const viewportKey = transcriptViewportKey({
+    activeStreamId,
+    parentStream,
+    transcriptViewerStreamId,
+  });
   const scopedTranscript = isScopedTranscriptViewport(viewportKey);
   const scrollbackStreamId = staticScrollbackStreamId({
     activeStreamId,
@@ -558,6 +565,7 @@ export function App(props: AppProps): React.JSX.Element {
     inputVisible: inputBarVisible,
     queuedFollowUpPanelRows,
     reverseSearchOpen,
+    reserveTranscriptRows: foregroundKind !== 'transcript',
     rows,
     slashPaletteOpen,
     streamTabsVisible,
@@ -741,7 +749,7 @@ export function App(props: AppProps): React.JSX.Element {
       )}
       <Box flexDirection="column">
         <Box flexDirection="column" overflowY="hidden">
-          {conversationRows > 0 ? (
+          {!transcriptViewerOpen && conversationRows > 0 ? (
             <ConversationPane
               colorEnabled={props.colorEnabled}
               mode={scopedTranscript ? 'scoped-history' : 'live-pending'}

--- a/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
+++ b/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
@@ -5,6 +5,8 @@ export const ROOT_SCROLLBACK_VIEWPORT_KEY = 'root-scrollback';
 /**
  * The root stream owns ordinary terminal scrollback through Ink `<Static>`.
  * Focused child streams own a scoped, self-contained transcript surface.
+ * Explicit transcript viewers also own a scoped surface, even when focus stays
+ * on the parent stream.
  * Moving between those viewports must redraw from a clean primary buffer so
  * a child page cannot appear under stale root scrollback, and returning to the
  * root can reprint the root static transcript as the active owner.
@@ -12,10 +14,13 @@ export const ROOT_SCROLLBACK_VIEWPORT_KEY = 'root-scrollback';
 export function transcriptViewportKey({
   activeStreamId,
   parentStream,
+  transcriptViewerStreamId,
 }: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly transcriptViewerStreamId?: StreamTabId;
 }): string {
+  if (transcriptViewerStreamId) return `viewer:${transcriptViewerStreamId}`;
   return activeStreamId && parentStream.has(activeStreamId)
     ? `scoped:${activeStreamId}`
     : ROOT_SCROLLBACK_VIEWPORT_KEY;

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -280,6 +280,13 @@ describe('cliState Phase 4 fields', () => {
         parentStream: cliState.parentStream.get(),
       }),
     ).toBe(`scoped:${child1}`);
+    expect(
+      transcriptViewportKey({
+        activeStreamId: root,
+        parentStream: cliState.parentStream.get(),
+        transcriptViewerStreamId: child1,
+      }),
+    ).toBe(`viewer:${child1}`);
   });
 });
 
@@ -330,6 +337,20 @@ describe('CLI TUI row allocation', () => {
 
     expect(layout.transcriptRows).toBe(1);
     expect(layout.foregroundRows).toBe(12);
+  });
+
+  it('lets transcript viewers own the full foreground region', () => {
+    const layout = allocateMiddleRows({
+      foregroundOpen: true,
+      reserveTranscriptRows: false,
+      reverseSearchOpen: false,
+      rows: 24,
+      slashPaletteOpen: false,
+      tipVisible: false,
+    });
+
+    expect(layout.transcriptRows).toBe(0);
+    expect(layout.foregroundRows).toBe(18);
   });
 
   it('uses a smaller row cap for empty child-control pickers', () => {


### PR DESCRIPTION
## Summary
- make explicit transcript viewers first-class transcript viewport owners, so opening one triggers the same clean repaint boundary as focusing a child stream
- stop rendering the active parent ConversationPane underneath transcript viewers and give viewers the full foreground region
- strengthen TUI harness coverage for first-level and nested subagent Enter-view paths so stale root/parent scrollback fails full-frame assertions

Closes #5405.

## Validation
- `npm run format`
- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- subagent-picker-enter-views-subagent nested-subagent-picker-enter-views-subagent`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build subagent-focused-submit subagent-tab-focus-full-frame subagent-focus-return-root-scrollback-deduped subagent-picker-enter-views-subagent nested-subagent-picker-enter-views-subagent nested-subagent-picker nested-task-picker orchestrate-launcher compact-orchestrate-launcher`
- `npm run typecheck`
- `npm run lint` (passes with existing 29 import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TUI viewport repaint and middle-row layout for transcript viewers; behavior is user-visible but localized to CLI Ink rendering, with added harness and unit tests.
> 
> **Overview**
> **Explicit transcript viewers** (e.g. subagent “Enter view” while focus stays on the parent) now get their own transcript viewport key (`viewer:<streamId>`), triggering the same clean repaint boundary as focusing a child stream.
> 
> **Layout:** When a transcript viewer is open, the live `ConversationPane` is not drawn underneath it, `allocateMiddleRows` can skip the reserved foreground transcript row (`reserveTranscriptRows: false`), and the viewer uses the full foreground region.
> 
> **Tests:** Unit coverage for `viewer:` viewport keys and full-foreground row allocation; TUI harness scenarios assert first-level and nested subagent Enter-view paths do not show stale root/parent chat lines or the wrong subagent transcript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d621323b80f9a69f63ba1c03c957b8d61c186e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->