### PR TITLE
refactor: share progress log bridge

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -16,19 +16,20 @@ import { createChannelTrace } from '@logger';
 import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import { ApprovalRequestHandler } from '@progressView/managers/ApprovalRequestHandler';
-import { WebviewBridge } from '@progressView/managers/WebviewBridge';
 import { WebviewUpdater } from '@progressView/managers/WebviewUpdater';
 import type {
   AgentProposalPermission,
   BashPermission,
   ExternalInquiryPermission,
   PlanApprovalPermission,
+  ProgressViewOutboundMessage,
   ProgressViewPlacement,
   StorageKey,
   StreamTabId,
   ToolEditPermission,
 } from '@shared/schemas';
 import { AGENT_CATEGORY } from '@shared/schemas';
+import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
 import {
@@ -122,7 +123,7 @@ export class ProgressViewProvider
     this.webviewUpdater = new WebviewUpdater(() => [this.getActiveWebview()]);
     this.webviewBridge = new WebviewBridge(
       this.state.streamLogs,
-      () => [this.getActiveWebview()],
+      (message) => this.sendToActiveProgressWebview(message),
       () => this.state.activeStream || null,
     );
 
@@ -700,6 +701,18 @@ export class ProgressViewProvider
     if (this._mainViewProvider?.getActiveMode() !== 'progress')
       return undefined;
     return this._sidebarWebviewGetter?.();
+  }
+
+  private async sendToActiveProgressWebview(
+    message: ProgressViewOutboundMessage,
+  ): Promise<boolean> {
+    const webview = this.getActiveWebview();
+    if (!webview) return false;
+    try {
+      return await webview.postMessage(message);
+    } catch {
+      return false;
+    }
   }
 
   private isViewActiveTarget(

--- a/packages/extension/src/progressView/events/ProgressEventHandler.ts
+++ b/packages/extension/src/progressView/events/ProgressEventHandler.ts
@@ -8,7 +8,6 @@ import { isInFlightStatus } from '@common/constants/streamStatus';
 import { bus } from '@eventBus/ProgressEventBus';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
-import { WebviewBridge } from '@progressView/managers/WebviewBridge';
 import {
   WebviewUpdater,
   type LogContentExtras,
@@ -28,6 +27,7 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
+import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
 import { OdysseyStore, isOdysseyInFlight } from '@tools/odyssey';
 import {
   isApprovalBypassedForStream,

--- a/packages/extension/src/progressView/managers/index.ts
+++ b/packages/extension/src/progressView/managers/index.ts
@@ -1,4 +1,3 @@
 export { ApprovalRequestHandler } from './ApprovalRequestHandler';
 export { ProgressStreamLifecycleHost } from './ProgressStreamLifecycleHost';
-export { WebviewBridge } from './WebviewBridge';
 export { WebviewUpdater } from './WebviewUpdater';

--- a/src/shared/progressView/backend/WebviewBridge.ts
+++ b/src/shared/progressView/backend/WebviewBridge.ts
@@ -1,19 +1,40 @@
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import type { StreamTabId } from '@shared/schemas';
-import type { StreamLogStore } from '@transcript';
-import type * as vscode from 'vscode';
+import type {
+  ProgressViewOutboundMessage,
+  StreamLogEntry,
+  StreamTabId,
+} from '@shared/schemas';
 
 const FRAME_INTERVAL_MS = 16;
+
+export type ProgressViewMessageSender = (
+  message: ProgressViewOutboundMessage,
+) => boolean | Promise<boolean>;
+
+export interface ProgressLogSource {
+  readonly head: number;
+  getRange(fromSeq: number, toSeq: number): StreamLogEntry[];
+  getDirtyUpdates(maxSeqInclusive: number): StreamLogEntry[];
+  ackDirtyUpdates(updates: readonly StreamLogEntry[]): void;
+}
+
+export interface ProgressLogStore {
+  onChange(listener: (streamId: StreamTabId) => void): () => void;
+  get(streamId: StreamTabId): ProgressLogSource | undefined;
+  clearDirtyUpdates(streamId: StreamTabId): void;
+}
 
 export class WebviewBridge {
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly changedStreams = new Set<StreamTabId>();
   private readonly cursors = new Map<StreamTabId, number>();
   private readonly unsubscribe: () => void;
+  private flushInProgress = false;
+  private flushRequested = false;
 
   constructor(
-    private readonly store: StreamLogStore,
-    private readonly getWebviews: () => (vscode.Webview | undefined)[],
+    private readonly store: ProgressLogStore,
+    private readonly sendMessage: ProgressViewMessageSender,
     private readonly getActiveStream: () => StreamTabId | null,
   ) {
     this.unsubscribe = this.store.onChange((streamId) => {
@@ -60,27 +81,42 @@ export class WebviewBridge {
   }
 
   private scheduleFlush(): void {
+    if (this.flushInProgress) {
+      this.flushRequested = true;
+      return;
+    }
     if (this.flushTimer) return;
     this.flushTimer = setTimeout(() => {
       this.flushTimer = null;
-      this.flush();
+      void this.runFlush();
     }, FRAME_INTERVAL_MS);
   }
 
-  private flush(): void {
-    const activeStream = this.getActiveStream();
-    if (!activeStream) return;
-    if (!this.changedStreams.has(activeStream)) return;
+  private async runFlush(): Promise<void> {
+    if (this.flushInProgress) {
+      this.flushRequested = true;
+      return;
+    }
+    this.flushInProgress = true;
+    const delivered = await this.flush();
+    this.flushInProgress = false;
+    if (delivered && this.flushRequested) {
+      this.flushRequested = false;
+      this.scheduleFlush();
+    } else if (!delivered) {
+      this.flushRequested = false;
+    }
+  }
 
-    const webviews = this.getWebviews().filter((wv): wv is vscode.Webview =>
-      Boolean(wv),
-    );
-    if (webviews.length === 0) return;
+  private async flush(): Promise<boolean> {
+    const activeStream = this.getActiveStream();
+    if (!activeStream) return true;
+    if (!this.changedStreams.has(activeStream)) return true;
 
     const log = this.store.get(activeStream);
     if (!log) {
       this.changedStreams.delete(activeStream);
-      return;
+      return true;
     }
 
     // `changedStreams` is a subset of `cursors`: onChange only enqueues a
@@ -89,12 +125,13 @@ export class WebviewBridge {
     // cursor here. The `?? 0` is therefore unreachable, kept only to satisfy
     // the type.
     const cursor = this.cursors.get(activeStream) ?? 0;
-    const entries = log.getRange(cursor, log.head);
-    const updates = log.drainDirtyUpdates(cursor);
+    const nextCursor = log.head;
+    const entries = log.getRange(cursor, nextCursor);
+    const updates = log.getDirtyUpdates(cursor);
 
     if (entries.length === 0 && updates.length === 0) {
       this.changedStreams.delete(activeStream);
-      return;
+      return true;
     }
 
     const payload = {
@@ -104,11 +141,25 @@ export class WebviewBridge {
       updates,
     } as const;
 
-    for (const webview of webviews) {
-      webview.postMessage(payload);
-    }
+    if (!(await this.deliver(payload))) return false;
 
-    this.cursors.set(activeStream, log.head);
-    this.changedStreams.delete(activeStream);
+    log.ackDirtyUpdates(updates);
+    this.cursors.set(activeStream, nextCursor);
+    if (this.flushRequested) {
+      this.changedStreams.add(activeStream);
+    } else {
+      this.changedStreams.delete(activeStream);
+    }
+    return true;
+  }
+
+  private async deliver(
+    message: ProgressViewOutboundMessage,
+  ): Promise<boolean> {
+    try {
+      return await this.sendMessage(message);
+    } catch {
+      return false;
+    }
   }
 }

--- a/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
@@ -17,7 +17,6 @@ vi.mock('vscode', () => ({
 
 // Local imports
 import { ProgressEventHandler } from '@progressView/events/ProgressEventHandler';
-import type { WebviewBridge } from '@progressView/managers/WebviewBridge';
 import type {
   SyncStreamContentPayload,
   WebviewUpdater,
@@ -25,6 +24,7 @@ import type {
 import type { MementoStorage } from '@progressView/persistence/PersistentMapManager';
 import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { Plan, TodoItem } from '@shared/schemas';
+import type { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
 
 class MemoryMementoStorage implements MementoStorage {
   private readonly values = new Map<string, unknown>();

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - common webview
 import { StreamLogStore, type StreamLogAppendInput } from '@transcript';
-import { WebviewBridge } from '@progressView/managers/WebviewBridge';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 
 // Local imports - progress view
@@ -15,6 +14,7 @@ import {
   STREAM_LOG_ENTRY_TYPES,
   type StreamTabId,
 } from '@shared/schemas';
+import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
 
 function logEntry(
   id: string,
@@ -31,6 +31,17 @@ function logEntry(
   };
 }
 
+function deferredBoolean(): {
+  promise: Promise<boolean>;
+  resolve: (value: boolean) => void;
+} {
+  let resolve!: (value: boolean) => void;
+  const promise = new Promise<boolean>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
 describe('WebviewBridge', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -40,18 +51,14 @@ describe('WebviewBridge', () => {
     vi.useFakeTimers();
     const store = new StreamLogStore();
     const activeStream = 'active' as StreamTabId;
-    const postMessage = vi.fn();
-    const bridge = new WebviewBridge(
-      store,
-      () => [{ postMessage } as never],
-      () => activeStream,
-    );
+    const sendMessage = vi.fn(() => true);
+    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
 
     bridge.syncStream(activeStream);
     store.append(activeStream, logEntry('active-1', 'active log', 100));
     await vi.advanceTimersByTimeAsync(20);
 
-    expect(postMessage).toHaveBeenCalledWith({
+    expect(sendMessage).toHaveBeenCalledWith({
       command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
       streamId: activeStream,
       entries: [
@@ -70,12 +77,8 @@ describe('WebviewBridge', () => {
     vi.useFakeTimers();
     const store = new StreamLogStore();
     let activeStream = 'active' as StreamTabId;
-    const postMessage = vi.fn();
-    const bridge = new WebviewBridge(
-      store,
-      () => [{ postMessage } as never],
-      () => activeStream,
-    );
+    const sendMessage = vi.fn(() => true);
+    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
 
     store.append(
       'inactive' as StreamTabId,
@@ -84,7 +87,7 @@ describe('WebviewBridge', () => {
     activeStream = 'inactive' as StreamTabId;
     await vi.advanceTimersByTimeAsync(20);
 
-    expect(postMessage).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
 
     bridge.dispose();
   });
@@ -93,12 +96,8 @@ describe('WebviewBridge', () => {
     vi.useFakeTimers();
     const store = new StreamLogStore();
     let activeStream = 'active' as StreamTabId;
-    const postMessage = vi.fn();
-    const bridge = new WebviewBridge(
-      store,
-      () => [{ postMessage } as never],
-      () => activeStream,
-    );
+    const sendMessage = vi.fn(() => true);
+    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
 
     store.append(
       'inactive' as StreamTabId,
@@ -109,7 +108,7 @@ describe('WebviewBridge', () => {
     bridge.syncStream(activeStream);
     await vi.advanceTimersByTimeAsync(20);
 
-    expect(postMessage).toHaveBeenCalledWith({
+    expect(sendMessage).toHaveBeenCalledWith({
       command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
       streamId: activeStream,
       entries: [
@@ -119,6 +118,92 @@ describe('WebviewBridge', () => {
         }),
       ],
       updates: [],
+    });
+
+    bridge.dispose();
+  });
+
+  it('keeps the cursor and dirty updates when no target accepts a log delta', async () => {
+    vi.useFakeTimers();
+    const store = new StreamLogStore();
+    const activeStream = 'active' as StreamTabId;
+    const sendMessage = vi
+      .fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+
+    bridge.syncStream(activeStream);
+    store.append(activeStream, logEntry('active-1', 'active log', 100));
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    store.update(activeStream, 'active-1', { text: 'edited log' });
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+
+    store.append(activeStream, logEntry('active-2', 'retry trigger', 200));
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenLastCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId: activeStream,
+      entries: [
+        expect.objectContaining({
+          id: 'active-2',
+          text: 'retry trigger',
+        }),
+      ],
+      updates: [
+        expect.objectContaining({
+          id: 'active-1',
+          text: 'edited log',
+        }),
+      ],
+    });
+
+    bridge.dispose();
+  });
+
+  it('serializes async flushes and preserves updates made during delivery', async () => {
+    vi.useFakeTimers();
+    const store = new StreamLogStore();
+    const activeStream = 'active' as StreamTabId;
+    const firstDelivery = deferredBoolean();
+    const sendMessage = vi
+      .fn()
+      .mockReturnValueOnce(firstDelivery.promise)
+      .mockResolvedValue(true);
+    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+
+    bridge.syncStream(activeStream);
+    store.append(activeStream, logEntry('active-1', 'active log', 100));
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    store.update(activeStream, 'active-1', { text: 'edited while sending' });
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    firstDelivery.resolve(true);
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenLastCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId: activeStream,
+      entries: [],
+      updates: [
+        expect.objectContaining({
+          id: 'active-1',
+          text: 'edited while sending',
+        }),
+      ],
     });
 
     bridge.dispose();

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -50,10 +50,15 @@ describe('StreamLog', () => {
     });
     expect(log.hasRunningGroup).toBe(false);
 
+    expect(log.getDirtyUpdates().map((entry) => entry.id)).toEqual([
+      'run',
+      'message-2500',
+    ]);
     expect(log.drainDirtyUpdates().map((entry) => entry.id)).toEqual([
       'run',
       'message-2500',
     ]);
+    expect(log.getDirtyUpdates()).toEqual([]);
   });
 
   it('does not mark no-op updates dirty', () => {

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -121,9 +121,7 @@ export class StreamLog {
     return this.entries.slice(safeFrom, safeTo);
   }
 
-  drainDirtyUpdates(
-    maxSeqInclusive: number = this.seqCounter,
-  ): StreamLogEntry[] {
+  getDirtyUpdates(maxSeqInclusive: number = this.seqCounter): StreamLogEntry[] {
     const updates: StreamLogEntry[] = [];
     for (const id of this.dirtyUpdates) {
       const index = this.indexById.get(id);
@@ -134,15 +132,44 @@ export class StreamLog {
       const entry = this.entries[index];
       if (entry.seqNo <= maxSeqInclusive) {
         updates.push(entry);
-        this.dirtyUpdates.delete(id);
       }
     }
     updates.sort((a, b) => a.seqNo - b.seqNo);
     return updates;
   }
 
-  clearDirtyUpdates(): void {
-    this.dirtyUpdates.clear();
+  drainDirtyUpdates(
+    maxSeqInclusive: number = this.seqCounter,
+  ): StreamLogEntry[] {
+    const updates = this.getDirtyUpdates(maxSeqInclusive);
+    this.ackDirtyUpdates(updates);
+    return updates;
+  }
+
+  clearDirtyUpdates(maxSeqInclusive: number = this.seqCounter): void {
+    for (const id of this.dirtyUpdates) {
+      const index = this.indexById.get(id);
+      if (index === undefined) {
+        this.dirtyUpdates.delete(id);
+        continue;
+      }
+      if (this.entries[index].seqNo <= maxSeqInclusive) {
+        this.dirtyUpdates.delete(id);
+      }
+    }
+  }
+
+  ackDirtyUpdates(updates: readonly StreamLogEntry[]): void {
+    for (const update of updates) {
+      const index = this.indexById.get(update.id);
+      if (index === undefined) {
+        this.dirtyUpdates.delete(update.id);
+        continue;
+      }
+      if (this.entries[index] === update) {
+        this.dirtyUpdates.delete(update.id);
+      }
+    }
   }
 
   toJSON(): StreamLogEntry[] {


### PR DESCRIPTION
## Summary

Part of #5451 P2.

- Relocate WebviewBridge from the extension manager folder into src/shared/progressView/backend.
- Replace its vscode.Webview dependency with an async-aware ProgressViewMessageSender.
- Define the minimal ProgressLogStore and ProgressLogSource protocol the bridge actually needs, so the shared backend does not depend on transcript storage internals.
- Split StreamLog dirty-update handling into peek and exact acknowledgment operations, so the bridge clears only the update objects that were actually delivered.
- Serialize async bridge flushes so overlapping postMessage calls cannot read or write the same cursor out of order.
- Keep extension behavior equivalent by wiring the active progress webview through ProgressViewProvider.sendToActiveProgressWebview and returning the actual postMessage result.
- Add coverage for failed sends, dirty-update preservation, and updates that arrive while delivery is pending.

## Validation

- corepack pnpm vitest run src/test-kernel/progressView/WebviewBridge.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts src/test-kernel/transcript/StreamLog.vitest.ts
- corepack pnpm exec eslint src/transcript/StreamLog.ts src/test-kernel/transcript/StreamLog.vitest.ts src/shared/progressView/backend/WebviewBridge.ts packages/extension/src/progressView/ProgressViewProvider.ts src/test-kernel/progressView/WebviewBridge.vitest.ts
- npm run typecheck
- npm run compile:fast
- npm run lint, passing with the existing import-order warnings outside this patch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot path for streaming progress logs to the webview; behavior changes only on delivery failure or concurrent flushes, but incorrect cursor/ack logic could cause missing or duplicate log lines in the UI.
> 
> **Overview**
> Moves **`WebviewBridge`** into `src/shared/progressView/backend` and decouples it from VS Code by injecting an async **`ProgressViewMessageSender`** instead of posting to `vscode.Webview` instances. The bridge depends on narrow **`ProgressLogStore` / `ProgressLogSource`** interfaces rather than transcript internals.
> 
> **`StreamLog`** gains **`getDirtyUpdates`** (peek) and **`ackDirtyUpdates`** (commit after delivery); **`drainDirtyUpdates`** composes those. The bridge only advances its cursor and clears dirty state when **`sendMessage`** succeeds, and **serializes** overlapping flushes so concurrent **`postMessage`** work cannot reorder cursor updates.
> 
> The extension wires delivery through **`ProgressViewProvider.sendToActiveProgressWebview`**, which targets the active progress webview and surfaces the real **`postMessage`** result. Tests cover failed sends, dirty-update retention, and edits during in-flight delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef7c4920af320626d25be60e8713d9c9a045d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->