### PR TITLE
refactor(progress-ui): consolidate seam, header alignment, and collapsible styles

### DIFF
--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -112,7 +112,7 @@ wa-button.desktop-command-button {
   display: flex;
   align-items: center;
   gap: var(--wa-space-xs);
-  min-height: 34px;
+  min-height: var(--height-header);
   padding: 0 var(--wa-space-xs) 0 var(--wa-space-s);
   border-bottom: 1px solid var(--wa-color-surface-border);
   box-sizing: border-box;

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -22,6 +22,10 @@
   --font-size-h2: 1.25em;
   --font-size-h3: 1em;
 
+  /* Shared pane-header height (mirrors extension litStyles.ts --height-header)
+     so the rail header and the conversation header line up across hosts. */
+  --height-header: 34px;
+
   --desktop-color-background: light-dark(#ffffff, #1e1e1e);
   --desktop-color-foreground: light-dark(#1f2328, #d4d4d4);
   --desktop-color-muted: light-dark(#57606a, #a6a6a6);

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -228,6 +228,15 @@ export class ProgressApp extends ProgressAppBase {
       wa-split-panel {
         width: 100%;
         height: 100%;
+        /* The divider is the one and only seam between the conversation and
+           the stream rail. Collapse WebAwesome's default 4px neutral bar to a
+           1px hairline that matches every other border in the view; the
+           invisible 0.75rem hit-area still makes it easy to drag. */
+        --divider-width: var(--border-thin, 1px);
+      }
+
+      wa-split-panel::part(divider) {
+        background-color: var(--color-border);
       }
 
       stream-tabs {
@@ -447,6 +456,7 @@ export class ProgressApp extends ProgressAppBase {
 
                   <stream-tabs
                     slot="end"
+                    .heading=${compactTabs ? '' : 'Sessions'}
                     .compact=${compactTabs}
                     .streams=${tabStreams$.get()}
                     .activeStreamId=${activeStreamId$.get()}

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -196,22 +196,16 @@ export class FileList extends LitElement {
         margin-left: var(--wa-space-3xs);
       }
 
-      /* Nested round collapsibles */
-      .round-collapsible {
-        border-top: var(--border-thin) solid var(--color-border);
-      }
-
+      /* Nested round collapsibles inherit the shared .panel-collapsible
+         chrome; they only drop the top rule on the first round (the parent
+         panel already rules above it) and shrink the header text so the
+         nested rounds read as subordinate. */
       .round-collapsible:first-child {
         border-top: none;
       }
 
       .round-collapsible::part(header) {
-        padding: var(--wa-space-3xs) var(--wa-space-xs);
         font-size: var(--font-size-sm);
-      }
-
-      .round-collapsible::part(body) {
-        padding: 0 var(--wa-space-xs);
       }
 
       .compile-warning {

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -9,7 +9,6 @@ import {
 } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { live } from 'lit/directives/live.js';
-import { when } from 'lit/directives/when.js';
 
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
@@ -32,7 +31,6 @@ import './QueuedFollowUps';
 
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/details/details.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
 @customElement('follow-up-input')
@@ -252,7 +250,7 @@ export class FollowUpInput extends LitElement {
 
   override render(): TemplateResult | typeof nothing {
     return html`
-      <wa-details class="panel-collapsible" summary="Follow-up Input">
+      <wa-details class="panel-collapsible" summary="Followup">
         <div id=${ELEMENT_IDS.FOLLOW_UP_CONTAINER} class="follow-up-container">
           <queued-follow-ups
             .messages=${this.queuedMessages}
@@ -276,9 +274,9 @@ export class FollowUpInput extends LitElement {
                 icon: 'sparkle',
                 label: 'Polish follow-up',
                 title: 'Polish follow-up with AI',
+                busy: this.polishing,
                 onClick: this.emitPolish,
               })}
-              ${when(this.polishing, () => html`<wa-spinner></wa-spinner>`)}
               ${renderIconActionButton({
                 id: ELEMENT_IDS.RECORD_FOLLOW_UP_BTN,
                 icon: this.recordingController.state.icon,

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -54,10 +54,6 @@ export class PlanView extends LitElement {
         display: none;
       }
 
-      .plan-collapsible {
-        border-bottom: var(--border-thin) solid var(--color-border);
-      }
-
       .plan-body {
         max-height: var(--height-xlarge);
         overflow-y: auto;
@@ -210,7 +206,7 @@ export class PlanView extends LitElement {
     return html`
       <wa-details
         id=${ELEMENT_IDS.PLAN_VIEW_CONTAINER}
-        class="plan-collapsible panel-collapsible"
+        class="panel-collapsible is-boxed"
         summary=${`Plan (${completed}/${total})`}
         ?open=${this.open}
         @wa-show=${this.handleShow}

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -84,7 +84,9 @@ export class RetryRequestPanel extends BaseRequestPanel {
           )}
           ${detailsText
             ? html`
-                <wa-details class="retry-request__error-details">
+                <wa-details
+                  class="retry-request__error-details collapsible-quiet"
+                >
                   <span slot="summary" class="retry-request__error-summary">
                     Error details
                   </span>

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -134,7 +134,10 @@ export class StreamHeader extends LitElement {
         font-size: var(--font-size-sm);
         display: flex;
         flex-direction: column;
+        justify-content: center;
         gap: var(--wa-space-2xs);
+        min-height: var(--height-header);
+        box-sizing: border-box;
         color: var(--color-text-secondary);
         border-bottom: var(--border-thin) solid var(--color-border);
       }

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -547,20 +547,44 @@ export class StreamTabs extends LitElement {
         display: none;
       }
 
+      /*
+       * No own border-left: the single separator between this rail and the
+       * conversation is owned by the host layout — the wa-split-panel divider
+       * in the extension Progress view, and the desktop-rail border-right in
+       * the desktop shell. Drawing one here too produced a doubled seam.
+       */
       .tabs {
         display: flex;
         flex-direction: column;
         flex: 1;
         min-width: 0;
         font-size: var(--font-size-sm);
-        border-left: var(--border-thin) solid var(--color-border);
         height: 100%;
         overflow: visible;
         background-color: var(--background-color);
       }
 
-      :host([compact]) .tabs {
-        border-left: none;
+      /*
+       * Optional rail header band. Pins to the shared --height-header token so
+       * it lines up with the conversation header in the Progress view (and the
+       * desktop rail header). Rendered only when a heading is set.
+       */
+      .stream-tabs-header {
+        display: flex;
+        align-items: center;
+        flex-shrink: 0;
+        box-sizing: border-box;
+        min-height: var(--height-header);
+        padding: var(--wa-space-2xs) var(--wa-space-xs);
+        border-bottom: var(--border-thin) solid var(--color-border);
+      }
+
+      .stream-tabs-title {
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-semibold, 600);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--color-text-secondary);
       }
 
       .tabs-content {
@@ -637,6 +661,8 @@ export class StreamTabs extends LitElement {
 
   @property({ attribute: false }) streams: StreamTabInfo[] = [];
   @property({ type: Boolean, reflect: true }) compact = false;
+  /** Optional rail-header title. Empty (default) renders no header band. */
+  @property({ type: String }) heading = '';
   @property({ attribute: false }) activeStreamId: string | null = null;
   @property({ attribute: false }) filter: StreamFilter = 'all';
   /**
@@ -804,6 +830,11 @@ export class StreamTabs extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="tabs">
+        ${this.heading && !this.compact
+          ? html`<header class="stream-tabs-header" part="header">
+              <span class="stream-tabs-title">${this.heading}</span>
+            </header>`
+          : nothing}
         <div class="tabs-content">
           <div id=${ELEMENT_IDS.STREAM_TABS} @click=${this.handleTabClick}>
             ${repeat(

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -43,11 +43,6 @@ export class TodoList extends LitElement {
         display: none;
       }
 
-      /* Add bottom border */
-      .todo-collapsible {
-        border-bottom: var(--border-thin) solid var(--color-border);
-      }
-
       .todo-list {
         display: flex;
         flex-direction: column;
@@ -135,7 +130,7 @@ export class TodoList extends LitElement {
     return html`
       <wa-details
         id=${ELEMENT_IDS.TODO_LIST_CONTAINER}
-        class="todo-collapsible panel-collapsible"
+        class="panel-collapsible is-boxed"
         summary=${`Todos (${completed}/${total})`}
         ?open=${this.open}
         @wa-show=${this.handleShow}

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -223,7 +223,7 @@ export class HistoryItemElement extends LitElement {
 
     return html`
       <wa-details
-        class="collapsible instruction-collapsible"
+        class="collapsible-quiet instruction-collapsible"
         summary="Show full instructions"
         ?open=${this.open}
         @wa-show=${(e: Event) => this.dispatchToggle(e, true)}

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -52,17 +52,6 @@ export class MemoryItem extends LitElement {
         margin-top: var(--wa-space-3xs);
       }
 
-      .memory-contents::part(header) {
-        min-height: 20px;
-        padding: 0;
-        font-size: var(--font-size-xs);
-        color: var(--color-text-secondary);
-      }
-
-      .memory-contents::part(content) {
-        padding: 0;
-      }
-
       .memory-preview {
         font-size: var(--font-size-sm);
         line-height: var(--line-height-tight, 1.3);
@@ -236,7 +225,7 @@ export class MemoryItem extends LitElement {
           ${this.renderMeta(this.item)}
         </div>
         <wa-details
-          class="collapsible memory-contents"
+          class="collapsible-quiet memory-contents"
           summary="Contents"
           ?open=${this.contentsOpened}
           @wa-show=${this.handleContentsShow}

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -47,7 +47,6 @@ import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 import '@awesome.me/webawesome/dist/components/radio/radio.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
@@ -400,25 +399,6 @@ export class InstructionPanel extends LitElement {
         transform-origin: center;
       }
 
-      /*
-       * Reserve a fixed slot for the polish spinner so the toolbar layout
-       * doesn't jump when isPolishing toggles. Width matches the wa-spinner
-       * font-size used inside the slot.
-       */
-      .polish-spinner-slot {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: var(--font-size-icon, 1em);
-        height: var(--font-size-icon, 1em);
-        opacity: 0;
-        transition: opacity var(--transition-fast);
-      }
-
-      .polish-spinner-slot[aria-hidden='false'] {
-        opacity: 1;
-      }
-
       @keyframes pulse-record {
         0%,
         100% {
@@ -718,22 +698,9 @@ export class InstructionPanel extends LitElement {
               icon: 'sparkle',
               label: 'Polish instruction',
               title: 'Polish instruction text with AI',
-              disabled: session.isPolishing,
+              busy: session.isPolishing,
               action: 'polish',
             })}
-            <span
-              class="polish-spinner-slot"
-              aria-hidden=${session.isPolishing ? 'false' : 'true'}
-            >
-              ${session.isPolishing
-                ? html`
-                    <wa-spinner
-                      id="polishProgressContainer"
-                      style="font-size: var(--font-size-icon, 1em)"
-                    ></wa-spinner>
-                  `
-                : nothing}
-            </span>
             ${renderIconActionButton({
               id: 'recordInstructionButton',
               icon: session.isRecording ? 'stop-circle' : 'mic',

--- a/packages/extension/src/webview/frontend/styles.ts
+++ b/packages/extension/src/webview/frontend/styles.ts
@@ -67,30 +67,10 @@ export const mainViewStyles: CSSResult = css`
    * slim summary row by default, keeping the primary "what do you want to
    * do?" textarea front-and-center and unblocked.
    */
+  /* Chrome comes from the shared .collapsible-quiet (applied in MainApp);
+     only the host margin and the summary layout are file-selection-specific. */
   wa-details.file-selection-details {
     margin-bottom: var(--wa-space-s);
-    background: transparent;
-  }
-
-  wa-details.file-selection-details::part(base) {
-    background: transparent;
-    border: none;
-    border-radius: 0;
-  }
-
-  wa-details.file-selection-details::part(header) {
-    padding: var(--wa-space-3xs) var(--wa-space-2xs);
-    min-height: 22px;
-    font-size: var(--font-size-sm);
-    color: var(--wa-color-text-quiet);
-  }
-
-  wa-details.file-selection-details[open]::part(header) {
-    color: var(--wa-color-text-normal);
-  }
-
-  wa-details.file-selection-details::part(content) {
-    padding: var(--wa-space-2xs) 0 0;
   }
 
   wa-details.file-selection-details .file-selection-summary {

--- a/packages/extension/src/webview/frontend/styles.ts
+++ b/packages/extension/src/webview/frontend/styles.ts
@@ -67,10 +67,33 @@ export const mainViewStyles: CSSResult = css`
    * slim summary row by default, keeping the primary "what do you want to
    * do?" textarea front-and-center and unblocked.
    */
-  /* Chrome comes from the shared .collapsible-quiet (applied in MainApp);
-     only the host margin and the summary layout are file-selection-specific. */
+  /* File selection keeps local disclosure chrome because its body hosts
+     dropdowns that require visible overflow; .collapsible-quiet clamps direct
+     child overflow for simple inline disclosures. */
   wa-details.file-selection-details {
     margin-bottom: var(--wa-space-s);
+    background: transparent;
+  }
+
+  wa-details.file-selection-details::part(base) {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+  }
+
+  wa-details.file-selection-details::part(header) {
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
+    min-height: 22px;
+    font-size: var(--font-size-sm);
+    color: var(--wa-color-text-quiet);
+  }
+
+  wa-details.file-selection-details[open]::part(header) {
+    color: var(--wa-color-text-normal);
+  }
+
+  wa-details.file-selection-details::part(content) {
+    padding: var(--wa-space-2xs) 0 0;
   }
 
   wa-details.file-selection-details .file-selection-summary {

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -52,6 +52,37 @@ export const compactIconActionButtonStyles: CSSResult = css`
   }
 `;
 
+/**
+ * Busy state for an icon action button: a spinner overlays the button while
+ * it works, instead of taking its own slot. The button stays in the flow
+ * (so the toolbar never shifts when the busy flag toggles) and its glyph is
+ * hidden under the spinner. Emitted by `renderIconActionButton({ busy })` —
+ * the helper owns the markup, this sheet styles the class hooks.
+ *
+ * Exported as a focused subset and interpolated into `commonViewStyles` below
+ * so the selectors have a single source of truth (mirrors
+ * `compactIconActionButtonStyles`).
+ */
+export const busyIconButtonStyles: CSSResult = css`
+  .action-icon-busy {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .action-icon-busy wa-button.is-busy {
+    visibility: hidden;
+  }
+
+  .action-icon-busy .action-busy-spinner {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    font-size: var(--font-size-icon, 1em);
+    pointer-events: none;
+  }
+`;
+
 export const commonViewStyles: CSSResult = css`
   .view-header {
     display: flex;
@@ -133,6 +164,12 @@ export const commonViewStyles: CSSResult = css`
     border-top: var(--border-thin) solid var(--color-border);
   }
 
+  /* Boxed variant: also rule off the bottom edge so the panel reads as a
+     standalone band (used by the Plan and Todos panels in the progress board). */
+  .panel-collapsible.is-boxed {
+    border-bottom: var(--border-thin) solid var(--color-border);
+  }
+
   .panel-collapsible::part(header) {
     padding: var(--wa-space-2xs) var(--wa-space-xs);
     background-color: var(--wa-color-surface-lowered, transparent);
@@ -159,6 +196,45 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .panel-collapsible::part(content) > * {
+    overflow: hidden;
+    min-height: 0;
+  }
+
+  /* Quiet collapsible - a borderless, low-emphasis disclosure for inline
+     toggles (e.g. "Show full instructions", a memory "Contents" preview, the
+     file-selection group). One shared look so the same control reads
+     identically wherever it appears, instead of each call site rolling its
+     own header padding/size/color. */
+  .collapsible-quiet::part(base) {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+  }
+
+  .collapsible-quiet::part(header) {
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-normal);
+    color: var(--wa-color-text-quiet);
+  }
+
+  .collapsible-quiet[open]::part(header) {
+    color: var(--wa-color-text-normal);
+  }
+
+  /* Same grid 1fr/0fr collapse as .collapsible / .panel-collapsible so the
+     quiet variant is self-contained (no need to also apply .collapsible). */
+  .collapsible-quiet::part(content) {
+    display: grid;
+    grid-template-rows: 1fr;
+    padding: var(--wa-space-2xs) 0 0;
+  }
+
+  .collapsible-quiet:not([open])::part(content) {
+    grid-template-rows: 0fr;
+  }
+
+  .collapsible-quiet::part(content) > * {
     overflow: hidden;
     min-height: 0;
   }
@@ -202,6 +278,7 @@ export const commonViewStyles: CSSResult = css`
   }
 
   ${compactIconActionButtonStyles}
+  ${busyIconButtonStyles}
   ${compactFormControlStyles}
 
   /* Stricter compactness for wa-checkbox / wa-radio — smaller label,

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -201,10 +201,9 @@ export const commonViewStyles: CSSResult = css`
   }
 
   /* Quiet collapsible - a borderless, low-emphasis disclosure for inline
-     toggles (e.g. "Show full instructions", a memory "Contents" preview, the
-     file-selection group). One shared look so the same control reads
-     identically wherever it appears, instead of each call site rolling its
-     own header padding/size/color. */
+     toggles (e.g. "Show full instructions" or a memory "Contents" preview).
+     One shared look so the same control reads identically wherever it appears,
+     instead of each call site rolling its own header padding/size/color. */
   .collapsible-quiet::part(base) {
     background: transparent;
     border: none;
@@ -213,8 +212,9 @@ export const commonViewStyles: CSSResult = css`
 
   .collapsible-quiet::part(header) {
     padding: var(--wa-space-3xs) var(--wa-space-2xs);
+    min-height: 20px;
     font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight);
     color: var(--wa-color-text-quiet);
   }
 

--- a/src/shared/styles/historyStyles.ts
+++ b/src/shared/styles/historyStyles.ts
@@ -68,7 +68,7 @@ export const historyListStyles: CSSResult = css`
   }
 
   .history-label {
-    font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight);
     color: var(--wa-color-text-quiet);
   }
 
@@ -103,13 +103,13 @@ export const historyListStyles: CSSResult = css`
   .history-title {
     flex: 1;
     min-width: 0;
-    font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight);
     color: var(--wa-color-text-normal);
     word-break: break-word;
   }
 
   .history-title .markdown-content {
-    font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight);
   }
 
   .config-section {
@@ -126,7 +126,7 @@ export const historyListStyles: CSSResult = css`
   }
 
   .config-key {
-    font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight);
     color: var(--wa-color-text-quiet);
     min-width: calc(
       var(--width-button-min) + var(--wa-space-l) + var(--wa-space-l)

--- a/src/shared/styles/historyStyles.ts
+++ b/src/shared/styles/historyStyles.ts
@@ -100,10 +100,6 @@ export const historyListStyles: CSSResult = css`
     line-height: var(--line-height-normal);
   }
 
-  .history-item .collapsible::part(header) {
-    font-weight: var(--font-weight-normal);
-  }
-
   .history-title {
     flex: 1;
     min-width: 0;

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -59,6 +59,10 @@ export const designTokens: CSSResult = css`
 
     /* Heights */
     --height-control: 24px;
+    /* Shared height for the Progress view's pane headers — the conversation
+       header and the stream-tabs rail header pin to this so the two panes
+       start their content at the same baseline (and match the desktop rail). */
+    --height-header: 34px;
     --height-button: 30px;
     --height-small: 100px;
     --height-medium: 200px;

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -1,7 +1,8 @@
 // Third-party imports
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { html, type TemplateResult } from 'lit';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import { html, nothing, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Local imports - Web Awesome
@@ -20,12 +21,20 @@ export interface IconActionButtonOptions {
   readonly appearance?: ActionButtonAppearance;
   readonly variant?: ActionButtonVariant;
   readonly disabled?: boolean;
+  /**
+   * Icon-only. When defined, the button renders inside an overlay wrapper:
+   * while `true` a spinner covers the (hidden, disabled) button so the toolbar
+   * layout does not shift. Styled by `busyIconButtonStyles` in commonViewStyles.
+   * Omitted from the labeled variant — the centered icon-sized spinner only
+   * makes sense over a square icon button.
+   */
+  readonly busy?: boolean;
   readonly onClick?: (event: MouseEvent) => void;
 }
 
 export interface LabeledActionButtonOptions extends Omit<
   IconActionButtonOptions,
-  'label'
+  'label' | 'busy'
 > {
   readonly text: string;
   readonly label?: string;
@@ -50,14 +59,19 @@ function renderActionButtonBase({
   appearance = 'plain',
   variant = 'neutral',
   disabled,
+  busy,
   onClick,
 }: ActionButtonBaseOptions): TemplateResult {
-  const classes = [text ? 'action-button' : 'action-icon-button', className]
+  const classes = [
+    text ? 'action-button' : 'action-icon-button',
+    busy ? 'is-busy' : undefined,
+    className,
+  ]
     .filter(Boolean)
     .join(' ');
   const ariaLabel = label ?? text ?? '';
 
-  return html`
+  const button = html`
     <wa-button
       id=${ifDefined(id)}
       class=${classes}
@@ -68,11 +82,26 @@ function renderActionButtonBase({
       aria-label=${ariaLabel}
       title=${title ?? ariaLabel}
       data-action=${ifDefined(action)}
-      ?disabled=${disabled}
+      ?disabled=${disabled || busy}
       @click=${onClick}
     >
       ${waIcon(icon, { slot: text ? 'start' : undefined })} ${text}
     </wa-button>
+  `;
+
+  // `busy` undefined → plain button (unchanged for every other caller).
+  // `busy` defined → stable overlay wrapper so toggling never reflows the row.
+  if (busy === undefined) return button;
+  return html`
+    <span class="action-icon-busy">
+      ${button}
+      ${busy
+        ? html`<wa-spinner
+            class="action-busy-spinner"
+            aria-hidden="true"
+          ></wa-spinner>`
+        : nothing}
+    </span>
   `;
 }
 


### PR DESCRIPTION
## What

A pixel-level consistency pass over the extension webviews (Progress board, Launcher, Settings), driven by a stream of UI nitpicks. Every change is **declarative** (Lit class hooks + reactive properties, no imperative DOM) and **consolidating** (removes overlapping/duplicated CSS rather than adding overrides). **19 files.**

## Changes

**Progress split seam → one hairline.** The divider was three stacked separators (the `wa-split-panel` 4px gray divider + `stream-tabs` own `border-left` + the per-tab status accent). Dropped the redundant tabs `border-left` (+ its compact override) and made `::part(divider)` a 1px hairline in `--color-border`.

**Pane alignment.** One shared `--height-header` token (in `litStyles` + desktop `themeTokens`) pins the conversation header, the rail header, and the desktop rail header to the same band, so the two panes start their content on the same baseline.

**Rail header is now part of the component.** `<stream-tabs>` gained a declarative `heading` property that renders the header band, replacing a hand-rolled `.stream-rail` wrapper in `ProgressApp`.

**Busy icon button (shared).** `busyIconButtonStyles` + a `busy?: boolean` option on `renderIconActionButton` overlay a spinner on the (hidden, disabled) polish button. `InstructionPanel` and `FollowUpInput` drop their duplicated `.polish-action` CSS — no permanent gap between the polish and record buttons, and no layout jump when polishing toggles. `busy` is icon-only by contract (omitted from the labeled variant).

**Collapsible panels share one style per kind.**
- Panel bands: a `.panel-collapsible.is-boxed` modifier (Plan + Todos stop duplicating an identical `border-bottom`).
- Inline disclosures: one `.collapsible-quiet` variant adopted by memory *Contents*, history *Show full instructions*, and retry *Error details* — consolidating simple disclosure chrome and removing a dead `historyStyles` `::part(header)` override. Launcher file-selection deliberately keeps local disclosure chrome because its body hosts dropdowns that need visible overflow. (QueuedFollowUps is left as a deliberate tinted info-callout.)
- `FileList` round-collapsible: dropped the redundant `border-top`, the dead `::part(body)` override (wrong part for `wa-details`), and the header-padding drift.

**Copy.** "Follow-up Input" → "Followup".

## Verification
- `npm run typecheck` (root + extension) — clean
- `prettier --check` — clean
- Not visually verified (CSS-only; reviewer eyeball welcome on the Progress board + Launcher).

## Coordination
- Branched off `main`, **independent of** #5607 (logos), then rebased over #5610. After the rebase this PR no longer changes `MainApp.ts`; the launcher file-selection disclosure stays on #5610's simplified markup and keeps local styles for dropdown overflow.

## Follow-ups (not in this PR)
- The bare `.collapsible` base style in `commonViewStyles` is now orphaned (its only two users migrated to `.collapsible-quiet`); safe to delete in a later cleanup.
- CLI transcript gutter alignment (flush-left) is designed but left out — it touches load-bearing TUI padding and was being concurrently edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and presentational Lit markup only; no auth, data, or API behavior changes.
> 
> **Overview**
> **Progress and desktop layout** now share a single `--height-header` token so the conversation header, sessions rail header, and desktop rail header align; the split between conversation and rail is one 1px hairline (`wa-split-panel` divider styling, `stream-tabs` `border-left` removed). `<stream-tabs>` gains an optional `heading` property (e.g. "Sessions" from `ProgressApp`) instead of a separate rail wrapper.
> 
> **Shared UI primitives** add `busy` on `renderIconActionButton` with `busyIconButtonStyles` (spinner overlays the icon button—Launcher polish and Progress follow-up polish drop ad-hoc spinner slots). Collapsible styling consolidates: `.panel-collapsible.is-boxed` for Plan/Todos bands, `.collapsible-quiet` for inline disclosures (history, memory, retry error details), with per-component border/padding overrides removed where redundant; `FileList` round collapsibles lean on shared panel chrome.
> 
> Minor copy: follow-up panel summary **Follow-up Input** → **Followup**; history labels use `--font-weight` instead of `--font-weight-normal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14aaf51153d1718d5312fb399c77a257c406d4ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

