### PR TITLE
fix: lighten CLI diff bands

### DIFF
--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -317,14 +317,27 @@ export function DiffView(props: DiffViewProps): React.JSX.Element {
   );
 }
 
+interface DiffLineStyle {
+  readonly backgroundColor: string;
+  readonly color: string;
+}
+
 /**
- * Full-width band backgrounds for changed lines — a muted green/red that fills
- * the whole row (GitHub/Codex-style), so additions and removals read as solid
- * bands rather than just tinted text. Context lines stay un-banded and dim.
+ * Full-width bands for changed lines. Use light backgrounds plus explicit
+ * foreground colors so text stays readable on both light and dark terminals.
+ * Context lines stay un-banded and dim.
  */
-export const DIFF_BAND_BG: Partial<Record<DiffDisplayLine['kind'], string>> = {
-  added: '#1f3a28',
-  removed: '#4a2526',
+export const DIFF_LINE_STYLE: Partial<
+  Record<DiffDisplayLine['kind'], DiffLineStyle>
+> = {
+  added: {
+    backgroundColor: '#dff4e8',
+    color: '#16351f',
+  },
+  removed: {
+    backgroundColor: '#f7d9dc',
+    color: '#4a171b',
+  },
 };
 
 function DiffLine({
@@ -335,9 +348,13 @@ function DiffLine({
   readonly width: number;
 }): React.JSX.Element {
   const content = wrapAnsiToWidth(line.text, width);
-  const bg = DIFF_BAND_BG[line.kind];
-  if (bg) {
-    return <Text backgroundColor={bg}>{fillRows(content, width)}</Text>;
+  const style = DIFF_LINE_STYLE[line.kind];
+  if (style) {
+    return (
+      <Text color={style.color} backgroundColor={style.backgroundColor}>
+        {fillRows(content, width)}
+      </Text>
+    );
   }
   return <Text dimColor>{content}</Text>;
 }

--- a/src/test-kernel/cli/DiffView.vitest.mts
+++ b/src/test-kernel/cli/DiffView.vitest.mts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   boundedDiffDisplayLines,
   buildHunks,
-  DIFF_BAND_BG,
+  DIFF_LINE_STYLE,
   diffVisualRowCount,
   maxDiffScrollOffset,
   scrollBoundedDiffDisplayLines,
@@ -139,11 +139,24 @@ describe('CLI diff display', () => {
 });
 
 describe('full-width diff bands', () => {
-  it('only added/removed lines get a band background', () => {
-    expect(DIFF_BAND_BG.added).toBeDefined();
-    expect(DIFF_BAND_BG.removed).toBeDefined();
-    expect(DIFF_BAND_BG.context).toBeUndefined();
-    expect(DIFF_BAND_BG.header).toBeUndefined();
+  it('only added/removed lines get readable band styling', () => {
+    expect(DIFF_LINE_STYLE.added).toMatchObject({
+      backgroundColor: expect.any(String),
+      color: expect.any(String),
+    });
+    expect(DIFF_LINE_STYLE.removed).toMatchObject({
+      backgroundColor: expect.any(String),
+      color: expect.any(String),
+    });
+    expect(DIFF_LINE_STYLE.context).toBeUndefined();
+    expect(DIFF_LINE_STYLE.header).toBeUndefined();
+  });
+
+  it('does not rely on dark background-only diff bands', () => {
+    expect(DIFF_LINE_STYLE.added?.backgroundColor).not.toBe('#1f3a28');
+    expect(DIFF_LINE_STYLE.removed?.backgroundColor).not.toBe('#4a2526');
+    expect(DIFF_LINE_STYLE.added?.color).toBeDefined();
+    expect(DIFF_LINE_STYLE.removed?.color).toBeDefined();
   });
 
   it('pads a short row out to the full width so the band fills the row', () => {


### PR DESCRIPTION
## Summary

- replace dark background-only edit diff bands with lighter full-row bands
- set explicit foreground colors for added/removed rows so text stays readable on light terminal themes
- update diff-view tests to cover readable style pairs and guard against the old dark colors

Closes #5440.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/DiffView.vitest.mts src/test-kernel/cli/EditApproval.vitest.mts src/test-kernel/cli/ToolRenderers.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --skip-if-missing-deps edit-approval narrow-edit-approval compact-long-bash-approval-scroll`
- `git diff --check`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/render/DiffView.tsx src/test-kernel/cli/DiffView.vitest.mts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in the CLI TUI diff renderer with updated unit tests; no auth, data, or business logic impact.
> 
> **Overview**
> The CLI TUI diff view now uses **light full-row bands** with **explicit foreground colors** for added/removed lines instead of dark background-only styling, so diff text stays readable on light terminal themes.
> 
> `DIFF_BAND_BG` is replaced by `DIFF_LINE_STYLE` (paired `backgroundColor` and `color` per line kind). `DiffLine` passes both into Ink `Text` for added/removed rows; context/header behavior is unchanged (dim, no band).
> 
> Tests import `DIFF_LINE_STYLE`, assert readable style pairs for add/remove only, and guard against the previous dark band hex values (`#1f3a28` / `#4a2526`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e9736aca9e0dff764e9ee9f052023512e21b30e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->