### PR TITLE
refactor: share progress webview updater

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -17,7 +17,6 @@ import { createChannelTrace } from '@logger';
 import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import { ApprovalRequestHandler } from '@progressView/managers/ApprovalRequestHandler';
-import { WebviewUpdater } from '@progressView/managers/WebviewUpdater';
 import type {
   AgentProposalPermission,
   BashPermission,
@@ -30,6 +29,7 @@ import type {
   ToolEditPermission,
 } from '@shared/schemas';
 import { AGENT_CATEGORY } from '@shared/schemas';
+import { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
 import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
@@ -121,7 +121,10 @@ export class ProgressViewProvider
     this.logger = createChannelTrace('ProgressViewProvider');
 
     this.state = new ProgressViewState(workspaceSM);
-    this.webviewUpdater = new WebviewUpdater(() => [this.getActiveWebview()]);
+    this.webviewUpdater = new WebviewUpdater(
+      (message) => void this.sendToActiveProgressWebview(message),
+      () => this.getActiveWebview() !== undefined,
+    );
     this.webviewBridge = new WebviewBridge(
       this.state.streamLogs,
       (message) => this.sendToActiveProgressWebview(message),

--- a/packages/extension/src/progressView/events/EventHandlerContext.ts
+++ b/packages/extension/src/progressView/events/EventHandlerContext.ts
@@ -12,7 +12,7 @@
  * This avoids wasted serialization + frontend state churn for non-visible streams.
  */
 
-import type { WebviewUpdater } from '@progressView/managers/WebviewUpdater';
+import type { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
 import type { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
 
 export interface EventHandlerContext {

--- a/packages/extension/src/progressView/events/ProgressEventHandler.ts
+++ b/packages/extension/src/progressView/events/ProgressEventHandler.ts
@@ -9,10 +9,6 @@ import { bus } from '@eventBus/ProgressEventBus';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import {
-  WebviewUpdater,
-  type LogContentExtras,
-} from '@progressView/managers/WebviewUpdater';
-import {
   STREAM_STATUS,
   type ConversationProgress,
   type StorageKey,
@@ -20,6 +16,10 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
+import {
+  WebviewUpdater,
+  type LogContentExtras,
+} from '@shared/progressView/backend/WebviewUpdater';
 import { mapToRecord } from '@shared/progressView/backend/persistence/serializationUtils';
 import {
   ProgressViewState,

--- a/packages/extension/src/progressView/managers/index.ts
+++ b/packages/extension/src/progressView/managers/index.ts
@@ -1,3 +1,2 @@
 export { ApprovalRequestHandler } from './ApprovalRequestHandler';
 export { ProgressStreamLifecycleHost } from './ProgressStreamLifecycleHost';
-export { WebviewUpdater } from './WebviewUpdater';

--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -1,5 +1,3 @@
-import * as vscode from 'vscode';
-
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   AgentCategoryFilter,
@@ -28,6 +26,10 @@ import {
 } from '@shared/progressView/backend/state/ProgressViewState';
 import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 import type { OdysseyStatus } from '@tools/odyssey';
+
+export type ProgressViewMessageSender = (
+  message: ProgressViewOutboundMessage,
+) => void;
 
 /**
  * Extra content to include with log updates.
@@ -87,18 +89,18 @@ export interface SyncStreamContentPayload {
  * Targets a single active webview at a time (sidebar OR editor panel).
  */
 export class WebviewUpdater {
-  constructor(private getWebviews: () => (vscode.Webview | undefined)[]) {}
+  constructor(
+    private readonly send: ProgressViewMessageSender,
+    private readonly hasTarget: () => boolean,
+  ) {}
 
   /**
    * Helper to send typed messages to the current active webview target.
    * Uses ProgressViewOutboundMessage union type for compile-time safety.
    */
   private sendMessage(message: ProgressViewOutboundMessage): void {
-    for (const webview of this.getWebviews()) {
-      if (webview) {
-        webview.postMessage(message);
-      }
-    }
+    if (!this.hasTarget()) return;
+    this.send(message);
   }
 
   /**
@@ -463,6 +465,6 @@ export class WebviewUpdater {
   }
 
   isAvailable(): boolean {
-    return this.getWebviews().some((w) => w !== undefined);
+    return this.hasTarget();
   }
 }

--- a/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
@@ -17,11 +17,11 @@ vi.mock('vscode', () => ({
 
 // Local imports
 import { ProgressEventHandler } from '@progressView/events/ProgressEventHandler';
+import type { Plan, TodoItem } from '@shared/schemas';
 import type {
   SyncStreamContentPayload,
   WebviewUpdater,
-} from '@progressView/managers/WebviewUpdater';
-import type { Plan, TodoItem } from '@shared/schemas';
+} from '@shared/progressView/backend/WebviewUpdater';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
 import type { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';


### PR DESCRIPTION
## Summary

P2c slice for #5451. This relocates `WebviewUpdater` into the shared progress backend after #5457 moved its state dependencies there.

- move `WebviewUpdater` to `src/shared/progressView/backend/WebviewUpdater.ts`
- replace its direct `vscode.Webview` constructor dependency with a host-provided `ProgressViewMessageSender` plus `hasTarget` predicate
- wire the extension provider to pass the active webview sender explicitly
- update event handler/test imports and remove the old manager barrel export

This keeps the update/message-building API intact and does not add pass-through adapters. `ProgressEventHandler` remains extension-local for the next P2 slice because it still owns `vscode.Disposable` lifecycle wiring.

## Validation

- `corepack pnpm vitest run src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts src/test-kernel/progressView/WebviewBridge.vitest.ts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings outside this slice remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only relocation with dependency injection; routing still goes through the same active-webview sender in ProgressViewProvider.
> 
> **Overview**
> Moves **`WebviewUpdater`** from the extension progress managers into **`src/shared/progressView/backend`**, so message-building logic can live alongside the shared progress backend without importing VS Code.
> 
> The updater no longer takes **`vscode.Webview`** instances. It now depends on a host-injected **`ProgressViewMessageSender`** and a **`hasTarget`** predicate; **`ProgressViewProvider`** wires those to **`sendToActiveProgressWebview`** and **`getActiveWebview()`**. Outbound IPC behavior and the public update API are unchanged; **`isAvailable()`** now reflects whether an active target exists.
> 
> Extension event handlers, **`EventHandlerContext`**, and the work-plan hydration test import the shared module. The managers barrel no longer re-exports **`WebviewUpdater`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97f0c72f0e035a196280b81bd633529386f99207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->