### PR TITLE
refactor: reuse slash command owner in TUI harness

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -42,10 +42,14 @@ import {
 } from '../src/chat/tui/state/transcriptViewportMode';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
 import {
+  findSlashCommand,
   listSlashCommands,
   parseSlashInput,
-  type SlashCommand,
 } from '../src/chat/tui/commands/slashRegistry';
+import {
+  openCliSlashCommandForm,
+  openRegisteredCliSlashForm,
+} from '../src/chat/tui/commands/slashForms';
 import { formatApprovalPolicyForCli } from '../src/chat/tui/forms/ApprovalPolicyForm';
 import {
   cliState,
@@ -1194,15 +1198,6 @@ function harnessRejectsChildSubmit(childStreamId: StreamTabId): boolean {
   return status !== undefined && !isInFlightStatus(status);
 }
 
-function findRegisteredSlashCommand(name: string): SlashCommand | undefined {
-  const lower = name.toLowerCase();
-  return listSlashCommands().find(
-    (command) =>
-      command.name.toLowerCase() === lower ||
-      command.aliases?.some((alias) => alias.toLowerCase() === lower) === true,
-  );
-}
-
 function formatHarnessSlashHelp(): string {
   return listSlashCommands()
     .map((command) => `/${command.name} - ${command.description}`)
@@ -1248,29 +1243,8 @@ function getHarnessModelSwitchDisabledReason(
     : undefined;
 }
 
-function openHarnessSlashForm(
-  command: SlashCommand,
-  remainder: string,
-): boolean {
-  const Form = command.formComponent;
-  if (!Form) return false;
-  cliState.activeForm.set({
-    commandName: command.name,
-    escapeAction: command.formEscapeAction,
-    render: (close, availableRows) => (
-      <Form
-        availableRows={availableRows}
-        remainder={remainder.trimStart()}
-        onDone={() => close()}
-      />
-    ),
-  });
-  return true;
-}
-
 function openHarnessApprovalPolicyForm(remainder: string): boolean {
-  const command = findRegisteredSlashCommand('approval');
-  return command ? openHarnessSlashForm(command, remainder) : false;
+  return openCliSlashCommandForm('approval', remainder);
 }
 
 function applyHarnessApprovalPolicySelection(
@@ -1393,12 +1367,12 @@ function handleHarnessSlashCommand(line: string): boolean {
       applyHarnessApprovalPolicySelection(rest || 'yolo', HARNESS_YOLO_USAGE);
       return true;
     default: {
-      const command = findRegisteredSlashCommand(commandName);
+      const command = findSlashCommand(commandName);
       if (!command) {
         appendHarnessAssistantTranscript(`Unknown command: /${parsed.name}`);
         return true;
       }
-      if (openHarnessSlashForm(command, rest)) return true;
+      if (openRegisteredCliSlashForm(command, rest)) return true;
       appendHarnessAssistantTranscript(
         `/${command.name} is registered but has no harness action.`,
       );


### PR DESCRIPTION
## Summary
- route the TUI harness through the shared slash command lookup helper
- use the command-owned slash form opener instead of rebuilding active form state in the harness
- remove harness-local duplicate lookup/form mounting helpers

## Design note
The PTY harness should exercise the same command registry and form mounting path as the real CLI. This keeps the harness as a fidelity check instead of a parallel implementation of slash command behavior.

## Validation
- `npx prettier --check packages/cli/scripts/tui-harness.tsx`
- `npx eslint packages/cli/scripts/tui-harness.tsx` (file ignored by current ESLint config)
- `git diff --check`
- `corepack pnpm --filter @texra-ai/cli validate:tui --skip-if-missing-deps slash-palette approval-form model-form tools-form skills-form`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness-only refactor with no production CLI path changes; reduces drift risk between test harness and real slash behavior.
> 
> **Overview**
> The TUI test harness now uses the same slash-command path as the real CLI instead of maintaining parallel helpers.
> 
> **Lookup and forms:** Harness slash handling calls `findSlashCommand` from `slashRegistry` and mounts forms via `openCliSlashCommandForm` / `openRegisteredCliSlashForm` from `slashForms`. The local `findRegisteredSlashCommand` and `openHarnessSlashForm` helpers (which duplicated registry lookup and `cliState.activeForm` wiring) are removed.
> 
> **Behavioral intent:** `/approval` and unknown registered commands with `formComponent` should behave like production TUI slash flows, so the harness stays a fidelity check for the shared registry and form mounting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1efca610ab1249b357f0d11aad6d4e30b39a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->