### PR TITLE
refactor: move CLI workflow output resolution to runtime

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -48,7 +48,7 @@ import {
   expectedOutputFilesForOutputDir,
   formatWorkflowTextResult,
   resolveWorkflowOutput,
-} from './_helpers/workflowOutput';
+} from '../runtime/workflowOutput';
 
 interface WorkflowRunInit {
   readonly agent: string;

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -6,16 +6,17 @@ import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
-import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+import { getRunDir } from '@utils/files';
+
+import { CliUsageError, type CliContext } from './cliContext';
 import {
   cliTerminalStatus,
   createCliRunResult,
   type CliRunResult,
   type ExecuteAgentResult,
-} from '@cli/runtime/terminalStatus';
-import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
-import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
-import { getRunDir } from '@utils/files';
+} from './terminalStatus';
 
 /** Resolve a user-supplied path against `cwd` when it isn't already absolute. */
 function joinCwdRelative(target: string, cwd: string): string {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -45,7 +45,7 @@ import {
 import {
   resolveWorkflowOutput,
   resumeWorkflowOutputFile,
-} from '@cli/commands/_helpers/workflowOutput';
+} from '@cli/runtime/workflowOutput';
 import { isKnownCliModel } from '@cli/runtime/cliConfig';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { pickGlobalArgs } from '@cli/runtime/globalArgs';

--- a/src/test-kernel/cli/OutputGuards.vitest.mts
+++ b/src/test-kernel/cli/OutputGuards.vitest.mts
@@ -8,7 +8,7 @@ import { CliUsageError } from '@cli/runtime/cliContext';
 import {
   assertOutputDirAvailable,
   assertOutputFileAvailable,
-} from '@cli/commands/_helpers/workflowOutput';
+} from '@cli/runtime/workflowOutput';
 
 describe('assertOutputDirAvailable', () => {
   it('no-ops when --output-dir was not passed', async () => {

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { resolveWorkflowOutput } from '@cli/commands/_helpers/workflowOutput';
+import { resolveWorkflowOutput } from '@cli/runtime/workflowOutput';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { END_GROUP_STATUS, EXECUTION_STATUS } from '@shared/schemas';
 


### PR DESCRIPTION
## Summary

- move workflow output resolution from `commands/_helpers` to `runtime`
- update `texra run` and CLI tests to import the runtime owner directly
- use sibling runtime imports inside the moved module; no pass-through shim

Closes #5568.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/runtime/workflowOutput.ts packages/cli/src/commands/workflow.ts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/OutputGuards.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/runtime/workflowOutput.ts packages/cli/src/commands/workflow.ts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/OutputGuards.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/OutputGuards.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and module-location refactor only; workflow output logic and tests are unchanged aside from import targets.
> 
> **Overview**
> **Moves workflow output resolution** from `commands/_helpers/workflowOutput` into `packages/cli/src/runtime/workflowOutput.ts`, aligning it with other CLI runtime concerns (`workflowInputs`, `terminalStatus`, `cliContext`).
> 
> `texra run` (`workflow.ts`) and CLI tests now import from `@cli/runtime/workflowOutput` (or `../runtime/workflowOutput`). Inside the moved module, `@cli/runtime/*` imports become **sibling** `./cliContext` and `./terminalStatus` imports. There is **no** pass-through shim left under `_helpers`—behavior of guards, copy resolution, and formatting is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93c52d06ccdf3106b4a6b36471859aa226a3f1c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->