### PR TITLE
refactor: carry stream status on launch context

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -51,13 +51,17 @@ import {
   shouldWarnMediaNeedsVision,
 } from './mediaVisionWarning';
 import { getStreamTabId } from './streamTab';
-import { StreamStatusService } from './StreamStatusService';
+import {
+  StreamStatusService,
+  type StreamStatusRegistry,
+} from './StreamStatusService';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 export interface AgentLaunchContext extends AgentCore {
   usageMonitor: UsageMonitor;
   storageKey: StorageKey;
   parentStage: StageHandle;
+  streamStatus: StreamStatusRegistry;
   coordinators: RunCoordinators;
   /** Whether approval or user prompts cannot be answered by the current host. */
   approvalPromptsUnavailable?: boolean;
@@ -76,6 +80,7 @@ export interface AgentLaunchInput {
   configPayload: AgentConfigPayload;
   executionId?: ExecutionId;
   runtimeHost: AgentRuntimeHost;
+  streamStatus?: StreamStatusRegistry;
   streamTabIdOverride?: StreamTabId;
   taskType?: string;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
@@ -167,6 +172,7 @@ async function beginRunStage(
 async function assembleAgentLaunchContext(
   input: AgentLaunchInput,
   executionId: ExecutionId,
+  streamStatus: StreamStatusRegistry,
   runtimeHost: AgentRuntimeHost,
   reservedStreamId: StreamTabId | undefined,
   onActivated: (streamId: StreamTabId) => void,
@@ -313,6 +319,7 @@ async function assembleAgentLaunchContext(
     userVarChannels,
     usageMonitor,
     runtimeHost,
+    streamStatus,
     workingDirectory: configPayload.workingDirectory?.trim() || undefined,
     coordinators: {
       plan: new PlanApprovalCoordinator(runtimeHost),
@@ -325,18 +332,19 @@ async function assembleAgentLaunchContext(
 
 function acquireStreamOrThrow(
   streamId: StreamTabId,
+  streamStatus: StreamStatusRegistry,
   runtimeHost: AgentRuntimeHost,
   taskType: string = 'Task',
 ): void {
   if (
-    StreamStatusService.tryAcquire(streamId, {
+    streamStatus.tryAcquire(streamId, {
       runtimeHost,
     })
   ) {
     return;
   }
 
-  const status = StreamStatusService.get(streamId) ?? '';
+  const status = streamStatus.get(streamId) ?? '';
   const statusMsg = STATUS_MESSAGES[status] || 'already running';
   throw new AgentError(
     `${taskType} "${streamId}" is ${statusMsg}. Please wait for it to complete or stop it first.`,
@@ -358,6 +366,7 @@ function compensateFailedActivation(args: {
   configPayload: AgentConfigPayload;
   reservedStreamId?: StreamTabId;
   activatedStreamId?: StreamTabId;
+  streamStatus: StreamStatusRegistry;
   runtimeHost: AgentRuntimeHost;
   err: unknown;
   // The run-trace from assembleAgentLaunchContext when it was created before the
@@ -369,6 +378,7 @@ function compensateFailedActivation(args: {
     configPayload,
     reservedStreamId,
     activatedStreamId,
+    streamStatus,
     runtimeHost,
     err,
     runTrace,
@@ -386,14 +396,14 @@ function compensateFailedActivation(args: {
         { operation: `start ${configPayload.agent}` },
       );
     }
-    StreamStatusService.set(activatedStreamId, STREAM_STATUS.ERROR, {
+    streamStatus.set(activatedStreamId, STREAM_STATUS.ERROR, {
       runtimeHost,
     });
     return;
   }
 
   if (reservedStreamId) {
-    StreamStatusService.releaseIfInitializing(reservedStreamId, {
+    streamStatus.releaseIfInitializing(reservedStreamId, {
       runtimeHost,
     });
   }
@@ -411,6 +421,7 @@ export async function buildAgentLaunchContext(
   input: AgentLaunchInput,
 ): Promise<AgentLaunchContext> {
   const { configPayload, runtimeHost } = input;
+  const streamStatus = input.streamStatus ?? StreamStatusService;
   const executionId = input.executionId ?? generateExecutionId();
   if (
     !input.streamTabIdOverride &&
@@ -423,7 +434,12 @@ export async function buildAgentLaunchContext(
     ? undefined
     : getStreamTabId(configPayload.agent, configPayload.model, { executionId });
   if (reservedStreamId) {
-    acquireStreamOrThrow(reservedStreamId, runtimeHost, input.taskType);
+    acquireStreamOrThrow(
+      reservedStreamId,
+      streamStatus,
+      runtimeHost,
+      input.taskType,
+    );
   }
 
   let activatedStreamId: StreamTabId | undefined;
@@ -435,6 +451,7 @@ export async function buildAgentLaunchContext(
     return await assembleAgentLaunchContext(
       input,
       executionId,
+      streamStatus,
       runtimeHost,
       reservedStreamId,
       (streamId) => {
@@ -449,6 +466,7 @@ export async function buildAgentLaunchContext(
       configPayload,
       reservedStreamId,
       activatedStreamId,
+      streamStatus,
       runtimeHost,
       err,
       runTrace,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -80,7 +80,6 @@ export interface AgentLaunchInput {
   configPayload: AgentConfigPayload;
   executionId?: ExecutionId;
   runtimeHost: AgentRuntimeHost;
-  streamStatus?: StreamStatusRegistry;
   streamTabIdOverride?: StreamTabId;
   taskType?: string;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
@@ -421,7 +420,7 @@ export async function buildAgentLaunchContext(
   input: AgentLaunchInput,
 ): Promise<AgentLaunchContext> {
   const { configPayload, runtimeHost } = input;
-  const streamStatus = input.streamStatus ?? StreamStatusService;
+  const streamStatus = StreamStatusService;
   const executionId = input.executionId ?? generateExecutionId();
   if (
     !input.streamTabIdOverride &&

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -16,7 +16,6 @@ import {
 } from '@shared/schemas';
 
 import { AgentExecutionHandle, executionRegistry } from './executionRegistry';
-import { StreamStatusService } from './StreamStatusService';
 import {
   buildTerminalFlowResult,
   type AgentFlowResult,
@@ -60,7 +59,7 @@ export async function runFlowWithLifecycle(
     agentName,
     category,
     ctx.runtimeHost,
-    StreamStatusService,
+    ctx.streamStatus,
     ctx.coordinators,
   );
   executionRegistry.track(handle);
@@ -76,10 +75,10 @@ export async function runFlowWithLifecycle(
     executionRegistry.untrack(ctx.executionId);
     ctx.parentStage.end(result.status);
 
-    if (!StreamStatusService.shouldPreserveOnCompletion(streamId)) {
+    if (!ctx.streamStatus.shouldPreserveOnCompletion(streamId)) {
       const status =
         result.status === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED;
-      StreamStatusService.set(streamId, status, {
+      ctx.streamStatus.set(streamId, status, {
         runtimeHost: ctx.runtimeHost,
         terminalStatus,
       });
@@ -109,7 +108,7 @@ export async function runFlowWithLifecycle(
     }
 
     ctx.parentStage.end(status);
-    StreamStatusService.set(streamId, streamStatus, {
+    ctx.streamStatus.set(streamId, streamStatus, {
       runtimeHost: ctx.runtimeHost,
       terminalStatus,
     });

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -40,7 +40,6 @@ import { executionRegistry } from './executionRegistry';
 import { createInterruptCallbacks } from './InterruptManager';
 import { generateSessionDescription } from './sessionDescription';
 import { getRunStorageService } from './RunStorageService';
-import { StreamStatusService } from './StreamStatusService';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type {
   AgentFlowResult,
@@ -255,7 +254,7 @@ export async function executeAgent(
       async (handle) => {
         // Pre-execution UI setup
         if (executionId) await ensureRunDir(executionId);
-        StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+        ctx.streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
           runtimeHost: ctx.runtimeHost,
         });
         logger.info(`Starting task execution (streamId: ${streamId})`);
@@ -400,7 +399,7 @@ export async function resumeToolUseFromSnapshot(
     }
 
     await runFlowWithLifecycle(ctx, async (handle) => {
-      StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+      ctx.streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
         runtimeHost: ctx.runtimeHost,
       });
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -3,11 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { AgentProposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import {
   StreamStatusRegistry,
   StreamStatusService,
 } from '@agent/runtime/StreamStatusService';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
+import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
+import { RetryRequestCoordinatorImpl } from '@agent/runtime/RetryRequestCoordinator';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import {
   END_GROUP_STATUS,
@@ -59,7 +62,11 @@ function createLifecycleContext({
       dispose: vi.fn(),
     },
     disposeTrace: vi.fn(),
-    coordinators: {},
+    coordinators: {
+      plan: new PlanApprovalCoordinator(explicit.host),
+      proposal: new AgentProposalCoordinator(explicit.host),
+      retry: new RetryRequestCoordinatorImpl(explicit.host),
+    },
   } as unknown as AgentLaunchContext;
 }
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -1,0 +1,97 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - runtime
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import {
+  StreamStatusRegistry,
+  StreamStatusService,
+} from '@agent/runtime/StreamStatusService';
+import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
+import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
+import {
+  END_GROUP_STATUS,
+  STREAM_STATUS,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+const storageMocks = vi.hoisted(() => ({
+  writeTerminalStatus: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@agent/storage', () => ({
+  writeTerminalStatus: storageMocks.writeTerminalStatus,
+}));
+
+function createLifecycleContext({
+  executionId,
+  streamId,
+  streamStatus,
+}: {
+  executionId: ExecutionId;
+  streamId: StreamTabId;
+  streamStatus: StreamStatusRegistry;
+}): AgentLaunchContext {
+  const explicit = createRecordingHost();
+
+  return {
+    config: {
+      agent: 'test-agent',
+      model: 'test-model',
+    },
+    setting: {
+      agentCategory: AgentCategory.ToolUse,
+    },
+    streamId,
+    executionId,
+    runtimeHost: explicit.host,
+    streamStatus,
+    logger: {
+      debug: vi.fn(),
+    },
+    parentStage: {
+      end: vi.fn(),
+    },
+    modelHandler: {
+      dispose: vi.fn(),
+    },
+    disposeTrace: vi.fn(),
+    coordinators: {},
+  } as unknown as AgentLaunchContext;
+}
+
+describe('runFlowWithLifecycle', () => {
+  it('finalizes the stream status owner from the launch context', async () => {
+    const executionId = 'execution-lifecycle-status-owner' as ExecutionId;
+    const streamId = 'stream-lifecycle-status-owner' as StreamTabId;
+    const streamStatus = new StreamStatusRegistry();
+    const ctx = createLifecycleContext({
+      executionId,
+      streamId,
+      streamStatus,
+    });
+
+    try {
+      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+        emit: false,
+      });
+
+      await runFlowWithLifecycle(ctx, async () => ({
+        category: 'toolUse',
+        status: END_GROUP_STATUS.STOPPED,
+        executionId,
+        streamId,
+      }));
+
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.WAITING);
+    } finally {
+      streamStatus.clear(streamId, { emit: false });
+      StreamStatusService.clear(streamId, { emit: false });
+    }
+  });
+});

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -80,6 +80,8 @@ describe('runFlowWithLifecycle', () => {
         emit: false,
       });
 
+      // This test scopes ownership to the lifecycle finalization path; other
+      // mid-run status transitions are migrated in separate Step 7 slices.
       await runFlowWithLifecycle(ctx, async () => ({
         category: 'toolUse',
         status: END_GROUP_STATUS.STOPPED,

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -1,8 +1,15 @@
 // Third-party imports
+import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { noopTrace } from '@agent/trace';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import {
+  AgentCategory,
+  AgentPromptSchema,
+  AgentSettingSchema,
+} from '@agent/core/definition/AgentDataclass';
 import { AgentProposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import {
   StreamStatusRegistry,
@@ -12,10 +19,12 @@ import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
 import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { RetryRequestCoordinatorImpl } from '@agent/runtime/RetryRequestCoordinator';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
+import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import {
   END_GROUP_STATUS,
   STREAM_STATUS,
   type ExecutionId,
+  type StorageKey,
   type StreamTabId,
 } from '@shared/schemas';
 
@@ -39,35 +48,71 @@ function createLifecycleContext({
   streamStatus: StreamStatusRegistry;
 }): AgentLaunchContext {
   const explicit = createRecordingHost();
+  const config = AgentConfigSchema.parse({
+    agent: 'test-agent',
+    model: 'test-model',
+    agentCategory: AgentCategory.ToolUse,
+  });
+  const setting = AgentSettingSchema.parse({
+    agentCategory: AgentCategory.ToolUse,
+  });
+  const prompt = AgentPromptSchema.parse({});
+  const storageKey = executionId as StorageKey;
+  const modelInfo = {
+    capabilities: {
+      supportsPromptCaching: false,
+      supportsAutoPromptCaching: false,
+      supportsReasoning: false,
+      cacheDiscountFactor: 0,
+    },
+    config: {
+      provider: ModelProvider.OPENAI,
+      name: 'test-model',
+      fullName: 'Test Model',
+      inputPrice: 0,
+      openRouterOnly: false,
+      requiresResponsesAPI: false,
+    },
+  };
 
   return {
-    config: {
-      agent: 'test-agent',
-      model: 'test-model',
-    },
-    setting: {
-      agentCategory: AgentCategory.ToolUse,
-    },
+    config,
+    setting,
+    prompt,
     streamId,
     executionId,
     runtimeHost: explicit.host,
     streamStatus,
-    logger: {
-      debug: vi.fn(),
+    logger: noopTrace,
+    parentStage: noopTrace.openStage('Run: test-agent'),
+    storageKey,
+    userVarChannels: {
+      input: Object.freeze({}),
+      transient: {},
     },
-    parentStage: {
-      end: vi.fn(),
-    },
+    usageMonitor: new UsageMonitor(
+      modelInfo,
+      {
+        logger: noopTrace,
+        runtimeHost: explicit.host,
+        storageKey,
+        streamId,
+      },
+      {
+        agentName: config.agent,
+        agentCategory: setting.agentCategory,
+      },
+    ),
     modelHandler: {
       dispose: vi.fn(),
-    },
+    } as unknown as AgentLaunchContext['modelHandler'],
     disposeTrace: vi.fn(),
     coordinators: {
       plan: new PlanApprovalCoordinator(explicit.host),
       proposal: new AgentProposalCoordinator(explicit.host),
       retry: new RetryRequestCoordinatorImpl(explicit.host),
     },
-  } as unknown as AgentLaunchContext;
+  };
 }
 
 describe('runFlowWithLifecycle', () => {


### PR DESCRIPTION
## Summary

- carry the runtime `StreamStatusRegistry` on `AgentLaunchContext`
- use that same owner for stream reservation, activation compensation, pre-run RUNNING transitions, lifecycle finalization, and execution-handle construction
- keep `StreamStatusService` as the internal production owner without exposing custom launch-time injection yet
- add a lifecycle regression test scoped to the finalization path

Closes #5581
Refs #4737

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/StreamStatusService.vitest.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/StreamStatusService.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core run lifecycle and stream tab state (acquire, RUNNING, terminal status); behavior should match production while enabling injectable registries for tests and future slices.
> 
> **Overview**
> **Stream status ownership** moves onto `AgentLaunchContext` as a `StreamStatusRegistry`, so launch, execution, and lifecycle code mutate the same instance instead of calling the `StreamStatusService` singleton directly.
> 
> `buildAgentLaunchContext` still wires production to the global `StreamStatusService`, but reservation (`tryAcquire` / `get`), activation failure compensation, pre-run **RUNNING** transitions in `executeAgent` / resume, and completion/error finalization in `runFlowWithLifecycle` (plus `AgentExecutionHandle` construction) all go through `ctx.streamStatus`.
> 
> A new lifecycle test uses a separate `StreamStatusRegistry` on the context and asserts successful runs finalize **that** registry while the singleton stays unchanged—scoped to the completion path for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f202cf92de8acf19b2471909d850bdad4eea5da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->