### PR TITLE
refactor: keep CLI run model source with candidate

### DIFF
--- a/packages/cli/src/commands/_helpers/modelArg.ts
+++ b/packages/cli/src/commands/_helpers/modelArg.ts
@@ -15,12 +15,12 @@ import { shouldRenderRunProgress } from '@cli/runtime/runProgressRenderer';
 import { effectiveCliApiMode } from '@cli/runtime/apiAccessMode';
 import { toErrorMessage } from '@common/errors/errorMessage';
 
-type CliRunModelCandidateSource = Extract<
+export type CliRunModelCandidateSource = Extract<
   CliModelSelectionSource,
   'override' | 'env' | 'config' | 'builtin'
 >;
 
-interface CliRunModelCandidate {
+export interface CliRunModelCandidate {
   readonly model: string;
   readonly source: CliRunModelCandidateSource;
 }
@@ -39,7 +39,13 @@ export function assertExplicitModelKnown(
   return trimmed;
 }
 
-function resolveCliRunModelCandidateDetails(
+/**
+ * Resolve the model candidate for a headless runner with the shared
+ * precedence: explicit `-m` > `TEXRA_MODEL` env > configured `chat`/`run`
+ * model > builtin. The source is part of the contract because model access
+ * fallback policy depends on where the value came from.
+ */
+export function resolveCliRunModelCandidate(
   context: CliContext,
   modelOverride: string | undefined,
   role: 'chat' | 'run',
@@ -54,28 +60,12 @@ function resolveCliRunModelCandidateDetails(
   return { model: CLI_BUILTIN_DEFAULT_MODEL, source: 'builtin' };
 }
 
-/**
- * Resolve the model for a headless runner with the shared precedence:
- * explicit `-m` > `TEXRA_MODEL` env > configured `chat`/`run` model > builtin.
- */
-export function resolveCliRunModelCandidate(
-  context: CliContext,
-  modelOverride: string | undefined,
-  role: 'chat' | 'run',
-): string {
-  return resolveCliRunModelCandidateDetails(context, modelOverride, role).model;
-}
-
 export async function resolveCliRunModel(
   context: CliContext,
   modelOverride: string | undefined,
   role: 'chat' | 'run',
 ): Promise<string> {
-  const candidate = resolveCliRunModelCandidateDetails(
-    context,
-    modelOverride,
-    role,
-  );
+  const candidate = resolveCliRunModelCandidate(context, modelOverride, role);
   await initCliPlatform({ ...context, quietLogs: true });
   const apiMode = effectiveCliApiMode(context);
   try {

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -83,9 +83,10 @@ describe('resolveCliRunModel precedence', () => {
       envModel: OTHER_MODEL,
       cliConfig: runConfig('deepseekR'),
     });
-    expect(resolveCliRunModelCandidate(context, KNOWN_MODEL, 'run')).toBe(
-      KNOWN_MODEL,
-    );
+    expect(resolveCliRunModelCandidate(context, KNOWN_MODEL, 'run')).toEqual({
+      model: KNOWN_MODEL,
+      source: 'override',
+    });
   });
 
   it('falls back to env when no explicit model is given', () => {
@@ -93,34 +94,41 @@ describe('resolveCliRunModel precedence', () => {
       envModel: OTHER_MODEL,
       cliConfig: runConfig('deepseekR'),
     });
-    expect(resolveCliRunModelCandidate(context, undefined, 'run')).toBe(
-      OTHER_MODEL,
-    );
+    expect(resolveCliRunModelCandidate(context, undefined, 'run')).toEqual({
+      model: OTHER_MODEL,
+      source: 'env',
+    });
   });
 
   it('uses the configured model when no explicit or env model', () => {
     const context = makeContext({ cliConfig: runConfig('deepseekR') });
-    expect(resolveCliRunModelCandidate(context, undefined, 'run')).toBe(
-      'deepseekR',
-    );
+    expect(resolveCliRunModelCandidate(context, undefined, 'run')).toEqual({
+      model: 'deepseekR',
+      source: 'config',
+    });
   });
 
   it('reads the role-specific config section', () => {
     const context = makeContext({
       cliConfig: { chat: { model: OTHER_MODEL }, run: { model: 'deepseekR' } },
     });
-    expect(resolveCliRunModelCandidate(context, undefined, 'chat')).toBe(
-      OTHER_MODEL,
-    );
-    expect(resolveCliRunModelCandidate(context, undefined, 'run')).toBe(
-      'deepseekR',
-    );
+    expect(resolveCliRunModelCandidate(context, undefined, 'chat')).toEqual({
+      model: OTHER_MODEL,
+      source: 'config',
+    });
+    expect(resolveCliRunModelCandidate(context, undefined, 'run')).toEqual({
+      model: 'deepseekR',
+      source: 'config',
+    });
   });
 
   it('falls back to the builtin default when nothing else is set', () => {
-    expect(resolveCliRunModelCandidate(makeContext(), undefined, 'run')).toBe(
-      CLI_BUILTIN_DEFAULT_MODEL,
-    );
+    expect(
+      resolveCliRunModelCandidate(makeContext(), undefined, 'run'),
+    ).toEqual({
+      model: CLI_BUILTIN_DEFAULT_MODEL,
+      source: 'builtin',
+    });
   });
 
   it('suppresses fallback notices for the implicit builtin default', async () => {


### PR DESCRIPTION
## Summary
- Make `resolveCliRunModelCandidate()` return the source-aware candidate directly.
- Remove the private details helper plus exported model-only pass-through.
- Update model resolution tests to assert both model precedence and source classification.

Closes #5542.

## Validation
- corepack pnpm exec vitest run src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/ModelArg.vitest.mts
- corepack pnpm exec prettier --check packages/cli/src/commands/_helpers/modelArg.ts src/test-kernel/cli/cliModelResolution.vitest.mts
- git diff --check
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings outside touched files)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API refactor in CLI model selection with unchanged precedence and updated unit tests only.
> 
> **Overview**
> **`resolveCliRunModelCandidate()`** now returns a **`CliRunModelCandidate`** (`model` + `source`) instead of only the model string. The private details helper is removed; precedence is unchanged (`-m` → env → config → builtin).
> 
> **`CliRunModelCandidate`** and **`CliRunModelCandidateSource`** are exported so callers can rely on source for **`cliRunnableModelOptionsForSource`** fallback behavior without duplicating resolution. **`resolveCliRunModel`** uses the candidate object directly.
> 
> Tests assert both model and **`source`** (`override`, `env`, `config`, `builtin`) for each precedence path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922575669ef6e8e814806ccc30c0f19170be60ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->