### PR TITLE
fix(request-panels): restore approval-button styling (dead vscode-toolbar selectors)

### DIFF
--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -101,6 +101,7 @@ export class RetryRequestPanel extends BaseRequestPanel {
               icon: 'key',
               text: 'Use your own API key',
               title: 'Use your own API key (k)',
+              action: 'useOwnApiKey',
               onClick: () => this.emitAction('useOwnApiKey'),
             }),
           )}
@@ -108,12 +109,14 @@ export class RetryRequestPanel extends BaseRequestPanel {
             icon: 'refresh',
             text: 'Retry',
             title: 'Retry (r)',
+            action: 'retry',
             onClick: () => this.emitAction('retry'),
           })}
           ${renderLabeledActionButton({
             icon: 'close',
             text: 'Dismiss',
             title: 'Dismiss (Esc)',
+            action: 'cancel',
             onClick: () => this.emitAction('cancel'),
           })}
         </div>

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -133,11 +133,27 @@ export const requestPanelStyles: CSSResult = css`
     gap: ${sp.small};
   }
 
-  :is(${ACTIONS}) wa-button {
+  /* The primary action buttons (which carry data-action) fill the row
+     equally; the diff dropdown's own buttons keep their bespoke sizing. */
+  :is(${ACTIONS}) wa-button[data-action] {
     min-width: auto;
+    flex: 1 1 var(--action-button-basis, 8rem);
   }
 
-  :is(${ACTIONS}) wa-button::part(base) {
+  /* Per-panel basis tunes how many action buttons fit per row before wrapping.
+     Default 8rem (retry / inquiry / question); approval + plan want wider rows,
+     the workflow proposal narrower. */
+  .approval-request__actions,
+  .bash-approval-request__actions,
+  .plan-approval-request__actions {
+    --action-button-basis: 12rem;
+  }
+
+  .workflow-proposal__actions {
+    --action-button-basis: 6rem;
+  }
+
+  :is(${ACTIONS}) wa-button[data-action]::part(base) {
     justify-content: flex-start;
     gap: ${sp.small};
   }
@@ -190,12 +206,6 @@ export const requestPanelStyles: CSSResult = css`
   }
   .user-question-request {
     border-left: var(--border-medium) solid var(--wa-color-focus);
-  }
-
-  /* Shared action button width — approval and bash use the same flex-basis */
-  .approval-request__actions wa-button,
-  .bash-approval-request__actions wa-button {
-    flex: 1 1 12rem;
   }
 
   /* ================================================================
@@ -309,10 +319,6 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--color-warning);
   }
 
-  .retry-request__actions wa-button {
-    flex: 1 1 8rem;
-  }
-
   .retry-request__operation {
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size-sm);
@@ -382,10 +388,6 @@ export const requestPanelStyles: CSSResult = css`
 
   .workflow-proposals__header wa-icon {
     color: var(--wa-color-text-link);
-  }
-
-  .workflow-proposal__actions wa-button {
-    flex: 1 1 6rem;
   }
 
   .workflow-proposal__header-row {
@@ -567,10 +569,6 @@ export const requestPanelStyles: CSSResult = css`
 
   .plan-approval-request__file {
     color: var(--wa-color-text-link);
-  }
-
-  .plan-approval-request__actions wa-button {
-    flex: 1 1 12rem;
   }
 
   /* ================================================================
@@ -905,10 +903,6 @@ export const requestPanelStyles: CSSResult = css`
     }
   }
 
-  .external-inquiry-request__actions wa-button {
-    flex: 1 1 8rem;
-  }
-
   /* ================================================================
    * User question requests
    * ================================================================ */
@@ -992,9 +986,5 @@ export const requestPanelStyles: CSSResult = css`
 
   .user-question-request__free-text {
     width: 100%;
-  }
-
-  .user-question-request__actions wa-button {
-    flex: 1 1 8rem;
   }
 `;

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -133,34 +133,28 @@ export const requestPanelStyles: CSSResult = css`
     gap: ${sp.small};
   }
 
-  :is(${ACTIONS})::part(container) {
-    display: flex;
-    flex-wrap: wrap;
-    gap: ${sp.small};
-  }
-
-  :is(${ACTIONS}) vscode-toolbar-button {
+  :is(${ACTIONS}) wa-button {
     min-width: auto;
   }
 
-  :is(${ACTIONS}) vscode-toolbar-button::part(control) {
+  :is(${ACTIONS}) wa-button::part(base) {
     justify-content: flex-start;
     gap: ${sp.small};
   }
 
   /* Shared action button colors */
-  :is(${ACTIONS}) vscode-toolbar-button[data-action='approve']::part(control),
-  :is(${ACTIONS}) vscode-toolbar-button[data-action='submit']::part(control) {
+  :is(${ACTIONS}) wa-button[data-action='approve']::part(base),
+  :is(${ACTIONS}) wa-button[data-action='submit']::part(base) {
     color: var(--wa-color-success-fill-loud);
   }
 
-  :is(${ACTIONS}) vscode-toolbar-button[data-action='setup']::part(control) {
+  :is(${ACTIONS}) wa-button[data-action='setup']::part(base) {
     color: var(--wa-color-text-link);
   }
 
   :is(${FEEDBACK_ACTIVE})
     :is(${ACTIONS})
-    vscode-toolbar-button[data-action='reject']::part(control) {
+    wa-button[data-action='reject']::part(base) {
     color: var(--wa-color-warning-border-quiet);
   }
 
@@ -199,8 +193,8 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   /* Shared action button width — approval and bash use the same flex-basis */
-  .approval-request__actions vscode-toolbar-button,
-  .bash-approval-request__actions vscode-toolbar-button {
+  .approval-request__actions wa-button,
+  .bash-approval-request__actions wa-button {
     flex: 1 1 12rem;
   }
 
@@ -315,7 +309,7 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--color-warning);
   }
 
-  .retry-request__actions vscode-toolbar-button {
+  .retry-request__actions wa-button {
     flex: 1 1 8rem;
   }
 
@@ -390,7 +384,7 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--wa-color-text-link);
   }
 
-  .workflow-proposal__actions vscode-toolbar-button {
+  .workflow-proposal__actions wa-button {
     flex: 1 1 6rem;
   }
 
@@ -575,7 +569,7 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--wa-color-text-link);
   }
 
-  .plan-approval-request__actions vscode-toolbar-button {
+  .plan-approval-request__actions wa-button {
     flex: 1 1 12rem;
   }
 
@@ -911,7 +905,7 @@ export const requestPanelStyles: CSSResult = css`
     }
   }
 
-  .external-inquiry-request__actions vscode-toolbar-button {
+  .external-inquiry-request__actions wa-button {
     flex: 1 1 8rem;
   }
 
@@ -1000,7 +994,7 @@ export const requestPanelStyles: CSSResult = css`
     width: 100%;
   }
 
-  .user-question-request__actions vscode-toolbar-button {
+  .user-question-request__actions wa-button {
     flex: 1 1 8rem;
   }
 `;

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -141,8 +141,8 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   /* Per-panel basis tunes how many action buttons fit per row before wrapping.
-     Default 8rem (retry / inquiry / question); approval + plan want wider rows,
-     the workflow proposal narrower. */
+     Default 8rem (retry / inquiry / question); approval / bash / plan want
+     wider rows, the workflow proposal narrower. */
   .approval-request__actions,
   .bash-approval-request__actions,
   .plan-approval-request__actions {

--- a/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
@@ -1,0 +1,59 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - progress view component types
+import type { PermissionState } from '@progressView/frontend/components/PermissionCard';
+import type { RetryRequestPanel } from '@progressView/frontend/components/RetryRequestPanel';
+
+// Local imports - shared constants
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+useLitComponentTestDom(
+  () => import('@progressView/frontend/components/RetryRequestPanel'),
+);
+
+function createRetryPermission(): PermissionState {
+  return {
+    kind: PERMISSION_KIND.RETRY,
+    data: {
+      streamId: 'stream-1',
+      operation: 'model request',
+      model: 'test-model',
+      errorMessage: 'Relay quota exhausted',
+      errorDetails: {
+        isCredentialExhausted: true,
+        isRelayError: true,
+        userRetryable: true,
+      },
+    },
+  };
+}
+
+async function mountPanel(): Promise<RetryRequestPanel> {
+  const element = document.createElement(
+    'retry-request-panel',
+  ) as RetryRequestPanel;
+  element.permission = createRetryPermission();
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+describe('retry-request-panel', () => {
+  it('marks retry action buttons with action ids for shared sizing styles', async () => {
+    const element = await mountPanel();
+
+    const buttons = [
+      ...(element.shadowRoot?.querySelectorAll(
+        '.retry-request__actions wa-button',
+      ) ?? []),
+    ];
+
+    expect(buttons.map((button) => button.getAttribute('data-action'))).toEqual(
+      ['useOwnApiKey', 'retry', 'cancel'],
+    );
+  });
+});


### PR DESCRIPTION
## What

`requestPanelStyles` styled approval/retry/proposal/plan/inquiry/question action buttons via `vscode-toolbar-button::part(control)`. Those buttons are now `<wa-button>` (rendered by `renderLabeledActionButton`/`renderIconActionButton`), which has **no `vscode-toolbar-button` tag and no `control` part** — it exposes `::part(base)`. So the *entire* shared action-button block was **dead**, and the buttons silently lost:

- their intended **equal-width sizing** — `flex: 1 1 12rem` (approve/bash/plan), `8rem` (retry/inquiry/question), `6rem` (proposal); and
- their **color accents** — approve/submit = `--wa-color-success-fill-loud`, setup = `--wa-color-text-link`, reject = `--wa-color-warning-border-quiet`.

## Fix

- Retarget every `vscode-toolbar-button` → `wa-button` and `::part(control)` → `::part(base)` so the rules hit the rendered element/part.
- Delete the dead `:is(${ACTIONS})::part(container)` block — `${ACTIONS}` are plain `<div>` containers (no shadow parts), and the live `:is(${ACTIONS}) { display:flex }` rule immediately above already provides that layout.

This **adds no new styling** — it reconnects rules already written for these panels (a leftover from the vscode-toolbar → WebAwesome migration). 1 file.

## Verification
- No `vscode-toolbar-button` / `::part(control)` / `::part(container)` selectors remain in the file.
- `prettier --check` clean.
- Off `main`; independent of #5611 / #5612 (no shared files).

## Context
This is the single HIGH finding (flagged in two independent audit rounds) from a comprehensive UI-consistency audit of the extension webviews. The remaining ~59 findings (token consolidation, same-element convergence, dead-CSS sweep, a11y) are being reported separately and mostly land in shared sheets that PR #5611 already edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and explicit action attributes on retry buttons; no auth, data, or API behavior changes.
> 
> **Overview**
> **Reconnects shared request-panel action button styling** after the Web Awesome migration by retargeting `requestPanelStyles` from dead `vscode-toolbar-button` / `::part(control)` rules to `wa-button[data-action]` / `::part(base)`, restoring equal-width flex layout and approve/submit/setup/reject color accents.
> 
> Sizing is **centralized** with `--action-button-basis` (defaults 8rem; 12rem for approval/bash/plan; 6rem for workflow proposals) instead of per-panel duplicate rules. A dead `::part(container)` block on action rows is removed.
> 
> **Retry panel** now passes explicit `action` ids (`useOwnApiKey`, `retry`, `cancel`) into `renderLabeledActionButton` so those buttons participate in the shared selectors. A **Vitest** asserts the rendered `data-action` attributes match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace22b789807fa9066b59ab51f547602116fadb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->