### PR TITLE
fix: advertise CLI transcript viewer

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -850,6 +850,7 @@ export function App(props: AppProps): React.JSX.Element {
           shortcutsActive={focusShortcutsActive}
           subagentControlsAvailable={subagentControlsAvailable}
           taskControlsAvailable={taskControlsAvailable}
+          transcriptAvailable={(activeSlice?.entries.length ?? 0) > 0}
         />
       </Box>
     </>

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -76,6 +76,8 @@ export interface StatusBarDisplayInput {
   /** Advertise Shift+Enter for newline when the Kitty keyboard protocol is
    *  active; otherwise the universal Ctrl-J is the only reliable binding. */
   readonly shiftEnterNewline?: boolean;
+  /** True when the focused stream has transcript entries. */
+  readonly transcriptAvailable?: boolean;
   /** Terminal width in columns. Used to keep right-side previews from
    *  colliding with durable left-side status segments. */
   readonly width?: number;
@@ -369,16 +371,19 @@ export function statusBarBindingsText(
   hasMultipleStreams: boolean,
   modifierLabel = defaultShortcutModifierLabel(),
   shiftEnterNewline = false,
+  transcriptAvailable = false,
   ctrlCAction: CtrlCAction = 'exit',
   maxColumns?: number,
 ): string {
   const focusBinding = metaShortcutLabel(modifierLabel, '1..9');
   const tasksBinding = metaShortcutLabel(modifierLabel, 'p');
   const subagentsBinding = metaShortcutLabel(modifierLabel, 's');
+  const transcriptBinding = '[Ctrl-T]transcript';
   const bindings: string[] = [
     // Stream cycling / numeric focus only do something when there is more
     // than one stream — hide the hints in a plain single-stream chat.
     ...(hasMultipleStreams ? ['[Tab]streams', `${focusBinding}focus`] : []),
+    ...(transcriptAvailable ? [transcriptBinding] : []),
     ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
     '[/status]details',
     ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
@@ -400,6 +405,7 @@ export function statusBarBindingsText(
 
   if (agentSelectionAvailable) {
     const setupBindings = joinStatusBindings([
+      ...(transcriptAvailable ? [transcriptBinding] : []),
       '[/agent]agents',
       '[/model]models',
       '[/api]api',
@@ -411,6 +417,7 @@ export function statusBarBindingsText(
 
   const compactBindings = joinStatusBindings([
     ...(hasMultipleStreams ? ['[Tab]streams'] : []),
+    ...(transcriptAvailable ? [transcriptBinding] : []),
     ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
     ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
     ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
@@ -421,6 +428,7 @@ export function statusBarBindingsText(
 
   const minimalBindings = joinStatusBindings([
     ...(hasMultipleStreams ? ['[Tab]streams'] : []),
+    ...(transcriptAvailable ? [transcriptBinding] : []),
     ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
     ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
     ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
@@ -431,6 +439,7 @@ export function statusBarBindingsText(
   if (hasMultipleStreams && taskControlsAvailable) {
     const taskFocusedBindings = joinStatusBindings([
       '[Tab]streams',
+      ...(transcriptAvailable ? [transcriptBinding] : []),
       `${tasksBinding}tasks`,
       `[Ctrl-C]${ctrlCAction}`,
     ]);
@@ -441,6 +450,7 @@ export function statusBarBindingsText(
 
   if (taskControlsAvailable) {
     const bareTaskBindings = joinStatusBindings([
+      ...(transcriptAvailable ? [transcriptBinding] : []),
       `${tasksBinding}tasks`,
       `[Ctrl-C]${ctrlCAction}`,
     ]);
@@ -452,6 +462,7 @@ export function statusBarBindingsText(
   if (subagentControlsAvailable) {
     const subagentFocusedBindings = joinStatusBindings([
       ...(hasMultipleStreams ? ['[Tab]streams'] : []),
+      ...(transcriptAvailable ? [transcriptBinding] : []),
       `${subagentsBinding}subagents`,
       `[Ctrl-C]${ctrlCAction}`,
     ]);
@@ -460,11 +471,31 @@ export function statusBarBindingsText(
     }
 
     const bareSubagentBindings = joinStatusBindings([
+      ...(transcriptAvailable ? [transcriptBinding] : []),
       `${subagentsBinding}subagents`,
       `[Ctrl-C]${ctrlCAction}`,
     ]);
     if (fitsStatusBindings(bareSubagentBindings, maxColumns)) {
       return bareSubagentBindings;
+    }
+  }
+
+  if (transcriptAvailable) {
+    const transcriptOnlyBindings = joinStatusBindings([
+      ...(hasMultipleStreams ? ['[Tab]streams'] : []),
+      transcriptBinding,
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(transcriptOnlyBindings, maxColumns)) {
+      return transcriptOnlyBindings;
+    }
+
+    const bareTranscriptBindings = joinStatusBindings([
+      transcriptBinding,
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(bareTranscriptBindings, maxColumns)) {
+      return bareTranscriptBindings;
     }
   }
 
@@ -700,6 +731,7 @@ export function buildStatusBarDisplay(
               input.hasMultipleStreams,
               input.shortcutModifierLabel,
               input.shiftEnterNewline,
+              input.transcriptAvailable,
               input.ctrlCAction,
               input.width === undefined
                 ? undefined
@@ -716,6 +748,7 @@ export interface StatusBarProps {
   readonly shortcutsActive?: boolean;
   readonly subagentControlsAvailable: boolean;
   readonly taskControlsAvailable: boolean;
+  readonly transcriptAvailable?: boolean;
 }
 
 export function StatusBar(props: StatusBarProps): React.JSX.Element {
@@ -762,6 +795,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     model: sessionMeta.model,
     apiMode: shortCliApiMode(sessionMeta.apiMode),
     shiftEnterNewline: caps.kittyKeyboard,
+    transcriptAvailable: props.transcriptAvailable,
     width: columns,
     ctrlCAction: ctrlCActionForFocus({
       activeStreamId,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -125,6 +125,81 @@ describe('CLI StatusBar display model', () => {
     expect(display.left.map(statusBarSegmentText)).not.toContain('deepseekT');
   });
 
+  it('advertises the transcript viewer when the focused stream has history', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+      transcriptAvailable: true,
+      width: 80,
+    });
+
+    expect(display.bindings).toContain('[Tab]streams');
+    expect(display.bindings).toContain('[Ctrl-T]transcript');
+    expect(display.bindings).toContain('[Alt-s]subagents');
+  });
+
+  it('keeps the transcript shortcut in narrow stream views', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+      transcriptAvailable: true,
+      width: 60,
+    });
+
+    expect(display.bindings).toContain('[Ctrl-T]transcript');
+    expect(display.bindings).toContain('[Ctrl-C]exit');
+  });
+
+  it('prefers transcript over stream cycling when the bar is very narrow', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: true,
+      hasMultipleStreams: true,
+      model: 'deepseekT',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+      transcriptAvailable: true,
+      width: 42,
+    });
+
+    expect(display.bindings).toBe('[Ctrl-T]transcript  [Ctrl-C]exit');
+  });
+
   it('advertises root agent selection while setup can still change it', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.WAITING,
@@ -149,6 +224,32 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toBe(
       '[/agent]agents  [/model]models  [/api]api  [Ctrl-J]newline  [Ctrl-C]exit',
     );
+  });
+
+  it('does not let setup bindings hide the transcript viewer', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      agentSelectionAvailable: true,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'gpt54',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+      transcriptAvailable: true,
+      width: 80,
+    });
+
+    expect(display.bindings).toContain('[Ctrl-T]transcript');
+    expect(display.bindings).toContain('[/agent]agents');
   });
 
   it('keeps root agent selection visible when setup bindings get narrow', () => {


### PR DESCRIPTION
## Summary

- advertise `[Ctrl-T]transcript` whenever the focused CLI stream has transcript entries
- keep the transcript shortcut through status-bar compaction so subagent tabs still expose the full-history viewer
- add focused StatusBar display-model coverage for normal and narrow stream views

Closes #5572.

## Design

The dogfood run showed the full subagent transcript already exists and is owned by the existing `TranscriptViewer`; `Ctrl-T` can jump back to the delegated instruction and first tool calls. This PR does not add a second scroll system or duplicate transcript state. It only exposes the existing viewer from the status-bar binding contract when the active stream actually has entries.

## Verification

- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run texra-local:build && npm run texra-local:link`
- TTY dogfood: resumed a long search stream with `TERM=xterm-256color texra-local --resume d349b818ef1f`; verified `[Ctrl-T]transcript` appears before and after replay
- `npm run lint` (passes with existing import-order warnings only)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only status-bar binding hints gated on existing transcript entry count; no changes to Ctrl-T handling or transcript state.
> 
> **Overview**
> Surfaces the existing **Ctrl-T** transcript viewer in the CLI status bar when the focused stream has transcript entries, without changing transcript behavior or adding new scroll state.
> 
> **App** passes `transcriptAvailable` from `activeSlice.entries.length > 0` into **StatusBar**. **statusBarBindingsText** adds `[Ctrl-T]transcript` to the shortcut hints and threads that through every width-compaction tier (setup, compact, minimal, task/subagent fallbacks), including transcript-only layouts on very narrow terminals so the hint is not dropped before less critical bindings.
> 
> Vitest coverage exercises normal width, narrow multi-stream views, ultra-narrow preference for transcript over stream cycling, and setup-mode bars that still show transcript alongside agent selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e616e85811dff199cad482046789202ee9549712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->