### PR TITLE
refactor(tools): consolidate duplicate formatSize, use shared line-count utilities

### DIFF
--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -51,6 +51,7 @@ import { isDirectory } from '@utils/files/fsEntryType';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 import { formatTimestamp, splitContentLines } from '@utils/text/stringUtils';
+import { formatSize } from './memory/memoryUtils';
 import {
   formatListingLine,
   formatProgressLine,
@@ -894,7 +895,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     }
 
     const lines = entries.map((entry) => {
-      const sizeStr = entry.isDir ? '<dir>' : this.formatSize(entry.size);
+      const sizeStr = entry.isDir ? '<dir>' : formatSize(entry.size);
       return `${sizeStr.padStart(8)}  ${entry.path}`;
     });
 
@@ -993,7 +994,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     }
 
     const lines = entries.map((entry) => {
-      const sizeStr = entry.isDirectory ? '<dir>' : this.formatSize(entry.size);
+      const sizeStr = entry.isDirectory ? '<dir>' : formatSize(entry.size);
       return `${sizeStr.padStart(8)}  ${entry.path}`;
     });
 
@@ -1070,12 +1071,6 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         return resolved ? [resolved.path] : [];
       }),
     );
-  }
-
-  private formatSize(bytes: number): string {
-    if (bytes < 1024) return `${bytes}B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}K`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)}M`;
   }
 
   private applyViewRange(output: string, viewRange?: number[]): string {

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -19,6 +19,7 @@ import {
   requestApprovedEditContent,
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
+import { countLines } from '@utils/text/stringUtils';
 import { WorkspaceFS } from '@utils/files';
 
 // Local file imports
@@ -87,8 +88,8 @@ export class WriteFileTool extends defineTool({
     );
     const output = userDiffNote ? `written\n\n${userDiffNote}` : 'written';
 
-    const originalLineCount = originalContent.split('\n').length;
-    const newLineCount = appliedContent.split('\n').length;
+    const originalLineCount = countLines(originalContent);
+    const newLineCount = countLines(appliedContent);
     const action = exists ? 'Overwrote' : 'Created';
     const summary = `${action} ${displayPath} (${newLineCount} lines)`;
     const userInstruction =

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -6,7 +6,10 @@ import { ToolResult, ToolError } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - utils
-import { truncateWithEllipsis } from '@utils/text/stringUtils';
+import {
+  splitContentLines,
+  truncateWithEllipsis,
+} from '@utils/text/stringUtils';
 
 // Local file imports
 import {
@@ -21,11 +24,8 @@ import {
  * line of the code so multi-line scripts still get a meaningful header.
  */
 export function wolframRunSummary(code: string): string {
-  const firstLine = code
-    .split('\n')
-    .map((line) => line.trim())
-    .find((line) => line.length > 0);
-  const preview = firstLine ? truncateWithEllipsis(firstLine, 60) : '';
+  const firstLine = splitContentLines(code).find((line) => line.trim());
+  const preview = firstLine ? truncateWithEllipsis(firstLine.trim(), 60) : '';
   return preview ? `Executed: ${preview}` : 'Executed';
 }
 


### PR DESCRIPTION
## Summary

After scanning the codebase for consolidation opportunities, three concrete improvements were found and applied:

- **`ExecutionsTool.ts`** — Remove private `formatSize()` method (handled only B/K/M) and import the shared `formatSize()` from `memoryUtils.ts` (which also covers G/T). The private copy was a simpler re-implementation of a function that already existed one directory away.
- **`WriteTool.ts`** — Replace `.split('\n').length` with `countLines()` from `@utils/text/stringUtils`. `countLines` normalises CRLF and ignores a trailing newline, giving an accurate semantic line count; the old form would count an extra phantom line for files with a trailing newline.
- **`WolframTool.ts`** — Use `splitContentLines()` in `wolframRunSummary` so CRLF input is handled consistently with the rest of the codebase. All four existing unit tests in `WolframRunSummary.vitest.ts` continue to pass unchanged.

## What was ruled out

The broader scan looked at ~30 other potential consolidation points. Most turned out to be intentional:

| Pattern | Why no change |
|---------|---------------|
| `shared/utils/path.ts` vs `pathCore.ts` | `shared/` module is browser-safe (no Node `path` import); separation is intentional |
| `normalizeFilePath` vs `toPosixPath` | Different semantics — former is a simple backslash→slash swap, latter trims and normalises segments |
| Raw `.split('\n')` in MemoryTool/TextEditorTool | Round-trip (split then rejoin `\n`) — must preserve exact content |
| `extractErrorMessage` vs `toErrorMessage` | Complementary: one returns `string | undefined`, the other always returns `string` |
| `formatRelativeTime` in shared utils | Used by non-UI tools (MemoryTool) as well as webview; location is appropriate |

## Test plan

- [x] `vitest run src/test-kernel/tools/WolframRunSummary.vitest.ts` — all 4 tests pass
- [x] `npm run compile:fast` — builds cleanly (esbuild + Vite)
- [x] `npm run lint` — passes (exit 0)
- [x] `corepack pnpm --filter @texra-ai/cli typecheck` — passes
- [x] Pre-existing `LoadSkills.vitest.mts` failure confirmed on base branch (unrelated)

https://claude.ai/code/session_0193epzaMoxxk3NP9T4KxfRt

---
_Generated by [Claude Code](https://claude.ai/code/session_0193epzaMoxxk3NP9T4KxfRt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior tweaks in tool output formatting only; no auth, persistence, or execution control paths changed.
> 
> **Overview**
> **Consolidates duplicate formatting helpers** across three tools so listings and user-facing summaries behave consistently.
> 
> `ExecutionsTool` drops its local `formatSize` and uses the shared `formatSize` from `memoryUtils` for generated-file and workspace-file listings (same B/K/M behavior, plus G/T for large files). `WriteTool` reports line counts via `countLines()` instead of `split('\n').length`, so CRLF and trailing newlines don’t inflate counts in summaries and user instructions. `wolframRunSummary` in `WolframTool` uses `splitContentLines()` for the first-line preview so CRLF scripts match the rest of the codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f5ed4d8686ca54e5e3f174055bbfdc38bafede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->