### PR TITLE
fix(webview-styles): drop dead status-dot CSS, fix token typos, use design tokens

### DIFF
--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -63,7 +63,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
       }
 
       .followup__label {
-        font-size: var(--font-size-small);
+        font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
       }
 

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -62,7 +62,7 @@ export class WorktreeChip extends LitElement {
         align-items: center;
         gap: var(--wa-space-3xs);
         padding: 0 var(--wa-space-2xs);
-        border-radius: var(--border-radius-pill, 999px);
+        border-radius: var(--wa-border-radius-pill);
         background-color: color-mix(
           in srgb,
           var(--color-text-secondary) 12%,

--- a/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
@@ -53,8 +53,8 @@ export class RelayQuotaMeter extends LitElement {
       .quota-meter {
         margin: 0 0 var(--wa-space-m);
         padding: var(--wa-space-m) var(--wa-space-l);
-        border: 1px solid var(--wa-color-neutral-border-quiet);
-        border-radius: var(--wa-border-radius-m);
+        border: var(--border-thin) solid var(--wa-color-neutral-border-quiet);
+        border-radius: var(--border-radius);
         background: var(--wa-color-neutral-background-quiet);
       }
       .quota-meter[data-state='exhausted'] {
@@ -85,7 +85,7 @@ export class RelayQuotaMeter extends LitElement {
         position: relative;
         height: 6px;
         background: var(--wa-color-neutral-border-quiet);
-        border-radius: 3px;
+        border-radius: var(--border-radius);
         overflow: hidden;
       }
       .quota-bar-fill {

--- a/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
@@ -61,7 +61,7 @@ export class OdysseyTab extends LitElement {
         font-size: var(--wa-font-size-xs);
         font-weight: var(--wa-font-weight-semibold);
         padding: 2px 8px;
-        border-radius: 999px;
+        border-radius: var(--wa-border-radius-pill);
         background: var(--_chip-bg, var(--wa-color-neutral-fill-quiet));
         color: var(--_chip-fg, var(--wa-color-neutral-on-quiet));
       }

--- a/src/shared/styles/statusIndicatorStyles.ts
+++ b/src/shared/styles/statusIndicatorStyles.ts
@@ -1,8 +1,7 @@
 import { css, type CSSResult } from 'lit';
 
 export const statusIndicatorStyles: CSSResult = css`
-  .status-indicator,
-  .tab-status {
+  .status-indicator {
     width: 8px;
     height: 8px;
     border-radius: 50%;
@@ -12,44 +11,33 @@ export const statusIndicatorStyles: CSSResult = css`
     opacity: var(--opacity-subtle, 0.7);
   }
 
-  .status-indicator.is-running,
-  .tab-status.is-running {
-    background-color: var(--color-success, #4caf50);
+  .status-indicator.is-running {
+    background-color: var(--color-success);
     opacity: var(--opacity-full);
   }
 
-  .status-indicator.is-stopped,
-  .tab-status.is-stopped {
+  .status-indicator.is-stopped {
     background-color: var(--wa-color-text-quiet);
     opacity: var(--opacity-subtle, 0.7);
   }
 
-  .status-indicator.is-error,
-  .tab-status.is-error {
-    background-color: var(--color-error, #f44336);
+  .status-indicator.is-error {
+    background-color: var(--color-error);
     opacity: var(--opacity-full);
   }
 
   .status-indicator.is-waiting,
-  .tab-status.is-waiting {
+  .status-indicator.is-resuming {
     background-color: var(--wa-color-text-link);
     opacity: var(--opacity-full);
   }
 
-  .status-indicator.is-resuming,
-  .tab-status.is-resuming {
-    background-color: var(--wa-color-text-link);
-    opacity: var(--opacity-full);
-  }
-
-  .status-indicator.is-initializing,
-  .tab-status.is-initializing {
+  .status-indicator.is-initializing {
     background-color: var(--wa-color-text-quiet);
     opacity: var(--opacity-full);
   }
 
-  .status-indicator.is-ready,
-  .tab-status.is-ready {
+  .status-indicator.is-ready {
     background-color: var(--wa-color-text-quiet);
     opacity: var(--opacity-disabled, 0.5);
   }
@@ -60,7 +48,7 @@ export const statusIndicatorStyles: CSSResult = css`
   }
 
   .status-text.is-running {
-    color: var(--color-success, #4caf50);
+    color: var(--color-success);
   }
 
   .status-text.is-stopped {
@@ -68,7 +56,7 @@ export const statusIndicatorStyles: CSSResult = css`
   }
 
   .status-text.is-error {
-    color: var(--color-error, #f44336);
+    color: var(--color-error);
   }
 
   .status-text.is-waiting,


### PR DESCRIPTION
## What

The safe, no-visual-change subset of a broader UI-consistency audit of the extension webviews — dead CSS removal, two undefined-token bugs, and hardcoded values swapped for the existing design tokens. **5 files.** Larger convergence work (same-element-divergent-styles, shared-widget migrations) is deferred to follow-ups.

## Changes

- **Dead CSS:** `statusIndicatorStyles` styled a `.tab-status` dot that is never rendered (StreamTab shows status via a left border, not a dot). Removed those selectors.
- **Bug — undefined token:** `WorkflowToolUseFollowupSection` used `var(--font-size-small)` (no such token, no fallback) → the label fell back to the inherited size. Fixed to `--font-size-sm`.
- **Bug — undefined token:** `WorktreeChip` pill used `var(--border-radius-pill, 999px)` — `--border-radius-pill` doesn't exist, so it always hit the `999px` fallback. Pointed at the real `--wa-border-radius-pill` (9999px). Same fully-rounded pill, no visual change.
- **Tokens:** `OdysseyTab` pill `999px` → `--wa-border-radius-pill`; `RelayQuotaMeter` card `1px`/`var(--wa-border-radius-m)`/bar `3px` → `--border-thin` / `--border-radius` (matching the sibling settings cards). Resolved values unchanged.
- **Misleading fallbacks:** dropped the per-use `#4caf50` / `#f44336` hex fallbacks in `statusIndicatorStyles` that never applied and contradicted the actual `--color-success` (`#2ea043`) / `--color-error` (`#f14c4c`).

## Verification
- `prettier --check` — clean.
- Each token's availability confirmed per shadow root (`designTokens` is in each component's styles array; `--wa-border-radius-pill` resolves where `--wa-*` tokens are already used).
- Branched off `main`, independent of #5611 (collapsible/seam/header consolidation) and #5610 (simplify pass) — no shared files.

## Deferred (from the same audit, reported separately)
Larger same-element-divergent-style convergences: status pills (odyssey-chip / status-chip / worktree pill → `.tinted-badge`); status→color map shared by dot + tab accent; cards → `.list-item`; empties → `renderEmptyState`; hand-rolled icon buttons → `renderIconActionButton`; a shared `wa-textarea` baseline; and restoring the (currently dead) approval-button color/width styling in `requestPanelStyles` — that one needs a design call on whether to restore or remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only changes in Lit component CSS with intentional no-visual-change token swaps; no auth, data, or runtime logic touched.
> 
> **Overview**
> Extension webview CSS is tightened for **token consistency and dead-code removal**, with fixes for two undefined custom properties that could affect typography and pill shape.
> 
> **`statusIndicatorStyles`** drops unused `.tab-status` selectors (StreamTab never renders that dot) and removes hex fallbacks on `--color-success` / `--color-error` that did not match the real token values. **Workflow follow-up** label font uses `--font-size-sm` instead of the nonexistent `--font-size-small`. **Pills/chips** (`WorktreeChip`, `OdysseyTab`) and **Relay quota meter** borders/radii now reference shared tokens (`--wa-border-radius-pill`, `--border-thin`, `--border-radius`) instead of hardcoded `999px`/`3px` or wrong variable names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ddc69a4657371a8706470a42d4962e0f718f2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->