### PR TITLE
fix: clarify CLI team root blocker

### DIFF
--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -282,7 +282,7 @@ export function cliMultiAgentPresetTeamLaunchBlockReason(
 ): string | undefined {
   if (!plan.rootAgent) return 'no runnable team root';
   if (!agentHasDelegationTools(plan.rootAgent)) {
-    return `root ${plan.rootAgent.name} cannot delegate`;
+    return `team root ${plan.rootAgent.name} is not a delegating agent`;
   }
   if (availablePresetTeamMemberCount(plan) === 0) {
     return 'no available team members';

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -261,6 +261,29 @@ describe('CLI multi-agent presets', () => {
     );
   });
 
+  it('formats explicit non-delegating team roots without old fallback wording', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'mathematician',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [agent('lean', AgentCategory.ToolUse)],
+      agentOverride: 'lean',
+    });
+
+    const message = formatCliMultiAgentTeamLaunchBlockMessage(plan, {
+      requestedPreset: 'mathematician',
+      followUpAdvice:
+        'Start a single-agent chat with `texra chat --agent lean` if that is what you want.',
+    });
+
+    expect(message).toBe(
+      'Multi-agent preset "mathematician" cannot start as a team: team root lean is not a delegating agent. Run `texra multi-agent inspect mathematician` to see missing agents. Start a single-agent chat with `texra chat --agent lean` if that is what you want.',
+    );
+    expect(message).not.toContain('cannot delegate');
+  });
+
   it('rejects launch block message formatting for launchable plans', () => {
     const preset = findCliMultiAgentPreset(
       cliMultiAgentPresets(undefined),


### PR DESCRIPTION
## Summary
- replace the stale `root <agent> cannot delegate` multi-agent blocker with clearer team-root wording
- add a regression test for explicit non-delegating root overrides

Fixes #5422.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `npm run texra-local:build`
- `texra-local multi-agent run mathematician --agent lean --instruction "probe" --no-input --no-color`
- `rg -n "cannot delegate|root .*cannot delegate|unavailable; root" packages/cli/src src/test-kernel/cli packages/cli/dist/bin/texra.js`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to an error string plus a test; no launch or delegation logic changes.
> 
> **Overview**
> When a multi-agent preset cannot start as a team because the chosen root lacks delegation tools, the CLI now reports **`team root <name> is not a delegating agent`** instead of the older **`root <name> cannot delegate`** phrasing. That string flows through `cliMultiAgentPresetTeamLaunchBlockReason` into the full team launch block message; **team launch rules are unchanged**.
> 
> A regression test covers an explicit `--agent lean` override on the mathematician preset and asserts the new wording while ensuring **`cannot delegate`** no longer appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c346b338c522d7180f47c78aad421f6b89b9269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->