### PR TITLE
refactor: remove CLI config schema re-export

### DIFF
--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -1,12 +1,10 @@
 import { INTEROP_SKILL_DIRS } from '@skills/skillSources';
 import {
   CLI_APPROVAL_POLICIES,
-  type CliApprovalPolicy,
-} from '@cli/schemas/cliSettings';
-import {
   CLI_OUTPUT_FORMATS,
+  type CliApprovalPolicy,
   type CliOutputFormat,
-} from '@cli/runtime/cliConfig';
+} from '@cli/schemas/cliSettings';
 import { CliUsageError } from '@cli/runtime/cliContext';
 
 /**

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -16,10 +16,6 @@ import {
 } from '../schemas/cliSettings';
 import { KNOWN_TEXRA_KEYS } from '../schemas/knownKeys';
 
-// Re-export so existing call sites (`from './cliConfig'`) keep working — the
-// canonical home is `../schemas/cliSettings`.
-export { CLI_OUTPUT_FORMATS, type CliOutputFormat };
-
 export const CLI_CONFIG_DIR = '.texra';
 export const CLI_CONFIG_FILE = 'config.json';
 export const CLI_BUILTIN_DEFAULT_MODEL = 'deepseekT';

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -7,7 +7,9 @@ import { isNonEmptyString } from '@utils/core/stringCore';
 
 import {
   CLI_APPROVAL_POLICIES,
+  CLI_OUTPUT_FORMATS,
   type CliApprovalPolicy,
+  type CliOutputFormat,
 } from '../schemas/cliSettings';
 import {
   CLI_API_MODE_INPUTS,
@@ -15,11 +17,9 @@ import {
   type CliApiMode,
 } from './apiAccessMode';
 import {
-  CLI_OUTPUT_FORMATS,
   isKnownCliModel,
   loadWorkspaceCliConfig,
   type CliConfigValues,
-  type CliOutputFormat,
 } from './cliConfig';
 import { resolveCliResourcesPath } from './resourcesPath';
 import type { SkillSourceOptions } from '@skills/skillSources';

--- a/packages/cli/src/runtime/globalArgs.ts
+++ b/packages/cli/src/runtime/globalArgs.ts
@@ -1,8 +1,10 @@
 import { isNonEmptyString } from '@utils/core/stringCore';
 
-import type { CliApprovalPolicy } from '../schemas/cliSettings';
+import type {
+  CliApprovalPolicy,
+  CliOutputFormat,
+} from '../schemas/cliSettings';
 import type { CliApiMode } from './apiAccessMode';
-import type { CliOutputFormat } from './cliConfig';
 import type { CliGlobalArgs } from './cliContext';
 
 /**


### PR DESCRIPTION
## Summary
- stop re-exporting CLI output-format schema data from runtime/cliConfig
- import CLI output-format constants/types directly from schemas/cliSettings
- keep cliConfig focused on config parsing/loading ownership

## Validation
- corepack pnpm exec prettier --check packages/cli/src/commands/_helpers/globalArgs.ts packages/cli/src/runtime/globalArgs.ts packages/cli/src/runtime/cliContext.ts packages/cli/src/runtime/cliConfig.ts
- corepack pnpm exec vitest run src/test-kernel/cli/CliContext.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/InitConfig.vitest.mts src/test-kernel/cli/InitCommand.vitest.mts
- npm run typecheck
- npm run compile:fast
- npm run lint (0 errors; existing import-order warnings only)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with no logic changes; low risk if tests and typecheck pass.
> 
> **Overview**
> **CLI output-format schema ownership** moves fully to `schemas/cliSettings`: `cliConfig` no longer re-exports `CLI_OUTPUT_FORMATS` or `CliOutputFormat`.
> 
> Call sites that previously pulled those symbols through `cliConfig` or split imports across modules now import **`CLI_OUTPUT_FORMATS`**, **`CLI_APPROVAL_POLICIES`**, and their types **directly from `@cli/schemas/cliSettings`** — including `commands/_helpers/globalArgs.ts`, `runtime/cliContext.ts`, and `runtime/globalArgs.ts`. `cliConfig` keeps using the same schema constants internally for parsing; it just stops acting as a passthrough barrel.
> 
> No runtime behavior change; this is import-path / module-boundary cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2260cccc4a1915d0af254bb39f11acb4fbba905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->