### PR TITLE
docs: add dependency injection cleanup audit

### DIFF
--- a/docs/proposals/dependency-injection-cleanup.md
+++ b/docs/proposals/dependency-injection-cleanup.md
@@ -308,7 +308,7 @@ flowchart LR
 
 Sequenced so nothing breaks, lowest-risk first:
 
-1. **Fold the 20 P-class setters into `Platform` ports.** _(Highest leverage, mostly mechanical.)_ Most consumers sit 1–2 hops from the setter (often the same file). Precedent already exists (`fs`, `workspace`, `secrets`). Eliminates the entire silent-no-op class at once — a missing wiring becomes a type error. Do the 6 ext-only no-op setters first (clearest user-facing bug surface in CLI/desktop).
+1. **Fold the 20 P-class setters into `Platform` ports.** _(Highest leverage, mostly mechanical.)_ Most consumers sit 1–2 hops from the setter (often the same file). Precedent already exists (`fs`, `workspace`, `secrets`). Eliminates the entire silent-no-op class at once — a missing wiring becomes a type error. Do the 7 ext-only no-op setters first (clearest user-facing bug surface in CLI/desktop).
 2. **De-duplicate the split-brain fields.** Stop threading the 7–8 fields already in `RunContext`; let flow nodes read them the way tools already do. This shrinks every flow-service interface for free.
 3. **Cohesion-split `AgentCore`** into `RunIdentity` / `DelegationPolicy` / `AgentDefinition` + ambient `logger`. The wholesale re-spread at the 2 nesting sites becomes `setServices({ identity, delegation, agent })`.
 4. **Narrow node interfaces (ISP).** A node reading 3 fields should declare those 3, not `ReflectionServices`. This removes the pressure to forward the whole bag.

--- a/docs/proposals/dependency-injection-cleanup.md
+++ b/docs/proposals/dependency-injection-cleanup.md
@@ -14,7 +14,7 @@ A multi-agent read-only audit: three parallel deep agents each owned a non-overl
 TeXRA already has **one genuinely clean DI seam**: `platform()` (`src/platform/platform.ts`) — a frozen, single-call composition root over small vscode-free ports. The problem is that **three other dependency-flow mechanisms grew up around it** instead of through it, and they now overlap:
 
 1. **A fat context bag** (`AgentCore` → `*Services`): 13 declared fields that balloon to **~31–35 at runtime** because the bag is spread wholesale into nested flows. Nodes read **3–9** fields while carrying 31–35 — **~70–90% is dead weight** at each node.
-2. **24 module-level `set*` singletons** (service-locator style): host capabilities injected via mutable module globals. **9 have silent no-op defaults**; **6 are unavailable in at least one non-extension host**, so they silently no-op outside the happy path. **8 are written from multiple composition roots.**
+2. **24 module-level `set*` singletons** (service-locator style): host capabilities injected via mutable module globals. **9 have silent no-op defaults**; several are unavailable in at least one non-extension host, so they silently no-op outside the happy path. **8 are written from multiple composition roots.**
 3. **Ambient state** (AsyncLocalStorage + 7 process-global registries): `RunContext` and `ToolCallContext` plus the runtime registries that — per [`agent-sdk-readiness.md`](./agent-sdk-readiness.md) — block concurrent in-process sessions.
 
 **The headline finding:** mechanisms A and C carry **the same 7–8 fields at once**, and the two halves of the codebase disagree on which is canonical — **flow nodes read them from the bag, tools read them from `RunContext`**. That split-brain is the strongest evidence that bag-threading those fields is redundant, and it tells us the migration target is already chosen by the code.
@@ -142,9 +142,9 @@ flowchart LR
     subgraph AFTER["4 cohesive objects"]
         direction TB
         RI["RunIdentity\n{runtimeHost, streamId, executionId}"]
-        DP["DelegationPolicy\n{depth, config}"]
+        DP["DelegationPolicy\n{depth, config,\napprovalPromptsUnavailable}"]
         AD["AgentDefinition\n{config, setting, prompt,\nmodelHandler, userVarChannels}"]
-        AMB["ambient: logger\n(genuine cross-cutting)"]
+        AMB["ambient: logger,\nworkingDirectory\n(genuine cross-cutting)"]
     end
 
     f1 & f2 & f3 --> RI
@@ -236,7 +236,7 @@ flowchart TB
 
 ### The silent-no-op trap
 
-9 setters default to a no-op. Six of those are unavailable in at least one non-extension host, so depending on host, the linter, manual criticism, build display, tool-missing toasts, tool-unavailable notifications, and the GitHub token are **silently absent with no error**. Folding into typed `Platform` ports turns each missing wiring into a compile error instead of a silent runtime gap.
+9 setters default to a no-op. Depending on host, examples such as the linter, manual criticism, build display, tool-missing toasts, tool-unavailable notifications, and the GitHub token are **silently absent with no error**. Folding into typed `Platform` ports turns each missing wiring into a compile error instead of a silent runtime gap.
 
 ---
 

--- a/docs/proposals/dependency-injection-cleanup.md
+++ b/docs/proposals/dependency-injection-cleanup.md
@@ -210,7 +210,7 @@ flowchart TB
 | `setToolNotificationHandler` `toolUnavailableNotification.ts:28`     | `() => {}`                | P           | —                     | **yes**                  |
 | `setGitHubTokenProvider` `github/githubAuth.ts:15`                   | `() => undefined`         | P           | —                     | **yes**                  |
 | `setExtensionChecker` `externalToolDefs.ts:60`                       | `() => false`             | P           | —                     | **yes**                  |
-| `setTexraCliEntrypointChecker` `externalToolDefs.ts:67`              | `() => false`             | P           | —                     | **yes**                  |
+| `setTexraCliEntrypointChecker` `externalToolDefs.ts:67`              | `() => false`             | P           | cli only              | **yes**                  |
 | `setLeanLanguageServices` `lean/leanLanguageServices.ts:53`          | undefined (getter throws) | P           | **ext+desktop+cli**   | no                       |
 | `setSetupPlatform` `setup/platform.ts:104`                           | undefined (getter throws) | P           | —                     | no                       |
 | `setRunStorageService` `runtime/RunStorageService.ts:17`             | `isViewVisible:()=>false` | P           | **ext+desktop**       | **yes**                  |
@@ -308,7 +308,7 @@ flowchart LR
 
 Sequenced so nothing breaks, lowest-risk first:
 
-1. **Fold the 20 P-class setters into `Platform` ports.** _(Highest leverage, mostly mechanical.)_ Most consumers sit 1–2 hops from the setter (often the same file). Precedent already exists (`fs`, `workspace`, `secrets`). Eliminates the entire silent-no-op class at once — a missing wiring becomes a type error. Do the 7 ext-only no-op setters first (clearest user-facing bug surface in CLI/desktop).
+1. **Fold the 20 P-class setters into `Platform` ports.** _(Highest leverage, mostly mechanical.)_ Most consumers sit 1–2 hops from the setter (often the same file). Precedent already exists (`fs`, `workspace`, `secrets`). Eliminates the entire silent-no-op class at once — a missing wiring becomes a type error. Do the 6 ext-only no-op setters first (clearest user-facing bug surface in CLI/desktop).
 2. **De-duplicate the split-brain fields.** Stop threading the 7–8 fields already in `RunContext`; let flow nodes read them the way tools already do. This shrinks every flow-service interface for free.
 3. **Cohesion-split `AgentCore`** into `RunIdentity` / `DelegationPolicy` / `AgentDefinition` + ambient `logger`. The wholesale re-spread at the 2 nesting sites becomes `setServices({ identity, delegation, agent })`.
 4. **Narrow node interfaces (ISP).** A node reading 3 fields should declare those 3, not `ReflectionServices`. This removes the pressure to forward the whole bag.

--- a/docs/proposals/dependency-injection-cleanup.md
+++ b/docs/proposals/dependency-injection-cleanup.md
@@ -14,7 +14,7 @@ A multi-agent read-only audit: three parallel deep agents each owned a non-overl
 TeXRA already has **one genuinely clean DI seam**: `platform()` (`src/platform/platform.ts`) — a frozen, single-call composition root over small vscode-free ports. The problem is that **three other dependency-flow mechanisms grew up around it** instead of through it, and they now overlap:
 
 1. **A fat context bag** (`AgentCore` → `*Services`): 13 declared fields that balloon to **~31–35 at runtime** because the bag is spread wholesale into nested flows. Nodes read **3–9** fields while carrying 31–35 — **~70–90% is dead weight** at each node.
-2. **24 module-level `set*` singletons** (service-locator style): host capabilities injected via mutable module globals. **9 have silent no-op defaults**; **6 are wired only in `extension.ts`**, so they silently no-op in the CLI and desktop hosts. **8 are written from multiple composition roots.**
+2. **24 module-level `set*` singletons** (service-locator style): host capabilities injected via mutable module globals. **9 have silent no-op defaults**; **6 are unavailable in at least one non-extension host**, so they silently no-op outside the happy path. **8 are written from multiple composition roots.**
 3. **Ambient state** (AsyncLocalStorage + 7 process-global registries): `RunContext` and `ToolCallContext` plus the runtime registries that — per [`agent-sdk-readiness.md`](./agent-sdk-readiness.md) — block concurrent in-process sessions.
 
 **The headline finding:** mechanisms A and C carry **the same 7–8 fields at once**, and the two halves of the codebase disagree on which is canonical — **flow nodes read them from the bag, tools read them from `RunContext`**. That split-brain is the strongest evidence that bag-threading those fields is redundant, and it tells us the migration target is already chosen by the code.
@@ -148,9 +148,9 @@ flowchart LR
     end
 
     f1 & f2 & f3 --> RI
-    f4 & f5 --> DP
+    f4 & f5 & f13 --> DP
     f6 & f7 & f8 & f9 & f10 --> AD
-    f11 --> AMB
+    f11 & f12 --> AMB
 
     style RI fill:#def,stroke:#36b
     style DP fill:#fed,stroke:#b83
@@ -204,7 +204,7 @@ flowchart TB
 | -------------------------------------------------------------------- | ------------------------- | ----------- | --------------------- | ------------------------ |
 | `setLinterProvider` `DiagnosticsTool.ts:12`                          | `async () => []`          | P           | —                     | **yes**                  |
 | `setAddCriticismSink` `AddCriticismTool.ts:48`                       | `{accepted:false}`        | P           | —                     | **yes**                  |
-| `setOpenPdfOpener` `OpenPdfTool.ts:42`                               | undefined                 | P           | —                     | yes                      |
+| `setOpenPdfOpener` `OpenPdfTool.ts:42`                               | undefined                 | P           | —                     | no (guarded error)       |
 | `setOpenBuildDisplay` `approval/latexPreview.ts:34`                  | `async () => {}`          | P           | **ext+desktop**       | **yes** (no-ops in CLI)  |
 | `setToolMissingHandler` `utils/system/toolUtils.ts:58`               | `() => {}`                | P           | —                     | **yes**                  |
 | `setToolNotificationHandler` `toolUnavailableNotification.ts:28`     | `() => {}`                | P           | —                     | **yes**                  |
@@ -236,7 +236,7 @@ flowchart TB
 
 ### The silent-no-op trap
 
-9 setters default to a no-op. Six of those are wired **only in `extension.ts`**, so in CLI/desktop the linter, manual criticism, PDF opening, tool-missing toasts, tool-unavailable notifications, and the GitHub token are **silently absent with no error**. Folding into typed `Platform` ports turns each missing wiring into a compile error instead of a silent runtime gap.
+9 setters default to a no-op. Six of those are unavailable in at least one non-extension host, so depending on host, the linter, manual criticism, build display, tool-missing toasts, tool-unavailable notifications, and the GitHub token are **silently absent with no error**. Folding into typed `Platform` ports turns each missing wiring into a compile error instead of a silent runtime gap.
 
 ---
 
@@ -291,13 +291,15 @@ flowchart TB
 ```mermaid
 flowchart LR
     P1["20 P-setters"] -->|fold into| PORTS["frozen Platform ports"]
-    P2["setToolEditApprovalHandler\n+ 7 registries"] -->|scope to| RUN["RunContext (per-run)"]
+    P2["setToolEditApprovalHandler"] -->|scope to| RUN["RunContext (per-run)"]
+    P2B["7 registries"] -->|scope to| SESSION["per-session runtime owner"]
     P3["7-8 duplicated bag fields"] -->|drop from bag,\nread like tools do| RUN
     P4["13-field AgentCore"] -->|cohesion split| FOUR["4 objects + ambient logger"]
     P5["wholesale {...services}\nre-spread ×2"] -->|narrow interfaces| ISP["nodes declare only\nwhat they read"]
 
     PORTS --> WIN["✓ typed wiring\n✓ no silent no-ops\n✓ concurrent sessions\n✓ ~80% less carried"]
     RUN --> WIN
+    SESSION --> WIN
     FOUR --> WIN
     ISP --> WIN
 

--- a/docs/proposals/dependency-injection-cleanup.md
+++ b/docs/proposals/dependency-injection-cleanup.md
@@ -1,0 +1,333 @@
+# Dependency Injection Cleanup — "Deep Injection" Audit & Plan
+
+**Status:** Audit (2026-06-07). Findings verified against current source; no code changed yet.
+**Scope:** How dependencies flow through the agent core — `src/agent/` (runtime, flows, toolUse), `src/tools/`, `src/platform/`, and the host composition roots (`packages/extension/src/extension.ts`, `packages/desktop`, `packages/cli`).
+**Target:** Make every dependency **visible at the point it is used**, **wired once** at a single composition root, **scoped** to the right lifetime (process vs. run vs. tool-call), and **carried only where read**.
+**Related:** [`agent-sdk-readiness.md`](./agent-sdk-readiness.md) (process-global registries as the concurrency blocker), [`logger-simplification-feasibility.md`](./logger-simplification-feasibility.md). See also `CLAUDE.md` → "Discouraged Factory Patterns", "Flattening Abstraction Layers", "Separation of Concerns: VS Code Coupling".
+
+## How this was produced
+
+A multi-agent read-only audit: three parallel deep agents each owned a non-overlapping slice — (A) the `AgentCore` context-bag threading, (B) the module-level `set*` singletons, (C) AsyncLocalStorage and process-global registries — plus a broad initial sweep. Each agent reported `file:line` for every claim and re-opened the cited code. Two early suspicions were **rejected on inspection** (`outputState` and `modelSwitchState` are properly threaded, not ambient; `TraceEmitter.stageScope` is deliberately per-instance and correct) — those rejections are recorded below because they mark traps.
+
+## TL;DR — verdict
+
+TeXRA already has **one genuinely clean DI seam**: `platform()` (`src/platform/platform.ts`) — a frozen, single-call composition root over small vscode-free ports. The problem is that **three other dependency-flow mechanisms grew up around it** instead of through it, and they now overlap:
+
+1. **A fat context bag** (`AgentCore` → `*Services`): 13 declared fields that balloon to **~31–35 at runtime** because the bag is spread wholesale into nested flows. Nodes read **3–9** fields while carrying 31–35 — **~70–90% is dead weight** at each node.
+2. **24 module-level `set*` singletons** (service-locator style): host capabilities injected via mutable module globals. **9 have silent no-op defaults**; **6 are wired only in `extension.ts`**, so they silently no-op in the CLI and desktop hosts. **8 are written from multiple composition roots.**
+3. **Ambient state** (AsyncLocalStorage + 7 process-global registries): `RunContext` and `ToolCallContext` plus the runtime registries that — per [`agent-sdk-readiness.md`](./agent-sdk-readiness.md) — block concurrent in-process sessions.
+
+**The headline finding:** mechanisms A and C carry **the same 8–9 fields at once**, and the two halves of the codebase disagree on which is canonical — **flow nodes read them from the bag, tools read them from `RunContext`**. That split-brain is the strongest evidence that bag-threading those fields is redundant, and it tells us the migration target is already chosen by the code.
+
+**The fundamentals** (Mark Seemann, *Dependency Injection*; ISP; functional-core/imperative-shell) all point the same way: depend on narrow interfaces, wire once at one root, scope to the right lifetime, carry only what you read.
+
+---
+
+## The three mechanisms at a glance
+
+```mermaid
+flowchart TB
+    subgraph CR["⚙️ Composition roots (should be ONE, are MANY)"]
+        EXT["extension.ts"]
+        DESK["desktop/index.ts"]
+        CLI["cli/initPlatform.ts"]
+    end
+
+    subgraph A["A · Fat bag (visible, over-carried)"]
+        AC["AgentCore (13)\n→ ~31-35 at runtime"]
+    end
+    subgraph B["B · set* singletons (invisible)"]
+        SET["24 module-level setters\n9 silent no-op defaults"]
+    end
+    subgraph C["C · Ambient (invisible)"]
+        RC["RunContext (ALS)"]
+        REG["7 process-global registries"]
+    end
+
+    EXT -->|"20 P-setters"| SET
+    DESK -->|"re-wires 8"| SET
+    CLI -->|"re-wires some,\nmisses others"| SET
+
+    EXT --> AC
+    AC -. "8-9 fields duplicated" .-> RC
+    SET -. "should fold into" .-> PORT["frozen Platform ports"]
+
+    style A fill:#fde,stroke:#b36
+    style B fill:#fed,stroke:#b63
+    style C fill:#eef,stroke:#36b
+    style PORT fill:#dfd,stroke:#3b6
+```
+
+| Mechanism | Count | Visibility at call site | Lifetime scope | Verdict |
+| --- | --- | --- | --- | --- |
+| **A. Fat context bag** (`AgentCore`→`*Services`) | 13 fields → ~31–35 runtime | Visible in types (but understated) | Per run | Over-carried; split into cohesive objects + narrow interfaces |
+| **B. `set*` module singletons** | 24 injectors | Invisible | Process (mostly) | Fold 20 into `Platform`; scope 1 to `RunContext`; 3 are test-only |
+| **C. ALS + process registries** | 3 ALS + 7 registries | Invisible | Run / process | Keep `RunContext` (good), de-dup vs. bag; registries block concurrency |
+
+---
+
+## Finding A — the fat context bag
+
+### The inheritance chain
+
+The root is `AgentCore<C>` (`src/agent/implementations/flows/common/BaseFlowServices.ts:18`). Every flow-service interface extends it through `BaseFlowContextInit`:
+
+```
+AgentCore (13)                         BaseFlowServices.ts:18
+  └─ BaseFlowContextInit (+4 = 17)     BaseFlowServices.ts:53
+       ├─ ReflectionServices (+~9)     ReflectionServices.ts:18      → ~26 declared
+       │    └─ ResponseCycleServices   CycleServices.ts:19           → 22 declared / ~31 runtime
+       └─ ToolUseServices (+~16)       ToolUseServices.ts:15         → ~33 declared
+            └─ ToolUseCycleServices    CycleServices.ts:30           → 23 declared / ~35 runtime
+```
+
+The inheritance is only **3 levels deep**, but the *runtime* object is larger than the declared interface because the outer bag is **spread wholesale** into the inner cycle (`{...this.services, ...}`) rather than narrowed. TypeScript understates what is actually carried.
+
+### The bag travels 4 hops and is re-spread twice
+
+```mermaid
+flowchart LR
+    EA["executeAgent\nspreads AgentLaunchContext"] -->|hop 1| RF["runToolUseFlow\nbuilds services bag"]
+    RF -->|"hop 2\nframework copies\nto every node"| PN["ToolUsePrepareNode\ncarries ~33 · reads 9"]
+    RF --> CN["ToolUseCycleNode\ncarries ~33 · reads 9"]
+    CN -->|"hop 3\nre-spread {...this.services}\nToolUseCycleNode.ts:75"| CF["inner cycle flow"]
+    CF -->|"hop 4\nframework copies again"| MI["ModelInvocationNode\ncarries ~35 · reads 4"]
+    CF --> DN["ToolUseDispatchNode\ncarries ~35 · reads 6"]
+
+    style MI fill:#fdd,stroke:#c33
+    style DN fill:#fdd,stroke:#c33
+    style CN fill:#fe9,stroke:#b83
+```
+
+The two re-spread sites are `ResponseCycleNode.ts:94` and `ToolUseCycleNode.ts:75`. The other `setServices` calls are the initial injection or framework plumbing (`persistedFlow.ts:185`, `node/index.ts:292`) that hands the *same* bag to every node in a flow.
+
+### Read-vs-carried per node
+
+| Node | File | Carries | Reads (distinct) |
+| --- | --- | --- | --- |
+| `MediaExtractionNode` | reflection/nodes | ~26 | 4 |
+| `OutputNode` | reflection/nodes | ~26 | 6 |
+| `PrepareContextNode` | reflection/nodes | ~26 | 3 |
+| `TeXCountNode` | reflection/nodes | ~26 | 3 |
+| `ResponseCycleNode` | reflection/nodes | ~26 | 6 (+re-spreads) |
+| `ToolUsePrepareNode` | tooluse/nodes | ~33 | 9 |
+| `ToolUseCycleNode` | tooluse/nodes | ~33 | 9 (+re-spreads) |
+| `ToolUseWaitNode` | tooluse/nodes | ~33 | 5 |
+| `ModelInvocationNode` | core/flows | ~35 | 4 |
+| `ToolUseDispatchNode` | core/flows | ~35 | 6 |
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+pie showData
+    title ModelInvocationNode — fields carried vs read
+    "Unread (carried for nothing)" : 31
+    "Actually read" : 4
+```
+
+### Cohesion: 13 loose fields → 4 objects
+
+Grouping verified by which fields are read **together at the same call sites** (not guessed):
+
+```mermaid
+flowchart LR
+    subgraph BEFORE["AgentCore — 13 loose fields"]
+        direction TB
+        f1[runtimeHost]; f2[streamId]; f3[executionId]
+        f4[delegationDepth]; f5[delegationConfig]
+        f6[config]; f7[setting]; f8[prompt]
+        f9[modelHandler]; f10[userVarChannels]
+        f11[logger]; f12[workingDirectory]; f13[approvalPromptsUnavailable]
+    end
+
+    subgraph AFTER["4 cohesive objects"]
+        direction TB
+        RI["RunIdentity\n{runtimeHost, streamId, executionId}"]
+        DP["DelegationPolicy\n{depth, config}"]
+        AD["AgentDefinition\n{config, setting, prompt,\nmodelHandler, userVarChannels}"]
+        AMB["ambient: logger\n(genuine cross-cutting)"]
+    end
+
+    f1 & f2 & f3 --> RI
+    f4 & f5 --> DP
+    f6 & f7 & f8 & f9 & f10 --> AD
+    f11 --> AMB
+
+    style RI fill:#def,stroke:#36b
+    style DP fill:#fed,stroke:#b83
+    style AD fill:#efd,stroke:#3b6
+    style AMB fill:#eee,stroke:#888
+```
+
+| Group | Fields | Evidence of co-usage |
+| --- | --- | --- |
+| `RunIdentity` | `runtimeHost, streamId, executionId` | `ToolUseCycleNode.ts:45-62`, `OutputNode.ts:263`, `contextHelpers.ts:36-48` |
+| `DelegationPolicy` | `delegationDepth, delegationConfig` (+ `approvalPromptsUnavailable, stopAfterCycle`) | `DelegationTools.ts:354-359, 1070-1073`; `AgentLaunchContext.ts:112-115` |
+| `AgentDefinition` | `config, setting, prompt` (+ `modelHandler, userVarChannels`) | `ResponseCycleNode.ts:69-71`, `AgentLaunchContext.ts:281-298`, `ToolUsePrepareNode.ts:24-78` |
+| ambient | `logger` (read by nearly every node), `workingDirectory` (tools only) | n/a — genuine cross-cutting |
+
+---
+
+## Finding B — the 24 `set*` module singletons
+
+### Pattern: service locator with a silent default
+
+```mermaid
+flowchart TB
+    subgraph NOW["❌ Now — service locator, invisible & silently absent"]
+        direction TB
+        E1["extension.ts\nsetLinterProvider(real)"] --> G1["module let\nlinterProvider = async ()=>[]"]
+        C1["CLI host\n(never calls setLinterProvider)"] -.->|"stays no-op"| G1
+        G1 --> T1["DiagnosticsTool\nsilently returns [] in CLI"]
+    end
+
+    subgraph TARGET["✅ Target — frozen Platform port, typed & visible"]
+        direction TB
+        E2["extension.ts"] --> IP["initPlatform({ linter, opener, … })"]
+        C2["CLI host"] --> IP
+        IP --> FZ["Object.freeze(Platform)"]
+        FZ --> T2["DiagnosticsTool\nplatform().linter\n(missing wiring = type error)"]
+    end
+
+    style NOW fill:#fee,stroke:#c33
+    style TARGET fill:#efe,stroke:#3b6
+```
+
+### Classification
+
+- **20 → `Platform` ports (P):** process-lifetime host capabilities that belong on the frozen `Platform` object.
+- **1 → `RunContext` (R):** `setToolEditApprovalHandler` — conceptually the *active session's* approval channel, currently a single module global mutated by whichever host UI is active.
+- **3 → test-only / justified lazy singleton (T):** `setDefaultStreamLogStore`, `setTierService`, `setServerSideKeyService`.
+
+### Full inventory
+
+| Setter (file:line) | Default | Class | Multi-root? | Silent no-op? |
+| --- | --- | --- | --- | --- |
+| `setLinterProvider` `DiagnosticsTool.ts:12` | `async () => []` | P | — | **yes** |
+| `setAddCriticismSink` `AddCriticismTool.ts:48` | `{accepted:false}` | P | — | **yes** |
+| `setOpenPdfOpener` `OpenPdfTool.ts:42` | undefined | P | — | yes |
+| `setOpenBuildDisplay` `approval/latexPreview.ts:34` | `async () => {}` | P | **ext+desktop** | **yes** (no-ops in CLI) |
+| `setToolMissingHandler` `utils/system/toolUtils.ts:58` | `() => {}` | P | — | **yes** |
+| `setToolNotificationHandler` `toolUnavailableNotification.ts:28` | `() => {}` | P | — | **yes** |
+| `setGitHubTokenProvider` `github/githubAuth.ts:15` | `() => undefined` | P | — | **yes** |
+| `setExtensionChecker` `externalToolDefs.ts:60` | `() => false` | P | — | **yes** |
+| `setTexraCliEntrypointChecker` `externalToolDefs.ts:67` | `() => false` | P | — | **yes** |
+| `setLeanLanguageServices` `lean/leanLanguageServices.ts:53` | undefined (getter throws) | P | **ext+desktop+cli** | no |
+| `setSetupPlatform` `setup/platform.ts:104` | undefined (getter throws) | P | — | no |
+| `setRunStorageService` `runtime/RunStorageService.ts:17` | `isViewVisible:()=>false` | P | **ext+desktop** | **yes** |
+| `setGitAuthorEnv` `utils/system/gitAuthorEnv.ts:16` | `{}` | P | **3 funnels** | benign |
+| `setWorktreeSupportEnabled` `worktreeConfig.ts:14` | `false` | P | **3 funnels** | intended off |
+| `setOutputChannelFactory` `logger/logUtils.ts:140` | `null` | P | **ext+cli** | null sink (desktop) |
+| `setAgentDirectories` `index/agentDirectoriesRegistry.ts:11` | `null` (getter throws) | P | **ext + core module** | no |
+| `setRuntimeSkillSources` `skills/runtimeSkills.ts:13` | `[]` | P | cli only | silent (cli-only) |
+| `setRuntimeExtensionId` `auth/config.ts:102` | `null` (const fallback) | P | — | benign |
+| `setExternalAuthCallbackResolver` `auth/config.ts:151` | `null` | P | — | benign |
+| `setToolEditApprovalHandler` `approval/toolEditApproval.ts:118` | undefined | **R** | **4 sites / 3 hosts** | falls back to controller |
+| `setDesktopAgentResumeHandler` `desktop/.../desktopAgentResume.ts:7` | undefined (`?? false`) | P (desktop) | — | benign |
+| `setDefaultStreamLogStore` `transcript/StreamLogStore.ts:789` | lazy `new` | T | — | no |
+| `setTierService` `auth/tier/index.ts:46` | lazy `new` | T | — | no |
+| `setServerSideKeyService` `auth/serverKeys/index.ts:52` | `null` (getter throws) | T | — | no |
+
+**Correctly-scoped already (not the anti-pattern, listed for completeness):** `setBashApprovalSessionBypass` / `setToolEditApprovalSessionBypass` are stream-keyed controllers (`createStreamApprovalController` map keyed by `streamId`), not singletons.
+
+### The two worst offenders
+
+1. **`setToolEditApprovalHandler`** — written from 4 call sites across 3 hosts into one module global; should be per-run state.
+2. **`setAgentDirectories`** — written from a host (`extension.ts:161`) **and** a core module (`platformAgentDirectories.ts:75`): two composition roots writing one global.
+
+### The silent-no-op trap
+
+9 setters default to a no-op. Six of those are wired **only in `extension.ts`**, so in CLI/desktop the linter, manual criticism, tool-missing toasts, tool-unavailable notifications, and the GitHub token are **silently absent with no error**. Folding into typed `Platform` ports turns each missing wiring into a compile error instead of a silent runtime gap.
+
+---
+
+## Finding C — ambient state (ALS + registries)
+
+### Split-brain: the same fields sourced two ways
+
+```mermaid
+flowchart TB
+    LC["AgentLaunchContext\n(populated once)"]
+
+    LC -->|"threaded into\nservices bag"| BAG["*Services bag"]
+    LC -->|"copied into\nRunContext (ALS)\nAgentLaunchContext.ts:103-116"| RC["RunContext"]
+
+    BAG --> FN["FLOW NODES\nread this.services.streamId\nthis.services.delegationDepth …"]
+    RC --> TL["TOOLS\nread tryUseRunContext().streamId\n…delegationDepth …\n(no tool imports the bag)"]
+
+    FN -. "same values" .- TL
+
+    DUP["runtimeHost · streamId · executionId\ndelegationDepth · delegationConfig\nworkingDirectory · stopAfterCycle\napprovalPromptsUnavailable · logger"]
+    BAG --- DUP
+    RC --- DUP
+
+    style DUP fill:#fdd,stroke:#c33
+    style FN fill:#eef,stroke:#36b
+    style TL fill:#efe,stroke:#3b6
+```
+
+**8–9 of `AgentCore`'s 13 fields are also in `RunContext`** (`RunContext.ts:18-49`, populated from the same `ctx` at `AgentLaunchContext.ts:103-116`): `runtimeHost`, `streamId`, `executionId`, `delegationDepth`, `delegationConfig`, `workingDirectory`, `approvalPromptsUnavailable`, `stopAfterCycle`, `logger`/`trace`. Flow nodes read them from the bag; tools read them from `RunContext` (`contextHelpers.ts:23,41,48`, `DelegationTools.ts:353-359`). Same data, two paths.
+
+### The three AsyncLocalStorage instances
+
+| ALS | File:line | Shape | Assessment |
+| --- | --- | --- | --- |
+| `runContextScope` | `RunContext.ts:70` | single value, per run | Good seam; but duplicates 8–9 bag fields. `tryUseRunContext()` silently returns `undefined` outside scope. |
+| `contextStackScope` | `ToolFileInteractionContext.ts:34` | **stack** | `getCurrentToolCallContext()` reads `.at(-1)` (`:49`) — a tool that spawns a sub-cycle then reads context gets the **child's** tracker, not its own. |
+| `stageScope` | `TraceEmitter.ts:49` | per-instance | **Correct by design** — per-instance prevents cross-trace stage leakage. Do not make module-global. |
+
+### Process-global registries (the concurrency blocker)
+
+`runCoordinatorBridge` (`runCoordinators.ts:212`), `executionRegistry` (`executionRegistry.ts:392`), `interruptRegistry` (`InterruptRegistry.ts:49`), `idleContinuationRegistry` (`idleContinuation.ts:55`), `toolInjectionRegistry` (`toolInjection.ts:34`), `StreamStatusService` (`StreamStatusService.ts:123`), `subagentDeliveryRegistry` (`subagentDeliveryState.ts:69`). These make the runtime a per-process singleton — documented as the blocker for concurrent in-process sessions in [`agent-sdk-readiness.md`](./agent-sdk-readiness.md) (§ "Host↔core coordination is process-global"). Tracked there; cross-referenced here for completeness.
+
+### Rejected suspicions (traps)
+
+- `outputState.ts` `setActiveRun`/`setCompileFailures` (`:109,134`) — **not** ambient: they mutate an `OutputState` passed in as the first arg; created per run via `createOutputState()`. Properly threaded.
+- `modelSwitchState.ts` `setToolUseSharedModel` (`:16`) — **not** a module singleton: pure update of the caller-owned `shared` object.
+
+---
+
+## The plan
+
+```mermaid
+flowchart LR
+    P1["20 P-setters"] -->|fold into| PORTS["frozen Platform ports"]
+    P2["setToolEditApprovalHandler\n+ 7 registries"] -->|scope to| RUN["RunContext (per-run)"]
+    P3["8-9 duplicated bag fields"] -->|drop from bag,\nread like tools do| RUN
+    P4["13-field AgentCore"] -->|cohesion split| FOUR["4 objects + ambient logger"]
+    P5["wholesale {...services}\nre-spread ×2"] -->|narrow interfaces| ISP["nodes declare only\nwhat they read"]
+
+    PORTS --> WIN["✓ typed wiring\n✓ no silent no-ops\n✓ concurrent sessions\n✓ ~80% less carried"]
+    RUN --> WIN
+    FOUR --> WIN
+    ISP --> WIN
+
+    style WIN fill:#dfd,stroke:#2a2,stroke-width:2px
+```
+
+Sequenced so nothing breaks, lowest-risk first:
+
+1. **Fold the 20 P-class setters into `Platform` ports.** *(Highest leverage, mostly mechanical.)* Most consumers sit 1–2 hops from the setter (often the same file). Precedent already exists (`fs`, `workspace`, `secrets`). Eliminates the entire silent-no-op class at once — a missing wiring becomes a type error. Do the 6 ext-only no-op setters first (clearest user-facing bug surface in CLI/desktop).
+2. **De-duplicate the split-brain fields.** Stop threading the 8–9 fields already in `RunContext`; let flow nodes read them the way tools already do. This shrinks every flow-service interface for free.
+3. **Cohesion-split `AgentCore`** into `RunIdentity` / `DelegationPolicy` / `AgentDefinition` + ambient `logger`. The wholesale re-spread at the 2 nesting sites becomes `setServices({ identity, delegation, agent })`.
+4. **Narrow node interfaces (ISP).** A node reading 3 fields should declare those 3, not `ReflectionServices`. This removes the pressure to forward the whole bag.
+5. **Scope `setToolEditApprovalHandler` to `RunContext`** (the one R-class setter).
+6. **Process registries → per-session** — larger, tracked in [`agent-sdk-readiness.md`](./agent-sdk-readiness.md); unblocks concurrent in-process sessions.
+
+### Fundamentals these steps apply
+
+| Step | Principle |
+| --- | --- |
+| 1, 5 | Single composition root; dependency injection over service location (Seemann) |
+| 1 | Immutable, set-once wiring (frozen `Platform`) over mutable module globals |
+| 2 | One canonical source of truth per datum |
+| 3 | Introduce Parameter Object **by cohesion**, not by aggregation |
+| 4 | Interface Segregation — depend on the narrowest contract you use |
+| 6 | Scope state to its real lifetime (per-run/per-session, not per-process) |
+
+## What NOT to change
+
+- **`platform()` itself** — it is the model to copy, not flatten.
+- **`TraceEmitter.stageScope`** — per-instance ALS is correct.
+- **`outputState` / `modelSwitchState`** — already properly threaded.
+- **Stream-keyed approval bypass controllers** — already correctly per-stream scoped.
+- **`logger`** — a genuine cross-cutting concern; leave it ambient/threaded as-is.

--- a/docs/proposals/dependency-injection-cleanup.md
+++ b/docs/proposals/dependency-injection-cleanup.md
@@ -19,7 +19,7 @@ TeXRA already has **one genuinely clean DI seam**: `platform()` (`src/platform/p
 
 **The headline finding:** mechanisms A and C carry **the same 8–9 fields at once**, and the two halves of the codebase disagree on which is canonical — **flow nodes read them from the bag, tools read them from `RunContext`**. That split-brain is the strongest evidence that bag-threading those fields is redundant, and it tells us the migration target is already chosen by the code.
 
-**The fundamentals** (Mark Seemann, *Dependency Injection*; ISP; functional-core/imperative-shell) all point the same way: depend on narrow interfaces, wire once at one root, scope to the right lifetime, carry only what you read.
+**The fundamentals** (Mark Seemann, _Dependency Injection_; ISP; functional-core/imperative-shell) all point the same way: depend on narrow interfaces, wire once at one root, scope to the right lifetime, carry only what you read.
 
 ---
 
@@ -58,11 +58,11 @@ flowchart TB
     style PORT fill:#dfd,stroke:#3b6
 ```
 
-| Mechanism | Count | Visibility at call site | Lifetime scope | Verdict |
-| --- | --- | --- | --- | --- |
-| **A. Fat context bag** (`AgentCore`→`*Services`) | 13 fields → ~31–35 runtime | Visible in types (but understated) | Per run | Over-carried; split into cohesive objects + narrow interfaces |
-| **B. `set*` module singletons** | 24 injectors | Invisible | Process (mostly) | Fold 20 into `Platform`; scope 1 to `RunContext`; 3 are test-only |
-| **C. ALS + process registries** | 3 ALS + 7 registries | Invisible | Run / process | Keep `RunContext` (good), de-dup vs. bag; registries block concurrency |
+| Mechanism                                        | Count                      | Visibility at call site            | Lifetime scope   | Verdict                                                                |
+| ------------------------------------------------ | -------------------------- | ---------------------------------- | ---------------- | ---------------------------------------------------------------------- |
+| **A. Fat context bag** (`AgentCore`→`*Services`) | 13 fields → ~31–35 runtime | Visible in types (but understated) | Per run          | Over-carried; split into cohesive objects + narrow interfaces          |
+| **B. `set*` module singletons**                  | 24 injectors               | Invisible                          | Process (mostly) | Fold 20 into `Platform`; scope 1 to `RunContext`; 3 are test-only      |
+| **C. ALS + process registries**                  | 3 ALS + 7 registries       | Invisible                          | Run / process    | Keep `RunContext` (good), de-dup vs. bag; registries block concurrency |
 
 ---
 
@@ -81,7 +81,7 @@ AgentCore (13)                         BaseFlowServices.ts:18
             └─ ToolUseCycleServices    CycleServices.ts:30           → 23 declared / ~35 runtime
 ```
 
-The inheritance is only **3 levels deep**, but the *runtime* object is larger than the declared interface because the outer bag is **spread wholesale** into the inner cycle (`{...this.services, ...}`) rather than narrowed. TypeScript understates what is actually carried.
+The inheritance is only **3 levels deep**, but the _runtime_ object is larger than the declared interface because the outer bag is **spread wholesale** into the inner cycle (`{...this.services, ...}`) rather than narrowed. TypeScript understates what is actually carried.
 
 ### The bag travels 4 hops and is re-spread twice
 
@@ -99,22 +99,22 @@ flowchart LR
     style CN fill:#fe9,stroke:#b83
 ```
 
-The two re-spread sites are `ResponseCycleNode.ts:94` and `ToolUseCycleNode.ts:75`. The other `setServices` calls are the initial injection or framework plumbing (`persistedFlow.ts:185`, `node/index.ts:292`) that hands the *same* bag to every node in a flow.
+The two re-spread sites are `ResponseCycleNode.ts:94` and `ToolUseCycleNode.ts:75`. The other `setServices` calls are the initial injection or framework plumbing (`persistedFlow.ts:185`, `node/index.ts:292`) that hands the _same_ bag to every node in a flow.
 
 ### Read-vs-carried per node
 
-| Node | File | Carries | Reads (distinct) |
-| --- | --- | --- | --- |
-| `MediaExtractionNode` | reflection/nodes | ~26 | 4 |
-| `OutputNode` | reflection/nodes | ~26 | 6 |
-| `PrepareContextNode` | reflection/nodes | ~26 | 3 |
-| `TeXCountNode` | reflection/nodes | ~26 | 3 |
-| `ResponseCycleNode` | reflection/nodes | ~26 | 6 (+re-spreads) |
-| `ToolUsePrepareNode` | tooluse/nodes | ~33 | 9 |
-| `ToolUseCycleNode` | tooluse/nodes | ~33 | 9 (+re-spreads) |
-| `ToolUseWaitNode` | tooluse/nodes | ~33 | 5 |
-| `ModelInvocationNode` | core/flows | ~35 | 4 |
-| `ToolUseDispatchNode` | core/flows | ~35 | 6 |
+| Node                  | File             | Carries | Reads (distinct) |
+| --------------------- | ---------------- | ------- | ---------------- |
+| `MediaExtractionNode` | reflection/nodes | ~26     | 4                |
+| `OutputNode`          | reflection/nodes | ~26     | 6                |
+| `PrepareContextNode`  | reflection/nodes | ~26     | 3                |
+| `TeXCountNode`        | reflection/nodes | ~26     | 3                |
+| `ResponseCycleNode`   | reflection/nodes | ~26     | 6 (+re-spreads)  |
+| `ToolUsePrepareNode`  | tooluse/nodes    | ~33     | 9                |
+| `ToolUseCycleNode`    | tooluse/nodes    | ~33     | 9 (+re-spreads)  |
+| `ToolUseWaitNode`     | tooluse/nodes    | ~33     | 5                |
+| `ModelInvocationNode` | core/flows       | ~35     | 4                |
+| `ToolUseDispatchNode` | core/flows       | ~35     | 6                |
 
 ```mermaid
 %%{init: {'theme':'neutral'}}%%
@@ -158,12 +158,12 @@ flowchart LR
     style AMB fill:#eee,stroke:#888
 ```
 
-| Group | Fields | Evidence of co-usage |
-| --- | --- | --- |
-| `RunIdentity` | `runtimeHost, streamId, executionId` | `ToolUseCycleNode.ts:45-62`, `OutputNode.ts:263`, `contextHelpers.ts:36-48` |
-| `DelegationPolicy` | `delegationDepth, delegationConfig` (+ `approvalPromptsUnavailable, stopAfterCycle`) | `DelegationTools.ts:354-359, 1070-1073`; `AgentLaunchContext.ts:112-115` |
-| `AgentDefinition` | `config, setting, prompt` (+ `modelHandler, userVarChannels`) | `ResponseCycleNode.ts:69-71`, `AgentLaunchContext.ts:281-298`, `ToolUsePrepareNode.ts:24-78` |
-| ambient | `logger` (read by nearly every node), `workingDirectory` (tools only) | n/a — genuine cross-cutting |
+| Group              | Fields                                                                               | Evidence of co-usage                                                                         |
+| ------------------ | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `RunIdentity`      | `runtimeHost, streamId, executionId`                                                 | `ToolUseCycleNode.ts:45-62`, `OutputNode.ts:263`, `contextHelpers.ts:36-48`                  |
+| `DelegationPolicy` | `delegationDepth, delegationConfig` (+ `approvalPromptsUnavailable, stopAfterCycle`) | `DelegationTools.ts:354-359, 1070-1073`; `AgentLaunchContext.ts:112-115`                     |
+| `AgentDefinition`  | `config, setting, prompt` (+ `modelHandler, userVarChannels`)                        | `ResponseCycleNode.ts:69-71`, `AgentLaunchContext.ts:281-298`, `ToolUsePrepareNode.ts:24-78` |
+| ambient            | `logger` (read by nearly every node), `workingDirectory` (tools only)                | n/a — genuine cross-cutting                                                                  |
 
 ---
 
@@ -195,37 +195,37 @@ flowchart TB
 ### Classification
 
 - **20 → `Platform` ports (P):** process-lifetime host capabilities that belong on the frozen `Platform` object.
-- **1 → `RunContext` (R):** `setToolEditApprovalHandler` — conceptually the *active session's* approval channel, currently a single module global mutated by whichever host UI is active.
+- **1 → `RunContext` (R):** `setToolEditApprovalHandler` — conceptually the _active session's_ approval channel, currently a single module global mutated by whichever host UI is active.
 - **3 → test-only / justified lazy singleton (T):** `setDefaultStreamLogStore`, `setTierService`, `setServerSideKeyService`.
 
 ### Full inventory
 
-| Setter (file:line) | Default | Class | Multi-root? | Silent no-op? |
-| --- | --- | --- | --- | --- |
-| `setLinterProvider` `DiagnosticsTool.ts:12` | `async () => []` | P | — | **yes** |
-| `setAddCriticismSink` `AddCriticismTool.ts:48` | `{accepted:false}` | P | — | **yes** |
-| `setOpenPdfOpener` `OpenPdfTool.ts:42` | undefined | P | — | yes |
-| `setOpenBuildDisplay` `approval/latexPreview.ts:34` | `async () => {}` | P | **ext+desktop** | **yes** (no-ops in CLI) |
-| `setToolMissingHandler` `utils/system/toolUtils.ts:58` | `() => {}` | P | — | **yes** |
-| `setToolNotificationHandler` `toolUnavailableNotification.ts:28` | `() => {}` | P | — | **yes** |
-| `setGitHubTokenProvider` `github/githubAuth.ts:15` | `() => undefined` | P | — | **yes** |
-| `setExtensionChecker` `externalToolDefs.ts:60` | `() => false` | P | — | **yes** |
-| `setTexraCliEntrypointChecker` `externalToolDefs.ts:67` | `() => false` | P | — | **yes** |
-| `setLeanLanguageServices` `lean/leanLanguageServices.ts:53` | undefined (getter throws) | P | **ext+desktop+cli** | no |
-| `setSetupPlatform` `setup/platform.ts:104` | undefined (getter throws) | P | — | no |
-| `setRunStorageService` `runtime/RunStorageService.ts:17` | `isViewVisible:()=>false` | P | **ext+desktop** | **yes** |
-| `setGitAuthorEnv` `utils/system/gitAuthorEnv.ts:16` | `{}` | P | **3 funnels** | benign |
-| `setWorktreeSupportEnabled` `worktreeConfig.ts:14` | `false` | P | **3 funnels** | intended off |
-| `setOutputChannelFactory` `logger/logUtils.ts:140` | `null` | P | **ext+cli** | null sink (desktop) |
-| `setAgentDirectories` `index/agentDirectoriesRegistry.ts:11` | `null` (getter throws) | P | **ext + core module** | no |
-| `setRuntimeSkillSources` `skills/runtimeSkills.ts:13` | `[]` | P | cli only | silent (cli-only) |
-| `setRuntimeExtensionId` `auth/config.ts:102` | `null` (const fallback) | P | — | benign |
-| `setExternalAuthCallbackResolver` `auth/config.ts:151` | `null` | P | — | benign |
-| `setToolEditApprovalHandler` `approval/toolEditApproval.ts:118` | undefined | **R** | **4 sites / 3 hosts** | falls back to controller |
-| `setDesktopAgentResumeHandler` `desktop/.../desktopAgentResume.ts:7` | undefined (`?? false`) | P (desktop) | — | benign |
-| `setDefaultStreamLogStore` `transcript/StreamLogStore.ts:789` | lazy `new` | T | — | no |
-| `setTierService` `auth/tier/index.ts:46` | lazy `new` | T | — | no |
-| `setServerSideKeyService` `auth/serverKeys/index.ts:52` | `null` (getter throws) | T | — | no |
+| Setter (file:line)                                                   | Default                   | Class       | Multi-root?           | Silent no-op?            |
+| -------------------------------------------------------------------- | ------------------------- | ----------- | --------------------- | ------------------------ |
+| `setLinterProvider` `DiagnosticsTool.ts:12`                          | `async () => []`          | P           | —                     | **yes**                  |
+| `setAddCriticismSink` `AddCriticismTool.ts:48`                       | `{accepted:false}`        | P           | —                     | **yes**                  |
+| `setOpenPdfOpener` `OpenPdfTool.ts:42`                               | undefined                 | P           | —                     | yes                      |
+| `setOpenBuildDisplay` `approval/latexPreview.ts:34`                  | `async () => {}`          | P           | **ext+desktop**       | **yes** (no-ops in CLI)  |
+| `setToolMissingHandler` `utils/system/toolUtils.ts:58`               | `() => {}`                | P           | —                     | **yes**                  |
+| `setToolNotificationHandler` `toolUnavailableNotification.ts:28`     | `() => {}`                | P           | —                     | **yes**                  |
+| `setGitHubTokenProvider` `github/githubAuth.ts:15`                   | `() => undefined`         | P           | —                     | **yes**                  |
+| `setExtensionChecker` `externalToolDefs.ts:60`                       | `() => false`             | P           | —                     | **yes**                  |
+| `setTexraCliEntrypointChecker` `externalToolDefs.ts:67`              | `() => false`             | P           | —                     | **yes**                  |
+| `setLeanLanguageServices` `lean/leanLanguageServices.ts:53`          | undefined (getter throws) | P           | **ext+desktop+cli**   | no                       |
+| `setSetupPlatform` `setup/platform.ts:104`                           | undefined (getter throws) | P           | —                     | no                       |
+| `setRunStorageService` `runtime/RunStorageService.ts:17`             | `isViewVisible:()=>false` | P           | **ext+desktop**       | **yes**                  |
+| `setGitAuthorEnv` `utils/system/gitAuthorEnv.ts:16`                  | `{}`                      | P           | **3 funnels**         | benign                   |
+| `setWorktreeSupportEnabled` `worktreeConfig.ts:14`                   | `false`                   | P           | **3 funnels**         | intended off             |
+| `setOutputChannelFactory` `logger/logUtils.ts:140`                   | `null`                    | P           | **ext+cli**           | null sink (desktop)      |
+| `setAgentDirectories` `index/agentDirectoriesRegistry.ts:11`         | `null` (getter throws)    | P           | **ext + core module** | no                       |
+| `setRuntimeSkillSources` `skills/runtimeSkills.ts:13`                | `[]`                      | P           | cli only              | silent (cli-only)        |
+| `setRuntimeExtensionId` `auth/config.ts:102`                         | `null` (const fallback)   | P           | —                     | benign                   |
+| `setExternalAuthCallbackResolver` `auth/config.ts:151`               | `null`                    | P           | —                     | benign                   |
+| `setToolEditApprovalHandler` `approval/toolEditApproval.ts:118`      | undefined                 | **R**       | **4 sites / 3 hosts** | falls back to controller |
+| `setDesktopAgentResumeHandler` `desktop/.../desktopAgentResume.ts:7` | undefined (`?? false`)    | P (desktop) | —                     | benign                   |
+| `setDefaultStreamLogStore` `transcript/StreamLogStore.ts:789`        | lazy `new`                | T           | —                     | no                       |
+| `setTierService` `auth/tier/index.ts:46`                             | lazy `new`                | T           | —                     | no                       |
+| `setServerSideKeyService` `auth/serverKeys/index.ts:52`              | `null` (getter throws)    | T           | —                     | no                       |
 
 **Correctly-scoped already (not the anti-pattern, listed for completeness):** `setBashApprovalSessionBypass` / `setToolEditApprovalSessionBypass` are stream-keyed controllers (`createStreamApprovalController` map keyed by `streamId`), not singletons.
 
@@ -269,11 +269,11 @@ flowchart TB
 
 ### The three AsyncLocalStorage instances
 
-| ALS | File:line | Shape | Assessment |
-| --- | --- | --- | --- |
-| `runContextScope` | `RunContext.ts:70` | single value, per run | Good seam; but duplicates 8–9 bag fields. `tryUseRunContext()` silently returns `undefined` outside scope. |
-| `contextStackScope` | `ToolFileInteractionContext.ts:34` | **stack** | `getCurrentToolCallContext()` reads `.at(-1)` (`:49`) — a tool that spawns a sub-cycle then reads context gets the **child's** tracker, not its own. |
-| `stageScope` | `TraceEmitter.ts:49` | per-instance | **Correct by design** — per-instance prevents cross-trace stage leakage. Do not make module-global. |
+| ALS                 | File:line                          | Shape                 | Assessment                                                                                                                                           |
+| ------------------- | ---------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `runContextScope`   | `RunContext.ts:70`                 | single value, per run | Good seam; but duplicates 8–9 bag fields. `tryUseRunContext()` silently returns `undefined` outside scope.                                           |
+| `contextStackScope` | `ToolFileInteractionContext.ts:34` | **stack**             | `getCurrentToolCallContext()` reads `.at(-1)` (`:49`) — a tool that spawns a sub-cycle then reads context gets the **child's** tracker, not its own. |
+| `stageScope`        | `TraceEmitter.ts:49`               | per-instance          | **Correct by design** — per-instance prevents cross-trace stage leakage. Do not make module-global.                                                  |
 
 ### Process-global registries (the concurrency blocker)
 
@@ -306,7 +306,7 @@ flowchart LR
 
 Sequenced so nothing breaks, lowest-risk first:
 
-1. **Fold the 20 P-class setters into `Platform` ports.** *(Highest leverage, mostly mechanical.)* Most consumers sit 1–2 hops from the setter (often the same file). Precedent already exists (`fs`, `workspace`, `secrets`). Eliminates the entire silent-no-op class at once — a missing wiring becomes a type error. Do the 6 ext-only no-op setters first (clearest user-facing bug surface in CLI/desktop).
+1. **Fold the 20 P-class setters into `Platform` ports.** _(Highest leverage, mostly mechanical.)_ Most consumers sit 1–2 hops from the setter (often the same file). Precedent already exists (`fs`, `workspace`, `secrets`). Eliminates the entire silent-no-op class at once — a missing wiring becomes a type error. Do the 6 ext-only no-op setters first (clearest user-facing bug surface in CLI/desktop).
 2. **De-duplicate the split-brain fields.** Stop threading the 8–9 fields already in `RunContext`; let flow nodes read them the way tools already do. This shrinks every flow-service interface for free.
 3. **Cohesion-split `AgentCore`** into `RunIdentity` / `DelegationPolicy` / `AgentDefinition` + ambient `logger`. The wholesale re-spread at the 2 nesting sites becomes `setServices({ identity, delegation, agent })`.
 4. **Narrow node interfaces (ISP).** A node reading 3 fields should declare those 3, not `ReflectionServices`. This removes the pressure to forward the whole bag.
@@ -315,14 +315,14 @@ Sequenced so nothing breaks, lowest-risk first:
 
 ### Fundamentals these steps apply
 
-| Step | Principle |
-| --- | --- |
+| Step | Principle                                                                     |
+| ---- | ----------------------------------------------------------------------------- |
 | 1, 5 | Single composition root; dependency injection over service location (Seemann) |
-| 1 | Immutable, set-once wiring (frozen `Platform`) over mutable module globals |
-| 2 | One canonical source of truth per datum |
-| 3 | Introduce Parameter Object **by cohesion**, not by aggregation |
-| 4 | Interface Segregation — depend on the narrowest contract you use |
-| 6 | Scope state to its real lifetime (per-run/per-session, not per-process) |
+| 1    | Immutable, set-once wiring (frozen `Platform`) over mutable module globals    |
+| 2    | One canonical source of truth per datum                                       |
+| 3    | Introduce Parameter Object **by cohesion**, not by aggregation                |
+| 4    | Interface Segregation — depend on the narrowest contract you use              |
+| 6    | Scope state to its real lifetime (per-run/per-session, not per-process)       |
 
 ## What NOT to change
 

--- a/docs/proposals/dependency-injection-cleanup.md
+++ b/docs/proposals/dependency-injection-cleanup.md
@@ -70,18 +70,18 @@ flowchart TB
 
 ### The inheritance chain
 
-The root is `AgentCore<C>` (`src/agent/implementations/flows/common/BaseFlowServices.ts:18`). Every flow-service interface extends it through `BaseFlowContextInit`:
+The root is `AgentCore<C>` (`src/agent/implementations/flows/common/BaseFlowServices.ts:18`). Every flow-service interface extends it through `BaseFlowContextInit`, but the cycle-service interfaces are siblings of the flow-specific interfaces, not children of them:
 
 ```
 AgentCore (13)                         BaseFlowServices.ts:18
   └─ BaseFlowContextInit (+4 = 17)     BaseFlowServices.ts:53
        ├─ ReflectionServices (+~9)     ReflectionServices.ts:18      → ~26 declared
-       │    └─ ResponseCycleServices   CycleServices.ts:19           → 22 declared / ~31 runtime
-       └─ ToolUseServices (+~16)       ToolUseServices.ts:15         → ~33 declared
-            └─ ToolUseCycleServices    CycleServices.ts:30           → 23 declared / ~35 runtime
+       ├─ ToolUseServices (+~16)       ToolUseServices.ts:15         → ~33 declared
+       ├─ ResponseCycleServices (+5)   CycleServices.ts:19           → 22 declared / ~31 runtime
+       └─ ToolUseCycleServices (+6)    CycleServices.ts:30           → 23 declared / ~35 runtime
 ```
 
-The inheritance is only **3 levels deep**, but the _runtime_ object is larger than the declared interface because the outer bag is **spread wholesale** into the inner cycle (`{...this.services, ...}`) rather than narrowed. TypeScript understates what is actually carried.
+The declared inheritance is only **2 levels deep** after `AgentCore`, but the _runtime_ object is larger than the declared cycle interface because the outer bag is **spread wholesale** into the inner cycle (`{...this.services, ...}`) rather than narrowed. TypeScript understates what is actually carried.
 
 ### The bag travels 4 hops and is re-spread twice
 
@@ -236,7 +236,7 @@ flowchart TB
 
 ### The silent-no-op trap
 
-9 setters default to a no-op. Six of those are wired **only in `extension.ts`**, so in CLI/desktop the linter, manual criticism, tool-missing toasts, tool-unavailable notifications, and the GitHub token are **silently absent with no error**. Folding into typed `Platform` ports turns each missing wiring into a compile error instead of a silent runtime gap.
+9 setters default to a no-op. Six of those are wired **only in `extension.ts`**, so in CLI/desktop the linter, manual criticism, PDF opening, tool-missing toasts, tool-unavailable notifications, and the GitHub token are **silently absent with no error**. Folding into typed `Platform` ports turns each missing wiring into a compile error instead of a silent runtime gap.
 
 ---
 

--- a/docs/proposals/dependency-injection-cleanup.md
+++ b/docs/proposals/dependency-injection-cleanup.md
@@ -17,7 +17,7 @@ TeXRA already has **one genuinely clean DI seam**: `platform()` (`src/platform/p
 2. **24 module-level `set*` singletons** (service-locator style): host capabilities injected via mutable module globals. **9 have silent no-op defaults**; **6 are wired only in `extension.ts`**, so they silently no-op in the CLI and desktop hosts. **8 are written from multiple composition roots.**
 3. **Ambient state** (AsyncLocalStorage + 7 process-global registries): `RunContext` and `ToolCallContext` plus the runtime registries that — per [`agent-sdk-readiness.md`](./agent-sdk-readiness.md) — block concurrent in-process sessions.
 
-**The headline finding:** mechanisms A and C carry **the same 8–9 fields at once**, and the two halves of the codebase disagree on which is canonical — **flow nodes read them from the bag, tools read them from `RunContext`**. That split-brain is the strongest evidence that bag-threading those fields is redundant, and it tells us the migration target is already chosen by the code.
+**The headline finding:** mechanisms A and C carry **the same 7–8 fields at once**, and the two halves of the codebase disagree on which is canonical — **flow nodes read them from the bag, tools read them from `RunContext`**. That split-brain is the strongest evidence that bag-threading those fields is redundant, and it tells us the migration target is already chosen by the code.
 
 **The fundamentals** (Mark Seemann, _Dependency Injection_; ISP; functional-core/imperative-shell) all point the same way: depend on narrow interfaces, wire once at one root, scope to the right lifetime, carry only what you read.
 
@@ -49,7 +49,7 @@ flowchart TB
     CLI -->|"re-wires some,\nmisses others"| SET
 
     EXT --> AC
-    AC -. "8-9 fields duplicated" .-> RC
+    AC -. "7-8 fields duplicated" .-> RC
     SET -. "should fold into" .-> PORT["frozen Platform ports"]
 
     style A fill:#fde,stroke:#b36
@@ -92,7 +92,7 @@ flowchart LR
     RF --> CN["ToolUseCycleNode\ncarries ~33 · reads 9"]
     CN -->|"hop 3\nre-spread {...this.services}\nToolUseCycleNode.ts:75"| CF["inner cycle flow"]
     CF -->|"hop 4\nframework copies again"| MI["ModelInvocationNode\ncarries ~35 · reads 4"]
-    CF --> DN["ToolUseDispatchNode\ncarries ~35 · reads 6"]
+    CF --> DN["ToolUseDispatchNode\nToolUseCycleFlow.ts:511\ncarries ~35 · reads 6"]
 
     style MI fill:#fdd,stroke:#c33
     style DN fill:#fdd,stroke:#c33
@@ -103,18 +103,18 @@ The two re-spread sites are `ResponseCycleNode.ts:94` and `ToolUseCycleNode.ts:7
 
 ### Read-vs-carried per node
 
-| Node                  | File             | Carries | Reads (distinct) |
-| --------------------- | ---------------- | ------- | ---------------- |
-| `MediaExtractionNode` | reflection/nodes | ~26     | 4                |
-| `OutputNode`          | reflection/nodes | ~26     | 6                |
-| `PrepareContextNode`  | reflection/nodes | ~26     | 3                |
-| `TeXCountNode`        | reflection/nodes | ~26     | 3                |
-| `ResponseCycleNode`   | reflection/nodes | ~26     | 6 (+re-spreads)  |
-| `ToolUsePrepareNode`  | tooluse/nodes    | ~33     | 9                |
-| `ToolUseCycleNode`    | tooluse/nodes    | ~33     | 9 (+re-spreads)  |
-| `ToolUseWaitNode`     | tooluse/nodes    | ~33     | 5                |
-| `ModelInvocationNode` | core/flows       | ~35     | 4                |
-| `ToolUseDispatchNode` | core/flows       | ~35     | 6                |
+| Node                  | File                                   | Carries | Reads (distinct) |
+| --------------------- | -------------------------------------- | ------- | ---------------- |
+| `MediaExtractionNode` | reflection/nodes                       | ~26     | 4                |
+| `OutputNode`          | reflection/nodes                       | ~26     | 6                |
+| `PrepareContextNode`  | reflection/nodes                       | ~26     | 3                |
+| `TeXCountNode`        | reflection/nodes                       | ~26     | 3                |
+| `ResponseCycleNode`   | reflection/nodes                       | ~26     | 6 (+re-spreads)  |
+| `ToolUsePrepareNode`  | tooluse/nodes                          | ~33     | 9                |
+| `ToolUseCycleNode`    | tooluse/nodes                          | ~33     | 9 (+re-spreads)  |
+| `ToolUseWaitNode`     | tooluse/nodes                          | ~33     | 5                |
+| `ModelInvocationNode` | core/flows                             | ~35     | 4                |
+| `ToolUseDispatchNode` | core/flows (`ToolUseCycleFlow.ts:511`) | ~35     | 6                |
 
 ```mermaid
 %%{init: {'theme':'neutral'}}%%
@@ -158,12 +158,12 @@ flowchart LR
     style AMB fill:#eee,stroke:#888
 ```
 
-| Group              | Fields                                                                               | Evidence of co-usage                                                                         |
-| ------------------ | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| `RunIdentity`      | `runtimeHost, streamId, executionId`                                                 | `ToolUseCycleNode.ts:45-62`, `OutputNode.ts:263`, `contextHelpers.ts:36-48`                  |
-| `DelegationPolicy` | `delegationDepth, delegationConfig` (+ `approvalPromptsUnavailable, stopAfterCycle`) | `DelegationTools.ts:354-359, 1070-1073`; `AgentLaunchContext.ts:112-115`                     |
-| `AgentDefinition`  | `config, setting, prompt` (+ `modelHandler, userVarChannels`)                        | `ResponseCycleNode.ts:69-71`, `AgentLaunchContext.ts:281-298`, `ToolUsePrepareNode.ts:24-78` |
-| ambient            | `logger` (read by nearly every node), `workingDirectory` (tools only)                | n/a — genuine cross-cutting                                                                  |
+| Group              | Fields                                                                                                        | Evidence of co-usage                                                                         |
+| ------------------ | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `RunIdentity`      | `runtimeHost, streamId, executionId`                                                                          | `ToolUseCycleNode.ts:45-62`, `OutputNode.ts:263`, `contextHelpers.ts:36-48`                  |
+| `DelegationPolicy` | `delegationDepth, delegationConfig` (+ `approvalPromptsUnavailable`; `stopAfterCycle` is launch-context only) | `DelegationTools.ts:354-359, 1070-1073`; `AgentLaunchContext.ts:112-115`                     |
+| `AgentDefinition`  | `config, setting, prompt` (+ `modelHandler, userVarChannels`)                                                 | `ResponseCycleNode.ts:69-71`, `AgentLaunchContext.ts:281-298`, `ToolUsePrepareNode.ts:24-78` |
+| ambient            | `logger` (read by nearly every node), `workingDirectory` (tools only)                                         | n/a — genuine cross-cutting                                                                  |
 
 ---
 
@@ -256,7 +256,7 @@ flowchart TB
 
     FN -. "same values" .- TL
 
-    DUP["runtimeHost · streamId · executionId\ndelegationDepth · delegationConfig\nworkingDirectory · stopAfterCycle\napprovalPromptsUnavailable · logger"]
+    DUP["runtimeHost · streamId · executionId\ndelegationDepth · delegationConfig\nworkingDirectory\napprovalPromptsUnavailable · logger/trace"]
     BAG --- DUP
     RC --- DUP
 
@@ -265,19 +265,19 @@ flowchart TB
     style TL fill:#efe,stroke:#3b6
 ```
 
-**8–9 of `AgentCore`'s 13 fields are also in `RunContext`** (`RunContext.ts:18-49`, populated from the same `ctx` at `AgentLaunchContext.ts:103-116`): `runtimeHost`, `streamId`, `executionId`, `delegationDepth`, `delegationConfig`, `workingDirectory`, `approvalPromptsUnavailable`, `stopAfterCycle`, `logger`/`trace`. Flow nodes read them from the bag; tools read them from `RunContext` (`contextHelpers.ts:23,41,48`, `DelegationTools.ts:353-359`). Same data, two paths.
+**7–8 of `AgentCore`'s 13 fields are also in `RunContext`** (`RunContext.ts:18-49`, populated from the same `ctx` at `AgentLaunchContext.ts:103-116`): `runtimeHost`, `streamId`, `executionId`, `delegationDepth`, `delegationConfig`, `workingDirectory`, `approvalPromptsUnavailable`, plus `logger`/`trace` if counted as the same underlying trace object. Flow nodes read them from the bag; tools read them from `RunContext` (`contextHelpers.ts:23,41,48`, `DelegationTools.ts:353-359`). Same data, two paths.
 
 ### The three AsyncLocalStorage instances
 
 | ALS                 | File:line                          | Shape                 | Assessment                                                                                                                                           |
 | ------------------- | ---------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `runContextScope`   | `RunContext.ts:70`                 | single value, per run | Good seam; but duplicates 8–9 bag fields. `tryUseRunContext()` silently returns `undefined` outside scope.                                           |
+| `runContextScope`   | `RunContext.ts:70`                 | single value, per run | Good seam; but duplicates 7–8 bag fields. `tryUseRunContext()` silently returns `undefined` outside scope.                                           |
 | `contextStackScope` | `ToolFileInteractionContext.ts:34` | **stack**             | `getCurrentToolCallContext()` reads `.at(-1)` (`:49`) — a tool that spawns a sub-cycle then reads context gets the **child's** tracker, not its own. |
 | `stageScope`        | `TraceEmitter.ts:49`               | per-instance          | **Correct by design** — per-instance prevents cross-trace stage leakage. Do not make module-global.                                                  |
 
 ### Process-global registries (the concurrency blocker)
 
-`runCoordinatorBridge` (`runCoordinators.ts:212`), `executionRegistry` (`executionRegistry.ts:392`), `interruptRegistry` (`InterruptRegistry.ts:49`), `idleContinuationRegistry` (`idleContinuation.ts:55`), `toolInjectionRegistry` (`toolInjection.ts:34`), `StreamStatusService` (`StreamStatusService.ts:123`), `subagentDeliveryRegistry` (`subagentDeliveryState.ts:69`). These make the runtime a per-process singleton — documented as the blocker for concurrent in-process sessions in [`agent-sdk-readiness.md`](./agent-sdk-readiness.md) (§ "Host↔core coordination is process-global"). Tracked there; cross-referenced here for completeness.
+`runCoordinatorBridge` (`runCoordinators.ts:220`), `executionRegistry` (`executionRegistry.ts:451`), `interruptRegistry` (`InterruptRegistry.ts:49`), `idleContinuationRegistry` (`idleContinuation.ts:55`), `toolInjectionRegistry` (`toolInjection.ts:34`), `StreamStatusService` (`StreamStatusService.ts:123`), `subagentDeliveryRegistry` (`subagentDeliveryState.ts:69`). These make the runtime a per-process singleton — documented as the blocker for concurrent in-process sessions in [`agent-sdk-readiness.md`](./agent-sdk-readiness.md) (§ "Host↔core coordination is process-global"). Tracked there; cross-referenced here for completeness.
 
 ### Rejected suspicions (traps)
 
@@ -292,7 +292,7 @@ flowchart TB
 flowchart LR
     P1["20 P-setters"] -->|fold into| PORTS["frozen Platform ports"]
     P2["setToolEditApprovalHandler\n+ 7 registries"] -->|scope to| RUN["RunContext (per-run)"]
-    P3["8-9 duplicated bag fields"] -->|drop from bag,\nread like tools do| RUN
+    P3["7-8 duplicated bag fields"] -->|drop from bag,\nread like tools do| RUN
     P4["13-field AgentCore"] -->|cohesion split| FOUR["4 objects + ambient logger"]
     P5["wholesale {...services}\nre-spread ×2"] -->|narrow interfaces| ISP["nodes declare only\nwhat they read"]
 
@@ -307,7 +307,7 @@ flowchart LR
 Sequenced so nothing breaks, lowest-risk first:
 
 1. **Fold the 20 P-class setters into `Platform` ports.** _(Highest leverage, mostly mechanical.)_ Most consumers sit 1–2 hops from the setter (often the same file). Precedent already exists (`fs`, `workspace`, `secrets`). Eliminates the entire silent-no-op class at once — a missing wiring becomes a type error. Do the 6 ext-only no-op setters first (clearest user-facing bug surface in CLI/desktop).
-2. **De-duplicate the split-brain fields.** Stop threading the 8–9 fields already in `RunContext`; let flow nodes read them the way tools already do. This shrinks every flow-service interface for free.
+2. **De-duplicate the split-brain fields.** Stop threading the 7–8 fields already in `RunContext`; let flow nodes read them the way tools already do. This shrinks every flow-service interface for free.
 3. **Cohesion-split `AgentCore`** into `RunIdentity` / `DelegationPolicy` / `AgentDefinition` + ambient `logger`. The wholesale re-spread at the 2 nesting sites becomes `setServices({ identity, delegation, agent })`.
 4. **Narrow node interfaces (ISP).** A node reading 3 fields should declare those 3, not `ReflectionServices`. This removes the pressure to forward the whole bag.
 5. **Scope `setToolEditApprovalHandler` to `RunContext`** (the one R-class setter).

--- a/docs/proposals/dependency-injection-cleanup.md
+++ b/docs/proposals/dependency-injection-cleanup.md
@@ -294,7 +294,7 @@ flowchart LR
     P2["setToolEditApprovalHandler"] -->|scope to| RUN["RunContext (per-run)"]
     P2B["7 registries"] -->|scope to| SESSION["per-session runtime owner"]
     P3["7-8 duplicated bag fields"] -->|drop from bag,\nread like tools do| RUN
-    P4["13-field AgentCore"] -->|cohesion split| FOUR["4 objects + ambient logger"]
+    P4["13-field AgentCore"] -->|cohesion split| FOUR["4 cohesive groups"]
     P5["wholesale {...services}\nre-spread ×2"] -->|narrow interfaces| ISP["nodes declare only\nwhat they read"]
 
     PORTS --> WIN["✓ typed wiring\n✓ no silent no-ops\n✓ concurrent sessions\n✓ ~80% less carried"]


### PR DESCRIPTION
Document the three "deep injection" mechanisms in the agent core
(fat AgentCore context bag, 24 set* module singletons, ambient
ALS/registries), the split-brain double-sourcing between the bag and
RunContext, and a sequenced migration plan toward Platform ports,
cohesive parameter objects, and narrow interfaces.

https://claude.ai/code/session_01J5iyihfNY6PakoochceLR7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only proposal with no code or wiring changes.
> 
> **Overview**
> Adds **`docs/proposals/dependency-injection-cleanup.md`**, a read-only audit (no runtime changes) of how dependencies move through the agent core and hosts.
> 
> The doc names **three overlapping mechanisms** beside the existing `platform()` seam: the **`AgentCore` / `*Services` context bag** (13 fields growing to ~31–35 via wholesale spreads), **24 module-level `set*` injectors** (many with silent no-op defaults and multiple composition roots), and **ambient state** (`RunContext` ALS plus seven process-global registries). Its central claim is **split-brain**: ~7–8 of the same fields are threaded in the bag for flow nodes while tools read them from `RunContext`.
> 
> It inventories setters with `file:line` citations, tables for bag read-vs-carried per node, mermaid diagrams, explicit **rejected traps** (`outputState`, `modelSwitchState`, `TraceEmitter.stageScope`), a **“what not to change”** list, and a **six-step migration plan** (Platform ports → de-dup vs `RunContext` → cohesive `AgentCore` groups → ISP on nodes → per-run approval handler → per-session registries, cross-linked to `agent-sdk-readiness.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ce0f722ab15fcfc995bc480fdbecda4ccdd9f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->