### PR TITLE
fix: show model switch disabled reasons first

### DIFF
--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -227,7 +227,7 @@ export function modelSelectItemsForCliMode(
     return {
       value: model.model.value,
       label: model.model.label || model.model.value,
-      description: disabledReason ? `${status}; ${disabledReason}` : status,
+      description: disabledReason ? `${disabledReason}; ${status}` : status,
       disabled: disabledReason != null,
     };
   });

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -416,7 +416,7 @@ describe('CLI model access resolution', () => {
         value: 'sonnet46T',
         label: 'Sonnet',
         description:
-          'api: api key set; different conversation format; start new chat',
+          'different conversation format; start new chat; api: api key set',
         disabled: true,
       },
       {


### PR DESCRIPTION
## Summary

Closes #5598.

This keeps the model picker row projection as the single owner of model row text, but puts live-switch disabled reasons before access status. In normal-width TUI rows, the actionable reason now survives truncation instead of being hidden after "api: api key set".

## Validation

- corepack pnpm vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-cli-ownership-scout-frames-fix model-switch-compatible-only
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-cli-ownership-scout-frames-subset subagent-tab-focus-full-frame hidden-root-approval-tab-return subagent-focused-own-scrollback-history subagent-focused-status-stays-scoped nested-subagent-picker-enter-views-subagent kitty-shift-enter-newline model-form-selectable model-switch-compatible-only edit-approval no-color-model-form
- npm run lint (passes with existing import-order warnings outside this diff)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string ordering change in CLI model picker projection with an updated unit test; no auth, API, or selection logic changes.
> 
> **Overview**
> Reorders how **model picker** row descriptions are built when a model is disabled for live switching: the **switch-disabled reason** (e.g. incompatible conversation format) now comes **before** API/relay access status instead of after.
> 
> That way, in **narrow TUI rows** where descriptions are truncated at the end, users still see the actionable explanation rather than only `api: api key set`. Rows without a disabled reason are unchanged (description is still status alone).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9276bf8a047647079e01f24ad9821db47fb30bf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->