### PR TITLE
refactor: more declarative code and single sources of truth (since 0.38.5)

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -11,7 +11,7 @@ import { ApprovalPolicyForm } from '../forms/ApprovalPolicyForm';
 import { MemoryListForm } from '../forms/MemoryListForm';
 import { ModelListForm } from '../forms/ModelListForm';
 import { ResumeListForm } from '../forms/ResumeListForm';
-import { SkillsListForm, type SkillSelectValue } from '../forms/SkillsListForm';
+import { SkillsListForm, type SkillActivation } from '../forms/SkillsListForm';
 import { ToolsListForm } from '../forms/ToolsListForm';
 import { cliState } from '../state/cliState';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
@@ -24,7 +24,7 @@ type ModelSelectHandler = (value: string) => void | Promise<void>;
 type ApiModeSelectHandler = (value: CliApiMode) => void | Promise<void>;
 type MemorySelectHandler = (storagePath: string) => void | Promise<void>;
 type ResumeSelectHandler = (id: ExecutionId) => void | Promise<void>;
-type SkillSelectHandler = (value: SkillSelectValue) => void | Promise<void>;
+type SkillSelectHandler = (value: SkillActivation) => void | Promise<void>;
 type ErrorHandler = (error: unknown) => void | Promise<void>;
 type SelectionCompletion = 'afterAction' | 'beforeAction';
 

--- a/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
@@ -25,11 +25,11 @@ import type {
 
 export interface SkillsListFormProps {
   readonly availableRows?: number;
-  readonly onSelect: (value: SkillSelectValue) => void;
+  readonly onSelect: (value: SkillActivation) => void;
   readonly onClose: () => void;
 }
 
-export interface SkillSelectValue {
+export interface SkillActivation {
   readonly name: string;
   readonly activationPrompt: string;
 }
@@ -53,7 +53,7 @@ export function formatSkillActivationPrompt(skill: SourcedSkill): string {
   ].join('\n');
 }
 
-export function skillSelectValueForTui(skill: SourcedSkill): SkillSelectValue {
+export function skillActivationForTui(skill: SourcedSkill): SkillActivation {
   const record = skillListRecord(skill);
   return {
     name: record.name,
@@ -63,11 +63,11 @@ export function skillSelectValueForTui(skill: SourcedSkill): SkillSelectValue {
 
 export function skillSelectItemsForTui(
   skills: readonly SourcedSkill[],
-): SelectItem<SkillSelectValue>[] {
+): SelectItem<SkillActivation>[] {
   return skills.map((skill) => {
     const record = skillListRecord(skill);
     return {
-      value: skillSelectValueForTui(skill),
+      value: skillActivationForTui(skill),
       label: record.name,
       description: formatSkillDescriptionForTui(skill),
     };

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -598,6 +598,17 @@ export function statusBarDisplaySlice({
   });
 }
 
+// Bypass badges, in emission order. One row per BypassState flag.
+const BYPASS_BADGES: ReadonlyArray<{
+  readonly field: keyof BypassState;
+  readonly text: string;
+  readonly badgeColor: 'red' | 'yellow';
+}> = [
+  { field: 'superYolo', text: 'YOLO', badgeColor: 'red' },
+  { field: 'bash', text: 'AUTO-BASH', badgeColor: 'yellow' },
+  { field: 'toolEdit', text: 'AUTO-APPROVE', badgeColor: 'yellow' },
+];
+
 export function buildStatusBarDisplay(
   input: StatusBarDisplayInput,
 ): StatusBarDisplay {
@@ -652,14 +663,14 @@ export function buildStatusBarDisplay(
     kind: input.approvalKind,
   });
   if (pendingInteraction) left.push(pendingInteraction);
-  if (input.bypass.superYolo) {
-    left.push({ text: 'YOLO', badge: true, badgeColor: 'red' });
-  }
-  if (input.bypass.bash) {
-    left.push({ text: 'AUTO-BASH', badge: true, badgeColor: 'yellow' });
-  }
-  if (input.bypass.toolEdit) {
-    left.push({ text: 'AUTO-APPROVE', badge: true, badgeColor: 'yellow' });
+  for (const badge of BYPASS_BADGES) {
+    if (input.bypass[badge.field]) {
+      left.push({
+        text: badge.text,
+        badge: true,
+        badgeColor: badge.badgeColor,
+      });
+    }
   }
   const fittedLeft = input.pendingExitHint
     ? fitPendingExitStatusBarLeftSegments(left, input.width)

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -142,6 +142,7 @@ import {
   transcriptViewportRepaintOptions,
   type TranscriptViewportChange,
 } from './state/transcriptViewportMode';
+import type { SkillActivation } from './forms/SkillsListForm';
 
 export interface ChatResult {
   exitCode: number;
@@ -198,15 +199,10 @@ export function buildInitialChatAgentConfig({
   };
 }
 
-export interface ReservedSkillActivation {
-  readonly name: string;
-  readonly activationPrompt: string;
-}
-
 export interface PreparedChatInstruction {
   readonly instruction: string;
   readonly displayInstruction?: string;
-  readonly reservedSkillActivations: readonly ReservedSkillActivation[];
+  readonly reservedSkillActivations: readonly SkillActivation[];
 }
 
 export function takePendingSkillActivations(
@@ -241,7 +237,7 @@ export function takePendingSkillActivations(
 
 export function restorePendingSkillActivations(
   pendingSkillActivations: Map<string, string>,
-  activations: readonly ReservedSkillActivation[],
+  activations: readonly SkillActivation[],
 ): void {
   for (const { name, activationPrompt } of activations) {
     if (!pendingSkillActivations.has(name)) {
@@ -1129,9 +1125,7 @@ export async function runChat(
       : undefined;
     return activeFlow?.modelSwitchDisabledReason(candidateModel);
   };
-  const activateSkillForNextMessage = (
-    selection: ReservedSkillActivation,
-  ): void => {
+  const activateSkillForNextMessage = (selection: SkillActivation): void => {
     const wasPending = pendingSkillActivations.has(selection.name);
     pendingSkillActivations.set(selection.name, selection.activationPrompt);
     appendLocalAssistantTranscript(

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -1,5 +1,5 @@
 import { platform } from '@platform/platform';
-import type { AgentEntry } from '@agent/index';
+import { REMOTE_ORCHESTRATOR_AGENT_NAMES, type AgentEntry } from '@agent/index';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { agentKey } from '@shared/schemas/agent';
@@ -72,7 +72,6 @@ export const MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION =
   'Root agent for the team run (defaults to the preset orchestrator)';
 export const MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION =
   'Model for the team root agent';
-const BUILT_IN_TEAM_ROOT_AGENT_NAMES = ['orchestrator', 'leanOrchestrator'];
 const MULTI_AGENT_INSPECT_HINT = `Hint: run \`${formatCliMultiAgentInspectCommand('<preset>')}\` to see missing agents for degraded or unavailable presets.`;
 const MULTI_AGENT_LOGIN_HINT =
   'Hint: built-in teams may load additional relay-served agents after `texra login`.';
@@ -516,8 +515,8 @@ function findPreferredRootAgent(
 ): AgentEntry | undefined {
   const searchOrder =
     presetSource === 'built-in'
-      ? BUILT_IN_TEAM_ROOT_AGENT_NAMES
-      : [...BUILT_IN_TEAM_ROOT_AGENT_NAMES, ...presetOrder];
+      ? REMOTE_ORCHESTRATOR_AGENT_NAMES
+      : [...REMOTE_ORCHESTRATOR_AGENT_NAMES, ...presetOrder];
   for (const name of searchOrder) {
     const entry = agents.find((agent) => agent.name === name);
     if (entry) return entry;

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -122,9 +122,19 @@ const TOOL_USE_LOOKUP_PRIORITY: AgentSource[] = [
  * by alphabetical accident.
  */
 const DEFAULT_WORKFLOW_AGENT = 'correct';
-const PREFERRED_TOOL_USE_AGENTS = [
+
+/**
+ * Relay-served orchestrator roots that delegate to a team. They need sign-in,
+ * so UIs surface them first. Single source of truth for "the built-in
+ * delegating roots" (also consumed by the CLI multi-agent presets).
+ */
+export const REMOTE_ORCHESTRATOR_AGENT_NAMES = [
   'orchestrator',
   'leanOrchestrator',
+] as const;
+
+const PREFERRED_TOOL_USE_AGENTS = [
+  ...REMOTE_ORCHESTRATOR_AGENT_NAMES,
   'research',
   'review',
 ] as const;
@@ -577,9 +587,7 @@ export function isRemoteAgent(identifier: string | undefined): boolean {
  * Agents are already deduplicated by name from the getter functions.
  * No default → undefined means "never configured" (show all).
  */
-export function getVisibleAgents(
-  category: 'workflow' | 'toolUse',
-): AgentEntry[] {
+export function getVisibleAgents(category: AgentCategory): AgentEntry[] {
   const isToolUse = category === 'toolUse';
   const entries = isToolUse ? getToolUseAgents() : getWorkflowAgents();
   const stateKey = isToolUse

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -68,4 +68,6 @@ export {
   getVisibleAgents,
   // Metadata update (for remote agent loading)
   updateAgentMeta,
+  // Built-in relay-served orchestrator roots
+  REMOTE_ORCHESTRATOR_AGENT_NAMES,
 } from './agentRegistry';

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -518,9 +518,7 @@ export class ModelHandlerOpenAI<
           // totalUsage() may fail if stream ended abnormally — leave usage
           // unset, but log so missing token accounting is traceable.
           this.logger.debug(
-            `totalUsage() fallback failed; usage unavailable: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
+            `totalUsage() fallback failed; usage unavailable: ${getSdkErrorMessage(err)}`,
           );
         }
       }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -775,9 +775,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // Fall back to output_tokens if token counting fails. Log so a degraded
         // post-compaction token estimate is visible rather than silent.
         this.logger.debug(
-          `Post-compaction token counting failed; falling back to output_tokens: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
+          `Post-compaction token counting failed; falling back to output_tokens: ${getSdkErrorMessage(err)}`,
         );
         // NOTE: It's unclear what output_tokens represents exactly for the compact
         // endpoint — it may be the generation cost rather than the reusable content

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -7,6 +7,7 @@
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import type { AgentCategory } from '@shared/schemas/agent';
 import type { RunCoordinators } from './RunContext';
 
 /** Round counters tracked per execution (both absent until the first update). */
@@ -31,7 +32,7 @@ export const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
 export interface ExecutionHandle {
   readonly executionId: string;
   readonly parentStreamId: StreamTabId;
-  readonly category: 'workflow' | 'toolUse' | 'process';
+  readonly category: AgentCategory | 'process';
   readonly agentName: string;
   readonly startedAt: number;
   readonly runtimeHost: AgentRuntimeHost;
@@ -78,7 +79,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
     parentStreamId: StreamTabId,
     readonly childStreamId: StreamTabId,
     readonly agentName: string,
-    readonly category: 'workflow' | 'toolUse',
+    readonly category: AgentCategory,
     readonly runtimeHost: AgentRuntimeHost,
     readonly coordinators?: RunCoordinators,
   ) {

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -1,23 +1,22 @@
 import { STREAM_STATUS } from '@shared/schemas';
 
+// cli and cliCompact share every label except the INITIALIZING ellipsis, so
+// cliCompact is derived from cli rather than hand-synced.
+const cliStreamStatusLabels = {
+  [STREAM_STATUS.INITIALIZING]: 'starting\u2026',
+  [STREAM_STATUS.RUNNING]: 'running',
+  [STREAM_STATUS.ERROR]: 'error',
+  [STREAM_STATUS.STOPPED]: 'stopped',
+  [STREAM_STATUS.READY]: 'ready',
+  [STREAM_STATUS.WAITING]: 'idle',
+  [STREAM_STATUS.RESUMING]: 'resuming',
+} as const;
+
 const STREAM_STATUS_LABELS = {
-  cli: {
-    [STREAM_STATUS.INITIALIZING]: 'starting\u2026',
-    [STREAM_STATUS.RUNNING]: 'running',
-    [STREAM_STATUS.ERROR]: 'error',
-    [STREAM_STATUS.STOPPED]: 'stopped',
-    [STREAM_STATUS.READY]: 'ready',
-    [STREAM_STATUS.WAITING]: 'idle',
-    [STREAM_STATUS.RESUMING]: 'resuming',
-  },
+  cli: cliStreamStatusLabels,
   cliCompact: {
+    ...cliStreamStatusLabels,
     [STREAM_STATUS.INITIALIZING]: 'starting',
-    [STREAM_STATUS.RUNNING]: 'running',
-    [STREAM_STATUS.ERROR]: 'error',
-    [STREAM_STATUS.STOPPED]: 'stopped',
-    [STREAM_STATUS.READY]: 'ready',
-    [STREAM_STATUS.WAITING]: 'idle',
-    [STREAM_STATUS.RESUMING]: 'resuming',
   },
   progressHeader: {
     [STREAM_STATUS.INITIALIZING]: 'Initializing',

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -632,10 +632,7 @@ async function resolveAvailableDelegationModel(input: {
 }
 
 /** Throw if no visible agent of the given category matches the name. */
-function assertVisibleAgent(
-  category: 'workflow' | 'toolUse',
-  name: string,
-): void {
+function assertVisibleAgent(category: AgentCategory, name: string): void {
   const visible = getVisibleAgents(category);
   if (visible.some((a) => a.name === name)) return;
   const available = visible.map((a) => a.name).join(', ');


### PR DESCRIPTION
## What

Follow-up to #5610. A second behavior-preserving pass focused on **more declarative code** and **single sources of truth**, driven by a read-only detection sweep over the surface changed since v0.38.5. **12 files, +67 / −60.** No runtime behavior, control flow, ordering, or effects change.

## Single source of truth

- **`SkillActivation`** — one type replaces the duplicated `SkillSelectValue` / `ReservedSkillActivation` pair (same `{ name, activationPrompt }` shape). The earlier alias `type ReservedSkillActivation = SkillSelectValue` was just renamed indirection; this is one canonical definition used everywhere.
- **`AgentCategory`** — the canonical type from `@shared/schemas/agent` replaces inline `'workflow' | 'toolUse'` literal unions in `ExecutionHandle`, `DelegationTools`, and `agentRegistry`. The execution-kind superset becomes `AgentCategory | 'process'`.
- **`REMOTE_ORCHESTRATOR_AGENT_NAMES`** — exported once from the agent registry (which owns agent identity) and reused by both `PREFERRED_TOOL_USE_AGENTS` and the CLI multi-agent presets, instead of each hardcoding `['orchestrator', 'leanOrchestrator']`.
- **Stream-status labels** — `cliCompact` derives from the `cli` table via spread + the one differing row (`INITIALIZING`), removing a hand-synced 6-row copy.
- **Error formatting** — the two new OpenAI debug logs use the shared `getSdkErrorMessage` helper the rest of the handlers already use, not a hand-rolled `instanceof Error` ternary.

## More declarative

- **Status-bar bypass badges** — `YOLO` / `AUTO-BASH` / `AUTO-APPROVE` render from a module-level `BYPASS_BADGES` descriptor table keyed by `BypassState` field, replacing three near-identical `if`-blocks (same emission order). A new bypass flag is one row.

## Deliberately not done

Several lower-value / higher-risk candidates from the detection sweep were skipped to keep this behavior-preserving and focused: the `routeApproval` dispatch table (the switch is the type-safe idiom and was deliberately kept in #5610), the model-handler routing decision, the external-agent session-class dedup, and consolidating the `ACTIVE_STATUSES` set with `isInFlightStatus()` (the two have genuinely different type contracts — a `string`-membership set vs a `StreamStatus` predicate — so merging would need a cast or loosening the canonical predicate).

## Verification

- `npm run typecheck` — clean
- `prettier --check` — clean
- `eslint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with no intended control-flow or runtime behavior changes; touches many files but mostly renames and type centralization.
> 
> **Overview**
> Behavior-preserving refactor that consolidates duplicated types and literals into shared definitions, plus a few small declarative UI/logging cleanups.
> 
> **Single sources of truth:** CLI skill selection now uses one **`SkillActivation`** type (replacing `SkillSelectValue` / `ReservedSkillActivation`) with renamed helpers (`skillActivationForTui`). Execution and delegation code adopt canonical **`AgentCategory`** instead of inline `'workflow' | 'toolUse'` unions. **`REMOTE_ORCHESTRATOR_AGENT_NAMES`** is defined once in the agent registry and reused for preferred tool-use ordering and CLI multi-agent root selection. CLI stream status **`cliCompact`** labels are derived from the `cli` table via spread instead of a duplicate map.
> 
> **Declarative / consistency:** Status-bar bypass badges (**YOLO**, **AUTO-BASH**, **AUTO-APPROVE**) render from a **`BYPASS_BADGES`** table keyed by `BypassState`. Two OpenAI handler debug paths now use **`getSdkErrorMessage`** like the rest of the handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 168d81576283efa430a6858501271167db19d4ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->