### PR TITLE
refactor: route child loop status through child streams

### DIFF
--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -158,6 +158,25 @@ export class ExecutionRegistry {
     this.track(handle);
   }
 
+  /**
+   * Publish an in-flight agent status through the registry-owned status store.
+   * Explicit user stops win over loop transitions, and stale handles cannot
+   * revive an execution that has already been untracked.
+   */
+  updateAgentExecutionStatus(
+    handle: AgentExecutionHandle,
+    status: StreamStatus,
+  ): boolean {
+    if (this.handles.get(handle.executionId) !== handle) return false;
+    if (this.streamStatus.get(handle.childStreamId) === STREAM_STATUS.STOPPED) {
+      return false;
+    }
+    this.streamStatus.set(handle.childStreamId, status, {
+      runtimeHost: handle.runtimeHost,
+    });
+    return true;
+  }
+
   /** Remove an execution handle and notify waiters. */
   untrack(executionId: string): void {
     const handle = this.handles.get(executionId);
@@ -207,7 +226,14 @@ export class ExecutionRegistry {
     options: FinishAgentExecutionOptions,
   ): void {
     const currentStatus = this.streamStatus.get(handle.childStreamId);
-    if (currentStatus !== STREAM_STATUS.STOPPED) {
+    const shouldUpdateStatus =
+      currentStatus !== STREAM_STATUS.STOPPED &&
+      currentStatus !== options.status;
+
+    // READY clears the status store. Do it after untracking so the status
+    // listener cannot summarize the still-tracked child via the RUNNING
+    // fallback before the removal update.
+    if (options.status !== STREAM_STATUS.READY && shouldUpdateStatus) {
       this.streamStatus.set(handle.childStreamId, options.status, {
         runtimeHost: handle.runtimeHost,
       });
@@ -217,6 +243,12 @@ export class ExecutionRegistry {
       this.untrackHandle(handle);
     } else {
       this.notifyWaiters(handle.executionId);
+    }
+
+    if (options.status === STREAM_STATUS.READY && shouldUpdateStatus) {
+      this.streamStatus.set(handle.childStreamId, options.status, {
+        runtimeHost: handle.runtimeHost,
+      });
     }
   }
 

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -247,6 +247,47 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('updates live agent status without reviving stopped or stale handles', () => {
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const parentStreamId = 'parent-update-agent-status-test' as StreamTabId;
+    const childStreamId = 'child-update-agent-status-test' as StreamTabId;
+    const executionId = 'exec-update-agent-status-test';
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+      explicit.host,
+    );
+
+    try {
+      registry.trackAgentExecution(handle, { status: STREAM_STATUS.RUNNING });
+
+      expect(
+        registry.updateAgentExecutionStatus(handle, STREAM_STATUS.WAITING),
+      ).toBe(true);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.WAITING);
+
+      streamStatus.set(childStreamId, STREAM_STATUS.STOPPED, { emit: false });
+      expect(
+        registry.updateAgentExecutionStatus(handle, STREAM_STATUS.RUNNING),
+      ).toBe(false);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+
+      registry.untrack(executionId);
+      streamStatus.set(childStreamId, STREAM_STATUS.WAITING, { emit: false });
+      expect(
+        registry.updateAgentExecutionStatus(handle, STREAM_STATUS.RUNNING),
+      ).toBe(false);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.WAITING);
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('finishes agent executions without overwriting explicit stops', () => {
     const explicit = createRecordingHost();
     const streamStatus = new StreamStatusRegistry();

--- a/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
@@ -1,9 +1,10 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   STREAM_STATUS,
   type ExecutionId,
@@ -15,6 +16,10 @@ import { createRecordingHost } from '../progressTestUtils';
 const executionId = 'exec:child-stream' as ExecutionId;
 const parentStreamId = 'stream:parent' as StreamTabId;
 const childStreamId = 'bash#exec:child-stream' as StreamTabId;
+const loopExecutionId = 'exec:child-stream-loop' as ExecutionId;
+const loopChildStreamId = 'codex#exec:child-stream-loop' as StreamTabId;
+const stoppedExecutionId = 'exec:child-stream-stopped' as ExecutionId;
+const stoppedChildStreamId = 'codex#exec:child-stream-stopped' as StreamTabId;
 const config = {
   agentCategory: AgentCategory.ToolUse,
   model: 'test-model',
@@ -22,6 +27,16 @@ const config = {
 } as unknown as AgentConfig;
 
 describe('child stream progress events', () => {
+  afterEach(() => {
+    for (const streamId of [
+      childStreamId,
+      loopChildStreamId,
+      stoppedChildStreamId,
+    ]) {
+      StreamStatusService.clear(streamId, { emit: false });
+    }
+  });
+
   it('publishes child stream lifecycle events through the explicit runtime host', () => {
     const active = createRecordingHost();
 
@@ -47,9 +62,8 @@ describe('child stream progress events', () => {
       'updateStreamStatus',
       'updateActiveSubagents',
       'setParentStream',
+      'updateActiveSubagents',
       'updateStreamStatus',
-      'updateActiveSubagents',
-      'updateActiveSubagents',
       'removeStream',
     ]);
     // Background child streams register without yanking the active tab —
@@ -94,6 +108,10 @@ describe('child stream progress events', () => {
       ],
     });
     expect(events[6]).toEqual({
+      event: 'updateActiveSubagents',
+      payload: { parentStreamId, children: [] },
+    });
+    expect(events[7]).toEqual({
       event: 'updateStreamStatus',
       payload: {
         streamId: childStreamId,
@@ -102,12 +120,77 @@ describe('child stream progress events', () => {
       },
     });
     expect(events[8]).toEqual({
-      event: 'updateActiveSubagents',
-      payload: { parentStreamId, children: [] },
-    });
-    expect(events[9]).toEqual({
       event: 'removeStream',
       payload: { streamId: childStreamId },
     });
+  });
+
+  it('publishes child loop status changes through the child stream owner', () => {
+    const active = createRecordingHost();
+
+    const childStream = createChildStream(loopExecutionId, parentStreamId, {
+      runtimeHost: active.host,
+      streamPrefix: 'codex',
+      streamCategory: AgentCategory.ToolUse,
+      agentName: 'codex',
+      description: 'Run a long-lived Codex child loop',
+      config,
+      toolName: 'codex',
+    });
+    active.events.splice(0);
+
+    childStream.waitForInput();
+    childStream.beginTurn();
+    childStream.failTurn();
+    childStream.finalize({ status: STREAM_STATUS.ERROR });
+
+    const statusEvents = active.events.filter(
+      (entry) => entry.event === 'updateStreamStatus',
+    );
+    const statuses = statusEvents.map(
+      (entry) => (entry.payload as { status: string }).status,
+    );
+    expect(statuses).toEqual([
+      STREAM_STATUS.WAITING,
+      STREAM_STATUS.RUNNING,
+      STREAM_STATUS.ERROR,
+    ]);
+    expect(StreamStatusService.get(loopChildStreamId)).toBe(
+      STREAM_STATUS.ERROR,
+    );
+    expect(active.events.at(-1)).toEqual({
+      event: 'updateActiveSubagents',
+      payload: { parentStreamId, children: [] },
+    });
+  });
+
+  it('preserves explicit user stops during child loop status changes', () => {
+    const active = createRecordingHost();
+
+    const childStream = createChildStream(stoppedExecutionId, parentStreamId, {
+      runtimeHost: active.host,
+      streamPrefix: 'codex',
+      streamCategory: AgentCategory.ToolUse,
+      agentName: 'codex',
+      description: 'Run a stopped Codex child loop',
+      config,
+      toolName: 'codex',
+    });
+    StreamStatusService.set(stoppedChildStreamId, STREAM_STATUS.STOPPED, {
+      emit: false,
+    });
+    active.events.splice(0);
+
+    childStream.waitForInput();
+    childStream.beginTurn();
+    childStream.failTurn();
+    childStream.finalize({ status: STREAM_STATUS.ERROR });
+
+    expect(StreamStatusService.get(stoppedChildStreamId)).toBe(
+      STREAM_STATUS.STOPPED,
+    );
+    expect(
+      active.events.filter((entry) => entry.event === 'updateStreamStatus'),
+    ).toHaveLength(0);
   });
 });

--- a/src/test-kernel/tools/CodexLoopStatus.vitest.ts
+++ b/src/test-kernel/tools/CodexLoopStatus.vitest.ts
@@ -1,94 +1,10 @@
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
-
-// Local imports - agent runtime
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-
-// Local imports - schemas
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { describe, expect, it } from 'vitest';
 
 // Local imports - tools
-import {
-  agentCliLoopTerminalStatus,
-  markAgentCliLoopError,
-} from '@tools/agentCliShared';
-import { finalizeCodexLoopStatus } from '@tools/codex';
+import { agentCliLoopTerminalStatus } from '@tools/agentCliShared';
 
-const streamIds = [
-  'stream:codex-loop-running',
-  'stream:codex-loop-waiting',
-  'stream:codex-loop-stopped',
-  'stream:codex-loop-error',
-] as const satisfies readonly StreamTabId[];
-
-const runtimeHost = { emit: () => {} } satisfies AgentRuntimeHost;
-
-function effectiveStatus(streamId: StreamTabId): string {
-  return StreamStatusService.get(streamId) ?? STREAM_STATUS.READY;
-}
-
-describe('finalizeCodexLoopStatus', () => {
-  afterEach(() => {
-    for (const streamId of streamIds) {
-      StreamStatusService.clear(streamId, { emit: false });
-    }
-  });
-
-  it('clears RUNNING when the Codex loop exits during an interrupted turn', () => {
-    const streamId = streamIds[0];
-    StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
-
-    finalizeCodexLoopStatus(streamId, runtimeHost);
-
-    expect(effectiveStatus(streamId)).toBe(STREAM_STATUS.READY);
-  });
-
-  it('clears WAITING when the Codex loop exits between turns', () => {
-    const streamId = streamIds[1];
-    StreamStatusService.set(streamId, STREAM_STATUS.WAITING, { emit: false });
-
-    finalizeCodexLoopStatus(streamId, runtimeHost);
-
-    expect(effectiveStatus(streamId)).toBe(STREAM_STATUS.READY);
-  });
-
-  it('preserves terminal statuses set by other runtime paths', () => {
-    const streamId = streamIds[2];
-    StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, { emit: false });
-
-    finalizeCodexLoopStatus(streamId, runtimeHost);
-
-    expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
-  });
-
-  it('preserves error statuses set by failed turns', () => {
-    const streamId = streamIds[3];
-    StreamStatusService.set(streamId, STREAM_STATUS.ERROR, { emit: false });
-
-    finalizeCodexLoopStatus(streamId, runtimeHost);
-
-    expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.ERROR);
-  });
-
-  it('marks loop-owned child streams as errored after a failed turn', () => {
-    const streamId = streamIds[0];
-    StreamStatusService.set(streamId, STREAM_STATUS.WAITING, { emit: false });
-
-    markAgentCliLoopError(streamId, runtimeHost);
-
-    expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.ERROR);
-  });
-
-  it('does not overwrite explicit user stops with failed-turn errors', () => {
-    const streamId = streamIds[2];
-    StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, { emit: false });
-
-    markAgentCliLoopError(streamId, runtimeHost);
-
-    expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
-  });
-
+describe('agent CLI loop status', () => {
   it('maps loop failure state to persisted terminal status', () => {
     expect(
       agentCliLoopTerminalStatus({

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -2,15 +2,7 @@
 // Host-agnostic, VS Code-free.
 
 import { type AgentTrace } from '@agent/trace';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import {
-  EXECUTION_STATUS,
-  type ExecutionStatus,
-  type StreamStatus,
-  STREAM_STATUS,
-  type StreamTabId,
-} from '@shared/schemas';
+import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import { formatDuration } from '@utils/core';
 
 /** True for an AbortController-style cancellation error. */
@@ -30,11 +22,6 @@ export function isCleanInterruption(
   return signal.aborted || session.isInterrupted() || isAbortError(err);
 }
 
-/** Transient statuses owned by a running agent loop. */
-export function isLoopOwnedStatus(status: StreamStatus | undefined): boolean {
-  return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.RUNNING;
-}
-
 export function agentCliLoopTerminalStatus(state: {
   readonly interrupted: boolean;
   readonly sawTurnFailure: boolean;
@@ -43,28 +30,6 @@ export function agentCliLoopTerminalStatus(state: {
   return state.interrupted
     ? EXECUTION_STATUS.INTERRUPTED
     : EXECUTION_STATUS.COMPLETED;
-}
-
-export function markAgentCliLoopError(
-  childStreamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  if (StreamStatusService.get(childStreamId) !== STREAM_STATUS.STOPPED) {
-    StreamStatusService.set(childStreamId, STREAM_STATUS.ERROR, {
-      runtimeHost,
-    });
-  }
-}
-
-export function finalizeAgentCliLoopStatus(
-  childStreamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  if (isLoopOwnedStatus(StreamStatusService.get(childStreamId))) {
-    StreamStatusService.set(childStreamId, STREAM_STATUS.READY, {
-      runtimeHost,
-    });
-  }
 }
 
 /** Log a turn summary (duration + token usage) to the child stream. */

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -40,18 +40,24 @@ interface FinalizeChildStreamOptions {
   } | null;
   error?: unknown;
   errorMessage?: string;
+  status?: ChildStreamTerminalStatus;
   /** Remove the child stream tab from the progress view once finalized. */
   autoClose?: boolean;
 }
 
+type ChildStreamTerminalStatus =
+  | typeof STREAM_STATUS.READY
+  | typeof STREAM_STATUS.ERROR;
+
 export interface ChildStream {
   childStreamId: StreamTabId;
   logger: AgentTrace;
-  /**
-   * Drop the run-trace subscribers attached by `createRunTrace`. Must be
-   * called once when a custom child-loop cleanup path does not use `finalize`.
-   */
-  disposeTrace: () => void;
+  /** The child loop is idle and waiting for the next follow-up instruction. */
+  waitForInput: () => void;
+  /** The child loop has started processing a turn. */
+  beginTurn: () => void;
+  /** The active turn failed; preserve explicit user stops. */
+  failTurn: () => void;
   /** Complete the child stream lifecycle through the owning execution handle. */
   finalize: (options?: FinalizeChildStreamOptions) => void;
 }
@@ -100,7 +106,23 @@ export function createChildStream(
   return {
     childStreamId,
     logger: runTrace.trace,
-    disposeTrace: runTrace.dispose,
+    // Mid-run status updates are intentionally best-effort. Explicit stops and
+    // stale handles are ignored by the registry; finalize owns terminal status.
+    waitForInput: () => {
+      executionRegistry.updateAgentExecutionStatus(
+        handle,
+        STREAM_STATUS.WAITING,
+      );
+    },
+    beginTurn: () => {
+      executionRegistry.updateAgentExecutionStatus(
+        handle,
+        STREAM_STATUS.RUNNING,
+      );
+    },
+    failTurn: () => {
+      executionRegistry.updateAgentExecutionStatus(handle, STREAM_STATUS.ERROR);
+    },
     finalize: (finalizeOptions) => {
       finalizeChildStream({
         handle,
@@ -139,7 +161,8 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   }
 
   executionRegistry.finishAgentExecution(handle, {
-    status: hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+    status:
+      options?.status ?? (hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY),
   });
   disposeTrace();
 

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -38,8 +38,6 @@ import {
 } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
 import {
   interruptRegistry,
@@ -72,14 +70,12 @@ import {
   importClaudeAgentSdk,
   findClaudeBinaryPath,
 } from './claudeAgentImport';
-import { createChildStream } from './childStream';
+import { createChildStream, type ChildStream } from './childStream';
 import { AgentCliSessionRegistry } from './agentCliSessionRegistry';
 import {
   agentCliLoopTerminalStatus,
-  finalizeAgentCliLoopStatus,
   isCleanInterruption,
   logTurnSummary,
-  markAgentCliLoopError,
 } from './agentCliShared';
 import {
   buildClaudeToolUseLog,
@@ -463,11 +459,9 @@ function extractToolErrorMessage(content: unknown): string | undefined {
 // ============================================================================
 
 function startClaudeAgentLoop(params: {
-  childStreamId: StreamTabId;
+  childStream: ChildStream;
   parentStreamId: StreamTabId;
   executionId: ExecutionId;
-  logger: AgentTrace;
-  disposeTrace: () => void;
   initialPrompt: string;
   model: string;
   permissionMode: ClaudeAgentPermissionMode;
@@ -479,14 +473,13 @@ function startClaudeAgentLoop(params: {
   runtimeHost: AgentRuntimeHost;
 }): void {
   const {
-    childStreamId,
+    childStream,
     parentStreamId,
     executionId,
-    logger,
-    disposeTrace,
     initialPrompt,
     runtimeHost,
   } = params;
+  const { childStreamId, logger } = childStream;
 
   const session = new ClaudeAgentSession();
   const queue = ToolUseFollowUpQueue.acquire(childStreamId);
@@ -498,9 +491,7 @@ function startClaudeAgentLoop(params: {
   const sessionStage = logger.openStage('Claude Code session');
 
   queue.enqueue(initialPrompt);
-  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
-    runtimeHost,
-  });
+  childStream.waitForInput();
 
   let resumeSessionId: string | undefined;
   const storedSessionIds = new Set<string>();
@@ -515,9 +506,7 @@ function startClaudeAgentLoop(params: {
         if (!messages || session.isInterrupted()) break;
 
         const prompt = messages.items.join('\n\n');
-        StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING, {
-          runtimeHost,
-        });
+        childStream.beginTurn();
         const startedAt = Date.now();
         const ac = session.startTurn();
 
@@ -597,14 +586,12 @@ function startClaudeAgentLoop(params: {
 
         if (turnFailed) {
           sawTurnFailure = true;
-          markAgentCliLoopError(childStreamId, runtimeHost);
+          childStream.failTurn();
           break;
         }
 
         if (!session.isInterrupted()) {
-          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
-            runtimeHost,
-          });
+          childStream.waitForInput();
         }
       }
     } finally {
@@ -619,9 +606,9 @@ function startClaudeAgentLoop(params: {
           sawTurnFailure,
         }),
       ).catch(() => {});
-      executionRegistry.untrack(executionId);
-      finalizeAgentCliLoopStatus(childStreamId, runtimeHost);
-      disposeTrace();
+      childStream.finalize({
+        status: sawTurnFailure ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+      });
     }
   })();
 }
@@ -719,26 +706,20 @@ async function launchClaudeAgentSession(
     throw new ToolError('Failed to register Claude Code CLI execution.');
   }
 
-  const { childStreamId, logger, disposeTrace } = createChildStream(
-    executionId,
-    parentStreamId,
-    {
-      streamPrefix: 'claude@agent-sdk',
-      streamCategory: AgentCategory.ToolUse,
-      agentName: CLAUDE_AGENT_NAME,
-      description: input.prompt,
-      config: agentConfig,
-      toolName: CLAUDE_AGENT_NAME,
-      runtimeHost,
-    },
-  );
+  const childStream = createChildStream(executionId, parentStreamId, {
+    streamPrefix: 'claude@agent-sdk',
+    streamCategory: AgentCategory.ToolUse,
+    agentName: CLAUDE_AGENT_NAME,
+    description: input.prompt,
+    config: agentConfig,
+    toolName: CLAUDE_AGENT_NAME,
+    runtimeHost,
+  });
 
   startClaudeAgentLoop({
-    childStreamId,
+    childStream,
     parentStreamId,
     executionId,
-    logger,
-    disposeTrace,
     initialPrompt: input.prompt,
     model,
     permissionMode,
@@ -750,6 +731,7 @@ async function launchClaudeAgentSession(
     runtimeHost,
   });
 
+  const { childStreamId } = childStream;
   const preview = truncateWithEllipsis(input.prompt, 60);
   return {
     summary: `Launched Claude Code CLI: ${preview}`,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -35,8 +35,6 @@ import {
 } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
 import {
   interruptRegistry,
@@ -68,14 +66,12 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 // Local file imports
 import { defineTool } from './core/define';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
-import { createChildStream } from './childStream';
+import { createChildStream, type ChildStream } from './childStream';
 import { AgentCliSessionRegistry } from './agentCliSessionRegistry';
 import {
   agentCliLoopTerminalStatus,
-  finalizeAgentCliLoopStatus,
   isCleanInterruption,
   logTurnSummary,
-  markAgentCliLoopError,
 } from './agentCliShared';
 import {
   buildCodexCommandToolLog,
@@ -206,18 +202,6 @@ class CodexFollowUpSession implements IInterruptible {
   finishTurn(): void {
     this.turnAbortController = null;
   }
-}
-
-/**
- * Clear the transient status owned by a Codex loop after the loop exits.
- * Explicit terminal statuses set by other runtime paths, such as STOPPED or
- * ERROR, are left intact.
- */
-export function finalizeCodexLoopStatus(
-  childStreamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  finalizeAgentCliLoopStatus(childStreamId, runtimeHost);
 }
 
 // ============================================================================
@@ -484,24 +468,21 @@ export async function runStreamedTurn(
  */
 function startCodexLoop(params: {
   thread: Thread;
-  childStreamId: StreamTabId;
+  childStream: ChildStream;
   parentStreamId: StreamTabId;
   executionId: ExecutionId;
-  logger: AgentTrace;
-  disposeTrace: () => void;
   initialPrompt: string;
   runtimeHost: AgentRuntimeHost;
 }): void {
   const {
     thread,
-    childStreamId,
+    childStream,
     parentStreamId,
     executionId,
-    logger,
-    disposeTrace,
     initialPrompt,
     runtimeHost,
   } = params;
+  const { childStreamId, logger } = childStream;
 
   const session = new CodexFollowUpSession();
   const queue = ToolUseFollowUpQueue.acquire(childStreamId);
@@ -529,9 +510,7 @@ function startCodexLoop(params: {
 
   // Seed the initial prompt; the loop drains it as the first turn.
   queue.enqueue(initialPrompt);
-  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
-    runtimeHost,
-  });
+  childStream.waitForInput();
 
   let sawTurnFailure = false;
   void (async () => {
@@ -543,9 +522,7 @@ function startCodexLoop(params: {
         if (!messages || session.isInterrupted()) break;
 
         const prompt = messages.items.join('\n\n');
-        StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING, {
-          runtimeHost,
-        });
+        childStream.beginTurn();
         const startedAt = Date.now();
         const signal = session.startTurn();
 
@@ -609,14 +586,12 @@ function startCodexLoop(params: {
 
         if (turnFailed) {
           sawTurnFailure = true;
-          markAgentCliLoopError(childStreamId, runtimeHost);
+          childStream.failTurn();
           break;
         }
 
         if (!session.isInterrupted()) {
-          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING, {
-            runtimeHost,
-          });
+          childStream.waitForInput();
         }
       }
     } finally {
@@ -625,8 +600,8 @@ function startCodexLoop(params: {
       ToolUseFollowUpQueue.release(childStreamId);
       const threadId = thread.id;
       if (threadId) codexThreads.release(threadId);
-      // Persist terminal status before untracking — executionRegistry.untrack fires
-      // notifyWaiters, so consumers must see the final status on disk.
+      // Persist terminal status before childStream.finalize() untracks and
+      // notifies waiters.
       await writeTerminalStatus(
         executionId,
         agentCliLoopTerminalStatus({
@@ -634,10 +609,10 @@ function startCodexLoop(params: {
           sawTurnFailure,
         }),
       ).catch(() => {});
-      executionRegistry.untrack(executionId);
 
-      finalizeCodexLoopStatus(childStreamId, runtimeHost);
-      disposeTrace();
+      childStream.finalize({
+        status: sawTurnFailure ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+      });
     }
   })();
 }
@@ -756,31 +731,26 @@ async function launchCodexSession(
     throw new ToolError('Failed to register Codex execution.');
   }
 
-  const { childStreamId, logger, disposeTrace } = createChildStream(
-    executionId,
-    parentStreamId,
-    {
-      streamPrefix: 'codex@codex-sdk',
-      streamCategory: AgentCategory.ToolUse,
-      agentName: 'codex',
-      description: input.prompt,
-      config,
-      toolName: 'codex',
-      runtimeHost,
-    },
-  );
+  const childStream = createChildStream(executionId, parentStreamId, {
+    streamPrefix: 'codex@codex-sdk',
+    streamCategory: AgentCategory.ToolUse,
+    agentName: 'codex',
+    description: input.prompt,
+    config,
+    toolName: 'codex',
+    runtimeHost,
+  });
 
   startCodexLoop({
     thread,
-    childStreamId,
+    childStream,
     parentStreamId,
     executionId,
-    logger,
-    disposeTrace,
     initialPrompt: input.prompt,
     runtimeHost,
   });
 
+  const { childStreamId } = childStream;
   const preview = truncateWithEllipsis(input.prompt, 60);
   return {
     summary: `Launched Codex: ${preview}`,


### PR DESCRIPTION
## Summary

Closes #5589.

This continues the Step 7 ownership cleanup by moving Codex/Claude child-loop stream status transitions behind the `ChildStream` owner boundary.

Changes:
- add `ExecutionRegistry.updateAgentExecutionStatus(handle, status)` for live handle-owned mid-run updates;
- expose semantic `ChildStream` lifecycle methods: `waitForInput()`, `beginTurn()`, `failTurn()`, and `finalize()`;
- remove direct `StreamStatusService` mutation helpers from `agentCliShared`;
- make Codex and Claude Code loops pass the `ChildStream` object instead of re-passing stream IDs, loggers, disposers, and status helpers;
- keep terminal execution-status persistence before `ChildStream.finalize()` untracks and notifies waiters.

Design notes:
- `childStream` is the only status owner touched by these tool loops now.
- `agentCliShared` is back to pure utility behavior; it no longer imports the status singleton.
- The new registry API rejects stale handles and preserves explicit user stops, so loop transitions cannot revive stopped/untracked children.
- This removes pass-through lifecycle cleanup (`disposeTrace`, helper-based finalization, manual loop untrack) rather than adding another resolver layer.

## Validation

- `corepack pnpm install`
- `npm run format -- src/agent/runtime/executionRegistry.ts src/tools/childStream.ts src/tools/agentCliShared.ts src/tools/codex.ts src/tools/claudeAgent.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts src/test-kernel/tools/CodexLoopStatus.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts src/test-kernel/tools/CodexLoopStatus.vitest.ts`
- `npx eslint src/agent/runtime/executionRegistry.ts src/tools/childStream.ts src/tools/agentCliShared.ts src/tools/codex.ts src/tools/claudeAgent.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts src/test-kernel/tools/CodexLoopStatus.vitest.ts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution/stream status ordering and stop semantics for long-lived Codex/Claude child tabs; regressions could show stale badges or overwrite user stops.
> 
> **Overview**
> Routes **Codex** and **Claude Code** child-loop stream status through **`ChildStream`** and **`ExecutionRegistry`** instead of tools calling **`StreamStatusService`** directly.
> 
> **`ExecutionRegistry`** gains **`updateAgentExecutionStatus`** for in-flight updates (rejects stale handles and won't overwrite **`STOPPED`**). **`finishAgentExecution`** now untracks before publishing **`READY`** so status listeners don't briefly see a tracked child as still **`RUNNING`**.
> 
> **`ChildStream`** exposes **`waitForInput`**, **`beginTurn`**, **`failTurn`**, and **`finalize`** (optional terminal **`status`**); loops pass a single **`ChildStream`** rather than IDs, loggers, and manual untrack/dispose. **`agentCliShared`** drops loop finalization/error helpers; tests move loop status behavior to registry and child-stream progress specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54c048f3b7f288307db65c6cbb46eefe2a955fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->