### PR TITLE
refactor(cli): centralize multi-agent plan loading

### DIFF
--- a/docs/architecture/cli-runtime-round-trips.md
+++ b/docs/architecture/cli-runtime-round-trips.md
@@ -24,7 +24,7 @@ flowchart TD
   defaultModel[resolveChatDefaults + resolveCliRunnableModelWithAccessList]
   picker[orchestration/runOrchestrationTui]
   chat[chat/tui/runChatTui runChat]
-  presetRun[commands/multiAgent fillMultiAgentRunPlanGaps]
+  presetRun[commands/multiAgent loadCliMultiAgentRunPlan]
 
   user --> orch
   orch --> platform
@@ -164,6 +164,7 @@ sequenceDiagram
   L->>R: maybe load remote agents if authenticated and gaps exist
   R-->>P: replan with remote agents
   L-->>Run: selected preset id
+  Run->>A: loadAgents({ includeRemote: false })
   Run->>P: plan current preset again
   Run->>R: maybe load remote agents again if gaps exist
   Run->>P: replan current preset

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -134,17 +134,13 @@ function planLoadedCliMultiAgentPresets(
  * the interactive `orchestrate` menu route through here so they can't drift
  * apart again.
  *
- * Assumes local agents are already loaded by the caller.
+ * Owns the local agent registry load (`loadAgents({ includeRemote: false })`)
+ * before planning, so callers no longer need to pre-load local agents.
  */
-export async function fillMultiAgentRunPlanGaps(
-  init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
-): Promise<CliMultiAgentPresetRunPlan> {
-  return (await loadCliMultiAgentRunPlan(init)).plan;
-}
-
 export async function loadCliMultiAgentRunPlan(
   init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
 ): Promise<MultiAgentRunPlanLoadResult> {
+  await loadAgents({ includeRemote: false });
   const result = await reloadRemoteAgentsForGaps(
     planCurrentMultiAgentRun(init),
     cliMultiAgentPlanHasGaps,
@@ -300,7 +296,6 @@ async function runMultiAgentInspect(
   presetIdOrName: string,
 ): Promise<number> {
   await initCliPlatform({ ...context, quietLogs: true });
-  await loadAgents({ includeRemote: false });
 
   const { plan, remoteAgentLoadAttempted } = await loadCliMultiAgentRunPlan({
     preset: presetIdOrName,
@@ -327,9 +322,8 @@ export async function runMultiAgentPreset(
   }
 
   await initCliPlatform({ ...context, quietLogs: true });
-  await loadAgents({ includeRemote: false });
 
-  const plan = await fillMultiAgentRunPlanGaps(init);
+  const { plan } = await loadCliMultiAgentRunPlan(init);
   if (plan.missingAgentOverride) {
     throw new CliUsageError(
       missingToolUseAgentMessage(plan.missingAgentOverride),

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -38,7 +38,7 @@ import {
   rejectHeadlessOnlyFlags,
 } from './_helpers/globalArgs';
 import {
-  fillMultiAgentRunPlanGaps,
+  loadCliMultiAgentRunPlan,
   loadCliMultiAgentPresetPlanSet,
   writeMissingPresetAgents,
 } from './multiAgent';
@@ -154,7 +154,9 @@ async function runOrchestration(context: CliContext): Promise<number> {
       // Match the headless path: load remote premium agents (orchestrator,
       // delegation specialists) and replan so the team starts with its real
       // root instead of silently degrading to the first local tool-use agent.
-      const plan = await fillMultiAgentRunPlanGaps({ preset: action.preset });
+      const { plan } = await loadCliMultiAgentRunPlan({
+        preset: action.preset,
+      });
       if (!cliMultiAgentPresetCanLaunchTeam(plan)) {
         writeTextStderr(
           formatCliMultiAgentTeamLaunchBlockMessage(plan, {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -254,7 +254,11 @@ describe('CLI multi-agent run command', () => {
 
     expect(result.remoteAgentLoadAttempted).toBe(true);
     expect(result.plan.rootAgent?.name).toBe('orchestrator');
-    expect(mocks.loadAgents).toHaveBeenCalledWith();
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(1, {
+      includeRemote: false,
+    });
+    // The second call is the remote-inclusive reload: `loadAgents()`.
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
     expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(2);
   });
 
@@ -269,7 +273,8 @@ describe('CLI multi-agent run command', () => {
     });
 
     expect(result.remoteAgentLoadAttempted).toBe(false);
-    expect(mocks.loadAgents).not.toHaveBeenCalled();
+    expect(mocks.loadAgents).toHaveBeenCalledOnce();
+    expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
     expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- make `loadCliMultiAgentRunPlan` own the local agent registry load before its optional remote replan
- remove the `fillMultiAgentRunPlanGaps` pass-through and call the run-plan loader directly from headless and launcher paths
- update the architecture note and tests to reflect the new ownership contract

## Design note
This keeps multi-agent planning local-first, but the run-plan loader now owns the full registry setup for that plan. Callers no longer need to remember to pre-load local agents before asking for a runnable plan.

Closes #5528

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run check:cli-architecture`
- `corepack pnpm exec prettier --check docs/architecture/cli-runtime-round-trips.md packages/cli/src/commands/multiAgent.ts packages/cli/src/commands/orchestrate.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `git diff --check`
- `npm run lint` (passes with existing import-order warnings outside this patch)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor that consolidates registry setup before planning; blast radius is limited to multi-agent inspect/run/orchestrate paths with updated tests.
> 
> **Overview**
> **`loadCliMultiAgentRunPlan`** now performs **`loadAgents({ includeRemote: false })`** before planning and optional authenticated remote replan, so inspect, headless **`multi-agent run`**, and interactive **`orchestrate`** preset launch no longer pre-load the registry themselves.
> 
> The **`fillMultiAgentRunPlanGaps`** pass-through is removed; all those paths call **`loadCliMultiAgentRunPlan`** and use its **`plan`** (and existing remote-load metadata where applicable). The CLI architecture note and tests document the new ownership and **`loadAgents`** call order (local first, then remote when gaps + auth).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43382a836a800835926a6b251a0f436cc4f1fc4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->