### PR TITLE
refactor: share progress lifecycle command handlers

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -1,3 +1,4 @@
+import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import {
   dispatchProgressViewInbound,
@@ -36,14 +37,13 @@ export function createDesktopProgressIpc(
   const progress = options.progress;
 
   const progressHandlers: ProgressViewInboundHandlerRegistry = {
-    [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: (d) =>
-      progress.setActiveStream(d.stream),
-    [PROGRESS_VIEW_COMMANDS.FILTER_STREAMS]: (d) =>
-      progress.setAgentFilter(d.filter),
-    [PROGRESS_VIEW_COMMANDS.DELETE_STREAM]: (d) =>
-      progress.deleteStream(d.stream),
-    [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: () => progress.deleteAllStreams(),
-    [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: (d) => progress.stopStream(d.stream),
+    ...createProgressViewLifecycleCommandHandlers({
+      setActiveStream: (stream) => progress.setActiveStream(stream),
+      setAgentFilter: (filter) => progress.setAgentFilter(filter),
+      deleteStream: (stream) => progress.deleteStream(stream),
+      deleteAllStreams: () => progress.deleteAllStreams(),
+      stopStream: (stream) => progress.stopStream(stream),
+    }),
     [PROGRESS_VIEW_COMMANDS.RESUME]: (d) => progress.resumeStream(d.stream),
     [PROGRESS_VIEW_COMMANDS.RUN_NEW]: (d) => progress.runNewStream(d.stream),
     [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]: (d) =>

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
 import { ProgressStreamLifecycleController } from '@controllers/progressView/ProgressStreamLifecycleController';
 import {
   ProgressFollowUpController,
@@ -175,13 +176,18 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.POP_BACK]: () => this.provider.popBackToSidebar(),
 
       // Stream management
-      [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: (data) =>
-        this.provider.setActiveStream(data.stream),
-      [PROGRESS_VIEW_COMMANDS.DELETE_STREAM]: (data) =>
-        this.handleDeleteStream(data),
-      [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
-      [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: (data) =>
-        this.streamLifecycleController.stopStream(data.stream),
+      ...createProgressViewLifecycleCommandHandlers({
+        setActiveStream: (stream) => this.provider.setActiveStream(stream),
+        setAgentFilter: (filter) => {
+          this.provider.state.agentCategoryFilter = filter;
+          this.provider.syncFullView();
+        },
+        deleteStream: (stream) =>
+          this.streamLifecycleController.deleteStream(stream),
+        deleteAllStreams: () => this.handleDeleteAll(),
+        stopStream: (stream) =>
+          this.streamLifecycleController.stopStream(stream),
+      }),
       [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: async (data) =>
         vscode.commands.executeCommand('texra.compactResponse', data.stream),
 
@@ -196,10 +202,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.workflowActionsController.runFileOperation(data.stream, 'pack'),
       [PROGRESS_VIEW_COMMANDS.CLEAN_STREAM]: (data) =>
         this.workflowActionsController.runFileOperation(data.stream, 'clean'),
-      [PROGRESS_VIEW_COMMANDS.FILTER_STREAMS]: (data) => {
-        this.provider.state.agentCategoryFilter = data.filter;
-        this.provider.syncFullView();
-      },
       [PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST]: (data) =>
         this.handleRetryStreamRequest(data),
       [PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST]: (data) => {

--- a/src/controllers/progressView/ProgressViewLifecycleCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewLifecycleCommandHandlers.ts
@@ -1,0 +1,28 @@
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type { AgentCategoryFilter, StreamTabId } from '@shared/schemas';
+import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
+
+export interface ProgressViewLifecycleCommandActions {
+  setActiveStream(stream: StreamTabId): Promise<void> | void;
+  setAgentFilter(filter: AgentCategoryFilter): Promise<void> | void;
+  deleteStream(stream: StreamTabId): Promise<void> | void;
+  deleteAllStreams(): Promise<void> | void;
+  stopStream(stream: StreamTabId): Promise<void> | void;
+}
+
+export function createProgressViewLifecycleCommandHandlers(
+  actions: ProgressViewLifecycleCommandActions,
+): ProgressViewInboundHandlerRegistry {
+  return {
+    [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: (data) =>
+      actions.setActiveStream(data.stream),
+    [PROGRESS_VIEW_COMMANDS.FILTER_STREAMS]: (data) =>
+      actions.setAgentFilter(data.filter),
+    [PROGRESS_VIEW_COMMANDS.DELETE_STREAM]: (data) =>
+      actions.deleteStream(data.stream),
+    [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: () => actions.deleteAllStreams(),
+    [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: (data) =>
+      actions.stopStream(data.stream),
+  };
+}

--- a/src/test-kernel/controllers/ProgressViewLifecycleCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewLifecycleCommandHandlers.vitest.ts
@@ -1,0 +1,58 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { dispatchProgressViewInbound } from '@shared/schemas/progressView';
+
+describe('createProgressViewLifecycleCommandHandlers', () => {
+  it('routes progress lifecycle commands to host actions', () => {
+    const actions = {
+      setActiveStream: vi.fn(),
+      setAgentFilter: vi.fn(),
+      deleteStream: vi.fn(),
+      deleteAllStreams: vi.fn(),
+      stopStream: vi.fn(),
+    };
+    const handlers = createProgressViewLifecycleCommandHandlers(actions);
+
+    expect(
+      dispatchProgressViewInbound(
+        { command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, stream: 'stream-a' },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        { command: PROGRESS_VIEW_COMMANDS.FILTER_STREAMS, filter: 'all' },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        { command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM, stream: 'stream-b' },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        { command: PROGRESS_VIEW_COMMANDS.DELETE_ALL },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        { command: PROGRESS_VIEW_COMMANDS.STOP_STREAM, stream: 'stream-c' },
+        handlers,
+      ),
+    ).toBe(true);
+
+    expect(actions.setActiveStream).toHaveBeenCalledWith('stream-a');
+    expect(actions.setAgentFilter).toHaveBeenCalledWith('all');
+    expect(actions.deleteStream).toHaveBeenCalledWith('stream-b');
+    expect(actions.deleteAllStreams).toHaveBeenCalledWith();
+    expect(actions.stopStream).toHaveBeenCalledWith('stream-c');
+    expect(handlers[PROGRESS_VIEW_COMMANDS.RESUME]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a host-neutral lifecycle command handler builder for progress-view inbound commands
- Use it from both the VS Code extension progress message handler and the desktop progress IPC handler
- Cover the shared mapping with a focused controller test

This is #5451 P3a. It intentionally only shares the lifecycle command group (`SWITCH_STREAM`, `FILTER_STREAMS`, `DELETE_STREAM`, `DELETE_ALL`, `STOP_STREAM`) and leaves host-specific commands in the host adapters.

## Validation
- `corepack pnpm vitest run src/test-kernel/controllers/ProgressViewLifecycleCommandHandlers.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain)

Part of #5451.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with behavior preserved via the same underlying host callbacks; scope is limited to five lifecycle commands and covered by a new routing test.
> 
> **Overview**
> Introduces **`createProgressViewLifecycleCommandHandlers`**, a shared factory that maps five progress-view inbound commands (`SWITCH_STREAM`, `FILTER_STREAMS`, `DELETE_STREAM`, `DELETE_ALL`, `STOP_STREAM`) to host-supplied actions.
> 
> **Desktop** (`desktopProgressIpc`) and the **VS Code extension** (`ProgressViewMessageHandler`) now spread that factory into their handler registries instead of duplicating the same command→callback wiring. Host-specific behavior stays in each adapter (e.g. extension still applies filter via provider state + `syncFullView`, delete-all confirmation, lifecycle controller for stop/delete).
> 
> Adds a **vitest** that dispatches each lifecycle command through `dispatchProgressViewInbound` and asserts the injected actions are called (and that unrelated commands like `RESUME` are not registered).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 601b2ebe3e28f690d9c8a090232ce9f9ea76ea50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->