### PR TITLE
fix: retry desktop ghost display restore

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -201,6 +201,8 @@ export class DesktopProgressBridge {
   private readonly durableSnapshots = new StreamSnapshotStore();
   /** Ghost streams whose persisted display has already been restored this session. */
   private readonly restoredDisplaySent = new Set<StreamTabId>();
+  /** Ghost streams with an async persisted-display restore already pending. */
+  private readonly restoredDisplayInFlight = new Set<StreamTabId>();
 
   readonly runtimeHost: AgentRuntimeHost;
 
@@ -489,6 +491,7 @@ export class DesktopProgressBridge {
     this.agentProposals.clear();
     this.restoredStreams.clear();
     this.restoredDisplaySent.clear();
+    this.restoredDisplayInFlight.clear();
   }
 
   private send(message: ProgressViewOutboundMessage): void {
@@ -518,15 +521,21 @@ export class DesktopProgressBridge {
   private sendRestoredDisplay(streamId: StreamTabId): void {
     if (
       !this.restoredStreams.has(streamId) ||
-      this.restoredDisplaySent.has(streamId)
+      this.restoredDisplaySent.has(streamId) ||
+      this.restoredDisplayInFlight.has(streamId)
     ) {
       return;
     }
-    this.restoredDisplaySent.add(streamId);
+    this.restoredDisplayInFlight.add(streamId);
     void this.durableSnapshots
       .read(streamId)
       .then((snap) => {
-        if (streamId !== this.state.activeStream) return;
+        if (
+          streamId !== this.state.activeStream ||
+          !this.restoredStreams.has(streamId)
+        ) {
+          return;
+        }
         // The persisted snapshot is authoritative for a restored stream: send
         // todos/plan verbatim so an intentionally-empty list or null plan CLEARS
         // any stale renderer state instead of being skipped — matching the CLI
@@ -571,11 +580,15 @@ export class DesktopProgressBridge {
             reset: true,
           });
         }
+        this.restoredDisplaySent.add(streamId);
       })
       .catch((error: unknown) => {
         this.logger.warn(`Failed to restore display for ${streamId}`, {
           data: error,
         });
+      })
+      .finally(() => {
+        this.restoredDisplayInFlight.delete(streamId);
       });
   }
 
@@ -696,6 +709,7 @@ export class DesktopProgressBridge {
     this.deleteAgentProposalsForStream(streamId);
     this.workflowFileActions.clearStreamBackups(streamId);
     this.restoredDisplaySent.delete(streamId);
+    this.restoredDisplayInFlight.delete(streamId);
     await OdysseyStore.forget(streamId);
     await this.state.clearStream(streamId);
     this.send({
@@ -728,6 +742,7 @@ export class DesktopProgressBridge {
     // ghosts come back zombie-style after relaunch.
     this.restoredStreams.clear();
     this.restoredDisplaySent.clear();
+    this.restoredDisplayInFlight.clear();
     if (this.options.streamSnapshotStore) {
       void this.options.streamSnapshotStore
         .replaceAll([])

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -100,6 +100,8 @@ type ProgressMessage = {
   activeStream?: string;
   stream?: string;
   streamId?: string;
+  todos?: unknown[];
+  plan?: unknown;
   entries?: Array<{ text?: string }>;
   streams?: Array<{ name: string; creationTimestamp: number }>;
   streamStates?: Record<string, unknown>;
@@ -528,6 +530,223 @@ describe('DesktopProgressBridge', () => {
       bridge.setActiveStream('ghost-stream');
 
       expect(messages).toEqual([]);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('retries ghost display restore after a durable read failure', async () => {
+    const messages: unknown[] = [];
+    let failed = false;
+    const kvRead = vi.fn(async (key: string) => {
+      if (!failed) {
+        failed = true;
+        throw new Error('temporary read failure');
+      }
+      if (key === 'workPlan') {
+        return {
+          todos: [
+            {
+              content: 'Persisted todo',
+              status: 'pending',
+              activeForm: 'Restoring persisted todo',
+            },
+          ],
+          plan: null,
+          planSummary: null,
+        };
+      }
+      return undefined;
+    });
+    const bridge = await createBridge(messages, {
+      kvRead,
+      streamSnapshotStore: createStreamSnapshotStore([
+        {
+          streamId: 'ghost-stream',
+          label: 'ghost-stream',
+          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          lastKnownStatus: STREAM_STATUS.STOPPED,
+          creationTimestamp: 1_000,
+          persistedAt: 2_000,
+        },
+      ]),
+    });
+
+    try {
+      bridge.setActiveStream('ghost-stream');
+      await settleProgressEvents();
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_TODOS),
+      ).toHaveLength(0);
+
+      messages.length = 0;
+      bridge.setActiveStream('ghost-stream');
+      await settleProgressEvents();
+
+      expect(kvRead).toHaveBeenCalledWith('workPlan');
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_TODOS).at(-1),
+      ).toMatchObject({
+        stream: 'ghost-stream',
+        todos: [
+          expect.objectContaining({
+            content: 'Persisted todo',
+          }),
+        ],
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('deduplicates overlapping ghost display restores', async () => {
+    const messages: unknown[] = [];
+    let releaseRead: () => void = () => undefined;
+    const firstRead = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    let shouldDelayFirstWorkPlanRead = true;
+    const kvRead = vi.fn(async (key: string) => {
+      if (key === 'workPlan' && shouldDelayFirstWorkPlanRead) {
+        shouldDelayFirstWorkPlanRead = false;
+        await firstRead;
+      }
+      if (key === 'workPlan') {
+        return {
+          todos: [
+            {
+              content: 'Single restored todo',
+              status: 'pending',
+              activeForm: 'Restoring once',
+            },
+          ],
+          plan: null,
+          planSummary: null,
+        };
+      }
+      return undefined;
+    });
+    const bridge = await createBridge(messages, {
+      kvRead,
+      streamSnapshotStore: createStreamSnapshotStore([
+        {
+          streamId: 'ghost-stream',
+          label: 'ghost-stream',
+          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          lastKnownStatus: STREAM_STATUS.STOPPED,
+          creationTimestamp: 1_000,
+          persistedAt: 2_000,
+        },
+      ]),
+    });
+
+    try {
+      bridge.setActiveStream('ghost-stream');
+      bridge.setActiveStream('ghost-stream');
+      await settleProgressEvents();
+      releaseRead();
+      await settleProgressEvents();
+
+      const todoUpdates = progressMessages(
+        messages,
+        PROGRESS_VIEW_COMMANDS.UPDATE_TODOS,
+      ).filter((message) => message.stream === 'ghost-stream');
+      expect(todoUpdates).toHaveLength(1);
+      expect(todoUpdates[0]).toMatchObject({
+        todos: [
+          expect.objectContaining({
+            content: 'Single restored todo',
+          }),
+        ],
+      });
+      expect(
+        kvRead.mock.calls.filter(([key]) => key === 'workPlan'),
+      ).toHaveLength(1);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('retries ghost display restore after a stale async read', async () => {
+    const messages: unknown[] = [];
+    let releaseRead: () => void = () => undefined;
+    let markReadStarted: () => void = () => undefined;
+    const firstRead = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    const firstReadStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    let shouldDelayFirstWorkPlanRead = true;
+    const kvRead = vi.fn(async (key: string) => {
+      if (key === 'workPlan' && shouldDelayFirstWorkPlanRead) {
+        shouldDelayFirstWorkPlanRead = false;
+        markReadStarted();
+        await firstRead;
+      }
+      if (key === 'workPlan') {
+        return {
+          todos: [
+            {
+              content: 'Delayed todo',
+              status: 'pending',
+              activeForm: 'Restoring delayed todo',
+            },
+          ],
+          plan: null,
+          planSummary: null,
+        };
+      }
+      return undefined;
+    });
+    const bridge = await createBridge(messages, {
+      kvRead,
+      streamSnapshotStore: createStreamSnapshotStore([
+        {
+          streamId: 'ghost-one',
+          label: 'ghost-one',
+          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          lastKnownStatus: STREAM_STATUS.STOPPED,
+          creationTimestamp: 1_000,
+          persistedAt: 2_000,
+        },
+        {
+          streamId: 'ghost-two',
+          label: 'ghost-two',
+          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          lastKnownStatus: STREAM_STATUS.STOPPED,
+          creationTimestamp: 1_100,
+          persistedAt: 2_100,
+        },
+      ]),
+    });
+
+    try {
+      bridge.setActiveStream('ghost-one');
+      await firstReadStarted;
+      bridge.setActiveStream('ghost-two');
+      releaseRead();
+      await settleProgressEvents();
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_TODOS).filter(
+          (message) => message.stream === 'ghost-one',
+        ),
+      ).toHaveLength(0);
+
+      messages.length = 0;
+      bridge.setActiveStream('ghost-one');
+      await settleProgressEvents();
+
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_TODOS).at(-1),
+      ).toMatchObject({
+        stream: 'ghost-one',
+        todos: [
+          expect.objectContaining({
+            content: 'Delayed todo',
+          }),
+        ],
+      });
     } finally {
       bridge.dispose();
     }


### PR DESCRIPTION
## Summary
- fix desktop ghost-stream restore so failed or stale async durable reads stay retryable
- mark a restored display only after the active stream still matches and the persisted snapshot is actually sent
- add focused desktop bridge coverage for read failures and stale async reads

Fixes #5472.
Advances #5451.

## Validation
- `corepack pnpm vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes; existing import-order warnings only)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to desktop ghost-stream display hydration in `sendRestoredDisplay`; behavior fix with focused tests and no auth or data-model changes.
> 
> **Overview**
> **Ghost stream UI restore** on the desktop progress bridge no longer treats a durable read as “done” when the async `StreamSnapshotStore.read` starts. A new **`restoredDisplayInFlight`** guard blocks overlapping restores; **`restoredDisplaySent`** is set only after todos/plan/usage/files are actually posted and the stream is still active and still a ghost.
> 
> Failed reads and **stale completions** (user switched away before the read finished) stay **retryable** on the next activation. **`restoredDisplayInFlight`** is cleared on stream delete, delete-all, and dispose.
> 
> Vitest adds coverage for read failure retry, duplicate in-flight deduplication, and stale async read after switching ghost streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a956d6cb81d74d8b01a916b02adc90f17be5583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->