### PR TITLE
refactor: consolidate CLI model recovery actions

### DIFF
--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -28,7 +28,7 @@ import { isPlainReturnInput } from '../input/inputKeys';
 
 const TUI_MODEL_EMPTY_RECOVERY = {
   includedModeAction: 'switch with /api included',
-  loginAction: 'Run /login',
+  loginAction: 'run /login',
   personalModeAction: 'switch with /api personal',
 } satisfies CliNoRunnableModelsMessageOptions;
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -631,6 +631,7 @@ export const CHAT_LOGIN_USAGE =
 
 const CHAT_API_MODE_MODEL_RECOVERY = {
   includedModeAction: 'switch to included relay with `/api included`',
+  loginAction: 'run `/login`',
   personalModeAction: 'switch to personal API keys with `/api personal`',
 } satisfies CliNoAvailableModelsRecoveryOptions;
 

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -67,12 +67,12 @@ export interface CliModelListOptions {
 
 export interface CliNoAvailableModelsRecoveryOptions {
   readonly includedModeAction?: string;
+  readonly loginAction?: string;
   readonly personalModeAction?: string;
 }
 
-export interface CliNoRunnableModelsMessageOptions extends CliNoAvailableModelsRecoveryOptions {
-  readonly loginAction?: string;
-}
+export type CliNoRunnableModelsMessageOptions =
+  CliNoAvailableModelsRecoveryOptions;
 
 export type NoRunnableModelAccessReason = CliApiMode | 'includedLoginRequired';
 
@@ -109,9 +109,30 @@ const NO_RUNNABLE_MODEL_ACCESS_COPY = {
   { readonly launchBlock: string; readonly summary: string }
 >;
 
+const DEFAULT_CLI_MODEL_RECOVERY_ACTIONS = {
+  includedModeAction: 'retry with `--api-mode included`',
+  loginAction: 'run `texra login`',
+  personalModeAction: 'retry with `--api-mode personal`',
+} satisfies Required<CliNoAvailableModelsRecoveryOptions>;
+
 function startSentence(text: string): string {
   if (text.length === 0) return text;
   return `${text[0]!.toUpperCase()}${text.slice(1)}`;
+}
+
+function cliModelRecoveryActions(
+  options: CliNoAvailableModelsRecoveryOptions = {},
+): Required<CliNoAvailableModelsRecoveryOptions> {
+  return {
+    includedModeAction:
+      options.includedModeAction ??
+      DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.includedModeAction,
+    loginAction:
+      options.loginAction ?? DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.loginAction,
+    personalModeAction:
+      options.personalModeAction ??
+      DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.personalModeAction,
+  };
 }
 
 function isCliModelOptionBasicallyAvailable(model: ModelOptionData): boolean {
@@ -176,14 +197,11 @@ function formatCliNoRunnableModelsRecovery(
   reason: NoRunnableModelAccessReason,
   options: CliNoRunnableModelsMessageOptions = {},
 ): string {
-  const includedModeAction =
-    options.includedModeAction ?? 'retry with `--api-mode included`';
-  const loginAction = options.loginAction ?? 'Run `texra login`';
-  const personalModeAction =
-    options.personalModeAction ?? 'retry with `--api-mode personal`';
+  const { includedModeAction, loginAction, personalModeAction } =
+    cliModelRecoveryActions(options);
 
   if (reason === 'includedLoginRequired') {
-    return `${loginAction} or ${personalModeAction}.`;
+    return `${startSentence(loginAction)} or ${personalModeAction}.`;
   }
   if (reason === 'included') {
     return `${startSentence(personalModeAction)} or try again later.`;
@@ -265,18 +283,16 @@ export function formatCliNoAvailableModelsRecovery(
   apiMode?: CliApiMode,
   options: CliNoAvailableModelsRecoveryOptions = {},
 ): string {
-  const includedModeAction =
-    options.includedModeAction ?? 'retry with `--api-mode included`';
-  const personalModeAction =
-    options.personalModeAction ?? 'retry with `--api-mode personal`';
+  const { includedModeAction, loginAction, personalModeAction } =
+    cliModelRecoveryActions(options);
 
   if (apiMode === 'personal') {
-    return `Configure a provider API key for personal mode, or ${includedModeAction} and run \`texra login\` for included relay access.`;
+    return `Configure a provider API key for personal mode, or ${includedModeAction} and ${loginAction} for included relay access.`;
   }
   if (apiMode === 'included') {
-    return `Run \`texra login\` for included relay access, or ${personalModeAction} after configuring a provider API key.`;
+    return `${startSentence(loginAction)} for included relay access, or ${personalModeAction} after configuring a provider API key.`;
   }
-  return `Run \`texra login\` for included relay access, ${includedModeAction}, or configure a provider API key.`;
+  return `${startSentence(loginAction)} for included relay access, ${includedModeAction}, or configure a provider API key.`;
 }
 
 function toCliModelAccess(

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -63,6 +63,12 @@ function resolveModelFromAccessList(
   return resolveCliRunnableModel(model, { ...options, accessList });
 }
 
+const INTERACTIVE_RECOVERY = {
+  includedModeAction: 'switch with /api included',
+  loginAction: 'run /login',
+  personalModeAction: 'switch with /api personal',
+} as const;
+
 describe('CLI model access resolution', () => {
   beforeEach(() => {
     computeModelOptionsDataMock.mockReset();
@@ -555,12 +561,6 @@ describe('CLI model access resolution', () => {
   });
 
   it('formats no-runnable model reasons for launch and model picker views', () => {
-    const interactiveRecovery = {
-      includedModeAction: 'switch with /api included',
-      loginAction: 'Run /login',
-      personalModeAction: 'switch with /api personal',
-    };
-
     expect(formatCliNoRunnableModelsLaunchBlock('includedLoginRequired')).toBe(
       'Sign in with texra login for included relay models',
     );
@@ -573,30 +573,34 @@ describe('CLI model access resolution', () => {
     expect(
       formatCliNoRunnableModelsMessage(
         'includedLoginRequired',
-        interactiveRecovery,
+        INTERACTIVE_RECOVERY,
       ),
     ).toBe(
       'Included relay models require sign-in. Run /login or switch with /api personal.',
     );
     expect(
-      formatCliNoRunnableModelsMessage('included', interactiveRecovery),
+      formatCliNoRunnableModelsMessage('included', INTERACTIVE_RECOVERY),
     ).toBe(
       'No included relay models are runnable. Switch with /api personal or try again later.',
     );
     expect(
-      formatCliNoRunnableModelsMessage('personal', interactiveRecovery),
+      formatCliNoRunnableModelsMessage('personal', INTERACTIVE_RECOVERY),
     ).toBe(
       'No personal API-key models are runnable. Configure a provider key or switch with /api included.',
+    );
+    expect(
+      formatCliNoAvailableModelsRecovery('included', INTERACTIVE_RECOVERY),
+    ).toBe(
+      'Run /login for included relay access, or switch with /api personal after configuring a provider API key.',
+    );
+    expect(
+      formatCliNoAvailableModelsRecovery('personal', INTERACTIVE_RECOVERY),
+    ).toBe(
+      'Configure a provider API key for personal mode, or switch with /api included and run /login for included relay access.',
     );
   });
 
   it('formats empty model picker messages with caller-owned recovery actions', () => {
-    const interactiveRecovery = {
-      includedModeAction: 'switch with /api included',
-      loginAction: 'Run /login',
-      personalModeAction: 'switch with /api personal',
-    };
-
     expect(
       emptyModelListMessageForCliMode(
         [
@@ -610,7 +614,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'included',
-        interactiveRecovery,
+        INTERACTIVE_RECOVERY,
       ),
     ).toBe(
       'Included relay models require sign-in. Run /login or switch with /api personal.',
@@ -628,7 +632,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'included',
-        interactiveRecovery,
+        INTERACTIVE_RECOVERY,
       ),
     ).toBe(
       'No included relay models are runnable. Switch with /api personal or try again later.',
@@ -646,7 +650,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'personal',
-        interactiveRecovery,
+        INTERACTIVE_RECOVERY,
       ),
     ).toBe(
       'No personal API-key models are runnable. Configure a provider key or switch with /api included.',


### PR DESCRIPTION
## Summary
- centralize CLI model recovery action defaults in `modelAccess`
- let no-runnable and no-available model messages share the same caller-owned `/api` and login wording
- keep model fallback policy owned by `modelAccess` without adding a new resolver layer

## Validation
- `corepack pnpm exec prettier --check packages/cli/src/runtime/modelAccess.ts src/test-kernel/cli/ModelAccess.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/ModelsRecord.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings only)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and option typing only; no changes to model resolution, auth, or API mode behavior.
> 
> **Overview**
> Centralizes CLI **no models** recovery hints in `modelAccess`: shared defaults (`texra login`, `--api-mode` retries) and a `cliModelRecoveryActions` merge so **no-runnable** (model picker) and **no-available** (resolution) messages use the same optional overrides.
> 
> `CliNoRunnableModelsMessageOptions` now matches `CliNoAvailableModelsRecoveryOptions` (including `loginAction`). Chat TUI passes slash-command wording (`run /login`, `/api` switches) via `CHAT_API_MODE_MODEL_RECOVERY` and the model list form; `formatCliNoAvailableModelsRecovery` respects those overrides instead of always embedding `texra login`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22813a4192b2c85c8ed4c5a62ce29745ca24fbc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->