### PR TITLE
test: cover desktop restored stream display

### DIFF
--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -102,7 +102,11 @@ type ProgressMessage = {
   streamId?: string;
   todos?: unknown[];
   plan?: unknown;
+  runId?: string;
+  usage?: unknown;
   entries?: Array<{ text?: string }>;
+  rounds?: Record<string, unknown>;
+  reset?: boolean;
   streams?: Array<{ name: string; creationTimestamp: number }>;
   streamStates?: Record<string, unknown>;
 };
@@ -530,6 +534,131 @@ describe('DesktopProgressBridge', () => {
       bridge.setActiveStream('ghost-stream');
 
       expect(messages).toEqual([]);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('restores a ghost stream display from shared streamData sidecars', async () => {
+    const messages: unknown[] = [];
+    const plan = {
+      summary: 'Restore the prior display state.',
+      steps: [
+        {
+          title: 'Read sidecars',
+          description: 'Load all durable progress-view sidecar fields.',
+          status: 'pending',
+          files: ['paper.tex'],
+        },
+      ],
+    };
+    const outputLocation = {
+      kind: 'workspace',
+      absolutePath: '/workspace/out/paper.pdf',
+      relativePath: 'out/paper.pdf',
+    };
+    const logLocation = {
+      kind: 'workspace',
+      absolutePath: '/workspace/out/paper.log',
+      relativePath: 'out/paper.log',
+    };
+    const sidecars: Record<string, unknown> = {
+      workPlan: {
+        todos: [
+          {
+            content: 'Persisted todo',
+            status: 'pending',
+            activeForm: 'Restoring persisted todo',
+          },
+        ],
+        plan,
+        planSummary: plan.summary,
+      },
+      usageStats: {
+        'run-1': {
+          inputTokens: 42,
+          outputTokens: 7,
+          cost: 0.12,
+        },
+      },
+      outputFiles: {
+        '1': [
+          {
+            source: 'paper.tex',
+            location: outputLocation,
+            round: 1,
+            lineage: null,
+            diff: null,
+          },
+        ],
+      },
+      missingOutputs: { '1': ['out/missing.pdf'] },
+      compileFailures: {
+        '1': [
+          {
+            round: 1,
+            displayName: 'paper.tex',
+            output: outputLocation,
+            log: logLocation,
+            logRelativePath: 'out/paper.log',
+          },
+        ],
+      },
+    };
+    const bridge = await createBridge(messages, {
+      kvRead: (key) => sidecars[key],
+      streamSnapshotStore: createStreamSnapshotStore([
+        {
+          streamId: 'ghost-stream',
+          label: 'ghost-stream',
+          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          lastKnownStatus: STREAM_STATUS.STOPPED,
+          creationTimestamp: 1_000,
+          persistedAt: 2_000,
+        },
+      ]),
+    });
+
+    try {
+      bridge.setActiveStream('ghost-stream');
+      await settleProgressEvents();
+      const last = (command: string) =>
+        progressMessages(messages, command).at(-1);
+
+      expect(last(PROGRESS_VIEW_COMMANDS.UPDATE_TODOS)).toMatchObject({
+        stream: 'ghost-stream',
+        todos: [expect.objectContaining({ content: 'Persisted todo' })],
+      });
+      expect(last(PROGRESS_VIEW_COMMANDS.UPDATE_PLAN)).toMatchObject({
+        stream: 'ghost-stream',
+        plan,
+      });
+      expect(last(PROGRESS_VIEW_COMMANDS.UPDATE_RUN_USAGE)).toMatchObject({
+        stream: 'ghost-stream',
+        runId: 'run-1',
+        usage: { inputTokens: 42, outputTokens: 7, cost: 0.12 },
+      });
+      expect(last(PROGRESS_VIEW_COMMANDS.UPDATE_FILES)).toMatchObject({
+        stream: 'ghost-stream',
+        rounds: {
+          '1': [expect.objectContaining({ source: 'paper.tex', round: 1 })],
+        },
+      });
+      expect(last(PROGRESS_VIEW_COMMANDS.UPDATE_MISSING_OUTPUTS)).toMatchObject(
+        {
+          stream: 'ghost-stream',
+          rounds: { '1': ['out/missing.pdf'] },
+        },
+      );
+      expect(
+        last(PROGRESS_VIEW_COMMANDS.UPDATE_COMPILE_FAILURES),
+      ).toMatchObject({
+        stream: 'ghost-stream',
+        rounds: {
+          '1': [expect.objectContaining({ logRelativePath: 'out/paper.log' })],
+        },
+        reset: true,
+      });
     } finally {
       bridge.dispose();
     }


### PR DESCRIPTION
## Summary
- add a desktop bridge regression covering restored ghost streams reading the shared streamData sidecars
- assert the renderer receives todos, plan, usage, output files, missing outputs, and compile failures from the durable snapshot read path
- progresses #5451 P5 without adding production indirection

## Verification
- corepack pnpm vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
- node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
- npm run typecheck -- --pretty false

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in DesktopAgentExecution.vitest.mts with no runtime behavior modified.
> 
> **Overview**
> Adds a **desktop bridge regression** that exercises restoring a persisted “ghost” stream when the user switches to it: mocked KV **streamData sidecars** (`workPlan`, `usageStats`, `outputFiles`, `missingOutputs`, `compileFailures`) plus a hydrated stream snapshot drive `setActiveStream`, and the test asserts the renderer gets the matching **progress-view** updates (todos, plan, run usage, files, missing outputs, compile failures with `reset: true`).
> 
> The shared **`ProgressMessage`** test helper type is extended with `runId`, `usage`, `rounds`, and `reset` so those IPC payloads can be asserted. **No production code** is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82268dc3ed776d2f88b8b5a137c03b028fe6ec25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->