### PR TITLE
fix(cli): avoid hidden approvals blocking active tabs

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -375,12 +375,6 @@ export function approvalVisibleForActiveStream({
   return streamId === undefined || streamId === activeStreamId;
 }
 
-export function approvalBlocksInput(
-  pending: PendingApproval | undefined,
-): boolean {
-  return pending !== undefined;
-}
-
 export function foregroundEscapeAction({
   activeFormEscapeAction,
   foregroundKind,
@@ -479,7 +473,6 @@ export function App(props: AppProps): React.JSX.Element {
     activeStreamId,
     pending,
   });
-  const approvalInputBlocked = approvalBlocksInput(pending);
 
   const stdin = useStdin();
   const foregroundOpen =
@@ -487,8 +480,7 @@ export function App(props: AppProps): React.JSX.Element {
     activeForm !== undefined ||
     childControlMode !== undefined ||
     transcriptViewerOpen;
-  const inputDisabled =
-    props.inputDisabled === true || foregroundOpen || approvalInputBlocked;
+  const inputDisabled = props.inputDisabled === true || foregroundOpen;
   const inputBarVisible = !foregroundOpen;
   const viewportKey = transcriptViewportKey({
     activeStreamId,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -22,7 +22,6 @@ import {
   allocateSidePanelRows,
   appEscapeInterruptActive,
   appFocusShortcutsActive,
-  approvalBlocksInput,
   approvalForegroundMaxRows,
   approvalVisibleForActiveStream,
   childControlForegroundMaxRows,
@@ -859,7 +858,7 @@ describe('CLI TUI row allocation', () => {
     ).toBe(true);
   });
 
-  it('blocks input for hidden stream-owned approvals', () => {
+  it('keeps hidden stream-owned approvals from taking the foreground', () => {
     const childApproval = {
       payload: {
         kind: 'bash',
@@ -879,8 +878,6 @@ describe('CLI TUI row allocation', () => {
         pending: childApproval,
       }),
     ).toBe(false);
-    expect(approvalBlocksInput(childApproval)).toBe(true);
-    expect(approvalBlocksInput(undefined)).toBe(false);
   });
 
   it('keeps stream focus shortcuts available for hidden approvals', () => {
@@ -903,7 +900,6 @@ describe('CLI TUI row allocation', () => {
         pending: childApproval,
       }),
     ).toBe(false);
-    expect(approvalBlocksInput(childApproval)).toBe(true);
     expect(
       appFocusShortcutsActive({
         foregroundOpen: false,


### PR DESCRIPTION
## Summary

- stop treating every queued approval as an input blocker in the CLI TUI
- let only the foreground approval for the active stream own input
- update the focused TUI state tests so hidden stream-owned approvals stay non-foreground while stream focus shortcuts remain available

## Root Cause

`App` already computed whether the current approval belonged to the active stream, but a second boolean still disabled input for any pending approval. If a root or child approval was pending while another stream was focused, the modal stayed hidden but the active tab could still be frozen.

## Validation

- `npm run test:kernel -- --run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ApprovalQueue.vitest.mts`
- `npx prettier --check packages/cli/src/chat/tui/App.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npx eslint packages/cli/src/chat/tui/App.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small focus/input gating change in the CLI TUI with targeted test updates; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a CLI TUI bug where **any** queued approval disabled input, even when the approval modal was hidden because it belonged to another stream tab.
> 
> **`App`** drops `approvalBlocksInput` and no longer treats `pending` alone as a blocker. Input is disabled only when `props.inputDisabled` is set or a **foreground** surface is open (`activeApprovalVisible` for the active stream, forms, child controls, or transcript viewer)—so you can keep typing on the focused tab while a child-stream approval waits in the queue.
> 
> Tests in **`TuiStateAndFocus.vitest.mts`** drop `approvalBlocksInput` coverage and assert hidden stream-owned approvals stay off the foreground while stream focus shortcuts remain available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97f8738756ca427d7405db732d83a2e759cb489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->