### PR TITLE
refactor: flatten CLI model resolver

### DIFF
--- a/docs/architecture/cli-runtime-round-trips.md
+++ b/docs/architecture/cli-runtime-round-trips.md
@@ -21,7 +21,7 @@ flowchart TD
   replan[planCliMultiAgentPresets replan]
   items[runtime/orchestration buildCliOrchestrationItems]
   modelList[runtime/modelAccess getCliModelAccessList]
-  defaultModel[resolveChatDefaults + resolveCliRunnableModelWithAccessList]
+  defaultModel[resolveChatDefaults + resolveCliRunnableModel]
   picker[orchestration/runOrchestrationTui]
   chat[chat/tui/runChatTui runChat]
   presetRun[commands/multiAgent loadCliMultiAgentRunPlan]

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -20,7 +20,7 @@ import {
 import { buildCliOrchestrationItems } from '../runtime/orchestration';
 import {
   getCliModelAccessList,
-  resolveCliRunnableModelWithAccessList,
+  resolveCliRunnableModel,
   type CliModelAccess,
 } from '../runtime/modelAccess';
 import { effectiveCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
@@ -56,9 +56,10 @@ async function canLaunchWithDefaultModel(
     envModel: context.envModel,
   });
   try {
-    await resolveCliRunnableModelWithAccessList(models, defaults.model, {
+    await resolveCliRunnableModel(defaults.model, {
       fallbackSource: defaults.modelSource,
       apiMode,
+      accessList: models,
     });
     return true;
   } catch {

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -33,6 +33,8 @@ export interface CliRunnableModelOptions {
   /** Source category that owns unavailable-model fallback behavior. */
   readonly fallbackSource: CliModelSelectionSource;
   readonly apiMode?: CliApiMode;
+  /** Optional preloaded list, used by launchers that already fetched access. */
+  readonly accessList?: readonly CliModelAccess[];
   readonly noAvailableModelsMessage?: string;
 }
 
@@ -476,15 +478,9 @@ export async function resolveCliRunnableModel(
   model: string,
   options: CliRunnableModelOptions,
 ): Promise<CliRunnableModelResolution> {
-  const models = await getCliModelAccessList({ apiMode: options.apiMode });
-  return resolveCliRunnableModelWithAccessList(models, model, options);
-}
-
-export async function resolveCliRunnableModelWithAccessList(
-  models: readonly CliModelAccess[],
-  model: string,
-  options: CliRunnableModelOptions,
-): Promise<CliRunnableModelResolution> {
+  const models =
+    options.accessList ??
+    (await getCliModelAccessList({ apiMode: options.apiMode }));
   const trimmed = model.trim();
   const hiddenModelId =
     trimmed && !findCliModelAccessEntry(models, trimmed)

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -13,7 +13,6 @@ import {
   runnableCliModelAccessEntries,
   resolveCliRunnableModel,
   resolveCliRunnableModelFromAccessList,
-  resolveCliRunnableModelWithAccessList,
   type CliModelAccess,
 } from '@cli/runtime/modelAccess';
 import { computeModelOptionsData } from '@model/computeModelOptions';
@@ -936,8 +935,10 @@ describe('CLI model access resolution', () => {
     ]);
 
     await expect(
-      resolveCliRunnableModelWithAccessList(
-        [
+      resolveCliRunnableModel('hiddenFixtureModel', {
+        fallbackSource: 'override',
+        apiMode: 'personal',
+        accessList: [
           model('deepseekT', {
             available: false,
             status: 'missing api key',
@@ -948,12 +949,7 @@ describe('CLI model access resolution', () => {
             }),
           }),
         ],
-        'hiddenFixtureModel',
-        {
-          fallbackSource: 'override',
-          apiMode: 'personal',
-        },
-      ),
+      }),
     ).resolves.toEqual({ model: 'hiddenFixtureModel' });
     expect(computeModelOptionsDataMock).toHaveBeenCalledWith([
       'hiddenFixtureModel',


### PR DESCRIPTION
## Summary

Remove the exported `resolveCliRunnableModelWithAccessList` pass-through layer. `resolveCliRunnableModel` now owns both cases directly:

- load the current CLI model access list when no list is provided
- use a caller-provided preloaded `accessList` when a launcher already fetched models

The hidden-model access check remains inside the same resolver, so orchestration keeps its current behavior without exposing a second public resolver shape.

## What Changed

- Add optional `accessList` to `CliRunnableModelOptions`.
- Delete the exported `resolveCliRunnableModelWithAccessList` wrapper.
- Update the orchestration launcher to call `resolveCliRunnableModel(default, { accessList })`.
- Update the hidden-model access test and the CLI round-trip architecture diagram.

## Dogfood / Verification

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-cli-refactor/tui-frames` — all 113 PTY scenarios passed before this code edit, covering model forms, approvals, Shift+Enter, subagent focus/history, task pickers, and compact frames.
- `corepack pnpm exec vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts`
- `npx prettier --check packages/cli/src/runtime/modelAccess.ts packages/cli/src/commands/orchestrate.ts src/test-kernel/cli/ModelAccess.vitest.mts docs/architecture/cli-runtime-round-trips.md`
- `npx eslint packages/cli/src/runtime/modelAccess.ts packages/cli/src/commands/orchestrate.ts src/test-kernel/cli/ModelAccess.vitest.mts`
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with behavior preserved via `accessList`; orchestration and hidden-model tests cover the main call paths.
> 
> **Overview**
> **Collapses CLI runnable model resolution into a single public API** by removing exported `resolveCliRunnableModelWithAccessList` and folding preloaded access lists into `resolveCliRunnableModel` via optional `accessList` on `CliRunnableModelOptions`.
> 
> When callers omit `accessList`, `resolveCliRunnableModel` still loads the model list with `getCliModelAccessList`; when they pass one (e.g. orchestration after `getCliModelAccessList`), it resolves against that list without a second fetch. Hidden-model handling stays in the same resolver path.
> 
> **Orchestration** now calls `resolveCliRunnableModel(defaults.model, { accessList: models, ... })` instead of the removed wrapper. Tests and `docs/architecture/cli-runtime-round-trips.md` are updated to match the new entry point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a42a43b02844dc03a5d75ca7c0f17378eb162b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->