### PR TITLE
fix: show token usage in CLI resume hints

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -118,7 +118,11 @@ import { tuiOutputStreamForColor } from './render/noColorOutput';
 import { formatCliSessionStatus } from './sessionStatus';
 import { clearApprovals } from './state/approvalQueue';
 import { cliState, patchStream, resetCliState } from './state/cliState';
-import { collectResumeTargets, formatResumeHint } from './state/resumeHint';
+import {
+  collectResumeTargets,
+  collectResumeUsage,
+  formatResumeHint,
+} from './state/resumeHint';
 import { installTuiApprovals } from './state/subscribeApprovals';
 import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
 import { subscribeStreamLog } from './state/subscribeStreamLog';
@@ -1298,9 +1302,9 @@ export async function runChat(
     // An older run with no persisted entries simply shows whatever exists
     // (possibly nothing) — the continued turn streams in regardless.
     await getDefaultStreamLogStore().ensureLoaded(resolution.streamId);
-    // Restore the durable per-stream display (todos/plan/usage) the previous
-    // run persisted, so resume shows more than just the transcript. Liveness is
-    // never persisted, so nothing stale (running badges, RUNNING status) leaks.
+    // Restore durable per-stream display state plus cumulative usage for exit
+    // summaries. Latest context-window usage is live-only and should not be
+    // rehydrated from the per-run total.
     await snapshotStore.load([resolution.streamId]);
     const restored = await snapshotStore.read(resolution.streamId);
     patchStream(resolution.streamId, (slice) => {
@@ -1310,7 +1314,9 @@ export async function runChat(
       // to stale slice state) rather than treating empty as "no data".
       return {
         ...slice,
-        usage: runUsages.length ? sumUsageStats(runUsages) : slice.usage,
+        cumulativeUsage: runUsages.length
+          ? sumUsageStats(runUsages)
+          : slice.cumulativeUsage,
         todos: restored.todos,
         plan: restored.plan,
       };
@@ -1621,11 +1627,13 @@ export async function runChat(
   // Read cliState before resetCliState() clears it.
   const printResumeHintOnExit = (): void => {
     if (!session.executionId) return;
+    const streams = cliState.streams.get();
     const hint = formatResumeHint(
       collectResumeTargets({
         rootExecutionId: session.executionId,
-        streams: cliState.streams.get(),
+        streams,
       }),
+      collectResumeUsage(streams),
     );
     if (hint) writeTextStdout(`\n${hint}`);
   };

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -85,7 +85,13 @@ export interface StreamSlice {
    *  token-less "thinking" turn still shows liveness. */
   readonly runStartedAt: number | undefined;
   readonly description: string | undefined;
+  /** Latest model usage snapshot. The StatusBar treats this as current context
+   *  occupancy, so it must not be accumulated across turns. */
   readonly usage: TokenUsageStats | undefined;
+  /** Accumulated usage for resume/exit summaries across all turns in this
+   *  stream. Kept separate from `usage` so the context-window indicator remains
+   *  a latest-snapshot display. */
+  readonly cumulativeUsage: TokenUsageStats | undefined;
   readonly conversation: ConversationProgress | undefined;
   readonly entries: readonly ConversationEntry[];
   readonly queuedFollowUps: number;
@@ -201,6 +207,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     runStartedAt: undefined,
     description: undefined,
     usage: undefined,
+    cumulativeUsage: undefined,
     conversation: undefined,
     entries: [],
     queuedFollowUps: 0,

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -5,7 +5,12 @@
 // (only tool-use agents do). Reads only the in-memory stream tree, which still
 // holds finished subagents for the session, so no exit-time disk I/O is needed.
 
-import { AGENT_CATEGORY, type StreamTabId } from '@shared/schemas';
+import {
+  AGENT_CATEGORY,
+  sumUsageStats,
+  type StreamTabId,
+  type TokenUsageStats,
+} from '@shared/schemas';
 
 import type { StreamSlice } from './cliState';
 
@@ -19,6 +24,70 @@ export interface ResumeTarget {
 export interface ResumeTargetsInput {
   readonly rootExecutionId: string | undefined;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}
+
+export type ResumeUsageStats = TokenUsageStats & {
+  readonly reasoningTokens?: number;
+};
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function usageHasTokens(usage: ResumeUsageStats): boolean {
+  return (
+    usage.inputTokens > 0 ||
+    usage.outputTokens > 0 ||
+    (usage.cacheReadInputTokens ?? 0) > 0 ||
+    (usage.cacheMissInputTokens ?? 0) > 0 ||
+    (usage.cacheCreationInputTokens ?? 0) > 0 ||
+    (usage.reasoningTokens ?? 0) > 0
+  );
+}
+
+export function sumResumeUsageStats(
+  items: Iterable<ResumeUsageStats>,
+): ResumeUsageStats {
+  const usages = [...items];
+  const total = sumUsageStats(usages);
+  const reasoningTokens = usages.reduce(
+    (sum, usage) => sum + (usage.reasoningTokens ?? 0),
+    0,
+  );
+  return reasoningTokens > 0 ? { ...total, reasoningTokens } : total;
+}
+
+export function collectResumeUsage(
+  streams: ReadonlyMap<StreamTabId, StreamSlice>,
+): ResumeUsageStats | undefined {
+  const usages: ResumeUsageStats[] = [];
+
+  for (const slice of streams.values()) {
+    const usage: ResumeUsageStats | undefined =
+      slice.cumulativeUsage ?? slice.usage;
+    if (!usage || !usageHasTokens(usage)) continue;
+    usages.push(usage);
+  }
+
+  const total = sumResumeUsageStats(usages);
+  return usageHasTokens(total) ? total : undefined;
+}
+
+export function formatResumeUsage(
+  usage: ResumeUsageStats | undefined,
+): string | undefined {
+  if (!usage || !usageHasTokens(usage)) return undefined;
+  const total = usage.inputTokens + usage.outputTokens;
+  const cached = usage.cacheReadInputTokens ?? 0;
+  const reasoning = usage.reasoningTokens ?? 0;
+  const lines = [
+    `total=${formatInteger(total)}`,
+    `input=${formatInteger(usage.inputTokens)}`,
+  ];
+  if (cached > 0) lines.push(`(+ ${formatInteger(cached)} cached)`);
+  lines.push(`output=${formatInteger(usage.outputTokens)}`);
+  if (reasoning > 0) lines.push(`(reasoning ${formatInteger(reasoning)})`);
+  return `Token usage: ${lines.join(' ')}`;
 }
 
 /** The main session followed by each tool-use subagent (any depth), deduped by
@@ -56,9 +125,12 @@ export function collectResumeTargets({
 /** Multi-line reopen hint, or undefined when there's nothing to resume. */
 export function formatResumeHint(
   targets: readonly ResumeTarget[],
+  usage?: ResumeUsageStats,
 ): string | undefined {
   if (targets.length === 0) return undefined;
-  const lines = ['Resume this session with:'];
+  const lines = [formatResumeUsage(usage), 'Resume this session with:'].filter(
+    (line): line is string => Boolean(line),
+  );
   for (const target of targets) {
     lines.push(`  texra --resume ${target.executionId}  (${target.label})`);
   }

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -21,6 +21,7 @@ import {
 } from './cliState';
 import { mergeChildStreams } from './childStreamMerge';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
+import { sumResumeUsageStats } from './resumeHint';
 
 type Emit = <K extends ProgressEvent>(
   event: K,
@@ -110,7 +111,13 @@ function applyToState<K extends ProgressEvent>(
       return;
     case 'updateStreamUsage': {
       const p = payload as ProgressEventPayloads['updateStreamUsage'];
-      patchStream(p.streamId, (s) => ({ ...s, usage: p.usage }));
+      patchStream(p.streamId, (s) => ({
+        ...s,
+        usage: p.usage,
+        cumulativeUsage: sumResumeUsageStats(
+          s.cumulativeUsage ? [s.cumulativeUsage, p.usage] : [p.usage],
+        ),
+      }));
       return;
     }
     case 'updateConversationProgress': {

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -85,6 +85,7 @@ function slice(
     runStartedAt: undefined,
     description: undefined,
     usage: undefined,
+    cumulativeUsage: undefined,
     conversation: undefined,
     entries: [],
     queuedFollowUps: 0,

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -747,6 +747,7 @@ function sliceWithEntries(
     runStartedAt: undefined,
     description: undefined,
     usage: undefined,
+    cumulativeUsage: undefined,
     conversation: undefined,
     entries,
     queuedFollowUps: 0,

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  collectResumeUsage,
   collectResumeTargets,
   formatResumeHint,
+  formatResumeUsage,
+  type ResumeUsageStats,
 } from '@cli/chat/tui/state/resumeHint';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
@@ -20,6 +23,7 @@ function makeSlice(
     runStartedAt: undefined,
     description: undefined,
     usage: undefined,
+    cumulativeUsage: undefined,
     conversation: undefined,
     entries: [],
     queuedFollowUps: 0,
@@ -135,7 +139,96 @@ describe('formatResumeHint', () => {
     );
   });
 
+  it('prepends token usage when available', () => {
+    expect(
+      formatResumeHint([{ executionId: 'root', label: 'main', isRoot: true }], {
+        inputTokens: 186_189_742,
+        outputTokens: 11_042_600,
+        cost: 0,
+        cacheReadInputTokens: 6_470_327_168,
+        reasoningTokens: 3_489_148,
+      } satisfies ResumeUsageStats),
+    ).toBe(
+      [
+        'Token usage: total=197,232,342 input=186,189,742 (+ 6,470,327,168 cached) output=11,042,600 (reasoning 3,489,148)',
+        'Resume this session with:',
+        '  texra --resume root  (main)',
+      ].join('\n'),
+    );
+  });
+
   it('is undefined when there is nothing to resume', () => {
     expect(formatResumeHint([])).toBeUndefined();
+  });
+});
+
+describe('collectResumeUsage', () => {
+  it('sums usage from every stream', () => {
+    const streams = streamsOf(
+      makeSlice({
+        streamId: 'main@m#root',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          cost: 0.2,
+          cacheReadInputTokens: 7,
+        },
+      }),
+      makeSlice({
+        streamId: 'review@m#rev',
+        usage: {
+          inputTokens: 40,
+          outputTokens: 8,
+          cost: 0.3,
+          cacheReadInputTokens: 3,
+          reasoningTokens: 5,
+        } as ResumeUsageStats,
+      }),
+    );
+
+    expect(collectResumeUsage(streams)).toEqual({
+      inputTokens: 140,
+      outputTokens: 28,
+      cost: 0.5,
+      cacheReadInputTokens: 10,
+      cacheMissInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      reasoningTokens: 5,
+    });
+  });
+
+  it('prefers cumulative usage over the latest status-bar snapshot', () => {
+    const streams = streamsOf(
+      makeSlice({
+        streamId: 'main@m#root',
+        usage: {
+          inputTokens: 40,
+          outputTokens: 8,
+          cost: 0.1,
+        },
+        cumulativeUsage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          cost: 0.3,
+        },
+      }),
+    );
+
+    expect(collectResumeUsage(streams)).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      cost: 0.3,
+      cacheReadInputTokens: 0,
+      cacheMissInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    });
+  });
+});
+
+describe('formatResumeUsage', () => {
+  it('omits empty usage', () => {
+    expect(
+      formatResumeUsage({ inputTokens: 0, outputTokens: 0, cost: 0 }),
+    ).toBeUndefined();
   });
 });

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -49,6 +49,7 @@ function slice(
     runStartedAt: undefined,
     description: undefined,
     usage: undefined,
+    cumulativeUsage: undefined,
     conversation: undefined,
     entries: [],
     queuedFollowUps: 0,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -89,6 +89,7 @@ import {
   AGENT_CATEGORY,
   MESSAGE_TYPES,
   STREAM_STATUS,
+  type StorageKey,
   type StreamTabId,
 } from '@shared/schemas';
 import { stripOrchestratorFollowup } from '@shared/subagentFollowup';
@@ -2271,6 +2272,49 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     } finally {
       ToolUseFollowUpQueue.release(root);
     }
+  });
+
+  it('keeps latest usage separate from cumulative resume usage', () => {
+    const wrapped = wrapRuntimeHost(makeHost());
+    const storageKey = 'root-run' as StorageKey;
+
+    wrapped.emit('updateStreamUsage', {
+      streamId: root,
+      storageKey,
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 1,
+        cacheReadInputTokens: 30,
+      },
+    });
+    wrapped.emit('updateStreamUsage', {
+      streamId: root,
+      storageKey,
+      usage: {
+        inputTokens: 40,
+        outputTokens: 10,
+        cost: 2,
+        cacheReadInputTokens: 5,
+        cacheCreationInputTokens: 7,
+      },
+    });
+
+    expect(cliState.streams.get().get(root)?.usage).toEqual({
+      inputTokens: 40,
+      outputTokens: 10,
+      cost: 2,
+      cacheReadInputTokens: 5,
+      cacheCreationInputTokens: 7,
+    });
+    expect(cliState.streams.get().get(root)?.cumulativeUsage).toEqual({
+      inputTokens: 140,
+      outputTokens: 30,
+      cost: 3,
+      cacheReadInputTokens: 35,
+      cacheMissInputTokens: 0,
+      cacheCreationInputTokens: 7,
+    });
   });
 
   it('persists a bounded completed-process transcript before pruning processOutput', () => {


### PR DESCRIPTION
## Summary
- show a token usage line before the printed `texra --resume` hint when a CLI TUI session exits
- sum usage across all stream slices so orchestrator sessions include subagents
- keep resume target collection and usage formatting owned by `resumeHint.ts`

## Validation
- `prettier --check packages/cli/src/chat/tui/state/resumeHint.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/ResumeHint.vitest.mts`
- `vitest run src/test-kernel/cli/ResumeHint.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `tsc --noEmit -p tsconfig.test-kernel.json`

Note: this branch inherits the current `origin/main` lockfile with fresh `@supabase/*@2.108.0` entries, so fresh `pnpm install --frozen-lockfile`/CI currently fails the pnpm minimum-release-age policy before tests run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only display and in-memory usage accounting; no changes to auth, billing, or model invocation paths.
> 
> **Overview**
> Adds a **token usage line** to the CLI exit scrollback hint (before the existing `texra --resume` commands), aggregating usage across the root stream and all subagent streams.
> 
> Introduces **`cumulativeUsage`** on each stream slice, separate from **`usage`**: live updates still set `usage` to the latest snapshot for the StatusBar context window, while `cumulativeUsage` accumulates per turn via `updateStreamUsage`. On resume, persisted snapshot `runUsage` rehydrates **`cumulativeUsage` only**, not the live context snapshot.
> 
> New helpers in `resumeHint.ts` (`collectResumeUsage`, `formatResumeUsage`, `sumResumeUsageStats`) sum per-stream totals (preferring cumulative over latest usage) and format input/output/cache/reasoning counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea353dc7d78b6329ce589285ebdc93e634fb848d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->