### PR TITLE
fix(cli): prompt for login provider interactively

### DIFF
--- a/packages/cli/scripts/check-host-imports.mjs
+++ b/packages/cli/scripts/check-host-imports.mjs
@@ -42,6 +42,7 @@ const processOutputAllowedFiles = new Set([
   'packages/cli/src/orchestration/runOrchestrationTui.tsx',
   'packages/cli/src/init/runInitWizard.tsx',
   'packages/cli/src/onboarding/runOnboarding.tsx',
+  'packages/cli/src/commands/loginProviderPicker.tsx',
 ]);
 
 const processOutputPatterns = [

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -23,6 +23,7 @@ import {
   signInCliSupabase,
   signOutCliSupabase,
 } from '../runtime/supabaseAuth';
+import { interactiveTerminalFailure } from '../runtime/terminalRequirements';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
@@ -32,14 +33,19 @@ import type { CliContext } from '../runtime/cliContext';
 export function resolveLoginProvider(
   positional: string | undefined,
   flag: string | undefined,
-): string {
-  if (isNonEmptyString(flag)) return flag.trim();
-  if (isNonEmptyString(positional)) return positional.trim();
-  return DEFAULT_OAUTH_PROVIDER;
+): { readonly provider: string; readonly explicit: boolean } {
+  if (isNonEmptyString(flag)) {
+    return { provider: flag.trim(), explicit: true };
+  }
+  if (isNonEmptyString(positional)) {
+    return { provider: positional.trim(), explicit: true };
+  }
+  return { provider: DEFAULT_OAUTH_PROVIDER, explicit: false };
 }
 
 export interface LoginInit {
   readonly provider: string;
+  readonly providerExplicit: boolean;
   readonly noBrowser: boolean;
   readonly selectAccount: boolean;
   readonly loginHint?: string;
@@ -66,13 +72,30 @@ function readStringArg(
 export function loginInitFromArgs(args: LoginCommandArgs): LoginInit {
   const positional = optString(args.providerArg);
   const flag = optString(args.provider);
+  const provider = resolveLoginProvider(positional, flag);
   return {
-    provider: resolveLoginProvider(positional, flag),
+    provider: provider.provider,
+    providerExplicit: provider.explicit,
     noBrowser:
       readBooleanArg(args, 'no-browser', 'noBrowser') || args.browser === false,
     selectAccount: readBooleanArg(args, 'select-account', 'selectAccount'),
     loginHint: readStringArg(args, 'login-hint', 'loginHint'),
   };
+}
+
+export function shouldPromptForLoginProvider(
+  context: Pick<
+    CliContext,
+    'mode' | 'outputFormat' | 'stdoutIsTty' | 'termIsDumb'
+  >,
+  init: Pick<LoginInit, 'providerExplicit' | 'noBrowser'>,
+): boolean {
+  return (
+    !init.providerExplicit &&
+    !init.noBrowser &&
+    context.outputFormat === 'text' &&
+    interactiveTerminalFailure(context) === undefined
+  );
 }
 
 async function runLogin(context: CliContext, init: LoginInit): Promise<number> {
@@ -157,9 +180,28 @@ export const loginCommand = defineCliCommand({
     },
   },
   run: (context, ctx) => {
-    return runLogin(context, loginInitFromArgs(ctx.args));
+    return runLoginCommand(context, loginInitFromArgs(ctx.args));
   },
 });
+
+async function runLoginCommand(
+  context: CliContext,
+  init: LoginInit,
+): Promise<number> {
+  if (!shouldPromptForLoginProvider(context, init)) {
+    return runLogin(context, init);
+  }
+
+  const { promptForLoginProvider } = await import('./loginProviderPicker');
+  const provider = await promptForLoginProvider(
+    context.stdoutColorEnabled ?? context.colorEnabled,
+  );
+  if (!provider) {
+    writeTextStderr('Cancelled. No sign-in started.');
+    return CliExitCode.Success;
+  }
+  return runLogin(context, { ...init, provider, providerExplicit: true });
+}
 
 export const logoutCommand = defineCliCommand({
   meta: { name: 'logout', description: 'Sign out of TeXRA' },

--- a/packages/cli/src/commands/loginProviderPicker.tsx
+++ b/packages/cli/src/commands/loginProviderPicker.tsx
@@ -1,0 +1,77 @@
+import { render, Box, Text, useApp } from 'ink';
+
+import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
+import type { OAuthProvider } from '@auth/sharedConfig';
+
+import { tuiOutputStreamForColor } from '../chat/tui/render/noColorOutput';
+import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
+import { KeyHints } from '../chat/tui/ui/KeyHints';
+import { Select, type SelectItem } from '../chat/tui/ui/Select';
+
+const LOGIN_PROVIDER_ITEMS = [
+  { value: 'github', label: 'GitHub' },
+  { value: 'google', label: 'Google' },
+] as const satisfies readonly SelectItem<OAuthProvider>[];
+
+function LoginProviderPicker(props: {
+  readonly onSelect: (provider: OAuthProvider | undefined) => void;
+}): React.JSX.Element {
+  const app = useApp();
+  const finish = (provider: OAuthProvider | undefined): void => {
+    props.onSelect(provider);
+    app.exit();
+  };
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor="cyan"
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color="cyan">
+        TeXRA login
+      </Text>
+      <Text dimColor>Choose a provider to sign in with:</Text>
+      <Box marginTop={1} flexDirection="column">
+        <Select<OAuthProvider>
+          items={LOGIN_PROVIDER_ITEMS}
+          activeValue={DEFAULT_OAUTH_PROVIDER}
+          onSelect={finish}
+          onCancel={() => finish(undefined)}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            { key: '1-2/Enter', action: 'select' },
+            { key: 'Esc', action: 'cancel' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+export async function promptForLoginProvider(
+  colorEnabled = true,
+): Promise<OAuthProvider | undefined> {
+  let selected: OAuthProvider | undefined;
+  const instance = render(
+    <LoginProviderPicker
+      onSelect={(provider) => {
+        selected = provider;
+      }}
+    />,
+    {
+      stdout: tuiOutputStreamForColor(process.stdout, colorEnabled),
+      stderr: process.stderr,
+      stdin: process.stdin,
+    },
+  );
+  await instance.waitUntilExit();
+  clearTerminalVisibleScreen();
+  return selected;
+}

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1060,7 +1060,10 @@ describe('CLI model flag validation contract', () => {
 
 describe('CLI login arguments', () => {
   it('prefers explicit provider flags over positional providers', () => {
-    expect(resolveLoginProvider('google', 'github')).toBe('github');
+    expect(resolveLoginProvider('google', 'github')).toEqual({
+      provider: 'github',
+      explicit: true,
+    });
   });
 });
 

--- a/src/test-kernel/cli/LoginArgs.vitest.mts
+++ b/src/test-kernel/cli/LoginArgs.vitest.mts
@@ -1,19 +1,32 @@
 import { describe, expect, it } from 'vitest';
 
-import { loginInitFromArgs, resolveLoginProvider } from '@cli/commands/auth';
+import {
+  loginInitFromArgs,
+  resolveLoginProvider,
+  shouldPromptForLoginProvider,
+} from '@cli/commands/auth';
 import { formatCliManualAuthUrlMessage } from '@cli/runtime/supabaseAuth';
 
 describe('CLI login arguments (texra login)', () => {
-  it('defaults texra login to GitHub sign-in', () => {
-    expect(resolveLoginProvider(undefined, undefined)).toBe('github');
+  it('marks bare texra login as using the fallback provider', () => {
+    expect(resolveLoginProvider(undefined, undefined)).toEqual({
+      provider: 'github',
+      explicit: false,
+    });
   });
 
   it('prefers the --provider flag over the positional argument', () => {
-    expect(resolveLoginProvider('github', 'google')).toBe('google');
+    expect(resolveLoginProvider('github', 'google')).toEqual({
+      provider: 'google',
+      explicit: true,
+    });
   });
 
   it('falls back to the positional argument when --provider is empty', () => {
-    expect(resolveLoginProvider('google', undefined)).toBe('google');
+    expect(resolveLoginProvider('google', undefined)).toEqual({
+      provider: 'google',
+      explicit: true,
+    });
   });
 
   it('reads login flags from hyphenated argument keys', () => {
@@ -26,6 +39,7 @@ describe('CLI login arguments (texra login)', () => {
       }),
     ).toEqual({
       provider: 'github',
+      providerExplicit: true,
       noBrowser: true,
       selectAccount: true,
       loginHint: 'octocat',
@@ -42,6 +56,7 @@ describe('CLI login arguments (texra login)', () => {
       }),
     ).toEqual({
       provider: 'google',
+      providerExplicit: true,
       noBrowser: true,
       selectAccount: true,
       loginHint: 'person@example.com',
@@ -52,6 +67,46 @@ describe('CLI login arguments (texra login)', () => {
     expect(loginInitFromArgs({ browser: false })).toMatchObject({
       noBrowser: true,
     });
+  });
+
+  it('prompts for provider only for bare interactive text login', () => {
+    const interactiveText = {
+      mode: 'interactive' as const,
+      outputFormat: 'text' as const,
+      stdoutIsTty: true,
+      termIsDumb: false,
+    };
+
+    expect(
+      shouldPromptForLoginProvider(interactiveText, {
+        providerExplicit: false,
+        noBrowser: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldPromptForLoginProvider(interactiveText, {
+        providerExplicit: true,
+        noBrowser: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPromptForLoginProvider(interactiveText, {
+        providerExplicit: false,
+        noBrowser: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPromptForLoginProvider(
+        { ...interactiveText, outputFormat: 'json' },
+        { providerExplicit: false, noBrowser: false },
+      ),
+    ).toBe(false);
+    expect(
+      shouldPromptForLoginProvider(
+        { ...interactiveText, mode: 'headless' },
+        { providerExplicit: false, noBrowser: false },
+      ),
+    ).toBe(false);
   });
 
   it('describes manual login as a loopback callback, not any-device auth', () => {


### PR DESCRIPTION
## Summary
- Track whether `texra login` got an explicit provider or is using the GitHub fallback.
- Show a small Ink GitHub/Google picker for bare interactive text login before starting OAuth.
- Keep explicit providers, `--no-browser`, headless mode, and `--output-format json|ndjson` on the existing non-picker path.

Fixes #5431.

## Verification
- `corepack pnpm vitest run src/test-kernel/cli/LoginArgs.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`
- Live TTY smoke: `TERM=xterm-256color node packages/cli/dist/bin/texra.js login --no-color` rendered GitHub/Google picker; Esc exited with `Cancelled. No sign-in started.`