### PR TITLE
refactor: own CLI model display in runtime

### DIFF
--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -1,16 +1,17 @@
 import { defineCommand } from 'citty';
 
-import type { ModelOptionData } from '@shared/schemas';
-
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 import { effectiveCliApiMode } from '../runtime/apiAccessMode';
 import {
+  cliModelRecord,
   findCliModelAccessEntry,
-  formatCliNoAvailableModelsRecovery,
+  formatCliModelDetails,
   getCliModelAccessList,
-  runnableCliModelAccessEntries,
+  formatNoListableModelsMessage,
+  listableModelAccessEntries,
+  type CliModelListOptions,
 } from '../runtime/modelAccess';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
@@ -23,43 +24,6 @@ import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
 
 type ModelAccessList = Awaited<ReturnType<typeof getCliModelAccessList>>;
-
-/**
- * Output projection for JSON/NDJSON: prefix the model record with `id` so the
- * model id is addressable under the same key (`.id`) as every other CLI
- * resource (`agents`, `multi-agent`, `history`). `value` is kept for backward
- * compatibility with existing scripts.
- */
-export function cliModelRecord(
-  model: ModelOptionData,
-): { id: string } & ModelOptionData {
-  return { id: model.value, ...model };
-}
-
-export function listableModelAccessEntries(
-  models: ModelAccessList,
-  options: {
-    readonly includeUnavailable?: boolean;
-  } = {},
-): ModelAccessList {
-  if (options.includeUnavailable === true) return models;
-  return runnableCliModelAccessEntries(models);
-}
-
-export function formatNoListableModelsMessage(
-  apiMode: CliContext['apiMode'],
-  options: { readonly includeUnavailable?: boolean } = {},
-): string {
-  const statusHint =
-    options.includeUnavailable === true
-      ? 'No model records were returned for this installation.'
-      : 'Run `texra models list --all` to see unavailable models and access status.';
-  return [
-    'No models are currently available.',
-    statusHint,
-    formatCliNoAvailableModelsRecovery(apiMode),
-  ].join('\n');
-}
 
 async function loadModelAccessList(context: CliContext): Promise<
   | { models: ModelAccessList; apiMode: CliContext['apiMode'] }
@@ -81,7 +45,7 @@ async function loadModelAccessList(context: CliContext): Promise<
 
 async function listModels(
   context: CliContext,
-  options: { readonly includeUnavailable?: boolean } = {},
+  options: CliModelListOptions = {},
 ): Promise<number> {
   const result = await loadModelAccessList(context);
   if ('error' in result) {
@@ -110,24 +74,6 @@ async function listModels(
   return CliExitCode.Success;
 }
 
-function formatModelDetails(entry: ModelAccessList[number]): string {
-  const { model, status } = entry;
-  const lines: string[] = [];
-  lines.push(`id: ${model.value}`);
-  lines.push(`label: ${model.label}`);
-  if (model.provider) lines.push(`provider: ${model.provider}`);
-  lines.push(`status: ${status}`);
-  if (model.availabilityLabel)
-    lines.push(`availability: ${model.availabilityLabel}`);
-  if (model.context) lines.push(`context: ${model.context}`);
-  if (model.cost) lines.push(`cost: ${model.cost}`);
-  if (model.hint) {
-    lines.push('');
-    lines.push(model.hint);
-  }
-  return lines.join('\n');
-}
-
 async function showModel(context: CliContext, id: string): Promise<number> {
   const result = await loadModelAccessList(context);
   if ('error' in result) {
@@ -144,7 +90,7 @@ async function showModel(context: CliContext, id: string): Promise<number> {
   emitCliResult(context, {
     json: cliModelRecord(entry.model),
     ndjson: { kind: 'model', model: cliModelRecord(entry.model) },
-    text: formatModelDetails(entry),
+    text: formatCliModelDetails(entry),
   });
   return CliExitCode.Success;
 }

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -58,6 +58,10 @@ export interface CliModelAccessListOptions {
   readonly apiMode?: CliApiMode;
 }
 
+export interface CliModelListOptions {
+  readonly includeUnavailable?: boolean;
+}
+
 export interface CliNoAvailableModelsRecoveryOptions {
   readonly includedModeAction?: string;
   readonly personalModeAction?: string;
@@ -341,6 +345,59 @@ export function findCliModelAccessEntry(
 
   const lower = model.toLowerCase();
   return models.find((entry) => entry.model.value.toLowerCase() === lower);
+}
+
+/**
+ * Output projection for JSON/NDJSON: prefix the model record with `id` so the
+ * model id is addressable under the same key (`.id`) as every other CLI
+ * resource (`agents`, `multi-agent`, `history`). `value` is kept for backward
+ * compatibility with existing scripts.
+ */
+export function cliModelRecord(
+  model: ModelOptionData,
+): { id: string } & ModelOptionData {
+  return { id: model.value, ...model };
+}
+
+export function listableModelAccessEntries(
+  models: readonly CliModelAccess[],
+  options: CliModelListOptions = {},
+): readonly CliModelAccess[] {
+  if (options.includeUnavailable === true) return models;
+  return runnableCliModelAccessEntries(models);
+}
+
+export function formatNoListableModelsMessage(
+  apiMode: CliApiMode | undefined,
+  options: CliModelListOptions = {},
+): string {
+  const statusHint =
+    options.includeUnavailable === true
+      ? 'No model records were returned for this installation.'
+      : 'Run `texra models list --all` to see unavailable models and access status.';
+  return [
+    'No models are currently available.',
+    statusHint,
+    formatCliNoAvailableModelsRecovery(apiMode),
+  ].join('\n');
+}
+
+export function formatCliModelDetails(entry: CliModelAccess): string {
+  const { model, status } = entry;
+  const lines: string[] = [];
+  lines.push(`id: ${model.value}`);
+  lines.push(`label: ${model.label}`);
+  if (model.provider) lines.push(`provider: ${model.provider}`);
+  lines.push(`status: ${status}`);
+  if (model.availabilityLabel)
+    lines.push(`availability: ${model.availabilityLabel}`);
+  if (model.context) lines.push(`context: ${model.context}`);
+  if (model.cost) lines.push(`cost: ${model.cost}`);
+  if (model.hint) {
+    lines.push('');
+    lines.push(model.hint);
+  }
+  return lines.join('\n');
 }
 
 function modelIds(models: readonly CliModelAccess[]): string[] {

--- a/src/test-kernel/cli/ModelsRecord.vitest.mts
+++ b/src/test-kernel/cli/ModelsRecord.vitest.mts
@@ -4,8 +4,8 @@ import {
   cliModelRecord,
   formatNoListableModelsMessage,
   listableModelAccessEntries,
-} from '@cli/commands/models';
-import type { CliModelAccess } from '@cli/runtime/modelAccess';
+  type CliModelAccess,
+} from '@cli/runtime/modelAccess';
 import type { ModelOptionData } from '@shared/schemas';
 
 function model(overrides: Partial<ModelOptionData> = {}): ModelOptionData {


### PR DESCRIPTION
## Summary

Closes #5556.

Moves pure CLI model display/projection helpers from `commands/models.ts` into `runtime/modelAccess.ts`, where the model availability and fallback policy already lives:

- `cliModelRecord`
- `listableModelAccessEntries`
- `formatNoListableModelsMessage`
- `formatCliModelDetails`

The command layer now keeps the actual CLI boundary concerns: platform init, fetch error handling, stdout/stderr result emission, and exit codes. This keeps model access display semantics in one place without adding a new wrapper layer.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/runtime/modelAccess.ts packages/cli/src/commands/models.ts src/test-kernel/cli/ModelsRecord.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/ModelsRecord.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes; existing import-order warnings outside this diff)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical relocation with no intended behavior change; command output and filtering semantics stay the same.
> 
> **Overview**
> **Refactors** where CLI model **display and list-projection** logic lives: pure helpers move from `commands/models.ts` into `runtime/modelAccess.ts` next to availability and fallback policy.
> 
> **Moved exports** (behavior unchanged): `cliModelRecord`, `listableModelAccessEntries`, `formatNoListableModelsMessage`, and `formatCliModelDetails` (renamed from the command-local `formatModelDetails`). **`CliModelListOptions`** is added in runtime; `listableModelAccessEntries` now types models as `readonly CliModelAccess[]`.
> 
> The **models command** only wires platform init, fetch errors, `emitCliResult`, and exit codes. **`ModelsRecord.vitest.mts`** imports those helpers from `@cli/runtime/modelAccess` instead of the command module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a09aa5aec03b437b8ca54cff90f77f4aae0d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->