### PR TITLE
fix: preserve raw LF in CLI text chunks

### DIFF
--- a/packages/cli/src/chat/tui/input/textInputEditing.ts
+++ b/packages/cli/src/chat/tui/input/textInputEditing.ts
@@ -92,12 +92,23 @@ export function applyTerminalInputChunk(
   let edit: TextEdit = { value, cursor: clampCursor(cursor, value.length) };
   let submit = false;
 
-  for (const ch of input) {
+  const chars = [...input];
+  for (let index = 0; index < chars.length; index += 1) {
+    const ch = chars[index];
     if (ch === SYNTHETIC_SHIFT_RETURN_INPUT) {
       edit = insertText(edit.value, edit.cursor, '\n');
       continue;
     }
-    if (ch === '\r' || ch === '\n') {
+    if (ch === '\n') {
+      edit = insertText(edit.value, edit.cursor, '\n');
+      continue;
+    }
+    if (ch === '\r') {
+      if (chars[index + 1] === '\n' && index + 2 < chars.length) {
+        edit = insertText(edit.value, edit.cursor, '\n');
+        index += 1;
+        continue;
+      }
       submit = true;
       break;
     }

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -216,6 +216,24 @@ describe('CLI TUI text input editing', () => {
     });
   });
 
+  it('keeps LF and embedded CRLF as newlines inside raw text chunks', () => {
+    expect(applyTerminalInputChunk('', 0, 'alpha\nbeta')).toEqual({
+      value: 'alpha\nbeta',
+      cursor: 10,
+      submit: false,
+    });
+    expect(applyTerminalInputChunk('', 0, 'alpha\nbeta\r')).toEqual({
+      value: 'alpha\nbeta',
+      cursor: 10,
+      submit: true,
+    });
+    expect(applyTerminalInputChunk('', 0, 'alpha\r\nbeta\r')).toEqual({
+      value: 'alpha\nbeta',
+      cursor: 10,
+      submit: true,
+    });
+  });
+
   it('inserts pasted multi-line text without submitting embedded newlines', () => {
     expect(insertText('ab', 1, 'x\ny')).toEqual({
       value: 'ax\nyb',


### PR DESCRIPTION
## Summary

- preserve bare LF as an editor newline inside raw terminal input chunks
- keep CR as the submit delimiter for raw chunks
- add a focused regression test for LF-preserving chunks followed by CR submit

Fixes #5474.

## Dogfood Evidence

Before the fix, a live `texra-local` TTY run submitted only the first line of a multiline prompt sent as one raw LF-containing chunk. The agent asked me to restate the math problem because the rest of the prompt was missing.

After rebuilding and relinking the CLI with this patch, the same raw multiline prompt rendered all three lines in the transcript before submit, and the agent operated on the intended full problem.

## Validation

- `git diff --check`
- `corepack pnpm vitest run src/test-kernel/cli/TextInputEditing.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside touched files)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to CLI TUI text chunk parsing with targeted tests; behavior shift is intentional for LF vs CR but could affect edge cases in how raw Enter/line endings are interpreted.
> 
> **Overview**
> Fixes multiline prompts being truncated when the TTY delivers a single raw chunk that contains line feeds (e.g. only the first line was submitted before the agent saw the rest).
> 
> **`applyTerminalInputChunk`** now treats bare **LF** as a literal newline in the editor buffer instead of treating LF like Enter. **CR** remains the submit delimiter for raw chunks. Chunks are iterated by Unicode code points (`[...input]`) so multi-byte characters stay correct. Embedded **CRLF** in the middle of a chunk is normalized to one newline when there is more text after the pair; a trailing **CR** still submits.
> 
> Regression coverage was added in **`TextInputEditing.vitest.mts`** for LF-only chunks, LF then CR submit, and embedded CRLF before submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572bbcc61f20ad922c49a093e186442fc9717cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->