### PR TITLE
refactor(cli): centralize active stream ancestor traversal

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -28,7 +28,10 @@ import {
   type BypassState,
   type StreamSlice,
 } from '../state/cliState';
-import { activeStreamScope } from '../state/streamViews';
+import {
+  activeStreamScope,
+  nearestActiveStreamAncestor,
+} from '../state/streamViews';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
@@ -551,19 +554,12 @@ function statusBarFindAncestorStream<T extends StatusBarVisibleStream>({
   readonly streams: ReadonlyMap<StreamTabId, T>;
   readonly canUseStream: (stream: T) => boolean;
 }): T | undefined {
-  if (activeStreamId === undefined) return undefined;
-
-  const visited = new Set<StreamTabId>([activeStreamId]);
-  let parentStreamId = parentStream.get(activeStreamId);
-  while (parentStreamId && !visited.has(parentStreamId)) {
-    visited.add(parentStreamId);
-    const parentStreamSlice = streams.get(parentStreamId);
-    if (parentStreamSlice && canUseStream(parentStreamSlice)) {
-      return parentStreamSlice;
-    }
-    parentStreamId = parentStream.get(parentStreamId);
-  }
-  return undefined;
+  return nearestActiveStreamAncestor({
+    activeStreamId,
+    parentStream,
+    values: streams,
+    canUseValue: canUseStream,
+  })?.value;
 }
 
 export function statusBarCanStopVisibleRun({

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -12,7 +12,11 @@ import { formatDuration } from '@utils/core';
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { visibleSubagentRows } from './childStreamMerge';
-import { activeStreamParentOrSelfId, streamDisplayLabel } from './streamViews';
+import {
+  activeStreamParentOrSelfId,
+  nearestActiveStreamAncestor,
+  streamDisplayLabel,
+} from './streamViews';
 import { orderedDescendantsFromTree } from './focusCycle';
 import { transcriptEntryLines } from './transcriptLines';
 import type {
@@ -284,20 +288,17 @@ export function resolveChildControlStreamTarget({
     return { streamId: activeStreamId, slice: activeSlice };
   }
 
-  const visited = new Set<StreamTabId>([activeStreamId]);
-  let parentStreamId = parentStream.get(activeStreamId);
-  while (parentStreamId && !visited.has(parentStreamId)) {
-    visited.add(parentStreamId);
-    const parentSlice = streams.get(parentStreamId);
-    const parentHasRows = hasChildControlItems(parentSlice, mode);
-    if (!parentHasRows) {
-      parentStreamId = parentStream.get(parentStreamId);
-      continue;
-    }
+  const ancestor = nearestActiveStreamAncestor({
+    activeStreamId,
+    parentStream,
+    values: streams,
+    canUseValue: (slice) => hasChildControlItems(slice, mode),
+  });
+  if (ancestor) {
     return {
       fallbackFromStreamId: activeStreamId,
-      streamId: parentStreamId,
-      slice: parentSlice,
+      streamId: ancestor.streamId,
+      slice: ancestor.value,
     };
   }
 

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -30,6 +30,11 @@ export type ActiveStreamScope =
       readonly streamId: StreamTabId;
     };
 
+export interface ActiveStreamAncestor<T> {
+  readonly streamId: StreamTabId;
+  readonly value: T;
+}
+
 export function activeStreamScope(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
@@ -58,6 +63,28 @@ export function activeStreamParentOrSelfId(init: {
   const scope = activeStreamScope(init);
   if (scope.kind === 'none') return undefined;
   return scope.kind === 'child' ? scope.parentStreamId : scope.streamId;
+}
+
+export function nearestActiveStreamAncestor<T>(init: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly values: ReadonlyMap<StreamTabId, T>;
+  readonly canUseValue: (value: T) => boolean;
+}): ActiveStreamAncestor<T> | undefined {
+  const activeStreamId = init.activeStreamId;
+  if (activeStreamId === undefined) return undefined;
+
+  const visited = new Set<StreamTabId>([activeStreamId]);
+  let parentStreamId = init.parentStream.get(activeStreamId);
+  while (parentStreamId && !visited.has(parentStreamId)) {
+    visited.add(parentStreamId);
+    const value = init.values.get(parentStreamId);
+    if (value !== undefined && init.canUseValue(value)) {
+      return { streamId: parentStreamId, value };
+    }
+    parentStreamId = init.parentStream.get(parentStreamId);
+  }
+  return undefined;
 }
 
 function childReferenceKey(child: ActiveChildInfo): string {

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -4,6 +4,7 @@ import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
   activeStreamParentOrSelfId,
   activeStreamScope,
+  nearestActiveStreamAncestor,
 } from '@cli/chat/tui/state/streamViews';
 import {
   streamTabSegmentText,
@@ -93,6 +94,71 @@ describe('active stream scope', () => {
     expect(
       activeStreamParentOrSelfId({ activeStreamId: child1, parentStream }),
     ).toBe(root);
+  });
+
+  it('owns nearest active ancestor traversal', () => {
+    const root = streamId('root');
+    const child1 = streamId('child-1');
+    const child2 = streamId('child-2');
+    const grandchild = streamId('grandchild');
+    const parentStream = new Map<StreamTabId, StreamTabId>([
+      [child1, root],
+      [child2, root],
+      [grandchild, child1],
+    ]);
+    const values = new Map([
+      [root, { usable: true }],
+      [child1, { usable: false }],
+      [child2, { usable: true }],
+      [grandchild, { usable: false }],
+    ]);
+
+    expect(
+      nearestActiveStreamAncestor({
+        activeStreamId: grandchild,
+        parentStream,
+        values,
+        canUseValue: (value) => value.usable,
+      }),
+    ).toEqual({ streamId: root, value: { usable: true } });
+    expect(
+      nearestActiveStreamAncestor({
+        activeStreamId: child2,
+        parentStream,
+        values,
+        canUseValue: (value) => value.usable,
+      }),
+    ).toEqual({ streamId: root, value: { usable: true } });
+    expect(
+      nearestActiveStreamAncestor({
+        activeStreamId: undefined,
+        parentStream,
+        values,
+        canUseValue: (value) => value.usable,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('stops nearest active ancestor traversal at parent cycles', () => {
+    const child1 = streamId('child-1');
+    const child2 = streamId('child-2');
+    const parentStream = new Map<StreamTabId, StreamTabId>([
+      [child1, child2],
+      [child2, child1],
+    ]);
+    const values = new Map([
+      [child1, { usable: true }],
+      [child2, { usable: false }],
+    ]);
+
+    expect(
+      nearestActiveStreamAncestor({
+        activeStreamId: child1,
+        parentStream,
+        values,
+        canUseValue: (value) => value.usable,
+      }),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- add `nearestActiveStreamAncestor` beside the active stream scope helpers so `streamViews` owns parent-edge traversal and cycle protection
- route child-control fallback and status-bar ancestor lookup through that single traversal owner while keeping their local predicates unchanged
- cover nearest ancestor matching and parent-cycle termination in the stream view tests

Closes #5538.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/streamViews.ts packages/cli/src/chat/tui/state/childControls.ts packages/cli/src/chat/tui/panes/StatusBar.tsx src/test-kernel/cli/StreamTabsStrip.vitest.mts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside touched files)
- `npm run compile:fast`

## Design note

The callers still own the meaning of a usable stream: child controls look for rows, and the status bar looks for status. The shared helper owns only the child-to-parent traversal so future focused-subagent behavior does not need to reimplement the same fallback walk.