### PR TITLE
refactor: consolidate CLI API mode aliases

### DIFF
--- a/packages/cli/src/runtime/apiAccessMode.ts
+++ b/packages/cli/src/runtime/apiAccessMode.ts
@@ -4,17 +4,23 @@ import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 export type CliApiMode = 'included' | 'personal';
 
-export const CLI_API_MODE_INPUTS = [
-  'included',
-  'relay',
-  'texra',
-  'personal',
-  'direct',
-  'api',
-  'byok',
-  'key',
-  'keys',
-] as const;
+const CLI_API_MODE_BY_INPUT = {
+  included: 'included',
+  relay: 'included',
+  texra: 'included',
+  personal: 'personal',
+  direct: 'personal',
+  api: 'personal',
+  byok: 'personal',
+  key: 'personal',
+  keys: 'personal',
+} as const satisfies Record<string, CliApiMode>;
+
+type CliApiModeInput = keyof typeof CLI_API_MODE_BY_INPUT;
+
+export const CLI_API_MODE_INPUTS = Object.keys(
+  CLI_API_MODE_BY_INPUT,
+) as readonly CliApiModeInput[];
 
 export function getCliApiMode(): CliApiMode {
   return getServerSideKeyService().getUseIncludedModelAccess()
@@ -38,15 +44,9 @@ export function shortCliApiMode(mode: CliApiMode): string {
 
 export function parseCliApiMode(input: string): CliApiMode | undefined {
   const normalized = input.trim().toLowerCase();
-  if (
-    ['personal', 'direct', 'api', 'byok', 'key', 'keys'].includes(normalized)
-  ) {
-    return 'personal';
-  }
-  if (['included', 'relay', 'texra'].includes(normalized)) {
-    return 'included';
-  }
-  return undefined;
+  return Object.hasOwn(CLI_API_MODE_BY_INPUT, normalized)
+    ? CLI_API_MODE_BY_INPUT[normalized as CliApiModeInput]
+    : undefined;
 }
 
 export async function setCliApiMode(mode: CliApiMode): Promise<void> {

--- a/src/test-kernel/cli/ApiAccessMode.vitest.mts
+++ b/src/test-kernel/cli/ApiAccessMode.vitest.mts
@@ -1,0 +1,23 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - CLI runtime
+import {
+  CLI_API_MODE_INPUTS,
+  parseCliApiMode,
+} from '@cli/runtime/apiAccessMode';
+
+describe('CLI API access mode aliases', () => {
+  it('parses every advertised API mode input', () => {
+    expect(CLI_API_MODE_INPUTS.every((input) => parseCliApiMode(input))).toBe(
+      true,
+    );
+  });
+
+  it('maps included-relay and personal-key aliases to their canonical modes', () => {
+    expect(parseCliApiMode('relay')).toBe('included');
+    expect(parseCliApiMode('texra')).toBe('included');
+    expect(parseCliApiMode('byok')).toBe('personal');
+    expect(parseCliApiMode('keys')).toBe('personal');
+  });
+});


### PR DESCRIPTION
## Summary
- replace duplicated CLI API-mode alias arrays with one canonical alias table
- derive advertised API-mode inputs from that table so parser and error text stay in sync
- add a focused parser contract test for the advertised aliases

## Validation
- corepack pnpm exec vitest run src/test-kernel/cli/ApiAccessMode.vitest.mts src/test-kernel/cli/CliContext.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts
- npm run typecheck
- npm run compile:fast
- npm run lint (0 errors; existing import-order warnings only)
- git diff --check HEAD~1 HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to alias parsing with tests; runtime API mode behavior (`included` vs `personal`) is unchanged.
> 
> **Overview**
> **Consolidates CLI API mode string aliases** into a single `CLI_API_MODE_BY_INPUT` table in `apiAccessMode.ts`, so `parseCliApiMode` and the advertised input list no longer maintain separate hard-coded alias arrays.
> 
> `CLI_API_MODE_INPUTS` is now derived from that table’s keys, which keeps invalid-argument help text (e.g. in `cliContext`) aligned with what the parser accepts. Parsing uses `Object.hasOwn` on the same map instead of two `includes` checks.
> 
> Adds `ApiAccessMode.vitest.mts` to assert every advertised input parses and that relay/texra → `included` and byok/keys → `personal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1e49d52277dbeb6bc842df6ede4f32cb72f0e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->