### PR TITLE
refactor: own CLI tool guides in runtime

### DIFF
--- a/packages/cli/src/commands/tools.ts
+++ b/packages/cli/src/commands/tools.ts
@@ -10,9 +10,12 @@ import {
   writeTextStdout,
 } from '../runtime/logSinks';
 import {
-  findCliToolDef,
   formatCliToolList,
+  formatCliToolMissingInstallCommandMessage,
+  formatCliToolNotFoundMessage,
+  formatCliToolNotToggleableMessage,
   formatCliToolStatus,
+  readCliToolGuide,
   readCliToolStatus,
   readCliToolStatuses,
   setCliToolEnabled,
@@ -39,7 +42,7 @@ async function showTool(context: CliContext, id: string): Promise<number> {
   await initCliPlatform({ ...context, quietLogs: true });
   const record = await readCliToolStatus(id);
   if (!record) {
-    writeTextStderr(`Tool integration not found: ${id}`);
+    writeTextStderr(formatCliToolNotFoundMessage(id));
     return CliExitCode.Usage;
   }
 
@@ -59,34 +62,11 @@ async function toggleTool(
   await initCliPlatform({ ...context, quietLogs: true });
   const ok = await setCliToolEnabled(id, enabled);
   if (!ok) {
-    writeTextStderr(`Tool integration is not toggleable: ${id}`);
+    writeTextStderr(formatCliToolNotToggleableMessage(id));
     return CliExitCode.Usage;
   }
   writeTextStdout(`${enabled ? 'Enabled' : 'Disabled'} ${id}.`);
   return CliExitCode.Success;
-}
-
-function formatGuide(id: string, kind: 'install' | 'auth'): string | undefined {
-  const def = findCliToolDef(id);
-  if (!def) return undefined;
-  if (kind === 'install') {
-    const lines = [def.installGuide ?? def.configNotes ?? 'No install guide.'];
-    if (def.installCommand) {
-      lines.push('');
-      lines.push(`Command: ${def.installCommand}`);
-    }
-    if (def.installUrl) {
-      lines.push(`URL: ${def.installUrl}`);
-    }
-    return lines.join('\n');
-  }
-
-  const lines = [def.authNote ?? def.configNotes ?? 'No auth guide.'];
-  if (def.authCommand) {
-    lines.push('');
-    lines.push(`Command: ${def.authCommand}`);
-  }
-  return lines.join('\n');
 }
 
 function shellRun(command: string): Promise<number> {
@@ -106,33 +86,33 @@ async function installTool(
   run: boolean,
 ): Promise<number> {
   await initCliPlatform({ ...context, quietLogs: true });
-  const def = findCliToolDef(id);
-  if (!def) {
-    writeTextStderr(`Tool integration not found: ${id}`);
+  const guide = readCliToolGuide(id, 'install');
+  if (!guide) {
+    writeTextStderr(formatCliToolNotFoundMessage(id));
     return CliExitCode.Usage;
   }
 
-  writeTextStdout(formatGuide(id, 'install') ?? '');
+  writeTextStdout(guide.text);
   if (!run) return CliExitCode.Success;
-  if (!def.installCommand) {
-    writeTextStderr(`No install command is registered for ${id}.`);
+  if (!guide.command) {
+    writeTextStderr(formatCliToolMissingInstallCommandMessage(id));
     return CliExitCode.Usage;
   }
-  return shellRun(def.installCommand);
+  return shellRun(guide.command);
 }
 
 async function authTool(context: CliContext, id: string): Promise<number> {
   await initCliPlatform({ ...context, quietLogs: true });
-  const def = findCliToolDef(id);
-  if (!def) {
-    writeTextStderr(`Tool integration not found: ${id}`);
+  const guide = readCliToolGuide(id, 'auth');
+  if (!guide) {
+    writeTextStderr(formatCliToolNotFoundMessage(id));
     return CliExitCode.Usage;
   }
 
-  writeTextStdout(formatGuide(id, 'auth') ?? '');
-  if (!def.authCommand) return CliExitCode.Success;
+  writeTextStdout(guide.text);
+  if (!guide.command) return CliExitCode.Success;
   try {
-    return await shellRun(def.authCommand);
+    return await shellRun(guide.command);
   } catch (error) {
     writeErrorStderr(error);
     return CliExitCode.AgentError;

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -27,6 +27,13 @@ export interface CliToolStatusRecord {
   readonly note?: string;
 }
 
+export type CliToolGuideKind = 'install' | 'auth';
+
+export interface CliToolGuide {
+  readonly text: string;
+  readonly command?: string;
+}
+
 const cliToolDefs = (): ExternalToolDef[] =>
   EXTERNAL_TOOL_DEFS.filter(
     (def) => !def.hideFromDashboard && !def.hideFromCli,
@@ -97,6 +104,33 @@ export function cliToolIds(): string[] {
   return cliToolDefs().map((def) => def.id);
 }
 
+export function readCliToolGuide(
+  id: string,
+  kind: CliToolGuideKind,
+): CliToolGuide | undefined {
+  const def = findCliToolDef(id);
+  if (!def) return undefined;
+
+  if (kind === 'install') {
+    const lines = [def.installGuide ?? def.configNotes ?? 'No install guide.'];
+    if (def.installCommand) {
+      lines.push('');
+      lines.push(`Command: ${def.installCommand}`);
+    }
+    if (def.installUrl) {
+      lines.push(`URL: ${def.installUrl}`);
+    }
+    return { text: lines.join('\n'), command: def.installCommand };
+  }
+
+  const lines = [def.authNote ?? def.configNotes ?? 'No auth guide.'];
+  if (def.authCommand) {
+    lines.push('');
+    lines.push(`Command: ${def.authCommand}`);
+  }
+  return { text: lines.join('\n'), command: def.authCommand };
+}
+
 export async function setCliToolEnabled(
   id: string,
   enabled: boolean,
@@ -110,6 +144,18 @@ export async function setCliToolEnabled(
 export function formatCliBoolean(value: boolean | null): string {
   if (value == null) return '-';
   return value ? 'yes' : 'no';
+}
+
+export function formatCliToolNotFoundMessage(id: string): string {
+  return `Tool integration not found: ${id}`;
+}
+
+export function formatCliToolNotToggleableMessage(id: string): string {
+  return `Tool integration is not toggleable: ${id}`;
+}
+
+export function formatCliToolMissingInstallCommandMessage(id: string): string {
+  return `No install command is registered for ${id}.`;
 }
 
 export function formatCliToolList(

--- a/src/test-kernel/cli/CliTools.vitest.mts
+++ b/src/test-kernel/cli/CliTools.vitest.mts
@@ -6,7 +6,11 @@ import {
   findCliToolDef,
   formatCliBoolean,
   formatCliToolList,
+  formatCliToolMissingInstallCommandMessage,
+  formatCliToolNotFoundMessage,
+  formatCliToolNotToggleableMessage,
   formatCliToolStatus,
+  readCliToolGuide,
   type CliToolStatusRecord,
 } from '@cli/runtime/tools';
 
@@ -54,6 +58,32 @@ describe('CLI tools runtime', () => {
     expect(
       formatCliToolStatus(record({ statusDetail: 'Codex not found.' })),
     ).toContain('authCommand: codex login\n\nCodex not found.');
+  });
+
+  it('formats tool command errors from the runtime owner', () => {
+    expect(formatCliToolNotFoundMessage('missing')).toBe(
+      'Tool integration not found: missing',
+    );
+    expect(formatCliToolNotToggleableMessage('lean4')).toBe(
+      'Tool integration is not toggleable: lean4',
+    );
+    expect(formatCliToolMissingInstallCommandMessage('external-inquiry')).toBe(
+      'No install command is registered for external-inquiry.',
+    );
+  });
+
+  it('reads install and auth guides from external tool definitions', () => {
+    const installGuide = readCliToolGuide('codex', 'install');
+    expect(installGuide?.text).toContain(
+      'Command: npm install -g @openai/codex',
+    );
+    expect(installGuide?.command).toBe('npm install -g @openai/codex');
+
+    const authGuide = readCliToolGuide('codex', 'auth');
+    expect(authGuide?.text).toContain('Command: codex login');
+    expect(authGuide?.command).toBe('codex login');
+
+    expect(readCliToolGuide('texra-cli', 'install')).toBeUndefined();
   });
 
   it('formats interactive tool descriptions with human state labels', () => {


### PR DESCRIPTION
## Summary

- move CLI tool install/auth guide formatting into `packages/cli/src/runtime/tools.ts`
- centralize tool command error strings with the runtime tool display contract
- keep `commands/tools.ts` focused on CLI plumbing and shell execution, without raw `ExternalToolDef` access

Closes #5558.

## Design note

This keeps the single source of truth narrow: external tool definition interpretation stays in the CLI tool runtime, while the command layer still owns process IO and `spawn()` execution. No new shell behavior or install/auth behavior is intended.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/runtime/tools.ts packages/cli/src/commands/tools.ts src/test-kernel/cli/CliTools.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/CliTools.vitest.mts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside this diff)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with tests locking guide/error strings; no intended change to shell execution or install/auth behavior.
> 
> **Overview**
> Moves **install/auth guide text** and **tool error strings** out of `commands/tools.ts` into `runtime/tools.ts`, so the command layer only handles IO and `spawn()` while the runtime owns how `ExternalToolDef` is interpreted.
> 
> `commands/tools.ts` now calls `readCliToolGuide` (returns `text` + optional `command`) and shared helpers like `formatCliToolNotFoundMessage` instead of inlining `formatGuide` or touching `findCliToolDef`. **User-visible install/auth output and exit paths are meant to stay the same.**
> 
> `CliTools.vitest.mts` adds coverage for the new guide reader and error formatters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c434d916915c1de437bc3569974fd042f96b7df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->