### PR TITLE
refactor: simplify CLI status bar fallbacks

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -364,6 +364,14 @@ function metaShortcutLabel(modifierLabel: string, key: string): string {
   return `[${modifierLabel}${separator}${key}]`;
 }
 
+function statusBarBindingRow(
+  bindings: readonly (string | false | undefined)[],
+): string {
+  return joinStatusBindings(
+    bindings.filter((binding): binding is string => !!binding),
+  );
+}
+
 export function statusBarBindingsText(
   taskControlsAvailable = true,
   agentSelectionAvailable = false,
@@ -379,160 +387,81 @@ export function statusBarBindingsText(
   const tasksBinding = metaShortcutLabel(modifierLabel, 'p');
   const subagentsBinding = metaShortcutLabel(modifierLabel, 's');
   const transcriptBinding = '[Ctrl-T]transcript';
-  const bindings: string[] = [
+  const streamTabs = hasMultipleStreams ? '[Tab]streams' : undefined;
+  const streamFocus = hasMultipleStreams ? `${focusBinding}focus` : undefined;
+  const transcript = transcriptAvailable ? transcriptBinding : undefined;
+  const tasks = taskControlsAvailable ? `${tasksBinding}tasks` : undefined;
+  const subagents = subagentControlsAvailable
+    ? `${subagentsBinding}subagents`
+    : undefined;
+  const agent = agentSelectionAvailable ? '[/agent]agents' : undefined;
+  const status = '[/status]details';
+  const model = '[/model]models';
+  const api = '[/api]api';
+  const newline = shiftEnterNewline
+    ? '[Shift-Enter]newline'
+    : '[Ctrl-J]newline';
+  const ctrlC = `[Ctrl-C]${ctrlCAction}`;
+  const candidates = [
     // Stream cycling / numeric focus only do something when there is more
     // than one stream — hide the hints in a plain single-stream chat.
-    ...(hasMultipleStreams ? ['[Tab]streams', `${focusBinding}focus`] : []),
-    ...(transcriptAvailable ? [transcriptBinding] : []),
-    ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
-    '[/status]details',
-    ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
-    '[/model]models',
-    '[/api]api',
-    shiftEnterNewline ? '[Shift-Enter]newline' : '[Ctrl-J]newline',
-    `[Ctrl-C]${ctrlCAction}`,
+    statusBarBindingRow([
+      streamTabs,
+      streamFocus,
+      transcript,
+      tasks,
+      subagents,
+      status,
+      agent,
+      model,
+      api,
+      newline,
+      ctrlC,
+    ]),
+    agentSelectionAvailable &&
+      statusBarBindingRow([transcript, agent, model, api, newline, ctrlC]),
+    statusBarBindingRow([
+      streamTabs,
+      transcript,
+      tasks,
+      subagents,
+      agent,
+      status,
+      ctrlC,
+    ]),
+    statusBarBindingRow([
+      streamTabs,
+      transcript,
+      tasks,
+      subagents,
+      agent,
+      ctrlC,
+    ]),
+    (taskControlsAvailable ||
+      subagentControlsAvailable ||
+      agentSelectionAvailable) &&
+      statusBarBindingRow([streamTabs, tasks, subagents, agent, ctrlC]),
+    hasMultipleStreams &&
+      taskControlsAvailable &&
+      statusBarBindingRow([streamTabs, transcript, tasks, ctrlC]),
+    taskControlsAvailable && statusBarBindingRow([transcript, tasks, ctrlC]),
+    taskControlsAvailable && statusBarBindingRow([tasks, ctrlC]),
+    subagentControlsAvailable &&
+      statusBarBindingRow([streamTabs, transcript, subagents, ctrlC]),
+    subagentControlsAvailable &&
+      statusBarBindingRow([transcript, subagents, ctrlC]),
+    subagentControlsAvailable && statusBarBindingRow([subagents, ctrlC]),
+    transcriptAvailable && statusBarBindingRow([streamTabs, transcript, ctrlC]),
+    transcriptAvailable && statusBarBindingRow([transcript, ctrlC]),
   ];
-  if (subagentControlsAvailable) {
-    const tasksIndex = bindings.indexOf(`${tasksBinding}tasks`);
-    const statusIndex = bindings.indexOf('[/status]details');
-    let insertSubagentsAt = bindings.length;
-    if (tasksIndex >= 0) insertSubagentsAt = tasksIndex + 1;
-    else if (statusIndex >= 0) insertSubagentsAt = statusIndex;
-    bindings.splice(insertSubagentsAt, 0, `${subagentsBinding}subagents`);
-  }
-  const fullBindings = joinStatusBindings(bindings);
-  if (fitsStatusBindings(fullBindings, maxColumns)) return fullBindings;
 
-  if (agentSelectionAvailable) {
-    const setupBindings = joinStatusBindings([
-      ...(transcriptAvailable ? [transcriptBinding] : []),
-      '[/agent]agents',
-      '[/model]models',
-      '[/api]api',
-      shiftEnterNewline ? '[Shift-Enter]newline' : '[Ctrl-J]newline',
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(setupBindings, maxColumns)) return setupBindings;
-  }
-
-  const compactBindings = joinStatusBindings([
-    ...(hasMultipleStreams ? ['[Tab]streams'] : []),
-    ...(transcriptAvailable ? [transcriptBinding] : []),
-    ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
-    ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
-    ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
-    '[/status]details',
-    `[Ctrl-C]${ctrlCAction}`,
-  ]);
-  if (fitsStatusBindings(compactBindings, maxColumns)) return compactBindings;
-
-  const minimalBindings = joinStatusBindings([
-    ...(hasMultipleStreams ? ['[Tab]streams'] : []),
-    ...(transcriptAvailable ? [transcriptBinding] : []),
-    ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
-    ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
-    ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
-    `[Ctrl-C]${ctrlCAction}`,
-  ]);
-  if (fitsStatusBindings(minimalBindings, maxColumns)) return minimalBindings;
-
-  if (
-    taskControlsAvailable ||
-    subagentControlsAvailable ||
-    agentSelectionAvailable
-  ) {
-    const controlFocusedBindings = joinStatusBindings([
-      ...(hasMultipleStreams ? ['[Tab]streams'] : []),
-      ...(taskControlsAvailable ? [`${tasksBinding}tasks`] : []),
-      ...(subagentControlsAvailable ? [`${subagentsBinding}subagents`] : []),
-      ...(agentSelectionAvailable ? ['[/agent]agents'] : []),
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(controlFocusedBindings, maxColumns)) {
-      return controlFocusedBindings;
-    }
-  }
-
-  if (hasMultipleStreams && taskControlsAvailable) {
-    const taskFocusedBindings = joinStatusBindings([
-      '[Tab]streams',
-      ...(transcriptAvailable ? [transcriptBinding] : []),
-      `${tasksBinding}tasks`,
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(taskFocusedBindings, maxColumns)) {
-      return taskFocusedBindings;
-    }
-  }
-
-  if (taskControlsAvailable) {
-    const bareTaskBindings = joinStatusBindings([
-      ...(transcriptAvailable ? [transcriptBinding] : []),
-      `${tasksBinding}tasks`,
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(bareTaskBindings, maxColumns)) {
-      return bareTaskBindings;
-    }
-
-    const bareTaskBindingsWithoutTranscript = joinStatusBindings([
-      `${tasksBinding}tasks`,
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(bareTaskBindingsWithoutTranscript, maxColumns)) {
-      return bareTaskBindingsWithoutTranscript;
-    }
-  }
-
-  if (subagentControlsAvailable) {
-    const subagentFocusedBindings = joinStatusBindings([
-      ...(hasMultipleStreams ? ['[Tab]streams'] : []),
-      ...(transcriptAvailable ? [transcriptBinding] : []),
-      `${subagentsBinding}subagents`,
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(subagentFocusedBindings, maxColumns)) {
-      return subagentFocusedBindings;
-    }
-
-    const bareSubagentBindings = joinStatusBindings([
-      ...(transcriptAvailable ? [transcriptBinding] : []),
-      `${subagentsBinding}subagents`,
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(bareSubagentBindings, maxColumns)) {
-      return bareSubagentBindings;
-    }
-
-    const bareSubagentBindingsWithoutTranscript = joinStatusBindings([
-      `${subagentsBinding}subagents`,
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(bareSubagentBindingsWithoutTranscript, maxColumns)) {
-      return bareSubagentBindingsWithoutTranscript;
-    }
-  }
-
-  if (transcriptAvailable) {
-    const transcriptOnlyBindings = joinStatusBindings([
-      ...(hasMultipleStreams ? ['[Tab]streams'] : []),
-      transcriptBinding,
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(transcriptOnlyBindings, maxColumns)) {
-      return transcriptOnlyBindings;
-    }
-
-    const bareTranscriptBindings = joinStatusBindings([
-      transcriptBinding,
-      `[Ctrl-C]${ctrlCAction}`,
-    ]);
-    if (fitsStatusBindings(bareTranscriptBindings, maxColumns)) {
-      return bareTranscriptBindings;
-    }
-  }
-
-  return `[Ctrl-C]${ctrlCAction}`;
+  return (
+    candidates.find(
+      (candidate): candidate is string =>
+        typeof candidate === 'string' &&
+        fitsStatusBindings(candidate, maxColumns),
+    ) ?? ctrlC
+  );
 }
 
 function joinStatusBindings(bindings: readonly string[]): string {


### PR DESCRIPTION
## Summary
- collapse the CLI status-bar shortcut fallback ladder into an ordered candidate list
- define each shortcut binding once before composing rows
- remove the splice-based subagent placement and repeated transcript/task/subagent fallback blocks

Closes #5603.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-cli-simplify-next-targeted subagents-with-todos-compact subagents-with-todos-narrow-status subagent-picker compact-subagent-picker compact-task-picker compact-task-picker-process-overflow narrow-subagent-picker narrow-subagent-picker-second narrow-task-picker tiny-status-separators empty-task-shortcut-hidden ctrl-c-exit ctrl-c-interrupt-active`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-cli-simplify-next-frames-final`
- `npm run typecheck`
- `npm run lint` (passes; existing import-order warnings only)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only TUI refactor with targeted tests and snapshot validation; no auth, API, or data-path changes.
> 
> **Overview**
> Refactors how the CLI TUI **status bar shortcut hints** shrink when the terminal is too narrow. Instead of a long chain of `if (fitsStatusBindings(...))` blocks and splice-based subagent placement, bindings are **named once** and composed into **ordered fallback rows** via a small `statusBarBindingRow` helper.
> 
> The first row that fits `maxColumns` wins; otherwise the bar falls back to **`[Ctrl-C]`** only. Behavior is intended to stay the same—covered by **StatusBar vitests** and **TUI snapshot validation** in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3117950f0603f7ec3bd9d19afd9ab89d963cfd53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->