### PR TITLE
Fix focused subagent transcript local notices

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -62,6 +62,7 @@ import {
 } from '../src/chat/tui/state/approvalQueue';
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
 import { effectiveStreamStatus } from '../src/chat/tui/state/streamStatus';
+import { resolveLocalTranscriptStreamId } from '../src/chat/tui/state/transcript';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
 import { parseCliApiMode, type CliApiMode } from '../src/runtime/apiAccessMode';
 import type { CliModelAccess } from '../src/runtime/modelAccess';
@@ -1057,8 +1058,11 @@ function markHarnessInterrupted(): void {
   }
 }
 
-function appendHarnessAssistantTranscript(text: string): void {
-  appendHarnessTranscript('assistant', text);
+function appendHarnessAssistantTranscript(
+  text: string,
+  streamId?: StreamTabId,
+): void {
+  appendHarnessTranscript('assistant', text, streamId);
 }
 
 function appendHarnessUserTranscript(text: string): void {
@@ -1068,8 +1072,9 @@ function appendHarnessUserTranscript(text: string): void {
 function appendHarnessTranscript(
   role: ConversationEntry['role'],
   text: string,
+  explicitStreamId?: StreamTabId,
 ): void {
-  const streamId = cliState.activeStreamId.get() ?? STREAM_ID;
+  const streamId = explicitStreamId ?? defaultHarnessTranscriptStreamId();
   patchStream(streamId, (slice) => ({
     ...slice,
     entries: [
@@ -1083,6 +1088,15 @@ function appendHarnessTranscript(
   }));
 }
 
+function defaultHarnessTranscriptStreamId(): StreamTabId {
+  return resolveLocalTranscriptStreamId({
+    activeStreamId: cliState.activeStreamId.get(),
+    fallbackStreamId: STREAM_ID,
+    parentStream: cliState.parentStream.get(),
+    rootStreamId: cliState.rootStreamId.get(),
+  });
+}
+
 function harnessActiveChildStreamId(): StreamTabId | undefined {
   const activeStreamId = cliState.activeStreamId.get();
   if (!activeStreamId) return undefined;
@@ -1091,9 +1105,7 @@ function harnessActiveChildStreamId(): StreamTabId | undefined {
     : undefined;
 }
 
-function harnessRejectsFocusedChildSubmit(): boolean {
-  const childStreamId = harnessActiveChildStreamId();
-  if (!childStreamId) return false;
+function harnessRejectsChildSubmit(childStreamId: StreamTabId): boolean {
   const status = effectiveStreamStatus(childStreamId);
   return status !== undefined && !isInFlightStatus(status);
 }
@@ -1247,13 +1259,15 @@ function markHarnessExecutionStopped(executionId: string): void {
 
 function handleHarnessSubmit(line: string): void {
   if (handleHarnessSlashCommand(line)) return;
-  if (harnessRejectsFocusedChildSubmit()) {
+  const childStreamId = harnessActiveChildStreamId();
+  if (childStreamId && harnessRejectsChildSubmit(childStreamId)) {
     appendHarnessAssistantTranscript(
       'The selected subagent is no longer accepting follow-ups.',
+      childStreamId,
     );
     return;
   }
-  appendHarnessAssistantTranscript(`Harness received: ${line}`);
+  appendHarnessAssistantTranscript(`Harness received: ${line}`, childStreamId);
 }
 
 function appendHarnessStatus(): void {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1384,6 +1384,32 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'subagent-focused-status-stays-scoped',
+    cols: 120,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: ['\t', '/status', '\r'],
+    frame: 'tail',
+    expect: [
+      'Please handle the harness-child-strategy sub-workflow.',
+      'strategy is checking the harness-child-strategy details',
+      '[1:strategy]*',
+    ],
+    unexpect: [
+      'agent: harness-agent',
+      'api: relay',
+      'entry-1 chat history line',
+      'entry-4 chat history line',
+      '[main]*',
+      'signal read during notification phase',
+      'ERROR',
+    ],
+  },
+  {
     name: 'subagent-focus-return-root-scrollback-deduped',
     cols: 120,
     env: {

--- a/packages/cli/src/chat/tui/state/compactionRequest.ts
+++ b/packages/cli/src/chat/tui/state/compactionRequest.ts
@@ -18,7 +18,7 @@ export interface CliCompactionRequestOptions {
     streamId: StreamTabId,
     runtimeHost?: AgentRuntimeHost,
   ) => void;
-  readonly appendTranscript: (message: string) => void;
+  readonly appendTranscript: (message: string, streamId?: StreamTabId) => void;
 }
 
 export function requestCliCompaction({
@@ -31,6 +31,7 @@ export function requestCliCompaction({
   if (!streamId || !flowContext) {
     appendTranscript(
       'No active tool-use session found for context compaction.',
+      streamId,
     );
     return;
   }
@@ -38,6 +39,7 @@ export function requestCliCompaction({
   if (!flowContext.modelHandler.supportsManualCompaction) {
     appendTranscript(
       'Manual context compaction is not available for the current model.',
+      streamId,
     );
     return;
   }
@@ -46,5 +48,6 @@ export function requestCliCompaction({
   notifyFollowUpSent(streamId, flowContext.runtimeHost);
   appendTranscript(
     'Context compaction requested. The agent will process it on the next model call.',
+    streamId,
   );
 }

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -97,8 +97,7 @@ function appendLocalTranscriptEntry(
   const normalized = normalizeTranscriptText(text);
   if (!normalized) return;
 
-  const streamId =
-    explicitStreamId ?? cliState.activeStreamId.get() ?? CLI_LOCAL_STREAM_ID;
+  const streamId = explicitStreamId ?? defaultLocalTranscriptStreamId();
   if (!cliState.activeStreamId.get()) cliState.activeStreamId.set(streamId);
   const syntheticAfterSeq = getDefaultStreamLogStore().get(streamId)?.head ?? 0;
 
@@ -113,6 +112,35 @@ function appendLocalTranscriptEntry(
       syntheticAfterSeq,
     };
     return { ...slice, entries: [...slice.entries, entry] };
+  });
+}
+
+/**
+ * Local UI notices are root-owned unless a caller explicitly targets a child.
+ * A focused child should not receive session-level slash/status/error rows.
+ */
+export function resolveLocalTranscriptStreamId({
+  activeStreamId,
+  fallbackStreamId,
+  parentStream,
+  rootStreamId,
+}: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly fallbackStreamId: StreamTabId;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly rootStreamId: StreamTabId | undefined;
+}): StreamTabId {
+  if (rootStreamId) return rootStreamId;
+  if (!activeStreamId) return fallbackStreamId;
+  return parentStream.get(activeStreamId) ?? activeStreamId;
+}
+
+function defaultLocalTranscriptStreamId(): StreamTabId {
+  return resolveLocalTranscriptStreamId({
+    activeStreamId: cliState.activeStreamId.get(),
+    fallbackStreamId: CLI_LOCAL_STREAM_ID,
+    parentStream: cliState.parentStream.get(),
+    rootStreamId: cliState.rootStreamId.get(),
   });
 }
 

--- a/src/test-kernel/cli/CompactionRequest.vitest.mts
+++ b/src/test-kernel/cli/CompactionRequest.vitest.mts
@@ -27,6 +27,7 @@ describe('requestCliCompaction', () => {
     expect(notifyFollowUpSent).not.toHaveBeenCalled();
     expect(appendTranscript).toHaveBeenCalledWith(
       'No active tool-use session found for context compaction.',
+      undefined,
     );
   });
 
@@ -46,6 +47,7 @@ describe('requestCliCompaction', () => {
     expect(notifyFollowUpSent).not.toHaveBeenCalled();
     expect(appendTranscript).toHaveBeenCalledWith(
       'No active tool-use session found for context compaction.',
+      'stream-1',
     );
   });
 
@@ -69,6 +71,7 @@ describe('requestCliCompaction', () => {
     expect(notifyFollowUpSent).not.toHaveBeenCalled();
     expect(appendTranscript).toHaveBeenCalledWith(
       'Manual context compaction is not available for the current model.',
+      'stream-1',
     );
   });
 
@@ -91,6 +94,7 @@ describe('requestCliCompaction', () => {
     );
     expect(appendTranscript).toHaveBeenCalledWith(
       'Context compaction requested. The agent will process it on the next model call.',
+      'stream-1',
     );
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -82,6 +82,7 @@ import {
   clearLocalTranscript,
   CLI_LOCAL_STREAM_ID,
   moveLocalTranscriptToStream,
+  resolveLocalTranscriptStreamId,
 } from '@cli/chat/tui/state/transcript';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import {
@@ -1615,6 +1616,72 @@ describe('CLI transcript state', () => {
         .get(child1)
         ?.entries.map((entry) => entry.text),
     ).toEqual(['Child stream note.']);
+  });
+
+  it('keeps root local notices out of a focused child stream', () => {
+    cliState.rootStreamId.set(root);
+    setParentStream(child1, root);
+    cliState.activeStreamId.set(child1);
+
+    appendLocalAssistantTranscript('Available commands: /help');
+    appendLocalErrorTranscript('Model claude-opus-4-7 not found');
+
+    expect(
+      cliState.streams
+        .get()
+        .get(root)
+        ?.entries.map((entry) => [entry.role, entry.text]),
+    ).toEqual([
+      ['assistant', 'Available commands: /help'],
+      ['error', 'Model claude-opus-4-7 not found'],
+    ]);
+    expect(cliState.streams.get().get(child1)?.entries ?? []).toEqual([]);
+    expect(cliState.activeStreamId.get()).toBe(child1);
+  });
+
+  it('uses the focused child parent for local notices before root id is set', () => {
+    setParentStream(child1, root);
+    cliState.activeStreamId.set(child1);
+
+    appendLocalAssistantTranscript('Slash command output.');
+
+    expect(
+      cliState.streams
+        .get()
+        .get(root)
+        ?.entries.map((entry) => entry.text),
+    ).toEqual(['Slash command output.']);
+    expect(cliState.streams.get().get(child1)?.entries ?? []).toEqual([]);
+    expect(cliState.activeStreamId.get()).toBe(child1);
+  });
+
+  it('resolves root-owned local transcript targets before active children', () => {
+    const parentStream = new Map([[child1, root]]);
+
+    expect(
+      resolveLocalTranscriptStreamId({
+        activeStreamId: child1,
+        fallbackStreamId: CLI_LOCAL_STREAM_ID,
+        parentStream,
+        rootStreamId: 'root-from-session' as StreamTabId,
+      }),
+    ).toBe('root-from-session');
+    expect(
+      resolveLocalTranscriptStreamId({
+        activeStreamId: child1,
+        fallbackStreamId: CLI_LOCAL_STREAM_ID,
+        parentStream,
+        rootStreamId: undefined,
+      }),
+    ).toBe(root);
+    expect(
+      resolveLocalTranscriptStreamId({
+        activeStreamId: undefined,
+        fallbackStreamId: CLI_LOCAL_STREAM_ID,
+        parentStream,
+        rootStreamId: undefined,
+      }),
+    ).toBe(CLI_LOCAL_STREAM_ID);
   });
 
   it('adds local runtime errors to the transcript', () => {


### PR DESCRIPTION
## Summary
- keep implicit local TUI notices owned by the root stream instead of the currently focused child
- share the stream-owner resolver with the TUI harness so dogfood scenarios exercise the same rule
- add focused-child coverage for slash/status output staying out of child history

## Root Cause
The renderer was already scoped: focusing a child stream renders the child `ConversationPane` without the root static transcript. The leak came from data ownership. `appendLocalTranscriptEntry` used `activeStreamId` as the default owner for synthetic slash/status/error rows, so a root-level notice issued while a child was focused was persisted into that child slice.

## Architecture
```text
local slash/status/error output
  -> appendLocalTranscriptEntry
  -> resolveLocalTranscriptStreamId(root > parent(active child) > active > cli-local)
  -> patchStream(owner).entries
  -> focused child ConversationPane reads only child entries
```

Explicit stream ids still take precedence, so genuinely child-targeted notices remain possible without adding renderer-side filtering.

Closes #5414.

## Validation
- `npx prettier --write packages/cli/src/chat/tui/state/transcript.ts packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `cd packages/cli && node scripts/build-harness.mjs`
- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --no-build subagent-focused-status-stays-scoped subagent-tab-focus-full-frame subagent-focus-return-root-scrollback-deduped subagent-picker-enter-views-subagent`
- `git diff --check`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped TUI state/transcript routing with explicit stream IDs preserved; no auth or persistence changes.
> 
> **Overview**
> Fixes a **data ownership bug** where implicit local TUI notices (slash help, `/status`, errors, compaction messages) were appended to whichever stream had `activeStreamId`—so with a **focused subagent tab**, session-level rows landed in the **child** slice even though the child pane only renders child entries.
> 
> **`resolveLocalTranscriptStreamId`** centralizes the default owner: `rootStreamId` → parent of an active child → active stream → fallback (`cli-local` / harness stream). Explicit `streamId` arguments are unchanged for child-targeted messages (e.g. “subagent no longer accepting follow-ups”).
> 
> The **TUI harness** uses the same resolver; **`requestCliCompaction`** forwards `streamId` into `appendTranscript`; a **validate-tui** scenario asserts `/status` on a focused child does not show root session metadata or pollute child history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79aac0bcff24ebb805c5746eca99271715fa0cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->