### PR TITLE
refactor: own runtime feature registries

### DIFF
--- a/src/agent/features/registerMemory.ts
+++ b/src/agent/features/registerMemory.ts
@@ -1,9 +1,9 @@
 import { platform } from '@platform/platform';
-import { registerToolInjection } from '@agent/runtime/toolInjection';
+import { toolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 export function registerMemoryFeature(): void {
-  registerToolInjection({
+  toolInjectionRegistry.register({
     toolName: 'memory',
     shouldInject: () =>
       platform().globalState.get<boolean>(GlobalStateKey.MEMORY_ENABLED, true),

--- a/src/agent/features/registerOdyssey.ts
+++ b/src/agent/features/registerOdyssey.ts
@@ -1,7 +1,7 @@
 import { platform } from '@platform/platform';
 import { maybeBuildOdysseyContinuation } from '@agent/odyssey';
-import { registerIdleContinuation } from '@agent/runtime/idleContinuation';
-import { registerToolInjection } from '@agent/runtime/toolInjection';
+import { idleContinuationRegistry } from '@agent/runtime/idleContinuation';
+import { toolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { ODYSSEY_FEATURE_FLAG_KEY } from '@tools/odyssey/odysseyMeta';
 import { OdysseyStore } from '@tools/odyssey/odysseyStore';
 
@@ -10,13 +10,13 @@ export function registerOdysseyFeature(): void {
   // (update / pause / complete). Auto-inject it when the experimental odyssey
   // flag is on so any tool-use agent can drive the autonomous loop without
   // having to opt into the tool in YAML.
-  registerToolInjection({
+  toolInjectionRegistry.register({
     toolName: 'plan',
     shouldInject: () =>
       platform().config.get<boolean>(ODYSSEY_FEATURE_FLAG_KEY, false),
   });
 
-  registerIdleContinuation({
+  idleContinuationRegistry.register({
     source: 'odyssey',
     async build(ctx) {
       const followUp = await maybeBuildOdysseyContinuation(ctx);

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -1,6 +1,7 @@
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
+import type { IdleContinuationRegistry } from '@agent/runtime/idleContinuation';
 import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
@@ -34,6 +35,7 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly stopAfterCycle?: boolean;
   /** Persist todos to the execution KV store. Injected by runToolUseFlow. */
   readonly persistTodos?: (todos: TodoItem[]) => Promise<void>;
+  readonly idleContinuations: IdleContinuationRegistry;
   /** True when this agent was launched as a subagent by an orchestrator. */
   readonly isSubagent?: boolean;
   /**

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -1,7 +1,6 @@
 import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { listIdleContinuationProviders } from '@agent/runtime/idleContinuation';
 import {
   countMediaFilesNeedingVision,
   formatMediaNeedsVisionWarning,
@@ -100,7 +99,7 @@ export class ToolUseWaitNode<C> extends Node<
     // arrived during the build win the race; providers do their persistent
     // side effects in `commit()` so a loser leaves no audit trace.
     if (!prepRes.afterError) {
-      for (const provider of listIdleContinuationProviders()) {
+      for (const provider of this.services.idleContinuations.list()) {
         const continuation = await provider.build({
           streamId,
           isSubagent: !!isSubagent,

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -2,6 +2,10 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { getExecutionStore } from '@agent/storage';
 import {
+  idleContinuationRegistry,
+  type IdleContinuationRegistry,
+} from '@agent/runtime/idleContinuation';
+import {
   activeModelHandlerCompatibilityKey,
   createModelHandler,
   modelHandlerCompatibilityKey,
@@ -18,6 +22,7 @@ import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
+import type { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import {
@@ -68,6 +73,10 @@ export interface RunToolUseFlowInput<
     modelHandler: ToolUseServices['modelHandler'],
     model: string,
   ) => void;
+  /** Runtime feature registry for auto-injected tools. */
+  toolInjections?: ToolInjectionRegistry;
+  /** Runtime feature registry for synthetic idle continuations. */
+  idleContinuations?: IdleContinuationRegistry;
 }
 
 export interface RunToolUseFlowResult {
@@ -124,6 +133,7 @@ export async function runToolUseFlow<C = unknown>(
     logger,
     delegationBlocked: !delegationGate.allowed,
     approvalPromptsUnavailable: input.approvalPromptsUnavailable,
+    toolInjections: input.toolInjections,
   });
 
   const kv = getExecutionStore(executionId);
@@ -138,6 +148,7 @@ export async function runToolUseFlow<C = unknown>(
     onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
     persistTodos: (todos) => kv.writeTodos(todos),
     fileService: new TaskRunFileService(executionId),
+    idleContinuations: input.idleContinuations ?? idleContinuationRegistry,
     delegationDepth,
     delegationConfig,
     delegationTrimmed,

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -37,7 +37,10 @@ import {
   withDelegationModelAvailability,
 } from '@tools/delegationModelAvailability';
 import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
-import { listToolInjections } from './toolInjection';
+import {
+  toolInjectionRegistry,
+  type ToolInjectionRegistry,
+} from './toolInjection';
 
 export interface ResolveAgentToolsInput {
   tools: AgentToolUseSetting['tools'];
@@ -48,6 +51,8 @@ export interface ResolveAgentToolsInput {
   delegationBlocked: boolean;
   /** When true, approval-gated tools are filtered out before model invocation. */
   approvalPromptsUnavailable?: boolean;
+  /** Conditional runtime tool injections. Defaults to the shared registry. */
+  toolInjections?: ToolInjectionRegistry;
 }
 
 export interface ResolvedAgentTools {
@@ -91,6 +96,7 @@ export async function resolveAgentTools({
   logger,
   delegationBlocked,
   approvalPromptsUnavailable,
+  toolInjections = toolInjectionRegistry,
 }: ResolveAgentToolsInput): Promise<ResolvedAgentTools> {
   const effectiveRegistry = registry ?? getDefaultToolRegistry();
   const disabled = getDisabledToolNames();
@@ -123,7 +129,7 @@ export async function resolveAgentTools({
     resolved.push(def);
     resolvedNames.add(def.name);
   }
-  for (const injection of listToolInjections()) {
+  for (const injection of toolInjections.list()) {
     if (!injection.shouldInject()) continue;
     if (resolvedNames.has(injection.toolName)) continue;
     if (DELEGATION_TOOLS.has(injection.toolName) && delegationBlocked) {

--- a/src/agent/runtime/idleContinuation.ts
+++ b/src/agent/runtime/idleContinuation.ts
@@ -35,22 +35,21 @@ export interface IdleContinuationProvider {
   build(ctx: IdleContinuationContext): Promise<IdleContinuation | null>;
 }
 
-const providers: IdleContinuationProvider[] = [];
+export class IdleContinuationRegistry {
+  private readonly providers: IdleContinuationProvider[] = [];
 
-export function registerIdleContinuation(
-  provider: IdleContinuationProvider,
-): void {
-  if (providers.some((p) => p.source === provider.source)) {
-    throw new Error(`Duplicate idle-continuation provider: ${provider.source}`);
+  register(provider: IdleContinuationProvider): void {
+    if (this.providers.some((p) => p.source === provider.source)) {
+      throw new Error(
+        `Duplicate idle-continuation provider: ${provider.source}`,
+      );
+    }
+    this.providers.push(provider);
   }
-  providers.push(provider);
+
+  list(): readonly IdleContinuationProvider[] {
+    return [...this.providers];
+  }
 }
 
-export function listIdleContinuationProviders(): readonly IdleContinuationProvider[] {
-  return [...providers];
-}
-
-/** Test-only — clears the registry so suites don't leak across runs. */
-export function __resetIdleContinuationRegistry(): void {
-  providers.length = 0;
-}
+export const idleContinuationRegistry = new IdleContinuationRegistry();

--- a/src/agent/runtime/toolInjection.ts
+++ b/src/agent/runtime/toolInjection.ts
@@ -14,24 +14,21 @@ export interface ConditionalToolInjection {
   shouldInject(): boolean;
 }
 
-const injections: ConditionalToolInjection[] = [];
+export class ToolInjectionRegistry {
+  private readonly injections: ConditionalToolInjection[] = [];
 
-export function registerToolInjection(
-  injection: ConditionalToolInjection,
-): void {
-  if (injections.some((i) => i.toolName === injection.toolName)) {
-    throw new Error(
-      `Duplicate conditional tool injection: ${injection.toolName}`,
-    );
+  register(injection: ConditionalToolInjection): void {
+    if (this.injections.some((i) => i.toolName === injection.toolName)) {
+      throw new Error(
+        `Duplicate conditional tool injection: ${injection.toolName}`,
+      );
+    }
+    this.injections.push(injection);
   }
-  injections.push(injection);
+
+  list(): readonly ConditionalToolInjection[] {
+    return [...this.injections];
+  }
 }
 
-export function listToolInjections(): readonly ConditionalToolInjection[] {
-  return [...injections];
-}
-
-/** Test-only — clears the registry so suites don't leak across runs. */
-export function __resetToolInjectionRegistry(): void {
-  injections.length = 0;
-}
+export const toolInjectionRegistry = new ToolInjectionRegistry();

--- a/src/test-kernel/agent/IdleContinuationRegistry.vitest.ts
+++ b/src/test-kernel/agent/IdleContinuationRegistry.vitest.ts
@@ -1,10 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
-  __resetIdleContinuationRegistry,
-  listIdleContinuationProviders,
-  registerIdleContinuation,
+  IdleContinuationRegistry,
   type IdleContinuationContext,
+  type IdleContinuationProvider,
 } from '@agent/runtime/idleContinuation';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -15,34 +14,36 @@ function emptyContext(): IdleContinuationContext {
 }
 
 describe('idle-continuation registry', () => {
+  let registry: IdleContinuationRegistry;
+
   beforeEach(() => {
-    __resetIdleContinuationRegistry();
+    registry = new IdleContinuationRegistry();
   });
 
   it('registers providers and returns them in insertion order', () => {
-    registerIdleContinuation({
+    registry.register({
       source: 'first',
       build: async () => null,
     });
-    registerIdleContinuation({
+    registry.register({
       source: 'second',
       build: async () => null,
     });
 
-    const sources = listIdleContinuationProviders().map((p) => p.source);
+    const sources = registry.list().map((p) => p.source);
     expect(sources).toEqual(['first', 'second']);
   });
 
   it('rejects duplicate `source` registrations', () => {
-    registerIdleContinuation({ source: 'dup', build: async () => null });
+    registry.register({ source: 'dup', build: async () => null });
     expect(() =>
-      registerIdleContinuation({ source: 'dup', build: async () => null }),
+      registry.register({ source: 'dup', build: async () => null }),
     ).toThrow(/Duplicate idle-continuation provider/);
   });
 
   it('lets a provider synthesize a continuation that the wait-node can commit', async () => {
     let committed = false;
-    registerIdleContinuation({
+    registry.register({
       source: 'test',
       build: async () => ({
         source: 'test',
@@ -53,10 +54,23 @@ describe('idle-continuation registry', () => {
       }),
     });
 
-    const [provider] = listIdleContinuationProviders();
+    const [provider] = registry.list();
     const result = await provider.build(emptyContext());
     expect(result?.followUp).toBe('keep going');
     await result?.commit();
     expect(committed).toBe(true);
+  });
+
+  it('keeps providers scoped to each registry instance', () => {
+    const other = new IdleContinuationRegistry();
+    const provider: IdleContinuationProvider = {
+      source: 'test',
+      build: async () => null,
+    };
+
+    registry.register(provider);
+
+    expect(registry.list()).toEqual([provider]);
+    expect(other.list()).toEqual([]);
   });
 });

--- a/src/test-kernel/agent/ToolInjectionRegistry.vitest.ts
+++ b/src/test-kernel/agent/ToolInjectionRegistry.vitest.ts
@@ -1,40 +1,54 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
-  __resetToolInjectionRegistry,
-  listToolInjections,
-  registerToolInjection,
+  ToolInjectionRegistry,
+  type ConditionalToolInjection,
 } from '@agent/runtime/toolInjection';
 
 describe('tool-injection registry', () => {
+  let registry: ToolInjectionRegistry;
+
   beforeEach(() => {
-    __resetToolInjectionRegistry();
+    registry = new ToolInjectionRegistry();
   });
 
   it('registers injections and returns them in insertion order', () => {
-    registerToolInjection({ toolName: 'memory', shouldInject: () => true });
-    registerToolInjection({ toolName: 'plan', shouldInject: () => false });
+    registry.register({ toolName: 'memory', shouldInject: () => true });
+    registry.register({ toolName: 'plan', shouldInject: () => false });
 
-    const names = listToolInjections().map((i) => i.toolName);
+    const names = registry.list().map((i) => i.toolName);
     expect(names).toEqual(['memory', 'plan']);
   });
 
   it('rejects duplicate `toolName` registrations', () => {
-    registerToolInjection({ toolName: 'memory', shouldInject: () => true });
+    registry.register({ toolName: 'memory', shouldInject: () => true });
     expect(() =>
-      registerToolInjection({ toolName: 'memory', shouldInject: () => false }),
+      registry.register({ toolName: 'memory', shouldInject: () => false }),
     ).toThrow(/Duplicate conditional tool injection/);
   });
 
   it('predicates are re-evaluated on each call (not captured at registration)', () => {
     let enabled = false;
-    registerToolInjection({
+    registry.register({
       toolName: 'memory',
       shouldInject: () => enabled,
     });
-    const [injection] = listToolInjections();
+    const [injection] = registry.list();
     expect(injection.shouldInject()).toBe(false);
     enabled = true;
     expect(injection.shouldInject()).toBe(true);
+  });
+
+  it('keeps injections scoped to each registry instance', () => {
+    const other = new ToolInjectionRegistry();
+    const injection: ConditionalToolInjection = {
+      toolName: 'memory',
+      shouldInject: () => true,
+    };
+
+    registry.register(injection);
+
+    expect(registry.list()).toEqual([injection]);
+    expect(other.list()).toEqual([]);
   });
 });

--- a/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
@@ -2,10 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
-import {
-  __resetToolInjectionRegistry,
-  registerToolInjection,
-} from '@agent/runtime/toolInjection';
+import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import type { ToolDefinition } from '@model';
 import type { ToolResult } from '@tools/result';
 
@@ -32,8 +29,10 @@ function toolDefs(names: readonly string[]): ToolDefinition[] {
 }
 
 describe('tool-use tool resolution', () => {
+  let toolInjections: ToolInjectionRegistry;
+
   beforeEach(() => {
-    __resetToolInjectionRegistry();
+    toolInjections = new ToolInjectionRegistry();
   });
 
   it('filters approval-gated tools when approval prompts are unavailable', async () => {
@@ -65,6 +64,7 @@ describe('tool-use tool resolution', () => {
       ]),
       registry,
       logger,
+      toolInjections,
       approvalPromptsUnavailable: true,
       delegationBlocked: false,
     });
@@ -96,6 +96,7 @@ describe('tool-use tool resolution', () => {
       ]),
       registry,
       logger,
+      toolInjections,
       approvalPromptsUnavailable: false,
       delegationBlocked: false,
     });
@@ -118,6 +119,7 @@ describe('tool-use tool resolution', () => {
       tools: toolDefs(['delegate_agent', 'grep']),
       registry,
       logger,
+      toolInjections,
       approvalPromptsUnavailable: false,
       delegationBlocked: true,
     });
@@ -133,6 +135,7 @@ describe('tool-use tool resolution', () => {
       tools: toolDefs(['bash', 'delegate_agent', 'grep']),
       registry,
       logger,
+      toolInjections,
       approvalPromptsUnavailable: true,
       delegationBlocked: true,
     });
@@ -143,7 +146,7 @@ describe('tool-use tool resolution', () => {
 
   it('also trims injected delegation tools by delegation depth', async () => {
     const registry = registryFor(['delegate_agent', 'grep']);
-    registerToolInjection({
+    toolInjections.register({
       toolName: 'delegate_agent',
       shouldInject: () => true,
     });
@@ -152,6 +155,7 @@ describe('tool-use tool resolution', () => {
       tools: toolDefs(['grep']),
       registry,
       logger,
+      toolInjections,
       approvalPromptsUnavailable: false,
       delegationBlocked: true,
     });
@@ -162,7 +166,7 @@ describe('tool-use tool resolution', () => {
 
   it('filters injected approval-gated tools when approval prompts are unavailable', async () => {
     const registry = registryFor(['grep', 'update_config']);
-    registerToolInjection({
+    toolInjections.register({
       toolName: 'update_config',
       shouldInject: () => true,
     });
@@ -171,6 +175,7 @@ describe('tool-use tool resolution', () => {
       tools: toolDefs(['grep']),
       registry,
       logger,
+      toolInjections,
       approvalPromptsUnavailable: true,
       delegationBlocked: false,
     });

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -6,6 +6,7 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { ToolUseWaitNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseWaitNode';
 import type { ToolUseRunShared } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
+import { IdleContinuationRegistry } from '@agent/runtime/idleContinuation';
 
 describe('ToolUseWaitNode', () => {
   it('marks a delivered subagent cycle before stopping on interruption', async () => {
@@ -19,6 +20,7 @@ describe('ToolUseWaitNode', () => {
 
     const services = {
       checkInterruption: () => interrupted,
+      idleContinuations: new IdleContinuationRegistry(),
       isSubagent: true,
       logger: { error: vi.fn() },
       modelHandler: { extractAssistantText: () => undefined },
@@ -60,6 +62,7 @@ describe('ToolUseWaitNode', () => {
 
     const services = {
       checkInterruption: () => interrupted,
+      idleContinuations: new IdleContinuationRegistry(),
       isSubagent: true,
       logger: { error: vi.fn(), info: vi.fn() },
       modelHandler: {


### PR DESCRIPTION
## Summary

- Replace hidden module arrays for tool injections and idle continuations with explicit registry owner classes.
- Keep singleton defaults for production wiring, while tests and future run-level composition can use fresh registry instances.
- Thread the registry owners through tool resolution and the tool-use wait-node service boundary.
- Remove the test-only reset exports instead of preserving pass-through compatibility wrappers.

## Design Notes

This keeps the change intentionally small: no generic registry abstraction, no behavior changes, and no extra compatibility layer. The owner objects preserve the existing duplicate-key checks and insertion-order behavior while making state ownership explicit.

## Review Fixes

- Updated `ToolUseWaitNode.vitest.ts` service mocks to provide the required idle-continuation owner.
- Removed the duplicated `toolInjectionRegistry` fallback from `runToolUseFlow`; `resolveAgentTools` owns that default.

## Verification

- `corepack pnpm vitest run src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/agent/ToolInjectionRegistry.vitest.ts src/test-kernel/agent/IdleContinuationRegistry.vitest.ts src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `rg -n "registerToolInjection|listToolInjections|__resetToolInjectionRegistry|registerIdleContinuation|listIdleContinuationProviders|__resetIdleContinuationRegistry" . -g '!node_modules' -g '!dist' -g '!out'`
- `npm run lint` (passes; existing import-order warnings only)
- `npm run compile:fast`

Closes #5497
Contributes to #4737
