### PR TITLE
refactor: simplify, de-imperative, and tighten types in code changed since 0.38.5

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -390,15 +390,22 @@ export function foregroundEscapeAction({
   readonly foregroundKind: ForegroundSurfaceKind | undefined;
   readonly pending: PendingApproval | undefined;
 }): string | undefined {
-  if (foregroundKind !== 'approval') {
-    if (foregroundKind === undefined) return undefined;
-    if (foregroundKind === 'form') return activeFormEscapeAction ?? 'close';
-    return foregroundKind === 'childControls' ? 'panel' : 'close';
+  switch (foregroundKind) {
+    case undefined:
+      return undefined;
+    case 'form':
+      return activeFormEscapeAction ?? 'close';
+    case 'childControls':
+      return 'panel';
+    case 'transcript':
+      return 'close';
+    case 'approval': {
+      const kind = pending?.payload.kind;
+      return kind === 'externalInquiry' || kind === 'userQuestion'
+        ? 'skip'
+        : 'cancel';
+    }
   }
-  const kind = pending?.payload.kind;
-  return kind === 'externalInquiry' || kind === 'userQuestion'
-    ? 'skip'
-    : 'cancel';
 }
 
 export function childControlForegroundMaxRows({

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -1,6 +1,7 @@
 // Registers the slash commands the input palette surfaces.
 
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
+import type { GetModelSwitchDisabledReason } from '@cli/runtime/modelAccess';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import type { ExecutionId } from '@shared/schemas';
 
@@ -76,7 +77,7 @@ export function registerBuiltinSlashCommands(options?: {
   onApprovalPolicySelect?: ApprovalPolicySelectHandler;
   onModelSelect?: ModelSelectHandler;
   canSelectModel?: () => boolean;
-  getModelSwitchDisabledReason?: (model: string) => string | undefined;
+  getModelSwitchDisabledReason?: GetModelSwitchDisabledReason;
   onApiModeSelect?: ApiModeSelectHandler;
   onMemorySelect?: MemorySelectHandler;
   onResumeSelect?: ResumeSelectHandler;

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -1,7 +1,7 @@
 // `/agent` form. It lists visible tool-use agents and workflows. Before the
 // first message, tool-use agents can be chosen as the root chat agent.
 
-import { Box, Text, useWindowSize } from 'ink';
+import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 
 import { computeAgentOptionsData } from '@agent/index';
@@ -10,11 +10,7 @@ import { agentName } from '@shared/schemas/agent';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
-import {
-  CompactFormKeyHints,
-  FormFrame,
-  formFrameWidth,
-} from './_shared/FormFrame';
+import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
 import {
   computeSelectWindowSize,
   isCompactFormRows,
@@ -154,7 +150,6 @@ export function agentSelectWindow({
 }
 
 export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
-  const { columns } = useWindowSize();
   const { data, loading, error } = useAsyncListForm<AgentGroups>({
     load: async () => {
       const options = await computeAgentOptionsData();
@@ -247,16 +242,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   }
 
   return (
-    <Box
-      borderStyle="round"
-      borderColor="cyan"
-      flexDirection="column"
-      paddingX={1}
-      width={formFrameWidth(columns)}
-    >
-      <Text bold color="cyan">
-        /agent
-      </Text>
+    <FormFrame color="cyan" title="/agent" showCloseHint={false}>
       <Text dimColor wrap="truncate-end">
         {selectable
           ? 'Choose the root agent for the first message.'
@@ -317,6 +303,6 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
           />
         )}
       </Box>
-    </Box>
+    </FormFrame>
   );
 }

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -11,6 +11,8 @@ import {
   getCliModelAccessList,
   modelSelectItemsForCliMode,
   type CliModelAccess,
+  type CliNoRunnableModelsMessageOptions,
+  type GetModelSwitchDisabledReason,
 } from '@cli/runtime/modelAccess';
 import { formatCliApiMode, type CliApiMode } from '@cli/runtime/apiAccessMode';
 import { Select } from '../ui/Select';
@@ -28,14 +30,14 @@ const TUI_MODEL_EMPTY_RECOVERY = {
   includedModeAction: 'switch with /api included',
   loginAction: 'Run /login',
   personalModeAction: 'switch with /api personal',
-};
+} satisfies CliNoRunnableModelsMessageOptions;
 
 export interface ModelListFormProps {
   readonly currentModel: string;
   readonly apiMode: CliApiMode;
   readonly availableRows?: number;
   readonly selectable?: boolean;
-  readonly getModelSwitchDisabledReason?: (model: string) => string | undefined;
+  readonly getModelSwitchDisabledReason?: GetModelSwitchDisabledReason;
   readonly onSelect?: (value: string) => void;
   readonly onClose: () => void;
 }

--- a/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
@@ -135,10 +135,6 @@ export function SkillsListForm(props: SkillsListFormProps): React.JSX.Element {
   });
   const items = skillSelectItemsForTui(skills);
 
-  function handleSelect(value: SkillSelectValue): void {
-    props.onSelect(value);
-  }
-
   if (isCompactFormRows(props.availableRows)) {
     return (
       <FormFrame color="cyan" title="/skills" showCloseHint={false}>
@@ -150,7 +146,7 @@ export function SkillsListForm(props: SkillsListFormProps): React.JSX.Element {
           items={items}
           maxVisibleItems={1}
           showOverflow={false}
-          onSelect={handleSelect}
+          onSelect={props.onSelect}
           onCancel={props.onClose}
         />
         <CompactFormKeyHints
@@ -168,7 +164,7 @@ export function SkillsListForm(props: SkillsListFormProps): React.JSX.Element {
         items={items}
         maxVisibleItems={selectWindow.maxVisibleItems}
         showOverflow={selectWindow.showOverflow}
-        onSelect={handleSelect}
+        onSelect={props.onSelect}
         onCancel={props.onClose}
       />
       <Box marginTop={1}>

--- a/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
@@ -64,10 +64,10 @@ export function useAsyncListForm<T>(
   const empty =
     data !== undefined && options.isEmpty ? options.isEmpty(data) : false;
 
-  useInput((_input, key) => {
+  useInput((input, key) => {
     if (
       shouldCloseAsyncListFormOnInput({
-        input: _input,
+        input,
         key,
         loading,
         error,

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -17,6 +17,7 @@ import {
   applyTerminalInputChunk,
   insertText,
   maskDisplayValue,
+  type CursorEdit,
   type TextEdit,
 } from './textInputEditing';
 import {
@@ -369,7 +370,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
   );
 
   const applyLatestEdit = useCallback(
-    (edit: (value: string, cursor: number) => TextEdit) => {
+    (edit: CursorEdit) => {
       const { value: v, cursor: c } = latestStateRef.current;
       applyEdit(edit(v, c));
     },

--- a/packages/cli/src/chat/tui/input/textInputEditing.ts
+++ b/packages/cli/src/chat/tui/input/textInputEditing.ts
@@ -16,6 +16,13 @@ export interface TextInputChunkEdit extends TextEdit {
   readonly submit: boolean;
 }
 
+/**
+ * Shape shared by every cursor-positioned editing primitive
+ * (`deleteBeforeCursor`, `deleteToEnd`, ...): given the current value and
+ * caret, produce the next `TextEdit`.
+ */
+export type CursorEdit = (value: string, cursor: number) => TextEdit;
+
 export function clampCursor(cursor: number, length: number): number {
   return clamp(cursor, 0, length);
 }
@@ -97,11 +104,7 @@ export function applyTerminalInputChunk(
   const chars = [...input];
   for (let index = 0; index < chars.length; index += 1) {
     const ch = chars[index];
-    if (ch === SYNTHETIC_SHIFT_RETURN_INPUT) {
-      edit = insertText(edit.value, edit.cursor, '\n');
-      continue;
-    }
-    if (ch === '\n') {
+    if (ch === SYNTHETIC_SHIFT_RETURN_INPUT || ch === '\n') {
       edit = insertText(edit.value, edit.cursor, '\n');
       continue;
     }

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -29,6 +29,17 @@ export interface ExternalInquiryDisplayLine {
 
 type CopyStatus = 'idle' | 'copying' | 'copied' | 'failed';
 
+function copyStatusLabel(status: Exclude<CopyStatus, 'idle'>): string {
+  switch (status) {
+    case 'copying':
+      return ' copying...';
+    case 'copied':
+      return ' copied to clipboard';
+    case 'failed':
+      return ' copy failed';
+  }
+}
+
 const MIN_EXTERNAL_INQUIRY_WIDTH = 20;
 const DEFAULT_EXTERNAL_INQUIRY_QUESTION_ROWS = 16;
 const COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS = 3;
@@ -349,11 +360,7 @@ export function ExternalInquiry(
             color={copyStatus === 'failed' ? 'yellow' : 'green'}
             dimColor={copyStatus === 'copying'}
           >
-            {copyStatus === 'copying'
-              ? ' copying...'
-              : copyStatus === 'copied'
-                ? ' copied to clipboard'
-                : ' copy failed'}
+            {copyStatusLabel(copyStatus)}
           </Text>
         ) : null}
       </Text>

--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -13,6 +13,7 @@ import { isEscapeInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 import {
   initialTranscriptScrollState,
+  maxTranscriptScrollOffset,
   scrollTranscriptToOffset,
   syncTranscriptScrollState,
 } from '../state/transcriptScroll';
@@ -48,7 +49,6 @@ export function TranscriptViewer({
   // when present, so the scrollable region never overflows availableRows.
   const titleRows = title ? 1 : 0;
   const viewRows = Math.max(1, availableRows - 1 - titleRows);
-  const maxOffset = Math.max(0, lines.length - viewRows);
   // Open pinned to the bottom — the latest output is what the user just asked
   // to inspect.
   const [{ offset }, setScrollState] = useState(() =>
@@ -82,7 +82,10 @@ export function TranscriptViewer({
     else if (key.pageDown) scrollTo((current) => current + viewRows);
     else if (key.pageUp) scrollTo((current) => current - viewRows);
     else if (input === 'g') scrollTo(0);
-    else if (input === 'G') scrollTo(maxOffset);
+    else if (input === 'G')
+      scrollTo(
+        maxTranscriptScrollOffset({ lineCount: lines.length, viewRows }),
+      );
   });
 
   const visible = lines.slice(offset, offset + viewRows);

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -549,12 +549,14 @@ function statusBarCanStopStatus(status: string | undefined): boolean {
   );
 }
 
-function rootActiveSegment(input: StatusBarDisplayInput) {
+function rootActiveSegment(
+  input: StatusBarDisplayInput,
+): StatusBarSegment | undefined {
   return input.ctrlCAction === 'stop root' &&
     !statusBarCanStopStatus(input.status)
     ? {
         text: 'root active',
-        color: 'yellow' as const,
+        color: 'yellow',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.rootActive,
       }
     : undefined;

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -12,7 +12,10 @@ import { fillRows } from '../render/terminalText';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
 import { ToolUseRow } from './ToolUseRow';
 import { toolUseDisplayLines } from './toolRenderers';
-import type { ConversationEntry } from '../state/cliState';
+import type {
+  CompletedProcessTranscript,
+  ConversationEntry,
+} from '../state/cliState';
 
 const INQUIRY_CONTINUATION_RE =
   /^\[inquiry\]\s+\S+\s+(?:answered|dropped by user)\.(?:\n|$)/;
@@ -147,7 +150,7 @@ function ProcessEntryRow({
   width,
 }: {
   readonly fillWidth?: boolean;
-  readonly process: NonNullable<ConversationEntry['process']>;
+  readonly process: CompletedProcessTranscript;
   readonly width?: number;
 }): React.JSX.Element {
   if (fillWidth === true) {

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -45,7 +45,7 @@ interface AnsiMarkdownStyle {
 
 // One color gate for the whole package: picocolors' `createColors(false)` hands
 // back identity functions, so there's no need to keep parallel on/off style
-// objects — same pattern as `runtime/style.ts`'s `createCliStyle`. Raw SGR codes
+// objects (same pattern as `runtime/style.ts`'s `createCliStyle`). Raw SGR codes
 // (strong/em/strikethrough/link) can't be neutered by `createColors`, so `sgr`
 // stays explicitly gated.
 function ansiMarkdownStyle(colorEnabled: boolean): AnsiMarkdownStyle {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -51,6 +51,7 @@ import {
   formatCliNoAvailableModelsRecovery,
   resolveCliRunnableModel,
   type CliNoAvailableModelsRecoveryOptions,
+  type CliRunnableModelResolution,
 } from '@cli/runtime/modelAccess';
 import {
   githubSelectAccountWarning,
@@ -992,7 +993,7 @@ export async function runChat(
   // wins, otherwise the persisted account default. Model resolution, the
   // no-models hints, and the header/status all read this same value so they can
   // never disagree.
-  let modelSelection: Awaited<ReturnType<typeof resolveCliRunnableModel>>;
+  let modelSelection: CliRunnableModelResolution;
   try {
     modelSelection = await resolveCliRunnableModel(
       defaults.model,
@@ -1128,10 +1129,9 @@ export async function runChat(
       : undefined;
     return activeFlow?.modelSwitchDisabledReason(candidateModel);
   };
-  const activateSkillForNextMessage = (selection: {
-    readonly name: string;
-    readonly activationPrompt: string;
-  }): void => {
+  const activateSkillForNextMessage = (
+    selection: ReservedSkillActivation,
+  ): void => {
     const wasPending = pendingSkillActivations.has(selection.name);
     pendingSkillActivations.set(selection.name, selection.activationPrompt);
     appendLocalAssistantTranscript(

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -177,7 +177,7 @@ function orderedStreamTree(init: {
   for (const [index, id] of ordered.entries()) {
     if (!init.streams.has(id)) continue;
     const position = index + 1;
-    const shortcutIndex = position <= 0 || position > 9 ? undefined : position;
+    const shortcutIndex = position > 9 ? undefined : position;
     out.push({ id, shortcutIndex });
   }
   return out;

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -28,10 +28,7 @@ import {
 } from '@cli/runtime/approvalEvents';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@eventBus/ProgressEventBus';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   handleProgressViewBashApprovalAction,
   setBashApprovalSessionBypass,
@@ -50,11 +47,6 @@ import {
   type ApprovalDecision,
   type ApprovalPayload,
 } from './approvalQueue';
-
-type Emit = <K extends ProgressEvent>(
-  event: K,
-  payload: ProgressEventPayloads[K],
-) => void;
 
 /**
  * Install the typed approval pipeline. Returns an `unbind` callback that
@@ -82,7 +74,7 @@ export function installTuiApprovals(
       return;
     }
     originalEmit(event, payload);
-  }) as Emit;
+  }) as CliRuntimeHost['emit'];
 
   setToolEditApprovalHandler(async (request) => {
     let decision: ApprovalDecision | undefined = immediateDecision(context);
@@ -204,7 +196,7 @@ function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
   // The Extract<...> cast narrows the queue payload to the kind we picked;
   // each dispatcher already trusts its payload shape via its own signature.
   const queuePayload = { kind, payload } as Extract<
-    Parameters<typeof enqueueApproval>[0],
+    ApprovalPayload,
     { kind: K }
   >;
   void enqueueTuiApproval(queuePayload, host).then((decision) => {

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -16,7 +16,7 @@ export const CLI_LOCAL_STREAM_ID = 'cli-local' as StreamTabId;
 /**
  * Stream statuses at which deferred-finalization entries (assistant text and
  * tool rows) are promoted into `<Static>` scrollback. This is exactly the
- * shared "execution ended" set ({@link isTerminalStatus}) — a terminal status
+ * shared "execution ended" set ({@link isTerminalStatus}): a terminal status
  * means the current cycle is done, so its entries are safe to finalize. Aliased
  * (not re-declared) so the membership stays single-sourced across all hosts.
  */

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -153,24 +153,28 @@ export const INTERACTIVE_AGENT_GLOBAL_ARGS = {
   ...SKILL_SOURCE_ARGS,
 } as const;
 
+// The long flag plus any single-character alias for a routable global flag.
+function flagSpellings(
+  name: string,
+  def: { type: string; alias?: string },
+): string[] {
+  const long = `--${name}`;
+  return def.alias ? [long, `-${def.alias}`] : [long];
+}
+
 // Derived from `ROOT_ROUTING_ARGS` so adding/renaming a leading-routable flag
 // in one place flows through to `reorderGlobalFlags` automatically. Commands
 // still choose which routed flags they accept through their own args objects.
 export const GLOBAL_VALUE_FLAGS = new Set<string>(
-  Object.entries(ROOT_ROUTING_ARGS).flatMap(([name, def]) => {
-    if (def.type === 'boolean') return [];
-    const long = `--${name}`;
-    const alias = 'alias' in def ? def.alias : undefined;
-    return alias ? [long, `-${alias}`] : [long];
-  }),
+  Object.entries(ROOT_ROUTING_ARGS).flatMap(([name, def]) =>
+    def.type === 'boolean' ? [] : flagSpellings(name, def),
+  ),
 );
 
 export const GLOBAL_BOOL_FLAGS = new Set<string>(
   Object.entries(ROOT_ROUTING_ARGS).flatMap(([name, def]) => {
     if (def.type !== 'boolean') return [];
-    const long = `--${name}`;
-    const alias = 'alias' in def ? def.alias : undefined;
-    const flags = alias ? [long, `-${alias}`] : [long];
+    const flags = flagSpellings(name, def);
     // Booleans defaulting to `true` are passed by their negated form
     // (`--no-color`); citty rewrites those to `<name>: false`.
     // Register the negated spelling so leading-flag reordering and unknown-

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -39,15 +39,13 @@ import {
   createCliRunResult,
   terminalStatusExitCode,
   toolUseResultText,
-  type CliRunResult,
+  type CliToolUseRunResult,
 } from '../runtime/terminalStatus';
 import { formatToolUseAgentRunInstruction } from './_helpers/toolUseRunInstruction';
 import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,
 } from '../runtime/workflowInputs';
-
-type CliToolUseRunResult = Extract<CliRunResult, { category: 'toolUse' }>;
 
 export interface ToolUseAgentRunInit {
   readonly agent: string;

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,5 +1,7 @@
 import { defineCommand } from 'citty';
 
+import type { SupabaseSession } from '@auth/SupabaseSession';
+
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import {
@@ -25,6 +27,7 @@ import {
   getCliAuthProfile,
   signInCliSupabase,
   signOutCliSupabase,
+  type CliAuthProfile,
 } from '../runtime/supabaseAuth';
 import { interactiveTerminalFailure } from '../runtime/terminalRequirements';
 
@@ -94,7 +97,7 @@ async function runLogin(
   if (context.outputFormat === 'text' && !init.noBrowser) {
     writeTextStdout(`Opening browser for TeXRA ${init.provider} sign-in...`);
   }
-  let session: Awaited<ReturnType<typeof signInCliSupabase>>;
+  let session: SupabaseSession;
   try {
     session = await signInCliSupabase({
       provider: init.provider,
@@ -211,7 +214,7 @@ const authStatusCommand = defineCliCommand({
     ...GLOBAL_ARGS,
   },
   async run(context) {
-    let profile: Awaited<ReturnType<typeof getCliAuthProfile>>;
+    let profile: CliAuthProfile;
     try {
       await initCliPlatform({ ...context, quietLogs: true });
       profile = await getCliAuthProfile();

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -12,6 +12,7 @@ import {
   parseCliHistoryId,
   preflightCliHistoryDeleteAll,
   readCliHistoryDetails,
+  type CliHistoryDeleteResult,
 } from '../runtime/history';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
@@ -97,7 +98,7 @@ async function runHistoryDelete(
     preCountForAll = preflight.count;
   }
 
-  let result: Awaited<ReturnType<typeof deleteCliHistory>>;
+  let result: CliHistoryDeleteResult;
   try {
     result = await deleteCliHistory({ ...options, preCountForAll });
   } catch (error) {

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -64,14 +64,12 @@ import {
   createCliRunResult,
   terminalStatusExitCode,
   toolUseResultText,
-  type CliRunResult,
+  type CliToolUseRunResult,
 } from '../runtime/terminalStatus';
 import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,
 } from '../runtime/workflowInputs';
-
-type CliToolUseRunResult = Extract<CliRunResult, { category: 'toolUse' }>;
 
 interface MultiAgentRunInit {
   readonly preset: string;

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -25,7 +25,7 @@ import {
   runnableCliModelAccessEntries,
   type CliModelAccess,
 } from '../runtime/modelAccess';
-import { effectiveCliApiMode } from '../runtime/apiAccessMode';
+import { effectiveCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
 import { loadCliApiStatusLines } from '../runtime/apiStatus';
 import { notifyCliUpdate } from '../runtime/updateChecker';
 import { resolveChatDefaults } from '../runtime/chatDefaults';
@@ -48,7 +48,7 @@ import type { CliContext } from '../runtime/cliContext';
 async function canLaunchWithDefaultModel(
   context: CliContext,
   models: readonly CliModelAccess[],
-  apiMode: ReturnType<typeof effectiveCliApiMode>,
+  apiMode: CliApiMode,
 ): Promise<boolean> {
   if (
     models.length === 0 ||

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -10,6 +10,7 @@ import {
   modelAccessLaunchBlockDescriptionForCliMode,
   modelSelectItemsForCliMode,
   type CliModelAccess,
+  type CliModelPickerItem,
 } from '../runtime/modelAccess';
 import type {
   CliOrchestrationAction,
@@ -37,7 +38,7 @@ export function orchestrationModelAccessView(
   } = {},
 ): {
   readonly items: readonly CliOrchestrationItem[];
-  readonly modelItems: ReturnType<typeof modelSelectItemsForCliMode>;
+  readonly modelItems: readonly CliModelPickerItem[];
 } {
   const modelItems = modelSelectItemsForCliMode(models, apiMode);
   if (
@@ -54,13 +55,10 @@ export function orchestrationModelAccessView(
   );
   return {
     modelItems,
-    items: items.map((item) =>
-      isModelPickAction(item.value)
-        ? item.disabled
-          ? item
-          : { ...item, description, disabled: true }
-        : item,
-    ),
+    items: items.map((item) => {
+      if (!isModelPickAction(item.value) || item.disabled) return item;
+      return { ...item, description, disabled: true };
+    }),
   };
 }
 
@@ -99,12 +97,9 @@ export function orchestrationFooterHints(
   return hints;
 }
 
-function orchestrationFooterRowCost(footerHints: readonly string[]): number {
-  return footerHints.length === 0 ? 0 : footerHints.length + 1;
-}
-
-function orchestrationStatusRowCost(statusLines: readonly string[]): number {
-  return statusLines.length === 0 ? 0 : statusLines.length + 1;
+/** Rows a marginTop=1 block of lines occupies (the lines plus the margin). */
+function blockRowCost(lines: readonly string[]): number {
+  return lines.length === 0 ? 0 : lines.length + 1;
 }
 
 function modelPickKeyHints(): readonly KeyHint[] {
@@ -138,8 +133,8 @@ export function OrchestrationApp(
     4,
     rows -
       8 -
-      orchestrationStatusRowCost(pending ? [] : statusLines) -
-      orchestrationFooterRowCost(footerHints),
+      blockRowCost(pending ? [] : statusLines) -
+      blockRowCost(footerHints),
   );
 
   const finish = (action: CliOrchestrationAction): void => {

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -87,18 +87,14 @@ export function formatCliAgentDetails(entry: AgentEntry): string {
     lines.push('');
     lines.push(entry.description);
   }
-  const metadataLines: string[] = [];
-  if (entry.tools && entry.tools.length > 0) {
-    metadataLines.push(`tools: ${entry.tools.join(', ')}`);
-  }
-  if (entry.defaultOutputFiles && entry.defaultOutputFiles.length > 0) {
-    metadataLines.push(
-      `defaultOutputFiles: ${entry.defaultOutputFiles.join(', ')}`,
-    );
-  }
-  if (entry.visibility && entry.visibility.length > 0) {
-    metadataLines.push(`visibility: ${entry.visibility.join(', ')}`);
-  }
+  const metadataFields: readonly [string, readonly string[] | undefined][] = [
+    ['tools', entry.tools],
+    ['defaultOutputFiles', entry.defaultOutputFiles],
+    ['visibility', entry.visibility],
+  ];
+  const metadataLines = metadataFields
+    .filter(([, values]) => values && values.length > 0)
+    .map(([label, values]) => `${label}: ${values!.join(', ')}`);
   if (metadataLines.length > 0) {
     lines.push('');
     lines.push(...metadataLines);

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -43,18 +43,31 @@ export function formatApiKeyShadowWarning(
   return 'note: a provider API key is set while signed in — `--api-mode` (or `/api`) controls which one is used.';
 }
 
+const CLI_API_STATUS_ACTION_HINTS: Record<
+  CliApiMode,
+  Record<'signedIn' | 'signedOut', string>
+> = {
+  included: {
+    signedIn:
+      'actions: `texra login --select-account` changes account; `--api-mode personal` uses provider keys',
+    signedOut:
+      'actions: `texra login` enables included relay; `--api-mode personal` uses provider keys',
+  },
+  personal: {
+    signedIn:
+      'actions: `--api-mode included` uses relay; `texra logout` signs out',
+    signedOut:
+      'actions: configure a provider key, or run `texra login` for included relay',
+  },
+};
+
 export function formatCliApiStatusActionHint(
   mode: CliApiMode,
   profile: Pick<CliAuthProfile, 'authenticated'>,
 ): string {
-  if (mode === 'included') {
-    return profile.authenticated
-      ? 'actions: `texra login --select-account` changes account; `--api-mode personal` uses provider keys'
-      : 'actions: `texra login` enables included relay; `--api-mode personal` uses provider keys';
-  }
-  return profile.authenticated
-    ? 'actions: `--api-mode included` uses relay; `texra logout` signs out'
-    : 'actions: configure a provider key, or run `texra login` for included relay';
+  return CLI_API_STATUS_ACTION_HINTS[mode][
+    profile.authenticated ? 'signedIn' : 'signedOut'
+  ];
 }
 
 async function anyPersonalKeyPresent(): Promise<boolean> {
@@ -90,19 +103,16 @@ export async function loadCliApiStatusLines(
   }
 
   if (profile.tier) lines.push(`tier: ${profile.tier}`);
-  if (!profile.authenticated || !profile.tier) {
-    if (actionHint) lines.push(actionHint);
-    return lines;
-  }
-
-  try {
-    lines.push(
-      formatRelayUsageStatus(
-        await fetchRelayUsageSummary({ tier: profile.tier }),
-      ),
-    );
-  } catch (error: unknown) {
-    lines.push(`relay usage: unavailable (${toErrorMessage(error)})`);
+  if (profile.authenticated && profile.tier) {
+    try {
+      lines.push(
+        formatRelayUsageStatus(
+          await fetchRelayUsageSummary({ tier: profile.tier }),
+        ),
+      );
+    } catch (error: unknown) {
+      lines.push(`relay usage: unavailable (${toErrorMessage(error)})`);
+    }
   }
 
   if (actionHint) lines.push(actionHint);

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { platform as osPlatform } from 'node:os';
+import type { ChildProcess } from 'node:child_process';
 
 export type ClipboardTextWriteResult =
   | { readonly ok: true }
@@ -74,7 +75,7 @@ function writeWithCommand(
     let stderr = '';
     const deadlineMs = Math.max(1, Math.floor(timeoutMs));
 
-    let child: ReturnType<SpawnCommand>;
+    let child: ChildProcess;
     try {
       child = spawnCommand(candidate.command, [...candidate.args], {
         stdio: ['pipe', 'ignore', 'pipe'],

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -119,9 +119,8 @@ export type CliHistoryDeleteResult =
     };
 
 export function parseCliHistoryId(raw: string): ExecutionId | undefined {
-  return ExecutionIdSchema.safeParse(raw).success
-    ? (raw as ExecutionId)
-    : undefined;
+  const parsed = ExecutionIdSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
 }
 
 export async function listCliHistoryEntries(): Promise<CliHistoryEntry[]> {

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -157,12 +157,6 @@ export function noRunnableModelAccessReason(
   return apiMode;
 }
 
-function formatCliNoRunnableModelsSummary(
-  reason: NoRunnableModelAccessReason,
-): string {
-  return NO_RUNNABLE_MODEL_ACCESS_SUMMARIES[reason];
-}
-
 export function formatCliNoRunnableModelsLaunchBlock(
   reason: NoRunnableModelAccessReason,
 ): string {
@@ -192,7 +186,7 @@ export function formatCliNoRunnableModelsMessage(
   reason: NoRunnableModelAccessReason,
   options: CliNoRunnableModelsMessageOptions = {},
 ): string {
-  return `${formatCliNoRunnableModelsSummary(reason)} ${formatCliNoRunnableModelsRecovery(reason, options)}`;
+  return `${NO_RUNNABLE_MODEL_ACCESS_SUMMARIES[reason]} ${formatCliNoRunnableModelsRecovery(reason, options)}`;
 }
 
 function formatModelAccessStatus(model: ModelOptionData): string {
@@ -216,10 +210,15 @@ export function formatModelStatusForCliMode(
   return RELAY_STATUS_BY_AVAILABILITY[availability];
 }
 
+// Reason a given model id cannot be switched to right now, or undefined if it can.
+export type GetModelSwitchDisabledReason = (
+  model: string,
+) => string | undefined;
+
 export function modelSelectItemsForCliMode(
   models: readonly CliModelAccess[],
   apiMode: CliApiMode,
-  getModelSwitchDisabledReason?: (model: string) => string | undefined,
+  getModelSwitchDisabledReason?: GetModelSwitchDisabledReason,
 ): readonly CliModelPickerItem[] {
   return runnableCliModelAccessEntries(models, apiMode).map((model) => {
     const disabledReason = getModelSwitchDisabledReason?.(model.model.value);

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -529,7 +529,8 @@ function includeAgent(
   agents: readonly AgentEntry[],
   rootAgent: AgentEntry,
 ): AgentEntry[] {
-  return agents.some((agent) => toAgentKey(agent) === toAgentKey(rootAgent))
+  const rootKey = toAgentKey(rootAgent);
+  return agents.some((agent) => toAgentKey(agent) === rootKey)
     ? [...agents]
     : [...agents, rootAgent];
 }

--- a/packages/cli/src/runtime/sessionResume.ts
+++ b/packages/cli/src/runtime/sessionResume.ts
@@ -14,7 +14,10 @@ import { toErrorMessage } from '@common/errors';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import { readCliHistoryConfig } from './history';
-import { readCliToolUseResumeData } from './toolUseResumeData';
+import {
+  readCliToolUseResumeData,
+  type CliToolUseResumeData,
+} from './toolUseResumeData';
 
 export type CliResumeResolution =
   | {
@@ -46,7 +49,7 @@ export async function resolveCliResumeSnapshot(
   const taskState = agentConfigToTaskState(config);
   if (!isToolUseTaskState(taskState)) return { kind: 'workflow' };
 
-  let resume: Awaited<ReturnType<typeof readCliToolUseResumeData>>;
+  let resume: CliToolUseResumeData | null;
   try {
     resume = await readCliToolUseResumeData(id, config);
   } catch (error) {

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -36,11 +36,14 @@ export function isExecutionStatus(
   );
 }
 
+export type CliToolUseRunResult = Extract<
+  CliRunResult,
+  { category: 'toolUse' }
+>;
+
 /** Display text for a finished tool-use run: the last response if present,
  *  otherwise a terse status/execution-id summary. */
-export function toolUseResultText(
-  result: Extract<CliRunResult, { category: 'toolUse' }>,
-): string {
+export function toolUseResultText(result: CliToolUseRunResult): string {
   return (
     result.lastResponse?.trim() ||
     `${result.status}\nExecution: ${result.executionId}`

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -6,6 +6,7 @@ import { glob, hasMagic } from 'glob';
 
 import { CliUsageError } from '@cli/runtime/cliContext';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import type { Stats } from 'node:fs';
 
 const STDIN_INPUT_TOKEN = '-';
 const STDIN_TEMP_PREFIX = '.texra-stdin-';
@@ -155,6 +156,13 @@ export async function expandWorkflowInputSpec(
   const trimmed = inputSpec.trim();
   if (!trimmed) return [];
 
+  const normalizeMatches = (matches: string[]): string[] =>
+    matches
+      .sort()
+      .map((match) =>
+        normalizeCliInputPathForRun(match, cwd, flagLabel, options),
+      );
+
   if (trimmed === STDIN_INPUT_TOKEN) {
     const stdinInputFile = requireStdinWorkflowInputFile(flagLabel, options);
     return [
@@ -177,18 +185,14 @@ export async function expandWorkflowInputSpec(
     if (matches.length === 0) {
       throw new CliUsageError(`No input files matched: ${trimmed}`);
     }
-    return matches
-      .sort()
-      .map((match) =>
-        normalizeCliInputPathForRun(match, cwd, flagLabel, options),
-      );
+    return normalizeMatches(matches);
   }
 
   const absolutePath = resolveAgainstCwd(trimmed, cwd);
   // Only treat true missing-path errors as "file not found"; other failures
   // (EACCES, EIO, ...) are environment problems, not Usage errors, and must
   // propagate so the user sees the real cause.
-  let stats: Awaited<ReturnType<typeof fs.stat>> | null = null;
+  let stats: Stats | null = null;
   try {
     stats = await fs.stat(absolutePath);
   } catch (error: unknown) {
@@ -209,11 +213,7 @@ export async function expandWorkflowInputSpec(
         `No .tex input files found in directory: ${trimmed}`,
       );
     }
-    return matches
-      .sort()
-      .map((match) =>
-        normalizeCliInputPathForRun(match, cwd, flagLabel, options),
-      );
+    return normalizeMatches(matches);
   }
 
   // Fail fast with a Usage error (exit 2) instead of paying full platform
@@ -309,38 +309,31 @@ export async function expandRunInputs(
     );
   }
 
+  const shared = {
+    requireWorkspaceFiles: options.requireWorkspaceFiles,
+    stdinInputFile: options.stdinInputFile,
+  };
   const inputExpansion = await prepareWorkflowInputExpansion(
     inputSpecs,
     cwd,
     '--input',
-    {
-      requireWorkspaceFiles: options.requireWorkspaceFiles,
-      stdinInputFile: options.stdinInputFile,
-    },
+    shared,
   );
   const contextExpansion = await prepareWorkflowInputExpansion(
     contextSpecs,
     cwd,
     '--context',
-    {
-      requireWorkspaceFiles: options.requireWorkspaceFiles,
-      stdinInputFile: options.stdinInputFile,
-    },
+    shared,
   );
 
   const inputFiles = await finishWorkflowInputExpansion(inputExpansion, cwd, {
+    ...shared,
     allowEmpty: options.allowEmptyInput,
-    requireWorkspaceFiles: options.requireWorkspaceFiles,
-    stdinInputFile: options.stdinInputFile,
   });
   const contextFiles = await finishWorkflowInputExpansion(
     contextExpansion,
     cwd,
-    {
-      allowEmpty: true,
-      requireWorkspaceFiles: options.requireWorkspaceFiles,
-      stdinInputFile: options.stdinInputFile,
-    },
+    { ...shared, allowEmpty: true },
   );
   return { inputFiles, contextFiles };
 }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -12,15 +12,15 @@ import { createProgressViewCommandHandlers } from '@controllers/progressView/Pro
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform, tryPlatform } from '@platform/platform';
-import {
-  StreamSnapshotStore,
-  type StreamSnapshotStore as SnapshotStore,
-} from '@transcript';
+import { StreamSnapshotStore } from '@transcript';
 import { streamDataDir } from '@transcript/streamDataPaths';
 import { readMeta } from '@transcript/streamSnapshotRead';
 import type { AgentTrace } from '@agent/trace';
 import type { ValidatedExecutionRequest } from '@agent/core/execution/executionRequests';
-import { TaskStateSchema } from '@agent/core/execution/TaskState';
+import {
+  TaskStateSchema,
+  type TaskState,
+} from '@agent/core/execution/TaskState';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -48,8 +48,8 @@ import { createChannelTrace } from '@logger';
 import {
   STREAM_STATUS,
   type AgentProposalPermission,
-  type AgentCategory,
   type AgentCategoryFilter,
+  type MainViewPersistedState,
   type ProgressViewOutboundMessage,
   type ExecutionId,
   type RestoredStreamSnapshot,
@@ -102,7 +102,7 @@ export interface DesktopAgentExecutionOptions {
    * previously-persisted "ghost" streams in the rail at launch.
    */
   streamSnapshotStore?: DesktopStreamSnapshotStore;
-  progressSnapshotStore?: SnapshotStore;
+  progressSnapshotStore?: StreamSnapshotStore;
 }
 
 export interface DesktopAgentExecution {
@@ -110,8 +110,6 @@ export interface DesktopAgentExecution {
   progress: DesktopProgressBridge;
   dispose(): void;
 }
-
-type TaskState = ProgressEventPayloads['setTaskState']['taskState'];
 
 type ResumeState = {
   taskState: TaskState;
@@ -134,7 +132,7 @@ export interface DesktopProgressBridgeOptions {
   showInfoMessage?: (message: string) => Promise<void> | void;
   showErrorMessage?: (message: string) => Promise<void> | void;
   streamSnapshotStore?: DesktopStreamSnapshotStore;
-  progressSnapshotStore?: SnapshotStore;
+  progressSnapshotStore?: StreamSnapshotStore;
 }
 
 function toFileLocation(filePath: string): FileLocation {
@@ -347,7 +345,7 @@ export class DesktopProgressBridge {
     this.agentProposalController = new ProgressAgentProposalController({
       getPendingProposal: (proposalId) => this.agentProposals.get(proposalId),
       restoreTaskState: async (taskState) => {
-        let state: ReturnType<typeof buildMainViewState>;
+        let state: MainViewPersistedState;
         try {
           state = buildMainViewState(taskState);
         } catch {

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -84,9 +84,7 @@ export async function initializeElectronPlatform(
   // bus event handling; the platform owns lifecycle flushing so app shutdown
   // drains the same writer instead of creating a second bus subscriber.
   const snapshotStore = new StreamSnapshotStore();
-  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => {
-    return snapshotStore.flush();
-  });
+  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => snapshotStore.flush());
 
   // Lean tools talk to `lake env lean --server` directly in the desktop build.
   // Servers are spawned lazily per Lake project root on first request.

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { DrainedFollowUpItem } from '@agent/toolUse/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
@@ -46,11 +47,7 @@ async function resumeFromSnapshot(
     runtimeHost,
   });
 
-  let queuedFollowUps: Array<{
-    text: string;
-    displayText?: string;
-    mediaFiles?: readonly string[];
-  }> = [];
+  let queuedFollowUps: DrainedFollowUpItem[] = [];
   try {
     queuedFollowUps = ToolUseFollowUpQueue.drainItems(streamId);
     runtimeHost.emit('updateQueuedFollowUps', {

--- a/packages/extension/src/commands/agent/resumeFromSnapshot.ts
+++ b/packages/extension/src/commands/agent/resumeFromSnapshot.ts
@@ -55,7 +55,7 @@ export async function tryResumeFromSnapshot(
     );
   } catch (error) {
     // Retrieval failed unexpectedly (distinct from "no resumable session").
-    // Auto-resume is best-effort here, so degrade — but log the real failure
+    // Auto-resume is best-effort here, so degrade, but log the real failure
     // rather than letting it masquerade as "nothing to resume".
     logger.error(`Failed to retrieve resume data for stream: ${streamId}`, {
       data: error,

--- a/packages/extension/src/commands/system/yamlCommands.ts
+++ b/packages/extension/src/commands/system/yamlCommands.ts
@@ -8,7 +8,7 @@ import * as yaml from 'yaml';
 // Local imports - utilities
 import { resolveAgent, getWorkflowAgents } from '@agent/index';
 import { loadYaml, loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
-import { getAgentPath } from '@agent/runtime/executeAgent';
+import { getAgentPath } from '@agent/runtime/AgentLaunchContext';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import {
   getActiveEditorWithGuards,

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -26,6 +26,7 @@ import { loadOptions } from '@frontend/agents/optionsLoader';
 import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nativeToolEditApproval';
 import { RecordingManager } from '@frontend/media/RecordingManager';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
+import { isApiProvider } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { StreamTabId } from '@shared/schemas';
@@ -113,10 +114,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.followUpController = this.createFollowUpController();
 
     const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
-      void this.handleDeleteStream({
-        command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
-        stream: streamId,
-      });
+      void this.streamLifecycleController.deleteStream(streamId);
       void OdysseyStore.forget(streamId);
     });
     context.subscriptions.push({ dispose: unsubscribeRemoveStream });
@@ -568,12 +566,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // Stream management handlers
   // ============================================================
 
-  private async handleDeleteStream(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.DELETE_STREAM>,
-  ): Promise<void> {
-    await this.streamLifecycleController.deleteStream(data.stream);
-  }
-
   private async handleDeleteAll(): Promise<void> {
     const confirmation = await vscode.window.showWarningMessage(
       'Are you sure you want to delete all streams? This action cannot be undone.',
@@ -607,11 +599,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async handleUseOwnApiKey(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY>,
   ): Promise<void> {
-    const providerArg = (
-      SecretManager.API_PROVIDERS as readonly string[]
-    ).includes(data.provider ?? '')
-      ? (data.provider as ApiProvider)
-      : undefined;
+    const providerArg =
+      data.provider !== undefined && isApiProvider(data.provider)
+        ? data.provider
+        : undefined;
 
     // The gate depends on WHICH credential is exhausted:
     //   - Upstream credit depletion (Anthropic 400 "credit balance is

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -12,7 +12,6 @@ import {
   setActiveSidebarView,
 } from '@common/webview';
 import { workspaceSM } from '@common/state';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
 import { computeModelOptionsData } from '@model/computeModelOptions';
@@ -24,9 +23,10 @@ import type {
   PlanApprovalPermission,
   ProgressViewOutboundMessage,
   ProgressViewPlacement,
-  StorageKey,
+  RetryPermission,
   StreamTabId,
   ToolEditPermission,
+  UserQuestionPermission,
 } from '@shared/schemas';
 import { AGENT_CATEGORY } from '@shared/schemas';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
@@ -94,7 +94,7 @@ export class ProgressViewProvider
     'requestId'
   >;
   private retryRequestHandler!: ApprovalRequestHandler<
-    ProgressEventPayloads['showRetryRequest'],
+    RetryPermission,
     'streamId'
   >;
   private agentProposalHandler!: ApprovalRequestHandler<
@@ -110,7 +110,7 @@ export class ProgressViewProvider
     'requestId'
   >;
   private userQuestionHandler!: ApprovalRequestHandler<
-    ProgressEventPayloads['showUserQuestion'],
+    UserQuestionPermission,
     'requestId'
   >;
 

--- a/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -102,7 +102,7 @@ export class LatexSettingsHandlers {
       } catch (error) {
         // Detection failed (e.g. a tool probe threw). Do NOT cache a fabricated
         // "nothing installed" status: caching it would mislead the user for the
-        // whole TTL — making an installed setup look broken — and hide the real
+        // whole TTL (making an installed setup look broken) and hide the real
         // failure. Post a best-effort default for this render only and retry
         // detection on the next open.
         this.ctx.logger.error(

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1,7 +1,6 @@
 import { html, nothing, type TemplateResult } from 'lit';
 import { provide } from '@lit/context';
 import { customElement, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -1659,9 +1658,6 @@ export class MainApp extends MainAppBase {
     }
 
     const isToolUse = this.sessionType.get() === SESSION_TYPES.TOOL_USE;
-    const fileSelectionClasses = classMap({
-      'file-selection-group': true,
-    });
     // Tool-use (interactive) agents read input/context via their own tools, so
     // only the Media group (pasted/added images the agent can view) is relevant
     // to them; workflow agents get the full set. Surfacing Media here lets an
@@ -1783,55 +1779,53 @@ export class MainApp extends MainAppBase {
               .handleComponentDismissGettingStarted}
           ></banner-group>
 
-          ${html`
-            <div class="section-separator" role="presentation"></div>
-            <wa-details
-              class="file-selection-details"
-              ?open=${this.fileSelectionOpen.get()}
-              @wa-show=${(event: Event) => {
-                // Filter by event source: child wa-dropdown components
-                // inside the panel also emit wa-show/wa-hide which bubble
-                // up. Without this guard, opening any dropdown inside
-                // the Files panel re-flips fileSelectionOpen on the next
-                // dropdown close (see webawesome#1540).
-                if (event.target === event.currentTarget) {
-                  this.fileSelectionOpen.set(true);
-                }
-              }}
-              @wa-hide=${(event: Event) => {
-                if (event.target === event.currentTarget) {
-                  this.fileSelectionOpen.set(false);
-                }
-              }}
-            >
-              <span slot="summary" class="file-selection-summary">
-                <wa-icon
-                  library=${TEXRA_ICON_LIBRARY}
-                  name="folder-tree"
-                  variant="solid"
-                ></wa-icon>
-                Files
-              </span>
-              <div class=${fileSelectionClasses}>
-                ${repeat(
-                  visibleFileConfigs,
-                  (config) => config.type,
-                  (config) => html`
-                    <file-select-group
-                      .config=${config}
-                      @add-opened-files=${this.handleComponentAddOpenedFiles}
-                      @empty-files=${this.handleComponentEmptyFiles}
-                      @select-multiple-files=${this
-                        .handleComponentSelectMultipleFiles}
-                      @remove-file=${this.handleComponentRemoveFile}
-                      @files-reordered=${this.handleComponentFilesReordered}
-                      @checkbox-change=${this.handleComponentCheckboxChange}
-                    ></file-select-group>
-                  `,
-                )}
-              </div>
-            </wa-details>
-          `}
+          <div class="section-separator" role="presentation"></div>
+          <wa-details
+            class="file-selection-details"
+            ?open=${this.fileSelectionOpen.get()}
+            @wa-show=${(event: Event) => {
+              // Filter by event source: child wa-dropdown components
+              // inside the panel also emit wa-show/wa-hide which bubble
+              // up. Without this guard, opening any dropdown inside
+              // the Files panel re-flips fileSelectionOpen on the next
+              // dropdown close (see webawesome#1540).
+              if (event.target === event.currentTarget) {
+                this.fileSelectionOpen.set(true);
+              }
+            }}
+            @wa-hide=${(event: Event) => {
+              if (event.target === event.currentTarget) {
+                this.fileSelectionOpen.set(false);
+              }
+            }}
+          >
+            <span slot="summary" class="file-selection-summary">
+              <wa-icon
+                library=${TEXRA_ICON_LIBRARY}
+                name="folder-tree"
+                variant="solid"
+              ></wa-icon>
+              Files
+            </span>
+            <div class="file-selection-group">
+              ${repeat(
+                visibleFileConfigs,
+                (config) => config.type,
+                (config) => html`
+                  <file-select-group
+                    .config=${config}
+                    @add-opened-files=${this.handleComponentAddOpenedFiles}
+                    @empty-files=${this.handleComponentEmptyFiles}
+                    @select-multiple-files=${this
+                      .handleComponentSelectMultipleFiles}
+                    @remove-file=${this.handleComponentRemoveFile}
+                    @files-reordered=${this.handleComponentFilesReordered}
+                    @checkbox-change=${this.handleComponentCheckboxChange}
+                  ></file-select-group>
+                `,
+              )}
+            </div>
+          </wa-details>
         </div>
 
         ${this.isDesktopHost

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -203,6 +203,14 @@ export interface ToolUseCycleShared extends ToolUseCycleFields {
   cycleNormalizedUsage?: NormalizedUsage;
 }
 
+/** Prep result for ToolUsePrepNode - drained queued follow-up plus interrupt flag. */
+interface ToolUsePrepResult {
+  interrupted: boolean;
+  queuedFollowUp: string | null;
+  queuedFollowUpDisplay: string | null;
+  synthetic: boolean;
+}
+
 /**
  * Prepares a tool-use cycle by checking interruptions and injecting queued follow-ups.
  *
@@ -215,12 +223,7 @@ class ToolUsePrepNode<C> extends BaseNode<
   CycleParams,
   ToolUseCycleServices<C>
 > {
-  async prep(_shared: ToolUseCycleShared): Promise<{
-    interrupted: boolean;
-    queuedFollowUp: string | null;
-    queuedFollowUpDisplay: string | null;
-    synthetic: boolean;
-  }> {
+  async prep(_shared: ToolUseCycleShared): Promise<ToolUsePrepResult> {
     const interrupted = this.services.checkInterruption();
 
     if (!this.services.session?.hasQueuedFollowUp()) {
@@ -244,12 +247,7 @@ class ToolUsePrepNode<C> extends BaseNode<
 
   async post(
     shared: ToolUseCycleShared,
-    prepRes: {
-      interrupted: boolean;
-      queuedFollowUp: string | null;
-      queuedFollowUpDisplay: string | null;
-      synthetic: boolean;
-    },
+    prepRes: ToolUsePrepResult,
   ): Promise<string | undefined> {
     if (prepRes.interrupted) {
       shared.shouldStop = true;

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -62,8 +62,11 @@ export const AgentFlowResultSchema = z.discriminatedUnion('category', [
 
 export type AgentFlowResult = z.infer<typeof AgentFlowResultSchema>;
 
+/** The discriminant of {@link AgentFlowResult}: which flow produced the result. */
+export type AgentFlowCategory = AgentFlowResult['category'];
+
 export function buildTerminalFlowResult(
-  category: 'workflow' | 'toolUse',
+  category: AgentFlowCategory,
   status: EndGroupStatus,
   executionId: ExecutionId,
   streamId: StreamTabId,

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -9,6 +9,12 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import type { RunCoordinators } from './RunContext';
 
+/** Round counters tracked per execution (both absent until the first update). */
+export interface ExecutionProgress {
+  currentRound?: number;
+  totalRounds?: number;
+}
+
 export interface ExecutionStatusInfo {
   status: string;
   elapsed: string | null;
@@ -30,9 +36,9 @@ export interface ExecutionHandle {
   readonly startedAt: number;
   readonly runtimeHost: AgentRuntimeHost;
 
-  getProgress(): { currentRound?: number; totalRounds?: number };
+  getProgress(): ExecutionProgress;
 
-  updateProgress(update: { currentRound?: number; totalRounds?: number }): void;
+  updateProgress(update: ExecutionProgress): void;
 }
 
 export interface LiveToolUseFlowContext {
@@ -60,7 +66,7 @@ export interface LiveToolUseFlowContext {
  */
 export class AgentExecutionHandle implements ExecutionHandle {
   readonly startedAt = Date.now();
-  private progress: { currentRound?: number; totalRounds?: number } = {};
+  private progress: ExecutionProgress = {};
   private _parentStreamId: StreamTabId;
   private toolUseFlowContext?: LiveToolUseFlowContext;
 
@@ -88,14 +94,11 @@ export class AgentExecutionHandle implements ExecutionHandle {
     this._parentStreamId = this.childStreamId;
   }
 
-  getProgress(): { currentRound?: number; totalRounds?: number } {
+  getProgress(): ExecutionProgress {
     return { ...this.progress };
   }
 
-  updateProgress(update: {
-    currentRound?: number;
-    totalRounds?: number;
-  }): void {
+  updateProgress(update: ExecutionProgress): void {
     Object.assign(this.progress, update);
   }
 
@@ -142,7 +145,7 @@ export class ProcessExecutionHandle implements ExecutionHandle {
     return this.killFn();
   }
 
-  getProgress(): { currentRound?: number; totalRounds?: number } {
+  getProgress(): ExecutionProgress {
     return {};
   }
 

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -14,6 +14,7 @@
 import {
   executionRegistry,
   type ExecutionHandle,
+  type ExecutionProgress,
   type ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -48,9 +49,7 @@ interface ExecutionSubscriptionBinderOptions {
   logger?: BinderLogger;
 }
 
-function progressLine(
-  progress: { currentRound?: number; totalRounds?: number } | undefined,
-): string | null {
+function progressLine(progress: ExecutionProgress | undefined): string | null {
   if (
     !progress ||
     progress.currentRound === undefined ||

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -4,6 +4,7 @@ import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/toolus
 import {
   runToolUseFlow,
   type IToolUseSession,
+  type RunToolUseFlowResult,
 } from '@agent/implementations/flows/tooluse';
 import {
   runReflectionFlow,
@@ -18,6 +19,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { computeDelegationDepthFromStorage } from '@agent/runtime/delegationPolicy';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { AgentError } from '@common/errors';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import {
   STREAM_STATUS,
@@ -27,7 +29,6 @@ import {
   type RoundOutput,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
-import { TaskRunFileService } from '@utils/files';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 
 import {
@@ -46,8 +47,6 @@ import type {
   CompileFailureSummary,
   OutputFileSummary,
 } from './AgentFlowResult';
-
-export { getAgentPath } from './AgentLaunchContext';
 
 const CHANNEL = 'executeAgent';
 const logger = createChannelTrace(CHANNEL);
@@ -106,6 +105,22 @@ function buildWorkflowFlowResult(
   };
 }
 
+/** Build a tool-use AgentFlowResult from a tool-use flow run. */
+function buildToolUseFlowResult(
+  result: RunToolUseFlowResult,
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+): AgentFlowResult {
+  return {
+    category: 'toolUse',
+    status: result.status,
+    lastResponse: result.lastResponse,
+    touchedFiles: result.touchedFiles,
+    executionId,
+    streamId,
+  };
+}
+
 /** Create an onRoundCompleted callback that feeds progress into the execution registry and orchestrator. */
 function createRoundProgressCallback(
   executionId: ExecutionId,
@@ -147,12 +162,12 @@ function createUsageRecordingCallback(
   };
 }
 
-function buildFallbackNotification(config: AgentConfig): {
-  agentName: string;
-  modelName: string;
-  inputName: string;
-  outputInfo: string;
-} {
+/** Toast payload shown when the progress view cannot be opened. */
+type FallbackNotification = NonNullable<
+  ProgressEventPayloads['requestEnsureProgressView']['fallbackNotification']
+>;
+
+function buildFallbackNotification(config: AgentConfig): FallbackNotification {
   const primaryInput = config.inputFiles[0];
   const inputName = primaryInput
     ? path.basename(primaryInput)
@@ -325,14 +340,7 @@ export async function executeAgent(
               return () => handle.detachToolUseFlow(flowContext);
             },
           );
-          return {
-            category: 'toolUse' as const,
-            status: result.status,
-            lastResponse: result.lastResponse,
-            touchedFiles: result.touchedFiles,
-            executionId: ctx.executionId,
-            streamId,
-          };
+          return buildToolUseFlowResult(result, ctx.executionId, streamId);
         }
 
         const onRoundCompleted = createRoundProgressCallback(
@@ -428,14 +436,7 @@ export async function resumeToolUseFromSnapshot(
           return () => handle.detachToolUseFlow(flowContext);
         },
       );
-      return {
-        category: 'toolUse' as const,
-        status: result.status,
-        lastResponse: result.lastResponse,
-        touchedFiles: result.touchedFiles,
-        executionId: ctx.executionId,
-        streamId,
-      };
+      return buildToolUseFlowResult(result, ctx.executionId, streamId);
     });
   });
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -25,6 +25,7 @@ import {
 import { formatDuration } from '@utils/core';
 import {
   type ExecutionHandle,
+  type ExecutionProgress,
   type ExecutionStatusInfo,
   type LiveToolUseFlowContext,
   AgentExecutionHandle,
@@ -38,6 +39,7 @@ import {
 
 export type { ExecutionHandle } from './ExecutionHandle';
 export {
+  type ExecutionProgress,
   type ExecutionStatusInfo,
   type LiveToolUseFlowContext,
   ACTIVE_STATUSES,
@@ -201,7 +203,6 @@ export class ExecutionRegistry {
   untrack(executionId: string): void {
     const handle = this.handles.get(executionId);
     if (!handle) {
-      this.handles.delete(executionId);
       this.notifyWaiters(executionId);
       return;
     }
@@ -377,10 +378,7 @@ export class ExecutionRegistry {
     }
   }
 
-  updateProgress(
-    executionId: string,
-    update: { currentRound?: number; totalRounds?: number },
-  ): void {
+  updateProgress(executionId: string, update: ExecutionProgress): void {
     const handle = this.handles.get(executionId);
     if (!handle) return;
     handle.updateProgress(update);

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -11,6 +11,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { getAgent, isAgentRegistryReady } from '@agent/index/agentRegistry';
 
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceFS } from '@utils/files';
@@ -142,9 +143,9 @@ export async function writeTerminalStatus(
     // Non-critical bookkeeping — don't let I/O errors disrupt execution lifecycle.
     logger.debug(
       'ExecutionLifecycle',
-      `Failed to persist terminal status for ${executionId}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `Failed to persist terminal status for ${executionId}: ${toErrorMessage(
+        err,
+      )}`,
     );
   }
 }
@@ -165,9 +166,9 @@ export async function writeSessionDescription(
     // Non-critical bookkeeping — don't let I/O errors disrupt execution lifecycle.
     logger.debug(
       'ExecutionLifecycle',
-      `Failed to persist session description for ${executionId}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `Failed to persist session description for ${executionId}: ${toErrorMessage(
+        err,
+      )}`,
     );
   }
 }

--- a/src/agent/toolUse/FollowUpQueue.ts
+++ b/src/agent/toolUse/FollowUpQueue.ts
@@ -25,6 +25,13 @@ export interface FollowUpQueueBatch {
   readonly mediaFiles: string[];
 }
 
+/** A single visible follow-up drained for resume replay. */
+export interface DrainedFollowUpItem {
+  text: string;
+  displayText?: string;
+  mediaFiles?: readonly string[];
+}
+
 export class FollowUpQueue {
   private readonly queued: FollowUpQueueItem[] = [];
   private resolver: ((value: FollowUpQueueItem | null) => void) | null = null;
@@ -72,11 +79,7 @@ export class FollowUpQueue {
    * Used by resume to replay queued user input without losing pasted images;
    * the text-only {@link drain} stays for display/back-compat.
    */
-  drainItems(): Array<{
-    text: string;
-    displayText?: string;
-    mediaFiles?: readonly string[];
-  }> {
+  drainItems(): DrainedFollowUpItem[] {
     return this.queued
       .splice(0)
       .filter((item) => !item.synthetic)

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -10,7 +10,10 @@
  * showing appropriate UI notifications based on the returned result.
  */
 
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import {
+  executionRegistry,
+  type ToolUseFollowUpQueueReason,
+} from '@agent/runtime/executionRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
@@ -23,7 +26,7 @@ export type SendFollowUpResult =
   | { status: 'sent' }
   | {
       status: 'queued';
-      reason: 'resuming' | 'waiting' | 'children_running';
+      reason: ToolUseFollowUpQueueReason;
     }
   | { status: 'no_session'; streamStatus: string | undefined };
 
@@ -71,7 +74,6 @@ export async function sendFollowUp(
   mediaFiles?: readonly string[],
   displayText?: string,
 ): Promise<SendFollowUpResult> {
-  const queueOptions = { mediaFiles, displayText };
   const target = executionRegistry.getToolUseFollowUpTarget(streamId);
 
   if (target.kind === 'active') {
@@ -85,22 +87,16 @@ export async function sendFollowUp(
     // must auto-resume the parent or release again to avoid stale delivery.
     const force = target.reason === 'children_running';
     ToolUseFollowUpQueue.enqueue(streamId, text, {
-      ...queueOptions,
+      mediaFiles,
+      displayText,
       ...(force ? { force: true } : {}),
     });
     return { status: 'queued', reason: target.reason };
   }
 
-  if (target.streamStatus !== undefined) {
-    logger.warn(
-      `No active session for follow-up on stream ${streamId}. Status: ${target.streamStatus}`,
-    );
-    return { status: 'no_session', streamStatus: target.streamStatus };
-  }
-
   // No active/waiting session found - caller should handle UI notification
   logger.warn(
-    `No active session for follow-up on stream ${streamId}. Status: undefined`,
+    `No active session for follow-up on stream ${streamId}. Status: ${target.streamStatus}`,
   );
-  return { status: 'no_session', streamStatus: undefined };
+  return { status: 'no_session', streamStatus: target.streamStatus };
 }

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -7,7 +7,7 @@
 
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
-import { FollowUpQueue } from './FollowUpQueue';
+import { FollowUpQueue, type DrainedFollowUpItem } from './FollowUpQueue';
 
 const logger = createChannelTrace('ToolUseFollowUpQueue');
 
@@ -105,11 +105,7 @@ export class ToolUseFollowUpQueue {
   }
 
   /** Drain queued follow-ups with their media file paths (resume replay). */
-  static drainItems(streamId: StreamTabId): Array<{
-    text: string;
-    displayText?: string;
-    mediaFiles?: readonly string[];
-  }> {
+  static drainItems(streamId: StreamTabId): DrainedFollowUpItem[] {
     return this.queues.get(streamId)?.drainItems() ?? [];
   }
 

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -66,6 +66,23 @@ export class ArxivSourceProcessor {
     logger.initialize(this.channel);
   }
 
+  /** Best-effort delete that logs failures at debug level instead of throwing. */
+  private async cleanUpBestEffort(
+    target: string,
+    description: string,
+    options?: { recursive?: boolean },
+  ): Promise<void> {
+    await AbsoluteFS.delete(target, options).catch((error: unknown) => {
+      logger.debug(
+        this.channel,
+        `Failed to clean up ${description} ${target}`,
+        {
+          data: error,
+        },
+      );
+    });
+  }
+
   /**
    * Determine file extension from content-type header.
    * Handles tar, gzip, and tex content types.
@@ -169,14 +186,7 @@ export class ArxivSourceProcessor {
       return destPath;
     } finally {
       if (shouldCleanup) {
-        void AbsoluteFS.delete(destPath).catch((error: unknown) => {
-          logger.debug(
-            this.channel,
-            `Failed to clean up partial download ${destPath}`,
-            { data: error },
-          );
-          return undefined;
-        });
+        void this.cleanUpBestEffort(destPath, 'partial download');
       }
     }
   }
@@ -281,28 +291,14 @@ export class ArxivSourceProcessor {
       // Detect PDF-only submissions (no LaTeX source available)
       if (downloadedPath.endsWith('.pdf')) {
         await AbsoluteFS.delete(downloadedPath);
-        await AbsoluteFS.delete(downloadDirFull, { recursive: true }).catch(
-          (error: unknown) => {
-            logger.debug(
-              this.channel,
-              `Failed to clean up download dir ${downloadDirFull}`,
-              { data: error },
-            );
-            return undefined;
-          },
-        );
+        await this.cleanUpBestEffort(downloadDirFull, 'download dir', {
+          recursive: true,
+        });
         // Only clean up the paper directory when it was created for this download
         if (!isRoot) {
-          await AbsoluteFS.delete(paperDirFull, { recursive: true }).catch(
-            (error: unknown) => {
-              logger.debug(
-                this.channel,
-                `Failed to clean up paper dir ${paperDirFull}`,
-                { data: error },
-              );
-              return undefined;
-            },
-          );
+          await this.cleanUpBestEffort(paperDirFull, 'paper dir', {
+            recursive: true,
+          });
         }
         throw new Error(PDF_ONLY_SUBMISSION_ERROR);
       }
@@ -357,16 +353,9 @@ export class ArxivSourceProcessor {
       }
 
       // Remove the temporary download directory (files are now in paper root)
-      await AbsoluteFS.delete(downloadDirFull, { recursive: true }).catch(
-        (error: unknown) => {
-          logger.debug(
-            this.channel,
-            `Failed to clean up temporary download dir ${downloadDirFull}`,
-            { data: error },
-          );
-          return undefined;
-        },
-      );
+      await this.cleanUpBestEffort(downloadDirFull, 'temporary download dir', {
+        recursive: true,
+      });
     }
 
     // Skip auto-indent for root destination to avoid reformatting existing workspace files

--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -22,7 +22,7 @@ import { buildStreamInfos } from '@shared/progressView/backend/streamInfoUtils';
 import {
   type ActiveStreamId,
   ProgressViewState,
-  type StreamExecutionState,
+  type StreamBadgeSnapshot,
 } from '@shared/progressView/backend/state/ProgressViewState';
 import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 import type { OdysseyStatus } from '@tools/odyssey';
@@ -67,12 +67,7 @@ export interface SyncStreamContentPayload {
   agentCategory?: string;
   /** Tab-switch state previously sent by syncActiveStreamState (R2). */
   conversationProgress?: ConversationProgress;
-  badges?: {
-    activeSubagents: StreamExecutionState['activeSubagents'];
-    finishedSubagentCount: StreamExecutionState['finishedSubagentCount'];
-    activeProcesses: StreamExecutionState['activeProcesses'];
-    finishedProcessCount: StreamExecutionState['finishedProcessCount'];
-  };
+  badges?: StreamBadgeSnapshot;
   parentStreamId?: StreamTabId;
   /** Toggle bypass state (hydrated on tab switch so toggles display correctly). */
   toolEditBypass?: boolean;
@@ -289,15 +284,7 @@ export class WebviewUpdater {
     });
   }
 
-  updateStreamBadges(
-    stream: StreamTabId,
-    badges: {
-      activeSubagents: StreamExecutionState['activeSubagents'];
-      finishedSubagentCount: StreamExecutionState['finishedSubagentCount'];
-      activeProcesses: StreamExecutionState['activeProcesses'];
-      finishedProcessCount: StreamExecutionState['finishedProcessCount'];
-    },
-  ): void {
+  updateStreamBadges(stream: StreamTabId, badges: StreamBadgeSnapshot): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
       stream,

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -9,10 +9,8 @@ import { createChannelTrace } from '@logger';
 import {
   STREAM_STATUS,
   type ConversationProgress,
-  type StorageKey,
   type StreamStatus,
   type StreamTabId,
-  type TokenUsageStats,
 } from '@shared/schemas';
 import {
   WebviewUpdater,
@@ -22,6 +20,7 @@ import { mapToRecord } from '@shared/progressView/backend/persistence/serializat
 import {
   ProgressViewState,
   type ActiveStreamId,
+  type StreamBadgeSnapshot,
   type StreamExecutionState,
 } from '@shared/progressView/backend/state/ProgressViewState';
 import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
@@ -39,13 +38,6 @@ export type { UICallbacks };
 
 /** Throttle interval for conversation progress webview pushes (ms). */
 const PROGRESS_THROTTLE_MS = 500;
-
-type StreamBadgeSnapshot = {
-  activeSubagents: StreamExecutionState['activeSubagents'];
-  finishedSubagentCount: StreamExecutionState['finishedSubagentCount'];
-  activeProcesses: StreamExecutionState['activeProcesses'];
-  finishedProcessCount: StreamExecutionState['finishedProcessCount'];
-};
 
 export type ProgressEventSubscription = {
   dispose(): void;
@@ -547,9 +539,7 @@ export class ProgressEventHandler {
 
     // Per-run usage map — shared by workflow and tool-use. Frontend derives
     // sessionUsage as the sum so cumulative totals survive resume.
-    const runUsage = Object.fromEntries(
-      this.state.snapshots.getRunUsage(stream).entries(),
-    ) as Record<string, TokenUsageStats>;
+    const runUsage = mapToRecord(this.state.snapshots.getRunUsage(stream));
 
     const contextState = this.state.getContextState(stream);
 

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -25,7 +25,6 @@ import {
   type AgentCategoryFilter,
   type ConversationProgress,
   type ContextStateData,
-  type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
@@ -83,6 +82,19 @@ export interface StreamExecutionState {
   activeProcesses: ActiveChildInfo[];
   finishedProcessCount: number;
 }
+
+/**
+ * Per-stream child-activity badge counts, projected from
+ * {@link StreamExecutionState}. Sent to the webview on tab switch and whenever
+ * subagent/process activity changes.
+ */
+export type StreamBadgeSnapshot = Pick<
+  StreamExecutionState,
+  | 'activeSubagents'
+  | 'finishedSubagentCount'
+  | 'activeProcesses'
+  | 'finishedProcessCount'
+>;
 
 function createExecutionState(
   kind: (typeof AgentCategory)[keyof typeof AgentCategory],

--- a/src/skills/skillSources.ts
+++ b/src/skills/skillSources.ts
@@ -35,6 +35,14 @@ function bundledSkillSources(resourcesPath: string): SkillSource[] {
   ];
 }
 
+function interopSkillSources(base: string, scopeLabel: string): SkillSource[] {
+  return INTEROP_SKILL_DIRS.map((dir) => ({
+    scope: 'interop',
+    path: path.join(base, dir, 'skills'),
+    label: `${dir} ${scopeLabel}`,
+  }));
+}
+
 function resolveSkillSourcePath(base: string, candidate: string): string {
   return path.isAbsolute(candidate)
     ? path.resolve(candidate)
@@ -82,13 +90,7 @@ export function defaultSkillSources(
   });
 
   if (options.includeInterop === true) {
-    for (const dir of INTEROP_SKILL_DIRS) {
-      sources.push({
-        scope: 'interop',
-        path: path.join(context.cwd, dir, 'skills'),
-        label: `${dir} project`,
-      });
-    }
+    sources.push(...interopSkillSources(context.cwd, 'project'));
   }
 
   sources.push({
@@ -98,13 +100,7 @@ export function defaultSkillSources(
   });
 
   if (options.includeInterop === true) {
-    for (const dir of INTEROP_SKILL_DIRS) {
-      sources.push({
-        scope: 'interop',
-        path: path.join(home, dir, 'skills'),
-        label: `${dir} user`,
-      });
-    }
+    sources.push(...interopSkillSources(home, 'user'));
   }
 
   sources.push(...bundledSkillSources(context.resourcesPath));

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -65,7 +65,10 @@ import {
   enableYoloOnChildStream,
   inheritBashBypassOnChildStream,
 } from '@tools/approval';
-import { computeAndWriteWorkflowDiffs } from '@tools/subagentDiffs';
+import {
+  computeAndWriteWorkflowDiffs,
+  type DiffFileInfo,
+} from '@tools/subagentDiffs';
 import {
   formatSubagentDelivery,
   formatSubagentError,
@@ -235,9 +238,7 @@ async function subagentDeliveryMessage(
     readonly workingDirectory?: string;
   },
 ): Promise<string> {
-  let diffInfos:
-    | Awaited<ReturnType<typeof computeAndWriteWorkflowDiffs>>
-    | undefined;
+  let diffInfos: Map<string, DiffFileInfo> | undefined;
   if (result.category === 'workflow' && result.outputs.length > 0) {
     try {
       diffInfos = await computeAndWriteWorkflowDiffs(
@@ -539,9 +540,7 @@ async function executeSubagent(
       // For workflow results, compute diffs and write them as files to the
       // execution's run directory. The delivery references diff file paths
       // so the orchestrator can read them on demand via /executions/{id}/files/.
-      let diffInfos:
-        | Awaited<ReturnType<typeof computeAndWriteWorkflowDiffs>>
-        | undefined;
+      let diffInfos: Map<string, DiffFileInfo> | undefined;
       if (result.category === 'workflow' && result.outputs.length > 0) {
         try {
           diffInfos = await computeAndWriteWorkflowDiffs(

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -15,7 +15,7 @@ import {
   type WorkspacePathResolution,
 } from '@tools/pathResolution';
 import { recordToolFileRead } from '@tools/fileInteractions';
-import { parseEml } from '@tools/emlParser';
+import { parseEml, type EmlImageAttachment } from '@tools/emlParser';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import {
   getMimeType,
@@ -95,7 +95,7 @@ export class ReadFileTool extends defineTool({
 
     // EML files use complex MIME encoding (multipart, base64, quoted-printable).
     // Parse into readable text and extract image attachments for vision models.
-    let emlImages: Awaited<ReturnType<typeof parseEml>>['images'] = [];
+    let emlImages: EmlImageAttachment[] = [];
     let lines: string[];
 
     if (hasExtension(input.path, '.eml')) {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -88,6 +88,7 @@ import {
   type ClaudeAgentPermissionMode,
   type ClaudeMessageBlock,
 } from './claudeAgentShared';
+import type { Options as ClaudeAgentSdkOptions } from '@anthropic-ai/claude-agent-sdk';
 
 let _configModule: typeof import('./claudeAgentConfig') | null = null;
 async function getClaudeAgentConfig(): Promise<
@@ -297,7 +298,7 @@ export async function runStreamedTurn(params: {
 
   const query = await importClaudeAgentSdk();
 
-  const sdkOptions: import('@anthropic-ai/claude-agent-sdk').Options = {
+  const sdkOptions: ClaudeAgentSdkOptions = {
     abortController: params.abortController,
     model: params.model,
     permissionMode: params.permissionMode,

--- a/src/tools/lean/direct/jsonRpc.ts
+++ b/src/tools/lean/direct/jsonRpc.ts
@@ -16,6 +16,7 @@ import {
   type MessageConnection,
 } from 'vscode-jsonrpc/node';
 
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 
 export type NotificationHandler = (params: unknown) => void;
@@ -127,7 +128,7 @@ export class JsonRpcConnection {
 
   private logLiveError(context: string, err: unknown): void {
     if (this.disposed || !err) return;
-    logger.debug('JsonRpcConnection', `${context}: ${errorMessage(err)}`);
+    logger.debug('JsonRpcConnection', `${context}: ${toErrorMessage(err)}`);
   }
 }
 
@@ -136,9 +137,5 @@ function isConnectionDisposedError(err: unknown): boolean {
   if (code === ConnectionErrors.Disposed || code === ConnectionErrors.Closed) {
     return true;
   }
-  return /\bconnection\b.*\b(disposed|closed)\b/i.test(errorMessage(err));
-}
-
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return /\bconnection\b.*\b(disposed|closed)\b/i.test(toErrorMessage(err));
 }

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -150,7 +150,7 @@ export class LeanSession {
       textDocument: { uri: pathToUri(absolute) },
       position: { line, character: column },
     };
-    return (await this.requireRpc().request(method, params)) as T;
+    return this.requireRpc().request<T>(method, params);
   }
 
   /** Return the live JSON-RPC connection, or throw if the session is down. */

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -76,6 +76,25 @@ type UsageUpdateResult =
   | undefined
   | Promise<TokenUsageStats | undefined>;
 
+/**
+ * Round-keyed delta shape carried by the `addOutputFiles` /
+ * `updateMissingOutputs` / `updateCompileFailures` bus events. Stated once here
+ * so the store's mutators don't each restate the `{ [round: number]: T[] }`
+ * literal. Mirrors the inline payload fields in `ProgressEventPayloads`.
+ */
+type RoundKeyedList<T> = { [round: number]: T[] };
+
+/**
+ * Match criteria for {@link StreamSnapshotStore.findWorkflowStreamsMatching}.
+ * Mirrors the `streamConfig` payload on the `clearMissingOutputs` bus event.
+ */
+interface WorkflowStreamMatch {
+  agent: string;
+  model: string;
+  inputFile: string;
+  outputFiles?: readonly string[];
+}
+
 function normalizeOutputFiles(outputFiles?: readonly string[]): string[] {
   return (outputFiles ?? [])
     .map((file) => file.replaceAll('\\', '/'))
@@ -311,9 +330,9 @@ export class StreamSnapshotStore {
     return inner;
   }
 
-  private parseOutputFilesPatch(filesByRound: {
-    [key: number]: OutputFileInfo[];
-  }): OutputFilesPatch {
+  private parseOutputFilesPatch(
+    filesByRound: RoundKeyedList<OutputFileInfo>,
+  ): OutputFilesPatch {
     const patch: OutputFilesPatch = new Map();
     for (const [round, files] of Object.entries(filesByRound)) {
       const key = RoundKeySchema.safeParse(round);
@@ -398,7 +417,7 @@ export class StreamSnapshotStore {
 
   addOutputFiles(
     stream: StreamTabId,
-    filesByRound: { [key: number]: OutputFileInfo[] },
+    filesByRound: RoundKeyedList<OutputFileInfo>,
   ): void {
     const patch = this.parseOutputFilesPatch(filesByRound);
     if (patch.size === 0) return;
@@ -417,7 +436,7 @@ export class StreamSnapshotStore {
 
   updateMissingOutputs(
     stream: StreamTabId,
-    filesByRound: { [key: number]: string[] },
+    filesByRound: RoundKeyedList<string>,
   ): void {
     this.mutate(stream, () => {
       const rounds = this.getOrCreate(this.missingOutputs, stream);
@@ -431,7 +450,7 @@ export class StreamSnapshotStore {
 
   updateCompileFailures(
     stream: StreamTabId,
-    filesByRound: { [key: number]: CompileFailure[] },
+    filesByRound: RoundKeyedList<CompileFailure>,
   ): void {
     this.mutate(stream, () => {
       const rounds = this.getOrCreate(this.compileFailures, stream);
@@ -530,6 +549,24 @@ export class StreamSnapshotStore {
   // Lifecycle (replace manager evict/evictAll)
   // ==========================================================================
 
+  /** Every stream id with any in-memory accumulator/overlay state. */
+  private allKnownStreams(): Set<StreamTabId> {
+    return new Set<StreamTabId>([
+      ...this.outputFiles.keys(),
+      ...this.missingOutputs.keys(),
+      ...this.compileFailures.keys(),
+      ...this.usage.keys(),
+      ...this.workPlan.keys(),
+      ...this.meta.keys(),
+      ...this.taskStates.keys(),
+      ...this.seeded,
+      ...this.seedChains.keys(),
+      ...this.outputFileOverlays.keys(),
+      ...this.usageOverlays.keys(),
+      ...this.kvCache.keys(),
+    ]);
+  }
+
   /** Drop a stream's in-memory state. Disk cleanup is the caller's job. */
   evict(stream: StreamTabId): void {
     this.bumpStreamVersion(stream);
@@ -552,21 +589,7 @@ export class StreamSnapshotStore {
   }
 
   evictAll(): void {
-    const streams = new Set<StreamTabId>([
-      ...this.outputFiles.keys(),
-      ...this.missingOutputs.keys(),
-      ...this.compileFailures.keys(),
-      ...this.usage.keys(),
-      ...this.workPlan.keys(),
-      ...this.meta.keys(),
-      ...this.taskStates.keys(),
-      ...this.seeded,
-      ...this.seedChains.keys(),
-      ...this.outputFileOverlays.keys(),
-      ...this.usageOverlays.keys(),
-      ...this.kvCache.keys(),
-    ]);
-    for (const stream of streams) this.bumpStreamVersion(stream);
+    for (const stream of this.allKnownStreams()) this.bumpStreamVersion(stream);
     this.outputFiles.clear();
     this.missingOutputs.clear();
     this.compileFailures.clear();
@@ -733,12 +756,7 @@ export class StreamSnapshotStore {
    * that surfaced markers for the cleaned files. Both sides are canonicalized
    * (agent source prefixes stripped, paths normalized to forward slashes).
    */
-  findWorkflowStreamsMatching(match: {
-    agent: string;
-    model: string;
-    inputFile: string;
-    outputFiles?: readonly string[];
-  }): StreamTabId[] {
+  findWorkflowStreamsMatching(match: WorkflowStreamMatch): StreamTabId[] {
     const wantAgent = getCleanAgentName(match.agent);
     const wantFile = match.inputFile.replaceAll('\\', '/');
     const wantOutputFiles = normalizeOutputFiles(match.outputFiles);
@@ -916,21 +934,7 @@ export class StreamSnapshotStore {
   }
 
   private evictStreamsExcept(keep: ReadonlySet<StreamTabId>): void {
-    const streams = new Set<StreamTabId>([
-      ...this.outputFiles.keys(),
-      ...this.missingOutputs.keys(),
-      ...this.compileFailures.keys(),
-      ...this.usage.keys(),
-      ...this.workPlan.keys(),
-      ...this.meta.keys(),
-      ...this.taskStates.keys(),
-      ...this.seeded,
-      ...this.seedChains.keys(),
-      ...this.outputFileOverlays.keys(),
-      ...this.usageOverlays.keys(),
-      ...this.kvCache.keys(),
-    ]);
-    for (const stream of streams) {
+    for (const stream of this.allKnownStreams()) {
       if (!keep.has(stream)) this.evict(stream);
     }
   }
@@ -1005,27 +1009,25 @@ export class StreamSnapshotStore {
     stream: StreamTabId,
     keys: Iterable<string>,
   ): void {
-    const byKey = new Map<string, Map<number | string, unknown> | undefined>([
-      [
-        STREAM_DATA_KEYS.OUTPUT_FILES,
-        this.outputFiles.get(stream) as Map<number, unknown> | undefined,
-      ],
-      [
-        STREAM_DATA_KEYS.MISSING_OUTPUTS,
-        this.missingOutputs.get(stream) as Map<number, unknown> | undefined,
-      ],
-      [
-        STREAM_DATA_KEYS.COMPILE_FAILURES,
-        this.compileFailures.get(stream) as Map<number, unknown> | undefined,
-      ],
-      [
-        STREAM_DATA_KEYS.USAGE_STATS,
-        this.usage.get(stream) as Map<string, unknown> | undefined,
-      ],
-    ]);
     for (const key of keys) {
-      const map = byKey.get(key);
-      if (map) this.write(stream, key, mapToRecord(map));
+      switch (key) {
+        case STREAM_DATA_KEYS.OUTPUT_FILES:
+          if (this.outputFiles.has(stream)) this.writeOutputFiles(stream);
+          break;
+        case STREAM_DATA_KEYS.USAGE_STATS:
+          if (this.usage.has(stream)) this.writeUsage(stream);
+          break;
+        case STREAM_DATA_KEYS.MISSING_OUTPUTS: {
+          const map = this.missingOutputs.get(stream);
+          if (map) this.write(stream, key, mapToRecord(map));
+          break;
+        }
+        case STREAM_DATA_KEYS.COMPILE_FAILURES: {
+          const map = this.compileFailures.get(stream);
+          if (map) this.write(stream, key, mapToRecord(map));
+          break;
+        }
+      }
     }
   }
 

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -296,7 +296,7 @@ function findToolInCommonPathsUncached(tool: string): string | null {
   const pathEnv = extendEnvPath();
 
   // kpsewhich resolves files through the TeX database rather than PATH, so it
-  // stays a subprocess — npm `which` only searches PATH.
+  // stays a subprocess. npm `which` only searches PATH.
   for (const name of candidates) {
     try {
       const result = execaSync('kpsewhich', [name], {


### PR DESCRIPTION
## What

Behavior-preserving cleanup of the source touched between `v0.38.5` and `main`, produced by several parallel code-simplifier passes over disjoint module batches (CLI/TUI, agent runtime, progress view, tools, transcript, desktop). **64 files, +482 / −526 (net −44 lines).**

No runtime behavior, control flow, ordering, or effects change — every edit is type-level or a provably-equivalent restructuring.

## Passes

**Simplification** — dedupe shared logic; inline trivial one-call factories and wrapper layers; drop dead code, unused vars, and stale imports; flatten nested conditionals.

**More declarative TUI/CLI** — replace nested-ternary / if-else ladders with module-level lookup tables and data tuples (status-bar segments, API-status hints, agent detail rows); reuse the shared `FormFrame` and `toErrorMessage` helpers; remove a degenerate single-class `classMap` and a redundant `` html`` `` wrapper in the webview Files panel.

**Tighter typing (no more layer-by-layer resolution)** — replace use-site derivation chains (`Awaited<ReturnType<…>>`, `Parameters<>`, deep indexed access) with single named/exported types; hoist inline structural object types restated across sites into one type; prefer `z.infer` + Zod `safeParse` over hand-written casts. Unified across files behind one source of truth: `CliToolUseRunResult`, `GetModelSwitchDisabledReason`, `DrainedFollowUpItem`.

**Pass-through collapse** — remove the `getAgentPath` re-export facade in `executeAgent.ts` (consumers import from `AgentLaunchContext` directly); inline the single-caller `handleDeleteStream` delegation method in the progress-view message handler.

## Verification

- `npm run typecheck` — clean
- `prettier --check` — clean
- `eslint` — 0 errors (1 pre-existing import-order warning in `MainApp.ts`, unrelated to this change)

## Deliberately out of scope

- The Supabase **relay edge functions** (`requestLimits.ts`, `index.ts`) — abuse-protection code where "simplification" risks weakening rate limits; left for manual review.
- A few cross-file type unifications that need a semantic naming decision rather than a mechanical merge: unifying `SkillSelectValue` / `ReservedSkillActivation` (two distinct domain concepts), the `AgentFlowCategory` union (differs at some sites with `| 'process'`), and the `TaskState` schema/interface gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are structural (types, deduplication, equivalent control-flow reshaping) with net line reduction and no deliberate logic changes; risk is mainly regression from a very wide touch surface, not security or data-path edits.
> 
> **Overview**
> This PR is a **behavior-preserving cleanup** across the CLI/TUI, agent runtime, progress view, tools, transcript store, desktop, and VS Code extension (~64 files, net fewer lines). It does not introduce new product features; it restructures and types code touched since v0.38.5.
> 
> **CLI / TUI:** Escape handling for foreground surfaces is expressed as a **`switch`** on surface kind (including explicit **transcript** vs **approval** skip/cancel). List forms share **`FormFrame`** (e.g. `/agent`), drop redundant wrappers, and wire **`GetModelSwitchDisabledReason`** from runtime. **`CursorEdit`**, transcript scroll helpers, and small UI dedupe (e.g. external-inquiry copy status) tighten the input and modal layers.
> 
> **CLI commands / runtime:** Global CLI flag spellings are centralized in **`flagSpellings`**. Command and runtime code replace inline **`Awaited<ReturnType<…>>`** chains with exported types (**`CliToolUseRunResult`**, **`CliRunnableModelResolution`**, auth/history types, etc.). API status action hints move to a **lookup table**; workflow input expansion and agent detail formatting use shared helpers instead of repeated blocks.
> 
> **Agent runtime:** Tool-use flow results are built via **`buildToolUseFlowResult`**; **`ExecutionProgress`**, **`AgentFlowCategory`**, **`DrainedFollowUpItem`**, and related types replace ad-hoc object shapes. **`getAgentPath`** is no longer re-exported from **`executeAgent`** (callers use **`AgentLaunchContext`**). Follow-up queue typing and logging are simplified; **`untrack`** drops a redundant map delete.
> 
> **Progress view / extension / desktop:** Approval handler types use schema permissions (**`RetryPermission`**, **`UserQuestionPermission`**); **`StreamBadgeSnapshot`** is shared. Stream delete goes straight to the lifecycle controller; API provider checks use **`isApiProvider`**. Main view Files panel markup is flattened (no extra **`classMap`** / nested **`html`**). Snapshot store eviction and sidecar writes consolidate duplicate stream-key iteration.
> 
> **Tools / infra:** Minor typing and dedupe (Claude SDK options type, Lean RPC generics, arXiv cleanup helper, skill source interop helper, delegation diff map type).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c740a88847c4715e7a659cc2327db789d81dba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->