### PR TITLE
[codex] Remove CLI availability pass-through helpers

### DIFF
--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -261,12 +261,6 @@ export function emptyModelListMessageForCliMode(
   );
 }
 
-function fallbackModeForModelSource(
-  source: CliModelSelectionSource,
-): CliModelFallbackMode {
-  return CLI_MODEL_FALLBACK_MODE_BY_SOURCE[source];
-}
-
 export function formatCliNoAvailableModelsRecovery(
   apiMode?: CliApiMode,
   options: CliNoAvailableModelsRecoveryOptions = {},
@@ -451,7 +445,8 @@ function resolveCliRunnableModelFromAccessList(
   model: string,
   options: CliRunnableModelOptions,
 ): CliRunnableModelResolution {
-  const fallbackMode = fallbackModeForModelSource(options.fallbackSource);
+  const fallbackMode =
+    CLI_MODEL_FALLBACK_MODE_BY_SOURCE[options.fallbackSource];
   const trimmed = model.trim();
   const runnableEntries = runnableCliModelAccessEntries(
     models,

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -135,12 +135,12 @@ export function planCliMultiAgentPresets(
 export function cliMultiAgentPresetAvailabilityParts(
   plan: CliMultiAgentPresetRunPlan,
 ): string[] {
-  const status = cliMultiAgentPlanStatus(plan);
+  const availability = cliMultiAgentPresetAvailability(plan);
   const parts = [
-    `workflow:${formatAvailablePresetAgentCount(plan.preset.workflowAgents, plan.missingWorkflowAgents)}`,
-    `tool-use:${formatAvailablePresetAgentCount(plan.preset.toolUseAgents, plan.missingToolUseAgents)}`,
+    `workflow:${availability.workflow.label}`,
+    `tool-use:${availability.toolUse.label}`,
   ];
-  if (status !== 'available') parts.push(status);
+  if (availability.status !== 'available') parts.push(availability.status);
   return parts;
 }
 
@@ -565,13 +565,6 @@ function availablePresetAgents(
 ): string[] {
   const missing = new Set(missingAgents);
   return presetAgents.filter((agent) => !missing.has(agent));
-}
-
-function formatAvailablePresetAgentCount(
-  presetAgents: readonly string[],
-  missingAgents: readonly string[],
-): string {
-  return presetAgentAvailability(presetAgents, missingAgents).label;
 }
 
 function presetAgentAvailability(


### PR DESCRIPTION
## Summary
- remove the private model fallback mode pass-through and read the source-owned table directly
- make multi-agent list availability parts use the planned availability object labels/status
- delete the now-redundant preset count-label helper

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/modelAccess.ts packages/cli/src/runtime/multiAgentPresets.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor only; behavior is intended to stay the same and targeted Vitest suites were run in validation.
> 
> **Overview**
> Removes thin private helpers in the CLI runtime so callers read shared tables/objects directly.
> 
> In **`modelAccess.ts`**, `fallbackModeForModelSource` is deleted; runnable model resolution now indexes **`CLI_MODEL_FALLBACK_MODE_BY_SOURCE`** at the call site.
> 
> In **`multiAgentPresets.ts`**, list availability strings are built from **`cliMultiAgentPresetAvailability(plan)`** (`workflow`/`tool-use` labels and overall status) instead of recomputing counts via **`formatAvailablePresetAgentCount`**, which is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ac55b169eb79b9a6e050e24520a18738503fe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->