### PR TITLE
refactor: move CLI terminal status helpers to runtime

### DIFF
--- a/packages/cli/src/commands/_helpers/runExecution.ts
+++ b/packages/cli/src/commands/_helpers/runExecution.ts
@@ -5,12 +5,11 @@ import type { ValidatedExecutionRequest } from '@agent/core/execution/executionR
 import type { CliContext } from '@cli/runtime/cliContext';
 import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
-import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
-
 import {
   readCliTerminalStatus,
   type ExecuteAgentResult,
-} from './terminalStatus';
+} from '@cli/runtime/terminalStatus';
+import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 
 export interface CliExecuteOptions {
   /** Forwarded to `runAgent`. */

--- a/packages/cli/src/commands/_helpers/workflowOutput.ts
+++ b/packages/cli/src/commands/_helpers/workflowOutput.ts
@@ -7,16 +7,15 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
 import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
-import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
-import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
-import { getRunDir } from '@utils/files';
-
 import {
   cliTerminalStatus,
   createCliRunResult,
   type CliRunResult,
   type ExecuteAgentResult,
-} from './terminalStatus';
+} from '@cli/runtime/terminalStatus';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+import { getRunDir } from '@utils/files';
 
 /** Resolve a user-supplied path against `cwd` when it isn't already absolute. */
 function joinCwdRelative(target: string, cwd: string): string {

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -40,7 +40,7 @@ import {
   terminalStatusExitCode,
   toolUseResultText,
   type CliRunResult,
-} from './_helpers/terminalStatus';
+} from '../runtime/terminalStatus';
 import { formatToolUseAgentRunInstruction } from './_helpers/toolUseRunInstruction';
 import {
   createStdinWorkflowInputMaterializer,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -65,7 +65,7 @@ import {
   terminalStatusExitCode,
   toolUseResultText,
   type CliRunResult,
-} from './_helpers/terminalStatus';
+} from '../runtime/terminalStatus';
 import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -36,7 +36,7 @@ import { executeCliRequest } from './_helpers/runExecution';
 import {
   terminalStatusExitCode,
   type CliRunResult,
-} from './_helpers/terminalStatus';
+} from '../runtime/terminalStatus';
 import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -1,11 +1,12 @@
 import { getExecutionStore } from '@agent/storage';
 import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import { runAgent } from '@agent/runtime/runAgent';
-import { CliExitCode } from '@cli/runtime/exitCodes';
-import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 
-import type { CliContext } from '@cli/runtime/cliContext';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+
+import { hasCliApprovalDenied } from './approvalAdapter';
+import { CliExitCode } from './exitCodes';
+import type { CliContext } from './cliContext';
 
 export type ExecuteAgentResult = Awaited<ReturnType<typeof runAgent>>;
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -35,7 +35,7 @@ import {
 import {
   cliTerminalStatus,
   createCliRunResult,
-} from '@cli/commands/_helpers/terminalStatus';
+} from '@cli/runtime/terminalStatus';
 import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -22,7 +22,7 @@ vi.mock('@cli/runtime/runtimeHost', () => ({
   createCliRuntimeHost: mocks.createCliRuntimeHost,
 }));
 
-vi.mock('@cli/commands/_helpers/terminalStatus', () => ({
+vi.mock('@cli/runtime/terminalStatus', () => ({
   readCliTerminalStatus: mocks.readCliTerminalStatus,
 }));
 


### PR DESCRIPTION
## Summary

- move CLI terminal/run-result status helpers from `commands/_helpers` into `runtime/terminalStatus.ts`
- update headless run commands, workflow output handling, and run execution to import the runtime owner directly
- update focused tests/mocks to the runtime path, with no compatibility shim left behind

Closes #5564

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/runtime/terminalStatus.ts packages/cli/src/commands/_helpers/runExecution.ts packages/cli/src/commands/_helpers/workflowOutput.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/terminalStatus.ts packages/cli/src/commands/_helpers/runExecution.ts packages/cli/src/commands/_helpers/workflowOutput.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and module-boundary refactor only; behavior of the moved helpers is unchanged.
> 
> **Overview**
> Relocates CLI terminal/run-result helpers (`readCliTerminalStatus`, `createCliRunResult`, `cliTerminalStatus`, `terminalStatusExitCode`, `toolUseResultText`, and related types) from `commands/_helpers` to **`packages/cli/src/runtime/terminalStatus.ts`**, with runtime-local imports for `approvalAdapter`, `exitCodes`, and `cliContext`.
> 
> Headless paths now import that module directly: `runExecution`, `workflowOutput`, `workflow`, `agentsRun`, and `multiAgent` (via `@cli/runtime/terminalStatus` or `../runtime/terminalStatus`). Vitest imports and the `RunExecution` mock target the runtime path; **no compatibility re-export** remains at the old helper location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3660baf4a651d2b8848b33f6a4aa5d7e3627fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->