### PR TITLE
fix: cap CLI slash form width

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -10,7 +10,11 @@ import { agentName } from '@shared/schemas/agent';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
-import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
+import {
+  CompactFormKeyHints,
+  FormFrame,
+  formFrameWidth,
+} from './_shared/FormFrame';
 import {
   computeSelectWindowSize,
   isCompactFormRows,
@@ -32,16 +36,6 @@ interface AgentGroups {
 
 type AgentIdentity = Pick<AgentOptionData, 'label' | 'value'>;
 type AgentDelegationFlag = Pick<AgentOptionData, 'isOrchestrator'>;
-
-const AGENT_FORM_MAX_WIDTH = 80;
-
-export function agentFormWidth(columns: number | undefined): number {
-  const normalized =
-    columns != null && Number.isFinite(columns) && columns > 0
-      ? Math.floor(columns)
-      : AGENT_FORM_MAX_WIDTH;
-  return Math.max(1, Math.min(normalized, AGENT_FORM_MAX_WIDTH));
-}
 
 function agentDescription(agent: AgentOptionData): string {
   const source = agent.isRemote
@@ -258,7 +252,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
       borderColor="cyan"
       flexDirection="column"
       paddingX={1}
-      width={agentFormWidth(columns)}
+      width={formFrameWidth(columns)}
     >
       <Text bold color="cyan">
         /agent

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -145,15 +145,11 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
   }
 
   return (
-    <Box
-      borderStyle="round"
-      borderColor="cyan"
-      flexDirection="column"
-      paddingX={1}
+    <FormFrame
+      color="cyan"
+      title={`/model · ${formatCliApiMode(props.apiMode)}`}
+      showCloseHint={false}
     >
-      <Text bold color="cyan">
-        {`/model · ${formatCliApiMode(props.apiMode)}`}
-      </Text>
       <Text dimColor>{description}</Text>
       {items.length === 0 ? (
         <EmptyModelListState
@@ -200,6 +196,6 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
           />
         )}
       </Box>
-    </Box>
+    </FormFrame>
   );
 }

--- a/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
@@ -2,7 +2,7 @@
 // empty). Replaces the per-form `XFrame` wrappers that all rendered the same
 // bordered column with a colored title and an `Esc close` footer.
 
-import { Box, Text } from 'ink';
+import { Box, Text, useWindowSize } from 'ink';
 
 import { KeyHints, type KeyHint } from '@cli/chat/tui/ui/KeyHints';
 
@@ -17,13 +17,26 @@ export interface FormFrameProps {
   readonly showCloseHint?: boolean;
 }
 
+const FORM_FRAME_MAX_WIDTH = 80;
+
+export function formFrameWidth(columns: number | undefined): number {
+  const normalized =
+    columns != null && Number.isFinite(columns) && columns > 0
+      ? Math.floor(columns)
+      : FORM_FRAME_MAX_WIDTH;
+  return Math.max(1, Math.min(normalized, FORM_FRAME_MAX_WIDTH));
+}
+
 export function FormFrame(props: FormFrameProps): React.JSX.Element {
+  const { columns } = useWindowSize();
+
   return (
     <Box
       borderStyle="round"
       borderColor={props.color}
       flexDirection="column"
       paddingX={1}
+      width={formFrameWidth(columns)}
     >
       <Text bold color={props.color}>
         {props.title}

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  agentFormWidth,
   agentPickerPrimarySectionTitle,
   agentSelectWindow,
   currentVisibleAgent,
   hiddenCurrentAgentHint,
 } from '@cli/chat/tui/forms/AgentListForm';
+import { formFrameWidth } from '@cli/chat/tui/forms/_shared/FormFrame';
 
 describe('CLI AgentListForm row budget', () => {
   const visibleAgents = [
@@ -15,9 +15,9 @@ describe('CLI AgentListForm row budget', () => {
   ];
 
   it('clamps the regular form width to the terminal columns', () => {
-    expect(agentFormWidth(120)).toBe(80);
-    expect(agentFormWidth(80)).toBe(80);
-    expect(agentFormWidth(60)).toBe(60);
+    expect(formFrameWidth(120)).toBe(80);
+    expect(formFrameWidth(80)).toBe(80);
+    expect(formFrameWidth(60)).toBe(60);
   });
 
   it('resolves the current visible agent from bare names or canonical keys', () => {


### PR DESCRIPTION
## Summary

- Move the 80-column slash-form width contract into the shared FormFrame
- Reuse that shared frame for the normal /model panel instead of hand-rolling its border
- Point /agent at the same shared width helper instead of keeping its own duplicate helper

Closes #5489.

## Dogfood evidence

Built the CLI and resumed a real TTY session with:

    TERM=xterm-256color node packages/cli/dist/bin/texra.js --cwd /private/tmp/texra-cli-play --resume f6ef5b84beab

Opening /model now renders the picker inside a capped frame; long disabled reasons truncate within the row instead of crowding the right edge.

## Verification

- corepack pnpm vitest run src/test-kernel/cli/AgentListForm.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts
- corepack pnpm --filter @texra-ai/cli run build
- npm run lint (passes with existing import-order warnings)