### PR TITLE
refactor: share desktop progress backend state

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -613,8 +613,10 @@ export class DesktopProgressBridge {
           });
           return;
         }
-        this.routeToProgress();
-        this.sendRestoredDisplay(data.streamId);
+        if (data.suppressViewSwitch !== true) {
+          this.routeToProgress();
+          this.sendRestoredDisplay(data.streamId);
+        }
         return;
       }
       case 'setTaskState': {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -12,17 +12,11 @@ import { ProgressWorkflowFileActionsController } from '@controllers/progressView
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform, tryPlatform } from '@platform/platform';
 import {
-  setDefaultStreamLogStore,
-  StreamLogStore,
   StreamSnapshotStore,
+  type StreamSnapshotStore as SnapshotStore,
 } from '@transcript';
 import { streamDataDir } from '@transcript/streamDataPaths';
 import { readMeta } from '@transcript/streamSnapshotRead';
-import {
-  buildStreamTabInfo,
-  peekWorktreeInfo,
-  resolveWorktreeInfo,
-} from '@agent/index';
 import type { AgentTrace } from '@agent/trace';
 import type { ValidatedExecutionRequest } from '@agent/core/execution/executionRequests';
 import { TaskStateSchema } from '@agent/core/execution/TaskState';
@@ -60,25 +54,22 @@ import { DEFAULT_MATH_MARKUP } from '@latex/latexdiff/mathMarkup';
 import { createChannelTrace } from '@logger';
 import {
   STREAM_STATUS,
-  type ActiveChildInfo,
   type AgentProposalPermission,
   type AgentCategory,
   type AgentCategoryFilter,
-  type ConversationProgress,
-  type OutputFileInfo,
   type ProgressViewInboundMessage,
   type ProgressViewOutboundMessage,
-  type StreamMetadata,
-  type StreamStatus,
   type ExecutionId,
   type StreamTabId,
-  type StreamTabInfo,
 } from '@shared/schemas';
 import type { RestoredStreamSnapshot } from '@shared/schemas';
+import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
+import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
+import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
-import { buildStreamMetadata as createStreamMetadata } from '@shared/streams/streamMetadata';
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import {
   cleanupAllApprovals,
   cleanupApprovalsForStream,
@@ -118,6 +109,7 @@ export interface DesktopAgentExecutionOptions {
    * previously-persisted "ghost" streams in the rail at launch.
    */
   streamSnapshotStore?: DesktopStreamSnapshotStore;
+  progressSnapshotStore?: SnapshotStore;
 }
 
 export interface DesktopAgentExecution {
@@ -127,14 +119,6 @@ export interface DesktopAgentExecution {
 }
 
 type TaskState = ProgressEventPayloads['setTaskState']['taskState'];
-type OutputFilesByRound = Map<number, OutputFileInfo[]>;
-
-type StreamBadgeSnapshot = {
-  activeSubagents: ActiveChildInfo[];
-  finishedSubagentCount: number;
-  activeProcesses: ActiveChildInfo[];
-  finishedProcessCount: number;
-};
 
 type ResumeState = {
   taskState: TaskState;
@@ -154,9 +138,10 @@ export interface DesktopProgressBridgeOptions {
   openBuildDisplay?: BuildDisplayFn;
   openDiff?: DiffViewHost['openDiff'];
   confirmAcceptFile?: (message: string) => Promise<boolean>;
-  showInfoMessage?: (message: string) => Promise<void>;
-  showErrorMessage?: (message: string) => Promise<void>;
+  showInfoMessage?: (message: string) => Promise<void> | void;
+  showErrorMessage?: (message: string) => Promise<void> | void;
   streamSnapshotStore?: DesktopStreamSnapshotStore;
+  progressSnapshotStore?: SnapshotStore;
 }
 
 function toFileLocation(filePath: string): FileLocation {
@@ -165,32 +150,36 @@ function toFileLocation(filePath: string): FileLocation {
     : pathToLocation(filePath);
 }
 
+class MemoryProgressStorage implements MementoStorage {
+  private readonly values = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    return this.values.has(key) ? (this.values.get(key) as T) : defaultValue;
+  }
+
+  async update<T>(key: string, value: T | undefined): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+      return;
+    }
+    this.values.set(key, value);
+  }
+}
+
 export class DesktopProgressBridge {
-  private readonly streamLogs = new StreamLogStore();
   private readonly logger: AgentTrace = createChannelTrace(
     'DesktopProgressBridge',
   );
+  private readonly backend: ProgressBackend;
+  private readonly state: ProgressBackend['state'];
+  readonly streamLogs: ProgressBackend['state']['streamLogs'];
   private readonly agentProposalController: ProgressAgentProposalController;
   private readonly workflowFileActions: ProgressWorkflowFileActionsController;
-  private readonly cursors = new Map<StreamTabId, number>();
-  private readonly taskStates = new Map<StreamTabId, TaskState>();
   private readonly agentProposals = new Map<string, AgentProposalPermission>();
-  private readonly outputFiles = new Map<StreamTabId, OutputFilesByRound>();
-  private readonly statuses = new Map<StreamTabId, StreamStatus>();
-  private readonly categories = new Map<StreamTabId, AgentCategory>();
-  private readonly executionIds = new Map<StreamTabId, string>();
-  private readonly descriptions = new Map<StreamTabId, string>();
-  private readonly parentStreams = new Map<StreamTabId, StreamTabId>();
   private readonly resumeAttempts = new Set<StreamTabId>();
   private readonly deletedStreams = new Set<StreamTabId>();
-  private readonly creationTimestamps = new Map<StreamTabId, number>();
-  private readonly conversationProgress = new Map<
-    StreamTabId,
-    ConversationProgress
-  >();
-  private readonly streamBadges = new Map<StreamTabId, StreamBadgeSnapshot>();
-  private activeStream: StreamTabId | '' = '';
-  private agentFilter: AgentCategoryFilter = 'all';
   private readonly unsubscribe: () => void;
   private readonly toolEditApprovals: DesktopToolEditApprovalController;
   /**
@@ -207,8 +196,7 @@ export class DesktopProgressBridge {
    * Durable per-stream sidecar reader. Restores a ghost (prior-session)
    * stream's persisted display — todos/plan/usage/output files — when it first
    * becomes active, the same data the CLI/extension show on resume. Reads are
-   * stateless disk reads, so a local instance is fine alongside the platform's
-   * bus-driven writer.
+   * stateless disk reads used only for restored rows from a previous launch.
    */
   private readonly durableSnapshots = new StreamSnapshotStore();
   /** Ghost streams whose persisted display has already been restored this session. */
@@ -220,17 +208,101 @@ export class DesktopProgressBridge {
     private readonly postToRenderer: (message: unknown) => void,
     private readonly options: DesktopProgressBridgeOptions = {},
   ) {
-    setDefaultStreamLogStore(this.streamLogs);
     setRunStorageService({ isViewVisible: () => true });
-    const unsubscribeStreamLogs = this.streamLogs.onChange((streamId) =>
-      this.flushLogs(streamId),
-    );
+    this.backend = new ProgressBackend({
+      storage: tryPlatform()?.workspaceState ?? new MemoryProgressStorage(),
+      snapshots: options.progressSnapshotStore ?? new StreamSnapshotStore(),
+      sendMessage: (message) => this.postToRenderer(message),
+      hasTarget: () => true,
+      configureUi: ({ webviewUpdater }) => ({
+        callbacks: {
+          showRetryRequest: () => undefined,
+          resolveRetryRequest: () => undefined,
+          showToolEditPermission: (payload) =>
+            webviewUpdater.showPermission({
+              kind: PERMISSION_KIND.TOOL_EDIT,
+              data: payload,
+            }),
+          resolveToolEditPermission: (requestId) =>
+            webviewUpdater.resolvePermission(
+              PERMISSION_KIND.TOOL_EDIT,
+              requestId,
+            ),
+          updateToolEditApprovalBypassState: (streamId, bypassActive) =>
+            webviewUpdater.updateBypassState(
+              streamId,
+              'toolEdit',
+              bypassActive,
+            ),
+          updateSuperYoloBypassState: (streamId, bypassActive) =>
+            webviewUpdater.updateBypassState(
+              streamId,
+              'superYolo',
+              bypassActive,
+            ),
+          showBashPermission: (payload) =>
+            webviewUpdater.showPermission({
+              kind: PERMISSION_KIND.BASH,
+              data: payload,
+            }),
+          resolveBashPermission: (requestId) =>
+            webviewUpdater.resolvePermission(PERMISSION_KIND.BASH, requestId),
+          showAgentProposal: (payload) => {
+            this.agentProposals.set(payload.proposalId, payload);
+            webviewUpdater.showPermission({
+              kind: PERMISSION_KIND.PROPOSAL,
+              data: payload,
+            });
+          },
+          resolveAgentProposal: (proposalId) => {
+            this.agentProposals.delete(proposalId);
+            webviewUpdater.resolvePermission(
+              PERMISSION_KIND.PROPOSAL,
+              proposalId,
+            );
+          },
+          showPlanApproval: (payload) =>
+            webviewUpdater.showPermission({
+              kind: PERMISSION_KIND.PLAN_APPROVAL,
+              data: payload,
+            }),
+          resolvePlanApproval: (approvalId) =>
+            webviewUpdater.resolvePermission(
+              PERMISSION_KIND.PLAN_APPROVAL,
+              approvalId,
+            ),
+          showExternalInquiry: () => undefined,
+          resolveExternalInquiry: () => undefined,
+          showUserQuestion: (payload) =>
+            webviewUpdater.showPermission({
+              kind: PERMISSION_KIND.USER_QUESTION,
+              data: payload,
+            }),
+          resolveUserQuestion: (requestId) =>
+            webviewUpdater.resolvePermission(
+              PERMISSION_KIND.USER_QUESTION,
+              requestId,
+            ),
+        },
+        hasPendingPermissions: () => false,
+      }),
+    });
+    this.state = this.backend.state;
+    this.streamLogs = this.state.streamLogs;
+    const backendSubscription = this.backend.setupEventListeners();
     const unsubscribeOdyssey = bus.on('odysseyStateChanged', ({ streamId }) => {
       this.updateOdysseyActiveFromStore(streamId);
     });
+    const unsubscribeEnsureProgress = bus.on(
+      'requestEnsureProgressView',
+      () => {
+        this.routeToProgress();
+      },
+    );
     this.unsubscribe = () => {
-      unsubscribeStreamLogs();
+      backendSubscription.dispose();
       unsubscribeOdyssey();
+      unsubscribeEnsureProgress();
     };
     this.runtimeHost = {
       emit: (event, payload) => this.handleProgressEvent(event, payload),
@@ -240,15 +312,14 @@ export class DesktopProgressBridge {
       openPath: options.openPath,
       openBuildDisplay: options.openBuildDisplay,
       openDiff: options.openDiff,
-      showErrorMessage: async (message) => {
-        await this.options.showErrorMessage?.(message);
-      },
+      showErrorMessage: this.options.showErrorMessage,
     });
     this.workflowFileActions = new ProgressWorkflowFileActionsController({
       state: {
-        getActiveStream: () => this.activeStream,
-        getExecutionId: (stream) => this.executionIds.get(stream),
-        getOutputFiles: (stream) => new Map(this.outputFiles.get(stream) ?? []),
+        getActiveStream: () => this.state.activeStream,
+        getExecutionId: (stream) => this.getStreamExecutionId(stream),
+        getOutputFiles: (stream) =>
+          new Map(this.state.snapshots.getOutputFiles(stream)),
         // The desktop bridge has no quick-pick UI, so Accept always replaces
         // the workspace file. Returning undefined keeps the controller from
         // building copy metadata that the desktop host would silently drop.
@@ -337,58 +408,48 @@ export class DesktopProgressBridge {
     const hydrated = options.streamSnapshotStore?.hydrated ?? [];
     for (const snapshot of hydrated) {
       this.restoredStreams.set(snapshot.streamId, snapshot);
-      this.creationTimestamps.set(
-        snapshot.streamId,
-        snapshot.creationTimestamp,
-      );
-      this.categories.set(snapshot.streamId, snapshot.agentCategory);
-      this.statuses.set(snapshot.streamId, snapshot.lastKnownStatus);
-      if (snapshot.description) {
-        this.descriptions.set(snapshot.streamId, snapshot.description);
-      }
-      if (snapshot.executionId) {
-        this.executionIds.set(snapshot.streamId, snapshot.executionId);
-      }
-      if (snapshot.parentStreamId) {
-        this.parentStreams.set(snapshot.streamId, snapshot.parentStreamId);
-      }
+      this.state.streamLogs.ensureStream(snapshot.streamId);
+      this.state.updateStreamHints(snapshot.streamId, {
+        agent: snapshot.agent,
+        agentCategory: snapshot.agentCategory,
+        inputFile: snapshot.inputFile,
+        creationTimestamp: snapshot.creationTimestamp,
+        executionId: snapshot.executionId,
+        parentStreamId: snapshot.parentStreamId,
+        description: snapshot.description,
+      });
+      StreamStatusService.set(snapshot.streamId, snapshot.lastKnownStatus, {
+        emit: false,
+      });
     }
   }
 
-  /**
-   * Build a RestoredStreamSnapshot for `streamId` from current bridge
-   * state and forward it to the persistence store. Best-effort: any
-   * write error is logged but never thrown — persistence problems
-   * must not break agent execution.
-   */
   private persistStreamSnapshot(streamId: StreamTabId): void {
     const store = this.options.streamSnapshotStore;
     if (!store) return;
 
-    const taskState = this.taskStates.get(streamId);
+    const taskState = this.state.snapshots.getTaskState(streamId);
+    const info = buildStreamInfo(this.state, streamId, 'all');
     const restored = this.restoredStreams.get(streamId);
-    const category =
-      taskState?.agentConfig.agentCategory ??
-      this.categories.get(streamId) ??
-      restored?.agentCategory ??
-      AGENT_CATEGORY.WORKFLOW;
-    const info = this.buildStreamInfo(streamId);
     const snapshot: RestoredStreamSnapshot = {
       streamId,
-      label: info.label,
-      agent: info.agent ?? restored?.agent,
-      agentCategory: category,
-      inputFile: info.inputFile || restored?.inputFile,
+      label: info?.label ?? restored?.label ?? streamId,
+      agent: info?.agent ?? restored?.agent,
+      agentCategory:
+        info?.agentCategory ??
+        restored?.agentCategory ??
+        AGENT_CATEGORY.WORKFLOW,
+      inputFile: info?.inputFile || restored?.inputFile,
       instruction: taskState?.agentConfig.instruction || restored?.instruction,
       lastKnownStatus:
-        this.statuses.get(streamId) ??
+        StreamStatusService.get(streamId) ??
         restored?.lastKnownStatus ??
         STREAM_STATUS.STOPPED,
-      description: this.descriptions.get(streamId) ?? restored?.description,
-      executionId: this.executionIds.get(streamId) ?? restored?.executionId,
-      parentStreamId:
-        this.parentStreams.get(streamId) ?? restored?.parentStreamId,
-      creationTimestamp: this.getCreationTimestamp(streamId),
+      description: info?.description ?? restored?.description,
+      executionId: info?.executionId ?? restored?.executionId,
+      parentStreamId: info?.parentStreamId ?? restored?.parentStreamId,
+      creationTimestamp:
+        info?.creationTimestamp ?? restored?.creationTimestamp ?? Date.now(),
       lastTimestamp:
         this.streamLogs.getLastTimestamp(streamId) ?? restored?.lastTimestamp,
       persistedAt: Date.now(),
@@ -414,23 +475,18 @@ export class DesktopProgressBridge {
   dispose(): void {
     this.toolEditApprovals.dispose();
     this.unsubscribe();
-    this.clearAllStreamMaps();
+    this.backend.dispose();
+    this.clearDesktopSessionMaps();
     this.workflowFileActions.clearAllBackups();
+    void this.state.flush().catch((error: unknown) => {
+      this.logger.warn('Failed to flush desktop progress state', {
+        data: error instanceof Error ? error : { error },
+      });
+    });
   }
 
-  private clearAllStreamMaps(): void {
+  private clearDesktopSessionMaps(): void {
     this.agentProposals.clear();
-    this.cursors.clear();
-    this.taskStates.clear();
-    this.outputFiles.clear();
-    this.statuses.clear();
-    this.categories.clear();
-    this.executionIds.clear();
-    this.descriptions.clear();
-    this.parentStreams.clear();
-    this.creationTimestamps.clear();
-    this.conversationProgress.clear();
-    this.streamBadges.clear();
     this.restoredStreams.clear();
     this.restoredDisplaySent.clear();
   }
@@ -439,179 +495,18 @@ export class DesktopProgressBridge {
     this.postToRenderer(message);
   }
 
+  private getStreamExecutionId(streamId: StreamTabId): ExecutionId | undefined {
+    return (
+      this.state.snapshots.getExecutionId(streamId) ??
+      this.state.getStreamHints(streamId).executionId
+    );
+  }
+
   private routeToProgress(): void {
     this.postToRenderer({
       command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
       route: 'progress',
     });
-  }
-
-  private ensureStream(
-    streamId: StreamTabId,
-    category: AgentCategory = AGENT_CATEGORY.WORKFLOW,
-  ): void {
-    this.getCreationTimestamp(streamId);
-    this.streamLogs.ensureStream(streamId);
-    if (!this.categories.has(streamId)) {
-      this.categories.set(streamId, category);
-    }
-  }
-
-  private getCreationTimestamp(streamId: StreamTabId): number {
-    const existing = this.creationTimestamps.get(streamId);
-    if (existing != null) return existing;
-    const createdAt = this.streamLogs.getFirstTimestamp(streamId) ?? Date.now();
-    this.creationTimestamps.set(streamId, createdAt);
-    return createdAt;
-  }
-
-  private buildStreamInfo(streamId: StreamTabId): StreamTabInfo {
-    const taskState = this.taskStates.get(streamId);
-    const restored = this.restoredStreams.get(streamId);
-    const workingDirectory =
-      taskState?.agentConfig.workingDirectory ?? undefined;
-    let worktreeInfo;
-    if (workingDirectory) {
-      worktreeInfo = peekWorktreeInfo(workingDirectory);
-      this.ensureWorktreeProbe(workingDirectory);
-    }
-    return buildStreamTabInfo({
-      streamId,
-      config: taskState?.agentConfig,
-      hints: {
-        agent: restored?.agent,
-        agentCategory: this.categories.get(streamId) ?? restored?.agentCategory,
-        inputFile: restored?.inputFile,
-      },
-      creationTimestamp: this.getCreationTimestamp(streamId),
-      executionId: this.executionIds.get(streamId),
-      parentStreamId: this.parentStreams.get(streamId),
-      description: this.descriptions.get(streamId),
-      worktreeInfo,
-    });
-  }
-
-  private ensureWorktreeProbe(workingDirectory: string): void {
-    // Fire-and-forget; the resolver owns TTL/in-flight de-duplication. Calling
-    // it on each render lets branch/dirty state refresh after the cache expires.
-    void resolveWorktreeInfo(workingDirectory).catch(() => {
-      /* best-effort chip enrichment */
-    });
-  }
-
-  private buildStreamMetadata(streamId: StreamTabId): StreamMetadata {
-    const category =
-      this.taskStates.get(streamId)?.agentConfig.agentCategory ??
-      this.categories.get(streamId) ??
-      AGENT_CATEGORY.WORKFLOW;
-    const badges = this.streamBadges.get(streamId);
-    return createStreamMetadata({
-      kind: category,
-      status: this.statuses.get(streamId),
-      lastTimestamp: this.streamLogs.getLastTimestamp(streamId),
-      conversationProgress: this.conversationProgress.get(streamId),
-      activeSubagents: badges?.activeSubagents,
-      finishedSubagentCount: badges?.finishedSubagentCount,
-      activeProcesses: badges?.activeProcesses,
-      finishedProcessCount: badges?.finishedProcessCount,
-    });
-  }
-
-  private updateActiveChildren(
-    parentStreamId: StreamTabId,
-    opts: {
-      activeField: 'activeSubagents' | 'activeProcesses';
-      countField: 'finishedSubagentCount' | 'finishedProcessCount';
-      next: ActiveChildInfo[];
-    },
-  ): StreamBadgeSnapshot {
-    this.ensureStream(parentStreamId);
-    const previous = this.streamBadges.get(parentStreamId) ?? {
-      activeSubagents: [],
-      finishedSubagentCount: 0,
-      activeProcesses: [],
-      finishedProcessCount: 0,
-    };
-    const previousIds = new Set(
-      previous[opts.activeField].map((child) => child.executionId),
-    );
-    const nextIds = new Set(opts.next.map((child) => child.executionId));
-    const newlyFinished = [...previousIds].filter(
-      (id) => !nextIds.has(id),
-    ).length;
-    const nextBadges = {
-      ...previous,
-      [opts.activeField]: opts.next,
-      [opts.countField]: previous[opts.countField] + newlyFinished,
-    };
-    this.streamBadges.set(parentStreamId, nextBadges);
-    return nextBadges;
-  }
-
-  private syncStreams(): void {
-    const liveIds = new Set(this.streamLogs.keys());
-    const liveStreams = [...liveIds].map((id) => this.buildStreamInfo(id));
-
-    // Restored "ghost" entries that haven't been replaced by live
-    // events yet. We surface them on the rail so the user can see the
-    // runs they had going (audit item D / trajectory #19). Skipping
-    // ghosts whose id is already in `liveIds` prevents duplicates when
-    // a previous run resumed in the same launch.
-    const ghostStreams: StreamTabInfo[] = [];
-    for (const [id, snapshot] of this.restoredStreams) {
-      if (liveIds.has(id)) continue;
-      ghostStreams.push(this.buildGhostStreamInfo(snapshot));
-    }
-
-    const streams = [...liveStreams, ...ghostStreams];
-    const streamStates = Object.fromEntries(
-      streams.map((stream) => [
-        stream.name,
-        this.buildStreamMetadata(stream.name),
-      ]),
-    );
-    this.send({
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-      streams,
-      activeStream: this.activeStream,
-      agentFilter: this.agentFilter,
-      streamStates,
-    });
-  }
-
-  private buildGhostStreamInfo(
-    snapshot: RestoredStreamSnapshot,
-  ): StreamTabInfo {
-    return buildStreamTabInfo({
-      streamId: snapshot.streamId,
-      hints: {
-        agent: snapshot.agent,
-        agentCategory: snapshot.agentCategory,
-        inputFile: snapshot.inputFile,
-      },
-      creationTimestamp: snapshot.creationTimestamp,
-      executionId: snapshot.executionId,
-      parentStreamId: snapshot.parentStreamId,
-      description: snapshot.description,
-    });
-  }
-
-  private flushLogs(streamId: StreamTabId): void {
-    if (streamId !== this.activeStream) return;
-    this.sendRestoredDisplay(streamId);
-    const log = this.streamLogs.get(streamId);
-    if (!log) return;
-    const cursor = this.cursors.get(streamId) ?? 0;
-    const entries = log.getRange(cursor, log.head);
-    const updates = log.drainDirtyUpdates(cursor);
-    if (entries.length === 0 && updates.length === 0) return;
-    this.send({
-      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
-      streamId,
-      entries,
-      updates,
-    });
-    this.cursors.set(streamId, log.head);
   }
 
   /**
@@ -631,7 +526,7 @@ export class DesktopProgressBridge {
     void this.durableSnapshots
       .read(streamId)
       .then((snap) => {
-        if (streamId !== this.activeStream) return;
+        if (streamId !== this.state.activeStream) return;
         // The persisted snapshot is authoritative for a restored stream: send
         // todos/plan verbatim so an intentionally-empty list or null plan CLEARS
         // any stale renderer state instead of being skipped — matching the CLI
@@ -686,13 +581,14 @@ export class DesktopProgressBridge {
 
   private updateOdysseyActiveFromStore(streamId: StreamTabId): void {
     const odyssey = OdysseyStore.getForStream(streamId);
-    this.send({
-      command: PROGRESS_VIEW_COMMANDS.ODYSSEY_ACTIVE_UPDATED,
-      stream: streamId,
-      active: isOdysseyInFlight(odyssey),
-      ...(odyssey?.status ? { status: odyssey.status } : {}),
-      ...(odyssey?.objective ? { objective: odyssey.objective } : {}),
-    });
+    this.backend.webviewUpdater.updateOdysseyActive(
+      streamId,
+      isOdysseyInFlight(odyssey),
+      {
+        status: odyssey?.status,
+        objective: odyssey?.objective,
+      },
+    );
   }
 
   private handleProgressEvent<K extends keyof ProgressEventPayloads>(
@@ -700,351 +596,94 @@ export class DesktopProgressBridge {
     payload: ProgressEventPayloads[K],
   ): void {
     bus.emit(event, payload);
-    this.progressEventHandlers[event]?.(payload);
+    this.updateDesktopRailForProgressEvent(event, payload);
   }
 
-  private sendActiveChildrenBadges(
-    parentStreamId: StreamTabId,
-    opts: {
-      activeField: 'activeSubagents' | 'activeProcesses';
-      countField: 'finishedSubagentCount' | 'finishedProcessCount';
-      next: ActiveChildInfo[];
-    },
-  ): void {
-    const badges = this.updateActiveChildren(parentStreamId, opts);
-    this.syncStreams();
-    this.send({
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
-      stream: parentStreamId,
-      ...badges,
-    });
-  }
-
-  // Maps each progress event to its desktop-side handler. A `null` entry is an
-  // explicit no-op: the event is either dispatched elsewhere (e.g.
-  // `odysseyStateChanged` via `bus.on` in the constructor; `runtimeHost.emit`
-  // is never its producer) or carries no desktop progress-mirror side effect.
-  // The map is exhaustive over `ProgressEventPayloads`, so adding a new event
-  // is a compile error until it is handled or explicitly marked `null` here.
-  private readonly progressEventHandlers: {
-    [K in keyof ProgressEventPayloads]:
-      | ((payload: ProgressEventPayloads[K]) => void)
-      | null;
-  } = {
-    requestEnsureProgressView: () => this.routeToProgress(),
-    setActiveStream: (data) => {
-      if (!data.streamId) {
-        this.activeStream = '';
-        this.send({
-          command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-          activeStream: '',
-        });
+  private updateDesktopRailForProgressEvent<
+    K extends keyof ProgressEventPayloads,
+  >(event: K, payload: ProgressEventPayloads[K]): void {
+    switch (event) {
+      case 'setActiveStream': {
+        const data = payload as ProgressEventPayloads['setActiveStream'];
+        if (!data.streamId) {
+          this.state.activeStream = '';
+          this.send({
+            command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+            activeStream: '',
+          });
+          return;
+        }
+        this.routeToProgress();
+        this.sendRestoredDisplay(data.streamId);
         return;
       }
-      this.ensureStream(
-        data.streamId,
-        data.agentCategory ?? AGENT_CATEGORY.WORKFLOW,
-      );
-      this.activeStream = data.streamId;
-      this.routeToProgress();
-      this.syncStreams();
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-        activeStream: data.streamId,
-      });
-      this.flushLogs(data.streamId);
-    },
-    setTaskState: (data) => {
-      this.ensureStream(
-        data.streamId,
-        data.taskState.agentConfig.agentCategory,
-      );
-      this.taskStates.set(data.streamId, data.taskState);
-      if (data.executionId)
-        this.executionIds.set(data.streamId, data.executionId);
-      // Live event arrived for what may have been a ghost. Drop the
-      // ghost entry — the live stream owns the rail row now.
-      this.restoredStreams.delete(data.streamId);
-      this.persistStreamSnapshot(data.streamId);
-      this.syncStreams();
-    },
-    updateStreamStatus: (data) => {
-      const wasKnownStream = this.streamLogs.has(data.streamId);
-      this.ensureStream(data.streamId);
-      this.statuses.set(data.streamId, data.status);
-      this.restoredStreams.delete(data.streamId);
-      this.persistStreamSnapshot(data.streamId);
-      if (!wasKnownStream) {
-        this.syncStreams();
+      case 'setTaskState': {
+        const data = payload as ProgressEventPayloads['setTaskState'];
+        this.streamLogs.ensureStream(data.streamId);
+        this.restoredStreams.delete(data.streamId);
+        this.persistStreamSnapshot(data.streamId);
+        return;
       }
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
-        stream: data.streamId,
-        status: data.status,
-        lastTimestamp: this.streamLogs.getLastTimestamp(data.streamId),
-      });
-    },
-    updateConversationProgress: (data) => {
-      this.conversationProgress.set(data.streamId, data.progress);
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS,
-        stream: data.streamId,
-        progress: data.progress,
-      });
-    },
-    updateTodos: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_TODOS,
-        stream: data.streamId,
-        todos: data.todos,
-      });
-    },
-    updatePlan: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PLAN,
-        stream: data.streamId,
-        plan: data.plan,
-      });
-    },
-    updateStreamUsage: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_RUN_USAGE,
-        stream: data.streamId,
-        runId: data.executionId ?? data.storageKey,
-        usage: data.usage,
-      });
-    },
-    addOutputFiles: (data) => {
-      const existing = this.outputFiles.get(data.streamId) ?? new Map();
-      for (const [round, files] of Object.entries(data.filesByRound)) {
-        existing.set(Number(round), files);
+      case 'updateStreamStatus': {
+        const data = payload as ProgressEventPayloads['updateStreamStatus'];
+        this.restoredStreams.delete(data.streamId);
+        this.persistStreamSnapshot(data.streamId);
+        return;
       }
-      this.outputFiles.set(data.streamId, existing);
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_FILES,
-        stream: data.streamId,
-        rounds: data.filesByRound,
-      });
-    },
-    updateMissingOutputs: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_MISSING_OUTPUTS,
-        stream: data.streamId,
-        rounds: data.filesByRound,
-      });
-    },
-    updateCompileFailures: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_COMPILE_FAILURES,
-        stream: data.streamId,
-        rounds: data.filesByRound,
-        reset: true,
-      });
-    },
-    updateStreamDescription: (data) => {
-      this.descriptions.set(data.streamId, data.description);
-      this.persistStreamSnapshot(data.streamId);
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION,
-        stream: data.streamId,
-        description: data.description,
-      });
-    },
-    setParentStream: (data) => {
-      if (data.parentStreamId == null) {
-        this.parentStreams.delete(data.childStreamId);
-      } else {
-        this.parentStreams.set(data.childStreamId, data.parentStreamId);
+      case 'updateStreamDescription': {
+        const data =
+          payload as ProgressEventPayloads['updateStreamDescription'];
+        this.persistStreamSnapshot(data.streamId);
+        return;
       }
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PARENT_STREAM,
-        stream: data.childStreamId,
-        parentStreamId: data.parentStreamId ?? undefined,
-      });
-      this.persistStreamSnapshot(data.childStreamId);
-    },
-    updateActiveSubagents: (data) =>
-      this.sendActiveChildrenBadges(data.parentStreamId, {
-        activeField: 'activeSubagents',
-        countField: 'finishedSubagentCount',
-        next: data.children,
-      }),
-    updateActiveProcesses: (data) =>
-      this.sendActiveChildrenBadges(data.parentStreamId, {
-        activeField: 'activeProcesses',
-        countField: 'finishedProcessCount',
-        next: data.processes,
-      }),
-    updateProcessOutput: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT,
-        stream: data.parentStreamId,
-        executionId: data.executionId,
-        stdout: data.stdout,
-        stderr: data.stderr,
-      });
-    },
-    showToolEditPermission: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'show',
-        permission: { kind: 'toolEdit', data },
-      });
-    },
-    resolveToolEditPermission: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'resolve',
-        kind: 'toolEdit',
-        id: data.requestId,
-      });
-    },
-    updateToolEditApprovalBypassState: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS,
-        stream: data.streamId,
-        type: 'toolEdit',
-        bypassActive: data.bypassActive,
-      });
-    },
-    showBashPermission: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'show',
-        permission: { kind: 'bash', data },
-      });
-    },
-    resolveBashPermission: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'resolve',
-        kind: 'bash',
-        id: data.requestId,
-      });
-    },
-    showAgentProposal: (data) => {
-      this.agentProposals.set(data.proposalId, data);
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'show',
-        permission: { kind: 'proposal', data },
-      });
-    },
-    resolveAgentProposal: (data) => {
-      this.agentProposals.delete(data.proposalId);
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'resolve',
-        kind: 'proposal',
-        id: data.proposalId,
-      });
-    },
-    showPlanApproval: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'show',
-        permission: { kind: 'planApproval', data },
-      });
-    },
-    resolvePlanApproval: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'resolve',
-        kind: 'planApproval',
-        id: data.approvalId,
-      });
-    },
-    showUserQuestion: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'show',
-        permission: { kind: 'userQuestion', data },
-      });
-    },
-    resolveUserQuestion: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
-        action: 'resolve',
-        kind: 'userQuestion',
-        id: data.requestId,
-      });
-    },
-    updateSuperYoloBypassState: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS,
-        stream: data.streamId,
-        type: 'superYolo',
-        bypassActive: data.bypassActive,
-      });
-    },
-    updateQueuedFollowUps: (data) => {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_QUEUED_FOLLOW_UPS,
-        stream: data.streamId,
-        messages: ToolUseFollowUpQueue.getAll(data.streamId),
-      });
-    },
-    // No-op events: produced elsewhere or with no desktop progress-mirror
-    // side effect. Kept as explicit `null` to preserve exhaustiveness.
-    odysseyStateChanged: null,
-    clearMissingOutputs: null,
-    updateBashApprovalBypassState: null,
-    showRetryRequest: null,
-    resolveRetryRequest: null,
-    showExternalInquiry: null,
-    resolveExternalInquiry: null,
-    inquiryThreadUpdated: null,
-    followUpSent: null,
-    removeStream: null,
-    extensionDeactivating: null,
-    githubTokenInvalid: null,
-    prSubscriptionsChanged: null,
-    prSubscriptionBindingsChanged: null,
-    repoSubscriptionsChanged: null,
-    repoSubscriptionBindingsChanged: null,
-    issueSubscriptionsChanged: null,
-    issueSubscriptionBindingsChanged: null,
-    toolAvailabilityChanged: null,
-    workspaceFilesWritten: null,
-    requestOpenFile: null,
-    requestShowInstruction: null,
-    showAgentConfigBanner: null,
-    requestShowError: null,
-  };
+      case 'setParentStream': {
+        const data = payload as ProgressEventPayloads['setParentStream'];
+        this.persistStreamSnapshot(data.childStreamId);
+        return;
+      }
+      default:
+        return;
+    }
+  }
 
   syncFullView(): void {
-    this.syncStreams();
-    if (this.activeStream) this.flushLogs(this.activeStream);
+    const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
+      this.state,
+      this.backend.eventHandler.getAllStreamStatuses(),
+    );
+    this.syncStreamContent(activeStream);
   }
 
   setActiveStream(streamId: StreamTabId): void {
-    if (
-      !this.streamLogs.has(streamId) &&
-      !this.taskStates.has(streamId) &&
-      !this.restoredStreams.has(streamId)
-    ) {
+    if (!this.streamLogs.has(streamId)) {
       return;
     }
-    this.activeStream = streamId;
-    this.syncStreams();
-    this.send({
-      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-      activeStream: streamId,
-    });
-    this.flushLogs(streamId);
+    const previous = this.state.activeStream;
+    if (previous && previous !== streamId) {
+      this.state.releasePreviousActive(previous);
+    }
+    this.state.activeStream = streamId;
+    this.backend.webviewUpdater.sendStreamMetadata(
+      this.state,
+      this.backend.eventHandler.getAllStreamStatuses(),
+    );
+    this.backend.webviewUpdater.setActiveStream(streamId);
+    this.syncStreamContent(streamId);
   }
 
   setAgentFilter(filter: AgentCategoryFilter): void {
-    this.agentFilter = filter;
-    this.syncStreams();
+    this.state.agentCategoryFilter = filter;
+    const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
+      this.state,
+      this.backend.eventHandler.getAllStreamStatuses(),
+    );
+    this.syncStreamContent(activeStream);
   }
 
   async deleteStream(streamId: StreamTabId): Promise<void> {
-    const hadStream =
-      this.streamLogs.has(streamId) ||
-      this.taskStates.has(streamId) ||
-      this.restoredStreams.has(streamId);
-    if (!hadStream) return;
+    if (!this.streamLogs.has(streamId) && !this.restoredStreams.has(streamId)) {
+      return;
+    }
     this.deletedStreams.add(streamId);
     this.removePersistedStream(streamId);
 
@@ -1052,38 +691,20 @@ export class DesktopProgressBridge {
     cleanupApprovalsForStream(streamId);
     ToolUseFollowUpQueue.release(streamId);
 
-    await this.streamLogs.delete(streamId);
-    this.taskStates.delete(streamId);
-    this.outputFiles.delete(streamId);
-    this.statuses.delete(streamId);
-    this.categories.delete(streamId);
-    this.executionIds.delete(streamId);
     this.deleteAgentProposalsForStream(streamId);
-    this.descriptions.delete(streamId);
-    this.parentStreams.delete(streamId);
-    this.creationTimestamps.delete(streamId);
-    this.conversationProgress.delete(streamId);
-    this.streamBadges.delete(streamId);
     this.workflowFileActions.clearStreamBackups(streamId);
-    this.cursors.delete(streamId);
+    this.restoredDisplaySent.delete(streamId);
     await OdysseyStore.forget(streamId);
-
-    const shouldSelectFallback = this.activeStream === streamId;
-    if (shouldSelectFallback) {
-      this.activeStream = this.streamLogs.keys()[0] ?? '';
-    }
+    await this.state.clearStream(streamId);
     this.send({
       command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
       stream: streamId,
     });
-    this.syncStreams();
-    if (shouldSelectFallback && this.activeStream) {
-      this.send({
-        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-        activeStream: this.activeStream,
-      });
-      this.flushLogs(this.activeStream);
-    }
+    const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
+      this.state,
+      this.backend.eventHandler.getAllStreamStatuses(),
+    );
+    this.syncStreamContent(activeStream);
   }
 
   async deleteAllStreams(): Promise<void> {
@@ -1091,7 +712,6 @@ export class DesktopProgressBridge {
     cleanupAllApprovals();
     const streamIds = new Set<StreamTabId>([
       ...this.streamLogs.keys(),
-      ...this.taskStates.keys(),
       ...this.restoredStreams.keys(),
     ]);
     for (const streamId of streamIds) {
@@ -1116,12 +736,29 @@ export class DesktopProgressBridge {
         });
     }
 
-    await this.streamLogs.clear();
-    this.clearAllStreamMaps();
+    await this.state.clearAll();
+    this.clearDesktopSessionMaps();
     this.workflowFileActions.clearAllBackups();
-    this.activeStream = '';
     this.send({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL });
-    this.syncStreams();
+    this.backend.webviewUpdater.sendStreamMetadata(
+      this.state,
+      this.backend.eventHandler.getAllStreamStatuses(),
+    );
+  }
+
+  private syncStreamContent(streamId: StreamTabId | ''): void {
+    if (!streamId) {
+      this.backend.eventHandler.syncStreamContent('');
+      return;
+    }
+
+    void this.streamLogs.ensureLoaded(streamId).then(() => {
+      if (this.state.activeStream !== streamId) return;
+      this.backend.eventHandler.syncStreamContent(streamId, {
+        includeActiveState: true,
+      });
+      this.sendRestoredDisplay(streamId);
+    });
   }
 
   stopStream(streamId: StreamTabId): void {
@@ -1252,8 +889,8 @@ export class DesktopProgressBridge {
   private async resolveResumeState(
     streamId: StreamTabId,
   ): Promise<ResumeState | undefined> {
-    const taskState = this.taskStates.get(streamId);
-    const executionId = this.executionIds.get(streamId);
+    const taskState = this.state.snapshots.getTaskState(streamId);
+    const executionId = this.getStreamExecutionId(streamId);
     if (taskState && executionId) return { taskState, executionId };
 
     const persisted = await this.readPersistedResumeMeta(streamId);
@@ -1262,17 +899,20 @@ export class DesktopProgressBridge {
     if (!restoredTaskState) return undefined;
 
     const restoredExecutionId = executionId ?? persisted?.executionId;
-    this.taskStates.set(streamId, restoredTaskState);
-    this.categories.set(streamId, restoredTaskState.agentConfig.agentCategory);
-    if (restoredExecutionId) {
-      this.executionIds.set(streamId, restoredExecutionId);
-    }
-
+    this.state.streamLogs.ensureStream(streamId);
+    this.state.updateStreamHints(streamId, {
+      agentCategory: restoredTaskState.agentConfig.agentCategory,
+    });
+    this.state.snapshots.setTaskState(
+      streamId,
+      restoredTaskState,
+      restoredExecutionId,
+    );
     if (persisted?.description !== undefined) {
-      this.descriptions.set(streamId, persisted.description);
+      this.state.snapshots.setDescription(streamId, persisted.description);
     }
     if (persisted?.parentStreamId !== undefined) {
-      this.parentStreams.set(streamId, persisted.parentStreamId);
+      this.state.snapshots.setParentStream(streamId, persisted.parentStreamId);
     }
 
     return {
@@ -1312,7 +952,7 @@ export class DesktopProgressBridge {
   }
 
   async runNewStream(streamId: StreamTabId): Promise<void> {
-    const taskState = this.taskStates.get(streamId);
+    const taskState = this.state.snapshots.getTaskState(streamId);
     if (!taskState) return;
 
     await this.runExecution({ config: taskState.agentConfig });
@@ -1614,9 +1254,10 @@ export function createDesktopAgentExecution(
     openBuildDisplay: options.opener?.openBuildDisplay,
     openDiff: options.diff?.openDiff,
     confirmAcceptFile: options.confirmAcceptFile,
-    showInfoMessage: async (message) => options.showInfoMessage?.(message),
-    showErrorMessage: async (message) => options.showErrorMessage?.(message),
+    showInfoMessage: options.showInfoMessage,
+    showErrorMessage: options.showErrorMessage,
     streamSnapshotStore: options.streamSnapshotStore,
+    progressSnapshotStore: options.progressSnapshotStore,
   });
 
   return {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -695,6 +695,9 @@ if (protocolLifecycle.shouldContinue) {
       } catch (error) {
         console.warn('Failed to open desktop stream snapshot store', error);
       }
+      await platformInit.progressSnapshotStore.load(
+        streamSnapshotStore?.hydrated.map((snapshot) => snapshot.streamId) ?? [],
+      );
       reopenMainWindow = () =>
         createWindow({
           workspacePath: platformInit.workspacePath,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -696,8 +696,7 @@ if (protocolLifecycle.shouldContinue) {
         console.warn('Failed to open desktop stream snapshot store', error);
       }
       await platformInit.progressSnapshotStore.load(
-        streamSnapshotStore?.hydrated.map((snapshot) => snapshot.streamId) ??
-          [],
+        streamSnapshotStore?.hydrated.map((snapshot) => snapshot.streamId) ?? [],
       );
       reopenMainWindow = () =>
         createWindow({

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -70,6 +70,7 @@ import {
   withNewWindowWorkspaceArgs,
   withWorkspacePathArg,
 } from '../workspacePath.js';
+import type { StreamSnapshotStore } from '@transcript';
 
 const moduleDirname = fileURLToPath(new URL('.', import.meta.url));
 const __dirname = findDesktopMainDir(moduleDirname);
@@ -238,6 +239,7 @@ function createWindow(options: {
   authCallbackState: DesktopAuthCallbackState;
   initializeCrashReporting: () => Promise<void>;
   streamSnapshotStore?: DesktopStreamSnapshotStore;
+  progressSnapshotStore: StreamSnapshotStore;
 }): void {
   const window = new BrowserWindow({
     width: 960,
@@ -431,6 +433,7 @@ function createWindow(options: {
     },
     showErrorMessage,
     streamSnapshotStore: options.streamSnapshotStore,
+    progressSnapshotStore: options.progressSnapshotStore,
   });
   const disposeAgentResumeHandler = setDesktopAgentResumeHandler((streamId) =>
     agentExecution.progress.tryResumeStream(streamId),
@@ -699,6 +702,7 @@ if (protocolLifecycle.shouldContinue) {
           authCallbackState,
           initializeCrashReporting,
           streamSnapshotStore,
+          progressSnapshotStore: platformInit.progressSnapshotStore,
         });
       reopenMainWindow();
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -695,7 +695,7 @@ if (protocolLifecycle.shouldContinue) {
       } catch (error) {
         console.warn('Failed to open desktop stream snapshot store', error);
       }
-      await platformInit.progressSnapshotStore.load(
+      await platformInit.progressSnapshotStore.preload(
         streamSnapshotStore?.hydrated.map((snapshot) => snapshot.streamId) ??
           [],
       );

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -696,7 +696,8 @@ if (protocolLifecycle.shouldContinue) {
         console.warn('Failed to open desktop stream snapshot store', error);
       }
       await platformInit.progressSnapshotStore.load(
-        streamSnapshotStore?.hydrated.map((snapshot) => snapshot.streamId) ?? [],
+        streamSnapshotStore?.hydrated.map((snapshot) => snapshot.streamId) ??
+          [],
       );
       reopenMainWindow = () =>
         createWindow({

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -14,7 +14,6 @@ import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { StreamSnapshotStore } from '@transcript';
 import { registerAgentFeatures } from '@agent/features';
 import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
-import { bus } from '@eventBus/ProgressEventBus';
 import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 
@@ -31,6 +30,7 @@ import type { LifecycleHost } from '@platform/interfaces/lifecycle';
 export interface ElectronPlatformInitResult {
   workspacePath: string | undefined;
   lifecycle: LifecycleHost;
+  progressSnapshotStore: StreamSnapshotStore;
 }
 
 export async function initializeElectronPlatform(
@@ -78,16 +78,11 @@ export async function initializeElectronPlatform(
   registerAgentFeatures();
 
   // Persist per-stream sidecar data (todos, plan, usage, output files) via the
-  // shared, host-agnostic snapshot store so desktop sessions write the same
-  // streamData/{id}/* files the CLI and extension read — making a session's
-  // display restorable cross-host. Liveness is never persisted. Single writer,
-  // driven by the shared progress bus; flushed on shutdown.
+  // shared, host-agnostic snapshot store. The desktop progress backend owns the
+  // bus event handling; the platform owns lifecycle flushing so app shutdown
+  // drains the same writer instead of creating a second bus subscriber.
   const snapshotStore = new StreamSnapshotStore();
-  const stopSnapshotSubscription = snapshotStore.subscribe(bus);
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => {
-    // Unsubscribe before the final flush so no late bus event re-queues a write,
-    // and so listeners don't accumulate if platform init is ever re-invoked.
-    stopSnapshotSubscription();
     return snapshotStore.flush();
   });
 
@@ -102,5 +97,5 @@ export async function initializeElectronPlatform(
     app.getVersion(),
   );
 
-  return { workspacePath, lifecycle };
+  return { workspacePath, lifecycle, progressSnapshotStore: snapshotStore };
 }

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -12,6 +12,7 @@ import {
 } from '@shared/progressView/backend/events/ProgressEventHandler';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
+import type { StreamSnapshotStore } from '@transcript';
 
 export type ProgressBackendMessageSender = ProgressViewMessageSender;
 
@@ -28,6 +29,7 @@ export interface ProgressBackendUiConfig {
 
 export interface ProgressBackendOptions {
   storage: MementoStorage;
+  snapshots?: StreamSnapshotStore;
   sendMessage: ProgressBackendMessageSender;
   hasTarget(): boolean;
   configureUi(services: ProgressBackendServices): ProgressBackendUiConfig;
@@ -58,7 +60,7 @@ export class ProgressBackend {
   readonly eventHandler: ProgressEventHandler;
 
   constructor(options: ProgressBackendOptions) {
-    this.state = new ProgressViewState(options.storage);
+    this.state = new ProgressViewState(options.storage, options.snapshots);
     this.webviewUpdater = new WebviewUpdater((message) => {
       sendUpdaterMessage(options.sendMessage, message);
     }, options.hasTarget);

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -356,7 +356,6 @@ export class ProgressEventHandler {
     const { streamId, executionId, taskState } = data;
     const isActiveStream = this.state.activeStream === streamId;
     const category = taskState.agentConfig.agentCategory;
-    const previousFilter = this.state.agentCategoryFilter;
 
     // Coordinate persistence + ephemeral side effects (formerly state.setTaskState).
     // taskState + executionId go in a single meta.json write.
@@ -371,17 +370,15 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      const filterChanged = this.state.agentCategoryFilter !== previousFilter;
-      if (filterChanged || isActiveStream) {
-        // sendStreamMetadata rebuilds StreamTabInfo[] for all visible streams.
-        // This fires once per run start (not during streaming) so the O(N)
-        // cost is acceptable. We need it here because setTaskState may change
-        // agentConfig (agent name, model, label) which the frontend tabs display.
-        this.webviewUpdater.sendStreamMetadata(
-          this.state,
-          StreamStatusService.getAll(),
-        );
-      }
+      // sendStreamMetadata rebuilds StreamTabInfo[] for all visible streams.
+      // This fires once per run start (not during streaming) so the O(N)
+      // cost is acceptable. We need it here because setTaskState may change
+      // agentConfig (agent name, model, label) which the frontend tabs display,
+      // including for background subagents that are not the active stream.
+      this.webviewUpdater.sendStreamMetadata(
+        this.state,
+        StreamStatusService.getAll(),
+      );
     }
   }
 

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -16,13 +16,16 @@ import { createChannelTrace } from '@logger';
 import {
   AgentCategoryFilterSchema,
   ContextStateDataSchema,
+  ExecutionIdSchema,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  StreamTabIdSchema,
   type ActiveChildInfo,
   type AgentCategoryFilter,
   type ConversationProgress,
   type ContextStateData,
+  type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
@@ -38,9 +41,14 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 /** Ephemeral stream metadata hints, displayed before TaskState is fully populated. */
 export const StreamHintsSchema = z.object({
+  agent: z.string().optional(),
   agentCategory: z.enum(AgentCategory).optional(),
+  inputFile: z.string().optional(),
   isRemote: z.boolean().optional(),
   creationTimestamp: z.number().optional(),
+  executionId: ExecutionIdSchema.optional(),
+  parentStreamId: StreamTabIdSchema.optional(),
+  description: z.string().optional(),
 });
 
 export type StreamHints = z.infer<typeof StreamHintsSchema>;
@@ -121,7 +129,7 @@ export class ProgressViewState {
 
   private readonly logger: AgentTrace;
 
-  constructor(storage: MementoStorage) {
+  constructor(storage: MementoStorage, snapshots = new StreamSnapshotStore()) {
     this.logger = createChannelTrace('ProgressViewState');
     this._prefs = new PersistedState(
       createBackendStorage(storage),
@@ -130,7 +138,7 @@ export class ProgressViewState {
     );
     this.streamLogs = new StreamLogStore();
     setDefaultStreamLogStore(this.streamLogs);
-    this.snapshots = new StreamSnapshotStore();
+    this.snapshots = snapshots;
   }
 
   // -- Preferences ------------------------------------------------------------

--- a/src/shared/progressView/backend/streamInfoUtils.ts
+++ b/src/shared/progressView/backend/streamInfoUtils.ts
@@ -71,13 +71,16 @@ export function buildStreamInfo(
     streamId: id,
     config,
     hints: {
+      agent: hints.agent,
       agentCategory: hints.agentCategory,
+      inputFile: hints.inputFile,
       isRemote: hints.isRemote,
     },
     creationTimestamp,
-    executionId: state.snapshots.getExecutionId(id),
-    parentStreamId: state.snapshots.getParentStreamId(id),
-    description: state.snapshots.getDescription(id),
+    executionId: state.snapshots.getExecutionId(id) ?? hints.executionId,
+    parentStreamId:
+      state.snapshots.getParentStreamId(id) ?? hints.parentStreamId,
+    description: state.snapshots.getDescription(id) ?? hints.description,
     worktreeInfo,
   });
 }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -224,10 +224,9 @@ async function createBridge(
   const { DesktopProgressBridge } = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
-  return new DesktopProgressBridge(
-    (message) => messages.push(message),
-    { streamSnapshotStore: options.streamSnapshotStore },
-  ) as TestableBridge;
+  return new DesktopProgressBridge((message) => messages.push(message), {
+    streamSnapshotStore: options.streamSnapshotStore,
+  }) as TestableBridge;
 }
 
 async function createExecution(options: {
@@ -311,7 +310,9 @@ function progressMessages(
 function createStreamSnapshotStore(
   hydrated: readonly RestoredStreamSnapshot[],
 ): TestDesktopStreamSnapshotStore {
-  const live = new Map(hydrated.map((snapshot) => [snapshot.streamId, snapshot]));
+  const live = new Map(
+    hydrated.map((snapshot) => [snapshot.streamId, snapshot]),
+  );
   return {
     hydrated,
     upsert: vi.fn(async (snapshot: RestoredStreamSnapshot) => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -224,9 +224,10 @@ async function createBridge(
   const { DesktopProgressBridge } = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
-  return new DesktopProgressBridge((message) => messages.push(message), {
-    streamSnapshotStore: options.streamSnapshotStore,
-  }) as TestableBridge;
+  return new DesktopProgressBridge(
+    (message) => messages.push(message),
+    { streamSnapshotStore: options.streamSnapshotStore },
+  ) as TestableBridge;
 }
 
 async function createExecution(options: {
@@ -368,7 +369,7 @@ function expectWorkflowResume(
 
 async function settleProgressEvents(): Promise<void> {
   await Promise.resolve();
-  await new Promise((resolve) => setTimeout(resolve, 25));
+  await new Promise((resolve) => setImmediate(resolve));
 }
 
 describe('DesktopProgressBridge', () => {
@@ -533,6 +534,31 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('does not route to progress for suppressed background stream switches', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'child-stream',
+        agentCategory: AGENT_CATEGORY.TOOL_USE,
+        suppressViewSwitch: true,
+      });
+      await settleProgressEvents();
+
+      expect(
+        messages.some(
+          (message) =>
+            (message as ProgressMessage).command ===
+              DESKTOP_SHELL_COMMANDS.SET_ROUTE &&
+            (message as { route?: string }).route === 'progress',
+        ),
+      ).toBe(false);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
   it('emits delete-stream cleanup and flushes fallback active stream logs', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_000);
     const messages: unknown[] = [];
@@ -560,14 +586,16 @@ describe('DesktopProgressBridge', () => {
       await bridge.deleteStream('second');
       await settleProgressEvents();
 
-      expect(
-        messages.map((message) => (message as ProgressMessage).command),
-      ).toEqual([
-        PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
-        PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-        PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
-        PROGRESS_VIEW_COMMANDS.LOG_DELTA,
-      ]);
+      await vi.waitFor(() =>
+        expect(
+          messages.map((message) => (message as ProgressMessage).command),
+        ).toEqual([
+          PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+          PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+          PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+          PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+        ]),
+      );
       expect(messages[0]).toMatchObject({
         command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
         stream: 'second',

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -224,9 +224,10 @@ async function createBridge(
   const { DesktopProgressBridge } = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
-  return new DesktopProgressBridge((message) => messages.push(message), {
-    streamSnapshotStore: options.streamSnapshotStore,
-  }) as TestableBridge;
+  return new DesktopProgressBridge(
+    (message) => messages.push(message),
+    { streamSnapshotStore: options.streamSnapshotStore },
+  ) as TestableBridge;
 }
 
 async function createExecution(options: {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -224,10 +224,9 @@ async function createBridge(
   const { DesktopProgressBridge } = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
-  return new DesktopProgressBridge(
-    (message) => messages.push(message),
-    { streamSnapshotStore: options.streamSnapshotStore },
-  ) as TestableBridge;
+  return new DesktopProgressBridge((message) => messages.push(message), {
+    streamSnapshotStore: options.streamSnapshotStore,
+  }) as TestableBridge;
 }
 
 async function createExecution(options: {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -8,6 +8,7 @@ import {
   LOG_LEVELS,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_STATUS,
+  type RestoredStreamSnapshot,
   type StreamTabId,
 } from '@shared/schemas';
 import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
@@ -24,6 +25,7 @@ type Bridge = {
 
 type TestableBridge = Bridge & {
   handleProgressEvent(event: string, payload: unknown): void;
+  syncFullView(): void;
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
   setActiveStream(streamId: StreamTabId): void;
   deleteStream(streamId: StreamTabId): Promise<void>;
@@ -65,6 +67,7 @@ type RunExecutionRequest = (
 interface DesktopAgentExecutionModule {
   DesktopProgressBridge: new (
     postToRenderer: (message: unknown) => void,
+    options?: { streamSnapshotStore?: TestDesktopStreamSnapshotStore },
   ) => Bridge;
   createDesktopAgentExecution(options: {
     postToRenderer(message: unknown): void;
@@ -81,6 +84,15 @@ type CreateBridgeOptions = {
   retrieveSessionResumeData?: ReturnType<typeof vi.fn>;
   resumeToolUseFromSnapshot?: ReturnType<typeof vi.fn>;
   runAgent?: RunExecutionRequest;
+  streamSnapshotStore?: TestDesktopStreamSnapshotStore;
+};
+
+type TestDesktopStreamSnapshotStore = {
+  readonly hydrated: readonly RestoredStreamSnapshot[];
+  upsert(snapshot: RestoredStreamSnapshot): Promise<void>;
+  remove(streamId: StreamTabId): Promise<void>;
+  replaceAll(snapshots: RestoredStreamSnapshot[]): Promise<void>;
+  getAll(): RestoredStreamSnapshot[];
 };
 
 type ProgressMessage = {
@@ -212,8 +224,9 @@ async function createBridge(
   const { DesktopProgressBridge } = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
-  return new DesktopProgressBridge((message) =>
-    messages.push(message),
+  return new DesktopProgressBridge(
+    (message) => messages.push(message),
+    { streamSnapshotStore: options.streamSnapshotStore },
   ) as TestableBridge;
 }
 
@@ -295,6 +308,68 @@ function progressMessages(
   );
 }
 
+function createStreamSnapshotStore(
+  hydrated: readonly RestoredStreamSnapshot[],
+): TestDesktopStreamSnapshotStore {
+  const live = new Map(hydrated.map((snapshot) => [snapshot.streamId, snapshot]));
+  return {
+    hydrated,
+    upsert: vi.fn(async (snapshot: RestoredStreamSnapshot) => {
+      live.set(snapshot.streamId, snapshot);
+    }),
+    remove: vi.fn(async (streamId: StreamTabId) => {
+      live.delete(streamId);
+    }),
+    replaceAll: vi.fn(async (snapshots: RestoredStreamSnapshot[]) => {
+      live.clear();
+      for (const snapshot of snapshots) live.set(snapshot.streamId, snapshot);
+    }),
+    getAll: () => [...live.values()],
+  };
+}
+
+function workflowTaskState(): {
+  agentConfig: {
+    agent: string;
+    model: string;
+    agentCategory: typeof AGENT_CATEGORY.WORKFLOW;
+    toolConfig: typeof DEFAULT_TOOL_CONFIG;
+  };
+  activeFiles: Record<string, boolean>;
+} {
+  return {
+    agentConfig: {
+      agent: 'proofreader',
+      model: 'deepseekproT',
+      agentCategory: AGENT_CATEGORY.WORKFLOW,
+      toolConfig: DEFAULT_TOOL_CONFIG,
+    },
+    activeFiles: {},
+  };
+}
+
+function expectWorkflowResume(
+  runAgent: ReturnType<typeof vi.fn>,
+  taskState: ReturnType<typeof workflowTaskState>,
+  executionId: string,
+): void {
+  expect(runAgent).toHaveBeenCalledWith(
+    {
+      config: expect.objectContaining(taskState.agentConfig),
+      executionId,
+    },
+    expect.objectContaining({
+      runtimeHost: expect.objectContaining({ emit: expect.any(Function) }),
+      openWorkflowOutput: expect.any(Function),
+    }),
+  );
+}
+
+async function settleProgressEvents(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
 describe('DesktopProgressBridge', () => {
   afterEach(() => {
     vi.doUnmock('@agent/runtime/RunStorageService');
@@ -353,6 +428,9 @@ describe('DesktopProgressBridge', () => {
         parentStreamId: 'parent',
         children: [{ executionId: 'agent-1', agentName: 'reviewer' }],
       });
+      await settleProgressEvents();
+      messages.length = 0;
+      bridge.syncFullView();
 
       const streamSync = progressMessages(
         messages,
@@ -431,10 +509,7 @@ describe('DesktopProgressBridge', () => {
 
       expect(
         messages.map((message) => (message as ProgressMessage).command),
-      ).toEqual([
-        PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-        PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
-      ]);
+      ).toEqual([PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS]);
       expect(
         progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS)[0]
           ?.streamStates?.['new-stream'],
@@ -478,16 +553,18 @@ describe('DesktopProgressBridge', () => {
         timestamp: 1_500,
         text: 'first stream log',
       });
+      await settleProgressEvents();
       messages.length = 0;
 
       await bridge.deleteStream('second');
+      await settleProgressEvents();
 
       expect(
         messages.map((message) => (message as ProgressMessage).command),
       ).toEqual([
         PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
         PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-        PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+        PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
         PROGRESS_VIEW_COMMANDS.LOG_DELTA,
       ]);
       expect(messages[0]).toMatchObject({
@@ -496,10 +573,6 @@ describe('DesktopProgressBridge', () => {
       });
       expect(messages[1]).toMatchObject({
         command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-        activeStream: 'first',
-      });
-      expect(messages[2]).toMatchObject({
-        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
         activeStream: 'first',
       });
       expect(messages[3]).toMatchObject({
@@ -573,6 +646,7 @@ describe('DesktopProgressBridge', () => {
         streamId: 'third',
         agentCategory: AGENT_CATEGORY.WORKFLOW,
       });
+      await settleProgressEvents();
       bridge.setActiveStream('second');
       messages.length = 0;
 
@@ -613,6 +687,7 @@ describe('DesktopProgressBridge', () => {
         streamId: 'second',
         agentCategory: AGENT_CATEGORY.WORKFLOW,
       });
+      await settleProgressEvents();
       bridge.setActiveStream('first');
       messages.length = 0;
 
@@ -628,10 +703,6 @@ describe('DesktopProgressBridge', () => {
       ).toEqual([
         {
           activeStream: 'second',
-          command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-        },
-        {
-          activeStream: 'first',
           command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
         },
       ]);
@@ -657,6 +728,7 @@ describe('DesktopProgressBridge', () => {
         streamId: 'active',
         agentCategory: AGENT_CATEGORY.WORKFLOW,
       });
+      await settleProgressEvents();
       messages.length = 0;
 
       await bridge.deleteAllStreams();
@@ -836,15 +908,7 @@ describe('DesktopProgressBridge', () => {
 
   it('resumes workflow streams from persisted meta', async () => {
     const executionId = 'abc123';
-    const taskState = {
-      agentConfig: {
-        agent: 'proofreader',
-        model: 'deepseekproT',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
-        toolConfig: DEFAULT_TOOL_CONFIG,
-      },
-      activeFiles: {},
-    };
+    const taskState = workflowTaskState();
     const retrieveSessionResumeData = vi.fn(async () => ({
       type: 'workflow',
       agentConfig: taskState.agentConfig,
@@ -879,16 +943,61 @@ describe('DesktopProgressBridge', () => {
           agentConfig: expect.objectContaining(taskState.agentConfig),
         }),
       );
-      expect(runAgent).toHaveBeenCalledWith(
+      expectWorkflowResume(runAgent, taskState, executionId);
+    } finally {
+      StreamStatusService.clear('stream-1', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('resumes hydrated ghost streams using hinted execution ids', async () => {
+    const executionId = 'abc123';
+    const taskState = workflowTaskState();
+    const retrieveSessionResumeData = vi.fn(async () => ({
+      type: 'workflow',
+      agentConfig: taskState.agentConfig,
+      executionId,
+    }));
+    const runAgent = vi.fn(async () => {});
+    const kvRead = vi.fn(async (key: string) =>
+      key === 'meta'
+        ? {
+            taskState,
+            description: 'Persisted workflow',
+          }
+        : undefined,
+    );
+    const bridge = await createBridge([], {
+      kvRead,
+      retrieveSessionResumeData,
+      runAgent,
+      streamSnapshotStore: createStreamSnapshotStore([
         {
-          config: expect.objectContaining(taskState.agentConfig),
+          streamId: 'stream-1',
+          label: 'proofreader',
+          agent: 'proofreader',
+          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          lastKnownStatus: STREAM_STATUS.STOPPED,
           executionId,
+          creationTimestamp: 1_000,
+          persistedAt: 2_000,
         },
+      ]),
+    });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(true);
+      expect(retrieveSessionResumeData).toHaveBeenCalledWith(
+        'stream-1',
+        executionId,
         expect.objectContaining({
-          runtimeHost: expect.objectContaining({ emit: expect.any(Function) }),
-          openWorkflowOutput: expect.any(Function),
+          activeFiles: {},
+          agentConfig: expect.objectContaining(taskState.agentConfig),
         }),
       );
+      expectWorkflowResume(runAgent, taskState, executionId);
     } finally {
       StreamStatusService.clear('stream-1', { emit: false });
       bridge.dispose();

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1,8 +1,16 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+// Local imports - agent
+import type { TaskState } from '@agent/core/execution/TaskState';
+import { bus } from '@eventBus/ProgressEventBus';
+
 // Local imports - shared
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  AgentCategory,
+  type ProgressViewOutboundMessage,
+} from '@shared/schemas';
 import {
   ProgressBackend,
   type ProgressBackendServices,
@@ -50,6 +58,16 @@ function createUiConfig(): ProgressBackendUiConfig {
     },
     hasPendingPermissions: vi.fn(() => false),
   };
+}
+
+function toolUseTaskState(agent: string, model: string): TaskState {
+  return {
+    agentConfig: {
+      agent,
+      model,
+      agentCategory: AgentCategory.ToolUse,
+    },
+  } as TaskState;
 }
 
 describe('ProgressBackend', () => {
@@ -126,5 +144,79 @@ describe('ProgressBackend', () => {
     expect(sent).toHaveBeenCalledTimes(2);
 
     backend.dispose();
+  });
+
+  it('refreshes stream metadata when inactive stream task state arrives', async () => {
+    const messages: ProgressViewOutboundMessage[] = [];
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      sendMessage: (message) => {
+        messages.push(message);
+        return true;
+      },
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+    });
+    const subscription = backend.setupEventListeners();
+
+    try {
+      bus.emit('setActiveStream', {
+        streamId: 'root',
+        agentCategory: AgentCategory.Workflow,
+      });
+      await vi.waitFor(() =>
+        expect(
+          messages.some(
+            (message) =>
+              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+          ),
+        ).toBe(true),
+      );
+
+      bus.emit('setActiveStream', {
+        streamId: 'child',
+        agentCategory: AgentCategory.ToolUse,
+        suppressViewSwitch: true,
+      });
+      await vi.waitFor(() =>
+        expect(
+          messages.some(
+            (message) =>
+              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS &&
+              message.streams.some((stream) => stream.name === 'child'),
+          ),
+        ).toBe(true),
+      );
+      messages.length = 0;
+
+      bus.emit('setTaskState', {
+        streamId: 'child',
+        executionId: 'exec-child',
+        taskState: toolUseTaskState('search', 'deepseekproT'),
+      });
+
+      await vi.waitFor(() =>
+        expect(
+          messages.find(
+            (message) =>
+              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+          ),
+        ).toMatchObject({
+          activeStream: 'root',
+          streams: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'child',
+              label: 'search',
+              agent: 'search',
+              model: 'deepseekproT',
+              executionId: 'exec-child',
+            }),
+          ]),
+        }),
+      );
+    } finally {
+      subscription.dispose();
+      backend.dispose();
+    }
   });
 });

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -49,6 +49,7 @@ async function installPlatform(): Promise<void> {
 }
 
 const STREAM = 'polish@gpt#abc123def' as StreamTabId;
+const OTHER_STREAM = 'review@gpt#fed321cba' as StreamTabId;
 const RUN = 'run-1' as StorageKey;
 const RUN_2 = 'run-2' as StorageKey;
 
@@ -206,6 +207,29 @@ describe('StreamSnapshotStore', () => {
 
     const store = new StreamSnapshotStore();
     const immediate = store.addUsage(STREAM, RUN_2, usage(50, 10, 0.25));
+    expect(immediate).toBeUndefined();
+    await store.flush();
+
+    const raw = await StorageFS.readJson(path.join(dir, 'usageStats.json'));
+    expect(raw).toMatchObject({
+      [RUN]: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
+      [RUN_2]: { inputTokens: 50, outputTokens: 10, cost: 0.25 },
+    });
+  });
+
+  it('keeps seed-before-write for streams outside a partial preload', async () => {
+    await installPlatform();
+    const dir = streamDataDir(OTHER_STREAM);
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'usageStats.json'),
+      JSON.stringify({ [RUN]: usage(100, 20, 0.5) }),
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.preload([STREAM]);
+
+    const immediate = store.addUsage(OTHER_STREAM, RUN_2, usage(50, 10, 0.25));
     expect(immediate).toBeUndefined();
     await store.flush();
 

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -10,14 +10,20 @@ import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
+import {
+  TaskStateSchema,
+  type TaskState,
+} from '@agent/core/execution/TaskState';
 import { bus } from '@eventBus/ProgressEventBus';
 import type {
+  ExecutionId,
   Plan,
   StorageKey,
   StreamTabId,
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
+import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { StorageFS } from '@utils/files';
 
 const tempDirs: string[] = [];
@@ -203,6 +209,40 @@ describe('StreamSnapshotStore', () => {
     expect(immediate).toBeUndefined();
     await store.flush();
 
+    const raw = await StorageFS.readJson(path.join(dir, 'usageStats.json'));
+    expect(raw).toMatchObject({
+      [RUN]: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
+      [RUN_2]: { inputTokens: 50, outputTokens: 10, cost: 0.25 },
+    });
+  });
+
+  it('makes task state readable immediately while preserving later seeded sidecars', async () => {
+    await installPlatform();
+    const dir = streamDataDir(STREAM);
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'usageStats.json'),
+      JSON.stringify({ [RUN]: usage(100, 20, 0.5) }),
+    );
+
+    const store = new StreamSnapshotStore();
+    const taskState = TaskStateSchema.parse({
+      agentConfig: {
+        agent: 'search',
+        model: 'deepseekproT',
+        agentCategory: AGENT_CATEGORY.TOOL_USE,
+      },
+    }) as TaskState;
+    const executionId = 'abc123' as ExecutionId;
+
+    store.setTaskState(STREAM, taskState, executionId);
+    expect(store.getTaskState(STREAM)).toEqual(taskState);
+    expect(store.getExecutionId(STREAM)).toBe(executionId);
+    expect(store.addUsage(STREAM, RUN_2, usage(50, 10, 0.25))).toBeUndefined();
+    await store.flush();
+
+    expect(store.getTaskState(STREAM)).toEqual(taskState);
+    expect(store.getExecutionId(STREAM)).toBe(executionId);
     const raw = await StorageFS.readJson(path.join(dir, 'usageStats.json'));
     expect(raw).toMatchObject({
       [RUN]: { inputTokens: 100, outputTokens: 20, cost: 0.5 },

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -114,7 +114,7 @@ export class StreamSnapshotStore {
   private readonly seedChains = new Map<StreamTabId, Promise<void>>();
   private readonly metaOverlays = new Set<StreamTabId>();
   private readonly streamVersions = new Map<StreamTabId, number>();
-  private hasLoadedKnownStreams = false;
+  private hasAuthoritativeStreamSet = false;
 
   private readonly kvCache = new Map<StreamTabId, KVStore>();
 
@@ -210,15 +210,17 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * Run a mutation only after existing disk state has been loaded. After the
-   * authoritative startup load, streams not seen on disk are treated as new and
-   * mutate synchronously so UI callers can read back their own writes.
+   * Run a mutation only after existing disk state has been loaded. After an
+   * authoritative full load, streams outside that loaded set are treated as new
+   * and mutate synchronously so UI callers can read back their own writes.
+   * Partial preloads intentionally do not enable this fast path because other
+   * streams may still have sidecars on disk.
    */
   private mutate<T>(stream: StreamTabId, apply: () => T): T | undefined {
     const version = this.streamVersion(stream);
     if (this.seeded.has(stream)) return apply();
 
-    if (this.hasLoadedKnownStreams && !this.seedChains.has(stream)) {
+    if (this.hasAuthoritativeStreamSet && !this.seedChains.has(stream)) {
       this.seeded.add(stream);
       return apply();
     }
@@ -769,13 +771,28 @@ export class StreamSnapshotStore {
    * per-stream chain and apply after the disk snapshot.
    */
   async load(streamIds: readonly StreamTabId[]): Promise<void> {
-    this.hasLoadedKnownStreams = false;
+    this.hasAuthoritativeStreamSet = false;
     this.evictStreamsExcept(new Set(streamIds));
+    await this.seedStreams(streamIds);
+    this.hasAuthoritativeStreamSet = true;
+    await this.backfillDescriptionsFromExecutionMeta();
+  }
+
+  /**
+   * Warm selected stream sidecars without claiming that `streamIds` is the full
+   * stream set. Use this when a host only has a partial rail snapshot at
+   * startup; later mutations for other streams must still seed from disk before
+   * writing.
+   */
+  async preload(streamIds: readonly StreamTabId[]): Promise<void> {
+    await this.seedStreams(streamIds);
+    await this.backfillDescriptionsFromExecutionMeta();
+  }
+
+  private async seedStreams(streamIds: readonly StreamTabId[]): Promise<void> {
     await pMap(streamIds, (streamId) => this.refreshSeed(streamId), {
       concurrency: SEED_IO_CONCURRENCY,
     });
-    this.hasLoadedKnownStreams = true;
-    await this.backfillDescriptionsFromExecutionMeta();
   }
 
   private evictStreamsExcept(keep: ReadonlySet<StreamTabId>): void {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -112,6 +112,7 @@ export class StreamSnapshotStore {
   // refresh/seed/mutate per stream.
   private readonly seeded = new Set<StreamTabId>();
   private readonly seedChains = new Map<StreamTabId, Promise<void>>();
+  private readonly metaOverlays = new Set<StreamTabId>();
   private readonly streamVersions = new Map<StreamTabId, number>();
   private hasLoadedKnownStreams = false;
 
@@ -421,6 +422,7 @@ export class StreamSnapshotStore {
     this.taskStates.delete(stream);
     this.seeded.delete(stream);
     this.seedChains.delete(stream);
+    this.metaOverlays.delete(stream);
     this.kvCache.delete(stream);
     for (const key of [...this.pendingWrites.keys()]) {
       if (key.startsWith(`${stream}::`)) this.pendingWrites.delete(key);
@@ -450,6 +452,7 @@ export class StreamSnapshotStore {
     this.taskStates.clear();
     this.seeded.clear();
     this.seedChains.clear();
+    this.metaOverlays.clear();
     this.kvCache.clear();
     this.pendingWrites.clear();
   }
@@ -494,9 +497,16 @@ export class StreamSnapshotStore {
     return this.workPlan.get(stream) ?? EMPTY_WORK_PLAN;
   }
 
-  private patchMeta(stream: StreamTabId, patch: Partial<StreamTabMeta>): void {
+  private patchMetaMemory(
+    stream: StreamTabId,
+    patch: Partial<StreamTabMeta>,
+  ): StreamTabMeta {
     const next: StreamTabMeta = { ...(this.meta.get(stream) ?? {}), ...patch };
     this.meta.set(stream, next);
+    return next;
+  }
+
+  private writeMeta(stream: StreamTabId, next: StreamTabMeta): void {
     // activeRunId is legacy and never re-written. Persist every explicitly-set
     // field (`!== undefined`, not falsy) so on-disk and in-memory never diverge
     // — e.g. clearing a description to "" must round-trip, not silently vanish.
@@ -509,6 +519,23 @@ export class StreamSnapshotStore {
       ...(next.description !== undefined && { description: next.description }),
     };
     this.write(stream, STREAM_DATA_KEYS.META, file);
+  }
+
+  private patchMeta(stream: StreamTabId, patch: Partial<StreamTabMeta>): void {
+    this.writeMeta(stream, this.patchMetaMemory(stream, patch));
+  }
+
+  private queueMetaPatch(
+    stream: StreamTabId,
+    patch: Partial<StreamTabMeta>,
+  ): void {
+    this.patchMetaMemory(stream, patch);
+    this.metaOverlays.add(stream);
+    const applied = this.mutate(stream, () => {
+      this.patchMeta(stream, patch);
+      return true;
+    });
+    if (applied) this.metaOverlays.delete(stream);
   }
 
   // ==========================================================================
@@ -524,26 +551,22 @@ export class StreamSnapshotStore {
     taskState: TaskState,
     executionId?: ExecutionId,
   ): void {
-    this.mutate(stream, () => {
-      this.taskStates.set(stream, taskState);
-      this.patchMeta(
-        stream,
-        executionId ? { taskState, executionId } : { taskState },
-      );
-    });
+    this.taskStates.set(stream, taskState);
+    this.queueMetaPatch(
+      stream,
+      executionId ? { taskState, executionId } : { taskState },
+    );
   }
 
   setParentStream(
     child: StreamTabId,
     parent: StreamTabId | null | undefined,
   ): void {
-    this.mutate(child, () =>
-      this.patchMeta(child, { parentStreamId: parent ?? undefined }),
-    );
+    this.queueMetaPatch(child, { parentStreamId: parent ?? undefined });
   }
 
   setDescription(stream: StreamTabId, description: string): void {
-    this.mutate(stream, () => this.patchMeta(stream, { description }));
+    this.queueMetaPatch(stream, { description });
   }
 
   getTaskState(stream: StreamTabId): TaskState | undefined {
@@ -792,6 +815,9 @@ export class StreamSnapshotStore {
 
   /** Seed the in-memory accumulators for one stream + migrate legacy once. */
   private applyStreamData(stream: StreamTabId, data: StreamData): void {
+    const metaOverlay = this.metaOverlays.has(stream)
+      ? this.meta.get(stream)
+      : undefined;
     this.outputFiles.set(stream, data.outputFiles);
     this.missingOutputs.set(stream, data.missingOutputs);
     this.compileFailures.set(stream, data.compileFailures);
@@ -801,10 +827,13 @@ export class StreamSnapshotStore {
     );
     this.workPlan.set(stream, data.workPlan);
     this.taskStates.delete(stream);
-    if (data.meta) {
-      this.meta.set(stream, data.meta);
-      if (data.meta.taskState !== undefined) {
-        const parsed = TaskStateSchema.safeParse(data.meta.taskState);
+    const meta = metaOverlay
+      ? { ...(data.meta ?? {}), ...metaOverlay }
+      : data.meta;
+    if (meta) {
+      this.meta.set(stream, meta);
+      if (meta.taskState !== undefined) {
+        const parsed = TaskStateSchema.safeParse(meta.taskState);
         if (parsed.success) {
           this.taskStates.set(stream, parsed.data as TaskState);
         }
@@ -812,6 +841,7 @@ export class StreamSnapshotStore {
     } else {
       this.meta.delete(stream);
     }
+    this.metaOverlays.delete(stream);
     this.seeded.add(stream);
     this.persistLegacyFlattened(stream, data);
   }


### PR DESCRIPTION
## Summary

Part of #5451. This migrates the desktop progress bridge onto the shared `ProgressBackend` for live progress state/rendering and removes the duplicate desktop event-to-renderer maps.

- pass the platform-owned `StreamSnapshotStore` into `ProgressBackend` so desktop has a single sidecar writer flushed on shutdown
- keep `DesktopProgressBridge` focused on desktop-specific IPC/actions, resume behavior, approval plumbing, and the slim restored-stream rail
- reuse shared `buildStreamInfo` for persisted rail snapshots instead of rebuilding labels/metadata with desktop-only fallback chains
- make `StreamSnapshotStore` meta updates immediately readable while preserving seed-before-write behavior for sidecars, so desktop resume does not need a duplicate task-state cache

## Design notes

This deliberately does not delete `DesktopProgressBridge`: it still owns host-specific behaviors like file actions, approvals, resume, and restored ghost rows. The important cleanup is that live progress state now flows through the shared backend instead of parallel desktop maps.

## Validation

- `corepack pnpm vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core progress persistence, stream resume, and desktop/extension parity; regressions could affect rail metadata, ghost streams, or sidecar writes on shutdown.
> 
> **Overview**
> **Desktop progress** now routes live stream state, logs, and renderer updates through the shared **`ProgressBackend`** instead of parallel maps in `DesktopProgressBridge`. The bridge keeps desktop-only work: IPC, approvals, resume, ghost rail persistence, and restored sidecar display.
> 
> The platform-owned **`StreamSnapshotStore`** is injected into **`ProgressBackend`** / **`ProgressViewState`** and flushed on shutdown; the separate bus subscriber on platform init is removed so there is one sidecar writer. Startup **`preload`**s that store from hydrated ghost stream ids.
> 
> **`StreamSnapshotStore`** gains **`preload`** vs authoritative **`load`**, immediate in-memory **task/meta** updates with overlays during seed, and **`StreamHints`** / **`buildStreamInfo`** carry rail fields (agent, execution id, etc.) for ghosts and resume without a duplicate desktop task-state cache.
> 
> **`ProgressEventHandler`** always refreshes stream metadata on **`setTaskState`**, including inactive background subagent tabs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8ebdf8f43618d14a4d2cf073a262835e6a220fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->