### PR TITLE
refactor: share progress file command handlers

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -1,3 +1,4 @@
+import { createProgressViewFileCommandHandlers } from '@controllers/progressView/ProgressViewFileCommandHandlers';
 import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
 import { createProgressViewRunCommandHandlers } from '@controllers/progressView/ProgressViewRunCommandHandlers';
@@ -55,6 +56,18 @@ export function createDesktopProgressIpc(
         progress.sendFollowUp(stream, text, mediaFiles),
       reportImageSaveError: (_image, error) => reportAsyncError(error),
     }),
+    ...createProgressViewFileCommandHandlers({
+      openFile: (file, line) => progress.openFile(file, line),
+      openFileCompile: (file) => progress.openFileCompile(file),
+      openTaskStorage: (stream) => progress.openTaskStorage(stream),
+      compareOriginal: (file, base) => progress.compareOriginal(file, base),
+      comparePrevious: (file, base, previous) =>
+        progress.comparePrevious(file, base, previous),
+      acceptFile: (file, base) => progress.acceptFile(file, base),
+      mergeFile: (file, base) => progress.mergeFile(file, base),
+      latexdiffFile: (file, base) => progress.latexdiffFile(file, base),
+      openLabel: (label) => progress.openLabel(label),
+    }),
     [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (d) => {
       if (!progress.handleToolEditApprovalAction(d)) onUnsupportedCommand(d);
     },
@@ -67,23 +80,6 @@ export function createDesktopProgressIpc(
     [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]: async (d) => {
       await progress.handleAgentProposalAction(d);
     },
-    [PROGRESS_VIEW_COMMANDS.OPEN_FILE]: (d) =>
-      progress.openFile(d.file, d.line),
-    [PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE]: (d) =>
-      progress.openFileCompile(d.file),
-    [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]: (d) =>
-      progress.openTaskStorage(d.stream),
-    [PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL]: (d) =>
-      progress.compareOriginal(d.file, d.base),
-    [PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS]: (d) =>
-      progress.comparePrevious(d.file, d.base, d.prev),
-    [PROGRESS_VIEW_COMMANDS.ACCEPT_FILE]: (d) =>
-      progress.acceptFile(d.file, d.base),
-    [PROGRESS_VIEW_COMMANDS.MERGE_FILE]: (d) =>
-      progress.mergeFile(d.file, d.base),
-    [PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE]: (d) =>
-      progress.latexdiffFile(d.file, d.base),
-    [PROGRESS_VIEW_COMMANDS.OPEN_LABEL]: (d) => progress.openLabel(d.label),
   };
 
   return {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { createProgressViewFileCommandHandlers } from '@controllers/progressView/ProgressViewFileCommandHandlers';
 import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
 import { createProgressViewRunCommandHandlers } from '@controllers/progressView/ProgressViewRunCommandHandlers';
@@ -235,8 +236,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           );
         },
       }),
-      [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]: (data) =>
-        this.workflowFileActionsController.openTaskStorage(data.stream),
       [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]: (data) =>
         this.handlePolishFollowUp(data),
       [PROGRESS_VIEW_COMMANDS.START_RECORDING]: async () => {
@@ -386,29 +385,30 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.handleRunCompileFixer(data.stream),
 
       // File operations
-      [PROGRESS_VIEW_COMMANDS.OPEN_FILE]: async (data) =>
-        vscode.commands.executeCommand('texra.openFile', data.file, data.line),
-      [PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE]: async (data) =>
-        vscode.commands.executeCommand('texra.openFileCompile', data.file),
-      [PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL]: (data) =>
-        this.workflowFileActionsController.compareOriginal(
-          data.file,
-          data.base,
-        ),
-      [PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS]: (data) =>
-        this.workflowFileActionsController.comparePrevious(
-          data.file,
-          data.base,
-          data.prev,
-        ),
-      [PROGRESS_VIEW_COMMANDS.ACCEPT_FILE]: (data) =>
-        this.workflowFileActionsController.acceptFile(data.file, data.base),
-      [PROGRESS_VIEW_COMMANDS.MERGE_FILE]: (data) =>
-        this.workflowFileActionsController.mergeFile(data.file, data.base),
-      [PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE]: (data) =>
-        this.workflowFileActionsController.latexdiffFile(data.file, data.base),
-      [PROGRESS_VIEW_COMMANDS.OPEN_LABEL]: async (data) =>
-        this.workflowFileActionsController.openLabel(data.label),
+      ...createProgressViewFileCommandHandlers({
+        openFile: async (file, line) =>
+          vscode.commands.executeCommand('texra.openFile', file, line),
+        openFileCompile: async (file) =>
+          vscode.commands.executeCommand('texra.openFileCompile', file),
+        openTaskStorage: (stream) =>
+          this.workflowFileActionsController.openTaskStorage(stream),
+        compareOriginal: (file, base) =>
+          this.workflowFileActionsController.compareOriginal(file, base),
+        comparePrevious: (file, base, previous) =>
+          this.workflowFileActionsController.comparePrevious(
+            file,
+            base,
+            previous,
+          ),
+        acceptFile: (file, base) =>
+          this.workflowFileActionsController.acceptFile(file, base),
+        mergeFile: (file, base) =>
+          this.workflowFileActionsController.mergeFile(file, base),
+        latexdiffFile: (file, base) =>
+          this.workflowFileActionsController.latexdiffFile(file, base),
+        openLabel: (label) =>
+          this.workflowFileActionsController.openLabel(label),
+      }),
     };
   }
 

--- a/src/controllers/progressView/ProgressViewFileCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewFileCommandHandlers.ts
@@ -1,0 +1,45 @@
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type { StreamTabId } from '@shared/schemas';
+import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
+
+export interface ProgressViewFileCommandActions {
+  openFile(file: string, line?: number): Promise<void> | void;
+  openFileCompile(file: string): Promise<void> | void;
+  openTaskStorage(stream: StreamTabId): Promise<void> | void;
+  compareOriginal(file: string, base?: string): Promise<void> | void;
+  comparePrevious(
+    file: string,
+    base?: string,
+    previous?: string,
+  ): Promise<void> | void;
+  acceptFile(file: string, base?: string): Promise<void> | void;
+  mergeFile(file: string, base?: string): Promise<void> | void;
+  latexdiffFile(file: string, base?: string): Promise<void> | void;
+  openLabel(label: string): Promise<void> | void;
+}
+
+export function createProgressViewFileCommandHandlers(
+  actions: ProgressViewFileCommandActions,
+): ProgressViewInboundHandlerRegistry {
+  return {
+    [PROGRESS_VIEW_COMMANDS.OPEN_FILE]: (data) =>
+      actions.openFile(data.file, data.line),
+    [PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE]: (data) =>
+      actions.openFileCompile(data.file),
+    [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]: (data) =>
+      actions.openTaskStorage(data.stream),
+    [PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL]: (data) =>
+      actions.compareOriginal(data.file, data.base),
+    [PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS]: (data) =>
+      actions.comparePrevious(data.file, data.base, data.prev),
+    [PROGRESS_VIEW_COMMANDS.ACCEPT_FILE]: (data) =>
+      actions.acceptFile(data.file, data.base),
+    [PROGRESS_VIEW_COMMANDS.MERGE_FILE]: (data) =>
+      actions.mergeFile(data.file, data.base),
+    [PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE]: (data) =>
+      actions.latexdiffFile(data.file, data.base),
+    [PROGRESS_VIEW_COMMANDS.OPEN_LABEL]: (data) =>
+      actions.openLabel(data.label),
+  };
+}

--- a/src/test-kernel/controllers/ProgressViewFileCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewFileCommandHandlers.vitest.ts
@@ -1,0 +1,131 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { createProgressViewFileCommandHandlers } from '@controllers/progressView/ProgressViewFileCommandHandlers';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { dispatchProgressViewInbound } from '@shared/schemas/progressView';
+
+describe('createProgressViewFileCommandHandlers', () => {
+  it('routes progress file commands to host actions', () => {
+    const actions = {
+      openFile: vi.fn(),
+      openFileCompile: vi.fn(),
+      openTaskStorage: vi.fn(),
+      compareOriginal: vi.fn(),
+      comparePrevious: vi.fn(),
+      acceptFile: vi.fn(),
+      mergeFile: vi.fn(),
+      latexdiffFile: vi.fn(),
+      openLabel: vi.fn(),
+    };
+    const handlers = createProgressViewFileCommandHandlers(actions);
+
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
+          file: 'paper.tex',
+          line: 12,
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE,
+          file: 'paper.tex',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE,
+          stream: 'stream-a',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
+          file: 'edited.tex',
+          base: 'paper.tex',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,
+          file: 'edited.tex',
+          base: 'paper.tex',
+          prev: 'previous.tex',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
+          file: 'edited.tex',
+          base: 'paper.tex',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
+          file: 'edited.tex',
+          base: 'paper.tex',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
+          file: 'edited.tex',
+          base: 'paper.tex',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        { command: PROGRESS_VIEW_COMMANDS.OPEN_LABEL, label: 'thm:main' },
+        handlers,
+      ),
+    ).toBe(true);
+
+    expect(actions.openFile).toHaveBeenCalledWith('paper.tex', 12);
+    expect(actions.openFileCompile).toHaveBeenCalledWith('paper.tex');
+    expect(actions.openTaskStorage).toHaveBeenCalledWith('stream-a');
+    expect(actions.compareOriginal).toHaveBeenCalledWith(
+      'edited.tex',
+      'paper.tex',
+    );
+    expect(actions.comparePrevious).toHaveBeenCalledWith(
+      'edited.tex',
+      'paper.tex',
+      'previous.tex',
+    );
+    expect(actions.acceptFile).toHaveBeenCalledWith('edited.tex', 'paper.tex');
+    expect(actions.mergeFile).toHaveBeenCalledWith('edited.tex', 'paper.tex');
+    expect(actions.latexdiffFile).toHaveBeenCalledWith(
+      'edited.tex',
+      'paper.tex',
+    );
+    expect(actions.openLabel).toHaveBeenCalledWith('thm:main');
+    expect(handlers[PROGRESS_VIEW_COMMANDS.RESUME]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared progress-view file command handler factory for OPEN_FILE, task storage, compare, accept, merge, latexdiff, and label commands
- wire both extension and desktop progress inbound registries through the shared factory
- add schema-dispatched unit coverage for the file command group

Part of #5451 P3d. This keeps the host-specific file implementations in their existing controllers/bridge and only centralizes the command-to-action mapping.

## Validation
- corepack pnpm vitest run src/test-kernel/controllers/ProgressViewFileCommandHandlers.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
- npm run typecheck
- npm run lint (0 errors; existing import-order warnings remain)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: behavior stays on existing bridge/controllers; risk is low wiring mistakes, covered by new dispatch tests.
> 
> **Overview**
> Introduces **`createProgressViewFileCommandHandlers`**, a shared factory that maps progress-view IPC commands (`OPEN_FILE`, compile open, task storage, compare/accept/merge/latexdiff, `OPEN_LABEL`) to injected host actions—matching the existing lifecycle/run/follow-up handler pattern.
> 
> **Desktop** (`desktopProgressIpc`) and the **VS Code extension** (`ProgressViewMessageHandler`) replace inline per-command handlers with spreads of that factory; desktop still delegates to `DesktopProgressBridge`, while the extension still uses `texra.*` commands and `ProgressWorkflowFileActionsController`. **`OPEN_TASK_STORAGE`** is no longer registered alone in the extension registry; it lives in the shared file-command group.
> 
> Adds **Vitest** coverage that dispatches each file command through the factory and asserts the right action arguments (including `data.prev` → `comparePrevious`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3138cebd302c96e7e1f9bd6e01b5e4bad40e0370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->