### PR TITLE
refactor: validate workflow runs before model lookup

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -21,6 +21,7 @@ import {
   buildHeadlessRunContext,
   resolveCliRunModel,
 } from '../runtime/runModel';
+import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import { missingAgentMessage } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
@@ -60,23 +61,22 @@ interface WorkflowRunInit {
   readonly instruction: string;
 }
 
-async function runWorkflowAgent(
+export async function runWorkflowAgent(
   context: CliContext,
   init: WorkflowRunInit,
 ): Promise<number> {
-  const model = await resolveCliRunModel(context, init.model, 'run');
-  const runContext = buildHeadlessRunContext(context, model);
   if (init.output && init.outputDir) {
     throw new CliUsageError('Use either --output or --output-dir, not both.');
   }
   // Reject `--output-dir <path>` early when the path already points at a
   // non-directory (else we'd run the full workflow and EEXIST at the end).
-  await assertOutputDirAvailable(init.outputDir, runContext.cwd);
+  await assertOutputDirAvailable(init.outputDir, context.cwd);
   // Same fast-fail for `--output <path>`: existing directory or file-typed
   // parent component blows up at copy time (`EISDIR` / `EEXIST`) after the
   // full agent run otherwise.
-  await assertOutputFileAvailable(init.output, runContext.cwd);
+  await assertOutputFileAvailable(init.output, context.cwd);
 
+  await initLocalCliPlatform(context);
   const agent = await resolveCliAgent(init.agent);
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
@@ -93,6 +93,9 @@ async function runWorkflowAgent(
       'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
     );
   }
+
+  const model = await resolveCliRunModel(context, init.model, 'run');
+  const runContext = buildHeadlessRunContext(context, model);
 
   const stdinInputFile = createStdinWorkflowInputMaterializer({
     readStdinText: readCliStdinText,

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { CliContext } from '@cli/runtime/cliContext';
+
+const mocks = vi.hoisted(() => {
+  const stdinInputFile = Object.assign(vi.fn(), { cleanup: vi.fn() });
+  return {
+    executeCliRequest: vi.fn(),
+    expandRunInputs: vi.fn(),
+    initLocalCliPlatform: vi.fn(),
+    installCliApprovalHandlers: vi.fn(),
+    resolveCliAgent: vi.fn(),
+    resolveCliRunModel: vi.fn(),
+    stdinInputFile,
+  };
+});
+
+vi.mock('@agent/storage', () => ({
+  writeTerminalStatus: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/approvalAdapter', () => ({
+  installCliApprovalHandlers: mocks.installCliApprovalHandlers,
+}));
+
+vi.mock('@cli/runtime/initPlatform', () => ({
+  initLocalCliPlatform: mocks.initLocalCliPlatform,
+}));
+
+vi.mock('@cli/runtime/runModel', () => ({
+  buildHeadlessRunContext: vi.fn((context: CliContext, model: string) => ({
+    ...context,
+    helperModel: model,
+    quietLogs: true,
+    renderRunProgress: false,
+  })),
+  resolveCliRunModel: mocks.resolveCliRunModel,
+}));
+
+vi.mock('@cli/runtime/agentResolution', () => ({
+  resolveCliAgent: mocks.resolveCliAgent,
+}));
+
+vi.mock('@cli/runtime/runExecution', () => ({
+  executeCliRequest: mocks.executeCliRequest,
+}));
+
+vi.mock('@cli/runtime/workflowInputs', () => ({
+  createStdinWorkflowInputMaterializer: vi.fn(() => mocks.stdinInputFile),
+  expandRunInputs: mocks.expandRunInputs,
+  hasMixedStdinWorkflowInputSpecs: vi.fn((inputFiles: readonly string[]) => {
+    const specs = new Set(
+      inputFiles.map((spec) => spec.trim()).filter(Boolean),
+    );
+    return specs.has('-') && specs.size > 1;
+  }),
+}));
+
+function cliContext(overrides: Partial<CliContext> = {}): CliContext {
+  return {
+    cwd: '/tmp/project',
+    mode: 'headless',
+    outputFormat: 'text',
+    approvalPolicy: 'never',
+    quietLogs: false,
+    renderRunProgress: true,
+    stderrIsTty: false,
+    stdoutColorEnabled: false,
+    stderrColorEnabled: false,
+    colorEnabled: false,
+    version: '0.0.0',
+    resourcesPath: '/tmp/resources',
+    ...overrides,
+  };
+}
+
+describe('CLI workflow run command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveCliAgent.mockResolvedValue({
+      name: 'polish',
+      category: AgentCategory.Workflow,
+      source: 'builtInWorkflow',
+      path: '/agents/polish.yaml',
+      tools: [],
+    });
+    mocks.resolveCliRunModel.mockImplementation(
+      async (_context: CliContext, model: string | undefined) =>
+        model ?? 'deepseekT',
+    );
+    mocks.expandRunInputs.mockResolvedValue({
+      inputFiles: ['paper.tex'],
+      contextFiles: [],
+    });
+  });
+
+  it('reports conflicting output targets before platform or model lookup', async () => {
+    const { runWorkflowAgent } = await import('@cli/commands/workflow');
+
+    await expect(
+      runWorkflowAgent(cliContext(), {
+        agent: 'polish',
+        inputFiles: ['paper.tex'],
+        contextFiles: [],
+        output: 'out.tex',
+        outputDir: 'out',
+        instruction: '',
+      }),
+    ).rejects.toThrow('Use either --output or --output-dir, not both.');
+
+    expect(mocks.initLocalCliPlatform).not.toHaveBeenCalled();
+    expect(mocks.resolveCliAgent).not.toHaveBeenCalled();
+    expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
+    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+  });
+
+  it('reports missing workflow agents before resolving the model', async () => {
+    mocks.resolveCliAgent.mockResolvedValueOnce(undefined);
+    const { runWorkflowAgent } = await import('@cli/commands/workflow');
+
+    await expect(
+      runWorkflowAgent(cliContext(), {
+        agent: 'missing-agent',
+        inputFiles: ['paper.tex'],
+        contextFiles: [],
+        instruction: '',
+      }),
+    ).rejects.toThrow(/Agent not found: missing-agent/);
+
+    expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    );
+    expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.resolveCliAgent.mock.invocationCallOrder[0],
+    );
+    expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
+    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+  });
+
+  it('reports tool-use agents before resolving the model', async () => {
+    mocks.resolveCliAgent.mockResolvedValueOnce({
+      name: 'chat',
+      category: AgentCategory.ToolUse,
+      source: 'builtInToolUse',
+      path: '/agents/chat.yaml',
+      tools: [],
+    });
+    const { runWorkflowAgent } = await import('@cli/commands/workflow');
+
+    await expect(
+      runWorkflowAgent(cliContext(), {
+        agent: 'chat',
+        inputFiles: ['paper.tex'],
+        contextFiles: [],
+        instruction: '',
+      }),
+    ).rejects.toThrow(/`texra run` only handles workflow agents/);
+
+    expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    );
+    expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
+    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+  });
+
+  it('reports single-output mixed stdin usage before resolving the model', async () => {
+    const { runWorkflowAgent } = await import('@cli/commands/workflow');
+
+    await expect(
+      runWorkflowAgent(cliContext(), {
+        agent: 'polish',
+        inputFiles: ['-', 'paper.tex'],
+        contextFiles: [],
+        output: 'out.tex',
+        instruction: '',
+      }),
+    ).rejects.toThrow(
+      'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
+    );
+
+    expect(mocks.initLocalCliPlatform).toHaveBeenCalled();
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('polish');
+    expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
+    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- validate `texra run` output flags and workflow-agent/category inputs before resolving the shared model
- initialize the local CLI platform explicitly before workflow agent lookup, matching agent-list/show and `agents run` behavior
- keep stdin expansion after model lookup so `-` is not consumed before model availability is known

## Design note
The workflow command now owns command-specific usage validation before entering the model resolver. Model fallback/access policy remains centralized in `resolveCliRunModel`; this only moves the boundary so invalid workflow-run requests do not trigger unrelated model/auth work first.

## Validation
- `npx prettier --check packages/cli/src/commands/workflow.ts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `npx eslint packages/cli/src/commands/workflow.ts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is startup ordering and earlier usage errors for invalid workflow runs; model resolution logic is unchanged and covered by new unit tests.
> 
> **Overview**
> **`texra run` (`runWorkflowAgent`)** now fails fast on invalid flags and workflow-specific inputs **before** `resolveCliRunModel`, so bad invocations avoid model/auth work. Output path checks use `context.cwd` instead of a headless run context built only after model resolution.
> 
> The command calls **`initLocalCliPlatform`** before agent lookup (aligned with `agents list`/`show` and `agents run`), then validates the agent exists and is a **workflow** agent, and rejects **`--output` with mixed stdin + file inputs** before model lookup. **`expandRunInputs`** / stdin materialization still run **after** model resolution so `-` is not consumed too early.
> 
> `runWorkflowAgent` is **exported** for tests; new **`WorkflowRunCommand.vitest.mts`** asserts this ordering with mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f74bf1dcdb72d72d390631a96dc010df090bcad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->