### PR TITLE
refactor: own subagent delivery state

### DIFF
--- a/src/test-kernel/tools/SubagentDeliveryState.vitest.ts
+++ b/src/test-kernel/tools/SubagentDeliveryState.vitest.ts
@@ -3,29 +3,42 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports
 import {
-  resolveSubagentBeforeWaitingDelivery,
   SUBAGENT_DELIVERY_DECISION,
+  SubagentDeliveryRegistry,
+  SubagentDeliveryState,
 } from '@tools/subagentDeliveryState';
 
 describe('subagent delivery state', () => {
   it('keeps an already delivered wait cycle marked delivered', () => {
-    expect(
-      resolveSubagentBeforeWaitingDelivery(
-        { hasDelivered: true },
-        'child-stream',
-      ),
-    ).toBe(SUBAGENT_DELIVERY_DECISION.AlreadyDelivered);
+    const state = new SubagentDeliveryState();
+    expect(state.markDelivered()).toBe(true);
+    expect(state.markDelivered()).toBe(false);
+
+    expect(state.resolveBeforeWaiting('child-stream')).toBe(
+      SUBAGENT_DELIVERY_DECISION.AlreadyDelivered,
+    );
   });
 
   it('distinguishes missing child streams from deliverable cycles', () => {
-    expect(
-      resolveSubagentBeforeWaitingDelivery({ hasDelivered: false }, undefined),
-    ).toBe(SUBAGENT_DELIVERY_DECISION.MissingStream);
-    expect(
-      resolveSubagentBeforeWaitingDelivery(
-        { hasDelivered: false },
-        'child-stream',
-      ),
-    ).toBe(SUBAGENT_DELIVERY_DECISION.Deliver);
+    const state = new SubagentDeliveryState();
+
+    expect(state.resolveBeforeWaiting(undefined)).toBe(
+      SUBAGENT_DELIVERY_DECISION.MissingStream,
+    );
+    expect(state.resolveBeforeWaiting('child-stream')).toBe(
+      SUBAGENT_DELIVERY_DECISION.Deliver,
+    );
+  });
+
+  it('owns active delivery states by execution id', () => {
+    const registry = new SubagentDeliveryRegistry();
+    const state = registry.start('exec-1');
+
+    expect(registry.getActive('exec-1')).toBe(state);
+    state.markDelivered();
+    expect(registry.getActive('exec-1')?.isDelivered()).toBe(true);
+
+    registry.finish('exec-1');
+    expect(registry.getActive('exec-1')).toBeUndefined();
   });
 });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -73,9 +73,8 @@ import {
   formatFollowUpInstruction,
 } from '@tools/subagentResults';
 import {
-  resolveSubagentBeforeWaitingDelivery,
   SUBAGENT_DELIVERY_DECISION,
-  type SubagentDeliveryState,
+  subagentDeliveryRegistry,
 } from '@tools/subagentDeliveryState';
 import {
   availableModelNamesFromOptions,
@@ -104,12 +103,6 @@ const LOG_CHANNEL = 'DelegationTools';
 logger.initialize(LOG_CHANNEL);
 
 const LARGE_BIB_LIMIT_BYTES = 100 * 1024;
-
-// ============================================================================
-// Subagent delivery state tracking
-// ============================================================================
-
-const activeSubagentDelivery = new Map<string, SubagentDeliveryState>();
 
 /**
  * Shared Zod field for the `memories` parameter on delegation tools.
@@ -456,24 +449,21 @@ async function executeSubagent(
     }
   }
 
-  // Track delivery state in the module-level map so delegate_agent (resume)
-  // can find live subagents and enqueue follow-up instructions.
-  // The flag prevents duplicate delivery of the same result via both
-  // onBeforeWaiting and onCompleted. When a follow-up is consumed, the next
-  // onBeforeWaiting will deliver the resumed cycle's result.
-  const deliveryState: SubagentDeliveryState = { hasDelivered: false };
-  activeSubagentDelivery.set(executionId, deliveryState);
+  // Register delivery state so delegate_agent (resume) can find live subagents.
+  // The state object owns duplicate-delivery protection between onBeforeWaiting
+  // and onCompleted. When a follow-up is consumed, the next onBeforeWaiting
+  // delivers the resumed cycle's result.
+  const deliveryState = subagentDeliveryRegistry.start(executionId);
   let childStreamId: StreamTabId | undefined;
 
   function onProgress(update: SubagentProgressUpdate): void {
-    if (deliveryState.hasDelivered) return;
+    if (deliveryState.isDelivered()) return;
     const msg = formatSubagentProgress(executionId, agentName, update);
     ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
   }
 
   function deliverSubagentError(err: unknown): void {
-    if (deliveryState.hasDelivered) return;
-    deliveryState.hasDelivered = true;
+    if (!deliveryState.markDelivered()) return;
     const wallTimeMs = Date.now() - startedAt;
     const msg = formatSubagentError(executionId, agentName, err, {
       wallTimeMs,
@@ -501,13 +491,11 @@ async function executeSubagent(
     },
     onProgress,
     onFollowUpConsumed: () => {
-      deliveryState.hasDelivered = false;
+      deliveryState.markPending();
     },
     onBeforeWaiting: async (lastResponse, touchedFiles) => {
-      const deliveryDecision = resolveSubagentBeforeWaitingDelivery(
-        deliveryState,
-        childStreamId,
-      );
+      const deliveryDecision =
+        deliveryState.resolveBeforeWaiting(childStreamId);
       if (deliveryDecision === SUBAGENT_DELIVERY_DECISION.AlreadyDelivered) {
         return true;
       }
@@ -541,13 +529,12 @@ async function executeSubagent(
       }
       // Mark delivered and enqueue only after the write attempt so that
       // onCompleted can still act as a fallback if we somehow never reach here.
-      deliveryState.hasDelivered = true;
+      if (!deliveryState.markDelivered()) return true;
       ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
       return true;
     },
     onCompleted: async (result) => {
-      if (deliveryState.hasDelivered) return;
-      deliveryState.hasDelivered = true;
+      if (!deliveryState.markDelivered()) return;
 
       // For workflow results, compute diffs and write them as files to the
       // execution's run directory. The delivery references diff file paths
@@ -584,7 +571,7 @@ async function executeSubagent(
       deliverSubagentError(err);
     })
     .finally(() => {
-      activeSubagentDelivery.delete(executionId);
+      subagentDeliveryRegistry.finish(executionId);
     });
   const isToolUse = configPayload.agentCategory === AgentCategory.ToolUse;
   const meta = options?.approvalMeta;
@@ -1100,7 +1087,7 @@ Git worktree support: ${
       );
     }
 
-    const deliveryState = activeSubagentDelivery.get(executionId);
+    const deliveryState = subagentDeliveryRegistry.getActive(executionId);
     if (!deliveryState) {
       throw new Error(
         `Execution '${executionId}' is no longer tracked for delivery. It may have already completed.`,
@@ -1112,7 +1099,7 @@ Git worktree support: ${
 
     switch (result.status) {
       case 'sent':
-        deliveryState.hasDelivered = false;
+        deliveryState.markPending();
         return {
           summary: `Follow-up sent to '${handle.agentName}'`,
           output: [
@@ -1121,7 +1108,7 @@ Git worktree support: ${
           ].join('\n'),
         };
       case 'queued':
-        deliveryState.hasDelivered = false;
+        deliveryState.markPending();
         return {
           summary: `Follow-up queued for '${handle.agentName}'`,
           output: [

--- a/src/tools/subagentDeliveryState.ts
+++ b/src/tools/subagentDeliveryState.ts
@@ -9,8 +9,52 @@ import type { StreamTabId } from '@shared/schemas';
  * pending immediately so interrupts before consumption still report back;
  * consuming a follow-up keeps the next cycle pending for `onBeforeWaiting`.
  */
-export interface SubagentDeliveryState {
-  hasDelivered: boolean;
+export class SubagentDeliveryState {
+  private hasDelivered = false;
+
+  isDelivered(): boolean {
+    return this.hasDelivered;
+  }
+
+  markPending(): void {
+    this.hasDelivered = false;
+  }
+
+  markDelivered(): boolean {
+    if (this.hasDelivered) return false;
+    this.hasDelivered = true;
+    return true;
+  }
+
+  resolveBeforeWaiting(
+    childStreamId: StreamTabId | undefined,
+  ): SubagentDeliveryDecision {
+    if (this.hasDelivered) {
+      return SUBAGENT_DELIVERY_DECISION.AlreadyDelivered;
+    }
+    if (!childStreamId) {
+      return SUBAGENT_DELIVERY_DECISION.MissingStream;
+    }
+    return SUBAGENT_DELIVERY_DECISION.Deliver;
+  }
+}
+
+export class SubagentDeliveryRegistry {
+  private readonly active = new Map<string, SubagentDeliveryState>();
+
+  start(executionId: string): SubagentDeliveryState {
+    const state = new SubagentDeliveryState();
+    this.active.set(executionId, state);
+    return state;
+  }
+
+  getActive(executionId: string): SubagentDeliveryState | undefined {
+    return this.active.get(executionId);
+  }
+
+  finish(executionId: string): void {
+    this.active.delete(executionId);
+  }
 }
 
 export const SUBAGENT_DELIVERY_DECISION = {
@@ -22,15 +66,4 @@ export const SUBAGENT_DELIVERY_DECISION = {
 export type SubagentDeliveryDecision =
   (typeof SUBAGENT_DELIVERY_DECISION)[keyof typeof SUBAGENT_DELIVERY_DECISION];
 
-export function resolveSubagentBeforeWaitingDelivery(
-  deliveryState: SubagentDeliveryState,
-  childStreamId: StreamTabId | undefined,
-): SubagentDeliveryDecision {
-  if (deliveryState.hasDelivered) {
-    return SUBAGENT_DELIVERY_DECISION.AlreadyDelivered;
-  }
-  if (!childStreamId) {
-    return SUBAGENT_DELIVERY_DECISION.MissingStream;
-  }
-  return SUBAGENT_DELIVERY_DECISION.Deliver;
-}
+export const subagentDeliveryRegistry = new SubagentDeliveryRegistry();


### PR DESCRIPTION
## Summary
- move subagent result-delivery ownership out of `DelegationTools`' raw module-level map
- replace the exposed `hasDelivered` flag with `SubagentDeliveryState` lifecycle methods
- keep resume/follow-up routing on a small registry API: start, get active, finish

## Design note
This is a narrow Step 7 cleanup for #4737. `DelegationTools` still orchestrates subagent execution, but the duplicate-delivery gate now lives with the delivery state itself instead of leaking the boolean/map shape into the tool implementation.

## Validation
- `corepack pnpm vitest run src/test-kernel/tools/SubagentDeliveryState.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration of async subagent follow-up delivery and resume routing; behavior should be equivalent but duplicate-delivery gates now depend on the new `markDelivered` API.
> 
> **Overview**
> Moves **subagent result-delivery tracking** out of `DelegationTools` into `subagentDeliveryState.ts`: a **`SubagentDeliveryState`** class (private `hasDelivered`, `isDelivered` / `markPending` / `markDelivered` / `resolveBeforeWaiting`) and a **`SubagentDeliveryRegistry`** with `start`, `getActive`, and `finish`, exposed as **`subagentDeliveryRegistry`**.
> 
> `DelegationTools` no longer keeps a module-level `Map` or mutates a public `hasDelivered` flag. Async subagent runs register via `start`, clear via `finish`, and resume lookups use `getActive`. Delivery paths use **`markDelivered()`** (idempotent) instead of direct boolean writes; follow-ups and `onFollowUpConsumed` call **`markPending()`**. The standalone **`resolveSubagentBeforeWaitingDelivery`** helper is removed in favor of **`deliveryState.resolveBeforeWaiting`**.
> 
> Tests now exercise the class and registry APIs directly, including registry lifecycle by execution id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620eaac175c327b238786d7f834f20411b9e1e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->