### PR TITLE
refactor: make runtime owners instantiable

### DIFF
--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -36,9 +36,10 @@ export {
  * the mutable maps and status subscription now live behind one explicit owner
  * instead of free module state.
  */
-class ExecutionRegistry {
+export class ExecutionRegistry {
   private readonly handles = new Map<string, ExecutionHandle>();
   private readonly changeCallbacks = new Map<string, Array<() => void>>();
+  private readonly disposeStatusListener: () => void;
   // Persistent listeners stay attached across notifications (unlike one-shot
   // waiters in `changeCallbacks`). Used by the executions subscribe action.
   private readonly persistentListeners = new Map<
@@ -50,23 +51,34 @@ class ExecutionRegistry {
     // Notify waiters and refresh UI badges when stream status changes
     // (e.g. RUNNING → WAITING). Without this, waitForChange only resolves
     // on progress/kill/untrack, and the background-tasks panel shows stale badges.
-    StreamStatusService.onDidChange(({ streamId }) => {
-      for (const [executionId, handle] of this.handles) {
-        if (
-          handle instanceof AgentExecutionHandle &&
-          handle.childStreamId === streamId
-        ) {
-          this.notifyWaiters(executionId);
-          if (handle.parentStreamId !== handle.childStreamId) {
-            this.emitActiveSubagentsUpdate(
-              handle.parentStreamId,
-              handle.runtimeHost,
-            );
+    this.disposeStatusListener = StreamStatusService.onDidChange(
+      ({ streamId }) => {
+        for (const [executionId, handle] of this.handles) {
+          if (
+            handle instanceof AgentExecutionHandle &&
+            handle.childStreamId === streamId
+          ) {
+            this.notifyWaiters(executionId);
+            if (handle.parentStreamId !== handle.childStreamId) {
+              this.emitActiveSubagentsUpdate(
+                handle.parentStreamId,
+                handle.runtimeHost,
+              );
+            }
+            break;
           }
-          break;
         }
-      }
-    });
+      },
+    );
+  }
+
+  dispose(): void {
+    this.disposeStatusListener();
+    for (const executionId of [...this.handles.keys()]) {
+      this.untrack(executionId);
+    }
+    this.changeCallbacks.clear();
+    this.persistentListeners.clear();
   }
 
   /** Register an execution handle. */

--- a/src/agent/runtime/runCoordinators.ts
+++ b/src/agent/runtime/runCoordinators.ts
@@ -33,7 +33,7 @@ function useRunCoordinators(): RunCoordinators {
  * the process-wide request id index while each entry still points at a concrete
  * AgentLaunchContext's coordinators.
  */
-class RunCoordinatorBridge {
+export class RunCoordinatorBridge {
   private readonly runStreams = new Map<string, RunCoordinators>();
   private readonly planApprovals = new Map<string, RunCoordinators>();
   private readonly planApprovalStreams = new Map<string, string>();

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -4,15 +4,17 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import {
   AgentExecutionHandle,
-  executionRegistry,
+  ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
-import type { StreamTabId } from '@shared/schemas';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
 describe('executionRegistry', () => {
   it('publishes handle updates through the handle runtime host', () => {
     const explicit = createRecordingHost();
+    const registry = new ExecutionRegistry();
     const executionId = 'exec-handle-runtime-host-test';
     const parentStreamId = 'parent-handle-runtime-host-test' as StreamTabId;
     const childStreamId = 'child-handle-runtime-host-test' as StreamTabId;
@@ -27,8 +29,8 @@ describe('executionRegistry', () => {
         explicit.host,
       );
 
-      executionRegistry.track(handle);
-      executionRegistry.untrack(executionId);
+      registry.track(handle);
+      registry.untrack(executionId);
 
       expect(explicit.events.map((entry) => entry.event)).toEqual([
         'updateActiveSubagents',
@@ -50,12 +52,13 @@ describe('executionRegistry', () => {
         children: [],
       });
     } finally {
-      executionRegistry.untrack(executionId);
+      registry.dispose();
     }
   });
 
   it('publishes detach updates through the caller runtime host', () => {
     const explicit = createRecordingHost();
+    const registry = new ExecutionRegistry();
     const executionId = 'exec-detach-runtime-host-test';
     const parentStreamId = 'parent-detach-runtime-host-test' as StreamTabId;
     const childStreamId = 'child-detach-runtime-host-test' as StreamTabId;
@@ -70,8 +73,8 @@ describe('executionRegistry', () => {
         explicit.host,
       );
 
-      executionRegistry.track(handle);
-      executionRegistry.detachActiveChildren(parentStreamId, explicit.host);
+      registry.track(handle);
+      registry.detachActiveChildren(parentStreamId, explicit.host);
 
       expect(explicit.events.map((entry) => entry.event)).toEqual([
         'updateActiveSubagents',
@@ -88,7 +91,36 @@ describe('executionRegistry', () => {
         children: [],
       });
     } finally {
-      executionRegistry.untrack(executionId);
+      registry.dispose();
     }
+  });
+
+  it('detaches its stream-status listener when disposed', () => {
+    const explicit = createRecordingHost();
+    const registry = new ExecutionRegistry();
+    const executionId = 'exec-dispose-runtime-host-test';
+    const parentStreamId = 'parent-dispose-runtime-host-test' as StreamTabId;
+    const childStreamId = 'child-dispose-runtime-host-test' as StreamTabId;
+
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+      explicit.host,
+    );
+
+    registry.track(handle);
+    registry.dispose();
+    explicit.events.length = 0;
+
+    StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
+      runtimeHost: explicit.host,
+    });
+
+    expect(
+      explicit.events.some((entry) => entry.event === 'updateActiveSubagents'),
+    ).toBe(false);
   });
 });

--- a/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
+++ b/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
 import type { AgentTrace } from '@agent/trace';
@@ -12,7 +12,7 @@ import {
   withRunContext,
   type RunCoordinators,
 } from '@agent/runtime/RunContext';
-import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
+import { RunCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
   AGENT_CATEGORY,
   TODO_STATUS,
@@ -59,30 +59,27 @@ function createLogger(): AgentTrace {
 }
 
 describe('runCoordinators', () => {
-  afterEach(() => {
-    runCoordinatorBridge.cleanupAllRequests();
-  });
-
   it('does not fall back to default coordinators when a run has none', async () => {
     const active = createRecordingHost();
+    const bridge = new RunCoordinatorBridge();
 
     await withRunContext(
       createRunContext({ runtimeHost: active.host }),
       async () => {
         await expect(
-          runCoordinatorBridge.waitForPlanApproval(streamId, {
+          bridge.waitForPlanApproval(streamId, {
             approvalId: 'approval:missing-coordinators',
             plan,
           }),
         ).rejects.toThrow(/active run coordinators/);
         await expect(
-          runCoordinatorBridge.waitForProposal(streamId, {
+          bridge.waitForProposal(streamId, {
             proposalId: 'proposal:missing-coordinators',
             proposal,
           }),
         ).rejects.toThrow(/active run coordinators/);
         await expect(
-          runCoordinatorBridge.waitForRetry(streamId, {
+          bridge.waitForRetry(streamId, {
             operation: 'Model invocation',
             logger: createLogger(),
           }),
@@ -95,6 +92,7 @@ describe('runCoordinators', () => {
 
   it('routes waits and resolver bridge events through active run coordinators', async () => {
     const active = createRecordingHost();
+    const bridge = new RunCoordinatorBridge();
     const coordinators = createCoordinators(active.host);
     const context = createRunContext({
       runtimeHost: active.host,
@@ -102,26 +100,26 @@ describe('runCoordinators', () => {
     });
 
     const planResult = withRunContext(context, () =>
-      runCoordinatorBridge.waitForPlanApproval(streamId, {
+      bridge.waitForPlanApproval(streamId, {
         approvalId: 'approval:active-coordinator',
         plan,
       }),
     );
     expect(
-      runCoordinatorBridge.resolvePlanApproval('approval:active-coordinator', {
+      bridge.resolvePlanApproval('approval:active-coordinator', {
         action: 'approve',
       }),
     ).toBe(true);
     await expect(planResult).resolves.toEqual({ action: 'approve' });
 
     const proposalResult = withRunContext(context, () =>
-      runCoordinatorBridge.waitForProposal(streamId, {
+      bridge.waitForProposal(streamId, {
         proposalId: 'proposal:active-coordinator',
         proposal,
       }),
     );
     expect(
-      runCoordinatorBridge.resolveProposal('proposal:active-coordinator', {
+      bridge.resolveProposal('proposal:active-coordinator', {
         action: 'approve',
         agent: 'reviewer',
         model: 'test-model',
@@ -134,14 +132,12 @@ describe('runCoordinators', () => {
     });
 
     const retryResult = withRunContext(context, () =>
-      runCoordinatorBridge.waitForRetry(streamId, {
+      bridge.waitForRetry(streamId, {
         operation: 'Model invocation',
         logger: createLogger(),
       }),
     );
-    expect(
-      runCoordinatorBridge.triggerRetry(streamId, 'try the request again'),
-    ).toBe(true);
+    expect(bridge.triggerRetry(streamId, 'try the request again')).toBe(true);
     await expect(retryResult).resolves.toEqual({
       action: 'retry',
       feedback: 'try the request again',


### PR DESCRIPTION
## Summary
- export the existing ExecutionRegistry and RunCoordinatorBridge owner classes while preserving the process-wide singleton exports
- make ExecutionRegistry own and dispose its StreamStatusService subscription
- move runtime-owner tests to fresh instances instead of shared global singleton cleanup

## Design note
This is Step 7 groundwork for #4737. It keeps the production API shape stable, but makes the owner classes usable as real per-instance state holders. The new ExecutionRegistry.dispose() path tears down through untrack() so child registrations and active-subagent updates follow the same lifecycle path as normal execution cleanup.

## Validation
- git diff --check
- npm run typecheck -- --pretty false
- npm run lint
- npm run compile:fast
- corepack pnpm vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/runCoordinators.vitest.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and test isolation only; production still uses the same module singletons, with additive lifecycle cleanup on ExecutionRegistry.
> 
> **Overview**
> **Exports `ExecutionRegistry` and `RunCoordinatorBridge`** as instantiable classes while keeping the existing `executionRegistry` and `runCoordinatorBridge` singleton exports, so production call sites stay unchanged.
> 
> **`ExecutionRegistry`** now stores and tears down its `StreamStatusService` subscription: `dispose()` unsubscribes the listener, untracks every handle (same path as normal cleanup), and clears change/persistent listener maps.
> 
> **Tests** construct fresh registry/bridge instances instead of mutating globals; `ExecutionRegistry` gains a test that stream-status changes no longer emit UI updates after `dispose()`. `runCoordinators` tests drop `afterEach` global cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a2bd6355db0a772b10a38175b817d57eeff9e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->