### PR TITLE
Refactor CLI stream status ownership

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -61,7 +61,7 @@ import {
   type ApprovalDecision,
 } from '../src/chat/tui/state/approvalQueue';
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
-import { effectiveStreamStatus } from '../src/chat/tui/state/streamStatus';
+import { streamStatusFromState } from '../src/chat/tui/state/streamStatus';
 import { resolveLocalTranscriptStreamId } from '../src/chat/tui/state/transcript';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
 import { parseCliApiMode, type CliApiMode } from '../src/runtime/apiAccessMode';
@@ -1106,7 +1106,7 @@ function harnessActiveChildStreamId(): StreamTabId | undefined {
 }
 
 function harnessRejectsChildSubmit(childStreamId: StreamTabId): boolean {
-  const status = effectiveStreamStatus(childStreamId);
+  const status = streamStatusFromState(childStreamId);
   return status !== undefined && !isInFlightStatus(status);
 }
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -120,8 +120,8 @@ import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
 import { subscribeStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
 import {
-  effectiveStreamStatus,
   onStreamStatusChange,
+  streamStatusFromState,
 } from './state/streamStatus';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
 import { requestCliCompaction } from './state/compactionRequest';
@@ -429,7 +429,7 @@ function chatTuiCanAcceptFollowUp(status: StreamStatus | undefined): boolean {
 export function chatTuiActiveChildFollowUpTarget(): StreamTabId | undefined {
   const activeStreamId = chatTuiActiveChildStreamId();
   if (!activeStreamId) return undefined;
-  return chatTuiCanAcceptFollowUp(effectiveStreamStatus(activeStreamId))
+  return chatTuiCanAcceptFollowUp(streamStatusFromState(activeStreamId))
     ? activeStreamId
     : undefined;
 }
@@ -438,13 +438,13 @@ export function chatTuiShouldAnnounceQueuedFollowUp(
   targetStreamId: StreamTabId | undefined,
 ): boolean {
   if (!targetStreamId) return true;
-  return effectiveStreamStatus(targetStreamId) !== STREAM_STATUS.WAITING;
+  return streamStatusFromState(targetStreamId) !== STREAM_STATUS.WAITING;
 }
 
 export function chatTuiRejectedChildFollowUpTarget(): StreamTabId | undefined {
   const activeStreamId = chatTuiActiveChildStreamId();
   if (!activeStreamId) return undefined;
-  return chatTuiCanAcceptFollowUp(effectiveStreamStatus(activeStreamId))
+  return chatTuiCanAcceptFollowUp(streamStatusFromState(activeStreamId))
     ? undefined
     : activeStreamId;
 }
@@ -1154,7 +1154,7 @@ export async function runChat(
   const pendingSkillActivations = new Map<string, string>();
   let pendingSkillActivationClearEpoch = 0;
   const rootStreamStatus = (): StreamStatus | undefined =>
-    session.streamId ? effectiveStreamStatus(session.streamId) : undefined;
+    session.streamId ? streamStatusFromState(session.streamId) : undefined;
   const hasActiveToolUseFlow = (): boolean =>
     Boolean(session.streamId && getToolUseFlowContext(session.streamId));
   const canSelectCurrentModel = (): boolean =>
@@ -1202,7 +1202,7 @@ export async function runChat(
   const resetSessionForClear = (): void => {
     const activeStreamId = session.streamId ?? cliState.activeStreamId.get();
     const activeStatus = activeStreamId
-      ? effectiveStreamStatus(activeStreamId)
+      ? streamStatusFromState(activeStreamId)
       : undefined;
     const isRunPending = Boolean(session.runPromise && !session.runCompleted);
 

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -11,10 +11,7 @@ import { formatDuration } from '@utils/core';
 
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
-import {
-  childWithEffectiveStatus,
-  visibleSubagentRows,
-} from './childStreamMerge';
+import { visibleSubagentRows } from './childStreamMerge';
 import { streamScopeDisplayLabel } from './streamLabels';
 import { orderedDescendantsFromTree } from './focusCycle';
 import { transcriptEntryLines } from './transcriptLines';
@@ -393,11 +390,8 @@ export function liveChildExecutionElapsedKey(
 
   const liveKeys: string[] = [];
   for (const child of slice.activeSubagents) {
-    const effectiveChild = childWithEffectiveStatus(child);
-    if (hasLiveChildElapsed(effectiveChild)) {
-      liveKeys.push(
-        `${effectiveChild.executionId}:${effectiveChild.startedAt}`,
-      );
+    if (hasLiveChildElapsed(child)) {
+      liveKeys.push(`${child.executionId}:${child.startedAt}`);
     }
   }
   for (const child of slice.activeProcesses) {

--- a/packages/cli/src/chat/tui/state/childStreamMerge.ts
+++ b/packages/cli/src/chat/tui/state/childStreamMerge.ts
@@ -1,8 +1,6 @@
 // Local imports - shared schemas
 import type { ActiveChildInfo } from '@shared/schemas';
 
-import { effectiveStreamStatus } from './streamStatus';
-
 function childKey(child: ActiveChildInfo): string {
   return child.childStreamId ?? child.executionId;
 }
@@ -18,14 +16,6 @@ export function mergeChildStreams(
   return [...byStream.values()];
 }
 
-export function childWithEffectiveStatus(
-  child: ActiveChildInfo,
-): ActiveChildInfo {
-  if (!child.childStreamId) return child;
-  const status = effectiveStreamStatus(child.childStreamId) ?? child.status;
-  return status === child.status ? child : { ...child, status };
-}
-
 /** Active subagents followed by any retained child streams that are no longer
  *  active — so completed/waiting subagent pages stay listed and addressable. */
 export function visibleSubagentRows(slice: {
@@ -36,5 +26,5 @@ export function visibleSubagentRows(slice: {
   return [
     ...slice.activeSubagents,
     ...slice.childStreams.filter((child) => !activeKeys.has(childKey(child))),
-  ].map(childWithEffectiveStatus);
+  ];
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -8,16 +8,17 @@
 import { signal, Signal } from '@lit-labs/signals';
 
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
-import type {
-  ActiveChildInfo,
-  AgentCategory,
-  ConversationProgress,
-  NormalizedToolUse,
-  Plan,
-  StreamStatus,
-  StreamTabId,
-  TodoItem,
-  TokenUsageStats,
+import {
+  STREAM_STATUS,
+  type ActiveChildInfo,
+  type AgentCategory,
+  type ConversationProgress,
+  type NormalizedToolUse,
+  type Plan,
+  type StreamStatus,
+  type StreamTabId,
+  type TodoItem,
+  type TokenUsageStats,
 } from '@shared/schemas';
 
 export interface ConversationEntry {
@@ -222,6 +223,89 @@ export function patchStream(
   const out = new Map(current);
   out.set(streamId, next);
   cliState.streams.set(out);
+}
+
+function streamSliceWithStatus(
+  slice: StreamSlice,
+  status: StreamStatus,
+  nowMs: number,
+): StreamSlice {
+  const runStartedAt =
+    status === STREAM_STATUS.RUNNING
+      ? (slice.runStartedAt ?? nowMs)
+      : undefined;
+  if (slice.status === status && slice.runStartedAt === runStartedAt) {
+    return slice;
+  }
+  return { ...slice, status, runStartedAt };
+}
+
+function updateChildStatusReferences(
+  children: readonly ActiveChildInfo[],
+  childStreamId: StreamTabId,
+  status: StreamStatus,
+): readonly ActiveChildInfo[] {
+  let out: ActiveChildInfo[] | undefined;
+  children.forEach((child, index) => {
+    if (child.childStreamId !== childStreamId || child.status === status) {
+      return;
+    }
+    out ??= [...children];
+    out[index] = { ...child, status };
+  });
+  return out ?? children;
+}
+
+function withMirroredChildStreamStatus(
+  slice: StreamSlice,
+  childStreamId: StreamTabId,
+  status: StreamStatus,
+): StreamSlice {
+  return mapChildStreamReferenceLists(slice, (children) =>
+    updateChildStatusReferences(children, childStreamId, status),
+  );
+}
+
+/**
+ * Apply a stream-status event once to the CLI state mirror.
+ *
+ * Runtime status still originates in StreamStatusService, but TUI renderers
+ * should read only StreamSlice data. Updating retained parent child rows here
+ * keeps side panels, tab labels, focus routing, and follow-up targeting on the
+ * same state snapshot instead of re-querying the runtime service at render time.
+ */
+export function setStreamStatusInCliState({
+  nowMs = Date.now(),
+  status,
+  streamId,
+}: {
+  readonly nowMs?: number;
+  readonly status: StreamStatus;
+  readonly streamId: StreamTabId;
+}): void {
+  const current = cliState.streams.get();
+  let out: Map<StreamTabId, StreamSlice> | undefined;
+
+  const existingSlice = current.get(streamId);
+  const targetSlice = streamSliceWithStatus(
+    existingSlice ?? emptySlice(streamId),
+    status,
+    nowMs,
+  );
+  if (targetSlice !== existingSlice) {
+    out = new Map(current);
+    out.set(streamId, targetSlice);
+  }
+
+  const readable = out ?? current;
+  for (const [id, slice] of readable) {
+    const next = withMirroredChildStreamStatus(slice, streamId, status);
+    if (next === slice) continue;
+    out ??= new Map(current);
+    out.set(id, next);
+  }
+
+  if (out) cliState.streams.set(out);
 }
 
 interface ParentStreamEdgeUpdate {

--- a/packages/cli/src/chat/tui/state/streamStatus.ts
+++ b/packages/cli/src/chat/tui/state/streamStatus.ts
@@ -2,38 +2,21 @@ import {
   StreamStatusService,
   type StreamStatusChange,
 } from '@agent/runtime/StreamStatusService';
-import {
-  STREAM_STATUS,
-  type StreamStatus,
-  type StreamTabId,
-} from '@shared/schemas';
+import { type StreamStatus, type StreamTabId } from '@shared/schemas';
 
-import { cliState, patchStream } from './cliState';
+import { cliState, setStreamStatusInCliState } from './cliState';
 
 export function applyStreamStatusChange(change: StreamStatusChange): void {
-  // StreamStatusService is the runtime source of truth. The slice status is a
-  // UI mirror used by panes that render one stream directly; child ownership
-  // rows project this value at read time instead of receiving copied updates.
-  patchStream(change.streamId, (slice) => {
-    if (slice.status === change.status) return slice;
-    // Stamp the turn-start clock when entering RUNNING (keeping any prior
-    // stamp if we re-enter without leaving), and clear it otherwise so the
-    // StatusBar's elapsed segment only ticks during an active turn.
-    const runStartedAt =
-      change.status === STREAM_STATUS.RUNNING
-        ? (slice.runStartedAt ?? Date.now())
-        : undefined;
-    return { ...slice, status: change.status, runStartedAt };
+  setStreamStatusInCliState({
+    streamId: change.streamId,
+    status: change.status,
   });
 }
 
-export function effectiveStreamStatus(
+export function streamStatusFromState(
   streamId: StreamTabId,
 ): StreamStatus | undefined {
-  return (
-    StreamStatusService.get(streamId) ??
-    cliState.streams.get().get(streamId)?.status
-  );
+  return cliState.streams.get().get(streamId)?.status;
 }
 
 export function onStreamStatusChange(

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -227,7 +227,7 @@ describe('cliState Phase 4 fields', () => {
 
       const parent = cliState.streams.get().get(root);
       expect(parent?.activeSubagents).toEqual([]);
-      expect(parent?.childStreams[0]?.status).toBe(STREAM_STATUS.RUNNING);
+      expect(parent?.childStreams[0]?.status).toBe(STREAM_STATUS.ERROR);
       expect(visibleSubagentRows(parent!)).toMatchObject([
         {
           executionId: 'agent-1',
@@ -1245,7 +1245,12 @@ describe('CLI TUI row allocation', () => {
     expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
   });
 
-  it('uses StreamStatusService before stale slice status for focused children', () => {
+  it('mirrors running child status events into focused child routing', () => {
+    const wrapped = wrapRuntimeHost({
+      emit: () => undefined,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const dispose = subscribeStreamStatus();
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
     patchStream(root, (s) => ({
       ...s,
@@ -1259,15 +1264,33 @@ describe('CLI TUI row allocation', () => {
       ],
     }));
     patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.STOPPED }));
-    StreamStatusService.set(child1, STREAM_STATUS.RUNNING, { emit: false });
     setParentStream(child1, root);
 
-    cliState.activeStreamId.set(child1);
-    expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
-    expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
+    try {
+      StreamStatusService.set(child1, STREAM_STATUS.RUNNING, {
+        runtimeHost: wrapped,
+      });
+
+      cliState.activeStreamId.set(child1);
+      expect(cliState.streams.get().get(child1)?.status).toBe(
+        STREAM_STATUS.RUNNING,
+      );
+      expect(cliState.streams.get().get(root)?.childStreams[0]?.status).toBe(
+        STREAM_STATUS.RUNNING,
+      );
+      expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
+      expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
+    } finally {
+      dispose();
+    }
   });
 
-  it('rejects focused children when only StreamStatusService is terminal', () => {
+  it('mirrors stopped child status events into focused child routing', () => {
+    const wrapped = wrapRuntimeHost({
+      emit: () => undefined,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const dispose = subscribeStreamStatus();
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
     patchStream(root, (s) => ({
       ...s,
@@ -1281,12 +1304,25 @@ describe('CLI TUI row allocation', () => {
       ],
     }));
     patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
-    StreamStatusService.set(child1, STREAM_STATUS.STOPPED, { emit: false });
     setParentStream(child1, root);
 
-    cliState.activeStreamId.set(child1);
-    expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
-    expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
+    try {
+      StreamStatusService.set(child1, STREAM_STATUS.STOPPED, {
+        runtimeHost: wrapped,
+      });
+
+      cliState.activeStreamId.set(child1);
+      expect(cliState.streams.get().get(child1)?.status).toBe(
+        STREAM_STATUS.STOPPED,
+      );
+      expect(cliState.streams.get().get(root)?.childStreams[0]?.status).toBe(
+        STREAM_STATUS.STOPPED,
+      );
+      expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
+      expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
+    } finally {
+      dispose();
+    }
   });
 
   it('clears stale resume ids when clearing chat session run state', () => {


### PR DESCRIPTION
## Summary

- mirror stream-status events into `cliState.streams` at the subscriber boundary
- update retained parent child rows in the same state write so subagent panels, tabs, focus routing, and follow-up targeting read one state snapshot
- remove render-time fallback helpers that queried `StreamStatusService` from child row/status display paths

Closes #5425.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `npm run check:cli-architecture`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches follow-up routing, subagent panels, and `/clear` gating via a single state-write path; behavior change is intentional but easy to miss if status events are not subscribed.
> 
> **Overview**
> The CLI TUI now treats **`cliState.streams` as the single read path for stream status** instead of merging runtime `StreamStatusService` lookups at render time.
> 
> **`setStreamStatusInCliState`** applies each status event in one write: it updates the target stream slice (including `runStartedAt` when entering `RUNNING`) and **mirrors that status onto every parent slice** that references the stream in `activeSubagents`, `activeProcesses`, or `childStreams`. **`applyStreamStatusChange`** delegates to this helper; **`effectiveStreamStatus`** is renamed to **`streamStatusFromState`** and only reads slice status.
> 
> Render-time **`childWithEffectiveStatus`** is removed from **`visibleSubagentRows`** and child elapsed keys—panels and follow-up routing use the mirrored rows directly. Tests now assert status flows through **`subscribeStreamStatus`** into parent **`childStreams`** and child follow-up targeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc8b9a5a23c377e8a4bd434f99f72776938e91e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->