### PR TITLE
refactor: remove CLI approval pass-through import

### DIFF
--- a/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
+++ b/packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts
@@ -1,9 +1,4 @@
-import {
-  approvalPromptsUnavailable,
-  type ApprovalInstructionContext,
-} from '@cli/runtime/approvalPolicyAvailability';
-
-export { approvalPromptsUnavailable, type ApprovalInstructionContext };
+import type { ApprovalInstructionContext } from '@cli/runtime/approvalPolicyAvailability';
 
 const PRIVILEGED_ACTION_GUIDANCE =
   'Do not call approval-gated tools such as bash/shell commands, file edits, setup/config updates, user questions, retry/plan approvals, or new subagent delegations; solve from the provided context or state what approval is needed.';

--- a/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
+++ b/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
@@ -1,7 +1,6 @@
-import {
-  formatUnavailableApprovalInstruction,
-  type ApprovalInstructionContext,
-} from './approvalPolicyInstruction';
+import type { ApprovalInstructionContext } from '@cli/runtime/approvalPolicyAvailability';
+
+import { formatUnavailableApprovalInstruction } from './approvalPolicyInstruction';
 import { formatCliRunFileInstruction } from './runFileInstruction';
 
 interface MultiAgentInstructionPreset {

--- a/packages/cli/src/commands/_helpers/runExecution.ts
+++ b/packages/cli/src/commands/_helpers/runExecution.ts
@@ -3,10 +3,10 @@ import { runAgent } from '@agent/runtime/runAgent';
 import type { ValidatedExecutionRequest } from '@agent/core/execution/executionRequests';
 
 import type { CliContext } from '@cli/runtime/cliContext';
+import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 
-import { approvalPromptsUnavailable } from './approvalPolicyInstruction';
 import {
   readCliTerminalStatus,
   type ExecuteAgentResult,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -13,6 +13,7 @@ import { agentKey } from '@shared/schemas/agent';
 import { generateExecutionId } from '@utils/core/executionId';
 import { CliUsageError, readCliStdinText } from '../runtime/cliContext';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
+import { approvalPromptsUnavailable } from '../runtime/approvalPolicyAvailability';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform, initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
@@ -61,7 +62,6 @@ import {
   toolUseResultText,
   type CliRunResult,
 } from './_helpers/terminalStatus';
-import { approvalPromptsUnavailable } from './_helpers/approvalPolicyInstruction';
 import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -1,12 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  approvalPromptsUnavailable,
-  formatUnavailableApprovalInstruction,
-} from '@cli/commands/_helpers/approvalPolicyInstruction';
+import { formatUnavailableApprovalInstruction } from '@cli/commands/_helpers/approvalPolicyInstruction';
 import { formatMultiAgentRunInstruction } from '@cli/commands/_helpers/multiAgentInstruction';
 import { formatCliRunFileInstruction } from '@cli/commands/_helpers/runFileInstruction';
 import { formatToolUseAgentRunInstruction } from '@cli/commands/_helpers/toolUseRunInstruction';
+import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
 
 const preset = {
   id: 'mathematician',


### PR DESCRIPTION
## Summary
- remove the approval availability re-export from approvalPolicyInstruction
- import approvalPromptsUnavailable directly from the runtime owner in command/runtime callers
- keep approvalPolicyInstruction focused on formatting unavailable-approval prompt text

Closes #5546.

## Validation
- corepack pnpm exec vitest run src/test-kernel/cli/MultiAgentInstruction.vitest.ts
- corepack pnpm exec prettier --check packages/cli/src/commands/_helpers/approvalPolicyInstruction.ts packages/cli/src/commands/_helpers/multiAgentInstruction.ts packages/cli/src/commands/_helpers/runExecution.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/MultiAgentInstruction.vitest.ts
- git diff --check
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings outside touched files)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path refactor only; approval behavior stays in approvalPolicyAvailability with no logic changes.
> 
> **Overview**
> Stops **`approvalPolicyInstruction`** from re-exporting **`approvalPromptsUnavailable`** and **`ApprovalInstructionContext`** so that helper only builds unavailable-approval prompt text via **`formatUnavailableApprovalInstruction`**.
> 
> **`runExecution`**, **`multi-agent`**, and **`MultiAgentInstruction.vitest`** now import **`approvalPromptsUnavailable`** from **`@cli/runtime/approvalPolicyAvailability`**; **`multiAgentInstruction`** pulls the context type from the same runtime module instead of the instruction helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7697a84a4fead7e61d8d3227f5e297cb3f94b1d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->