### PR TITLE
refactor: route child stream status through registry

### DIFF
--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -18,6 +18,7 @@ import {
   STREAM_STATUS,
   LIVE_ELAPSED_STREAM_STATUSES,
   type ActiveChildInfo,
+  type StreamStatus,
   type StreamTabId,
 } from '@shared/schemas';
 import { formatDuration } from '@utils/core';
@@ -46,6 +47,14 @@ export {
 export interface StopAgentStreamOptions {
   readonly detachActiveChildren?: boolean;
   readonly runtimeHost?: AgentRuntimeHost;
+}
+
+export interface TrackAgentExecutionOptions {
+  readonly status?: StreamStatus;
+}
+
+export interface FinishAgentExecutionOptions {
+  readonly status: StreamStatus;
 }
 
 /**
@@ -133,12 +142,37 @@ export class ExecutionRegistry {
     }
   }
 
+  /**
+   * Register an agent execution and, when requested, publish its initial
+   * stream status through the registry-owned status store.
+   */
+  trackAgentExecution(
+    handle: AgentExecutionHandle,
+    options: TrackAgentExecutionOptions = {},
+  ): void {
+    if (options.status) {
+      this.streamStatus.set(handle.childStreamId, options.status, {
+        runtimeHost: handle.runtimeHost,
+      });
+    }
+    this.track(handle);
+  }
+
   /** Remove an execution handle and notify waiters. */
   untrack(executionId: string): void {
     const handle = this.handles.get(executionId);
-    this.handles.delete(executionId);
-    this.notifyWaiters(executionId);
-    if (!handle) return;
+    if (!handle) {
+      this.handles.delete(executionId);
+      this.notifyWaiters(executionId);
+      return;
+    }
+
+    this.untrackHandle(handle);
+  }
+
+  private untrackHandle(handle: ExecutionHandle): void {
+    this.handles.delete(handle.executionId);
+    this.notifyWaiters(handle.executionId);
     const { runtimeHost } = handle;
 
     if (
@@ -153,7 +187,7 @@ export class ExecutionRegistry {
       // The final read must complete before the badge update, because the
       // badge handler prunes output entries for processes no longer active.
       const finalize = (): void => {
-        this.processOutput.unregister(executionId);
+        this.processOutput.unregister(handle.executionId);
         this.emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
       };
       if (handle.outputPaths) {
@@ -161,6 +195,28 @@ export class ExecutionRegistry {
       } else {
         finalize();
       }
+    }
+  }
+
+  /**
+   * Finalize an agent execution from its owning handle while preserving
+   * explicit user stops.
+   */
+  finishAgentExecution(
+    handle: AgentExecutionHandle,
+    options: FinishAgentExecutionOptions,
+  ): void {
+    const currentStatus = this.streamStatus.get(handle.childStreamId);
+    if (currentStatus !== STREAM_STATUS.STOPPED) {
+      this.streamStatus.set(handle.childStreamId, options.status, {
+        runtimeHost: handle.runtimeHost,
+      });
+    }
+
+    if (this.handles.get(handle.executionId) === handle) {
+      this.untrackHandle(handle);
+    } else {
+      this.notifyWaiters(handle.executionId);
     }
   }
 

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -214,6 +214,109 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('publishes initial status when tracking an agent execution', () => {
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const parentStreamId = 'parent-track-agent-status-test' as StreamTabId;
+    const childStreamId = 'child-track-agent-status-test' as StreamTabId;
+    const executionId = 'exec-track-agent-status-test';
+
+    try {
+      registry.trackAgentExecution(
+        new AgentExecutionHandle(
+          executionId,
+          parentStreamId,
+          childStreamId,
+          'test-subagent',
+          'toolUse',
+          explicit.host,
+        ),
+        { status: STREAM_STATUS.RUNNING },
+      );
+
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.RUNNING);
+      expect(registry.getActiveChildren(parentStreamId).subagents).toEqual([
+        expect.objectContaining({
+          executionId,
+          status: STREAM_STATUS.RUNNING,
+        }),
+      ]);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('finishes agent executions without overwriting explicit stops', () => {
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const parentStreamId = 'parent-finish-agent-status-test' as StreamTabId;
+    const childStreamId = 'child-finish-agent-status-test' as StreamTabId;
+    const executionId = 'exec-finish-agent-status-test';
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+      explicit.host,
+    );
+
+    try {
+      registry.track(handle);
+      streamStatus.set(childStreamId, STREAM_STATUS.STOPPED, { emit: false });
+
+      registry.finishAgentExecution(handle, {
+        status: STREAM_STATUS.READY,
+      });
+
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(registry.getHandle(executionId)).toBeUndefined();
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('can finish an agent execution from its handle after untracking', () => {
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const parentStreamId = 'parent-finish-untracked-agent-test' as StreamTabId;
+    const childStreamId = 'child-finish-untracked-agent-test' as StreamTabId;
+    const executionId = 'exec-finish-untracked-agent-test';
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+      explicit.host,
+    );
+
+    try {
+      registry.trackAgentExecution(handle, { status: STREAM_STATUS.RUNNING });
+      registry.untrack(executionId);
+      const activeUpdateCount = explicit.events.filter(
+        (event) => event.event === 'updateActiveSubagents',
+      ).length;
+
+      registry.finishAgentExecution(handle, {
+        status: STREAM_STATUS.ERROR,
+      });
+
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.ERROR);
+      expect(
+        explicit.events.filter(
+          (event) => event.event === 'updateActiveSubagents',
+        ),
+      ).toHaveLength(activeUpdateCount);
+      expect(registry.getHandle(executionId)).toBeUndefined();
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('requires a runtime host when detaching without a tracked root handle', () => {
     const registry = new ExecutionRegistry();
     const streamId = 'missing-host-detach-stop-policy-test' as StreamTabId;

--- a/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
@@ -9,7 +9,7 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
-import { createChildStream, finalizeChildStream } from '@tools/childStream';
+import { createChildStream } from '@tools/childStream';
 import { createRecordingHost } from '../progressTestUtils';
 
 const executionId = 'exec:child-stream' as ExecutionId;
@@ -25,11 +25,7 @@ describe('child stream progress events', () => {
   it('publishes child stream lifecycle events through the explicit runtime host', () => {
     const active = createRecordingHost();
 
-    const {
-      childStreamId: actualChildStreamId,
-      logger,
-      disposeTrace,
-    } = createChildStream(executionId, parentStreamId, {
+    const childStream = createChildStream(executionId, parentStreamId, {
       runtimeHost: active.host,
       streamPrefix: 'bash',
       streamCategory: AgentCategory.ToolUse,
@@ -39,23 +35,16 @@ describe('child stream progress events', () => {
       toolName: 'bash',
     });
 
-    expect(actualChildStreamId).toBe(childStreamId);
+    expect(childStream.childStreamId).toBe(childStreamId);
 
-    finalizeChildStream({
-      childStreamId,
-      executionId,
-      logger,
-      disposeTrace,
-      runtimeHost: active.host,
-      options: { autoClose: true },
-    });
+    childStream.finalize({ autoClose: true });
 
     const { events } = active;
     expect(events.map((entry) => entry.event)).toEqual([
-      'updateStreamStatus',
       'setActiveStream',
       'setTaskState',
       'updateStreamDescription',
+      'updateStreamStatus',
       'updateActiveSubagents',
       'setParentStream',
       'updateStreamStatus',
@@ -63,17 +52,9 @@ describe('child stream progress events', () => {
       'updateActiveSubagents',
       'removeStream',
     ]);
-    expect(events[0]).toEqual({
-      event: 'updateStreamStatus',
-      payload: {
-        streamId: childStreamId,
-        status: STREAM_STATUS.RUNNING,
-        previousStatus: STREAM_STATUS.READY,
-      },
-    });
     // Background child streams register without yanking the active tab —
     // suppressViewSwitch: true keeps the user's current view stable.
-    expect(events[1]).toEqual({
+    expect(events[0]).toEqual({
       event: 'setActiveStream',
       payload: {
         streamId: childStreamId,
@@ -81,7 +62,7 @@ describe('child stream progress events', () => {
         suppressViewSwitch: true,
       },
     });
-    expect(events[2]).toEqual({
+    expect(events[1]).toEqual({
       event: 'setTaskState',
       payload: {
         streamId: childStreamId,
@@ -90,6 +71,14 @@ describe('child stream progress events', () => {
           agentConfig: config,
           toolSessionState: {},
         },
+      },
+    });
+    expect(events[3]).toEqual({
+      event: 'updateStreamStatus',
+      payload: {
+        streamId: childStreamId,
+        status: STREAM_STATUS.RUNNING,
+        previousStatus: STREAM_STATUS.READY,
       },
     });
     expect(events[4].payload).toEqual({

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -39,7 +39,7 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { createChildStream, finalizeChildStream } from './childStream';
+import { createChildStream } from './childStream';
 import { parseWorkingDirectory } from './pathResolution';
 
 const BASH_TIMEOUT_MS = 120_000; // 120 s
@@ -224,19 +224,16 @@ export class BashTool extends defineTool({
       'process',
     );
 
-    const { childStreamId, logger, disposeTrace } = createChildStream(
-      executionId,
-      parentStreamId,
-      {
-        streamPrefix: 'bash@tool',
-        streamCategory: AgentCategory.ToolUse,
-        agentName: 'bash',
-        description: command,
-        config: syntheticConfig,
-        toolName: 'bash',
-        runtimeHost,
-      },
-    );
+    const childStream = createChildStream(executionId, parentStreamId, {
+      streamPrefix: 'bash@tool',
+      streamCategory: AgentCategory.ToolUse,
+      agentName: 'bash',
+      description: command,
+      config: syntheticConfig,
+      toolName: 'bash',
+      runtimeHost,
+    });
+    const { childStreamId, logger } = childStream;
     let stdoutTail = '';
     let stderrTail = '';
     let loggedChars = 0;
@@ -297,21 +294,14 @@ export class BashTool extends defineTool({
         const terminalStatus = result.success ? 'completed' : 'error';
         await writeTerminalStatus(executionId, terminalStatus).catch(() => {});
         interruptRegistry.unregister(childStreamId);
-        finalizeChildStream({
-          childStreamId,
-          executionId,
-          logger,
-          disposeTrace,
-          runtimeHost,
-          options: {
-            wallTimeMs,
-            error: result.success
-              ? undefined
-              : new ToolError(
-                  `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
-                ),
-            autoClose: true,
-          },
+        childStream.finalize({
+          wallTimeMs,
+          error: result.success
+            ? undefined
+            : new ToolError(
+                `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
+              ),
+          autoClose: true,
         });
 
         const msg = formatBashDelivery(
@@ -328,16 +318,9 @@ export class BashTool extends defineTool({
       .catch(async (err: unknown) => {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
         interruptRegistry.unregister(childStreamId);
-        finalizeChildStream({
-          childStreamId,
-          executionId,
-          logger,
-          disposeTrace,
-          runtimeHost,
-          options: {
-            error: err,
-            autoClose: true,
-          },
+        childStream.finalize({
+          error: err,
+          autoClose: true,
         });
 
         const msg = formatBashError(executionId, command, err);

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -4,7 +4,6 @@ import type { AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   AgentExecutionHandle,
   executionRegistry,
@@ -45,28 +44,27 @@ interface FinalizeChildStreamOptions {
   autoClose?: boolean;
 }
 
+export interface ChildStream {
+  childStreamId: StreamTabId;
+  logger: AgentTrace;
+  /**
+   * Drop the run-trace subscribers attached by `createRunTrace`. Must be
+   * called once when a custom child-loop cleanup path does not use `finalize`.
+   */
+  disposeTrace: () => void;
+  /** Complete the child stream lifecycle through the owning execution handle. */
+  finalize: (options?: FinalizeChildStreamOptions) => void;
+}
+
 /** Create a child stream tab and execution handle for a background child task. */
 export function createChildStream(
   executionId: ExecutionId,
   parentStreamId: StreamTabId,
   options: CreateChildStreamOptions,
-): {
-  childStreamId: StreamTabId;
-  logger: AgentTrace;
-  /**
-   * Drop the run-trace subscribers attached by `createRunTrace`. Must be
-   * called once when the child stream finalizes, either via
-   * `finalizeChildStream` (which calls it for you) or directly from a custom
-   * cleanup path.
-   */
-  disposeTrace: () => void;
-} {
+): ChildStream {
   const childStreamId = `${options.streamPrefix}#${executionId}` as StreamTabId;
   const { runtimeHost } = options;
 
-  StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING, {
-    runtimeHost,
-  });
   // Register the child stream (state, logs, hints) without switching the
   // active tab. Background child streams (bash, codex) shouldn't yank the
   // user away from whatever they're viewing — the tab simply appears.
@@ -95,35 +93,35 @@ export function createChildStream(
     runtimeHost,
   );
   if (options.toolName) handle.toolName = options.toolName;
-  executionRegistry.track(handle);
+  executionRegistry.trackAgentExecution(handle, {
+    status: STREAM_STATUS.RUNNING,
+  });
 
   return {
     childStreamId,
     logger: runTrace.trace,
     disposeTrace: runTrace.dispose,
+    finalize: (finalizeOptions) => {
+      finalizeChildStream({
+        handle,
+        logger: runTrace.trace,
+        disposeTrace: runTrace.dispose,
+        options: finalizeOptions,
+      });
+    },
   };
 }
 
 interface FinalizeChildStreamArgs {
-  childStreamId: StreamTabId;
-  executionId: ExecutionId;
+  handle: AgentExecutionHandle;
   logger: AgentTrace;
-  /** From `createChildStream` — releases the run-trace subscribers. */
   disposeTrace: () => void;
-  runtimeHost: AgentRuntimeHost;
   options?: FinalizeChildStreamOptions;
 }
 
 /** Finalize a child stream tab and untrack its execution handle. */
-export function finalizeChildStream(args: FinalizeChildStreamArgs): void {
-  const {
-    childStreamId,
-    executionId,
-    logger,
-    disposeTrace,
-    runtimeHost,
-    options,
-  } = args;
+function finalizeChildStream(args: FinalizeChildStreamArgs): void {
+  const { handle, logger, disposeTrace, options } = args;
   const hasError = options?.error != null || options?.errorMessage != null;
 
   if (options?.errorMessage) {
@@ -140,19 +138,12 @@ export function finalizeChildStream(args: FinalizeChildStreamArgs): void {
     );
   }
 
-  // Preserve user-initiated STOPPED status — don't overwrite with ERROR/READY
-  const currentStatus = StreamStatusService.get(childStreamId);
-  if (currentStatus !== STREAM_STATUS.STOPPED) {
-    StreamStatusService.set(
-      childStreamId,
-      hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
-      { runtimeHost },
-    );
-  }
-  executionRegistry.untrack(executionId);
+  executionRegistry.finishAgentExecution(handle, {
+    status: hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+  });
   disposeTrace();
 
   if (options?.autoClose) {
-    runtimeHost.emit('removeStream', { streamId: childStreamId });
+    handle.runtimeHost.emit('removeStream', { streamId: handle.childStreamId });
   }
 }


### PR DESCRIPTION
## Summary

- add registry-owned tracking/finalization helpers for `AgentExecutionHandle` status transitions
- remove direct `StreamStatusService` writes from `childStream` create/finalize paths
- return a bound child-stream lifecycle object so bash finalization no longer passes IDs, runtime host, logger, and disposal callbacks back into the helper
- preserve explicit STOPPED status by default during registry-owned finalization

## Design note

This keeps the lifecycle status boundary with `ExecutionRegistry`, which already owns tracked execution status reads. `childStream` still creates stream metadata and removes the UI stream, but no longer reaches into the status singleton for agent execution lifecycle updates.

The `RUNNING` status event now fires after `setActiveStream`, `setTaskState`, and `updateStreamDescription`. That ordering is intentional: consumers see the child stream metadata before receiving a status update for that stream.

The review follow-up also makes finalization handle-bound. If a caller still owns the child stream object, registry finalization can settle status from the original `AgentExecutionHandle` without a fallback status write or a runtime-host pass-through. If the handle has already been untracked, finalization writes the terminal status and notifies waiters without running active-child cleanup a second time.

Closes #5587. Part of #4737.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npx eslint src/agent/runtime/executionRegistry.ts src/tools/childStream.ts src/tools/bash.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts`
- `npm run lint` (passes with existing import-order warnings outside this change)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent execution lifecycle and UI progress event ordering for background child streams; behavior is covered by tests but affects visible stream status and subagent badges.
> 
> **Overview**
> Routes **agent child stream status** through `ExecutionRegistry` instead of direct `StreamStatusService` calls from `childStream`.
> 
> `ExecutionRegistry` gains **`trackAgentExecution`** (optional initial status on register) and **`finishAgentExecution`** (terminal status from the owning `AgentExecutionHandle`, **without overwriting** user **STOPPED**). **`untrack`** is refactored through a private **`untrackHandle`** so finish can untrack or only notify waiters if the handle was already removed.
> 
> **`createChildStream`** returns a **`ChildStream`** object with a bound **`finalize()`**; **`finalizeChildStream`** is internal and handle-driven. Child creation emits stream metadata first, then publishes **RUNNING** via the registry. **`bash`** uses the new object API instead of passing IDs, logger, and runtime host into a standalone finalizer.
> 
> Tests cover registry track/finish behavior (including post-untrack finish) and updated progress event ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45d6a472603618fa5e12aa9b68f620cbe2e5e329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->