### PR TITLE
fix: hide delegated sessions from CLI launcher

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -26,6 +26,7 @@ import {
   TODO_STATUS,
   TOOL_USE_STATUS,
   type ActiveChildInfo,
+  type ExecutionId,
   type ExternalInquiryThreadId,
   type NormalizedToolUse,
   type RetryPermission,
@@ -72,6 +73,10 @@ import {
 } from '../src/runtime/multiAgentPresets';
 import { buildCliOrchestrationItems } from '../src/runtime/orchestration';
 import {
+  CLI_HISTORY_RESUMABLE_STATUS,
+  type CliHistoryEntry,
+} from '../src/runtime/history';
+import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
 } from '../src/schemas/cliSettings';
@@ -100,6 +105,8 @@ const SHOW_LONG_CHILD_OUTPUT = process.env.HARNESS_LONG_CHILD_OUTPUT === '1';
 const SHOW_WIDE_FIRST_CHILD_LINE =
   process.env.HARNESS_WIDE_FIRST_CHILD_LINE === '1';
 const SHOW_ORCHESTRATION = process.env.HARNESS_ORCHESTRATION === '1';
+const SHOW_DELEGATED_ORCHESTRATION_HISTORY =
+  process.env.HARNESS_DELEGATED_ORCHESTRATION_HISTORY === '1';
 const SHOW_NO_RUNNABLE_ORCHESTRATION_MODELS =
   process.env.HARNESS_NO_RUNNABLE_MODELS === '1';
 const HARNESS_API_MODE_FROM_ENV = parseCliApiMode(
@@ -237,9 +244,45 @@ const HARNESS_ORCHESTRATION_ITEMS = buildCliOrchestrationItems({
     workflowAgents: getWorkflowAgents(),
     toolUseAgents: getToolUseAgents(),
   }),
-  history: [],
+  history: harnessOrchestrationHistory(),
   toolUseAgents: getToolUseAgents(),
 });
+
+function harnessOrchestrationHistory(): readonly CliHistoryEntry[] {
+  if (!SHOW_DELEGATED_ORCHESTRATION_HISTORY) return [];
+  return [
+    {
+      id: 'aaaaaaaaaaaa' as ExecutionId,
+      timestamp: '2026-06-06T00:00:00Z',
+      agent: 'search',
+      model: 'harness-model',
+      status: CLI_HISTORY_RESUMABLE_STATUS,
+      inputBasename: '-',
+      category: AGENT_CATEGORY.TOOL_USE,
+      parentExecutionId: 'root-session' as ExecutionId,
+      delegationDepth: 1,
+    },
+    {
+      id: 'bbbbbbbbbbbb' as ExecutionId,
+      timestamp: '2026-06-06T00:01:00Z',
+      agent: 'review',
+      model: 'harness-model',
+      status: CLI_HISTORY_RESUMABLE_STATUS,
+      inputBasename: '-',
+      category: AGENT_CATEGORY.TOOL_USE,
+      delegationDepth: 1,
+    },
+    {
+      id: 'cccccccccccc' as ExecutionId,
+      timestamp: '2026-06-06T00:02:00Z',
+      agent: 'orchestrator',
+      model: 'harness-model',
+      status: CLI_HISTORY_RESUMABLE_STATUS,
+      inputBasename: '-',
+      category: AGENT_CATEGORY.TOOL_USE,
+    },
+  ];
+}
 
 type HarnessModelFixture = Readonly<{
   value: string;

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -243,6 +243,29 @@ const SCENARIOS = [
     unexpect: ['[/model]models', 'Tip:', 'tool-use:', 'workflow:'],
   },
   {
+    name: 'orchestrate-delegated-history',
+    env: {
+      HARNESS_ORCHESTRATION: '1',
+      HARNESS_DELEGATED_ORCHESTRATION_HISTORY: '1',
+    },
+    bootExpect: 'Choose how to start this CLI session.',
+    exitKeys: [ESC],
+    expectExit: true,
+    expect: [
+      'Choose how to start this CLI session.',
+      'New chat',
+      'Resume cccccccccccc',
+      'Team Lean Project',
+      'Help',
+    ],
+    unexpect: [
+      'Resume aaaaaaaaaaaa',
+      'Resume bbbbbbbbbbbb',
+      'Chat with search',
+      'Chat with review',
+    ],
+  },
+  {
     name: 'compact-orchestrate-launcher',
     rows: 10,
     cols: 80,

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -47,6 +47,8 @@ export interface CliHistoryEntry {
   readonly inputBasename: string;
   readonly category?: string;
   readonly description?: string;
+  readonly parentExecutionId?: ExecutionId;
+  readonly delegationDepth?: number;
 }
 
 export interface CliHistoryDetails {
@@ -92,6 +94,20 @@ export function resumableCliHistoryEntries<
   T extends Pick<CliHistoryEntry, 'status'>,
 >(entries: readonly T[]): T[] {
   return entries.filter(isCliHistoryEntryResumable);
+}
+
+export function isCliHistoryEntryUserStarted(
+  entry: Pick<CliHistoryEntry, 'parentExecutionId' | 'delegationDepth'>,
+): boolean {
+  return (
+    entry.parentExecutionId === undefined && (entry.delegationDepth ?? 0) === 0
+  );
+}
+
+export function userStartedCliHistoryEntries<
+  T extends Pick<CliHistoryEntry, 'parentExecutionId' | 'delegationDepth'>,
+>(entries: readonly T[]): T[] {
+  return entries.filter(isCliHistoryEntryUserStarted);
 }
 
 export type CliHistoryDeleteResult =
@@ -272,6 +288,9 @@ export function formatCliHistoryDetailsText(
   }
   if (config?.agentCategory) lines.push(`Category: ${config.agentCategory}`);
   if (meta?.parentExecutionId) lines.push(`Parent: ${meta.parentExecutionId}`);
+  if (meta?.delegationDepth !== undefined) {
+    lines.push(`Delegation depth: ${meta.delegationDepth}`);
+  }
   if (meta?.description) lines.push(`Description: ${meta.description}`);
   if (details.resultMeta) {
     lines.push(`Result: ${JSON.stringify(details.resultMeta)}`);
@@ -312,6 +331,8 @@ async function toCliHistoryEntry(
     inputBasename,
     category: entry.category,
     description: entry.description,
+    parentExecutionId: entry.parentExecutionId,
+    delegationDepth: entry.delegationDepth,
   };
 }
 

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -10,7 +10,11 @@ import {
 } from './multiAgentPresets';
 import { implicitDefaultToolUseAgents } from './defaultAgents';
 import { formatCliHistoryResumeInputLabel } from './historyLabels';
-import { resumableCliHistoryEntries, type CliHistoryEntry } from './history';
+import {
+  resumableCliHistoryEntries,
+  userStartedCliHistoryEntries,
+  type CliHistoryEntry,
+} from './history';
 
 export type CliOrchestrationAction =
   | { readonly kind: 'chat'; readonly agent?: string; readonly model?: string }
@@ -47,6 +51,7 @@ const MAX_PRESET_ITEMS = 6;
 export function buildCliOrchestrationItems(
   input: BuildCliOrchestrationItemsInput,
 ): CliOrchestrationItem[] {
+  const userStartedHistory = userStartedCliHistoryEntries(input.history);
   const items: CliOrchestrationItem[] = [
     {
       value: { kind: 'chat' },
@@ -55,8 +60,8 @@ export function buildCliOrchestrationItems(
     },
   ];
 
-  items.push(...recentResumeItems(input.history));
-  items.push(...recentAgentItems(input.history, input.toolUseAgents));
+  items.push(...recentResumeItems(userStartedHistory));
+  items.push(...recentAgentItems(userStartedHistory, input.toolUseAgents));
   items.push(
     ...presetItems(input.presetPlans, {
       includeLoginHint: input.includeMultiAgentLoginHint,

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -44,6 +44,7 @@ export interface ExecutionListingEntry {
   id: ExecutionId;
   timestamp: string;
   parentExecutionId?: ExecutionId;
+  delegationDepth?: number;
   agent: string;
   model: string;
   agentConfig: AgentConfig | null;
@@ -134,6 +135,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
           id,
           timestamp: meta.timestamp,
           parentExecutionId: meta.parentExecutionId,
+          delegationDepth: meta.delegationDepth,
           agent: cfg?.agent ?? 'unknown',
           model: cfg?.model ?? 'unknown',
           agentConfig: cfg ?? null,
@@ -285,6 +287,7 @@ async function backfillEntries(entries: unknown[]): Promise<void> {
         agentConfig?: AgentConfig;
         config?: AgentConfig; // Legacy field name
         parentExecutionId?: ExecutionId;
+        delegationDepth?: number;
       };
 
       const rawConfig = candidate.agentConfig ?? candidate.config;
@@ -307,6 +310,7 @@ async function backfillEntries(entries: unknown[]): Promise<void> {
         store.writeMeta({
           timestamp: candidate.timestamp,
           parentExecutionId: candidate.parentExecutionId,
+          delegationDepth: candidate.delegationDepth,
         }),
         store.writeConfig(normalizedConfig),
       ]);

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -11,6 +11,7 @@ import {
   resumableCliHistoryEntries,
   readCliHistoryDetails,
   resolveCliHistoryStatus,
+  userStartedCliHistoryEntries,
 } from '@cli/runtime/history';
 import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
@@ -79,6 +80,17 @@ describe('CLI history status formatting', () => {
     ).toEqual([{ id: 'resume-me', status: CLI_HISTORY_RESUMABLE_STATUS }]);
   });
 
+  it('filters history entries to user-started sessions only', () => {
+    expect(
+      userStartedCliHistoryEntries([
+        { id: 'root' },
+        { id: 'root-with-depth', delegationDepth: 0 },
+        { id: 'child-with-parent', parentExecutionId: 'root' as ExecutionId },
+        { id: 'child-with-depth', delegationDepth: 1 },
+      ]),
+    ).toEqual([{ id: 'root' }, { id: 'root-with-depth', delegationDepth: 0 }]);
+  });
+
   it('keeps legacy terminal-status-free entries completed when no flow remains', () => {
     expect(resolveCliHistoryStatus({ hasFlowRecord: false })).toBe(
       EXECUTION_STATUS.COMPLETED,
@@ -92,6 +104,7 @@ describe('CLI history status formatting', () => {
       meta: {
         timestamp: '2026-06-03T05:03:06.717Z',
         category: 'toolUse',
+        delegationDepth: 0,
       },
       config: null,
       resultMeta: null,
@@ -102,6 +115,7 @@ describe('CLI history status formatting', () => {
     });
 
     expect(text).toContain('Status: resumable');
+    expect(text).toContain('Delegation depth: 0');
     expect(text).toContain('Resumable flow record: present');
     expect(text).not.toContain(`Status: ${EXECUTION_STATUS.COMPLETED}`);
   });

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -179,6 +179,41 @@ describe('CLI orchestration items', () => {
     expect(items[2]?.description).toBe('orchestrator; resumable; no input');
   });
 
+  it('hides delegated child executions from startup recent rows', () => {
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [
+        historyEntry('aaaaaaaaaaaa', {
+          agent: 'search',
+          status: CLI_HISTORY_RESUMABLE_STATUS,
+          parentExecutionId: 'root-session' as ExecutionId,
+          delegationDepth: 1,
+        }),
+        historyEntry('bbbbbbbbbbbb', {
+          agent: 'review',
+          status: CLI_HISTORY_RESUMABLE_STATUS,
+          delegationDepth: 1,
+        }),
+        historyEntry('cccccccccccc', {
+          agent: 'orchestrator',
+          status: CLI_HISTORY_RESUMABLE_STATUS,
+        }),
+      ],
+      toolUseAgents: [
+        toolUseAgent('search'),
+        toolUseAgent('review'),
+        toolUseAgent('orchestrator'),
+      ],
+    });
+
+    expect(items.map((item) => item.label)).toEqual([
+      'New chat',
+      'Resume cccccccccccc',
+      'Chat with orchestrator',
+      'Help',
+    ]);
+  });
+
   it('does not list completed executions as resume launcher rows', () => {
     const items = buildCliOrchestrationItems({
       presetPlans: [],


### PR DESCRIPTION
## Summary
- carry execution lineage metadata into CLI history entries
- filter startup launcher history to user-started sessions before building resume/recent-agent rows
- add unit coverage and a TUI harness scenario for delegated child history

Closes #5433.

## Verification
- corepack pnpm vitest run src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/HistoryStatus.vitest.ts src/test-kernel/cli/TuiValidatorArgs.vitest.mts
- node packages/cli/scripts/validate-tui.mjs --no-build orchestrate-delegated-history
- npm run format
- npm run typecheck
- npm run lint (passes with existing import-order warnings outside this change)
- npm run compile:fast
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launcher and history-display filtering only; delegated sessions remain in storage and are not removed from other history paths.
> 
> **Overview**
> **Delegated child executions no longer appear on the CLI startup launcher** — only sessions the user started (no parent, delegation depth 0) feed **Resume** and **Chat with …** rows.
> 
> Lineage is threaded through execution listing into `CliHistoryEntry` via **`parentExecutionId`** and **`delegationDepth`**, with new **`userStartedCliHistoryEntries`** used in **`buildCliOrchestrationItems`**. History detail text can show delegation depth; legacy history backfill preserves these fields.
> 
> Coverage adds unit tests and a TUI validator scenario (`orchestrate-delegated-history`) plus harness fixtures for mixed root/delegated history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73ffb941ad9b7c009ee65873488f455bfc3b23d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->