### PR TITLE
refactor: move CLI headless execution to runtime

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -34,7 +34,7 @@ import {
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
 import { emitCliResult } from './_helpers/output';
 import { resolveCliAgent } from '../runtime/agentResolution';
-import { executeCliRequest } from './_helpers/runExecution';
+import { executeCliRequest } from '../runtime/runExecution';
 import {
   createCliRunResult,
   terminalStatusExitCode,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -59,7 +59,7 @@ import {
   optString,
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
-import { executeCliRequest } from './_helpers/runExecution';
+import { executeCliRequest } from '../runtime/runExecution';
 import {
   createCliRunResult,
   terminalStatusExitCode,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -32,7 +32,7 @@ import {
   optString,
 } from './_helpers/globalArgs';
 import { resolveCliAgent } from '../runtime/agentResolution';
-import { executeCliRequest } from './_helpers/runExecution';
+import { executeCliRequest } from '../runtime/runExecution';
 import {
   terminalStatusExitCode,
   type CliRunResult,

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,15 +1,15 @@
 import { writeTerminalStatus } from '@agent/storage';
 import { runAgent } from '@agent/runtime/runAgent';
 import type { ValidatedExecutionRequest } from '@agent/core/execution/executionRequests';
+import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 
-import type { CliContext } from '@cli/runtime/cliContext';
-import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
-import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
+import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
+import { createCliRuntimeHost } from './runtimeHost';
 import {
   readCliTerminalStatus,
   type ExecuteAgentResult,
-} from '@cli/runtime/terminalStatus';
-import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+} from './terminalStatus';
+import type { CliContext } from './cliContext';
 
 export interface CliExecuteOptions {
   /** Forwarded to `runAgent`. */
@@ -31,11 +31,11 @@ export interface CliExecuteOptions {
 }
 
 /**
- * Shared headless-execution skeleton for `run`, `multi-agent run`, and
- * `resume`: stand up a runtime host, run the request (optionally wrapped),
- * always close the host, and resolve the terminal status. Centralizing this
- * stops the three runners from drifting apart on host lifecycle and status
- * handling, which is how their behavior diverged before.
+ * Shared headless-execution skeleton for `run`, `agents run`, and
+ * `multi-agent run`: stand up a runtime host, run the request (optionally
+ * wrapped), always close the host, and resolve the terminal status.
+ * Centralizing this stops the three runners from drifting apart on host
+ * lifecycle and status handling, which is how their behavior diverged before.
  */
 export async function executeCliRequest(
   request: ValidatedExecutionRequest,

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -46,7 +46,7 @@ vi.mock('@cli/runtime/agentResolution', () => ({
   resolveCliAgent: mocks.resolveCliAgent,
 }));
 
-vi.mock('@cli/commands/_helpers/runExecution', () => ({
+vi.mock('@cli/runtime/runExecution', () => ({
   executeCliRequest: mocks.executeCliRequest,
 }));
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -118,7 +118,7 @@ vi.mock('@cli/runtime/runModel', () => ({
   ),
 }));
 
-vi.mock('@cli/commands/_helpers/runExecution', () => ({
+vi.mock('@cli/runtime/runExecution', () => ({
   executeCliRequest: mocks.executeCliRequest,
 }));
 

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -60,8 +60,7 @@ describe('executeCliRequest', () => {
   });
 
   it('marks headless never runs as approval-unavailable for agent execution', async () => {
-    const { executeCliRequest } =
-      await import('@cli/commands/_helpers/runExecution');
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = {
       config: {},
       executionId: 'exec-1',
@@ -78,8 +77,7 @@ describe('executeCliRequest', () => {
   });
 
   it('marks headless ask runs as approval-unavailable for agent execution', async () => {
-    const { executeCliRequest } =
-      await import('@cli/commands/_helpers/runExecution');
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = {
       config: {},
       executionId: 'exec-1',
@@ -96,8 +94,7 @@ describe('executeCliRequest', () => {
   });
 
   it('keeps yolo runs approval-available for agent execution', async () => {
-    const { executeCliRequest } =
-      await import('@cli/commands/_helpers/runExecution');
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = {
       config: {},
       executionId: 'exec-1',


### PR DESCRIPTION
## Summary

- move shared CLI headless execution from `commands/_helpers` to `runtime`
- update `run`, `agents run`, `multi-agent run`, and tests to import/mock the runtime owner directly
- use sibling runtime imports inside the moved module; no pass-through shim

Closes #5570.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/runtime/runExecution.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/runtime/runExecution.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and module-location refactor only; no changes to `executeCliRequest` logic beyond documentation.
> 
> **Overview**
> Moves shared headless CLI execution (`executeCliRequest`) from `commands/_helpers` into **`packages/cli/src/runtime/runExecution`**, so runtime owns the execution skeleton instead of command helpers.
> 
> **`workflow`**, **`agentsRun`**, and **`multiAgent`** now import from `../runtime/runExecution`. Inside the moved module, `@cli/runtime/*` imports become sibling `./` imports. Vitest mocks and dynamic imports target `@cli/runtime/runExecution`. The module doc comment now names **`run`**, **`agents run`**, and **`multi-agent run`** (not `resume`). No pass-through shim; execution behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3245ba76bded4a4657bde3d42e9424e80721b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->