### PR TITLE
refactor: validate agent runs before model lookup

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -19,6 +19,7 @@ import {
   buildHeadlessRunContext,
   resolveCliRunModel,
 } from '../runtime/runModel';
+import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import {
   TOOL_USE_AGENT_NAME_DESCRIPTION,
@@ -71,14 +72,11 @@ export async function runToolUseAgent(
   context: CliContext,
   init: ToolUseAgentRunInit,
 ): Promise<number> {
-  const model = await resolveCliRunModel(context, init.model, 'chat');
-  const runContext = buildHeadlessRunContext(context, model);
-
   let inputFiles: string[];
   let contextFiles: string[];
   let instruction: string;
   try {
-    instruction = await resolveToolUseInstruction(init, runContext.cwd);
+    instruction = await resolveToolUseInstruction(init, context.cwd);
   } catch (error: unknown) {
     if (!(error instanceof CliUsageError)) {
       throw error;
@@ -87,6 +85,7 @@ export async function runToolUseAgent(
     return CliExitCode.Usage;
   }
 
+  await initLocalCliPlatform(context);
   const agent = await resolveCliAgent(init.agent);
 
   if (!agent) {
@@ -99,6 +98,9 @@ export async function runToolUseAgent(
     );
     return CliExitCode.Usage;
   }
+
+  const model = await resolveCliRunModel(context, init.model, 'chat');
+  const runContext = buildHeadlessRunContext(context, model);
 
   const stdinInputFile = createStdinWorkflowInputMaterializer({
     readStdinText: readCliStdinText,

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -8,9 +8,13 @@ const mocks = vi.hoisted(() => {
   return {
     executeCliRequest: vi.fn(),
     expandRunInputs: vi.fn(),
+    initLocalCliPlatform: vi.fn(),
     installCliApprovalHandlers: vi.fn(),
     resolveCliAgent: vi.fn(),
+    resolveCliRunModel: vi.fn(),
     stdinInputFile,
+    writeErrorStderr: vi.fn(),
+    writeTextStderr: vi.fn(),
   };
 });
 
@@ -26,6 +30,10 @@ vi.mock('@cli/runtime/approvalAdapter', () => ({
   installCliApprovalHandlers: mocks.installCliApprovalHandlers,
 }));
 
+vi.mock('@cli/runtime/initPlatform', () => ({
+  initLocalCliPlatform: mocks.initLocalCliPlatform,
+}));
+
 vi.mock('@cli/runtime/runModel', () => ({
   buildHeadlessRunContext: vi.fn((context: CliContext, model: string) => ({
     ...context,
@@ -33,9 +41,12 @@ vi.mock('@cli/runtime/runModel', () => ({
     quietLogs: true,
     renderRunProgress: false,
   })),
-  resolveCliRunModel: vi.fn(
-    async (_context: CliContext, model: string | undefined) => model ?? 'gpt54',
-  ),
+  resolveCliRunModel: mocks.resolveCliRunModel,
+}));
+
+vi.mock('@cli/runtime/logSinks', () => ({
+  writeErrorStderr: mocks.writeErrorStderr,
+  writeTextStderr: mocks.writeTextStderr,
 }));
 
 vi.mock('@cli/commands/_helpers/output', () => ({
@@ -87,6 +98,10 @@ describe('CLI agents run command', () => {
       path: '/agents/chat.yaml',
       tools: ['read_file'],
     });
+    mocks.resolveCliRunModel.mockImplementation(
+      async (_context: CliContext, model: string | undefined) =>
+        model ?? 'gpt54',
+    );
     mocks.executeCliRequest.mockResolvedValue({
       result: {
         category: AgentCategory.ToolUse,
@@ -110,6 +125,12 @@ describe('CLI agents run command', () => {
     });
 
     expect(exitCode).toBe(0);
+    expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    );
+    expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.resolveCliAgent.mock.invocationCallOrder[0],
+    );
     expect(mocks.expandRunInputs).toHaveBeenCalledWith(
       ['problem.md'],
       ['notes.md'],
@@ -135,6 +156,81 @@ describe('CLI agents run command', () => {
     );
     expect(request?.config.instruction).toContain(
       'Assess the proof concisely.',
+    );
+  });
+
+  it('reports missing instruction before resolving the model', async () => {
+    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
+
+    const exitCode = await runToolUseAgent(cliContext(), {
+      agent: 'chat',
+      inputFiles: [],
+      contextFiles: [],
+      model: 'gpt54',
+      instruction: '',
+    });
+
+    expect(exitCode).toBe(2);
+    expect(mocks.initLocalCliPlatform).not.toHaveBeenCalled();
+    expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
+    expect(mocks.resolveCliAgent).not.toHaveBeenCalled();
+    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.writeErrorStderr).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Provide --instruction or --instruction-file.',
+      }),
+    );
+  });
+
+  it('reports missing agents before resolving the model', async () => {
+    mocks.resolveCliAgent.mockResolvedValueOnce(undefined);
+    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
+
+    const exitCode = await runToolUseAgent(cliContext(), {
+      agent: 'missing-agent',
+      inputFiles: [],
+      contextFiles: [],
+      model: 'gpt54',
+      instruction: 'Check this.',
+    });
+
+    expect(exitCode).toBe(2);
+    expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    );
+    expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
+    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+    );
+  });
+
+  it('reports workflow agents before resolving the model', async () => {
+    mocks.resolveCliAgent.mockResolvedValueOnce({
+      name: 'polish',
+      category: AgentCategory.Workflow,
+      source: 'builtInWorkflow',
+      path: '/agents/polish.yaml',
+      tools: [],
+    });
+    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
+
+    const exitCode = await runToolUseAgent(cliContext(), {
+      agent: 'polish',
+      inputFiles: [],
+      contextFiles: [],
+      model: 'gpt54',
+      instruction: 'Check this.',
+    });
+
+    expect(exitCode).toBe(2);
+    expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    );
+    expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
+    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'Agent "polish" is a workflow agent; `texra agents run` only handles tool-use agents. Use `texra run polish` for workflow agents.',
     );
   });
 });


### PR DESCRIPTION
## Summary
- validate `texra agents run` instruction and agent/category inputs before resolving the shared model
- keep input expansion after model lookup so `-` stdin is not consumed before model availability is known
- add order-contract coverage for missing instruction, missing agent, and workflow-agent misuse

## Design note
The command now owns command-specific usage validation before entering the model resolver. Model fallback/access policy remains centralized in `resolveCliRunModel`; this change only moves the boundary so invalid agent-run requests do not trigger unrelated model/auth work first.

## Validation
- `npx prettier --check packages/cli/src/commands/agentsRun.ts src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `npx eslint packages/cli/src/commands/agentsRun.ts src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only control-flow reordering with no auth or data-model changes; behavior improves early validation and avoids unnecessary model resolution on usage errors.
> 
> **Overview**
> **`texra agents run`** now validates usage and agent inputs before **`resolveCliRunModel`**, so bad requests skip model lookup and related auth/fallback work.
> 
> The flow resolves **instruction** first (using **`context.cwd`**), calls **`initLocalCliPlatform`**, then checks the agent exists and is **tool-use**; only after that does it resolve the model and build the headless run context. **Input expansion** (including stdin via `-`) stays **after** model resolution so stdin is not read until the model path is known.
> 
> Tests mock **`initLocalCliPlatform`** and **`resolveCliRunModel`**, assert **`initLocalCliPlatform`** runs before agent resolution on success, and add cases that missing instruction skips platform/model/agent work, while missing or workflow agents fail before model resolution but after platform init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd236ec854bff68fa763364ff5d9e52d6629f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->