### PR TITLE
refactor: centralize slash picker availability defaults

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -89,6 +89,8 @@ export function registerBuiltinSlashCommands(options?: {
     options?.onModelSelect ?? ((value) => patchSessionMeta('model', value));
   const onApiModeSelect: ApiModeSelectHandler =
     options?.onApiModeSelect ?? ((value) => patchSessionMeta('apiMode', value));
+  const canSelectAgent = options?.canSelectAgent ?? (() => true);
+  const canSelectModel = options?.canSelectModel ?? (() => true);
 
   // Picking the root agent and the root model is a single up-front choice
   // before the first message, so advance straight from the agent picker into
@@ -108,7 +110,7 @@ export function registerBuiltinSlashCommands(options?: {
 
   function AgentListFormAdapter(props: SlashFormProps): React.JSX.Element {
     const current = cliState.sessionMeta.get().agent;
-    const selectable = options?.canSelectAgent?.() ?? true;
+    const selectable = canSelectAgent();
     return (
       <AgentListForm
         currentAgent={current}
@@ -117,10 +119,7 @@ export function registerBuiltinSlashCommands(options?: {
         onSelect={(value) => {
           // Chain into the model picker only while still choosing the root
           // (before the first message) and model selection is available.
-          // Mirror ModelListFormAdapter's own default (`?? true`) so the two
-          // agree on what "model selection available" means; otherwise close.
-          const advanceToModel =
-            selectable && (options?.canSelectModel?.() ?? true);
+          const advanceToModel = selectable && canSelectModel();
           runFormSelection({
             action: () => onAgentSelect(value),
             value,
@@ -173,7 +172,7 @@ export function registerBuiltinSlashCommands(options?: {
 
   function ModelListFormAdapter(props: SlashFormProps): React.JSX.Element {
     const current = cliState.sessionMeta.get().model;
-    const selectable = options?.canSelectModel?.() ?? true;
+    const selectable = canSelectModel();
     return (
       <ModelListForm
         currentModel={current}

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -179,6 +179,35 @@ describe('slashRegistry', () => {
     });
   });
 
+  it('does not advance agent picks into the model form when model selection is unavailable', async () => {
+    resetCliState({
+      agent: 'chat',
+      model: 'deepseekT',
+      cwd: '/tmp/workspace',
+      apiMode: 'included',
+      canDelegate: false,
+      version: 'test',
+    });
+    registerBuiltinSlashCommands({
+      canSelectModel: () => false,
+    });
+    const agent = listSlashCommands().find((cmd) => cmd.name === 'agent');
+
+    if (!agent) throw new Error('Expected /agent to be registered');
+
+    expect(openRegisteredCliSlashForm(agent, '')).toBe(true);
+
+    const agentNode = renderOpenForm<{
+      onSelect?: (value: string) => void;
+    }>();
+    agentNode.props?.onSelect?.('review');
+    await settleFormSelection();
+
+    expect(cliState.sessionMeta.get().agent).toBe('review');
+    expect(agentNode.isClosed()).toBe(true);
+    expect(cliState.activeForm.get()?.commandName).toBe('agent');
+  });
+
   it('marks the agent picker read-only when root selection is closed', () => {
     resetCliState({
       agent: 'chat',


### PR DESCRIPTION
## Summary
- Normalize built-in slash picker availability callbacks once at registration time.
- Use the same canSelectModel contract for the /agent to /model handoff and the /model form.
- Add a slash registry regression test for the unavailable-model handoff case.

Closes #5540.

## Validation
- corepack pnpm exec vitest run src/test-kernel/cli/SlashRegistry.vitest.mts
- corepack pnpm exec prettier --check packages/cli/src/chat/tui/commands/registerBuiltins.tsx src/test-kernel/cli/SlashRegistry.vitest.mts
- git diff --check
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings outside touched files)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small TUI registration refactor with behavior locked by an existing test suite addition; no auth, data, or API surface changes.
> 
> **Overview**
> **Centralizes** `canSelectAgent` and `canSelectModel` defaults once at `registerBuiltinSlashCommands` registration (defaulting to always available), so the `/agent` and `/model` form adapters and the agent→model handoff all use the **same** callbacks instead of repeating `?? true` at each call site.
> 
> When model selection is disabled, picking an agent **still updates** session meta but **no longer** chains into the model picker—the agent form **closes** like a normal selection.
> 
> Adds a **slash registry regression test** for that handoff when `canSelectModel` returns false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3e39e73e4a7e34f8ae00f38923ee32b525db77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->