### PR TITLE
refactor: move CLI slash form ownership into commands

### DIFF
--- a/packages/cli/src/chat/tui/commands/slashForms.tsx
+++ b/packages/cli/src/chat/tui/commands/slashForms.tsx
@@ -1,0 +1,23 @@
+import { cliState } from '../state/cliState';
+
+import type { SlashCommand } from './slashRegistry';
+
+export function openRegisteredCliSlashForm(
+  command: SlashCommand,
+  remainder: string,
+): boolean {
+  const Form = command.formComponent;
+  if (!Form) return false;
+  cliState.activeForm.set({
+    commandName: command.name,
+    escapeAction: command.formEscapeAction,
+    render: (close, availableRows) => (
+      <Form
+        availableRows={availableRows}
+        remainder={remainder.trimStart()}
+        onDone={() => close()}
+      />
+    ),
+  });
+  return true;
+}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -103,6 +103,7 @@ import { App } from './App';
 import { assertNever } from './assertNever';
 import { formatApprovalPolicyForCli as formatApprovalPolicy } from './forms/ApprovalPolicyForm';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
+import { openRegisteredCliSlashForm } from './commands/slashForms';
 import {
   listSlashCommands,
   parseSlashInput,
@@ -736,26 +737,6 @@ async function showCliMemoryList(): Promise<void> {
 
 async function showCliMemoryPreview(inputPath: string): Promise<void> {
   appendLocalAssistantTranscript(await formatCliMemoryPreview(inputPath));
-}
-
-export function openRegisteredCliSlashForm(
-  command: SlashCommand,
-  remainder: string,
-): boolean {
-  const Form = command.formComponent;
-  if (!Form) return false;
-  cliState.activeForm.set({
-    commandName: command.name,
-    escapeAction: command.formEscapeAction,
-    render: (close, availableRows) => (
-      <Form
-        availableRows={availableRows}
-        remainder={remainder.trimStart()}
-        onDone={() => close()}
-      />
-    ),
-  });
-  return true;
 }
 
 function findRegisteredCliSlashCommand(

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -11,7 +11,7 @@ import {
   unregisterSlashCommand,
 } from '@cli/chat/tui/commands/slashRegistry';
 import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
-import { openRegisteredCliSlashForm } from '@cli/chat/tui/runChatTui';
+import { openRegisteredCliSlashForm } from '@cli/chat/tui/commands/slashForms';
 import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 


### PR DESCRIPTION
## Summary
- move registered slash form mounting from `runChatTui` into `commands/slashForms`
- keep command registry tests on the command-layer surface instead of importing the full chat runtime
- leave runtime command behavior unchanged

## Design note
`runChatTui` should orchestrate chat execution, while the command subsystem owns registered slash command forms. This keeps the ownership boundary tighter without adding a pass-through layer.

## Validation
- `npm run test:kernel -- --run src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/InputBar.vitest.mts`
- `npx prettier --check packages/cli/src/chat/tui/commands/slashForms.tsx packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npx eslint packages/cli/src/chat/tui/commands/slashForms.tsx packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/SlashRegistry.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure module move with identical logic and updated test imports; no runtime behavior change.
> 
> **Overview**
> Moves **`openRegisteredCliSlashForm`** out of `runChatTui` into new **`commands/slashForms`**, so the command subsystem owns mounting registered slash command forms (`cliState.activeForm` + form adapter) instead of the chat runtime orchestrator.
> 
> `runChatTui` now imports that helper and keeps the same call sites (`openRegisteredCliSlashCommandForm` and the default slash handler). **`SlashRegistry` tests** import from `slashForms` instead of the full chat entry module, so registry/form behavior is tested at the command layer without pulling in `runChatTui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb76a53deca3d794f6a6bd917d7900357f65def4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->