### PR TITLE
refactor: resolve coordinators from execution handles

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -50,7 +50,6 @@ import {
   formatMediaNeedsVisionWarning,
   shouldWarnMediaNeedsVision,
 } from './mediaVisionWarning';
-import { runCoordinatorBridge } from './runCoordinators';
 import { getStreamTabId } from './streamTab';
 import { StreamStatusService } from './StreamStatusService';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
@@ -98,8 +97,6 @@ export async function withExecutionRunContext<T>(
   ctx: AgentLaunchContext,
   fn: () => T | Promise<T>,
 ): Promise<T> {
-  // Build the run context first: createRunContext throws on a null
-  // runtimeHost, and we must not retain a coordinator we can't release.
   const runContext = createRunContext({
     runtimeHost: ctx.runtimeHost,
     streamId: ctx.streamId,
@@ -114,15 +111,7 @@ export async function withExecutionRunContext<T>(
     approvalPromptsUnavailable: ctx.approvalPromptsUnavailable,
     stopAfterCycle: ctx.stopAfterCycle,
   });
-  const release = runCoordinatorBridge.retainForStream(
-    ctx.streamId,
-    ctx.coordinators,
-  );
-  try {
-    return await withRunContext(runContext, fn);
-  } finally {
-    release();
-  }
+  return await withRunContext(runContext, fn);
 }
 
 export async function getAgentPath(

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -15,6 +15,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { formatDuration } from '@utils/core';
+import type { RunCoordinators } from './RunContext';
 
 export interface ExecutionStatusInfo {
   status: string;
@@ -67,6 +68,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
     readonly agentName: string,
     readonly category: 'workflow' | 'toolUse',
     readonly runtimeHost: AgentRuntimeHost,
+    readonly coordinators?: RunCoordinators,
   ) {
     this._parentStreamId = parentStreamId;
   }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -182,6 +182,7 @@ async function runFlowWithLifecycle(
     agentName,
     category,
     ctx.runtimeHost,
+    ctx.coordinators,
   );
   executionRegistry.track(handle);
   try {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -143,6 +143,27 @@ export class ExecutionRegistry {
     return this.handles.get(executionId);
   }
 
+  getAgentHandleByStream(
+    streamId: StreamTabId,
+  ): AgentExecutionHandle | undefined {
+    for (const handle of this.handles.values()) {
+      if (
+        handle instanceof AgentExecutionHandle &&
+        handle.childStreamId === streamId
+      ) {
+        return handle;
+      }
+    }
+    return undefined;
+  }
+
+  getAgentHandles(): AgentExecutionHandle[] {
+    return [...this.handles.values()].filter(
+      (handle): handle is AgentExecutionHandle =>
+        handle instanceof AgentExecutionHandle,
+    );
+  }
+
   /** Terminate an execution via its handle. Returns true on success. */
   kill(executionId: string): boolean {
     const handle = this.handles.get(executionId);

--- a/src/agent/runtime/runCoordinators.ts
+++ b/src/agent/runtime/runCoordinators.ts
@@ -1,4 +1,5 @@
 import { useRunContext, type RunCoordinators } from './RunContext';
+import { executionRegistry, type ExecutionRegistry } from './executionRegistry';
 import type {
   ProposalRequestOptions,
   ProposalResult,
@@ -30,19 +31,16 @@ function useRunCoordinators(): RunCoordinators {
  * AgentLaunchContext's coordinators.
  */
 export class RunCoordinatorBridge {
-  private readonly streamCoordinators = new Map<string, RunCoordinators>();
   private readonly planApprovals = new Map<string, CoordinatorRequest>();
   private readonly proposals = new Map<string, CoordinatorRequest>();
   private readonly retries = new Map<string, RunCoordinators>();
 
-  retainForStream(streamId: string, coordinators: RunCoordinators): () => void {
-    this.streamCoordinators.set(streamId, coordinators);
-    return () => {
-      if (this.streamCoordinators.get(streamId) === coordinators) {
-        this.streamCoordinators.delete(streamId);
-      }
-    };
-  }
+  constructor(
+    private readonly registry: Pick<
+      ExecutionRegistry,
+      'getAgentHandleByStream' | 'getAgentHandles'
+    > = executionRegistry,
+  ) {}
 
   async waitForPlanApproval(
     streamId: string,
@@ -72,7 +70,7 @@ export class RunCoordinatorBridge {
       this.planApprovals.delete(approvalId);
     }
     if (entries.length === 0) {
-      this.streamCoordinators.get(streamId)?.plan.clearForStream(streamId);
+      this.coordinatorsForStream(streamId)?.plan.clearForStream(streamId);
     }
   }
 
@@ -127,7 +125,7 @@ export class RunCoordinatorBridge {
     const coordinators = new Set<RunCoordinators>();
     const mappedCoordinators = this.retries.get(streamId);
     if (mappedCoordinators) coordinators.add(mappedCoordinators);
-    const runCoordinators = this.streamCoordinators.get(streamId);
+    const runCoordinators = this.coordinatorsForStream(streamId);
     if (runCoordinators) coordinators.add(runCoordinators);
     for (const coordinator of coordinators) {
       coordinator.retry.clearRequest(streamId);
@@ -151,7 +149,7 @@ export class RunCoordinatorBridge {
     const coordinators = new Set(
       [...this.planApprovals.values()].map((entry) => entry.coordinators),
     );
-    for (const runCoordinators of this.streamCoordinators.values()) {
+    for (const runCoordinators of this.activeCoordinators()) {
       coordinators.add(runCoordinators);
     }
     for (const coordinator of coordinators) {
@@ -182,7 +180,7 @@ export class RunCoordinatorBridge {
 
   private clearAllRetryRequests(): void {
     const coordinators = new Set<RunCoordinators>();
-    for (const runCoordinators of this.streamCoordinators.values()) {
+    for (const runCoordinators of this.activeCoordinators()) {
       coordinators.add(runCoordinators);
     }
     for (const runCoordinators of this.retries.values()) {
@@ -192,6 +190,16 @@ export class RunCoordinatorBridge {
       coordinator.retry.clearAll();
     }
     this.retries.clear();
+  }
+
+  private coordinatorsForStream(streamId: string): RunCoordinators | undefined {
+    return this.registry.getAgentHandleByStream(streamId)?.coordinators;
+  }
+
+  private activeCoordinators(): RunCoordinators[] {
+    return this.registry
+      .getAgentHandles()
+      .flatMap((handle) => (handle.coordinators ? [handle.coordinators] : []));
   }
 }
 

--- a/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
+++ b/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
@@ -14,6 +14,10 @@ import {
 } from '@agent/runtime/RunContext';
 import { RunCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
+  AgentExecutionHandle,
+  ExecutionRegistry,
+} from '@agent/runtime/executionRegistry';
+import {
   AGENT_CATEGORY,
   TODO_STATUS,
   type AgentProposal,
@@ -159,14 +163,24 @@ describe('runCoordinators', () => {
 
   it('cleans pending requests for one stream through their owning coordinators', async () => {
     const active = createRecordingHost();
-    const bridge = new RunCoordinatorBridge();
+    const registry = new ExecutionRegistry();
+    const bridge = new RunCoordinatorBridge(registry);
     const coordinators = createCoordinators(active.host);
     const context = createRunContext({
       runtimeHost: active.host,
       coordinators,
     });
+    const handle = new AgentExecutionHandle(
+      'execution:cleanup-stream',
+      streamId,
+      streamId,
+      'orchestrator',
+      'toolUse',
+      active.host,
+      coordinators,
+    );
 
-    const release = bridge.retainForStream(streamId, coordinators);
+    registry.track(handle);
     try {
       const planResult = withRunContext(context, () =>
         bridge.waitForPlanApproval(streamId, {
@@ -204,7 +218,42 @@ describe('runCoordinators', () => {
         }),
       ).toBe(false);
     } finally {
-      release();
+      registry.dispose();
+    }
+  });
+
+  it('clears active-handle coordinator requests even without a bridge request index', async () => {
+    const active = createRecordingHost();
+    const registry = new ExecutionRegistry();
+    const bridge = new RunCoordinatorBridge(registry);
+    const coordinators = createCoordinators(active.host);
+    const handle = new AgentExecutionHandle(
+      'execution:direct-plan-clear',
+      streamId,
+      streamId,
+      'orchestrator',
+      'toolUse',
+      active.host,
+      coordinators,
+    );
+
+    registry.track(handle);
+    try {
+      const planResult = coordinators.plan.waitForApproval(streamId, {
+        approvalId: 'approval:direct-plan-clear',
+        plan,
+      });
+
+      bridge.clearPlanApprovalForStream(streamId);
+
+      await expect(planResult).resolves.toEqual({ action: 'reject' });
+      expect(
+        bridge.resolvePlanApproval('approval:direct-plan-clear', {
+          action: 'approve',
+        }),
+      ).toBe(false);
+    } finally {
+      registry.dispose();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Store run coordinators on `AgentExecutionHandle`, the active per-run object already registered for each agent stream.
- Add execution-registry lookup for active agent handles by stream.
- Remove the coordinator bridge's duplicate `streamId -> RunCoordinators` retention map and `retainForStream()` API.
- Keep the bridge responsible only for request-id indexes needed by host/UI callbacks.

## Design Notes

This is a small Step 7 ownership slice. The coordinator owner now travels with the execution handle instead of being mirrored in a second bridge map. The bridge still resolves callback ids outside the async run context, but stream-level cleanup asks the execution registry for the active handle.

No generic registry abstraction or compatibility pass-through was added.

## Verification

- `corepack pnpm vitest run src/test-kernel/agent/runtime/runCoordinators.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test/agent/runtime/PromiseCoordinators.test.ts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `rg -n "retainForStream|streamCoordinators" . -g '!node_modules' -g '!dist' -g '!out'`
- `npm run lint` (passes; existing import-order warnings only)
- `npm run compile:fast`

Closes #5499
Contributes to #4737

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plan/proposal/retry cleanup paths used when streams end or the host resolves UI callbacks; behavior should be equivalent but coordinator lookup now depends on handles being tracked with coordinators attached.
> 
> **Overview**
> **Run coordinators** now live on **`AgentExecutionHandle`** (passed from launch context when tracking an execution) instead of being mirrored in **`RunCoordinatorBridge`**.
> 
> **`withExecutionRunContext`** no longer calls **`retainForStream`** / release around **`withRunContext`** — coordinator lifetime follows the tracked handle.
> 
> **`ExecutionRegistry`** gains **`getAgentHandleByStream`** and **`getAgentHandles`** so the bridge can resolve stream-level cleanup without its own **`streamId → RunCoordinators`** map.
> 
> **`RunCoordinatorBridge`** drops **`retainForStream()`**; stream cleanup and global clears use the registry’s active agent handles. Request-id indexes for host/UI callbacks are unchanged.
> 
> Tests register handles on a registry and add a case where plan approval is cleared via the handle when no bridge index entry exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d9b81f32c6e40123884701bc74db73792938e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->