### PR TITLE
fix(cli): keep TUI stream ownership navigable

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -123,6 +123,8 @@ const HARNESS_API_MODE: CliApiMode = HARNESS_API_MODE_FROM_ENV ?? 'personal';
 const HARNESS_AUTHENTICATED = process.env.HARNESS_AUTHENTICATED?.trim();
 const BASH_APPROVAL_COMMAND =
   process.env.HARNESS_BASH_APPROVAL_COMMAND ?? 'npm run compile:safe';
+const SHOW_BASH_APPROVAL_AFTER_CHILD_FOCUS =
+  process.env.HARNESS_BASH_APPROVAL_AFTER_CHILD_FOCUS === '1';
 const EXTERNAL_INQUIRY_QUESTION =
   process.env.HARNESS_EXTERNAL_INQUIRY_QUESTION ??
   [
@@ -1020,13 +1022,31 @@ if (SHOW_EDIT_APPROVAL) {
 }
 
 if (SHOW_BASH_APPROVAL) {
-  void enqueueApproval(
-    {
-      kind: 'bash',
-      payload: makeBashApprovalPayload(),
-    },
-    { onPresent: () => notify({ kind: 'approvalNeeded' }) },
-  ).then(applyHarnessApprovalDecision);
+  const showApproval = () =>
+    void enqueueApproval(
+      {
+        kind: 'bash',
+        payload: makeBashApprovalPayload(),
+      },
+      { onPresent: () => notify({ kind: 'approvalNeeded' }) },
+    ).then(applyHarnessApprovalDecision);
+
+  if (SHOW_BASH_APPROVAL_AFTER_CHILD_FOCUS) {
+    let pollCount = 0;
+    const timer = setInterval(() => {
+      pollCount += 1;
+      const activeStreamId = cliState.activeStreamId.get();
+      if (activeStreamId === undefined || activeStreamId === STREAM_ID) {
+        if (pollCount >= 200) clearInterval(timer);
+        return;
+      }
+      clearInterval(timer);
+      showApproval();
+    }, 25);
+    timer.unref?.();
+  } else {
+    showApproval();
+  }
 }
 
 if (SHOW_RETRY_APPROVAL) {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1427,6 +1427,33 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'hidden-root-approval-tab-return',
+    cols: 120,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+      HARNESS_BASH_APPROVAL: '1',
+      HARNESS_BASH_APPROVAL_AFTER_CHILD_FOCUS: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: ['\t', '\t', '\t', '\t'],
+    expect: [
+      'agent: chat · model: harness-model',
+      'Run bash command?',
+      '$ npm run compile:safe',
+      'y approve',
+      '[main]*',
+      'Use foreground panel shortcuts',
+    ],
+    unexpect: [
+      'subagent: strategy · parent: main · model: harness-model',
+      '[1:strategy]*',
+      'signal read during notification phase',
+      'ERROR',
+    ],
+  },
+  {
     name: 'subagent-focused-own-scrollback-history',
     cols: 120,
     rows: 14,

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -255,7 +255,12 @@ export function staticTranscriptRowBudget({
   return Math.max(0, optionalRows - liveTranscriptReserveRows);
 }
 
-export function staticScrollbackStreamId({
+export interface StaticScrollbackTarget {
+  readonly ownerKey: string;
+  readonly streamId: StreamTabId | undefined;
+}
+
+export function staticScrollbackTarget({
   activeStreamId,
   rootStreamId,
   scopedTranscript = false,
@@ -263,13 +268,21 @@ export function staticScrollbackStreamId({
   readonly activeStreamId: StreamTabId | undefined;
   readonly rootStreamId: StreamTabId | undefined;
   readonly scopedTranscript?: boolean;
-}): StreamTabId | undefined {
-  if (scopedTranscript) return activeStreamId;
-  if (rootStreamId) return rootStreamId;
+}): StaticScrollbackTarget {
+  if (scopedTranscript) {
+    return {
+      ownerKey: activeStreamId ? `stream:${activeStreamId}` : 'scoped:none',
+      streamId: activeStreamId,
+    };
+  }
   // Before a root run resolves, local helper output and harness-built root
-  // streams still need static scrollback. Once `rootStreamId` is set, focused
-  // children redirect this owner only while their scoped transcript is focused.
-  return activeStreamId;
+  // streams still need static scrollback. The root owner key is deliberately
+  // stable across the later rootStreamId resolution so Ink's append-only
+  // <Static> cache does not remount and print the session header twice.
+  return {
+    ownerKey: 'root',
+    streamId: rootStreamId ?? activeStreamId,
+  };
 }
 
 export function shouldShowTipRow({
@@ -299,15 +312,15 @@ export function shouldShowTodosPlanPanel({
 }
 
 export function appFocusShortcutsActive({
-  inputDisabled,
+  foregroundOpen,
   reverseSearchOpen,
   slashPaletteOpen,
 }: {
-  readonly inputDisabled: boolean;
+  readonly foregroundOpen: boolean;
   readonly reverseSearchOpen: boolean;
   readonly slashPaletteOpen: boolean;
 }): boolean {
-  return !inputDisabled && !slashPaletteOpen && !reverseSearchOpen;
+  return !foregroundOpen && !slashPaletteOpen && !reverseSearchOpen;
 }
 
 export function appEscapeInterruptActive({
@@ -322,12 +335,7 @@ export function appEscapeInterruptActive({
   readonly slashPaletteOpen: boolean;
 }): boolean {
   return (
-    runPending &&
-    appFocusShortcutsActive({
-      inputDisabled,
-      reverseSearchOpen,
-      slashPaletteOpen,
-    })
+    runPending && !inputDisabled && !slashPaletteOpen && !reverseSearchOpen
   );
 }
 
@@ -481,7 +489,7 @@ export function App(props: AppProps): React.JSX.Element {
     transcriptViewerStreamId,
   });
   const scopedTranscript = isScopedTranscriptViewport(viewportKey);
-  const scrollbackStreamId = staticScrollbackStreamId({
+  const scrollbackTarget = staticScrollbackTarget({
     activeStreamId,
     rootStreamId,
     scopedTranscript,
@@ -686,7 +694,7 @@ export function App(props: AppProps): React.JSX.Element {
   const foregroundSurface = renderForegroundSurface();
 
   const focusShortcutsActive = appFocusShortcutsActive({
-    inputDisabled,
+    foregroundOpen,
     reverseSearchOpen,
     slashPaletteOpen,
   });
@@ -775,7 +783,8 @@ export function App(props: AppProps): React.JSX.Element {
         <StaticConversationTranscript
           colorEnabled={props.colorEnabled}
           maxRows={staticTranscriptRows}
-          scrollbackStreamId={scrollbackStreamId}
+          ownerKey={scrollbackTarget.ownerKey}
+          scrollbackStreamId={scrollbackTarget.streamId}
           width={transcriptWidth}
         />
       )}

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -226,18 +226,19 @@ export function appendStaticTranscriptItems({
 export function StaticConversationTranscript({
   colorEnabled,
   maxRows,
+  ownerKey,
   scrollbackStreamId,
   width,
 }: {
   readonly colorEnabled?: boolean;
   readonly maxRows?: number;
+  readonly ownerKey: string;
   readonly scrollbackStreamId: StreamTabId | undefined;
   readonly width?: number;
 }): React.JSX.Element {
   const streams = useSignal(cliState.streams);
   const sessionMeta = useSignal(cliState.sessionMeta);
   const parentStream = useSignal(cliState.parentStream);
-  const ownerKey = scrollbackStreamId ?? 'none';
   const [state, setState] = useState<StaticTranscriptState>(() => ({
     ownerKey,
     items: appendStaticTranscriptItems({

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -12,7 +12,7 @@ import {
   appendStaticTranscriptItems,
   sessionHeaderIdentityLine,
 } from '@cli/chat/tui/panes/StaticConversationTranscript';
-import { staticScrollbackStreamId } from '@cli/chat/tui/App';
+import { staticScrollbackTarget } from '@cli/chat/tui/App';
 import {
   transcriptViewportChange,
   transcriptViewportKey,
@@ -531,19 +531,19 @@ describe('CLI conversation transcript splitting', () => {
       [CHILD, sliceWithEntries(CHILD, [childAssistant])],
     ]);
 
-    const scrollbackStreamId = staticScrollbackStreamId({
+    const scrollbackTarget = staticScrollbackTarget({
       activeStreamId: CHILD,
       rootStreamId: ROOT,
       scopedTranscript: false,
     });
     const items = appendStaticTranscriptItems({
-      scrollbackStreamId,
+      scrollbackStreamId: scrollbackTarget.streamId,
       currentItems: [],
       streams,
       meta: SESSION_META,
     });
 
-    expect(scrollbackStreamId).toBe(ROOT);
+    expect(scrollbackTarget).toEqual({ ownerKey: 'root', streamId: ROOT });
     expect(items.slice(1).map((item) => item.id)).toEqual(['u1']);
   });
 
@@ -557,35 +557,44 @@ describe('CLI conversation transcript splitting', () => {
       [CHILD, sliceWithEntries(CHILD, [childAssistant])],
     ]);
 
-    const scrollbackStreamId = staticScrollbackStreamId({
+    const scrollbackTarget = staticScrollbackTarget({
       activeStreamId: CHILD,
       rootStreamId: ROOT,
       scopedTranscript: true,
     });
     const items = appendStaticTranscriptItems({
-      scrollbackStreamId,
+      scrollbackStreamId: scrollbackTarget.streamId,
       currentItems: [],
       streams,
       meta: SESSION_META,
     });
 
-    expect(scrollbackStreamId).toBe(CHILD);
+    expect(scrollbackTarget).toEqual({
+      ownerKey: `stream:${CHILD}`,
+      streamId: CHILD,
+    });
     expect(items.slice(1).map((item) => item.id)).toEqual(['a1']);
   });
 
-  it('falls back to active stream only before the root owner resolves', () => {
+  it('keeps the root static owner stable while the root stream resolves', () => {
     expect(
-      staticScrollbackStreamId({
+      staticScrollbackTarget({
         activeStreamId: STREAM_ID,
         rootStreamId: undefined,
       }),
-    ).toBe(STREAM_ID);
+    ).toEqual({ ownerKey: 'root', streamId: STREAM_ID });
     expect(
-      staticScrollbackStreamId({
+      staticScrollbackTarget({
         activeStreamId: CLI_LOCAL_STREAM_ID,
         rootStreamId: undefined,
       }),
-    ).toBe(CLI_LOCAL_STREAM_ID);
+    ).toEqual({ ownerKey: 'root', streamId: CLI_LOCAL_STREAM_ID });
+    expect(
+      staticScrollbackTarget({
+        activeStreamId: STREAM_ID,
+        rootStreamId: 'resolved-root' as StreamTabId,
+      }),
+    ).toEqual({ ownerKey: 'root', streamId: 'resolved-root' });
   });
 
   it('separates root scrollback from scoped child transcript viewports', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -694,23 +694,30 @@ describe('CLI TUI row allocation', () => {
   it('lets input overlays own focus shortcuts', () => {
     expect(
       appFocusShortcutsActive({
-        inputDisabled: false,
+        foregroundOpen: false,
         reverseSearchOpen: false,
         slashPaletteOpen: false,
       }),
     ).toBe(true);
     expect(
       appFocusShortcutsActive({
-        inputDisabled: false,
+        foregroundOpen: false,
         reverseSearchOpen: true,
         slashPaletteOpen: false,
       }),
     ).toBe(false);
     expect(
       appFocusShortcutsActive({
-        inputDisabled: false,
+        foregroundOpen: false,
         reverseSearchOpen: false,
         slashPaletteOpen: true,
+      }),
+    ).toBe(false);
+    expect(
+      appFocusShortcutsActive({
+        foregroundOpen: true,
+        reverseSearchOpen: false,
+        slashPaletteOpen: false,
       }),
     ).toBe(false);
   });
@@ -875,6 +882,36 @@ describe('CLI TUI row allocation', () => {
     ).toBe(false);
     expect(approvalBlocksInput(childApproval)).toBe(true);
     expect(approvalBlocksInput(undefined)).toBe(false);
+  });
+
+  it('keeps stream focus shortcuts available for hidden approvals', () => {
+    const childApproval = {
+      payload: {
+        kind: 'bash',
+        payload: {
+          requestId: 'bash-1',
+          command: 'echo ok',
+          allowBypass: true,
+          streamId: 'child-1',
+        },
+      },
+      decide: () => undefined,
+    } satisfies PendingApproval;
+
+    expect(
+      approvalVisibleForActiveStream({
+        activeStreamId: 'root',
+        pending: childApproval,
+      }),
+    ).toBe(false);
+    expect(approvalBlocksInput(childApproval)).toBe(true);
+    expect(
+      appFocusShortcutsActive({
+        foregroundOpen: false,
+        reverseSearchOpen: false,
+        slashPaletteOpen: false,
+      }),
+    ).toBe(true);
   });
 
   it('labels foreground escape actions from the owning surface', () => {


### PR DESCRIPTION
## Summary
- keep the root static scrollback owner stable while the root stream id resolves, preventing duplicate session headers
- separate chat input blocking from stream focus shortcuts so hidden approvals do not trap users on a subagent tab
- add a deterministic TUI frame scenario for returning from a focused subagent to a root-owned approval

Fixes #5453

## Validation
- corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ApprovalQueue.vitest.mts src/test-kernel/cli/TuiValidatorArgs.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm exec prettier --check packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- git diff --check
- cd packages/cli && node scripts/validate-tui.mjs --no-build hidden-root-approval-tab-return bash-approval subagent-tab-focus-full-frame subagent-focus-return-root-scrollback-deduped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TUI focus, static scrollback ownership, and approval visibility—user-facing navigation and transcript rendering, with targeted tests but moderate interaction complexity.
> 
> **Overview**
> Fixes CLI TUI stream navigation when a **root-owned approval** is pending while focus is on a **subagent tab**, and stops **duplicate session headers** when the root stream id resolves.
> 
> **Static scrollback:** `staticScrollbackStreamId` becomes `staticScrollbackTarget` with a stable `ownerKey` (`'root'` vs `stream:${id}`) separate from which stream id supplies entries. Root view keeps `ownerKey: 'root'` before and after `rootStreamId` resolves so Ink `<Static>` does not remount and reprint the header. `StaticConversationTranscript` takes explicit `ownerKey` for remount keys.
> 
> **Focus vs input:** `appFocusShortcutsActive` keys off `foregroundOpen` (visible modal/surface) instead of `inputDisabled`. Hidden approvals still block chat input via `approvalBlocksInput`, but **Tab / stream shortcuts stay active** so users can return to main and see the bash approval modal.
> 
> **Tests:** Harness flag `HARNESS_BASH_APPROVAL_AFTER_CHILD_FOCUS` defers bash approval until a child is focused; new `hidden-root-approval-tab-return` validate-tui scenario; unit tests for stable root owner and hidden-approval focus behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deef3cc8d6463bc1e90f0bf0fdc87bf6c5177c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->