### PR TITLE
refactor: convert value-map switches to lookup tables in stable code

### DIFF
--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -14,26 +14,21 @@ import {
 import { cliState } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 
+// Marker glyph + color per todo status; statuses absent here (e.g. PENDING)
+// fall back to the default empty box with no color.
+const TODO_STATUS_DISPLAY: Partial<
+  Record<TodoStatus, { marker: string; color: string }>
+> = {
+  [TODO_STATUS.COMPLETED]: { marker: '☑', color: 'green' },
+  [TODO_STATUS.IN_PROGRESS]: { marker: '☐', color: 'cyan' },
+};
+
 function todoMarker(status: TodoStatus): string {
-  switch (status) {
-    case TODO_STATUS.COMPLETED:
-      return '☑';
-    case TODO_STATUS.IN_PROGRESS:
-      return '☐';
-    default:
-      return '□';
-  }
+  return TODO_STATUS_DISPLAY[status]?.marker ?? '□';
 }
 
 function todoColor(status: TodoStatus): string | undefined {
-  switch (status) {
-    case TODO_STATUS.COMPLETED:
-      return 'green';
-    case TODO_STATUS.IN_PROGRESS:
-      return 'cyan';
-    default:
-      return undefined;
-  }
+  return TODO_STATUS_DISPLAY[status]?.color;
 }
 
 function TodoRow({
@@ -74,32 +69,39 @@ export type CompactTodosPlanRow =
       stepIndex: number;
     };
 
+// Sort priority by (row kind, status). Statuses absent for a kind use
+// DEFAULT_TODO_ROW_PRIORITY; planSummary has a single fixed priority.
+const COMPACT_ROW_PRIORITY: Record<
+  'todo' | 'planStep',
+  Partial<Record<TodoStatus, number>>
+> = {
+  todo: {
+    [TODO_STATUS.IN_PROGRESS]: 0,
+    [TODO_STATUS.PENDING]: 1,
+    [TODO_STATUS.COMPLETED]: 4,
+  },
+  planStep: {
+    [TODO_STATUS.IN_PROGRESS]: 2,
+    [TODO_STATUS.PENDING]: 3,
+    [TODO_STATUS.COMPLETED]: 6,
+  },
+};
+const DEFAULT_TODO_ROW_PRIORITY = 3;
+const PLAN_SUMMARY_PRIORITY = 5;
+
 function compactRowPriority(row: CompactTodosPlanRow): number {
   switch (row.kind) {
     case 'todo':
-      switch (row.todo.status) {
-        case TODO_STATUS.IN_PROGRESS:
-          return 0;
-        case TODO_STATUS.PENDING:
-          return 1;
-        case TODO_STATUS.COMPLETED:
-          return 4;
-        default:
-          return 3;
-      }
+      return (
+        COMPACT_ROW_PRIORITY.todo[row.todo.status] ?? DEFAULT_TODO_ROW_PRIORITY
+      );
     case 'planStep':
-      switch (row.step.status) {
-        case TODO_STATUS.IN_PROGRESS:
-          return 2;
-        case TODO_STATUS.PENDING:
-          return 3;
-        case TODO_STATUS.COMPLETED:
-          return 6;
-        default:
-          return 3;
-      }
+      return (
+        COMPACT_ROW_PRIORITY.planStep[row.step.status] ??
+        DEFAULT_TODO_ROW_PRIORITY
+      );
     case 'planSummary':
-      return 5;
+      return PLAN_SUMMARY_PRIORITY;
   }
   const exhaustive: never = row;
   return exhaustive;

--- a/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
@@ -1,5 +1,8 @@
 // Local imports - shared utilities
-import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import {
+  PERMISSION_KIND,
+  type PermissionKind,
+} from '@shared/utils/uiConstants';
 
 // Local imports - progress view component types
 import type { BaseRequestPanel } from './BaseRequestPanel';
@@ -30,37 +33,26 @@ export function createEmptyPermissionGroups(): PermissionGroups {
   };
 }
 
+const KIND_TO_GROUP: Record<PermissionKind, keyof PermissionGroups> = {
+  [PERMISSION_KIND.TOOL_EDIT]: 'approval',
+  [PERMISSION_KIND.BASH]: 'bash',
+  [PERMISSION_KIND.RETRY]: 'retry',
+  [PERMISSION_KIND.PROPOSAL]: 'proposal',
+  [PERMISSION_KIND.PLAN_APPROVAL]: 'planApproval',
+  [PERMISSION_KIND.EXTERNAL_INQUIRY]: 'externalInquiry',
+  [PERMISSION_KIND.USER_QUESTION]: 'userQuestion',
+};
+
 export function groupPermissions(
   permissions: PermissionState[],
 ): PermissionGroups {
   const groups = createEmptyPermissionGroups();
-
   for (const permission of permissions) {
-    switch (permission.kind) {
-      case PERMISSION_KIND.TOOL_EDIT:
-        groups.approval.push(permission);
-        break;
-      case PERMISSION_KIND.BASH:
-        groups.bash.push(permission);
-        break;
-      case PERMISSION_KIND.RETRY:
-        groups.retry.push(permission);
-        break;
-      case PERMISSION_KIND.PROPOSAL:
-        groups.proposal.push(permission);
-        break;
-      case PERMISSION_KIND.PLAN_APPROVAL:
-        groups.planApproval.push(permission);
-        break;
-      case PERMISSION_KIND.EXTERNAL_INQUIRY:
-        groups.externalInquiry.push(permission);
-        break;
-      case PERMISSION_KIND.USER_QUESTION:
-        groups.userQuestion.push(permission);
-        break;
-    }
+    // Guard against malformed IPC data: an unknown kind is dropped (matching
+    // the old switch's no-default behavior) rather than throwing in render.
+    const group = KIND_TO_GROUP[permission.kind];
+    if (group) groups[group].push(permission);
   }
-
   return groups;
 }
 

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -70,23 +70,24 @@ type OpenRouterReasoningEffort = NonNullable<
   NonNullable<ChatRequest['reasoning']>['effort']
 >;
 
+// OpenRouter's reasoning tiers passed through unchanged. It has no 'max' tier,
+// so 'max' maps to the top tier 'xhigh' and anything unknown falls back to 'low'.
+const OPENROUTER_REASONING_EFFORTS: ReadonlySet<string> = new Set([
+  'xhigh',
+  'high',
+  'medium',
+  'low',
+  'minimal',
+  'none',
+]);
+
 export function toOpenRouterReasoningEffort(
   effort: string,
 ): OpenRouterReasoningEffort {
-  switch (effort) {
-    case 'max':
-      // OpenRouter has no 'max' tier; map to its top tier 'xhigh'.
-      return 'xhigh';
-    case 'xhigh':
-    case 'high':
-    case 'medium':
-    case 'low':
-    case 'minimal':
-    case 'none':
-      return effort;
-    default:
-      return 'low';
-  }
+  if (effort === 'max') return 'xhigh';
+  return OPENROUTER_REASONING_EFFORTS.has(effort)
+    ? (effort as OpenRouterReasoningEffort)
+    : 'low';
 }
 
 // ============================================================================

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -153,15 +153,17 @@ function getMinAnnotationLevel(
   return input.min_annotation_level ?? DEFAULT_CHECK_ANNOTATION_LEVEL;
 }
 
+const ANNOTATION_LEVEL_DESCRIPTIONS: Record<
+  GitHubCheckAnnotationLevel,
+  string
+> = {
+  failure: 'failures only',
+  warning: 'warnings and failures',
+  notice: 'notices, warnings, and failures',
+};
+
 function describeAnnotationLevel(level: GitHubCheckAnnotationLevel): string {
-  switch (level) {
-    case 'failure':
-      return 'failures only';
-    case 'warning':
-      return 'warnings and failures';
-    case 'notice':
-      return 'notices, warnings, and failures';
-  }
+  return ANNOTATION_LEVEL_DESCRIPTIONS[level];
 }
 
 /** Shared body sentence describing what a PR subscription delivers. */

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -343,23 +343,17 @@ export function attachTranscriptRecorder(
  * the DEFAULT bucket. Renderers that key on messageType (latexdiff,
  * scratchpad, missingOutputs) keep working without subscriber changes.
  */
+const DOMAIN_MESSAGE_TYPE: Record<string, MessageType> = {
+  latexdiff: MESSAGE_TYPES.LATEXDIFF,
+  scratchpad: MESSAGE_TYPES.SCRATCHPAD,
+  missingOutputs: MESSAGE_TYPES.MISSING_OUTPUTS,
+  webSearch: MESSAGE_TYPES.WEB_SEARCH,
+  webFetch: MESSAGE_TYPES.WEB_FETCH,
+  contextManagement: MESSAGE_TYPES.CONTEXT_MANAGEMENT,
+};
+
 function domainMessageType(key: string): MessageType {
-  switch (key) {
-    case 'latexdiff':
-      return MESSAGE_TYPES.LATEXDIFF;
-    case 'scratchpad':
-      return MESSAGE_TYPES.SCRATCHPAD;
-    case 'missingOutputs':
-      return MESSAGE_TYPES.MISSING_OUTPUTS;
-    case 'webSearch':
-      return MESSAGE_TYPES.WEB_SEARCH;
-    case 'webFetch':
-      return MESSAGE_TYPES.WEB_FETCH;
-    case 'contextManagement':
-      return MESSAGE_TYPES.CONTEXT_MANAGEMENT;
-    default:
-      return MESSAGE_TYPES.DEFAULT;
-  }
+  return DOMAIN_MESSAGE_TYPE[key] ?? MESSAGE_TYPES.DEFAULT;
 }
 
 /** Re-exported so SDK consumers can introspect the persisted shape. */


### PR DESCRIPTION
## What

Six behavior-preserving conversions of `switch`/if-else ladders that map a discriminant to a value, turning the data into module-level lookup tables. **5 files, +89 / −101.**

You asked whether stable code (outside the changes since 0.38.5) could be more declarative. A read-only detection sweep over the codebase's switch/if-else hotspots found that the dense files are *mostly already* well-factored — legitimate distinct-logic dispatches, discriminated-union payload narrowing, and exhaustiveness-checked switches (e.g. `chatExportFormatter.ts` is already aggressively declarative). These six are the genuine value-map opportunities it surfaced.

| Conversion | |
|---|---|
| `toOpenRouterReasoningEffort` | passthrough `Set` + the `max`→`xhigh` remap |
| `todoMarker`/`todoColor` | one `TODO_STATUS_DISPLAY` table backs both accessors (was two parallel switches) |
| `compactRowPriority` | `(kind, status)`→priority numbers move to a table (outer `kind` switch kept for payload narrowing) |
| `groupPermissions` | `KIND_TO_GROUP` record replaces the 7-arm push switch (buckets uniformly typed) |
| `domainMessageType` | `DOMAIN_MESSAGE_TYPE` record + default fallback |
| `describeAnnotationLevel` | exhaustive `Record<GitHubCheckAnnotationLevel, string>` |

## Left as switches (correctly)

The detection flagged 11 "keep": large event/state dispatches (`TexraTranscriptRecorder`, `subscribeRuntimeHost`), discriminated-union notification builders (`latexHousekeepingNotifications`), per-provider export logic, and partial value-maps whose default arm carries real logic (`accelerators.ts`). Flattening those would lose type-narrowing or merge distinct logic.

## Verification

- `npm run typecheck`, `prettier --check`, `eslint` — clean
- Affected vitest suites pass: `ReasoningEffortMapping`, `TodosPlanPanel`, `RequestPanels`, github

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical, behavior-preserving refactors in UI mapping and small helpers; OpenRouter reasoning mapping logic is unchanged aside from structure.
> 
> **Overview**
> Replaces **value-map** `switch` ladders with module-level lookup tables across six areas, without intended behavior changes.
> 
> **CLI TUI (`TodosPlanPanel`)** — `TODO_STATUS_DISPLAY` backs both todo markers/colors; `COMPACT_ROW_PRIORITY` holds compact-row sort priorities (outer `kind` switch kept for narrowing).
> 
> **Extension progress view** — `groupPermissions` uses `KIND_TO_GROUP`; unknown permission kinds are skipped instead of throwing (same as the old switch with no default).
> 
> **OpenRouter handler** — `toOpenRouterReasoningEffort` uses a passthrough `Set` plus `max` → `xhigh`; unknown efforts still fall back to `low`.
> 
> **GitHub subscription tool** — `describeAnnotationLevel` uses an exhaustive `Record`.
> 
> **Transcript recorder** — `domainMessageType` uses `DOMAIN_MESSAGE_TYPE` with `DEFAULT` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac87b8ec665ddf62cbf2cd0e767d1af5156a72d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->