### PR TITLE
refactor: share stream status display labels

### DIFF
--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from 'ink';
 
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 
 import { cliState, type StreamSlice } from '../state/cliState';
 import { orderedDescendantsFromTree } from '../state/focusCycle';
@@ -24,23 +25,6 @@ const MAX_LABEL_WIDTH = 18;
 interface OrderedStreamTab {
   readonly id: StreamTabId;
   readonly shortcutIndex?: number;
-}
-
-function statusLabel(status: string | undefined): string | undefined {
-  switch (status) {
-    case STREAM_STATUS.INITIALIZING:
-      return 'starting';
-    case STREAM_STATUS.RUNNING:
-      return 'running';
-    case STREAM_STATUS.WAITING:
-      return 'idle';
-    case STREAM_STATUS.STOPPED:
-      return 'stopped';
-    case STREAM_STATUS.READY:
-      return 'ready';
-    default:
-      return status;
-  }
 }
 
 function truncate(value: string, maxWidth: number): string {
@@ -254,7 +238,9 @@ export function streamTabsDisplayItems(init: {
   const items = ordered.map((tab): StreamTabDisplayItem => {
     const { id } = tab;
     const slice = init.streams.get(id);
-    const status = statusLabel(slice?.status);
+    const status = formatStreamStatusLabel(slice?.status, {
+      style: 'cliCompact',
+    });
     return {
       id,
       label: truncate(

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -1,5 +1,5 @@
-import { STREAM_STATUS } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
+import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { truncateSummary } from '@utils/text/stringUtils';
 
 import type { BypassState } from './state/cliState';
@@ -18,20 +18,10 @@ export interface CliSessionStatusInput {
 }
 
 export function formatCliStatusLabel(status: string | undefined): string {
-  switch (status) {
-    case STREAM_STATUS.INITIALIZING:
-      return 'starting…';
-    case STREAM_STATUS.RUNNING:
-      return 'running';
-    case STREAM_STATUS.WAITING:
-      return 'idle';
-    case STREAM_STATUS.STOPPED:
-      return 'stopped';
-    case STREAM_STATUS.READY:
-      return 'ready';
-    default:
-      return status ?? '—';
-  }
+  return formatStreamStatusLabel(status, {
+    style: 'cli',
+    missingLabel: '—',
+  });
 }
 
 function queuedFollowUpStatusLines(messages: readonly string[]): string[] {

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -17,6 +17,7 @@ import {
   type ConversationProgress,
   type StreamTabInfo,
 } from '@shared/schemas';
+import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { statusIndicatorStyles } from '@shared/styles/statusIndicatorStyles';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 
@@ -43,17 +44,6 @@ interface ToolbarButton {
   disabled?: boolean;
   isToggle?: boolean;
 }
-
-/** Status display labels - extracted as constant to avoid recreation on each render */
-const STATUS_LABELS: Record<string, string> = {
-  [STREAM_STATUS.RUNNING]: 'Running',
-  [STREAM_STATUS.ERROR]: 'Error',
-  [STREAM_STATUS.STOPPED]: 'Stopped',
-  [STREAM_STATUS.READY]: 'Ready',
-  [STREAM_STATUS.WAITING]: 'Waiting for follow-up',
-  [STREAM_STATUS.RESUMING]: 'Resuming',
-  [STREAM_STATUS.INITIALIZING]: 'Initializing',
-};
 
 /**
  * Buttons enabled per status - pre-computed as Sets to avoid
@@ -341,7 +331,9 @@ export class StreamHeader extends LitElement {
     }
 
     const status = this.status || STREAM_STATUS.READY;
-    const statusLabel = STATUS_LABELS[status] ?? status;
+    const statusLabel = formatStreamStatusLabel(status, {
+      style: 'progressHeader',
+    });
     const hasExecutionId = Boolean(this.stream.executionId);
     const agentCategory = this.stream.agentCategory;
     const toolbarButtons =

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -1,0 +1,72 @@
+import { STREAM_STATUS } from '@shared/schemas';
+
+const STREAM_STATUS_LABELS = {
+  cli: {
+    [STREAM_STATUS.INITIALIZING]: 'starting\u2026',
+    [STREAM_STATUS.RUNNING]: 'running',
+    [STREAM_STATUS.ERROR]: 'error',
+    [STREAM_STATUS.STOPPED]: 'stopped',
+    [STREAM_STATUS.READY]: 'ready',
+    [STREAM_STATUS.WAITING]: 'idle',
+    [STREAM_STATUS.RESUMING]: 'resuming',
+  },
+  cliCompact: {
+    [STREAM_STATUS.INITIALIZING]: 'starting',
+    [STREAM_STATUS.RUNNING]: 'running',
+    [STREAM_STATUS.ERROR]: 'error',
+    [STREAM_STATUS.STOPPED]: 'stopped',
+    [STREAM_STATUS.READY]: 'ready',
+    [STREAM_STATUS.WAITING]: 'idle',
+    [STREAM_STATUS.RESUMING]: 'resuming',
+  },
+  progressHeader: {
+    [STREAM_STATUS.INITIALIZING]: 'Initializing',
+    [STREAM_STATUS.RUNNING]: 'Running',
+    [STREAM_STATUS.ERROR]: 'Error',
+    [STREAM_STATUS.STOPPED]: 'Stopped',
+    [STREAM_STATUS.READY]: 'Ready',
+    [STREAM_STATUS.WAITING]: 'Waiting for follow-up',
+    [STREAM_STATUS.RESUMING]: 'Resuming',
+  },
+} as const;
+
+export type StreamStatusLabelStyle = keyof typeof STREAM_STATUS_LABELS;
+
+export function formatStreamStatusLabel(
+  status: string | undefined,
+  options: {
+    readonly style?: StreamStatusLabelStyle;
+    readonly missingLabel: string;
+  },
+): string;
+
+export function formatStreamStatusLabel(
+  status: string,
+  options?: {
+    readonly style?: StreamStatusLabelStyle;
+    readonly missingLabel?: string;
+  },
+): string;
+
+export function formatStreamStatusLabel(
+  status: string | undefined,
+  options?: {
+    readonly style?: StreamStatusLabelStyle;
+    readonly missingLabel?: string;
+  },
+): string | undefined;
+
+export function formatStreamStatusLabel(
+  status: string | undefined,
+  options: {
+    readonly style?: StreamStatusLabelStyle;
+    readonly missingLabel?: string;
+  } = {},
+): string | undefined {
+  if (status == null) return options.missingLabel;
+  return (
+    STREAM_STATUS_LABELS[options.style ?? 'progressHeader'][
+      status as keyof (typeof STREAM_STATUS_LABELS)['progressHeader']
+    ] ?? status
+  );
+}

--- a/src/test-kernel/shared/StreamStatusDisplay.vitest.ts
+++ b/src/test-kernel/shared/StreamStatusDisplay.vitest.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { STREAM_STATUS } from '@shared/schemas';
+import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
+
+describe('stream status display labels', () => {
+  it('preserves CLI status wording', () => {
+    expect(
+      formatStreamStatusLabel(STREAM_STATUS.INITIALIZING, { style: 'cli' }),
+    ).toBe('starting\u2026');
+    expect(
+      formatStreamStatusLabel(STREAM_STATUS.WAITING, { style: 'cli' }),
+    ).toBe('idle');
+  });
+
+  it('preserves compact CLI stream-tab wording', () => {
+    expect(
+      formatStreamStatusLabel(STREAM_STATUS.INITIALIZING, {
+        style: 'cliCompact',
+      }),
+    ).toBe('starting');
+    expect(
+      formatStreamStatusLabel(STREAM_STATUS.WAITING, {
+        style: 'cliCompact',
+      }),
+    ).toBe('idle');
+  });
+
+  it('preserves progress-view header wording', () => {
+    expect(
+      formatStreamStatusLabel(STREAM_STATUS.WAITING, {
+        style: 'progressHeader',
+      }),
+    ).toBe('Waiting for follow-up');
+    expect(
+      formatStreamStatusLabel(STREAM_STATUS.INITIALIZING, {
+        style: 'progressHeader',
+      }),
+    ).toBe('Initializing');
+  });
+
+  it('passes through unknown statuses and supports an explicit missing label', () => {
+    expect(formatStreamStatusLabel('custom')).toBe('custom');
+    expect(formatStreamStatusLabel('')).toBe('');
+    expect(formatStreamStatusLabel(undefined, { missingLabel: '-' })).toBe('-');
+  });
+});


### PR DESCRIPTION
## Summary

- add a host-neutral stream status display helper under `src/shared/streams/`
- use it from CLI detailed status, CLI stream tabs, and the progress-view stream header
- keep each host wording via explicit styles (`cli`, `cliCompact`, `progressHeader`)

This is a small #5451 CLI-sharing slice: it shares a real status-presentation contract without trying to force the webview `ProgressBackend` into the Ink TUI.

## Validation

- `corepack pnpm vitest run src/test-kernel/shared/StreamStatusDisplay.vitest.ts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing warning-only import-order noise)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor with tests guarding label parity; no auth, data, or stream lifecycle logic changes.
> 
> **Overview**
> Introduces **`formatStreamStatusLabel`** in `src/shared/streams/streamStatusDisplay.ts` so CLI and progress UI share one mapping from `STREAM_STATUS` to user-facing text, with **style-specific wording** (`cli`, `cliCompact`, `progressHeader`).
> 
> **CLI** stream tabs and session status drop local `switch` / inline mappers and call the helper instead. **Progress view** `StreamHeader` removes its `STATUS_LABELS` constant and uses `progressHeader` style for the status tooltip.
> 
> Adds **`StreamStatusDisplay.vitest.ts`** to lock in existing labels per style, unknown-status passthrough, and optional `missingLabel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24bb7983e0837bd4ce86bb893f8635b7bf415ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->