### PR TITLE
refactor(cli): reuse model access in init wizard

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -10,7 +10,10 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
 import { effectiveCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
-import { getCliModelAccessList } from '../runtime/modelAccess';
+import {
+  getCliModelAccessList,
+  type CliModelAccess,
+} from '../runtime/modelAccess';
 import {
   buildInitConfig,
   configFileExists,
@@ -40,33 +43,21 @@ export function defaultInitAgentOptions(
 
 async function gatherOptions(apiMode: CliApiMode): Promise<{
   agents: InitAgentOption[];
-  models: {
-    value: string;
-    label: string;
-    available: boolean;
-    status: string;
-  }[];
+  models: CliModelAccess[];
 }> {
   await loadAgents({ includeRemote: false });
   const agents = defaultInitAgentOptions(
     getVisibleAgents(AgentCategory.ToolUse),
   );
-  const models = (await getCliModelAccessList({ apiMode })).map((entry) => ({
-    value: entry.model.value,
-    label: entry.model.label ?? entry.model.value,
-    available: entry.available,
-    status: entry.status,
-  }));
+  const models = await getCliModelAccessList({ apiMode });
   return { agents, models };
 }
 
-function defaultAnswers(
-  models: { value: string; available: boolean }[],
-): InitAnswers {
+function defaultAnswers(models: readonly CliModelAccess[]): InitAnswers {
   const firstAvailable = models.find((model) => model.available);
   return {
     agent: BUILTIN_DEFAULT_CHAT_AGENT,
-    model: firstAvailable?.value ?? CLI_BUILTIN_DEFAULT_MODEL,
+    model: firstAvailable?.model.value ?? CLI_BUILTIN_DEFAULT_MODEL,
     // Match the runtime default (see buildCliContext). `ask` prompts in
     // interactive runs and safely denies in headless ones — unlike `never`,
     // which silently denies every privileged action.
@@ -78,7 +69,7 @@ function defaultAnswers(
 function printSummary(
   filePath: string,
   answers: InitAnswers,
-  models: { value: string; available: boolean }[],
+  models: readonly CliModelAccess[],
 ): void {
   const lines = [
     `Wrote ${filePath}`,
@@ -87,7 +78,7 @@ function printSummary(
     `  approval: ${answers.approvalPolicy}`,
     `  output: ${answers.outputFormat}`,
   ];
-  const chosen = models.find((model) => model.value === answers.model);
+  const chosen = models.find((model) => model.model.value === answers.model);
   if (chosen && !chosen.available) {
     lines.push(
       '',

--- a/packages/cli/src/init/runInitWizard.tsx
+++ b/packages/cli/src/init/runInitWizard.tsx
@@ -18,22 +18,16 @@ import {
 } from '../schemas/cliSettings';
 import { BUILTIN_DEFAULT_CHAT_AGENT } from '../runtime/defaultAgents';
 import type { InitAnswers } from '../runtime/initConfig';
+import type { CliModelAccess } from '../runtime/modelAccess';
 
 export interface InitWizardAgentOption {
   readonly name: string;
   readonly description?: string;
 }
 
-export interface InitWizardModelOption {
-  readonly value: string;
-  readonly label: string;
-  readonly available: boolean;
-  readonly status: string;
-}
-
 export interface InitWizardOptions {
   readonly agents: readonly InitWizardAgentOption[];
-  readonly models: readonly InitWizardModelOption[];
+  readonly models: readonly CliModelAccess[];
   readonly colorEnabled?: boolean;
 }
 
@@ -116,18 +110,18 @@ function StepFrame(props: {
   );
 }
 
-function firstAvailableIndex(models: readonly InitWizardModelOption[]): number {
+function firstAvailableIndex(models: readonly CliModelAccess[]): number {
   const index = models.findIndex((model) => model.available);
   return index >= 0 ? index : 0;
 }
 
 export function initWizardModelSelectItems(
-  models: readonly InitWizardModelOption[],
+  models: readonly CliModelAccess[],
 ): ReadonlyArray<SelectItem<string>> {
   const hasAvailableModel = models.some((model) => model.available);
   return models.map((model) => ({
-    value: model.value,
-    label: model.label,
+    value: model.model.value,
+    label: model.model.label || model.model.value,
     description: model.available
       ? model.status
       : `${model.status} (unavailable now)`,

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -2,6 +2,19 @@ import { describe, expect, it } from 'vitest';
 
 import { defaultInitAgentOptions, initCommand } from '@cli/commands/init';
 import { initWizardModelSelectItems } from '@cli/init/runInitWizard';
+import type { CliModelAccess } from '@cli/runtime/modelAccess';
+
+function modelAccess(
+  value: string,
+  overrides: Partial<CliModelAccess> = {},
+): CliModelAccess {
+  return {
+    model: { value, label: value },
+    available: true,
+    status: 'available',
+    ...overrides,
+  };
+}
 
 describe('CLI init command', () => {
   it('accepts global CLI flags while keeping init-specific cwd help', () => {
@@ -41,18 +54,16 @@ describe('CLI init command', () => {
   it('disables init model rows unavailable in the active API mode', () => {
     expect(
       initWizardModelSelectItems([
-        {
-          value: 'sonnet46T',
-          label: 'Sonnet',
+        modelAccess('sonnet46T', {
+          model: { value: 'sonnet46T', label: 'Sonnet' },
           available: true,
           status: 'included access',
-        },
-        {
-          value: 'deepseekT',
-          label: 'DeepSeek',
+        }),
+        modelAccess('deepseekT', {
+          model: { value: 'deepseekT', label: 'DeepSeek' },
           available: false,
           status: 'api key set',
-        },
+        }),
       ]),
     ).toEqual([
       {
@@ -73,18 +84,16 @@ describe('CLI init command', () => {
   it('keeps all-unavailable init model rows selectable as a fallback', () => {
     expect(
       initWizardModelSelectItems([
-        {
-          value: 'sonnet46T',
-          label: 'Sonnet',
+        modelAccess('sonnet46T', {
+          model: { value: 'sonnet46T', label: 'Sonnet' },
           available: false,
           status: 'login required',
-        },
-        {
-          value: 'deepseekT',
-          label: 'DeepSeek',
+        }),
+        modelAccess('deepseekT', {
+          model: { value: 'deepseekT', label: 'DeepSeek' },
           available: false,
           status: 'missing key',
-        },
+        }),
       ]),
     ).toEqual([
       {


### PR DESCRIPTION
## Summary
- pass `CliModelAccess` entries directly through `texra init` instead of projecting a second wizard-only model shape
- update default/summary model lookup to read the canonical model access entry
- keep the init wizard owning only its init-specific disabled-row policy

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/InitCommand.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside this patch)
- `npm run check:cli-architecture`
- `git diff --check`

Closes #5518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type/shape consolidation in init and wizard with no new runtime paths; behavior should match prior mapping aside from shared canonical fields.
> 
> **Overview**
> **`texra init`** now threads the shared **`CliModelAccess`** shape from **`getCliModelAccessList`** through the command and interactive wizard instead of mapping models into a separate wizard-only `{ value, label, available, status }` type.
> 
> Default model selection, post-init summary lookup, and wizard select items read **`model.model.value`** / **`model.model.label`** on those entries. **`InitWizardModelOption`** is removed; init-specific behavior (disabling unavailable rows when any model is available) stays in **`initWizardModelSelectItems`**. Tests build **`CliModelAccess`** via a small **`modelAccess`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20fc5689821bbf8f4db54d16646a8f9bef4518e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->