### PR TITLE
[codex] Align relay model catalog version

### DIFF
--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -8,7 +8,7 @@
  * - Ultra: All models above $3/M input
  */
 
-import { MODEL_CONFIGS, type ModelConfig } from 'npm:llm-zoo@^1.6.1';
+import { MODEL_CONFIGS, type ModelConfig } from 'npm:llm-zoo@^1.8.1';
 import { FREE_TIER, MAX_TIER, ULTRA_TIER } from './tierConstants.ts';
 
 export { FREE_TIER, MAX_TIER, ULTRA_TIER };


### PR DESCRIPTION
## Summary

- Align the Supabase relay function's `llm-zoo` npm import with the repo's `^1.8.1` dependency.
- Keeps the relay-derived tier allowlist on the same model catalog that already includes `gemini35f` / Gemini 3.5 Flash.

## Root cause

The default model list and docs already use the newer `llm-zoo` catalog, but the relay edge function still referenced `npm:llm-zoo@^1.6.1`. Since relay tier availability is derived from that package, the edge function could lag the app-side model catalog.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/model/ModelOptionsBasic.vitest.ts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelsRecord.vitest.mts src/test-kernel/supabase/RelayRequestLimits.vitest.ts src/test-kernel/supabase/RelayReasoningCaps.vitest.ts`
- `node --input-type=module -e "import { MODEL_CONFIGS } from 'llm-zoo'; const m = MODEL_CONFIGS.gemini35f; if (!m) throw new Error('missing gemini35f'); console.log(JSON.stringify({name:m.name,fullName:m.fullName,label:m.label,inputPrice:m.inputPrice,openRouterOnly:m.openRouterOnly}))"`
- `npx prettier --check supabase/functions/relay/models.ts src/model/modelOptionsBasic.ts src/test-kernel/model/ModelOptionsBasic.vitest.ts`
- `git diff --check`

Note: Deno is not installed in this local environment, so I could not directly execute the Supabase edge module here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump in relay model config; no logic changes, only catalog parity with the rest of the repo.
> 
> **Overview**
> Bumps the Supabase relay edge function’s **`llm-zoo`** Deno import from **`^1.6.1`** to **`^1.8.1`**, matching the app’s **`package.json`** dependency.
> 
> Relay tier allowlists and model resolution are built from **`MODEL_CONFIGS`** in that package, so this keeps edge enforcement aligned with the newer catalog (e.g. **`gemini35f`** / Gemini 3.5 Flash) instead of lagging the client-side model list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e067f5262e7184923f64cab8e3e895014e2bb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->