### PR TITLE
Clarify empty CLI model picker

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -542,11 +542,16 @@ const SCENARIOS = [
     frame: 'tail',
     expect: [
       '/model · included relay',
+      'No model choices in this API mode.',
       'No included relay models are runnable.',
       'Switch with /api personal or try again later.',
       'Enter close',
     ],
-    unexpect: ['No models are available in this API mode.'],
+    unexpect: [
+      'Available models.',
+      'Finish the active response before switching models.',
+      'No models are available in this API mode.',
+    ],
   },
   {
     name: 'api-form',

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -44,6 +44,19 @@ export function modelSelectWindow(args: {
   return computeSelectWindowSize({ ...args, chromeRows: 5 });
 }
 
+export function modelListDescription({
+  itemCount,
+  selectable,
+}: {
+  readonly itemCount: number;
+  readonly selectable: boolean;
+}): string {
+  if (itemCount === 0) return 'No model choices in this API mode.';
+  return selectable
+    ? 'Choose the model for future turns.'
+    : 'Available models. Finish the active response before switching models.';
+}
+
 function EmptyModelListState(props: {
   readonly models: readonly CliModelAccess[];
   readonly apiMode: CliApiMode;
@@ -91,6 +104,10 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     availableRows: props.availableRows,
     itemCount: items.length,
   });
+  const description = modelListDescription({
+    itemCount: items.length,
+    selectable,
+  });
 
   function handleSelect(value: string): void {
     if (selectable) {
@@ -137,11 +154,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
       <Text bold color="cyan">
         {`/model · ${formatCliApiMode(props.apiMode)}`}
       </Text>
-      <Text dimColor>
-        {selectable
-          ? 'Choose the model for future turns.'
-          : 'Available models. Finish the active response before switching models.'}
-      </Text>
+      <Text dimColor>{description}</Text>
       {items.length === 0 ? (
         <EmptyModelListState
           models={models}

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -5,7 +5,10 @@ import {
   formatModelStatusForCliMode,
   modelSelectItemsForCliMode,
 } from '@cli/chat/tui/modelAccessDisplay';
-import { modelSelectWindow } from '@cli/chat/tui/forms/ModelListForm';
+import {
+  modelListDescription,
+  modelSelectWindow,
+} from '@cli/chat/tui/forms/ModelListForm';
 import { shouldCloseAsyncListFormOnInput } from '@cli/chat/tui/forms/_shared/useAsyncListForm';
 import {
   COMPACT_FORM_MAX_ROWS,
@@ -271,6 +274,21 @@ describe('CLI ModelListForm model visibility', () => {
 });
 
 describe('CLI ModelListForm empty state', () => {
+  it('uses a truthful description for empty and non-empty model lists', () => {
+    expect(modelListDescription({ itemCount: 0, selectable: false })).toBe(
+      'No model choices in this API mode.',
+    );
+    expect(modelListDescription({ itemCount: 0, selectable: true })).toBe(
+      'No model choices in this API mode.',
+    );
+    expect(modelListDescription({ itemCount: 2, selectable: false })).toBe(
+      'Available models. Finish the active response before switching models.',
+    );
+    expect(modelListDescription({ itemCount: 2, selectable: true })).toBe(
+      'Choose the model for future turns.',
+    );
+  });
+
   it('explains that included relay models require sign-in', () => {
     const models = [
       access(


### PR DESCRIPTION
## Summary
- centralize the `/model` form description for selectable, read-only, and empty states
- stop empty model pickers from claiming that models are available or that switching is only blocked by an active response
- tighten the `model-form-included-empty` TUI scenario so it rejects the stale copy

Closes #5416.

## Evidence
The harness snapshot for signed-in included mode with no runnable relay models now reads:

```text
/model · included relay
No model choices in this API mode.
No included relay models are runnable. Switch with /api personal or try again later.
Enter close · Esc close
```

Snapshot report: `/tmp/texra-tui-model-empty/index.html`

## Validation
- `npx prettier --write packages/cli/src/chat/tui/forms/ModelListForm.tsx src/test-kernel/cli/ModelListForm.vitest.mts packages/cli/scripts/validate-tui.mjs`
- `corepack pnpm vitest run src/test-kernel/cli/ModelListForm.vitest.mts`
- `cd packages/cli && node scripts/build-harness.mjs`
- `node packages/cli/scripts/validate-tui.mjs --no-build --snapshot-dir /tmp/texra-tui-model-empty model-form model-form-selectable model-form-included-empty no-color-model-form`
- `git diff --check`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and test-only changes in the CLI model list form; no auth, API, or data-path changes.
> 
> **Overview**
> The `/model` picker now uses a shared **`modelListDescription`** helper so the header line matches whether the list is empty, selectable, or read-only during an active response.
> 
> When there are **no runnable models** in the current API mode, the form shows **"No model choices in this API mode."** instead of implying models exist or that switching is only blocked by an in-flight reply. The **`model-form-included-empty`** TUI harness scenario expects that copy and rejects stale strings like **"Available models."** and **"No models are available in this API mode."**
> 
> Unit tests cover all four description branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3d5b9e1ef1207d3af0bbd79f06ca78b8e36cc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->