### PR TITLE
refactor(html-export): single --ce-* token source for Lit + document CSS

### DIFF
--- a/packages/extension/src/commands/history/htmlExport/chat.css
+++ b/packages/extension/src/commands/history/htmlExport/chat.css
@@ -10,30 +10,12 @@
  *   - the footer.
  *
  * Copied verbatim from the source tree by scripts/copy-html-export-assets.mjs.
+ *
+ * The `--ce-*` design tokens (light/dark palette, fonts, radii) are the single
+ * source of truth in src/shared/htmlExport/styles/tokens.ts; buildExportTemplate
+ * inlines them on `:root` in the document <head>, so this stylesheet just reads
+ * them via var(). Keep token *values* there, not here.
  */
-
-:root {
-  color-scheme: light dark;
-  --doc-bg: #ffffff;
-  --doc-fg: #1f2328;
-  --doc-fg-muted: #59636e;
-  --doc-border: #d0d7de;
-  --doc-border-strong: #afb8c1;
-  --doc-accent: #0969da;
-  --doc-code-bg: #f6f8fa;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --doc-bg: #0d1117;
-    --doc-fg: #e6edf3;
-    --doc-fg-muted: #8d96a0;
-    --doc-border: #30363d;
-    --doc-border-strong: #484f58;
-    --doc-accent: #2f81f7;
-    --doc-code-bg: #161b22;
-  }
-}
 
 * {
   box-sizing: border-box;
@@ -43,8 +25,8 @@ html,
 body {
   margin: 0;
   padding: 0;
-  background: var(--doc-bg);
-  color: var(--doc-fg);
+  background: var(--ce-bg);
+  color: var(--ce-fg);
   font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
     sans-serif;
@@ -66,7 +48,7 @@ body {
 /* ---------- Header ---------- */
 
 .export-header {
-  border-bottom: 1px solid var(--doc-border);
+  border-bottom: 1px solid var(--ce-border);
   padding-bottom: 20px;
   margin-bottom: 28px;
 }
@@ -79,7 +61,7 @@ body {
 
 .export-subtitle {
   margin: 0 0 16px;
-  color: var(--doc-fg-muted);
+  color: var(--ce-fg-muted);
   font-size: 14px;
 }
 
@@ -92,7 +74,7 @@ body {
 }
 
 .meta-grid dt {
-  color: var(--doc-fg-muted);
+  color: var(--ce-fg-muted);
   font-weight: 500;
 }
 
@@ -105,7 +87,7 @@ body {
   margin: 16px 0 0;
   padding: 12px 16px;
   background: rgba(9, 105, 218, 0.1);
-  border-left: 3px solid var(--doc-accent);
+  border-left: 3px solid var(--ce-accent);
   border-radius: 4px;
   white-space: pre-wrap;
 }
@@ -113,8 +95,8 @@ body {
 .meta-files {
   margin-top: 12px;
   padding: 12px 14px;
-  background: var(--doc-code-bg);
-  border: 1px solid var(--doc-border);
+  background: var(--ce-code-bg);
+  border: 1px solid var(--ce-border);
   border-radius: 8px;
   font-size: 13px;
 }
@@ -122,7 +104,7 @@ body {
 .meta-files-title {
   margin: 0 0 6px;
   font-weight: 600;
-  color: var(--doc-fg-muted);
+  color: var(--ce-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 11px;
@@ -175,7 +157,7 @@ body {
 }
 
 .md a {
-  color: var(--doc-accent);
+  color: var(--ce-accent);
 }
 
 .md ul,
@@ -187,13 +169,13 @@ body {
 .md blockquote {
   margin: 8px 0;
   padding: 4px 14px;
-  border-left: 3px solid var(--doc-border-strong);
-  color: var(--doc-fg-muted);
+  border-left: 3px solid var(--ce-border-strong);
+  color: var(--ce-fg-muted);
 }
 
 .md hr {
   border: 0;
-  border-top: 1px solid var(--doc-border);
+  border-top: 1px solid var(--ce-border);
   margin: 18px 0;
 }
 
@@ -204,12 +186,12 @@ body {
 }
 .md th,
 .md td {
-  border: 1px solid var(--doc-border);
+  border: 1px solid var(--ce-border);
   padding: 6px 10px;
   text-align: left;
 }
 .md th {
-  background: var(--doc-code-bg);
+  background: var(--ce-code-bg);
 }
 
 /* ---------- Code ---------- */
@@ -222,17 +204,17 @@ body {
 }
 
 .md :not(pre) > code {
-  background: var(--doc-code-bg);
+  background: var(--ce-code-bg);
   padding: 1px 6px;
   border-radius: 4px;
-  border: 1px solid var(--doc-border);
+  border: 1px solid var(--ce-border);
 }
 
 .md pre,
 pre.hljs {
-  background: var(--doc-code-bg);
-  color: var(--doc-fg);
-  border: 1px solid var(--doc-border);
+  background: var(--ce-code-bg);
+  color: var(--ce-fg);
+  border: 1px solid var(--ce-border);
   border-radius: 8px;
   padding: 12px 14px;
   overflow-x: auto;
@@ -253,11 +235,11 @@ pre.hljs code,
 .attachment-chip {
   display: inline-block;
   padding: 2px 8px;
-  border: 1px solid var(--doc-border);
+  border: 1px solid var(--ce-border);
   border-radius: 999px;
-  background: var(--doc-code-bg);
+  background: var(--ce-code-bg);
   font-size: 12px;
-  color: var(--doc-fg-muted);
+  color: var(--ce-fg-muted);
   margin: 2px 4px 2px 0;
 }
 
@@ -269,8 +251,8 @@ pre.hljs code,
 .export-footer {
   margin-top: 48px;
   padding-top: 16px;
-  border-top: 1px solid var(--doc-border);
-  color: var(--doc-fg-muted);
+  border-top: 1px solid var(--ce-border);
+  color: var(--ce-fg-muted);
   font-size: 12px;
   text-align: center;
 }

--- a/src/shared/htmlExport/buildExportTemplate.ts
+++ b/src/shared/htmlExport/buildExportTemplate.ts
@@ -19,6 +19,8 @@ import { html as serverHtml } from '@lit-labs/ssr';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
+import { documentTokens } from './styles/tokens';
+
 // Side-effecting imports — registers the custom elements so
 // `<texra-chat-message>` etc. resolve to a class during SSR.
 import './components/ChatMessage';
@@ -104,6 +106,13 @@ export function buildExportTemplate(doc: ExportDocument) {
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="generator" content="TeXRA chat export" />
   <title>${doc.title}</title>
+  ${
+    // Server-only templates forbid bindings *inside* a <style> tag, so build
+    // the whole element via unsafeHTML. The content is our own trusted token
+    // CSS (no user data), inlined so the document and shadow components share
+    // one `--ce-*` source by inheritance.
+    unsafeHTML(`<style>${documentTokens.cssText}</style>`)
+  }
   <link rel="stylesheet" href="${doc.assetsHref}/katex.min.css" />
   <link rel="stylesheet" href="${doc.assetsHref}/texmath.css" />
   <link

--- a/src/shared/htmlExport/components/ChatMessage.ts
+++ b/src/shared/htmlExport/components/ChatMessage.ts
@@ -4,7 +4,9 @@
  * Pure presentation: no signals, no event listeners, no VS Code theme
  * variables. Body content is light-DOM (slotted) so KaTeX / hljs CSS in
  * the host document reaches it normally; the bubble frame lives inside
- * shadow DOM so it can be styled in isolation.
+ * shadow DOM so it can be styled in isolation. The `--ce-*` tokens are
+ * defined once on `:root` (see styles/tokens) and inherit across the
+ * shadow boundary, so the frame reads them via `var()` without redefining.
  *
  * `data-role` (not `role`) — `role` is a reserved ARIA attribute whose
  * valid values don't include "user"/"assistant"; using it would trip
@@ -19,14 +21,13 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { bubbleFrame, chatTokens } from '../styles/tokens';
+import { bubbleFrame } from '../styles/tokens';
 
 export type ChatRole = 'user' | 'assistant';
 
 @customElement('texra-chat-message')
 export class ChatMessage extends LitElement {
   static override styles = [
-    chatTokens,
     bubbleFrame,
     css`
       :host([data-role='user']) .frame {

--- a/src/shared/htmlExport/components/ChatToolBlock.ts
+++ b/src/shared/htmlExport/components/ChatToolBlock.ts
@@ -15,7 +15,7 @@
 import { LitElement, css, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { bubbleFrame, chatTokens } from '../styles/tokens';
+import { bubbleFrame } from '../styles/tokens';
 
 export type ToolBlockKind =
   | 'call'
@@ -35,7 +35,6 @@ const ROLE_LABELS: Record<ToolBlockKind, string> = {
 @customElement('texra-chat-tool-block')
 export class ChatToolBlock extends LitElement {
   static override styles = [
-    chatTokens,
     bubbleFrame,
     css`
       :host {

--- a/src/shared/htmlExport/styles/tokens.ts
+++ b/src/shared/htmlExport/styles/tokens.ts
@@ -1,11 +1,15 @@
 /**
- * Design tokens shared between the chat-export Lit components.
+ * Design tokens for the chat export — the single source of truth for the
+ * `--ce-*` palette used by both the light-DOM document (`chat.css`) and the
+ * shadow-DOM bubble components.
  *
- * The tokens are defined as CSS custom properties on `:host`, with a
- * `@media (prefers-color-scheme: dark)` block that re-binds them. Each
- * component composes `chatTokens` first in its `static styles` array, so
- * the component-local rules can read `var(--ce-fg)` etc. without caring
- * whether the page is light or dark.
+ * Tokens are defined as CSS custom properties on `:root` (not `:host`), with
+ * a `@media (prefers-color-scheme: dark)` block that re-binds them. Custom
+ * properties inherit across the shadow boundary, so a token set on `:root`
+ * is readable via `var(--ce-fg)` inside every component's shadow styles
+ * without redefining it there. `buildExportTemplate` inlines this block into
+ * the document `<head>` (via `.cssText`), so the components consume it by
+ * inheritance and `chat.css` consumes it directly.
  *
  * Tokens are deliberately a small, neutral set — this is a static page
  * shared with people who don't have the user's VS Code theme. The token
@@ -14,8 +18,9 @@
  */
 import { css } from 'lit';
 
-export const chatTokens = css`
-  :host {
+export const documentTokens = css`
+  :root {
+    color-scheme: light dark;
     --ce-bg: #ffffff;
     --ce-bg-elevated: #f6f8fa;
     --ce-bg-user: #eef4ff;
@@ -40,7 +45,7 @@ export const chatTokens = css`
   }
 
   @media (prefers-color-scheme: dark) {
-    :host {
+    :root {
       --ce-bg: #0d1117;
       --ce-bg-elevated: #161b22;
       --ce-bg-user: #1c2a3a;

--- a/src/test-kernel/commands/htmlFormatter.vitest.ts
+++ b/src/test-kernel/commands/htmlFormatter.vitest.ts
@@ -110,11 +110,20 @@ describe('formatChatAsHtml', () => {
     expect(html).toMatch(/<template[^>]*shadowrootmode="open"/);
   });
 
+  it('defines the --ce-* tokens once on :root in the document head', () => {
+    // The palette is the single source of truth in styles/tokens.ts and is
+    // inlined into <head> on :root (not redefined per shadow root). The token
+    // *definition* (`--ce-bg:`) lives in the head, before the asset links.
+    const head = html.slice(0, html.indexOf('</head>'));
+    expect(head).toMatch(/<style>[\s\S]*:root\s*\{[\s\S]*--ce-bg:/);
+  });
+
   it('inlines component-scoped CSS inside the declarative shadow root', () => {
-    // Scoped styles should appear inside <style> inside the DSD template.
-    // Token CSS variables (`--ce-bg-*`) are a tell that chatTokens applied.
+    // Scoped frame styles (.frame/.role) appear inside <style> inside the DSD
+    // template; they *consume* the inherited tokens via var(--ce-*) rather than
+    // redefining them, so the shadow root references but does not declare them.
     expect(html).toMatch(
-      /<template[^>]*shadowrootmode="open">\s*<style>[\s\S]*--ce-bg/,
+      /<template[^>]*shadowrootmode="open">\s*<style>[\s\S]*var\(--ce-/,
     );
   });
 


### PR DESCRIPTION
The chat-export palette was duplicated: --ce-* tokens on :host in the Lit
css (tokens.ts) and an identical --doc-* set on :root in chat.css. Custom
properties inherit across the shadow boundary, so define the palette once
on :root in tokens.ts (documentTokens), inline it into the document <head>
via .cssText, and let both the shadow-DOM components and chat.css read the
same --ce-* names by inheritance. Components no longer redefine tokens.

https://claude.ai/code/session_01CyhAD9sM4ad1uVWxKZV6ve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor for static HTML export CSS with no auth, data, or runtime behavior changes beyond how theme variables are sourced.
> 
> **Overview**
> Consolidates the HTML chat export palette so **`--ce-*` tokens live only in `tokens.ts`** (`documentTokens` on `:root`) instead of duplicating the same colors as per-component `:host` tokens and as `--doc-*` in `chat.css`.
> 
> **`buildExportTemplate`** now inlines that token block into the document `<head>` via `documentTokens.cssText` (trusted CSS through `unsafeHTML`). **`chat.css`** drops its local `:root` / dark-mode definitions and references **`var(--ce-*)`** everywhere. **`ChatMessage`** and **`ChatToolBlock`** stop composing `chatTokens` in shadow styles and only use inherited tokens plus frame-specific rules.
> 
> Tests assert tokens are defined once on `:root` in the head and that declarative shadow roots **consume** `var(--ce-*)` without redefining them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4762a71048e7f23867c34b314b1af716f356d2d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->