### PR TITLE
refactor: own CLI model fallback by source

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -47,7 +47,6 @@ import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
-  cliRunnableModelOptionsForSource,
   formatCliNoAvailableModelsRecovery,
   resolveCliRunnableModel,
   type CliNoAvailableModelsRecoveryOptions,
@@ -561,7 +560,7 @@ async function reconcileRootModelAfterApiModeChange(
 
   const currentModel = cliState.sessionMeta.get().model;
   const selection = await resolveCliRunnableModel(currentModel, {
-    fallbackMode: 'notice',
+    fallbackSource: 'config',
     apiMode,
     noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
       apiMode,
@@ -956,16 +955,14 @@ export async function runChat(
   // never disagree.
   let modelSelection: CliRunnableModelResolution;
   try {
-    modelSelection = await resolveCliRunnableModel(
-      defaults.model,
-      cliRunnableModelOptionsForSource(defaults.modelSource, {
+    modelSelection = await resolveCliRunnableModel(defaults.model, {
+      fallbackSource: defaults.modelSource,
+      apiMode,
+      noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
         apiMode,
-        noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
-          apiMode,
-          CHAT_STARTUP_MODEL_RECOVERY,
-        ),
-      }),
-    );
+        CHAT_STARTUP_MODEL_RECOVERY,
+      ),
+    });
   } catch (error: unknown) {
     writeTextStderr(toErrorMessage(error));
     return { exitCode: CliExitCode.Usage };
@@ -1398,7 +1395,7 @@ export async function runChat(
         const currentAgent = meta.agent || agent;
         const currentModel = meta.model || model;
         const selection = await resolveCliRunnableModel(currentModel, {
-          fallbackMode: 'reject',
+          fallbackSource: 'override',
           apiMode: meta.apiMode,
           noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
             meta.apiMode,

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -19,7 +19,6 @@ import {
 } from '../runtime/multiAgentPresets';
 import { buildCliOrchestrationItems } from '../runtime/orchestration';
 import {
-  cliRunnableModelOptionsForSource,
   getCliModelAccessList,
   resolveCliRunnableModelWithAccessList,
   type CliModelAccess,
@@ -57,11 +56,10 @@ async function canLaunchWithDefaultModel(
     envModel: context.envModel,
   });
   try {
-    await resolveCliRunnableModelWithAccessList(
-      models,
-      defaults.model,
-      cliRunnableModelOptionsForSource(defaults.modelSource, { apiMode }),
-    );
+    await resolveCliRunnableModelWithAccessList(models, defaults.model, {
+      fallbackSource: defaults.modelSource,
+      apiMode,
+    });
     return true;
   } catch {
     return false;

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -27,10 +27,11 @@ export interface CliRunnableModelResolution {
   readonly notice?: string;
 }
 
-export type CliModelFallbackMode = 'reject' | 'notice' | 'silent';
+type CliModelFallbackMode = 'reject' | 'notice' | 'silent';
 
 export interface CliRunnableModelOptions {
-  readonly fallbackMode: CliModelFallbackMode;
+  /** Source category that owns unavailable-model fallback behavior. */
+  readonly fallbackSource: CliModelSelectionSource;
   readonly apiMode?: CliApiMode;
   readonly noAvailableModelsMessage?: string;
 }
@@ -252,20 +253,10 @@ export function emptyModelListMessageForCliMode(
   );
 }
 
-export function cliModelFallbackModeForSource(
+function fallbackModeForModelSource(
   source: CliModelSelectionSource,
 ): CliModelFallbackMode {
   return CLI_MODEL_FALLBACK_MODE_BY_SOURCE[source];
-}
-
-export function cliRunnableModelOptionsForSource(
-  source: CliModelSelectionSource,
-  options: Omit<CliRunnableModelOptions, 'fallbackMode'> = {},
-): CliRunnableModelOptions {
-  return {
-    ...options,
-    fallbackMode: cliModelFallbackModeForSource(source),
-  };
 }
 
 export function formatCliNoAvailableModelsRecovery(
@@ -452,6 +443,7 @@ export function resolveCliRunnableModelFromAccessList(
   model: string,
   options: CliRunnableModelOptions,
 ): CliRunnableModelResolution {
+  const fallbackMode = fallbackModeForModelSource(options.fallbackSource);
   const trimmed = model.trim();
   const runnableEntries = runnableCliModelAccessEntries(
     models,
@@ -468,12 +460,12 @@ export function resolveCliRunnableModelFromAccessList(
     availableIds,
     options,
   );
-  if (options.fallbackMode === 'reject' || availableIds.length === 0) {
+  if (fallbackMode === 'reject' || availableIds.length === 0) {
     throw new Error(unavailableMessage);
   }
 
   const fallback = availableIds[0]!;
-  if (options.fallbackMode === 'silent') return { model: fallback };
+  if (fallbackMode === 'silent') return { model: fallback };
   return {
     model: fallback,
     notice: `${unavailableMessage} Using "${fallback}" instead.`,

--- a/packages/cli/src/runtime/runModel.ts
+++ b/packages/cli/src/runtime/runModel.ts
@@ -9,7 +9,6 @@ import { CliUsageError, type CliContext } from './cliContext';
 import { initCliPlatform, setCliHelperModel } from './initPlatform';
 import { writeTextStderr } from './logSinks';
 import {
-  cliRunnableModelOptionsForSource,
   resolveCliRunnableModel,
   type CliModelSelectionSource,
 } from './modelAccess';
@@ -70,12 +69,10 @@ export async function resolveCliRunModel(
   await initCliPlatform({ ...context, quietLogs: true });
   const apiMode = effectiveCliApiMode(context);
   try {
-    const resolution = await resolveCliRunnableModel(
-      candidate.model,
-      cliRunnableModelOptionsForSource(candidate.source, {
-        apiMode,
-      }),
-    );
+    const resolution = await resolveCliRunnableModel(candidate.model, {
+      fallbackSource: candidate.source,
+      apiMode,
+    });
     if (resolution.notice && context.quietLogs !== true) {
       writeTextStderr(resolution.notice);
     }

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  cliModelFallbackModeForSource,
   emptyModelListMessageForCliMode,
   findCliModelAccessEntry,
   formatCliNoAvailableModelsRecovery,
@@ -16,8 +15,6 @@ import {
   resolveCliRunnableModelFromAccessList,
   resolveCliRunnableModelWithAccessList,
   type CliModelAccess,
-  type CliModelFallbackMode,
-  type CliModelSelectionSource,
 } from '@cli/runtime/modelAccess';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { ModelOptionData } from '@shared/schemas';
@@ -68,27 +65,62 @@ describe('CLI model access resolution', () => {
       resolveCliRunnableModelFromAccessList(
         [model('sonnet46T'), model('opus48T')],
         'opus48T',
-        { fallbackMode: 'reject' },
+        { fallbackSource: 'override' },
       ),
     ).toEqual({ model: 'opus48T' });
   });
 
-  it('centralizes fallback policy by model source', () => {
-    const expectedModes = {
-      override: 'reject',
-      env: 'reject',
-      config: 'notice',
-      workspace: 'notice',
-      user: 'notice',
-      history: 'notice',
-      builtin: 'silent',
-    } satisfies Record<CliModelSelectionSource, CliModelFallbackMode>;
+  it('owns fallback behavior by model source', () => {
+    const entries = [
+      model('missingModel', {
+        available: false,
+        status: 'missing api key',
+        model: modelOption('missingModel', {
+          availability: 'missing-key',
+          disabled: true,
+          requiresKey: true,
+        }),
+      }),
+      model('deepseekT'),
+    ];
 
-    for (const [source, mode] of Object.entries(expectedModes)) {
-      expect(
-        cliModelFallbackModeForSource(source as CliModelSelectionSource),
-      ).toBe(mode);
-    }
+    expect(() =>
+      resolveCliRunnableModelFromAccessList(entries, 'missingModel', {
+        fallbackSource: 'override',
+      }),
+    ).toThrow(
+      'Model "missingModel" is not available in the active API mode (missing api key). Available models: deepseekT.',
+    );
+    expect(() =>
+      resolveCliRunnableModelFromAccessList(entries, 'missingModel', {
+        fallbackSource: 'env',
+      }),
+    ).toThrow(
+      'Model "missingModel" is not available in the active API mode (missing api key). Available models: deepseekT.',
+    );
+    expect(
+      resolveCliRunnableModelFromAccessList(entries, 'missingModel', {
+        fallbackSource: 'config',
+      }),
+    ).toEqual({
+      model: 'deepseekT',
+      notice:
+        'Model "missingModel" is not available in the active API mode (missing api key). Available models: deepseekT. Using "deepseekT" instead.',
+    });
+    expect(
+      resolveCliRunnableModelFromAccessList(entries, 'missingModel', {
+        fallbackSource: 'history',
+      }),
+    ).toEqual({
+      model: 'deepseekT',
+      notice:
+        'Model "missingModel" is not available in the active API mode (missing api key). Available models: deepseekT. Using "deepseekT" instead.',
+    });
+    expect(
+      resolveCliRunnableModelFromAccessList(entries, 'missingModel', {
+        fallbackSource: 'builtin',
+      }),
+    ).toEqual({ model: 'deepseekT' });
   });
 
   it('rejects an explicit model that is unavailable in the active API mode', () => {
@@ -106,7 +138,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'opus48T',
-        { fallbackMode: 'reject' },
+        { fallbackSource: 'override' },
       ),
     ).toThrow(
       'Model "opus48T" is not available in the active API mode (not included). Available models: sonnet46T.',
@@ -129,7 +161,7 @@ describe('CLI model access resolution', () => {
           model('sonnet46T'),
         ],
         'opus48T',
-        { fallbackMode: 'notice' },
+        { fallbackSource: 'config' },
       ),
     ).toEqual({
       model: 'deepseekT',
@@ -154,7 +186,7 @@ describe('CLI model access resolution', () => {
           model('gpt55'),
         ],
         'deepseekT',
-        { fallbackMode: 'silent' },
+        { fallbackSource: 'builtin' },
       ),
     ).toEqual({ model: 'gpt55' });
   });
@@ -629,7 +661,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'deepseekT',
-        { fallbackMode: 'reject', apiMode: 'included' },
+        { fallbackSource: 'override', apiMode: 'included' },
       ),
     ).toThrow(
       'Model "deepseekT" is not available in the active API mode (api key set). Available models: sonnet46T.',
@@ -654,7 +686,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'sonnet46T',
-        { fallbackMode: 'notice', apiMode: 'personal' },
+        { fallbackSource: 'config', apiMode: 'personal' },
       ),
     ).toEqual({
       model: 'deepseekT',
@@ -678,7 +710,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'gemini31p',
-        { fallbackMode: 'notice' },
+        { fallbackSource: 'config' },
       ),
     ).toThrow(
       'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Run `texra login` for included relay access, retry with `--api-mode included`, or configure a provider API key.',
@@ -703,7 +735,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'gemini31p',
-        { fallbackMode: 'notice', apiMode: 'personal' },
+        { fallbackSource: 'config', apiMode: 'personal' },
       ),
     ).toThrow(
       'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Configure a provider API key for personal mode, or retry with `--api-mode included` and run `texra login` for included relay access.',
@@ -726,7 +758,7 @@ describe('CLI model access resolution', () => {
         ],
         'gemini31p',
         {
-          fallbackMode: 'notice',
+          fallbackSource: 'config',
           noAvailableModelsMessage:
             'Run `texra login` for included relay access.',
         },
@@ -887,7 +919,7 @@ describe('CLI model access resolution', () => {
 
     await expect(
       resolveCliRunnableModel('HIDDENFIXTUREMODEL', {
-        fallbackMode: 'reject',
+        fallbackSource: 'override',
       }),
     ).resolves.toEqual({ model: 'hiddenFixtureModel' });
     expect(computeModelOptionsDataMock).toHaveBeenNthCalledWith(2, [
@@ -918,7 +950,7 @@ describe('CLI model access resolution', () => {
         ],
         'hiddenFixtureModel',
         {
-          fallbackMode: 'reject',
+          fallbackSource: 'override',
           apiMode: 'personal',
         },
       ),
@@ -937,7 +969,7 @@ describe('CLI model access resolution', () => {
 
     await expect(
       resolveCliRunnableModel('hiddenFixtureModel', {
-        fallbackMode: 'reject',
+        fallbackSource: 'override',
       }),
     ).rejects.toThrow(
       'Model "hiddenFixtureModel" is configured but has no option data.',

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -140,7 +140,7 @@ describe('resolveCliRunModel precedence', () => {
       CLI_BUILTIN_DEFAULT_MODEL,
       {
         apiMode: 'personal',
-        fallbackMode: 'silent',
+        fallbackSource: 'builtin',
       },
     );
     expect(mocks.setCliHelperModel).toHaveBeenCalledWith(
@@ -162,7 +162,7 @@ describe('resolveCliRunModel precedence', () => {
     );
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith(
       'staleConfiguredModel',
-      expect.objectContaining({ fallbackMode: 'notice' }),
+      expect.objectContaining({ fallbackSource: 'config' }),
     );
     expect(mocks.initCliPlatform).toHaveBeenCalledWith({
       ...context,
@@ -189,7 +189,7 @@ describe('resolveCliRunModel precedence', () => {
     );
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
       apiMode: 'personal',
-      fallbackMode: 'reject',
+      fallbackSource: 'override',
     });
   });
 
@@ -203,7 +203,7 @@ describe('resolveCliRunModel precedence', () => {
 
     expect(resolveCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
       apiMode: 'personal',
-      fallbackMode: 'reject',
+      fallbackSource: 'env',
     });
     expect(mocks.setCliHelperModel).toHaveBeenCalledWith('opus48T');
   });


### PR DESCRIPTION
## Summary

Simplify CLI model resolution ownership: callers now pass the model selection `fallbackSource` to `modelAccess`, and `modelAccess` privately owns the `fallbackSource` -> fallback policy.

This removes the public fallback-mode helper layer (`cliRunnableModelOptionsForSource` / `cliModelFallbackModeForSource`) so startup, orchestration, and TUI code no longer pass raw fallback modes around. The public contract now says which source category should own fallback behavior; modelAccess decides whether that source rejects, notices, or silently falls back.

## What Changed

- `CliRunnableModelOptions` now takes `fallbackSource: CliModelSelectionSource` instead of `fallbackMode`.
- The fallback mode type/table/helper are private to `modelAccess`.
- `runModel`, `orchestrate`, and the chat TUI pass fallback source values directly.
- Tests assert behavior by fallback source rather than importing the policy helper.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `npx prettier --check packages/cli/src/runtime/modelAccess.ts packages/cli/src/runtime/runModel.ts packages/cli/src/commands/orchestrate.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts`
- `npx eslint packages/cli/src/runtime/modelAccess.ts packages/cli/src/runtime/runModel.ts packages/cli/src/commands/orchestrate.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts`
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor centralizes unchanged fallback rules in one module with updated unit tests; no auth, billing, or new runtime paths.
> 
> **Overview**
> **CLI model resolution** now takes a **model selection source** (`fallbackSource`) instead of callers passing `fallbackMode` (`reject` / `notice` / `silent`). `modelAccess` maps source → fallback policy internally and drops the public helpers `cliRunnableModelOptionsForSource` and `cliModelFallbackModeForSource`.
> 
> Chat TUI, `texra run` model resolution (`runModel`), and orchestration pass `defaults.modelSource`, `'config'`, `'override'`, or the run candidate source directly. Tests assert fallback behavior per source rather than importing the policy table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bda4e1c845edb4fc02d409179065d7dfe6872f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->