### PR TITLE
refactor: route desktop progress ipc through handlers

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -8,6 +8,7 @@ import {
 
 import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
 import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
+import { createProgressViewCommandHandlers } from '@controllers/progressView/ProgressViewCommandHandlers';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform, tryPlatform } from '@platform/platform';
@@ -57,12 +58,12 @@ import {
   type AgentProposalPermission,
   type AgentCategory,
   type AgentCategoryFilter,
-  type ProgressViewInboundMessage,
   type ProgressViewOutboundMessage,
   type ExecutionId,
+  type RestoredStreamSnapshot,
   type StreamTabId,
 } from '@shared/schemas';
-import type { RestoredStreamSnapshot } from '@shared/schemas';
+import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
@@ -205,6 +206,7 @@ export class DesktopProgressBridge {
   private readonly restoredDisplayInFlight = new Set<StreamTabId>();
 
   readonly runtimeHost: AgentRuntimeHost;
+  readonly progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
 
   constructor(
     private readonly postToRenderer: (message: unknown) => void,
@@ -398,6 +400,7 @@ export class DesktopProgressBridge {
         );
       },
     });
+    this.progressViewInboundHandlers = this.createProgressViewInboundHandlers();
 
     // Hydrate previously-persisted "ghost" streams so the rail shows
     // the user's prior runs at launch (audit item D / trajectory #19).
@@ -424,6 +427,80 @@ export class DesktopProgressBridge {
         emit: false,
       });
     }
+  }
+
+  private createProgressViewInboundHandlers(): ProgressViewInboundHandlerRegistry {
+    return createProgressViewCommandHandlers({
+      lifecycle: {
+        setActiveStream: (stream) => this.setActiveStream(stream),
+        setAgentFilter: (filter) => this.setAgentFilter(filter),
+        deleteStream: (stream) => this.deleteStream(stream),
+        deleteAllStreams: () => this.deleteAllStreams(),
+        stopStream: (stream) => this.stopStream(stream),
+      },
+      run: {
+        resumeStream: (stream) => this.tryResumeStream(stream),
+        runNewStream: (stream) => this.runNewStream(stream),
+      },
+      followUp: {
+        sendFollowUp: ({ stream, text, mediaFiles }) =>
+          this.sendFollowUp(stream, text, mediaFiles),
+        reportImageSaveError: (image, error) => {
+          this.logger.warn(
+            `Failed to save pasted follow-up image ${image.fileName}`,
+            { data: error instanceof Error ? error : { error } },
+          );
+        },
+      },
+      bypass: {
+        runtimeHost: this.runtimeHost,
+      },
+      file: {
+        openFile: async (file, line) => {
+          await this.options.openPath?.(file, line);
+        },
+        openFileCompile: (file) => this.openFileCompile(file),
+        openTaskStorage: (stream) =>
+          this.workflowFileActions.openTaskStorage(stream),
+        compareOriginal: (file, base) =>
+          this.workflowFileActions.compareOriginal(file, base),
+        comparePrevious: (file, base, previous) =>
+          this.workflowFileActions.comparePrevious(file, base, previous),
+        acceptFile: (file, base) =>
+          this.workflowFileActions.acceptFile(file, base),
+        mergeFile: (file, base) =>
+          this.workflowFileActions.mergeFile(file, base),
+        latexdiffFile: (file, base) =>
+          this.workflowFileActions.latexdiffFile(file, base),
+        openLabel: (label) => this.workflowFileActions.openLabel(label),
+      },
+      approval: {
+        handleToolEditApprovalAction: (message) =>
+          this.toolEditApprovals.handleAction(message),
+        onUnsupportedToolEditApproval: (message) => {
+          this.logger.warn('Unsupported desktop tool-edit approval action', {
+            data: {
+              requestId: message.requestId,
+              action: message.action,
+            },
+          });
+        },
+        handleBashApprovalAction: (message) =>
+          handleProgressViewBashApprovalAction(message),
+        handlePlanApprovalAction: (message) => {
+          resolvePlanApproval(message.approvalId, {
+            action: message.action,
+            ...(message.action === 'reject' && {
+              feedback: message.feedback,
+            }),
+          });
+        },
+        handleUserQuestionAction: (message) =>
+          handleUserQuestionAction(message),
+        handleAgentProposalAction: (message) =>
+          this.agentProposalController.handleAction(message),
+      },
+    });
   }
 
   private persistStreamSnapshot(streamId: StreamTabId): void {
@@ -686,7 +763,7 @@ export class DesktopProgressBridge {
     this.syncStreamContent(streamId);
   }
 
-  setAgentFilter(filter: AgentCategoryFilter): void {
+  private setAgentFilter(filter: AgentCategoryFilter): void {
     this.state.agentCategoryFilter = filter;
     const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
       this.state,
@@ -778,7 +855,7 @@ export class DesktopProgressBridge {
     });
   }
 
-  stopStream(streamId: StreamTabId): void {
+  private stopStream(streamId: StreamTabId): void {
     clearRetryRequest(streamId);
     if (this.options.detachSubagentsOnStop === true) {
       detachActiveChildren(streamId, this.runtimeHost);
@@ -789,10 +866,6 @@ export class DesktopProgressBridge {
     StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {
       runtimeHost: this.runtimeHost,
     });
-  }
-
-  async resumeStream(streamId: StreamTabId): Promise<void> {
-    await this.tryResumeStream(streamId);
   }
 
   async tryResumeStream(streamId: StreamTabId): Promise<boolean> {
@@ -968,14 +1041,14 @@ export class DesktopProgressBridge {
     }
   }
 
-  async runNewStream(streamId: StreamTabId): Promise<void> {
+  private async runNewStream(streamId: StreamTabId): Promise<void> {
     const taskState = this.state.snapshots.getTaskState(streamId);
     if (!taskState) return;
 
     await this.runExecution({ config: taskState.agentConfig });
   }
 
-  async sendFollowUp(
+  private async sendFollowUp(
     streamId: StreamTabId,
     text: string,
     mediaFiles?: readonly string[],
@@ -991,10 +1064,6 @@ export class DesktopProgressBridge {
     );
   }
 
-  async openFile(filePath: string, line?: number): Promise<void> {
-    await this.options.openPath?.(filePath, line);
-  }
-
   async openFileCompile(filePath: string): Promise<void> {
     if (this.options.openBuildDisplay) {
       await this.options.openBuildDisplay(toFileLocation(filePath));
@@ -1003,86 +1072,6 @@ export class DesktopProgressBridge {
     await this.options.showErrorMessage?.(
       'Desktop LaTeX preview is unavailable. Cannot compile and open this file.',
     );
-  }
-
-  async openTaskStorage(streamId: StreamTabId): Promise<void> {
-    await this.workflowFileActions.openTaskStorage(streamId);
-  }
-
-  async compareOriginal(file: string, base?: string): Promise<void> {
-    await this.workflowFileActions.compareOriginal(file, base);
-  }
-
-  async comparePrevious(
-    file: string,
-    base?: string,
-    previous?: string,
-  ): Promise<void> {
-    await this.workflowFileActions.comparePrevious(file, base, previous);
-  }
-
-  async acceptFile(file: string, base?: string): Promise<void> {
-    await this.workflowFileActions.acceptFile(file, base);
-  }
-
-  async mergeFile(file: string, base?: string): Promise<void> {
-    await this.workflowFileActions.mergeFile(file, base);
-  }
-
-  async latexdiffFile(file: string, base?: string): Promise<void> {
-    await this.workflowFileActions.latexdiffFile(file, base);
-  }
-
-  async openLabel(label: string): Promise<void> {
-    await this.workflowFileActions.openLabel(label);
-  }
-
-  async handleBashApprovalAction(
-    message: Extract<
-      ProgressViewInboundMessage,
-      { command: typeof PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION }
-    >,
-  ): Promise<void> {
-    await handleProgressViewBashApprovalAction(message);
-  }
-
-  handleToolEditApprovalAction(
-    message: Extract<
-      ProgressViewInboundMessage,
-      { command: typeof PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION }
-    >,
-  ): boolean {
-    return this.toolEditApprovals.handleAction(message);
-  }
-
-  handlePlanApprovalAction(
-    message: Extract<
-      ProgressViewInboundMessage,
-      { command: typeof PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION }
-    >,
-  ): void {
-    resolvePlanApproval(message.approvalId, {
-      action: message.action,
-      ...(message.action === 'reject' && { feedback: message.feedback }),
-    });
-  }
-
-  async handleUserQuestionAction(
-    message: Extract<
-      ProgressViewInboundMessage,
-      { command: typeof PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION }
-    >,
-  ): Promise<void> {
-    await handleUserQuestionAction(message);
-  }
-
-  async handleAgentProposalAction(
-    message: Extract<
-      ProgressViewInboundMessage,
-      { command: typeof PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION }
-    >,
-  ): Promise<boolean> {
-    return this.agentProposalController.handleAction(message);
   }
 
   async runExecution(request: ValidatedExecutionRequest): Promise<void> {

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -1,9 +1,7 @@
-import { createProgressViewCommandHandlers } from '@controllers/progressView/ProgressViewCommandHandlers';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import {
   dispatchProgressViewInbound,
   ProgressViewInboundMessageSchema,
-  type ProgressViewInboundHandlerRegistry,
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
 
@@ -14,8 +12,13 @@ import {
 } from './desktopIpcTypes.js';
 import type { DesktopProgressBridge } from './desktopAgentExecution.js';
 
+type DesktopProgressIpcBridge = Pick<
+  DesktopProgressBridge,
+  'progressViewInboundHandlers' | 'syncFullView'
+>;
+
 export interface DesktopProgressIpcOptions {
-  progress: DesktopProgressBridge;
+  progress: DesktopProgressIpcBridge;
   onUnsupportedCommand?: (message: ProgressViewInboundMessage) => void;
   onAsyncError?: (error: unknown) => void;
 }
@@ -36,55 +39,6 @@ export function createDesktopProgressIpc(
     options.onUnsupportedCommand ?? defaultUnsupportedCommand;
   const progress = options.progress;
 
-  const progressHandlers: ProgressViewInboundHandlerRegistry =
-    createProgressViewCommandHandlers({
-      lifecycle: {
-        setActiveStream: (stream) => progress.setActiveStream(stream),
-        setAgentFilter: (filter) => progress.setAgentFilter(filter),
-        deleteStream: (stream) => progress.deleteStream(stream),
-        deleteAllStreams: () => progress.deleteAllStreams(),
-        stopStream: (stream) => progress.stopStream(stream),
-      },
-      run: {
-        resumeStream: (stream) => progress.resumeStream(stream),
-        runNewStream: (stream) => progress.runNewStream(stream),
-      },
-      followUp: {
-        sendFollowUp: ({ stream, text, mediaFiles }) =>
-          progress.sendFollowUp(stream, text, mediaFiles),
-        reportImageSaveError: (_image, error) => reportAsyncError(error),
-      },
-      bypass: {
-        runtimeHost: progress.runtimeHost,
-      },
-      file: {
-        openFile: (file, line) => progress.openFile(file, line),
-        openFileCompile: (file) => progress.openFileCompile(file),
-        openTaskStorage: (stream) => progress.openTaskStorage(stream),
-        compareOriginal: (file, base) => progress.compareOriginal(file, base),
-        comparePrevious: (file, base, previous) =>
-          progress.comparePrevious(file, base, previous),
-        acceptFile: (file, base) => progress.acceptFile(file, base),
-        mergeFile: (file, base) => progress.mergeFile(file, base),
-        latexdiffFile: (file, base) => progress.latexdiffFile(file, base),
-        openLabel: (label) => progress.openLabel(label),
-      },
-      approval: {
-        handleToolEditApprovalAction: (message) =>
-          progress.handleToolEditApprovalAction(message),
-        onUnsupportedToolEditApproval: (message) =>
-          onUnsupportedCommand(message),
-        handleBashApprovalAction: (message) =>
-          progress.handleBashApprovalAction(message),
-        handlePlanApprovalAction: (message) =>
-          progress.handlePlanApprovalAction(message),
-        handleUserQuestionAction: (message) =>
-          progress.handleUserQuestionAction(message),
-        handleAgentProposalAction: (message) =>
-          progress.handleAgentProposalAction(message),
-      },
-    });
-
   return {
     handleMessage(message: DesktopCommandMessage): boolean {
       const result = ProgressViewInboundMessageSchema.safeParse(message);
@@ -100,7 +54,11 @@ export function createDesktopProgressIpc(
       if (passThroughCommands.has(command)) return false;
 
       if (
-        dispatchProgressViewInbound(message, progressHandlers, reportAsyncError)
+        dispatchProgressViewInbound(
+          message,
+          progress.progressViewInboundHandlers,
+          reportAsyncError,
+        )
       ) {
         return true;
       }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -13,6 +13,7 @@ import {
 } from '@shared/schemas';
 import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
+import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 // Local imports - desktop test paths
@@ -30,11 +31,7 @@ type TestableBridge = Bridge & {
   setActiveStream(streamId: StreamTabId): void;
   deleteStream(streamId: StreamTabId): Promise<void>;
   deleteAllStreams(): Promise<void>;
-  handleAgentProposalAction(message: {
-    command: typeof PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION;
-    proposalId: string;
-    action: 'setup';
-  }): Promise<boolean>;
+  progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
   streamLogs: {
     append(
       streamId: StreamTabId,
@@ -1610,13 +1607,16 @@ describe('DesktopProgressBridge', () => {
       });
       messages.length = 0;
 
-      await expect(
-        bridge.handleAgentProposalAction({
-          command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-          proposalId: 'proposal-1',
-          action: 'setup',
-        }),
-      ).resolves.toBe(true);
+      const handleProposal =
+        bridge.progressViewInboundHandlers[
+          PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION
+        ];
+      expect(handleProposal).toBeTypeOf('function');
+      await handleProposal?.({
+        command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+        proposalId: 'proposal-1',
+        action: 'setup',
+      });
 
       expect(messages).toEqual([
         { command: DESKTOP_SHELL_COMMANDS.SET_ROUTE, route: 'main' },

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -1,10 +1,9 @@
 // Third-party imports
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - webview command constants
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
-import { cleanupAllApprovals } from '@tools/approval';
+import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
@@ -13,71 +12,14 @@ interface DesktopProgressIpcModule {
   createDesktopProgressIpc(options: {
     progress: {
       syncFullView(): void;
-      setActiveStream(stream: string): void;
-      setAgentFilter(filter: string): void;
-      deleteStream(stream: string): Promise<void>;
-      deleteAllStreams(): Promise<void>;
-      stopStream(stream: string): void;
-      resumeStream(stream: string): Promise<void>;
-      runNewStream(stream: string): Promise<void>;
-      sendFollowUp(
-        stream: string,
-        text: string,
-        mediaFiles?: readonly string[],
-      ): Promise<void>;
-      openFile(file: string, line?: number): Promise<void>;
-      openFileCompile(file: string): Promise<void>;
-      openTaskStorage(stream: string): Promise<void>;
-      compareOriginal(file: string, base?: string): Promise<void>;
-      comparePrevious(
-        file: string,
-        base?: string,
-        previous?: string,
-      ): Promise<void>;
-      acceptFile(file: string, base?: string): Promise<void>;
-      mergeFile(file: string, base?: string): Promise<void>;
-      latexdiffFile(file: string, base?: string): Promise<void>;
-      openLabel(label: string): Promise<void>;
-      handleToolEditApprovalAction(message: {
-        command: string;
-        requestId: string;
-        action: string;
-        feedback?: string;
-      }): boolean;
-      handleBashApprovalAction(message: {
-        command: string;
-        requestId: string;
-        action: string;
-        feedback?: string;
-      }): Promise<void>;
-      handlePlanApprovalAction(message: {
-        command: string;
-        approvalId: string;
-        action: string;
-        feedback?: string;
-      }): void;
-      handleUserQuestionAction(message: {
-        command: string;
-        questionId: string;
-        action: string;
-        answer?: string;
-      }): Promise<void>;
-      handleAgentProposalAction(message: {
-        command: string;
-        proposalId: string;
-        action: string;
-        feedback?: string;
-        model?: string;
-        agent?: string;
-      }): Promise<boolean>;
-      runtimeHost: AgentRuntimeHost;
+      progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
     };
     onUnsupportedCommand?: (message: { command: string }) => void;
     onAsyncError?: (error: unknown) => void;
   }): {
     handleMessage(
       message: { command: string } & Record<string, unknown>,
-    ): boolean | Promise<boolean>;
+    ): boolean;
   };
 }
 
@@ -88,50 +30,16 @@ async function loadDesktopProgressIpc(): Promise<DesktopProgressIpcModule> {
   ) as Promise<DesktopProgressIpcModule>;
 }
 
-function createProgress() {
+function createProgress(
+  progressViewInboundHandlers: ProgressViewInboundHandlerRegistry = {},
+) {
   return {
     syncFullView: vi.fn(),
-    setActiveStream: vi.fn(),
-    setAgentFilter: vi.fn(),
-    deleteStream: vi.fn(async (_stream: string) => {}),
-    deleteAllStreams: vi.fn(async () => {}),
-    stopStream: vi.fn(),
-    resumeStream: vi.fn(async (_stream: string) => {}),
-    runNewStream: vi.fn(async (_stream: string) => {}),
-    sendFollowUp: vi.fn(
-      async (
-        _stream: string,
-        _text: string,
-        _mediaFiles?: readonly string[],
-      ) => {},
-    ),
-    openFile: vi.fn(async (_file: string, _line?: number) => {}),
-    openFileCompile: vi.fn(async (_file: string) => {}),
-    openTaskStorage: vi.fn(async (_stream: string) => {}),
-    compareOriginal: vi.fn(async (_file: string, _base?: string) => {}),
-    comparePrevious: vi.fn(
-      async (_file: string, _base?: string, _previous?: string) => {},
-    ),
-    acceptFile: vi.fn(async (_file: string, _base?: string) => {}),
-    mergeFile: vi.fn(async (_file: string, _base?: string) => {}),
-    latexdiffFile: vi.fn(async (_file: string, _base?: string) => {}),
-    openLabel: vi.fn(async (_label: string) => {}),
-    handleToolEditApprovalAction: vi.fn(() => true),
-    handleBashApprovalAction: vi.fn(async () => {}),
-    handlePlanApprovalAction: vi.fn(),
-    handleUserQuestionAction: vi.fn(async () => {}),
-    handleAgentProposalAction: vi.fn(async () => true),
-    runtimeHost: {
-      emit: vi.fn(),
-    },
+    progressViewInboundHandlers,
   };
 }
 
 describe('desktop Progress IPC', () => {
-  afterEach(() => {
-    cleanupAllApprovals();
-  });
-
   it('syncs Progress state on readiness while allowing shared view-state handling', async () => {
     const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
     const progress = createProgress();
@@ -143,9 +51,12 @@ describe('desktop Progress IPC', () => {
     expect(progress.syncFullView).toHaveBeenCalledTimes(1);
   });
 
-  it('handles basic Progress stream commands through the shared bridge', async () => {
+  it('dispatches recognized Progress commands through the bridge registry', async () => {
     const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-    const progress = createProgress();
+    const switchStream = vi.fn();
+    const progress = createProgress({
+      [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: switchStream,
+    });
     const ipc = createDesktopProgressIpc({ progress });
 
     expect(
@@ -154,145 +65,17 @@ describe('desktop Progress IPC', () => {
         stream: 'run-1',
       }),
     ).toBe(true);
-    expect(progress.setActiveStream).toHaveBeenCalledWith('run-1');
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.FILTER_STREAMS,
-        filter: 'workflow',
-      }),
-    ).toBe(true);
-    expect(progress.setAgentFilter).toHaveBeenCalledWith('workflow');
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
-        stream: 'run-1',
-      }),
-    ).toBe(true);
-    await Promise.resolve();
-    expect(progress.deleteStream).toHaveBeenCalledWith('run-1');
-
-    expect(
-      ipc.handleMessage({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL }),
-    ).toBe(true);
-    await Promise.resolve();
-    expect(progress.deleteAllStreams).toHaveBeenCalledTimes(1);
+    expect(switchStream).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
+      stream: 'run-1',
+    });
   });
 
-  it('opens Progress file actions through the desktop preview host', async () => {
+  it('consumes recognized but unhandled commands with an explicit warning path', async () => {
     const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-    const progress = createProgress();
-    const ipc = createDesktopProgressIpc({ progress });
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
-        file: '/tmp/output.pdf',
-      }),
-    ).toBe(true);
-    await Promise.resolve();
-    expect(progress.openFile).toHaveBeenCalledWith(
-      '/tmp/output.pdf',
-      undefined,
-    );
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE,
-        file: '/tmp/output.tex',
-      }),
-    ).toBe(true);
-    await Promise.resolve();
-    expect(progress.openFileCompile).toHaveBeenCalledWith('/tmp/output.tex');
-  });
-
-  it('maps workflow file operations to the desktop bridge', async () => {
-    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-    const progress = createProgress();
-    const ipc = createDesktopProgressIpc({ progress });
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE,
-        stream: 'run-1',
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
-        file: '/tmp/r1.tex',
-        base: '/tmp/base.tex',
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,
-        file: '/tmp/r2.tex',
-        base: '/tmp/base.tex',
-        prev: '/tmp/r1.tex',
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
-        file: '/tmp/r1.tex',
-        base: '/tmp/base.tex',
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
-        file: '/tmp/r1.tex',
-        base: '/tmp/base.tex',
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
-        file: '/tmp/r1.tex',
-        base: '/tmp/base.tex',
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.OPEN_LABEL,
-        label: 'eq:main',
-      }),
-    ).toBe(true);
-
-    await Promise.resolve();
-    expect(progress.openTaskStorage).toHaveBeenCalledWith('run-1');
-    expect(progress.compareOriginal).toHaveBeenCalledWith(
-      '/tmp/r1.tex',
-      '/tmp/base.tex',
-    );
-    expect(progress.comparePrevious).toHaveBeenCalledWith(
-      '/tmp/r2.tex',
-      '/tmp/base.tex',
-      '/tmp/r1.tex',
-    );
-    expect(progress.acceptFile).toHaveBeenCalledWith(
-      '/tmp/r1.tex',
-      '/tmp/base.tex',
-    );
-    expect(progress.mergeFile).toHaveBeenCalledWith(
-      '/tmp/r1.tex',
-      '/tmp/base.tex',
-    );
-    expect(progress.latexdiffFile).toHaveBeenCalledWith(
-      '/tmp/r1.tex',
-      '/tmp/base.tex',
-    );
-    expect(progress.openLabel).toHaveBeenCalledWith('eq:main');
-  });
-
-  it('routes unsupported Progress commands through an explicit handler', async () => {
-    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-    const progress = createProgress();
     const onUnsupportedCommand = vi.fn();
     const ipc = createDesktopProgressIpc({
-      progress,
+      progress: createProgress(),
       onUnsupportedCommand,
     });
 
@@ -302,8 +85,19 @@ describe('desktop Progress IPC', () => {
         stream: 'run-1',
       }),
     ).toBe(true);
-    expect(progress.stopStream).toHaveBeenCalledWith('run-1');
-    expect(onUnsupportedCommand).not.toHaveBeenCalled();
+    expect(onUnsupportedCommand).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.STOP_STREAM,
+      stream: 'run-1',
+    });
+  });
+
+  it('leaves shell-level pass-through commands for sibling desktop handlers', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const onUnsupportedCommand = vi.fn();
+    const ipc = createDesktopProgressIpc({
+      progress: createProgress(),
+      onUnsupportedCommand,
+    });
 
     expect(
       ipc.handleMessage({
@@ -314,254 +108,33 @@ describe('desktop Progress IPC', () => {
     expect(onUnsupportedCommand).not.toHaveBeenCalled();
   });
 
-  it('maps high-use Progress action commands to the desktop bridge', async () => {
+  it('reports async registry failures through the desktop error path', async () => {
     const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-    const progress = createProgress();
-    const ipc = createDesktopProgressIpc({ progress });
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.RESUME,
-        stream: 'run-1',
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.RUN_NEW,
-        stream: 'run-1',
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
-        stream: 'run-1',
-        text: 'continue please',
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
-        file: '/tmp/out.tex',
-        line: 4,
-      }),
-    ).toBe(true);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE,
-        file: '/tmp/out.pdf',
-      }),
-    ).toBe(true);
-
-    await Promise.resolve();
-    expect(progress.resumeStream).toHaveBeenCalledWith('run-1');
-    expect(progress.runNewStream).toHaveBeenCalledWith('run-1');
-    expect(progress.sendFollowUp.mock.calls[0]?.slice(0, 2)).toEqual([
-      'run-1',
-      'continue please',
-    ]);
-    expect(progress.openFile).toHaveBeenCalledWith('/tmp/out.tex', 4);
-    expect(progress.openFileCompile).toHaveBeenCalledWith('/tmp/out.pdf');
-  });
-
-  it('passes pasted follow-up images through the desktop bridge', async () => {
-    vi.doMock('@utils/files/pastedImageUtils', () => ({
-      savePastedImageBase64: vi.fn(async () => '/tmp/pasted/fig.png'),
-    }));
-    try {
-      const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-      const { savePastedImageBase64 } =
-        await import('@utils/files/pastedImageUtils');
-      const progress = createProgress();
-      const ipc = createDesktopProgressIpc({ progress });
-
-      expect(
-        ipc.handleMessage({
-          command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
-          stream: 'run-1',
-          text: 'look at this figure',
-          images: [
-            {
-              base64: 'encoded',
-              mediaType: 'image/png',
-              fileName: 'pasted_1.png',
-            },
-          ],
-        }),
-      ).toBe(true);
-
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(savePastedImageBase64).toHaveBeenCalledWith(
-        'encoded',
-        'pasted_1.png',
-      );
-      expect(progress.sendFollowUp).toHaveBeenCalledWith(
-        'run-1',
-        'look at this figure',
-        ['/tmp/pasted/fig.png'],
-      );
-    } finally {
-      vi.doUnmock('@utils/files/pastedImageUtils');
-    }
-  });
-
-  it('maps approval actions and reports desktop-only unsupported approval variants', async () => {
-    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-    const progress = createProgress();
-    const onUnsupportedCommand = vi.fn();
+    const error = new Error('dispatch failed');
+    const onAsyncError = vi.fn();
     const ipc = createDesktopProgressIpc({
-      progress,
-      onUnsupportedCommand,
-    });
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
-        requestId: 'bash-1',
-        action: 'approve',
+      progress: createProgress({
+        [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: () => Promise.reject(error),
       }),
-    ).toBe(true);
-    expect(progress.handleBashApprovalAction).toHaveBeenCalledWith({
-      command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
-      requestId: 'bash-1',
-      action: 'approve',
+      onAsyncError,
     });
 
     expect(
       ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
-        approvalId: 'plan-1',
-        action: 'reject',
-        feedback: 'needs work',
-      }),
-    ).toBe(true);
-    expect(progress.handlePlanApprovalAction).toHaveBeenCalledWith({
-      command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
-      approvalId: 'plan-1',
-      action: 'reject',
-      feedback: 'needs work',
-    });
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-        requestId: 'edit-1',
-        action: 'approve',
-      }),
-    ).toBe(true);
-    expect(progress.handleToolEditApprovalAction).toHaveBeenCalledWith({
-      command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-      requestId: 'edit-1',
-      action: 'approve',
-    });
-
-    progress.handleToolEditApprovalAction.mockReturnValueOnce(false);
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-        requestId: 'edit-2',
-        action: 'openDiff',
-      }),
-    ).toBe(true);
-    expect(onUnsupportedCommand).toHaveBeenCalledWith({
-      command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-      requestId: 'edit-2',
-      action: 'openDiff',
-    });
-  });
-
-  it('handles bypass toggles through shared policy instead of unsupported fallback', async () => {
-    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-    const progress = createProgress();
-    const onUnsupportedCommand = vi.fn();
-    const ipc = createDesktopProgressIpc({
-      progress,
-      onUnsupportedCommand,
-    });
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
+        command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
         stream: 'run-1',
       }),
     ).toBe(true);
     await Promise.resolve();
-    expect(onUnsupportedCommand).not.toHaveBeenCalled();
-    expect(progress.runtimeHost.emit).toHaveBeenCalledWith(
-      'updateToolEditApprovalBypassState',
-      { streamId: 'run-1', bypassActive: true },
+    expect(onAsyncError).toHaveBeenCalledWith(error);
+  });
+
+  it('ignores invalid Progress IPC payloads', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const ipc = createDesktopProgressIpc({ progress: createProgress() });
+
+    expect(ipc.handleMessage({ command: 'not-a-progress-command' })).toBe(
+      false,
     );
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
-        stream: 'run-2',
-      }),
-    ).toBe(true);
-    await Promise.resolve();
-    expect(onUnsupportedCommand).not.toHaveBeenCalled();
-    expect(progress.runtimeHost.emit).toHaveBeenCalledWith(
-      'updateSuperYoloBypassState',
-      { streamId: 'run-2', bypassActive: true },
-    );
-    expect(progress.runtimeHost.emit).toHaveBeenCalledWith(
-      'updateToolEditApprovalBypassState',
-      { streamId: 'run-2', bypassActive: true },
-    );
-  });
-
-  it('routes agent proposal setup through the desktop bridge', async () => {
-    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-    const progress = createProgress();
-    const onUnsupportedCommand = vi.fn();
-    const ipc = createDesktopProgressIpc({
-      progress,
-      onUnsupportedCommand,
-    });
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-        proposalId: 'proposal-1',
-        action: 'setup',
-      }),
-    ).toBe(true);
-
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(progress.handleAgentProposalAction).toHaveBeenCalledWith({
-      command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-      proposalId: 'proposal-1',
-      action: 'setup',
-    });
-    expect(onUnsupportedCommand).not.toHaveBeenCalled();
-  });
-
-  it('does not report failed agent proposal setup as unsupported', async () => {
-    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
-    const progress = createProgress();
-    progress.handleAgentProposalAction.mockResolvedValueOnce(false);
-    const onUnsupportedCommand = vi.fn();
-    const ipc = createDesktopProgressIpc({
-      progress,
-      onUnsupportedCommand,
-    });
-
-    expect(
-      ipc.handleMessage({
-        command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-        proposalId: 'proposal-1',
-        action: 'setup',
-      }),
-    ).toBe(true);
-
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(progress.handleAgentProposalAction).toHaveBeenCalledWith({
-      command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-      proposalId: 'proposal-1',
-      action: 'setup',
-    });
-    expect(onUnsupportedCommand).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Refs #5451.

This is a small P3 cleanup slice: desktop progress IPC now dispatches the `DesktopProgressBridge` inbound handler registry directly instead of rebuilding a command-by-command bridge shim. The actual desktop command callbacks now live beside the bridge state/controllers that own them.

Changes:
- Expose one `progressViewInboundHandlers` registry from `DesktopProgressBridge`.
- Make desktop IPC responsible only for schema validation, readiness/pass-through commands, unsupported-command reporting, and async-error routing.
- Remove one-line desktop bridge relay methods for workflow file actions, approvals, follow-up, resume, and filter/stop/run-new commands.
- Trim the IPC test from per-command mapping boilerplate down to the IPC contract it now owns.

## Validation

- `corepack pnpm vitest run src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing warning-only import-order noise outside touched files)
- `npm run compile:fast`
- `git diff --check`

## Design note

This intentionally does not add another wrapper/facade. The shared contract remains `ProgressViewInboundHandlerRegistry`; desktop IPC just consumes it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with the same shared dispatch contract; behavior should match aside from localized error logging for pasted follow-up images and unsupported tool-edit approvals.
> 
> **Overview**
> Desktop progress IPC no longer wires each renderer command to its own `DesktopProgressBridge` method. **`DesktopProgressBridge`** now builds and exposes a single **`progressViewInboundHandlers`** registry (via **`createProgressViewCommandHandlers`**) next to the controllers that implement lifecycle, resume/run, follow-ups, file actions, bypass toggles, and approvals.
> 
> **`createDesktopProgressIpc`** is narrowed to schema validation, **`WEBVIEW_READY`** → **`syncFullView`**, pass-through shell commands, **`dispatchProgressViewInbound`** on that registry, unsupported-command warnings, and async-error reporting. One-line public bridge relays and the **`resumeStream`** wrapper are removed; several handlers are **`private`** again.
> 
> Tests shift integration coverage to the bridge/registry (**`DesktopAgentExecution`**) and keep IPC tests focused on dispatch contract only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a344140622ccac7bca5f1e07053a1068938dd7a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->