### PR TITLE
refactor: centralize execution status reporting

### DIFF
--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -59,7 +59,6 @@ export async function runFlowWithLifecycle(
     agentName,
     category,
     ctx.runtimeHost,
-    ctx.streamStatus,
     ctx.coordinators,
   );
   executionRegistry.track(handle);

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -6,22 +6,13 @@
  */
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
-import {
-  LIVE_ELAPSED_STREAM_STATUSES,
-  STREAM_STATUS,
-  type ActiveChildInfo,
-  type StreamTabId,
-} from '@shared/schemas';
-import { formatDuration } from '@utils/core';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import type { RunCoordinators } from './RunContext';
 
 export interface ExecutionStatusInfo {
   status: string;
   elapsed: string | null;
 }
-
-export type StreamStatusReader = Pick<StreamStatusRegistry, 'get'>;
 
 /** Statuses that represent a live execution (running, transitioning, or paused). */
 export const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
@@ -38,8 +29,6 @@ export interface ExecutionHandle {
   readonly agentName: string;
   readonly startedAt: number;
   readonly runtimeHost: AgentRuntimeHost;
-
-  getStatus(): ExecutionStatusInfo;
 
   getProgress(): { currentRound?: number; totalRounds?: number };
 
@@ -85,7 +74,6 @@ export class AgentExecutionHandle implements ExecutionHandle {
     readonly agentName: string,
     readonly category: 'workflow' | 'toolUse',
     readonly runtimeHost: AgentRuntimeHost,
-    private readonly streamStatus: StreamStatusReader,
     readonly coordinators?: RunCoordinators,
   ) {
     this._parentStreamId = parentStreamId;
@@ -98,18 +86,6 @@ export class AgentExecutionHandle implements ExecutionHandle {
   /** Promote this subagent to a top-level execution (detach from parent). */
   detach(): void {
     this._parentStreamId = this.childStreamId;
-  }
-
-  getStatus(): ExecutionStatusInfo {
-    const status =
-      this.streamStatus.get(this.childStreamId) ?? STREAM_STATUS.RUNNING;
-    if (!LIVE_ELAPSED_STREAM_STATUSES.has(status)) {
-      return { status, elapsed: null };
-    }
-    return {
-      status,
-      elapsed: formatDuration(Date.now() - this.startedAt),
-    };
   }
 
   getProgress(): { currentRound?: number; totalRounds?: number } {
@@ -162,13 +138,6 @@ export class ProcessExecutionHandle implements ExecutionHandle {
     readonly runtimeHost: AgentRuntimeHost,
   ) {}
 
-  getStatus(): ExecutionStatusInfo {
-    return {
-      status: STREAM_STATUS.RUNNING,
-      elapsed: formatDuration(Date.now() - this.startedAt),
-    };
-  }
-
   terminate(): boolean {
     return this.killFn();
   }
@@ -194,37 +163,4 @@ export function isChildExecution(
     return handle.childStreamId !== parentStreamId;
   }
   return true;
-}
-
-/** Collect {executionId, agentName, ...} for handles matching a class under a parent stream. */
-export function collectChildSummary(
-  parentStreamId: StreamTabId,
-  handles: Iterable<ExecutionHandle>,
-  ctor: typeof AgentExecutionHandle | typeof ProcessExecutionHandle,
-): ActiveChildInfo[] {
-  const result: ActiveChildInfo[] = [];
-  for (const handle of handles) {
-    if (
-      !(handle instanceof ctor) ||
-      !isChildExecution(handle, parentStreamId)
-    ) {
-      continue;
-    }
-    const { status, elapsed } = handle.getStatus();
-    const info: ActiveChildInfo = {
-      executionId: handle.executionId,
-      agentName: handle.agentName,
-      status,
-      startedAt: handle.startedAt,
-      elapsed: elapsed ?? null,
-    };
-    if (handle instanceof AgentExecutionHandle) {
-      info.childStreamId = handle.childStreamId;
-      if (handle.toolName) info.toolName = handle.toolName;
-    } else if (handle instanceof ProcessExecutionHandle && handle.toolName) {
-      info.toolName = handle.toolName;
-    }
-    result.push(info);
-  }
-  return result;
 }

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -43,7 +43,7 @@ interface BinderLogger {
 }
 
 interface ExecutionSubscriptionBinderOptions {
-  registry?: Pick<ExecutionRegistry, 'addListener' | 'getHandle'>;
+  registry?: Pick<ExecutionRegistry, 'addListener' | 'getHandle' | 'getStatus'>;
   releaseSource?: ReleaseSource;
   logger?: BinderLogger;
 }
@@ -67,8 +67,11 @@ interface SnapshotState {
   round: string | null;
 }
 
-function snapshot(handle: ExecutionHandle): SnapshotState {
-  const info = handle.getStatus();
+function snapshot(
+  registry: Pick<ExecutionRegistry, 'getStatus'>,
+  handle: ExecutionHandle,
+): SnapshotState {
+  const info = registry.getStatus(handle);
   return {
     status: info.status,
     elapsed: info.elapsed,
@@ -90,14 +93,14 @@ class ExecutionSubscription implements Disposable {
     private readonly runtimeHost: AgentRuntimeHost,
     private readonly registry: Pick<
       ExecutionRegistry,
-      'addListener' | 'getHandle'
+      'addListener' | 'getHandle' | 'getStatus'
     >,
     private readonly onDisposed: () => void,
   ) {
     this.executionId = handle.executionId;
     this.agentName = handle.agentName;
     this.category = handle.category;
-    this.last = snapshot(handle);
+    this.last = snapshot(this.registry, handle);
   }
 
   bind(): boolean {
@@ -133,7 +136,7 @@ class ExecutionSubscription implements Disposable {
       return;
     }
 
-    const current = snapshot(handle);
+    const current = snapshot(this.registry, handle);
     const statusChanged = !this.last || this.last.status !== current.status;
     const roundChanged = this.last?.round !== current.round;
     if (!statusChanged && !roundChanged) {
@@ -177,7 +180,7 @@ class ExecutionSubscription implements Disposable {
 export class ExecutionSubscriptionBinder {
   private readonly registry: Pick<
     ExecutionRegistry,
-    'addListener' | 'getHandle'
+    'addListener' | 'getHandle' | 'getStatus'
   >;
   private readonly releaseSource: ReleaseSource;
   private readonly logger: BinderLogger;

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -16,15 +16,17 @@ import {
 } from '@agent/runtime/InterruptRegistry';
 import {
   STREAM_STATUS,
+  LIVE_ELAPSED_STREAM_STATUSES,
   type ActiveChildInfo,
   type StreamTabId,
 } from '@shared/schemas';
+import { formatDuration } from '@utils/core';
 import {
   type ExecutionHandle,
+  type ExecutionStatusInfo,
   type LiveToolUseFlowContext,
   AgentExecutionHandle,
   ProcessExecutionHandle,
-  collectChildSummary,
   isChildExecution,
 } from './ExecutionHandle';
 import {
@@ -164,6 +166,22 @@ export class ExecutionRegistry {
 
   getHandle(executionId: string): ExecutionHandle | undefined {
     return this.handles.get(executionId);
+  }
+
+  getStatus(handle: ExecutionHandle): ExecutionStatusInfo {
+    const status =
+      handle instanceof AgentExecutionHandle
+        ? (this.streamStatus.get(handle.childStreamId) ?? STREAM_STATUS.RUNNING)
+        : STREAM_STATUS.RUNNING;
+
+    if (!LIVE_ELAPSED_STREAM_STATUSES.has(status)) {
+      return { status, elapsed: null };
+    }
+
+    return {
+      status,
+      elapsed: formatDuration(Date.now() - handle.startedAt),
+    };
   }
 
   getAgentHandleByStream(
@@ -367,14 +385,9 @@ export class ExecutionRegistry {
     processes: ActiveChildInfo[];
   } {
     return {
-      subagents: collectChildSummary(
+      subagents: this.collectChildSummary(parentStreamId, AgentExecutionHandle),
+      processes: this.collectChildSummary(
         parentStreamId,
-        this.handles.values(),
-        AgentExecutionHandle,
-      ),
-      processes: collectChildSummary(
-        parentStreamId,
-        this.handles.values(),
         ProcessExecutionHandle,
       ),
     };
@@ -411,11 +424,7 @@ export class ExecutionRegistry {
   ): void {
     runtimeHost.emit('updateActiveSubagents', {
       parentStreamId,
-      children: collectChildSummary(
-        parentStreamId,
-        this.handles.values(),
-        AgentExecutionHandle,
-      ),
+      children: this.collectChildSummary(parentStreamId, AgentExecutionHandle),
     });
   }
 
@@ -425,12 +434,42 @@ export class ExecutionRegistry {
   ): void {
     runtimeHost.emit('updateActiveProcesses', {
       parentStreamId,
-      processes: collectChildSummary(
+      processes: this.collectChildSummary(
         parentStreamId,
-        this.handles.values(),
         ProcessExecutionHandle,
       ),
     });
+  }
+
+  private collectChildSummary(
+    parentStreamId: StreamTabId,
+    ctor: typeof AgentExecutionHandle | typeof ProcessExecutionHandle,
+  ): ActiveChildInfo[] {
+    const result: ActiveChildInfo[] = [];
+    for (const handle of this.handles.values()) {
+      if (
+        !(handle instanceof ctor) ||
+        !isChildExecution(handle, parentStreamId)
+      ) {
+        continue;
+      }
+      const { status, elapsed } = this.getStatus(handle);
+      const info: ActiveChildInfo = {
+        executionId: handle.executionId,
+        agentName: handle.agentName,
+        status,
+        startedAt: handle.startedAt,
+        elapsed: elapsed ?? null,
+      };
+      if (handle instanceof AgentExecutionHandle) {
+        info.childStreamId = handle.childStreamId;
+        if (handle.toolName) info.toolName = handle.toolName;
+      } else if (handle instanceof ProcessExecutionHandle && handle.toolName) {
+        info.toolName = handle.toolName;
+      }
+      result.push(info);
+    }
+    return result;
   }
 
   private terminate(handle: ExecutionHandle): boolean {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -8,10 +8,7 @@ import {
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
-import {
-  StreamStatusRegistry,
-  StreamStatusService,
-} from '@agent/runtime/StreamStatusService';
+import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -36,7 +33,6 @@ describe('executionRegistry', () => {
         'test-subagent',
         'toolUse',
         explicit.host,
-        streamStatus,
       );
       registry.track(handle);
 
@@ -71,7 +67,6 @@ describe('executionRegistry', () => {
           'test-root',
           'toolUse',
           explicit.host,
-          streamStatus,
         ),
       );
       registry.track(
@@ -82,7 +77,6 @@ describe('executionRegistry', () => {
           'test-subagent',
           'toolUse',
           explicit.host,
-          streamStatus,
         ),
       );
 
@@ -122,7 +116,6 @@ describe('executionRegistry', () => {
           'test-root',
           'toolUse',
           explicit.host,
-          streamStatus,
         ),
       );
       registry.track(
@@ -133,7 +126,6 @@ describe('executionRegistry', () => {
           'test-subagent',
           'toolUse',
           explicit.host,
-          streamStatus,
         ),
       );
 
@@ -208,7 +200,6 @@ describe('executionRegistry', () => {
           'test-subagent',
           'toolUse',
           explicit.host,
-          streamStatus,
         ),
       );
 
@@ -253,7 +244,6 @@ describe('executionRegistry', () => {
         'test-subagent',
         'toolUse',
         explicit.host,
-        StreamStatusService,
       );
 
       registry.track(handle);
@@ -309,7 +299,6 @@ describe('executionRegistry', () => {
         'test-tool-use',
         'toolUse',
         explicit.host,
-        StreamStatusService,
       );
 
       handle.attachToolUseFlow(context);
@@ -341,7 +330,6 @@ describe('executionRegistry', () => {
         'test-subagent',
         'toolUse',
         explicit.host,
-        StreamStatusService,
       );
 
       registry.track(handle);
@@ -381,7 +369,6 @@ describe('executionRegistry', () => {
       'test-subagent',
       'toolUse',
       explicit.host,
-      streamStatus,
     );
 
     registry.track(handle);

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts
@@ -7,7 +7,6 @@ import {
   ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
 import { ExecutionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import type { StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -61,7 +60,6 @@ describe('ExecutionSubscriptionBinder', () => {
       'search',
       'toolUse',
       explicit.host,
-      StreamStatusService,
     );
 
     try {
@@ -96,7 +94,6 @@ describe('ExecutionSubscriptionBinder', () => {
       'search',
       'toolUse',
       explicit.host,
-      StreamStatusService,
     );
 
     try {
@@ -129,7 +126,6 @@ describe('ExecutionSubscriptionBinder', () => {
       'search',
       'toolUse',
       explicit.host,
-      StreamStatusService,
     );
 
     try {

--- a/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
+++ b/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
@@ -17,7 +17,6 @@ import {
   AgentExecutionHandle,
   ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   AGENT_CATEGORY,
   TODO_STATUS,
@@ -178,7 +177,6 @@ describe('runCoordinators', () => {
       'orchestrator',
       'toolUse',
       active.host,
-      StreamStatusService,
       coordinators,
     );
 
@@ -236,7 +234,6 @@ describe('runCoordinators', () => {
       'orchestrator',
       'toolUse',
       active.host,
-      StreamStatusService,
       coordinators,
     );
 

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -51,7 +51,6 @@ describe('tool-use follow-up progress events', () => {
       'search',
       'toolUse',
       host,
-      StreamStatusService,
     );
     handle.attachToolUseFlow({
       session: { appendFollowUp },
@@ -131,7 +130,6 @@ describe('tool-use follow-up progress events', () => {
       'critic',
       'toolUse',
       noopAgentRuntimeHost,
-      StreamStatusService,
     );
 
     StreamStatusService.set(parentStreamId, STREAM_STATUS.STOPPED, {

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -11,7 +11,6 @@ import {
   executionRegistry,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
@@ -62,7 +61,6 @@ describe('ToolUseFollowUp', () => {
       'demo-agent',
       'toolUse',
       noopAgentRuntimeHost,
-      StreamStatusService,
     );
     handle.attachToolUseFlow({
       session: { appendFollowUp },
@@ -101,7 +99,6 @@ describe('ToolUseFollowUp', () => {
       'test-subagent',
       'toolUse',
       noopAgentRuntimeHost,
-      StreamStatusService,
     );
     executionRegistry.track(handle);
 
@@ -135,7 +132,6 @@ describe('ToolUseFollowUp', () => {
       'test-subagent',
       'toolUse',
       noopAgentRuntimeHost,
-      StreamStatusService,
     );
     executionRegistry.track(handle);
     ToolUseFollowUpQueue.release(parentStreamId);

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -203,7 +203,7 @@ function shouldSkipWait(executionId: string): boolean {
   const handle = executionRegistry.getHandle(executionId);
   if (!handle) return true;
 
-  const { status } = handle.getStatus();
+  const { status } = executionRegistry.getStatus(handle);
   if (!ACTIVE_STATUSES.has(status)) return true;
 
   // Tool-use subagent in WAITING = job delivered via onBeforeWaiting, don't block.
@@ -463,7 +463,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         store.readReport(),
       ]);
 
-      const info = handle.getStatus();
+      const info = executionRegistry.getStatus(handle);
       const lines = [
         `Execution: ${executionId}`,
         `Agent: ${handle.agentName}`,

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -93,7 +93,6 @@ export function createChildStream(
     options.agentName,
     'toolUse',
     runtimeHost,
-    StreamStatusService,
   );
   if (options.toolName) handle.toolName = options.toolName;
   executionRegistry.track(handle);

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -59,7 +59,7 @@ export function getExecutionStatusInfo(
   terminalStatus?: string,
 ): ExecutionStatusInfo {
   const handle = executionRegistry.getHandle(executionId);
-  if (handle) return handle.getStatus();
+  if (handle) return executionRegistry.getStatus(handle);
   return {
     status: terminalStatus ?? EXECUTION_STATUS.COMPLETED,
     elapsed: null,


### PR DESCRIPTION
## Summary
- Move live execution status reporting behind `ExecutionRegistry`, the owner of the stream-status registry and status-change subscription.
- Remove the status-reader argument from `AgentExecutionHandle` so handles carry identity, lineage, progress, runtime host, and attached tool-use context only.
- Update execution tools and subscription snapshots to ask the registry for status instead of asking handles directly.

## Design
This collapses a duplicated ownership path rather than adding another resolver layer. The registry already owns the live status registry; this PR makes status display and child-summary status formatting use that same owner. Handles no longer need to know where status comes from.

Closes #5585.
Part of #4737.

## Validation
- `corepack pnpm vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts src/test-kernel/agent/runtime/runCoordinators.vitest.ts src/test/agent/toolUse/ToolUseFollowUp.test.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts`
- `npm run format`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared runtime paths (active-child badges, execution subscriptions, executions wait/view) but is largely a move of existing status logic with tests updated; wrong wiring could show stale status or elapsed time.
> 
> **Overview**
> **Live execution status and elapsed time now come from `ExecutionRegistry.getStatus(handle)`** instead of `handle.getStatus()`. The registry already owns the stream-status map, so agent handles no longer take a stream-status reader and no longer implement status reporting.
> 
> **`AgentExecutionHandle` construction is simplified** across lifecycle, child streams, and tests: the `streamStatus` argument is removed from `AgentRunLifecycle` and everywhere handles are created.
> 
> **Child summaries and subscriptions use the registry path.** `collectChildSummary` moves from `ExecutionHandle.ts` into a private `ExecutionRegistry` method (active subagent/process UI and `getActiveChildren`). `ExecutionSubscriptionBinder` snapshots status via `registry.getStatus`.
> 
> **Execution tooling and formatters** (`ExecutionsTool`, `executionFormatters`, `shouldSkipWait`) resolve status through `executionRegistry.getStatus` after `getHandle`, keeping the same display and wait/skip behavior with a single ownership boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f801c9871e1f99d7057ec0f6fd9ad2c2e44752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->