### PR TITLE
[codex] Consolidate CLI no-runnable model copy

### DIFF
--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -91,17 +91,23 @@ const RELAY_STATUS_BY_AVAILABILITY = {
   'missing-key': 'relay: unavailable; missing api key',
 } satisfies Record<ModelAvailabilityKind, string>;
 
-const NO_RUNNABLE_MODEL_ACCESS_SUMMARIES = {
-  includedLoginRequired: 'Included relay models require sign-in.',
-  included: 'No included relay models are runnable.',
-  personal: 'No personal API-key models are runnable.',
-} satisfies Record<NoRunnableModelAccessReason, string>;
-
-const NO_RUNNABLE_MODEL_ACCESS_LAUNCH_BLOCKS = {
-  includedLoginRequired: 'Sign in with texra login for included relay models',
-  included: 'No included relay models are runnable',
-  personal: 'No personal API-key models are runnable',
-} satisfies Record<NoRunnableModelAccessReason, string>;
+const NO_RUNNABLE_MODEL_ACCESS_COPY = {
+  includedLoginRequired: {
+    launchBlock: 'Sign in with texra login for included relay models',
+    summary: 'Included relay models require sign-in.',
+  },
+  included: {
+    launchBlock: 'No included relay models are runnable',
+    summary: 'No included relay models are runnable.',
+  },
+  personal: {
+    launchBlock: 'No personal API-key models are runnable',
+    summary: 'No personal API-key models are runnable.',
+  },
+} satisfies Record<
+  NoRunnableModelAccessReason,
+  { readonly launchBlock: string; readonly summary: string }
+>;
 
 function startSentence(text: string): string {
   if (text.length === 0) return text;
@@ -163,7 +169,7 @@ export function noRunnableModelAccessReason(
 export function formatCliNoRunnableModelsLaunchBlock(
   reason: NoRunnableModelAccessReason,
 ): string {
-  return NO_RUNNABLE_MODEL_ACCESS_LAUNCH_BLOCKS[reason];
+  return NO_RUNNABLE_MODEL_ACCESS_COPY[reason].launchBlock;
 }
 
 function formatCliNoRunnableModelsRecovery(
@@ -189,7 +195,7 @@ export function formatCliNoRunnableModelsMessage(
   reason: NoRunnableModelAccessReason,
   options: CliNoRunnableModelsMessageOptions = {},
 ): string {
-  return `${NO_RUNNABLE_MODEL_ACCESS_SUMMARIES[reason]} ${formatCliNoRunnableModelsRecovery(reason, options)}`;
+  return `${NO_RUNNABLE_MODEL_ACCESS_COPY[reason].summary} ${formatCliNoRunnableModelsRecovery(reason, options)}`;
 }
 
 function formatModelAccessStatus(model: ModelOptionData): string {


### PR DESCRIPTION
## Summary
- collapse the parallel no-runnable-model summary and launch-block maps into one typed copy table
- keep the existing formatter APIs and user-facing strings unchanged
- reduce drift risk when adding or changing model access reasons

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/modelAccess.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal constant reshuffle only; same strings and public formatters, covered by existing CLI model-access tests.
> 
> **Overview**
> Refactors CLI **no runnable model** messaging by replacing two parallel lookup tables (`NO_RUNNABLE_MODEL_ACCESS_SUMMARIES` and `NO_RUNNABLE_MODEL_ACCESS_LAUNCH_BLOCKS`) with a single typed **`NO_RUNNABLE_MODEL_ACCESS_COPY`** map. Each `NoRunnableModelAccessReason` now has paired **`launchBlock`** and **`summary`** strings in one place.
> 
> `formatCliNoRunnableModelsLaunchBlock` and `formatCliNoRunnableModelsMessage` read from that table instead of separate maps. **User-facing copy and exported formatter behavior are unchanged**—this is structural consolidation to avoid summary vs launch-block drift when reasons are added or edited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a96658776add2bbc9bde3a666ff46359c2a391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->