### PR TITLE
refactor: consolidate CLI headless-only flag contract

### DIFF
--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -10,7 +10,12 @@ import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
 import { readCliAmbientState } from '@cli/runtime/cliContext';
 import { stripAnsiSequences } from '@cli/runtime/ansiEscapes';
 
-import { GLOBAL_BOOL_FLAGS, GLOBAL_VALUE_FLAGS } from './globalArgs';
+import {
+  GLOBAL_ARGS,
+  GLOBAL_BOOL_FLAGS,
+  GLOBAL_VALUE_FLAGS,
+  HEADLESS_ONLY_GLOBAL_ARG_NAMES,
+} from './globalArgs';
 
 interface LeadingGlobalFlags {
   readonly leadingGlobals: readonly string[];
@@ -561,10 +566,9 @@ function addFlagSpec(specs: CommandFlagSpecs, name: string, def: ArgDef): void {
 }
 
 function addInteractiveHeadlessOnlyFlags(specs: CommandFlagSpecs): void {
-  specs.long.set('--print', { takesValue: false });
-  specs.short.set('-p', { takesValue: false });
-  specs.long.set('--no-input', { takesValue: false });
-  addLongFlag(specs, 'output-format', { takesValue: true });
+  for (const name of HEADLESS_ONLY_GLOBAL_ARG_NAMES) {
+    addFlagSpec(specs, name, GLOBAL_ARGS[name]);
+  }
 }
 
 async function commandFlagSpecs(

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -128,16 +128,24 @@ export const AGENT_RUN_GLOBAL_ARGS = {
 
 export const ROOT_ROUTING_ARGS = AGENT_RUN_GLOBAL_ARGS;
 
+export const HEADLESS_ONLY_GLOBAL_ARG_NAMES = [
+  'print',
+  'output-format',
+  'no-input',
+] as const;
+type HeadlessOnlyGlobalArgName =
+  (typeof HEADLESS_ONLY_GLOBAL_ARG_NAMES)[number];
+
 /**
  * Flags that are meaningful for commands which necessarily own the terminal.
- * In particular, `chat` and `orchestrate` cannot honor `--print`,
- * `--output-format`, or `--no-input` (which forces headless); scripts should use
- * a concrete headless command instead. `--no-color` still applies — a terminal
- * session may legitimately want plain output.
+ * In particular, `chat` and `orchestrate` cannot honor the headless-only
+ * globals above; scripts should use a concrete headless command instead.
+ * `--no-color` still applies — a terminal session may legitimately want plain
+ * output.
  */
 export const INTERACTIVE_GLOBAL_ARGS: Omit<
   CliGlobalArgsDef,
-  'print' | 'output-format' | 'no-input'
+  HeadlessOnlyGlobalArgName
 > = {
   quiet: GLOBAL_ARGS.quiet,
   cwd: GLOBAL_ARGS.cwd,
@@ -182,19 +190,25 @@ export const GLOBAL_BOOL_FLAGS = new Set<string>(
   }),
 );
 
+const HEADLESS_ONLY_GLOBAL_FLAG_SPELLINGS =
+  HEADLESS_ONLY_GLOBAL_ARG_NAMES.flatMap((name) =>
+    flagSpellings(name, GLOBAL_ARGS[name]),
+  );
+const HEADLESS_ONLY_GLOBAL_FLAG_LABELS = formatCommaList(
+  HEADLESS_ONLY_GLOBAL_FLAG_SPELLINGS.filter((flag) => flag.startsWith('--')),
+);
+const HEADLESS_ONLY_GLOBAL_FLAGS = new Set<string>(
+  HEADLESS_ONLY_GLOBAL_FLAG_SPELLINGS,
+);
+
 export function optString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
 function isHeadlessOnlyFlag(arg: string): boolean {
-  return (
-    arg === '--print' ||
-    arg.startsWith('--print=') ||
-    arg === '-p' ||
-    arg === '--no-input' ||
-    arg.startsWith('--no-input=') ||
-    arg === '--output-format' ||
-    arg.startsWith('--output-format=')
+  if (HEADLESS_ONLY_GLOBAL_FLAGS.has(arg)) return true;
+  return HEADLESS_ONLY_GLOBAL_FLAG_SPELLINGS.some(
+    (flag) => flag.startsWith('--') && arg.startsWith(`${flag}=`),
   );
 }
 
@@ -205,7 +219,7 @@ export function rejectHeadlessOnlyFlags(
   if (!rawArgs.some(isHeadlessOnlyFlag)) return;
 
   throw new CliUsageError(
-    `texra ${commandName} is interactive and does not support --print, --no-input, or --output-format. For scripting, use \`texra run\` or a concrete non-interactive subcommand.`,
+    `texra ${commandName} is interactive and does not support ${HEADLESS_ONLY_GLOBAL_FLAG_LABELS}. For scripting, use \`texra run\` or a concrete non-interactive subcommand.`,
   );
 }
 


### PR DESCRIPTION
## Summary
- derive the interactive-only global arg omission and rejection matcher from one headless-only flag list
- keep `--print`, `--print=`, `-p`, `--no-input`, `--no-input=`, `--output-format`, and `--output-format=` behavior unchanged
- avoid another resolver/pass-through layer by keeping the contract in the existing global args module

## Validation
- `corepack pnpm exec prettier --check packages/cli/src/commands/_helpers/globalArgs.ts`
- `corepack pnpm exec vitest run src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/Completion.vitest.mts src/test-kernel/cli/AuthCommand.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings only)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with explicit goal of unchanged `--print`, `-p`, `--no-input`, and `--output-format` behavior; limited to CLI arg parsing helpers.
> 
> **Overview**
> Introduces **`HEADLESS_ONLY_GLOBAL_ARG_NAMES`** (`print`, `output-format`, `no-input`) as the single contract for flags that interactive commands must reject.
> 
> **`globalArgs.ts`** derives interactive arg omission, flag spellings (including `-p`), inline `flag=value` matching, and usage-error labels from that list plus **`GLOBAL_ARGS`**, replacing hardcoded checks in **`isHeadlessOnlyFlag`** and **`rejectHeadlessOnlyFlags`**.
> 
> **`dispatch.ts`** registers those flags for `chat` / `orchestrate` / `setup` unknown-flag handling by looping **`HEADLESS_ONLY_GLOBAL_ARG_NAMES`** through **`addFlagSpec`**, instead of manually wiring each long/short flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 823a92ef716a1ac7e0f0718596fd24f341293944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->