### PR TITLE
fix: keep snapshot output usage updates readable

### DIFF
--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -194,12 +194,10 @@ export class ProgressEventHandler {
         // Usage events — workflow tabs collapse to a single accumulated value;
         // tool-use tabs keep per-run accumulation (resume produces multiple runs).
         updateStreamUsage: (ctx, { streamId, usage, storageKey }) => {
-          const accumulated = ctx.state.snapshots.addUsage(
-            streamId,
-            storageKey,
-            usage,
-          );
-          if (accumulated) {
+          void Promise.resolve(
+            ctx.state.snapshots.addUsage(streamId, storageKey, usage),
+          ).then((accumulated) => {
+            if (!accumulated) return;
             this.sendIfActive(streamId, () =>
               ctx.webviewUpdater.updateRunUsage(
                 streamId,
@@ -207,7 +205,7 @@ export class ProgressEventHandler {
                 accumulated,
               ),
             );
-          }
+          });
         },
         // Todo events
         updateTodos: (ctx, { streamId, todos }) => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -17,6 +17,7 @@ import {
 import { bus } from '@eventBus/ProgressEventBus';
 import type {
   ExecutionId,
+  OutputFileInfo,
   Plan,
   StorageKey,
   StreamTabId,
@@ -73,6 +74,20 @@ const PLAN: Plan = {
 
 function usage(input: number, output: number, cost: number): TokenUsageStats {
   return { inputTokens: input, outputTokens: output, cost };
+}
+
+function outputFile(relativePath: string, round: number): OutputFileInfo {
+  return {
+    source: 'document',
+    location: {
+      kind: 'workspace',
+      absolutePath: `/workspace/${relativePath}`,
+      relativePath,
+    },
+    round,
+    lineage: null,
+    diff: null,
+  };
 }
 
 describe('StreamSnapshotStore', () => {
@@ -196,7 +211,7 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
-  it('seeds existing disk data before a direct mutator, so extension writes cannot erase it', async () => {
+  it('resolves pre-seed usage after merging existing disk usage', async () => {
     await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
@@ -206,8 +221,17 @@ describe('StreamSnapshotStore', () => {
     );
 
     const store = new StreamSnapshotStore();
-    const immediate = store.addUsage(STREAM, RUN_2, usage(50, 10, 0.25));
-    expect(immediate).toBeUndefined();
+    const pending = store.addUsage(STREAM, RUN_2, usage(50, 10, 0.25));
+    expect(store.getRunUsage(STREAM).get(RUN_2)).toMatchObject({
+      inputTokens: 50,
+      outputTokens: 10,
+      cost: 0.25,
+    });
+    await expect(Promise.resolve(pending)).resolves.toMatchObject({
+      inputTokens: 50,
+      outputTokens: 10,
+      cost: 0.25,
+    });
     await store.flush();
 
     const raw = await StorageFS.readJson(path.join(dir, 'usageStats.json'));
@@ -217,7 +241,7 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
-  it('keeps seed-before-write for streams outside a partial preload', async () => {
+  it('returns pre-seed usage only after a partial preload baseline is merged', async () => {
     await installPlatform();
     const dir = streamDataDir(OTHER_STREAM);
     await StorageFS.ensureDir(dir);
@@ -229,14 +253,104 @@ describe('StreamSnapshotStore', () => {
     const store = new StreamSnapshotStore();
     await store.preload([STREAM]);
 
-    const immediate = store.addUsage(OTHER_STREAM, RUN_2, usage(50, 10, 0.25));
-    expect(immediate).toBeUndefined();
+    const pending = store.addUsage(OTHER_STREAM, RUN_2, usage(50, 10, 0.25));
+    expect(store.getRunUsage(OTHER_STREAM).get(RUN_2)).toMatchObject({
+      inputTokens: 50,
+      outputTokens: 10,
+      cost: 0.25,
+    });
+    await expect(Promise.resolve(pending)).resolves.toMatchObject({
+      inputTokens: 50,
+      outputTokens: 10,
+      cost: 0.25,
+    });
     await store.flush();
 
     const raw = await StorageFS.readJson(path.join(dir, 'usageStats.json'));
     expect(raw).toMatchObject({
       [RUN]: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
       [RUN_2]: { inputTokens: 50, outputTokens: 10, cost: 0.25 },
+    });
+  });
+
+  it('includes the disk baseline in a pre-seed usage result for the same run', async () => {
+    await installPlatform();
+    const dir = streamDataDir(OTHER_STREAM);
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'usageStats.json'),
+      JSON.stringify({ [RUN]: usage(100, 20, 0.5) }),
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.preload([STREAM]);
+
+    const pending = store.addUsage(OTHER_STREAM, RUN, usage(50, 10, 0.25));
+    expect(store.getRunUsage(OTHER_STREAM).get(RUN)).toMatchObject({
+      inputTokens: 50,
+      outputTokens: 10,
+      cost: 0.25,
+    });
+    await expect(Promise.resolve(pending)).resolves.toMatchObject({
+      inputTokens: 150,
+      outputTokens: 30,
+      cost: 0.75,
+    });
+    await store.flush();
+
+    const raw = await StorageFS.readJson(path.join(dir, 'usageStats.json'));
+    expect(raw).toMatchObject({
+      [RUN]: { inputTokens: 150, outputTokens: 30, cost: 0.75 },
+    });
+  });
+
+  it('returns output files immediately for streams outside a partial preload without erasing disk outputs', async () => {
+    await installPlatform();
+    const dir = streamDataDir(OTHER_STREAM);
+    await StorageFS.ensureDir(dir);
+    const prior = outputFile('prior.tex', 0);
+    const next = outputFile('next.tex', 1);
+    await StorageFS.write(
+      path.join(dir, 'outputFiles.json'),
+      JSON.stringify({ '0': [prior] }),
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.preload([STREAM]);
+
+    store.addOutputFiles(OTHER_STREAM, { 1: [next] });
+    expect(store.getOutputFiles(OTHER_STREAM).get(1)).toEqual([next]);
+    await store.flush();
+
+    const raw = await StorageFS.readJson(path.join(dir, 'outputFiles.json'));
+    expect(raw).toMatchObject({
+      '0': [prior],
+      '1': [next],
+    });
+  });
+
+  it('keeps output overlays when flattening legacy output files after preload', async () => {
+    await installPlatform();
+    const dir = streamDataDir(OTHER_STREAM);
+    await StorageFS.ensureDir(dir);
+    const prior = outputFile('prior.tex', 0);
+    const next = outputFile('next.tex', 1);
+    await StorageFS.write(
+      path.join(dir, 'outputFiles.json'),
+      JSON.stringify({ [RUN]: { '0': [prior] } }),
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.preload([STREAM]);
+
+    store.addOutputFiles(OTHER_STREAM, { 1: [next] });
+    expect(store.getOutputFiles(OTHER_STREAM).get(1)).toEqual([next]);
+    await store.flush();
+
+    const raw = await StorageFS.readJson(path.join(dir, 'outputFiles.json'));
+    expect(raw).toEqual({
+      '0': [prior],
+      '1': [next],
     });
   });
 
@@ -262,7 +376,13 @@ describe('StreamSnapshotStore', () => {
     store.setTaskState(STREAM, taskState, executionId);
     expect(store.getTaskState(STREAM)).toEqual(taskState);
     expect(store.getExecutionId(STREAM)).toBe(executionId);
-    expect(store.addUsage(STREAM, RUN_2, usage(50, 10, 0.25))).toBeUndefined();
+    await expect(
+      Promise.resolve(store.addUsage(STREAM, RUN_2, usage(50, 10, 0.25))),
+    ).resolves.toMatchObject({
+      inputTokens: 50,
+      outputTokens: 10,
+      cost: 0.25,
+    });
     await store.flush();
 
     expect(store.getTaskState(STREAM)).toEqual(taskState);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -71,6 +71,12 @@ const CHANNEL = 'StreamSnapshotStore';
  *  managers' `pMap` hydration so startup doesn't open a file handle per tab). */
 const SEED_IO_CONCURRENCY = 8;
 
+type OutputFilesPatch = Map<number, OutputFileInfo[] | null>;
+type UsageUpdateResult =
+  | TokenUsageStats
+  | undefined
+  | Promise<TokenUsageStats | undefined>;
+
 function normalizeOutputFiles(outputFiles?: readonly string[]): string[] {
   return (outputFiles ?? [])
     .map((file) => file.replaceAll('\\', '/'))
@@ -113,6 +119,14 @@ export class StreamSnapshotStore {
   private readonly seeded = new Set<StreamTabId>();
   private readonly seedChains = new Map<StreamTabId, Promise<void>>();
   private readonly metaOverlays = new Set<StreamTabId>();
+  private readonly outputFileOverlays = new Map<
+    StreamTabId,
+    OutputFilesPatch
+  >();
+  private readonly usageOverlays = new Map<
+    StreamTabId,
+    Map<StorageKey, TokenUsageStats>
+  >();
   private readonly streamVersions = new Map<StreamTabId, number>();
   private hasAuthoritativeStreamSet = false;
 
@@ -133,6 +147,17 @@ export class StreamSnapshotStore {
 
   private bumpStreamVersion(stream: StreamTabId): void {
     this.streamVersions.set(stream, this.streamVersion(stream) + 1);
+  }
+
+  private canMutateSynchronously(stream: StreamTabId): boolean {
+    if (this.seeded.has(stream)) return true;
+
+    if (this.hasAuthoritativeStreamSet && !this.seedChains.has(stream)) {
+      this.seeded.add(stream);
+      return true;
+    }
+
+    return false;
   }
 
   // ==========================================================================
@@ -170,8 +195,9 @@ export class StreamSnapshotStore {
       ),
       bus.on(
         'updateStreamUsage',
-        ({ streamId, storageKey, usage }) =>
-          this.addUsage(streamId, storageKey, usage),
+        ({ streamId, storageKey, usage }) => {
+          void this.addUsage(streamId, storageKey, usage);
+        },
         options,
       ),
       bus.on(
@@ -218,13 +244,17 @@ export class StreamSnapshotStore {
    */
   private mutate<T>(stream: StreamTabId, apply: () => T): T | undefined {
     const version = this.streamVersion(stream);
-    if (this.seeded.has(stream)) return apply();
+    if (this.canMutateSynchronously(stream)) return apply();
 
-    if (this.hasAuthoritativeStreamSet && !this.seedChains.has(stream)) {
-      this.seeded.add(stream);
-      return apply();
-    }
+    this.queueAfterSeed(stream, version, apply);
+    return undefined;
+  }
 
+  private queueAfterSeed(
+    stream: StreamTabId,
+    version: number,
+    apply: () => unknown,
+  ): Promise<void> {
     let next: Promise<void> = Promise.resolve();
     next = this.ensureSeeded(stream, version)
       .then(() => {
@@ -246,7 +276,7 @@ export class StreamSnapshotStore {
         });
       });
     this.seedChains.set(stream, next);
-    return undefined;
+    return next;
   }
 
   /** Read a stream's existing disk data into memory once. */
@@ -282,23 +312,108 @@ export class StreamSnapshotStore {
     return inner;
   }
 
+  private parseOutputFilesPatch(filesByRound: {
+    [key: number]: OutputFileInfo[];
+  }): OutputFilesPatch {
+    const patch: OutputFilesPatch = new Map();
+    for (const [round, files] of Object.entries(filesByRound)) {
+      const key = RoundKeySchema.safeParse(round);
+      if (!key.success) continue;
+      const normalized = OutputFileInfoListSchema.parse(
+        Array.isArray(files) ? files : [],
+      );
+      patch.set(key.data, normalized.length === 0 ? null : normalized);
+    }
+    return patch;
+  }
+
+  private applyOutputFilesPatch(
+    stream: StreamTabId,
+    patch: OutputFilesPatch,
+  ): Map<number, OutputFileInfo[]> {
+    const rounds = this.getOrCreate(this.outputFiles, stream);
+    for (const [round, files] of patch) {
+      if (files === null) rounds.delete(round);
+      else rounds.set(round, files);
+    }
+    return rounds;
+  }
+
+  private addOutputFilesOverlay(
+    stream: StreamTabId,
+    patch: OutputFilesPatch,
+  ): void {
+    if (patch.size === 0) return;
+    const overlay =
+      this.outputFileOverlays.get(stream) ??
+      new Map<number, OutputFileInfo[] | null>();
+    for (const [round, files] of patch) overlay.set(round, files);
+    this.outputFileOverlays.set(stream, overlay);
+  }
+
+  private writeOutputFiles(stream: StreamTabId): void {
+    this.write(
+      stream,
+      STREAM_DATA_KEYS.OUTPUT_FILES,
+      mapToRecord(this.outputFiles.get(stream) ?? new Map()),
+    );
+  }
+
+  private applyUsageDeltaMemory(
+    stream: StreamTabId,
+    storageKey: StorageKey,
+    delta: TokenUsageStats,
+  ): TokenUsageStats | undefined {
+    const current =
+      this.usage.get(stream) ?? new Map<string, TokenUsageStats>();
+    if (isEmptyUsage(delta)) return current.get(storageKey);
+    const existing = current.get(storageKey) ?? emptyUsageStats();
+    const accumulated = sumUsageStats([existing, delta]);
+    current.set(storageKey, accumulated);
+    this.usage.set(stream, current);
+    return accumulated;
+  }
+
+  private addUsageOverlay(
+    stream: StreamTabId,
+    storageKey: StorageKey,
+    delta: TokenUsageStats,
+  ): void {
+    if (isEmptyUsage(delta)) return;
+    const overlay =
+      this.usageOverlays.get(stream) ?? new Map<StorageKey, TokenUsageStats>();
+    overlay.set(
+      storageKey,
+      sumUsageStats([overlay.get(storageKey) ?? emptyUsageStats(), delta]),
+    );
+    this.usageOverlays.set(stream, overlay);
+  }
+
+  private writeUsage(stream: StreamTabId): void {
+    this.write(
+      stream,
+      STREAM_DATA_KEYS.USAGE_STATS,
+      mapToRecord(this.usage.get(stream) ?? new Map()),
+    );
+  }
+
   addOutputFiles(
     stream: StreamTabId,
     filesByRound: { [key: number]: OutputFileInfo[] },
   ): void {
-    this.mutate(stream, () => {
-      const rounds = this.getOrCreate(this.outputFiles, stream);
-      for (const [round, files] of Object.entries(filesByRound)) {
-        const key = RoundKeySchema.safeParse(round);
-        if (!key.success) continue;
-        const normalized = OutputFileInfoListSchema.parse(
-          Array.isArray(files) ? files : [],
-        );
-        if (normalized.length === 0) rounds.delete(key.data);
-        else rounds.set(key.data, normalized);
-      }
-      this.write(stream, STREAM_DATA_KEYS.OUTPUT_FILES, mapToRecord(rounds));
-    });
+    const patch = this.parseOutputFilesPatch(filesByRound);
+    if (patch.size === 0) return;
+
+    if (this.canMutateSynchronously(stream)) {
+      this.applyOutputFilesPatch(stream, patch);
+      this.writeOutputFiles(stream);
+      return;
+    }
+
+    const version = this.streamVersion(stream);
+    this.applyOutputFilesPatch(stream, patch);
+    this.addOutputFilesOverlay(stream, patch);
+    this.queueAfterSeed(stream, version, () => undefined);
   }
 
   updateMissingOutputs(
@@ -346,18 +461,22 @@ export class StreamSnapshotStore {
     stream: StreamTabId,
     storageKey: StorageKey,
     usage: TokenUsageStats,
-  ): TokenUsageStats | undefined {
-    return this.mutate(stream, () => {
-      const delta = TokenUsageStatsParsingSchema.parse(usage);
-      const current =
-        this.usage.get(stream) ?? new Map<string, TokenUsageStats>();
-      if (isEmptyUsage(delta)) return current.get(storageKey);
-      const existing = current.get(storageKey) ?? emptyUsageStats();
-      const accumulated = sumUsageStats([existing, delta]);
-      current.set(storageKey, accumulated);
-      this.usage.set(stream, current);
-      this.write(stream, STREAM_DATA_KEYS.USAGE_STATS, mapToRecord(current));
+  ): UsageUpdateResult {
+    const delta = TokenUsageStatsParsingSchema.parse(usage);
+    if (this.canMutateSynchronously(stream)) {
+      const accumulated = this.applyUsageDeltaMemory(stream, storageKey, delta);
+      if (!isEmptyUsage(delta)) this.writeUsage(stream);
       return accumulated;
+    }
+
+    const version = this.streamVersion(stream);
+    this.applyUsageDeltaMemory(stream, storageKey, delta);
+    this.addUsageOverlay(stream, storageKey, delta);
+    return this.queueAfterSeed(stream, version, () => undefined).then(() => {
+      if (this.streamVersion(stream) !== version || !this.seeded.has(stream)) {
+        return undefined;
+      }
+      return this.usage.get(stream)?.get(storageKey);
     });
   }
 
@@ -425,6 +544,8 @@ export class StreamSnapshotStore {
     this.seeded.delete(stream);
     this.seedChains.delete(stream);
     this.metaOverlays.delete(stream);
+    this.outputFileOverlays.delete(stream);
+    this.usageOverlays.delete(stream);
     this.kvCache.delete(stream);
     for (const key of [...this.pendingWrites.keys()]) {
       if (key.startsWith(`${stream}::`)) this.pendingWrites.delete(key);
@@ -442,6 +563,8 @@ export class StreamSnapshotStore {
       ...this.taskStates.keys(),
       ...this.seeded,
       ...this.seedChains.keys(),
+      ...this.outputFileOverlays.keys(),
+      ...this.usageOverlays.keys(),
       ...this.kvCache.keys(),
     ]);
     for (const stream of streams) this.bumpStreamVersion(stream);
@@ -455,6 +578,8 @@ export class StreamSnapshotStore {
     this.seeded.clear();
     this.seedChains.clear();
     this.metaOverlays.clear();
+    this.outputFileOverlays.clear();
+    this.usageOverlays.clear();
     this.kvCache.clear();
     this.pendingWrites.clear();
   }
@@ -806,6 +931,8 @@ export class StreamSnapshotStore {
       ...this.taskStates.keys(),
       ...this.seeded,
       ...this.seedChains.keys(),
+      ...this.outputFileOverlays.keys(),
+      ...this.usageOverlays.keys(),
       ...this.kvCache.keys(),
     ]);
     for (const stream of streams) {
@@ -835,6 +962,9 @@ export class StreamSnapshotStore {
     const metaOverlay = this.metaOverlays.has(stream)
       ? this.meta.get(stream)
       : undefined;
+    const outputFileOverlay = this.outputFileOverlays.get(stream);
+    const usageOverlay = this.usageOverlays.get(stream);
+    const sidecarsToWrite = new Set(data.legacyKeys);
     this.outputFiles.set(stream, data.outputFiles);
     this.missingOutputs.set(stream, data.missingOutputs);
     this.compileFailures.set(stream, data.compileFailures);
@@ -859,24 +989,46 @@ export class StreamSnapshotStore {
       this.meta.delete(stream);
     }
     this.metaOverlays.delete(stream);
+    if (outputFileOverlay) {
+      this.applyOutputFilesPatch(stream, outputFileOverlay);
+      sidecarsToWrite.add(STREAM_DATA_KEYS.OUTPUT_FILES);
+      this.outputFileOverlays.delete(stream);
+    }
+    if (usageOverlay) {
+      for (const [storageKey, delta] of usageOverlay) {
+        this.applyUsageDeltaMemory(stream, storageKey, delta);
+      }
+      sidecarsToWrite.add(STREAM_DATA_KEYS.USAGE_STATS);
+      this.usageOverlays.delete(stream);
+    }
     this.seeded.add(stream);
-    this.persistLegacyFlattened(stream, data);
+    this.writeMergedSidecars(stream, sidecarsToWrite);
   }
 
-  /** Rewrite any legacy-nested sidecar file to its flattened form (once). */
-  private persistLegacyFlattened(stream: StreamTabId, data: StreamData): void {
-    const byKey = new Map<string, Map<number, unknown>>([
-      [STREAM_DATA_KEYS.OUTPUT_FILES, data.outputFiles as Map<number, unknown>],
+  /** Persist sidecars from merged memory after seeding and overlays converge. */
+  private writeMergedSidecars(
+    stream: StreamTabId,
+    keys: Iterable<string>,
+  ): void {
+    const byKey = new Map<string, Map<number | string, unknown> | undefined>([
+      [
+        STREAM_DATA_KEYS.OUTPUT_FILES,
+        this.outputFiles.get(stream) as Map<number, unknown> | undefined,
+      ],
       [
         STREAM_DATA_KEYS.MISSING_OUTPUTS,
-        data.missingOutputs as Map<number, unknown>,
+        this.missingOutputs.get(stream) as Map<number, unknown> | undefined,
       ],
       [
         STREAM_DATA_KEYS.COMPILE_FAILURES,
-        data.compileFailures as Map<number, unknown>,
+        this.compileFailures.get(stream) as Map<number, unknown> | undefined,
+      ],
+      [
+        STREAM_DATA_KEYS.USAGE_STATS,
+        this.usage.get(stream) as Map<string, unknown> | undefined,
       ],
     ]);
-    for (const key of data.legacyKeys) {
+    for (const key of keys) {
       const map = byKey.get(key);
       if (map) this.write(stream, key, mapToRecord(map));
     }


### PR DESCRIPTION
Fixes #5470.

## Summary
- keep `addOutputFiles` and `addUsage` immediately readable after a partial `preload()` seed
- merge output/usage overlays at the same deferred seed boundary as task metadata
- centralize the seeded/authoritative fast path in `StreamSnapshotStore` instead of adding handler-side waits or pass-through fallbacks

## Design
`StreamSnapshotStore` now treats output file patches and usage deltas like metadata overlays: update memory first, queue the seed merge once, then write the merged sidecar when disk state arrives. This keeps the progress backend contract simple: event handlers can read the store synchronously after writing, and the store owns consistency with disk.

## Validation
- `corepack pnpm vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deferred seeding and sidecar merge/write behavior for usage and output files; incorrect merging could corrupt persisted stream data or show wrong usage, though scope is localized and heavily tested.
> 
> **Overview**
> Fixes snapshot consistency when streams are only **partially preloaded**: **output file** and **usage** updates are now readable in memory immediately and merged with on-disk sidecars at the same deferred seed boundary as task metadata, instead of blocking on seed or returning nothing.
> 
> **`StreamSnapshotStore`** adds in-memory **overlays** for output rounds and usage deltas, applies patches to memory first, queues seed work via **`canMutateSynchronously`**, and persists merged **`outputFiles.json`** / **`usageStats.json`** (including legacy flattening) through **`writeMergedSidecars`**. **`addUsage`** can return a **Promise** that resolves to the fully accumulated totals once the disk baseline is merged.
> 
> **`ProgressEventHandler`** waits on that promise before pushing run usage to the webview so UI totals stay correct after partial preload.
> 
> Vitest coverage expands for pre-seed usage resolution, disk baseline merging, output files without clobbering disk, and legacy output flattening with overlays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609bf0046bab69ab00e697a8c09a11a6158c6614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->