### PR TITLE
refactor: compose shared progress backend

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -126,8 +126,7 @@ export class ProgressViewProvider
         const canSend = () => this.canSendToWebview();
         this.toolEditHandler = new ApprovalRequestHandler(
           'requestId',
-          (p) =>
-            u.showPermission({ kind: PERMISSION_KIND.TOOL_EDIT, data: p }),
+          (p) => u.showPermission({ kind: PERMISSION_KIND.TOOL_EDIT, data: p }),
           (id) => u.resolvePermission(PERMISSION_KIND.TOOL_EDIT, id),
           canSend,
         );
@@ -189,11 +188,9 @@ export class ProgressViewProvider
         return {
           callbacks: {
             showRetryRequest: (p) => this.retryRequestHandler.show(p),
-            resolveRetryRequest: (id) =>
-              this.retryRequestHandler.resolve(id),
+            resolveRetryRequest: (id) => this.retryRequestHandler.resolve(id),
             showToolEditPermission: (p) => this.toolEditHandler.show(p),
-            resolveToolEditPermission: (id) =>
-              this.toolEditHandler.resolve(id),
+            resolveToolEditPermission: (id) => this.toolEditHandler.resolve(id),
             updateToolEditApprovalBypassState: (streamId, bypassActive) => {
               if (canSend())
                 u.updateBypassState(streamId, 'toolEdit', bypassActive);
@@ -203,11 +200,9 @@ export class ProgressViewProvider
                 u.updateBypassState(streamId, 'superYolo', bypassActive);
             },
             showBashPermission: (p) => this.bashApprovalHandler.show(p),
-            resolveBashPermission: (id) =>
-              this.bashApprovalHandler.resolve(id),
+            resolveBashPermission: (id) => this.bashApprovalHandler.resolve(id),
             showAgentProposal: (p) => this.agentProposalHandler.show(p),
-            resolveAgentProposal: (id) =>
-              this.agentProposalHandler.resolve(id),
+            resolveAgentProposal: (id) => this.agentProposalHandler.resolve(id),
             showPlanApproval: (p) => this.planApprovalHandler.show(p),
             resolvePlanApproval: (id) => this.planApprovalHandler.resolve(id),
             showExternalInquiry: (p) => this.externalInquiryHandler.show(p),

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -29,11 +29,8 @@ import type {
   ToolEditPermission,
 } from '@shared/schemas';
 import { AGENT_CATEGORY } from '@shared/schemas';
-import { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
-import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
-import { ProgressEventHandler } from '@shared/progressView/backend/events/ProgressEventHandler';
+import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
 import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
 import {
   getOpenTurnDraft,
@@ -66,10 +63,11 @@ export class ProgressViewProvider
   public static readonly viewType = 'texra.progress';
   private static _instance: ProgressViewProvider | undefined;
 
-  public readonly state: ProgressViewState;
-  public readonly eventHandler: ProgressEventHandler;
-  public readonly webviewBridge: WebviewBridge;
-  public readonly webviewUpdater: WebviewUpdater;
+  public readonly backend: ProgressBackend;
+  public readonly state: ProgressBackend['state'];
+  public readonly eventHandler: ProgressBackend['eventHandler'];
+  public readonly webviewBridge: ProgressBackend['webviewBridge'];
+  public readonly webviewUpdater: ProgressBackend['webviewUpdater'];
 
   protected readonly contentProvider: ProgressViewContentProvider;
   protected readonly messageHandler: ProgressViewMessageHandler;
@@ -87,31 +85,31 @@ export class ProgressViewProvider
   private _sidebarWebviewGetter?: () => vscode.Webview | undefined;
   private _mainViewProvider?: MainViewProvider;
 
-  private readonly toolEditHandler: ApprovalRequestHandler<
+  private toolEditHandler!: ApprovalRequestHandler<
     ToolEditPermission,
     'requestId'
   >;
-  private readonly bashApprovalHandler: ApprovalRequestHandler<
+  private bashApprovalHandler!: ApprovalRequestHandler<
     BashPermission,
     'requestId'
   >;
-  private readonly retryRequestHandler: ApprovalRequestHandler<
+  private retryRequestHandler!: ApprovalRequestHandler<
     ProgressEventPayloads['showRetryRequest'],
     'streamId'
   >;
-  private readonly agentProposalHandler: ApprovalRequestHandler<
+  private agentProposalHandler!: ApprovalRequestHandler<
     AgentProposalPermission,
     'proposalId'
   >;
-  private readonly planApprovalHandler: ApprovalRequestHandler<
+  private planApprovalHandler!: ApprovalRequestHandler<
     PlanApprovalPermission,
     'approvalId'
   >;
-  private readonly externalInquiryHandler: ApprovalRequestHandler<
+  private externalInquiryHandler!: ApprovalRequestHandler<
     ExternalInquiryPermission,
     'requestId'
   >;
-  private readonly userQuestionHandler: ApprovalRequestHandler<
+  private userQuestionHandler!: ApprovalRequestHandler<
     ProgressEventPayloads['showUserQuestion'],
     'requestId'
   >;
@@ -120,109 +118,113 @@ export class ProgressViewProvider
     super(context);
     this.logger = createChannelTrace('ProgressViewProvider');
 
-    this.state = new ProgressViewState(workspaceSM);
-    this.webviewUpdater = new WebviewUpdater(
-      (message) => void this.sendToActiveProgressWebview(message),
-      () => this.getActiveWebview() !== undefined,
-    );
-    this.webviewBridge = new WebviewBridge(
-      this.state.streamLogs,
-      (message) => this.sendToActiveProgressWebview(message),
-      () => this.state.activeStream || null,
-    );
+    this.backend = new ProgressBackend({
+      storage: workspaceSM,
+      sendMessage: (message) => this.sendToActiveProgressWebview(message),
+      hasTarget: () => this.getActiveWebview() !== undefined,
+      configureUi: ({ webviewUpdater: u }) => {
+        const canSend = () => this.canSendToWebview();
+        this.toolEditHandler = new ApprovalRequestHandler(
+          'requestId',
+          (p) =>
+            u.showPermission({ kind: PERMISSION_KIND.TOOL_EDIT, data: p }),
+          (id) => u.resolvePermission(PERMISSION_KIND.TOOL_EDIT, id),
+          canSend,
+        );
+        this.bashApprovalHandler = new ApprovalRequestHandler(
+          'requestId',
+          (p) => u.showPermission({ kind: PERMISSION_KIND.BASH, data: p }),
+          (id) => u.resolvePermission(PERMISSION_KIND.BASH, id),
+          canSend,
+        );
+        this.retryRequestHandler = new ApprovalRequestHandler(
+          'streamId',
+          (p) => u.showPermission({ kind: PERMISSION_KIND.RETRY, data: p }),
+          (id) => u.resolvePermission(PERMISSION_KIND.RETRY, id),
+          canSend,
+        );
+        this.agentProposalHandler = new ApprovalRequestHandler(
+          'proposalId',
+          (p) => {
+            // Show proposal immediately with basic model dropdown (synchronous)
+            u.showPermission({
+              kind: PERMISSION_KIND.PROPOSAL,
+              data: p,
+              modelOptionsData: buildBasicModelOptionsData(),
+            });
+            // Then upgrade with availability metadata if possible
+            void this.sendProposalModelOptions(p);
+          },
+          (id) => u.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
+          canSend,
+        );
+        this.planApprovalHandler = new ApprovalRequestHandler(
+          'approvalId',
+          (p) =>
+            u.showPermission({ kind: PERMISSION_KIND.PLAN_APPROVAL, data: p }),
+          (id) => u.resolvePermission(PERMISSION_KIND.PLAN_APPROVAL, id),
+          canSend,
+        );
+        this.externalInquiryHandler = new ApprovalRequestHandler(
+          'requestId',
+          (p) =>
+            u.showPermission({
+              kind: PERMISSION_KIND.EXTERNAL_INQUIRY,
+              data: p,
+            }),
+          (id) => u.resolvePermission(PERMISSION_KIND.EXTERNAL_INQUIRY, id),
+          canSend,
+        );
+        this.userQuestionHandler = new ApprovalRequestHandler(
+          'requestId',
+          (p) =>
+            u.showPermission({
+              kind: PERMISSION_KIND.USER_QUESTION,
+              data: p,
+            }),
+          (id) => u.resolvePermission(PERMISSION_KIND.USER_QUESTION, id),
+          canSend,
+        );
 
-    const canSend = () => this.canSendToWebview();
-    const u = this.webviewUpdater;
-    this.toolEditHandler = new ApprovalRequestHandler(
-      'requestId',
-      (p) => u.showPermission({ kind: PERMISSION_KIND.TOOL_EDIT, data: p }),
-      (id) => u.resolvePermission(PERMISSION_KIND.TOOL_EDIT, id),
-      canSend,
-    );
-    this.bashApprovalHandler = new ApprovalRequestHandler(
-      'requestId',
-      (p) => u.showPermission({ kind: PERMISSION_KIND.BASH, data: p }),
-      (id) => u.resolvePermission(PERMISSION_KIND.BASH, id),
-      canSend,
-    );
-    this.retryRequestHandler = new ApprovalRequestHandler(
-      'streamId',
-      (p) => u.showPermission({ kind: PERMISSION_KIND.RETRY, data: p }),
-      (id) => u.resolvePermission(PERMISSION_KIND.RETRY, id),
-      canSend,
-    );
-    this.agentProposalHandler = new ApprovalRequestHandler(
-      'proposalId',
-      (p) => {
-        // Show proposal immediately with basic model dropdown (synchronous)
-        u.showPermission({
-          kind: PERMISSION_KIND.PROPOSAL,
-          data: p,
-          modelOptionsData: buildBasicModelOptionsData(),
-        });
-        // Then upgrade with availability metadata if possible
-        void this.sendProposalModelOptions(p);
+        return {
+          callbacks: {
+            showRetryRequest: (p) => this.retryRequestHandler.show(p),
+            resolveRetryRequest: (id) =>
+              this.retryRequestHandler.resolve(id),
+            showToolEditPermission: (p) => this.toolEditHandler.show(p),
+            resolveToolEditPermission: (id) =>
+              this.toolEditHandler.resolve(id),
+            updateToolEditApprovalBypassState: (streamId, bypassActive) => {
+              if (canSend())
+                u.updateBypassState(streamId, 'toolEdit', bypassActive);
+            },
+            updateSuperYoloBypassState: (streamId, bypassActive) => {
+              if (canSend())
+                u.updateBypassState(streamId, 'superYolo', bypassActive);
+            },
+            showBashPermission: (p) => this.bashApprovalHandler.show(p),
+            resolveBashPermission: (id) =>
+              this.bashApprovalHandler.resolve(id),
+            showAgentProposal: (p) => this.agentProposalHandler.show(p),
+            resolveAgentProposal: (id) =>
+              this.agentProposalHandler.resolve(id),
+            showPlanApproval: (p) => this.planApprovalHandler.show(p),
+            resolvePlanApproval: (id) => this.planApprovalHandler.resolve(id),
+            showExternalInquiry: (p) => this.externalInquiryHandler.show(p),
+            resolveExternalInquiry: (id) =>
+              this.externalInquiryHandler.resolve(id),
+            showUserQuestion: (p) => this.userQuestionHandler.show(p),
+            resolveUserQuestion: (id) => this.userQuestionHandler.resolve(id),
+          },
+          hasPendingPermissions: (streamId) =>
+            this.hasPendingPermissionsForStream(streamId),
+        };
       },
-      (id) => u.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
-      canSend,
-    );
-    this.planApprovalHandler = new ApprovalRequestHandler(
-      'approvalId',
-      (p) => u.showPermission({ kind: PERMISSION_KIND.PLAN_APPROVAL, data: p }),
-      (id) => u.resolvePermission(PERMISSION_KIND.PLAN_APPROVAL, id),
-      canSend,
-    );
-    this.externalInquiryHandler = new ApprovalRequestHandler(
-      'requestId',
-      (p) =>
-        u.showPermission({
-          kind: PERMISSION_KIND.EXTERNAL_INQUIRY,
-          data: p,
-        }),
-      (id) => u.resolvePermission(PERMISSION_KIND.EXTERNAL_INQUIRY, id),
-      canSend,
-    );
-    this.userQuestionHandler = new ApprovalRequestHandler(
-      'requestId',
-      (p) =>
-        u.showPermission({
-          kind: PERMISSION_KIND.USER_QUESTION,
-          data: p,
-        }),
-      (id) => u.resolvePermission(PERMISSION_KIND.USER_QUESTION, id),
-      canSend,
-    );
-
-    this.eventHandler = new ProgressEventHandler(
-      this.state,
-      this.webviewUpdater,
-      this.webviewBridge,
-      {
-        showRetryRequest: (p) => this.retryRequestHandler.show(p),
-        resolveRetryRequest: (id) => this.retryRequestHandler.resolve(id),
-        showToolEditPermission: (p) => this.toolEditHandler.show(p),
-        resolveToolEditPermission: (id) => this.toolEditHandler.resolve(id),
-        updateToolEditApprovalBypassState: (streamId, bypassActive) => {
-          if (canSend())
-            u.updateBypassState(streamId, 'toolEdit', bypassActive);
-        },
-        updateSuperYoloBypassState: (streamId, bypassActive) => {
-          if (canSend())
-            u.updateBypassState(streamId, 'superYolo', bypassActive);
-        },
-        showBashPermission: (p) => this.bashApprovalHandler.show(p),
-        resolveBashPermission: (id) => this.bashApprovalHandler.resolve(id),
-        showAgentProposal: (p) => this.agentProposalHandler.show(p),
-        resolveAgentProposal: (id) => this.agentProposalHandler.resolve(id),
-        showPlanApproval: (p) => this.planApprovalHandler.show(p),
-        resolvePlanApproval: (id) => this.planApprovalHandler.resolve(id),
-        showExternalInquiry: (p) => this.externalInquiryHandler.show(p),
-        resolveExternalInquiry: (id) => this.externalInquiryHandler.resolve(id),
-        showUserQuestion: (p) => this.userQuestionHandler.show(p),
-        resolveUserQuestion: (id) => this.userQuestionHandler.resolve(id),
-      },
-      (streamId) => this.hasPendingPermissionsForStream(streamId),
-    );
+    });
+    this.state = this.backend.state;
+    this.webviewUpdater = this.backend.webviewUpdater;
+    this.webviewBridge = this.backend.webviewBridge;
+    this.eventHandler = this.backend.eventHandler;
 
     this.contentProvider = new ProgressViewContentProvider(context);
     this.messageHandler = new ProgressViewMessageHandler(this, context);
@@ -232,7 +234,7 @@ export class ProgressViewProvider
 
     this._disposables.push(
       vscode.workspace.onDidChangeWorkspaceFolders(async () => {
-        await this.state.load();
+        await this.backend.load();
         this.syncFullView({ forceRebuild: true });
       }),
       vscode.window.onDidChangeActiveColorTheme(() => {
@@ -244,8 +246,8 @@ export class ProgressViewProvider
   }
 
   public async initialize(): Promise<void> {
-    await this.state.load();
-    this._disposables.push(this.eventHandler.setupEventListeners());
+    await this.backend.load();
+    this._disposables.push(this.backend.setupEventListeners());
     this.logger.debug('ProgressViewProvider initialized');
   }
 
@@ -678,7 +680,7 @@ export class ProgressViewProvider
 
   public override dispose(): void {
     this.disposePanelResources(true);
-    this.webviewBridge.dispose();
+    this.backend.dispose();
     super.dispose();
   }
 

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -1,0 +1,88 @@
+// Local imports - shared progress backend
+import type { ProgressViewOutboundMessage } from '@shared/schemas';
+import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
+import { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
+import {
+  ProgressEventHandler,
+  type ProgressEventSubscription,
+  type UICallbacks,
+} from '@shared/progressView/backend/events/ProgressEventHandler';
+import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
+import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
+
+export type ProgressBackendMessageSender = (
+  message: ProgressViewOutboundMessage,
+) => boolean | Promise<boolean>;
+
+export interface ProgressBackendServices {
+  state: ProgressViewState;
+  webviewUpdater: WebviewUpdater;
+  webviewBridge: WebviewBridge;
+}
+
+export interface ProgressBackendUiConfig {
+  callbacks: UICallbacks;
+  hasPendingPermissions(streamId: string): boolean;
+}
+
+export interface ProgressBackendOptions {
+  storage: MementoStorage;
+  sendMessage: ProgressBackendMessageSender;
+  hasTarget(): boolean;
+  configureUi(services: ProgressBackendServices): ProgressBackendUiConfig;
+}
+
+/**
+ * Host-neutral progress-view backend composition.
+ *
+ * Hosts provide only storage, transport, and UI callbacks. The state manager,
+ * message builders, log bridge, and event bus subscriber are constructed as one
+ * graph so extension and desktop can converge on the same backend boundary.
+ */
+export class ProgressBackend {
+  readonly state: ProgressViewState;
+  readonly webviewUpdater: WebviewUpdater;
+  readonly webviewBridge: WebviewBridge;
+  readonly eventHandler: ProgressEventHandler;
+
+  constructor(options: ProgressBackendOptions) {
+    this.state = new ProgressViewState(options.storage);
+    this.webviewUpdater = new WebviewUpdater(
+      (message) => {
+        void options.sendMessage(message);
+      },
+      options.hasTarget,
+    );
+    this.webviewBridge = new WebviewBridge(
+      this.state.streamLogs,
+      options.sendMessage,
+      () => this.state.activeStream || null,
+    );
+
+    const services = {
+      state: this.state,
+      webviewUpdater: this.webviewUpdater,
+      webviewBridge: this.webviewBridge,
+    };
+    const ui = options.configureUi(services);
+    this.eventHandler = new ProgressEventHandler(
+      this.state,
+      this.webviewUpdater,
+      this.webviewBridge,
+      ui.callbacks,
+      ui.hasPendingPermissions,
+    );
+  }
+
+  async load(): Promise<void> {
+    await this.state.load();
+  }
+
+  setupEventListeners(): ProgressEventSubscription {
+    return this.eventHandler.setupEventListeners();
+  }
+
+  dispose(): void {
+    this.webviewBridge.dispose();
+  }
+}

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -1,6 +1,9 @@
 // Local imports - shared progress backend
 import type { ProgressViewOutboundMessage } from '@shared/schemas';
-import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
+import {
+  WebviewBridge,
+  type ProgressViewMessageSender,
+} from '@shared/progressView/backend/WebviewBridge';
 import { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
 import {
   ProgressEventHandler,
@@ -10,9 +13,7 @@ import {
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
 
-export type ProgressBackendMessageSender = (
-  message: ProgressViewOutboundMessage,
-) => boolean | Promise<boolean>;
+export type ProgressBackendMessageSender = ProgressViewMessageSender;
 
 export interface ProgressBackendServices {
   state: ProgressViewState;
@@ -32,6 +33,17 @@ export interface ProgressBackendOptions {
   configureUi(services: ProgressBackendServices): ProgressBackendUiConfig;
 }
 
+function sendUpdaterMessage(
+  sendMessage: ProgressBackendMessageSender,
+  message: ProgressViewOutboundMessage,
+): void {
+  try {
+    void Promise.resolve(sendMessage(message)).catch(() => undefined);
+  } catch {
+    // View refreshes are best-effort; a closed transport must not take down the backend.
+  }
+}
+
 /**
  * Host-neutral progress-view backend composition.
  *
@@ -48,7 +60,7 @@ export class ProgressBackend {
   constructor(options: ProgressBackendOptions) {
     this.state = new ProgressViewState(options.storage);
     this.webviewUpdater = new WebviewUpdater((message) => {
-      void options.sendMessage(message);
+      sendUpdaterMessage(options.sendMessage, message);
     }, options.hasTarget);
     this.webviewBridge = new WebviewBridge(
       this.state.streamLogs,

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -47,12 +47,9 @@ export class ProgressBackend {
 
   constructor(options: ProgressBackendOptions) {
     this.state = new ProgressViewState(options.storage);
-    this.webviewUpdater = new WebviewUpdater(
-      (message) => {
-        void options.sendMessage(message);
-      },
-      options.hasTarget,
-    );
+    this.webviewUpdater = new WebviewUpdater((message) => {
+      void options.sendMessage(message);
+    }, options.hasTarget);
     this.webviewBridge = new WebviewBridge(
       this.state.streamLogs,
       options.sendMessage,

--- a/src/shared/progressView/backend/WebviewBridge.ts
+++ b/src/shared/progressView/backend/WebviewBridge.ts
@@ -9,7 +9,7 @@ const FRAME_INTERVAL_MS = 16;
 
 export type ProgressViewMessageSender = (
   message: ProgressViewOutboundMessage,
-) => boolean | Promise<boolean>;
+) => boolean | PromiseLike<boolean>;
 
 export interface ProgressLogSource {
   readonly head: number;

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1,0 +1,104 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  ProgressBackend,
+  type ProgressBackendServices,
+  type ProgressBackendUiConfig,
+} from '@shared/progressView/backend/ProgressBackend';
+import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
+
+class MemoryMementoStorage implements MementoStorage {
+  private readonly values = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    return this.values.has(key) ? (this.values.get(key) as T) : defaultValue;
+  }
+
+  async update<T>(key: string, value: T | undefined): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+      return;
+    }
+    this.values.set(key, value);
+  }
+}
+
+function createUiConfig(): ProgressBackendUiConfig {
+  return {
+    callbacks: {
+      showRetryRequest: vi.fn(),
+      resolveRetryRequest: vi.fn(),
+      showToolEditPermission: vi.fn(),
+      resolveToolEditPermission: vi.fn(),
+      updateToolEditApprovalBypassState: vi.fn(),
+      updateSuperYoloBypassState: vi.fn(),
+      showBashPermission: vi.fn(),
+      resolveBashPermission: vi.fn(),
+      showAgentProposal: vi.fn(),
+      resolveAgentProposal: vi.fn(),
+      showPlanApproval: vi.fn(),
+      resolvePlanApproval: vi.fn(),
+      showExternalInquiry: vi.fn(),
+      resolveExternalInquiry: vi.fn(),
+      showUserQuestion: vi.fn(),
+      resolveUserQuestion: vi.fn(),
+    },
+    hasPendingPermissions: vi.fn(() => false),
+  };
+}
+
+describe('ProgressBackend', () => {
+  it('constructs the shared progress backend service graph', () => {
+    let servicesFromConfig: ProgressBackendServices | undefined;
+
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      sendMessage: vi.fn(() => true),
+      hasTarget: () => true,
+      configureUi: (services) => {
+        servicesFromConfig = services;
+        return createUiConfig();
+      },
+    });
+
+    expect(servicesFromConfig).toEqual({
+      state: backend.state,
+      webviewUpdater: backend.webviewUpdater,
+      webviewBridge: backend.webviewBridge,
+    });
+    expect(backend.eventHandler).toBeDefined();
+
+    backend.dispose();
+  });
+
+  it('uses the injected target predicate before sending messages', () => {
+    const sent = vi.fn(() => true);
+    let hasTarget = false;
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      sendMessage: sent,
+      hasTarget: () => hasTarget,
+      configureUi: () => createUiConfig(),
+    });
+
+    backend.webviewUpdater.updateStreams([], '', 'all');
+    expect(sent).not.toHaveBeenCalled();
+
+    hasTarget = true;
+    backend.webviewUpdater.updateStreams([], '', 'all');
+    expect(sent).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      streams: [],
+      activeStream: '',
+      agentFilter: 'all',
+      streamStates: undefined,
+    });
+
+    backend.dispose();
+  });
+});

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -101,4 +101,30 @@ describe('ProgressBackend', () => {
 
     backend.dispose();
   });
+
+  it('contains updater transport failures', async () => {
+    const sent = vi
+      .fn<() => boolean | Promise<boolean>>()
+      .mockImplementationOnce(() => {
+        throw new Error('closed transport');
+      })
+      .mockRejectedValueOnce(new Error('closed transport'));
+
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      sendMessage: sent,
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+    });
+
+    expect(() =>
+      backend.webviewUpdater.updateStreams([], '', 'all'),
+    ).not.toThrow();
+    backend.webviewUpdater.updateStreams([], '', 'all');
+    await Promise.resolve();
+
+    expect(sent).toHaveBeenCalledTimes(2);
+
+    backend.dispose();
+  });
 });


### PR DESCRIPTION
## Summary

- add a host-neutral `ProgressBackend` composition object for `ProgressViewState`, `WebviewUpdater`, `WebviewBridge`, and `ProgressEventHandler`
- wire the VS Code progress provider through that backend while preserving its existing public state/updater/bridge/event-handler fields
- keep host-specific approval prompt wiring in the provider via `configureUi`, avoiding a giant optional callback bag
- add focused kernel coverage for backend construction and target-guarded message sending

This is #5451 P4a: it creates the shared backend target before migrating the desktop bridge onto it. Desktop behavior is intentionally unchanged in this slice.

## Validation

- `corepack pnpm vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm --filter texra typecheck`
- `npm run lint` (0 errors, existing 34 import-order warnings)
- `npm run test:kernel -- src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts`
- `npm run compile:fast`
- `npm run test:kernel`
- `npm run typecheck`

Refs #5451

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches progress view orchestration and webview messaging paths; behavior is intended to be preserved but approval/event wiring moved behind a new composition boundary.
> 
> **Overview**
> Introduces a shared **`ProgressBackend`** that wires `ProgressViewState`, `WebviewUpdater`, `WebviewBridge`, and `ProgressEventHandler` in one place. Hosts inject storage, message transport, a **has-target** guard, and **`configureUi`** (approval callbacks + pending-permission checks) instead of assembling those pieces locally.
> 
> **`ProgressViewProvider`** now delegates to `ProgressBackend` while keeping the same public `state` / `webviewUpdater` / `webviewBridge` / `eventHandler` surface; load, event subscription, and dispose go through `backend`. Updater sends are wrapped so sync/async transport errors do not crash the backend. **`ProgressViewMessageSender`** now allows `PromiseLike<boolean>`.
> 
> Adds kernel tests for graph construction, target-gated sends, and transport failure containment. Desktop migration is out of scope for this slice (#5451 P4a).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523edeb8c3edbb41108b00c51953768119cba07e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->