### PR TITLE
refactor: share progress approval command handlers

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -1,3 +1,4 @@
+import { createProgressViewApprovalCommandHandlers } from '@controllers/progressView/ProgressViewApprovalCommandHandlers';
 import { createProgressViewFileCommandHandlers } from '@controllers/progressView/ProgressViewFileCommandHandlers';
 import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
@@ -68,18 +69,19 @@ export function createDesktopProgressIpc(
       latexdiffFile: (file, base) => progress.latexdiffFile(file, base),
       openLabel: (label) => progress.openLabel(label),
     }),
-    [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (d) => {
-      if (!progress.handleToolEditApprovalAction(d)) onUnsupportedCommand(d);
-    },
-    [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]: (d) =>
-      progress.handleBashApprovalAction(d),
-    [PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION]: (d) =>
-      progress.handlePlanApprovalAction(d),
-    [PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION]: (d) =>
-      progress.handleUserQuestionAction(d),
-    [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]: async (d) => {
-      await progress.handleAgentProposalAction(d);
-    },
+    ...createProgressViewApprovalCommandHandlers({
+      handleToolEditApprovalAction: (message) =>
+        progress.handleToolEditApprovalAction(message),
+      onUnsupportedToolEditApproval: (message) => onUnsupportedCommand(message),
+      handleBashApprovalAction: (message) =>
+        progress.handleBashApprovalAction(message),
+      handlePlanApprovalAction: (message) =>
+        progress.handlePlanApprovalAction(message),
+      handleUserQuestionAction: (message) =>
+        progress.handleUserQuestionAction(message),
+      handleAgentProposalAction: (message) =>
+        progress.handleAgentProposalAction(message),
+    }),
   };
 
   return {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { createProgressViewApprovalCommandHandlers } from '@controllers/progressView/ProgressViewApprovalCommandHandlers';
 import { createProgressViewFileCommandHandlers } from '@controllers/progressView/ProgressViewFileCommandHandlers';
 import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
@@ -249,8 +250,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]: async (data) => {
         await vscode.window.showInformationMessage(data.text);
       },
-      [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (data) =>
-        handleProgressViewToolEditApprovalAction(data),
       [PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS]: async (
         data,
       ) => {
@@ -307,9 +306,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           : 'Delegated task auto-approval disabled for this stream.';
         await vscode.window.showInformationMessage(msg);
       },
-      [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]: async (data) => {
-        await this.agentProposalController.handleAction(data);
-      },
       [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: async (data) => {
         const restored =
           await this.agentProposalController.restoreProposalConfig(
@@ -328,10 +324,20 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           );
         }
       },
-      [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]: (data) =>
-        handleProgressViewBashApprovalAction(data),
-      [PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION]: (data) =>
-        this.handlePlanApprovalAction(data),
+      ...createProgressViewApprovalCommandHandlers({
+        handleToolEditApprovalAction: async (message) => {
+          await handleProgressViewToolEditApprovalAction(message);
+          return true;
+        },
+        handleBashApprovalAction: (message) =>
+          handleProgressViewBashApprovalAction(message),
+        handlePlanApprovalAction: (message) =>
+          this.handlePlanApprovalAction(message),
+        handleUserQuestionAction: (message) =>
+          handleUserQuestionAction(message),
+        handleAgentProposalAction: (message) =>
+          this.agentProposalController.handleAction(message),
+      }),
       [PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION]: async (data) => {
         if (data.action === 'draft') {
           await persistOpenTurnDraft({
@@ -363,8 +369,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           feedback: data.feedback,
         });
       },
-      [PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION]: (data) =>
-        handleUserQuestionAction(data),
 
       // Profile & Memory - direct command execution
       [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: async () => {

--- a/src/controllers/progressView/ProgressViewApprovalCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewApprovalCommandHandlers.ts
@@ -1,0 +1,76 @@
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type {
+  ProgressViewInboundHandlerRegistry,
+  ProgressViewInboundMessage,
+} from '@shared/schemas/progressView';
+
+type ApprovalMessage<C extends ProgressViewInboundMessage['command']> = Extract<
+  ProgressViewInboundMessage,
+  { command: C }
+>;
+
+export interface ProgressViewApprovalCommandActions {
+  handleToolEditApprovalAction(
+    message: ApprovalMessage<
+      typeof PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION
+    >,
+  ): boolean | Promise<boolean>;
+  onUnsupportedToolEditApproval?(
+    message: ApprovalMessage<
+      typeof PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION
+    >,
+  ): void;
+  handleBashApprovalAction(
+    message: ApprovalMessage<
+      typeof PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION
+    >,
+  ): unknown;
+  handlePlanApprovalAction(
+    message: ApprovalMessage<
+      typeof PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION
+    >,
+  ): unknown;
+  handleUserQuestionAction(
+    message: ApprovalMessage<
+      typeof PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION
+    >,
+  ): unknown;
+  handleAgentProposalAction(
+    message: ApprovalMessage<
+      typeof PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION
+    >,
+  ): unknown;
+}
+
+export function createProgressViewApprovalCommandHandlers(
+  actions: ProgressViewApprovalCommandActions,
+): ProgressViewInboundHandlerRegistry {
+  return {
+    [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (data) => {
+      const handled = actions.handleToolEditApprovalAction(data);
+      if (handled instanceof Promise) {
+        return handled.then((result) => {
+          if (result === false) {
+            actions.onUnsupportedToolEditApproval?.(data);
+          }
+        });
+      }
+      if (handled === false) {
+        actions.onUnsupportedToolEditApproval?.(data);
+      }
+    },
+    [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]: async (data) => {
+      await actions.handleBashApprovalAction(data);
+    },
+    [PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION]: async (data) => {
+      await actions.handlePlanApprovalAction(data);
+    },
+    [PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION]: async (data) => {
+      await actions.handleUserQuestionAction(data);
+    },
+    [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]: async (data) => {
+      await actions.handleAgentProposalAction(data);
+    },
+  };
+}

--- a/src/test-kernel/controllers/ProgressViewApprovalCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewApprovalCommandHandlers.vitest.ts
@@ -1,0 +1,199 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { createProgressViewApprovalCommandHandlers } from '@controllers/progressView/ProgressViewApprovalCommandHandlers';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { dispatchProgressViewInbound } from '@shared/schemas/progressView';
+
+describe('createProgressViewApprovalCommandHandlers', () => {
+  it('routes progress approval commands to host actions', async () => {
+    const actions = {
+      handleToolEditApprovalAction: vi.fn(() => true),
+      onUnsupportedToolEditApproval: vi.fn(),
+      handleBashApprovalAction: vi.fn(),
+      handlePlanApprovalAction: vi.fn(),
+      handleUserQuestionAction: vi.fn(),
+      handleAgentProposalAction: vi.fn(),
+    };
+    const handlers = createProgressViewApprovalCommandHandlers(actions);
+
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+          requestId: 'edit-1',
+          action: 'approve',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+          requestId: 'bash-1',
+          action: 'reject',
+          feedback: 'needs a smaller command',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+          approvalId: 'plan-1',
+          action: 'approve_and_odyssey',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION,
+          requestId: 'question-1',
+          action: 'submit',
+          answers: { answer: 'yes' },
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+          proposalId: 'proposal-1',
+          action: 'setup',
+          agent: 'review',
+          model: 'deepseek',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+
+    await Promise.resolve();
+
+    expect(actions.handleToolEditApprovalAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+      requestId: 'edit-1',
+      action: 'approve',
+    });
+    expect(actions.handleBashApprovalAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+      requestId: 'bash-1',
+      action: 'reject',
+      feedback: 'needs a smaller command',
+    });
+    expect(actions.handlePlanApprovalAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+      approvalId: 'plan-1',
+      action: 'approve_and_odyssey',
+    });
+    expect(actions.handleUserQuestionAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION,
+      requestId: 'question-1',
+      action: 'submit',
+      answers: { answer: 'yes' },
+    });
+    expect(actions.handleAgentProposalAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+      proposalId: 'proposal-1',
+      action: 'setup',
+      agent: 'review',
+      model: 'deepseek',
+    });
+    expect(actions.onUnsupportedToolEditApproval).not.toHaveBeenCalled();
+    expect(handlers[PROGRESS_VIEW_COMMANDS.OPEN_FILE]).toBeUndefined();
+  });
+
+  it('reports unsupported tool-edit approval actions when the host returns false', async () => {
+    const actions = {
+      handleToolEditApprovalAction: vi.fn(() => false),
+      onUnsupportedToolEditApproval: vi.fn(),
+      handleBashApprovalAction: vi.fn(),
+      handlePlanApprovalAction: vi.fn(),
+      handleUserQuestionAction: vi.fn(),
+      handleAgentProposalAction: vi.fn(),
+    };
+    const handlers = createProgressViewApprovalCommandHandlers(actions);
+
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+          requestId: 'edit-2',
+          action: 'openDiff',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+
+    await Promise.resolve();
+
+    expect(actions.onUnsupportedToolEditApproval).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+      requestId: 'edit-2',
+      action: 'openDiff',
+    });
+  });
+
+  it('reports unsupported tool-edit approval actions from async host results', async () => {
+    const actions = {
+      handleToolEditApprovalAction: vi.fn(() => Promise.resolve(false)),
+      onUnsupportedToolEditApproval: vi.fn(),
+      handleBashApprovalAction: vi.fn(),
+      handlePlanApprovalAction: vi.fn(),
+      handleUserQuestionAction: vi.fn(),
+      handleAgentProposalAction: vi.fn(),
+    };
+    const handlers = createProgressViewApprovalCommandHandlers(actions);
+
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+          requestId: 'edit-3',
+          action: 'approve',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+
+    await Promise.resolve();
+
+    expect(actions.onUnsupportedToolEditApproval).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+      requestId: 'edit-3',
+      action: 'approve',
+    });
+  });
+
+  it('does not report unsupported tool-edit approval actions from async handled results', async () => {
+    const actions = {
+      handleToolEditApprovalAction: vi.fn(() => Promise.resolve(true)),
+      onUnsupportedToolEditApproval: vi.fn(),
+      handleBashApprovalAction: vi.fn(),
+      handlePlanApprovalAction: vi.fn(),
+      handleUserQuestionAction: vi.fn(),
+      handleAgentProposalAction: vi.fn(),
+    };
+    const handlers = createProgressViewApprovalCommandHandlers(actions);
+
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+          requestId: 'edit-4',
+          action: 'reject',
+        },
+        handlers,
+      ),
+    ).toBe(true);
+
+    await Promise.resolve();
+
+    expect(actions.onUnsupportedToolEditApproval).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared progress-view approval/action command handler factory for tool-edit, bash, plan, user-question, and agent-proposal actions
- wire both extension and desktop progress inbound registries through the shared factory
- preserve the desktop-only unsupported tool-edit approval path with an explicit callback
- add schema-dispatched unit coverage for approval command routing and the unsupported tool-edit case

Part of #5451 P3e. This leaves bypass toggles and external inquiry handlers host-specific because they are not shared by desktop and extension.

## Validation
- corepack pnpm vitest run src/test-kernel/controllers/ProgressViewApprovalCommandHandlers.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
- npm run test:kernel
- npm run typecheck
- npm run lint (0 errors; existing import-order warnings remain)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors routing for user-facing approval flows (tool edits, bash, plans, questions, proposals); behavior is intended to be preserved via injected callbacks and new unit tests, but regressions in async handling or unsupported tool-edit paths would affect agent safety UX.
> 
> **Overview**
> Introduces **`createProgressViewApprovalCommandHandlers`**, a shared factory that registers inbound handlers for tool-edit, bash, plan, user-question, and agent-proposal approval commands. Desktop and extension progress IPC registries now spread this factory instead of duplicating those five command blocks.
> 
> The factory centralizes **tool-edit “unsupported” handling**: when the host handler returns `false` (sync or async), an optional `onUnsupportedToolEditApproval` callback runs—desktop still wires that to `onUnsupportedCommand`. Other approval commands are invoked through `async` wrappers that `await` host actions.
> 
> **Vitest** coverage dispatches each approval command through `dispatchProgressViewInbound` and asserts the unsupported tool-edit paths for sync/async `false` vs handled `true`. Bypass toggles and external inquiry remain host-specific and are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb451b88f6684fd22acabe4c2d33d48f91601bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->