### PR TITLE
refactor: own execution subscriptions

### DIFF
--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -14,6 +14,7 @@
 import {
   executionRegistry,
   type ExecutionHandle,
+  type ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
@@ -32,33 +33,19 @@ interface Disposable {
 
 type PerStream = Map<string, Disposable>;
 
-const perStream = new Map<StreamTabId, PerStream>();
-let releaseHookRegistered = false;
-
-function ensureReleaseHook(): void {
-  if (releaseHookRegistered) return;
-  ToolUseFollowUpQueue.onRelease((streamId) => {
-    const bound = perStream.get(streamId);
-    if (!bound) return;
-    for (const d of bound.values()) {
-      try {
-        d.dispose();
-      } catch (err) {
-        logger.warn(`Disposer threw during release: ${String(err)}`);
-      }
-    }
-    perStream.delete(streamId);
-  });
-  releaseHookRegistered = true;
+interface ReleaseSource {
+  onRelease(observer: (streamId: StreamTabId) => void): () => void;
 }
 
-function removeBoundKey(
-  streamId: StreamTabId,
-  bound: PerStream,
-  executionId: string,
-): void {
-  bound.delete(executionId);
-  if (bound.size === 0) perStream.delete(streamId);
+interface BinderLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+interface ExecutionSubscriptionBinderOptions {
+  registry?: Pick<ExecutionRegistry, 'addListener' | 'getHandle'>;
+  releaseSource?: ReleaseSource;
+  logger?: BinderLogger;
 }
 
 function progressLine(
@@ -101,6 +88,11 @@ class ExecutionSubscription implements Disposable {
     private readonly streamId: StreamTabId,
     handle: ExecutionHandle,
     private readonly runtimeHost: AgentRuntimeHost,
+    private readonly registry: Pick<
+      ExecutionRegistry,
+      'addListener' | 'getHandle'
+    >,
+    private readonly onDisposed: () => void,
   ) {
     this.executionId = handle.executionId;
     this.agentName = handle.agentName;
@@ -109,17 +101,17 @@ class ExecutionSubscription implements Disposable {
   }
 
   bind(): boolean {
-    this.removeListener = executionRegistry.addListener(
+    this.removeListener = this.registry.addListener(
       this.executionId,
       (handle) => {
         this.handleChange(handle);
       },
     );
 
-    // TOCTOU: handle could untrack between the initial executionRegistry.getHandle() check
-    // and listener registration. Re-check; if gone, fire the terminal event
-    // and dispose so the listener never leaks.
-    if (!executionRegistry.getHandle(this.executionId)) {
+    // TOCTOU: handle could untrack between the initial registry.getHandle()
+    // check and listener registration. Re-check; if gone, fire the terminal
+    // event and dispose so the listener never leaks.
+    if (!this.registry.getHandle(this.executionId)) {
       this.sendFinished();
       this.dispose();
       return false;
@@ -131,8 +123,7 @@ class ExecutionSubscription implements Disposable {
     if (this.disposed) return;
     this.disposed = true;
     this.removeListener?.();
-    const current = perStream.get(this.streamId);
-    if (current) removeBoundKey(this.streamId, current, this.executionId);
+    this.onDisposed();
   }
 
   private handleChange(handle: ExecutionHandle | undefined): void {
@@ -183,57 +174,117 @@ class ExecutionSubscription implements Disposable {
   }
 }
 
-/**
- * Subscribe `streamId` to status, progress, and termination events for
- * `executionId`. Subsequent calls for the same pair are no-ops. Throws if
- * the execution is not currently tracked — terminal executions cannot be
- * subscribed (use `executions view` to read the final report).
- */
-export function bindExecutionSubscription(
-  streamId: StreamTabId,
-  executionId: string,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  ensureReleaseHook();
+export class ExecutionSubscriptionBinder {
+  private readonly registry: Pick<
+    ExecutionRegistry,
+    'addListener' | 'getHandle'
+  >;
+  private readonly releaseSource: ReleaseSource;
+  private readonly logger: BinderLogger;
+  private readonly perStream = new Map<StreamTabId, PerStream>();
+  private releaseHook: (() => void) | undefined;
 
-  const handle = executionRegistry.getHandle(executionId);
-  if (!handle) {
-    throw new Error(
-      `Execution ${executionId} is not active. Subscribe only works on tracked executions; use 'view' to read the final report.`,
-    );
+  constructor(options: ExecutionSubscriptionBinderOptions = {}) {
+    this.registry = options.registry ?? executionRegistry;
+    this.releaseSource = options.releaseSource ?? ToolUseFollowUpQueue;
+    this.logger = options.logger ?? logger;
   }
 
-  let bound = perStream.get(streamId);
-  if (!bound) {
-    bound = new Map();
-    perStream.set(streamId, bound);
-  }
-  if (bound.has(executionId)) return;
+  /**
+   * Subscribe `streamId` to status, progress, and termination events for
+   * `executionId`. Subsequent calls for the same pair are no-ops. Throws if
+   * the execution is not currently tracked — terminal executions cannot be
+   * subscribed (use `executions view` to read the final report).
+   */
+  bind(
+    streamId: StreamTabId,
+    executionId: string,
+    runtimeHost: AgentRuntimeHost,
+  ): void {
+    this.ensureReleaseHook();
 
-  const subscription = new ExecutionSubscription(streamId, handle, runtimeHost);
-  bound.set(executionId, subscription);
-  if (subscription.bind()) {
-    logger.info(
-      `Bound execution subscription ${executionId} → stream ${streamId}`,
+    const handle = this.registry.getHandle(executionId);
+    if (!handle) {
+      throw new Error(
+        `Execution ${executionId} is not active. Subscribe only works on tracked executions; use 'view' to read the final report.`,
+      );
+    }
+
+    let bound = this.perStream.get(streamId);
+    if (!bound) {
+      bound = new Map();
+      this.perStream.set(streamId, bound);
+    }
+    if (bound.has(executionId)) return;
+
+    const subscription = new ExecutionSubscription(
+      streamId,
+      handle,
+      runtimeHost,
+      this.registry,
+      () => this.removeBoundKey(streamId, executionId),
     );
+    bound.set(executionId, subscription);
+    if (subscription.bind()) {
+      this.logger.info(
+        `Bound execution subscription ${executionId} → stream ${streamId}`,
+      );
+    }
+  }
+
+  /**
+   * Returns true if a subscription existed and was removed for this
+   * (stream, execution) pair.
+   */
+  unbind(streamId: StreamTabId, executionId: string): boolean {
+    const bound = this.perStream.get(streamId);
+    const d = bound?.get(executionId);
+    if (!bound || !d) return false;
+    try {
+      d.dispose();
+    } catch (err) {
+      this.logger.warn(
+        `Disposer threw on explicit unsubscribe: ${String(err)}`,
+      );
+    }
+    return true;
+  }
+
+  dispose(): void {
+    this.releaseHook?.();
+    this.releaseHook = undefined;
+    for (const bound of [...this.perStream.values()]) {
+      this.disposeBoundSubscriptions(bound, 'binder disposal');
+    }
+    this.perStream.clear();
+  }
+
+  private ensureReleaseHook(): void {
+    if (this.releaseHook) return;
+    this.releaseHook = this.releaseSource.onRelease((streamId) => {
+      const bound = this.perStream.get(streamId);
+      if (!bound) return;
+      this.disposeBoundSubscriptions(bound, 'release');
+      this.perStream.delete(streamId);
+    });
+  }
+
+  private disposeBoundSubscriptions(bound: PerStream, reason: string): void {
+    for (const d of [...bound.values()]) {
+      try {
+        d.dispose();
+      } catch (err) {
+        this.logger.warn(`Disposer threw during ${reason}: ${String(err)}`);
+      }
+    }
+  }
+
+  private removeBoundKey(streamId: StreamTabId, executionId: string): void {
+    const bound = this.perStream.get(streamId);
+    if (!bound) return;
+    bound.delete(executionId);
+    if (bound.size === 0) this.perStream.delete(streamId);
   }
 }
 
-/**
- * Returns true if a subscription existed and was removed for this
- * (stream, execution) pair.
- */
-export function unbindExecutionSubscription(
-  streamId: StreamTabId,
-  executionId: string,
-): boolean {
-  const bound = perStream.get(streamId);
-  const d = bound?.get(executionId);
-  if (!bound || !d) return false;
-  try {
-    d.dispose();
-  } catch (err) {
-    logger.warn(`Disposer threw on explicit unsubscribe: ${String(err)}`);
-  }
-  return true;
-}
+export const executionSubscriptionBinder = new ExecutionSubscriptionBinder();

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts
@@ -1,0 +1,144 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import {
+  AgentExecutionHandle,
+  ExecutionRegistry,
+} from '@agent/runtime/executionRegistry';
+import { ExecutionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
+import type { StreamTabId } from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+const streamId = 'stream:execution-subscription-test' as StreamTabId;
+const childStreamId = 'child:execution-subscription-test' as StreamTabId;
+
+function createReleaseSource() {
+  let observer: ((streamId: StreamTabId) => void) | undefined;
+  return {
+    source: {
+      onRelease(nextObserver: (streamId: StreamTabId) => void): () => void {
+        observer = nextObserver;
+        return () => {
+          if (observer === nextObserver) observer = undefined;
+        };
+      },
+    },
+    release(stream: StreamTabId): void {
+      observer?.(stream);
+    },
+    hasObserver(): boolean {
+      return observer !== undefined;
+    },
+  };
+}
+
+function createLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+describe('ExecutionSubscriptionBinder', () => {
+  it('owns bind and unbind state per stream/execution pair', () => {
+    const registry = new ExecutionRegistry();
+    const releaseSource = createReleaseSource();
+    const logger = createLogger();
+    const explicit = createRecordingHost();
+    const binder = new ExecutionSubscriptionBinder({
+      registry,
+      releaseSource: releaseSource.source,
+      logger,
+    });
+    const executionId = 'exec-subscription-bind-test';
+    const handle = new AgentExecutionHandle(
+      executionId,
+      streamId,
+      childStreamId,
+      'search',
+      'toolUse',
+      explicit.host,
+    );
+
+    try {
+      registry.track(handle);
+
+      binder.bind(streamId, executionId, explicit.host);
+      binder.bind(streamId, executionId, explicit.host);
+
+      expect(binder.unbind(streamId, executionId)).toBe(true);
+      expect(binder.unbind(streamId, executionId)).toBe(false);
+      expect(logger.info).toHaveBeenCalledTimes(1);
+    } finally {
+      binder.dispose();
+      registry.dispose();
+    }
+  });
+
+  it('disposes stream subscriptions when the follow-up queue is released', () => {
+    const registry = new ExecutionRegistry();
+    const releaseSource = createReleaseSource();
+    const explicit = createRecordingHost();
+    const binder = new ExecutionSubscriptionBinder({
+      registry,
+      releaseSource: releaseSource.source,
+      logger: createLogger(),
+    });
+    const executionId = 'exec-subscription-release-test';
+    const handle = new AgentExecutionHandle(
+      executionId,
+      streamId,
+      childStreamId,
+      'search',
+      'toolUse',
+      explicit.host,
+    );
+
+    try {
+      registry.track(handle);
+      binder.bind(streamId, executionId, explicit.host);
+
+      releaseSource.release(streamId);
+
+      expect(binder.unbind(streamId, executionId)).toBe(false);
+    } finally {
+      binder.dispose();
+      registry.dispose();
+    }
+  });
+
+  it('unregisters the release observer when disposed', () => {
+    const registry = new ExecutionRegistry();
+    const releaseSource = createReleaseSource();
+    const explicit = createRecordingHost();
+    const binder = new ExecutionSubscriptionBinder({
+      registry,
+      releaseSource: releaseSource.source,
+      logger: createLogger(),
+    });
+    const executionId = 'exec-subscription-dispose-test';
+    const handle = new AgentExecutionHandle(
+      executionId,
+      streamId,
+      childStreamId,
+      'search',
+      'toolUse',
+      explicit.host,
+    );
+
+    try {
+      registry.track(handle);
+      binder.bind(streamId, executionId, explicit.host);
+
+      expect(releaseSource.hasObserver()).toBe(true);
+      binder.dispose();
+
+      expect(releaseSource.hasObserver()).toBe(false);
+      expect(binder.unbind(streamId, executionId)).toBe(false);
+    } finally {
+      registry.dispose();
+    }
+  });
+});

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -31,10 +31,7 @@ import {
   ProcessExecutionHandle,
   executionRegistry,
 } from '@agent/runtime/executionRegistry';
-import {
-  bindExecutionSubscription,
-  unbindExecutionSubscription,
-} from '@agent/runtime/ExecutionSubscriptionBinder';
+import { executionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
 import { onFollowUpSent } from '@agent/toolUse/ToolUseFollowUp';
 
 // Local imports - utils
@@ -667,7 +664,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       );
     }
     try {
-      bindExecutionSubscription(streamId, executionId, ctx.runtimeHost);
+      executionSubscriptionBinder.bind(streamId, executionId, ctx.runtimeHost);
     } catch (err) {
       throw new ToolError(toErrorMessage(err));
     }
@@ -684,7 +681,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         'unsubscribe must be called from within an agent stream.',
       );
     }
-    const removed = unbindExecutionSubscription(streamId, executionId);
+    const removed = executionSubscriptionBinder.unbind(streamId, executionId);
     return {
       output: removed
         ? `Unsubscribed from ${executionId}.`


### PR DESCRIPTION
## Summary
- move execution subscription state from module-level `perStream` / release-hook globals into an instantiable `ExecutionSubscriptionBinder`
- replace the free `bindExecutionSubscription` / `unbindExecutionSubscription` functions with the binder singleton used by `ExecutionsTool`
- add focused binder lifecycle coverage for bind/unbind, follow-up queue release cleanup, and owner disposal

## Design note
This is another narrow Step 7 groundwork slice for #4737. It does not relocate all runtime state to an `AgentRun` handle yet, but it makes one more hidden runtime owner explicit and testable without preserving pass-through wrappers.

## Validation
- `corepack pnpm vitest run src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/runCoordinators.vitest.ts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving structural refactor with new unit tests; subscribe/unsubscribe paths unchanged aside from calling the binder singleton.
> 
> **Overview**
> **Execution subscription state** moves from module-level `perStream` and a one-shot release hook into an **`ExecutionSubscriptionBinder`** class with injectable registry, follow-up queue release source, and logger. **`bind` / `unbind`** replace the former free functions; **`dispose`** tears down the release observer and all bound subscriptions.
> 
> **`ExecutionsTool`** now calls the exported **`executionSubscriptionBinder`** singleton instead of importing bind/unbind helpers. **`ExecutionSubscription`** cleanup uses an **`onDisposed`** callback instead of reaching into global maps.
> 
> New **Vitest** coverage exercises duplicate bind idempotency, queue-release cleanup, and binder disposal unregistering the release observer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8179ade8cf83395e795427f7b68044e0397b484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->