### PR TITLE
refactor: route follow-up admission through execution registry

### DIFF
--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -14,6 +14,7 @@ import {
   interruptRegistry,
   type InterruptRegistry,
 } from '@agent/runtime/InterruptRegistry';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import {
   STREAM_STATUS,
   LIVE_ELAPSED_STREAM_STATUSES,
@@ -56,6 +57,25 @@ export interface TrackAgentExecutionOptions {
 export interface FinishAgentExecutionOptions {
   readonly status: StreamStatus;
 }
+
+export type ToolUseFollowUpQueueReason =
+  | 'resuming'
+  | 'waiting'
+  | 'children_running';
+
+export type ToolUseFollowUpTarget =
+  | {
+      readonly kind: 'active';
+      readonly context: LiveToolUseFlowContext;
+    }
+  | {
+      readonly kind: 'queue';
+      readonly reason: ToolUseFollowUpQueueReason;
+    }
+  | {
+      readonly kind: 'no_session';
+      readonly streamStatus: StreamStatus | undefined;
+    };
 
 /**
  * Process-wide owner for active executions and their change listeners.
@@ -297,6 +317,36 @@ export class ExecutionRegistry {
     streamId: StreamTabId,
   ): LiveToolUseFlowContext | undefined {
     return this.getAgentHandleByStream(streamId)?.getToolUseFlow();
+  }
+
+  /**
+   * Decide how a tool-use follow-up should be admitted from one registry-owned
+   * snapshot of stream status, active flow context, and child executions.
+   */
+  getToolUseFollowUpTarget(streamId: StreamTabId): ToolUseFollowUpTarget {
+    const status = this.streamStatus.get(streamId);
+    const hasActiveChildren = this.hasActiveChildren(streamId);
+
+    if (status !== undefined && !isInFlightStatus(status)) {
+      if (hasActiveChildren) {
+        return { kind: 'queue', reason: 'children_running' };
+      }
+      return { kind: 'no_session', streamStatus: status };
+    }
+
+    const context = this.getToolUseFlowContext(streamId);
+    if (context) return { kind: 'active', context };
+
+    if (status === STREAM_STATUS.RESUMING) {
+      return { kind: 'queue', reason: 'resuming' };
+    }
+    if (status === STREAM_STATUS.WAITING) {
+      return { kind: 'queue', reason: 'waiting' };
+    }
+    if (hasActiveChildren) {
+      return { kind: 'queue', reason: 'children_running' };
+    }
+    return { kind: 'no_session', streamStatus: status };
   }
 
   /** Terminate an execution via its handle. Returns true on success. */
@@ -558,6 +608,13 @@ export class ExecutionRegistry {
       result.push(info);
     }
     return result;
+  }
+
+  private hasActiveChildren(parentStreamId: StreamTabId): boolean {
+    for (const handle of this.handles.values()) {
+      if (isChildExecution(handle, parentStreamId)) return true;
+    }
+    return false;
   }
 
   private terminate(handle: ExecutionHandle): boolean {

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -12,10 +12,8 @@
 
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { isInFlightStatus } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
 
 /**
@@ -73,59 +71,36 @@ export async function sendFollowUp(
   mediaFiles?: readonly string[],
   displayText?: string,
 ): Promise<SendFollowUpResult> {
-  const status = StreamStatusService.get(streamId);
-  const activeChildren = executionRegistry.getActiveChildren(streamId);
-  const hasActiveChildren =
-    activeChildren.subagents.length > 0 || activeChildren.processes.length > 0;
   const queueOptions = { mediaFiles, displayText };
-  if (status !== undefined && !isInFlightStatus(status)) {
-    if (hasActiveChildren) {
-      ToolUseFollowUpQueue.enqueue(streamId, text, {
-        ...queueOptions,
-        force: true,
-      });
-      return { status: 'queued', reason: 'children_running' };
-    }
-    logger.warn(
-      `No active session for follow-up on stream ${streamId}. Status: ${status}`,
-    );
-    return { status: 'no_session', streamStatus: status };
-  }
+  const target = executionRegistry.getToolUseFollowUpTarget(streamId);
 
-  // Try active flow context first
-  const flowContext = executionRegistry.getToolUseFlowContext(streamId);
-  if (flowContext) {
-    flowContext.session.appendFollowUp(text, mediaFiles, displayText);
-    notifyFollowUpSent(streamId, flowContext.runtimeHost);
+  if (target.kind === 'active') {
+    target.context.session.appendFollowUp(text, mediaFiles, displayText);
+    notifyFollowUpSent(streamId, target.context.runtimeHost);
     return { status: 'sent' };
   }
 
-  // Queue if session is resuming
-  if (ToolUseFollowUpQueue.isResuming(streamId)) {
-    ToolUseFollowUpQueue.enqueue(streamId, text, queueOptions);
-    return { status: 'queued', reason: 'resuming' };
-  }
-
-  // Queue if session is waiting (paused, can be resumed)
-  if (status === STREAM_STATUS.WAITING) {
-    ToolUseFollowUpQueue.enqueue(streamId, text, queueOptions);
-    return { status: 'queued', reason: 'waiting' };
-  }
-
-  if (hasActiveChildren) {
-    // force:true reopens a queue sealed by sessionLifecycle disposal — the
-    // caller must auto-resume the parent or re-release, or late child
-    // deliveries will leak into the next run on this stream.
+  if (target.kind === 'queue') {
+    // children_running reopens a queue sealed by session disposal; callers
+    // must auto-resume the parent or release again to avoid stale delivery.
+    const force = target.reason === 'children_running';
     ToolUseFollowUpQueue.enqueue(streamId, text, {
       ...queueOptions,
-      force: true,
+      ...(force ? { force: true } : {}),
     });
-    return { status: 'queued', reason: 'children_running' };
+    return { status: 'queued', reason: target.reason };
+  }
+
+  if (target.streamStatus !== undefined) {
+    logger.warn(
+      `No active session for follow-up on stream ${streamId}. Status: ${target.streamStatus}`,
+    );
+    return { status: 'no_session', streamStatus: target.streamStatus };
   }
 
   // No active/waiting session found - caller should handle UI notification
   logger.warn(
-    `No active session for follow-up on stream ${streamId}. Status: ${status ?? 'undefined'}`,
+    `No active session for follow-up on stream ${streamId}. Status: undefined`,
   );
-  return { status: 'no_session', streamStatus: status };
+  return { status: 'no_session', streamStatus: undefined };
 }

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -5,9 +5,8 @@
  * follow-ups to active/resuming sessions.
  */
 
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { createChannelTrace } from '@logger';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import { FollowUpQueue } from './FollowUpQueue';
 
 const logger = createChannelTrace('ToolUseFollowUpQueue');
@@ -68,14 +67,6 @@ export class ToolUseFollowUpQueue {
         );
       }
     }
-  }
-
-  /**
-   * Check if a stream is currently resuming.
-   * Uses StreamStatusService as the single source of truth.
-   */
-  static isResuming(streamId: StreamTabId): boolean {
-    return StreamStatusService.get(streamId) === STREAM_STATUS.RESUMING;
   }
 
   /**

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -459,6 +459,95 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('owns tool-use follow-up admission from status, context, and children', () => {
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const activeStreamId = 'stream-follow-up-active-test' as StreamTabId;
+    const resumingStreamId = 'stream-follow-up-resuming-test' as StreamTabId;
+    const waitingStreamId = 'stream-follow-up-waiting-test' as StreamTabId;
+    const stoppedStreamId = 'stream-follow-up-stopped-test' as StreamTabId;
+    const parentStreamId = 'stream-follow-up-parent-test' as StreamTabId;
+    const childStreamId = 'stream-follow-up-child-test' as StreamTabId;
+    const context: LiveToolUseFlowContext = {
+      session: {
+        appendFollowUp: vi.fn(),
+      },
+      modelHandler: {
+        supportsManualCompaction: true,
+      },
+      runtimeHost: explicit.host,
+      requestImmediateCompaction: vi.fn(),
+      modelSwitchDisabledReason: vi.fn(),
+      switchModel: vi.fn(),
+    };
+
+    try {
+      const activeHandle = new AgentExecutionHandle(
+        'exec-follow-up-active-test',
+        activeStreamId,
+        activeStreamId,
+        'test-tool-use',
+        'toolUse',
+        explicit.host,
+      );
+      activeHandle.attachToolUseFlow(context);
+      registry.track(activeHandle);
+      streamStatus.set(activeStreamId, STREAM_STATUS.RUNNING, {
+        emit: false,
+      });
+
+      expect(registry.getToolUseFollowUpTarget(activeStreamId)).toEqual({
+        kind: 'active',
+        context,
+      });
+
+      streamStatus.set(resumingStreamId, STREAM_STATUS.RESUMING, {
+        emit: false,
+      });
+      expect(registry.getToolUseFollowUpTarget(resumingStreamId)).toEqual({
+        kind: 'queue',
+        reason: 'resuming',
+      });
+
+      streamStatus.set(waitingStreamId, STREAM_STATUS.WAITING, {
+        emit: false,
+      });
+      expect(registry.getToolUseFollowUpTarget(waitingStreamId)).toEqual({
+        kind: 'queue',
+        reason: 'waiting',
+      });
+
+      streamStatus.set(stoppedStreamId, STREAM_STATUS.STOPPED, {
+        emit: false,
+      });
+      expect(registry.getToolUseFollowUpTarget(stoppedStreamId)).toEqual({
+        kind: 'no_session',
+        streamStatus: STREAM_STATUS.STOPPED,
+      });
+
+      streamStatus.set(parentStreamId, STREAM_STATUS.STOPPED, {
+        emit: false,
+      });
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-follow-up-child-test',
+          parentStreamId,
+          childStreamId,
+          'test-subagent',
+          'toolUse',
+          explicit.host,
+        ),
+      );
+      expect(registry.getToolUseFollowUpTarget(parentStreamId)).toEqual({
+        kind: 'queue',
+        reason: 'children_running',
+      });
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('publishes detach updates through the caller runtime host', () => {
     const explicit = createRecordingHost();
     const registry = new ExecutionRegistry();

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -119,6 +119,31 @@ describe('tool-use follow-up progress events', () => {
     expect(appendFollowUp).not.toHaveBeenCalled();
   });
 
+  it('queues follow-ups for resuming streams through registry admission', async () => {
+    const resumingStreamId = 'stream:resuming-follow-up' as StreamTabId;
+
+    StreamStatusService.set(resumingStreamId, STREAM_STATUS.RESUMING, {
+      emit: false,
+    });
+
+    try {
+      const result = await sendFollowUp(
+        resumingStreamId,
+        'queued while resuming',
+      );
+
+      expect(result).toEqual({
+        status: 'queued',
+        reason: 'resuming',
+      });
+      expect(ToolUseFollowUpQueue.getAll(resumingStreamId)).toEqual([
+        'queued while resuming',
+      ]);
+    } finally {
+      ToolUseFollowUpQueue.release(resumingStreamId);
+    }
+  });
+
   it('keeps terminal parents with active children on the children-running queue path', async () => {
     const parentStreamId = 'stream:terminal-parent' as StreamTabId;
     const childStreamId = 'stream:terminal-parent-child' as StreamTabId;


### PR DESCRIPTION
## Summary

Closes #5591.

This finishes the remaining Step 7 follow-up admission ownership slice:

- moves the follow-up admission decision into `ExecutionRegistry.getToolUseFollowUpTarget()` so stream status, active tool-use context, and child execution state are read from one owner snapshot
- removes direct `StreamStatusService` imports from `ToolUseFollowUp` and `ToolUseFollowUpQueueManager`
- removes `ToolUseFollowUpQueue.isResuming()` so the queue manager owns only queue lifecycle, not stream status
- keeps host/progress/TUI status subscriptions unchanged as UI integration readers

## Design Notes

The PR avoids adding a raw `getStreamStatus()` pass-through. The registry answers the actual domain question: whether a follow-up should append to a live context, be queued with a reason, or return no-session with the terminal/current status.

`ToolUseFollowUp` now performs only the resulting side effect. Queue reopening for `children_running` remains there because it is enqueue policy, not registry state.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts`
- `npx eslint src/agent/runtime/executionRegistry.ts src/agent/toolUse/ToolUseFollowUp.ts src/agent/toolUse/ToolUseFollowUpQueueManager.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent follow-up routing and queue reopen behavior; behavior is intended to be equivalent but admission logic moved to a new registry API with expanded test coverage.
> 
> **Overview**
> **Follow-up admission** for tool-use sessions is now decided in one place: `ExecutionRegistry.getToolUseFollowUpTarget()` returns whether to append to a live session, queue (with `resuming` / `waiting` / `children_running`), or report no session—using a single snapshot of stream status, attached tool-use flow, and active child executions.
> 
> `sendFollowUp` only maps that result to append, enqueue (still applying `force` for `children_running`), or `no_session`. **`ToolUseFollowUpQueueManager`** no longer reads stream status (`isResuming` removed); **`ToolUseFollowUp`** no longer imports `StreamStatusService` or duplicates admission branches.
> 
> Tests cover registry admission matrix and resuming-stream queueing through `sendFollowUp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee46c10bd112f69995d360008a887f1cd3c768c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->