### PR TITLE
refactor: use shared desktop progress snapshots

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -185,13 +185,6 @@ export class DesktopProgressBridge {
     StreamTabId,
     RestoredStreamSnapshot
   >();
-  /**
-   * Durable per-stream sidecar reader. Restores a ghost (prior-session)
-   * stream's persisted display — todos/plan/usage/output files — when it first
-   * becomes active, the same data the CLI/extension show on resume. Reads are
-   * stateless disk reads used only for restored rows from a previous launch.
-   */
-  private readonly durableSnapshots = new StreamSnapshotStore();
   /** Ghost streams whose persisted display has already been restored this session. */
   private readonly restoredDisplaySent = new Set<StreamTabId>();
   /** Ghost streams with an async persisted-display restore already pending. */
@@ -596,7 +589,7 @@ export class DesktopProgressBridge {
       return;
     }
     this.restoredDisplayInFlight.add(streamId);
-    void this.durableSnapshots
+    void this.state.snapshots
       .read(streamId)
       .then((snap) => {
         if (

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -18,6 +18,7 @@ import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+import type { StreamSnapshotStore as ProgressSnapshotStore } from '@transcript';
 
 type Bridge = {
   openFileCompile(filePath: string): Promise<void>;
@@ -64,7 +65,10 @@ type RunExecutionRequest = (
 interface DesktopAgentExecutionModule {
   DesktopProgressBridge: new (
     postToRenderer: (message: unknown) => void,
-    options?: { streamSnapshotStore?: TestDesktopStreamSnapshotStore },
+    options?: {
+      streamSnapshotStore?: TestDesktopStreamSnapshotStore;
+      progressSnapshotStore?: ProgressSnapshotStore;
+    },
   ) => Bridge;
   createDesktopAgentExecution(options: {
     postToRenderer(message: unknown): void;
@@ -82,6 +86,7 @@ type CreateBridgeOptions = {
   resumeToolUseFromSnapshot?: ReturnType<typeof vi.fn>;
   runAgent?: RunExecutionRequest;
   streamSnapshotStore?: TestDesktopStreamSnapshotStore;
+  configureProgressSnapshotStore?: (store: ProgressSnapshotStore) => void;
 };
 
 type TestDesktopStreamSnapshotStore = {
@@ -224,11 +229,20 @@ async function createBridge(
       workspaceFolders: [],
     },
   }));
+  let progressSnapshotStore: ProgressSnapshotStore | undefined;
+  if (options.configureProgressSnapshotStore) {
+    const { StreamSnapshotStore } = await import('@transcript');
+    progressSnapshotStore = new StreamSnapshotStore();
+    await progressSnapshotStore.load([]);
+    options.configureProgressSnapshotStore(progressSnapshotStore);
+    await progressSnapshotStore.flush();
+  }
   const { DesktopProgressBridge } = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
   return new DesktopProgressBridge((message) => messages.push(message), {
     streamSnapshotStore: options.streamSnapshotStore,
+    progressSnapshotStore,
   }) as TestableBridge;
 }
 
@@ -655,6 +669,54 @@ describe('DesktopProgressBridge', () => {
           '1': [expect.objectContaining({ logRelativePath: 'out/paper.log' })],
         },
         reset: true,
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('restores ghost display from the backend snapshot store', async () => {
+    const messages: unknown[] = [];
+    const kvRead = vi.fn(async () => {
+      throw new Error('unexpected sidecar disk read');
+    });
+    const bridge = await createBridge(messages, {
+      kvRead,
+      configureProgressSnapshotStore: (store) => {
+        store.setTodos('ghost-stream', [
+          {
+            content: 'Preloaded backend todo',
+            status: 'pending',
+            activeForm: 'Restoring from backend store',
+          },
+        ]);
+      },
+      streamSnapshotStore: createStreamSnapshotStore([
+        {
+          streamId: 'ghost-stream',
+          label: 'ghost-stream',
+          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          lastKnownStatus: STREAM_STATUS.STOPPED,
+          creationTimestamp: 1_000,
+          persistedAt: 2_000,
+        },
+      ]),
+    });
+
+    try {
+      bridge.setActiveStream('ghost-stream');
+      await settleProgressEvents();
+
+      expect(kvRead).not.toHaveBeenCalled();
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_TODOS).at(-1),
+      ).toMatchObject({
+        stream: 'ghost-stream',
+        todos: [
+          expect.objectContaining({
+            content: 'Preloaded backend todo',
+          }),
+        ],
       });
     } finally {
       bridge.dispose();


### PR DESCRIPTION
## Summary

- remove the private `DesktopProgressBridge` snapshot reader used only for ghost-stream display restore
- restore ghost display through the backend-owned `this.state.snapshots` store instead
- add a regression proving a restored ghost stream can render from a pre-seeded backend snapshot without falling back to raw sidecar reads

Closes #5596.

## Validation

- `corepack pnpm vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (0 errors; existing import-order warnings outside this patch)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how prior-session stream UI is hydrated on desktop; wrong snapshot wiring could leave ghost streams empty or stale, but scope is limited to display restore for restored rail entries.
> 
> **Overview**
> **Ghost-stream display restore** on desktop no longer uses a second, bridge-local `StreamSnapshotStore` for reading `streamData/` sidecars. Restored todos, plan, usage, and output fields now come from **`this.state.snapshots.read`**, the same backend-owned snapshot store `ProgressBackend` already uses.
> 
> Tests can inject that store via **`progressSnapshotStore`** / **`configureProgressSnapshotStore`**. A new case asserts a pre-seeded backend snapshot can hydrate ghost UI **without** falling back to raw sidecar `KVStore` reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc79041c55ea41e977f712ec1c8ce81a5edd43a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->