### PR TITLE
fix: show focused subagent in CLI header

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1412,11 +1412,13 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     keys: ['\t'],
     expect: [
+      'subagent: strategy · parent: main · model: harness-model',
       'Please handle the harness-child-strategy sub-workflow.',
       'strategy is checking the harness-child-strategy details',
       '[1:strategy]*',
     ],
     unexpect: [
+      'agent: chat · model: harness-model',
       'entry-1 chat history line',
       'entry-4 chat history line',
       '[main]*',

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -17,6 +17,10 @@ import {
   type SessionMeta,
   type StreamSlice,
 } from '../state/cliState';
+import {
+  childStreamDisplayLabel,
+  streamScopeDisplayLabel,
+} from '../state/streamLabels';
 import { transcriptEntryLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
 import { TranscriptEntry } from './TranscriptEntry';
@@ -26,6 +30,7 @@ export type StaticTranscriptItem =
       readonly id: string;
       readonly kind: 'header';
       readonly compact: boolean;
+      readonly identityLine: string;
       readonly meta: SessionMeta;
     }
   | {
@@ -50,8 +55,29 @@ function shortenCwd(cwd: string): string {
   return cwd;
 }
 
-export function sessionHeaderIdentityLine(meta: SessionMeta): string {
+export function sessionHeaderIdentityLine(
+  meta: SessionMeta,
+  context: {
+    readonly parentStream?: ReadonlyMap<StreamTabId, StreamTabId>;
+    readonly streamId?: StreamTabId;
+    readonly streams?: ReadonlyMap<StreamTabId, StreamSlice>;
+  } = {},
+): string {
   const model = meta.model || '—';
+  const parentStreamId =
+    context.streamId && context.parentStream?.get(context.streamId);
+  if (context.streamId && parentStreamId && context.streams) {
+    const parentLabel = streamScopeDisplayLabel({
+      parentStream: context.parentStream ?? new Map(),
+      streamId: parentStreamId,
+      streams: context.streams,
+    });
+    const childLabel = childStreamDisplayLabel(
+      context.streams.get(parentStreamId),
+      context.streamId,
+    );
+    return `subagent: ${childLabel} · parent: ${parentLabel} · model: ${model}`;
+  }
   if (meta.teamName) {
     return `team: ${meta.teamName} · root: ${meta.agent || 'chat'} · model: ${model}`;
   }
@@ -60,10 +86,12 @@ export function sessionHeaderIdentityLine(meta: SessionMeta): string {
 
 function SessionHeaderBlock({
   compact,
+  identityLine,
   meta,
   width,
 }: {
   readonly compact: boolean;
+  readonly identityLine: string;
   readonly meta: SessionMeta;
   readonly width?: number;
 }): React.JSX.Element {
@@ -77,7 +105,7 @@ function SessionHeaderBlock({
           </Text>{' '}
           <Text dimColor>v{meta.version}</Text>{' '}
           <Text dimColor>{shortCliApiMode(meta.apiMode)}</Text>{' '}
-          <Text>{sessionHeaderIdentityLine(meta)}</Text>
+          <Text>{identityLine}</Text>
         </Text>
       </Box>
     );
@@ -97,7 +125,7 @@ function SessionHeaderBlock({
           <Text dimColor>{shortCliApiMode(meta.apiMode)}</Text>
         </Box>
         <Box>
-          <Text wrap="truncate-end">{sessionHeaderIdentityLine(meta)}</Text>
+          <Text wrap="truncate-end">{identityLine}</Text>
         </Box>
         <Text dimColor wrap="truncate-end">
           {shortenCwd(meta.cwd)}
@@ -137,6 +165,7 @@ export function appendStaticTranscriptItems({
   streams,
   meta,
   maxRows,
+  parentStream = new Map(),
   scrollbackStreamId,
   width,
 }: {
@@ -144,6 +173,7 @@ export function appendStaticTranscriptItems({
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly meta: SessionMeta;
   readonly maxRows?: number;
+  readonly parentStream?: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly scrollbackStreamId: StreamTabId | undefined;
   readonly width?: number;
 }): readonly StaticTranscriptItem[] {
@@ -158,6 +188,11 @@ export function appendStaticTranscriptItems({
       id: SESSION_HEADER_ID,
       kind: 'header',
       compact: maxRows !== undefined && maxRows < FULL_SESSION_HEADER_ROWS,
+      identityLine: sessionHeaderIdentityLine(meta, {
+        parentStream,
+        streamId: scrollbackStreamId,
+        streams,
+      }),
       meta,
     };
     if (
@@ -200,6 +235,7 @@ export function StaticConversationTranscript({
 }): React.JSX.Element {
   const streams = useSignal(cliState.streams);
   const sessionMeta = useSignal(cliState.sessionMeta);
+  const parentStream = useSignal(cliState.parentStream);
   const ownerKey = scrollbackStreamId ?? 'none';
   const [state, setState] = useState<StaticTranscriptState>(() => ({
     ownerKey,
@@ -208,6 +244,7 @@ export function StaticConversationTranscript({
       streams,
       meta: sessionMeta,
       maxRows,
+      parentStream,
       scrollbackStreamId,
       width,
     }),
@@ -221,6 +258,7 @@ export function StaticConversationTranscript({
           streams,
           meta: sessionMeta,
           maxRows,
+          parentStream,
           scrollbackStreamId,
           width,
         });
@@ -239,6 +277,7 @@ export function StaticConversationTranscript({
         streams,
         meta: sessionMeta,
         maxRows,
+        parentStream,
         scrollbackStreamId,
         width,
       });
@@ -247,7 +286,15 @@ export function StaticConversationTranscript({
       }
       return { ownerKey, items: nextItems };
     });
-  }, [maxRows, ownerKey, scrollbackStreamId, sessionMeta, streams, width]);
+  }, [
+    maxRows,
+    ownerKey,
+    parentStream,
+    scrollbackStreamId,
+    sessionMeta,
+    streams,
+    width,
+  ]);
 
   return (
     // Remount <Static> on a width or owner change so Ink regenerates
@@ -262,6 +309,7 @@ export function StaticConversationTranscript({
           {item.kind === 'header' ? (
             <SessionHeaderBlock
               compact={item.compact}
+              identityLine={item.identityLine}
               meta={item.meta}
               width={width}
             />

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -423,6 +423,48 @@ describe('CLI conversation transcript splitting', () => {
     );
   });
 
+  it('labels focused subagent scrollback with the child stream identity', () => {
+    const ROOT = 'root-stream' as StreamTabId;
+    const CHILD = 'search-stream' as StreamTabId;
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        ROOT,
+        sliceWithEntries(ROOT, [entry('u1', 'user', 'send scouts', true)], {
+          activeSubagents: [
+            {
+              executionId: 'ei_search',
+              agentName: 'search',
+              childStreamId: CHILD,
+              status: STREAM_STATUS.RUNNING,
+            },
+          ],
+        }),
+      ],
+      [CHILD, sliceWithEntries(CHILD, [entry('a1', 'assistant', 'ok', true)])],
+    ]);
+
+    expect(
+      sessionHeaderIdentityLine(SESSION_META, {
+        parentStream: new Map([[CHILD, ROOT]]),
+        streamId: CHILD,
+        streams,
+      }),
+    ).toBe('subagent: search · parent: main · model: deepseekT');
+
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: CHILD,
+        currentItems: [],
+        streams,
+        meta: SESSION_META,
+        parentStream: new Map([[CHILD, ROOT]]),
+      })[0],
+    ).toMatchObject({
+      kind: 'header',
+      identityLine: 'subagent: search · parent: main · model: deepseekT',
+    });
+  });
+
   it('only feeds the root scrollback stream, not background subagents', () => {
     const rootUser = entry('u1', 'user', 'do x', true);
     const childAssistant = entry('a1', 'assistant', 'done', true);
@@ -650,6 +692,7 @@ describe('CLI conversation transcript splitting', () => {
 function sliceWithEntries(
   streamId: StreamTabId,
   entries: readonly ConversationEntry[],
+  init: Partial<StreamSlice> = {},
 ): StreamSlice {
   return {
     streamId,
@@ -669,6 +712,7 @@ function sliceWithEntries(
     plan: null,
     processOutput: new Map(),
     bypass: { bash: false, toolEdit: false, superYolo: false },
+    ...init,
   };
 }
 


### PR DESCRIPTION
## Summary

- derive the static CLI header identity from the active scrollback stream
- show focused child streams as `subagent: <label> · parent: <label> · model: ...` using the same stream-label helpers as tabs and subagent controls
- add unit and TUI harness coverage so subagent tab focus no longer shows the root agent banner

Closes #5437.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run typecheck`
- `node packages/cli/scripts/validate-tui.mjs --skip-if-missing-deps subagent-tab-focus-full-frame subagent-focused-own-scrollback-history subagent-focused-status-stays-scoped subagent-focus-return-root-scrollback-deduped`
- `git diff --check -- packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/ConversationPane.vitest.mts`
- `npm run lint` (0 errors; existing import-order warnings, plus one warning from unrelated local dogfood edit not included in this PR)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only header labeling in the CLI TUI with targeted unit and harness tests; no auth, data, or runtime behavior changes.
> 
> **Overview**
> The static CLI transcript header now reflects **which stream owns scrollback**, not only root session metadata. When the focused scrollback stream is a child, `sessionHeaderIdentityLine` builds **`subagent: … · parent: … · model: …`** via the same `childStreamDisplayLabel` / `streamScopeDisplayLabel` helpers used for tabs and subagent UI; team and root-agent labels are unchanged for non-child streams.
> 
> The header stores a precomputed **`identityLine`** on static transcript items, and `StaticConversationTranscript` threads **`cliState.parentStream`** through `appendStaticTranscriptItems` so the banner updates with subagent tab focus.
> 
> Coverage adds a **ConversationPane** unit test for child scrollback headers and tightens the **`subagent-tab-focus-full-frame`** TUI harness to expect the subagent banner and reject the root `agent: chat` line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae771b487b19f497bf70c847091c02564200ea03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->