### PR TITLE
fix: keep CLI task shortcuts visible when narrow

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -580,7 +580,8 @@ const SCENARIOS = [
       '/model · included relay',
       'No model choices in this API mode.',
       'No included relay models are runnable.',
-      'Switch with /api personal or try again later.',
+      'Switch with /api personal or try',
+      'again later.',
       'Enter close',
     ],
     unexpect: [

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -436,6 +436,23 @@ export function statusBarBindingsText(
   ]);
   if (fitsStatusBindings(minimalBindings, maxColumns)) return minimalBindings;
 
+  if (
+    taskControlsAvailable ||
+    subagentControlsAvailable ||
+    agentSelectionAvailable
+  ) {
+    const controlFocusedBindings = joinStatusBindings([
+      ...(hasMultipleStreams ? ['[Tab]streams'] : []),
+      ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
+      ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
+      ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(controlFocusedBindings, maxColumns)) {
+      return controlFocusedBindings;
+    }
+  }
+
   if (hasMultipleStreams && taskControlsAvailable) {
     const taskFocusedBindings = joinStatusBindings([
       '[Tab]streams',
@@ -457,6 +474,14 @@ export function statusBarBindingsText(
     if (fitsStatusBindings(bareTaskBindings, maxColumns)) {
       return bareTaskBindings;
     }
+
+    const bareTaskBindingsWithoutTranscript = joinStatusBindings([
+      `${tasksBinding}tasks`,
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(bareTaskBindingsWithoutTranscript, maxColumns)) {
+      return bareTaskBindingsWithoutTranscript;
+    }
   }
 
   if (subagentControlsAvailable) {
@@ -477,6 +502,14 @@ export function statusBarBindingsText(
     ]);
     if (fitsStatusBindings(bareSubagentBindings, maxColumns)) {
       return bareSubagentBindings;
+    }
+
+    const bareSubagentBindingsWithoutTranscript = joinStatusBindings([
+      `${subagentsBinding}subagents`,
+      `[Ctrl-C]${ctrlCAction}`,
+    ]);
+    if (fitsStatusBindings(bareSubagentBindingsWithoutTranscript, maxColumns)) {
+      return bareSubagentBindingsWithoutTranscript;
     }
   }
 

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -163,7 +163,8 @@ describe('CLI StatusBar display model', () => {
       activeSubagents: 0,
       activeProcesses: 0,
       approvalDepth: 0,
-      subagentControlsAvailable: true,
+      taskControlsAvailable: false,
+      subagentControlsAvailable: false,
       hasMultipleStreams: true,
       model: 'deepseekT',
       apiMode: PERSONAL_API_MODE_LABEL,
@@ -188,7 +189,8 @@ describe('CLI StatusBar display model', () => {
       activeSubagents: 0,
       activeProcesses: 0,
       approvalDepth: 0,
-      subagentControlsAvailable: true,
+      taskControlsAvailable: false,
+      subagentControlsAvailable: false,
       hasMultipleStreams: true,
       model: 'deepseekT',
       apiMode: PERSONAL_API_MODE_LABEL,
@@ -453,6 +455,7 @@ describe('CLI StatusBar display model', () => {
       apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
       ctrlCAction: 'stop',
+      transcriptAvailable: true,
       width: 60,
     });
 
@@ -481,6 +484,7 @@ describe('CLI StatusBar display model', () => {
       apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Option',
       ctrlCAction: 'stop',
+      transcriptAvailable: true,
       width: 44,
     });
 


### PR DESCRIPTION
## Summary
- keep narrow CLI status-bar fallback focused on live controls before falling back to transcript-only hints
- cover real transcript-history cases in status-bar unit tests
- make the included-relay model-picker harness assertion robust to normal wrapping

Closes #5600.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-scout-next-targeted-built model-form-included-empty subagents-with-todos-narrow-status compact-task-picker-process-overflow narrow-subagent-picker narrow-subagent-picker-second narrow-task-picker`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-scout-next-frames-full`
- `npm run typecheck`
- `npm run lint` (passes; existing import-order warnings only)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only status-bar binding order and test/harness updates; no auth, data, or API behavior changes.
> 
> **Overview**
> Improves **narrow CLI status-bar** shortcut discovery so **task, subagent, and agent** bindings stay visible instead of collapsing to transcript-only or Ctrl-C when width is tight.
> 
> `statusBarBindingsText` adds earlier fallbacks: a **control-focused** row (streams + live child controls, no transcript/`/status`) and **task/subagent-only** rows that drop `[Ctrl-T]transcript` when needed. Unit tests align with real flags (`taskControlsAvailable`, `transcriptAvailable`) for narrow stream and subagent sessions. The **included-relay empty model** TUI harness expects wrapped hint text on two lines so assertions tolerate normal terminal wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5087026fee0ee35d15709983cd854507803d5167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->