### PR TITLE
feat(desktop): resume streams from persisted state

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -16,6 +16,8 @@ import {
   StreamLogStore,
   StreamSnapshotStore,
 } from '@transcript';
+import { streamDataDir } from '@transcript/streamDataPaths';
+import { readMeta } from '@transcript/streamSnapshotRead';
 import {
   buildStreamTabInfo,
   peekWorktreeInfo,
@@ -23,13 +25,16 @@ import {
 } from '@agent/index';
 import type { AgentTrace } from '@agent/trace';
 import type { ValidatedExecutionRequest } from '@agent/core/execution/executionRequests';
+import { TaskStateSchema } from '@agent/core/execution/TaskState';
 import {
   clearRetryRequest,
   resolvePlanApproval,
   resolveProposal,
 } from '@agent/runtime/runCoordinators';
+import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
 import {
   detachActiveChildren,
   interruptActiveChildren,
@@ -38,12 +43,14 @@ import { setRunStorageService } from '@agent/runtime/RunStorageService';
 import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import { toErrorMessage } from '@common/errors';
 import {
   getFileListConfig,
   loadFileListSettings,
   type ListableFileType,
 } from '@common/files/fileListingRules';
 import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
+import { KVStore } from '@common/storage/KVStore';
 import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { DiffViewHost } from '@hosts/diffViewHost';
 import type { ExternalOpener } from '@hosts/externalOpener';
@@ -63,6 +70,7 @@ import {
   type ProgressViewOutboundMessage,
   type StreamMetadata,
   type StreamStatus,
+  type ExecutionId,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
@@ -128,6 +136,18 @@ type StreamBadgeSnapshot = {
   finishedProcessCount: number;
 };
 
+type ResumeState = {
+  taskState: TaskState;
+  executionId?: ExecutionId;
+};
+
+type PersistedResumeMeta = {
+  taskState?: TaskState;
+  executionId?: ExecutionId;
+  description?: string;
+  parentStreamId?: StreamTabId;
+};
+
 export interface DesktopProgressBridgeOptions {
   detachSubagentsOnStop?: boolean;
   openPath?: (filePath: string, line?: number) => Promise<void>;
@@ -161,6 +181,8 @@ export class DesktopProgressBridge {
   private readonly executionIds = new Map<StreamTabId, string>();
   private readonly descriptions = new Map<StreamTabId, string>();
   private readonly parentStreams = new Map<StreamTabId, StreamTabId>();
+  private readonly resumeAttempts = new Set<StreamTabId>();
+  private readonly deletedStreams = new Set<StreamTabId>();
   private readonly creationTimestamps = new Map<StreamTabId, number>();
   private readonly conversationProgress = new Map<
     StreamTabId,
@@ -1023,6 +1045,7 @@ export class DesktopProgressBridge {
       this.taskStates.has(streamId) ||
       this.restoredStreams.has(streamId);
     if (!hadStream) return;
+    this.deletedStreams.add(streamId);
     this.removePersistedStream(streamId);
 
     // Shared approval cleanup also owns retry/proposal/plan coordinator cleanup.
@@ -1072,6 +1095,9 @@ export class DesktopProgressBridge {
       ...this.restoredStreams.keys(),
     ]);
     for (const streamId of streamIds) {
+      this.deletedStreams.add(streamId);
+    }
+    for (const streamId of streamIds) {
       ToolUseFollowUpQueue.release(streamId);
     }
     await OdysseyStore.forgetMany([...streamIds]);
@@ -1112,24 +1138,177 @@ export class DesktopProgressBridge {
   }
 
   async resumeStream(streamId: StreamTabId): Promise<void> {
-    const taskState = this.taskStates.get(streamId);
-    if (!taskState) {
-      // Ghost stream from a prior launch: we don't have taskState in
-      // memory and reviving the runtime is out of scope (audit item
-      // D Phase 2). Surface a clear message rather than silently no-op.
-      if (this.restoredStreams.has(streamId)) {
-        await this.options.showInfoMessage?.(
-          'This run is from a previous session. Live resume is not yet supported — please start a fresh run.',
-        );
-      }
-      return;
+    await this.tryResumeStream(streamId);
+  }
+
+  async tryResumeStream(streamId: StreamTabId): Promise<boolean> {
+    if (
+      StreamStatusService.isActiveOrResuming(streamId) ||
+      this.resumeAttempts.has(streamId) ||
+      this.deletedStreams.has(streamId)
+    ) {
+      this.logger.debug(
+        `Stream ${streamId} cannot be resumed, skipping desktop resume`,
+      );
+      return false;
     }
 
+    this.resumeAttempts.add(streamId);
+    let ownsResumingStatus = false;
+    try {
+      const resumeState = await this.resolveResumeState(streamId);
+      if (!resumeState) {
+        await this.options.showInfoMessage?.(
+          'No persisted run state was found for this stream. Start a new run instead.',
+        );
+        return false;
+      }
+
+      const { taskState, executionId } = resumeState;
+      if (!executionId) {
+        await this.options.showInfoMessage?.(
+          'This stream has no persisted execution id. Start a new run instead.',
+        );
+        return false;
+      }
+
+      const resume = await retrieveSessionResumeData(
+        streamId,
+        executionId,
+        taskState,
+      );
+      if (!resume) {
+        await this.options.showInfoMessage?.(
+          'This run has no resumable session state. Start a new run instead.',
+        );
+        return false;
+      }
+
+      if (resume.type === 'toolUse') {
+        ToolUseFollowUpQueue.acquire(streamId);
+        ownsResumingStatus = true;
+        StreamStatusService.set(streamId, STREAM_STATUS.RESUMING, {
+          runtimeHost: this.runtimeHost,
+        });
+        const queuedFollowUps = ToolUseFollowUpQueue.drainItems(streamId);
+        this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
+        try {
+          await resumeToolUseFromSnapshot(resume.snapshot, this.runtimeHost, {
+            setupSession: (session) => {
+              for (const item of queuedFollowUps) {
+                session.appendFollowUp(
+                  item.text,
+                  item.mediaFiles,
+                  item.displayText,
+                );
+              }
+            },
+          });
+        } catch (error) {
+          for (const item of queuedFollowUps) {
+            ToolUseFollowUpQueue.enqueue(streamId, item.text, {
+              mediaFiles: item.mediaFiles,
+              displayText: item.displayText,
+            });
+          }
+          if (queuedFollowUps.length > 0) {
+            this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
+          }
+          throw error;
+        }
+        return true;
+      }
+
+      ownsResumingStatus = true;
+      StreamStatusService.set(streamId, STREAM_STATUS.RESUMING, {
+        runtimeHost: this.runtimeHost,
+      });
+      await this.runExecution({
+        config: resume.agentConfig,
+        executionId: resume.executionId,
+      });
+      return true;
+    } catch (error) {
+      this.logger.error(`Failed to resume desktop stream ${streamId}`, {
+        data: error instanceof Error ? error : { error },
+      });
+      if (
+        ownsResumingStatus &&
+        StreamStatusService.get(streamId) === STREAM_STATUS.RESUMING
+      ) {
+        StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+          runtimeHost: this.runtimeHost,
+        });
+      }
+      await this.options.showErrorMessage?.(
+        `Resume failed: ${toErrorMessage(error)}`,
+      );
+      return false;
+    } finally {
+      this.resumeAttempts.delete(streamId);
+    }
+  }
+
+  private async resolveResumeState(
+    streamId: StreamTabId,
+  ): Promise<ResumeState | undefined> {
+    const taskState = this.taskStates.get(streamId);
     const executionId = this.executionIds.get(streamId);
-    await this.runExecution({
-      config: taskState.agentConfig,
-      ...(executionId && { executionId }),
-    });
+    if (taskState && executionId) return { taskState, executionId };
+
+    const persisted = await this.readPersistedResumeMeta(streamId);
+
+    const restoredTaskState = taskState ?? persisted?.taskState;
+    if (!restoredTaskState) return undefined;
+
+    const restoredExecutionId = executionId ?? persisted?.executionId;
+    this.taskStates.set(streamId, restoredTaskState);
+    this.categories.set(streamId, restoredTaskState.agentConfig.agentCategory);
+    if (restoredExecutionId) {
+      this.executionIds.set(streamId, restoredExecutionId);
+    }
+
+    if (persisted?.description !== undefined) {
+      this.descriptions.set(streamId, persisted.description);
+    }
+    if (persisted?.parentStreamId !== undefined) {
+      this.parentStreams.set(streamId, persisted.parentStreamId);
+    }
+
+    return {
+      taskState: restoredTaskState,
+      ...(restoredExecutionId && { executionId: restoredExecutionId }),
+    };
+  }
+
+  private async readPersistedResumeMeta(
+    streamId: StreamTabId,
+  ): Promise<PersistedResumeMeta | undefined> {
+    try {
+      // Resume only needs meta.json. Read it directly so this bridge does not
+      // create a second StreamSnapshotStore loader/writer for streamData/.
+      const meta = await readMeta(new KVStore(streamDataDir(streamId)));
+      if (!meta) return undefined;
+
+      const taskState = TaskStateSchema.safeParse(meta.taskState);
+      return {
+        ...(taskState.success && { taskState: taskState.data }),
+        ...(meta.executionId && {
+          executionId: meta.executionId as ExecutionId,
+        }),
+        ...(meta.description !== undefined && {
+          description: meta.description,
+        }),
+        ...(meta.parentStreamId !== undefined && {
+          parentStreamId: meta.parentStreamId,
+        }),
+      };
+    } catch (error) {
+      this.logger.warn(`Failed to read persisted resume data for ${streamId}`, {
+        data: error instanceof Error ? error : { error },
+      });
+      return undefined;
+    }
   }
 
   async runNewStream(streamId: StreamTabId): Promise<void> {

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -1,0 +1,22 @@
+import type { StreamTabId } from '@shared/schemas';
+
+type DesktopResumeHandler = (streamId: StreamTabId) => Promise<boolean>;
+
+let activeHandler: DesktopResumeHandler | undefined;
+
+export function setDesktopAgentResumeHandler(
+  handler: DesktopResumeHandler,
+): () => void {
+  activeHandler = handler;
+  return () => {
+    if (activeHandler === handler) {
+      activeHandler = undefined;
+    }
+  };
+}
+
+export async function tryResumeDesktopStream(
+  streamId: StreamTabId,
+): Promise<boolean> {
+  return activeHandler?.(streamId) ?? false;
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -24,6 +24,7 @@ import { interruptAllClaudeAgentSessions } from '@tools/claudeAgent';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
+import { setDesktopAgentResumeHandler } from './desktopAgentResume.js';
 import {
   openDesktopStreamSnapshotStore,
   type DesktopStreamSnapshotStore,
@@ -431,6 +432,9 @@ function createWindow(options: {
     showErrorMessage,
     streamSnapshotStore: options.streamSnapshotStore,
   });
+  const disposeAgentResumeHandler = setDesktopAgentResumeHandler((streamId) =>
+    agentExecution.progress.tryResumeStream(streamId),
+  );
   const fileSelection = createDesktopFileSelection({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     showOpenFileDialog: async (options) => {
@@ -595,6 +599,7 @@ function createWindow(options: {
     if (mainWindow === window) {
       mainWindow = null;
     }
+    disposeAgentResumeHandler();
     agentExecution.dispose();
     desktopAuth.dispose();
   });

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -11,10 +11,10 @@ import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { initPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
-import { registerAgentFeatures } from '@agent/features';
-import { bus } from '@eventBus/ProgressEventBus';
 import { StreamSnapshotStore } from '@transcript';
+import { registerAgentFeatures } from '@agent/features';
 import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
+import { bus } from '@eventBus/ProgressEventBus';
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 
@@ -23,6 +23,7 @@ import { ElectronSecrets } from './electronSecrets.js';
 import { repairLaunchPath } from './pathFix.js';
 import { resolveResourcesPath, resolveWorkspacePath } from './paths.js';
 import { showSecretStorageWarningDialog } from './secretStorageWarningDialog.js';
+import { tryResumeDesktopStream } from '../desktopAgentResume.js';
 
 // Type imports - platform
 import type { LifecycleHost } from '@platform/interfaces/lifecycle';
@@ -72,7 +73,7 @@ export async function initializeElectronPlatform(
       showWarningMessage: showSecretStorageWarningDialog,
     }),
     lifecycle,
-    agentResume: { tryResumeStream: async () => false },
+    agentResume: { tryResumeStream: tryResumeDesktopStream },
   });
   registerAgentFeatures();
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -24,6 +24,7 @@ type Bridge = {
 
 type TestableBridge = Bridge & {
   handleProgressEvent(event: string, payload: unknown): void;
+  tryResumeStream(streamId: StreamTabId): Promise<boolean>;
   setActiveStream(streamId: StreamTabId): void;
   deleteStream(streamId: StreamTabId): Promise<void>;
   deleteAllStreams(): Promise<void>;
@@ -75,6 +76,13 @@ interface DesktopAgentExecutionModule {
   }): DesktopExecution;
 }
 
+type CreateBridgeOptions = {
+  kvRead?: (key: string) => Promise<unknown> | unknown;
+  retrieveSessionResumeData?: ReturnType<typeof vi.fn>;
+  resumeToolUseFromSnapshot?: ReturnType<typeof vi.fn>;
+  runAgent?: RunExecutionRequest;
+};
+
 type ProgressMessage = {
   command?: string;
   activeStream?: string;
@@ -85,18 +93,29 @@ type ProgressMessage = {
   streamStates?: Record<string, unknown>;
 };
 
-async function createBridge(messages: unknown[]): Promise<TestableBridge> {
+async function createBridge(
+  messages: unknown[],
+  options: CreateBridgeOptions = {},
+): Promise<TestableBridge> {
   vi.resetModules();
   vi.doMock('@agent/runtime/RunStorageService', () => ({
     setRunStorageService: vi.fn(),
   }));
+  vi.doMock('@agent/runtime/SessionResumeRetrieval', () => ({
+    retrieveSessionResumeData:
+      options.retrieveSessionResumeData ?? vi.fn(async () => null),
+  }));
+  vi.doMock('@agent/runtime/executeAgent', () => ({
+    resumeToolUseFromSnapshot:
+      options.resumeToolUseFromSnapshot ?? vi.fn(async () => {}),
+  }));
   vi.doMock('@agent/runtime/runAgent', () => ({
-    runAgent: vi.fn(),
+    runAgent: options.runAgent ?? vi.fn(),
   }));
   vi.doMock('@common/storage/KVStore', () => ({
     KVStore: class {
-      async read(): Promise<undefined> {
-        return undefined;
+      async read(key: string): Promise<unknown> {
+        return options.kvRead?.(key);
       }
 
       async write(): Promise<void> {}
@@ -212,6 +231,12 @@ async function createExecution(options: {
   vi.doMock('@agent/runtime/RunStorageService', () => ({
     setRunStorageService: vi.fn(),
   }));
+  vi.doMock('@agent/runtime/SessionResumeRetrieval', () => ({
+    retrieveSessionResumeData: vi.fn(async () => null),
+  }));
+  vi.doMock('@agent/runtime/executeAgent', () => ({
+    resumeToolUseFromSnapshot: vi.fn(async () => {}),
+  }));
   vi.doMock('@agent/runtime/runAgent', () => ({
     runAgent: options.runAgent ?? vi.fn(async () => {}),
   }));
@@ -273,6 +298,8 @@ function progressMessages(
 describe('DesktopProgressBridge', () => {
   afterEach(() => {
     vi.doUnmock('@agent/runtime/RunStorageService');
+    vi.doUnmock('@agent/runtime/SessionResumeRetrieval');
+    vi.doUnmock('@agent/runtime/executeAgent');
     vi.doUnmock('@agent/runtime/runAgent');
     vi.doUnmock('@common/storage/KVStore');
     vi.doUnmock('@controllers/mainView/MainViewExecutionController');
@@ -480,6 +507,50 @@ describe('DesktopProgressBridge', () => {
         streamId: 'first',
         entries: [expect.objectContaining({ text: 'first stream log' })],
       });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('does not resume a stream deleted in this desktop session', async () => {
+    const taskState = {
+      agentConfig: {
+        agent: 'search',
+        model: 'deepseekproT',
+        agentCategory: AGENT_CATEGORY.TOOL_USE,
+      },
+    };
+    const retrieveSessionResumeData = vi.fn(async () => ({
+      type: 'toolUse',
+      snapshot: {
+        executionId: 'exec-1',
+        streamId: 'stream-1',
+        agentConfig: taskState.agentConfig,
+      },
+    }));
+    const bridge = await createBridge([], {
+      kvRead: vi.fn(async () => ({
+        executionId: 'exec-1',
+        taskState,
+      })),
+      retrieveSessionResumeData,
+    });
+
+    try {
+      bridge.handleProgressEvent('setTaskState', {
+        streamId: 'stream-1',
+        executionId: 'exec-1',
+        taskState,
+      });
+
+      await bridge.deleteStream('stream-1');
+      bridge.handleProgressEvent('setTaskState', {
+        streamId: 'stream-1',
+        executionId: 'exec-1',
+        taskState,
+      });
+      await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
+      expect(retrieveSessionResumeData).not.toHaveBeenCalled();
     } finally {
       bridge.dispose();
     }
@@ -760,6 +831,276 @@ describe('DesktopProgressBridge', () => {
       );
     } finally {
       execution.dispose();
+    }
+  });
+
+  it('resumes workflow streams from persisted meta', async () => {
+    const executionId = 'abc123';
+    const taskState = {
+      agentConfig: {
+        agent: 'proofreader',
+        model: 'deepseekproT',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        toolConfig: DEFAULT_TOOL_CONFIG,
+      },
+      activeFiles: {},
+    };
+    const retrieveSessionResumeData = vi.fn(async () => ({
+      type: 'workflow',
+      agentConfig: taskState.agentConfig,
+      executionId,
+    }));
+    const runAgent = vi.fn(async () => {});
+    const kvRead = vi.fn(async (key: string) =>
+      key === 'meta'
+        ? {
+            executionId,
+            taskState,
+            description: 'Persisted workflow',
+          }
+        : undefined,
+    );
+    const bridge = await createBridge([], {
+      kvRead,
+      retrieveSessionResumeData,
+      runAgent,
+    });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(true);
+      expect(kvRead).toHaveBeenCalledWith('meta');
+      expect(retrieveSessionResumeData).toHaveBeenCalledWith(
+        'stream-1',
+        executionId,
+        expect.objectContaining({
+          activeFiles: {},
+          agentConfig: expect.objectContaining(taskState.agentConfig),
+        }),
+      );
+      expect(runAgent).toHaveBeenCalledWith(
+        {
+          config: expect.objectContaining(taskState.agentConfig),
+          executionId,
+        },
+        expect.objectContaining({
+          runtimeHost: expect.objectContaining({ emit: expect.any(Function) }),
+          openWorkflowOutput: expect.any(Function),
+        }),
+      );
+    } finally {
+      StreamStatusService.clear('stream-1', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('resumes tool-use streams through the shared snapshot path', async () => {
+    const retrieveSessionResumeData = vi.fn(async () => ({
+      type: 'toolUse',
+      snapshot: {
+        executionId: 'exec-1',
+        streamId: 'stream-1',
+        agentConfig: {
+          agent: 'search',
+          model: 'deepseekproT',
+          agentCategory: AGENT_CATEGORY.TOOL_USE,
+        },
+      },
+    }));
+    const resumeToolUseFromSnapshot = vi.fn(async () => {});
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages, {
+      retrieveSessionResumeData,
+      resumeToolUseFromSnapshot,
+    });
+    const { ToolUseFollowUpQueue } =
+      await import('@agent/toolUse/ToolUseFollowUpQueueManager');
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+    const taskState = {
+      agentConfig: {
+        agent: 'search',
+        model: 'deepseekproT',
+        agentCategory: AGENT_CATEGORY.TOOL_USE,
+      },
+    };
+
+    try {
+      bridge.handleProgressEvent('setTaskState', {
+        streamId: 'stream-1',
+        executionId: 'exec-1',
+        taskState,
+      });
+      ToolUseFollowUpQueue.enqueue('stream-1', 'queued follow-up', {
+        force: true,
+      });
+
+      await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(true);
+      expect(retrieveSessionResumeData).toHaveBeenCalledWith(
+        'stream-1',
+        'exec-1',
+        taskState,
+      );
+      expect(resumeToolUseFromSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executionId: 'exec-1',
+          streamId: 'stream-1',
+        }),
+        expect.objectContaining({ emit: expect.any(Function) }),
+        expect.objectContaining({ setupSession: expect.any(Function) }),
+      );
+      const [, , resumeOptions] = resumeToolUseFromSnapshot.mock
+        .calls[0] as unknown as [
+        unknown,
+        unknown,
+        {
+          setupSession(session: {
+            appendFollowUp(
+              text: string,
+              mediaFiles?: readonly string[],
+              displayText?: string,
+            ): void;
+          }): void;
+        },
+      ];
+      const appendFollowUp = vi.fn();
+      resumeOptions.setupSession({ appendFollowUp });
+      expect(appendFollowUp).toHaveBeenCalledWith(
+        'queued follow-up',
+        undefined,
+        undefined,
+      );
+    } finally {
+      ToolUseFollowUpQueue.release('stream-1');
+      StreamStatusService.clear('stream-1', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('keeps queued follow-ups when tool-use resume fails', async () => {
+    const retrieveSessionResumeData = vi.fn(async () => ({
+      type: 'toolUse',
+      snapshot: {
+        executionId: 'exec-1',
+        streamId: 'stream-1',
+        agentConfig: {
+          agent: 'search',
+          model: 'deepseekproT',
+          agentCategory: AGENT_CATEGORY.TOOL_USE,
+        },
+      },
+    }));
+    const resumeToolUseFromSnapshot = vi.fn(async () => {
+      throw new Error('resume failed');
+    });
+    const bridge = await createBridge([], {
+      retrieveSessionResumeData,
+      resumeToolUseFromSnapshot,
+    });
+    const { ToolUseFollowUpQueue } =
+      await import('@agent/toolUse/ToolUseFollowUpQueueManager');
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      bridge.handleProgressEvent('setTaskState', {
+        streamId: 'stream-1',
+        executionId: 'exec-1',
+        taskState: {
+          agentConfig: {
+            agent: 'search',
+            model: 'deepseekproT',
+            agentCategory: AGENT_CATEGORY.TOOL_USE,
+          },
+        },
+      });
+      ToolUseFollowUpQueue.enqueue('stream-1', 'queued follow-up', {
+        force: true,
+      });
+
+      await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
+      expect(ToolUseFollowUpQueue.getAll('stream-1')).toEqual([
+        'queued follow-up',
+      ]);
+      expect(StreamStatusService.get('stream-1')).toBe(STREAM_STATUS.WAITING);
+    } finally {
+      ToolUseFollowUpQueue.release('stream-1');
+      StreamStatusService.clear('stream-1', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('does not launch a duplicate resume for active streams', async () => {
+    const retrieveSessionResumeData = vi.fn(async () => null);
+    const bridge = await createBridge([], { retrieveSessionResumeData });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      StreamStatusService.set('stream-1', STREAM_STATUS.RUNNING, {
+        emit: false,
+      });
+
+      await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
+      expect(retrieveSessionResumeData).not.toHaveBeenCalled();
+    } finally {
+      StreamStatusService.clear('stream-1', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('does not launch duplicate concurrent resume attempts', async () => {
+    let allowRetrieve: () => void = () => undefined;
+    const retrieveGate = new Promise<void>((resolve) => {
+      allowRetrieve = resolve;
+    });
+    let retrieveStarted: () => void = () => undefined;
+    const retrieveStartedPromise = new Promise<void>((resolve) => {
+      retrieveStarted = resolve;
+    });
+    const retrieveSessionResumeData = vi.fn(async () => {
+      retrieveStarted();
+      await retrieveGate;
+      return {
+        type: 'toolUse',
+        snapshot: {
+          executionId: 'exec-1',
+          streamId: 'stream-1',
+          agentConfig: {
+            agent: 'search',
+            model: 'deepseekproT',
+            agentCategory: AGENT_CATEGORY.TOOL_USE,
+          },
+        },
+      };
+    });
+    const bridge = await createBridge([], { retrieveSessionResumeData });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      bridge.handleProgressEvent('setTaskState', {
+        streamId: 'stream-1',
+        executionId: 'exec-1',
+        taskState: {
+          agentConfig: {
+            agent: 'search',
+            model: 'deepseekproT',
+            agentCategory: AGENT_CATEGORY.TOOL_USE,
+          },
+        },
+      });
+
+      const firstResume = bridge.tryResumeStream('stream-1');
+      await retrieveStartedPromise;
+      await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
+      allowRetrieve();
+      await expect(firstResume).resolves.toBe(true);
+      expect(retrieveSessionResumeData).toHaveBeenCalledTimes(1);
+    } finally {
+      StreamStatusService.clear('stream-1', { emit: false });
+      bridge.dispose();
     }
   });
 


### PR DESCRIPTION
## Summary
- replace the desktop platform's hardcoded `tryResumeStream: false` with a live resume port registered by the active window
- make desktop `Resume` load persisted task state/execution id from the shared `StreamSnapshotStore` sidecar before continuing a run
- resume tool-use streams through `retrieveSessionResumeData` + `resumeToolUseFromSnapshot`, and workflow streams through the existing `runExecution` path with the persisted execution id

## Design notes
- This keeps ownership with the existing shared resume/snapshot contracts instead of adopting the broader generated patch from #5452.
- The late-bound desktop resume port is intentionally tiny: platform init owns the port, the window registers the current bridge action, and window teardown clears only its own registration.
- The old previous-session fallback message is gone; missing task state, missing execution ids, and non-resumable flow records now fail explicitly without silently re-running.

## Tests
- corepack pnpm vitest run src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
- npm run typecheck
- npm run lint
- corepack pnpm --filter @texra/desktop build:main
- npm run compile:fast

Closes #5452

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Resume re-enters agent execution and reads persisted session state; incorrect resume could restart runs or mishandle follow-ups, though guards and tests limit duplicate/concurrent attempts and deleted streams.
> 
> **Overview**
> **Desktop can resume agent runs** instead of always no-oping through the platform `agentResume` port. A small `desktopAgentResume` module holds a window-scoped handler; platform init forwards `tryResumeStream` there, and each BrowserWindow registers `DesktopProgressBridge.tryResumeStream` on create and clears it on close.
> 
> **Resume logic** replaces the old “previous session not supported” stub. `tryResumeStream` skips active/resuming streams, in-flight attempts, and streams deleted this session; loads `taskState` / `executionId` (and related meta) from memory or **`streamData/{id}/meta.json`** via `readMeta`; then uses **`retrieveSessionResumeData`** and either **`resumeToolUseFromSnapshot`** (with queued follow-ups drained/replayed on failure) or **`runExecution`** for workflows. Missing or non-resumable state surfaces explicit info/error dialogs instead of silently re-running.
> 
> **Tests** add coverage for persisted workflow/tool-use resume, follow-up preservation, duplicate resume guards, and post-delete resume blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d0f0a634432c7784975d33d2be0f57d9fbbfe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->