### PR TITLE
refactor: own proposal bypass state

### DIFF
--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -104,7 +104,7 @@ The runtime has 7 user-facing gates today (Electron PRD §9 #18 inventory + scou
 | Agent proposal (delegation) | `AgentProposalCoordinator`                                          | **Fully host-neutral.**                    | Same pattern                                                             |
 | Retry request               | `RetryRequestCoordinator`                                           | **Fully host-neutral.**                    | Same pattern                                                             |
 | External inquiry            | `awaitExternalInquiryResponse` + `showExternalInquiry` event        | Coordinator yes                            | CLI prompts on stderr + reads stdin                                      |
-| Proposal bypass (YOLO)      | `toggleProposalBypass`, per-stream                                  | Pure state                                 | CLI exposes via `--yolo` / `--allow-delegation` flags                    |
+| Proposal bypass (YOLO)      | `proposalApprovalState.toggleBypass`, per-stream                    | Pure state                                 | CLI exposes via `--yolo` / `--allow-delegation` flags                    |
 
 The current approval _config_ is binary: `texra.toolUse.requireEditApproval` and `texra.toolUse.requireBashApproval` are bool. CI usage demands richer policies — see §9.
 
@@ -1056,19 +1056,19 @@ Things explicitly out of scope for v1.
 
 From the parallel scout:
 
-| Metric                                                          | Value                                                                                                                                                                       |
-| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Total TS files in `src/` (today, pre-monorepo-split)            | 853                                                                                                                                                                         |
-| Files importing `vscode` reachable from `executeAgent()`        | **0**                                                                                                                                                                       |
-| Platform interface LOC                                          | ~470                                                                                                                                                                        |
-| Existing Node-default platform impls (`src/platform/defaults/`) | ~462 LOC across 6 files                                                                                                                                                     |
-| Of which CLI reuses byte-for-byte                               | 5 of 6 (`consoleLog`, `memoryState`, `nodeFilesystem`, `nodeStorage`, `nodeWorkspace`); `EnvSecrets` is replaced by `KeyringSecrets`                                        |
-| New CLI-side platform adapters needed                           | 2 (`ConfConfigProvider`, `KeyringSecrets`) at ~180 LOC combined                                                                                                             |
-| Tool surfaces fully reused (no CLI shim)                        | 14 of the 16 listed in §4.2 (every entry except the 2 explicitly marked as needing a CLI handler)                                                                           |
-| Approval gates fully host-neutral today                         | 5 of 7 (3 standalone `BasePromiseCoordinator`s — plan, proposal, retry — plus the `awaitExternalInquiryResponse` event pattern and the `toggleProposalBypass` state toggle) |
-| Approval gates needing CLI-specific settle path                 | 2 of 7 (edit, bash — both have host-neutral controllers; the _handler_ is what's host-specific)                                                                             |
-| Approval gates needing CLI-specific handler                     | 2 (edit, bash)                                                                                                                                                              |
-| Pre-refactorings still required in `core/`                      | 6 small items (~430 LOC + a server-side edge function)                                                                                                                      |
+| Metric                                                          | Value                                                                                                                                                                        |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Total TS files in `src/` (today, pre-monorepo-split)            | 853                                                                                                                                                                          |
+| Files importing `vscode` reachable from `executeAgent()`        | **0**                                                                                                                                                                        |
+| Platform interface LOC                                          | ~470                                                                                                                                                                         |
+| Existing Node-default platform impls (`src/platform/defaults/`) | ~462 LOC across 6 files                                                                                                                                                      |
+| Of which CLI reuses byte-for-byte                               | 5 of 6 (`consoleLog`, `memoryState`, `nodeFilesystem`, `nodeStorage`, `nodeWorkspace`); `EnvSecrets` is replaced by `KeyringSecrets`                                         |
+| New CLI-side platform adapters needed                           | 2 (`ConfConfigProvider`, `KeyringSecrets`) at ~180 LOC combined                                                                                                              |
+| Tool surfaces fully reused (no CLI shim)                        | 14 of the 16 listed in §4.2 (every entry except the 2 explicitly marked as needing a CLI handler)                                                                            |
+| Approval gates fully host-neutral today                         | 5 of 7 (3 standalone `BasePromiseCoordinator`s — plan, proposal, retry — plus the `awaitExternalInquiryResponse` event pattern and the `proposalApprovalState` state toggle) |
+| Approval gates needing CLI-specific settle path                 | 2 of 7 (edit, bash — both have host-neutral controllers; the _handler_ is what's host-specific)                                                                              |
+| Approval gates needing CLI-specific handler                     | 2 (edit, bash)                                                                                                                                                               |
+| Pre-refactorings still required in `core/`                      | 6 small items (~430 LOC + a server-side edge function)                                                                                                                       |
 
 ### 19.1 Effort-by-the-numbers (LOC budget)
 

--- a/src/controllers/progressView/ProgressViewBypassCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewBypassCommandHandlers.ts
@@ -4,9 +4,9 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import {
   isApprovalBypassedForStream,
+  proposalApprovalState,
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
-  toggleProposalBypass,
   toggleToolEditApprovalSessionBypass,
 } from '@tools/approval';
 
@@ -43,7 +43,10 @@ export function createProgressViewBypassCommandHandlers(
       );
     },
     [PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS]: async (data) => {
-      const isNowEnabled = toggleProposalBypass(data.stream, runtimeHost);
+      const isNowEnabled = proposalApprovalState.toggleBypass(
+        data.stream,
+        runtimeHost,
+      );
       if (isNowEnabled) {
         if (!isApprovalBypassedForStream(data.stream)) {
           setToolEditApprovalSessionBypass(data.stream, true, runtimeHost);

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -28,7 +28,7 @@ import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
 import { OdysseyStore, isOdysseyInFlight } from '@tools/odyssey';
 import {
   isApprovalBypassedForStream,
-  isProposalBypassedForStream,
+  proposalApprovalState,
 } from '@tools/approval';
 
 import { registerHandlers } from './registerHandlers';
@@ -510,7 +510,7 @@ export class ProgressEventHandler {
 
     // Always include toggle bypass state so buttons render correctly on tab switch.
     const toolEditBypass = isApprovalBypassedForStream(stream);
-    const superYoloBypass = isProposalBypassedForStream(stream);
+    const superYoloBypass = proposalApprovalState.isBypassed(stream);
     const odyssey = OdysseyStore.getForStream(stream);
     const odysseyActive = isOdysseyInFlight(odyssey);
 

--- a/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
@@ -11,9 +11,9 @@ import {
 } from '@tools/userQuestion';
 import {
   cleanupAllApprovals,
+  proposalApprovalState,
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
-  toggleProposalBypass,
   toggleBashApprovalSessionBypass,
   toggleToolEditApprovalSessionBypass,
 } from '@tools/approval';
@@ -269,7 +269,7 @@ describe('human prompt progress events', () => {
     const explicit = createRecordingHost();
     const streamId = 'stream:proposal-bypass' as StreamTabId;
 
-    const enabled = toggleProposalBypass(streamId, explicit.host);
+    const enabled = proposalApprovalState.toggleBypass(streamId, explicit.host);
 
     expect(enabled).toBe(true);
     expect(explicit.events).toEqual([

--- a/src/test-kernel/controllers/ProgressViewBypassCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewBypassCommandHandlers.vitest.ts
@@ -10,7 +10,7 @@ import {
   cleanupAllApprovals,
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
-  isProposalBypassedForStream,
+  proposalApprovalState,
 } from '@tools/approval';
 
 function createRecordingRuntimeHost(): {
@@ -104,7 +104,7 @@ describe('createProgressViewBypassCommandHandlers', () => {
     ).toBe(true);
     await Promise.resolve();
 
-    expect(isProposalBypassedForStream(stream)).toBe(true);
+    expect(proposalApprovalState.isBypassed(stream)).toBe(true);
     expect(isApprovalBypassedForStream(stream)).toBe(true);
     expect(isBashApprovalBypassedForStream(stream)).toBe(true);
     expect(events).toEqual([
@@ -132,7 +132,7 @@ describe('createProgressViewBypassCommandHandlers', () => {
     ).toBe(true);
     await Promise.resolve();
 
-    expect(isProposalBypassedForStream(stream)).toBe(false);
+    expect(proposalApprovalState.isBypassed(stream)).toBe(false);
     expect(isApprovalBypassedForStream(stream)).toBe(false);
     expect(isBashApprovalBypassedForStream(stream)).toBe(false);
     expect(events.slice(-2)).toEqual([

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   getExecutionStore: vi.fn(),
   getVisibleAgents: vi.fn(),
   isApprovalBypassedForStream: vi.fn(),
-  isProposalBypassedForStream: vi.fn(),
+  isProposalBypassed: vi.fn(),
   registerExecution: vi.fn(),
   writeReport: vi.fn(),
   computeModelOptionsData: vi.fn(),
@@ -45,7 +45,9 @@ vi.mock('@tools/approval', () => ({
   enableYoloOnChildStream: mocks.enableYoloOnChildStream,
   inheritBashBypassOnChildStream: mocks.inheritBashBypassOnChildStream,
   isApprovalBypassedForStream: mocks.isApprovalBypassedForStream,
-  isProposalBypassedForStream: mocks.isProposalBypassedForStream,
+  proposalApprovalState: {
+    isBypassed: mocks.isProposalBypassed,
+  },
 }));
 
 function runtimeHost() {
@@ -70,7 +72,7 @@ describe('headless delegation', () => {
         requiresKey: false,
       },
     ]);
-    mocks.isProposalBypassedForStream.mockReturnValue(true);
+    mocks.isProposalBypassed.mockReturnValue(true);
     mocks.isApprovalBypassedForStream.mockReturnValue(false);
     mocks.registerExecution.mockResolvedValue(undefined);
     mocks.writeReport.mockResolvedValue(undefined);

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -60,8 +60,8 @@ import { formatBytes } from '@shared/utils/string';
 // Local imports - tools
 import type { ToolResult } from '@tools/result';
 import {
-  isProposalBypassedForStream,
   isApprovalBypassedForStream,
+  proposalApprovalState,
   enableYoloOnChildStream,
   inheritBashBypassOnChildStream,
 } from '@tools/approval';
@@ -711,7 +711,7 @@ async function proposeAndExecute(
   agentName: string,
   streamId: StreamTabId,
 ): Promise<ToolResult> {
-  if (isProposalBypassedForStream(streamId)) {
+  if (proposalApprovalState.isBypassed(streamId)) {
     return executeSubagent(toConfigPayload(proposal), agentName, streamId, {
       enableYoloOnChild: true,
       approvalMeta: { autoApproved: true },

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -15,10 +15,7 @@ import {
 } from '@tools/userQuestion';
 
 import { bashApprovalController } from './bashApproval';
-import {
-  _clearAllProposalBypass,
-  _clearProposalBypassForStream,
-} from './proposalApproval';
+import { proposalApprovalState } from './proposalApproval';
 import {
   toolEditApprovalController,
   enableYoloOnChildStream,
@@ -35,7 +32,7 @@ export function cleanupApprovalsForStream(streamId: StreamTabId): void {
   _rejectPendingUserQuestionsForStream(streamId);
   toolEditApprovalController.clearBypassForStream(streamId);
   bashApprovalController.clearBypassForStream(streamId);
-  _clearProposalBypassForStream(streamId);
+  proposalApprovalState.clearForStream(streamId);
   runCoordinatorBridge.cleanupRequestsForStream(streamId);
 }
 
@@ -49,7 +46,7 @@ export function cleanupAllApprovals(): void {
   _rejectAllPendingUserQuestions();
   toolEditApprovalController.clearAllBypass();
   bashApprovalController.clearAllBypass();
-  _clearAllProposalBypass();
+  proposalApprovalState.clearAll();
   runCoordinatorBridge.cleanupAllRequests();
 }
 
@@ -73,8 +70,7 @@ export {
 
 export {
   // Proposal approval
-  toggleProposalBypass,
-  isProposalBypassedForStream,
+  proposalApprovalState,
 } from './proposalApproval';
 
 export {

--- a/src/tools/approval/proposalApproval.ts
+++ b/src/tools/approval/proposalApproval.ts
@@ -1,41 +1,40 @@
-/** Per-stream bypass state for agent delegation proposals. */
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
-const bypassedByStream = new Map<StreamTabId, boolean>();
+/** Owns per-stream bypass state for agent delegation proposals. */
+export class ProposalApprovalState {
+  private readonly bypassedByStream = new Map<StreamTabId, boolean>();
 
-function notifyBypassState(
-  streamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  runtimeHost.emit('updateSuperYoloBypassState', {
-    streamId,
-    bypassActive: bypassedByStream.get(streamId) ?? false,
-  });
+  /** Toggle per-stream proposal bypass. Returns new state. */
+  toggleBypass(streamId: StreamTabId, runtimeHost: AgentRuntimeHost): boolean {
+    const next = !this.isBypassed(streamId);
+    this.bypassedByStream.set(streamId, next);
+    this.notifyBypassState(streamId, runtimeHost);
+    return next;
+  }
+
+  /** Check if proposals are bypassed for a specific stream. */
+  isBypassed(streamId: StreamTabId): boolean {
+    return this.bypassedByStream.get(streamId) ?? false;
+  }
+
+  clearForStream(streamId: StreamTabId): void {
+    this.bypassedByStream.delete(streamId);
+  }
+
+  clearAll(): void {
+    this.bypassedByStream.clear();
+  }
+
+  private notifyBypassState(
+    streamId: StreamTabId,
+    runtimeHost: AgentRuntimeHost,
+  ): void {
+    runtimeHost.emit('updateSuperYoloBypassState', {
+      streamId,
+      bypassActive: this.isBypassed(streamId),
+    });
+  }
 }
 
-/** Toggle per-stream proposal bypass. Returns new state. */
-export function toggleProposalBypass(
-  streamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
-): boolean {
-  const newState = !(bypassedByStream.get(streamId) ?? false);
-  bypassedByStream.set(streamId, newState);
-  notifyBypassState(streamId, runtimeHost);
-  return newState;
-}
-
-/** Check if proposals are bypassed for a specific stream. */
-export function isProposalBypassedForStream(streamId: StreamTabId): boolean {
-  return bypassedByStream.get(streamId) ?? false;
-}
-
-/** @internal Called by unified cleanup in index.ts */
-export function _clearProposalBypassForStream(streamId: StreamTabId): void {
-  bypassedByStream.delete(streamId);
-}
-
-/** @internal Called by unified cleanup in index.ts */
-export function _clearAllProposalBypass(): void {
-  bypassedByStream.clear();
-}
+export const proposalApprovalState = new ProposalApprovalState();

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -31,7 +31,7 @@ import {
   countByStatus,
   type Plan,
 } from '@shared/schemas';
-import { isProposalBypassedForStream } from '@tools/approval';
+import { proposalApprovalState } from '@tools/approval';
 import {
   ODYSSEY_FEATURE_FLAG_KEY,
   OdysseyStore,
@@ -206,7 +206,7 @@ Best practices:
         logger.warn(
           'New plan created without streamId — skipping approval gate',
         );
-      } else if (isProposalBypassedForStream(runContext.streamId)) {
+      } else if (proposalApprovalState.isBypassed(runContext.streamId)) {
         logger.info('Plan auto-approved via delegated-task auto-approval');
         return this.buildApprovedResult({
           autoApproved: true,


### PR DESCRIPTION
## Summary

- Move delegated-task proposal bypass state into a ProposalApprovalState owner.
- Update progress-view, plan, and delegation callers to use the owner directly.
- Remove the old toggle/query/cleanup helper exports instead of keeping pass-through wrappers.
- Keep existing per-stream toggle, cleanup, and updateSuperYoloBypassState behavior.

Closes #5495.
Contributes to #4737 and CLI approval usability cleanup.

## Verification

- corepack pnpm vitest run src/test-kernel/controllers/ProgressViewBypassCommandHandlers.vitest.ts src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts src/test-kernel/tools/DelegationHeadless.vitest.mts
- git diff --check
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of per-stream bypass state and cleanup; risk is limited to missed call-site updates, which tests cover.
> 
> **Overview**
> Refactors **delegation proposal bypass** (“super YOLO”) from loose module helpers into a **`ProposalApprovalState`** owner exposed as **`proposalApprovalState`**, with **`toggleBypass`**, **`isBypassed`**, and stream/global cleanup methods.
> 
> Callers in progress-view bypass commands, progress sync, **`DelegationTools`**, **`PlanTool`**, and unified approval cleanup now use the owner directly. The public **`@tools/approval`** barrel drops **`toggleProposalBypass`**, **`isProposalBypassedForStream`**, and internal **`_clear*`** helpers in favor of exporting **`proposalApprovalState`** only. Tests and the CLI PRD gate inventory are updated to match the new API; per-stream toggle behavior and **`updateSuperYoloBypassState`** emissions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c7fbf48f609e8a52fd0f95a9cf3144a937aa41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->