### PR TITLE
fix(webview): slim inline banners and correct sign-in model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Open VSX Version](https://img.shields.io/open-vsx/v/texra-ai/texra)](https://open-vsx.org/extension/texra-ai/texra)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/texra-ai/texra)](https://open-vsx.org/extension/texra-ai/texra)
 [![npm version](https://img.shields.io/npm/v/@texra-ai/cli?label=%40texra-ai%2Fcli)](https://www.npmjs.com/package/@texra-ai/cli)
-[![npm downloads](https://img.shields.io/npm/dm/@texra-ai/cli)](https://www.npmjs.com/package/@texra-ai/cli)
+[![CLI downloads](https://img.shields.io/npm/dm/@texra-ai/cli?label=CLI%20downloads)](https://www.npmjs.com/package/@texra-ai/cli)
 
 A LaTeX research assistant for VS Code and the terminal. Multi-agent
 workflows for writing, reviewing, formalizing, and rendering academic

--- a/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
@@ -26,7 +26,8 @@ export class WorkflowHintBanner extends LitElement {
     }
     wa-callout {
       margin: 0 0 var(--wa-space-2xs) 0;
-      --padding: var(--wa-space-2xs) var(--wa-space-xs);
+      /* wa-callout ignores --padding; set the real property (its :host hardcodes 1em). */
+      padding: var(--wa-space-2xs) var(--wa-space-xs);
     }
     .banner-row {
       display: flex;

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -324,7 +324,8 @@ export class LaTeXTab extends LitElement {
          inline command text live here. */
       wa-callout.prerequisite-hint {
         margin-bottom: var(--wa-space-xs);
-        --padding: var(--wa-space-xs);
+        /* wa-callout ignores --padding; set the real property (its :host hardcodes 1em). */
+        padding: var(--wa-space-xs);
       }
 
       .hint-title {

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -37,10 +37,23 @@ export class LoginBanner extends LitElement {
         letter-spacing: -0.005em;
       }
 
-      .banner-description {
+      .banner-lead {
         font-size: var(--font-size-sm);
-        opacity: 0.78;
-        line-height: var(--line-height-relaxed, 1.5);
+        opacity: 0.85;
+        line-height: var(--line-height-normal, 1.4);
+      }
+
+      .banner-fineprint {
+        font-size: var(--font-size-xs);
+        opacity: 0.6;
+        line-height: var(--line-height-normal, 1.4);
+      }
+
+      /* Pair the sparkle with the title row instead of centering it in the
+         taller text block. */
+      #loginBanner::part(icon) {
+        align-self: flex-start;
+        margin-block-start: 0.05em;
       }
 
       #loginBannerButton::part(base) {
@@ -76,7 +89,10 @@ export class LoginBanner extends LitElement {
           <div class="banner-row">
             <div class="banner-text">
               <span class="banner-title">Researcher Access Program</span>
-              <span class="banner-description">${PROMO_NOTICE_SHORT}</span>
+              <span class="banner-lead">${PROMO_NOTICE_SHORT.lead}</span>
+              <span class="banner-fineprint"
+                >${PROMO_NOTICE_SHORT.fineprint}</span
+              >
             </div>
             <div class="actions">
               <wa-button

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -1,6 +1,7 @@
 // Shared layout for inline wa-callout banners. wa-callout owns the variant
-// color, border, and padding; this stylesheet handles host display and the
-// row layout for the message + action buttons inside the callout's default slot.
+// color and border; we override its padding here (its :host hardcodes 1em),
+// and this stylesheet handles host display and the row layout for the message
+// + action buttons inside the callout's default slot.
 
 import { css, type CSSResult } from 'lit';
 
@@ -28,11 +29,14 @@ export const bannerStyles: CSSResult = css`
 
   wa-callout {
     margin-bottom: var(--wa-space-s);
-    --padding: var(--wa-space-2xs) var(--wa-space-xs);
+    /* wa-callout's :host hardcodes padding: 1em and never reads a --padding
+       custom property, so set the real padding to keep the banner compact.
+       Outer-scope rules win over the component's :host via shadow encapsulation. */
+    padding: var(--wa-space-xs) var(--wa-space-s);
   }
 
   wa-callout::part(message) {
-    padding-block: var(--wa-space-2xs);
+    padding-block: 0;
     line-height: var(--line-height-normal);
   }
 

--- a/src/shared/copy/promoNotice.ts
+++ b/src/shared/copy/promoNotice.ts
@@ -8,13 +8,16 @@
  */
 
 /**
- * Short one-liner suitable for a banner subtitle (sign-in callout, getting
- * started). Plain text — no HTML.
+ * Short banner copy (sign-in callout), split into a value `lead` and a lighter
+ * privacy `fineprint` so the banner can render a clear two-tier hierarchy.
+ * Plain text — no HTML.
  */
-export const PROMO_NOTICE_SHORT =
-  'Sign in for free access to GPT-5, Claude Sonnet 4.6, Gemini, and more. ' +
-  'Your messages go directly to the model provider — TeXRA never stores or ' +
-  'trains on your conversations.';
+export const PROMO_NOTICE_SHORT = {
+  lead: 'Free access to GPT-5, Claude, Gemini, DeepSeek, and more.',
+  fineprint:
+    'Your messages go directly to the model provider — TeXRA never stores or ' +
+    'trains on your conversations.',
+} as const;
 
 /**
  * Structured fragments for the full Settings → Profile notice. Strings are


### PR DESCRIPTION
## Summary

The "Researcher Access Program" sign-in banner was too tall. Root cause: WebAwesome's `wa-callout` `:host` hardcodes `padding: 1em` and **never reads a `--padding` custom property**, so every inline banner that set `--padding` was silently stuck at the 1em default. The fix sets the real `padding` property instead (outer-scope rules win over the component's `:host` via shadow-DOM encapsulation).

This was systemic — the same dead `--padding`-on-`wa-callout` pattern existed in three places, all fixed here:
- shared `bannerStyles.ts` → Login, ApiKey, GettingStarted, Dependency, AgentConfig banners
- standalone `WorkflowHintBanner` (progress view)
- LaTeX-tab prerequisite hint (settings)

(`SettingsApp.ts` also sets `--padding`, but on `wa-tab-panel`, which *does* read it — left unchanged.)

## Changes

- **`bannerStyles.ts`** — dead `--padding` → real `padding: var(--wa-space-xs) var(--wa-space-s)` (8/12px) for the five shared banners. This is a deliberately chosen compact value (the previous dead value was `2xs/xs` = 4/8px, which was too tight for the icon + multi-line + buttons login layout). Also zeroed the message-part `padding-block` to drop the prior padding *doubling*; the 8px callout padding now supplies the vertical spacing.
- **`LoginBanner.ts`** — split the description into a value **lead** and a lighter, smaller privacy **fineprint** for a clear two-tier hierarchy; tightened line-height to normal; top-aligned the sparkle icon so it pairs with the title.
- **`promoNotice.ts`** — updated the free-model list to "GPT-5, Claude, Gemini, DeepSeek, and more." (added DeepSeek, dropped the pinned Claude version so it won't go stale); restructured `PROMO_NOTICE_SHORT` into `{ lead, fineprint }` (single consumer: `LoginBanner`; `PROMO_NOTICE_LONG` untouched).
- **`WorkflowHintBanner.ts`**, **`LaTeXTab.ts`** — same dead-`--padding` fix, keeping each of *these two* components' originally-intended compact value (they are simpler single-line hints).
- **`README.md`** — relabeled the npm badge as **CLI downloads** instead of the generic "downloads".

## Notes
- CHANGELOG.md was intentionally **not** touched (a 0.38.6 release-notes draft is already in progress locally).
- Heads-up: the four sibling banners and the two extra callouts will render more compact now too — that's the intended consistency fix, but worth an eyeball.
- Spacing is real: `--wa-space-scale: 1` in every webview bundle, so `--wa-space-xs` = 8px (not a hairline).

## Verification
- `npm run compile:fast` — built clean
- `npm run typecheck` — clean
- code-simplifier reviewed the diff (zero changes; flagged the WorkflowHintBanner instance, now folded in)
- Both review bots green (claude: "no issues"; TeXRA/deepseek: non-blocking notes, dispositioned in a comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)