### PR TITLE
refactor: centralize progress command groups

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -1,9 +1,4 @@
-import { createProgressViewApprovalCommandHandlers } from '@controllers/progressView/ProgressViewApprovalCommandHandlers';
-import { createProgressViewBypassCommandHandlers } from '@controllers/progressView/ProgressViewBypassCommandHandlers';
-import { createProgressViewFileCommandHandlers } from '@controllers/progressView/ProgressViewFileCommandHandlers';
-import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
-import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
-import { createProgressViewRunCommandHandlers } from '@controllers/progressView/ProgressViewRunCommandHandlers';
+import { createProgressViewCommandHandlers } from '@controllers/progressView/ProgressViewCommandHandlers';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import {
   dispatchProgressViewInbound,
@@ -41,52 +36,54 @@ export function createDesktopProgressIpc(
     options.onUnsupportedCommand ?? defaultUnsupportedCommand;
   const progress = options.progress;
 
-  const progressHandlers: ProgressViewInboundHandlerRegistry = {
-    ...createProgressViewLifecycleCommandHandlers({
-      setActiveStream: (stream) => progress.setActiveStream(stream),
-      setAgentFilter: (filter) => progress.setAgentFilter(filter),
-      deleteStream: (stream) => progress.deleteStream(stream),
-      deleteAllStreams: () => progress.deleteAllStreams(),
-      stopStream: (stream) => progress.stopStream(stream),
-    }),
-    ...createProgressViewRunCommandHandlers({
-      resumeStream: (stream) => progress.resumeStream(stream),
-      runNewStream: (stream) => progress.runNewStream(stream),
-    }),
-    ...createProgressViewFollowUpCommandHandlers({
-      sendFollowUp: ({ stream, text, mediaFiles }) =>
-        progress.sendFollowUp(stream, text, mediaFiles),
-      reportImageSaveError: (_image, error) => reportAsyncError(error),
-    }),
-    ...createProgressViewBypassCommandHandlers({
-      runtimeHost: progress.runtimeHost,
-    }),
-    ...createProgressViewFileCommandHandlers({
-      openFile: (file, line) => progress.openFile(file, line),
-      openFileCompile: (file) => progress.openFileCompile(file),
-      openTaskStorage: (stream) => progress.openTaskStorage(stream),
-      compareOriginal: (file, base) => progress.compareOriginal(file, base),
-      comparePrevious: (file, base, previous) =>
-        progress.comparePrevious(file, base, previous),
-      acceptFile: (file, base) => progress.acceptFile(file, base),
-      mergeFile: (file, base) => progress.mergeFile(file, base),
-      latexdiffFile: (file, base) => progress.latexdiffFile(file, base),
-      openLabel: (label) => progress.openLabel(label),
-    }),
-    ...createProgressViewApprovalCommandHandlers({
-      handleToolEditApprovalAction: (message) =>
-        progress.handleToolEditApprovalAction(message),
-      onUnsupportedToolEditApproval: (message) => onUnsupportedCommand(message),
-      handleBashApprovalAction: (message) =>
-        progress.handleBashApprovalAction(message),
-      handlePlanApprovalAction: (message) =>
-        progress.handlePlanApprovalAction(message),
-      handleUserQuestionAction: (message) =>
-        progress.handleUserQuestionAction(message),
-      handleAgentProposalAction: (message) =>
-        progress.handleAgentProposalAction(message),
-    }),
-  };
+  const progressHandlers: ProgressViewInboundHandlerRegistry =
+    createProgressViewCommandHandlers({
+      lifecycle: {
+        setActiveStream: (stream) => progress.setActiveStream(stream),
+        setAgentFilter: (filter) => progress.setAgentFilter(filter),
+        deleteStream: (stream) => progress.deleteStream(stream),
+        deleteAllStreams: () => progress.deleteAllStreams(),
+        stopStream: (stream) => progress.stopStream(stream),
+      },
+      run: {
+        resumeStream: (stream) => progress.resumeStream(stream),
+        runNewStream: (stream) => progress.runNewStream(stream),
+      },
+      followUp: {
+        sendFollowUp: ({ stream, text, mediaFiles }) =>
+          progress.sendFollowUp(stream, text, mediaFiles),
+        reportImageSaveError: (_image, error) => reportAsyncError(error),
+      },
+      bypass: {
+        runtimeHost: progress.runtimeHost,
+      },
+      file: {
+        openFile: (file, line) => progress.openFile(file, line),
+        openFileCompile: (file) => progress.openFileCompile(file),
+        openTaskStorage: (stream) => progress.openTaskStorage(stream),
+        compareOriginal: (file, base) => progress.compareOriginal(file, base),
+        comparePrevious: (file, base, previous) =>
+          progress.comparePrevious(file, base, previous),
+        acceptFile: (file, base) => progress.acceptFile(file, base),
+        mergeFile: (file, base) => progress.mergeFile(file, base),
+        latexdiffFile: (file, base) => progress.latexdiffFile(file, base),
+        openLabel: (label) => progress.openLabel(label),
+      },
+      approval: {
+        handleToolEditApprovalAction: (message) =>
+          progress.handleToolEditApprovalAction(message),
+        onUnsupportedToolEditApproval: (message) =>
+          onUnsupportedCommand(message),
+        handleBashApprovalAction: (message) =>
+          progress.handleBashApprovalAction(message),
+        handlePlanApprovalAction: (message) =>
+          progress.handlePlanApprovalAction(message),
+        handleUserQuestionAction: (message) =>
+          progress.handleUserQuestionAction(message),
+        handleAgentProposalAction: (message) =>
+          progress.handleAgentProposalAction(message),
+      },
+    });
 
   return {
     handleMessage(message: DesktopCommandMessage): boolean {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,11 +1,6 @@
 import * as vscode from 'vscode';
 
-import { createProgressViewApprovalCommandHandlers } from '@controllers/progressView/ProgressViewApprovalCommandHandlers';
-import { createProgressViewBypassCommandHandlers } from '@controllers/progressView/ProgressViewBypassCommandHandlers';
-import { createProgressViewFileCommandHandlers } from '@controllers/progressView/ProgressViewFileCommandHandlers';
-import { createProgressViewFollowUpCommandHandlers } from '@controllers/progressView/ProgressViewFollowUpCommandHandlers';
-import { createProgressViewLifecycleCommandHandlers } from '@controllers/progressView/ProgressViewLifecycleCommandHandlers';
-import { createProgressViewRunCommandHandlers } from '@controllers/progressView/ProgressViewRunCommandHandlers';
+import { createProgressViewCommandHandlers } from '@controllers/progressView/ProgressViewCommandHandlers';
 import { ProgressStreamLifecycleController } from '@controllers/progressView/ProgressStreamLifecycleController';
 import {
   ProgressFollowUpController,
@@ -172,27 +167,90 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.POP_OUT]: () => this.provider.popOutToEditor(),
       [PROGRESS_VIEW_COMMANDS.POP_BACK]: () => this.provider.popBackToSidebar(),
 
-      // Stream management
-      ...createProgressViewLifecycleCommandHandlers({
-        setActiveStream: (stream) => this.provider.setActiveStream(stream),
-        setAgentFilter: (filter) => {
-          this.provider.state.agentCategoryFilter = filter;
-          this.provider.syncFullView();
+      // Shared progress command groups
+      ...createProgressViewCommandHandlers({
+        lifecycle: {
+          setActiveStream: (stream) => this.provider.setActiveStream(stream),
+          setAgentFilter: (filter) => {
+            this.provider.state.agentCategoryFilter = filter;
+            this.provider.syncFullView();
+          },
+          deleteStream: (stream) =>
+            this.streamLifecycleController.deleteStream(stream),
+          deleteAllStreams: () => this.handleDeleteAll(),
+          stopStream: (stream) =>
+            this.streamLifecycleController.stopStream(stream),
         },
-        deleteStream: (stream) =>
-          this.streamLifecycleController.deleteStream(stream),
-        deleteAllStreams: () => this.handleDeleteAll(),
-        stopStream: (stream) =>
-          this.streamLifecycleController.stopStream(stream),
+        run: {
+          resumeStream: (stream) =>
+            this.workflowActionsController.resume(stream),
+          runNewStream: (stream) =>
+            this.workflowActionsController.runNew(stream),
+        },
+        followUp: {
+          sendFollowUp: async ({ stream, text, mediaFiles }) => {
+            await vscode.commands.executeCommand('texra.sendFollowUp', {
+              stream,
+              text,
+              ...(mediaFiles && mediaFiles.length > 0 ? { mediaFiles } : {}),
+            });
+          },
+          reportImageSaveError: (_image, error) => {
+            // Best-effort: a failed image save must not block the text, but log
+            // it so a missing attachment is diagnosable.
+            this.logger.warn(
+              this.channel,
+              `Failed to save pasted follow-up image: ${toErrorMessage(error)}`,
+            );
+          },
+        },
+        bypass: {
+          runtimeHost: extensionAgentRuntimeHost,
+          showInfo: (message) => vscode.window.showInformationMessage(message),
+        },
+        file: {
+          openFile: async (file, line) =>
+            vscode.commands.executeCommand('texra.openFile', file, line),
+          openFileCompile: async (file) =>
+            vscode.commands.executeCommand('texra.openFileCompile', file),
+          openTaskStorage: (stream) =>
+            this.workflowFileActionsController.openTaskStorage(stream),
+          compareOriginal: (file, base) =>
+            this.workflowFileActionsController.compareOriginal(file, base),
+          comparePrevious: (file, base, previous) =>
+            this.workflowFileActionsController.comparePrevious(
+              file,
+              base,
+              previous,
+            ),
+          acceptFile: (file, base) =>
+            this.workflowFileActionsController.acceptFile(file, base),
+          mergeFile: (file, base) =>
+            this.workflowFileActionsController.mergeFile(file, base),
+          latexdiffFile: (file, base) =>
+            this.workflowFileActionsController.latexdiffFile(file, base),
+          openLabel: (label) =>
+            this.workflowFileActionsController.openLabel(label),
+        },
+        approval: {
+          handleToolEditApprovalAction: async (message) => {
+            await handleProgressViewToolEditApprovalAction(message);
+            return true;
+          },
+          handleBashApprovalAction: (message) =>
+            handleProgressViewBashApprovalAction(message),
+          handlePlanApprovalAction: (message) =>
+            this.handlePlanApprovalAction(message),
+          handleUserQuestionAction: (message) =>
+            handleUserQuestionAction(message),
+          handleAgentProposalAction: (message) =>
+            this.agentProposalController.handleAction(message),
+        },
       }),
       [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: async (data) =>
         vscode.commands.executeCommand('texra.compactResponse', data.stream),
 
       // Actions
-      ...createProgressViewRunCommandHandlers({
-        resumeStream: (stream) => this.workflowActionsController.resume(stream),
-        runNewStream: (stream) => this.workflowActionsController.runNew(stream),
-      }),
       [PROGRESS_VIEW_COMMANDS.DIFF_STREAM]: (data) =>
         this.workflowActionsController.diffStream(data.stream),
       [PROGRESS_VIEW_COMMANDS.PACK_STREAM]: (data) =>
@@ -214,23 +272,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           await vscode.commands.executeCommand('texra.restoreState', taskState);
         }
       },
-      ...createProgressViewFollowUpCommandHandlers({
-        sendFollowUp: async ({ stream, text, mediaFiles }) => {
-          await vscode.commands.executeCommand('texra.sendFollowUp', {
-            stream,
-            text,
-            ...(mediaFiles && mediaFiles.length > 0 ? { mediaFiles } : {}),
-          });
-        },
-        reportImageSaveError: (_image, error) => {
-          // Best-effort: a failed image save must not block the text, but log
-          // it so a missing attachment is diagnosable.
-          this.logger.warn(
-            this.channel,
-            `Failed to save pasted follow-up image: ${toErrorMessage(error)}`,
-          );
-        },
-      }),
       [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]: (data) =>
         this.handlePolishFollowUp(data),
       [PROGRESS_VIEW_COMMANDS.START_RECORDING]: async () => {
@@ -244,10 +285,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]: async (data) => {
         await vscode.window.showInformationMessage(data.text);
       },
-      ...createProgressViewBypassCommandHandlers({
-        runtimeHost: extensionAgentRuntimeHost,
-        showInfo: (message) => vscode.window.showInformationMessage(message),
-      }),
       [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: async (data) => {
         const restored =
           await this.agentProposalController.restoreProposalConfig(
@@ -266,20 +303,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           );
         }
       },
-      ...createProgressViewApprovalCommandHandlers({
-        handleToolEditApprovalAction: async (message) => {
-          await handleProgressViewToolEditApprovalAction(message);
-          return true;
-        },
-        handleBashApprovalAction: (message) =>
-          handleProgressViewBashApprovalAction(message),
-        handlePlanApprovalAction: (message) =>
-          this.handlePlanApprovalAction(message),
-        handleUserQuestionAction: (message) =>
-          handleUserQuestionAction(message),
-        handleAgentProposalAction: (message) =>
-          this.agentProposalController.handleAction(message),
-      }),
       [PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION]: async (data) => {
         if (data.action === 'draft') {
           await persistOpenTurnDraft({
@@ -329,32 +352,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.processToolUseFollowup(data, true),
       [PROGRESS_VIEW_COMMANDS.RUN_COMPILE_FIXER]: (data) =>
         this.handleRunCompileFixer(data.stream),
-
-      // File operations
-      ...createProgressViewFileCommandHandlers({
-        openFile: async (file, line) =>
-          vscode.commands.executeCommand('texra.openFile', file, line),
-        openFileCompile: async (file) =>
-          vscode.commands.executeCommand('texra.openFileCompile', file),
-        openTaskStorage: (stream) =>
-          this.workflowFileActionsController.openTaskStorage(stream),
-        compareOriginal: (file, base) =>
-          this.workflowFileActionsController.compareOriginal(file, base),
-        comparePrevious: (file, base, previous) =>
-          this.workflowFileActionsController.comparePrevious(
-            file,
-            base,
-            previous,
-          ),
-        acceptFile: (file, base) =>
-          this.workflowFileActionsController.acceptFile(file, base),
-        mergeFile: (file, base) =>
-          this.workflowFileActionsController.mergeFile(file, base),
-        latexdiffFile: (file, base) =>
-          this.workflowFileActionsController.latexdiffFile(file, base),
-        openLabel: (label) =>
-          this.workflowFileActionsController.openLabel(label),
-      }),
     };
   }
 

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -1,0 +1,56 @@
+// Local imports - shared
+import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
+
+// Local imports - controllers
+import {
+  createProgressViewApprovalCommandHandlers,
+  type ProgressViewApprovalCommandActions,
+} from './ProgressViewApprovalCommandHandlers';
+import {
+  createProgressViewBypassCommandHandlers,
+  type ProgressViewBypassCommandOptions,
+} from './ProgressViewBypassCommandHandlers';
+import {
+  createProgressViewFileCommandHandlers,
+  type ProgressViewFileCommandActions,
+} from './ProgressViewFileCommandHandlers';
+import {
+  createProgressViewFollowUpCommandHandlers,
+  type ProgressViewFollowUpCommandActions,
+} from './ProgressViewFollowUpCommandHandlers';
+import {
+  createProgressViewLifecycleCommandHandlers,
+  type ProgressViewLifecycleCommandActions,
+} from './ProgressViewLifecycleCommandHandlers';
+import {
+  createProgressViewRunCommandHandlers,
+  type ProgressViewRunCommandActions,
+} from './ProgressViewRunCommandHandlers';
+
+export interface ProgressViewCommandActions {
+  lifecycle: ProgressViewLifecycleCommandActions;
+  run: ProgressViewRunCommandActions;
+  followUp: ProgressViewFollowUpCommandActions;
+  bypass: ProgressViewBypassCommandOptions;
+  file: ProgressViewFileCommandActions;
+  approval: ProgressViewApprovalCommandActions;
+}
+
+/**
+ * Shared progress-view command groups used by both extension and desktop.
+ *
+ * Host-only commands stay with each host; this factory owns the command groups
+ * whose routing should not drift across hosts.
+ */
+export function createProgressViewCommandHandlers(
+  actions: ProgressViewCommandActions,
+): ProgressViewInboundHandlerRegistry {
+  return {
+    ...createProgressViewLifecycleCommandHandlers(actions.lifecycle),
+    ...createProgressViewRunCommandHandlers(actions.run),
+    ...createProgressViewFollowUpCommandHandlers(actions.followUp),
+    ...createProgressViewBypassCommandHandlers(actions.bypass),
+    ...createProgressViewFileCommandHandlers(actions.file),
+    ...createProgressViewApprovalCommandHandlers(actions.approval),
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared progress-view command-group factory for the inbound commands used by both extension and desktop
- wire extension and desktop through that shared group contract while leaving host-only commands and host-specific callbacks local
- reduce drift risk for #5451 P3 without adding a new router layer

## Verification
- npm run typecheck -- --pretty false
- node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src/controllers/progressView/ProgressViewCommandHandlers.ts packages/desktop/src/main/desktopProgressIpc.ts packages/extension/src/progressView/ProgressViewMessageHandler.ts
- corepack pnpm vitest run src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/controllers/ProgressViewLifecycleCommandHandlers.vitest.ts src/test-kernel/controllers/ProgressViewRunCommandHandlers.vitest.ts src/test-kernel/controllers/ProgressViewFollowUpCommandHandlers.vitest.ts src/test-kernel/controllers/ProgressViewBypassCommandHandlers.vitest.ts src/test-kernel/controllers/ProgressViewFileCommandHandlers.vitest.ts src/test-kernel/controllers/ProgressViewApprovalCommandHandlers.vitest.ts
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor that preserves existing handler factories and host callbacks; no new dispatch behavior beyond consolidating imports and registry assembly.
> 
> **Overview**
> Introduces **`createProgressViewCommandHandlers`** in `ProgressViewCommandHandlers.ts`, a single factory that builds the shared inbound handler registry by composing the existing lifecycle, run, follow-up, bypass, file, and approval command-group factories behind one **`ProgressViewCommandActions`** contract.
> 
> **Desktop** (`desktopProgressIpc.ts`) and the **VS Code extension** (`ProgressViewMessageHandler.ts`) stop importing and spreading those six factories separately; they each pass host-specific callbacks into that factory once. Extension-only commands (recording, pop-out, external inquiry, etc.) stay in the local handler map—only the shared groups are centralized.
> 
> This is wiring/organization only: same handler modules and dispatch path, with the goal of keeping extension and desktop progress command routing aligned without adding another router layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396f5da05b280d14972ce96c00d0c9fd332d31d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->