### PR TITLE
refactor: centralize CLI login options

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -33,8 +33,6 @@ import {
 } from '@agent/toolUse/ToolUseFollowUp';
 import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
-import { isOAuthProvider, type OAuthProvider } from '@auth/sharedConfig';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
 import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
@@ -55,6 +53,10 @@ import {
   resolveCliRunnableModel,
   type CliNoAvailableModelsRecoveryOptions,
 } from '@cli/runtime/modelAccess';
+import {
+  githubSelectAccountWarning,
+  parseChatLoginSlashArgs,
+} from '@cli/runtime/loginOptions';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { writeTextStderr, writeTextStdout } from '@cli/runtime/logSinks';
 import {
@@ -635,55 +637,6 @@ const CHAT_STARTUP_MODEL_RECOVERY = {
   personalModeAction: 'retry with `texra chat --api-mode personal`',
 } satisfies CliNoAvailableModelsRecoveryOptions;
 
-interface ChatLoginSlashArgs {
-  readonly provider: OAuthProvider;
-  readonly noBrowser: boolean;
-  readonly selectAccount: boolean;
-  readonly loginHint?: string;
-}
-
-export function parseChatLoginSlashArgs(
-  input: string,
-): ChatLoginSlashArgs | undefined {
-  const tokens = input.trim().split(/\s+/).filter(Boolean);
-  let provider: string = DEFAULT_OAUTH_PROVIDER;
-  let providerSet = false;
-  let noBrowser = false;
-  let selectAccount = false;
-  let loginHint: string | undefined;
-
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index];
-    if (token === '--no-browser') {
-      noBrowser = true;
-      continue;
-    }
-    if (token === '--select-account') {
-      selectAccount = true;
-      continue;
-    }
-    if (token === '--login-hint') {
-      const next = tokens[index + 1];
-      if (!next || next.startsWith('--')) return undefined;
-      loginHint = next;
-      index += 1;
-      continue;
-    }
-    if (token.startsWith('--login-hint=')) {
-      const value = token.slice('--login-hint='.length).trim();
-      if (!value || value.startsWith('--')) return undefined;
-      loginHint = value;
-      continue;
-    }
-    if (token.startsWith('--') || providerSet) return undefined;
-    provider = token;
-    providerSet = true;
-  }
-
-  if (!isOAuthProvider(provider)) return undefined;
-  return { provider, noBrowser, selectAccount, loginHint };
-}
-
 async function loginFromChat(input: string): Promise<void> {
   const args = parseChatLoginSlashArgs(input);
   if (!args) {
@@ -691,11 +644,8 @@ async function loginFromChat(input: string): Promise<void> {
     return;
   }
 
-  if (args.provider === 'github' && args.selectAccount && !args.loginHint) {
-    appendLocalAssistantTranscript(
-      'GitHub does not support --select-account by itself. Use --login-hint <username> to request a specific GitHub account.',
-    );
-  }
+  const accountWarning = githubSelectAccountWarning(args);
+  if (accountWarning) appendLocalAssistantTranscript(accountWarning);
   appendLocalAssistantTranscript(
     args.noBrowser
       ? `Starting TeXRA ${args.provider} sign-in.`

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,11 +1,14 @@
 import { defineCommand } from 'citty';
 
-import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
-import { isOAuthProvider } from '@auth/sharedConfig';
-import { isNonEmptyString } from '@utils/core/stringCore';
-
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
+import {
+  githubSelectAccountWarning,
+  isCliLoginProvider,
+  resolveLoginProvider,
+  unsupportedLoginProviderMessage,
+  type CliLoginInit,
+} from '../runtime/loginOptions';
 import {
   writeErrorStderr,
   writeTextStderr,
@@ -30,27 +33,6 @@ import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
 
-export function resolveLoginProvider(
-  positional: string | undefined,
-  flag: string | undefined,
-): { readonly provider: string; readonly explicit: boolean } {
-  if (isNonEmptyString(flag)) {
-    return { provider: flag.trim(), explicit: true };
-  }
-  if (isNonEmptyString(positional)) {
-    return { provider: positional.trim(), explicit: true };
-  }
-  return { provider: DEFAULT_OAUTH_PROVIDER, explicit: false };
-}
-
-export interface LoginInit {
-  readonly provider: string;
-  readonly providerExplicit: boolean;
-  readonly noBrowser: boolean;
-  readonly selectAccount: boolean;
-  readonly loginHint?: string;
-}
-
 type LoginCommandArgs = Record<string, unknown>;
 
 function readBooleanArg(
@@ -69,7 +51,7 @@ function readStringArg(
   return optString(args[hyphenKey]) ?? optString(args[camelKey]);
 }
 
-export function loginInitFromArgs(args: LoginCommandArgs): LoginInit {
+export function loginInitFromArgs(args: LoginCommandArgs): CliLoginInit {
   const positional = optString(args.providerArg);
   const flag = optString(args.provider);
   const provider = resolveLoginProvider(positional, flag);
@@ -88,7 +70,7 @@ export function shouldPromptForLoginProvider(
     CliContext,
     'mode' | 'outputFormat' | 'stdoutIsTty' | 'termIsDumb'
   >,
-  init: Pick<LoginInit, 'providerExplicit' | 'noBrowser'>,
+  init: Pick<CliLoginInit, 'providerExplicit' | 'noBrowser'>,
 ): boolean {
   return (
     !init.providerExplicit &&
@@ -98,19 +80,17 @@ export function shouldPromptForLoginProvider(
   );
 }
 
-async function runLogin(context: CliContext, init: LoginInit): Promise<number> {
-  if (!isOAuthProvider(init.provider)) {
-    writeTextStderr(
-      `Unsupported provider: ${init.provider}. Expected ${CLI_OAUTH_PROVIDER_INPUTS}.`,
-    );
+async function runLogin(
+  context: CliContext,
+  init: CliLoginInit,
+): Promise<number> {
+  if (!isCliLoginProvider(init.provider)) {
+    writeTextStderr(unsupportedLoginProviderMessage(init.provider));
     return CliExitCode.Usage;
   }
   await initCliPlatform({ ...context, quietLogs: true });
-  if (init.provider === 'github' && init.selectAccount && !init.loginHint) {
-    writeTextStderr(
-      'GitHub does not support --select-account by itself. Use --login-hint <username> to request a specific GitHub account.',
-    );
-  }
+  const accountWarning = githubSelectAccountWarning(init);
+  if (accountWarning) writeTextStderr(accountWarning);
   if (context.outputFormat === 'text' && !init.noBrowser) {
     writeTextStdout(`Opening browser for TeXRA ${init.provider} sign-in...`);
   }
@@ -185,7 +165,7 @@ export const loginCommand = defineCliCommand({
 
 async function runLoginCommand(
   context: CliContext,
-  init: LoginInit,
+  init: CliLoginInit,
 ): Promise<number> {
   if (!shouldPromptForLoginProvider(context, init)) {
     return runLogin(context, init);

--- a/packages/cli/src/runtime/loginOptions.ts
+++ b/packages/cli/src/runtime/loginOptions.ts
@@ -1,0 +1,93 @@
+import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
+import { isOAuthProvider, type OAuthProvider } from '@auth/sharedConfig';
+import { isNonEmptyString } from '@utils/core/stringCore';
+
+import { CLI_OAUTH_PROVIDER_INPUTS } from './oauthProviderDisplay';
+
+export interface CliLoginInit {
+  readonly provider: string;
+  readonly providerExplicit: boolean;
+  readonly noBrowser: boolean;
+  readonly selectAccount: boolean;
+  readonly loginHint?: string;
+}
+
+export interface CliLoginSlashArgs {
+  readonly provider: OAuthProvider;
+  readonly noBrowser: boolean;
+  readonly selectAccount: boolean;
+  readonly loginHint?: string;
+}
+
+export function resolveLoginProvider(
+  positional: string | undefined,
+  flag: string | undefined,
+): { readonly provider: string; readonly explicit: boolean } {
+  if (isNonEmptyString(flag)) {
+    return { provider: flag.trim(), explicit: true };
+  }
+  if (isNonEmptyString(positional)) {
+    return { provider: positional.trim(), explicit: true };
+  }
+  return { provider: DEFAULT_OAUTH_PROVIDER, explicit: false };
+}
+
+export function unsupportedLoginProviderMessage(provider: string): string {
+  return `Unsupported provider: ${provider}. Expected ${CLI_OAUTH_PROVIDER_INPUTS}.`;
+}
+
+export function isCliLoginProvider(
+  provider: string,
+): provider is OAuthProvider {
+  return isOAuthProvider(provider);
+}
+
+export function githubSelectAccountWarning(
+  init: Pick<CliLoginInit, 'provider' | 'selectAccount' | 'loginHint'>,
+): string | undefined {
+  return init.provider === 'github' && init.selectAccount && !init.loginHint
+    ? 'GitHub does not support --select-account by itself. Use --login-hint <username> to request a specific GitHub account.'
+    : undefined;
+}
+
+export function parseChatLoginSlashArgs(
+  input: string,
+): CliLoginSlashArgs | undefined {
+  const tokens = input.trim().split(/\s+/).filter(Boolean);
+  let provider: string = DEFAULT_OAUTH_PROVIDER;
+  let providerSet = false;
+  let noBrowser = false;
+  let selectAccount = false;
+  let loginHint: string | undefined;
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === '--no-browser') {
+      noBrowser = true;
+      continue;
+    }
+    if (token === '--select-account') {
+      selectAccount = true;
+      continue;
+    }
+    if (token === '--login-hint') {
+      const next = tokens[index + 1];
+      if (!next || next.startsWith('--')) return undefined;
+      loginHint = next;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith('--login-hint=')) {
+      const value = token.slice('--login-hint='.length).trim();
+      if (!value || value.startsWith('--')) return undefined;
+      loginHint = value;
+      continue;
+    }
+    if (token.startsWith('--') || providerSet) return undefined;
+    provider = token;
+    providerSet = true;
+  }
+
+  if (!isCliLoginProvider(provider)) return undefined;
+  return { provider, noBrowser, selectAccount, loginHint };
+}

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -11,7 +11,6 @@ import {
   detectUnknownCliFlag,
   runCli,
 } from '@cli/commands/root';
-import { resolveLoginProvider } from '@cli/commands/auth';
 import { doctorPlatformInitContext } from '@cli/commands/doctor';
 import {
   formatUnknownCliCommand,
@@ -21,6 +20,7 @@ import {
   reorderGlobalFlags,
 } from '@cli/commands/_helpers/dispatch';
 import { CliUsageError, formatCrashReportLine } from '@cli/runtime/cliContext';
+import { resolveLoginProvider } from '@cli/runtime/loginOptions';
 import {
   formatCliModelListError,
   isCliFetchStackLog,

--- a/src/test-kernel/cli/LoginArgs.vitest.mts
+++ b/src/test-kernel/cli/LoginArgs.vitest.mts
@@ -2,9 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import {
   loginInitFromArgs,
-  resolveLoginProvider,
   shouldPromptForLoginProvider,
 } from '@cli/commands/auth';
+import {
+  githubSelectAccountWarning,
+  parseChatLoginSlashArgs,
+  resolveLoginProvider,
+  unsupportedLoginProviderMessage,
+} from '@cli/runtime/loginOptions';
 import { formatCliManualAuthUrlMessage } from '@cli/runtime/supabaseAuth';
 
 describe('CLI login arguments (texra login)', () => {
@@ -67,6 +72,65 @@ describe('CLI login arguments (texra login)', () => {
     expect(loginInitFromArgs({ browser: false })).toMatchObject({
       noBrowser: true,
     });
+  });
+
+  it('parses in-chat login slash command options through the same runtime owner', () => {
+    expect(parseChatLoginSlashArgs('')).toEqual({
+      provider: 'github',
+      noBrowser: false,
+      selectAccount: false,
+      loginHint: undefined,
+    });
+    expect(
+      parseChatLoginSlashArgs('google --no-browser --select-account'),
+    ).toEqual({
+      provider: 'google',
+      noBrowser: true,
+      selectAccount: true,
+      loginHint: undefined,
+    });
+    expect(parseChatLoginSlashArgs('--login-hint user@example.edu')).toEqual({
+      provider: 'github',
+      noBrowser: false,
+      selectAccount: false,
+      loginHint: 'user@example.edu',
+    });
+    expect(parseChatLoginSlashArgs('github --login-hint=octocat')).toEqual({
+      provider: 'github',
+      noBrowser: false,
+      selectAccount: false,
+      loginHint: 'octocat',
+    });
+  });
+
+  it('rejects invalid in-chat login slash command options', () => {
+    expect(parseChatLoginSlashArgs('slack')).toBeUndefined();
+    expect(parseChatLoginSlashArgs('github google')).toBeUndefined();
+    expect(parseChatLoginSlashArgs('--login-hint')).toBeUndefined();
+    expect(
+      parseChatLoginSlashArgs('--login-hint --no-browser'),
+    ).toBeUndefined();
+    expect(parseChatLoginSlashArgs('--unexpected')).toBeUndefined();
+  });
+
+  it('formats login provider policy messages from one runtime owner', () => {
+    expect(unsupportedLoginProviderMessage('slack')).toBe(
+      'Unsupported provider: slack. Expected github or google.',
+    );
+    expect(
+      githubSelectAccountWarning({
+        provider: 'github',
+        selectAccount: true,
+      }),
+    ).toBe(
+      'GitHub does not support --select-account by itself. Use --login-hint <username> to request a specific GitHub account.',
+    );
+    expect(
+      githubSelectAccountWarning({
+        provider: 'google',
+        selectAccount: true,
+      }),
+    ).toBeUndefined();
   });
 
   it('prompts for provider only for bare interactive text login', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -70,7 +70,6 @@ import {
   chatTuiCanSelectModel,
   chatTuiSigintAction,
   chatTuiFocusedChildFollowUpRoute,
-  parseChatLoginSlashArgs,
   clearTuiSessionRunState,
   markChatTuiRunPending,
 } from '@cli/chat/tui/runChatTui';
@@ -1256,45 +1255,6 @@ describe('CLI TUI row allocation', () => {
         canInterruptActiveRun: true,
       }),
     ).toBe('force-exit');
-  });
-
-  it('parses in-chat login slash command options', () => {
-    expect(parseChatLoginSlashArgs('')).toEqual({
-      provider: 'github',
-      noBrowser: false,
-      selectAccount: false,
-      loginHint: undefined,
-    });
-    expect(
-      parseChatLoginSlashArgs('google --no-browser --select-account'),
-    ).toEqual({
-      provider: 'google',
-      noBrowser: true,
-      selectAccount: true,
-      loginHint: undefined,
-    });
-    expect(parseChatLoginSlashArgs('--login-hint user@example.edu')).toEqual({
-      provider: 'github',
-      noBrowser: false,
-      selectAccount: false,
-      loginHint: 'user@example.edu',
-    });
-    expect(parseChatLoginSlashArgs('github --login-hint=octocat')).toEqual({
-      provider: 'github',
-      noBrowser: false,
-      selectAccount: false,
-      loginHint: 'octocat',
-    });
-  });
-
-  it('rejects invalid in-chat login slash command options', () => {
-    expect(parseChatLoginSlashArgs('slack')).toBeUndefined();
-    expect(parseChatLoginSlashArgs('github google')).toBeUndefined();
-    expect(parseChatLoginSlashArgs('--login-hint')).toBeUndefined();
-    expect(
-      parseChatLoginSlashArgs('--login-hint --no-browser'),
-    ).toBeUndefined();
-    expect(parseChatLoginSlashArgs('--unexpected')).toBeUndefined();
   });
 
   it('selects the focused child stream as a follow-up target', () => {


### PR DESCRIPTION
## Summary
- add a CLI runtime loginOptions module as the owner for login provider defaults, validation, slash parsing, and provider warning text
- update texra login and TUI /login to consume that shared contract instead of duplicating provider policy
- move slash parser tests out of the broad TUI suite and into the login-args ownership suite

Closes #5548.

## Validation
- corepack pnpm exec vitest run src/test-kernel/cli/LoginArgs.vitest.mts src/test-kernel/cli/AuthCommand.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts
- corepack pnpm exec prettier --check packages/cli/src/runtime/loginOptions.ts packages/cli/src/commands/auth.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/LoginArgs.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts
- git diff --check
- npm run typecheck -- --pretty false
- npm run lint (passes with existing import-order warnings outside touched files)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no intended auth behavior change; risk is limited to accidental drift between CLI and TUI login paths, which the consolidated tests are meant to prevent.
> 
> **Overview**
> Introduces **`packages/cli/src/runtime/loginOptions.ts`** as the single place for CLI login policy: provider default resolution (`resolveLoginProvider`), OAuth validation (`isCliLoginProvider`, `unsupportedLoginProviderMessage`), GitHub `--select-account` guidance (`githubSelectAccountWarning`), and in-chat `/login` token parsing (`parseChatLoginSlashArgs`). Shared types are renamed to `CliLoginInit` / `CliLoginSlashArgs`.
> 
> **`texra login`** (`auth.ts`) and **chat `/login`** (`runChatTui.tsx`) now import that module instead of duplicating parsing, validation, and warning strings. Tests for slash parsing and policy messages move from `TuiStateAndFocus.vitest.mts` into `LoginArgs.vitest.mts`; `CliRootArgs` imports `resolveLoginProvider` from the new runtime path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a54cb8f9ca6ac2a9a4fec1250254bcad589a884b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->