### PR TITLE
refactor: centralize agent stream stop policy

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1149,8 +1149,7 @@ export async function runChat(
   const interruptActive = (): void => {
     clearApprovals();
     if (!session.streamId) return;
-    executionRegistry.interruptActiveChildren(session.streamId);
-    interruptRegistry.get(session.streamId)?.interrupt();
+    executionRegistry.stopAgentStream(session.streamId);
   };
 
   const resetSessionForClear = (): void => {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -28,7 +28,6 @@ import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
-import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { toErrorMessage } from '@common/errors';
@@ -850,13 +849,8 @@ export class DesktopProgressBridge {
 
   private stopStream(streamId: StreamTabId): void {
     runCoordinatorBridge.clearRetryRequest(streamId);
-    if (this.options.detachSubagentsOnStop === true) {
-      executionRegistry.detachActiveChildren(streamId, this.runtimeHost);
-    } else {
-      executionRegistry.interruptActiveChildren(streamId);
-    }
-    interruptRegistry.get(streamId)?.interrupt();
-    StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {
+    executionRegistry.stopAgentStream(streamId, {
+      detachActiveChildren: this.options.detachSubagentsOnStop === true,
       runtimeHost: this.runtimeHost,
     });
   }

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -2,25 +2,19 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { notifyFollowUpSent } from '@agent/toolUse/ToolUseFollowUp';
 import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
-import { STREAM_STATUS } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
 
 export function stopAgent(streamId: StreamTabId): void {
-  if (
-    workspaceSM.get<boolean>(WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP, false)
-  ) {
-    executionRegistry.detachActiveChildren(streamId, extensionAgentRuntimeHost);
-  } else {
-    executionRegistry.interruptActiveChildren(streamId);
-  }
-  interruptRegistry.get(streamId)?.interrupt();
-  StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {
+  executionRegistry.stopAgentStream(streamId, {
+    detachActiveChildren: workspaceSM.get<boolean>(
+      WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+      false,
+    ),
     runtimeHost: extensionAgentRuntimeHost,
   });
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -39,6 +39,11 @@ export {
   ProcessExecutionHandle,
 } from './ExecutionHandle';
 
+export interface StopAgentStreamOptions {
+  readonly detachActiveChildren?: boolean;
+  readonly runtimeHost?: AgentRuntimeHost;
+}
+
 /**
  * Process-wide owner for active executions and their change listeners.
  *
@@ -315,6 +320,39 @@ export class ExecutionRegistry {
     this.emitActiveSubagentsUpdate(parentStreamId, runtimeHost);
   }
 
+  /**
+   * Stop a visible agent stream and apply the same child policy everywhere.
+   *
+   * Hosts should call this instead of reconstructing stop behavior from
+   * child-interrupts, root interrupts, and stream-status writes.
+   */
+  stopAgentStream(
+    streamId: StreamTabId,
+    options: StopAgentStreamOptions = {},
+  ): boolean {
+    const rootHandle = this.getAgentHandleByStream(streamId);
+    const runtimeHost = options.runtimeHost ?? rootHandle?.runtimeHost;
+
+    if (options.detachActiveChildren === true) {
+      if (!runtimeHost) {
+        throw new Error(
+          'stopAgentStream requires a runtimeHost to detach active children',
+        );
+      }
+      this.detachActiveChildren(streamId, runtimeHost);
+    } else {
+      this.interruptActiveChildren(streamId);
+    }
+
+    const stopped = rootHandle
+      ? this.terminate(rootHandle)
+      : this.interruptRegisteredStream(streamId, runtimeHost);
+    if (!stopped && runtimeHost) {
+      this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, { runtimeHost });
+    }
+    return stopped;
+  }
+
   /** Get active subagent and process children for a parent stream. */
   getActiveChildren(parentStreamId: StreamTabId): {
     subagents: ActiveChildInfo[];
@@ -403,6 +441,19 @@ export class ExecutionRegistry {
     }
 
     return false;
+  }
+
+  private interruptRegisteredStream(
+    streamId: StreamTabId,
+    runtimeHost: AgentRuntimeHost | undefined,
+  ): boolean {
+    const interruptible = this.interrupts.get(streamId);
+    if (!interruptible) return false;
+    interruptible.interrupt();
+    if (runtimeHost) {
+      this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, { runtimeHost });
+    }
+    return true;
   }
 
   private addChangeCallback(executionId: string, cb: () => void): void {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -45,6 +45,157 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('owns visible stream stop policy for root and children', () => {
+    const explicit = createRecordingHost();
+    const interrupts = new InterruptRegistry();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const rootStreamId = 'root-stop-policy-test' as StreamTabId;
+    const childStreamId = 'child-stop-policy-test' as StreamTabId;
+    const rootInterrupt = vi.fn();
+    const childInterrupt = vi.fn();
+
+    try {
+      interrupts.register(rootStreamId, { interrupt: rootInterrupt });
+      interrupts.register(childStreamId, { interrupt: childInterrupt });
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-root-stop-policy-test',
+          rootStreamId,
+          rootStreamId,
+          'test-root',
+          'toolUse',
+          explicit.host,
+        ),
+      );
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-child-stop-policy-test',
+          rootStreamId,
+          childStreamId,
+          'test-subagent',
+          'toolUse',
+          explicit.host,
+        ),
+      );
+
+      expect(
+        registry.stopAgentStream(rootStreamId, {
+          runtimeHost: explicit.host,
+        }),
+      ).toBe(true);
+
+      expect(rootInterrupt).toHaveBeenCalledOnce();
+      expect(childInterrupt).toHaveBeenCalledOnce();
+      expect(streamStatus.get(rootStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('detaches children when stopping a stream with detached subagents', () => {
+    const explicit = createRecordingHost();
+    const interrupts = new InterruptRegistry();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const rootStreamId = 'root-detach-stop-policy-test' as StreamTabId;
+    const childStreamId = 'child-detach-stop-policy-test' as StreamTabId;
+    const rootInterrupt = vi.fn();
+    const childInterrupt = vi.fn();
+
+    try {
+      interrupts.register(rootStreamId, { interrupt: rootInterrupt });
+      interrupts.register(childStreamId, { interrupt: childInterrupt });
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-root-detach-stop-policy-test',
+          rootStreamId,
+          rootStreamId,
+          'test-root',
+          'toolUse',
+          explicit.host,
+        ),
+      );
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-child-detach-stop-policy-test',
+          rootStreamId,
+          childStreamId,
+          'test-subagent',
+          'toolUse',
+          explicit.host,
+        ),
+      );
+
+      expect(
+        registry.stopAgentStream(rootStreamId, {
+          detachActiveChildren: true,
+          runtimeHost: explicit.host,
+        }),
+      ).toBe(true);
+
+      expect(rootInterrupt).toHaveBeenCalledOnce();
+      expect(childInterrupt).not.toHaveBeenCalled();
+      expect(registry.getActiveChildren(rootStreamId).subagents).toHaveLength(
+        0,
+      );
+      expect(
+        registry.getAgentHandleByStream(childStreamId)?.parentStreamId,
+      ).toBe(childStreamId);
+      expect(streamStatus.get(rootStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(childStreamId)).toBeUndefined();
+      expect(explicit.events).toContainEqual({
+        event: 'setParentStream',
+        payload: {
+          childStreamId,
+          parentStreamId: null,
+        },
+      });
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('stops a registered stream before its execution handle is tracked', () => {
+    const explicit = createRecordingHost();
+    const interrupts = new InterruptRegistry();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const streamId = 'untracked-stop-policy-test' as StreamTabId;
+    const interrupt = vi.fn();
+
+    try {
+      interrupts.register(streamId, { interrupt });
+
+      expect(
+        registry.stopAgentStream(streamId, {
+          runtimeHost: explicit.host,
+        }),
+      ).toBe(true);
+
+      expect(interrupt).toHaveBeenCalledOnce();
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('requires a runtime host when detaching without a tracked root handle', () => {
+    const registry = new ExecutionRegistry();
+    const streamId = 'missing-host-detach-stop-policy-test' as StreamTabId;
+
+    try {
+      expect(() =>
+        registry.stopAgentStream(streamId, {
+          detachActiveChildren: true,
+        }),
+      ).toThrow('requires a runtimeHost');
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('publishes handle updates through the handle runtime host', () => {
     const explicit = createRecordingHost();
     const registry = new ExecutionRegistry();


### PR DESCRIPTION
## Summary

- move visible agent-stream stop behavior into \
- have CLI, Desktop, and Extension stop handlers provide only policy inputs instead of reconstructing child/root/status handling
- cover root+child stop, detach-on-stop, registered-before-tracked streams, and missing-host detach misuse with focused runtime tests

## Design

This keeps the existing singleton as the current composition point, but makes the stop policy a single owned contract. It does not add compatibility pass-through functions; the host call sites now stop at the execution owner instead of reaching separately into child execution state, interrupt registry state, and stream status state.

The Desktop and Extension paths preserve their existing visible STOPPED write. The CLI path now also writes STOPPED when a tracked root handle is actively interrupted; that is intentional because this path is used for active stop/exit handling, not the resumable-idle WAIT path, and it aligns CLI visible stop semantics with the other hosts.

Closes #5575
Refs #4737

## Validation

- \
 RUN  v4.1.8 /private/tmp/texra-step7-next


 Test Files  2 passed (2)
      Tests  12 passed (12)
   Start at  04:45:44
   Duration  254ms (transform 244ms, setup 0ms, import 382ms, tests 7ms, environment 0ms)
- \
> texra-workspace@0.38.7 typecheck
> tsc --noEmit && tsc --noEmit -p tsconfig.test-kernel.json && corepack pnpm --filter texra typecheck && corepack pnpm --filter @texra-ai/cli typecheck --pretty false
- \
> texra-workspace@0.38.7 lint
> node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src packages/extension/src packages/desktop/src packages/cli/src


/private/tmp/texra-step7-next/packages/extension/src/progressView/frontend/components/UserMessage.ts
  22:1  warning  `@shared/subagentFollowup` import should occur before import of `@shared/styles/litStyles`  import/order

/private/tmp/texra-step7-next/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
  17:1  warning  `@utils/core` import should occur after type import of `@tools/memory/MemoryTool`  import/order

/private/tmp/texra-step7-next/packages/extension/src/webview/frontend/MainApp.ts
  59:1  warning  `@shared/wa/tabs` type import should occur before import of `@utils/text/stringUtils`  import/order

/private/tmp/texra-step7-next/src/agent/core/execution/AgentWorkspaceState.ts
  13:1  warning  `@tools/result` import should occur before import of `@utils/core`  import/order

/private/tmp/texra-step7-next/src/agent/core/flows/RetryState.ts
  9:1  warning  `@utils/config/configUtils` import should occur after import of `@shared/schemas`  import/order

/private/tmp/texra-step7-next/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
  30:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-step7-next/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
  13:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-step7-next/src/agent/modelHandlers/support/ProxyConfigResolver.ts
  2:1  warning  `@utils/config/configUtils` import should occur after import of `@model/openRouterRouting`  import/order

/private/tmp/texra-step7-next/src/agent/utils/debugMessageSaver.ts
  4:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-step7-next/src/agent/utils/userVars.ts
  12:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/core`  import/order

/private/tmp/texra-step7-next/src/latex/TikzPictureManager.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-step7-next/src/latex/acceptedFileTarget.ts
  9:1  warning  `@utils/files` import should occur before import of `@utils/core/pathCore`  import/order

/private/tmp/texra-step7-next/src/latex/formatter/latexindentpt.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/system`  import/order

/private/tmp/texra-step7-next/src/latex/formatter/texfmt.ts
  2:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/system`  import/order

/private/tmp/texra-step7-next/src/latex/texTools.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/system`  import/order

/private/tmp/texra-step7-next/src/replacement/engine.ts
  8:1  warning  `@utils/config/configUtils` import should occur after import of `@shared/schemas/coreSettings`  import/order

/private/tmp/texra-step7-next/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
  6:1  warning  `@utils/config/configUtils` import should occur after import of `@tools/approval/bashApproval`  import/order

/private/tmp/texra-step7-next/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
  14:1  warning  `@agent/modelHandlers/openai/modelHandlerOpenAIResponse` import should occur before import of `@utils/config/configUtils`  import/order

/private/tmp/texra-step7-next/src/tools/OpenPdfTool.ts
  22:1  warning  `@utils/files` import should occur before import of `@utils/core/pathCore`  import/order

/private/tmp/texra-step7-next/src/tools/WriteTool.ts
  23:1  warning  `@utils/files` import should occur before import of `@utils/text/stringUtils`  import/order

/private/tmp/texra-step7-next/src/tools/approval/bashApproval.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@tools/result`  import/order

/private/tmp/texra-step7-next/src/tools/approval/toolEditApproval.ts
  11:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-step7-next/src/tools/claudeAgentImport.ts
  20:1  warning  `@anthropic-ai/claude-agent-sdk` type import should occur after import of `./support/externalBinaryUtils`  import/order

/private/tmp/texra-step7-next/src/tools/latex/ExtractBibliographyTool.ts
  5:1  warning  `@utils/config/configUtils` import should occur after import of `@utils/files`  import/order

/private/tmp/texra-step7-next/src/tools/zotero/bbtClient.ts
  14:1  warning  `@utils/config/configUtils` import should occur after import of `@tools/timeouts`  import/order

✖ 25 problems (0 errors, 25 warnings)
  0 errors and 24 warnings potentially fixable with the `--fix` option. (0 errors; existing import-order warnings only)
- \
> texra-workspace@0.38.7 compile:fast
> corepack pnpm --filter texra compile:fast

[esbuild] Building extension...
[esbuild] Extension built in 352ms
vite v8.0.16 building client environment for development...
[2Ktransforming...✓ 756 modules transformed.
rendering chunks...
computing gzip size...
dist/progressView/KaTeX_Size3-Regular.woff2             3.62 kB
dist/progressView/KaTeX_Size3-Regular.woff              4.42 kB
dist/progressView/KaTeX_Size4-Regular.woff2             4.92 kB
dist/progressView/KaTeX_Size2-Regular.woff2             5.20 kB
dist/progressView/KaTeX_Size1-Regular.woff2             5.46 kB
dist/progressView/KaTeX_Size4-Regular.woff              5.98 kB
dist/progressView/KaTeX_Size2-Regular.woff              6.18 kB
dist/progressView/KaTeX_Size1-Regular.woff              6.49 kB
dist/progressView/KaTeX_Caligraphic-Regular.woff2       6.90 kB
dist/progressView/KaTeX_Caligraphic-Bold.woff2          6.91 kB
dist/progressView/KaTeX_Size3-Regular.ttf               7.58 kB
dist/progressView/KaTeX_Caligraphic-Regular.woff        7.65 kB
dist/progressView/KaTeX_Caligraphic-Bold.woff           7.71 kB
dist/progressView/KaTeX_Script-Regular.woff2            9.64 kB
dist/progressView/KaTeX_SansSerif-Regular.woff2        10.34 kB
dist/progressView/KaTeX_Size4-Regular.ttf              10.36 kB
dist/progressView/KaTeX_Script-Regular.woff            10.58 kB
dist/progressView/KaTeX_Fraktur-Regular.woff2          11.31 kB
dist/progressView/KaTeX_Fraktur-Bold.woff2             11.34 kB
dist/progressView/KaTeX_Size2-Regular.ttf              11.50 kB
dist/progressView/KaTeX_SansSerif-Italic.woff2         12.02 kB
dist/progressView/KaTeX_SansSerif-Bold.woff2           12.21 kB
dist/progressView/KaTeX_Size1-Regular.ttf              12.22 kB
dist/progressView/KaTeX_SansSerif-Regular.woff         12.31 kB
dist/progressView/KaTeX_Caligraphic-Regular.ttf        12.34 kB
dist/progressView/KaTeX_Caligraphic-Bold.ttf           12.36 kB
dist/progressView/KaTeX_Fraktur-Regular.woff           13.20 kB
dist/progressView/KaTeX_Fraktur-Bold.woff              13.29 kB
dist/progressView/KaTeX_Typewriter-Regular.woff2       13.56 kB
dist/progressView/KaTeX_SansSerif-Italic.woff          14.11 kB
dist/progressView/KaTeX_SansSerif-Bold.woff            14.40 kB
dist/progressView/KaTeX_Typewriter-Regular.woff        16.02 kB
dist/progressView/KaTeX_Math-BoldItalic.woff2          16.40 kB
dist/progressView/KaTeX_Math-Italic.woff2              16.44 kB
dist/progressView/KaTeX_Script-Regular.ttf             16.64 kB
dist/progressView/KaTeX_Main-BoldItalic.woff2          16.78 kB
dist/progressView/KaTeX_Main-Italic.woff2              16.98 kB
dist/progressView/KaTeX_Math-BoldItalic.woff           18.66 kB
dist/progressView/KaTeX_Math-Italic.woff               18.74 kB
dist/progressView/KaTeX_Main-BoldItalic.woff           19.41 kB
dist/progressView/KaTeX_SansSerif-Regular.ttf          19.43 kB
dist/progressView/KaTeX_Fraktur-Regular.ttf            19.57 kB
dist/progressView/KaTeX_Fraktur-Bold.ttf               19.58 kB
dist/progressView/KaTeX_Main-Italic.woff               19.67 kB
dist/progressView/KaTeX_SansSerif-Italic.ttf           22.36 kB
dist/progressView/KaTeX_SansSerif-Bold.ttf             24.50 kB
dist/progressView/KaTeX_Main-Bold.woff2                25.32 kB
dist/progressView/KaTeX_Main-Regular.woff2             26.27 kB
dist/progressView/KaTeX_Typewriter-Regular.ttf         27.55 kB
dist/progressView/KaTeX_AMS-Regular.woff2              28.07 kB
dist/progressView/KaTeX_Main-Bold.woff                 29.91 kB
dist/progressView/KaTeX_Main-Regular.woff              30.77 kB
dist/progressView/KaTeX_Math-BoldItalic.ttf            31.19 kB
dist/progressView/KaTeX_Math-Italic.ttf                31.30 kB
dist/progressView/KaTeX_Main-BoldItalic.ttf            32.96 kB
dist/progressView/KaTeX_AMS-Regular.woff               33.51 kB
dist/progressView/KaTeX_Main-Italic.ttf                33.58 kB
dist/progressView/KaTeX_Main-Bold.ttf                  51.33 kB
dist/progressView/KaTeX_Main-Regular.ttf               53.58 kB
dist/progressView/KaTeX_AMS-Regular.ttf                63.63 kB
dist/progressView/index.css                            86.80 kB │ gzip:    12.73 kB
dist/progressView/bundle.js                        13,370.58 kB │ gzip: 3,176.60 kB │ map: 7,111.96 kB

✓ built in 481ms
vite v8.0.16 building client environment for development...
[2Ktransforming...✓ 593 modules transformed.
rendering chunks...
computing gzip size...
dist/settingsView/index.css     63.21 kB │ gzip:     9.11 kB
dist/settingsView/bundle.js  6,433.03 kB │ gzip: 1,544.22 kB │ map: 3,421.18 kB

✓ built in 135ms
vite v8.0.16 building client environment for development...
[2Ktransforming...✓ 727 modules transformed.
rendering chunks...
computing gzip size...
dist/webview/KaTeX_Size3-Regular.woff2             3.62 kB
dist/webview/KaTeX_Size3-Regular.woff              4.42 kB
dist/webview/KaTeX_Size4-Regular.woff2             4.92 kB
dist/webview/KaTeX_Size2-Regular.woff2             5.20 kB
dist/webview/KaTeX_Size1-Regular.woff2             5.46 kB
dist/webview/KaTeX_Size4-Regular.woff              5.98 kB
dist/webview/KaTeX_Size2-Regular.woff              6.18 kB
dist/webview/KaTeX_Size1-Regular.woff              6.49 kB
dist/webview/KaTeX_Caligraphic-Regular.woff2       6.90 kB
dist/webview/KaTeX_Caligraphic-Bold.woff2          6.91 kB
dist/webview/KaTeX_Size3-Regular.ttf               7.58 kB
dist/webview/KaTeX_Caligraphic-Regular.woff        7.65 kB
dist/webview/KaTeX_Caligraphic-Bold.woff           7.71 kB
dist/webview/KaTeX_Script-Regular.woff2            9.64 kB
dist/webview/KaTeX_SansSerif-Regular.woff2        10.34 kB
dist/webview/KaTeX_Size4-Regular.ttf              10.36 kB
dist/webview/KaTeX_Script-Regular.woff            10.58 kB
dist/webview/KaTeX_Fraktur-Regular.woff2          11.31 kB
dist/webview/KaTeX_Fraktur-Bold.woff2             11.34 kB
dist/webview/KaTeX_Size2-Regular.ttf              11.50 kB
dist/webview/KaTeX_SansSerif-Italic.woff2         12.02 kB
dist/webview/KaTeX_SansSerif-Bold.woff2           12.21 kB
dist/webview/KaTeX_Size1-Regular.ttf              12.22 kB
dist/webview/KaTeX_SansSerif-Regular.woff         12.31 kB
dist/webview/KaTeX_Caligraphic-Regular.ttf        12.34 kB
dist/webview/KaTeX_Caligraphic-Bold.ttf           12.36 kB
dist/webview/KaTeX_Fraktur-Regular.woff           13.20 kB
dist/webview/KaTeX_Fraktur-Bold.woff              13.29 kB
dist/webview/KaTeX_Typewriter-Regular.woff2       13.56 kB
dist/webview/KaTeX_SansSerif-Italic.woff          14.11 kB
dist/webview/KaTeX_SansSerif-Bold.woff            14.40 kB
dist/webview/KaTeX_Typewriter-Regular.woff        16.02 kB
dist/webview/KaTeX_Math-BoldItalic.woff2          16.40 kB
dist/webview/KaTeX_Math-Italic.woff2              16.44 kB
dist/webview/KaTeX_Script-Regular.ttf             16.64 kB
dist/webview/KaTeX_Main-BoldItalic.woff2          16.78 kB
dist/webview/KaTeX_Main-Italic.woff2              16.98 kB
dist/webview/KaTeX_Math-BoldItalic.woff           18.66 kB
dist/webview/KaTeX_Math-Italic.woff               18.74 kB
dist/webview/KaTeX_Main-BoldItalic.woff           19.41 kB
dist/webview/KaTeX_SansSerif-Regular.ttf          19.43 kB
dist/webview/KaTeX_Fraktur-Regular.ttf            19.57 kB
dist/webview/KaTeX_Fraktur-Bold.ttf               19.58 kB
dist/webview/KaTeX_Main-Italic.woff               19.67 kB
dist/webview/KaTeX_SansSerif-Italic.ttf           22.36 kB
dist/webview/KaTeX_SansSerif-Bold.ttf             24.50 kB
dist/webview/KaTeX_Main-Bold.woff2                25.32 kB
dist/webview/KaTeX_Main-Regular.woff2             26.27 kB
dist/webview/KaTeX_Typewriter-Regular.ttf         27.55 kB
dist/webview/KaTeX_AMS-Regular.woff2              28.07 kB
dist/webview/KaTeX_Main-Bold.woff                 29.91 kB
dist/webview/KaTeX_Main-Regular.woff              30.77 kB
dist/webview/KaTeX_Math-BoldItalic.ttf            31.19 kB
dist/webview/KaTeX_Math-Italic.ttf                31.30 kB
dist/webview/KaTeX_Main-BoldItalic.ttf            32.96 kB
dist/webview/KaTeX_AMS-Regular.woff               33.51 kB
dist/webview/KaTeX_Main-Italic.ttf                33.58 kB
dist/webview/KaTeX_Main-Bold.ttf                  51.33 kB
dist/webview/KaTeX_Main-Regular.ttf               53.58 kB
dist/webview/KaTeX_AMS-Regular.ttf                63.63 kB
dist/webview/index.css                            63.21 kB │ gzip:     9.11 kB
dist/webview/bundle.js                        12,994.50 kB │ gzip: 3,061.10 kB │ map: 6,834.71 kB

✓ built in 1.05s
- \