### PR TITLE
chore: bump pnpm to 11.5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js
@@ -134,7 +133,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js
@@ -192,7 +190,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "texra-workspace",
   "version": "0.38.6",
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1628,7 +1628,7 @@
     "webpack-cli": "^7.0.3",
     "zod-v3-to-v4": "^1.21.2"
   },
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
   "private": false,
   "scripts": {
     "vscode:prepublish": "[ \"$SKIP_VSCE_PREPUBLISH\" = \"1\" ] || corepack pnpm run package",


### PR DESCRIPTION
## What

Bump the `packageManager` pin from `pnpm@11.1.1` to `pnpm@11.5.2` (latest) in **both** the workspace root and `packages/extension/package.json`.

## Why

The two pins must stay in sync. The nested fast-build scripts run `corepack pnpm` from inside `packages/extension/`, so corepack reads *that* package's pin. If only the root is bumped, corepack launches the extension's pinned version and pnpm refuses with:

> This project is configured to use 11.5.2 of pnpm. Your current pnpm is v11.1.1

Bumping both keeps `npm run compile:fast` (and CI) working.

## Verification

- `corepack use pnpm@11.5.2` → `pnpm --version` reports `11.5.2`
- `npm run compile:fast` succeeds (exit 0) with both pins synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only version alignment with no application or dependency logic changes; main risk is CI/local install behavior if Corepack and the new pin disagree.
> 
> **Overview**
> Bumps the workspace **pnpm** pin from **11.1.1** to **11.5.2** (with Corepack integrity hash) in both the **root** `package.json` and **`packages/extension/package.json`**, so local `corepack pnpm` and extension fast-build scripts agree on the same toolchain.
> 
> GitHub Actions workflows (**CI**, **desktop-package**, **format-pr**, **version-bump**) drop the hard-coded `version: 11.1.1` on `pnpm/action-setup` and rely on the repo `packageManager` field instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6744fdb66048de26517420de46460c3610fadfea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->