### PR TITLE
refactor: replace ad hoc types with native SDK types from Anthropic/OpenAI/GenAI

### DIFF
--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -12,6 +12,10 @@ import {
 } from '@agent/modelHandlers/types/ServerToolTypes';
 import { MESSAGE_TYPES, type StreamDiagnostics } from '@shared/schemas';
 import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta/messages';
+// BetaMessageStream is only exported from lib/ — not re-exported from the SDK's
+// public resources/ entry point. The BetaMessageStream class is what
+// client.beta.messages.stream() returns, and ./lib/* is in the SDK's exports
+// map, so this import is semantically correct even if the path is less stable.
 import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream';
 import type {
   ServerToolUseBlock,

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -12,6 +12,7 @@ import {
 } from '@agent/modelHandlers/types/ServerToolTypes';
 import { MESSAGE_TYPES, type StreamDiagnostics } from '@shared/schemas';
 import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta/messages';
+import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream';
 import type {
   ServerToolUseBlock,
   WebSearchToolResultBlock,
@@ -21,15 +22,11 @@ import type {
 } from '@anthropic-ai/sdk/resources/messages';
 
 /**
- * Duck-typed interface for Anthropic message streams.
- * Allows us to work with the stream without importing SDK-internal types.
+ * Minimal stream interface derived from the Anthropic SDK's BetaMessageStream.
+ * Accepts any stream with the same typed `.on()` method — callers pass the
+ * SDK's BetaMessageStream directly; tests pass a compatible stub.
  */
-interface AnthropicMessageStream {
-  on(
-    event: 'streamEvent',
-    callback: (event: BetaRawMessageStreamEvent) => void,
-  ): void;
-}
+type AnthropicMessageStream = Pick<BetaMessageStream, 'on'>;
 
 /**
  * Maximum size for accumulated server tool input JSON (64KB).

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -404,7 +404,7 @@ export type ClaudeAgentPermissionMode = z.infer<
   typeof ClaudeAgentPermissionModeSchema
 >;
 
-/** Claude Code CLI effort levels — derived from @anthropic-ai/claude-agent-sdk's EffortLevel. */
+/** Claude Code CLI effort levels — mirrors the SDK's EffortLevel. */
 export const ClaudeAgentEffortSchema = z.enum([
   'low',
   'medium',

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -404,7 +404,7 @@ export type ClaudeAgentPermissionMode = z.infer<
   typeof ClaudeAgentPermissionModeSchema
 >;
 
-/** Claude Code CLI effort levels (mirrors CLAUDE_AGENT_EFFORT_LEVELS). */
+/** Claude Code CLI effort levels — derived from @anthropic-ai/claude-agent-sdk's EffortLevel. */
 export const ClaudeAgentEffortSchema = z.enum([
   'low',
   'medium',

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -309,7 +309,7 @@ export async function runStreamedTurn(params: {
 
   const query = await importClaudeAgentSdk();
 
-  const sdkOptions: Record<string, unknown> = {
+  const sdkOptions: import('@anthropic-ai/claude-agent-sdk').Options = {
     abortController: params.abortController,
     model: params.model,
     permissionMode: params.permissionMode,

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -17,13 +17,15 @@
 
 import * as path from 'path';
 
+import type { Options, Query } from '@anthropic-ai/claude-agent-sdk';
+
 import { isModuleNotFoundError } from '@common/errors';
 import { pathExists, resolveBinary } from './support/externalBinaryUtils';
 
 type QueryFn = (params: {
   prompt: string | AsyncIterable<unknown>;
-  options?: Record<string, unknown>;
-}) => AsyncGenerator<unknown, void>;
+  options?: Options;
+}) => Query;
 
 type PlatformInfo = { pkgs: readonly string[] };
 

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -10,14 +10,19 @@ export type ClaudeAgentEffort = EffortLevel;
 
 /**
  * Compile-time guard: our const array and the SDK's `EffortLevel` union must
- * stay synchronized. If the SDK adds/removes an effort level, this line will
- * produce a type error, forcing a review of whether to adopt the new level.
+ * stay synchronized in both directions. If the SDK adds or removes an effort
+ * level, this line produces a type error so `CLAUDE_AGENT_EFFORT_LEVELS` and
+ * `ClaudeAgentEffortSchema` are reviewed together.
  */
-type _AssertEqual<T, U extends T> = true;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _EffortLevelsAligned = _AssertEqual<
-  ClaudeAgentEffort,
-  (typeof CLAUDE_AGENT_EFFORT_LEVELS)[number]
+type _AssertExact<T extends true> = T;
+type _IsExact<A, B> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : false
+  : false;
+
+type _EffortLevelsAligned = _AssertExact<
+  _IsExact<ClaudeAgentEffort, (typeof CLAUDE_AGENT_EFFORT_LEVELS)[number]>
 >;
 
 export const CLAUDE_AGENT_NAME = 'claude_code';

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -3,9 +3,7 @@
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
 import { truncateSummary } from '@utils/text/stringUtils';
 
-import type {
-  EffortLevel,
-} from '@anthropic-ai/claude-agent-sdk';
+import type { EffortLevel } from '@anthropic-ai/claude-agent-sdk';
 
 // Re-export native SDK types where our values match exactly.
 export type ClaudeAgentEffort = EffortLevel;

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -3,8 +3,24 @@
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
 import { truncateSummary } from '@utils/text/stringUtils';
 
+import type {
+  EffortLevel,
+} from '@anthropic-ai/claude-agent-sdk';
+
 // Re-export native SDK types where our values match exactly.
-export type { EffortLevel as ClaudeAgentEffort } from '@anthropic-ai/claude-agent-sdk';
+export type ClaudeAgentEffort = EffortLevel;
+
+/**
+ * Compile-time guard: our const array and the SDK's `EffortLevel` union must
+ * stay synchronized. If the SDK adds/removes an effort level, this line will
+ * produce a type error, forcing a review of whether to adopt the new level.
+ */
+type _AssertEqual<T, U extends T> = true;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _EffortLevelsAligned = _AssertEqual<
+  ClaudeAgentEffort,
+  (typeof CLAUDE_AGENT_EFFORT_LEVELS)[number]
+>;
 
 export const CLAUDE_AGENT_NAME = 'claude_code';
 export const CLAUDE_AGENT_DISPLAY_MODEL = 'claude';

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -3,8 +3,17 @@
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
 import { truncateSummary } from '@utils/text/stringUtils';
 
+// Re-export native SDK types where our values match exactly.
+export type { EffortLevel as ClaudeAgentEffort } from '@anthropic-ai/claude-agent-sdk';
+
 export const CLAUDE_AGENT_NAME = 'claude_code';
 export const CLAUDE_AGENT_DISPLAY_MODEL = 'claude';
+
+/**
+ * Permission modes exposed in the settings UI.
+ * Subset of the SDK's PermissionMode — 'dontAsk' and 'auto' are internal only.
+ * The type is derived from this subset so it stays narrower than the SDK type.
+ */
 export const CLAUDE_AGENT_PERMISSION_MODES = [
   'default',
   'acceptEdits',
@@ -23,7 +32,6 @@ export const CLAUDE_AGENT_EFFORT_LEVELS = [
   'xhigh',
   'max',
 ] as const;
-export type ClaudeAgentEffort = (typeof CLAUDE_AGENT_EFFORT_LEVELS)[number];
 
 /** Canonical Claude model IDs surfaced by the settings dropdown.
  * The SDK accepts arbitrary model strings; this list is what we expose in the


### PR DESCRIPTION
Replace hand-rolled type definitions that duplicate SDK types from `@anthropic-ai/sdk`, `@anthropic-ai/claude-agent-sdk`, and `openai`.

## Changes

- **`AnthropicStreamHandler.ts`** — Duck-typed `AnthropicMessageStream` interface replaced with `Pick<BetaMessageStream, "on">` imported directly from `@anthropic-ai/sdk/lib/BetaMessageStream`. The SDK's `BetaMessageStream` class has a fully typed `.on()` method keyed on `MessageStreamEvents` — our handler now inherits that type safety instead of mimicking a subset.

- **`claudeAgentShared.ts`** — `ClaudeAgentEffort` now re-exports `EffortLevel` from `@anthropic-ai/claude-agent-sdk` (values are identical). `ClaudeAgentPermissionMode` stays derived from our subset constant because the SDK's `PermissionMode` includes `dontAsk | auto` which we don't expose in the UI.

- **`claudeAgentImport.ts`** — Uses `Options` and `Query` from `@anthropic-ai/claude-agent-sdk` instead of `Record<string, unknown>` / `AsyncGenerator<unknown, void>`.

- **`settingsViewMessages.ts`** — Comment updated to reference SDK source.

## Audit

The remaining custom types (`SdkToolCall`, `ProviderMessage`, `ServerToolTypes`, `StopReasonTypes`, `UsageNormalizer`, error adapters) are valid provider-agnostic abstractions — they compose SDK types rather than duplicating them. Both `tsc` and `tsc -p tsconfig.test-kernel.json` compile without errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with no intentional runtime or API behavior changes; main risk is SDK import path stability for BetaMessageStream from lib/.
> 
> **Overview**
> Replaces hand-rolled Anthropic and Claude Agent SDK types with **native SDK types** so compile-time checks stay aligned with upstream.
> 
> **Anthropic streaming:** `AnthropicMessageStream` is now `Pick<BetaMessageStream, 'on'>` from `@anthropic-ai/sdk/lib/BetaMessageStream` instead of a local duck-typed interface.
> 
> **Claude Code CLI integration:** `query()` wiring uses `Options` and `Query` from `@anthropic-ai/claude-agent-sdk` (including `sdkOptions` in `runStreamedTurn`). **`ClaudeAgentEffort`** is re-exported as the SDK’s `EffortLevel`, with a compile-time guard tying `CLAUDE_AGENT_EFFORT_LEVELS` to that union. Permission modes stay a UI subset of the SDK’s `PermissionMode`.
> 
> A settings schema comment now points at the SDK for effort levels; runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6933fed679ec40d9a26e95a0e7946919674cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->