### PR TITLE
fix(cli): report unreadable workspace config

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -4,7 +4,8 @@ import path from 'node:path';
 import { MODEL_CONFIGS } from 'llm-zoo';
 import { z } from 'zod';
 
-import { toErrorMessage } from '@common/errors';
+import { isFileNotFoundError } from '@common/errors';
+import { toErrorMessage } from '@common/errors/errorMessage';
 
 import {
   CLI_APPROVAL_POLICIES,
@@ -203,8 +204,15 @@ export async function loadWorkspaceCliConfig(
   let raw: string;
   try {
     raw = await readFile(filePath, 'utf8');
-  } catch {
-    return { values: {}, warnings: [] };
+  } catch (error: unknown) {
+    if (isFileNotFoundError(error)) {
+      return { values: {}, warnings: [] };
+    }
+    return {
+      path: filePath,
+      values: {},
+      warnings: [`Could not read ${filePath}: ${toErrorMessage(error)}`],
+    };
   }
 
   let parsed: unknown;

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -200,6 +200,19 @@ describe('CLI context config defaults', () => {
     expect(loaded.warnings.join('\n')).toContain('Could not parse');
   });
 
+  it('reports unreadable workspace config files without treating them as absent', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'texra-cli-context-'));
+    await mkdir(join(workspace, '.texra', 'config.json'), {
+      recursive: true,
+    });
+
+    const loaded = await loadWorkspaceCliConfig(workspace);
+
+    expect(loaded.values).toEqual({});
+    expect(loaded.path).toContain('.texra/config.json');
+    expect(loaded.warnings.join('\n')).toContain('Could not read');
+  });
+
   it('ignores unknown TEXRA_MODEL values before they reach runtime', async () => {
     const context = await buildCliContext({
       ambient,


### PR DESCRIPTION
## Summary

- keep missing `.texra/config.json` as the quiet no-config case
- report non-missing read failures from the CLI config loader as config warnings
- cover the unreadable config path with a focused CLI context test

Closes #5524

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliContext.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run check:cli-architecture`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/cliConfig.ts src/test-kernel/cli/CliContext.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to workspace config loading and warning behavior; no auth or runtime execution paths affected.
> 
> **Overview**
> **`loadWorkspaceCliConfig`** no longer treats every `readFile` failure like a missing config: only **file-not-found** still returns empty values with no warnings. Other read errors (permissions, path is a directory, I/O, etc.) now return empty values plus a **`Could not read …`** warning that includes the config path and error message, aligned with existing parse-failure handling.
> 
> Imports are split so **`isFileNotFoundError`** comes from `@common/errors` and **`toErrorMessage`** from `@common/errors/errorMessage`. A CLI context test asserts that a **directory** at `.texra/config.json` surfaces **`Could not read`** instead of behaving as if no config exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96536bd5f0e512265621eb6b8a9e93eea59ce1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->