### PR TITLE
refactor: move CLI agent resolution to runtime

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -20,7 +20,7 @@ import {
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
-import { resolveCliAgent } from './_helpers/agentResolution';
+import { resolveCliAgent } from '../runtime/agentResolution';
 import { agentsRunCommand } from './agentsRun';
 import type { CliContext } from '../runtime/cliContext';
 

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -33,7 +33,7 @@ import {
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
 import { emitCliResult } from './_helpers/output';
-import { resolveCliAgent } from './_helpers/agentResolution';
+import { resolveCliAgent } from '../runtime/agentResolution';
 import { executeCliRequest } from './_helpers/runExecution';
 import {
   createCliRunResult,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -31,7 +31,7 @@ import {
   optionalStringFlagValue,
   optString,
 } from './_helpers/globalArgs';
-import { resolveCliAgent } from './_helpers/agentResolution';
+import { resolveCliAgent } from '../runtime/agentResolution';
 import { executeCliRequest } from './_helpers/runExecution';
 import {
   terminalStatusExitCode,

--- a/packages/cli/src/runtime/agentResolution.ts
+++ b/packages/cli/src/runtime/agentResolution.ts
@@ -1,6 +1,6 @@
 import { getAgent, loadAgents, type AgentEntry } from '@agent/index';
 
-import { getCliAuthProvider } from '@cli/runtime/supabaseAuth';
+import { getCliAuthProvider } from './supabaseAuth';
 
 export async function shouldHonorRemoteAgentPriority(
   agentName: string,

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -43,8 +43,7 @@ describe('CLI agent resolution', () => {
   it('loads the local registry and returns a local agent for signed-out users', async () => {
     const local = agent('lean');
     mocks.getAgent.mockReturnValue(local);
-    const { resolveCliAgent } =
-      await import('@cli/commands/_helpers/agentResolution');
+    const { resolveCliAgent } = await import('@cli/runtime/agentResolution');
 
     await expect(resolveCliAgent('lean')).resolves.toBe(local);
 
@@ -56,8 +55,7 @@ describe('CLI agent resolution', () => {
   it('does a full registry load when the local registry misses', async () => {
     const remote = agent('orchestrator', 'remote');
     mocks.getAgent.mockReturnValueOnce(undefined).mockReturnValueOnce(remote);
-    const { resolveCliAgent } =
-      await import('@cli/commands/_helpers/agentResolution');
+    const { resolveCliAgent } = await import('@cli/runtime/agentResolution');
 
     await expect(resolveCliAgent('orchestrator')).resolves.toBe(remote);
 
@@ -73,8 +71,7 @@ describe('CLI agent resolution', () => {
     const remote = agent('lean', 'remote');
     mocks.authProvider.isAuthenticated.mockResolvedValue(true);
     mocks.getAgent.mockReturnValueOnce(local).mockReturnValueOnce(remote);
-    const { resolveCliAgent } =
-      await import('@cli/commands/_helpers/agentResolution');
+    const { resolveCliAgent } = await import('@cli/runtime/agentResolution');
 
     await expect(resolveCliAgent('lean')).resolves.toBe(remote);
 
@@ -89,8 +86,7 @@ describe('CLI agent resolution', () => {
     const local = agent('local:lean');
     mocks.authProvider.isAuthenticated.mockResolvedValue(true);
     mocks.getAgent.mockReturnValue(local);
-    const { resolveCliAgent } =
-      await import('@cli/commands/_helpers/agentResolution');
+    const { resolveCliAgent } = await import('@cli/runtime/agentResolution');
 
     await expect(resolveCliAgent('local:lean')).resolves.toBe(local);
 

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -35,7 +35,7 @@ vi.mock('@cli/commands/_helpers/output', () => ({
   emitCliResult: mocks.emitCliResult,
 }));
 
-vi.mock('@cli/commands/_helpers/agentResolution', () => ({
+vi.mock('@cli/runtime/agentResolution', () => ({
   resolveCliAgent: mocks.resolveCliAgent,
 }));
 

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -42,7 +42,7 @@ vi.mock('@cli/commands/_helpers/output', () => ({
   emitCliResult: vi.fn(),
 }));
 
-vi.mock('@cli/commands/_helpers/agentResolution', () => ({
+vi.mock('@cli/runtime/agentResolution', () => ({
   resolveCliAgent: mocks.resolveCliAgent,
 }));
 


### PR DESCRIPTION
## Summary

- move CLI agent registry/remote-priority resolution from `commands/_helpers` into `runtime/agentResolution.ts`
- update `agents`, `agents run`, and workflow run commands to import the runtime owner directly
- update focused CLI tests/mocks to the runtime path, with no compatibility shim left behind

Closes #5562

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/runtime/agentResolution.ts packages/cli/src/commands/agents.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/agentResolution.ts packages/cli/src/commands/agents.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path refactor with no logic changes; resolution behavior stays covered by existing vitest suites.
> 
> **Overview**
> Moves **`resolveCliAgent`** (and related registry local/remote priority logic) from `commands/_helpers` to **`packages/cli/src/runtime/agentResolution.ts`**, treating agent resolution as runtime infrastructure rather than a command helper.
> 
> **`agents`**, **`agents run`**, and **`workflow run`** now import from `../runtime/agentResolution` instead of `./_helpers/agentResolution`. Inside the moved module, **`getCliAuthProvider`** is imported via a relative `./supabaseAuth` path instead of `@cli/runtime/supabaseAuth`.
> 
> CLI tests update dynamic imports and **`vi.mock`** targets to **`@cli/runtime/agentResolution`**; behavior is unchanged and there is no compatibility shim at the old path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b526b93d561dd3d3012c7418f2768baa47c9d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->