### PR TITLE
refactor: share external agent session registry

### DIFF
--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -1,0 +1,49 @@
+import { getExecutionStore } from '@agent/storage';
+import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+export interface AgentCliSessionEntry {
+  childStreamId: StreamTabId;
+  executionId: ExecutionId;
+}
+
+export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
+  private readonly sessions = new Map<string, T>();
+
+  constructor(private readonly persistedSessionKey: string) {}
+
+  /**
+   * Register an active external-agent session and persist its SDK id for later
+   * display or cross-reference after an extension reload clears memory.
+   */
+  register(sessionId: string, entry: T): void {
+    this.sessions.set(sessionId, entry);
+    void getExecutionStore(entry.executionId)
+      .write(this.persistedSessionKey, sessionId)
+      .catch(() => {});
+  }
+
+  isActive(sessionId: string): boolean {
+    return this.sessions.has(sessionId);
+  }
+
+  lookup(sessionId: string): T | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  release(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  releaseMany(sessionIds: Iterable<string>): void {
+    for (const sessionId of sessionIds) {
+      this.release(sessionId);
+    }
+  }
+
+  interruptAll(): void {
+    for (const { childStreamId } of [...this.sessions.values()]) {
+      interruptRegistry.get(childStreamId)?.interrupt();
+    }
+  }
+}

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -73,6 +73,7 @@ import {
   findClaudeBinaryPath,
 } from './claudeAgentImport';
 import { createChildStream } from './childStream';
+import { AgentCliSessionRegistry } from './agentCliSessionRegistry';
 import {
   agentCliLoopTerminalStatus,
   finalizeAgentCliLoopStatus,
@@ -152,19 +153,12 @@ interface ActiveSession {
   additionalDirectories?: string[];
 }
 
-const sessionRegistry = new Map<string, ActiveSession>();
-
-function storeSession(sessionId: string, entry: ActiveSession): void {
-  sessionRegistry.set(sessionId, entry);
-  void getExecutionStore(entry.executionId)
-    .write('claude_agent_session_id', sessionId)
-    .catch(() => {});
-}
+const claudeAgentSessions = new AgentCliSessionRegistry<ActiveSession>(
+  'claude_agent_session_id',
+);
 
 export function interruptAllClaudeAgentSessions(): void {
-  for (const { childStreamId } of [...sessionRegistry.values()]) {
-    interruptRegistry.get(childStreamId)?.interrupt();
-  }
+  claudeAgentSessions.interruptAll();
 }
 
 // ============================================================================
@@ -562,9 +556,9 @@ function startClaudeAgentLoop(params: {
         if (
           !turnFailed &&
           turn?.sessionId &&
-          !sessionRegistry.has(turn.sessionId)
+          !claudeAgentSessions.isActive(turn.sessionId)
         ) {
-          storeSession(turn.sessionId, {
+          claudeAgentSessions.register(turn.sessionId, {
             childStreamId,
             parentStreamId,
             executionId,
@@ -615,9 +609,7 @@ function startClaudeAgentLoop(params: {
       }
     } finally {
       sessionStage.end(sawTurnFailure ? 'error' : 'stopped');
-      for (const sessionId of storedSessionIds) {
-        sessionRegistry.delete(sessionId);
-      }
+      claudeAgentSessions.releaseMany(storedSessionIds);
       interruptRegistry.unregister(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
       await writeTerminalStatus(
@@ -775,7 +767,7 @@ function resumeClaudeAgentSession(
   prompt: string,
   callerStreamId: StreamTabId | undefined,
 ): ToolResult {
-  const stored = sessionRegistry.get(sessionId);
+  const stored = claudeAgentSessions.lookup(sessionId);
   if (!stored) {
     throw new ToolError(
       `Claude Code CLI session '${sessionId}' is not active. It may have completed or been stopped; start a new session without session_id.`,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -69,6 +69,7 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { defineTool } from './core/define';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { createChildStream } from './childStream';
+import { AgentCliSessionRegistry } from './agentCliSessionRegistry';
 import {
   agentCliLoopTerminalStatus,
   finalizeAgentCliLoopStatus,
@@ -155,23 +156,13 @@ interface ActiveThread {
   executionId: ExecutionId;
 }
 
-const threadRegistry = new Map<string, ActiveThread>();
-
-/** Store a thread for multi-turn reuse and persist thread ID to disk. */
-function storeThread(threadId: string, entry: ActiveThread): void {
-  threadRegistry.set(threadId, entry);
-  // Extension reload clears memory but SDK stores sessions on disk —
-  // persist the ID so later code can display or cross-reference it.
-  void getExecutionStore(entry.executionId)
-    .write('codex_thread_id', threadId)
-    .catch(() => {});
-}
+const codexThreads = new AgentCliSessionRegistry<ActiveThread>(
+  'codex_thread_id',
+);
 
 /** Prevents codex streams from remaining in stale WAITING state during reload. */
 export function interruptAllCodexSessions(): void {
-  for (const { childStreamId } of [...threadRegistry.values()]) {
-    interruptRegistry.get(childStreamId)?.interrupt();
-  }
+  codexThreads.interruptAll();
 }
 
 // ============================================================================
@@ -528,7 +519,7 @@ function startCodexLoop(params: {
   // guard and start a concurrent loop. Fresh threads don't have thread.id
   // yet; they're registered after the first turn completes.
   if (thread.id) {
-    storeThread(thread.id, {
+    codexThreads.register(thread.id, {
       thread,
       childStreamId,
       parentStreamId,
@@ -581,8 +572,8 @@ function startCodexLoop(params: {
         const wallTimeMs = Date.now() - startedAt;
         const turnFailed = err != null;
         const threadId = thread.id;
-        if (!turnFailed && threadId && !threadRegistry.has(threadId)) {
-          storeThread(threadId, {
+        if (!turnFailed && threadId && !codexThreads.isActive(threadId)) {
+          codexThreads.register(threadId, {
             thread,
             childStreamId,
             parentStreamId,
@@ -633,7 +624,7 @@ function startCodexLoop(params: {
       interruptRegistry.unregister(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
       const threadId = thread.id;
-      if (threadId) threadRegistry.delete(threadId);
+      if (threadId) codexThreads.release(threadId);
       // Persist terminal status before untracking — executionRegistry.untrack fires
       // notifyWaiters, so consumers must see the final status on disk.
       await writeTerminalStatus(
@@ -718,7 +709,7 @@ export class CodexTool extends defineTool({
     const runContext = contexts?.runContext;
     callContext?.onExecutionReady?.();
 
-    if (input.thread_id && threadRegistry.has(input.thread_id)) {
+    if (input.thread_id && codexThreads.isActive(input.thread_id)) {
       return resumeCodexThread(
         input.thread_id,
         input.prompt,
@@ -807,7 +798,7 @@ function resumeCodexThread(
   prompt: string,
   callerStreamId: StreamTabId | undefined,
 ): ToolResult {
-  const stored = threadRegistry.get(threadId);
+  const stored = codexThreads.lookup(threadId);
   if (!stored) {
     throw new ToolError(
       `Codex thread '${threadId}' is not active. It may have completed or been stopped; start a new session without thread_id.`,


### PR DESCRIPTION
## Summary
- Add a shared `AgentCliSessionRegistry` owner for external CLI-agent session/thread state.
- Replace duplicated Claude Code and Codex module maps for session lookup, persistence, release, and shutdown interruption.
- Keep tool-specific session payloads local and preserve existing process-wide behavior; this is Step 7 groundwork, not full per-run isolation.

## Validation
- `git diff --check`
- `corepack pnpm vitest run src/test-kernel/agent/toolUse/ClaudeAgentProgressEvents.vitest.ts src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts src/test-kernel/tools/CodexLoopStatus.vitest.ts src/test/tools/codexConfig.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`

Contributes to #4737.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: same registry semantics and persistence keys; no new auth or execution paths, with existing tests covering Claude/Codex tool behavior.
> 
> **Overview**
> Introduces a shared **`AgentCliSessionRegistry`** so Claude Code and Codex no longer each maintain their own in-memory `Map` plus ad-hoc register/persist/interrupt helpers.
> 
> Each tool now owns one registry instance with its own persisted execution-store key (`claude_agent_session_id` vs `codex_thread_id`) and tool-specific entry type; **register**, **isActive**/**lookup**, **release**/**releaseMany**, and **`interruptAllClaudeAgentSessions` / `interruptAllCodexSessions`** all delegate to the shared class. Follow-up routing, parent-stream ownership checks, and disk persistence behavior are unchanged—this is structural deduplication ahead of broader per-run isolation work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f84a845ad123463b57c2e67e5bb147ae328339a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->