### PR TITLE
refactor: own multi-agent run warnings in presets

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -9,7 +9,6 @@ import {
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { EXECUTION_STATUS } from '@shared/schemas';
-import { agentKey } from '@shared/schemas/agent';
 import { generateExecutionId } from '@utils/core/executionId';
 import { CliUsageError, readCliStdinText } from '../runtime/cliContext';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
@@ -28,6 +27,7 @@ import {
   formatCliMultiAgentPresetDetails,
   formatCliMultiAgentPresetInspection,
   formatCliMultiAgentPresetList,
+  formatCliMultiAgentPresetRunWarnings,
   planCliMultiAgentPresets,
   planCliMultiAgentPresetRun,
   readCliMultiAgentPresets,
@@ -182,33 +182,9 @@ async function reloadRemoteAgentsForGaps<T>(
 export function writeMissingPresetAgents(
   plan: CliMultiAgentPresetRunPlan,
 ): void {
-  const missing = [
-    ...plan.missingWorkflowAgents.map((agent) => `workflow:${agent}`),
-    ...plan.missingToolUseAgents.map((agent) => `tool-use:${agent}`),
-  ];
-  if (missing.length === 0) return;
-  writeTextStderr(
-    `WARN preset ${plan.preset.id} references unavailable agents: ${missing.join(', ')}`,
-  );
-  if (!plan.rootAgent) return;
-
-  const availableTeamAgents = new Set([
-    ...plan.workflowAgentKeys,
-    ...plan.toolUseAgentKeys,
-  ]);
-  availableTeamAgents.delete(
-    agentKey(plan.rootAgent.source, plan.rootAgent.name),
-  );
-  if (!agentHasDelegationTools(plan.rootAgent)) return;
-  if (availableTeamAgents.size === 0) return;
-
-  const availableText =
-    availableTeamAgents.size === 1
-      ? '1 available team agent'
-      : `${availableTeamAgents.size} available team agents`;
-  writeTextStderr(
-    `WARN preset ${plan.preset.id} is degraded; running root agent ${plan.rootAgent.name} with ${availableText}.`,
-  );
+  for (const warning of formatCliMultiAgentPresetRunWarnings(plan)) {
+    writeTextStderr(warning);
+  }
 }
 
 function writeApprovalUnavailableDelegationWarning(

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -315,6 +315,32 @@ export function formatCliMultiAgentTeamLaunchBlockMessage(
   return parts.filter((part): part is string => !!part).join(' ');
 }
 
+export function formatCliMultiAgentPresetRunWarnings(
+  plan: CliMultiAgentPresetRunPlan,
+): readonly string[] {
+  const missing = [
+    ...plan.missingWorkflowAgents.map((agent) => `workflow:${agent}`),
+    ...plan.missingToolUseAgents.map((agent) => `tool-use:${agent}`),
+  ];
+  if (missing.length === 0) return [];
+
+  const warnings = [
+    `WARN preset ${plan.preset.id} references unavailable agents: ${missing.join(', ')}`,
+  ];
+
+  if (!plan.rootAgent || !agentHasDelegationTools(plan.rootAgent)) {
+    return warnings;
+  }
+
+  const availableTeamMembers = availablePresetTeamMemberCount(plan);
+  if (availableTeamMembers === 0) return warnings;
+
+  warnings.push(
+    `WARN preset ${plan.preset.id} is degraded; running root agent ${plan.rootAgent.name} with ${formatAvailableTeamAgentCount(availableTeamMembers)}.`,
+  );
+  return warnings;
+}
+
 export function cliMultiAgentPresetAvailability(
   plan: CliMultiAgentPresetRunPlan,
 ): CliMultiAgentPresetAvailability {
@@ -517,6 +543,12 @@ function availablePresetTeamMemberCount(
     ...plan.toolUseAgentKeys.filter((key) => key !== rootKey),
   ];
   return new Set(memberKeys).size;
+}
+
+function formatAvailableTeamAgentCount(count: number): string {
+  return count === 1
+    ? '1 available team agent'
+    : `${count} available team agents`;
 }
 
 export function agentHasDelegationTools(agent: AgentEntry): boolean {

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -16,6 +16,7 @@ import {
   formatCliMultiAgentPresetDetails,
   formatCliMultiAgentPresetInspection,
   formatCliMultiAgentPresetList,
+  formatCliMultiAgentPresetRunWarnings,
   planCliMultiAgentPresets,
   planCliMultiAgentPresetRun,
   parseCliCustomAgentPresets,
@@ -200,6 +201,42 @@ describe('CLI multi-agent presets', () => {
       'degraded; 2/9 tool-use agents; 0/4 workflow agents',
     );
     expect(cliMultiAgentPresetCanLaunchTeam(plan)).toBe(true);
+  });
+
+  it('formats run warnings from planned missing team members', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'physicist',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
+        agent('review', AgentCategory.ToolUse),
+      ],
+    });
+
+    expect(formatCliMultiAgentPresetRunWarnings(plan)).toEqual([
+      'WARN preset physicist references unavailable agents: workflow:criticize, workflow:generic, workflow:devise, workflow:apply, tool-use:research, tool-use:numerics, tool-use:search, tool-use:presenter, tool-use:simplifier, tool-use:latexFixer, tool-use:progressCheck',
+      'WARN preset physicist is degraded; running root agent orchestrator with 1 available team agent.',
+    ]);
+  });
+
+  it('omits degraded run warnings when only the root is available', () => {
+    const preset = findCliMultiAgentPreset(
+      cliMultiAgentPresets(undefined),
+      'physicist',
+    )!;
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [],
+      toolUseAgents: [
+        agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
+      ],
+    });
+
+    expect(formatCliMultiAgentPresetRunWarnings(plan)).toEqual([
+      'WARN preset physicist references unavailable agents: workflow:criticize, workflow:generic, workflow:devise, workflow:apply, tool-use:research, tool-use:numerics, tool-use:review, tool-use:search, tool-use:presenter, tool-use:simplifier, tool-use:latexFixer, tool-use:progressCheck',
+    ]);
   });
 
   it('formats ready launcher team summaries without raw availability keys', () => {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => {
     expandRunInputs: vi.fn(),
     cliMultiAgentPlanHasGaps: vi.fn(),
     cliMultiAgentPresetCanLaunchTeam: vi.fn(),
+    formatCliMultiAgentPresetRunWarnings: vi.fn(),
     formatCliMultiAgentTeamLaunchBlockMessage: vi.fn(),
     getToolUseAgents: vi.fn(),
     getWorkflowAgents: vi.fn(),
@@ -88,6 +89,8 @@ vi.mock('@cli/runtime/multiAgentPresets', () => {
     formatCliMultiAgentPresetDetails: vi.fn(() => ''),
     formatCliMultiAgentPresetInspection: vi.fn(() => ''),
     formatCliMultiAgentPresetList: vi.fn(() => ''),
+    formatCliMultiAgentPresetRunWarnings:
+      mocks.formatCliMultiAgentPresetRunWarnings,
     formatCliMultiAgentTeamLaunchBlockMessage:
       mocks.formatCliMultiAgentTeamLaunchBlockMessage,
     MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION:
@@ -160,6 +163,7 @@ describe('CLI multi-agent run command', () => {
     mocks.formatCliMultiAgentTeamLaunchBlockMessage.mockReturnValue(
       'blocked preset message',
     );
+    mocks.formatCliMultiAgentPresetRunWarnings.mockReturnValue([]);
     mocks.planCliMultiAgentPresets.mockImplementation((presets) =>
       presets.map((preset: unknown) =>
         mocks.planCliMultiAgentPresetRun(preset, {
@@ -509,6 +513,9 @@ describe('CLI multi-agent run command', () => {
   });
 
   it('keeps degraded-team wording when the root can delegate', async () => {
+    const warning =
+      'WARN preset mathematician is degraded; running root agent orchestrator with 1 available team agent.';
+    mocks.formatCliMultiAgentPresetRunWarnings.mockReturnValueOnce([warning]);
     mocks.planCliMultiAgentPresetRun.mockReturnValue({
       preset: {
         id: 'mathematician',
@@ -538,9 +545,7 @@ describe('CLI multi-agent run command', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'WARN preset mathematician is degraded; running root agent orchestrator with 1 available team agent.',
-    );
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(warning);
   });
 
   it('refuses a delegating root with no available team members', async () => {


### PR DESCRIPTION
## Summary
- move multi-agent missing/degraded run warning formatting into `runtime/multiAgentPresets.ts`
- keep `commands/multiAgent.ts` responsible only for emitting the returned warning lines
- reuse the preset runtime member-count ownership instead of recomputing root-excluded team counts in the command layer

Closes #5552.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/multiAgentPresets.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside this diff)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with preserved warning behavior; covered by existing and new unit tests.
> 
> **Overview**
> Moves **multi-agent preset run warnings** (missing agents and degraded-team messages) from `commands/multiAgent.ts` into **`formatCliMultiAgentPresetRunWarnings`** in `runtime/multiAgentPresets.ts`.
> 
> `writeMissingPresetAgents` now only loops those strings to stderr. Degraded runs reuse **`availablePresetTeamMemberCount`** for team size instead of recomputing root-excluded counts in the command. Tests cover the formatter and mock it in the run-command suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63840a6d328756863dcee4b87c6a6a8f62f88bb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->