### PR TITLE
test: avoid mirroring workspace storage ids

### DIFF
--- a/packages/desktop/tests/e2e/settingsPersistence.spec.ts
+++ b/packages/desktop/tests/e2e/settingsPersistence.spec.ts
@@ -1,7 +1,13 @@
-import { createHash } from 'node:crypto';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import { test, expect } from '@playwright/test';
 
@@ -25,34 +31,52 @@ const MEMORY_FILE_CONTENT = `${MEMORY_PREVIEW_TEXT}
 It verifies that the same workspace storage is read after relaunch.
 `;
 
-// Mirror of `workspaceStorageId` from
-// `src/platform/defaults/workspaceStorage.ts`. Inlined because Playwright's
-// ESM loader cannot safely import root TypeScript modules through `.js`
-// specifiers during test discovery.
-function workspaceStorageId(workspacePath: string | undefined): string {
-  const source = workspacePath?.trim() || 'no-workspace';
-  const hash = createHash('sha256').update(source).digest('hex').slice(0, 8);
-  const stem =
-    source === 'no-workspace'
-      ? 'no-workspace'
-      : basename(source)
-          .replaceAll(/[^A-Za-z0-9._-]/g, '-')
-          .replaceAll(/-+/g, '-')
-          .replaceAll(/^-|-$/g, '') || 'workspace';
-  return `${stem}-${hash}`;
+function tryReadWorkspaceSidecar(path: string): string | undefined {
+  try {
+    const sidecar = JSON.parse(readFileSync(path, 'utf8')) as {
+      path?: unknown;
+    };
+    return typeof sidecar.path === 'string' ? resolve(sidecar.path) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function findWorkspaceStoragePath(input: {
+  userDataPath: string;
+  workspacePath: string;
+}): string {
+  const targetWorkspacePath = resolve(input.workspacePath);
+
+  for (const storageRoot of readdirSync(input.userDataPath, {
+    withFileTypes: true,
+  })) {
+    if (!storageRoot.isDirectory()) continue;
+
+    const storageRootPath = join(input.userDataPath, storageRoot.name);
+    for (const candidate of readdirSync(storageRootPath, {
+      withFileTypes: true,
+    })) {
+      if (!candidate.isDirectory()) continue;
+
+      const candidatePath = join(storageRootPath, candidate.name);
+      const sidecarPath = join(candidatePath, '_workspace.json');
+      if (tryReadWorkspaceSidecar(sidecarPath) === targetWorkspacePath) {
+        return candidatePath;
+      }
+    }
+  }
+
+  throw new Error(
+    `No TeXRA workspace storage directory found for ${targetWorkspacePath}`,
+  );
 }
 
 function writeMemoryEntry(input: {
   userDataPath: string;
   workspacePath: string;
 }): void {
-  const workspaceId = workspaceStorageId(resolve(input.workspacePath));
-  const memoryDir = join(
-    input.userDataPath,
-    'workspace-storage',
-    workspaceId,
-    'memories',
-  );
+  const memoryDir = join(findWorkspaceStoragePath(input), 'memories');
   mkdirSync(memoryDir, { recursive: true });
   writeFileSync(join(memoryDir, MEMORY_FILE_NAME), MEMORY_FILE_CONTENT, 'utf8');
 }


### PR DESCRIPTION
## Summary

- Remove the copied workspace storage id hash and sanitize algorithm from the desktop settings persistence E2E test.
- Locate the real app-created workspace storage directory through the _workspace.json sidecar written by WorkspaceStorageProvider.
- Seed memory under that observed directory so src/platform/defaults/workspaceStorage.ts remains the single source of truth.

Closes #5530

## Validation

- corepack pnpm --filter @texra/desktop exec playwright test --list tests/e2e/settingsPersistence.spec.ts
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings outside this change)
- corepack pnpm exec prettier --check packages/desktop/tests/e2e/settingsPersistence.spec.ts
- git diff --check

## Not Run

- corepack pnpm --filter @texra/desktop typecheck currently fails on existing packages/desktop/src/main/desktopAgentExecution.ts errors unrelated to this E2E-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper changes with no production code paths affected.
> 
> **Overview**
> The desktop **settings persistence** E2E no longer duplicates `workspaceStorageId` hashing/sanitization from `workspaceStorage.ts`. Instead, **`writeMemoryEntry`** discovers the app’s real workspace storage folder by scanning `userData` and matching each candidate’s **`_workspace.json`** sidecar `path` to the test workspace, then seeds memory under that directory’s `memories` folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f1ff30a9aff843df21386782e2ed02ac4241e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->