### PR TITLE
fix: show CLI startup auth status

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -64,7 +64,15 @@ import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
 import { streamStatusFromState } from '../src/chat/tui/state/streamStatus';
 import { resolveLocalTranscriptStreamId } from '../src/chat/tui/state/transcript';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
-import { parseCliApiMode, type CliApiMode } from '../src/runtime/apiAccessMode';
+import {
+  formatCliApiMode,
+  parseCliApiMode,
+  type CliApiMode,
+} from '../src/runtime/apiAccessMode';
+import {
+  formatCliApiStatusActionHint,
+  formatCliAuthStatusLine,
+} from '../src/runtime/apiStatus';
 import type { CliModelAccess } from '../src/runtime/modelAccess';
 import {
   cliMultiAgentPresets,
@@ -353,6 +361,19 @@ function harnessOrchestrationModels(
     : models;
 }
 
+function harnessOrchestrationStatusLines(): readonly string[] {
+  const authenticated = HARNESS_AUTHENTICATED === '1';
+  const profile = {
+    authenticated,
+    accountLabel: authenticated ? 'harness@example.edu' : undefined,
+  };
+  return [
+    `api: ${formatCliApiMode(HARNESS_API_MODE)}`,
+    formatCliAuthStatusLine(profile),
+    formatCliApiStatusActionHint(HARNESS_API_MODE, profile),
+  ];
+}
+
 if (SHOW_ORCHESTRATION) {
   const instance = render(
     <OrchestrationApp
@@ -363,6 +384,7 @@ if (SHOW_ORCHESTRATION) {
           : []
       }
       apiMode={HARNESS_API_MODE}
+      statusLines={harnessOrchestrationStatusLines()}
       allowDefaultModelLaunch={false}
       onResolve={() => undefined}
     />,

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -227,6 +227,9 @@ const SCENARIOS = [
     expect: [
       'TeXRA',
       'Choose how to start this CLI session.',
+      'api: personal API keys',
+      'auth: signed out',
+      'actions: configure a provider key, or run `texra login` for included relay',
       'New chat',
       'Team Lean Project',
       'unavailable',
@@ -253,6 +256,8 @@ const SCENARIOS = [
     expectExit: true,
     expect: [
       'Choose how to start this CLI session.',
+      'api: personal API keys',
+      'auth: signed out',
       'New chat',
       'Resume cccccccccccc',
       'Team Lean Project',
@@ -342,6 +347,8 @@ const SCENARIOS = [
     expectExit: true,
     expect: [
       'Choose how to start this CLI session.',
+      'api: personal API keys',
+      'auth: signed out',
       'New chat',
       'No personal API-key models are runnable',
       'Help',

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -120,12 +120,12 @@ async function runOrchestration(context: CliContext): Promise<number> {
   // after an agent/team choice. Best-effort: an unavailable registry just
   // launches with the default model instead of blocking the launcher.
   const apiMode = effectiveCliApiMode(context);
-  const models: readonly CliModelAccess[] = await getCliModelAccessList({
-    apiMode,
-  }).catch(() => []);
-  const statusLines = await loadCliApiStatusLines({
-    includeActionHint: true,
-  });
+  const [models, statusLines] = await Promise.all([
+    getCliModelAccessList({ apiMode }).catch(
+      (): readonly CliModelAccess[] => [],
+    ),
+    loadCliApiStatusLines({ apiMode, includeActionHint: true }),
+  ]);
   const allowDefaultModelLaunch = await canLaunchWithDefaultModel(
     context,
     models,

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -26,6 +26,7 @@ import {
   type CliModelAccess,
 } from '../runtime/modelAccess';
 import { effectiveCliApiMode } from '../runtime/apiAccessMode';
+import { loadCliApiStatusLines } from '../runtime/apiStatus';
 import { notifyCliUpdate } from '../runtime/updateChecker';
 import { resolveChatDefaults } from '../runtime/chatDefaults';
 
@@ -122,6 +123,9 @@ async function runOrchestration(context: CliContext): Promise<number> {
   const models: readonly CliModelAccess[] = await getCliModelAccessList({
     apiMode,
   }).catch(() => []);
+  const statusLines = await loadCliApiStatusLines({
+    includeActionHint: true,
+  });
   const allowDefaultModelLaunch = await canLaunchWithDefaultModel(
     context,
     models,
@@ -132,6 +136,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
   const action = await runOrchestrationTui(items, {
     models,
     apiMode,
+    statusLines,
     allowDefaultModelLaunch,
     colorEnabled: context.stdoutColorEnabled ?? context.colorEnabled,
   });

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -71,6 +71,7 @@ export interface OrchestrationAppProps {
    *  a known list with no runnable model disables chat/team starts. */
   readonly models: readonly CliModelAccess[];
   readonly apiMode: CliApiMode;
+  readonly statusLines?: readonly string[];
   readonly allowDefaultModelLaunch?: boolean;
   readonly onResolve: (action: CliOrchestrationAction) => void;
 }
@@ -102,6 +103,10 @@ function orchestrationFooterRowCost(footerHints: readonly string[]): number {
   return footerHints.length === 0 ? 0 : footerHints.length + 1;
 }
 
+function orchestrationStatusRowCost(statusLines: readonly string[]): number {
+  return statusLines.length === 0 ? 0 : statusLines.length + 1;
+}
+
 function modelPickKeyHints(): readonly KeyHint[] {
   return [
     { key: '↑/↓', action: 'navigate' },
@@ -122,6 +127,7 @@ export function OrchestrationApp(
     { allowDefaultModelLaunch: props.allowDefaultModelLaunch },
   );
   const listFooterHints = orchestrationFooterHints(items);
+  const statusLines = props.statusLines ?? [];
   // When set, the launcher is on its second step: choosing the model for this
   // chat/team. Esc returns to the item list rather than exiting.
   const [pending, setPending] = useState<ModelPickAction | undefined>(
@@ -130,7 +136,10 @@ export function OrchestrationApp(
   const footerHints = pending ? [] : listFooterHints;
   const maxVisibleItems = Math.max(
     4,
-    rows - 8 - orchestrationFooterRowCost(footerHints),
+    rows -
+      8 -
+      orchestrationStatusRowCost(pending ? [] : statusLines) -
+      orchestrationFooterRowCost(footerHints),
   );
 
   const finish = (action: CliOrchestrationAction): void => {
@@ -191,6 +200,15 @@ export function OrchestrationApp(
         TeXRA
       </Text>
       <Text dimColor>Choose how to start this CLI session.</Text>
+      {statusLines.length > 0 ? (
+        <Box marginTop={1} flexDirection="column">
+          {statusLines.map((line, index) => (
+            <Text key={`${index}:${line}`} dimColor wrap="truncate-end">
+              {line}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
       <Box marginTop={1}>
         <Select
           items={items}
@@ -223,6 +241,7 @@ export interface RunOrchestrationTuiOptions {
    *  hidden configured model. */
   readonly models: readonly CliModelAccess[];
   readonly apiMode: CliApiMode;
+  readonly statusLines?: readonly string[];
   readonly allowDefaultModelLaunch?: boolean;
   readonly colorEnabled?: boolean;
 }
@@ -243,6 +262,7 @@ export async function runOrchestrationTui(
         items={items}
         models={options.models}
         apiMode={options.apiMode}
+        statusLines={options.statusLines}
         allowDefaultModelLaunch={options.allowDefaultModelLaunch}
         onResolve={record}
       />,

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -3,7 +3,11 @@ import { toErrorMessage } from '@common/errors/errorMessage';
 import { API_PROVIDERS, lookupApiKeyOrigin } from '@model/apiProviders';
 
 import { formatCliAccountLabelForDisplay } from './accountDisplay';
-import { formatCliApiMode, getCliApiMode } from './apiAccessMode';
+import {
+  formatCliApiMode,
+  getCliApiMode,
+  type CliApiMode,
+} from './apiAccessMode';
 import { fetchRelayUsageSummary, type RelayUsageSummary } from './relayUsage';
 import { getCliAuthProfile, type CliAuthProfile } from './supabaseAuth';
 
@@ -44,6 +48,20 @@ export function formatApiKeyShadowWarning(
   return 'note: a provider API key is set while signed in — `--api-mode` (or `/api`) controls which one is used.';
 }
 
+export function formatCliApiStatusActionHint(
+  mode: CliApiMode,
+  profile: Pick<CliAuthProfile, 'authenticated'>,
+): string {
+  if (mode === 'included') {
+    return profile.authenticated
+      ? 'actions: `texra login --select-account` changes account; `--api-mode personal` uses provider keys'
+      : 'actions: `texra login` enables included relay; `--api-mode personal` uses provider keys';
+  }
+  return profile.authenticated
+    ? 'actions: `--api-mode included` uses relay; `texra logout` signs out'
+    : 'actions: configure a provider key, or run `texra login` for included relay';
+}
+
 async function anyPersonalKeyPresent(): Promise<boolean> {
   const secrets = platform().secrets;
   const origins = await Promise.all(
@@ -52,13 +70,18 @@ async function anyPersonalKeyPresent(): Promise<boolean> {
   return origins.some((origin) => origin !== 'none');
 }
 
-export async function loadCliApiStatusLines(): Promise<string[]> {
+export async function loadCliApiStatusLines(
+  options: { readonly includeActionHint?: boolean } = {},
+): Promise<string[]> {
   const mode = getCliApiMode();
   const profile = await getCliAuthProfile();
   const lines = [
     `api: ${formatCliApiMode(mode)}`,
     formatCliAuthStatusLine(profile),
   ];
+  const actionHint = options.includeActionHint
+    ? formatCliApiStatusActionHint(mode, profile)
+    : undefined;
 
   if (profile.authenticated) {
     const shadowWarning = formatApiKeyShadowWarning(
@@ -69,7 +92,10 @@ export async function loadCliApiStatusLines(): Promise<string[]> {
   }
 
   if (profile.tier) lines.push(`tier: ${profile.tier}`);
-  if (!profile.authenticated || !profile.tier) return lines;
+  if (!profile.authenticated || !profile.tier) {
+    if (actionHint) lines.push(actionHint);
+    return lines;
+  }
 
   try {
     lines.push(
@@ -81,5 +107,6 @@ export async function loadCliApiStatusLines(): Promise<string[]> {
     lines.push(`relay usage: unavailable (${toErrorMessage(error)})`);
   }
 
+  if (actionHint) lines.push(actionHint);
   return lines;
 }

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -71,9 +71,12 @@ async function anyPersonalKeyPresent(): Promise<boolean> {
 }
 
 export async function loadCliApiStatusLines(
-  options: { readonly includeActionHint?: boolean } = {},
+  options: {
+    readonly apiMode?: CliApiMode;
+    readonly includeActionHint?: boolean;
+  } = {},
 ): Promise<string[]> {
-  const mode = getCliApiMode();
+  const mode = options.apiMode ?? getCliApiMode();
   const profile = await getCliAuthProfile();
   const lines = [
     `api: ${formatCliApiMode(mode)}`,

--- a/src/test-kernel/cli/ApiStatus.vitest.mts
+++ b/src/test-kernel/cli/ApiStatus.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { formatCliAccountLabelForDisplay } from '@cli/runtime/accountDisplay';
 import {
+  formatCliApiStatusActionHint,
   formatCliAuthStatusLine,
   formatRelayUsageStatus,
 } from '@cli/runtime/apiStatus';
@@ -60,6 +61,29 @@ describe('CLI API status text', () => {
     );
     expect(formatCliAuthStatusLine({ authenticated: false })).toBe(
       'auth: signed out',
+    );
+  });
+
+  it('formats startup action hints from API mode and sign-in state', () => {
+    expect(
+      formatCliApiStatusActionHint('included', { authenticated: false }),
+    ).toBe(
+      'actions: `texra login` enables included relay; `--api-mode personal` uses provider keys',
+    );
+    expect(
+      formatCliApiStatusActionHint('included', { authenticated: true }),
+    ).toBe(
+      'actions: `texra login --select-account` changes account; `--api-mode personal` uses provider keys',
+    );
+    expect(
+      formatCliApiStatusActionHint('personal', { authenticated: true }),
+    ).toBe(
+      'actions: `--api-mode included` uses relay; `texra logout` signs out',
+    );
+    expect(
+      formatCliApiStatusActionHint('personal', { authenticated: false }),
+    ).toBe(
+      'actions: configure a provider key, or run `texra login` for included relay',
     );
   });
 });

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getCliApiMode: vi.fn(),
+  getCliAuthProfile: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/apiAccessMode', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@cli/runtime/apiAccessMode')>();
+  return {
+    ...actual,
+    getCliApiMode: mocks.getCliApiMode,
+  };
+});
+
+vi.mock('@cli/runtime/supabaseAuth', () => ({
+  getCliAuthProfile: mocks.getCliAuthProfile,
+}));
+
+const { loadCliApiStatusLines } = await import('@cli/runtime/apiStatus');
+
+describe('loadCliApiStatusLines', () => {
+  beforeEach(() => {
+    mocks.getCliApiMode.mockReset();
+    mocks.getCliAuthProfile.mockReset();
+    mocks.getCliApiMode.mockReturnValue('personal');
+    mocks.getCliAuthProfile.mockResolvedValue({ authenticated: false });
+  });
+
+  it('uses an invocation API mode override for launcher status text', async () => {
+    await expect(
+      loadCliApiStatusLines({
+        apiMode: 'included',
+        includeActionHint: true,
+      }),
+    ).resolves.toEqual([
+      'api: included relay',
+      'auth: signed out',
+      'actions: `texra login` enables included relay; `--api-mode personal` uses provider keys',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- show the current API mode, auth status, and an access action hint near the bare CLI startup launcher title
- keep auth probing in the existing `loadCliApiStatusLines` runtime helper, with the launcher receiving precomputed display lines
- update orchestration TUI harness coverage so startup snapshots assert the status block

Closes #5432.

## Validation
- `npm run format`
- `corepack pnpm vitest run src/test-kernel/cli/ApiStatus.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --skip-if-missing-deps orchestrate-launcher orchestrate-delegated-history compact-orchestrate-launcher orchestrate-relay-model-pick orchestrate-personal-model-pick orchestrate-no-runnable-models`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only launcher copy and display plumbing; auth probing reuses existing `loadCliApiStatusLines` with new optional flags and no change to credential handling.
> 
> **Overview**
> The bare **`texra` orchestration launcher** now shows **API mode**, **auth state**, and a short **actions** hint under the session picker, using precomputed lines from `loadCliApiStatusLines` (loaded in parallel with the model list in `orchestrate`).
> 
> `loadCliApiStatusLines` gains optional **`apiMode`** override and **`includeActionHint`**; **`formatCliApiStatusActionHint`** encodes the next-step copy for included vs personal and signed-in vs signed-out. The launcher TUI reserves vertical space for those lines and hides them on the model-pick step; the TUI harness mirrors the same status block for snapshot tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c89b53e29bdee52136436979d2c708fab9468d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->