### PR TITLE
refactor(cli): pass child control availability to status bar

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -848,6 +848,8 @@ export function App(props: AppProps): React.JSX.Element {
           })}
           queuedFollowUpPreview={!queuedFollowUpPanelVisible}
           shortcutsActive={focusShortcutsActive}
+          subagentControlsAvailable={subagentControlsAvailable}
+          taskControlsAvailable={taskControlsAvailable}
         />
       </Box>
     </>

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -28,7 +28,6 @@ import {
   type BypassState,
   type StreamSlice,
 } from '../state/cliState';
-import { resolveChildControlDisplayTargets } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
@@ -718,6 +717,8 @@ export interface StatusBarProps {
   readonly foregroundEscapeAction?: string;
   readonly queuedFollowUpPreview?: boolean;
   readonly shortcutsActive?: boolean;
+  readonly subagentControlsAvailable: boolean;
+  readonly taskControlsAvailable: boolean;
 }
 
 export function StatusBar(props: StatusBarProps): React.JSX.Element {
@@ -732,11 +733,6 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const statusSlice = statusBarDisplaySlice({
-    activeStreamId,
-    parentStream,
-    streams,
-  });
-  const childControlTargets = resolveChildControlDisplayTargets({
     activeStreamId,
     parentStream,
     streams,
@@ -762,9 +758,9 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     activeProcesses: statusSlice?.activeProcesses.length ?? 0,
     approvalDepth: approvals.depth,
     approvalKind: approvals.kind,
-    taskControlsAvailable: childControlTargets.tasks.hasItems,
+    taskControlsAvailable: props.taskControlsAvailable,
     agentSelectionAvailable: props.agentSelectionAvailable,
-    subagentControlsAvailable: childControlTargets.subagents.hasItems,
+    subagentControlsAvailable: props.subagentControlsAvailable,
     hasMultipleStreams: streams.size > 1,
     model: sessionMeta.model,
     apiMode: shortCliApiMode(sessionMeta.apiMode),


### PR DESCRIPTION
## Summary
- make App pass task/subagent control availability into StatusBar
- remove StatusBar's duplicate child-control target resolution
- keep StatusBar focused on display assembly and shortcut formatting

## Validation
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- npm run typecheck -- --pretty false
- npm run lint (passes with the existing 25 import-order warnings outside this patch)
- npm run check:cli-architecture
- git diff --check

Closes #5522

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only refactor that preserves the same availability logic by sourcing it from App; no auth, data, or runtime behavior changes beyond prop wiring.
> 
> **Overview**
> **App** now owns whether task/subagent shortcuts apply: it derives `taskControlsAvailable` and `subagentControlsAvailable` from the existing `resolveChildControlDisplayTargets` call (shared with keyboard chords and the child-control picker) and passes them into **StatusBar**.
> 
> **StatusBar** no longer imports or calls `resolveChildControlDisplayTargets`; it uses the required props when building shortcut hints via `buildStatusBarDisplay` / `statusBarBindingsText`. Behavior should match the previous inline resolution, with one place deciding availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7cd21fa0bca6f3032c50bcc07faf9e60a8610e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->