### PR TITLE
refactor: centralize CLI slash command lookup

### DIFF
--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -57,6 +57,17 @@ export function listSlashCommands(): readonly SlashCommand[] {
   return [...COMMANDS.values()];
 }
 
+export function findSlashCommand(
+  nameOrAlias: string,
+): SlashCommand | undefined {
+  const lower = nameOrAlias.toLowerCase();
+  return listSlashCommands().find(
+    (cmd) =>
+      cmd.name.toLowerCase() === lower ||
+      cmd.aliases?.some((alias) => alias.toLowerCase() === lower) === true,
+  );
+}
+
 /**
  * Returns registered commands whose name or an alias starts with `prefix`.
  * Results are case-insensitive and preserve registration order.

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -105,9 +105,9 @@ import { formatApprovalPolicyForCli as formatApprovalPolicy } from './forms/Appr
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
 import { openRegisteredCliSlashForm } from './commands/slashForms';
 import {
+  findSlashCommand,
   listSlashCommands,
   parseSlashInput,
-  type SlashCommand,
 } from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
@@ -739,22 +739,11 @@ async function showCliMemoryPreview(inputPath: string): Promise<void> {
   appendLocalAssistantTranscript(await formatCliMemoryPreview(inputPath));
 }
 
-function findRegisteredCliSlashCommand(
-  commandName: string,
-): SlashCommand | undefined {
-  const lower = commandName.toLowerCase();
-  return listSlashCommands().find(
-    (cmd) =>
-      cmd.name.toLowerCase() === lower ||
-      cmd.aliases?.some((alias) => alias.toLowerCase() === lower) === true,
-  );
-}
-
 function openRegisteredCliSlashCommandForm(
   commandName: string,
   remainder: string,
 ): boolean {
-  const registered = findRegisteredCliSlashCommand(commandName);
+  const registered = findSlashCommand(commandName);
   return registered ? openRegisteredCliSlashForm(registered, remainder) : false;
 }
 
@@ -905,7 +894,7 @@ async function handleTuiSlashCommand(
       });
       return true;
     default: {
-      const registered = findRegisteredCliSlashCommand(command);
+      const registered = findSlashCommand(command);
       if (registered) {
         if (openRegisteredCliSlashForm(registered, parsed.remainder)) {
           return true;

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  findSlashCommand,
   listSlashCommands,
   matchSlashCommands,
   parseSlashInput,
@@ -504,6 +505,18 @@ describe('slashRegistry', () => {
     });
     expect(matchSlashCommands('h').map((c) => c.name)).toEqual(['help']);
     expect(matchSlashCommands('us').map((c) => c.name)).toEqual(['help']);
+  });
+
+  it('finds exact command names and aliases case-insensitively', () => {
+    registerSlashCommand({
+      name: 'agent',
+      description: 'pick an agent',
+      aliases: ['agents'],
+    });
+
+    expect(findSlashCommand('agent')?.name).toBe('agent');
+    expect(findSlashCommand('AGENTS')?.name).toBe('agent');
+    expect(findSlashCommand('age')).toBeUndefined();
   });
 
   it('submits no-form commands on Enter and completes on Tab', () => {


### PR DESCRIPTION
## Summary
- add `findSlashCommand()` to the slash command registry
- remove duplicate exact name/alias lookup logic from `runChatTui`
- cover case-insensitive exact alias lookup in the CLI registry tests

## Design note
Slash command registration, autocomplete, and exact lookup should use the same registry-owned matching semantics. This avoids another dispatcher-local copy of alias rules.

## Validation
- `npm run test:kernel -- --run src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/InputBar.vitest.mts`
- `npx prettier --check packages/cli/src/chat/tui/commands/slashRegistry.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npx eslint packages/cli/src/chat/tui/commands/slashRegistry.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/SlashRegistry.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with new unit tests; no auth, persistence, or runtime execution paths changed.
> 
> **Overview**
> Adds **`findSlashCommand()`** to the slash command registry so exact lookup by canonical name or alias (case-insensitive) lives next to `matchSlashCommands` and registration.
> 
> **`runChatTui`** drops its local `findRegisteredCliSlashCommand` helper and calls the registry for opening structured forms and handling unknown/custom registered commands, so alias rules aren’t duplicated in the TUI dispatcher.
> 
> Registry tests now cover exact alias resolution (e.g. `AGENTS` → `agent`) and that prefix-only tokens like `age` do not match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98218f7e6ce7fd6fb40ffdd1f3f2b7e7d35022d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->