### PR TITLE
refactor: share progress follow-up command handler

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1139,8 +1139,12 @@ export class DesktopProgressBridge {
     await this.runExecution({ config: taskState.agentConfig });
   }
 
-  async sendFollowUp(streamId: StreamTabId, text: string): Promise<void> {
-    const result = await sendFollowUp(streamId, text);
+  async sendFollowUp(
+    streamId: StreamTabId,
+    text: string,
+    mediaFiles?: readonly string[],
+  ): Promise<void> {
+    const result = await sendFollowUp(streamId, text, mediaFiles);
     if (result.status === 'sent' || result.status === 'queued') {
       this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
       return;

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -1,3 +1,4 @@
+import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
 import { createProgressViewRunCommandHandlers } from '@controllers/progressView/ProgressViewRunCommandHandlers';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
@@ -49,8 +50,11 @@ export function createDesktopProgressIpc(
       resumeStream: (stream) => progress.resumeStream(stream),
       runNewStream: (stream) => progress.runNewStream(stream),
     }),
-    [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]: (d) =>
-      progress.sendFollowUp(d.stream, d.text),
+    ...createProgressViewFollowUpCommandHandlers({
+      sendFollowUp: ({ stream, text, mediaFiles }) =>
+        progress.sendFollowUp(stream, text, mediaFiles),
+      reportImageSaveError: (_image, error) => reportAsyncError(error),
+    }),
     [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (d) => {
       if (!progress.handleToolEditApprovalAction(d)) onUnsupportedCommand(d);
     },

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
 import { createProgressViewRunCommandHandlers } from '@controllers/progressView/ProgressViewRunCommandHandlers';
 import { ProgressStreamLifecycleController } from '@controllers/progressView/ProgressStreamLifecycleController';
@@ -58,7 +59,6 @@ import {
   pathToLocation,
   WorkspaceFS,
 } from '@utils/files';
-import { savePastedImageBase64 } from '@utils/files/pastedImageUtils';
 import {
   buildFileContextFromTaskState,
   polishTextWithAI,
@@ -218,31 +218,23 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           await vscode.commands.executeCommand('texra.restoreState', taskState);
         }
       },
-      [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]: async (data) => {
-        // Persist any pasted follow-up images to the shared `pasted/` dir (the
-        // same path the main webview uses) and forward their file paths so they
-        // reach the model on this follow-up turn via addMediaToUserMessage.
-        const mediaFiles: string[] = [];
-        for (const img of data.images ?? []) {
-          try {
-            mediaFiles.push(
-              await savePastedImageBase64(img.base64, img.fileName),
-            );
-          } catch (err) {
-            // Best-effort: a failed image save must not block the text, but log
-            // it so a missing attachment is diagnosable.
-            this.logger.warn(
-              this.channel,
-              `Failed to save pasted follow-up image: ${toErrorMessage(err)}`,
-            );
-          }
-        }
-        await vscode.commands.executeCommand('texra.sendFollowUp', {
-          stream: data.stream,
-          text: data.text,
-          ...(mediaFiles.length > 0 ? { mediaFiles } : {}),
-        });
-      },
+      ...createProgressViewFollowUpCommandHandlers({
+        sendFollowUp: async ({ stream, text, mediaFiles }) => {
+          await vscode.commands.executeCommand('texra.sendFollowUp', {
+            stream,
+            text,
+            ...(mediaFiles && mediaFiles.length > 0 ? { mediaFiles } : {}),
+          });
+        },
+        reportImageSaveError: (_image, error) => {
+          // Best-effort: a failed image save must not block the text, but log
+          // it so a missing attachment is diagnosable.
+          this.logger.warn(
+            this.channel,
+            `Failed to save pasted follow-up image: ${toErrorMessage(error)}`,
+          );
+        },
+      }),
       [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]: (data) =>
         this.workflowFileActionsController.openTaskStorage(data.stream),
       [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]: (data) =>

--- a/src/controllers/progressView/ProgressViewFollowUpCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewFollowUpCommandHandlers.ts
@@ -1,0 +1,67 @@
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type { StreamTabId } from '@shared/schemas';
+import type {
+  ProgressViewInboundHandlerRegistry,
+  ProgressViewInboundMessage,
+} from '@shared/schemas/progressView';
+
+// Local imports - utilities
+import { savePastedImageBase64 } from '@utils/files/pastedImageUtils';
+
+type SendFollowUpMessage = Extract<
+  ProgressViewInboundMessage,
+  { command: typeof PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP }
+>;
+
+export type ProgressViewFollowUpImage = NonNullable<
+  SendFollowUpMessage['images']
+>[number];
+
+export interface ProgressViewFollowUpSubmission {
+  stream: StreamTabId;
+  text: string;
+  mediaFiles?: readonly string[];
+}
+
+export interface ProgressViewFollowUpCommandActions {
+  sendFollowUp(
+    submission: ProgressViewFollowUpSubmission,
+  ): Promise<void> | void;
+  reportImageSaveError(image: ProgressViewFollowUpImage, error: unknown): void;
+}
+
+export function createProgressViewFollowUpCommandHandlers(
+  actions: ProgressViewFollowUpCommandActions,
+): ProgressViewInboundHandlerRegistry {
+  return {
+    [PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]: async (data) => {
+      const mediaFiles = await saveFollowUpImages(
+        data.images ?? [],
+        actions.reportImageSaveError,
+      );
+      await actions.sendFollowUp({
+        stream: data.stream,
+        text: data.text,
+        ...(mediaFiles.length > 0 ? { mediaFiles } : {}),
+      });
+    },
+  };
+}
+
+async function saveFollowUpImages(
+  images: readonly ProgressViewFollowUpImage[],
+  reportImageSaveError: ProgressViewFollowUpCommandActions['reportImageSaveError'],
+): Promise<string[]> {
+  const mediaFiles: string[] = [];
+  for (const image of images) {
+    try {
+      mediaFiles.push(
+        await savePastedImageBase64(image.base64, image.fileName),
+      );
+    } catch (error) {
+      reportImageSaveError(image, error);
+    }
+  }
+  return mediaFiles;
+}

--- a/src/test-kernel/controllers/ProgressViewFollowUpCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewFollowUpCommandHandlers.vitest.ts
@@ -1,0 +1,113 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  ProgressViewInboundMessageSchema,
+  type ProgressViewInboundMessage,
+} from '@shared/schemas/progressView';
+import { savePastedImageBase64 } from '@utils/files/pastedImageUtils';
+
+vi.mock('@utils/files/pastedImageUtils', () => ({
+  savePastedImageBase64: vi.fn(),
+}));
+
+const savePastedImageBase64Mock = vi.mocked(savePastedImageBase64);
+
+type SendFollowUpMessage = Extract<
+  ProgressViewInboundMessage,
+  { command: typeof PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP }
+>;
+
+function parseSendFollowUpMessage(message: unknown): SendFollowUpMessage {
+  const parsed = ProgressViewInboundMessageSchema.parse(message);
+  if (parsed.command !== PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP) {
+    throw new Error(`Expected SEND_FOLLOW_UP, got ${parsed.command}`);
+  }
+  return parsed;
+}
+
+describe('createProgressViewFollowUpCommandHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes text-only follow-ups to the host action', async () => {
+    const actions = {
+      sendFollowUp: vi.fn(),
+      reportImageSaveError: vi.fn(),
+    };
+    const handlers = createProgressViewFollowUpCommandHandlers(actions);
+
+    await handlers[PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]?.(
+      parseSendFollowUpMessage({
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        stream: 'stream-a',
+        text: 'continue',
+      }),
+    );
+
+    expect(savePastedImageBase64Mock).not.toHaveBeenCalled();
+    expect(actions.reportImageSaveError).not.toHaveBeenCalled();
+    expect(actions.sendFollowUp).toHaveBeenCalledWith({
+      stream: 'stream-a',
+      text: 'continue',
+    });
+  });
+
+  it('persists follow-up images and keeps sending text after an image save fails', async () => {
+    const failedImageError = new Error('bad image');
+    savePastedImageBase64Mock
+      .mockResolvedValueOnce('/tmp/pasted/a.png')
+      .mockRejectedValueOnce(failedImageError);
+
+    const actions = {
+      sendFollowUp: vi.fn(),
+      reportImageSaveError: vi.fn(),
+    };
+    const handlers = createProgressViewFollowUpCommandHandlers(actions);
+    const failedImage = {
+      base64: 'broken',
+      mediaType: 'image/png',
+      fileName: 'pasted_2.png',
+    };
+
+    await handlers[PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP]?.(
+      parseSendFollowUpMessage({
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        stream: 'stream-a',
+        text: 'look at these',
+        images: [
+          {
+            base64: 'ok',
+            mediaType: 'image/png',
+            fileName: 'pasted_1.png',
+          },
+          failedImage,
+        ],
+      }),
+    );
+
+    expect(savePastedImageBase64Mock).toHaveBeenNthCalledWith(
+      1,
+      'ok',
+      'pasted_1.png',
+    );
+    expect(savePastedImageBase64Mock).toHaveBeenNthCalledWith(
+      2,
+      'broken',
+      'pasted_2.png',
+    );
+    expect(actions.reportImageSaveError).toHaveBeenCalledWith(
+      failedImage,
+      failedImageError,
+    );
+    expect(actions.sendFollowUp).toHaveBeenCalledWith({
+      stream: 'stream-a',
+      text: 'look at these',
+      mediaFiles: ['/tmp/pasted/a.png'],
+    });
+  });
+});

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -18,7 +18,11 @@ interface DesktopProgressIpcModule {
       stopStream(stream: string): void;
       resumeStream(stream: string): Promise<void>;
       runNewStream(stream: string): Promise<void>;
-      sendFollowUp(stream: string, text: string): Promise<void>;
+      sendFollowUp(
+        stream: string,
+        text: string,
+        mediaFiles?: readonly string[],
+      ): Promise<void>;
       openFile(file: string, line?: number): Promise<void>;
       openFileCompile(file: string): Promise<void>;
       openTaskStorage(stream: string): Promise<void>;
@@ -85,7 +89,13 @@ function createProgress() {
     stopStream: vi.fn(),
     resumeStream: vi.fn(async (_stream: string) => {}),
     runNewStream: vi.fn(async (_stream: string) => {}),
-    sendFollowUp: vi.fn(async (_stream: string, _text: string) => {}),
+    sendFollowUp: vi.fn(
+      async (
+        _stream: string,
+        _text: string,
+        _mediaFiles?: readonly string[],
+      ) => {},
+    ),
     openFile: vi.fn(async (_file: string, _line?: number) => {}),
     openFileCompile: vi.fn(async (_file: string) => {}),
     openTaskStorage: vi.fn(async (_stream: string) => {}),
@@ -328,12 +338,54 @@ describe('desktop Progress IPC', () => {
     await Promise.resolve();
     expect(progress.resumeStream).toHaveBeenCalledWith('run-1');
     expect(progress.runNewStream).toHaveBeenCalledWith('run-1');
-    expect(progress.sendFollowUp).toHaveBeenCalledWith(
+    expect(progress.sendFollowUp.mock.calls[0]?.slice(0, 2)).toEqual([
       'run-1',
       'continue please',
-    );
+    ]);
     expect(progress.openFile).toHaveBeenCalledWith('/tmp/out.tex', 4);
     expect(progress.openFileCompile).toHaveBeenCalledWith('/tmp/out.pdf');
+  });
+
+  it('passes pasted follow-up images through the desktop bridge', async () => {
+    vi.doMock('@utils/files/pastedImageUtils', () => ({
+      savePastedImageBase64: vi.fn(async () => '/tmp/pasted/fig.png'),
+    }));
+    try {
+      const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+      const { savePastedImageBase64 } =
+        await import('@utils/files/pastedImageUtils');
+      const progress = createProgress();
+      const ipc = createDesktopProgressIpc({ progress });
+
+      expect(
+        ipc.handleMessage({
+          command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+          stream: 'run-1',
+          text: 'look at this figure',
+          images: [
+            {
+              base64: 'encoded',
+              mediaType: 'image/png',
+              fileName: 'pasted_1.png',
+            },
+          ],
+        }),
+      ).toBe(true);
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(savePastedImageBase64).toHaveBeenCalledWith(
+        'encoded',
+        'pasted_1.png',
+      );
+      expect(progress.sendFollowUp).toHaveBeenCalledWith(
+        'run-1',
+        'look at this figure',
+        ['/tmp/pasted/fig.png'],
+      );
+    } finally {
+      vi.doUnmock('@utils/files/pastedImageUtils');
+    }
   });
 
   it('maps approval actions and reports desktop-only unsupported approval variants', async () => {


### PR DESCRIPTION
## Summary
- Add a shared progress-view `SEND_FOLLOW_UP` handler for extension and desktop
- Move pasted follow-up image persistence into the shared handler so hosts submit semantic follow-up requests
- Pass optional media files through the desktop progress bridge instead of dropping pasted follow-up images

This is #5451 P3c. It keeps the slice to one command group and leaves approval/file/action command groups for later PRs.

## Validation
- `corepack pnpm vitest run src/test-kernel/controllers/ProgressViewFollowUpCommandHandlers.vitest.ts src/test-kernel/controllers/ProgressViewRunCommandHandlers.vitest.ts src/test-kernel/controllers/ProgressViewLifecycleCommandHandlers.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain)

Part of #5451.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior parity for extension and a targeted desktop fix for follow-up attachments; covered by new unit/integration-style tests.
> 
> **Overview**
> Introduces **`createProgressViewFollowUpCommandHandlers`** so extension and desktop share one **`SEND_FOLLOW_UP`** path: pasted images are saved to disk via `savePastedImageBase64`, failures are reported through a host callback without blocking the text, and hosts receive a semantic `{ stream, text, mediaFiles? }` submission.
> 
> **Extension** and **desktop IPC** replace inline follow-up handling with this factory; desktop **`sendFollowUp`** now accepts optional **`mediaFiles`** and forwards them to the agent **`sendFollowUp`** (fixing dropped pasted images on desktop). Unit tests cover the shared handler and the desktop bridge image flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd5852b56b1ef6bbfda05bdefef4295d9ed1a0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->