### PR TITLE
Refactor CLI multi-agent launch block messages

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -19,10 +19,11 @@ import { writeTextStderr } from '../runtime/logSinks';
 import {
   agentHasDelegationTools,
   cliMultiAgentPlanHasGaps,
-  cliMultiAgentPresetTeamLaunchBlockReason,
+  cliMultiAgentPresetCanLaunchTeam,
   cliMultiAgentPresetNdjsonRecords,
   cliMultiAgentPresetListRecords,
   findCliMultiAgentPreset,
+  formatCliMultiAgentTeamLaunchBlockMessage,
   formatCliMultiAgentPresetDetails,
   formatCliMultiAgentPresetInspection,
   formatCliMultiAgentPresetList,
@@ -340,17 +341,19 @@ export async function runMultiAgentPreset(
       missingToolUseAgentMessage(plan.missingAgentOverride),
     );
   }
-  const rootAgent = plan.rootAgent;
-  const teamLaunchBlockReason = cliMultiAgentPresetTeamLaunchBlockReason(plan);
-  if (teamLaunchBlockReason || !rootAgent) {
-    const singleAgentAdvice = rootAgent
-      ? `Start a single-agent chat with \`texra chat --agent ${rootAgent.name}\` if that is what you want.`
+  if (!cliMultiAgentPresetCanLaunchTeam(plan)) {
+    const singleAgentAdvice = plan.rootAgent
+      ? `Start a single-agent chat with \`texra chat --agent ${plan.rootAgent.name}\` if that is what you want.`
       : 'Install or sign in for a runnable team root before launching this preset.';
     writeTextStderr(
-      `Multi-agent preset "${init.preset}" cannot start as a team: ${teamLaunchBlockReason ?? 'no runnable team root'}. Run \`texra multi-agent inspect ${plan.preset.id}\` to see missing agents. ${singleAgentAdvice}`,
+      formatCliMultiAgentTeamLaunchBlockMessage(plan, {
+        requestedPreset: init.preset,
+        followUpAdvice: singleAgentAdvice,
+      }),
     );
     return CliExitCode.Usage;
   }
+  const rootAgent = plan.rootAgent;
   writeMissingPresetAgents(plan);
 
   // A team run drives a tool-use orchestrator, so it follows the `chat`

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -12,7 +12,8 @@ import {
   interactiveTerminalFailure,
 } from '../runtime/terminalRequirements';
 import {
-  cliMultiAgentPresetTeamLaunchBlockReason,
+  cliMultiAgentPresetCanLaunchTeam,
+  formatCliMultiAgentTeamLaunchBlockMessage,
   readCliMultiAgentPresets,
   withCliMultiAgentPresetVisibility,
 } from '../runtime/multiAgentPresets';
@@ -147,19 +148,20 @@ async function runOrchestration(context: CliContext): Promise<number> {
       // delegation specialists) and replan so the team starts with its real
       // root instead of silently degrading to the first local tool-use agent.
       const plan = await fillMultiAgentRunPlanGaps({ preset: action.preset });
-      const teamLaunchBlockReason =
-        cliMultiAgentPresetTeamLaunchBlockReason(plan);
-      if (teamLaunchBlockReason || !plan.rootAgent) {
+      if (!cliMultiAgentPresetCanLaunchTeam(plan)) {
         writeTextStderr(
-          `Multi-agent preset "${action.preset}" cannot start as a team: ${teamLaunchBlockReason ?? 'no runnable team root'}. Run \`texra multi-agent inspect ${plan.preset.id}\` to see missing agents.`,
+          formatCliMultiAgentTeamLaunchBlockMessage(plan, {
+            requestedPreset: action.preset,
+          }),
         );
         return CliExitCode.Usage;
       }
+      const rootAgent = plan.rootAgent;
       writeMissingPresetAgents(plan);
       const { runChat } = await import('../chat/tui/runChatTui');
       const result = await withCliMultiAgentPresetVisibility(plan, () =>
         runChat(context, {
-          agentOverride: plan.rootAgent?.name,
+          agentOverride: rootAgent.name,
           teamName: plan.preset.name,
           modelOverride: action.model,
           cliMultiAgentPresetId: plan.preset.id,

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -30,6 +30,11 @@ export interface CliMultiAgentPresetFormatOptions {
   readonly includeLoginHint?: boolean;
 }
 
+export interface CliMultiAgentTeamLaunchBlockMessageOptions {
+  readonly requestedPreset?: string;
+  readonly followUpAdvice?: string;
+}
+
 export type CliMultiAgentPlanStatus = 'available' | 'degraded' | 'unavailable';
 
 export interface CliMultiAgentPresetAgentAvailability {
@@ -267,8 +272,27 @@ export function cliMultiAgentPresetTeamLaunchBlockReason(
 
 export function cliMultiAgentPresetCanLaunchTeam(
   plan: CliMultiAgentPresetRunPlan,
-): boolean {
+): plan is CliMultiAgentPresetRunPlan & { readonly rootAgent: AgentEntry } {
   return cliMultiAgentPresetTeamLaunchBlockReason(plan) === undefined;
+}
+
+export function formatCliMultiAgentTeamLaunchBlockMessage(
+  plan: CliMultiAgentPresetRunPlan,
+  options: CliMultiAgentTeamLaunchBlockMessageOptions = {},
+): string {
+  const preset = options.requestedPreset ?? plan.preset.id;
+  const reason = cliMultiAgentPresetTeamLaunchBlockReason(plan);
+  if (!reason) {
+    throw new Error(
+      `Cannot format team launch block for launchable multi-agent preset "${plan.preset.id}".`,
+    );
+  }
+  const parts = [
+    `Multi-agent preset "${preset}" cannot start as a team: ${reason}.`,
+    `Run \`texra multi-agent inspect ${plan.preset.id}\` to see missing agents.`,
+    options.followUpAdvice,
+  ];
+  return parts.filter((part): part is string => !!part).join(' ');
 }
 
 export function cliMultiAgentPresetAvailability(

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -9,6 +9,7 @@ import {
   cliMultiAgentPresetNdjsonRecords,
   cliMultiAgentPresets,
   findCliMultiAgentPreset,
+  formatCliMultiAgentTeamLaunchBlockMessage,
   formatCliMultiAgentPresetLauncherSummary,
   formatCliMultiAgentPresetDetails,
   formatCliMultiAgentPresetInspection,
@@ -182,6 +183,48 @@ describe('CLI multi-agent presets', () => {
 
     expect(formatCliMultiAgentPresetLauncherSummary(plan)).toBe(
       'unavailable; no runnable team root; 0/9 tool-use agents; 0/4 workflow agents',
+    );
+  });
+
+  it('formats team launch block messages from the planned preset state', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [agent('lean', AgentCategory.ToolUse)],
+    });
+
+    expect(
+      formatCliMultiAgentTeamLaunchBlockMessage(plan, {
+        requestedPreset: 'Lean Project',
+        followUpAdvice:
+          'Install or sign in for a runnable team root before launching this preset.',
+      }),
+    ).toBe(
+      'Multi-agent preset "Lean Project" cannot start as a team: no runnable team root. Run `texra multi-agent inspect lean-project` to see missing agents. Install or sign in for a runnable team root before launching this preset.',
+    );
+  });
+
+  it('rejects launch block message formatting for launchable plans', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'lean-project',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: preset.toolUseAgents.map((name) =>
+        agent(
+          name,
+          AgentCategory.ToolUse,
+          name === 'leanOrchestrator' ? ['delegate_agent'] : [],
+        ),
+      ),
+    });
+
+    expect(() => formatCliMultiAgentTeamLaunchBlockMessage(plan)).toThrow(
+      /launchable multi-agent preset "lean-project"/,
     );
   });
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => {
     executeCliRequest: vi.fn(),
     expandRunInputs: vi.fn(),
     cliMultiAgentPlanHasGaps: vi.fn(),
-    cliMultiAgentPresetTeamLaunchBlockReason: vi.fn(),
+    cliMultiAgentPresetCanLaunchTeam: vi.fn(),
+    formatCliMultiAgentTeamLaunchBlockMessage: vi.fn(),
     getToolUseAgents: vi.fn(),
     getWorkflowAgents: vi.fn(),
     initCliPlatform: vi.fn(),
@@ -74,8 +75,7 @@ vi.mock('@cli/runtime/multiAgentPresets', () => {
         agent.tools?.some((tool) => delegationTools.has(tool)) ?? false,
     ),
     cliMultiAgentPlanHasGaps: mocks.cliMultiAgentPlanHasGaps,
-    cliMultiAgentPresetTeamLaunchBlockReason:
-      mocks.cliMultiAgentPresetTeamLaunchBlockReason,
+    cliMultiAgentPresetCanLaunchTeam: mocks.cliMultiAgentPresetCanLaunchTeam,
     cliMultiAgentPresetNdjsonRecords: vi.fn(() => []),
     findCliMultiAgentPreset: vi.fn(() => ({
       id: 'mathematician',
@@ -88,6 +88,8 @@ vi.mock('@cli/runtime/multiAgentPresets', () => {
     formatCliMultiAgentPresetDetails: vi.fn(() => ''),
     formatCliMultiAgentPresetInspection: vi.fn(() => ''),
     formatCliMultiAgentPresetList: vi.fn(() => ''),
+    formatCliMultiAgentTeamLaunchBlockMessage:
+      mocks.formatCliMultiAgentTeamLaunchBlockMessage,
     MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION:
       'Root agent for the team run (defaults to the preset orchestrator)',
     MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION: 'Model for the team root agent',
@@ -154,7 +156,10 @@ describe('CLI multi-agent run command', () => {
     });
     mocks.getWorkflowAgents.mockReturnValue([]);
     mocks.cliMultiAgentPlanHasGaps.mockReturnValue(false);
-    mocks.cliMultiAgentPresetTeamLaunchBlockReason.mockReturnValue(undefined);
+    mocks.cliMultiAgentPresetCanLaunchTeam.mockReturnValue(true);
+    mocks.formatCliMultiAgentTeamLaunchBlockMessage.mockReturnValue(
+      'blocked preset message',
+    );
     mocks.planCliMultiAgentPresets.mockImplementation((presets) =>
       presets.map((preset: unknown) =>
         mocks.planCliMultiAgentPresetRun(preset, {
@@ -454,10 +459,7 @@ describe('CLI multi-agent run command', () => {
   });
 
   it('refuses built-in presets without a runnable root agent', async () => {
-    mocks.cliMultiAgentPresetTeamLaunchBlockReason.mockReturnValueOnce(
-      'no runnable team root',
-    );
-    mocks.planCliMultiAgentPresetRun.mockReturnValue({
+    const plan = {
       preset: {
         id: 'mathematician',
         name: 'Mathematician',
@@ -468,7 +470,14 @@ describe('CLI multi-agent run command', () => {
       missingToolUseAgents: ['simplifier', 'progressCheck', 'orchestrator'],
       workflowAgentKeys: [],
       toolUseAgentKeys: ['builtInToolUse:lean'],
-    });
+    };
+    const message =
+      'Multi-agent preset "mathematician" cannot start as a team: no runnable team root. Run `texra multi-agent inspect mathematician` to see missing agents. Install or sign in for a runnable team root before launching this preset.';
+    mocks.cliMultiAgentPresetCanLaunchTeam.mockReturnValueOnce(false);
+    mocks.formatCliMultiAgentTeamLaunchBlockMessage.mockReturnValueOnce(
+      message,
+    );
+    mocks.planCliMultiAgentPresetRun.mockReturnValue(plan);
     const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
 
     const exitCode = await runMultiAgentPreset(cliContext(), {
@@ -481,9 +490,14 @@ describe('CLI multi-agent run command', () => {
 
     expect(exitCode).toBe(2);
     expect(mocks.executeCliRequest).not.toHaveBeenCalled();
-    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'Multi-agent preset "mathematician" cannot start as a team: no runnable team root. Run `texra multi-agent inspect mathematician` to see missing agents. Install or sign in for a runnable team root before launching this preset.',
-    );
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(message);
+    expect(
+      mocks.formatCliMultiAgentTeamLaunchBlockMessage,
+    ).toHaveBeenCalledWith(plan, {
+      requestedPreset: 'mathematician',
+      followUpAdvice:
+        'Install or sign in for a runnable team root before launching this preset.',
+    });
     expect(mocks.writeTextStderr).not.toHaveBeenCalledWith(
       expect.stringContaining('WARN team delegation unavailable'),
     );
@@ -525,10 +539,7 @@ describe('CLI multi-agent run command', () => {
   });
 
   it('refuses a delegating root with no available team members', async () => {
-    mocks.cliMultiAgentPresetTeamLaunchBlockReason.mockReturnValueOnce(
-      'no available team members',
-    );
-    mocks.planCliMultiAgentPresetRun.mockReturnValue({
+    const plan = {
       preset: {
         id: 'mathematician',
         name: 'Mathematician',
@@ -545,7 +556,14 @@ describe('CLI multi-agent run command', () => {
       missingToolUseAgents: ['simplifier'],
       workflowAgentKeys: [],
       toolUseAgentKeys: ['builtInToolUse:orchestrator'],
-    });
+    };
+    const message =
+      'Multi-agent preset "mathematician" cannot start as a team: no available team members. Run `texra multi-agent inspect mathematician` to see missing agents. Start a single-agent chat with `texra chat --agent orchestrator` if that is what you want.';
+    mocks.cliMultiAgentPresetCanLaunchTeam.mockReturnValueOnce(false);
+    mocks.formatCliMultiAgentTeamLaunchBlockMessage.mockReturnValueOnce(
+      message,
+    );
+    mocks.planCliMultiAgentPresetRun.mockReturnValue(plan);
     const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
 
     const exitCode = await runMultiAgentPreset(cliContext(), {
@@ -558,9 +576,14 @@ describe('CLI multi-agent run command', () => {
 
     expect(exitCode).toBe(2);
     expect(mocks.executeCliRequest).not.toHaveBeenCalled();
-    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'Multi-agent preset "mathematician" cannot start as a team: no available team members. Run `texra multi-agent inspect mathematician` to see missing agents. Start a single-agent chat with `texra chat --agent orchestrator` if that is what you want.',
-    );
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(message);
+    expect(
+      mocks.formatCliMultiAgentTeamLaunchBlockMessage,
+    ).toHaveBeenCalledWith(plan, {
+      requestedPreset: 'mathematician',
+      followUpAdvice:
+        'Start a single-agent chat with `texra chat --agent orchestrator` if that is what you want.',
+    });
     expect(mocks.writeTextStderr).not.toHaveBeenCalledWith(
       expect.stringContaining('Enable a delegating team root'),
     );


### PR DESCRIPTION
## Summary

- centralize CLI multi-agent team launch-block message formatting in the preset runtime
- make launchability a type guard so commands use a concrete root after validation
- remove the fallback launch-block reason and fail fast if the formatter is called for a launchable preset

Closes #5412.

## Validation

- `npx prettier --write packages/cli/src/runtime/multiAgentPresets.ts packages/cli/src/commands/multiAgent.ts packages/cli/src/commands/orchestrate.ts src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (passes with existing 29 import-order warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/scripts/validate-tui.mjs --no-build orchestrate-launcher compact-orchestrate-launcher`
- `texra-local multi-agent list --no-color`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of CLI error messaging and TypeScript narrowing only; launch rules still delegate to existing `cliMultiAgentPresetTeamLaunchBlockReason`.
> 
> **Overview**
> Centralizes **multi-agent team launch failure** stderr text in `formatCliMultiAgentTeamLaunchBlockMessage` in the preset runtime, with optional `requestedPreset` and `followUpAdvice` so headless `multi-agent run` and interactive `orchestrate` stay aligned.
> 
> **`cliMultiAgentPresetCanLaunchTeam`** is now a **type guard** (launchable plans must have a concrete `rootAgent`), so commands assign `rootAgent` after the check instead of optional chaining. Launch-block copy no longer uses a generic fallback reason; the formatter **throws** if invoked on a launchable plan.
> 
> Tests cover the shared formatter and mock the new APIs in the run-command suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6799911f744df0b0f4fda6f2b4236a0a8d0090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->