### PR TITLE
refactor: share progress stream metadata builder

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -70,6 +70,7 @@ import type { RestoredStreamSnapshot } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { buildStreamMetadata as createStreamMetadata } from '@shared/streams/streamMetadata';
 import {
   cleanupAllApprovals,
   cleanupApprovalsForStream,
@@ -481,21 +482,17 @@ export class DesktopProgressBridge {
       this.taskStates.get(streamId)?.agentConfig.agentCategory ??
       this.categories.get(streamId) ??
       AGENT_CATEGORY.WORKFLOW;
-    return {
+    const badges = this.streamBadges.get(streamId);
+    return createStreamMetadata({
       kind: category,
-      status: this.statuses.get(streamId) ?? STREAM_STATUS.READY,
+      status: this.statuses.get(streamId),
       lastTimestamp: this.streamLogs.getLastTimestamp(streamId),
-      conversationProgress: this.conversationProgress.get(streamId) ?? {
-        conversationTurns: 0,
-        toolCallCount: 0,
-      },
-      activeSubagents: this.streamBadges.get(streamId)?.activeSubagents ?? [],
-      finishedSubagentCount:
-        this.streamBadges.get(streamId)?.finishedSubagentCount ?? 0,
-      activeProcesses: this.streamBadges.get(streamId)?.activeProcesses ?? [],
-      finishedProcessCount:
-        this.streamBadges.get(streamId)?.finishedProcessCount ?? 0,
-    };
+      conversationProgress: this.conversationProgress.get(streamId),
+      activeSubagents: badges?.activeSubagents,
+      finishedSubagentCount: badges?.finishedSubagentCount,
+      activeProcesses: badges?.activeProcesses,
+      finishedProcessCount: badges?.finishedProcessCount,
+    });
   }
 
   private updateActiveChildren(

--- a/packages/extension/src/progressView/managers/WebviewUpdater.ts
+++ b/packages/extension/src/progressView/managers/WebviewUpdater.ts
@@ -7,7 +7,6 @@ import {
   type StreamExecutionState,
 } from '@progressView/state/ProgressViewState';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import { STREAM_STATUS } from '@shared/schemas';
 import type {
   AgentCategoryFilter,
   ConversationProgress,
@@ -27,6 +26,7 @@ import type {
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
+import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 import type { OdysseyStatus } from '@tools/odyssey';
 
 /**
@@ -440,19 +440,16 @@ export class WebviewUpdater {
     const streamMetadata: Record<StreamTabId, StreamMetadata> = {};
     for (const { name, agentCategory } of streams) {
       const current = allStates[name];
-      streamMetadata[name] = {
+      streamMetadata[name] = buildStreamMetadata({
         kind: agentCategory,
-        status: statuses?.get(name) ?? STREAM_STATUS.READY,
+        status: statuses?.get(name),
         lastTimestamp: state.streamLogs.getLastTimestamp(name),
-        conversationProgress: current?.conversationProgress ?? {
-          conversationTurns: 0,
-          toolCallCount: 0,
-        },
-        activeSubagents: current?.activeSubagents ?? [],
-        finishedSubagentCount: current?.finishedSubagentCount ?? 0,
-        activeProcesses: current?.activeProcesses ?? [],
-        finishedProcessCount: current?.finishedProcessCount ?? 0,
-      };
+        conversationProgress: current?.conversationProgress,
+        activeSubagents: current?.activeSubagents,
+        finishedSubagentCount: current?.finishedSubagentCount,
+        activeProcesses: current?.activeProcesses,
+        finishedProcessCount: current?.finishedProcessCount,
+      });
     }
 
     this.updateStreams(

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -7,7 +7,7 @@ import {
   type AgentCategory,
 } from './agent';
 import { CompileFailureSchema, OutputFileInfoSchema } from './output';
-import { StreamStatusSchema } from './stream';
+import { STREAM_STATUS, StreamStatusSchema } from './stream';
 import { TaskGroupSchema } from './taskGroup';
 import { PlanSchema } from './plan';
 import { TodoItemSchema } from './todo';
@@ -44,17 +44,27 @@ export const ConversationProgressSchema = z.object({
 
 export type ConversationProgress = z.infer<typeof ConversationProgressSchema>;
 
+export const DEFAULT_CONVERSATION_PROGRESS: ConversationProgress = {
+  conversationTurns: 0,
+  toolCallCount: 0,
+};
+
+export const DEFAULT_STREAM_METADATA_STATUS = STREAM_STATUS.READY;
+export const DEFAULT_FINISHED_CHILD_COUNT = 0;
+
 // Stream Metadata — the lightweight subset sent over postMessage in UPDATE_STREAMS.
 // Contains only backend-owned fields that mergeBackendOwnedState() actually reads.
 
 const BackendOwnedFieldsSchema = z.object({
-  status: StreamStatusSchema.optional(),
+  status: StreamStatusSchema.prefault(DEFAULT_STREAM_METADATA_STATUS),
   lastTimestamp: z.number().optional(),
-  conversationProgress: ConversationProgressSchema.prefault({}),
+  conversationProgress: ConversationProgressSchema.prefault(
+    DEFAULT_CONVERSATION_PROGRESS,
+  ),
   activeSubagents: z.array(ActiveChildInfoSchema).prefault([]),
-  finishedSubagentCount: z.number().prefault(0),
+  finishedSubagentCount: z.number().prefault(DEFAULT_FINISHED_CHILD_COUNT),
   activeProcesses: z.array(ActiveChildInfoSchema).prefault([]),
-  finishedProcessCount: z.number().prefault(0),
+  finishedProcessCount: z.number().prefault(DEFAULT_FINISHED_CHILD_COUNT),
 });
 
 export const StreamMetadataSchema = BackendOwnedFieldsSchema.extend({

--- a/src/shared/streams/streamMetadata.ts
+++ b/src/shared/streams/streamMetadata.ts
@@ -1,0 +1,44 @@
+import {
+  DEFAULT_CONVERSATION_PROGRESS,
+  DEFAULT_FINISHED_CHILD_COUNT,
+  DEFAULT_STREAM_METADATA_STATUS,
+  type ActiveChildInfo,
+  type AgentCategory,
+  type ConversationProgress,
+  type StreamMetadata,
+  type StreamStatus,
+} from '@shared/schemas';
+
+/**
+ * Host-neutral stream metadata builder used by the extension and desktop
+ * progress backends before sending UPDATE_STREAMS payloads.
+ */
+export interface StreamMetadataInputs {
+  kind: AgentCategory;
+  status?: StreamStatus;
+  lastTimestamp?: number;
+  conversationProgress?: ConversationProgress;
+  activeSubagents?: ActiveChildInfo[];
+  finishedSubagentCount?: number;
+  activeProcesses?: ActiveChildInfo[];
+  finishedProcessCount?: number;
+}
+
+export function buildStreamMetadata(
+  inputs: StreamMetadataInputs,
+): StreamMetadata {
+  return {
+    kind: inputs.kind,
+    status: inputs.status ?? DEFAULT_STREAM_METADATA_STATUS,
+    lastTimestamp: inputs.lastTimestamp,
+    conversationProgress: inputs.conversationProgress ?? {
+      ...DEFAULT_CONVERSATION_PROGRESS,
+    },
+    activeSubagents: inputs.activeSubagents ?? [],
+    finishedSubagentCount:
+      inputs.finishedSubagentCount ?? DEFAULT_FINISHED_CHILD_COUNT,
+    activeProcesses: inputs.activeProcesses ?? [],
+    finishedProcessCount:
+      inputs.finishedProcessCount ?? DEFAULT_FINISHED_CHILD_COUNT,
+  };
+}

--- a/src/test-kernel/shared/StreamMetadata.vitest.ts
+++ b/src/test-kernel/shared/StreamMetadata.vitest.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_CATEGORY,
+  STREAM_STATUS,
+  type ActiveChildInfo,
+} from '@shared/schemas';
+import { buildStreamMetadata } from '@shared/streams/streamMetadata';
+
+describe('buildStreamMetadata', () => {
+  it('fills backend-owned defaults for a stream state metadata payload', () => {
+    expect(
+      buildStreamMetadata({ kind: AGENT_CATEGORY.WORKFLOW }),
+    ).toMatchObject({
+      kind: AGENT_CATEGORY.WORKFLOW,
+      status: STREAM_STATUS.READY,
+      conversationProgress: { conversationTurns: 0, toolCallCount: 0 },
+      activeSubagents: [],
+      finishedSubagentCount: 0,
+      activeProcesses: [],
+      finishedProcessCount: 0,
+    });
+  });
+
+  it('preserves supplied status, progress, child badges, and timestamps', () => {
+    const child: ActiveChildInfo = {
+      executionId: 'agent-1',
+      agentName: 'review',
+      status: STREAM_STATUS.RUNNING,
+    };
+
+    expect(
+      buildStreamMetadata({
+        kind: AGENT_CATEGORY.TOOL_USE,
+        status: STREAM_STATUS.RUNNING,
+        lastTimestamp: 123,
+        conversationProgress: { conversationTurns: 2, toolCallCount: 5 },
+        activeSubagents: [child],
+        finishedSubagentCount: 1,
+        activeProcesses: [child],
+        finishedProcessCount: 3,
+      }),
+    ).toEqual({
+      kind: AGENT_CATEGORY.TOOL_USE,
+      status: STREAM_STATUS.RUNNING,
+      lastTimestamp: 123,
+      conversationProgress: { conversationTurns: 2, toolCallCount: 5 },
+      activeSubagents: [child],
+      finishedSubagentCount: 1,
+      activeProcesses: [child],
+      finishedProcessCount: 3,
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n\n- Extract shared `buildStreamMetadata` for backend-owned progress stream metadata defaults\n- Use it from both the VS Code progress webview updater and Electron desktop progress bridge\n- Add focused unit coverage for default and populated metadata payloads\n\nThis is the P1 slice from #5451: share the pure stream metadata mapper before attempting any larger progress backend relocation.\n\nCloses part of #5451.\n\n## Validation\n\n- `corepack pnpm vitest run src/test-kernel/shared/StreamMetadata.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test/progressView/streamInfoUtils.test.ts`\n- `npm run typecheck`\n- `npm run lint` (passes; existing import-order warnings remain outside this patch)\n- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with centralized defaults and unit tests; no auth, data, or execution-path changes beyond how metadata objects are assembled.
> 
> **Overview**
> Introduces a **host-neutral** `buildStreamMetadata` helper in `@shared/streams/streamMetadata` so VS Code (`WebviewUpdater`) and Electron (`DesktopProgressBridge`) build the same `UPDATE_STREAMS` metadata instead of duplicating inline defaults.
> 
> **Schema alignment:** `streamState.ts` now exports named defaults (`DEFAULT_CONVERSATION_PROGRESS`, `DEFAULT_STREAM_METADATA_STATUS`, `DEFAULT_FINISHED_CHILD_COUNT`) and applies them via Zod `prefault` on backend-owned `StreamMetadata` fields (notably `status` is no longer optional on the schema). The builder applies the same fallbacks when callers pass partial/undefined inputs.
> 
> **Tests:** `StreamMetadata.vitest.ts` covers default-filled payloads and fully populated metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb2b1afb7ee9308a492d7081817a5df0b285f807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->