### PR TITLE
refactor(webview): remove orphan collapsible style

### DIFF
--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -126,39 +126,6 @@ export const commonViewStyles: CSSResult = css`
     gap: var(--wa-space-2xs);
   }
 
-  .collapsible {
-    margin-top: var(--wa-space-2xs);
-  }
-
-  /*
-   * Legacy vscode-collapsible support: 'body' is the part name for that
-   * component. Long content historically clipped at --height-max; the grid
-   * trick below replaces the discrete max-height jump for wa-details
-   * ('content' part), which is the modern variant.
-   */
-  .collapsible::part(body) {
-    max-height: var(--height-medium);
-    overflow: hidden;
-  }
-
-  .collapsible[open]::part(body) {
-    max-height: var(--height-max);
-  }
-
-  .collapsible::part(content) {
-    display: grid;
-    grid-template-rows: 1fr;
-  }
-
-  .collapsible:not([open])::part(content) {
-    grid-template-rows: 0fr;
-  }
-
-  .collapsible::part(content) > * {
-    overflow: hidden;
-    min-height: 0;
-  }
-
   /* Panel collapsible - consistent styling for collapsible panels */
   .panel-collapsible {
     border-top: var(--border-thin) solid var(--color-border);
@@ -222,8 +189,8 @@ export const commonViewStyles: CSSResult = css`
     color: var(--wa-color-text-normal);
   }
 
-  /* Same grid 1fr/0fr collapse as .collapsible / .panel-collapsible so the
-     quiet variant is self-contained (no need to also apply .collapsible). */
+  /* Same grid 1fr/0fr collapse as .panel-collapsible so the quiet variant is
+     self-contained. */
   .collapsible-quiet::part(content) {
     display: grid;
     grid-template-rows: 1fr;


### PR DESCRIPTION
## Summary

Closes #5613.

- remove the unused bare `.collapsible` rules from `commonViewStyles`
- keep the active `panel-collapsible` and `collapsible-quiet` contracts as the only shared collapsible variants
- update the quiet variant comment now that it no longer references the deleted helper

## Evidence

`rg` found no bare `.collapsible` consumers; remaining uses are `panel-collapsible`, `collapsible-quiet`, view-local `queued-collapsible`, or comments about `vscode-collapsible` parts.

## Validation

- `corepack pnpm exec prettier --check src/shared/styles/commonViewStyles.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/TaskGroupListIndex.vitest.ts`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only cleanup of unused selectors with no remaining `.collapsible` consumers; active panel and quiet variants are unchanged.
> 
> **Overview**
> Removes the unused bare **`.collapsible`** block from `commonViewStyles`, including legacy `vscode-collapsible` **body** max-height rules and the shared grid collapse on **`::part(content)`**.
> 
> Shared collapsible styling is now only **`panel-collapsible`** and **`collapsible-quiet`**; the quiet variant comment no longer refers to the deleted helper class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91cc7174b84d68a6624673875eae9bf4f32ca92f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->