### PR TITLE
test: cover Gemini 3.5 Flash included access

### DIFF
--- a/docs/supabase/RELAY_SETUP.md
+++ b/docs/supabase/RELAY_SETUP.md
@@ -6,9 +6,9 @@ This guide explains how to deploy and configure the Relay Edge Function for serv
 
 The Relay function allows authenticated users to access AI models without providing their own API keys. Access is tier-based:
 
-- **Ultra**: All models including premium ($3+/M input)
-- **Max**: Mid-tier models ($1-3/M) + all free tier models
-- **free**: Budget models only (under $1/M input)
+- **Ultra**: All models above $3/M input
+- **Max**: Free-tier models plus any future Max-only additions
+- **free**: Included non-premium models (up to $3/M input)
 
 The API keys are stored as Supabase secrets and the relay forwards requests to the appropriate provider.
 
@@ -65,7 +65,7 @@ https://your-project.supabase.co/functions/v1/relay/openai/v1/chat/completions
 ## How It Works
 
 1. **User makes request** - Client sends request with user's JWT in Authorization header
-2. **Relay validates user** - Checks JWT and verifies user has Ultra tier
+2. **Relay validates user** - Checks JWT and verifies tier access for the requested model
 3. **Relay adds API key** - Retrieves server-side API key from secrets
 4. **Request forwarded** - Request is forwarded to the actual provider
 5. **Response streamed back** - Response is streamed back to the client

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -10,8 +10,8 @@
  *
  * TIER-BASED ACCESS (cumulative):
  * - Ultra tier: Access to ALL models via relay (full access)
- * - Max tier: Mid-tier models ($1-3/M) + all free tier models
- * - free tier: Budget models only (under $1/M input)
+ * - Max tier: Free-tier models plus any future Max-only additions
+ * - free tier: Included non-premium models (up to $3/M input)
  */
 
 import { EventEmitter } from 'events';

--- a/src/auth/serverKeys/index.ts
+++ b/src/auth/serverKeys/index.ts
@@ -9,8 +9,8 @@
  *
  * TIER-BASED ACCESS (cumulative):
  * - Ultra tier: Access to ALL models via relay (full access)
- * - Max tier: Mid-tier models ($1-3/M) + all free tier models
- * - free tier: Budget models only (under $1/M input)
+ * - Max tier: Free-tier models plus any future Max-only additions
+ * - free tier: Included non-premium models (up to $3/M input)
  */
 
 import { SUPABASE_CUSTOM_DOMAIN } from '../sharedConfig';

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -8,9 +8,9 @@
  * All server-side API key access is provided as a convenience for researchers.
  *
  * TIER HIERARCHY (cumulative access):
- * - free: Budget models only (under $1/M input)
- * - Max: Mid-tier models ($1-3/M) + all free tier models
- * - Ultra: All models including premium ($3+/M input)
+ * - free: Included non-premium models (up to $3/M input)
+ * - Max: Free-tier models plus any future Max-only additions
+ * - Ultra: All models above $3/M input
  */
 
 import { toErrorMessage } from '@common/errors/errorMessage';

--- a/src/auth/tier/index.ts
+++ b/src/auth/tier/index.ts
@@ -12,9 +12,9 @@
  * Users can always choose between server-side keys or their own API keys.
  *
  * TIER HIERARCHY (cumulative access):
- * - free: Budget models only (under $1/M input)
- * - Max: Mid-tier models ($1-3/M) + all free tier models
- * - Ultra: All models including premium ($3+/M input)
+ * - free: Included non-premium models (up to $3/M input)
+ * - Max: Free-tier models plus any future Max-only additions
+ * - Ultra: All models above $3/M input
  */
 
 import { SUPABASE_CUSTOM_DOMAIN } from '../sharedConfig';

--- a/src/auth/tier/types.ts
+++ b/src/auth/tier/types.ts
@@ -6,9 +6,9 @@
  * Users can always choose between server-side keys or their own API keys.
  *
  * TIER HIERARCHY (cumulative access):
- * - free: Budget models only (under $1/M input)
- * - Max: Mid-tier models ($1-3/M) + all free tier models
- * - Ultra: All models including premium ($3+/M input)
+ * - free: Included non-premium models (up to $3/M input)
+ * - Max: Free-tier models plus any future Max-only additions
+ * - Ultra: All models above $3/M input
  *
  * ACCESS EXPIRATION:
  * - All researcher access has an expiration date to prevent abuse

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -792,6 +792,10 @@ describe('CLI model access resolution', () => {
 
   it('marks only included-access models runnable in included relay mode', async () => {
     computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('gemini35f', {
+        availability: 'included-access',
+        availabilityLabel: 'Included access',
+      }),
       modelOption('sonnet46T', {
         availability: 'included-access',
         availabilityLabel: 'Included access',
@@ -809,6 +813,7 @@ describe('CLI model access resolution', () => {
     await expect(
       getCliModelAccessList({ apiMode: 'included' }),
     ).resolves.toMatchObject([
+      { model: { value: 'gemini35f' }, available: true },
       { model: { value: 'sonnet46T' }, available: true },
       { model: { value: 'deepseekT' }, available: false },
       { model: { value: 'openrouterOnlyT' }, available: false },

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -37,9 +37,9 @@
  * ============================================================================
  *
  * TIER HIERARCHY (cumulative access):
- * - Ultra: All models including premium ($3+/M input)
- * - Max: Mid-tier models ($1-3/M) + all free tier models
- * - free: Budget models only (under $1/M input)
+ * - Ultra: All models above $3/M input
+ * - Max: Free-tier models plus any future Max-only additions
+ * - free: Included non-premium models (up to $3/M input)
  *
  * Authentication: JWT tokens are extracted from SDK auth headers:
  * - OpenAI: Authorization: Bearer {jwt}

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -3,9 +3,9 @@
  *
  * SINGLE SOURCE OF TRUTH: llm-zoo npm package
  * Tier assignments are derived from model pricing:
- * - free: Budget models (under $1/M input)
- * - Max: Mid-tier models ($1-3/M input) + free tier
- * - Ultra: All models including premium ($3+/M input)
+ * - free: Included non-premium models (up to $3/M input)
+ * - Max: Free-tier models plus any future Max-only additions
+ * - Ultra: All models above $3/M input
  */
 
 import { MODEL_CONFIGS, type ModelConfig } from 'npm:llm-zoo@^1.6.1';
@@ -53,7 +53,7 @@ interface RelayModel {
 // Tier Assignment Logic
 // =============================================================================
 
-/** Derive tier from model pricing */
+/** Derive tier from model pricing. */
 function getTierFromPrice(inputPrice: number): MinTier {
   if (inputPrice <= 3) return 'free';
   return 'Ultra';


### PR DESCRIPTION
## Summary
- assert the CLI included-access model list treats `gemini35f` as runnable when the model source marks it included
- align relay/auth tier comments with the current `<= $3/M` free-tier threshold that includes Gemini 3.5 Flash

## Validation
- `npx vitest run src/test-kernel/model/ModelOptionsBasic.vitest.ts src/test-kernel/cli/ModelAccess.vitest.mts`
- `texra-local models list --api-mode included --all --output-format json | jq 'map(select(.id=="gemini35f"))'`\n- `npm run lint` (passes with existing import-order warnings)\n- `npm run typecheck`\n- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and test-only changes; relay tier logic in models.ts is unchanged aside from documentation.
> 
> **Overview**
> Updates **relay and auth tier documentation** so it matches the current pricing rule: **free** covers models up to **$3/M input**, **Ultra** is above that, and **Max** is described as free-tier plus future Max-only models (replacing outdated $1/M and $1–3/M wording). **Relay setup** now says validation checks **tier access per model**, not Ultra-only.
> 
> Adds a **CLI model-access test** that **`gemini35f`** is **runnable** in **`--api-mode included`** when model options mark it as **included-access**, alongside existing included models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2174bcb680fc4d69412c0424f3d61b615df535ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->