### PR TITLE
refactor: route mid-run status through flow services

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -5,8 +5,7 @@ import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { type RetryResult } from '@agent/runtime/RetryRequestCoordinator';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { getConfig } from '@utils/config/configUtils';
+import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   ensureError,
@@ -15,6 +14,7 @@ import {
 } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import { STREAM_STATUS, type RetryErrorInfo } from '@shared/schemas';
+import { getConfig } from '@utils/config/configUtils';
 
 const BACKGROUND_MODE_MIN_RETRIES = 3;
 
@@ -48,6 +48,7 @@ export type InvocationResult<TSuccess> =
 interface RetryableNodeServices {
   streamId: string;
   runtimeHost: AgentRuntimeHost;
+  streamStatus: StreamStatusRegistry;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
   refreshClient?: () => Promise<void>;
@@ -253,7 +254,7 @@ export abstract class RetryableInvocationNode<
   protected async handleManualRetryPrompt(
     error: Error,
   ): Promise<ManualRetryPromptResult> {
-    const { streamId, logger, runtimeHost } = this.services;
+    const { streamId, logger, runtimeHost, streamStatus } = this.services;
     const operationName = this.getOperationName();
     const formatted = normalizeProviderError(error);
 
@@ -267,7 +268,7 @@ export abstract class RetryableInvocationNode<
       formatted,
     );
 
-    StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+    streamStatus.set(streamId, STREAM_STATUS.WAITING, {
       runtimeHost,
     });
     const result: RetryResult = await runCoordinatorBridge.waitForRetry(
@@ -282,7 +283,7 @@ export abstract class RetryableInvocationNode<
 
     if (result.action === 'retry') {
       logger.debug('Manual retry triggered');
-      StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+      streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
         runtimeHost,
       });
       return { shouldRetry: true, userCancelled: false };
@@ -293,7 +294,7 @@ export abstract class RetryableInvocationNode<
         ? 'Retry timed out (no response)'
         : 'Retry cancelled by user';
     logProgressStatus(logger, message);
-    StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+    streamStatus.set(streamId, STREAM_STATUS.WAITING, {
       runtimeHost,
     });
     return { shouldRetry: false, userCancelled: true };

--- a/src/agent/implementations/flows/common/BaseFlowServices.ts
+++ b/src/agent/implementations/flows/common/BaseFlowServices.ts
@@ -12,6 +12,7 @@ import type {
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 
@@ -28,6 +29,7 @@ export interface AgentCore<C = unknown> {
   prompt: AgentPrompt;
   logger: AgentTrace;
   runtimeHost: AgentRuntimeHost;
+  streamStatus: StreamStatusRegistry;
   streamId: StreamTabId;
   executionId: ExecutionId;
   userVarChannels: UserVariableChannels;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -6,7 +6,6 @@ import {
   formatMediaNeedsVisionWarning,
   shouldWarnMediaNeedsVision,
 } from '@agent/runtime/mediaVisionWarning';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS } from '@shared/schemas';
 
 import { findLastAssistantText, extractTouchedFiles } from './types';
@@ -60,6 +59,7 @@ export class ToolUseWaitNode<C> extends Node<
       checkInterruption,
       session,
       streamId,
+      streamStatus,
       onBeforeWaiting,
       runtimeHost,
       isSubagent,
@@ -117,7 +117,7 @@ export class ToolUseWaitNode<C> extends Node<
     }
 
     if (!session.hasQueuedFollowUp()) {
-      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+      streamStatus.set(streamId, STREAM_STATUS.WAITING, {
         runtimeHost,
       });
     }
@@ -155,6 +155,7 @@ export class ToolUseWaitNode<C> extends Node<
       logger,
       modelHandler,
       runtimeHost,
+      streamStatus,
       fileService,
     } = this.services;
 
@@ -184,7 +185,7 @@ export class ToolUseWaitNode<C> extends Node<
       onFollowUpConsumed?.();
       logUserMessage(logger, execRes.displayFollowUp ?? execRes.followUp);
     }
-    StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+    streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
       runtimeHost,
     });
     shared.messages = await modelHandler.createUserFollowUpMessages(

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -1,17 +1,49 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent runtime
+import { noopTrace, type AgentTrace } from '@agent/trace';
 import type { NonIterableObject } from '@agent/node';
 import { RetryableInvocationNode } from '@agent/core/flows/RetryState';
+import {
+  StreamStatusRegistry,
+  StreamStatusService,
+} from '@agent/runtime/StreamStatusService';
+import {
+  noopAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+
+const coordinatorMocks = vi.hoisted(() => ({
+  waitForRetry: vi.fn(),
+}));
+
+vi.mock('@agent/runtime/runCoordinators', () => ({
+  runCoordinatorBridge: {
+    waitForRetry: coordinatorMocks.waitForRetry,
+  },
+}));
+
+interface TestRetryServices {
+  streamId: StreamTabId;
+  runtimeHost: AgentRuntimeHost;
+  streamStatus: StreamStatusRegistry;
+  logger: AgentTrace;
+  setAbortController: (ac: AbortController | null) => void;
+}
 
 class ExposedRetryNode extends RetryableInvocationNode<
   unknown,
   NonIterableObject,
-  never
+  TestRetryServices
 > {
   protected getOperationName(): string {
     return 'Tool-use call';
+  }
+
+  promptFor(error: Error): Promise<unknown> {
+    return this.handleManualRetryPrompt(error);
   }
 
   fallbackFor(error: Error): unknown {
@@ -26,5 +58,41 @@ describe('RetryState', () => {
 
     expect(node.shouldAutoRetry(abort)).toBe(false);
     expect(node.fallbackFor(abort)).toEqual({ kind: 'cancelled' });
+  });
+
+  it('updates the injected stream status owner during manual retry', async () => {
+    const streamId = 'retry-state-owner' as StreamTabId;
+    const streamStatus = new StreamStatusRegistry();
+    const node = new ExposedRetryNode().setServices({
+      streamId,
+      runtimeHost: noopAgentRuntimeHost,
+      streamStatus,
+      logger: noopTrace,
+      setAbortController: vi.fn(),
+    });
+
+    coordinatorMocks.waitForRetry.mockResolvedValueOnce({ action: 'retry' });
+
+    try {
+      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+      StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {
+        emit: false,
+      });
+
+      await node.promptFor(new Error('temporary provider failure'));
+
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
+      expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(coordinatorMocks.waitForRetry).toHaveBeenCalledWith(
+        streamId,
+        expect.objectContaining({
+          operation: 'Tool-use call',
+        }),
+      );
+    } finally {
+      streamStatus.clear(streamId, { emit: false });
+      StreamStatusService.clear(streamId, { emit: false });
+      coordinatorMocks.waitForRetry.mockReset();
+    }
   });
 });

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -7,6 +7,11 @@ import { ToolUseWaitNode } from '@agent/implementations/flows/tooluse/nodes/Tool
 import type { ToolUseRunShared } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import { IdleContinuationRegistry } from '@agent/runtime/idleContinuation';
+import {
+  StreamStatusRegistry,
+  StreamStatusService,
+} from '@agent/runtime/StreamStatusService';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 describe('ToolUseWaitNode', () => {
   it('marks a delivered subagent cycle before stopping on interruption', async () => {
@@ -33,6 +38,7 @@ describe('ToolUseWaitNode', () => {
           return null;
         },
       },
+      streamStatus: new StreamStatusRegistry(),
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
 
@@ -87,6 +93,7 @@ describe('ToolUseWaitNode', () => {
           return null;
         },
       },
+      streamStatus: new StreamStatusRegistry(),
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
 
@@ -127,6 +134,7 @@ describe('ToolUseWaitNode', () => {
         hasQueuedFollowUp: () => false,
         waitForFollowUp: vi.fn(),
       },
+      streamStatus: new StreamStatusRegistry(),
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
 
@@ -165,6 +173,7 @@ describe('ToolUseWaitNode', () => {
         createUserFollowUpMessages: vi.fn(async () => []),
       },
       runtimeHost: { emit: vi.fn() },
+      streamStatus: new StreamStatusRegistry(),
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
 
@@ -189,5 +198,58 @@ describe('ToolUseWaitNode', () => {
       expect.stringContaining('Model has no vision support'),
     );
     expect(addMediaToUserMessage).toHaveBeenCalledOnce();
+  });
+
+  it('updates the injected stream status owner while waiting and resuming', async () => {
+    const streamId = 'wait-node-owner' as StreamTabId;
+    const streamStatus = new StreamStatusRegistry();
+    const shared: ToolUseRunShared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const createUserFollowUpMessages = vi.fn(async () => []);
+    const services = {
+      checkInterruption: () => false,
+      idleContinuations: new IdleContinuationRegistry(),
+      logger: { error: vi.fn() },
+      modelHandler: {
+        createUserFollowUpMessages,
+        extractAssistantText: () => undefined,
+      },
+      runtimeHost: { emit: vi.fn() },
+      session: {
+        hasQueuedFollowUp: () => false,
+        waitForFollowUp: async () => ({
+          displayItems: ['continue'],
+          items: ['continue'],
+          mediaFiles: [],
+          synthetic: true,
+        }),
+      },
+      streamId,
+      streamStatus,
+    } as unknown as ToolUseServices;
+    const node = new ToolUseWaitNode().setServices(services);
+
+    try {
+      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+      StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {
+        emit: false,
+      });
+
+      const prep = await node.prep(shared);
+      const exec = await node.exec(prep);
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.WAITING);
+      expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+
+      await node.post(shared, prep, exec);
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
+      expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(createUserFollowUpMessages).toHaveBeenCalledOnce();
+    } finally {
+      streamStatus.clear(streamId, { emit: false });
+      StreamStatusService.clear(streamId, { emit: false });
+    }
   });
 });

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -25,6 +25,7 @@ import type { ToolUseCycleServices } from '@agent/core/flows/CycleServices';
 // Local imports - agent runtime
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 // Type imports
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ExecResult } from '@agent/types/ResultTypes';
@@ -169,6 +170,7 @@ describe('BashTool', () => {
       userVarChannels: { input: {}, transient: {} },
       logger: createRunTrace('BashToolTest').trace,
       runtimeHost: noopAgentRuntimeHost,
+      streamStatus: new StreamStatusRegistry(),
       client: {} as OpenAI,
       toolRegistry: new MapToolRegistry({ bash: bashTool }),
       checkInterruption: () => false,


### PR DESCRIPTION
## Summary

Closes #5583.

This is the next Step 7 ownership slice after #5582. It moves mid-run flow status transitions onto the flow service owner instead of reaching back to the process singleton.

Changes:
- Add `streamStatus: StreamStatusRegistry` to the base flow service contract.
- Update manual retry WAITING/RUNNING transitions in `RetryState` to use `this.services.streamStatus`.
- Update tool-use follow-up WAITING/RUNNING transitions in `ToolUseWaitNode` to use `this.services.streamStatus`.
- Add focused tests proving retry and wait-node transitions mutate an injected registry while the global singleton remains unchanged.
- Update the one exact `ToolUseCycleServices` test fixture with an explicit status owner.

## Design Notes

This keeps ownership explicit without adding resolver/pass-through helpers. `executeAgent` already passes the launch context into both workflow and tool-use flow services; after #5582 that context owns the production `StreamStatusRegistry`. This PR carries that same owner into nodes that perform mid-run status changes.

Out of scope: `ExecutionRegistry` stop/kill paths still own their injected registry separately and default to `StreamStatusService`. That is a different slice because it affects stop semantics and active-execution subscription behavior.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts src/test/tools/BashTool.test.ts`
- `npm run typecheck -- --pretty false`
- `npx eslint src/agent/implementations/flows/common/BaseFlowServices.ts src/agent/core/flows/RetryState.ts src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test/tools/BashTool.test.ts`
- `npm run lint` (passes with existing import-order warnings outside this change)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-visible run/wait/retry status wiring; behavior should match prior semantics if launch context injects the production registry, but wrong wiring could desync UI from the singleton.
> 
> **Overview**
> **Mid-run stream status** (manual retry and tool-use wait/resume) now goes through an injected `streamStatus: StreamStatusRegistry` on flow services instead of the `StreamStatusService` singleton.
> 
> `AgentCore` / `RetryableNodeServices` gain `streamStatus`, and `RetryState.handleManualRetryPrompt` plus `ToolUseWaitNode` WAITING/RUNNING transitions call `streamStatus.set(...)`. New tests assert the injected registry changes while the global singleton does not; cycle/tool fixtures supply an explicit registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66539a4b0ae25478ff34e1a0c2763d945afbc363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->