### PR TITLE
fix: snapshot asserted TUI harness frames

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2611,13 +2611,12 @@ function snapshotSvgDocument(name, frame) {
 `;
 }
 
-function writeSnapshot(index, name, frame, rows) {
+function writeSnapshot(index, name, frame) {
   if (!snapshotDir) return;
-  const content = frameTail(frame, rows);
   const textFile = path.join(snapshotDir, snapshotFileName(index, name));
   const svgFile = path.join(snapshotDir, snapshotFileName(index, name, 'svg'));
-  writeFileSync(textFile, `${content}${content.endsWith('\n') ? '' : '\n'}`);
-  writeFileSync(svgFile, snapshotSvgDocument(name, content));
+  writeFileSync(textFile, `${frame}${frame.endsWith('\n') ? '' : '\n'}`);
+  writeFileSync(svgFile, snapshotSvgDocument(name, frame));
 }
 
 function snapshotHtmlDocument(results) {
@@ -2626,7 +2625,7 @@ function snapshotHtmlDocument(results) {
     .map((result, index) => {
       const textFile = snapshotFileName(index, result.name);
       const svgFile = snapshotFileName(index, result.name, 'svg');
-      const frame = frameTail(result.fullFrame, result.rows);
+      const frame = result.frame;
       const statusClass = result.ok ? 'ok' : 'failed';
       const failures = result.failures.length
         ? `<ul>${result.failures
@@ -2721,7 +2720,6 @@ async function runScenario(scenario) {
       skipReason,
       failures: [],
       frame: skipReason,
-      fullFrame: skipReason,
       rows: scenarioRows(scenario),
     };
   }
@@ -2936,7 +2934,6 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
     skipped: false,
     failures,
     frame,
-    fullFrame,
     rows,
   };
 }
@@ -2950,7 +2947,7 @@ for (const [index, scenario] of scenarios.entries()) {
   // eslint-disable-next-line no-await-in-loop
   const result = await runScenario(scenario);
   results.push(result);
-  writeSnapshot(index, result.name, result.fullFrame, result.rows);
+  writeSnapshot(index, result.name, result.frame);
   if (result.skipped) {
     skipped += 1;
     console.log(`- ${result.name} (skipped: ${result.skipReason})`);


### PR DESCRIPTION
## Summary

- Save TUI harness snapshots from the same `result.frame` used for assertions.
- Update the snapshot HTML report to render that same asserted frame instead of tailing `fullFrame` again.
- Close #5594.

## Root Cause

`validate-tui.mjs` computed `result.frame` for pass/fail checks, but snapshot writing used `result.fullFrame` and then unconditionally applied `frameTail(..., rows)`. Scenarios that assert against full-frame/scrollback content could pass while the generated `.txt`, `.svg`, and `index.html` report hid the evidence.

The dogfood repro was `subagent-focused-own-scrollback-history`: the scenario expected `strategy detail line 01`, but the saved snapshot started at `strategy detail line 11` before this fix.

## Validation

- `node --check packages/cli/scripts/validate-tui.mjs`
- `corepack pnpm --filter @texra-ai/cli check:architecture`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /private/tmp/texra-tui-snapshot-frame-check subagent-focused-own-scrollback-history`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /private/tmp/texra-tui-snapshot-frame-broad subagent-tab-focus-full-frame subagent-focused-own-scrollback-history subagent-focused-status-stays-scoped subagent-focus-return-root-scrollback-deduped external-inquiry-copy-question long-bash-approval compact-long-bash-approval-scroll edit-approval`
- `npm run lint` exits 0 with existing unrelated import-order warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only change in validate-tui.mjs; no production CLI or runtime behavior.
> 
> **Overview**
> Fixes a mismatch in the TUI harness validator where **pass/fail checks used `result.frame`** (full scrollback or tail per scenario) but **snapshots and the HTML report re-derived content from `fullFrame` and always applied `frameTail`**, so scenarios asserting on full-frame content could pass while `.txt`/`.svg`/`index.html` showed only the viewport tail.
> 
> **`writeSnapshot`** now takes the asserted `frame` only; **`snapshotHtmlDocument`** embeds `result.frame` directly. **`fullFrame`** is dropped from scenario results and skip paths so artifacts match what assertions actually evaluated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e348eb68899a28cea05e9529784dc7d8e3db3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->