### PR TITLE
refactor: route input slash forms through command owner

### DIFF
--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -12,6 +12,7 @@ import {
 import { ImagePasteQueue } from '../input/imagePasteQueue';
 import { ReverseSearch } from '../input/ReverseSearch';
 import { isCtrlInput } from '../input/inputKeys';
+import { openRegisteredCliSlashForm } from '../commands/slashForms';
 import { SlashPalette } from '../commands/SlashPalette';
 import {
   matchSlashCommands,
@@ -40,14 +41,14 @@ export interface InputBarProps {
 function slashSubmitText(
   current: string,
   commandName: string,
-  fallbackRemainder: string,
+  remainder: string,
   typedName?: string,
 ): string {
   const parsedName = parseSlashInput(current)?.name;
   const nameToReplace =
     typedName && current.startsWith(`/${typedName}`) ? typedName : parsedName;
   if (!nameToReplace) {
-    return `/${commandName}${fallbackRemainder ? ` ${fallbackRemainder.trimStart()}` : ''}`;
+    return `/${commandName}${remainder ? ` ${remainder.trimStart()}` : ''}`;
   }
   const suffix = current.slice(nameToReplace.length + 1);
   const separator = suffix.length > 0 && !/^\s/.test(suffix) ? ' ' : '';
@@ -56,22 +57,22 @@ function slashSubmitText(
 
 export function submitSlashCommandWhenReady({
   commandName,
-  fallbackRemainder,
   handleSubmit,
   imagePasteQueue,
   readDraft,
+  remainder,
   typedName,
 }: {
   readonly commandName: string;
-  readonly fallbackRemainder: string;
   readonly handleSubmit: (value: string) => void;
   readonly imagePasteQueue: ImagePasteQueue;
   readonly readDraft: () => string;
+  readonly remainder: string;
   readonly typedName?: string;
 }): void {
   imagePasteQueue.runWhenIdle(() => {
     handleSubmit(
-      slashSubmitText(readDraft(), commandName, fallbackRemainder, typedName),
+      slashSubmitText(readDraft(), commandName, remainder, typedName),
     );
   });
 }
@@ -184,28 +185,17 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       if (cmd.formComponent) {
         // Structured forms own the screen — clear the input and let
         // the active-form signal mount the component (see App.tsx).
-        const Form = cmd.formComponent;
         clearDraft();
-        cliState.activeForm.set({
-          commandName: cmd.name,
-          escapeAction: cmd.formEscapeAction,
-          render: (close, availableRows) => (
-            <Form
-              remainder={remainder.trimStart()}
-              availableRows={availableRows}
-              onDone={() => close()}
-            />
-          ),
-        });
+        openRegisteredCliSlashForm(cmd, remainder);
         return;
       }
       if (intent === 'submit') {
         submitSlashCommandWhenReady({
           commandName: cmd.name,
-          fallbackRemainder: remainder,
           handleSubmit,
           imagePasteQueue,
           readDraft: () => draftValueRef.current,
+          remainder,
           typedName,
         });
         return;

--- a/src/test-kernel/cli/InputBar.vitest.mts
+++ b/src/test-kernel/cli/InputBar.vitest.mts
@@ -34,10 +34,10 @@ describe('InputBar slash submit', () => {
 
     submitSlashCommandWhenReady({
       commandName: 'help',
-      fallbackRemainder: '',
       handleSubmit: (value) => submitted.push(value),
       imagePasteQueue,
       readDraft: () => draft,
+      remainder: '',
       typedName: 'h',
     });
 
@@ -64,10 +64,10 @@ describe('InputBar slash submit', () => {
 
     submitSlashCommandWhenReady({
       commandName: 'help',
-      fallbackRemainder: '',
       handleSubmit: (value) => submitted.push(value),
       imagePasteQueue,
       readDraft: () => draft,
+      remainder: '',
       typedName: 'h',
     });
 


### PR DESCRIPTION
## Summary
- route InputBar structured slash-form activation through `openRegisteredCliSlashForm`
- remove InputBar's duplicate `cliState.activeForm` construction
- rename the slash submit helper parameter from `fallbackRemainder` to `remainder`

## Design note
Structured slash form mounting now has one owner in `commands/slashForms`. InputBar still owns input editing and submit timing, but no longer rebuilds the active-form payload itself.

## Validation
- `npm run test:kernel -- --run src/test-kernel/cli/InputBar.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npx prettier --check packages/cli/src/chat/tui/panes/InputBar.tsx src/test-kernel/cli/InputBar.vitest.mts`
- `npx eslint packages/cli/src/chat/tui/panes/InputBar.tsx src/test-kernel/cli/InputBar.vitest.mts`
- `git diff --check`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build --skip-if-missing-deps slash-palette model-form skills-form tools-form`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with no behavior change beyond deduplicating active-form setup; tests cover slash submit timing.
> 
> **Overview**
> **InputBar** no longer builds `cliState.activeForm` when a slash command has a structured form; it clears the draft and calls **`openRegisteredCliSlashForm`** so form mounting lives in `commands/slashForms` with the rest of the CLI slash-form flow.
> 
> The slash submit helper renames **`fallbackRemainder`** to **`remainder`** in `slashSubmitText` and `submitSlashCommandWhenReady`; tests follow the new parameter name. Submit timing and image-paste behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58ffbf6843f06201762ea46996e720dcdfc757ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->