### PR TITLE
feat: include Gemini 3.5 Flash by default

### DIFF
--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -52,6 +52,7 @@ GPT-5 reasoning summaries require account verification. Enable with `texra.model
 | Model ID    | Use Case                       | Cost | Speed  |
 | :---------- | :----------------------------- | :--- | :----- |
 | `gemini31p` | Pro with reasoning, 1M context | $$$  | Medium |
+| `gemini35f` | Flash model with 1M context    | $$   | Fast   |
 
 ## DeepSeek Models
 

--- a/docs/relay-tier-config.md
+++ b/docs/relay-tier-config.md
@@ -67,6 +67,7 @@ GET https://remote.texra.ai/functions/v1/relay/tier-config
         "sonnet46",
         "sonnet46T",
         "gemini31p",
+        "gemini35f",
         "grok4",
         "deepseekpro",
         "deepseekproT",
@@ -101,6 +102,7 @@ GET https://remote.texra.ai/functions/v1/relay/tier-config
         "sonnet46",
         "sonnet46T",
         "gemini31p",
+        "gemini35f",
         "grok4",
         "deepseekpro",
         "deepseekproT",
@@ -159,7 +161,7 @@ Model names must match the short names defined by the [`llm-zoo`](https://www.np
 ::: warning Auto-derived snapshot
 The model rows and prices below are a **snapshot of `llm-zoo` `MODEL_CONFIGS`**. The relay builds its model list and tier assignments automatically from that package (see [Single Source of Truth](#single-source-of-truth)), so individual IDs and prices here drift whenever `llm-zoo` is bumped. Treat the tables as illustrative and re-derive from `MODEL_CONFIGS` before relying on a specific value.
 
-**Prices last verified against `llm-zoo@1.8.0` `MODEL_CONFIGS`: 2026-05-29.**
+**Prices last verified against `llm-zoo@1.8.1` `MODEL_CONFIGS`: 2026-06-08.**
 :::
 
 ### Free / Max Tier Models (≤$3/M Input)
@@ -184,6 +186,7 @@ Available to all authenticated users (free and Max tiers have the same access).
 | `sonnet46`     | claude-sonnet-4-6                    | Anthropic | $3.00/$15.00            |
 | `sonnet46T`    | claude-sonnet-4-6 (Thinking)         | Anthropic | $3.00/$15.00            |
 | `gemini31p`    | gemini-3.1-pro-preview               | Google    | $2.00/$12.00            |
+| `gemini35f`    | gemini-3.5-flash                     | Google    | $1.50/$9.00             |
 | `grok4`        | grok-4-0709                          | xAI       | $3.00/$15.00            |
 | `deepseekpro`  | deepseek-v4-pro                      | DeepSeek  | $0.44/$0.87             |
 | `deepseekproT` | deepseek-v4-pro (Thinking)           | DeepSeek  | $0.44/$0.87             |

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -49,7 +49,8 @@ function reconcileEnabledModels(
   // current. Introduced at version 15 (sonnet/opus tiers) and re-bumped to 16
   // when opus47/opus47T were deprecated in favor of opus48/opus48T. Bump the
   // guard to the current MODEL_LIST_VERSION whenever the registry deprecates
-  // more defaults.
+  // more defaults. Version 17 adds gemini35f to DEFAULT_MODELS only, so the
+  // deprecated-model sweep intentionally remains guarded at version 16.
   if ((previousVersion ?? 0) < 16) {
     for (const model of currentModels) {
       if (isDeprecatedModel(model)) strippedSet.add(model);

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -15,6 +15,7 @@ import {
 /** Models that should be present in every user's model list. */
 export const DEFAULT_MODELS = [
   'gemini31p',
+  'gemini35f',
   'sonnet46T',
   'opus48T',
   'gpt55',
@@ -25,7 +26,7 @@ export const DEFAULT_MODELS = [
 ];
 
 /** Increment when the persisted model list needs reconciliation. */
-export const MODEL_LIST_VERSION = 16;
+export const MODEL_LIST_VERSION = 17;
 
 const MILLION = 1_000_000;
 const THOUSAND = 1_000;

--- a/src/test-kernel/model/ModelOptionsBasic.vitest.ts
+++ b/src/test-kernel/model/ModelOptionsBasic.vitest.ts
@@ -1,0 +1,26 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+// Local imports - model
+import { DEFAULT_MODELS } from '@model/modelOptionsBasic';
+
+describe('default model list', () => {
+  it('includes Gemini 3.5 Flash as a free-tier relay model', () => {
+    const config = MODEL_CONFIGS.gemini35f;
+
+    expect(DEFAULT_MODELS).toContain('gemini35f');
+    expect(config).toMatchObject({
+      fullName: 'gemini-3.5-flash',
+      label: 'Gemini 3.5 Flash',
+      provider: 'google',
+      openRouterOnly: false,
+    });
+    expect(config.deprecated ?? false).toBe(false);
+    expect(config.inputPrice).toBeLessThanOrEqual(3);
+  });
+
+  it('only contains model ids known by llm-zoo', () => {
+    expect(DEFAULT_MODELS.filter((model) => !MODEL_CONFIGS[model])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `gemini35f` / Gemini 3.5 Flash to `DEFAULT_MODELS`
- bump `MODEL_LIST_VERSION` so existing persisted visible model lists reconcile the new default
- update relay/model docs snapshots and add a focused guard test for `llm-zoo` metadata + free-tier pricing

Closes #5608.

## Validation
- `corepack pnpm vitest run src/test-kernel/model/ModelOptionsBasic.vitest.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and documentation only; no auth or relay logic changes in the diff beyond default picker reconciliation.
> 
> **Overview**
> Adds **Gemini 3.5 Flash** (`gemini35f`) as a default visible model for new and upgraded installs by appending it to `DEFAULT_MODELS` and bumping **`MODEL_LIST_VERSION` to 17**, so persisted enabled-model lists reconcile and pick up the new default without re-running the deprecated-model sweep (still gated at version 16).
> 
> Documentation snapshots are updated: user-facing **Google models** table, relay **free/Max tier** example JSON and pricing table, plus **`llm-zoo@1.8.1`** verification date. A small **Vitest** suite asserts `gemini35f` is in defaults, matches `llm-zoo` metadata, and stays within free-tier input pricing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 469df799e9b27ae9e5e7268f13fa20400c16345b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->