### PR TITLE
refactor(cli): centralize agent resolution loading

### DIFF
--- a/packages/cli/src/commands/_helpers/agentResolution.ts
+++ b/packages/cli/src/commands/_helpers/agentResolution.ts
@@ -10,14 +10,17 @@ export async function shouldHonorRemoteAgentPriority(
 }
 
 /**
- * Resolve an agent from the local registry, falling back to a full
- * (remote-inclusive) reload when it is missing or remote agents should take
- * priority. Callers must populate the local registry first (typically via
- * `loadAgents({ includeRemote: false })`).
+ * Resolve a CLI launch target from the agent registry.
+ *
+ * The lookup owns the full local/remote loading policy: commands do not
+ * pre-load agents before calling it. Local built-ins are loaded first; then a
+ * full remote-inclusive reload runs when the agent is missing locally or an
+ * authenticated relay session should prefer remote agent definitions.
  */
-export async function resolveAgentWithRemoteFallback(
+export async function resolveCliAgent(
   name: string,
 ): Promise<AgentEntry | undefined> {
+  await loadAgents({ includeRemote: false });
   let agent = getAgent(name);
   if (!agent || (await shouldHonorRemoteAgentPriority(name))) {
     await loadAgents();

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -20,7 +20,7 @@ import {
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
-import { resolveAgentWithRemoteFallback } from './_helpers/remoteAgents';
+import { resolveCliAgent } from './_helpers/agentResolution';
 import { agentsRunCommand } from './agentsRun';
 import type { CliContext } from '../runtime/cliContext';
 
@@ -158,9 +158,7 @@ export async function showAgent(
   name: string,
 ): Promise<number> {
   await initLocalCliPlatform(context);
-  await loadAgents({ includeRemote: false });
-
-  const entry = await resolveAgentWithRemoteFallback(name);
+  const entry = await resolveCliAgent(name);
   if (!entry) {
     writeTextStderr(missingAgentMessage(name));
     return CliExitCode.Usage;

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -1,4 +1,3 @@
-import { loadAgents } from '@agent/index';
 import { writeTerminalStatus } from '@agent/storage';
 import {
   AgentConfigSchema,
@@ -34,7 +33,7 @@ import {
   resolveCliRunModel,
 } from './_helpers/modelArg';
 import { emitCliResult } from './_helpers/output';
-import { resolveAgentWithRemoteFallback } from './_helpers/remoteAgents';
+import { resolveCliAgent } from './_helpers/agentResolution';
 import { executeCliRequest } from './_helpers/runExecution';
 import {
   createCliRunResult,
@@ -90,8 +89,7 @@ export async function runToolUseAgent(
     return CliExitCode.Usage;
   }
 
-  await loadAgents({ includeRemote: false });
-  const agent = await resolveAgentWithRemoteFallback(init.agent);
+  const agent = await resolveCliAgent(init.agent);
 
   if (!agent) {
     writeTextStderr(missingToolUseAgentMessage(init.agent));

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 
-import { loadAgents } from '@agent/index';
 import { writeTerminalStatus } from '@agent/storage';
 import {
   AgentConfigSchema,
@@ -28,7 +27,7 @@ import {
   optionalStringFlagValue,
   optString,
 } from './_helpers/globalArgs';
-import { resolveAgentWithRemoteFallback } from './_helpers/remoteAgents';
+import { resolveCliAgent } from './_helpers/agentResolution';
 import { executeCliRequest } from './_helpers/runExecution';
 import {
   terminalStatusExitCode,
@@ -75,8 +74,7 @@ async function runWorkflowAgent(
   // full agent run otherwise.
   await assertOutputFileAvailable(init.output, runContext.cwd);
 
-  await loadAgents({ includeRemote: false });
-  const agent = await resolveAgentWithRemoteFallback(init.agent);
+  const agent = await resolveCliAgent(init.agent);
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
   if (!agent) {

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentEntry } from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+
+const mocks = vi.hoisted(() => ({
+  authProvider: {
+    isAuthenticated: vi.fn(),
+  },
+  getAgent: vi.fn(),
+  loadAgents: vi.fn(),
+}));
+
+vi.mock('@agent/index', () => ({
+  getAgent: mocks.getAgent,
+  loadAgents: mocks.loadAgents,
+}));
+
+vi.mock('@cli/runtime/supabaseAuth', () => ({
+  getCliAuthProvider: () => mocks.authProvider,
+}));
+
+function agent(
+  name: string,
+  source: AgentEntry['source'] = 'builtInToolUse',
+): AgentEntry {
+  return {
+    name,
+    source,
+    path: `/agents/${name}.yaml`,
+    category: AgentCategory.ToolUse,
+  };
+}
+
+describe('CLI agent resolution', () => {
+  beforeEach(() => {
+    mocks.authProvider.isAuthenticated.mockReset();
+    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    mocks.getAgent.mockReset();
+    mocks.loadAgents.mockReset();
+  });
+
+  it('loads the local registry and returns a local agent for signed-out users', async () => {
+    const local = agent('lean');
+    mocks.getAgent.mockReturnValue(local);
+    const { resolveCliAgent } =
+      await import('@cli/commands/_helpers/agentResolution');
+
+    await expect(resolveCliAgent('lean')).resolves.toBe(local);
+
+    expect(mocks.loadAgents).toHaveBeenCalledOnce();
+    expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
+    expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
+  });
+
+  it('does a full registry load when the local registry misses', async () => {
+    const remote = agent('orchestrator', 'remote');
+    mocks.getAgent.mockReturnValueOnce(undefined).mockReturnValueOnce(remote);
+    const { resolveCliAgent } =
+      await import('@cli/commands/_helpers/agentResolution');
+
+    await expect(resolveCliAgent('orchestrator')).resolves.toBe(remote);
+
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(1, {
+      includeRemote: false,
+    });
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
+    expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it('lets authenticated relay users prefer remote definitions over local built-ins', async () => {
+    const local = agent('lean');
+    const remote = agent('lean', 'remote');
+    mocks.authProvider.isAuthenticated.mockResolvedValue(true);
+    mocks.getAgent.mockReturnValueOnce(local).mockReturnValueOnce(remote);
+    const { resolveCliAgent } =
+      await import('@cli/commands/_helpers/agentResolution');
+
+    await expect(resolveCliAgent('lean')).resolves.toBe(remote);
+
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(1, {
+      includeRemote: false,
+    });
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
+    expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
+  });
+
+  it('does not apply remote priority to source-qualified agent names', async () => {
+    const local = agent('local:lean');
+    mocks.authProvider.isAuthenticated.mockResolvedValue(true);
+    mocks.getAgent.mockReturnValue(local);
+    const { resolveCliAgent } =
+      await import('@cli/commands/_helpers/agentResolution');
+
+    await expect(resolveCliAgent('local:lean')).resolves.toBe(local);
+
+    expect(mocks.loadAgents).toHaveBeenCalledOnce();
+    expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
+    expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   getWorkflowAgents: vi.fn(),
   initLocalCliPlatform: vi.fn(),
   loadAgents: vi.fn(),
-  resolveAgentWithRemoteFallback: vi.fn(),
+  resolveCliAgent: vi.fn(),
   writeTextStderr: vi.fn(),
 }));
 
@@ -35,8 +35,8 @@ vi.mock('@cli/commands/_helpers/output', () => ({
   emitCliResult: mocks.emitCliResult,
 }));
 
-vi.mock('@cli/commands/_helpers/remoteAgents', () => ({
-  resolveAgentWithRemoteFallback: mocks.resolveAgentWithRemoteFallback,
+vi.mock('@cli/commands/_helpers/agentResolution', () => ({
+  resolveCliAgent: mocks.resolveCliAgent,
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
@@ -207,7 +207,7 @@ describe('CLI agents command', () => {
     );
   });
 
-  it('uses the remote fallback resolver for agent details', async () => {
+  it('uses the CLI agent resolver for agent details', async () => {
     const localAgent = {
       name: 'lean',
       source: 'builtInToolUse',
@@ -216,16 +216,15 @@ describe('CLI agents command', () => {
       description: 'Lean 4 proof assistant.',
       tools: ['lean_diagnostics'],
     };
-    mocks.resolveAgentWithRemoteFallback.mockResolvedValue(localAgent);
+    mocks.resolveCliAgent.mockResolvedValue(localAgent);
     const { showAgent } = await import('@cli/commands/agents');
 
     const exitCode = await showAgent(cliContext(), 'lean');
 
     expect(exitCode).toBe(0);
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledTimes(1);
-    expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
     expect(mocks.getAgent).not.toHaveBeenCalled();
-    expect(mocks.resolveAgentWithRemoteFallback).toHaveBeenCalledWith('lean');
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('lean');
     expect(mocks.emitCliResult).toHaveBeenCalledWith(expect.anything(), {
       json: localAgent,
       ndjson: { kind: 'agent', agent: localAgent },
@@ -243,14 +242,14 @@ describe('CLI agents command', () => {
       tools: ['delegate_agent', 'lean_diagnostics'],
       visibility: ['public'],
     };
-    mocks.resolveAgentWithRemoteFallback.mockResolvedValue(remoteAgent);
+    mocks.resolveCliAgent.mockResolvedValue(remoteAgent);
     const { showAgent } = await import('@cli/commands/agents');
 
     const exitCode = await showAgent(cliContext(), 'lean');
 
     expect(exitCode).toBe(0);
     expect(mocks.getAgent).not.toHaveBeenCalled();
-    expect(mocks.resolveAgentWithRemoteFallback).toHaveBeenCalledWith('lean');
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('lean');
     expect(mocks.emitCliResult).toHaveBeenCalledWith(expect.anything(), {
       json: remoteAgent,
       ndjson: { kind: 'agent', agent: remoteAgent },
@@ -258,7 +257,7 @@ describe('CLI agents command', () => {
     });
   });
 
-  it('uses the remote fallback resolver when local lookup misses', async () => {
+  it('uses the CLI agent resolver when local lookup misses', async () => {
     const remoteAgent = {
       name: 'orchestrator',
       source: 'remote',
@@ -268,17 +267,14 @@ describe('CLI agents command', () => {
       tools: ['delegate_agent', 'delegate_workflow'],
       visibility: ['public'],
     };
-    mocks.resolveAgentWithRemoteFallback.mockResolvedValue(remoteAgent);
+    mocks.resolveCliAgent.mockResolvedValue(remoteAgent);
     const { showAgent } = await import('@cli/commands/agents');
 
     const exitCode = await showAgent(cliContext(), 'orchestrator');
 
     expect(exitCode).toBe(0);
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledTimes(1);
-    expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
-    expect(mocks.resolveAgentWithRemoteFallback).toHaveBeenCalledWith(
-      'orchestrator',
-    );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('orchestrator');
     expect(mocks.emitCliResult).toHaveBeenCalledWith(expect.anything(), {
       json: remoteAgent,
       ndjson: { kind: 'agent', agent: remoteAgent },
@@ -286,8 +282,8 @@ describe('CLI agents command', () => {
     });
   });
 
-  it('reports missing agents after the remote fallback is exhausted', async () => {
-    mocks.resolveAgentWithRemoteFallback.mockResolvedValue(undefined);
+  it('reports missing agents after CLI agent resolution misses', async () => {
+    mocks.resolveCliAgent.mockResolvedValue(undefined);
     const { showAgent } = await import('@cli/commands/agents');
 
     const exitCode = await showAgent(cliContext(), 'missing-agent');

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -9,14 +9,13 @@ const mocks = vi.hoisted(() => {
     executeCliRequest: vi.fn(),
     expandRunInputs: vi.fn(),
     installCliApprovalHandlers: vi.fn(),
-    loadAgents: vi.fn(),
-    resolveAgentWithRemoteFallback: vi.fn(),
+    resolveCliAgent: vi.fn(),
     stdinInputFile,
   };
 });
 
 vi.mock('@agent/index', () => ({
-  loadAgents: mocks.loadAgents,
+  loadAgents: vi.fn(),
 }));
 
 vi.mock('@agent/storage', () => ({
@@ -43,8 +42,8 @@ vi.mock('@cli/commands/_helpers/output', () => ({
   emitCliResult: vi.fn(),
 }));
 
-vi.mock('@cli/commands/_helpers/remoteAgents', () => ({
-  resolveAgentWithRemoteFallback: mocks.resolveAgentWithRemoteFallback,
+vi.mock('@cli/commands/_helpers/agentResolution', () => ({
+  resolveCliAgent: mocks.resolveCliAgent,
 }));
 
 vi.mock('@cli/commands/_helpers/runExecution', () => ({
@@ -81,7 +80,7 @@ describe('CLI agents run command', () => {
       inputFiles: ['problem.md'],
       contextFiles: ['notes.md'],
     });
-    mocks.resolveAgentWithRemoteFallback.mockResolvedValue({
+    mocks.resolveCliAgent.mockResolvedValue({
       name: 'chat',
       category: AgentCategory.ToolUse,
       source: 'builtInToolUse',


### PR DESCRIPTION
## Summary
- rename the CLI remote-agent helper to `agentResolution` and make it own local-first plus remote-priority loading
- remove duplicated `loadAgents({ includeRemote: false })` setup from `agents show`, `agents run`, and `texra run`
- add focused resolver tests for signed-out local lookup, local miss, authenticated relay priority, and source-qualified names

## Design note
This makes agent launch resolution the single source of truth for deciding when the local registry is enough and when a remote-inclusive reload is needed. Command handlers no longer need to remember part of that policy.

Closes #5526

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside this patch)
- `npm run check:cli-architecture`
- `corepack pnpm exec prettier --check packages/cli/src/commands/_helpers/agentResolution.ts packages/cli/src/commands/agents.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor consolidates existing local/remote resolution behavior without changing command surfaces; risk is limited to subtle loading-order regressions, covered by new resolver tests.
> 
> **Overview**
> **Centralizes CLI agent lookup** in `resolveCliAgent` (`agentResolution.ts`), replacing `resolveAgentWithRemoteFallback` and folding in the initial `loadAgents({ includeRemote: false })` so launch paths share one local-first / remote-reload policy.
> 
> **`texra agents show`**, **`texra agents run`**, and **`texra run`** now call only `resolveCliAgent`—no duplicated registry setup. **`agents list`** is unchanged and still loads the catalog on its own.
> 
> Adds **`AgentResolution.vitest.mts`** for signed-out local hits, local misses, authenticated remote priority, and `source:name` skipping remote priority; command tests mock the new resolver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c065693dbf79b1f1dd6761e23a53c8c18c862f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->