### PR TITLE
refactor: own live tool-use flow context

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -31,7 +31,6 @@ import {
   notifyFollowUpSent,
   sendFollowUp,
 } from '@agent/toolUse/ToolUseFollowUp';
-import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
 import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
@@ -519,7 +518,7 @@ async function applyCliModelSelection(
   }
 
   const activeFlow = context.session.streamId
-    ? interruptRegistry.getToolUseFlowContext(context.session.streamId)
+    ? executionRegistry.getToolUseFlowContext(context.session.streamId)
     : undefined;
   if (!activeFlow) {
     appendLocalAssistantTranscript(
@@ -922,7 +921,7 @@ async function handleTuiSlashCommand(
       requestCliCompaction({
         streamId: cliState.activeStreamId.get(),
         getFlowContext: (streamId) =>
-          interruptRegistry.getToolUseFlowContext(streamId),
+          executionRegistry.getToolUseFlowContext(streamId),
         notifyFollowUpSent,
         appendTranscript: appendLocalAssistantTranscript,
       });
@@ -1109,7 +1108,7 @@ export async function runChat(
   const hasActiveToolUseFlow = (): boolean =>
     Boolean(
       session.streamId &&
-      interruptRegistry.getToolUseFlowContext(session.streamId),
+      executionRegistry.getToolUseFlowContext(session.streamId),
     );
   const canSelectCurrentModel = (): boolean =>
     chatTuiCanSelectModel({
@@ -1125,7 +1124,7 @@ export async function runChat(
       return undefined;
     }
     const activeFlow = session.streamId
-      ? interruptRegistry.getToolUseFlowContext(session.streamId)
+      ? executionRegistry.getToolUseFlowContext(session.streamId)
       : undefined;
     return activeFlow?.modelSwitchDisabledReason(candidateModel);
   };

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -4,7 +4,6 @@ import * as vscode from 'vscode';
 // Local imports - agent
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { notifyFollowUpSent } from '@agent/toolUse/ToolUseFollowUp';
-import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
@@ -20,7 +19,7 @@ export function stopAgent(streamId: StreamTabId): void {
 }
 
 export async function compactResponse(streamId: StreamTabId): Promise<void> {
-  const flowContext = interruptRegistry.getToolUseFlowContext(streamId);
+  const flowContext = executionRegistry.getToolUseFlowContext(streamId);
   if (!flowContext) {
     await vscode.window.showInformationMessage(
       'No active tool-use session found for this stream.',

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -97,7 +97,9 @@ export interface ToolUseFlowContext {
   switchModel(model: string): Promise<void>;
 }
 
-export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
+export type ToolUseFlowSetupCallback = (
+  context: ToolUseFlowContext,
+) => void | (() => void);
 
 type ToolUsePersistedFlow<C> = PersistedFlow<
   ToolUseRunShared,
@@ -263,6 +265,7 @@ export async function runToolUseFlow<C = unknown>(
   let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
   let lastResponse: string | undefined;
   let touchedFiles: string[] | undefined;
+  let teardownSetup: (() => void) | undefined;
 
   let shared: ToolUseRunShared = {
     messages: [],
@@ -272,7 +275,7 @@ export async function runToolUseFlow<C = unknown>(
 
   try {
     interruptRegistry.register(streamId, flowContext);
-    onSetup?.(flowContext);
+    teardownSetup = onSetup?.(flowContext) ?? undefined;
     let flowRecord: FlowRecord | null = null;
     try {
       flowRecord = (await kv.read<FlowRecord>(flowKey(executionId))) ?? null;
@@ -347,6 +350,8 @@ export async function runToolUseFlow<C = unknown>(
     }
   } finally {
     activePersistedFlow = undefined;
+    teardownSetup?.();
+    teardownSetup = undefined;
     if (shared.userCancelledRetry) {
       logger.debug('Flow record preserved for resume after retry cancellation');
     } else {

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -43,7 +43,7 @@ export interface RunFlowLifecycleOptions {
  */
 export async function runFlowWithLifecycle(
   ctx: AgentLaunchContext,
-  runner: () => Promise<AgentFlowResult>,
+  runner: (handle: AgentExecutionHandle) => Promise<AgentFlowResult>,
   options?: RunFlowLifecycleOptions,
 ): Promise<AgentFlowResult> {
   const { streamId } = ctx;
@@ -64,7 +64,7 @@ export async function runFlowWithLifecycle(
   );
   executionRegistry.track(handle);
   try {
-    const result = await runner();
+    const result = await runner(handle);
     await options?.onCompleted?.(result);
     const terminalStatus =
       result.status === END_GROUP_STATUS.ERROR

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -44,6 +44,24 @@ export interface ExecutionHandle {
   updateProgress(update: { currentRound?: number; totalRounds?: number }): void;
 }
 
+export interface LiveToolUseFlowContext {
+  readonly session: {
+    appendFollowUp(
+      text: string,
+      mediaFiles?: readonly string[],
+      displayText?: string,
+    ): void;
+  };
+  readonly modelHandler: {
+    readonly supportsManualCompaction: boolean;
+  };
+  readonly runtimeHost?: AgentRuntimeHost;
+
+  requestImmediateCompaction(): void;
+  modelSwitchDisabledReason(model: string): string | undefined;
+  switchModel(model: string): Promise<void>;
+}
+
 /**
  * Handle for agent-based executions (workflow or toolUse subagents).
  * When `parentStreamId` differs from `childStreamId`, the handle represents
@@ -53,6 +71,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
   readonly startedAt = Date.now();
   private progress: { currentRound?: number; totalRounds?: number } = {};
   private _parentStreamId: StreamTabId;
+  private toolUseFlowContext?: LiveToolUseFlowContext;
 
   /** Stable tool name for UI identification (e.g. "bash", "codex"). */
   toolName?: string;
@@ -99,6 +118,22 @@ export class AgentExecutionHandle implements ExecutionHandle {
     totalRounds?: number;
   }): void {
     Object.assign(this.progress, update);
+  }
+
+  attachToolUseFlow(context: LiveToolUseFlowContext): void {
+    if (this.category !== 'toolUse') {
+      throw new Error('Only tool-use execution handles can attach tool flows.');
+    }
+    this.toolUseFlowContext = context;
+  }
+
+  detachToolUseFlow(context?: LiveToolUseFlowContext): void {
+    if (context !== undefined && this.toolUseFlowContext !== context) return;
+    this.toolUseFlowContext = undefined;
+  }
+
+  getToolUseFlow(): LiveToolUseFlowContext | undefined {
+    return this.toolUseFlowContext;
   }
 }
 

--- a/src/agent/runtime/InterruptRegistry.ts
+++ b/src/agent/runtime/InterruptRegistry.ts
@@ -1,18 +1,10 @@
 /** Registry for live executions that can be interrupted by stream id. */
 
-import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse';
 import type { StreamTabId } from '@shared/schemas';
 
 /** Live flow or process handle that can receive a user stop request. */
 export interface IInterruptible {
   interrupt(): void;
-}
-
-function isToolUseFlowContext(
-  entry: IInterruptible | undefined,
-): entry is ToolUseFlowContext {
-  const session = (entry as ToolUseFlowContext | undefined)?.session;
-  return session !== undefined && typeof session.appendFollowUp === 'function';
 }
 
 export class InterruptRegistry {
@@ -28,13 +20,6 @@ export class InterruptRegistry {
 
   get(streamTabId: StreamTabId): IInterruptible | undefined {
     return this.entries.get(streamTabId);
-  }
-
-  getToolUseFlowContext(
-    streamTabId: StreamTabId,
-  ): ToolUseFlowContext | undefined {
-    const entry = this.entries.get(streamTabId);
-    return isToolUseFlowContext(entry) ? entry : undefined;
   }
 
   retainOnly(streamIds: ReadonlySet<StreamTabId>): void {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -252,7 +252,7 @@ export async function executeAgent(
     ).catch(() => {});
     return runFlowWithLifecycle(
       ctx,
-      async () => {
+      async (handle) => {
         // Pre-execution UI setup
         if (executionId) await ensureRunDir(executionId);
         StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
@@ -283,42 +283,49 @@ export async function executeAgent(
         if (setting.agentCategory === AgentCategory.ToolUse) {
           let toolUseTurns = 0;
           const onRoundFinalized = createUsageRecordingCallback(ctx);
-          const result = await runToolUseFlow({
-            ...ctx,
-            ...interrupts,
-            onRoundFinalized,
-            setting,
-            isSubagent,
-            approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-            onBeforeWaiting: options.onBeforeWaiting,
-            stopAfterCycle: options.stopAfterCycle,
-            onProgress: (update) => {
-              if (update.kind === 'overview') {
-                toolUseTurns++;
-                ctx.runtimeHost.emit('updateConversationProgress', {
-                  streamId,
-                  progress: {
-                    conversationTurns: toolUseTurns,
-                    toolCallCount: update.toolCallCount,
-                  },
+          const result = await runToolUseFlow(
+            {
+              ...ctx,
+              ...interrupts,
+              onRoundFinalized,
+              setting,
+              isSubagent,
+              approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+              onBeforeWaiting: options.onBeforeWaiting,
+              stopAfterCycle: options.stopAfterCycle,
+              onProgress: (update) => {
+                if (update.kind === 'overview') {
+                  toolUseTurns++;
+                  ctx.runtimeHost.emit('updateConversationProgress', {
+                    streamId,
+                    progress: {
+                      conversationTurns: toolUseTurns,
+                      toolCallCount: update.toolCallCount,
+                    },
+                  });
+                }
+                options.onProgress?.(update);
+              },
+              onFollowUpConsumed: () => {
+                ctx.runtimeHost.emit('updateQueuedFollowUps', {
+                  streamId: ctx.streamId,
                 });
-              }
-              options.onProgress?.(update);
+                options.onFollowUpConsumed?.();
+              },
+              onModelChanged: (modelHandler, model) => {
+                ctx.config.model = model;
+                ctx.usageMonitor.setModelInfo({
+                  capabilities: modelHandler.capabilities,
+                  config: modelHandler.config,
+                });
+              },
             },
-            onFollowUpConsumed: () => {
-              ctx.runtimeHost.emit('updateQueuedFollowUps', {
-                streamId: ctx.streamId,
-              });
-              options.onFollowUpConsumed?.();
+            undefined,
+            (flowContext) => {
+              handle.attachToolUseFlow(flowContext);
+              return () => handle.detachToolUseFlow(flowContext);
             },
-            onModelChanged: (modelHandler, model) => {
-              ctx.config.model = model;
-              ctx.usageMonitor.setModelInfo({
-                capabilities: modelHandler.capabilities,
-                config: modelHandler.config,
-              });
-            },
-          });
+          );
           return {
             category: 'toolUse' as const,
             status: result.status,
@@ -392,7 +399,7 @@ export async function resumeToolUseFromSnapshot(
       );
     }
 
-    await runFlowWithLifecycle(ctx, async () => {
+    await runFlowWithLifecycle(ctx, async (handle) => {
       StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
         runtimeHost: ctx.runtimeHost,
       });
@@ -416,9 +423,11 @@ export async function resumeToolUseFromSnapshot(
             }),
         },
         undefined,
-        options.setupSession
-          ? (context) => options.setupSession?.(context.session)
-          : undefined,
+        (flowContext) => {
+          handle.attachToolUseFlow(flowContext);
+          options.setupSession?.(flowContext.session);
+          return () => handle.detachToolUseFlow(flowContext);
+        },
       );
       return {
         category: 'toolUse' as const,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -21,6 +21,7 @@ import {
 } from '@shared/schemas';
 import {
   type ExecutionHandle,
+  type LiveToolUseFlowContext,
   AgentExecutionHandle,
   ProcessExecutionHandle,
   collectChildSummary,
@@ -34,6 +35,7 @@ import {
 export type { ExecutionHandle } from './ExecutionHandle';
 export {
   type ExecutionStatusInfo,
+  type LiveToolUseFlowContext,
   ACTIVE_STATUSES,
   AgentExecutionHandle,
   ProcessExecutionHandle,
@@ -183,6 +185,12 @@ export class ExecutionRegistry {
       (handle): handle is AgentExecutionHandle =>
         handle instanceof AgentExecutionHandle,
     );
+  }
+
+  getToolUseFlowContext(
+    streamId: StreamTabId,
+  ): LiveToolUseFlowContext | undefined {
+    return this.getAgentHandleByStream(streamId)?.getToolUseFlow();
   }
 
   /** Terminate an execution via its handle. Returns true on success. */

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -11,7 +11,6 @@
  */
 
 import { executionRegistry } from '@agent/runtime/executionRegistry';
-import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { isInFlightStatus } from '@common/constants/streamStatus';
@@ -94,7 +93,7 @@ export async function sendFollowUp(
   }
 
   // Try active flow context first
-  const flowContext = interruptRegistry.getToolUseFlowContext(streamId);
+  const flowContext = executionRegistry.getToolUseFlowContext(streamId);
   if (flowContext) {
     flowContext.session.appendFollowUp(text, mediaFiles, displayText);
     notifyFollowUpSent(streamId, flowContext.runtimeHost);

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   AgentExecutionHandle,
   ExecutionRegistry,
+  type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
@@ -235,6 +236,48 @@ describe('executionRegistry', () => {
         parentStreamId,
         children: [],
       });
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('clears live tool-use context while the handle remains tracked', () => {
+    const explicit = createRecordingHost();
+    const registry = new ExecutionRegistry();
+    const executionId = 'exec-live-flow-context-test';
+    const streamId = 'stream-live-flow-context-test' as StreamTabId;
+    const context: LiveToolUseFlowContext = {
+      session: {
+        appendFollowUp: vi.fn(),
+      },
+      modelHandler: {
+        supportsManualCompaction: true,
+      },
+      runtimeHost: explicit.host,
+      requestImmediateCompaction: vi.fn(),
+      modelSwitchDisabledReason: vi.fn(),
+      switchModel: vi.fn(),
+    };
+
+    try {
+      const handle = new AgentExecutionHandle(
+        executionId,
+        streamId,
+        streamId,
+        'test-tool-use',
+        'toolUse',
+        explicit.host,
+      );
+
+      handle.attachToolUseFlow(context);
+      registry.track(handle);
+
+      expect(registry.getToolUseFlowContext(streamId)).toBe(context);
+
+      handle.detachToolUseFlow(context);
+
+      expect(registry.getToolUseFlowContext(streamId)).toBeUndefined();
+      expect(registry.getAgentHandleByStream(streamId)).toBe(handle);
     } finally {
       registry.dispose();
     }

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -2,14 +2,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse';
-import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  noopAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import {
   AgentExecutionHandle,
   executionRegistry,
+  type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { onFollowUpSent, sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
@@ -19,24 +21,54 @@ const streamId = 'stream:follow-up' as StreamTabId;
 
 describe('tool-use follow-up progress events', () => {
   let unsubscribeFollowUpObserver: (() => void) | undefined;
+  const trackedExecutionIds = new Set<string>();
 
   afterEach(() => {
     unsubscribeFollowUpObserver?.();
     unsubscribeFollowUpObserver = undefined;
-    interruptRegistry.unregister(streamId);
+    for (const executionId of trackedExecutionIds) {
+      executionRegistry.untrack(executionId);
+    }
+    trackedExecutionIds.clear();
     StreamStatusService.clearAll({ emit: false });
   });
+
+  function trackToolUseFlow({
+    stream = streamId,
+    host = noopAgentRuntimeHost,
+    appendFollowUp,
+    executionId = `exec-${stream}`,
+  }: {
+    readonly stream?: StreamTabId;
+    readonly host?: AgentRuntimeHost;
+    readonly appendFollowUp: LiveToolUseFlowContext['session']['appendFollowUp'];
+    readonly executionId?: string;
+  }): void {
+    const handle = new AgentExecutionHandle(
+      executionId,
+      stream,
+      stream,
+      'search',
+      'toolUse',
+      host,
+    );
+    handle.attachToolUseFlow({
+      session: { appendFollowUp },
+      modelHandler: { supportsManualCompaction: true },
+      runtimeHost: host,
+      requestImmediateCompaction: () => {},
+      modelSwitchDisabledReason: () => undefined,
+      switchModel: async () => {},
+    });
+    executionRegistry.track(handle);
+    trackedExecutionIds.add(executionId);
+  }
 
   it('publishes sent follow-up events through the active runtime host', async () => {
     const { events, host } = createRecordingHost();
     const appendFollowUp = vi.fn();
 
-    interruptRegistry.register(streamId, {
-      session: { appendFollowUp },
-      modelHandler: {},
-      runtimeHost: host,
-      interrupt: vi.fn(),
-    } as unknown as ToolUseFlowContext);
+    trackToolUseFlow({ host, appendFollowUp });
 
     const result = await sendFollowUp(streamId, 'please continue');
 
@@ -61,12 +93,7 @@ describe('tool-use follow-up progress events', () => {
       observed.push(observedStreamId);
     });
 
-    interruptRegistry.register(streamId, {
-      session: { appendFollowUp: vi.fn() },
-      modelHandler: {},
-      runtimeHost: host,
-      interrupt: vi.fn(),
-    } as unknown as ToolUseFlowContext);
+    trackToolUseFlow({ host, appendFollowUp: vi.fn() });
 
     await sendFollowUp(streamId, 'break wait');
     unsubscribeFollowUpObserver();
@@ -81,12 +108,7 @@ describe('tool-use follow-up progress events', () => {
     const appendFollowUp = vi.fn();
 
     StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, { emit: false });
-    interruptRegistry.register(streamId, {
-      session: { appendFollowUp },
-      modelHandler: {},
-      runtimeHost: host,
-      interrupt: vi.fn(),
-    } as unknown as ToolUseFlowContext);
+    trackToolUseFlow({ host, appendFollowUp });
 
     const result = await sendFollowUp(streamId, 'late follow-up');
 

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -9,13 +9,11 @@ import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   AgentExecutionHandle,
   executionRegistry,
+  type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-// Type imports
-import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
-import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import type { StreamTabId } from '@shared/schemas';
 
 describe('ToolUseFollowUp', () => {
@@ -45,20 +43,42 @@ describe('ToolUseFollowUp', () => {
   };
 
   afterEach(() => {
-    interruptRegistry.unregister(streamId);
+    for (const executionId of executionRegistry.getActiveIds()) {
+      executionRegistry.untrack(executionId);
+    }
+    ToolUseFollowUpQueue.release(streamId);
   });
+
+  function trackToolUseFlow(
+    stream: StreamTabId,
+    appendFollowUp: LiveToolUseFlowContext['session']['appendFollowUp'],
+    executionId = `exec-${stream}`,
+  ): string {
+    const handle = new AgentExecutionHandle(
+      executionId,
+      stream,
+      stream,
+      'demo-agent',
+      'toolUse',
+      noopAgentRuntimeHost,
+    );
+    handle.attachToolUseFlow({
+      session: { appendFollowUp },
+      modelHandler: { supportsManualCompaction: true },
+      runtimeHost: noopAgentRuntimeHost,
+      requestImmediateCompaction: () => {},
+      modelSwitchDisabledReason: () => undefined,
+      switchModel: async () => {},
+    });
+    executionRegistry.track(handle);
+    return executionId;
+  }
 
   it('sends follow-ups to active flow contexts', async () => {
     const calls: string[] = [];
-    interruptRegistry.register(streamId, {
-      session: {
-        appendFollowUp: (text: string) => {
-          calls.push(text);
-        },
-      },
-      modelHandler: {},
-      interrupt: () => {},
-    } as unknown as ToolUseFlowContext);
+    trackToolUseFlow(streamId, (text: string) => {
+      calls.push(text);
+    });
 
     const result = await sendFollowUp(streamId, 'hello');
 


### PR DESCRIPTION
## Summary

- attach the live tool-use flow context to the active `AgentExecutionHandle` when `runToolUseFlow` finishes setup
- route CLI model switching, CLI/extension compaction, and follow-up delivery through `ExecutionRegistry`/tracked handles
- remove `InterruptRegistry.getToolUseFlowContext()` so `InterruptRegistry` returns to an opaque interrupt-only map

## Design

This is a Step 7 ownership slice, not a new wrapper layer. The live tool-use session/control object belongs to the active agent execution handle. `InterruptRegistry` should only own interruptible entries, not expose concrete tool-use flow internals to host/UI code.

## Validation

- `corepack pnpm vitest run src/test/agent/toolUse/ToolUseFollowUp.test.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts src/test-kernel/cli/CompactionRequest.vitest.mts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (0 errors; existing import-order warnings only)
- `npm run compile:fast`
- `git diff --check`

Closes #5577
Refs #4737

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches follow-up delivery, compaction, and mid-chat model switching across CLI and extension; behavior should be equivalent but depends on attach/detach timing matching the old interrupt-registry registration window.
> 
> **Overview**
> **Live tool-use session control** now hangs off the tracked `AgentExecutionHandle` instead of being discoverable through `InterruptRegistry`.
> 
> During `runToolUseFlow`, `executeAgent` / `resumeToolUseFromSnapshot` attach the flow as `LiveToolUseFlowContext` on the lifecycle handle and return a teardown that detaches it when the flow ends; `ToolUseFlowSetupCallback` can optionally return that cleanup. `runFlowWithLifecycle` passes the handle into the flow runner so attachment happens in one place.
> 
> **Call sites** (CLI chat model switch and `/compact`, extension compaction, `sendFollowUp`) now use `executionRegistry.getToolUseFlowContext(streamId)` instead of `interruptRegistry.getToolUseFlowContext`. `InterruptRegistry` is interrupt-only again (`register` / `get` / `interrupt()`), with no tool-use typing leak.
> 
> Tests were updated to register flows via `AgentExecutionHandle.attachToolUseFlow` + `executionRegistry.track`, including coverage that detaching clears live context while the handle stays tracked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a21b7005af50906941b982ce7c79e8189e2b2ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->