### PR TITLE
refactor: share CLI resume summary formatting

### DIFF
--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -9,7 +9,7 @@ import {
   resumableCliHistoryEntries,
   type CliHistoryEntry,
 } from '@cli/runtime/history';
-import { formatCliHistoryResumeInputLabel } from '@cli/runtime/historyLabels';
+import { formatCliHistoryResumeSummary } from '@cli/runtime/historyLabels';
 import type { ExecutionId } from '@shared/schemas';
 
 import { KeyHints } from '../ui/KeyHints';
@@ -35,8 +35,7 @@ export function resumeSelectWindow(args: {
 }
 
 export function resumeEntryDescription(entry: CliHistoryEntry): string {
-  const input = formatCliHistoryResumeInputLabel(entry);
-  return `${entry.timestamp}; ${entry.agent}; ${entry.status}; ${input}`;
+  return `${entry.timestamp}; ${formatCliHistoryResumeSummary(entry)}`;
 }
 
 export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {

--- a/packages/cli/src/runtime/historyLabels.ts
+++ b/packages/cli/src/runtime/historyLabels.ts
@@ -4,11 +4,20 @@ function formatCliHistoryInputLabel(inputBasename: string): string {
   return inputBasename === '-' ? 'no input' : inputBasename;
 }
 
-export function formatCliHistoryResumeInputLabel(
+function formatCliHistoryResumeInputLabel(
   entry: Pick<CliHistoryEntry, 'description' | 'inputBasename'>,
 ): string {
   if (entry.inputBasename !== '-') {
     return formatCliHistoryInputLabel(entry.inputBasename);
   }
   return entry.description?.trim() || 'no input';
+}
+
+export function formatCliHistoryResumeSummary(
+  entry: Pick<
+    CliHistoryEntry,
+    'agent' | 'description' | 'inputBasename' | 'status'
+  >,
+): string {
+  return `${entry.agent}; ${entry.status}; ${formatCliHistoryResumeInputLabel(entry)}`;
 }

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -9,7 +9,7 @@ import {
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
 import { implicitDefaultToolUseAgents } from './defaultAgents';
-import { formatCliHistoryResumeInputLabel } from './historyLabels';
+import { formatCliHistoryResumeSummary } from './historyLabels';
 import {
   resumableCliHistoryEntries,
   userStartedCliHistoryEntries,
@@ -83,7 +83,7 @@ function recentResumeItems(
     .map((entry) => ({
       value: { kind: 'resume', id: entry.id },
       label: `Resume ${entry.id}`,
-      description: `${entry.agent}; ${entry.status}; ${formatCliHistoryResumeInputLabel(entry)}`,
+      description: formatCliHistoryResumeSummary(entry),
     }));
 }
 


### PR DESCRIPTION
## Summary
- add one runtime formatter for the shared CLI resumable-history row summary
- use it from both startup resume rows and the in-chat `/resume` picker
- keep the `/resume` timestamp as local UI context instead of duplicating the shared summary

Closes #5550.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ResumeListForm.vitest.mts src/test-kernel/cli/HistoryStatus.vitest.ts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/historyLabels.ts packages/cli/src/runtime/orchestration.ts packages/cli/src/chat/tui/forms/ResumeListForm.tsx src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ResumeListForm.vitest.mts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside this diff)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-string refactor only; behavior should stay aligned aside from consistent formatting between launcher and `/resume`.
> 
> **Overview**
> Introduces **`formatCliHistoryResumeSummary`** in `historyLabels.ts` so resumable history rows share one string for **agent, status, and input/description** instead of duplicating that logic.
> 
> The startup launcher (`orchestration.ts`) now uses that helper for recent resume item descriptions. The in-chat **`/resume`** picker (`ResumeListForm.tsx`) uses the same helper and only prepends **`timestamp`** for local UI context. **`formatCliHistoryResumeInputLabel`** is no longer exported; it stays internal to the summary builder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 205e7ea01fc17796e18c98b300b1f7911fc559c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->