### PR TITLE
[codex] Preserve CLI model source in session state

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -32,7 +32,12 @@ function patchSessionMeta<K extends 'agent' | 'model' | 'apiMode'>(
   key: K,
   value: K extends 'apiMode' ? CliApiMode : string,
 ): void {
-  cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), [key]: value });
+  const meta = cliState.sessionMeta.get();
+  cliState.sessionMeta.set({
+    ...meta,
+    [key]: value,
+    ...(key === 'model' ? { modelSource: 'override' } : {}),
+  });
 }
 
 /** Run a form selection handler with consistent completion and error routing. */

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -50,6 +50,7 @@ import {
   formatCliNoAvailableModelsRecovery,
   resolveCliRunnableModel,
   type CliNoAvailableModelsRecoveryOptions,
+  type CliModelSelectionSource,
   type CliRunnableModelResolution,
 } from '@cli/runtime/modelAccess';
 import {
@@ -502,6 +503,7 @@ async function applyCliModelSelection(
       cliState.sessionMeta.set({
         ...cliState.sessionMeta.get(),
         model: nextModel,
+        modelSource: 'override',
       });
       appendLocalAssistantTranscript(`Root model set to ${nextModel}.`);
     } catch (error: unknown) {
@@ -532,6 +534,7 @@ async function applyCliModelSelection(
     cliState.sessionMeta.set({
       ...cliState.sessionMeta.get(),
       model: nextModel,
+      modelSource: 'override',
     });
   } catch (error: unknown) {
     appendLocalAssistantTranscript(toErrorMessage(error));
@@ -558,9 +561,9 @@ async function reconcileRootModelAfterApiModeChange(
 ): Promise<string | undefined> {
   if (!context || !chatTuiCanStartRootRun(context.session)) return undefined;
 
-  const currentModel = cliState.sessionMeta.get().model;
+  const { model: currentModel, modelSource } = cliState.sessionMeta.get();
   const selection = await resolveCliRunnableModel(currentModel, {
-    fallbackSource: 'config',
+    fallbackSource: modelSource,
     apiMode,
     noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
       apiMode,
@@ -1005,6 +1008,7 @@ export async function runChat(
   cliState.sessionMeta.set({
     agent,
     model,
+    modelSource: defaults.modelSource,
     cwd: context.cwd,
     apiMode,
     canDelegate: agentSupportsDelegation(agent),
@@ -1284,6 +1288,7 @@ export async function runChat(
       ...cliState.sessionMeta.get(),
       agent: resolution.config.agent,
       model: resolution.config.model,
+      modelSource: 'history',
       canDelegate: agentSupportsDelegation(resolution.config.agent),
     });
 
@@ -1394,8 +1399,11 @@ export async function runChat(
         const meta = cliState.sessionMeta.get();
         const currentAgent = meta.agent || agent;
         const currentModel = meta.model || model;
+        const currentModelSource: CliModelSelectionSource = meta.model
+          ? meta.modelSource
+          : defaults.modelSource;
         const selection = await resolveCliRunnableModel(currentModel, {
-          fallbackSource: 'override',
+          fallbackSource: currentModelSource,
           apiMode: meta.apiMode,
           noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
             meta.apiMode,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -8,6 +8,7 @@
 import { signal, Signal } from '@lit-labs/signals';
 
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
+import type { CliModelSelectionSource } from '@cli/runtime/modelAccess';
 import {
   STREAM_STATUS,
   type ActiveChildInfo,
@@ -53,6 +54,7 @@ export interface CompletedProcessTranscript {
 export interface SessionMeta {
   readonly agent: string;
   readonly model: string;
+  readonly modelSource: CliModelSelectionSource;
   readonly cwd: string;
   readonly apiMode: CliApiMode;
   readonly canDelegate: boolean;
@@ -107,6 +109,7 @@ export interface StreamSlice {
 const EMPTY_SESSION_META: SessionMeta = {
   agent: '',
   model: '',
+  modelSource: 'builtin',
   cwd: '',
   apiMode: 'personal',
   canDelegate: false,

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -46,6 +46,7 @@ const STREAM_ID = 'cli-test-stream' as StreamTabId;
 const SESSION_META = {
   agent: 'research',
   model: 'deepseekT',
+  modelSource: 'builtin',
   cwd: '/tmp/project',
   apiMode: 'personal',
   canDelegate: false,

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -162,6 +162,7 @@ describe('slashRegistry', () => {
     resetCliState({
       agent: 'chat',
       model: 'deepseekT',
+      modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
       canDelegate: false,
@@ -197,6 +198,7 @@ describe('slashRegistry', () => {
     resetCliState({
       agent: 'chat',
       model: 'deepseekT',
+      modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
       canDelegate: false,
@@ -226,6 +228,7 @@ describe('slashRegistry', () => {
     resetCliState({
       agent: 'chat',
       model: 'deepseekT',
+      modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
       canDelegate: false,
@@ -253,6 +256,7 @@ describe('slashRegistry', () => {
     resetCliState({
       agent: 'chat',
       model: 'deepseekT',
+      modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
       canDelegate: false,
@@ -269,16 +273,23 @@ describe('slashRegistry', () => {
     expect(openRegisteredCliSlashForm(model, '')).toBe(true);
 
     const modelNode = renderFormAdapter<{
+      onSelect?: (value: string) => void;
       selectable?: boolean;
     }>(cliState.activeForm.get()?.render(() => {}, 20));
+    modelNode.props?.onSelect?.('gpt55');
 
     expect(modelNode.props).toMatchObject({ selectable: true });
+    expect(cliState.sessionMeta.get()).toMatchObject({
+      model: 'gpt55',
+      modelSource: 'override',
+    });
   });
 
   it('passes live model-switch disabled reasons into the model picker', () => {
     resetCliState({
       agent: 'chat',
       model: 'gpt54',
+      modelSource: 'override',
       cwd: '/tmp/workspace',
       apiMode: 'personal',
       canDelegate: false,
@@ -364,6 +375,7 @@ describe('slashRegistry', () => {
     resetCliState({
       agent: 'chat',
       model: 'deepseekT',
+      modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
       canDelegate: false,
@@ -398,6 +410,7 @@ describe('slashRegistry', () => {
     resetCliState({
       agent: 'chat',
       model: 'deepseekT',
+      modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
       canDelegate: false,


### PR DESCRIPTION
## Summary
- Store the resolved CLI model source in TUI session state alongside the model.
- Mark explicit `/model` selections as `override` in both production and default slash-command paths.
- Reuse the stored model source for API-mode and first-message model re-resolution instead of hard-coding fallback policy at each call site.

## Why
`chatDefaults` already derives where the startup model came from, and `modelAccess` already owns source-to-fallback behavior. The TUI was discarding that source and later passing hard-coded fallback sources, which made fallback behavior depend on the call site rather than the model selection contract.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts`
- `npm run typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build model-form-selectable model-form-selectable-submit model-form-included-empty approval-form bash-approval subagent-tab-focus-full-frame hidden-root-approval-tab-return`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/cliState.ts packages/cli/src/chat/tui/runChatTui.tsx packages/cli/src/chat/tui/commands/registerBuiltins.tsx src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI model-resolution behavior; changes when unavailable models fall back vs reject, but does not touch auth or persistence beyond session meta.
> 
> **Overview**
> The CLI TUI now keeps **`modelSource`** on `SessionMeta` next to the chosen model, so later **`resolveCliRunnableModel`** calls reuse the same fallback contract instead of hard-coding sources per call site.
> 
> **Startup and resume** seed `modelSource` from chat defaults (`defaults.modelSource`) or **`history`** when continuing a session. **Explicit model picks** (slash `/model`, default `patchSessionMeta`, and `applyCliModelSelection`) set **`override`**.
> 
> **API mode changes** and **first-message** model re-resolution read the stored source for `fallbackSource`, replacing the previous fixed `'config'` / `'override'` behavior at those paths. Tests were updated to require `modelSource` in session fixtures and to assert override on model form selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4831f4e53278ef7a0cc8c6ec5dcd85a2c12f6b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->