### PR TITLE
refactor(cli): centralize focused child follow-up routing

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -410,41 +410,39 @@ export function chatTuiIsResumableIdleOnExit(input: {
   return input.canInterruptActiveRun && !input.canStopActiveRun;
 }
 
-function chatTuiActiveChildStreamId(): StreamTabId | undefined {
-  const activeStreamId = cliState.activeStreamId.get();
-  if (!activeStreamId) return undefined;
-  return cliState.parentStream.get().has(activeStreamId)
-    ? activeStreamId
-    : undefined;
-}
+export type ChatTuiFocusedChildFollowUpRoute =
+  | { readonly kind: 'none' }
+  | {
+      readonly kind: 'accept';
+      readonly streamId: StreamTabId;
+      readonly shouldAnnounceQueuedFollowUp: boolean;
+    }
+  | { readonly kind: 'reject'; readonly streamId: StreamTabId };
 
-function chatTuiCanAcceptFollowUp(status: StreamStatus | undefined): boolean {
+export function chatTuiFocusedChildFollowUpRoute(): ChatTuiFocusedChildFollowUpRoute {
+  const activeStreamId = cliState.activeStreamId.get();
+  if (!activeStreamId || !cliState.parentStream.get().has(activeStreamId)) {
+    return { kind: 'none' };
+  }
+
+  const status = streamStatusFromState(activeStreamId);
   // A focused child normally has a status. Keep the previous permissive
   // behavior during the brief edge where parent focus arrives first.
-  return status === undefined || isInFlightStatus(status);
+  if (status !== undefined && !isInFlightStatus(status)) {
+    return { kind: 'reject', streamId: activeStreamId };
+  }
+  return {
+    kind: 'accept',
+    streamId: activeStreamId,
+    shouldAnnounceQueuedFollowUp: status !== STREAM_STATUS.WAITING,
+  };
 }
 
-export function chatTuiActiveChildFollowUpTarget(): StreamTabId | undefined {
-  const activeStreamId = chatTuiActiveChildStreamId();
-  if (!activeStreamId) return undefined;
-  return chatTuiCanAcceptFollowUp(streamStatusFromState(activeStreamId))
-    ? activeStreamId
-    : undefined;
-}
-
-export function chatTuiShouldAnnounceQueuedFollowUp(
+function shouldAnnounceQueuedFollowUpToStream(
   targetStreamId: StreamTabId | undefined,
 ): boolean {
   if (!targetStreamId) return true;
   return streamStatusFromState(targetStreamId) !== STREAM_STATUS.WAITING;
-}
-
-export function chatTuiRejectedChildFollowUpTarget(): StreamTabId | undefined {
-  const activeStreamId = chatTuiActiveChildStreamId();
-  if (!activeStreamId) return undefined;
-  return chatTuiCanAcceptFollowUp(streamStatusFromState(activeStreamId))
-    ? undefined
-    : activeStreamId;
 }
 
 interface SlashCommandContext {
@@ -1547,15 +1545,18 @@ export async function runChat(
     line: string,
     mediaFiles?: readonly string[],
   ): Promise<void> => {
-    const rejectedChildFollowUpTarget = chatTuiRejectedChildFollowUpTarget();
-    if (rejectedChildFollowUpTarget) {
+    const focusedChildRoute = chatTuiFocusedChildFollowUpRoute();
+    if (focusedChildRoute.kind === 'reject') {
       appendLocalAssistantTranscript(
         'The selected subagent is no longer accepting follow-ups.',
-        rejectedChildFollowUpTarget,
+        focusedChildRoute.streamId,
       );
       return;
     }
-    const childFollowUpTarget = chatTuiActiveChildFollowUpTarget();
+    const childFollowUpTarget =
+      focusedChildRoute.kind === 'accept'
+        ? focusedChildRoute.streamId
+        : undefined;
     const prepared = takePendingSkillActivations(pendingSkillActivations, line);
     const skillActivationClearEpoch = pendingSkillActivationClearEpoch;
     const restoreReservedSkillActivations = (): void => {
@@ -1583,7 +1584,11 @@ export async function runChat(
     // p-queue serializes work but doesn't have an "await predicate" primitive,
     // so the task itself waits for the stream id via a tiny poll loop.
     const initialFollowUpTarget = childFollowUpTarget ?? session.streamId;
-    if (chatTuiShouldAnnounceQueuedFollowUp(initialFollowUpTarget)) {
+    const shouldAnnounceQueuedFollowUp =
+      focusedChildRoute.kind === 'accept'
+        ? focusedChildRoute.shouldAnnounceQueuedFollowUp
+        : shouldAnnounceQueuedFollowUpToStream(initialFollowUpTarget);
+    if (shouldAnnounceQueuedFollowUp) {
       appendLocalAssistantTranscript(
         `Queued follow-up: ${truncateSummary(
           line,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -69,9 +69,7 @@ import {
   chatTuiCanStartRootRun,
   chatTuiCanSelectModel,
   chatTuiSigintAction,
-  chatTuiActiveChildFollowUpTarget,
-  chatTuiRejectedChildFollowUpTarget,
-  chatTuiShouldAnnounceQueuedFollowUp,
+  chatTuiFocusedChildFollowUpRoute,
   parseChatLoginSlashArgs,
   clearTuiSessionRunState,
   markChatTuiRunPending,
@@ -1305,12 +1303,14 @@ describe('CLI TUI row allocation', () => {
     setParentStream(child1, root);
 
     cliState.activeStreamId.set(root);
-    expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
-    expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
+    expect(chatTuiFocusedChildFollowUpRoute()).toEqual({ kind: 'none' });
 
     cliState.activeStreamId.set(child1);
-    expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
-    expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
+    expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
+      kind: 'accept',
+      streamId: child1,
+      shouldAnnounceQueuedFollowUp: false,
+    });
   });
 
   it('ignores stale child row status when routing focused child follow-ups', () => {
@@ -1330,8 +1330,11 @@ describe('CLI TUI row allocation', () => {
     setParentStream(child1, root);
 
     cliState.activeStreamId.set(child1);
-    expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
-    expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
+    expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
+      kind: 'accept',
+      streamId: child1,
+      shouldAnnounceQueuedFollowUp: true,
+    });
   });
 
   it('uses child slice status as a fallback for focused child follow-ups', () => {
@@ -1351,8 +1354,10 @@ describe('CLI TUI row allocation', () => {
     setParentStream(child1, root);
 
     cliState.activeStreamId.set(child1);
-    expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
-    expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
+    expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
+      kind: 'reject',
+      streamId: child1,
+    });
   });
 
   it('mirrors running child status events into focused child routing', () => {
@@ -1388,8 +1393,11 @@ describe('CLI TUI row allocation', () => {
       expect(cliState.streams.get().get(root)?.childStreams[0]?.status).toBe(
         STREAM_STATUS.RUNNING,
       );
-      expect(chatTuiActiveChildFollowUpTarget()).toBe(child1);
-      expect(chatTuiRejectedChildFollowUpTarget()).toBeUndefined();
+      expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
+        kind: 'accept',
+        streamId: child1,
+        shouldAnnounceQueuedFollowUp: true,
+      });
     } finally {
       dispose();
     }
@@ -1428,8 +1436,10 @@ describe('CLI TUI row allocation', () => {
       expect(cliState.streams.get().get(root)?.childStreams[0]?.status).toBe(
         STREAM_STATUS.STOPPED,
       );
-      expect(chatTuiActiveChildFollowUpTarget()).toBeUndefined();
-      expect(chatTuiRejectedChildFollowUpTarget()).toBe(child1);
+      expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
+        kind: 'reject',
+        streamId: child1,
+      });
     } finally {
       dispose();
     }


### PR DESCRIPTION
## Summary
- replace separate focused-child accept and reject helpers with one route decision
- keep queued follow-up notice behavior on the same child-route decision
- update focused TUI state tests to assert the unified route contract

Closes #5534.

## Validation
- corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- git diff --check
- corepack pnpm exec prettier --check packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings outside touched files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved via existing TUI state tests; no auth, persistence, or API surface changes beyond internal routing helpers.
> 
> **Overview**
> **Replaces three separate focused-child follow-up helpers** (`chatTuiActiveChildFollowUpTarget`, `chatTuiRejectedChildFollowUpTarget`, `chatTuiShouldAnnounceQueuedFollowUp`) with a single exported **`chatTuiFocusedChildFollowUpRoute()`** that returns a discriminated union: `none`, `accept` (with `streamId` and `shouldAnnounceQueuedFollowUp`), or `reject` (with `streamId`).
> 
> `submitChatMessage` now branches on that one route for rejection messages, child follow-up targets, and whether to show the “Queued follow-up” notice; root-stream announcements still use a private `shouldAnnounceQueuedFollowUpToStream` helper.
> 
> **Tests** in `TuiStateAndFocus.vitest.mts` assert the unified route object instead of separate accept/reject/announce helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7701b5a007ec433c9fd6362e9123cab23f3909c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->