### PR TITLE
refactor: introduce shared clamp() utility to replace scattered Math.max/min patterns

### DIFF
--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -3,13 +3,14 @@
 import { Box, Text, useInput } from 'ink';
 import { useState, useEffect } from 'react';
 
+import { clamp } from '@utils/core';
+
 import {
   matchSlashCommands,
   slashPickIntent,
   type SlashCommand,
   type SlashPickIntent,
 } from './slashRegistry';
-import { clamp } from '@utils/core';
 
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
@@ -34,11 +35,6 @@ export interface SlashPaletteWindow {
   readonly hiddenAfter: number;
 }
 
-function clampHighlight(index: number, itemCount: number): number {
-  if (itemCount <= 0) return 0;
-  return clamp(index, 0, itemCount - 1);
-}
-
 export function nextSlashPaletteHighlight({
   direction,
   highlight,
@@ -49,7 +45,7 @@ export function nextSlashPaletteHighlight({
   readonly itemCount: number;
 }): number {
   if (itemCount <= 0) return 0;
-  const clamped = clampHighlight(highlight, itemCount);
+  const clamped = clamp(highlight, 0, itemCount - 1);
   if (direction === 1) return (clamped + 1) % itemCount;
   return clamped <= 0 ? itemCount - 1 : clamped - 1;
 }
@@ -72,7 +68,7 @@ export function slashPaletteWindow({
     return { start: 0, end: itemCount, hiddenBefore: 0, hiddenAfter: 0 };
   }
 
-  const clamped = clampHighlight(highlight, itemCount);
+  const clamped = clamp(highlight, 0, itemCount - 1);
   if (clamped < visibleAtEdge) {
     return {
       start: 0,
@@ -140,7 +136,7 @@ export function SlashPalette(
       return;
     }
     if (highlight < 0 || highlight >= matchCount) {
-      setHighlight(clampHighlight(highlight, matchCount));
+      setHighlight(clamp(highlight, 0, matchCount - 1));
     }
   }, [matchCount, highlight]);
 

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -9,6 +9,8 @@ import {
   type SlashCommand,
   type SlashPickIntent,
 } from './slashRegistry';
+import { clamp } from '@utils/core';
+
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 
@@ -34,7 +36,7 @@ export interface SlashPaletteWindow {
 
 function clampHighlight(index: number, itemCount: number): number {
   if (itemCount <= 0) return 0;
-  return Math.min(Math.max(index, 0), itemCount - 1);
+  return clamp(index, 0, itemCount - 1);
 }
 
 export function nextSlashPaletteHighlight({

--- a/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
@@ -4,9 +4,8 @@
 
 import { Box, Text, useWindowSize } from 'ink';
 
-import { clamp } from '@utils/core';
-
 import { KeyHints, type KeyHint } from '@cli/chat/tui/ui/KeyHints';
+import { clamp } from '@utils/core';
 
 export interface FormFrameProps {
   readonly color: string;

--- a/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
@@ -4,6 +4,8 @@
 
 import { Box, Text, useWindowSize } from 'ink';
 
+import { clamp } from '@utils/core';
+
 import { KeyHints, type KeyHint } from '@cli/chat/tui/ui/KeyHints';
 
 export interface FormFrameProps {
@@ -24,7 +26,7 @@ export function formFrameWidth(columns: number | undefined): number {
     columns != null && Number.isFinite(columns) && columns > 0
       ? Math.floor(columns)
       : FORM_FRAME_MAX_WIDTH;
-  return Math.max(1, Math.min(normalized, FORM_FRAME_MAX_WIDTH));
+  return clamp(normalized, 1, FORM_FRAME_MAX_WIDTH);
 }
 
 export function FormFrame(props: FormFrameProps): React.JSX.Element {

--- a/packages/cli/src/chat/tui/input/textInputEditing.ts
+++ b/packages/cli/src/chat/tui/input/textInputEditing.ts
@@ -1,3 +1,5 @@
+import { clamp } from '@utils/core';
+
 import {
   isEscapeInput,
   isUnhandledControlInput,
@@ -15,7 +17,7 @@ export interface TextInputChunkEdit extends TextEdit {
 }
 
 export function clampCursor(cursor: number, length: number): number {
-  return Math.max(0, Math.min(cursor, length));
+  return clamp(cursor, 0, length);
 }
 
 /**

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -356,9 +356,7 @@ export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
   }
 
   useEffect(() => {
-    setScrollOffset((current) =>
-      clamp(current, 0, maxScrollOffset),
-    );
+    setScrollOffset((current) => clamp(current, 0, maxScrollOffset));
   }, [maxScrollOffset]);
 
   useInput(

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -6,6 +6,7 @@ import {
   getProposalFileGroups,
   type AgentProposalPermission,
 } from '@shared/schemas';
+import { clamp } from '@utils/core';
 
 import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -350,13 +351,13 @@ export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
   function scrollTo(next: number | ((currentOffset: number) => number)): void {
     setScrollOffset((current) => {
       const requested = typeof next === 'function' ? next(current) : next;
-      return Math.max(0, Math.min(maxScrollOffset, requested));
+      return clamp(requested, 0, maxScrollOffset);
     });
   }
 
   useEffect(() => {
     setScrollOffset((current) =>
-      Math.max(0, Math.min(maxScrollOffset, current)),
+      clamp(current, 0, maxScrollOffset),
     );
   }, [maxScrollOffset]);
 

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -160,12 +160,10 @@ export function boundedBashCommandDisplayLines({
 
   if (maxDisplayLines <= COMPACT_BASH_COMMAND_ROWS) {
     const contentRows = Math.max(1, maxDisplayLines - 1);
-    const offset = Math.max(
+    const offset = clamp(
+      scrollOffset,
       0,
-      Math.min(
-        scrollOffset,
-        maxBashCommandScrollOffset(lines.length, maxDisplayLines),
-      ),
+      maxBashCommandScrollOffset(lines.length, maxDisplayLines),
     );
 
     if (maxDisplayLines === 1) {

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -267,9 +267,7 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
   }
 
   useEffect(() => {
-    setScrollOffset((current) =>
-      clamp(current, 0, maxScrollOffset),
-    );
+    setScrollOffset((current) => clamp(current, 0, maxScrollOffset));
   }, [maxScrollOffset]);
 
   useInput(

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput, useWindowSize } from 'ink';
 
 import type { BashPermission } from '@shared/schemas';
+import { clamp } from '@utils/core';
 
 import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -59,7 +60,7 @@ export function bashApprovalCommandRowsBudget({
     availableRows -
     BASH_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE -
     titleRows;
-  return Math.max(1, Math.min(COMPACT_BASH_COMMAND_ROWS, compactRows));
+  return clamp(compactRows, 1, COMPACT_BASH_COMMAND_ROWS);
 }
 
 export function bashCommandDisplayLines({
@@ -261,13 +262,13 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
   function scrollTo(next: number | ((currentOffset: number) => number)): void {
     setScrollOffset((current) => {
       const requested = typeof next === 'function' ? next(current) : next;
-      return Math.max(0, Math.min(maxScrollOffset, requested));
+      return clamp(requested, 0, maxScrollOffset);
     });
   }
 
   useEffect(() => {
     setScrollOffset((current) =>
-      Math.max(0, Math.min(maxScrollOffset, current)),
+      clamp(current, 0, maxScrollOffset),
     );
   }, [maxScrollOffset]);
 

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -151,9 +151,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   }
 
   useEffect(() => {
-    setScrollOffset((current) =>
-      clamp(current, 0, maxScrollOffset),
-    );
+    setScrollOffset((current) => clamp(current, 0, maxScrollOffset));
   }, [maxScrollOffset]);
 
   useInput(

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput, useWindowSize } from 'ink';
 
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
+import { clamp } from '@utils/core';
 
 import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import {
@@ -75,7 +76,7 @@ export function editApprovalDiffRowsBudget({
     EDIT_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE -
     titleRows -
     feedbackRows;
-  return Math.max(1, Math.min(COMPACT_DIFF_DISPLAY_LINES, compactDiffRows));
+  return clamp(compactDiffRows, 1, COMPACT_DIFF_DISPLAY_LINES);
 }
 
 export function editApprovalFeedbackRows({
@@ -145,13 +146,13 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   function scrollTo(next: number | ((currentOffset: number) => number)): void {
     setScrollOffset((current) => {
       const requested = typeof next === 'function' ? next(current) : next;
-      return Math.max(0, Math.min(maxScrollOffset, requested));
+      return clamp(requested, 0, maxScrollOffset);
     });
   }
 
   useEffect(() => {
     setScrollOffset((current) =>
-      Math.max(0, Math.min(maxScrollOffset, current)),
+      clamp(current, 0, maxScrollOffset),
     );
   }, [maxScrollOffset]);
 

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -300,9 +300,7 @@ export function ExternalInquiry(
   }
 
   useEffect(() => {
-    setQuestionOffset((current) =>
-      clamp(current, 0, maxQuestionOffset),
-    );
+    setQuestionOffset((current) => clamp(current, 0, maxQuestionOffset));
   }, [maxQuestionOffset]);
 
   useInput((input, key) => {

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput, useWindowSize } from 'ink';
 
 import { writeClipboardText } from '@cli/runtime/clipboardText';
 import type { ExternalInquiryPermission } from '@shared/schemas';
+import { clamp } from '@utils/core';
 
 import { CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import { BaseTextInput } from '../input/BaseTextInput';
@@ -284,7 +285,7 @@ export function ExternalInquiry(
   ): void {
     setQuestionOffset((current) => {
       const requested = typeof next === 'function' ? next(current) : next;
-      return Math.max(0, Math.min(maxQuestionOffset, requested));
+      return clamp(requested, 0, maxQuestionOffset);
     });
   }
 
@@ -300,7 +301,7 @@ export function ExternalInquiry(
 
   useEffect(() => {
     setQuestionOffset((current) =>
-      Math.max(0, Math.min(maxQuestionOffset, current)),
+      clamp(current, 0, maxQuestionOffset),
     );
   }, [maxQuestionOffset]);
 

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -7,7 +7,7 @@ import {
   type ActiveChildInfo,
   type StreamTabId,
 } from '@shared/schemas';
-import { formatDuration } from '@utils/core';
+import { clamp, formatDuration } from '@utils/core';
 
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
@@ -437,7 +437,7 @@ export function numericFocusTargetForActiveStream(init: {
 
 export function clampPickerIndex(index: number, length: number): number {
   if (length <= 0) return 0;
-  return Math.min(Math.max(index, 0), length - 1);
+  return clamp(index, 0, length - 1);
 }
 
 export function nextPickerIndex(

--- a/packages/cli/src/chat/tui/state/transcriptScroll.ts
+++ b/packages/cli/src/chat/tui/state/transcriptScroll.ts
@@ -1,3 +1,5 @@
+import { clamp } from '@utils/core';
+
 export interface TranscriptScrollWindow {
   readonly lineCount: number;
   readonly viewRows: number;
@@ -19,7 +21,7 @@ function clampTranscriptScrollOffset(
   offset: number,
   window: TranscriptScrollWindow,
 ): number {
-  return Math.max(0, Math.min(maxTranscriptScrollOffset(window), offset));
+  return clamp(offset, 0, maxTranscriptScrollOffset(window));
 }
 
 export function initialTranscriptScrollState(

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -11,6 +11,8 @@
 import { Box, Text, useInput } from 'ink';
 import { useEffect, useState } from 'react';
 
+import { clamp } from '@utils/core';
+
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 
 export const SELECT_LABEL_MAX_COLS = 24;
@@ -36,7 +38,7 @@ export interface SelectProps<T> {
 
 function clampIndex(index: number, length: number): number {
   if (length <= 0) return 0;
-  return Math.min(Math.max(index, 0), length - 1);
+  return clamp(index, 0, length - 1);
 }
 
 function firstEnabledSelectIndex<T>(

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -10,6 +10,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
 import type { TokenUsageStats } from '@shared/schemas';
+import { clamp } from '@utils/core';
 
 // Local imports - progress view
 import { formatTokens } from '../formatters/timestampUtils';
@@ -234,7 +235,7 @@ export class UsagePanel extends LitElement {
     if (!this.contextState) return nothing;
     const { inputTokens, contextWindow, utilizationPercent } =
       this.contextState;
-    const clamped = Math.min(100, Math.max(0, utilizationPercent));
+    const clamped = clamp(utilizationPercent, 0, 100);
 
     return html`
       <span class="context-gauge" title="${clamped.toFixed(0)}% context used">

--- a/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
@@ -5,6 +5,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens } from '@shared/styles';
 import type { SpendingStatus } from '@shared/schemas/spendingStatus';
+import { clamp } from '@utils/core';
 
 import { profileViewStyles } from './styles';
 
@@ -119,7 +120,7 @@ export class RelayQuotaMeter extends LitElement {
     const s = this.status;
     if (!s) return nothing;
 
-    const percent = Math.min(100, Math.max(0, s.percentUsed));
+    const percent = clamp(s.percentUsed, 0, 100);
     const remainingPercent = Math.max(0, Math.round(100 - percent));
     const state = quotaState(s);
     const note = quotaNote(state, this.autoSwitched, remainingPercent);

--- a/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
@@ -12,6 +12,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa';
 import { createEvent } from '@shared/utils/events';
+import { clamp } from '@utils/core';
 
 /** Detail payload for the `page-change` custom event. */
 export interface PageChangeDetail {
@@ -31,7 +32,7 @@ export function paginate<T>(
   pageSize: number,
 ): { paged: T[]; totalPages: number } {
   const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
-  const safePage = Math.max(0, Math.min(page, totalPages - 1));
+  const safePage = clamp(page, 0, totalPages - 1);
   const start = safePage * pageSize;
   return {
     paged: items.slice(start, start + pageSize) as T[],

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -46,7 +46,7 @@ import {
 // Local imports - shared utilities
 import { copyTextToClipboard } from '@shared/utils/clipboard';
 import { createEvent } from '@shared/utils/events';
-import { filterNotNullish } from '@utils/core';
+import { clamp, filterNotNullish } from '@utils/core';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
@@ -995,10 +995,10 @@ export class LaTeXTab extends LitElement {
               // Coerce to integer first — paste / spinner can produce decimals
               // that the backend `.int()` schema would silently reject.
               const integer = Math.round(raw);
-              const clamped = Math.max(
-                opts.min,
-                opts.max !== undefined ? Math.min(opts.max, integer) : integer,
-              );
+              const clamped =
+                opts.max !== undefined
+                  ? clamp(integer, opts.min, opts.max)
+                  : Math.max(opts.min, integer);
               this.dispatchSetConfigValue(opts.field, clamped);
             }}
             style="margin-top:var(--wa-space-2xs);width:140px;"

--- a/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
@@ -9,6 +9,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 // Local imports - shared styles and icons
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { clamp } from '@utils/core';
 
 /**
  * Visual-only mock of a context window utilization chip. Shows the
@@ -87,7 +88,7 @@ export class ContextUtilizationMock extends LitElement {
   @property({ type: String }) tokens = '24k / 200k';
 
   override render(): TemplateResult {
-    const clamped = Math.max(0, Math.min(100, this.percent));
+    const clamped = clamp(this.percent, 0, 100);
     const scale = (clamped / 100).toFixed(3);
     const title = `Context ${clamped}% used — ${this.tokens}`;
     return html`

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -22,3 +22,4 @@ export {
   ensureArray,
 } from './typeGuards';
 export { debounce, delay } from './async';
+export { clamp } from './math';

--- a/src/utils/core/math.ts
+++ b/src/utils/core/math.ts
@@ -1,0 +1,7 @@
+/**
+ * Clamp `value` to the inclusive range [`min`, `max`].
+ * When `min > max` the lower bound wins and the result equals `min`.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}


### PR DESCRIPTION
## Summary

- **Add `src/utils/core/math.ts`** with a single `clamp(value, min, max)` utility and export it through the `@utils/core` barrel (no Node deps, browser-safe)
- **Replace 5 file-local named clamp wrappers** in the CLI TUI (`clampPickerIndex`, `clampCursor`, `clampHighlight`, `clampIndex`, `clampTranscriptScrollOffset`) to delegate to the shared function
- **Replace inline `Math.max(0, Math.min(max, x))` patterns** in 8 more files across CLI modals and extension components

### Motivation

Seven independent implementations of the same `Math.max(min, Math.min(max, value))` idiom existed across the codebase — some as file-local named functions, some inlined. Each new file that needed range-clamping re-invented it. A single `clamp()` in `@utils/core` removes the duplication and makes the intent immediately obvious at every call site.

### Files changed

| File | Change |
|------|--------|
| `src/utils/core/math.ts` | **New** — `clamp(value, min, max)` |
| `src/utils/core/index.ts` | Re-export `clamp` through barrel |
| `cli/…/state/childControls.ts` | `clampPickerIndex` delegates to `clamp` |
| `cli/…/state/transcriptScroll.ts` | `clampTranscriptScrollOffset` delegates to `clamp` |
| `cli/…/input/textInputEditing.ts` | `clampCursor` delegates to `clamp` |
| `cli/…/commands/SlashPalette.tsx` | `clampHighlight` delegates to `clamp` |
| `cli/…/ui/Select.tsx` | `clampIndex` delegates to `clamp` |
| `cli/…/forms/_shared/FormFrame.tsx` | Inline → `clamp` |
| `cli/…/modals/BashApproval.tsx` | 3× inline → `clamp` |
| `cli/…/modals/EditApproval.tsx` | 3× inline → `clamp` |
| `cli/…/modals/AgentProposal.tsx` | 2× inline → `clamp` |
| `cli/…/modals/ExternalInquiry.tsx` | 2× inline → `clamp` |
| `extension/…/UsagePanel.ts` | Inline percent clamp → `clamp` |
| `extension/…/RelayQuotaMeter.ts` | Inline percent clamp → `clamp` |
| `extension/…/Pagination.ts` | Inline page clamp → `clamp` |
| `extension/…/LaTeXTab.ts` | Inline integer clamp → `clamp` |
| `extension/…/ContextUtilizationMock.ts` | Inline percent clamp → `clamp` |

## Test plan

- [x] `npm run compile:fast` passes with no errors
- [ ] CLI TUI navigation (arrow keys in slash palette, select, scroll in approval modals) works correctly
- [ ] Extension context utilization chip and relay quota meter render percentages within [0, 100]
- [ ] Settings pagination stays within valid page range

https://claude.ai/code/session_015vjVjehE3TMezEcBSPyQC9

---
_Generated by [Claude Code](https://claude.ai/code/session_015vjVjehE3TMezEcBSPyQC9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with equivalent bounding behavior; no auth, data, or API contract changes.
> 
> **Overview**
> Introduces a shared **`clamp(value, min, max)`** in `@utils/core` (`math.ts` + barrel export) and uses it everywhere the codebase was repeating `Math.max(min, Math.min(max, value))`.
> 
> **CLI TUI:** Removes the local `clampHighlight` helper in the slash palette and routes highlight/window logic through `clamp`. Existing named helpers (`clampCursor`, `clampPickerIndex`, `clampIndex`, transcript scroll) now delegate to `clamp` instead of inlining bounds math. Approval modals, form frame width, and scroll state updates swap inline min/max for `clamp` on row budgets and scroll offsets.
> 
> **Extension:** Progress/context gauges, relay quota meter, list pagination, LaTeX numeric settings, and the context-utilization mock clamp percentages and page indices with the same helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99101f4bb8b49c0ef5d084168616190fe656a13a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->