### PR TITLE
Fix duplicated plan and todo labels

### DIFF
--- a/src/test-kernel/tools/WorkPlanGranularityFeedback.vitest.ts
+++ b/src/test-kernel/tools/WorkPlanGranularityFeedback.vitest.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FileInteractionState,
+  WorkPlanState,
+} from '@agent/core/execution/AgentWorkspaceState';
+import { withToolEnvironment } from '@agent/toolUse/ToolFileInteractionContext';
+import {
+  TODO_STATUS,
+  type Plan,
+  type StreamTabId,
+  type TodoItem,
+} from '@shared/schemas';
+import { PlanTool } from '@tools/plan/PlanTool';
+import { TodoWriteTool } from '@tools/todo/TodoTool';
+import { createRecordingHost } from '../agent/progressTestUtils';
+
+const todoItem: TodoItem = {
+  content: 'Replace ClaudeAgentEffort with SDK effort type',
+  activeForm: 'Replacing ClaudeAgentEffort with SDK effort type',
+  status: TODO_STATUS.COMPLETED,
+};
+
+const overlappingPlan: Plan = {
+  summary: 'Replace local Claude SDK type aliases.',
+  steps: [
+    {
+      title: todoItem.content,
+      description: 'Use the SDK effort type directly.',
+      files: [],
+      status: TODO_STATUS.COMPLETED,
+    },
+    {
+      title: 'Verify compilation',
+      description: 'Run focused checks.',
+      files: [],
+      status: TODO_STATUS.IN_PROGRESS,
+    },
+  ],
+};
+
+function callContext(workPlanState: WorkPlanState) {
+  return {
+    tracker: new FileInteractionState(),
+    workPlanState,
+  };
+}
+
+function runContext() {
+  return {
+    runtimeHost: createRecordingHost().host,
+    streamId: 'stream:work-plan-granularity' as StreamTabId,
+  };
+}
+
+describe('work plan granularity feedback', () => {
+  it('warns when todo_write repeats a plan milestone label', async () => {
+    const workPlanState = new WorkPlanState();
+    workPlanState.updatePlan(overlappingPlan);
+
+    const result = await withToolEnvironment(
+      { run: runContext(), call: callContext(workPlanState) },
+      () => new TodoWriteTool().call({ todos: [todoItem] }),
+    );
+
+    expect(result.summary).toContain('todo/plan granularity overlap');
+    expect(result.output).toContain(
+      'Warning: todo_write and plan use the same labels for work at different levels.',
+    );
+    expect(result.output).toContain(`1. ${todoItem.content}`);
+    expect(result.output).toContain(
+      'Use plan for long-running goal/odyssey milestones and todo_write for microscopic execution steps.',
+    );
+    expect(result.output).not.toContain('todo is completed');
+    expect(result.output).not.toContain('plan is completed');
+    expect(workPlanState.todos).toEqual([todoItem]);
+    expect(workPlanState.plan).toEqual(overlappingPlan);
+  });
+
+  it('warns when plan repeats a todo label', async () => {
+    const workPlanState = new WorkPlanState();
+    workPlanState.updateTodos([todoItem]);
+
+    const result = await withToolEnvironment(
+      {
+        run: runContext(),
+        call: callContext(workPlanState),
+      },
+      () => new PlanTool().call({ command: 'update', plan: overlappingPlan }),
+    );
+
+    expect(result.summary).toContain('todo/plan granularity overlap');
+    expect(result.output).toContain(
+      'Warning: todo_write and plan use the same labels for work at different levels.',
+    );
+    expect(result.output).toContain(`1. ${todoItem.content}`);
+    expect(workPlanState.todos).toEqual([todoItem]);
+    expect(workPlanState.plan).toEqual(overlappingPlan);
+  });
+});

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -42,6 +42,10 @@ import {
 } from '@tools/odyssey';
 import { ToolError, type ToolResult } from '@tools/result';
 import { requireNonEmptyString } from '@tools/utils';
+import {
+  appendWorkPlanGranularityWarning,
+  formatWorkPlanGranularityWarning,
+} from '@tools/workPlanGranularityFeedback';
 import { defineTool } from '@tools/core/define';
 import { filterNotNull } from '@utils/core';
 
@@ -190,6 +194,10 @@ Best practices:
     }
 
     const isNewPlan = plan.steps.every((s) => s.status === TODO_STATUS.PENDING);
+    const granularityWarning = formatWorkPlanGranularityWarning(
+      callContext.workPlanState.todos,
+      plan,
+    );
 
     callContext.workPlanState.updatePlan(plan);
 
@@ -200,17 +208,21 @@ Best practices:
         );
       } else if (isProposalBypassedForStream(runContext.streamId)) {
         logger.info('Plan auto-approved via delegated-task auto-approval');
-        return this.buildApprovedResult({ autoApproved: true });
+        return this.buildApprovedResult({
+          autoApproved: true,
+          granularityWarning,
+        });
       } else {
         return this.requestApproval(
           plan,
           runContext.streamId,
           callContext.workPlanState,
+          granularityWarning,
         );
       }
     }
 
-    return this.buildProgressResult(plan);
+    return this.buildProgressResult(plan, granularityWarning);
   }
 
   private async executePause(
@@ -285,6 +297,7 @@ Best practices:
     plan: Plan,
     streamId: string,
     workPlanState: WorkPlanState,
+    granularityWarning?: string,
   ): Promise<ToolResult> {
     const approvalId = `plan-${Date.now().toString(36)}-${++approvalCounter}`;
     const odysseyEnabled = platform().config.get<boolean>(
@@ -302,12 +315,15 @@ Best practices:
 
     if (result.action === 'approve') {
       logger.info('Plan approved by user');
-      return this.buildApprovedResult({ autoApproved: false });
+      return this.buildApprovedResult({
+        autoApproved: false,
+        granularityWarning,
+      });
     }
 
     if (result.action === 'approve_and_odyssey') {
       logger.info('Plan approved by user with odyssey mode');
-      return this.startOdysseyForPlan(plan, streamId);
+      return this.startOdysseyForPlan(plan, streamId, granularityWarning);
     }
 
     // Rejected or timed out — clear the plan from UI
@@ -347,6 +363,7 @@ Best practices:
   private async startOdysseyForPlan(
     plan: Plan,
     streamId: string,
+    granularityWarning?: string,
   ): Promise<ToolResult> {
     const odysseyEnabled = platform().config.get<boolean>(
       ODYSSEY_FEATURE_FLAG_KEY,
@@ -359,12 +376,14 @@ Best practices:
       );
       return {
         summary: 'Plan approved — autonomous run unavailable',
-        output:
+        output: appendWorkPlanGranularityWarning(
           `The user selected Approve & Run, but the odyssey feature flag is ` +
-          `currently disabled. The plan is approved, but no autonomous ` +
-          `odyssey was started.\n\n` +
-          `Proceed with the plan steps as a normal turn-by-turn workflow. ` +
-          `Update plan step statuses as you go.`,
+            `currently disabled. The plan is approved, but no autonomous ` +
+            `odyssey was started.\n\n` +
+            `Proceed with the plan steps as a normal turn-by-turn workflow. ` +
+            `Update plan step statuses as you go.`,
+          granularityWarning,
+        ),
       };
     }
 
@@ -393,18 +412,20 @@ Best practices:
             : retargeted;
         return {
           summary: `Plan approved — odyssey ${active.odysseyId} retargeted`,
-          output:
+          output: appendWorkPlanGranularityWarning(
             `The user approved a new plan while odyssey ${active.odysseyId} ` +
-            `was already in flight. The odyssey has been retargeted to ` +
-            `the newly approved plan instead of leaving the old objective ` +
-            `active.\n\n` +
-            `${formatOdysseyView(active)}\n\n` +
-            `Discipline:\n` +
-            `- Work through the new plan steps and update their statuses with plan(command="update") as you progress.\n` +
-            `- Discard any progress that only served the previous objective.\n` +
-            `- Do not call plan(command="complete") until every step of the new plan is marked completed AND verified.\n` +
-            `- If you genuinely need user input to proceed, call plan(command="pause") with a reason.\n\n` +
-            `Objective:\n${objective}`,
+              `was already in flight. The odyssey has been retargeted to ` +
+              `the newly approved plan instead of leaving the old objective ` +
+              `active.\n\n` +
+              `${formatOdysseyView(active)}\n\n` +
+              `Discipline:\n` +
+              `- Work through the new plan steps and update their statuses with plan(command="update") as you progress.\n` +
+              `- Discard any progress that only served the previous objective.\n` +
+              `- Do not call plan(command="complete") until every step of the new plan is marked completed AND verified.\n` +
+              `- If you genuinely need user input to proceed, call plan(command="pause") with a reason.\n\n` +
+              `Objective:\n${objective}`,
+            granularityWarning,
+          ),
         };
       } catch (err) {
         const reason = toErrorMessage(err);
@@ -429,15 +450,17 @@ Best practices:
       const odyssey = await OdysseyStore.start(streamId, objective, { plan });
       return {
         summary: `Plan approved — odyssey ${odyssey.odysseyId} started`,
-        output:
+        output: appendWorkPlanGranularityWarning(
           `The user approved this plan and started an autonomous odyssey ` +
-          `(${odyssey.odysseyId}) toward the plan's stopping condition.\n\n` +
-          `Discipline:\n` +
-          `- Work through the plan steps and update their statuses with plan(command="update") as you progress.\n` +
-          `- Do not call plan(command="complete") until every plan step is marked completed AND the result is verified against current external state (file contents, command output, test results).\n` +
-          `- If you genuinely need user input to proceed, call plan(command="pause") with a reason describing what you need.\n` +
-          `- Otherwise, keep working in scoped checkpoints until the plan is finished.\n\n` +
-          `Objective:\n${objective}`,
+            `(${odyssey.odysseyId}) toward the plan's stopping condition.\n\n` +
+            `Discipline:\n` +
+            `- Work through the plan steps and update their statuses with plan(command="update") as you progress.\n` +
+            `- Do not call plan(command="complete") until every plan step is marked completed AND the result is verified against current external state (file contents, command output, test results).\n` +
+            `- If you genuinely need user input to proceed, call plan(command="pause") with a reason describing what you need.\n` +
+            `- Otherwise, keep working in scoped checkpoints until the plan is finished.\n\n` +
+            `Objective:\n${objective}`,
+          granularityWarning,
+        ),
       };
     } catch (err) {
       const reason = toErrorMessage(err);
@@ -458,8 +481,10 @@ Best practices:
 
   private buildApprovedResult({
     autoApproved,
+    granularityWarning,
   }: {
     autoApproved: boolean;
+    granularityWarning?: string;
   }): ToolResult {
     const prefix = autoApproved
       ? 'Plan auto-approved via delegated-task auto-approval (user did not review).'
@@ -468,18 +493,26 @@ Best practices:
       summary: autoApproved
         ? 'Plan auto-approved — proceed with implementation'
         : 'Plan approved — proceed with implementation',
-      output: `${prefix} You may now begin implementing the plan steps. Update step statuses as you work through them.`,
+      output: appendWorkPlanGranularityWarning(
+        `${prefix} You may now begin implementing the plan steps. Update step statuses as you work through them.`,
+        granularityWarning,
+      ),
     };
   }
 
-  private buildProgressResult(plan: Plan): ToolResult {
+  private buildProgressResult(
+    plan: Plan,
+    granularityWarning: string | undefined,
+  ): ToolResult {
     const { completed, inProgress, pending } = countByStatus(plan.steps);
 
     const summary = `Plan updated: ${completed} completed, ${inProgress} in progress, ${pending} pending`;
 
     return {
-      summary,
-      output: 'OK',
+      summary: granularityWarning
+        ? `${summary}; todo/plan granularity overlap`
+        : summary,
+      output: appendWorkPlanGranularityWarning('OK', granularityWarning),
     };
   }
 

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -20,6 +20,10 @@ import {
   type TodoItem,
 } from '@shared/schemas';
 import { type ToolResult } from '@tools/result';
+import {
+  appendWorkPlanGranularityWarning,
+  formatWorkPlanGranularityWarning,
+} from '@tools/workPlanGranularityFeedback';
 import { defineTool } from '@tools/core/define';
 
 const logger = createChannelTrace('TodoWriteTool');
@@ -98,6 +102,10 @@ Best practices:
     // Update the todos in workspace state
     // This triggers the onUpdate callback which emits events to the UI
     context.workPlanState.updateTodos(input.todos);
+    const granularityWarning = formatWorkPlanGranularityWarning(
+      input.todos,
+      context.workPlanState.plan,
+    );
 
     const { completed, inProgress, pending } = countByStatus(input.todos);
 
@@ -105,8 +113,10 @@ Best practices:
 
     // Return minimal output - the UI already shows the input, no need to repeat the list
     return {
-      summary,
-      output: 'OK',
+      summary: granularityWarning
+        ? `${summary}; todo/plan granularity overlap`
+        : summary,
+      output: appendWorkPlanGranularityWarning('OK', granularityWarning),
     };
   }
 

--- a/src/tools/workPlanGranularityFeedback.ts
+++ b/src/tools/workPlanGranularityFeedback.ts
@@ -1,0 +1,33 @@
+import { type Plan, type TodoItem } from '@shared/schemas';
+
+function taskKey(value: string): string {
+  return value.trim().replaceAll(/\s+/g, ' ').toLowerCase();
+}
+
+export function formatWorkPlanGranularityWarning(
+  todos: readonly TodoItem[],
+  plan: Plan | null,
+): string | undefined {
+  if (!plan || todos.length === 0) return undefined;
+
+  const todoKeys = new Set(todos.map((todo) => taskKey(todo.content)));
+  const overlaps = plan.steps.flatMap((step, index) => {
+    if (!todoKeys.has(taskKey(step.title))) return [];
+    return [`${index + 1}. ${step.title}`];
+  });
+
+  if (overlaps.length === 0) return undefined;
+
+  return [
+    'Warning: todo_write and plan use the same labels for work at different levels.',
+    ...overlaps.map((overlap) => `- ${overlap}`),
+    'Use plan for long-running goal/odyssey milestones and todo_write for microscopic execution steps. Make plan items more macroscopic, or make todos more granular, instead of duplicating the same checklist item in both tools.',
+  ].join('\n');
+}
+
+export function appendWorkPlanGranularityWarning(
+  output: string,
+  warning: string | undefined,
+): string {
+  return warning ? `${output}\n\n${warning}` : output;
+}


### PR DESCRIPTION
## Summary
- clarify that plan is for long-running goal/odyssey milestones and todo_write is for microscopic execution steps
- add shared producer-side feedback when an agent submits the same label in both plan steps and todos
- cover both plan-after-todo and todo-after-plan paths with focused tool tests

Fixes #5443.
Supersedes the renderer-side approach from #5445.

## Tests
- corepack pnpm vitest run src/test-kernel/tools/WorkPlanGranularityFeedback.vitest.ts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
- npm run typecheck
- npm run compile:fast
- npm run lint (passes with existing import-order warnings)
- git diff --check -- src/tools/plan/PlanTool.ts src/tools/todo/TodoTool.ts src/tools/workPlanGranularityFeedback.ts src/test-kernel/tools/WorkPlanGranularityFeedback.vitest.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive agent-facing warnings and tests only; no change to persistence, approval, or odyssey control flow beyond appending text to tool results.
> 
> **Overview**
> Adds **producer-side feedback** when an agent uses the same label for both `plan` milestones and `todo_write` items, so duplicated checklists are caught in tool results instead of only in the UI.
> 
> A shared helper in `workPlanGranularityFeedback.ts` normalizes todo `content` and plan step `title` text, lists overlapping plan steps, and appends guidance that **plan** is for macro milestones and **todo_write** for fine-grained steps. **`PlanTool`** runs this on plan updates (including approval and odyssey paths) and **`TodoWriteTool`** runs it after each todo write; both extend the tool **summary** with `todo/plan granularity overlap` when applicable.
> 
> New Vitest coverage exercises overlap when todos are written after a plan exists and when a plan update repeats an existing todo label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b29864ee02901637dedc730420c448b67ad6a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->