### PR TITLE
refactor: share progress bypass command handlers

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -1,4 +1,5 @@
 import { createProgressViewApprovalCommandHandlers } from '@controllers/progressView/ProgressViewApprovalCommandHandlers';
+import { createProgressViewBypassCommandHandlers } from '@controllers/progressView/ProgressViewBypassCommandHandlers';
 import { createProgressViewFileCommandHandlers } from '@controllers/progressView/ProgressViewFileCommandHandlers';
 import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
@@ -56,6 +57,9 @@ export function createDesktopProgressIpc(
       sendFollowUp: ({ stream, text, mediaFiles }) =>
         progress.sendFollowUp(stream, text, mediaFiles),
       reportImageSaveError: (_image, error) => reportAsyncError(error),
+    }),
+    ...createProgressViewBypassCommandHandlers({
+      runtimeHost: progress.runtimeHost,
     }),
     ...createProgressViewFileCommandHandlers({
       openFile: (file, line) => progress.openFile(file, line),

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { createProgressViewApprovalCommandHandlers } from '@controllers/progressView/ProgressViewApprovalCommandHandlers';
+import { createProgressViewBypassCommandHandlers } from '@controllers/progressView/ProgressViewBypassCommandHandlers';
 import { createProgressViewFileCommandHandlers } from '@controllers/progressView/ProgressViewFileCommandHandlers';
 import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
 import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
@@ -45,14 +46,7 @@ import {
 } from '@shared/schemas/progressView';
 import { handleExternalInquiryAction } from '@tools/inquiry';
 import { handleUserQuestionAction } from '@tools/userQuestion';
-import {
-  handleProgressViewBashApprovalAction,
-  toggleToolEditApprovalSessionBypass,
-  setToolEditApprovalSessionBypass,
-  setBashApprovalSessionBypass,
-  isApprovalBypassedForStream,
-  toggleProposalBypass,
-} from '@tools/approval';
+import { handleProgressViewBashApprovalAction } from '@tools/approval';
 import { OdysseyStore, isOdysseyInFlight } from '@tools/odyssey';
 import { persistOpenTurnDraft } from '@tools/inquiry/externalInquiryStorage';
 import {
@@ -250,62 +244,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]: async (data) => {
         await vscode.window.showInformationMessage(data.text);
       },
-      [PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS]: async (
-        data,
-      ) => {
-        const isNowEnabled = toggleToolEditApprovalSessionBypass(
-          data.stream,
-          extensionAgentRuntimeHost,
-        );
-        // Keep bash approval symmetric with tool edits: the single YOLO shield
-        // covers both. Bash gained an independent per-stream flag in #4739 and
-        // the extension has no separate bash toggle, so mirror it here. Silent
-        // because the shield's active state renders from the tool-edit flag.
-        setBashApprovalSessionBypass(
-          data.stream,
-          isNowEnabled,
-          extensionAgentRuntimeHost,
-          { silent: true },
-        );
-        const msg = isNowEnabled
-          ? 'YOLO mode enabled: Tool actions and bash commands will be auto-approved for this stream.'
-          : 'YOLO mode disabled: Tool actions and bash commands will prompt for approval.';
-        await vscode.window.showInformationMessage(msg);
-      },
-      [PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS]: async (data) => {
-        const isNowEnabled = toggleProposalBypass(
-          data.stream,
-          extensionAgentRuntimeHost,
-        );
-        if (isNowEnabled) {
-          // Delegation auto-approval also accepts tool edits in this stream.
-          if (!isApprovalBypassedForStream(data.stream)) {
-            setToolEditApprovalSessionBypass(
-              data.stream,
-              true,
-              extensionAgentRuntimeHost,
-            );
-          }
-        } else {
-          // Returning to manual task approval also restores edit prompts.
-          setToolEditApprovalSessionBypass(
-            data.stream,
-            false,
-            extensionAgentRuntimeHost,
-          );
-        }
-        // Bash bypass stays symmetric with the tool-edit bypass above.
-        setBashApprovalSessionBypass(
-          data.stream,
-          isNowEnabled,
-          extensionAgentRuntimeHost,
-          { silent: true },
-        );
-        const msg = isNowEnabled
-          ? 'Delegated task auto-approval enabled for this stream.'
-          : 'Delegated task auto-approval disabled for this stream.';
-        await vscode.window.showInformationMessage(msg);
-      },
+      ...createProgressViewBypassCommandHandlers({
+        runtimeHost: extensionAgentRuntimeHost,
+        showInfo: (message) => vscode.window.showInformationMessage(message),
+      }),
       [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: async (data) => {
         const restored =
           await this.agentProposalController.restoreProposalConfig(

--- a/src/controllers/progressView/ProgressViewBypassCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewBypassCommandHandlers.ts
@@ -1,0 +1,64 @@
+// Local imports - shared
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
+import {
+  isApprovalBypassedForStream,
+  setBashApprovalSessionBypass,
+  setToolEditApprovalSessionBypass,
+  toggleProposalBypass,
+  toggleToolEditApprovalSessionBypass,
+} from '@tools/approval';
+
+export interface ProgressViewBypassCommandOptions {
+  runtimeHost: AgentRuntimeHost;
+  showInfo?(message: string): void | PromiseLike<unknown>;
+}
+
+/**
+ * Shared policy for progress-view bypass toggles.
+ *
+ * The UI exposes one shield for file edits + bash and one stronger delegated
+ * task auto-approval. Keep the cross-approval side effects here so hosts do
+ * not each reimplement the same symmetry rules.
+ */
+export function createProgressViewBypassCommandHandlers(
+  options: ProgressViewBypassCommandOptions,
+): ProgressViewInboundHandlerRegistry {
+  const { runtimeHost, showInfo } = options;
+
+  return {
+    [PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS]: async (data) => {
+      const isNowEnabled = toggleToolEditApprovalSessionBypass(
+        data.stream,
+        runtimeHost,
+      );
+      setBashApprovalSessionBypass(data.stream, isNowEnabled, runtimeHost, {
+        silent: true,
+      });
+      await showInfo?.(
+        isNowEnabled
+          ? 'YOLO mode enabled: Tool actions and bash commands will be auto-approved for this stream.'
+          : 'YOLO mode disabled: Tool actions and bash commands will prompt for approval.',
+      );
+    },
+    [PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS]: async (data) => {
+      const isNowEnabled = toggleProposalBypass(data.stream, runtimeHost);
+      if (isNowEnabled) {
+        if (!isApprovalBypassedForStream(data.stream)) {
+          setToolEditApprovalSessionBypass(data.stream, true, runtimeHost);
+        }
+      } else {
+        setToolEditApprovalSessionBypass(data.stream, false, runtimeHost);
+      }
+      setBashApprovalSessionBypass(data.stream, isNowEnabled, runtimeHost, {
+        silent: true,
+      });
+      await showInfo?.(
+        isNowEnabled
+          ? 'Delegated task auto-approval enabled for this stream.'
+          : 'Delegated task auto-approval disabled for this stream.',
+      );
+    },
+  };
+}

--- a/src/test-kernel/controllers/ProgressViewBypassCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewBypassCommandHandlers.vitest.ts
@@ -1,0 +1,149 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { createProgressViewBypassCommandHandlers } from '@controllers/progressView/ProgressViewBypassCommandHandlers';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { dispatchProgressViewInbound } from '@shared/schemas/progressView';
+import {
+  cleanupAllApprovals,
+  isApprovalBypassedForStream,
+  isBashApprovalBypassedForStream,
+  isProposalBypassedForStream,
+} from '@tools/approval';
+
+function createRecordingRuntimeHost(): {
+  events: Array<{ event: string; payload: unknown }>;
+  host: AgentRuntimeHost;
+} {
+  const events: Array<{ event: string; payload: unknown }> = [];
+  return {
+    events,
+    host: {
+      emit: (event, payload) => {
+        events.push({ event, payload });
+      },
+    },
+  };
+}
+
+describe('createProgressViewBypassCommandHandlers', () => {
+  afterEach(() => {
+    cleanupAllApprovals();
+  });
+
+  it('keeps tool-edit and bash bypass symmetric behind the edit shield', async () => {
+    const stream = 'stream:edit-bypass';
+    const { events, host } = createRecordingRuntimeHost();
+    const showInfo = vi.fn();
+    const handlers = createProgressViewBypassCommandHandlers({
+      runtimeHost: host,
+      showInfo,
+    });
+
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
+          stream,
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(isApprovalBypassedForStream(stream)).toBe(true);
+    expect(isBashApprovalBypassedForStream(stream)).toBe(true);
+    expect(events).toEqual([
+      {
+        event: 'updateToolEditApprovalBypassState',
+        payload: { streamId: stream, bypassActive: true },
+      },
+    ]);
+    expect(showInfo).toHaveBeenCalledWith(
+      'YOLO mode enabled: Tool actions and bash commands will be auto-approved for this stream.',
+    );
+
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
+          stream,
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(isApprovalBypassedForStream(stream)).toBe(false);
+    expect(isBashApprovalBypassedForStream(stream)).toBe(false);
+    expect(events.at(-1)).toEqual({
+      event: 'updateToolEditApprovalBypassState',
+      payload: { streamId: stream, bypassActive: false },
+    });
+  });
+
+  it('makes delegated task bypass enable edit and bash bypasses', async () => {
+    const stream = 'stream:proposal-bypass';
+    const { events, host } = createRecordingRuntimeHost();
+    const showInfo = vi.fn();
+    const handlers = createProgressViewBypassCommandHandlers({
+      runtimeHost: host,
+      showInfo,
+    });
+
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
+          stream,
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(isProposalBypassedForStream(stream)).toBe(true);
+    expect(isApprovalBypassedForStream(stream)).toBe(true);
+    expect(isBashApprovalBypassedForStream(stream)).toBe(true);
+    expect(events).toEqual([
+      {
+        event: 'updateSuperYoloBypassState',
+        payload: { streamId: stream, bypassActive: true },
+      },
+      {
+        event: 'updateToolEditApprovalBypassState',
+        payload: { streamId: stream, bypassActive: true },
+      },
+    ]);
+    expect(showInfo).toHaveBeenCalledWith(
+      'Delegated task auto-approval enabled for this stream.',
+    );
+
+    expect(
+      dispatchProgressViewInbound(
+        {
+          command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
+          stream,
+        },
+        handlers,
+      ),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(isProposalBypassedForStream(stream)).toBe(false);
+    expect(isApprovalBypassedForStream(stream)).toBe(false);
+    expect(isBashApprovalBypassedForStream(stream)).toBe(false);
+    expect(events.slice(-2)).toEqual([
+      {
+        event: 'updateSuperYoloBypassState',
+        payload: { streamId: stream, bypassActive: false },
+      },
+      {
+        event: 'updateToolEditApprovalBypassState',
+        payload: { streamId: stream, bypassActive: false },
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -1,8 +1,10 @@
 // Third-party imports
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - webview command constants
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
+import { cleanupAllApprovals } from '@tools/approval';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
@@ -54,6 +56,12 @@ interface DesktopProgressIpcModule {
         action: string;
         feedback?: string;
       }): void;
+      handleUserQuestionAction(message: {
+        command: string;
+        questionId: string;
+        action: string;
+        answer?: string;
+      }): Promise<void>;
       handleAgentProposalAction(message: {
         command: string;
         proposalId: string;
@@ -62,6 +70,7 @@ interface DesktopProgressIpcModule {
         model?: string;
         agent?: string;
       }): Promise<boolean>;
+      runtimeHost: AgentRuntimeHost;
     };
     onUnsupportedCommand?: (message: { command: string }) => void;
     onAsyncError?: (error: unknown) => void;
@@ -110,11 +119,19 @@ function createProgress() {
     handleToolEditApprovalAction: vi.fn(() => true),
     handleBashApprovalAction: vi.fn(async () => {}),
     handlePlanApprovalAction: vi.fn(),
+    handleUserQuestionAction: vi.fn(async () => {}),
     handleAgentProposalAction: vi.fn(async () => true),
+    runtimeHost: {
+      emit: vi.fn(),
+    },
   };
 }
 
 describe('desktop Progress IPC', () => {
+  afterEach(() => {
+    cleanupAllApprovals();
+  });
+
   it('syncs Progress state on readiness while allowing shared view-state handling', async () => {
     const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
     const progress = createProgress();
@@ -451,6 +468,46 @@ describe('desktop Progress IPC', () => {
       requestId: 'edit-2',
       action: 'openDiff',
     });
+  });
+
+  it('handles bypass toggles through shared policy instead of unsupported fallback', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    const onUnsupportedCommand = vi.fn();
+    const ipc = createDesktopProgressIpc({
+      progress,
+      onUnsupportedCommand,
+    });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
+        stream: 'run-1',
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    expect(onUnsupportedCommand).not.toHaveBeenCalled();
+    expect(progress.runtimeHost.emit).toHaveBeenCalledWith(
+      'updateToolEditApprovalBypassState',
+      { streamId: 'run-1', bypassActive: true },
+    );
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
+        stream: 'run-2',
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    expect(onUnsupportedCommand).not.toHaveBeenCalled();
+    expect(progress.runtimeHost.emit).toHaveBeenCalledWith(
+      'updateSuperYoloBypassState',
+      { streamId: 'run-2', bypassActive: true },
+    );
+    expect(progress.runtimeHost.emit).toHaveBeenCalledWith(
+      'updateToolEditApprovalBypassState',
+      { streamId: 'run-2', bypassActive: true },
+    );
   });
 
   it('routes agent proposal setup through the desktop bridge', async () => {


### PR DESCRIPTION
## Summary
- move progress-view bypass toggle policy into a shared host-neutral command handler
- wire extension and desktop IPC to the shared handler without adding DesktopProgressBridge pass-through methods
- make desktop consume edit/delegation bypass toggles instead of reporting them as unsupported

## Design notes
- This is the #5451 P3f slice for the remaining progress-view command handling split.
- The shared module owns the cross-approval symmetry rules: edit shield also mirrors bash bypass, delegated auto-approval enables edit/bash bypass, and disabling restores prompts.
- Host-specific UI remains at the edge: the extension passes its existing information-message callback; desktop uses the shared state/event path without adding notification plumbing in this slice.

## Tests
- corepack pnpm vitest run src/test-kernel/controllers/ProgressViewBypassCommandHandlers.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
- npm run typecheck
- npm run lint
- npm run compile:fast

Refs #5451
