### PR TITLE
refactor: make run coordinator bridge explicit

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -13,12 +13,7 @@
 // it returns a typed Promise<ToolEditApprovalResult>, not a fire-and-forget
 // event).
 
-import {
-  cancelRetry,
-  resolvePlanApproval,
-  resolveProposal,
-  triggerRetry,
-} from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
   denyMessage,
   immediateDecision,
@@ -255,7 +250,7 @@ function dispatchPlan(
   decision: ApprovalDecision,
 ): void {
   const feedback = feedbackOnReject(decision);
-  resolvePlanApproval(payload.approvalId, {
+  runCoordinatorBridge.resolvePlanApproval(payload.approvalId, {
     action: decision.accepted ? (decision.planAction ?? 'approve') : 'reject',
     ...(feedback ? { feedback } : {}),
   });
@@ -266,7 +261,7 @@ function dispatchProposal(
   decision: ApprovalDecision,
 ): void {
   const feedback = feedbackOnReject(decision);
-  resolveProposal(payload.proposalId, {
+  runCoordinatorBridge.resolveProposal(payload.proposalId, {
     action: decision.accepted ? 'approve' : 'reject',
     ...(feedback ? { feedback } : {}),
   });
@@ -279,7 +274,7 @@ function dispatchRetry(
   if (decision.accepted) {
     void applyRetryDecision(payload, decision);
   } else {
-    cancelRetry(payload.streamId);
+    runCoordinatorBridge.cancelRetry(payload.streamId);
   }
 }
 
@@ -294,7 +289,7 @@ async function applyRetryDecision(
       apiMode: decision.apiMode,
     });
   }
-  triggerRetry(payload.streamId, decision.userMessage);
+  runCoordinatorBridge.triggerRetry(payload.streamId, decision.userMessage);
 }
 
 function handleExternalInquiry(

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -2,12 +2,7 @@
 import { structuredPatch } from 'diff';
 
 // Local imports - runtime
-import {
-  cancelRetry,
-  resolvePlanApproval,
-  resolveProposal,
-  triggerRetry,
-} from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   agentProposalCategoryLabel,
@@ -336,7 +331,7 @@ function dispatchApprovalDecision<K extends CliDecisionApprovalEvent>(
     }
     case 'showPlanApproval': {
       const data = payload as ProgressEventPayloads['showPlanApproval'];
-      resolvePlanApproval(data.approvalId, {
+      runCoordinatorBridge.resolvePlanApproval(data.approvalId, {
         action,
         ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
       });
@@ -344,7 +339,7 @@ function dispatchApprovalDecision<K extends CliDecisionApprovalEvent>(
     }
     case 'showAgentProposal': {
       const data = payload as ProgressEventPayloads['showAgentProposal'];
-      resolveProposal(data.proposalId, {
+      runCoordinatorBridge.resolveProposal(data.proposalId, {
         action,
         ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
       });
@@ -353,7 +348,7 @@ function dispatchApprovalDecision<K extends CliDecisionApprovalEvent>(
     case 'showRetryRequest': {
       const data = payload as ProgressEventPayloads['showRetryRequest'];
       if (decision.accepted) {
-        triggerRetry(data.streamId);
+        runCoordinatorBridge.triggerRetry(data.streamId);
         return;
       }
       if (options.writeRejectionToStderr) {
@@ -364,7 +359,7 @@ function dispatchApprovalDecision<K extends CliDecisionApprovalEvent>(
             : summary,
         );
       }
-      cancelRetry(data.streamId);
+      runCoordinatorBridge.cancelRetry(data.streamId);
       return;
     }
     default: {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -21,11 +21,7 @@ import { readMeta } from '@transcript/streamSnapshotRead';
 import type { AgentTrace } from '@agent/trace';
 import type { ValidatedExecutionRequest } from '@agent/core/execution/executionRequests';
 import { TaskStateSchema } from '@agent/core/execution/TaskState';
-import {
-  clearRetryRequest,
-  resolvePlanApproval,
-  resolveProposal,
-} from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -379,7 +375,7 @@ export class DesktopProgressBridge {
         return true;
       },
       resolveProposal: (proposalId, result) => {
-        resolveProposal(proposalId, result);
+        runCoordinatorBridge.resolveProposal(proposalId, result);
       },
       onMissingProposal: (proposalId) => {
         this.logger.warn(
@@ -488,7 +484,7 @@ export class DesktopProgressBridge {
         handleBashApprovalAction: (message) =>
           handleProgressViewBashApprovalAction(message),
         handlePlanApprovalAction: (message) => {
-          resolvePlanApproval(message.approvalId, {
+          runCoordinatorBridge.resolvePlanApproval(message.approvalId, {
             action: message.action,
             ...(message.action === 'reject' && {
               feedback: message.feedback,
@@ -856,7 +852,7 @@ export class DesktopProgressBridge {
   }
 
   private stopStream(streamId: StreamTabId): void {
-    clearRetryRequest(streamId);
+    runCoordinatorBridge.clearRetryRequest(streamId);
     if (this.options.detachSubagentsOnStop === true) {
       detachActiveChildren(streamId, this.runtimeHost);
     } else {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -10,12 +10,7 @@ import { ProgressAgentProposalController } from '@controllers/progressView/Progr
 import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { getAgent } from '@agent/index';
-import {
-  cancelRetry,
-  resolvePlanApproval,
-  resolveProposal,
-  triggerRetry,
-} from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
   validateExecutionRequest,
   type ExecutionRequest,
@@ -260,7 +255,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST]: (data) =>
         this.handleRetryStreamRequest(data),
       [PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST]: (data) => {
-        cancelRetry(data.stream);
+        runCoordinatorBridge.cancelRetry(data.stream);
       },
       [PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY]: (data) =>
         this.handleUseOwnApiKey(data),
@@ -534,7 +529,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         );
       },
       resolveProposal: (proposalId, result) => {
-        resolveProposal(proposalId, result);
+        runCoordinatorBridge.resolveProposal(proposalId, result);
       },
       onMissingProposal: (proposalId) => {
         this.logger.warn(
@@ -598,7 +593,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async handleRetryStreamRequest(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST>,
   ): Promise<void> {
-    const success = triggerRetry(data.stream, data.feedback);
+    const success = runCoordinatorBridge.triggerRetry(
+      data.stream,
+      data.feedback,
+    );
     if (!success) {
       await vscode.window.showInformationMessage(
         'No retryable request is available for this stream yet.',
@@ -676,7 +674,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       await getServerSideKeyService().setUseIncludedModelAccess(false);
       invalidateModelOptionsCache();
     }
-    const retried = triggerRetry(data.stream);
+    const retried = runCoordinatorBridge.triggerRetry(data.stream);
     if (!retried) {
       await vscode.window.showInformationMessage(
         'Switched to your own API key. No pending retry to resume — run the agent again when ready.',
@@ -755,17 +753,17 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const { approvalId, action } = data;
     switch (action) {
       case 'approve':
-        resolvePlanApproval(approvalId, {
+        runCoordinatorBridge.resolvePlanApproval(approvalId, {
           action: 'approve',
         });
         break;
       case 'approve_and_odyssey':
-        resolvePlanApproval(approvalId, {
+        runCoordinatorBridge.resolvePlanApproval(approvalId, {
           action: 'approve_and_odyssey',
         });
         break;
       case 'reject':
-        resolvePlanApproval(approvalId, {
+        runCoordinatorBridge.resolvePlanApproval(approvalId, {
           action: 'reject',
           feedback: data.feedback,
         });

--- a/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
+++ b/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { clearRetryRequest } from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { isInFlightStatus } from '@common/constants/streamStatus';
@@ -41,7 +41,7 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
     options: { clearRetryRequest?: boolean } = {},
   ): Promise<void> {
     if (options.clearRetryRequest === true) {
-      clearRetryRequest(stream);
+      runCoordinatorBridge.clearRetryRequest(stream);
     }
     await vscode.commands.executeCommand('texra.stopAgent', stream);
   }

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -4,7 +4,7 @@ import { Node, type NonIterableObject } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { type RetryResult } from '@agent/runtime/RetryRequestCoordinator';
-import { waitForRetry } from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getConfig } from '@utils/config/configUtils';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -270,12 +270,15 @@ export abstract class RetryableInvocationNode<
     StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
       runtimeHost,
     });
-    const result: RetryResult = await waitForRetry(streamId, {
-      operation: operationName,
-      errorMessage: formatted.message,
-      logger,
-      errorDetails: formatted,
-    });
+    const result: RetryResult = await runCoordinatorBridge.waitForRetry(
+      streamId,
+      {
+        operation: operationName,
+        errorMessage: formatted.message,
+        logger,
+        errorDetails: formatted,
+      },
+    );
 
     if (result.action === 'retry') {
       logger.debug('Manual retry triggered');

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -14,10 +14,7 @@ import {
   type IInterruptible,
 } from '@agent/runtime/InterruptRegistry';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
-import {
-  clearPlanApprovalForStream,
-  clearRetryRequest,
-} from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { AgentRunStateSnapshotSchema } from '@agent/core/execution/AgentState';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
@@ -170,8 +167,8 @@ export async function runReflectionFlow<C = unknown>(
   const interruptible: IInterruptible = {
     interrupt(): void {
       input.onInterrupt?.();
-      clearRetryRequest(streamId);
-      clearPlanApprovalForStream(streamId);
+      runCoordinatorBridge.clearRetryRequest(streamId);
+      runCoordinatorBridge.clearPlanApprovalForStream(streamId);
     },
   };
 
@@ -313,8 +310,8 @@ export async function runReflectionFlow<C = unknown>(
       }
     }
 
-    clearRetryRequest(streamId);
-    clearPlanApprovalForStream(streamId);
+    runCoordinatorBridge.clearRetryRequest(streamId);
+    runCoordinatorBridge.clearPlanApprovalForStream(streamId);
 
     interruptRegistry.unregister(streamId);
   }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -7,10 +7,7 @@ import {
   modelHandlerCompatibilityKey,
 } from '@agent/runtime/ModelFactory';
 import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
-import {
-  clearPlanApprovalForStream,
-  clearRetryRequest,
-} from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
   PersistedFlow,
   flowKey,
@@ -236,8 +233,8 @@ export async function runToolUseFlow<C = unknown>(
     },
     interrupt(): void {
       onInterrupt?.();
-      clearRetryRequest(streamId);
-      clearPlanApprovalForStream(streamId);
+      runCoordinatorBridge.clearRetryRequest(streamId);
+      runCoordinatorBridge.clearPlanApprovalForStream(streamId);
       sessionLifecycle.interrupt();
     },
     requestImmediateCompaction(): void {
@@ -350,7 +347,7 @@ export async function runToolUseFlow<C = unknown>(
     }
 
     sessionLifecycle.dispose();
-    clearPlanApprovalForStream(streamId);
+    runCoordinatorBridge.clearPlanApprovalForStream(streamId);
     interruptRegistry.unregister(streamId);
     for (const handler of switchedHandlers) {
       handler.dispose();

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -50,7 +50,7 @@ import {
   formatMediaNeedsVisionWarning,
   shouldWarnMediaNeedsVision,
 } from './mediaVisionWarning';
-import { retainRunCoordinatorsForStream } from './runCoordinators';
+import { runCoordinatorBridge } from './runCoordinators';
 import { getStreamTabId } from './streamTab';
 import { StreamStatusService } from './StreamStatusService';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
@@ -114,7 +114,7 @@ export async function withExecutionRunContext<T>(
     approvalPromptsUnavailable: ctx.approvalPromptsUnavailable,
     stopAfterCycle: ctx.stopAfterCycle,
   });
-  const release = retainRunCoordinatorsForStream(
+  const release = runCoordinatorBridge.retainForStream(
     ctx.streamId,
     ctx.coordinators,
   );

--- a/src/agent/runtime/runCoordinators.ts
+++ b/src/agent/runtime/runCoordinators.ts
@@ -24,218 +24,217 @@ function useRunCoordinators(): RunCoordinators {
   return coordinators;
 }
 
-const bridgeState = {
-  runStreams: new Map<string, RunCoordinators>(),
-  planApprovals: new Map<string, RunCoordinators>(),
-  planApprovalStreams: new Map<string, string>(),
-  planStreams: new Map<string, RunCoordinators>(),
-  proposals: new Map<string, RunCoordinators>(),
-  proposalStreams: new Map<string, string>(),
-  retries: new Map<string, RunCoordinators>(),
-  retryCoordinatorRefs: new Map<RunCoordinators, number>(),
-};
+/**
+ * Bridge host/UI decisions back to the run coordinators that created each
+ * pending request.
+ *
+ * Tool calls create requests inside an active RunContext. Host callbacks resolve
+ * those requests later by id, often outside that async scope, so the bridge owns
+ * the process-wide request id index while each entry still points at a concrete
+ * AgentLaunchContext's coordinators.
+ */
+class RunCoordinatorBridge {
+  private readonly runStreams = new Map<string, RunCoordinators>();
+  private readonly planApprovals = new Map<string, RunCoordinators>();
+  private readonly planApprovalStreams = new Map<string, string>();
+  private readonly planStreams = new Map<string, RunCoordinators>();
+  private readonly proposals = new Map<string, RunCoordinators>();
+  private readonly proposalStreams = new Map<string, string>();
+  private readonly retries = new Map<string, RunCoordinators>();
+  private readonly retryCoordinatorRefs = new Map<RunCoordinators, number>();
 
-export function retainRunCoordinatorsForStream(
-  streamId: string,
-  coordinators: RunCoordinators,
-): () => void {
-  bridgeState.runStreams.set(streamId, coordinators);
-  return () => {
-    if (bridgeState.runStreams.get(streamId) === coordinators) {
-      bridgeState.runStreams.delete(streamId);
+  retainForStream(streamId: string, coordinators: RunCoordinators): () => void {
+    this.runStreams.set(streamId, coordinators);
+    return () => {
+      if (this.runStreams.get(streamId) === coordinators) {
+        this.runStreams.delete(streamId);
+      }
+    };
+  }
+
+  async waitForPlanApproval(
+    streamId: string,
+    options: PlanApprovalRequestOptions,
+  ): Promise<PlanApprovalResult> {
+    const coordinators = useRunCoordinators();
+    this.planApprovals.set(options.approvalId, coordinators);
+    this.planApprovalStreams.set(options.approvalId, streamId);
+    this.planStreams.set(streamId, coordinators);
+    try {
+      return await coordinators.plan.waitForApproval(streamId, options);
+    } finally {
+      this.planApprovals.delete(options.approvalId);
+      this.planApprovalStreams.delete(options.approvalId);
+      this.planStreams.delete(streamId);
     }
-  };
-}
+  }
 
-function retainRetryCoordinator(coordinators: RunCoordinators): void {
-  bridgeState.retryCoordinatorRefs.set(
-    coordinators,
-    (bridgeState.retryCoordinatorRefs.get(coordinators) ?? 0) + 1,
-  );
-}
+  resolvePlanApproval(approvalId: string, result: PlanApprovalResult): boolean {
+    return (
+      this.planApprovals
+        .get(approvalId)
+        ?.plan.resolveRequest(approvalId, result) ?? false
+    );
+  }
 
-function releaseRetryCoordinator(coordinators: RunCoordinators): void {
-  const nextCount =
-    (bridgeState.retryCoordinatorRefs.get(coordinators) ?? 0) - 1;
-  if (nextCount > 0) {
-    bridgeState.retryCoordinatorRefs.set(coordinators, nextCount);
-  } else {
-    bridgeState.retryCoordinatorRefs.delete(coordinators);
+  clearPlanApprovalForStream(streamId: string): void {
+    (
+      this.planStreams.get(streamId)?.plan ??
+      this.runStreams.get(streamId)?.plan ??
+      tryUseRunContext()?.coordinators?.plan
+    )?.clearForStream(streamId);
+    this.clearPlanBridgeForStream(streamId);
+  }
+
+  async waitForProposal(
+    streamId: string,
+    options: ProposalRequestOptions,
+  ): Promise<ProposalResult> {
+    const coordinators = useRunCoordinators();
+    this.proposals.set(options.proposalId, coordinators);
+    this.proposalStreams.set(options.proposalId, streamId);
+    try {
+      return await coordinators.proposal.waitForProposal(streamId, options);
+    } finally {
+      this.proposals.delete(options.proposalId);
+      this.proposalStreams.delete(options.proposalId);
+    }
+  }
+
+  resolveProposal(proposalId: string, result: ProposalResult): boolean {
+    return (
+      this.proposals
+        .get(proposalId)
+        ?.proposal.resolveRequest(proposalId, result) ?? false
+    );
+  }
+
+  async waitForRetry(
+    streamId: string,
+    options: RetryRequestOptions,
+  ): Promise<RetryResult> {
+    const coordinators = useRunCoordinators();
+    this.retainRetryCoordinator(coordinators);
+    this.retries.set(streamId, coordinators);
+    try {
+      return await coordinators.retry.waitForRetry(streamId, options);
+    } finally {
+      this.retries.delete(streamId);
+      this.releaseRetryCoordinator(coordinators);
+    }
+  }
+
+  triggerRetry(streamId: string, feedback?: string): boolean {
+    return (
+      this.retries.get(streamId)?.retry.triggerRetry(streamId, feedback) ??
+      false
+    );
+  }
+
+  cancelRetry(streamId: string): boolean {
+    return this.retries.get(streamId)?.retry.cancelRetry(streamId) ?? false;
+  }
+
+  clearRetryRequest(streamId: string): void {
+    const coordinators = new Set<RunCoordinators>();
+    const mappedCoordinators = this.retries.get(streamId);
+    if (mappedCoordinators) coordinators.add(mappedCoordinators);
+    const runCoordinators = this.runStreams.get(streamId);
+    if (runCoordinators) coordinators.add(runCoordinators);
+    const ambient = tryUseRunContext()?.coordinators;
+    if (ambient) coordinators.add(ambient);
+    for (const coordinator of coordinators) {
+      coordinator.retry.clearRequest(streamId);
+    }
+    this.retries.delete(streamId);
+  }
+
+  cleanupRequestsForStream(streamId: string): void {
+    this.clearPlanApprovalForStream(streamId);
+    this.clearProposalForStream(streamId);
+    this.clearRetryRequest(streamId);
+  }
+
+  cleanupAllRequests(): void {
+    this.clearAllPlanApprovals();
+    this.clearAllProposals();
+    this.clearAllRetryRequests();
+  }
+
+  private retainRetryCoordinator(coordinators: RunCoordinators): void {
+    this.retryCoordinatorRefs.set(
+      coordinators,
+      (this.retryCoordinatorRefs.get(coordinators) ?? 0) + 1,
+    );
+  }
+
+  private releaseRetryCoordinator(coordinators: RunCoordinators): void {
+    const nextCount = (this.retryCoordinatorRefs.get(coordinators) ?? 0) - 1;
+    if (nextCount > 0) {
+      this.retryCoordinatorRefs.set(coordinators, nextCount);
+    } else {
+      this.retryCoordinatorRefs.delete(coordinators);
+    }
+  }
+
+  private clearPlanBridgeForStream(streamId: string): void {
+    this.planStreams.delete(streamId);
+    const approvalIds = [...this.planApprovalStreams.entries()]
+      .filter(([, approvalStreamId]) => approvalStreamId === streamId)
+      .map(([approvalId]) => approvalId);
+    for (const approvalId of approvalIds) {
+      this.planApprovals.delete(approvalId);
+      this.planApprovalStreams.delete(approvalId);
+    }
+  }
+
+  private clearAllPlanApprovals(): void {
+    const coordinators = new Set(this.planStreams.values());
+    for (const runCoordinators of this.runStreams.values()) {
+      coordinators.add(runCoordinators);
+    }
+    for (const coordinator of coordinators) {
+      coordinator.plan.clearAll();
+    }
+    this.planApprovals.clear();
+    this.planApprovalStreams.clear();
+    this.planStreams.clear();
+  }
+
+  private clearProposalForStream(streamId: string): void {
+    const proposalIds = [...this.proposalStreams.entries()]
+      .filter(([, proposalStreamId]) => proposalStreamId === streamId)
+      .map(([proposalId]) => proposalId);
+    for (const proposalId of proposalIds) {
+      this.proposals.get(proposalId)?.proposal.clearRequest(proposalId);
+      this.proposals.delete(proposalId);
+      this.proposalStreams.delete(proposalId);
+    }
+  }
+
+  private clearAllProposals(): void {
+    const coordinators = new Set(this.proposals.values());
+    for (const coordinator of coordinators) {
+      coordinator.proposal.clearAll();
+    }
+    this.proposals.clear();
+    this.proposalStreams.clear();
+  }
+
+  private clearAllRetryRequests(): void {
+    const coordinators = new Set(this.retryCoordinatorRefs.keys());
+    for (const runCoordinators of this.runStreams.values()) {
+      coordinators.add(runCoordinators);
+    }
+    for (const runCoordinators of this.retries.values()) {
+      coordinators.add(runCoordinators);
+    }
+    for (const coordinator of coordinators) {
+      coordinator.retry.clearAll();
+    }
+    this.retryCoordinatorRefs.clear();
+    this.retries.clear();
   }
 }
 
-function clearPlanBridgeForStream(streamId: string): void {
-  bridgeState.planStreams.delete(streamId);
-  const approvalIds = [...bridgeState.planApprovalStreams.entries()]
-    .filter(([, approvalStreamId]) => approvalStreamId === streamId)
-    .map(([approvalId]) => approvalId);
-  for (const approvalId of approvalIds) {
-    bridgeState.planApprovals.delete(approvalId);
-    bridgeState.planApprovalStreams.delete(approvalId);
-  }
-}
-
-export async function waitForPlanApproval(
-  streamId: string,
-  options: PlanApprovalRequestOptions,
-): Promise<PlanApprovalResult> {
-  const coordinators = useRunCoordinators();
-  bridgeState.planApprovals.set(options.approvalId, coordinators);
-  bridgeState.planApprovalStreams.set(options.approvalId, streamId);
-  bridgeState.planStreams.set(streamId, coordinators);
-  try {
-    return await coordinators.plan.waitForApproval(streamId, options);
-  } finally {
-    bridgeState.planApprovals.delete(options.approvalId);
-    bridgeState.planApprovalStreams.delete(options.approvalId);
-    bridgeState.planStreams.delete(streamId);
-  }
-}
-
-export function resolvePlanApproval(
-  approvalId: string,
-  result: PlanApprovalResult,
-): boolean {
-  return (
-    bridgeState.planApprovals
-      .get(approvalId)
-      ?.plan.resolveRequest(approvalId, result) ?? false
-  );
-}
-
-export function clearPlanApprovalForStream(streamId: string): void {
-  (
-    bridgeState.planStreams.get(streamId)?.plan ??
-    bridgeState.runStreams.get(streamId)?.plan ??
-    tryUseRunContext()?.coordinators?.plan
-  )?.clearForStream(streamId);
-  clearPlanBridgeForStream(streamId);
-}
-
-function clearAllPlanApprovals(): void {
-  const coordinators = new Set(bridgeState.planStreams.values());
-  for (const runCoordinators of bridgeState.runStreams.values()) {
-    coordinators.add(runCoordinators);
-  }
-  for (const coordinator of coordinators) {
-    coordinator.plan.clearAll();
-  }
-  bridgeState.planApprovals.clear();
-  bridgeState.planApprovalStreams.clear();
-  bridgeState.planStreams.clear();
-}
-
-export async function waitForProposal(
-  streamId: string,
-  options: ProposalRequestOptions,
-): Promise<ProposalResult> {
-  const coordinators = useRunCoordinators();
-  bridgeState.proposals.set(options.proposalId, coordinators);
-  bridgeState.proposalStreams.set(options.proposalId, streamId);
-  try {
-    return await coordinators.proposal.waitForProposal(streamId, options);
-  } finally {
-    bridgeState.proposals.delete(options.proposalId);
-    bridgeState.proposalStreams.delete(options.proposalId);
-  }
-}
-
-export function resolveProposal(
-  proposalId: string,
-  result: ProposalResult,
-): boolean {
-  return (
-    bridgeState.proposals
-      .get(proposalId)
-      ?.proposal.resolveRequest(proposalId, result) ?? false
-  );
-}
-
-function clearProposalForStream(streamId: string): void {
-  const proposalIds = [...bridgeState.proposalStreams.entries()]
-    .filter(([, proposalStreamId]) => proposalStreamId === streamId)
-    .map(([proposalId]) => proposalId);
-  for (const proposalId of proposalIds) {
-    bridgeState.proposals.get(proposalId)?.proposal.clearRequest(proposalId);
-    bridgeState.proposals.delete(proposalId);
-    bridgeState.proposalStreams.delete(proposalId);
-  }
-}
-
-function clearAllProposals(): void {
-  const coordinators = new Set(bridgeState.proposals.values());
-  for (const coordinator of coordinators) {
-    coordinator.proposal.clearAll();
-  }
-  bridgeState.proposals.clear();
-  bridgeState.proposalStreams.clear();
-}
-
-export async function waitForRetry(
-  streamId: string,
-  options: RetryRequestOptions,
-): Promise<RetryResult> {
-  const coordinators = useRunCoordinators();
-  retainRetryCoordinator(coordinators);
-  bridgeState.retries.set(streamId, coordinators);
-  try {
-    return await coordinators.retry.waitForRetry(streamId, options);
-  } finally {
-    bridgeState.retries.delete(streamId);
-    releaseRetryCoordinator(coordinators);
-  }
-}
-
-export function triggerRetry(streamId: string, feedback?: string): boolean {
-  return (
-    bridgeState.retries.get(streamId)?.retry.triggerRetry(streamId, feedback) ??
-    false
-  );
-}
-
-export function cancelRetry(streamId: string): boolean {
-  return (
-    bridgeState.retries.get(streamId)?.retry.cancelRetry(streamId) ?? false
-  );
-}
-
-export function clearRetryRequest(streamId: string): void {
-  const coordinators = new Set<RunCoordinators>();
-  const mappedCoordinators = bridgeState.retries.get(streamId);
-  if (mappedCoordinators) coordinators.add(mappedCoordinators);
-  const runCoordinators = bridgeState.runStreams.get(streamId);
-  if (runCoordinators) coordinators.add(runCoordinators);
-  const ambient = tryUseRunContext()?.coordinators;
-  if (ambient) coordinators.add(ambient);
-  for (const coordinator of coordinators) {
-    coordinator.retry.clearRequest(streamId);
-  }
-  bridgeState.retries.delete(streamId);
-}
-
-export function clearAllRetryRequests(): void {
-  const coordinators = new Set(bridgeState.retryCoordinatorRefs.keys());
-  for (const runCoordinators of bridgeState.runStreams.values()) {
-    coordinators.add(runCoordinators);
-  }
-  for (const runCoordinators of bridgeState.retries.values()) {
-    coordinators.add(runCoordinators);
-  }
-  for (const coordinator of coordinators) {
-    coordinator.retry.clearAll();
-  }
-  bridgeState.retryCoordinatorRefs.clear();
-  bridgeState.retries.clear();
-}
-
-export function cleanupCoordinatorRequestsForStream(streamId: string): void {
-  clearPlanApprovalForStream(streamId);
-  clearProposalForStream(streamId);
-  clearRetryRequest(streamId);
-}
-
-export function cleanupAllCoordinatorRequests(): void {
-  clearAllPlanApprovals();
-  clearAllProposals();
-  clearAllRetryRequests();
-}
+export const runCoordinatorBridge = new RunCoordinatorBridge();

--- a/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
+++ b/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
@@ -12,15 +12,7 @@ import {
   withRunContext,
   type RunCoordinators,
 } from '@agent/runtime/RunContext';
-import {
-  cleanupAllCoordinatorRequests,
-  resolvePlanApproval,
-  resolveProposal,
-  triggerRetry,
-  waitForPlanApproval,
-  waitForProposal,
-  waitForRetry,
-} from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
   AGENT_CATEGORY,
   TODO_STATUS,
@@ -68,7 +60,7 @@ function createLogger(): AgentTrace {
 
 describe('runCoordinators', () => {
   afterEach(() => {
-    cleanupAllCoordinatorRequests();
+    runCoordinatorBridge.cleanupAllRequests();
   });
 
   it('does not fall back to default coordinators when a run has none', async () => {
@@ -78,19 +70,19 @@ describe('runCoordinators', () => {
       createRunContext({ runtimeHost: active.host }),
       async () => {
         await expect(
-          waitForPlanApproval(streamId, {
+          runCoordinatorBridge.waitForPlanApproval(streamId, {
             approvalId: 'approval:missing-coordinators',
             plan,
           }),
         ).rejects.toThrow(/active run coordinators/);
         await expect(
-          waitForProposal(streamId, {
+          runCoordinatorBridge.waitForProposal(streamId, {
             proposalId: 'proposal:missing-coordinators',
             proposal,
           }),
         ).rejects.toThrow(/active run coordinators/);
         await expect(
-          waitForRetry(streamId, {
+          runCoordinatorBridge.waitForRetry(streamId, {
             operation: 'Model invocation',
             logger: createLogger(),
           }),
@@ -110,26 +102,26 @@ describe('runCoordinators', () => {
     });
 
     const planResult = withRunContext(context, () =>
-      waitForPlanApproval(streamId, {
+      runCoordinatorBridge.waitForPlanApproval(streamId, {
         approvalId: 'approval:active-coordinator',
         plan,
       }),
     );
     expect(
-      resolvePlanApproval('approval:active-coordinator', {
+      runCoordinatorBridge.resolvePlanApproval('approval:active-coordinator', {
         action: 'approve',
       }),
     ).toBe(true);
     await expect(planResult).resolves.toEqual({ action: 'approve' });
 
     const proposalResult = withRunContext(context, () =>
-      waitForProposal(streamId, {
+      runCoordinatorBridge.waitForProposal(streamId, {
         proposalId: 'proposal:active-coordinator',
         proposal,
       }),
     );
     expect(
-      resolveProposal('proposal:active-coordinator', {
+      runCoordinatorBridge.resolveProposal('proposal:active-coordinator', {
         action: 'approve',
         agent: 'reviewer',
         model: 'test-model',
@@ -142,12 +134,14 @@ describe('runCoordinators', () => {
     });
 
     const retryResult = withRunContext(context, () =>
-      waitForRetry(streamId, {
+      runCoordinatorBridge.waitForRetry(streamId, {
         operation: 'Model invocation',
         logger: createLogger(),
       }),
     );
-    expect(triggerRetry(streamId, 'try the request again')).toBe(true);
+    expect(
+      runCoordinatorBridge.triggerRetry(streamId, 'try the request again'),
+    ).toBe(true);
     await expect(retryResult).resolves.toEqual({
       action: 'retry',
       feedback: 'try the request again',

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -22,7 +22,7 @@ import {
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
-import { waitForProposal } from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
 import {
   getHandle,
@@ -733,7 +733,7 @@ async function proposeAndExecute(
 
   const proposalId = randomUUID();
 
-  const result = await waitForProposal(streamId, {
+  const result = await runCoordinatorBridge.waitForProposal(streamId, {
     proposalId,
     proposal,
   });

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -7,10 +7,7 @@
  * Import cleanup helpers from here, not from individual modules.
  */
 
-import {
-  cleanupAllCoordinatorRequests,
-  cleanupCoordinatorRequestsForStream,
-} from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import type { StreamTabId } from '@shared/schemas';
 import {
   _rejectAllPendingUserQuestions,
@@ -39,7 +36,7 @@ export function cleanupApprovalsForStream(streamId: StreamTabId): void {
   toolEditApprovalController.clearBypassForStream(streamId);
   bashApprovalController.clearBypassForStream(streamId);
   _clearProposalBypassForStream(streamId);
-  cleanupCoordinatorRequestsForStream(streamId);
+  runCoordinatorBridge.cleanupRequestsForStream(streamId);
 }
 
 /**
@@ -53,7 +50,7 @@ export function cleanupAllApprovals(): void {
   toolEditApprovalController.clearAllBypass();
   bashApprovalController.clearAllBypass();
   _clearAllProposalBypass();
-  cleanupAllCoordinatorRequests();
+  runCoordinatorBridge.cleanupAllRequests();
 }
 
 export { enableYoloOnChildStream, inheritBashBypassOnChildStream };

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -19,7 +19,7 @@ import { z } from 'zod';
 import { platform } from '@platform/platform';
 import type { WorkPlanState } from '@agent/core/execution/AgentWorkspaceState';
 import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
-import { waitForPlanApproval } from '@agent/runtime/runCoordinators';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
 import type { CurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
 import { toErrorMessage } from '@common/errors';
@@ -307,11 +307,12 @@ Best practices:
 
     logger.info(`Requesting approval for plan: ${plan.summary}`);
 
-    const result: PlanApprovalResult = await waitForPlanApproval(streamId, {
-      approvalId,
-      plan,
-      odysseyEnabled,
-    });
+    const result: PlanApprovalResult =
+      await runCoordinatorBridge.waitForPlanApproval(streamId, {
+        approvalId,
+        plan,
+        odysseyEnabled,
+      });
 
     if (result.action === 'approve') {
       logger.info('Plan approved by user');


### PR DESCRIPTION
## Summary
- replace the loose module-level coordinator bridge state with a `RunCoordinatorBridge` owner
- update approval, proposal, retry, and cleanup call sites to use the bridge object directly instead of pass-through free functions
- keep the existing runtime behavior while making the remaining #4737 Step 7 boundary explicit: host callbacks still need a process-wide request-id index because they resolve outside the active RunContext

## Validation
- `git diff --check`
- `corepack pnpm vitest run src/test-kernel/agent/runtime/runCoordinators.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts src/test/agent/runtime/PromiseCoordinators.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`

Contributes to #4737.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plan/proposal/retry resolution and cleanup on every host (CLI, extension, desktop) but is a mechanical API encapsulation with existing tests updated; wrong wiring could break approval or retry flows.
> 
> **Overview**
> Replaces the loose module-level coordinator bridge maps and pass-through exports in `runCoordinators.ts` with a **`RunCoordinatorBridge`** class and a single exported **`runCoordinatorBridge`** instance. The class still owns the process-wide request-id index so host/UI callbacks can resolve plan approvals, agent proposals, and retries outside the active `RunContext`.
> 
> **Call sites** across CLI (TUI + headless approval adapter), VS Code progress view, desktop execution, agent flows (`RetryState`, reflection/tool-use interrupt/cleanup), `AgentLaunchContext` (`retainForStream`), and tools (`PlanTool`, delegation, approval cleanup) now call **`runCoordinatorBridge.*`** instead of importing individual functions. Cleanup helpers are renamed to **`cleanupRequestsForStream`** / **`cleanupAllRequests`**. Tests in `runCoordinators.vitest.ts` follow the same API. Runtime behavior is intended to stay the same; this makes the Step 7 host↔coordinator boundary explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a927c689766e4b6376703c0914a6ee821c9551b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->