### PR TITLE
refactor: own slash form lookup in command layer

### DIFF
--- a/packages/cli/src/chat/tui/commands/slashForms.tsx
+++ b/packages/cli/src/chat/tui/commands/slashForms.tsx
@@ -1,6 +1,6 @@
 import { cliState } from '../state/cliState';
 
-import type { SlashCommand } from './slashRegistry';
+import { findSlashCommand, type SlashCommand } from './slashRegistry';
 
 export function openRegisteredCliSlashForm(
   command: SlashCommand,
@@ -20,4 +20,12 @@ export function openRegisteredCliSlashForm(
     ),
   });
   return true;
+}
+
+export function openCliSlashCommandForm(
+  commandName: string,
+  remainder: string,
+): boolean {
+  const command = findSlashCommand(commandName);
+  return command ? openRegisteredCliSlashForm(command, remainder) : false;
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -103,7 +103,10 @@ import { App } from './App';
 import { assertNever } from './assertNever';
 import { formatApprovalPolicyForCli as formatApprovalPolicy } from './forms/ApprovalPolicyForm';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
-import { openRegisteredCliSlashForm } from './commands/slashForms';
+import {
+  openCliSlashCommandForm,
+  openRegisteredCliSlashForm,
+} from './commands/slashForms';
 import {
   findSlashCommand,
   listSlashCommands,
@@ -715,7 +718,7 @@ function applyCliApprovalPolicySelection(
 ): void {
   const normalized = input.trim().toLowerCase();
   if (!normalized || normalized === 'status') {
-    openRegisteredCliSlashCommandForm('approval', '');
+    openCliSlashCommandForm('approval', '');
     return;
   }
 
@@ -737,14 +740,6 @@ async function showCliMemoryList(): Promise<void> {
 
 async function showCliMemoryPreview(inputPath: string): Promise<void> {
   appendLocalAssistantTranscript(await formatCliMemoryPreview(inputPath));
-}
-
-function openRegisteredCliSlashCommandForm(
-  commandName: string,
-  remainder: string,
-): boolean {
-  const registered = findSlashCommand(commandName);
-  return registered ? openRegisteredCliSlashForm(registered, remainder) : false;
 }
 
 async function handleTuiSlashCommand(
@@ -791,16 +786,16 @@ async function handleTuiSlashCommand(
       } else if (rest) {
         applyInitialCliAgentSelection(rest, context);
       } else {
-        openRegisteredCliSlashCommandForm('agent', rest);
+        openCliSlashCommandForm('agent', rest);
       }
       return true;
     case 'model':
     case 'models':
-      openRegisteredCliSlashCommandForm('model', rest);
+      openCliSlashCommandForm('model', rest);
       return true;
     case 'api':
       if (!rest) {
-        openRegisteredCliSlashCommandForm('api', rest);
+        openCliSlashCommandForm('api', rest);
         return true;
       }
       try {
@@ -826,7 +821,7 @@ async function handleTuiSlashCommand(
       if (rest) {
         applyCliApprovalPolicySelection(rest, context);
       } else {
-        openRegisteredCliSlashCommandForm('approval', rest);
+        openCliSlashCommandForm('approval', rest);
       }
       return true;
     case 'yolo':
@@ -859,7 +854,7 @@ async function handleTuiSlashCommand(
     }
     case 'resume': {
       if (!rest) {
-        openRegisteredCliSlashCommandForm('resume', rest);
+        openCliSlashCommandForm('resume', rest);
         return true;
       }
       const id = parseCliHistoryId(rest);
@@ -873,7 +868,7 @@ async function handleTuiSlashCommand(
     case 'memory': {
       try {
         if (!rest) {
-          openRegisteredCliSlashCommandForm('memory', rest);
+          openCliSlashCommandForm('memory', rest);
         } else if (rest.toLowerCase() === 'list') {
           await showCliMemoryList();
         } else {

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -12,7 +12,10 @@ import {
   unregisterSlashCommand,
 } from '@cli/chat/tui/commands/slashRegistry';
 import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
-import { openRegisteredCliSlashForm } from '@cli/chat/tui/commands/slashForms';
+import {
+  openCliSlashCommandForm,
+  openRegisteredCliSlashForm,
+} from '@cli/chat/tui/commands/slashForms';
 import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 
@@ -143,6 +146,16 @@ describe('slashRegistry', () => {
 
     expect(openRegisteredCliSlashForm(tools, '')).toBe(true);
     expect(cliState.activeForm.get()?.commandName).toBe('tools');
+  });
+
+  it('opens structured forms by registered command name or alias', () => {
+    registerBuiltinSlashCommands();
+
+    expect(openCliSlashCommandForm('TOOLS', '')).toBe(true);
+    expect(cliState.activeForm.get()?.commandName).toBe('tools');
+
+    expect(openCliSlashCommandForm('skill', '')).toBe(true);
+    expect(cliState.activeForm.get()?.commandName).toBe('skills');
   });
 
   it('chains selectable agent picks into the API-mode-aware model picker', async () => {


### PR DESCRIPTION
## Summary
- move registered slash form lookup-by-name into `commands/slashForms`
- remove the dispatcher-local lookup/open helper from `runChatTui`
- add coverage for opening slash forms by canonical command name and alias

## Design note
The command layer now owns both resolving a registered slash command and mounting its structured form. `runChatTui` keeps orchestration-specific behavior, but no longer carries a pass-through helper for command form lookup.

## Validation
- `npm run test:kernel -- --run src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/InputBar.vitest.mts`
- `npx prettier --check packages/cli/src/chat/tui/commands/slashForms.tsx packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npx eslint packages/cli/src/chat/tui/commands/slashForms.tsx packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/SlashRegistry.vitest.mts`
- `git diff --check`
- `corepack pnpm --filter @texra-ai/cli validate:tui --skip-if-missing-deps slash-palette tools-form skills-form`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with no behavior change beyond shared resolution; slash dispatch and form mounting paths stay the same.
> 
> **Overview**
> Moves **slash form lookup-by-name** from the chat TUI dispatcher into the command layer: `slashForms` now exports `openCliSlashCommandForm`, which resolves a registered command (including aliases, case-insensitive) via `findSlashCommand` and mounts its structured form through the existing `openRegisteredCliSlashForm` path.
> 
> `runChatTui` drops its local pass-through helper and calls the shared opener for `/agent`, `/model`, `/api`, `/approval`, `/resume`, and `/memory` (and approval **status** via `/yolo`). Tests assert opening forms by canonical name (`TOOLS`) and alias (`skill` → `skills`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf3c3d68d71071e8a749bd4cff94f8265b691b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->