### PR TITLE
refactor: own CLI agent catalog in runtime

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,14 +1,14 @@
 import { defineCommand } from 'citty';
 
 import {
-  getToolUseAgents,
-  getVisibleAgents,
-  getWorkflowAgents,
-  loadAgents,
-} from '@agent/index';
-import type { AgentEntry } from '@agent/index';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-
+  CLI_AGENT_CATEGORY_FILTER_VALUES,
+  formatCliAgentDetails,
+  formatCliAgentList,
+  formatCliHiddenAgentsNotice,
+  loadCliAgentList,
+  parseCliAgentCategoryFilter,
+  type CliAgentListOptions,
+} from '../runtime/agents';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
@@ -24,133 +24,28 @@ import { resolveCliAgent } from './_helpers/agentResolution';
 import { agentsRunCommand } from './agentsRun';
 import type { CliContext } from '../runtime/cliContext';
 
-interface ListAgentsOptions {
-  readonly includeHidden?: boolean;
-  readonly category?: AgentCategory;
-}
-
-const AGENT_CATEGORY_FILTER_ALIASES = [
-  [AgentCategory.Workflow, AgentCategory.Workflow],
-  [AgentCategory.ToolUse, AgentCategory.ToolUse],
-  ['tool-use', AgentCategory.ToolUse],
-  ['tool_use', AgentCategory.ToolUse],
-] as const satisfies readonly (readonly [string, AgentCategory])[];
-
-const AGENT_CATEGORY_FILTER_VALUES = AGENT_CATEGORY_FILTER_ALIASES.map(
-  ([value]) => value,
-);
-
-const AGENT_CATEGORY_FILTERS = new Map<string, AgentCategory>(
-  AGENT_CATEGORY_FILTER_ALIASES.map(([value, category]) => [
-    value.toLowerCase(),
-    category,
-  ]),
-);
-
-const ALL_AGENT_LOADERS = {
-  [AgentCategory.Workflow]: getWorkflowAgents,
-  [AgentCategory.ToolUse]: getToolUseAgents,
-} satisfies Record<AgentCategory, () => AgentEntry[]>;
-
-function collectAgents(
-  source: 'all' | 'visible',
-  categoryFilter?: AgentCategory,
-): (AgentEntry & { readonly category: AgentCategory })[] {
-  const categories = categoryFilter
-    ? [categoryFilter]
-    : [AgentCategory.Workflow, AgentCategory.ToolUse];
-  return categories.flatMap((category) => {
-    const agents =
-      source === 'visible'
-        ? getVisibleAgents(category)
-        : ALL_AGENT_LOADERS[category]();
-
-    return agents.map((agent) => ({
-      ...agent,
-      category,
-    }));
-  });
-}
-
-export function parseAgentCategoryFilter(
-  input: string | undefined,
-): AgentCategory | undefined {
-  const normalized = input?.trim();
-  if (!normalized) return undefined;
-  return AGENT_CATEGORY_FILTERS.get(normalized.toLowerCase());
-}
-
-function formatAgentListText(
-  agents: readonly (AgentEntry & { readonly category: AgentCategory })[],
-): string {
-  return agents
-    .map(
-      (agent) => `${agent.category}\t${agent.name}\t${agent.description ?? ''}`,
-    )
-    .join('\n');
-}
-
 export async function listAgents(
   context: CliContext,
-  options: ListAgentsOptions = {},
+  options: CliAgentListOptions = {},
 ): Promise<number> {
   await initLocalCliPlatform(context);
-  const includeHidden = options.includeHidden === true;
-  await loadAgents(includeHidden ? undefined : { includeRemote: false });
-  const agents = collectAgents(
-    includeHidden ? 'all' : 'visible',
-    options.category,
-  );
+  const result = await loadCliAgentList(options);
 
-  if (!includeHidden && context.outputFormat === 'text') {
-    const hiddenCount =
-      collectAgents('all', options.category).length - agents.length;
-    if (hiddenCount > 0) {
-      writeTextStderr(
-        `Showing visible agents only; ${hiddenCount} hidden agent${hiddenCount === 1 ? '' : 's'} omitted. Use \`texra agents list --all\` to show the full catalog.`,
-      );
-    }
+  if (context.outputFormat === 'text') {
+    const hiddenNotice = formatCliHiddenAgentsNotice(result.hiddenCount);
+    if (hiddenNotice) writeTextStderr(hiddenNotice);
   }
 
   emitCliResult(
     context,
     {
-      json: agents,
-      ndjson: agents.map((agent) => ({ kind: 'agent', agent })),
-      text: formatAgentListText(agents),
+      json: result.agents,
+      ndjson: result.agents.map((agent) => ({ kind: 'agent', agent })),
+      text: formatCliAgentList(result.agents),
     },
     { paged: true },
   );
   return CliExitCode.Success;
-}
-
-function formatAgentDetails(entry: AgentEntry): string {
-  const lines: string[] = [];
-  lines.push(`name: ${entry.name}`);
-  lines.push(`category: ${entry.category}`);
-  lines.push(`source: ${entry.source}`);
-  if (entry.path) lines.push(`path: ${entry.path}`);
-  if (entry.description) {
-    lines.push('');
-    lines.push(entry.description);
-  }
-  const metadataLines: string[] = [];
-  if (entry.tools && entry.tools.length > 0) {
-    metadataLines.push(`tools: ${entry.tools.join(', ')}`);
-  }
-  if (entry.defaultOutputFiles && entry.defaultOutputFiles.length > 0) {
-    metadataLines.push(
-      `defaultOutputFiles: ${entry.defaultOutputFiles.join(', ')}`,
-    );
-  }
-  if (entry.visibility && entry.visibility.length > 0) {
-    metadataLines.push(`visibility: ${entry.visibility.join(', ')}`);
-  }
-  if (metadataLines.length > 0) {
-    lines.push('');
-    lines.push(...metadataLines);
-  }
-  return lines.join('\n');
 }
 
 export async function showAgent(
@@ -167,7 +62,7 @@ export async function showAgent(
   emitCliResult(context, {
     json: entry,
     ndjson: { kind: 'agent', agent: entry },
-    text: formatAgentDetails(entry),
+    text: formatCliAgentDetails(entry),
   });
   return CliExitCode.Success;
 }
@@ -183,7 +78,7 @@ const agentsListCommand = defineCliCommand({
     },
     category: {
       type: 'enum',
-      options: AGENT_CATEGORY_FILTER_VALUES,
+      options: CLI_AGENT_CATEGORY_FILTER_VALUES,
       description:
         'Only list one category: workflow or toolUse (also accepts tool-use/tool_use)',
     },
@@ -191,7 +86,7 @@ const agentsListCommand = defineCliCommand({
   run: (context, ctx) => {
     return listAgents(context, {
       includeHidden: ctx.args.all === true,
-      category: parseAgentCategoryFilter(optString(ctx.args.category)),
+      category: parseCliAgentCategoryFilter(optString(ctx.args.category)),
     });
   },
 });

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -1,0 +1,126 @@
+import {
+  getToolUseAgents,
+  getVisibleAgents,
+  getWorkflowAgents,
+  loadAgents,
+} from '@agent/index';
+import type { AgentEntry } from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+
+export interface CliAgentListOptions {
+  readonly includeHidden?: boolean;
+  readonly category?: AgentCategory;
+}
+
+export interface CliAgentListResult {
+  readonly agents: readonly AgentEntry[];
+  readonly hiddenCount: number;
+}
+
+const AGENT_CATEGORY_FILTER_ALIASES = [
+  [AgentCategory.Workflow, AgentCategory.Workflow],
+  [AgentCategory.ToolUse, AgentCategory.ToolUse],
+  ['tool-use', AgentCategory.ToolUse],
+  ['tool_use', AgentCategory.ToolUse],
+] as const satisfies readonly (readonly [string, AgentCategory])[];
+
+export const CLI_AGENT_CATEGORY_FILTER_VALUES =
+  AGENT_CATEGORY_FILTER_ALIASES.map(([value]) => value);
+
+const AGENT_CATEGORY_FILTERS = new Map<string, AgentCategory>(
+  AGENT_CATEGORY_FILTER_ALIASES.map(([value, category]) => [
+    value.toLowerCase(),
+    category,
+  ]),
+);
+
+const AGENT_CATEGORIES = [
+  AgentCategory.Workflow,
+  AgentCategory.ToolUse,
+] as const satisfies readonly AgentCategory[];
+
+const ALL_AGENT_LOADERS = {
+  [AgentCategory.Workflow]: getWorkflowAgents,
+  [AgentCategory.ToolUse]: getToolUseAgents,
+} satisfies Record<AgentCategory, () => AgentEntry[]>;
+
+export function parseCliAgentCategoryFilter(
+  input: string | undefined,
+): AgentCategory | undefined {
+  const normalized = input?.trim();
+  if (!normalized) return undefined;
+  return AGENT_CATEGORY_FILTERS.get(normalized.toLowerCase());
+}
+
+export async function loadCliAgentList(
+  options: CliAgentListOptions = {},
+): Promise<CliAgentListResult> {
+  const includeHidden = options.includeHidden === true;
+  await loadAgents(includeHidden ? undefined : { includeRemote: false });
+
+  const agents = collectCliAgents(
+    includeHidden ? 'all' : 'visible',
+    options.category,
+  );
+  const hiddenCount = includeHidden
+    ? 0
+    : collectCliAgents('all', options.category).length - agents.length;
+
+  return { agents, hiddenCount };
+}
+
+export function formatCliAgentList(agents: readonly AgentEntry[]): string {
+  return agents
+    .map(
+      (agent) => `${agent.category}\t${agent.name}\t${agent.description ?? ''}`,
+    )
+    .join('\n');
+}
+
+export function formatCliAgentDetails(entry: AgentEntry): string {
+  const lines: string[] = [];
+  lines.push(`name: ${entry.name}`);
+  lines.push(`category: ${entry.category}`);
+  lines.push(`source: ${entry.source}`);
+  if (entry.path) lines.push(`path: ${entry.path}`);
+  if (entry.description) {
+    lines.push('');
+    lines.push(entry.description);
+  }
+  const metadataLines: string[] = [];
+  if (entry.tools && entry.tools.length > 0) {
+    metadataLines.push(`tools: ${entry.tools.join(', ')}`);
+  }
+  if (entry.defaultOutputFiles && entry.defaultOutputFiles.length > 0) {
+    metadataLines.push(
+      `defaultOutputFiles: ${entry.defaultOutputFiles.join(', ')}`,
+    );
+  }
+  if (entry.visibility && entry.visibility.length > 0) {
+    metadataLines.push(`visibility: ${entry.visibility.join(', ')}`);
+  }
+  if (metadataLines.length > 0) {
+    lines.push('');
+    lines.push(...metadataLines);
+  }
+  return lines.join('\n');
+}
+
+export function formatCliHiddenAgentsNotice(
+  hiddenCount: number,
+): string | undefined {
+  if (hiddenCount <= 0) return undefined;
+  return `Showing visible agents only; ${hiddenCount} hidden agent${hiddenCount === 1 ? '' : 's'} omitted. Use \`texra agents list --all\` to show the full catalog.`;
+}
+
+function collectCliAgents(
+  source: 'all' | 'visible',
+  categoryFilter?: AgentCategory,
+): AgentEntry[] {
+  const categories = categoryFilter ? [categoryFilter] : AGENT_CATEGORIES;
+  return categories.flatMap((category) =>
+    source === 'visible'
+      ? getVisibleAgents(category)
+      : ALL_AGENT_LOADERS[category](),
+  );
+}

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -66,14 +66,16 @@ describe('CLI agents command', () => {
   });
 
   it('parses agent category filter spellings', async () => {
-    const { parseAgentCategoryFilter } = await import('@cli/commands/agents');
+    const { parseCliAgentCategoryFilter } = await import('@cli/runtime/agents');
 
-    expect(parseAgentCategoryFilter('workflow')).toBe(AgentCategory.Workflow);
-    expect(parseAgentCategoryFilter('toolUse')).toBe(AgentCategory.ToolUse);
-    expect(parseAgentCategoryFilter('tool-use')).toBe(AgentCategory.ToolUse);
-    expect(parseAgentCategoryFilter('tool_use')).toBe(AgentCategory.ToolUse);
-    expect(parseAgentCategoryFilter('work-flow')).toBeUndefined();
-    expect(parseAgentCategoryFilter('unknown')).toBeUndefined();
+    expect(parseCliAgentCategoryFilter('workflow')).toBe(
+      AgentCategory.Workflow,
+    );
+    expect(parseCliAgentCategoryFilter('toolUse')).toBe(AgentCategory.ToolUse);
+    expect(parseCliAgentCategoryFilter('tool-use')).toBe(AgentCategory.ToolUse);
+    expect(parseCliAgentCategoryFilter('tool_use')).toBe(AgentCategory.ToolUse);
+    expect(parseCliAgentCategoryFilter('work-flow')).toBeUndefined();
+    expect(parseCliAgentCategoryFilter('unknown')).toBeUndefined();
   });
 
   it('lists visible agents by default and reports hidden agents in text mode', async () => {


### PR DESCRIPTION
## Summary

Closes #5554.

Moves the CLI agent catalog contract out of `commands/agents.ts` and into `packages/cli/src/runtime/agents.ts`:

- category filter alias parsing
- visible/full catalog loading and hidden-agent counting
- `agents list` text rows
- `agents show` details text
- visible-only hidden-agent notice

The command layer now initializes the platform, asks runtime for the catalog result, and emits stdout/stderr. This removes command-owned duplicate catalog semantics without adding a generic resolver or pass-through stack.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/AgentsCommand.vitest.mts src/test-kernel/cli/Completion.vitest.mts`
- `git diff --check`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/agents.ts packages/cli/src/commands/agents.ts src/test-kernel/cli/AgentsCommand.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes; existing import-order warnings outside this diff)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with behavior preserved; tests still cover list/show and category parsing.
> 
> **Overview**
> Moves CLI agent catalog behavior out of `commands/agents.ts` into a new **`packages/cli/src/runtime/agents.ts`** module so the command layer only initializes the platform, loads catalog data, and emits output.
> 
> The runtime module now owns category filter aliases and **`parseCliAgentCategoryFilter`**, **`loadCliAgentList`** (visible vs full catalog, hidden-agent count), and text formatters for list rows, show details, and the visible-only stderr notice. **`listAgents`** / **`showAgent`** call these helpers instead of in-file loaders and formatters; list still uses **`CLI_AGENT_CATEGORY_FILTER_VALUES`** for the `--category` enum.
> 
> Tests import **`parseCliAgentCategoryFilter`** from **`@cli/runtime/agents`** instead of the command file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1aa6a6b342f49c6a9ef8c8f35cbe525718cc091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->