### PR TITLE
fix: avoid duplicate CLI final transcript fallback

### DIFF
--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -32,6 +32,17 @@ function normalizeTranscriptText(text: string): string {
   return text.trim();
 }
 
+function transcriptDedupeText(text: string): string {
+  return normalizeTranscriptText(text).replaceAll('\\checkmark', '✓');
+}
+
+function currentTurnStartIndex(entries: readonly ConversationEntry[]): number {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (entries[index]?.role === 'user') return index;
+  }
+  return 0;
+}
+
 export function appendAssistantTranscriptIfMissing(
   streamId: StreamTabId,
   text: string | undefined,
@@ -39,22 +50,30 @@ export function appendAssistantTranscriptIfMissing(
 ): void {
   const normalized = normalizeTranscriptText(text ?? '');
   if (!normalized) return;
+  const dedupeText = transcriptDedupeText(normalized);
   const syntheticAfterSeq = getDefaultStreamLogStore().get(streamId)?.head ?? 0;
 
   patchStream(streamId, (slice) => {
     const entryId = `${idPrefix}:${streamId}`;
-    const alreadyRendered = slice.entries.some(
-      (entry) =>
-        entry.id === entryId ||
-        (!entry.synthetic &&
-          entry.role === 'assistant' &&
-          normalizeTranscriptText(entry.text) === normalized) ||
-        (entry.synthetic &&
-          entry.syntheticKind === 'final' &&
-          entry.syntheticAfterSeq === syntheticAfterSeq &&
-          entry.role === 'assistant' &&
-          normalizeTranscriptText(entry.text) === normalized),
-    );
+    const turnStartIndex = currentTurnStartIndex(slice.entries);
+    const alreadyRendered = slice.entries.some((entry, index) => {
+      if (entry.id === entryId) return true;
+      if (
+        !entry.synthetic &&
+        index >= turnStartIndex &&
+        entry.role === 'assistant' &&
+        transcriptDedupeText(entry.text) === dedupeText
+      ) {
+        return true;
+      }
+      return (
+        entry.synthetic === true &&
+        entry.syntheticKind === 'final' &&
+        entry.syntheticAfterSeq === syntheticAfterSeq &&
+        entry.role === 'assistant' &&
+        transcriptDedupeText(entry.text) === dedupeText
+      );
+    });
     if (alreadyRendered) return slice;
 
     const entry: ConversationEntry = {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -78,6 +78,7 @@ import {
   appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
   appendLocalErrorTranscript,
+  appendLocalUserTranscript,
   clearLocalTranscript,
   CLI_LOCAL_STREAM_ID,
   moveLocalTranscriptToStream,
@@ -1676,6 +1677,101 @@ describe('CLI transcript state', () => {
     }
   });
 
+  it('lets the stream-log assistant own final text even when fallback text differs', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info('| x | Check |\n|---|---|\n| 3 | 1 ✓ |', {
+        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+      });
+      syncStreamLog(root);
+      appendAssistantTranscriptIfMissing(
+        root,
+        '| x | Check |\n|---|---|\n| 3 | 1 \\checkmark |',
+        'final:first',
+      );
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        '| x | Check |\n|---|---|\n| 3 | 1 ✓ |',
+      ]);
+      expect(entries[0]?.synthetic).toBeUndefined();
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('dedupes fallback text against stream-log assistant text before trailing tools', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info('| x | Check |\n|---|---|\n| 3 | 1 ✓ |', {
+        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+      });
+      logger.info('', {
+        messageType: MESSAGE_TYPES.TOOL_USE,
+        data: {
+          toolName: 'bash',
+          input: { command: 'true' },
+          output: { summary: 'Executed: true', output: 'ok' },
+          status: 'completed',
+        },
+      });
+      syncStreamLog(root);
+      appendAssistantTranscriptIfMissing(
+        root,
+        '| x | Check |\n|---|---|\n| 3 | 1 \\checkmark |',
+        'final:first',
+      );
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.role)).toEqual(['assistant', 'tool']);
+      expect(entries.map((entry) => entry.text)).toEqual([
+        '| x | Check |\n|---|---|\n| 3 | 1 ✓ |',
+        '',
+      ]);
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('does not dedupe fallback text against a matching prior-turn assistant', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      logger.info('Done ✓', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+      syncStreamLog(root);
+
+      logger.info('second prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      syncStreamLog(root);
+      appendAssistantTranscriptIfMissing(root, 'Done \\checkmark', 'final:2');
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        'first prompt',
+        'Done ✓',
+        'second prompt',
+        'Done \\checkmark',
+      ]);
+      expect(entries.at(-1)).toMatchObject({
+        synthetic: true,
+        syntheticKind: 'final',
+      });
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
   it('projects a turn boundary without duplicating fallback assistant text', () => {
     const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();
@@ -1717,6 +1813,17 @@ describe('CLI transcript state', () => {
     expect(entries.map((entry) => entry.text)).toEqual([
       'Available commands: /help',
       'Available commands: /help',
+    ]);
+  });
+
+  it('preserves literal checkmark commands in local user transcript text', () => {
+    cliState.activeStreamId.set(root);
+
+    appendLocalUserTranscript('literal \\checkmark');
+
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => [entry.role, entry.text])).toEqual([
+      ['user', 'literal \\checkmark'],
     ]);
   });
 


### PR DESCRIPTION
## Summary
- dedupe the CLI final-response fallback against current-turn stream-log assistant text even when glyphs differ (`\\checkmark` vs `✓`)
- keep transcript storage/display trim-only so user text and genuinely missing fallback text preserve their original glyphs
- keep exact same-anchor synthetic fallback dedupe global while scoping non-synthetic assistant text matches to the latest user turn

Fixes #5620.

## Validation
- `npm run test:kernel -- --run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `git diff --check`
- `npm run lint` (passes with existing import-order warnings)
- `npm run typecheck`
- `npm run compile:fast`
- `npm --prefix packages/cli run validate:tui -- --snapshot-dir /private/tmp/texra-tui-round3-fix4 transcript bash-approval`
