### PR TITLE
refactor: own stream status state

### DIFF
--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -10,9 +10,6 @@ import {
   type StreamStatus,
 } from '@shared/schemas';
 
-const statusMemory = new Map<StreamTabId, StreamStatus>();
-const statusListeners = new Set<(change: StreamStatusChange) => void>();
-
 export interface StreamStatusChange {
   streamId: StreamTabId;
   status: StreamStatus;
@@ -34,32 +31,37 @@ interface SilentSetOptions {
 
 type SetOptions = EmitSetOptions | SilentSetOptions;
 
-export const StreamStatusService = {
+export class StreamStatusRegistry {
+  private readonly statusMemory = new Map<StreamTabId, StreamStatus>();
+  private readonly statusListeners = new Set<
+    (change: StreamStatusChange) => void
+  >();
+
   get(stream: StreamTabId): StreamStatus | undefined {
-    return statusMemory.get(stream);
-  },
+    return this.statusMemory.get(stream);
+  }
 
   tryAcquire(stream: StreamTabId, options: SetOptions): boolean {
-    if (isInFlightStatus(statusMemory.get(stream))) {
+    if (isInFlightStatus(this.statusMemory.get(stream))) {
       return false;
     }
     this.set(stream, STREAM_STATUS.INITIALIZING, options);
     return true;
-  },
+  }
 
   releaseIfInitializing(stream: StreamTabId, options: SetOptions): void {
-    if (statusMemory.get(stream) === STREAM_STATUS.INITIALIZING) {
+    if (this.statusMemory.get(stream) === STREAM_STATUS.INITIALIZING) {
       this.clear(stream, options);
     }
-  },
+  }
 
   set(stream: StreamTabId, status: StreamStatus, options: SetOptions): void {
-    const previousStatus = statusMemory.get(stream) ?? STREAM_STATUS.READY;
+    const previousStatus = this.statusMemory.get(stream) ?? STREAM_STATUS.READY;
 
     if (status === STREAM_STATUS.READY) {
-      statusMemory.delete(stream);
+      this.statusMemory.delete(stream);
     } else {
-      statusMemory.set(stream, status);
+      this.statusMemory.set(stream, status);
     }
 
     if (options.emit !== false) {
@@ -72,48 +74,50 @@ export const StreamStatusService = {
           : {}),
       };
       options.runtimeHost.emit('updateStreamStatus', change);
-      for (const listener of statusListeners) {
+      for (const listener of this.statusListeners) {
         listener(change);
       }
     }
-  },
+  }
 
   clear(stream: StreamTabId, options: SetOptions): void {
     this.set(stream, STREAM_STATUS.READY, options);
-  },
+  }
 
   /** Reset every stream to READY. Used by ProgressViewState.clearAll(). */
   clearAll(options: SetOptions): void {
-    for (const stream of [...statusMemory.keys()]) {
+    for (const stream of [...this.statusMemory.keys()]) {
       this.clear(stream, options);
     }
-  },
+  }
 
   entries(): IterableIterator<[StreamTabId, StreamStatus]> {
-    return statusMemory.entries();
-  },
+    return this.statusMemory.entries();
+  }
 
   getAll(): Map<StreamTabId, StreamStatus> {
-    return new Map(statusMemory);
-  },
+    return new Map(this.statusMemory);
+  }
 
   has(stream: StreamTabId): boolean {
-    return statusMemory.has(stream);
-  },
+    return this.statusMemory.has(stream);
+  }
 
   isActiveOrResuming(stream: StreamTabId): boolean {
-    return isActiveStatus(statusMemory.get(stream));
-  },
+    return isActiveStatus(this.statusMemory.get(stream));
+  }
 
   shouldPreserveOnCompletion(stream: StreamTabId): boolean {
-    const status = statusMemory.get(stream);
+    const status = this.statusMemory.get(stream);
     return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.STOPPED;
-  },
+  }
 
   onDidChange(listener: (change: StreamStatusChange) => void): () => void {
-    statusListeners.add(listener);
+    this.statusListeners.add(listener);
     return () => {
-      statusListeners.delete(listener);
+      this.statusListeners.delete(listener);
     };
-  },
-};
+  }
+}
+
+export const StreamStatusService = new StreamStatusRegistry();

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -6,7 +6,10 @@
  */
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  StreamStatusService,
+  type StreamStatusRegistry,
+} from '@agent/runtime/StreamStatusService';
 import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 import {
   type ExecutionHandle,
@@ -47,29 +50,27 @@ export class ExecutionRegistry {
     Set<(handle: ExecutionHandle | undefined) => void>
   >();
 
-  constructor() {
+  constructor(streamStatus: StreamStatusRegistry = StreamStatusService) {
     // Notify waiters and refresh UI badges when stream status changes
     // (e.g. RUNNING → WAITING). Without this, waitForChange only resolves
     // on progress/kill/untrack, and the background-tasks panel shows stale badges.
-    this.disposeStatusListener = StreamStatusService.onDidChange(
-      ({ streamId }) => {
-        for (const [executionId, handle] of this.handles) {
-          if (
-            handle instanceof AgentExecutionHandle &&
-            handle.childStreamId === streamId
-          ) {
-            this.notifyWaiters(executionId);
-            if (handle.parentStreamId !== handle.childStreamId) {
-              this.emitActiveSubagentsUpdate(
-                handle.parentStreamId,
-                handle.runtimeHost,
-              );
-            }
-            break;
+    this.disposeStatusListener = streamStatus.onDidChange(({ streamId }) => {
+      for (const [executionId, handle] of this.handles) {
+        if (
+          handle instanceof AgentExecutionHandle &&
+          handle.childStreamId === streamId
+        ) {
+          this.notifyWaiters(executionId);
+          if (handle.parentStreamId !== handle.childStreamId) {
+            this.emitActiveSubagentsUpdate(
+              handle.parentStreamId,
+              handle.runtimeHost,
+            );
           }
+          break;
         }
-      },
-    );
+      }
+    });
   }
 
   dispose(): void {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -6,7 +6,7 @@ import {
   AgentExecutionHandle,
   ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -97,7 +97,8 @@ describe('executionRegistry', () => {
 
   it('detaches its stream-status listener when disposed', () => {
     const explicit = createRecordingHost();
-    const registry = new ExecutionRegistry();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry(streamStatus);
     const executionId = 'exec-dispose-runtime-host-test';
     const parentStreamId = 'parent-dispose-runtime-host-test' as StreamTabId;
     const childStreamId = 'child-dispose-runtime-host-test' as StreamTabId;
@@ -115,7 +116,7 @@ describe('executionRegistry', () => {
     registry.dispose();
     explicit.events.length = 0;
 
-    StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
+    streamStatus.set(childStreamId, STREAM_STATUS.WAITING, {
       runtimeHost: explicit.host,
     });
 

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -1,0 +1,39 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+describe('StreamStatusRegistry', () => {
+  it('keeps stream status state per instance', () => {
+    const first = new StreamStatusRegistry();
+    const second = new StreamStatusRegistry();
+    const streamId = 'stream-status-instance-test' as StreamTabId;
+
+    first.set(streamId, STREAM_STATUS.WAITING, { emit: false });
+
+    expect(first.get(streamId)).toBe(STREAM_STATUS.WAITING);
+    expect(second.get(streamId)).toBeUndefined();
+  });
+
+  it('keeps listeners per instance', () => {
+    const first = new StreamStatusRegistry();
+    const second = new StreamStatusRegistry();
+    const explicit = createRecordingHost();
+    const streamId = 'stream-status-listener-test' as StreamTabId;
+    const changes: string[] = [];
+
+    first.onDidChange((change) => changes.push(change.streamId));
+    second.set(streamId, STREAM_STATUS.WAITING, {
+      runtimeHost: explicit.host,
+    });
+
+    expect(changes).toEqual([]);
+    expect(explicit.events.map((entry) => entry.event)).toEqual([
+      'updateStreamStatus',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Convert StreamStatusService from a module-closure object into an exported StreamStatusRegistry owner plus the existing shared singleton
- Let ExecutionRegistry subscribe to an injected status owner, keeping existing callers on the shared singleton
- Add focused tests proving separate status owners do not share state or listeners

Closes #5491.
Contributes to #4737 Step 7.

## Design note

This keeps the current public singleton stable while moving the mutable map and listener set out of hidden module state. It does not add pass-through wrappers or start a broad call-site rewrite.

## Verification

- corepack pnpm vitest run src/test-kernel/agent/runtime/StreamStatusService.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings)
- npm run compile:fast
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving structural refactor with the same public singleton; limited to runtime status wiring and tests.
> 
> **Overview**
> Refactors stream status from **hidden module-level maps and listener sets** into an explicit **`StreamStatusRegistry` class** that owns that mutable state per instance. The existing **`StreamStatusService` export remains a shared singleton**, so current call sites keep the same entry point without a broad rewrite.
> 
> **`ExecutionRegistry`** now takes an optional **`StreamStatusRegistry`** (defaulting to the singleton) for its stream-status subscription, so tests can use an isolated owner instead of mutating global module state.
> 
> Adds focused tests that **separate registry instances do not share status or `onDidChange` listeners**, and updates the dispose test to prove **`ExecutionRegistry` stops reacting** after teardown when using an injected registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 582e9c2539ea22c6db6e4ed7614d62532481ff71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->