### PR TITLE
fix(cli): align doctor auth status with live auth

### DIFF
--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -26,7 +26,7 @@ import {
 } from './logSinks';
 import { getCliModelAccessList } from './modelAccess';
 import { createCliStyle } from './style';
-import { getCliStoredAuthProfile } from './supabaseAuth';
+import { getCliAuthProfile } from './supabaseAuth';
 
 // Type imports - CLI runtime
 import type { CliContext } from './cliContext';
@@ -203,7 +203,7 @@ async function checkAuth(
       return pass(
         'auth',
         'Included access',
-        `Stored sign-in found for ${accountLabel}${tier}.`,
+        `Signed in as ${accountLabel}${tier}.`,
       );
     }
     return warn(
@@ -330,7 +330,7 @@ export async function buildDoctorReport(
 ): Promise<DoctorReport> {
   const resolved = {
     nodeVersion: deps.nodeVersion ?? process.versions.node,
-    authProfile: deps.authProfile ?? getCliStoredAuthProfile,
+    authProfile: deps.authProfile ?? getCliAuthProfile,
     modelAccessList: deps.modelAccessList ?? getCliModelAccessList,
     latexToolchain: deps.latexToolchain ?? probeLatexToolchain,
     pathStat: deps.pathStat ?? stat,

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -177,13 +177,3 @@ export async function getCliAuthProfile(): Promise<CliAuthProfile> {
     expiresAt: session ? new Date(session.expiresAt).toISOString() : undefined,
   };
 }
-
-export async function getCliStoredAuthProfile(): Promise<CliAuthProfile> {
-  const session = await getCliSupabaseAuthCoordinator().loadSession();
-  if (!session) return { authenticated: false };
-  return {
-    authenticated: true,
-    accountLabel: session.account.label,
-    expiresAt: new Date(session.expiresAt).toISOString(),
-  };
-}

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -231,11 +231,11 @@ describe('CLI doctor', () => {
     const records = doctorNdjsonRecords(report, '2026-05-18T00:00:00.000Z');
 
     expect(authCheck?.message).toContain('user@example.edu');
-    expect(text).toContain('Stored sign-in found for user@example.edu, Max.');
+    expect(text).toContain('Signed in as user@example.edu, Max.');
     expect(records).toContainEqual(
       expect.objectContaining({
         id: 'auth',
-        message: 'Stored sign-in found for user@example.edu, Max.',
+        message: 'Signed in as user@example.edu, Max.',
       }),
     );
   });
@@ -248,7 +248,7 @@ describe('CLI doctor', () => {
           id: 'auth',
           name: 'Included access',
           status: 'pass',
-          message: 'Stored sign-in found for user@example.edu.',
+          message: 'Signed in as user@example.edu.',
         },
         {
           id: 'config',
@@ -263,7 +263,7 @@ describe('CLI doctor', () => {
     const text = formatDoctorText(report);
     const records = doctorNdjsonRecords(report, '2026-05-18T00:00:00.000Z');
 
-    expect(text).toContain('Stored sign-in found for user@example.edu.');
+    expect(text).toContain('Signed in as user@example.edu.');
     expect(text).toContain('Workspace config references o***@e***.edu.');
     expect(text).toContain('Ask a***@e***.edu to update it.');
     expect(text).not.toContain('owner@example.edu');
@@ -303,11 +303,11 @@ describe('CLI doctor', () => {
     const text = formatDoctorText(report);
     const records = doctorNdjsonRecords(report, '2026-05-18T00:00:00.000Z');
 
-    expect(text).toContain('Stored sign-in found for team@internal.');
+    expect(text).toContain('Signed in as team@internal.');
     expect(records).toContainEqual(
       expect.objectContaining({
         id: 'auth',
-        message: 'Stored sign-in found for team@internal.',
+        message: 'Signed in as team@internal.',
       }),
     );
   });
@@ -336,7 +336,7 @@ describe('CLI doctor', () => {
     });
 
     expect(report.checks.find((check) => check.id === 'auth')?.message).toBe(
-      'Stored sign-in found for unknown.',
+      'Signed in as unknown.',
     );
   });
 


### PR DESCRIPTION
## Summary

Closes #5615.

- make `texra doctor` use the live CLI auth profile instead of the stored-session shortcut
- change the healthy included-access message from `Stored sign-in found...` to `Signed in as...` so doctor describes usable auth, not just a secret on disk
- update doctor rendering/NDJSON tests for the new contract

## Dogfood evidence

Before the change, in a fresh temp project:

- `texra-local doctor --output-format json` reported `Included access` as pass with a stored sign-in
- `texra-local auth status --output-format json` reported `{ "authenticated": false }`
- `TERM=xterm-256color texra-local` showed `auth: signed out` on the launcher

After the change, doctor agrees with the launcher/auth command and warns that included access is not signed in while still reporting provider-key models available.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/Doctor.vitest.mts src/test-kernel/cli/ApiStatusLoad.vitest.mts src/test-kernel/cli/CliInitPlatform.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run texra-local:build && npm run texra-local:link`
- `texra-local doctor --output-format json`
- `npm --prefix packages/cli run validate:tui -- --no-build orchestrate-launcher`
- live PTY: `TERM=xterm-256color texra-local`, then `Esc`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI diagnostic change with clearer messaging; auth evaluation now matches existing live checks used elsewhere, with no new auth surface area.
> 
> **Overview**
> **`texra doctor`** now resolves included-access auth through **`getCliAuthProfile`** (live Supabase authentication plus session metadata) instead of the removed **`getCliStoredAuthProfile`** shortcut that only checked for a stored session, so doctor matches **`texra auth status`** and the launcher when a secret exists but the user is not actually signed in.
> 
> When auth passes, the check message is **`Signed in as {account}{tier}.`** rather than **`Stored sign-in found for...`**, reflecting usable sign-in rather than credentials on disk. Doctor tests were updated for the new wording in text and NDJSON output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e69371b48ba4c700c2bb9cd92dd1ec9572ad8f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->