### PR TITLE
refactor: inject execution handle status owner

### DIFF
--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -60,6 +60,7 @@ export async function runFlowWithLifecycle(
     agentName,
     category,
     ctx.runtimeHost,
+    StreamStatusService,
     ctx.coordinators,
   );
   executionRegistry.track(handle);

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import {
   LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
@@ -20,6 +20,8 @@ export interface ExecutionStatusInfo {
   status: string;
   elapsed: string | null;
 }
+
+export type StreamStatusReader = Pick<StreamStatusRegistry, 'get'>;
 
 /** Statuses that represent a live execution (running, transitioning, or paused). */
 export const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
@@ -83,6 +85,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
     readonly agentName: string,
     readonly category: 'workflow' | 'toolUse',
     readonly runtimeHost: AgentRuntimeHost,
+    private readonly streamStatus: StreamStatusReader,
     readonly coordinators?: RunCoordinators,
   ) {
     this._parentStreamId = parentStreamId;
@@ -99,7 +102,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
 
   getStatus(): ExecutionStatusInfo {
     const status =
-      StreamStatusService.get(this.childStreamId) ?? STREAM_STATUS.RUNNING;
+      this.streamStatus.get(this.childStreamId) ?? STREAM_STATUS.RUNNING;
     if (!LIVE_ELAPSED_STREAM_STATUSES.has(status)) {
       return { status, elapsed: null };
     }

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -8,7 +8,10 @@ import {
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
-import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
+import {
+  StreamStatusRegistry,
+  StreamStatusService,
+} from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -33,6 +36,7 @@ describe('executionRegistry', () => {
         'test-subagent',
         'toolUse',
         explicit.host,
+        streamStatus,
       );
       registry.track(handle);
 
@@ -67,6 +71,7 @@ describe('executionRegistry', () => {
           'test-root',
           'toolUse',
           explicit.host,
+          streamStatus,
         ),
       );
       registry.track(
@@ -77,6 +82,7 @@ describe('executionRegistry', () => {
           'test-subagent',
           'toolUse',
           explicit.host,
+          streamStatus,
         ),
       );
 
@@ -116,6 +122,7 @@ describe('executionRegistry', () => {
           'test-root',
           'toolUse',
           explicit.host,
+          streamStatus,
         ),
       );
       registry.track(
@@ -126,6 +133,7 @@ describe('executionRegistry', () => {
           'test-subagent',
           'toolUse',
           explicit.host,
+          streamStatus,
         ),
       );
 
@@ -182,6 +190,39 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('reports agent status from its stream-status owner', () => {
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const parentStreamId = 'parent-owned-status-test' as StreamTabId;
+    const childStreamId = 'child-owned-status-test' as StreamTabId;
+    const executionId = 'exec-owned-status-test';
+
+    try {
+      streamStatus.set(childStreamId, STREAM_STATUS.WAITING, { emit: false });
+      registry.track(
+        new AgentExecutionHandle(
+          executionId,
+          parentStreamId,
+          childStreamId,
+          'test-subagent',
+          'toolUse',
+          explicit.host,
+          streamStatus,
+        ),
+      );
+
+      expect(registry.getActiveChildren(parentStreamId).subagents).toEqual([
+        expect.objectContaining({
+          executionId,
+          status: STREAM_STATUS.WAITING,
+        }),
+      ]);
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('requires a runtime host when detaching without a tracked root handle', () => {
     const registry = new ExecutionRegistry();
     const streamId = 'missing-host-detach-stop-policy-test' as StreamTabId;
@@ -212,6 +253,7 @@ describe('executionRegistry', () => {
         'test-subagent',
         'toolUse',
         explicit.host,
+        StreamStatusService,
       );
 
       registry.track(handle);
@@ -267,6 +309,7 @@ describe('executionRegistry', () => {
         'test-tool-use',
         'toolUse',
         explicit.host,
+        StreamStatusService,
       );
 
       handle.attachToolUseFlow(context);
@@ -298,6 +341,7 @@ describe('executionRegistry', () => {
         'test-subagent',
         'toolUse',
         explicit.host,
+        StreamStatusService,
       );
 
       registry.track(handle);
@@ -337,6 +381,7 @@ describe('executionRegistry', () => {
       'test-subagent',
       'toolUse',
       explicit.host,
+      streamStatus,
     );
 
     registry.track(handle);

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts
@@ -7,6 +7,7 @@ import {
   ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
 import { ExecutionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import type { StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -60,6 +61,7 @@ describe('ExecutionSubscriptionBinder', () => {
       'search',
       'toolUse',
       explicit.host,
+      StreamStatusService,
     );
 
     try {
@@ -94,6 +96,7 @@ describe('ExecutionSubscriptionBinder', () => {
       'search',
       'toolUse',
       explicit.host,
+      StreamStatusService,
     );
 
     try {
@@ -126,6 +129,7 @@ describe('ExecutionSubscriptionBinder', () => {
       'search',
       'toolUse',
       explicit.host,
+      StreamStatusService,
     );
 
     try {

--- a/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
+++ b/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
@@ -17,6 +17,7 @@ import {
   AgentExecutionHandle,
   ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   AGENT_CATEGORY,
   TODO_STATUS,
@@ -177,6 +178,7 @@ describe('runCoordinators', () => {
       'orchestrator',
       'toolUse',
       active.host,
+      StreamStatusService,
       coordinators,
     );
 
@@ -234,6 +236,7 @@ describe('runCoordinators', () => {
       'orchestrator',
       'toolUse',
       active.host,
+      StreamStatusService,
       coordinators,
     );
 

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -51,6 +51,7 @@ describe('tool-use follow-up progress events', () => {
       'search',
       'toolUse',
       host,
+      StreamStatusService,
     );
     handle.attachToolUseFlow({
       session: { appendFollowUp },
@@ -130,6 +131,7 @@ describe('tool-use follow-up progress events', () => {
       'critic',
       'toolUse',
       noopAgentRuntimeHost,
+      StreamStatusService,
     );
 
     StreamStatusService.set(parentStreamId, STREAM_STATUS.STOPPED, {

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -11,6 +11,7 @@ import {
   executionRegistry,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
@@ -61,6 +62,7 @@ describe('ToolUseFollowUp', () => {
       'demo-agent',
       'toolUse',
       noopAgentRuntimeHost,
+      StreamStatusService,
     );
     handle.attachToolUseFlow({
       session: { appendFollowUp },
@@ -99,6 +101,7 @@ describe('ToolUseFollowUp', () => {
       'test-subagent',
       'toolUse',
       noopAgentRuntimeHost,
+      StreamStatusService,
     );
     executionRegistry.track(handle);
 
@@ -132,6 +135,7 @@ describe('ToolUseFollowUp', () => {
       'test-subagent',
       'toolUse',
       noopAgentRuntimeHost,
+      StreamStatusService,
     );
     executionRegistry.track(handle);
     ToolUseFollowUpQueue.release(parentStreamId);

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -93,6 +93,7 @@ export function createChildStream(
     options.agentName,
     'toolUse',
     runtimeHost,
+    StreamStatusService,
   );
   if (options.toolName) handle.toolName = options.toolName;
   executionRegistry.track(handle);


### PR DESCRIPTION
## Summary

- remove the hidden `StreamStatusService` singleton read from `AgentExecutionHandle`
- make agent execution handles receive their stream-status reader through construction
- pass the same status owner used by production composition points and isolated runtime tests
- add a regression test proving child summaries read status from the injected owner

Closes #5579
Refs #4737

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts src/test-kernel/agent/runtime/runCoordinators.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts src/test/agent/toolUse/ToolUseFollowUp.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`