### PR TITLE
fix(auth): stop Codespaces/web OAuth failing with bad_oauth_state

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -289,7 +289,11 @@ export async function activate(context: vscode.ExtensionContext) {
       const vscodeState = new URLSearchParams(externalUri.query).get('state');
       const baseUrl = `${externalUri.scheme}://${externalUri.authority}${externalUri.path}`;
 
-      return { baseUrl, vscodeState, fullUrl: externalUri.toString() };
+      // skipEncoding (toString(true)) so auth-js's encodeURIComponent over the
+      // redirectTo does not double-encode the already percent-encoded tunnel
+      // ?state= token; double-encoding corrupts the routing token and the
+      // callback never makes it back to the editor (silent timeout).
+      return { baseUrl, vscodeState, fullUrl: externalUri.toString(true) };
     });
 
     if (!isSupabaseConfigured()) {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -286,14 +286,14 @@ export async function activate(context: vscode.ExtensionContext) {
         getAuthCallbackUri(vscode.env.uriScheme),
       );
       const externalUri = await vscode.env.asExternalUri(baseCallbackUri);
-      const vscodeState = new URLSearchParams(externalUri.query).get('state');
-      const baseUrl = `${externalUri.scheme}://${externalUri.authority}${externalUri.path}`;
 
-      // skipEncoding (toString(true)) so auth-js's encodeURIComponent over the
-      // redirectTo does not double-encode the already percent-encoded tunnel
-      // ?state= token; double-encoding corrupts the routing token and the
-      // callback never makes it back to the editor (silent timeout).
-      return { baseUrl, vscodeState, fullUrl: externalUri.toString(true) };
+      // asExternalUri adds a ?state= routing token in Codespaces; carrying it on
+      // fullUrl (used as redirectTo) is what routes the callback back into the
+      // editor. skipEncoding (toString(true)) so auth-js's encodeURIComponent
+      // over redirectTo does not double-encode the already percent-encoded
+      // token; double-encoding corrupts it and the callback never returns
+      // (silent timeout).
+      return { fullUrl: externalUri.toString(true) };
     });
 
     if (!isSupabaseConfigured()) {

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -260,8 +260,8 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       // (fullUrl already carries ?state=TUNNEL). Passing it as queryParams.state
       // instead overwrites GoTrue's own OAuth state on /authorize, which makes
       // the callback fail with bad_oauth_state ("OAuth state not found or
-      // expired"). fullUrl === baseUrl when there is no tunnel state, so this is
-      // also correct for plain web.
+      // expired"). With no tunnel state, fullUrl is just the bare callback URL,
+      // so this is also correct for plain web.
       // NOTE: assumes the implicit flow (tokens in the URL fragment). If the
       // client is ever switched to PKCE, tokens arrive as ?code= and the
       // fragment-first callback parser would need to exchange the code instead.

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -256,12 +256,16 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
         'SupabaseAuthProvider',
         `OAuth callback URI (web): ${callbackInfo.fullUrl}`,
       );
-      return callbackInfo.vscodeState
-        ? {
-            redirectTo: callbackInfo.baseUrl,
-            queryParams: { state: callbackInfo.vscodeState },
-          }
-        : { redirectTo: callbackInfo.baseUrl };
+      // In Codespaces/web the tunnel routing token must ride on redirect_to
+      // (fullUrl already carries ?state=TUNNEL). Passing it as queryParams.state
+      // instead overwrites GoTrue's own OAuth state on /authorize, which makes
+      // the callback fail with bad_oauth_state ("OAuth state not found or
+      // expired"). fullUrl === baseUrl when there is no tunnel state, so this is
+      // also correct for plain web.
+      // NOTE: assumes the implicit flow (tokens in the URL fragment). If the
+      // client is ever switched to PKCE, tokens arrive as ?code= and the
+      // fragment-first callback parser would need to exchange the code instead.
+      return { redirectTo: callbackInfo.fullUrl };
     }
 
     const redirectTo = getAuthCallbackUri(vscode.env.uriScheme);

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -123,16 +123,13 @@ export function getAuthCallbackUri(uriScheme: string): string {
 }
 
 /**
- * Result of parsing the external auth callback URI.
- * In Codespaces, VS Code adds a state parameter that must be preserved
- * for the callback routing to work.
+ * Result of resolving the external auth callback URI.
+ * In Codespaces, VS Code adds a ?state= routing token to the URL that must be
+ * preserved on redirect_to for the callback to route back into the editor, so
+ * the OAuth flow uses this full URL (token included) as its redirectTo.
  */
 export interface ExternalAuthCallbackInfo {
-  /** Base URL without query params (for Supabase redirectTo) */
-  baseUrl: string;
-  /** VS Code's state parameter (must be passed through OAuth flow) */
-  vscodeState: string | null;
-  /** Full URL with state (for logging/debugging) */
+  /** Full callback URL, including any VS Code ?state= routing token. */
   fullUrl: string;
 }
 
@@ -167,8 +164,7 @@ export function setExternalAuthCallbackResolver(
  */
 export async function getExternalAuthCallbackInfo(): Promise<ExternalAuthCallbackInfo> {
   if (!externalAuthCallbackResolver) {
-    const baseUrl = getAuthCallbackUri('vscode');
-    return { baseUrl, vscodeState: null, fullUrl: baseUrl };
+    return { fullUrl: getAuthCallbackUri('vscode') };
   }
   return externalAuthCallbackResolver();
 }

--- a/src/test/auth/config.test.ts
+++ b/src/test/auth/config.test.ts
@@ -12,22 +12,16 @@ describe('auth config', () => {
 
   it('uses a host-provided external callback resolver', async () => {
     setExternalAuthCallbackResolver(async () => ({
-      baseUrl: 'https://example.test/extension-auth-callback',
-      vscodeState: 'state-value',
       fullUrl: 'https://example.test/extension-auth-callback?state=state-value',
     }));
 
     assert.deepEqual(await getExternalAuthCallbackInfo(), {
-      baseUrl: 'https://example.test/extension-auth-callback',
-      vscodeState: 'state-value',
       fullUrl: 'https://example.test/extension-auth-callback?state=state-value',
     });
   });
 
   it('falls back without importing host APIs', async () => {
     assert.deepEqual(await getExternalAuthCallbackInfo(), {
-      baseUrl: 'vscode://texra-ai.texra/auth-callback',
-      vscodeState: null,
       fullUrl: 'vscode://texra-ai.texra/auth-callback',
     });
   });


### PR DESCRIPTION
## Summary

Signing in from Codespaces / vscode.dev (web/tunnel environments) failed the OAuth callback with **`bad_oauth_state`** ("OAuth state not found or expired"). Two compounding bugs in the VS Code web auth redirect:

1. **Tunnel state clobbered GoTrue's OAuth state.** The VS Code callback's tunnel routing token (`?state=TUNNEL`) was passed to GoTrue as `queryParams.state` on `/authorize`, which overwrote GoTrue's *own* OAuth state. Now the tunnel token rides on `redirect_to` instead, by using the full callback URL as `redirectTo`. `fullUrl === baseUrl` when there is no tunnel state, so plain web is unaffected.
2. **Double-encoded routing token.** The callback URL was serialized with default encoding, so `auth-js` then percent-encoded the already-encoded tunnel token a *second* time, corrupting it and silently dropping the callback (timeout). Serialize with `skipEncoding` (`externalUri.toString(true)`) to avoid the double-encode.

The two changes work together: `extension.ts` now produces a correctly-encoded `fullUrl`, and `SupabaseAuthProvider.ts` uses that `fullUrl` as `redirectTo`.

## Changes
- `packages/extension/src/extension.ts` — serialize the external callback URI with `toString(true)` (skipEncoding).
- `src/auth/SupabaseAuthProvider.ts` — return `{ redirectTo: callbackInfo.fullUrl }` instead of putting the tunnel token in `queryParams.state`.

## Notes
- Scope: implicit flow (tokens in the URL fragment). A code comment flags that switching the client to PKCE would require the callback parser to exchange `?code=` instead.
- Desktop / standard `vscode://` redirect path is unchanged (still uses `getAuthCallbackUri`).

## Verification
- `npm run typecheck` — clean (0 errors)
- Confirmed the change merges cleanly on top of current `main` (sits between the unrelated upstream `toolAvailability` edits in `extension.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth redirect and encoding on web/tunnel hosts only; desktop path is unchanged, but auth callback misconfiguration could still break sign-in in Codespaces.
> 
> **Overview**
> Fixes **Codespaces / vscode.dev** Supabase OAuth sign-in by changing how the web callback URL is built and passed to GoTrue.
> 
> **`extension.ts`** now returns only `fullUrl` from the external auth resolver, serialized with `externalUri.toString(true)` so VS Code’s tunnel `?state=` token is not **double-encoded** when `auth-js` encodes `redirectTo` (which previously caused silent callback timeouts).
> 
> **`SupabaseAuthProvider`** uses that **`fullUrl` as `redirectTo`** on web instead of splitting the URL and sending the tunnel token as `queryParams.state`, which had **overwritten GoTrue’s OAuth state** and produced `bad_oauth_state`.
> 
> **`ExternalAuthCallbackInfo`** is simplified to a single `fullUrl` field; tests and fallbacks are updated accordingly. **Desktop** OAuth still uses `getAuthCallbackUri` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849e9ed7ed7cf12cbfef442ba6b6bb7f77c4f4fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->