### PR TITLE
refactor: let execution registry own agent interrupts

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -1,11 +1,10 @@
 /**
  * Polymorphic execution handles.
  *
- * Replaces data-oriented maps with handles that know how to report status,
- * interrupt/kill, and describe themselves.
+ * Replaces data-oriented maps with handles that know how to report status and
+ * describe themselves. Termination policy lives with the owning registry.
  */
 
-import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
@@ -39,9 +38,6 @@ export interface ExecutionHandle {
   readonly runtimeHost: AgentRuntimeHost;
 
   getStatus(): ExecutionStatusInfo;
-
-  /** Interrupt or kill. Returns true if the call had an effect. */
-  terminate(): boolean;
 
   getProgress(): { currentRound?: number; totalRounds?: number };
 
@@ -92,16 +88,6 @@ export class AgentExecutionHandle implements ExecutionHandle {
       status,
       elapsed: formatDuration(Date.now() - this.startedAt),
     };
-  }
-
-  terminate(): boolean {
-    const interruptible = interruptRegistry.get(this.childStreamId);
-    if (!interruptible) return false;
-    interruptible.interrupt();
-    StreamStatusService.set(this.childStreamId, STREAM_STATUS.STOPPED, {
-      runtimeHost: this.runtimeHost,
-    });
-    return true;
   }
 
   getProgress(): { currentRound?: number; totalRounds?: number } {
@@ -159,7 +145,7 @@ export class ProcessExecutionHandle implements ExecutionHandle {
 }
 
 /** True when the handle is a child of parentStreamId (not the parent itself). */
-function isChildOf(
+export function isChildExecution(
   handle: ExecutionHandle,
   parentStreamId: StreamTabId,
 ): boolean {
@@ -172,22 +158,6 @@ function isChildOf(
   return true;
 }
 
-/**
- * Interrupt all active subagents of a parent stream. Called before
- * interrupting the parent so subagents stop promptly instead of running to
- * completion.
- */
-export function interruptActiveChildren(
-  parentStreamId: StreamTabId,
-  handles: Iterable<ExecutionHandle>,
-): void {
-  for (const handle of handles) {
-    if (isChildOf(handle, parentStreamId)) {
-      handle.terminate();
-    }
-  }
-}
-
 /** Collect {executionId, agentName, ...} for handles matching a class under a parent stream. */
 export function collectChildSummary(
   parentStreamId: StreamTabId,
@@ -196,7 +166,10 @@ export function collectChildSummary(
 ): ActiveChildInfo[] {
   const result: ActiveChildInfo[] = [];
   for (const handle of handles) {
-    if (!(handle instanceof ctor) || !isChildOf(handle, parentStreamId)) {
+    if (
+      !(handle instanceof ctor) ||
+      !isChildExecution(handle, parentStreamId)
+    ) {
       continue;
     }
     const { status, elapsed } = handle.getStatus();

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -10,13 +10,21 @@ import {
   StreamStatusService,
   type StreamStatusRegistry,
 } from '@agent/runtime/StreamStatusService';
-import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
+import {
+  interruptRegistry,
+  type InterruptRegistry,
+} from '@agent/runtime/InterruptRegistry';
+import {
+  STREAM_STATUS,
+  type ActiveChildInfo,
+  type StreamTabId,
+} from '@shared/schemas';
 import {
   type ExecutionHandle,
   AgentExecutionHandle,
   ProcessExecutionHandle,
   collectChildSummary,
-  interruptActiveChildren as interruptChildren,
+  isChildExecution,
 } from './ExecutionHandle';
 import {
   processOutputPoller,
@@ -43,6 +51,8 @@ export class ExecutionRegistry {
   private readonly changeCallbacks = new Map<string, Array<() => void>>();
   private readonly disposeStatusListener: () => void;
   private readonly processOutput: ProcessOutputPoller;
+  private readonly streamStatus: StreamStatusRegistry;
+  private readonly interrupts: InterruptRegistry;
   // Persistent listeners stay attached across notifications (unlike one-shot
   // waiters in `changeCallbacks`). Used by the executions subscribe action.
   private readonly persistentListeners = new Map<
@@ -51,33 +61,39 @@ export class ExecutionRegistry {
   >();
 
   constructor({
+    interrupts = interruptRegistry,
     processOutput = processOutputPoller,
     streamStatus = StreamStatusService,
   }: {
+    readonly interrupts?: InterruptRegistry;
     readonly processOutput?: ProcessOutputPoller;
     readonly streamStatus?: StreamStatusRegistry;
   } = {}) {
+    this.interrupts = interrupts;
     this.processOutput = processOutput;
+    this.streamStatus = streamStatus;
     // Notify waiters and refresh UI badges when stream status changes
     // (e.g. RUNNING → WAITING). Without this, waitForChange only resolves
     // on progress/kill/untrack, and the background-tasks panel shows stale badges.
-    this.disposeStatusListener = streamStatus.onDidChange(({ streamId }) => {
-      for (const [executionId, handle] of this.handles) {
-        if (
-          handle instanceof AgentExecutionHandle &&
-          handle.childStreamId === streamId
-        ) {
-          this.notifyWaiters(executionId);
-          if (handle.parentStreamId !== handle.childStreamId) {
-            this.emitActiveSubagentsUpdate(
-              handle.parentStreamId,
-              handle.runtimeHost,
-            );
+    this.disposeStatusListener = this.streamStatus.onDidChange(
+      ({ streamId }) => {
+        for (const [executionId, handle] of this.handles) {
+          if (
+            handle instanceof AgentExecutionHandle &&
+            handle.childStreamId === streamId
+          ) {
+            this.notifyWaiters(executionId);
+            if (handle.parentStreamId !== handle.childStreamId) {
+              this.emitActiveSubagentsUpdate(
+                handle.parentStreamId,
+                handle.runtimeHost,
+              );
+            }
+            break;
           }
-          break;
         }
-      }
-    });
+      },
+    );
   }
 
   dispose(): void {
@@ -168,7 +184,7 @@ export class ExecutionRegistry {
   kill(executionId: string): boolean {
     const handle = this.handles.get(executionId);
     if (!handle) return false;
-    const result = handle.terminate();
+    const result = this.terminate(handle);
     // Always notify waiters — even if terminate() returned false (e.g. PID not
     // yet assigned), callers blocking on this execution should be unblocked.
     this.notifyWaiters(executionId);
@@ -264,7 +280,11 @@ export class ExecutionRegistry {
 
   /** Interrupt all active subagents of a parent stream. */
   interruptActiveChildren(parentStreamId: StreamTabId): void {
-    interruptChildren(parentStreamId, this.handles.values());
+    for (const handle of this.handles.values()) {
+      if (isChildExecution(handle, parentStreamId)) {
+        this.terminate(handle);
+      }
+    }
   }
 
   /**
@@ -289,7 +309,7 @@ export class ExecutionRegistry {
           parentStreamId: null,
         });
       } else if (handle instanceof ProcessExecutionHandle) {
-        handle.terminate();
+        this.terminate(handle);
       }
     }
     this.emitActiveSubagentsUpdate(parentStreamId, runtimeHost);
@@ -365,6 +385,24 @@ export class ExecutionRegistry {
         ProcessExecutionHandle,
       ),
     });
+  }
+
+  private terminate(handle: ExecutionHandle): boolean {
+    if (handle instanceof AgentExecutionHandle) {
+      const interruptible = this.interrupts.get(handle.childStreamId);
+      if (!interruptible) return false;
+      interruptible.interrupt();
+      this.streamStatus.set(handle.childStreamId, STREAM_STATUS.STOPPED, {
+        runtimeHost: handle.runtimeHost,
+      });
+      return true;
+    }
+
+    if (handle instanceof ProcessExecutionHandle) {
+      return handle.terminate();
+    }
+
+    return false;
   }
 
   private addChangeCallback(executionId: string, cb: () => void): void {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -1,17 +1,50 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
   AgentExecutionHandle,
   ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
+import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
 describe('executionRegistry', () => {
+  it('uses its interrupt registry when terminating agent handles', () => {
+    const explicit = createRecordingHost();
+    const interrupts = new InterruptRegistry();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const executionId = 'exec-injected-interrupt-test';
+    const parentStreamId = 'parent-injected-interrupt-test' as StreamTabId;
+    const childStreamId = 'child-injected-interrupt-test' as StreamTabId;
+    const interrupt = vi.fn();
+
+    try {
+      interrupts.register(childStreamId, { interrupt });
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        explicit.host,
+      );
+      registry.track(handle);
+
+      expect(registry.kill(executionId)).toBe(true);
+
+      expect(interrupt).toHaveBeenCalledOnce();
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+    } finally {
+      registry.dispose();
+      interrupts.unregister(childStreamId);
+    }
+  });
+
   it('publishes handle updates through the handle runtime host', () => {
     const explicit = createRecordingHost();
     const registry = new ExecutionRegistry();


### PR DESCRIPTION
## Summary

- move agent interrupt lookup and stopped-status updates out of AgentExecutionHandle and into ExecutionRegistry
- inject the InterruptRegistry dependency into ExecutionRegistry, keeping the module-default instance as the production default
- remove the generic handle termination helper that forced agent handles to know about process-global live state
- add a focused runtime test for terminating an agent through an injected interrupt registry

Closes #5501.

## Validation

- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
- npm run typecheck
- npm run lint

Note: lint exits 0 with existing import-order warnings in unrelated files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agent runs are stopped (interrupt + stream status) on a central registry path used by kill and parent-child interruption; behavior should match prior handle logic but is security/availability sensitive for long-running agents.
> 
> **Overview**
> **Agent execution termination** is centralized in `ExecutionRegistry` instead of on `AgentExecutionHandle` and the shared `ExecutionHandle` interface.
> 
> `kill`, `interruptActiveChildren`, and `detachActiveChildren` now route through a private `terminate()` that looks up interrupts via an injectable `InterruptRegistry`, calls `interrupt()`, and sets the child stream to `STOPPED` through the registry’s `StreamStatusRegistry`. `AgentExecutionHandle` no longer imports or touches global interrupt state; **process** handles still terminate via their existing `killFn`-backed `terminate()`.
> 
> The standalone `interruptActiveChildren` helper is removed from `ExecutionHandle.ts`; child detection is renamed/exported as `isChildExecution` for reuse in summaries and registry logic. A new test asserts that `kill` on an agent handle uses the **injected** interrupt registry and stream status instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63dc5d021332a8325a755e3765641f9a6243c14b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->