### PR TITLE
refactor(cli): gate ansiMarkdown color through createColors (drop parallel style objects)

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -422,12 +422,12 @@ export function renderAnsiMarkdown(
   options: RenderAnsiMarkdownOptions = {},
 ): string {
   const colorEnabled = options.colorEnabled ?? true;
-  const style = ansiMarkdownStyle(colorEnabled);
   if (
     !cachedProcessor ||
     cachedWidth !== options.width ||
     cachedColorEnabled !== colorEnabled
   ) {
+    const style = ansiMarkdownStyle(colorEnabled);
     const renderer = createMarkdownRenderer({
       highlight: (code, lang) => highlightForTui(code, lang, style),
       configure: (md) => configureAnsi(md, options.width, style),

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -32,7 +32,6 @@ import type { RenderRule } from 'markdown-it/lib/renderer.mjs';
  *  raw control chars). */
 const ESC = String.fromCharCode(27);
 const sgr = (code: number): string => `${ESC}[${code}m`;
-const plain = (text: string): string => text;
 
 interface AnsiMarkdownStyle {
   readonly enabled: boolean;
@@ -44,28 +43,22 @@ interface AnsiMarkdownStyle {
   sgr(code: number): string;
 }
 
-const ColorAnsiStyle: AnsiMarkdownStyle = {
-  enabled: true,
-  bold: pico.bold,
-  cyan: pico.cyan,
-  dim: pico.dim,
-  gray: pico.gray,
-  underline: pico.underline,
-  sgr,
-};
-
-const PlainAnsiStyle: AnsiMarkdownStyle = {
-  enabled: false,
-  bold: plain,
-  cyan: plain,
-  dim: plain,
-  gray: plain,
-  underline: plain,
-  sgr: () => '',
-};
-
+// One color gate for the whole package: picocolors' `createColors(false)` hands
+// back identity functions, so there's no need to keep parallel on/off style
+// objects — same pattern as `runtime/style.ts`'s `createCliStyle`. Raw SGR codes
+// (strong/em/strikethrough/link) can't be neutered by `createColors`, so `sgr`
+// stays explicitly gated.
 function ansiMarkdownStyle(colorEnabled: boolean): AnsiMarkdownStyle {
-  return colorEnabled ? ColorAnsiStyle : PlainAnsiStyle;
+  const c = pico.createColors(colorEnabled);
+  return {
+    enabled: colorEnabled,
+    bold: c.bold,
+    cyan: c.cyan,
+    dim: c.dim,
+    gray: c.gray,
+    underline: c.underline,
+    sgr: colorEnabled ? sgr : () => '',
+  };
 }
 
 function highlightForTui(


### PR DESCRIPTION
## What

Collapse the ANSI markdown renderer's two hand-maintained `AnsiMarkdownStyle`
objects (`ColorAnsiStyle` + `PlainAnsiStyle`), their dispatcher, and a `plain`
identity helper into a single `createColors(colorEnabled)` factory.

## Why

picocolors' `createColors(false)` already returns identity functions, so the
all-identity "off" variant was redundant duplication. This is the exact
single-gate pattern the package **already** standardized in `runtime/style.ts`
(`createCliStyle`), where "call sites never branch on color themselves." This
brings the markdown renderer onto that same single source of truth.

Net **−7 lines**, one fewer indirection, and one fewer place to keep two style
tables in sync.

## Behavior

Byte-identical in every real flow (verified directly against picocolors):

- `createColors(true).{bold,cyan,dim,gray,underline}` produce the same output as
  the previous module-level `pico.*` formatters.
- `createColors(false).{…}` are identity — same as the previous `plain`.
- The raw-SGR emitter for strong/em/strikethrough/link stays **explicitly gated**
  (`colorEnabled ? sgr : () => ''`), since `createColors` can't neuter literal
  `\e[Nm` codes.

Color is resolved upstream honoring `NO_COLOR` / `FORCE_COLOR` / `TERM=dumb` /
`--no-color` / TTY, so gating markdown styles on the resolved `colorEnabled`
(instead of picocolors' own env-sniffing, as the old module-level `pico.*` did)
also makes markdown color consistent with the rest of the CLI's color path.

## Verification

- `tsc --noEmit -p packages/cli/tsconfig.json` — clean
- `eslint` — clean
- picocolors parity check: `createColors(true).*` === old `pico.*`, and
  `createColors(false).*` === identity, for all five formatters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with intended byte-identical output; color still follows the resolved `colorEnabled` flag and explicit SGR gating.
> 
> **Overview**
> **ANSI markdown color** now goes through a single `ansiMarkdownStyle(colorEnabled)` factory built on `picocolors.createColors`, matching the existing `createCliStyle` pattern in `runtime/style.ts`.
> 
> The PR removes the parallel `ColorAnsiStyle` / `PlainAnsiStyle` objects, the `plain` identity helper, and the branch that picked between them. Picocolors formatters (`bold`, `cyan`, `dim`, `gray`, `underline`) come from `createColors(colorEnabled)`; literal SGR for strong/em/strike/links stays gated with `colorEnabled ? sgr : () => ''` because `createColors` cannot strip raw escape sequences.
> 
> `renderAnsiMarkdown` only constructs that style when the cached markdown processor is rebuilt (width or `colorEnabled` change), not on every render call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d281688a4309642e4d76818c87684abfc9b42cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->