### PR TITLE
refactor: simplify launcher default model check

### DIFF
--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -22,7 +22,6 @@ import {
   cliRunnableModelOptionsForSource,
   getCliModelAccessList,
   resolveCliRunnableModelWithAccessList,
-  runnableCliModelAccessEntries,
   type CliModelAccess,
 } from '../runtime/modelAccess';
 import { effectiveCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
@@ -50,12 +49,7 @@ async function canLaunchWithDefaultModel(
   models: readonly CliModelAccess[],
   apiMode: CliApiMode,
 ): Promise<boolean> {
-  if (
-    models.length === 0 ||
-    runnableCliModelAccessEntries(models, apiMode).length > 0
-  ) {
-    return true;
-  }
+  if (models.length === 0) return true;
 
   const defaults = await resolveChatDefaults({
     cwd: context.cwd,


### PR DESCRIPTION
## Summary
- remove the launcher precheck that separately counted visible runnable model rows
- let the shared model-access resolver own default-model fallback decisions
- keep the unknown-registry path active so startup does not block when the model list cannot load

## Design note
`runOrchestrationTui` already routes visible runnable models through the model picker, so `allowDefaultModelLaunch` only matters for the hidden/default-model case. The command layer now asks the shared resolver once instead of duplicating part of model availability policy.

## Validation
- `npx prettier --check packages/cli/src/commands/orchestrate.ts`
- `npx eslint packages/cli/src/commands/orchestrate.ts`
- `git diff --check`
- `corepack pnpm exec vitest run src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --skip-if-missing-deps orchestrate-launcher orchestrate-relay-model-pick orchestrate-personal-model-pick orchestrate-no-runnable-models`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small policy refactor in the interactive launcher; empty-registry and resolver paths are unchanged in intent and covered by existing CLI/TUI tests.
> 
> **Overview**
> **`canLaunchWithDefaultModel`** in the orchestrate command no longer treats “at least one visible runnable model” as permission to launch with the default model. It only short-circuits when the model list is empty (registry failed to load), then always asks **`resolveCliRunnableModelWithAccessList`** whether the configured default model is runnable.
> 
> That drops the orchestrate-only use of **`runnableCliModelAccessEntries`** and leaves default-model fallback rules in the shared model-access layer, while the TUI still uses the picker when runnable models are visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fbc15752602b86d2434f893ce4d7bb23f713314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->