### PR TITLE
refactor: move CLI run model policy to runtime

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -15,6 +15,10 @@ import {
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
+import {
+  buildHeadlessRunContext,
+  resolveCliRunModel,
+} from '../runtime/runModel';
 
 import {
   TOOL_USE_AGENT_NAME_DESCRIPTION,
@@ -28,10 +32,6 @@ import {
   optString,
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
-import {
-  buildHeadlessRunContext,
-  resolveCliRunModel,
-} from './_helpers/modelArg';
 import { emitCliResult } from './_helpers/output';
 import { resolveCliAgent } from './_helpers/agentResolution';
 import { executeCliRequest } from './_helpers/runExecution';

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from 'citty';
 
+import { assertExplicitModelKnown } from '../runtime/runModel';
 import { notifyCliUpdate } from '../runtime/updateChecker';
 
 import { contextFromArgs } from './_helpers/context';
@@ -10,7 +11,6 @@ import {
   optString,
   rejectHeadlessOnlyFlags,
 } from './_helpers/globalArgs';
-import { assertExplicitModelKnown } from './_helpers/modelArg';
 
 export const chatCommand = withUsageSections(
   defineCommand({

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -10,9 +10,13 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
-import { CliUsageError, readCliStdinText } from '../runtime/cliContext';
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { approvalPromptsUnavailable } from '../runtime/approvalPolicyAvailability';
+import {
+  CliUsageError,
+  readCliStdinText,
+  type CliContext,
+} from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform, initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
@@ -37,14 +41,14 @@ import {
   type CliMultiAgentPreset,
   type CliMultiAgentPresetRunPlan,
 } from '../runtime/multiAgentPresets';
+import {
+  buildHeadlessRunContext,
+  resolveCliRunModel,
+} from '../runtime/runModel';
 import { getCliAuthProvider } from '../runtime/supabaseAuth';
 
 import { missingToolUseAgentMessage } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
-import {
-  buildHeadlessRunContext,
-  resolveCliRunModel,
-} from './_helpers/modelArg';
 import { formatMultiAgentRunInstruction } from './_helpers/multiAgentInstruction';
 import { emitCliResult } from './_helpers/output';
 import {
@@ -66,7 +70,6 @@ import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,
 } from './_helpers/workflowInputs';
-import type { CliContext } from '../runtime/cliContext';
 
 type CliToolUseRunResult = Extract<CliRunResult, { category: 'toolUse' }>;
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -10,16 +10,20 @@ import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
 import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
-import { CliUsageError, readCliStdinText } from '../runtime/cliContext';
+import {
+  CliUsageError,
+  readCliStdinText,
+  type CliContext,
+} from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import { writeErrorStderr } from '../runtime/logSinks';
-
-import { missingAgentMessage } from './_helpers/agentLookupText';
-import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
   buildHeadlessRunContext,
   resolveCliRunModel,
-} from './_helpers/modelArg';
+} from '../runtime/runModel';
+
+import { missingAgentMessage } from './_helpers/agentLookupText';
+import { defineCliCommand } from './_helpers/defineCliCommand';
 import { emitCliResult } from './_helpers/output';
 import {
   AGENT_RUN_GLOBAL_ARGS,
@@ -45,7 +49,6 @@ import {
   formatWorkflowTextResult,
   resolveWorkflowOutput,
 } from './_helpers/workflowOutput';
-import type { CliContext } from '../runtime/cliContext';
 
 interface WorkflowRunInit {
   readonly agent: string;

--- a/packages/cli/src/runtime/runModel.ts
+++ b/packages/cli/src/runtime/runModel.ts
@@ -1,19 +1,20 @@
+import { toErrorMessage } from '@common/errors/errorMessage';
+
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
   isKnownCliModel,
   resolveConfiguredModel,
-} from '@cli/runtime/cliConfig';
-import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
-import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
-import { writeTextStderr } from '@cli/runtime/logSinks';
+} from './cliConfig';
+import { CliUsageError, type CliContext } from './cliContext';
+import { initCliPlatform, setCliHelperModel } from './initPlatform';
+import { writeTextStderr } from './logSinks';
 import {
   cliRunnableModelOptionsForSource,
   resolveCliRunnableModel,
   type CliModelSelectionSource,
-} from '@cli/runtime/modelAccess';
-import { shouldRenderRunProgress } from '@cli/runtime/runProgressRenderer';
-import { effectiveCliApiMode } from '@cli/runtime/apiAccessMode';
-import { toErrorMessage } from '@common/errors/errorMessage';
+} from './modelAccess';
+import { shouldRenderRunProgress } from './runProgressRenderer';
+import { effectiveCliApiMode } from './apiAccessMode';
 
 export type CliRunModelCandidateSource = Extract<
   CliModelSelectionSource,

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -26,7 +26,7 @@ vi.mock('@cli/runtime/approvalAdapter', () => ({
   installCliApprovalHandlers: mocks.installCliApprovalHandlers,
 }));
 
-vi.mock('@cli/commands/_helpers/modelArg', () => ({
+vi.mock('@cli/runtime/runModel', () => ({
   buildHeadlessRunContext: vi.fn((context: CliContext, model: string) => ({
     ...context,
     helperModel: model,

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -105,7 +105,7 @@ vi.mock('@cli/runtime/multiAgentPresets', () => {
   };
 });
 
-vi.mock('@cli/commands/_helpers/modelArg', () => ({
+vi.mock('@cli/runtime/runModel', () => ({
   buildHeadlessRunContext: vi.fn((context: CliContext, model: string) => ({
     ...context,
     helperModel: model,

--- a/src/test-kernel/cli/RunModel.vitest.mts
+++ b/src/test-kernel/cli/RunModel.vitest.mts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { CliUsageError } from '@cli/runtime/cliContext';
-import { assertExplicitModelKnown } from '@cli/commands/_helpers/modelArg';
+import { assertExplicitModelKnown } from '@cli/runtime/runModel';
 
 describe('assertExplicitModelKnown', () => {
   it('returns undefined when no model flag was passed', () => {

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -4,7 +4,7 @@ import {
   buildHeadlessRunContext,
   resolveCliRunModelCandidate,
   resolveCliRunModel,
-} from '@cli/commands/_helpers/modelArg';
+} from '@cli/runtime/runModel';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
   type CliConfigValues,


### PR DESCRIPTION
## Summary

- move shared CLI run/chat model selection policy from `commands/_helpers/modelArg.ts` to `runtime/runModel.ts`
- update `chat`, `agents run`, `run`, and `multi-agent run` to import the runtime owner directly
- rename the small model-arg unit test to match the new runtime module and update mocks/imports

Closes #5560.

## Design note

This is a move, not a compatibility layer. The command layer still owns command plumbing, file/input handling, and execution dispatch. The runtime now owns the shared model-run policy alongside `modelAccess`, `cliConfig`, and `runProgressRenderer`.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/runtime/runModel.ts packages/cli/src/commands/chat.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/RunModel.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/runtime/runModel.ts packages/cli/src/commands/chat.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/RunModel.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/RunModel.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside this diff)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path refactor with no intended logic changes; model resolution behavior is unchanged and covered by existing tests.
> 
> **Overview**
> Moves shared CLI **model selection and headless run context** logic from `commands/_helpers/modelArg` into **`runtime/runModel`**, so run/chat policy lives next to `modelAccess`, `cliConfig`, and related runtime modules—not in command helpers.
> 
> **`chat`**, **`agents run`**, **`workflow run`**, and **`multi-agent run`** now import `assertExplicitModelKnown`, `resolveCliRunModel`, and `buildHeadlessRunContext` from `../runtime/runModel` instead of the old helper. `runModel.ts` switches its internal imports to **relative** runtime paths (no `@cli/runtime/...` aliases in that file).
> 
> Vitest mocks and imports are retargeted to `@cli/runtime/runModel` (including `RunModel.vitest.mts` and `cliModelResolution.vitest.mts`). **No behavior change** intended—layering/import ownership only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d6242c24b771be69d3fcb810cff859cbee484e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->