### PR TITLE
fix(cli): isolate transcript entry render failures with an error boundary

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -5,6 +5,7 @@ import { Box } from 'ink';
 
 import { cliState, type ConversationEntry } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
+import { EntryErrorBoundary } from './EntryErrorBoundary';
 import { BoundedTranscriptEntry, LiveTranscriptEntry } from './TranscriptEntry';
 import { ToolUseRow } from './ToolUseRow';
 import { splitTranscriptEntries } from './transcriptEntries';
@@ -34,24 +35,33 @@ function renderConversationPaneEntry({
   // When the newest entry alone overflows the pane, the bounded renderer is the
   // paint contract. Apply it before role/mode branches so sizing and painting
   // stay in lockstep.
-  if (rowLimit !== undefined) {
-    return (
-      <BoundedTranscriptEntry
-        key={entry.id}
-        colorEnabled={colorEnabled}
-        entry={entry}
-        maxRows={rowLimit}
-        width={width}
-      />
-    );
-  }
-  if (entry.role === 'tool' && entry.toolUse) {
-    return <ToolUseRow key={entry.id} toolUse={entry.toolUse} width={width} />;
-  }
-  if (entry.role === 'assistant') {
-    return <LiveTranscriptEntry key={entry.id} entry={entry} width={width} />;
-  }
-  return null;
+  const content = ((): React.JSX.Element | null => {
+    if (rowLimit !== undefined) {
+      return (
+        <BoundedTranscriptEntry
+          colorEnabled={colorEnabled}
+          entry={entry}
+          maxRows={rowLimit}
+          width={width}
+        />
+      );
+    }
+    if (entry.role === 'tool' && entry.toolUse) {
+      return <ToolUseRow toolUse={entry.toolUse} width={width} />;
+    }
+    if (entry.role === 'assistant') {
+      return <LiveTranscriptEntry entry={entry} width={width} />;
+    }
+    return null;
+  })();
+  if (content === null) return null;
+  // Isolate per entry so a single throwing renderer can't blank the live pane.
+  // The key moves to the boundary since it is now the list child.
+  return (
+    <EntryErrorBoundary key={entry.id} label={entry.role}>
+      {content}
+    </EntryErrorBoundary>
+  );
 }
 
 export function ConversationPane(

--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -56,7 +56,9 @@ export class EntryErrorBoundary extends Component<
       logUtils.error(
         'cli.tui',
         `transcript entry render failed (${this.props.label ?? 'entry'}): ${
-          error instanceof Error ? (error.stack ?? error.message) : String(error)
+          error instanceof Error
+            ? (error.stack ?? error.message)
+            : String(error)
         }`,
       );
     } catch {

--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -28,8 +28,13 @@ interface EntryErrorBoundaryState {
   readonly error: unknown;
 }
 
-function formatRenderError(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
+export function formatRenderError(error: unknown): string {
+  let message = '';
+  try {
+    message = error instanceof Error ? error.message : String(error);
+  } catch {
+    return '';
+  }
   // The marker is a single line: collapse whitespace and cap length so a long
   // or multi-line message can't reflow the transcript.
   const oneLine = message.replaceAll(/\s+/g, ' ').trim();

--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -1,0 +1,78 @@
+// Isolates a render failure in a single transcript entry. Without this, one
+// malformed entry — bad markdown, a throwing tool renderer, an unexpected
+// payload shape — would throw during render and tear down the entire
+// long-lived Ink tree, ending the session. The boundary degrades the offending
+// entry to a one-line marker and lets the rest of the transcript keep
+// rendering.
+//
+// React error boundaries have no hook equivalent (getDerivedStateFromError /
+// componentDidCatch are class-only), so this is a deliberate, localized
+// exception to the TUI's stateless-renderer rule. Keep it minimal: the only
+// state is the captured error, and the fallback never does width math or
+// anything that could itself throw.
+
+import { Box, Text } from 'ink';
+import { Component, type ReactNode } from 'react';
+
+import * as logUtils from '@logger/logUtils';
+
+interface EntryErrorBoundaryProps {
+  // Names the failed entry in the inline marker and the log line (e.g. its
+  // role or "session header"). Falls back to "entry" when omitted.
+  readonly label?: string;
+  readonly children: ReactNode;
+}
+
+interface EntryErrorBoundaryState {
+  readonly hasError: boolean;
+  readonly error: unknown;
+}
+
+function formatRenderError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  // The marker is a single line: collapse whitespace and cap length so a long
+  // or multi-line message can't reflow the transcript.
+  const oneLine = message.replaceAll(/\s+/g, ' ').trim();
+  return oneLine.length > 120 ? `${oneLine.slice(0, 119)}…` : oneLine;
+}
+
+export class EntryErrorBoundary extends Component<
+  EntryErrorBoundaryProps,
+  EntryErrorBoundaryState
+> {
+  // `hasError` is tracked separately from `error` so a thrown `null`/`undefined`
+  // still latches the fallback instead of re-rendering children and looping.
+  state: EntryErrorBoundaryState = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: unknown): EntryErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: unknown): void {
+    // Best-effort: while the TUI owns the screen the CLI log sink is a no-op,
+    // so the inline marker below is the primary surfacing. Logging serves the
+    // verbose / trace path and must never itself break the error unwind.
+    try {
+      logUtils.error(
+        'cli.tui',
+        `transcript entry render failed (${this.props.label ?? 'entry'}): ${
+          error instanceof Error ? (error.stack ?? error.message) : String(error)
+        }`,
+      );
+    } catch {
+      // Nothing actionable if logging fails mid-unwind.
+    }
+  }
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+    const detail = formatRenderError(this.state.error);
+    return (
+      <Box paddingX={1}>
+        <Text color="red" dimColor>
+          {`⚠ failed to render ${this.props.label ?? 'entry'}${detail ? `: ${detail}` : ''}`}
+        </Text>
+      </Box>
+    );
+  }
+}

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -23,6 +23,7 @@ import {
 } from '../state/streamLabels';
 import { transcriptEntryLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
+import { EntryErrorBoundary } from './EntryErrorBoundary';
 import { TranscriptEntry } from './TranscriptEntry';
 
 export type StaticTranscriptItem =
@@ -305,21 +306,28 @@ export function StaticConversationTranscript({
       items={[...items]}
     >
       {(item: StaticTranscriptItem) => (
+        // Isolate per item: a throw here would otherwise crash the whole Ink
+        // tree, and `<Static>` commits each row to scrollback exactly once, so
+        // the fallback marker is printed once in place of the bad entry.
         <Box key={item.id} flexDirection="column">
-          {item.kind === 'header' ? (
-            <SessionHeaderBlock
-              compact={item.compact}
-              identityLine={item.identityLine}
-              meta={item.meta}
-              width={width}
-            />
-          ) : (
-            <TranscriptEntry
-              entry={item.entry}
-              width={width}
-              colorEnabled={colorEnabled}
-            />
-          )}
+          <EntryErrorBoundary
+            label={item.kind === 'header' ? 'session header' : item.entry.role}
+          >
+            {item.kind === 'header' ? (
+              <SessionHeaderBlock
+                compact={item.compact}
+                identityLine={item.identityLine}
+                meta={item.meta}
+                width={width}
+              />
+            ) : (
+              <TranscriptEntry
+                entry={item.entry}
+                width={width}
+                colorEnabled={colorEnabled}
+              />
+            )}
+          </EntryErrorBoundary>
         </Box>
       )}
     </Static>

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -6,6 +6,16 @@ import { LIVE_TAIL_ROWS, tailWindow } from './TranscriptEntry';
 import { toolUseDisplayLines } from './toolRenderers';
 import type { ConversationEntry } from '../state/cliState';
 
+const FAILED_ENTRY_ESTIMATE_ROWS = 1;
+
+function estimateEntryRows(computeRows: () => number): number {
+  try {
+    return computeRows();
+  } catch {
+    return FAILED_ENTRY_ESTIMATE_ROWS;
+  }
+}
+
 function estimateWrappedRows(text: string, width: number): number {
   const cols = Math.max(1, width);
   const lines = text.length > 0 ? text.split('\n') : [''];
@@ -20,15 +30,23 @@ export function estimateTranscriptEntryRows(
   width = 80,
 ): number {
   if (entry.role === 'tool' && entry.toolUse) {
-    const lines = toolUseDisplayLines(entry.toolUse);
-    return lines.length + (lines.length > 1 ? 1 : 0);
+    const toolUse = entry.toolUse;
+    return estimateEntryRows(() => {
+      const lines = toolUseDisplayLines(toolUse);
+      return lines.length + (lines.length > 1 ? 1 : 0);
+    });
   }
   if (entry.role === 'process' && entry.process) {
-    return Math.max(1, completedProcessDisplayLines(entry.process).length) + 1;
+    const process = entry.process;
+    return estimateEntryRows(() => {
+      return Math.max(1, completedProcessDisplayLines(process).length) + 1;
+    });
   }
   if (entry.role === 'assistant') {
-    const rendered = renderAnsiMarkdown(entry.text, { width });
-    return Math.max(1, rendered.split('\n').length) + 1;
+    return estimateEntryRows(() => {
+      const rendered = renderAnsiMarkdown(entry.text, { width });
+      return Math.max(1, rendered.split('\n').length) + 1;
+    });
   }
   // User / error rows render without a trailing margin (compact mode) so
   // chat-heavy sessions don't burn half the viewport on blank gaps. Their
@@ -51,11 +69,13 @@ export function estimateLiveTranscriptEntryRows(
   // multi-MB reply never gets split in full just for an estimate that
   // discards everything above the tail.
   if (entry.role === 'assistant') {
-    const cols = Math.max(1, width);
-    return Math.min(
-      LIVE_TAIL_ROWS,
-      estimateWrappedRows(tailWindow(entry.text, cols, LIVE_TAIL_ROWS), cols),
-    );
+    return estimateEntryRows(() => {
+      const cols = Math.max(1, width);
+      return Math.min(
+        LIVE_TAIL_ROWS,
+        estimateWrappedRows(tailWindow(entry.text, cols, LIVE_TAIL_ROWS), cols),
+      );
+    });
   }
   return estimateTranscriptEntryRows(entry, width);
 }

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -6,6 +6,7 @@ import {
   compactPrefixedDisplayRows,
   isInquiryContinuationText,
 } from '@cli/chat/tui/panes/TranscriptEntry';
+import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
 import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
 import {
   appendStaticTranscriptItems,
@@ -263,6 +264,41 @@ describe('CLI conversation transcript splitting', () => {
     expect(selected.entries.map((item) => item.id)).toEqual(['a1']);
     expect(selected.usedRows).toBe(4);
     expect(selected.rowLimits.get('a1')).toBe(4);
+  });
+
+  it('falls back when a malformed tool entry cannot be estimated', () => {
+    const malformedTool = {
+      ...toolEntry('tool', TOOL_USE_STATUS.IN_PROGRESS).toolUse,
+      toolName: {} as string,
+    } as NormalizedToolUse;
+    const malformedEntry: ConversationEntry = {
+      id: 'tool',
+      role: 'tool',
+      text: '',
+      finalized: false,
+      toolUse: malformedTool,
+    };
+
+    expect(estimateTranscriptEntryRows(malformedEntry, 80)).toBe(1);
+
+    const selected = selectTranscriptEntriesForViewport(
+      [malformedEntry],
+      3,
+      80,
+    );
+    expect(selected.entries.map((item) => item.id)).toEqual(['tool']);
+    expect(selected.usedRows).toBe(1);
+    expect(selected.rowLimits.has('tool')).toBe(false);
+  });
+
+  it('formats unprintable render errors without throwing', () => {
+    const unprintable = {
+      toString() {
+        throw new Error('cannot stringify');
+      },
+    };
+
+    expect(formatRenderError(unprintable)).toBe('');
   });
 
   it('renders bounded finalized assistant tails through markdown', () => {


### PR DESCRIPTION
## What

Wrap every transcript entry — both the finalized `<Static>` rows and the live
pane rows — in a small per-entry React **error boundary**
(`EntryErrorBoundary`).

## Why

Today a single throwing entry renderer (malformed markdown, an unexpected tool
payload shape, a bad process record) throws during render, propagates all the
way to Ink's root, and **tears down the whole long-lived chat TUI** — ending the
session over one bad row.

This follows the standard Ink/terminal-UI best practice for a long-lived REPL:
**bound a render failure to the offending list item** instead of letting it take
down the tree. The bad entry degrades to a one-line marker
(`⚠ failed to render <role>: <message>`) while the rest of the transcript keeps
rendering. In the `<Static>` path the marker is committed to scrollback exactly
once, in place of the bad row.

## Notes / design

- The boundary is a minimal class component — `getDerivedStateFromError` /
  `componentDidCatch` have no hook equivalent — and is the only intentional
  exception to the TUI's stateless-renderer rule. It returns its children
  **unchanged on the success path**, so layout and render output are byte-identical
  when nothing throws.
- `hasError` is tracked separately from the captured error so a thrown
  `null`/`undefined` still latches the fallback instead of re-rendering children
  and looping.
- The fallback never does width math and collapses/caps the message to a single
  line, so it can't itself throw or reflow the transcript.
- Logging is best-effort via `@logger/logUtils` (a no-op sink while the TUI owns
  the screen, so the inline marker is the primary surfacing).
- Headless / non-TTY paths don't mount these panes, so parity is unaffected.

## Verification

- `tsc --noEmit -p packages/cli/tsconfig.json` — clean.
- `eslint` on all three files — clean.
- Runtime smoke test against the real `ink@7.0.5`: a throwing child wrapped in
  the boundary renders the fallback, the process exits 0 with no uncaught error,
  and sibling entries still render — confirming Ink propagates the throw to the
  nested boundary and the failure is isolated.

The CLI package has no `ink-testing-library` / vitest harness for these panes, so
no unit test is added here; the runtime smoke test above validated the mechanism.

Worth a one-line CHANGELOG entry (Bug Fixes) at release time: "A single
malformed chat entry no longer crashes the whole session."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only defensive rendering and viewport math; success path is unchanged when entries render normally.
> 
> **Overview**
> Adds **per-entry error boundaries** around live (`ConversationPane`) and finalized (`StaticConversationTranscript`) transcript rows so one bad entry shows a one-line `⚠ failed to render …` marker instead of tearing down the whole Ink chat TUI.
> 
> Introduces **`EntryErrorBoundary`** (minimal class component with safe `formatRenderError`, best-effort logging) and hardens **viewport row estimation** in `transcriptViewport.ts` with try/catch so malformed tool/assistant/process payloads still budget **1 row** and viewport selection keeps working. Vitest covers the estimation fallback and unprintable errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eb9303b6f2a7182df6e743b71b7de7112e8319c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->