### PR TITLE
Rename CLI agent delegation labels

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -406,7 +406,8 @@ const SCENARIOS = [
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
-      'Tool-use and orchestrator agents',
+      'Tool-use and delegating agents',
+      'delegating; built-in',
       'Current: chat (hidden from picker)',
       'texra chat --agent=<name>',
       'Esc close',
@@ -415,6 +416,7 @@ const SCENARIOS = [
       'Platform not initialized',
       '/agent - error',
       'texra --agent=<name>',
+      'orchestrator; built-in',
     ],
   },
   {
@@ -428,7 +430,8 @@ const SCENARIOS = [
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
-      'Tool-use and orchestrator agents',
+      'Tool-use and delegating agents',
+      'delegating; built-in',
       'Current: chat (hidden from picker)',
       'texra chat --agent=<name>',
       'Esc close',
@@ -437,6 +440,7 @@ const SCENARIOS = [
       'Platform not initialized',
       '/agent - error',
       'texra --agent=<name>',
+      'orchestrator; built-in',
     ],
     maxLineColumns: 80,
   },
@@ -647,7 +651,7 @@ const SCENARIOS = [
     expect: [
       '/agent',
       'Current: chat (hidden from picker)',
-      'Tool-use and orchestrator agents',
+      'Tool-use and delegating agents',
       '+8 more',
       '↑/↓ navigate',
       'Enter close',

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -31,7 +31,7 @@ interface AgentGroups {
 }
 
 type AgentIdentity = Pick<AgentOptionData, 'label' | 'value'>;
-type AgentOrchestrationFlag = Pick<AgentOptionData, 'isOrchestrator'>;
+type AgentDelegationFlag = Pick<AgentOptionData, 'isOrchestrator'>;
 
 const AGENT_FORM_MAX_WIDTH = 80;
 
@@ -49,26 +49,26 @@ function agentDescription(agent: AgentOptionData): string {
     : agent.isCustom
       ? 'custom'
       : 'built-in';
-  const kind = isOrchestratorAgent(agent) ? 'orchestrator' : 'tool-use';
+  const kind = isDelegatingAgent(agent) ? 'delegating' : 'tool-use';
   return agent.description ? `${kind}; ${source}; ${agent.description}` : kind;
 }
 
-function isOrchestratorAgent(agent: AgentOrchestrationFlag): boolean {
+function isDelegatingAgent(agent: AgentDelegationFlag): boolean {
   return agent.isOrchestrator === true;
 }
 
 export function agentPickerPrimarySectionTitle(
-  agents: readonly AgentOrchestrationFlag[],
+  agents: readonly AgentDelegationFlag[],
 ): string {
-  const hasOrchestrators = agents.some(isOrchestratorAgent);
+  const hasDelegatingAgents = agents.some(isDelegatingAgent);
   const hasToolUseSpecialists = agents.some(
-    (agent) => !isOrchestratorAgent(agent),
+    (agent) => !isDelegatingAgent(agent),
   );
 
-  if (hasOrchestrators && hasToolUseSpecialists) {
-    return 'Tool-use and orchestrator agents';
+  if (hasDelegatingAgents && hasToolUseSpecialists) {
+    return 'Tool-use and delegating agents';
   }
-  return hasOrchestrators ? 'Orchestrator agents' : 'Tool-use agents';
+  return hasDelegatingAgents ? 'Delegating agents' : 'Tool-use agents';
 }
 
 export function currentVisibleAgent(

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -46,14 +46,14 @@ describe('CLI AgentListForm row budget', () => {
       agentPickerPrimarySectionTitle([{ isOrchestrator: undefined }]),
     ).toBe('Tool-use agents');
     expect(agentPickerPrimarySectionTitle([{ isOrchestrator: true }])).toBe(
-      'Orchestrator agents',
+      'Delegating agents',
     );
     expect(
       agentPickerPrimarySectionTitle([
         { isOrchestrator: false },
         { isOrchestrator: true },
       ]),
-    ).toBe('Tool-use and orchestrator agents');
+    ).toBe('Tool-use and delegating agents');
   });
 
   it('windows long agent lists inside the available foreground rows', () => {


### PR DESCRIPTION
## Summary

Closes #5420.

- Renames the `/agent` picker's delegation-capable row kind from `orchestrator` to `delegating`.
- Updates the primary section title from `Tool-use and orchestrator agents` to `Tool-use and delegating agents`.
- Keeps behavior and registry data unchanged; this is UI terminology only.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/AgentListForm.vitest.mts`
- `cd packages/cli && node scripts/build-harness.mjs`
- `node packages/cli/scripts/validate-tui.mjs --no-build --snapshot-dir /tmp/texra-tui-agent-delegating agent-form agent-form-80-cols compact-agent-form`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (passes with existing 29 import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run compile:fast`

## Snapshot

`/tmp/texra-tui-agent-delegating/index.html`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only UI and test updates in the agent list form; no logic or registry data changes.
> 
> **Overview**
> Renames **delegation-capable** agent wording in the CLI `/agent` picker from **orchestrator** to **delegating**, without changing registry fields or selection behavior (`isOrchestrator` still drives the flag).
> 
> **`AgentListForm`** updates section titles (e.g. **Tool-use and delegating agents**), per-row kind labels (`delegating` vs `tool-use`), and internal helpers/types (`isDelegatingAgent`, `AgentDelegationFlag`). **`validate-tui.mjs`** and **`AgentListForm.vitest.mts`** expectations now assert the new strings and reject the old **orchestrator** copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ec6b6636dde58f1ead6c293d1276ff55d144f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->