### PR TITLE
[codex] Simplify CLI child control availability

### DIFF
--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -249,26 +249,16 @@ function hasVisibleSubagents(
   return slice !== undefined && visibleSubagentRows(slice).length > 0;
 }
 
-function hasVisibleTasks(
-  slice:
-    | Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'childStreams'>
-    | undefined,
-): boolean {
-  return (
-    slice !== undefined &&
-    (visibleSubagentRows(slice).length > 0 || slice.activeProcesses.length > 0)
-  );
-}
-
 export function hasChildControlItems(
   slice:
     | Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'childStreams'>
     | undefined,
   mode: ChildControlMode,
 ): boolean {
+  if (slice === undefined) return false;
   return mode === 'subagents'
     ? hasVisibleSubagents(slice)
-    : hasVisibleTasks(slice);
+    : visibleSubagentRows(slice).length > 0 || slice.activeProcesses.length > 0;
 }
 
 export function resolveChildControlStreamTarget({
@@ -409,10 +399,7 @@ export function hasChildExecutionRows(
     | Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'childStreams'>
     | undefined,
 ): boolean {
-  return (
-    slice !== undefined &&
-    (visibleSubagentRows(slice).length > 0 || slice.activeProcesses.length > 0)
-  );
+  return hasChildControlItems(slice, 'tasks');
 }
 
 export function numericFocusTargetForActiveStream(init: {


### PR DESCRIPTION
## Summary
- remove the duplicate task-availability helper in CLI child controls
- make child execution-row visibility delegate to the child-control availability contract
- keep behavior unchanged while leaving one owner for child-control availability

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/childControls.ts`
- `git diff --check`
- `npm run typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build subagent-tab-focus-full-frame hidden-root-approval-tab-return approval-form bash-approval`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor in pure TUI state helpers with behavior explicitly unchanged and targeted tests listed in the PR description.
> 
> **Overview**
> Refactors CLI TUI **child control** availability so there is one contract instead of two copies of the same checks.
> 
> **`hasChildControlItems`** now returns early when the stream slice is missing, and in **`tasks`** mode it decides visibility inline (visible subagent rows or active processes) instead of calling a separate **`hasVisibleTasks`** helper that duplicated that logic.
> 
> **`hasChildExecutionRows`** (used e.g. in `App.tsx` for the subagent panel) no longer repeats the subagent/process condition; it delegates to **`hasChildControlItems(slice, 'tasks')`**, so execution-row UI stays aligned with task-mode child controls without changing intended behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b742ccf009c5495b6132ee6109249e1a8267b1cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->