### PR TITLE
Refactor CLI no-runnable model messages

### DIFF
--- a/packages/cli/src/chat/tui/modelAccessDisplay.ts
+++ b/packages/cli/src/chat/tui/modelAccessDisplay.ts
@@ -1,8 +1,9 @@
 import {
+  formatCliNoRunnableModelsLaunchBlock,
+  formatCliNoRunnableModelsMessage,
   noRunnableModelAccessReason,
   runnableCliModelAccessEntries,
   type CliModelAccess,
-  type NoRunnableModelAccessReason,
 } from '@cli/runtime/modelAccess';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { ModelAvailabilityKind } from '@shared/schemas';
@@ -18,24 +19,6 @@ const RELAY_STATUS_BY_AVAILABILITY = {
   'openrouter-key': 'relay: unavailable; openrouter key set',
   'missing-key': 'relay: unavailable; missing api key',
 } satisfies Record<ModelAvailabilityKind, string>;
-
-const EMPTY_MODEL_LIST_SUMMARIES = {
-  includedLoginRequired: 'Included relay models require sign-in.',
-  included: 'No included relay models are runnable.',
-  personal: 'No personal API-key models are runnable.',
-} satisfies Record<NoRunnableModelAccessReason, string>;
-
-const MODEL_ACCESS_LAUNCH_BLOCK_DESCRIPTIONS = {
-  includedLoginRequired: 'Sign in with texra login for included relay models',
-  included: 'No included relay models are runnable',
-  personal: 'No personal API-key models are runnable',
-} satisfies Record<NoRunnableModelAccessReason, string>;
-
-const EMPTY_MODEL_LIST_RECOVERY = {
-  includedLoginRequired: 'Run /login or switch with /api personal.',
-  included: 'Switch with /api personal or try again later.',
-  personal: 'Configure a provider key or switch with /api included.',
-} satisfies Record<NoRunnableModelAccessReason, string>;
 
 export function formatModelStatusForCliMode(
   model: CliModelAccess,
@@ -69,15 +52,21 @@ export function modelAccessLaunchBlockDescriptionForCliMode(
   models: readonly CliModelAccess[],
   apiMode: CliApiMode,
 ): string {
-  return MODEL_ACCESS_LAUNCH_BLOCK_DESCRIPTIONS[
-    noRunnableModelAccessReason(models, apiMode)
-  ];
+  return formatCliNoRunnableModelsLaunchBlock(
+    noRunnableModelAccessReason(models, apiMode),
+  );
 }
 
 export function emptyModelListMessageForCliMode(
   models: readonly CliModelAccess[],
   apiMode: CliApiMode,
 ): string {
-  const reason = noRunnableModelAccessReason(models, apiMode);
-  return `${EMPTY_MODEL_LIST_SUMMARIES[reason]} ${EMPTY_MODEL_LIST_RECOVERY[reason]}`;
+  return formatCliNoRunnableModelsMessage(
+    noRunnableModelAccessReason(models, apiMode),
+    {
+      includedModeAction: 'switch with /api included',
+      loginAction: 'Run /login',
+      personalModeAction: 'switch with /api personal',
+    },
+  );
 }

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -56,12 +56,33 @@ export interface CliNoAvailableModelsRecoveryOptions {
   readonly personalModeAction?: string;
 }
 
+export interface CliNoRunnableModelsMessageOptions extends CliNoAvailableModelsRecoveryOptions {
+  readonly loginAction?: string;
+}
+
 export type NoRunnableModelAccessReason = CliApiMode | 'includedLoginRequired';
 
 const CLI_MODEL_AVAILABILITY_BY_API_MODE = {
   included: new Set<ModelAvailabilityKind>(['included-access']),
   personal: new Set<ModelAvailabilityKind>(['provider-key', 'openrouter-key']),
 } satisfies Record<CliApiMode, ReadonlySet<ModelAvailabilityKind>>;
+
+const NO_RUNNABLE_MODEL_ACCESS_SUMMARIES = {
+  includedLoginRequired: 'Included relay models require sign-in.',
+  included: 'No included relay models are runnable.',
+  personal: 'No personal API-key models are runnable.',
+} satisfies Record<NoRunnableModelAccessReason, string>;
+
+const NO_RUNNABLE_MODEL_ACCESS_LAUNCH_BLOCKS = {
+  includedLoginRequired: 'Sign in with texra login for included relay models',
+  included: 'No included relay models are runnable',
+  personal: 'No personal API-key models are runnable',
+} satisfies Record<NoRunnableModelAccessReason, string>;
+
+function startSentence(text: string): string {
+  if (text.length === 0) return text;
+  return `${text[0]!.toUpperCase()}${text.slice(1)}`;
+}
 
 function isCliModelOptionBasicallyAvailable(model: ModelOptionData): boolean {
   return model.disabled !== true && model.requiresKey !== true;
@@ -113,6 +134,44 @@ export function noRunnableModelAccessReason(
     return 'includedLoginRequired';
   }
   return apiMode;
+}
+
+function formatCliNoRunnableModelsSummary(
+  reason: NoRunnableModelAccessReason,
+): string {
+  return NO_RUNNABLE_MODEL_ACCESS_SUMMARIES[reason];
+}
+
+export function formatCliNoRunnableModelsLaunchBlock(
+  reason: NoRunnableModelAccessReason,
+): string {
+  return NO_RUNNABLE_MODEL_ACCESS_LAUNCH_BLOCKS[reason];
+}
+
+function formatCliNoRunnableModelsRecovery(
+  reason: NoRunnableModelAccessReason,
+  options: CliNoRunnableModelsMessageOptions = {},
+): string {
+  const includedModeAction =
+    options.includedModeAction ?? 'retry with `--api-mode included`';
+  const loginAction = options.loginAction ?? 'Run `texra login`';
+  const personalModeAction =
+    options.personalModeAction ?? 'retry with `--api-mode personal`';
+
+  if (reason === 'includedLoginRequired') {
+    return `${loginAction} or ${personalModeAction}.`;
+  }
+  if (reason === 'included') {
+    return `${startSentence(personalModeAction)} or try again later.`;
+  }
+  return `Configure a provider key or ${includedModeAction}.`;
+}
+
+export function formatCliNoRunnableModelsMessage(
+  reason: NoRunnableModelAccessReason,
+  options: CliNoRunnableModelsMessageOptions = {},
+): string {
+  return `${formatCliNoRunnableModelsSummary(reason)} ${formatCliNoRunnableModelsRecovery(reason, options)}`;
 }
 
 function formatModelAccessStatus(model: ModelOptionData): string {

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -4,6 +4,8 @@ import {
   cliModelFallbackModeForSource,
   findCliModelAccessEntry,
   formatCliNoAvailableModelsRecovery,
+  formatCliNoRunnableModelsLaunchBlock,
+  formatCliNoRunnableModelsMessage,
   getCliModelAccessList,
   noRunnableModelAccessReason,
   runnableCliModelAccessEntries,
@@ -277,6 +279,42 @@ describe('CLI model access resolution', () => {
         'included',
       ),
     ).toBe('included');
+  });
+
+  it('formats no-runnable model reasons for launch and model picker views', () => {
+    const interactiveRecovery = {
+      includedModeAction: 'switch with /api included',
+      loginAction: 'Run /login',
+      personalModeAction: 'switch with /api personal',
+    };
+
+    expect(formatCliNoRunnableModelsLaunchBlock('includedLoginRequired')).toBe(
+      'Sign in with texra login for included relay models',
+    );
+    expect(formatCliNoRunnableModelsLaunchBlock('included')).toBe(
+      'No included relay models are runnable',
+    );
+    expect(formatCliNoRunnableModelsLaunchBlock('personal')).toBe(
+      'No personal API-key models are runnable',
+    );
+    expect(
+      formatCliNoRunnableModelsMessage(
+        'includedLoginRequired',
+        interactiveRecovery,
+      ),
+    ).toBe(
+      'Included relay models require sign-in. Run /login or switch with /api personal.',
+    );
+    expect(
+      formatCliNoRunnableModelsMessage('included', interactiveRecovery),
+    ).toBe(
+      'No included relay models are runnable. Switch with /api personal or try again later.',
+    );
+    expect(
+      formatCliNoRunnableModelsMessage('personal', interactiveRecovery),
+    ).toBe(
+      'No personal API-key models are runnable. Configure a provider key or switch with /api included.',
+    );
   });
 
   it('rejects personal-key models in included relay mode', () => {


### PR DESCRIPTION
## Summary
- move no-runnable-model summary, recovery, and launch-block formatting into the CLI model access runtime
- keep the TUI model picker as a thin adapter that only supplies slash-command wording
- add focused coverage for the shared formatter used by startup and /model views

Closes #5408.

## Validation
- corepack pnpm vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts
- git diff --check
- npm run typecheck
- npm run lint (passes with 29 existing import-order warnings)
- npm run compile:fast
- corepack pnpm --filter @texra-ai/cli build
- node packages/cli/scripts/validate-tui.mjs model-form no-color-model-form model-form-selectable orchestrate-no-runnable-models orchestrate-relay-model-pick orchestrate-personal-model-pick

## Design note
The runtime already owns `NoRunnableModelAccessReason`; this removes the parallel reason maps from the TUI view layer so API/relay empty states have a single formatting source while views can still choose their command vocabulary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of user-facing strings with tests preserving TUI wording; no auth or model-resolution logic changes.
> 
> **Overview**
> **Centralizes “no runnable models” copy** in `@cli/runtime/modelAccess` so startup, orchestration, and the TUI model picker share one formatter instead of parallel maps in the TUI layer.
> 
> `formatCliNoRunnableModelsLaunchBlock` and `formatCliNoRunnableModelsMessage` take a `NoRunnableModelAccessReason` and optional recovery hints (`loginAction`, `includedModeAction`, `personalModeAction`). Defaults target non-interactive CLI (`texra login`, `--api-mode`); `modelAccessDisplay` only overrides those with slash-command wording for `/model` and launch blocks.
> 
> Adds a focused vitest case that locks launch-block text and interactive recovery sentences for all three reasons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ddbf1597b70815cd2b939dd7733139594450310. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->