### PR TITLE
refactor: centralize CLI config key variants

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -65,9 +65,15 @@ const COMMAND_FIELD_SCHEMAS: ReadonlyArray<[string, z.ZodType]> = [
   ['agent', NonEmptyStringSchema],
   ['model', ModelSchema],
 ];
+const COMMAND_SECTIONS = ['chat', 'run'] as const;
 
 const TOP_LEVEL_KEYS = new Set<string>(CLI_SETTING_PATHS);
 const COMMAND_KEYS = new Set(COMMAND_FIELD_SCHEMAS.map(([key]) => key));
+
+/** Preferred config key order: unified `texra.*` first, legacy bare key second. */
+function configKeyVariants(bareKey: string): readonly [string, string] {
+  return [`texra.${bareKey}`, bareKey];
+}
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -122,21 +128,24 @@ function collectValidationWarnings(
 
   // Validate top-level fields in both bare (legacy) and `texra.*` forms.
   for (const [key, schema] of TOP_LEVEL_FIELD_SCHEMAS) {
-    warnInvalidField(warnings, filePath, record, key, schema);
-    warnInvalidField(warnings, filePath, record, `texra.${key}`, schema);
+    for (const variant of configKeyVariants(key)) {
+      warnInvalidField(warnings, filePath, record, variant, schema);
+    }
   }
 
-  for (const section of ['chat', 'run', 'texra.chat', 'texra.run'] as const) {
-    if (!Object.hasOwn(record, section)) continue;
-    const sectionValue = record[section];
-    if (!isPlainRecord(sectionValue)) {
-      warnings.push(`Ignoring invalid ${filePath} key "${section}".`);
-      continue;
-    }
-    const prefix = `${section}.`;
-    warnUnknownKeys(warnings, filePath, sectionValue, COMMAND_KEYS, prefix);
-    for (const [key, schema] of COMMAND_FIELD_SCHEMAS) {
-      warnInvalidField(warnings, filePath, sectionValue, key, schema, prefix);
+  for (const section of COMMAND_SECTIONS) {
+    for (const sectionKey of configKeyVariants(section)) {
+      if (!Object.hasOwn(record, sectionKey)) continue;
+      const sectionValue = record[sectionKey];
+      if (!isPlainRecord(sectionValue)) {
+        warnings.push(`Ignoring invalid ${filePath} key "${sectionKey}".`);
+        continue;
+      }
+      const prefix = `${sectionKey}.`;
+      warnUnknownKeys(warnings, filePath, sectionValue, COMMAND_KEYS, prefix);
+      for (const [key, schema] of COMMAND_FIELD_SCHEMAS) {
+        warnInvalidField(warnings, filePath, sectionValue, key, schema, prefix);
+      }
     }
   }
   return warnings;
@@ -159,7 +168,7 @@ function pickValue<T>(
   bareKey: string,
   schema: z.ZodType<T>,
 ): T | undefined {
-  for (const key of [`texra.${bareKey}`, bareKey]) {
+  for (const key of configKeyVariants(bareKey)) {
     if (Object.hasOwn(record, key)) return parseOptional(schema, record[key]);
   }
   return undefined;
@@ -169,7 +178,7 @@ function pickRecord(
   record: Record<string, unknown>,
   bareKey: string,
 ): Record<string, unknown> | undefined {
-  for (const key of [`texra.${bareKey}`, bareKey]) {
+  for (const key of configKeyVariants(bareKey)) {
     const value = record[key];
     if (isPlainRecord(value)) return value;
   }

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -169,6 +169,29 @@ describe('CLI context config defaults', () => {
     expect(loaded.warnings).toEqual([]);
   });
 
+  it('prefers prefixed config keys over legacy bare keys', async () => {
+    const workspace = await workspaceWithConfig(
+      JSON.stringify({
+        agent: 'legacy-agent',
+        model: 'gpt55',
+        chat: { agent: 'legacy-chat', model: 'sonnet46T' },
+        'texra.agent': 'generic',
+        'texra.model': 'deepseekT',
+        'texra.chat': { agent: 'chat', model: 'gpt55' },
+      }),
+    );
+
+    const loaded = await loadWorkspaceCliConfig(workspace);
+
+    expect(loaded.values.agent).toBe('generic');
+    expect(loaded.values.model).toBe('deepseekT');
+    expect(loaded.values.chat).toEqual({
+      agent: 'chat',
+      model: 'gpt55',
+    });
+    expect(loaded.warnings).toEqual([]);
+  });
+
   it('canonicalizes existing workspace paths before reading config', async () => {
     const root = await mkdtemp(join(tmpdir(), 'texra-cli-context-link-'));
     const workspace = join(root, 'workspace');


### PR DESCRIPTION
## Summary
- Add one local helper for preferred CLI config key variants: prefixed texra.* first, legacy bare key second.
- Reuse that rule for config validation and parsing of top-level fields and command sections.
- Add a regression test proving prefixed keys win when both prefixed and legacy keys are present.

Closes #5544.

## Validation
- corepack pnpm exec vitest run src/test-kernel/cli/CliContext.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts
- corepack pnpm exec prettier --check packages/cli/src/runtime/cliConfig.ts src/test-kernel/cli/CliContext.vitest.mts
- git diff --check
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings outside touched files)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of config parsing/validation with explicit test coverage; no new features or security-sensitive paths.
> 
> **Overview**
> Introduces **`configKeyVariants`** so every code path uses the same rule: try **`texra.*`** first, then the legacy bare key. That helper now drives top-level field validation, **`chat`/`run`** section validation (via **`COMMAND_SECTIONS`** instead of four hard-coded section names), and **`pickValue`** / **`pickRecord`** during load.
> 
> Adds a regression test that when both prefixed and bare keys exist in **`.texra/config.json`**, loaded values come from the **`texra.*`** entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5034484fcc30992ee19b676d7798bd406f68f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->