### PR TITLE
refactor(cli): centralize auth display choices

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -36,7 +36,6 @@ import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager
 import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
 import { isOAuthProvider, type OAuthProvider } from '@auth/sharedConfig';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
-import { formatCliAccountLabelForDisplay } from '@cli/runtime/accountDisplay';
 import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
 import {
@@ -716,7 +715,7 @@ async function loginFromChat(input: string): Promise<void> {
     });
     appendLocalAssistantTranscript(
       [
-        `Signed in as ${formatCliAccountLabelForDisplay(session.account.label)}.`,
+        `Signed in as ${session.account.label}.`,
         ...(await loadCliApiStatusLines()),
       ].join('\n'),
     );

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -4,7 +4,6 @@ import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
 import { isOAuthProvider } from '@auth/sharedConfig';
 import { isNonEmptyString } from '@utils/core/stringCore';
 
-import { formatCliAccountLabelForDisplay } from '../runtime/accountDisplay';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import {
@@ -17,6 +16,7 @@ import {
   parseUtcMonth,
   type RelayUsageSummary,
 } from '../runtime/relayUsage';
+import { CLI_OAUTH_PROVIDER_INPUTS } from '../runtime/oauthProviderDisplay';
 import {
   formatCliManualAuthUrlMessage,
   getCliAuthProfile,
@@ -101,7 +101,7 @@ export function shouldPromptForLoginProvider(
 async function runLogin(context: CliContext, init: LoginInit): Promise<number> {
   if (!isOAuthProvider(init.provider)) {
     writeTextStderr(
-      `Unsupported provider: ${init.provider}. Expected github or google.`,
+      `Unsupported provider: ${init.provider}. Expected ${CLI_OAUTH_PROVIDER_INPUTS}.`,
     );
     return CliExitCode.Usage;
   }
@@ -155,13 +155,12 @@ export const loginCommand = defineCliCommand({
     ...GLOBAL_ARGS,
     provider: {
       type: 'string',
-      description:
-        'OAuth provider: github or google (alternative to positional)',
+      description: `OAuth provider: ${CLI_OAUTH_PROVIDER_INPUTS} (alternative to positional)`,
     },
     providerArg: {
       type: 'positional',
       required: false,
-      description: 'OAuth provider: github or google',
+      description: `OAuth provider: ${CLI_OAUTH_PROVIDER_INPUTS}`,
     },
     'no-browser': {
       type: 'boolean',
@@ -245,11 +244,7 @@ const authStatusCommand = defineCliCommand({
       json: profile,
       ndjson: { kind: 'auth-status', ...profile },
       text: profile.authenticated
-        ? `Signed in as ${
-            profile.accountLabel
-              ? formatCliAccountLabelForDisplay(profile.accountLabel)
-              : 'unknown'
-          } (${profile.tier ?? 'unknown'}).`
+        ? `Signed in as ${profile.accountLabel || 'unknown'} (${profile.tier ?? 'unknown'}).`
         : 'Not signed in.',
     });
     return CliExitCode.Success;

--- a/packages/cli/src/commands/loginProviderPicker.tsx
+++ b/packages/cli/src/commands/loginProviderPicker.tsx
@@ -6,12 +6,8 @@ import type { OAuthProvider } from '@auth/sharedConfig';
 import { tuiOutputStreamForColor } from '../chat/tui/render/noColorOutput';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import { KeyHints } from '../chat/tui/ui/KeyHints';
-import { Select, type SelectItem } from '../chat/tui/ui/Select';
-
-const LOGIN_PROVIDER_ITEMS = [
-  { value: 'github', label: 'GitHub' },
-  { value: 'google', label: 'Google' },
-] as const satisfies readonly SelectItem<OAuthProvider>[];
+import { Select } from '../chat/tui/ui/Select';
+import { CLI_OAUTH_PROVIDER_ITEMS } from '../runtime/oauthProviderDisplay';
 
 function LoginProviderPicker(props: {
   readonly onSelect: (provider: OAuthProvider | undefined) => void;
@@ -35,7 +31,7 @@ function LoginProviderPicker(props: {
       <Text dimColor>Choose a provider to sign in with:</Text>
       <Box marginTop={1} flexDirection="column">
         <Select<OAuthProvider>
-          items={LOGIN_PROVIDER_ITEMS}
+          items={CLI_OAUTH_PROVIDER_ITEMS}
           activeValue={DEFAULT_OAUTH_PROVIDER}
           onSelect={finish}
           onCancel={() => finish(undefined)}
@@ -45,7 +41,10 @@ function LoginProviderPicker(props: {
         <KeyHints
           hints={[
             { key: '↑/↓', action: 'navigate' },
-            { key: '1-2/Enter', action: 'select' },
+            {
+              key: `1-${CLI_OAUTH_PROVIDER_ITEMS.length}/Enter`,
+              action: 'select',
+            },
             { key: 'Esc', action: 'cancel' },
           ]}
           confirmCancel={false}

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -29,10 +29,10 @@ import { tuiOutputStreamForColor } from '../chat/tui/render/noColorOutput';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { Select, type SelectItem } from '../chat/tui/ui/Select';
-import { formatCliAccountLabelForDisplay } from '../runtime/accountDisplay';
 import { type CliApiMode } from '../runtime/apiAccessMode';
 import { hasCliCredentialForApiMode } from '../runtime/credentialStatus';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
+import { CLI_OAUTH_PROVIDER_ITEMS } from '../runtime/oauthProviderDisplay';
 import {
   CLI_MANUAL_AUTH_REMOTE_HINT,
   CLI_MANUAL_AUTH_URL_PROMPT,
@@ -253,9 +253,7 @@ function OnboardingApp(props: OnboardingAppProps): React.JSX.Element {
           finish({
             configured: true,
             declined: false,
-            summary: `Signed in as ${formatCliAccountLabelForDisplay(
-              label,
-            )}. Included relay access is active.`,
+            summary: `Signed in as ${label}. Included relay access is active.`,
           })
         }
         onError={(message) => {
@@ -460,16 +458,13 @@ function RelayProviderStep(props: {
       error={props.error}
       hints={[
         { key: '↑/↓', action: 'navigate' },
-        { key: '1-2/Enter', action: 'select' },
+        { key: `1-${CLI_OAUTH_PROVIDER_ITEMS.length}/Enter`, action: 'select' },
         { key: 'n', action: 'no-browser' },
         { key: 'Esc', action: 'back' },
       ]}
     >
       <Select<OAuthProvider>
-        items={[
-          { value: 'github', label: 'GitHub' },
-          { value: 'google', label: 'Google' },
-        ]}
+        items={CLI_OAUTH_PROVIDER_ITEMS}
         activeValue={props.activeProvider}
         onSelect={props.onSelect}
         onCancel={props.onCancel}

--- a/packages/cli/src/runtime/accountDisplay.ts
+++ b/packages/cli/src/runtime/accountDisplay.ts
@@ -1,3 +1,0 @@
-export function formatCliAccountLabelForDisplay(accountLabel: string): string {
-  return accountLabel.trim();
-}

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -2,7 +2,6 @@ import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { API_PROVIDERS, lookupApiKeyOrigin } from '@model/apiProviders';
 
-import { formatCliAccountLabelForDisplay } from './accountDisplay';
 import {
   formatCliApiMode,
   getCliApiMode,
@@ -27,11 +26,7 @@ export function formatCliAuthStatusLine(
   profile: Pick<CliAuthProfile, 'authenticated' | 'accountLabel'>,
 ): string {
   if (!profile.authenticated) return 'auth: signed out';
-  return `auth: signed in${
-    profile.accountLabel
-      ? ` as ${formatCliAccountLabelForDisplay(profile.accountLabel)}`
-      : ''
-  }`;
+  return `auth: signed in${profile.accountLabel ? ` as ${profile.accountLabel}` : ''}`;
 }
 
 /**

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -17,7 +17,6 @@ import {
 import { extractErrorMessage } from '@utils/core';
 
 // Local imports - CLI runtime
-import { formatCliAccountLabelForDisplay } from './accountDisplay';
 import { workspaceCliConfigPath } from './cliConfig';
 import { CliExitCode } from './exitCodes';
 import {
@@ -200,9 +199,7 @@ async function checkAuth(
     const profile = await deps.authProfile();
     if (profile.authenticated) {
       const tier = profile.tier ? `, ${profile.tier}` : '';
-      const accountLabel = profile.accountLabel
-        ? formatCliAccountLabelForDisplay(profile.accountLabel)
-        : 'unknown';
+      const accountLabel = profile.accountLabel || 'unknown';
       return pass(
         'auth',
         'Included access',

--- a/packages/cli/src/runtime/oauthProviderDisplay.ts
+++ b/packages/cli/src/runtime/oauthProviderDisplay.ts
@@ -1,0 +1,19 @@
+import { OAUTH_PROVIDERS, type OAuthProvider } from '@auth/sharedConfig';
+
+export interface CliOAuthProviderItem {
+  readonly value: OAuthProvider;
+  readonly label: string;
+}
+
+const CLI_OAUTH_PROVIDER_LABELS = {
+  github: 'GitHub',
+  google: 'Google',
+} satisfies Record<OAuthProvider, string>;
+
+export const CLI_OAUTH_PROVIDER_INPUTS = OAUTH_PROVIDERS.join(' or ');
+
+export const CLI_OAUTH_PROVIDER_ITEMS: readonly CliOAuthProviderItem[] =
+  OAUTH_PROVIDERS.map((provider) => ({
+    value: provider,
+    label: CLI_OAUTH_PROVIDER_LABELS[provider],
+  }));

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -18,7 +18,7 @@ export const SupabaseSessionSchema = z.object({
   refreshToken: z.string(),
   account: z.object({
     id: z.string(),
-    label: z.string(),
+    label: z.string().transform((label) => label.trim()),
   }),
   expiresAt: z.number(),
   useCustomRefresh: z.boolean().optional(),
@@ -98,6 +98,16 @@ export type SupabaseCallbackResult =
 interface StableSessionSnapshot {
   session: SupabaseSession | null;
   version: number;
+}
+
+function firstAccountLabel(
+  ...candidates: readonly (string | null | undefined)[]
+): string {
+  for (const candidate of candidates) {
+    const label = candidate?.trim();
+    if (label) return label;
+  }
+  return 'unknown';
 }
 
 /**
@@ -221,7 +231,7 @@ export function toStorableSupabaseSession(
     refreshToken: nativeSession.refresh_token,
     account: {
       id: nativeSession.user.id,
-      label: nativeSession.user.email || nativeSession.user.id,
+      label: firstAccountLabel(nativeSession.user.email, nativeSession.user.id),
     },
     expiresAt: nativeSession.expires_at
       ? nativeSession.expires_at * 1000
@@ -242,7 +252,7 @@ export function toStorableGitHubTokenExchangeSession(
     refreshToken: data.refresh_token,
     account: {
       id: data.user.id,
-      label: data.user.email || fallbackLabel,
+      label: firstAccountLabel(data.user.email, fallbackLabel, data.user.id),
     },
     expiresAt: data.expires_at
       ? data.expires_at * 1000
@@ -342,7 +352,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
         refreshToken,
         account: {
           id: data.user.id,
-          label: data.user.email || data.user.id,
+          label: firstAccountLabel(data.user.email, data.user.id),
         },
         expiresAt,
       },

--- a/src/test-kernel/auth/SupabaseSession.vitest.ts
+++ b/src/test-kernel/auth/SupabaseSession.vitest.ts
@@ -1,0 +1,57 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - auth
+import {
+  DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+  parseStoredSupabaseSession,
+  toStorableGitHubTokenExchangeSession,
+  toStorableSupabaseSession,
+  type SupabaseSession,
+} from '@auth/SupabaseSession';
+import type { Session as SupabaseNativeSession } from '@supabase/supabase-js';
+
+describe('SupabaseSession account labels', () => {
+  it('normalizes stored and newly-created account labels at the auth boundary', () => {
+    const stored: SupabaseSession = {
+      id: 'user-id',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      account: {
+        id: 'user-id',
+        label: '  stored@example.com  ',
+      },
+      expiresAt: Date.now() + 120_000,
+    };
+    const nativeSession = {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_at: 123,
+      user: {
+        id: 'user-id',
+        email: '  native@example.com  ',
+      },
+    } as unknown as SupabaseNativeSession;
+    const githubSession = toStorableGitHubTokenExchangeSession(
+      {
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        token_type: 'bearer',
+        user: {
+          id: 'user-id',
+          email: null,
+        },
+      },
+      '  github@example.com  ',
+      DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+    );
+
+    expect(
+      parseStoredSupabaseSession(JSON.stringify(stored))?.account.label,
+    ).toBe('stored@example.com');
+    expect(toStorableSupabaseSession(nativeSession).account.label).toBe(
+      'native@example.com',
+    );
+    expect(githubSession.account.label).toBe('github@example.com');
+  });
+});

--- a/src/test-kernel/cli/ApiStatus.vitest.mts
+++ b/src/test-kernel/cli/ApiStatus.vitest.mts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatCliAccountLabelForDisplay } from '@cli/runtime/accountDisplay';
 import {
   formatCliApiStatusActionHint,
   formatCliAuthStatusLine,
@@ -34,9 +33,12 @@ describe('CLI API status text', () => {
   });
 
   it('shows account labels plainly in auth status', () => {
-    expect(formatCliAccountLabelForDisplay('sirui.lu.phys@gmail.com')).toBe(
-      'sirui.lu.phys@gmail.com',
-    );
+    expect(
+      formatCliAuthStatusLine({
+        authenticated: true,
+        accountLabel: 'sirui.lu.phys@gmail.com',
+      }),
+    ).toBe('auth: signed in as sirui.lu.phys@gmail.com');
     expect(
       formatCliAuthStatusLine({
         authenticated: true,
@@ -46,10 +48,12 @@ describe('CLI API status text', () => {
   });
 
   it('keeps non-email account labels readable', () => {
-    expect(formatCliAccountLabelForDisplay('github-user')).toBe('github-user');
-    expect(formatCliAccountLabelForDisplay('team@internal')).toBe(
-      'team@internal',
-    );
+    expect(
+      formatCliAuthStatusLine({
+        authenticated: true,
+        accountLabel: 'github-user',
+      }),
+    ).toBe('auth: signed in as github-user');
     expect(
       formatCliAuthStatusLine({
         authenticated: true,

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -312,6 +312,34 @@ describe('CLI doctor', () => {
     );
   });
 
+  it('falls back to unknown for an empty auth account label', async () => {
+    const report = await buildDoctorReport(context, {
+      nodeVersion: '24.15.0',
+      authProfile: async () => ({
+        authenticated: true,
+        accountLabel: '',
+      }),
+      modelAccessList: async () =>
+        [
+          {
+            available: true,
+            status: 'available',
+            model: { value: 'deepseekT', label: 'DeepSeek T' },
+          },
+        ] as never,
+      latexToolchain: async () => ({
+        ...latexProbe,
+        tools: latexProbe.tools.map((tool) => ({ ...tool, installed: true })),
+      }),
+      pathStat: async () => directory,
+      pathAccess: async () => undefined,
+    });
+
+    expect(report.checks.find((check) => check.id === 'auth')?.message).toBe(
+      'Stored sign-in found for unknown.',
+    );
+  });
+
   it('emits stable ndjson record kinds', async () => {
     const report = await buildDoctorReport(context, {
       nodeVersion: '24.15.0',


### PR DESCRIPTION
## Summary
- derive CLI OAuth provider picker rows and provider input text from one runtime display module
- reuse that provider source in both Opening browser for TeXRA github sign-in...
Signed in as divergence_lu@icloud.com. and first-run onboarding
- remove the pass-through account label formatter so auth labels render directly from the session/profile owner
- normalize Supabase account labels once at the auth session boundary instead of trimming at each CLI display site

## Validation
- 
> texra-workspace@0.38.7 typecheck
> tsc --noEmit && tsc --noEmit -p tsconfig.test-kernel.json && corepack pnpm --filter texra typecheck && corepack pnpm --filter @texra-ai/cli typecheck
- 
 RUN  v4.1.8 /private/tmp/texra-next-refactor


 Test Files  6 passed (6)
      Tests  32 passed (32)
   Start at  17:05:50
   Duration  1.60s (transform 1.60s, setup 0ms, import 3.27s, tests 20ms, environment 0ms)
- 
> texra-workspace@0.38.7 lint
> node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src packages/extension/src packages/desktop/src packages/cli/src


/private/tmp/texra-next-refactor/packages/extension/src/progressView/frontend/components/UserMessage.ts
  22:1  warning  `@shared/subagentFollowup` import should occur before import of `@shared/styles/litStyles`  import/order

/private/tmp/texra-next-refactor/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
  17:1  warning  `@utils/core` import should occur after type import of `@tools/memory/MemoryTool`  import/order

/private/tmp/texra-next-refactor/packages/extension/src/webview/frontend/MainApp.ts
  59:1  warning  `@shared/wa/tabs` type import should occur before import of `@utils/text/stringUtils`  import/order

/private/tmp/texra-next-refactor/src/agent/core/execution/AgentWorkspaceState.ts
  13:1  warning  `@tools/result` import should occur before import of `@utils/core`  import/order

/private/tmp/texra-next-refactor/src/agent/core/flows/RetryState.ts
  9:1  warning  `@utils/config/configUtils` import should occur after import of `@shared/schemas`  import/order

/private/tmp/texra-next-refactor/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
  30:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-next-refactor/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
  13:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-next-refactor/src/agent/modelHandlers/support/ProxyConfigResolver.ts
  2:1  warning  `@utils/config/configUtils` import should occur after import of `@model/openRouterRouting`  import/order

/private/tmp/texra-next-refactor/src/agent/utils/debugMessageSaver.ts
  4:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-next-refactor/src/agent/utils/userVars.ts
  12:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/core`  import/order

/private/tmp/texra-next-refactor/src/latex/TikzPictureManager.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-next-refactor/src/latex/acceptedFileTarget.ts
  9:1  warning  `@utils/files` import should occur before import of `@utils/core/pathCore`  import/order

/private/tmp/texra-next-refactor/src/latex/formatter/latexindentpt.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/system`  import/order

/private/tmp/texra-next-refactor/src/latex/formatter/texfmt.ts
  2:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/system`  import/order

/private/tmp/texra-next-refactor/src/latex/texTools.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/system`  import/order

/private/tmp/texra-next-refactor/src/replacement/engine.ts
  8:1  warning  `@utils/config/configUtils` import should occur after import of `@shared/schemas/coreSettings`  import/order

/private/tmp/texra-next-refactor/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
  6:1  warning  `@utils/config/configUtils` import should occur after import of `@tools/approval/bashApproval`  import/order

/private/tmp/texra-next-refactor/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
  14:1  warning  `@agent/modelHandlers/openai/modelHandlerOpenAIResponse` import should occur before import of `@utils/config/configUtils`  import/order

/private/tmp/texra-next-refactor/src/tools/OpenPdfTool.ts
  22:1  warning  `@utils/files` import should occur before import of `@utils/core/pathCore`  import/order

/private/tmp/texra-next-refactor/src/tools/WriteTool.ts
  23:1  warning  `@utils/files` import should occur before import of `@utils/text/stringUtils`  import/order

/private/tmp/texra-next-refactor/src/tools/approval/bashApproval.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@tools/result`  import/order

/private/tmp/texra-next-refactor/src/tools/approval/toolEditApproval.ts
  11:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-next-refactor/src/tools/claudeAgentImport.ts
  20:1  warning  `@anthropic-ai/claude-agent-sdk` type import should occur after import of `./support/externalBinaryUtils`  import/order

/private/tmp/texra-next-refactor/src/tools/latex/ExtractBibliographyTool.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-next-refactor/src/tools/zotero/bbtClient.ts
  14:1  warning  `@utils/config/configUtils` import should occur after import of `@tools/timeouts`  import/order

✖ 25 problems (0 errors, 25 warnings)
  0 errors and 24 warnings potentially fixable with the `--fix` option. (passes; existing import-order warnings outside this patch)
- 
> texra-workspace@0.38.7 check:cli-architecture
> corepack pnpm --filter @texra-ai/cli check:architecture

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and auth-label normalization only; no credential or OAuth flow logic changes beyond trimming and fallback selection.
> 
> **Overview**
> Introduces **`oauthProviderDisplay`** so login help text, the interactive provider picker, and onboarding relay sign-in all share the same OAuth provider list and labels (derived from `OAUTH_PROVIDERS`).
> 
> **Removes** the pass-through **`formatCliAccountLabelForDisplay`** helper; chat, `auth status`, doctor, and API status lines now print **`account.label` / `accountLabel` as stored**.
> 
> **Moves label cleanup to auth:** stored sessions trim `account.label` on parse, and **`firstAccountLabel`** picks the first non-empty trimmed email/fallback when building sessions (native Supabase, GitHub token exchange, OAuth callback). Doctor still shows **`unknown`** when the label is empty.
> 
> Tests cover session label normalization and the empty-label doctor fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9eff74b9c19a59ebdf8acde7a1f822930c32f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->