### PR TITLE
fix: dedupe CLI todo plan rows

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -170,6 +170,8 @@ const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_NESTED_CHILDREN = process.env.HARNESS_NESTED_CHILDREN === '1';
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
 const SHOW_IDLE_TODOS = process.env.HARNESS_TODOS_IDLE === '1';
+const SHOW_DUPLICATE_TODOS_PLAN =
+  process.env.HARNESS_DUPLICATE_TODOS_PLAN === '1';
 const FAILED_CHILD_AGENT = process.env.HARNESS_FAILED_CHILD?.trim();
 const TEAM_NAME = process.env.HARNESS_TEAM_NAME?.trim() || undefined;
 let canInterrupt = process.env.HARNESS_CAN_INTERRUPT === '1';
@@ -963,42 +965,110 @@ if (SHOW_CHILDREN) {
 }
 
 if (SHOW_TODOS) {
-  patchStream(STREAM_ID, (slice) => ({
-    ...slice,
-    todos: [
-      {
-        content: 'Split theorem into algebraic and analytic checks',
-        activeForm: 'Splitting theorem into checks',
-        status: TODO_STATUS.COMPLETED,
-      },
-      {
-        content: 'Ask leanSolver to verify the finite case',
-        activeForm: 'Waiting for leanSolver',
-        status: TODO_STATUS.IN_PROGRESS,
-      },
-      {
-        content: 'Merge subagent conclusions into final answer',
-        activeForm: 'Merging subagent conclusions',
-        status: TODO_STATUS.PENDING,
-      },
-    ],
-    plan: {
-      summary: 'Coordinate a small math proof through nested CLI work.',
-      steps: [
+  const todos = SHOW_DUPLICATE_TODOS_PLAN
+    ? [
         {
-          title: 'Route proof obligations',
-          description: 'Choose the right specialist for each proof branch.',
-          files: [],
+          content:
+            'Replace AnthropicMessageStream duck type with BetaMessageStream',
+          activeForm:
+            'Replacing AnthropicMessageStream duck type with BetaMessageStream',
           status: TODO_STATUS.COMPLETED,
         },
         {
-          title: 'Check formalizable parts',
-          description: 'Have a subagent inspect the Lean-style finite case.',
-          files: [],
+          content: "Replace ClaudeAgentEffort with SDK's EffortLevel",
+          activeForm: "Replacing ClaudeAgentEffort with SDK's EffortLevel",
+          status: TODO_STATUS.COMPLETED,
+        },
+        {
+          content:
+            "Replace ClaudeAgentPermissionMode with SDK's PermissionMode",
+          activeForm:
+            "Replacing ClaudeAgentPermissionMode with SDK's PermissionMode",
+          status: TODO_STATUS.COMPLETED,
+        },
+        {
+          content: 'Audit remaining custom types for SDK-native equivalents',
+          activeForm:
+            'Auditing remaining custom types for SDK-native equivalents',
+          status: TODO_STATUS.COMPLETED,
+        },
+      ]
+    : [
+        {
+          content: 'Split theorem into algebraic and analytic checks',
+          activeForm: 'Splitting theorem into checks',
+          status: TODO_STATUS.COMPLETED,
+        },
+        {
+          content: 'Ask leanSolver to verify the finite case',
+          activeForm: 'Waiting for leanSolver',
           status: TODO_STATUS.IN_PROGRESS,
         },
-      ],
-    },
+        {
+          content: 'Merge subagent conclusions into final answer',
+          activeForm: 'Merging subagent conclusions',
+          status: TODO_STATUS.PENDING,
+        },
+      ];
+  const plan = SHOW_DUPLICATE_TODOS_PLAN
+    ? {
+        summary: 'Replace local Claude SDK aliases with native types.',
+        steps: [
+          {
+            title:
+              'Replace AnthropicMessageStream duck type with BetaMessageStream',
+            description: 'Use the SDK stream type directly.',
+            files: [],
+            status: TODO_STATUS.PENDING,
+          },
+          {
+            title: "Replace ClaudeAgentEffort with SDK's EffortLevel",
+            description: 'Use the SDK effort type directly.',
+            files: [],
+            status: TODO_STATUS.PENDING,
+          },
+          {
+            title:
+              "Replace ClaudeAgentPermissionMode with SDK's PermissionMode",
+            description: 'Use the SDK permission type directly.',
+            files: [],
+            status: TODO_STATUS.PENDING,
+          },
+          {
+            title: 'Audit remaining custom types for SDK-native equivalents',
+            description: 'Find any remaining local aliases.',
+            files: [],
+            status: TODO_STATUS.PENDING,
+          },
+          {
+            title: 'Verify compilation and clean up imports',
+            description: 'Run focused checks and remove stale imports.',
+            files: [],
+            status: TODO_STATUS.PENDING,
+          },
+        ],
+      }
+    : {
+        summary: 'Coordinate a small math proof through nested CLI work.',
+        steps: [
+          {
+            title: 'Route proof obligations',
+            description: 'Choose the right specialist for each proof branch.',
+            files: [],
+            status: TODO_STATUS.COMPLETED,
+          },
+          {
+            title: 'Check formalizable parts',
+            description: 'Have a subagent inspect the Lean-style finite case.',
+            files: [],
+            status: TODO_STATUS.IN_PROGRESS,
+          },
+        ],
+      };
+  patchStream(STREAM_ID, (slice) => ({
+    ...slice,
+    todos,
+    plan,
   }));
 }
 

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2175,6 +2175,30 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'duplicate-todos-plan',
+    cols: 120,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_TODOS: '1',
+      HARNESS_DUPLICATE_TODOS_PLAN: '1',
+    },
+    expect: [
+      'Replace AnthropicMessageStream duck type with BetaMessageStream',
+      'Replace local Claude SDK aliases with native types.',
+      '5. Verify compilation and clean up imports',
+    ],
+    maxOccurrences: [
+      {
+        text: 'Replace AnthropicMessageStream duck type with BetaMessageStream',
+        max: 1,
+      },
+      {
+        text: "Replace ClaudeAgentEffort with SDK's EffortLevel",
+        max: 1,
+      },
+    ],
+  },
+  {
     name: 'idle-todos-hidden',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -105,6 +105,52 @@ function compactRowPriority(row: CompactTodosPlanRow): number {
   return exhaustive;
 }
 
+function normalizedTaskLabel(value: string): string {
+  return value.trim().replaceAll(/\s+/g, ' ').toLowerCase();
+}
+
+function todoLabels(todos: readonly TodoItem[]): ReadonlySet<string> {
+  const labels = new Set<string>();
+  for (const todo of todos) {
+    labels.add(normalizedTaskLabel(todo.content));
+    labels.add(normalizedTaskLabel(todo.activeForm));
+  }
+  labels.delete('');
+  return labels;
+}
+
+export function todosPlanDisplayRows({
+  plan,
+  todos,
+}: {
+  readonly plan: Plan | null;
+  readonly todos: readonly TodoItem[];
+}): readonly CompactTodosPlanRow[] {
+  const rows: CompactTodosPlanRow[] = todos.map((todo, index) => ({
+    kind: 'todo',
+    sourceIndex: index,
+    todo,
+  }));
+  if (!plan) return rows;
+
+  const duplicateTodoLabels = todoLabels(todos);
+  rows.push({
+    kind: 'planSummary',
+    sourceIndex: rows.length,
+    summary: plan.summary,
+  });
+  for (const [stepIndex, step] of plan.steps.entries()) {
+    if (duplicateTodoLabels.has(normalizedTaskLabel(step.title))) continue;
+    rows.push({
+      kind: 'planStep',
+      sourceIndex: rows.length,
+      step,
+      stepIndex,
+    });
+  }
+  return rows;
+}
+
 export function compactTodosPlanRows({
   maxRows,
   plan,
@@ -118,26 +164,7 @@ export function compactTodosPlanRows({
   readonly rows: readonly CompactTodosPlanRow[];
 } {
   const rowBudget = Math.max(0, Math.floor(maxRows));
-  const allRows: CompactTodosPlanRow[] = todos.map((todo, index) => ({
-    kind: 'todo',
-    sourceIndex: index,
-    todo,
-  }));
-  if (plan) {
-    allRows.push({
-      kind: 'planSummary',
-      sourceIndex: allRows.length,
-      summary: plan.summary,
-    });
-    for (const [stepIndex, step] of plan.steps.entries()) {
-      allRows.push({
-        kind: 'planStep',
-        sourceIndex: allRows.length,
-        step,
-        stepIndex,
-      });
-    }
-  }
+  const allRows = todosPlanDisplayRows({ plan, todos });
 
   if (allRows.length <= rowBudget) {
     return { hiddenCount: 0, rows: allRows };
@@ -165,15 +192,15 @@ export function compactTodosPlanRows({
 }
 
 /**
- * Natural (uncapped) compact-row count for a slice's todos + plan: one row per
- * todo, plus the plan summary and one row per plan step. Drives the bottom-panel
- * reservation in App so the panel takes only the height it needs.
+ * Natural (uncapped) compact-row count for the deduplicated display model.
+ * Drives the bottom-panel reservation in App so the panel takes only the height
+ * it needs.
  */
 export function todosPlanPanelRowCount(
   todos: readonly TodoItem[],
   plan: Plan | null,
 ): number {
-  return todos.length + (plan ? 1 + plan.steps.length : 0);
+  return todosPlanDisplayRows({ plan, todos }).length;
 }
 
 function CompactRow({ row }: { row: CompactTodosPlanRow }): React.JSX.Element {
@@ -220,6 +247,10 @@ export function TodosPlanPanel(
       ? undefined
       : Math.max(0, Math.floor(props.maxRows));
   if (rowBudget !== undefined && rowBudget <= 0) return null;
+  const displayRows = todosPlanDisplayRows({ plan, todos });
+  if (displayRows.length === 0) return null;
+  const hasTodoRows = displayRows.some((row) => row.kind === 'todo');
+  const hasPlanRows = displayRows.some((row) => row.kind !== 'todo');
 
   if (rowBudget !== undefined) {
     const { hiddenCount, rows } = compactTodosPlanRows({
@@ -257,30 +288,44 @@ export function TodosPlanPanel(
       paddingX={1}
       marginBottom={props.maxRows === undefined ? 1 : 0}
     >
-      {todos.length > 0 ? (
+      {hasTodoRows ? (
         <Box flexDirection="column">
           <Text bold dimColor>
             Todos
           </Text>
-          {todos.map((todo, i) => (
-            <TodoRow key={i} todo={todo} />
-          ))}
+          {displayRows.map((row) =>
+            row.kind === 'todo' ? (
+              <TodoRow key={`todo:${row.sourceIndex}`} todo={row.todo} />
+            ) : null,
+          )}
         </Box>
       ) : null}
-      {plan ? (
-        <Box flexDirection="column" marginTop={todos.length > 0 ? 1 : 0}>
+      {hasPlanRows ? (
+        <Box flexDirection="column" marginTop={hasTodoRows ? 1 : 0}>
           <Text bold dimColor>
             Plan
           </Text>
-          <Text dimColor>{plan.summary}</Text>
-          {plan.steps.map((step, i) => (
-            <Box key={i}>
-              <Text color={todoColor(step.status)}>
-                {todoMarker(step.status)}{' '}
-              </Text>
-              <Text>{`${i + 1}. ${step.title}`}</Text>
-            </Box>
-          ))}
+          {displayRows.map((row) => {
+            switch (row.kind) {
+              case 'planSummary':
+                return (
+                  <Text key={`plan-summary:${row.sourceIndex}`} dimColor>
+                    {row.summary}
+                  </Text>
+                );
+              case 'planStep':
+                return (
+                  <Box key={`plan-step:${row.sourceIndex}`}>
+                    <Text color={todoColor(row.step.status)}>
+                      {todoMarker(row.step.status)}{' '}
+                    </Text>
+                    <Text>{`${row.stepIndex + 1}. ${row.step.title}`}</Text>
+                  </Box>
+                );
+              case 'todo':
+                return null;
+            }
+          })}
         </Box>
       ) : null}
     </Box>

--- a/src/test-kernel/cli/TodosPlanPanel.vitest.mts
+++ b/src/test-kernel/cli/TodosPlanPanel.vitest.mts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   compactTodosPlanRows,
+  todosPlanDisplayRows,
+  todosPlanPanelRowCount,
   type CompactTodosPlanRow,
 } from '@cli/chat/tui/panes/TodosPlanPanel';
 import { TODO_STATUS, type Plan, type TodoItem } from '@shared/schemas';
@@ -106,5 +108,87 @@ describe('CLI TodosPlanPanel display model', () => {
 
     expect(display.rows.map(rowKey)).toEqual(['plan:Check the last lemma']);
     expect(display.hiddenCount).toBe(2);
+  });
+
+  it('lets todo rows own plan steps with duplicate labels', () => {
+    const duplicateTodos: TodoItem[] = [
+      {
+        content:
+          'Replace AnthropicMessageStream duck type with BetaMessageStream',
+        activeForm:
+          'Replacing AnthropicMessageStream duck type with BetaMessageStream',
+        status: TODO_STATUS.COMPLETED,
+      },
+      {
+        content: "Replace ClaudeAgentEffort with SDK's EffortLevel",
+        activeForm: "Replacing ClaudeAgentEffort with SDK's EffortLevel",
+        status: TODO_STATUS.COMPLETED,
+      },
+      {
+        content: "Replace ClaudeAgentPermissionMode with SDK's PermissionMode",
+        activeForm:
+          "Replacing ClaudeAgentPermissionMode with SDK's PermissionMode",
+        status: TODO_STATUS.COMPLETED,
+      },
+      {
+        content: 'Audit remaining custom types for SDK-native equivalents',
+        activeForm:
+          'Auditing remaining custom types for SDK-native equivalents',
+        status: TODO_STATUS.COMPLETED,
+      },
+    ];
+    const duplicatePlan: Plan = {
+      summary: 'Replace local Claude SDK aliases with native types.',
+      steps: [
+        {
+          title:
+            'Replace AnthropicMessageStream duck type with BetaMessageStream',
+          description: 'Use the SDK stream type directly.',
+          files: [],
+          status: TODO_STATUS.PENDING,
+        },
+        {
+          title: "Replace ClaudeAgentEffort with SDK's EffortLevel",
+          description: 'Use the SDK effort type directly.',
+          files: [],
+          status: TODO_STATUS.PENDING,
+        },
+        {
+          title: "Replace ClaudeAgentPermissionMode with SDK's PermissionMode",
+          description: 'Use the SDK permission type directly.',
+          files: [],
+          status: TODO_STATUS.PENDING,
+        },
+        {
+          title: 'Audit remaining custom types for SDK-native equivalents',
+          description: 'Find any remaining local aliases.',
+          files: [],
+          status: TODO_STATUS.PENDING,
+        },
+        {
+          title: 'Verify compilation and clean up imports',
+          description: 'Run focused checks and remove stale imports.',
+          files: [],
+          status: TODO_STATUS.PENDING,
+        },
+      ],
+    };
+
+    const rows = todosPlanDisplayRows({
+      plan: duplicatePlan,
+      todos: duplicateTodos,
+    });
+
+    expect(rows.map(rowKey)).toEqual([
+      'todo:Replace AnthropicMessageStream duck type with BetaMessageStream',
+      "todo:Replace ClaudeAgentEffort with SDK's EffortLevel",
+      "todo:Replace ClaudeAgentPermissionMode with SDK's PermissionMode",
+      'todo:Audit remaining custom types for SDK-native equivalents',
+      'plan:summary',
+      'plan:Verify compilation and clean up imports',
+    ]);
+    expect(todosPlanPanelRowCount(duplicateTodos, duplicatePlan)).toBe(
+      rows.length,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add a single deduplicated display model for CLI todo + plan rows
- have full rendering, compact rendering, and row reservation consume the same rows
- add unit coverage and a TUI harness scenario for duplicate todo/plan labels

Fixes #5443.

## Tests
- corepack pnpm vitest run src/test-kernel/cli/TodosPlanPanel.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- duplicate-todos-plan
- npm run typecheck
- npm run lint (passes with existing import-order warnings outside this change)
- npm run compile:fast
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only display logic for todos/plan with tests and harness coverage; no auth, API, or data-path changes.
> 
> **Overview**
> **Deduplicates CLI todo/plan panel rows** when a plan step title matches a todo’s `content` or `activeForm` (case-insensitive, normalized whitespace). Todos keep the row; matching plan steps are omitted.
> 
> Introduces **`todosPlanDisplayRows`** as the single display model. **Compact mode**, **full Todos/Plan rendering**, and **`todosPlanPanelRowCount`** (bottom-panel height in `App`) all use it so layout and on-screen text stay aligned.
> 
> Adds a **TUI harness** flag `HARNESS_DUPLICATE_TODOS_PLAN`, a **`duplicate-todos-plan`** validate-tui scenario (including max-once assertions for duplicate labels), and **Vitest** coverage for the duplicate-label case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d933e76d7c6b3d55d9d0488f10deba4d966e5314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->