### PR TITLE
refactor(cli): centralize active stream scope

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -28,6 +28,7 @@ import {
   type BypassState,
   type StreamSlice,
 } from '../state/cliState';
+import { activeStreamScope } from '../state/streamViews';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
@@ -501,7 +502,7 @@ export function ctrlCActionForFocus({
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
 }): CtrlCAction {
   if (!canStopActiveRun) return 'exit';
-  return activeStreamId && parentStream.has(activeStreamId)
+  return activeStreamScope({ activeStreamId, parentStream }).kind === 'child'
     ? 'stop root'
     : 'stop';
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -121,6 +121,7 @@ import {
   onStreamStatusChange,
   streamStatusFromState,
 } from './state/streamStatus';
+import { activeStreamScope } from './state/streamViews';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
 import { requestCliCompaction } from './state/compactionRequest';
 import {
@@ -420,20 +421,23 @@ export type ChatTuiFocusedChildFollowUpRoute =
   | { readonly kind: 'reject'; readonly streamId: StreamTabId };
 
 export function chatTuiFocusedChildFollowUpRoute(): ChatTuiFocusedChildFollowUpRoute {
-  const activeStreamId = cliState.activeStreamId.get();
-  if (!activeStreamId || !cliState.parentStream.get().has(activeStreamId)) {
+  const scope = activeStreamScope({
+    activeStreamId: cliState.activeStreamId.get(),
+    parentStream: cliState.parentStream.get(),
+  });
+  if (scope.kind !== 'child') {
     return { kind: 'none' };
   }
 
-  const status = streamStatusFromState(activeStreamId);
+  const status = streamStatusFromState(scope.streamId);
   // A focused child normally has a status. Keep the previous permissive
   // behavior during the brief edge where parent focus arrives first.
   if (status !== undefined && !isInFlightStatus(status)) {
-    return { kind: 'reject', streamId: activeStreamId };
+    return { kind: 'reject', streamId: scope.streamId };
   }
   return {
     kind: 'accept',
-    streamId: activeStreamId,
+    streamId: scope.streamId,
     shouldAnnounceQueuedFollowUp: status !== STREAM_STATUS.WAITING,
   };
 }

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -12,7 +12,7 @@ import { formatDuration } from '@utils/core';
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { visibleSubagentRows } from './childStreamMerge';
-import { streamDisplayLabel } from './streamViews';
+import { activeStreamParentOrSelfId, streamDisplayLabel } from './streamViews';
 import { orderedDescendantsFromTree } from './focusCycle';
 import { transcriptEntryLines } from './transcriptLines';
 import type {
@@ -420,9 +420,12 @@ export function numericFocusTargetForActiveStream(init: {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly zeroBasedIndex: number;
 }): StreamTabId | undefined {
-  if (!init.activeStreamId || init.zeroBasedIndex < 0) return undefined;
-  const root =
-    init.parentStream.get(init.activeStreamId) ?? init.activeStreamId;
+  const activeStreamId = init.activeStreamId;
+  if (!activeStreamId || init.zeroBasedIndex < 0) return undefined;
+  const root = activeStreamParentOrSelfId({
+    activeStreamId,
+    parentStream: init.parentStream,
+  });
   return orderedDescendantsFromTree({
     parent: root,
     parentSlice: init.streams.get(root),

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -21,6 +21,45 @@ export interface StreamView {
   readonly shortcutIndex?: number;
 }
 
+export type ActiveStreamScope =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'root'; readonly streamId: StreamTabId }
+  | {
+      readonly kind: 'child';
+      readonly parentStreamId: StreamTabId;
+      readonly streamId: StreamTabId;
+    };
+
+export function activeStreamScope(init: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+}): ActiveStreamScope {
+  const activeStreamId = init.activeStreamId;
+  if (!activeStreamId) return { kind: 'none' };
+
+  const parentStreamId = init.parentStream.get(activeStreamId);
+  return parentStreamId === undefined
+    ? { kind: 'root', streamId: activeStreamId }
+    : { kind: 'child', parentStreamId, streamId: activeStreamId };
+}
+
+export function activeStreamParentOrSelfId(init: {
+  readonly activeStreamId: StreamTabId;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+}): StreamTabId;
+export function activeStreamParentOrSelfId(init: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+}): StreamTabId | undefined;
+export function activeStreamParentOrSelfId(init: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+}): StreamTabId | undefined {
+  const scope = activeStreamScope(init);
+  if (scope.kind === 'none') return undefined;
+  return scope.kind === 'child' ? scope.parentStreamId : scope.streamId;
+}
+
 function childReferenceKey(child: ActiveChildInfo): string {
   return child.childStreamId ?? child.executionId;
 }
@@ -92,8 +131,7 @@ interface OrderedStreamViewInput {
 }
 
 function activeTreeRoot(init: OrderedStreamViewInput): StreamTabId | undefined {
-  if (!init.activeStreamId) return init.streams.keys().next().value;
-  return init.parentStream.get(init.activeStreamId) ?? init.activeStreamId;
+  return activeStreamParentOrSelfId(init) ?? init.streams.keys().next().value;
 }
 
 function orderedStreamTree(init: {

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -9,6 +9,7 @@ import {
   registerCliStateResetHook,
   type ConversationEntry,
 } from './cliState';
+import { activeStreamParentOrSelfId } from './streamViews';
 
 export const CLI_LOCAL_STREAM_ID = 'cli-local' as StreamTabId;
 
@@ -126,8 +127,10 @@ export function resolveLocalTranscriptStreamId({
   readonly rootStreamId: StreamTabId | undefined;
 }): StreamTabId {
   if (rootStreamId) return rootStreamId;
-  if (!activeStreamId) return fallbackStreamId;
-  return parentStream.get(activeStreamId) ?? activeStreamId;
+  return (
+    activeStreamParentOrSelfId({ activeStreamId, parentStream }) ??
+    fallbackStreamId
+  );
 }
 
 function defaultLocalTranscriptStreamId(): StreamTabId {

--- a/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
+++ b/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
@@ -1,5 +1,7 @@
 import type { StreamTabId } from '@shared/schemas';
 
+import { activeStreamScope } from './streamViews';
+
 export const ROOT_SCROLLBACK_VIEWPORT_KEY = 'root-scrollback';
 
 /**
@@ -22,8 +24,9 @@ export function transcriptViewportKey({
   readonly transcriptViewerStreamId?: StreamTabId;
 }): string {
   if (transcriptViewerStreamId) return `viewer:${transcriptViewerStreamId}`;
-  return activeStreamId && parentStream.has(activeStreamId)
-    ? `scoped:${activeStreamId}`
+  const scope = activeStreamScope({ activeStreamId, parentStream });
+  return scope.kind === 'child'
+    ? `scoped:${scope.streamId}`
     : ROOT_SCROLLBACK_VIEWPORT_KEY;
 }
 

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
+  activeStreamParentOrSelfId,
+  activeStreamScope,
+} from '@cli/chat/tui/state/streamViews';
+import {
   streamTabSegmentText,
   streamTabsLineSegments,
   streamTabsLineText,
@@ -58,6 +62,39 @@ function slice(
     ...init,
   };
 }
+
+describe('active stream scope', () => {
+  it('owns the active stream child/root projection', () => {
+    const root = streamId('root');
+    const child1 = streamId('child-1');
+    const parentStream = new Map<StreamTabId, StreamTabId>([[child1, root]]);
+
+    expect(
+      activeStreamScope({ activeStreamId: undefined, parentStream }),
+    ).toEqual({ kind: 'none' });
+    expect(activeStreamScope({ activeStreamId: root, parentStream })).toEqual({
+      kind: 'root',
+      streamId: root,
+    });
+    expect(activeStreamScope({ activeStreamId: child1, parentStream })).toEqual(
+      {
+        kind: 'child',
+        parentStreamId: root,
+        streamId: child1,
+      },
+    );
+
+    expect(
+      activeStreamParentOrSelfId({ activeStreamId: undefined, parentStream }),
+    ).toBeUndefined();
+    expect(
+      activeStreamParentOrSelfId({ activeStreamId: root, parentStream }),
+    ).toBe(root);
+    expect(
+      activeStreamParentOrSelfId({ activeStreamId: child1, parentStream }),
+    ).toBe(root);
+  });
+});
 
 describe('CLI stream tabs strip', () => {
   it('suppresses the strip for a single stream', () => {


### PR DESCRIPTION
## Summary
- add one active-stream scope projection for root/child/no active stream in `streamViews`
- route scrollback viewport keys, local transcript routing, status bar Ctrl-C wording, focus targeting, and child follow-up routing through that projection
- add focused coverage for the active stream scope and parent-or-self contract

Closes #5536.

## Validation
- corepack pnpm vitest run src/test-kernel/cli/StreamTabsStrip.vitest.mts
- corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts
- corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts
- corepack pnpm vitest run src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- git diff --check
- corepack pnpm exec prettier --check packages/cli/src/chat/tui/panes/StatusBar.tsx packages/cli/src/chat/tui/runChatTui.tsx packages/cli/src/chat/tui/state/childControls.ts packages/cli/src/chat/tui/state/streamViews.ts packages/cli/src/chat/tui/state/transcript.ts packages/cli/src/chat/tui/state/transcriptViewportMode.ts src/test-kernel/cli/StreamTabsStrip.vitest.mts
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings outside touched files)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with equivalent branching and new tests; no auth, persistence, or runtime protocol changes.
> 
> **Overview**
> Introduces **`activeStreamScope`** and **`activeStreamParentOrSelfId`** in `streamViews` so the CLI TUI has one place to answer whether focus is on no stream, a root stream, or a child (with parent id).
> 
> Call sites that previously inlined `parentStream.get` / `parentStream.has` now use that projection for **Ctrl-C labeling** (`stop` vs `stop root`), **focused-child follow-up routing**, **numeric focus targets**, **local transcript stream resolution**, **transcript viewport keys**, and **active stream tree root** selection. Behavior is intended to stay the same; the change is consolidation and a typed contract.
> 
> Adds unit tests for the scope and parent-or-self helpers in `StreamTabsStrip.vitest.mts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1923237b74706405c73ae906a03d3eed34250d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->