### PR TITLE
refactor: share progress run command handlers

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -1,4 +1,5 @@
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
+import { createProgressViewRunCommandHandlers } from '@controllers/progressView/ProgressViewRunCommandHandlers';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import {
   dispatchProgressViewInbound,
@@ -44,8 +45,10 @@ export function createDesktopProgressIpc(
       deleteAllStreams: () => progress.deleteAllStreams(),
       stopStream: (stream) => progress.stopStream(stream),
     }),
-    [PROGRESS_VIEW_COMMANDS.RESUME]: (d) => progress.resumeStream(d.stream),
-    [PROGRESS_VIEW_COMMANDS.RUN_NEW]: (d) => progress.runNewStream(d.stream),
+    ...createProgressViewRunCommandHandlers({
+      resumeStream: (stream) => progress.resumeStream(stream),
+      runNewStream: (stream) => progress.runNewStream(stream),
+    }),
     [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]: (d) =>
       progress.sendFollowUp(d.stream, d.text),
     [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (d) => {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
+import { createProgressViewRunCommandHandlers } from '@controllers/progressView/ProgressViewRunCommandHandlers';
 import { ProgressStreamLifecycleController } from '@controllers/progressView/ProgressStreamLifecycleController';
 import {
   ProgressFollowUpController,
@@ -192,10 +193,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         vscode.commands.executeCommand('texra.compactResponse', data.stream),
 
       // Actions
-      [PROGRESS_VIEW_COMMANDS.RESUME]: (data) =>
-        this.workflowActionsController.resume(data.stream),
-      [PROGRESS_VIEW_COMMANDS.RUN_NEW]: (data) =>
-        this.workflowActionsController.runNew(data.stream),
+      ...createProgressViewRunCommandHandlers({
+        resumeStream: (stream) => this.workflowActionsController.resume(stream),
+        runNewStream: (stream) => this.workflowActionsController.runNew(stream),
+      }),
       [PROGRESS_VIEW_COMMANDS.DIFF_STREAM]: (data) =>
         this.workflowActionsController.diffStream(data.stream),
       [PROGRESS_VIEW_COMMANDS.PACK_STREAM]: (data) =>

--- a/src/controllers/progressView/ProgressViewRunCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewRunCommandHandlers.ts
@@ -1,0 +1,20 @@
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type { StreamTabId } from '@shared/schemas';
+import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
+
+export interface ProgressViewRunCommandActions {
+  resumeStream(stream: StreamTabId): Promise<void> | void;
+  runNewStream(stream: StreamTabId): Promise<void> | void;
+}
+
+export function createProgressViewRunCommandHandlers(
+  actions: ProgressViewRunCommandActions,
+): ProgressViewInboundHandlerRegistry {
+  return {
+    [PROGRESS_VIEW_COMMANDS.RESUME]: (data) =>
+      actions.resumeStream(data.stream),
+    [PROGRESS_VIEW_COMMANDS.RUN_NEW]: (data) =>
+      actions.runNewStream(data.stream),
+  };
+}

--- a/src/test-kernel/controllers/ProgressViewRunCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewRunCommandHandlers.vitest.ts
@@ -1,0 +1,34 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { createProgressViewRunCommandHandlers } from '@controllers/progressView/ProgressViewRunCommandHandlers';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { dispatchProgressViewInbound } from '@shared/schemas/progressView';
+
+describe('createProgressViewRunCommandHandlers', () => {
+  it('routes run-control commands to host actions', () => {
+    const actions = {
+      resumeStream: vi.fn(),
+      runNewStream: vi.fn(),
+    };
+    const handlers = createProgressViewRunCommandHandlers(actions);
+
+    expect(
+      dispatchProgressViewInbound(
+        { command: PROGRESS_VIEW_COMMANDS.RESUME, stream: 'stream-a' },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        { command: PROGRESS_VIEW_COMMANDS.RUN_NEW, stream: 'stream-b' },
+        handlers,
+      ),
+    ).toBe(true);
+
+    expect(actions.resumeStream).toHaveBeenCalledWith('stream-a');
+    expect(actions.runNewStream).toHaveBeenCalledWith('stream-b');
+    expect(handlers[PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a host-neutral run-control command handler builder for progress-view inbound commands
- Use it from both the VS Code extension progress message handler and desktop progress IPC handler
- Cover the shared mapping with a focused controller test

This is #5451 P3b. It intentionally only shares the run-control command group (`RESUME`, `RUN_NEW`) and leaves follow-up/file/action commands in later focused slices.

## Validation
- `corepack pnpm vitest run src/test-kernel/controllers/ProgressViewRunCommandHandlers.vitest.ts src/test-kernel/controllers/ProgressViewLifecycleCommandHandlers.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain)

Part of #5451.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only wiring with no behavior change; scope is limited to two run-control commands and covered by a unit test.
> 
> **Overview**
> Introduces **`createProgressViewRunCommandHandlers`**, a shared builder that maps progress-view inbound commands **`RESUME`** and **`RUN_NEW`** to host-injected `resumeStream` / `runNewStream` actions.
> 
> **Desktop** (`desktopProgressIpc`) and the **VS Code extension** (`ProgressViewMessageHandler`) replace inline handler entries with this factory, wiring their existing progress bridge or `ProgressWorkflowActionsController` respectively. Other command groups (follow-up, file ops, approvals) are unchanged in this slice.
> 
> Adds a focused vitest that dispatches both commands through `dispatchProgressViewInbound` and asserts the injected actions are called.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c792d78781a68874a58ccbd4e4fbe4a11efaeef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->