### PR TITLE
Harden CLI Shift-Enter input rewriting

### DIFF
--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -122,45 +122,115 @@ export function isTextInputNewlineInput(
   );
 }
 
-// Under the Kitty disambiguate flag, terminals report keypad Enter as its own
-// key (codepoint 57414, "kpenter") distinct from the main Enter (codepoint 13).
-// Ink parses it but `useInput` surfaces no field for it, so keypad Enter would
-// silently stop submitting once the protocol is on. App.tsx re-dispatches this
-// raw sequence as a plain Enter. Matches only the unmodified form (bare, or the
-// explicit "no modifiers" `;1`) so Ctrl/Alt+keypad-Enter pass through untouched.
-const KITTY_KEYPAD_ENTER_INPUTS = [`${ESC}[57414u`, `${ESC}[57414;1u`];
+const KITTY_KEYPAD_ENTER_CODEPOINT = '57414';
+const KITTY_SHIFT_MODIFIER_BITS = 1;
+const KITTY_NO_MODIFIER_BITS = 0;
 
-// Ink only parses the semicolon CSI-u form as a shifted Return key when it is
-// the whole input event. The colon form can still be emitted by terminals, but
-// Ink surfaces it as an unhandled raw sequence, so TeXRA must synthesize the
-// newline token for that spelling itself.
-const INK_PARSED_KITTY_SHIFT_ENTER_INPUTS = [`${ESC}[13;2u`];
-const RAW_KITTY_SHIFT_ENTER_INPUTS = [`${ESC}[13:2u`];
-const KITTY_SHIFT_ENTER_INPUTS = [
-  ...INK_PARSED_KITTY_SHIFT_ENTER_INPUTS,
-  ...RAW_KITTY_SHIFT_ENTER_INPUTS,
-];
+// Kitty keyboard protocol: CSI codepoint ; modifiers [: eventType]
+// [; text-as-codepoints] u. Some terminals also emit the colon-only spelling
+// CSI codepoint : modifiers u for shifted Return, which Ink does not parse.
+const KITTY_ENTER_INPUT_RE = new RegExp(
+  `${ESC}\\[(13|57414)(?:([;:])(\\d+)(?::(\\d+))?(?:;[\\d:]+)?)?u`,
+  'g',
+);
 
-function isInkParsedStandaloneShiftEnterInput(data: string): boolean {
-  return INK_PARSED_KITTY_SHIFT_ENTER_INPUTS.includes(data);
+interface KittyEnterInput {
+  readonly delimiter?: ';' | ':';
+  readonly eventType?: number;
+  readonly key: 'mainEnter' | 'keypadEnter';
+  readonly modifierBits: number;
+}
+
+function parseKittyEnterInput(
+  codepoint: string,
+  delimiter: string | undefined,
+  modifier: string | undefined,
+  eventType: string | undefined,
+): KittyEnterInput {
+  const modifierBits =
+    modifier == null
+      ? KITTY_NO_MODIFIER_BITS
+      : Math.max(KITTY_NO_MODIFIER_BITS, Number(modifier) - 1);
+  const parsedDelimiter =
+    delimiter === ';' || delimiter === ':' ? delimiter : undefined;
+  return {
+    delimiter: parsedDelimiter,
+    eventType: eventType == null ? undefined : Number(eventType),
+    key:
+      codepoint === KITTY_KEYPAD_ENTER_CODEPOINT ? 'keypadEnter' : 'mainEnter',
+    modifierBits,
+  };
+}
+
+function isStandaloneMatch(
+  data: string,
+  sequence: string,
+  offset: number,
+): boolean {
+  return offset === 0 && sequence.length === data.length;
+}
+
+function isInkParsedStandaloneShiftEnterInput(
+  data: string,
+  sequence: string,
+  offset: number,
+  input: KittyEnterInput,
+): boolean {
+  return (
+    isStandaloneMatch(data, sequence, offset) &&
+    input.delimiter === ';' &&
+    input.key === 'mainEnter' &&
+    input.modifierBits === KITTY_SHIFT_MODIFIER_BITS
+  );
+}
+
+function rewriteKittyEnterMatch(
+  data: string,
+  sequence: string,
+  offset: number,
+  input: KittyEnterInput,
+  shiftEnter: 'newline' | 'preserve',
+): string {
+  if (input.eventType === 3) return sequence;
+  if (
+    input.key === 'keypadEnter' &&
+    input.modifierBits === KITTY_NO_MODIFIER_BITS
+  ) {
+    return '\r';
+  }
+  if (shiftEnter === 'preserve') return sequence;
+  if (
+    input.key === 'mainEnter' &&
+    input.modifierBits === KITTY_SHIFT_MODIFIER_BITS
+  ) {
+    return isInkParsedStandaloneShiftEnterInput(data, sequence, offset, input)
+      ? sequence
+      : SYNTHETIC_SHIFT_RETURN_INPUT;
+  }
+  return sequence;
 }
 
 export function rewriteKittyEnterInput(
   data: string,
   options: { readonly shiftEnter: 'newline' | 'preserve' },
 ): string | undefined {
-  let rewritten = data;
-  for (const sequence of KITTY_KEYPAD_ENTER_INPUTS) {
-    rewritten = rewritten.replaceAll(sequence, '\r');
-  }
-  if (options.shiftEnter === 'preserve') {
-    return rewritten === data ? undefined : rewritten;
-  }
-  if (isInkParsedStandaloneShiftEnterInput(rewritten)) {
-    return undefined;
-  }
-  for (const sequence of KITTY_SHIFT_ENTER_INPUTS) {
-    rewritten = rewritten.replaceAll(sequence, SYNTHETIC_SHIFT_RETURN_INPUT);
-  }
+  const rewritten = data.replaceAll(
+    KITTY_ENTER_INPUT_RE,
+    (
+      sequence,
+      codepoint: string,
+      delimiter: string | undefined,
+      modifier: string | undefined,
+      eventType: string | undefined,
+      offset: number,
+    ) =>
+      rewriteKittyEnterMatch(
+        data,
+        sequence,
+        offset,
+        parseKittyEnterInput(codepoint, delimiter, modifier, eventType),
+        options.shiftEnter,
+      ),
+  );
   return rewritten === data ? undefined : rewritten;
 }

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -112,6 +112,31 @@ describe('CLI TUI text input editing', () => {
       cursor: 10,
       submit: false,
     });
+
+    const associatedTextRewritten = rewriteKittyEnterInput(
+      `alpha${ESC}[13;2;13ubeta`,
+      { shiftEnter: 'newline' },
+    );
+
+    expect(associatedTextRewritten).toBe(
+      `alpha${SYNTHETIC_SHIFT_RETURN_INPUT}beta`,
+    );
+    expect(
+      applyTerminalInputChunk('', 0, associatedTextRewritten ?? ''),
+    ).toEqual({
+      value: 'alpha\nbeta',
+      cursor: 10,
+      submit: false,
+    });
+
+    const pressEventRewritten = rewriteKittyEnterInput(
+      `alpha${ESC}[13;2:1ubeta`,
+      { shiftEnter: 'newline' },
+    );
+
+    expect(pressEventRewritten).toBe(
+      `alpha${SYNTHETIC_SHIFT_RETURN_INPUT}beta`,
+    );
   });
 
   it('preserves Shift+Enter while still rewriting keypad Enter', () => {
@@ -123,6 +148,32 @@ describe('CLI TUI text input editing', () => {
         shiftEnter: 'preserve',
       }),
     ).toBe('pick\r');
+  });
+
+  it('does not rewrite Kitty Enter forms that Ink can handle or should ignore', () => {
+    expect(
+      rewriteKittyEnterInput(`${ESC}[13;2;13u`, { shiftEnter: 'newline' }),
+    ).toBeUndefined();
+    expect(
+      rewriteKittyEnterInput(`alpha${ESC}[13;2:3ubeta`, {
+        shiftEnter: 'newline',
+      }),
+    ).toBeUndefined();
+    expect(
+      rewriteKittyEnterInput(`alpha${ESC}[13;6ubeta`, {
+        shiftEnter: 'newline',
+      }),
+    ).toBeUndefined();
+    expect(
+      rewriteKittyEnterInput(`alpha${ESC}[57414;5ubeta`, {
+        shiftEnter: 'newline',
+      }),
+    ).toBeUndefined();
+    expect(
+      rewriteKittyEnterInput(`alpha${ESC}[57414;1:3ubeta`, {
+        shiftEnter: 'newline',
+      }),
+    ).toBeUndefined();
   });
 
   it('recognizes Option/Alt chords from normalized meta and ESC-prefixed input', () => {


### PR DESCRIPTION
## Summary
- replace exact Kitty Enter string lists with a structural CSI-u Enter classifier
- keep standalone semicolon Shift+Enter delegated to Ink, while rewriting batched Shift+Enter into the internal newline token
- preserve Ctrl-J, plain Enter, modified keypad Enter, and release-event behavior

Closes #5410.

## Validation
- git diff --check
- corepack pnpm vitest run src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts
- npm run typecheck
- npm run lint (passes with 29 existing import-order warnings)
- npm run compile:fast
- corepack pnpm --filter @texra-ai/cli build
- node packages/cli/scripts/validate-tui.mjs --no-build kitty-shift-enter-newline ctrl-j-newline plain-submit

## Design note
Ink already parses standalone Kitty CSI-u keypresses. TeXRA only needs to repair raw chunks that Ink cannot parse as a standalone keypress, so the rewrite path now classifies Enter-related CSI-u sequences by codepoint, modifier bits, optional event type, and optional associated text instead of maintaining parallel exact-string fallbacks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI input normalization only; behavior is tightened with regression tests and no auth or data-path changes.
> 
> **Overview**
> Replaces hardcoded Kitty Enter CSI-u string lists in `rewriteKittyEnterInput` with a **regex classifier** that parses codepoint (main vs keypad), modifier bits, delimiter (`;` vs `:`), optional event type, and associated-text suffixes.
> 
> **Unmodified keypad Enter** still becomes `\r`; **Shift+Enter** in embedded chunks still becomes the internal newline token, while **standalone `ESC[13;2u`** is left for Ink. **Release events** (`eventType === 3`), **Ctrl/Alt-modified Enter**, and other Ink-handled forms are no longer rewritten.
> 
> Tests add coverage for associated-text and press-event spellings plus explicit “do not rewrite” cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb5a4e6bfcf5f1108984bad2a52fd75938b3cba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->