### PR TITLE
refactor: make execution registry ownership explicit

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -24,10 +24,7 @@ import {
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import {
-  interruptActiveChildren,
-  killExecution,
-} from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import {
   executeAgent,
   resumeToolUseFromSnapshot,
@@ -1208,7 +1205,7 @@ export async function runChat(
   const interruptActive = (): void => {
     clearApprovals();
     if (!session.streamId) return;
-    interruptActiveChildren(session.streamId);
+    executionRegistry.interruptActiveChildren(session.streamId);
     interruptRegistry.get(session.streamId)?.interrupt();
   };
 
@@ -1657,7 +1654,7 @@ export async function runChat(
       onCtrlC={() => handleSigint()}
       onKillExecution={(executionId) => {
         clearApprovals();
-        killExecution(executionId);
+        executionRegistry.kill(executionId);
       }}
       history={inputHistory}
     />,

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -26,10 +26,7 @@ import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
-import {
-  detachActiveChildren,
-  interruptActiveChildren,
-} from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
 import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
@@ -854,9 +851,9 @@ export class DesktopProgressBridge {
   private stopStream(streamId: StreamTabId): void {
     runCoordinatorBridge.clearRetryRequest(streamId);
     if (this.options.detachSubagentsOnStop === true) {
-      detachActiveChildren(streamId, this.runtimeHost);
+      executionRegistry.detachActiveChildren(streamId, this.runtimeHost);
     } else {
-      interruptActiveChildren(streamId);
+      executionRegistry.interruptActiveChildren(streamId);
     }
     interruptRegistry.get(streamId)?.interrupt();
     StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -15,7 +15,7 @@ import {
   type AgentEntry,
 } from '@agent/index/agentRegistry';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
-import { getActiveExecutionIds } from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { MAX_TIER, ULTRA_TIER } from '@auth/sharedConfig';
 import {
   API_PROVIDERS,
@@ -446,7 +446,7 @@ export function createDesktopSettingsIpc(
   }
 
   async function deleteHistoryItem(historyId: string): Promise<void> {
-    if (getActiveExecutionIds().includes(historyId)) {
+    if (executionRegistry.getActiveIds().includes(historyId)) {
       await options.showInfoMessage?.('Cannot delete a running execution');
       return;
     }
@@ -460,7 +460,7 @@ export function createDesktopSettingsIpc(
   }
 
   async function clearHistory(): Promise<void> {
-    await deleteAllExecutions(new Set(getActiveExecutionIds()));
+    await deleteAllExecutions(new Set(executionRegistry.getActiveIds()));
     options.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
     });

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -15,7 +15,7 @@ import {
 import { platform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
-import { killBackgroundProcesses } from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import type { TerminalRunResult } from '@hosts/terminalHost';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
@@ -625,7 +625,7 @@ if (protocolLifecycle.shouldContinue) {
       const platformInit = await initializeElectronPlatform(__dirname);
       const { lifecycle } = platformInit;
       lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-        killBackgroundProcesses(),
+        executionRegistry.killBackgroundProcesses(),
       );
       lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
         interruptAllCodexSessions(),

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -3,10 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - agent
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import {
-  detachActiveChildren,
-  interruptActiveChildren,
-} from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { notifyFollowUpSent } from '@agent/toolUse/ToolUseFollowUp';
 import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
@@ -18,9 +15,9 @@ export function stopAgent(streamId: StreamTabId): void {
   if (
     workspaceSM.get<boolean>(WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP, false)
   ) {
-    detachActiveChildren(streamId, extensionAgentRuntimeHost);
+    executionRegistry.detachActiveChildren(streamId, extensionAgentRuntimeHost);
   } else {
-    interruptActiveChildren(streamId);
+    executionRegistry.interruptActiveChildren(streamId);
   }
   interruptRegistry.get(streamId)?.interrupt();
   StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -17,7 +17,7 @@ import { loadAgents, setAgentDirectories } from '@agent/index';
 import { clearStoreCache } from '@agent/storage';
 import { registerAgentFeatures } from '@agent/features';
 import { initializeOdysseyPrompts } from '@agent/odyssey';
-import { killBackgroundProcesses } from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { initializePolishModel } from '@agent/runtime/polishModel';
 import {
   getServerSideKeyService,
@@ -187,7 +187,9 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   registerAgentFeatures();
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => disposeStatusListener?.());
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => killBackgroundProcesses());
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+    executionRegistry.killBackgroundProcesses(),
+  );
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
     interruptAllCodexSessions(),
   );

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -27,7 +27,7 @@ import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
-import { getActiveExecutionIds } from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { FREE_TIER, ULTRA_TIER, MAX_TIER } from '@auth/config';
@@ -1198,7 +1198,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof SETTINGS_VIEW_CMD.DELETE_AGENT>,
   ): Promise<void> {
     try {
-      const activeIds = getActiveExecutionIds();
+      const activeIds = executionRegistry.getActiveIds();
       if (activeIds.includes(data.historyId)) {
         await vscode.window.showWarningMessage(
           'Cannot delete a running execution',
@@ -1224,7 +1224,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   private async handleClearHistory(): Promise<void> {
     try {
-      await deleteAllExecutions(new Set(getActiveExecutionIds()));
+      await deleteAllExecutions(new Set(executionRegistry.getActiveIds()));
       await vscode.window.showInformationMessage('Agent history cleared');
       await this.withActiveWebview(async (w) => {
         await w.postMessage({

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -12,7 +12,7 @@ import {
 } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
-import { getActiveChildren } from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {
   maybeSaveDebugObject,
@@ -127,7 +127,9 @@ export async function saveCycleDebug(
 export function defaultPostCompactionContext(
   services: CycleServices,
 ): string | null {
-  const { subagents, processes } = getActiveChildren(services.streamId);
+  const { subagents, processes } = executionRegistry.getActiveChildren(
+    services.streamId,
+  );
   return formatPostCompactionContext(
     subagents,
     processes,

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -12,8 +12,7 @@
  */
 
 import {
-  addExecutionListener,
-  getHandle,
+  executionRegistry,
   type ExecutionHandle,
 } from '@agent/runtime/executionRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -110,14 +109,17 @@ class ExecutionSubscription implements Disposable {
   }
 
   bind(): boolean {
-    this.removeListener = addExecutionListener(this.executionId, (handle) => {
-      this.handleChange(handle);
-    });
+    this.removeListener = executionRegistry.addListener(
+      this.executionId,
+      (handle) => {
+        this.handleChange(handle);
+      },
+    );
 
-    // TOCTOU: handle could untrack between the initial getHandle() check
+    // TOCTOU: handle could untrack between the initial executionRegistry.getHandle() check
     // and listener registration. Re-check; if gone, fire the terminal event
     // and dispose so the listener never leaks.
-    if (!getHandle(this.executionId)) {
+    if (!executionRegistry.getHandle(this.executionId)) {
       this.sendFinished();
       this.dispose();
       return false;
@@ -194,7 +196,7 @@ export function bindExecutionSubscription(
 ): void {
   ensureReleaseHook();
 
-  const handle = getHandle(executionId);
+  const handle = executionRegistry.getHandle(executionId);
   if (!handle) {
     throw new Error(
       `Execution ${executionId} is not active. Subscribe only works on tracked executions; use 'view' to read the final report.`,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -49,12 +49,7 @@ import {
   type AgentLaunchContext,
 } from './AgentLaunchContext';
 import { createInterruptCallbacks } from './InterruptManager';
-import {
-  trackExecution,
-  untrackExecution,
-  updateExecutionProgress,
-  AgentExecutionHandle,
-} from './executionRegistry';
+import { AgentExecutionHandle, executionRegistry } from './executionRegistry';
 import { generateSessionDescription } from './sessionDescription';
 import { getRunStorageService } from './RunStorageService';
 import { StreamStatusService } from './StreamStatusService';
@@ -136,7 +131,7 @@ function createRoundProgressCallback(
   outputPaths?: readonly string[],
 ) => void {
   return (roundIndex, totalRounds, outputPaths) => {
-    updateExecutionProgress(executionId, {
+    executionRegistry.updateProgress(executionId, {
       currentRound: roundIndex,
       totalRounds,
     });
@@ -188,7 +183,7 @@ async function runFlowWithLifecycle(
     category,
     ctx.runtimeHost,
   );
-  trackExecution(handle);
+  executionRegistry.track(handle);
   try {
     const result = await runner();
     await options?.onCompleted?.(result);
@@ -198,7 +193,7 @@ async function runFlowWithLifecycle(
         : EXECUTION_STATUS.COMPLETED;
     await writeTerminalStatus(ctx.executionId, terminalStatus).catch(() => {});
 
-    untrackExecution(ctx.executionId);
+    executionRegistry.untrack(ctx.executionId);
     ctx.parentStage.end(result.status);
 
     if (!StreamStatusService.shouldPreserveOnCompletion(streamId)) {
@@ -220,7 +215,7 @@ async function runFlowWithLifecycle(
     const streamStatus =
       kind === 'abort' ? STREAM_STATUS.STOPPED : STREAM_STATUS.ERROR;
     await writeTerminalStatus(ctx.executionId, terminalStatus).catch(() => {});
-    untrackExecution(ctx.executionId);
+    executionRegistry.untrack(ctx.executionId);
     const errorMsg = `Error executing agent ${agentName}: ${getSdkErrorMessage(err)}`;
 
     // Root-agent failures are surfaced in the stream log. Subagent failures
@@ -380,7 +375,7 @@ export interface ExecuteAgentOptions {
   stopAfterCycle?: boolean;
   /** Hide tools whose approval prompts cannot be answered in this host mode. */
   approvalPromptsUnavailable?: boolean;
-  /** Fires after flow completes but BEFORE untrackExecution, so follow-ups are enqueued before waiters resolve. */
+  /** Fires after flow completes but before executionRegistry.untrack, so follow-ups are enqueued before waiters resolve. */
   onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
   /** Fires when a subagent fails and should report the failure to its orchestrator. */
   onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -29,331 +29,344 @@ export {
   ProcessExecutionHandle,
 } from './ExecutionHandle';
 
-const registry = new Map<string, ExecutionHandle>();
-const changeCallbacks = new Map<string, Array<() => void>>();
-// Persistent listeners stay attached across notifications (unlike one-shot
-// waiters in `changeCallbacks`). Used by the executions subscribe action.
-const persistentListeners = new Map<
-  string,
-  Set<(handle: ExecutionHandle | undefined) => void>
->();
+/**
+ * Process-wide owner for active executions and their change listeners.
+ *
+ * This is still a singleton while AgentRun ownership is being introduced, but
+ * the mutable maps and status subscription now live behind one explicit owner
+ * instead of free module state.
+ */
+class ExecutionRegistry {
+  private readonly handles = new Map<string, ExecutionHandle>();
+  private readonly changeCallbacks = new Map<string, Array<() => void>>();
+  // Persistent listeners stay attached across notifications (unlike one-shot
+  // waiters in `changeCallbacks`). Used by the executions subscribe action.
+  private readonly persistentListeners = new Map<
+    string,
+    Set<(handle: ExecutionHandle | undefined) => void>
+  >();
 
-// Notify waiters and refresh UI badges when stream status changes
-// (e.g. RUNNING → WAITING). Without this, waitForExecutionChange only resolves
-// on progress/kill/untrack, and the background-tasks panel shows stale badges.
-StreamStatusService.onDidChange(({ streamId }) => {
-  for (const [executionId, handle] of registry) {
+  constructor() {
+    // Notify waiters and refresh UI badges when stream status changes
+    // (e.g. RUNNING → WAITING). Without this, waitForChange only resolves
+    // on progress/kill/untrack, and the background-tasks panel shows stale badges.
+    StreamStatusService.onDidChange(({ streamId }) => {
+      for (const [executionId, handle] of this.handles) {
+        if (
+          handle instanceof AgentExecutionHandle &&
+          handle.childStreamId === streamId
+        ) {
+          this.notifyWaiters(executionId);
+          if (handle.parentStreamId !== handle.childStreamId) {
+            this.emitActiveSubagentsUpdate(
+              handle.parentStreamId,
+              handle.runtimeHost,
+            );
+          }
+          break;
+        }
+      }
+    });
+  }
+
+  /** Register an execution handle. */
+  track(handle: ExecutionHandle): void {
+    this.handles.set(handle.executionId, handle);
+    const { runtimeHost } = handle;
+
+    if (handle instanceof AgentExecutionHandle) {
+      if (handle.parentStreamId !== handle.childStreamId) {
+        this.emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
+        runtimeHost.emit('setParentStream', {
+          childStreamId: handle.childStreamId,
+          parentStreamId: handle.parentStreamId,
+        });
+      }
+    } else if (handle instanceof ProcessExecutionHandle) {
+      registerProcessOutput(handle, runtimeHost);
+      this.emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
+    }
+  }
+
+  /** Remove an execution handle and notify waiters. */
+  untrack(executionId: string): void {
+    const handle = this.handles.get(executionId);
+    this.handles.delete(executionId);
+    this.notifyWaiters(executionId);
+    if (!handle) return;
+    const { runtimeHost } = handle;
+
     if (
       handle instanceof AgentExecutionHandle &&
-      handle.childStreamId === streamId
+      handle.parentStreamId !== handle.childStreamId
     ) {
-      notifyWaiters(executionId);
-      if (handle.parentStreamId !== handle.childStreamId) {
-        emitActiveSubagentsUpdate(handle.parentStreamId, handle.runtimeHost);
-      }
-      break;
+      this.emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
+      return;
     }
-  }
-});
 
-/** Register an execution handle. */
-export function trackExecution(handle: ExecutionHandle): void {
-  registry.set(handle.executionId, handle);
-  const { runtimeHost } = handle;
-
-  if (handle instanceof AgentExecutionHandle) {
-    if (handle.parentStreamId !== handle.childStreamId) {
-      emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
-      runtimeHost.emit('setParentStream', {
-        childStreamId: handle.childStreamId,
-        parentStreamId: handle.parentStreamId,
-      });
-    }
-  } else if (handle instanceof ProcessExecutionHandle) {
-    registerProcessOutput(handle, runtimeHost);
-    emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
-  }
-}
-
-/** Remove an execution handle and notify waiters. */
-export function untrackExecution(executionId: string): void {
-  const handle = registry.get(executionId);
-  registry.delete(executionId);
-  notifyWaiters(executionId);
-  if (!handle) return;
-  const { runtimeHost } = handle;
-
-  if (
-    handle instanceof AgentExecutionHandle &&
-    handle.parentStreamId !== handle.childStreamId
-  ) {
-    emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
-    return;
-  }
-
-  if (handle instanceof ProcessExecutionHandle) {
-    // The final read must complete before the badge update, because the
-    // badge handler prunes output entries for processes no longer active.
-    const finalize = (): void => {
-      unregisterProcessOutput(executionId);
-      emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
-    };
-    if (handle.outputPaths) {
-      void flushProcessOutput(handle, runtimeHost).finally(finalize);
-    } else {
-      finalize();
-    }
-  }
-}
-
-export function getHandle(executionId: string): ExecutionHandle | undefined {
-  return registry.get(executionId);
-}
-
-/** Terminate an execution via its handle. Returns true on success. */
-export function killExecution(executionId: string): boolean {
-  const handle = registry.get(executionId);
-  if (!handle) return false;
-  const result = handle.terminate();
-  // Always notify waiters — even if terminate() returned false (e.g. PID not
-  // yet assigned), callers blocking on this execution should be unblocked.
-  notifyWaiters(executionId);
-  return result;
-}
-
-export function getActiveExecutionIds(): string[] {
-  return [...registry.keys()];
-}
-
-/**
- * Kill only background OS processes (bash, codex) without touching agent
- * stream status. Agent executions are left in RUNNING so restart recovery can
- * restore them to WAITING (resumable) if a flow record exists.
- */
-export function killBackgroundProcesses(): void {
-  for (const [executionId, handle] of registry) {
     if (handle instanceof ProcessExecutionHandle) {
-      killExecution(executionId);
+      // The final read must complete before the badge update, because the
+      // badge handler prunes output entries for processes no longer active.
+      const finalize = (): void => {
+        unregisterProcessOutput(executionId);
+        this.emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
+      };
+      if (handle.outputPaths) {
+        void flushProcessOutput(handle, runtimeHost).finally(finalize);
+      } else {
+        finalize();
+      }
     }
   }
-}
 
-export function updateExecutionProgress(
-  executionId: string,
-  update: { currentRound?: number; totalRounds?: number },
-): void {
-  const handle = registry.get(executionId);
-  if (!handle) return;
-  handle.updateProgress(update);
-  notifyWaiters(executionId);
-}
+  getHandle(executionId: string): ExecutionHandle | undefined {
+    return this.handles.get(executionId);
+  }
 
-/**
- * Wait for any change on an execution: status transition, progress update,
- * kill, or completion (untrack). Pass an AbortSignal for timeout cleanup.
- */
-export function waitForExecutionChange(
-  executionId: string,
-  signal?: AbortSignal,
-): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const cb = (): void => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    };
-    const onAbort = (): void => {
-      removeChangeCallback(executionId, cb);
-      resolve();
-    };
-    addChangeCallback(executionId, cb);
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
+  /** Terminate an execution via its handle. Returns true on success. */
+  kill(executionId: string): boolean {
+    const handle = this.handles.get(executionId);
+    if (!handle) return false;
+    const result = handle.terminate();
+    // Always notify waiters — even if terminate() returned false (e.g. PID not
+    // yet assigned), callers blocking on this execution should be unblocked.
+    this.notifyWaiters(executionId);
+    return result;
+  }
 
-/**
- * Wait for any of the given executions to change.
- * Resolves with the execution id that changed first (or '' on abort).
- */
-export function waitForAnyExecutionChange(
-  executionIds: string[],
-  signal?: AbortSignal,
-): Promise<string> {
-  return new Promise<string>((resolve) => {
-    let resolved = false;
-    const callbacks = new Map<string, () => void>();
+  getActiveIds(): string[] {
+    return [...this.handles.keys()];
+  }
 
-    const cleanup = (): void => {
-      signal?.removeEventListener('abort', onAbort);
-      for (const [id, cb] of callbacks) {
-        removeChangeCallback(id, cb);
+  /**
+   * Kill only background OS processes (bash, codex) without touching agent
+   * stream status. Agent executions are left in RUNNING so restart recovery can
+   * restore them to WAITING (resumable) if a flow record exists.
+   */
+  killBackgroundProcesses(): void {
+    for (const [executionId, handle] of this.handles) {
+      if (handle instanceof ProcessExecutionHandle) {
+        this.kill(executionId);
       }
-    };
+    }
+  }
 
-    const onAbort = (): void => {
-      if (resolved) return;
-      resolved = true;
-      cleanup();
-      resolve('');
-    };
+  updateProgress(
+    executionId: string,
+    update: { currentRound?: number; totalRounds?: number },
+  ): void {
+    const handle = this.handles.get(executionId);
+    if (!handle) return;
+    handle.updateProgress(update);
+    this.notifyWaiters(executionId);
+  }
 
-    for (const id of executionIds) {
+  /**
+   * Wait for any change on an execution: status transition, progress update,
+   * kill, or completion (untrack). Pass an AbortSignal for timeout cleanup.
+   */
+  waitForChange(executionId: string, signal?: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve) => {
       const cb = (): void => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      };
+      const onAbort = (): void => {
+        this.removeChangeCallback(executionId, cb);
+        resolve();
+      };
+      this.addChangeCallback(executionId, cb);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  /**
+   * Wait for any of the given executions to change.
+   * Resolves with the execution id that changed first (or '' on abort).
+   */
+  waitForAnyChange(
+    executionIds: string[],
+    signal?: AbortSignal,
+  ): Promise<string> {
+    return new Promise<string>((resolve) => {
+      let resolved = false;
+      const callbacks = new Map<string, () => void>();
+
+      const cleanup = (): void => {
+        signal?.removeEventListener('abort', onAbort);
+        for (const [id, cb] of callbacks) {
+          this.removeChangeCallback(id, cb);
+        }
+      };
+
+      const onAbort = (): void => {
         if (resolved) return;
         resolved = true;
         cleanup();
-        resolve(id);
+        resolve('');
       };
-      callbacks.set(id, cb);
-      addChangeCallback(id, cb);
+
+      for (const id of executionIds) {
+        const cb = (): void => {
+          if (resolved) return;
+          resolved = true;
+          cleanup();
+          resolve(id);
+        };
+        callbacks.set(id, cb);
+        this.addChangeCallback(id, cb);
+      }
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  /** Interrupt all active subagents of a parent stream. */
+  interruptActiveChildren(parentStreamId: StreamTabId): void {
+    interruptChildren(parentStreamId, this.handles.values());
+  }
+
+  /**
+   * Detach all active subagents from a parent, promoting them to top-level.
+   * Subagents continue running independently and deliver results via the
+   * follow-up queue. Called when stopping an orchestrator without killing
+   * children.
+   */
+  detachActiveChildren(
+    parentStreamId: StreamTabId,
+    runtimeHost: AgentRuntimeHost,
+  ): void {
+    for (const handle of this.handles.values()) {
+      if (handle.parentStreamId !== parentStreamId) continue;
+      if (
+        handle instanceof AgentExecutionHandle &&
+        handle.childStreamId !== parentStreamId
+      ) {
+        handle.detach();
+        runtimeHost.emit('setParentStream', {
+          childStreamId: handle.childStreamId,
+          parentStreamId: null,
+        });
+      } else if (handle instanceof ProcessExecutionHandle) {
+        handle.terminate();
+      }
+    }
+    this.emitActiveSubagentsUpdate(parentStreamId, runtimeHost);
+  }
+
+  /** Get active subagent and process children for a parent stream. */
+  getActiveChildren(parentStreamId: StreamTabId): {
+    subagents: ActiveChildInfo[];
+    processes: ActiveChildInfo[];
+  } {
+    return {
+      subagents: collectChildSummary(
+        parentStreamId,
+        this.handles.values(),
+        AgentExecutionHandle,
+      ),
+      processes: collectChildSummary(
+        parentStreamId,
+        this.handles.values(),
+        ProcessExecutionHandle,
+      ),
+    };
+  }
+
+  /**
+   * Add a persistent listener invoked on every change to `executionId` (status
+   * transition, progress update, kill, untrack). Returns a disposer.
+   *
+   * The callback receives the current `ExecutionHandle`, or `undefined` once the
+   * execution has been untracked (terminal event).
+   */
+  addListener(
+    executionId: string,
+    cb: (handle: ExecutionHandle | undefined) => void,
+  ): () => void {
+    let set = this.persistentListeners.get(executionId);
+    if (!set) {
+      set = new Set();
+      this.persistentListeners.set(executionId, set);
+    }
+    set.add(cb);
+    return () => {
+      const s = this.persistentListeners.get(executionId);
+      if (!s) return;
+      s.delete(cb);
+      if (s.size === 0) this.persistentListeners.delete(executionId);
+    };
+  }
+
+  private emitActiveSubagentsUpdate(
+    parentStreamId: StreamTabId,
+    runtimeHost: AgentRuntimeHost,
+  ): void {
+    runtimeHost.emit('updateActiveSubagents', {
+      parentStreamId,
+      children: collectChildSummary(
+        parentStreamId,
+        this.handles.values(),
+        AgentExecutionHandle,
+      ),
+    });
+  }
+
+  private emitActiveProcessesUpdate(
+    parentStreamId: StreamTabId,
+    runtimeHost: AgentRuntimeHost,
+  ): void {
+    runtimeHost.emit('updateActiveProcesses', {
+      parentStreamId,
+      processes: collectChildSummary(
+        parentStreamId,
+        this.handles.values(),
+        ProcessExecutionHandle,
+      ),
+    });
+  }
+
+  private addChangeCallback(executionId: string, cb: () => void): void {
+    let callbacks = this.changeCallbacks.get(executionId);
+    if (!callbacks) {
+      callbacks = [];
+      this.changeCallbacks.set(executionId, callbacks);
+    }
+    callbacks.push(cb);
+  }
+
+  private removeChangeCallback(executionId: string, cb: () => void): void {
+    const callbacks = this.changeCallbacks.get(executionId);
+    if (!callbacks) return;
+    const idx = callbacks.indexOf(cb);
+    if (idx !== -1) callbacks.splice(idx, 1);
+    if (callbacks.length === 0) this.changeCallbacks.delete(executionId);
+  }
+
+  private notifyWaiters(executionId: string): void {
+    const listeners = this.persistentListeners.get(executionId);
+    const callbacks = this.changeCallbacks.get(executionId);
+    if (!listeners && !callbacks) return;
+
+    // Persistent listeners fire first and stay attached so subscribers keep
+    // receiving every transition until they dispose themselves.
+    if (listeners) {
+      const handle = this.handles.get(executionId);
+      // Iterate a snapshot so a listener disposing itself mid-fire is safe.
+      for (const cb of [...listeners]) cb(handle);
     }
 
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
+    if (callbacks) {
+      this.changeCallbacks.delete(executionId);
+      for (const cb of callbacks) cb();
+    }
 
-/** Interrupt all active subagents of a parent stream. */
-export function interruptActiveChildren(parentStreamId: StreamTabId): void {
-  interruptChildren(parentStreamId, registry.values());
-}
-
-/**
- * Detach all active subagents from a parent, promoting them to top-level.
- * Subagents continue running independently and deliver results via the
- * follow-up queue. Called when stopping an orchestrator without killing
- * children.
- */
-export function detachActiveChildren(
-  parentStreamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  for (const handle of registry.values()) {
-    if (handle.parentStreamId !== parentStreamId) continue;
-    if (
-      handle instanceof AgentExecutionHandle &&
-      handle.childStreamId !== parentStreamId
-    ) {
-      handle.detach();
-      runtimeHost.emit('setParentStream', {
-        childStreamId: handle.childStreamId,
-        parentStreamId: null,
-      });
-    } else if (handle instanceof ProcessExecutionHandle) {
-      handle.terminate();
+    // Backstop against listener leaks: if the execution is no longer tracked,
+    // any still-registered persistent listener is firing into the void.
+    if (!this.handles.has(executionId)) {
+      this.persistentListeners.delete(executionId);
     }
   }
-  emitActiveSubagentsUpdate(parentStreamId, runtimeHost);
 }
 
-/** Get active subagent and process children for a parent stream. */
-export function getActiveChildren(parentStreamId: StreamTabId): {
-  subagents: ActiveChildInfo[];
-  processes: ActiveChildInfo[];
-} {
-  return {
-    subagents: collectChildSummary(
-      parentStreamId,
-      registry.values(),
-      AgentExecutionHandle,
-    ),
-    processes: collectChildSummary(
-      parentStreamId,
-      registry.values(),
-      ProcessExecutionHandle,
-    ),
-  };
-}
-
-function emitActiveSubagentsUpdate(
-  parentStreamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  runtimeHost.emit('updateActiveSubagents', {
-    parentStreamId,
-    children: collectChildSummary(
-      parentStreamId,
-      registry.values(),
-      AgentExecutionHandle,
-    ),
-  });
-}
-
-function emitActiveProcessesUpdate(
-  parentStreamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  runtimeHost.emit('updateActiveProcesses', {
-    parentStreamId,
-    processes: collectChildSummary(
-      parentStreamId,
-      registry.values(),
-      ProcessExecutionHandle,
-    ),
-  });
-}
-
-function addChangeCallback(executionId: string, cb: () => void): void {
-  let callbacks = changeCallbacks.get(executionId);
-  if (!callbacks) {
-    callbacks = [];
-    changeCallbacks.set(executionId, callbacks);
-  }
-  callbacks.push(cb);
-}
-
-function removeChangeCallback(executionId: string, cb: () => void): void {
-  const callbacks = changeCallbacks.get(executionId);
-  if (!callbacks) return;
-  const idx = callbacks.indexOf(cb);
-  if (idx !== -1) callbacks.splice(idx, 1);
-  if (callbacks.length === 0) changeCallbacks.delete(executionId);
-}
-
-function notifyWaiters(executionId: string): void {
-  const listeners = persistentListeners.get(executionId);
-  const callbacks = changeCallbacks.get(executionId);
-  if (!listeners && !callbacks) return;
-
-  // Persistent listeners fire first and stay attached so subscribers keep
-  // receiving every transition until they dispose themselves.
-  if (listeners) {
-    const handle = registry.get(executionId);
-    // Iterate a snapshot so a listener disposing itself mid-fire is safe.
-    for (const cb of [...listeners]) cb(handle);
-  }
-
-  if (callbacks) {
-    changeCallbacks.delete(executionId);
-    for (const cb of callbacks) cb();
-  }
-
-  // Backstop against listener leaks: if the execution is no longer tracked,
-  // any still-registered persistent listener is firing into the void.
-  if (!registry.has(executionId)) {
-    persistentListeners.delete(executionId);
-  }
-}
-
-/**
- * Add a persistent listener invoked on every change to `executionId` (status
- * transition, progress update, kill, untrack). Returns a disposer.
- *
- * The callback receives the current `ExecutionHandle`, or `undefined` once the
- * execution has been untracked (terminal event).
- */
-export function addExecutionListener(
-  executionId: string,
-  cb: (handle: ExecutionHandle | undefined) => void,
-): () => void {
-  let set = persistentListeners.get(executionId);
-  if (!set) {
-    set = new Set();
-    persistentListeners.set(executionId, set);
-  }
-  set.add(cb);
-  return () => {
-    const s = persistentListeners.get(executionId);
-    if (!s) return;
-    s.delete(cb);
-    if (s.size === 0) persistentListeners.delete(executionId);
-  };
-}
+export const executionRegistry = new ExecutionRegistry();

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -129,7 +129,7 @@ export async function registerExecution(
  * Serialized with other meta updates for the same execution to prevent
  * read-modify-write races (e.g. with writeSessionDescription).
  * Never throws — storage failures are swallowed so callers' lifecycle
- * logic (untrackExecution, follow-up delivery) always runs.
+ * logic (registry untrack, follow-up delivery) always runs.
  */
 export async function writeTerminalStatus(
   executionId: ExecutionId,

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -10,7 +10,7 @@
  * showing appropriate UI notifications based on the returned result.
  */
 
-import { getActiveChildren } from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -75,7 +75,7 @@ export async function sendFollowUp(
   displayText?: string,
 ): Promise<SendFollowUpResult> {
   const status = StreamStatusService.get(streamId);
-  const activeChildren = getActiveChildren(streamId);
+  const activeChildren = executionRegistry.getActiveChildren(streamId);
   const hasActiveChildren =
     activeChildren.subagents.length > 0 || activeChildren.processes.length > 0;
   const queueOptions = { mediaFiles, displayText };

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -4,9 +4,7 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import {
   AgentExecutionHandle,
-  detachActiveChildren,
-  trackExecution,
-  untrackExecution,
+  executionRegistry,
 } from '@agent/runtime/executionRegistry';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -29,8 +27,8 @@ describe('executionRegistry', () => {
         explicit.host,
       );
 
-      trackExecution(handle);
-      untrackExecution(executionId);
+      executionRegistry.track(handle);
+      executionRegistry.untrack(executionId);
 
       expect(explicit.events.map((entry) => entry.event)).toEqual([
         'updateActiveSubagents',
@@ -52,7 +50,7 @@ describe('executionRegistry', () => {
         children: [],
       });
     } finally {
-      untrackExecution(executionId);
+      executionRegistry.untrack(executionId);
     }
   });
 
@@ -72,8 +70,8 @@ describe('executionRegistry', () => {
         explicit.host,
       );
 
-      trackExecution(handle);
-      detachActiveChildren(parentStreamId, explicit.host);
+      executionRegistry.track(handle);
+      executionRegistry.detachActiveChildren(parentStreamId, explicit.host);
 
       expect(explicit.events.map((entry) => entry.event)).toEqual([
         'updateActiveSubagents',
@@ -90,7 +88,7 @@ describe('executionRegistry', () => {
         children: [],
       });
     } finally {
-      untrackExecution(executionId);
+      executionRegistry.untrack(executionId);
     }
   });
 });

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -6,8 +6,7 @@ import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   AgentExecutionHandle,
-  trackExecution,
-  untrackExecution,
+  executionRegistry,
 } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
@@ -114,7 +113,7 @@ describe('tool-use follow-up progress events', () => {
     StreamStatusService.set(parentStreamId, STREAM_STATUS.STOPPED, {
       emit: false,
     });
-    trackExecution(handle);
+    executionRegistry.track(handle);
 
     try {
       const result = await sendFollowUp(parentStreamId, 'continue child');
@@ -127,7 +126,7 @@ describe('tool-use follow-up progress events', () => {
         'continue child',
       ]);
     } finally {
-      untrackExecution(executionId);
+      executionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -8,8 +8,7 @@ import { AgentRunStateSnapshotSchema } from '@agent/core/execution/AgentState';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   AgentExecutionHandle,
-  trackExecution,
-  untrackExecution,
+  executionRegistry,
 } from '@agent/runtime/executionRegistry';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
@@ -81,7 +80,7 @@ describe('ToolUseFollowUp', () => {
       'toolUse',
       noopAgentRuntimeHost,
     );
-    trackExecution(handle);
+    executionRegistry.track(handle);
 
     try {
       const result = await sendFollowUp(parentStreamId, 'hello while running');
@@ -94,7 +93,7 @@ describe('ToolUseFollowUp', () => {
         'hello while running',
       ]);
     } finally {
-      untrackExecution(executionId);
+      executionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });
@@ -114,7 +113,7 @@ describe('ToolUseFollowUp', () => {
       'toolUse',
       noopAgentRuntimeHost,
     );
-    trackExecution(handle);
+    executionRegistry.track(handle);
     ToolUseFollowUpQueue.release(parentStreamId);
 
     try {
@@ -128,7 +127,7 @@ describe('ToolUseFollowUp', () => {
         'after release',
       ]);
     } finally {
-      untrackExecution(executionId);
+      executionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -25,8 +25,8 @@ import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
 import {
-  getHandle,
   AgentExecutionHandle,
+  executionRegistry,
 } from '@agent/runtime/executionRegistry';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
@@ -1087,7 +1087,7 @@ Git worktree support: ${
     );
     if (gated) return gated;
 
-    const handle = getHandle(executionId);
+    const handle = executionRegistry.getHandle(executionId);
     if (!(handle instanceof AgentExecutionHandle)) {
       throw new Error(
         `Execution '${executionId}' not found or not an agent execution. Use the executions tool to check status.`,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -29,11 +29,7 @@ import {
   ACTIVE_STATUSES,
   AgentExecutionHandle,
   ProcessExecutionHandle,
-  getHandle,
-  getActiveExecutionIds,
-  waitForExecutionChange,
-  waitForAnyExecutionChange,
-  killExecution,
+  executionRegistry,
 } from '@agent/runtime/executionRegistry';
 import {
   bindExecutionSubscription,
@@ -206,7 +202,7 @@ export type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
  * One getHandle + one getStatus per call — no redundant lookups.
  */
 function shouldSkipWait(executionId: string): boolean {
-  const handle = getHandle(executionId);
+  const handle = executionRegistry.getHandle(executionId);
   if (!handle) return true;
 
   const { status } = handle.getStatus();
@@ -378,7 +374,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
   ): Promise<void> {
     const candidateIds = ids?.length
       ? [...new Set(ids)]
-      : getActiveExecutionIds();
+      : executionRegistry.getActiveIds();
     if (candidateIds.length === 0) return;
 
     // Exclude executions that are already effectively done
@@ -391,7 +387,10 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     // Abort early if a follow-up is sent to this stream (user wants to break the wait)
     const cleanupFollowUp = listenForFollowUp(ac);
     // Register callback before re-checking to close the race window
-    const waitPromise = waitForAnyExecutionChange(pendingIds, ac.signal);
+    const waitPromise = executionRegistry.waitForAnyChange(
+      pendingIds,
+      ac.signal,
+    );
     // Re-check after registration: if all resolved in the gap, abort.
     if (pendingIds.every(shouldSkipWait)) ac.abort();
     await waitPromise;
@@ -411,7 +410,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     // Abort early if a follow-up is sent to this stream (user wants to break the wait)
     const cleanupFollowUp = listenForFollowUp(ac);
     // Register callback before re-checking to close the race window
-    const waitPromise = waitForExecutionChange(executionId, ac.signal);
+    const waitPromise = executionRegistry.waitForChange(executionId, ac.signal);
     // Re-check after registration: if state changed in the gap, abort.
     if (shouldSkipWait(executionId)) ac.abort();
     await waitPromise;
@@ -437,9 +436,9 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     const lines = page.map(formatListingLine);
 
     // Count active background processes for the header
-    const activeIds = getActiveExecutionIds();
+    const activeIds = executionRegistry.getActiveIds();
     const bgCount = activeIds.filter(
-      (id) => getHandle(id)?.category === 'process',
+      (id) => executionRegistry.getHandle(id)?.category === 'process',
     ).length;
     const bgSuffix =
       bgCount > 0
@@ -454,7 +453,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
 
   private async showSummary(executionId: ExecutionId): Promise<ToolResult> {
     // Check in-memory handle first (free) — running executions have everything we need
-    const handle = getHandle(executionId);
+    const handle = executionRegistry.getHandle(executionId);
 
     if (handle) {
       // Running execution: agent/status from handle, only fetch live data from KV
@@ -615,7 +614,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       };
     }
 
-    const target = getHandle(executionId);
+    const target = executionRegistry.getHandle(executionId);
     if (!target) {
       return {
         output: `Execution ${executionId} not found or already completed.`,
@@ -646,7 +645,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       };
     }
 
-    const success = killExecution(executionId);
+    const success = executionRegistry.kill(executionId);
     if (success) {
       return { output: `Execution ${executionId} terminated.` };
     }
@@ -697,7 +696,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     viewRange?: number[],
   ): Promise<ToolResult> {
     // Running process: read live output from ephemeral temp files
-    const handle = getHandle(executionId);
+    const handle = executionRegistry.getHandle(executionId);
     if (handle instanceof ProcessExecutionHandle && handle.outputPaths) {
       const [stdout, stderr] = await Promise.all([
         platform()

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -7,8 +7,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   AgentExecutionHandle,
-  trackExecution,
-  untrackExecution,
+  executionRegistry,
 } from '@agent/runtime/executionRegistry';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 
@@ -96,7 +95,7 @@ export function createChildStream(
     runtimeHost,
   );
   if (options.toolName) handle.toolName = options.toolName;
-  trackExecution(handle);
+  executionRegistry.track(handle);
 
   return {
     childStreamId,
@@ -150,7 +149,7 @@ export function finalizeChildStream(args: FinalizeChildStreamArgs): void {
       { runtimeHost },
     );
   }
-  untrackExecution(executionId);
+  executionRegistry.untrack(executionId);
   disposeTrace();
 
   if (options?.autoClose) {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -38,7 +38,7 @@ import {
 } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { untrackExecution } from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
 import {
@@ -627,7 +627,7 @@ function startClaudeAgentLoop(params: {
           sawTurnFailure,
         }),
       ).catch(() => {});
-      untrackExecution(executionId);
+      executionRegistry.untrack(executionId);
       finalizeAgentCliLoopStatus(childStreamId, runtimeHost);
       disposeTrace();
     }

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -35,7 +35,7 @@ import {
 } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { untrackExecution } from '@agent/runtime/executionRegistry';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
 import {
@@ -634,7 +634,7 @@ function startCodexLoop(params: {
       ToolUseFollowUpQueue.release(childStreamId);
       const threadId = thread.id;
       if (threadId) threadRegistry.delete(threadId);
-      // Persist terminal status before untracking — untrackExecution fires
+      // Persist terminal status before untracking — executionRegistry.untrack fires
       // notifyWaiters, so consumers must see the final status on disk.
       await writeTerminalStatus(
         executionId,
@@ -643,7 +643,7 @@ function startCodexLoop(params: {
           sawTurnFailure,
         }),
       ).catch(() => {});
-      untrackExecution(executionId);
+      executionRegistry.untrack(executionId);
 
       finalizeCodexLoopStatus(childStreamId, runtimeHost);
       disposeTrace();

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -2,7 +2,7 @@ import type { ExecutionListingEntry, TodoEntry } from '@agent/storage';
 import {
   type ExecutionHandle,
   type ExecutionStatusInfo,
-  getHandle,
+  executionRegistry,
 } from '@agent/runtime/executionRegistry';
 import {
   EXECUTION_STATUS,
@@ -58,7 +58,7 @@ export function getExecutionStatusInfo(
   executionId: string,
   terminalStatus?: string,
 ): ExecutionStatusInfo {
-  const handle = getHandle(executionId);
+  const handle = executionRegistry.getHandle(executionId);
   if (handle) return handle.getStatus();
   return {
     status: terminalStatus ?? EXECUTION_STATUS.COMPLETED,


### PR DESCRIPTION
## Summary
- Move active execution handles, one-shot waiters, persistent listeners, and the stream-status subscription behind a single private `ExecutionRegistry` owner.
- Update callers to use `executionRegistry.*` directly instead of exported free-function wrappers.
- Keep current process-wide behavior unchanged; this contributes to #4737 Step 7 but does not claim to finish per-run `AgentRun` handle relocation.

## Validation
- `git diff --check`
- `corepack pnpm vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts src/test/agent/toolUse/ToolUseFollowUp.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`

Contributes to #4737.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving structural refactor across hosts; execution lifecycle logic is relocated, not redesigned.
> 
> **Overview**
> Encapsulates active execution tracking behind a single **`ExecutionRegistry`** class and exports one process-wide **`executionRegistry`** singleton, instead of module-level maps and many free functions.
> 
> Call sites across CLI, desktop, extension, agent runtime, and tools now call **`executionRegistry.*`** (e.g. **`track`/`untrack`**, **`kill`**, **`getActiveIds`**, **`waitForChange`**, **`addListener`**, **`interruptActiveChildren`**, **`detachActiveChildren`**, **`killBackgroundProcesses`**). Listener and waiter APIs are renamed slightly (**`waitForExecutionChange`** → **`waitForChange`**, **`addExecutionListener`** → **`addListener`**, etc.) with the same semantics.
> 
> This is groundwork for clearer **AgentRun** ownership (#4737); runtime behavior is intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ead22985771a91352e79281077a165d914ca78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->