### PR TITLE
fix: reduce CLI follow-up prompt duplication

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -21,7 +21,11 @@ import { streamViewForId } from '../state/streamViews';
 import { transcriptEntryLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
-import { TranscriptEntry } from './TranscriptEntry';
+import {
+  isInquiryContinuationText,
+  TranscriptEntry,
+  USER_ENTRY_MARGIN_BOTTOM_ROWS,
+} from './TranscriptEntry';
 
 export type StaticTranscriptItem =
   | {
@@ -152,8 +156,14 @@ function staticTranscriptItemRowCount(
   }
   // Compact budgeting can over-count tool rows because the transcript viewer
   // keeps full tool output while the static scrollback renderer elides it.
-  return transcriptEntryLines(item.entry, Math.max(1, Math.floor(width ?? 80)))
-    .length;
+  const lines = transcriptEntryLines(
+    item.entry,
+    Math.max(1, Math.floor(width ?? 80)),
+  ).length;
+  return item.entry.role === 'user' &&
+    !isInquiryContinuationText(item.entry.text)
+    ? lines + USER_ENTRY_MARGIN_BOTTOM_ROWS
+    : lines;
 }
 
 export function appendStaticTranscriptItems({

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -55,6 +55,7 @@ export interface StatusBarDisplayInput {
   readonly pendingExitHint: boolean;
   readonly pendingExitResumeId: string | undefined;
   readonly bypass: BypassState;
+  readonly thinkingActive?: boolean;
   readonly queuedFollowUpMessages: readonly string[];
   readonly queuedFollowUpPreview?: boolean;
   readonly usage: TokenUsageStats | undefined;
@@ -171,6 +172,7 @@ const STATUS_BAR_COMPACT_PRIORITY = {
   approvalDepth: 60,
   rootActive: 65,
   elapsed: 70,
+  thinking: 75,
 } as const;
 
 function truncateSummaryToColumns(text: string, maxColumns: number): string {
@@ -628,6 +630,16 @@ export function buildStatusBarDisplay(
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.elapsed,
       });
     }
+    if (
+      input.status === STREAM_STATUS.RUNNING &&
+      input.thinkingActive === true
+    ) {
+      left.push({
+        text: 'thinking',
+        color: 'dim',
+        compactPriority: STATUS_BAR_COMPACT_PRIORITY.thinking,
+      });
+    }
   }
 
   const rootActive = rootActiveSegment(input);
@@ -755,6 +767,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     pendingExitHint,
     pendingExitResumeId,
     bypass: statusSlice?.bypass ?? NO_BYPASS,
+    thinkingActive: statusSlice?.thinkingActive ?? false,
     queuedFollowUpMessages: statusSlice?.queuedFollowUpMessages ?? [],
     queuedFollowUpPreview: props.queuedFollowUpPreview,
     usage: statusSlice?.usage,

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -19,6 +19,7 @@ import type {
 
 const INQUIRY_CONTINUATION_RE =
   /^\[inquiry\]\s+\S+\s+(?:answered|dropped by user)\.(?:\n|$)/;
+export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 1;
 
 export function isInquiryContinuationText(text: string): boolean {
   return INQUIRY_CONTINUATION_RE.test(text);
@@ -98,11 +99,11 @@ function UserEntryRow({
   // stays full-width across a resize because `<Static>` is remounted on a width
   // change (key={columns} in StaticConversationTranscript) — that regenerates
   // `fullStaticOutput` at the new width, which the resize full-repaint then
-  // reprints. The `› ` chevron is 2 cols, matching the static row count in
-  // transcriptLines.ts.
+  // reprints. The `› ` chevron is 2 cols; row estimators add the exported
+  // margin constant alongside their wrapped-line count.
   const cols = Math.max(1, Math.floor(width ?? 80));
   return (
-    <Box>
+    <Box marginBottom={USER_ENTRY_MARGIN_BOTTOM_ROWS}>
       <Text inverse={colorEnabled !== false}>
         {compactPrefixedDisplayRows({
           fillWidth: true,

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -2,7 +2,12 @@
 
 import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
-import { LIVE_TAIL_ROWS, tailWindow } from './TranscriptEntry';
+import {
+  isInquiryContinuationText,
+  LIVE_TAIL_ROWS,
+  USER_ENTRY_MARGIN_BOTTOM_ROWS,
+  tailWindow,
+} from './TranscriptEntry';
 import { toolUseDisplayLines } from './toolRenderers';
 import type { ConversationEntry } from '../state/cliState';
 
@@ -48,11 +53,15 @@ export function estimateTranscriptEntryRows(
       return Math.max(1, rendered.split('\n').length) + 1;
     });
   }
-  // User / error rows render without a trailing margin (compact mode) so
-  // chat-heavy sessions don't burn half the viewport on blank gaps. Their
-  // box uses `paddingX={1}` (2 cols) and a 2-col prefix (`› ` / `! `), so
-  // long text wraps to `width - 4` — keep the estimate in sync.
-  if (entry.role === 'user' || entry.role === 'error') {
+  if (entry.role === 'user') {
+    const rows = estimateWrappedRows(entry.text, Math.max(1, width - 2));
+    return isInquiryContinuationText(entry.text)
+      ? rows
+      : rows + USER_ENTRY_MARGIN_BOTTOM_ROWS;
+  }
+  if (entry.role === 'error') {
+    // Error rows render inside a padded box plus the `! ` prefix, so long text
+    // wraps to `width - 4`.
     return estimateWrappedRows(entry.text, Math.max(1, width - 4));
   }
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -97,7 +97,6 @@ import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { escapeText } from '@shared/utils/xmlEscape';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 import { generateExecutionId } from '@utils/core/executionId';
-import { truncateSummary } from '@utils/text/stringUtils';
 
 import { App } from './App';
 import { assertNever } from './assertNever';
@@ -173,8 +172,6 @@ export interface RunChatInit {
    */
   readonly resumeExecutionId?: ExecutionId;
 }
-
-const QUEUED_FOLLOW_UP_NOTICE_LENGTH = 96;
 
 export interface BuildInitialChatAgentConfigInput {
   readonly agent: string;
@@ -419,11 +416,7 @@ export function chatTuiIsResumableIdleOnExit(input: {
 
 export type ChatTuiFocusedChildFollowUpRoute =
   | { readonly kind: 'none' }
-  | {
-      readonly kind: 'accept';
-      readonly streamId: StreamTabId;
-      readonly shouldAnnounceQueuedFollowUp: boolean;
-    }
+  | { readonly kind: 'accept'; readonly streamId: StreamTabId }
   | { readonly kind: 'reject'; readonly streamId: StreamTabId };
 
 export function chatTuiFocusedChildFollowUpRoute(): ChatTuiFocusedChildFollowUpRoute {
@@ -441,18 +434,7 @@ export function chatTuiFocusedChildFollowUpRoute(): ChatTuiFocusedChildFollowUpR
   if (status !== undefined && !isInFlightStatus(status)) {
     return { kind: 'reject', streamId: scope.streamId };
   }
-  return {
-    kind: 'accept',
-    streamId: scope.streamId,
-    shouldAnnounceQueuedFollowUp: status !== STREAM_STATUS.WAITING,
-  };
-}
-
-function shouldAnnounceQueuedFollowUpToStream(
-  targetStreamId: StreamTabId | undefined,
-): boolean {
-  if (!targetStreamId) return true;
-  return streamStatusFromState(targetStreamId) !== STREAM_STATUS.WAITING;
+  return { kind: 'accept', streamId: scope.streamId };
 }
 
 interface SlashCommandContext {
@@ -1506,20 +1488,6 @@ export async function runChat(
     // user submits before `onStreamResolved` populates `session.streamId`.
     // p-queue serializes work but doesn't have an "await predicate" primitive,
     // so the task itself waits for the stream id via a tiny poll loop.
-    const initialFollowUpTarget = childFollowUpTarget ?? session.streamId;
-    const shouldAnnounceQueuedFollowUp =
-      focusedChildRoute.kind === 'accept'
-        ? focusedChildRoute.shouldAnnounceQueuedFollowUp
-        : shouldAnnounceQueuedFollowUpToStream(initialFollowUpTarget);
-    if (shouldAnnounceQueuedFollowUp) {
-      appendLocalAssistantTranscript(
-        `Queued follow-up: ${truncateSummary(
-          line,
-          QUEUED_FOLLOW_UP_NOTICE_LENGTH,
-        )}`,
-        initialFollowUpTarget,
-      );
-    }
     void followUpQueue.add(async () => {
       let delivered = false;
       let followUpTarget = childFollowUpTarget;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -92,6 +92,10 @@ export interface StreamSlice {
    *  stream. Kept separate from `usage` so the context-window indicator remains
    *  a latest-snapshot display. */
   readonly cumulativeUsage: TokenUsageStats | undefined;
+  /** True while the latest hidden provider-side reasoning/thinking stream is
+   *  the current live activity. The CLI never renders the content directly;
+   *  this only drives a lightweight liveness indicator. */
+  readonly thinkingActive: boolean;
   readonly conversation: ConversationProgress | undefined;
   readonly entries: readonly ConversationEntry[];
   readonly queuedFollowUps: number;
@@ -206,6 +210,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     status: undefined,
     runStartedAt: undefined,
     description: undefined,
+    thinkingActive: false,
     usage: undefined,
     cumulativeUsage: undefined,
     conversation: undefined,

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -29,10 +29,37 @@ const CHILD_STREAM_LOG_MESSAGE_TYPES = new Set<string>([
   MESSAGE_TYPES.DEFAULT,
 ]);
 
+const LIVE_ACTIVITY_MESSAGE_TYPES = new Set<string>([
+  MESSAGE_TYPES.THINKING,
+  MESSAGE_TYPES.MODEL_RESPONSE,
+  MESSAGE_TYPES.TOOL_USE,
+  MESSAGE_TYPES.ERROR,
+  MESSAGE_TYPES.USER_MESSAGE,
+]);
+
 function transcriptMessageTypesForStream(streamId: StreamTabId): Set<string> {
   return /^(bash@tool|claude@agent-sdk|codex@codex-sdk)#/.test(streamId)
     ? CHILD_STREAM_LOG_MESSAGE_TYPES
     : TRANSCRIPT_MESSAGE_TYPES;
+}
+
+function logEntryHasText(entry: StreamLogEntry): boolean {
+  return (entry.text ?? '').trim().length > 0;
+}
+
+function latestLogActivityIsThinking(
+  entries: readonly StreamLogEntry[],
+): boolean {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (!entry || !LIVE_ACTIVITY_MESSAGE_TYPES.has(entry.messageType ?? '')) {
+      continue;
+    }
+    return (
+      entry.messageType === MESSAGE_TYPES.THINKING && logEntryHasText(entry)
+    );
+  }
+  return false;
 }
 
 /** Tool inputs are typed `unknown` (model-supplied JSON) and reach us
@@ -283,12 +310,12 @@ export function syncStreamLog(streamId: StreamTabId): void {
   const log = store.get(streamId);
   if (!log) return;
 
+  const allEntries = log.getRange(0);
+  const thinkingActive = latestLogActivityIsThinking(allEntries);
   const transcriptMessageTypes = transcriptMessageTypesForStream(streamId);
-  const responses = log
-    .getRange(0)
-    .filter((entry: StreamLogEntry) =>
-      transcriptMessageTypes.has(entry.messageType ?? ''),
-    );
+  const responses = allEntries.filter((entry: StreamLogEntry) =>
+    transcriptMessageTypes.has(entry.messageType ?? ''),
+  );
 
   patchStream(streamId, (slice) => {
     const existing = new Map(slice.entries.map((e) => [e.id, e]));
@@ -349,8 +376,8 @@ export function syncStreamLog(streamId: StreamTabId): void {
           !entriesEqual(entry, candidate)
         );
       });
-    if (!changed) return slice;
-    return { ...slice, entries: next };
+    if (!changed && slice.thinkingActive === thinkingActive) return slice;
+    return { ...slice, entries: next, thinkingActive };
   });
 
   // Surface stream as active if we don't already have one — handles bare

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -84,6 +84,7 @@ function slice(
     status: undefined,
     runStartedAt: undefined,
     description: undefined,
+    thinkingActive: false,
     usage: undefined,
     cumulativeUsage: undefined,
     conversation: undefined,

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -347,6 +347,23 @@ describe('CLI conversation transcript splitting', () => {
     ).toBe('  ef  ');
   });
 
+  it('budgets the visual gap after finalized user turns', () => {
+    const user = entry('u1', 'user', 'why do you write as a latex?', true);
+
+    expect(estimateTranscriptEntryRows(user, 80)).toBe(2);
+  });
+
+  it('does not budget regular user margin for inquiry continuations', () => {
+    const continuation = entry(
+      'u1',
+      'user',
+      '[inquiry] ei_123 answered.\nQ: Can this be simplified?\nA: Yes.',
+      true,
+    );
+
+    expect(estimateTranscriptEntryRows(continuation, 80)).toBe(3);
+  });
+
   it('appends only finalized entries to terminal scrollback items', () => {
     const user = entry('u1', 'user', 'What is a tensor network?', true);
     const assistant = entry('a1', 'assistant', 'A decomposition.', false);
@@ -746,6 +763,7 @@ function sliceWithEntries(
     status: undefined,
     runStartedAt: undefined,
     description: undefined,
+    thinkingActive: false,
     usage: undefined,
     cumulativeUsage: undefined,
     conversation: undefined,

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -22,6 +22,7 @@ function makeSlice(
     status: undefined,
     runStartedAt: undefined,
     description: undefined,
+    thinkingActive: false,
     usage: undefined,
     cumulativeUsage: undefined,
     conversation: undefined,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -996,6 +996,18 @@ describe('CLI StatusBar display model', () => {
       PERSONAL_API_MODE_LABEL,
     ]);
 
+    const thinking = buildStatusBarDisplay({
+      ...runningInput,
+      thinkingActive: true,
+    });
+    expect(thinking.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'running',
+      '110s',
+      'thinking',
+      PERSONAL_API_MODE_LABEL,
+    ]);
+
     // The same elapsed reading is suppressed once the turn is no longer running.
     const idle = buildStatusBarDisplay({
       status: STREAM_STATUS.WAITING,
@@ -1014,6 +1026,7 @@ describe('CLI StatusBar display model', () => {
       model: 'deepseekT',
       apiMode: PERSONAL_API_MODE_LABEL,
       shortcutModifierLabel: 'Alt',
+      thinkingActive: true,
     });
 
     expect(idle.left.map(statusBarSegmentText)).toEqual([

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -48,6 +48,7 @@ function slice(
     status: undefined,
     runStartedAt: undefined,
     description: undefined,
+    thinkingActive: false,
     usage: undefined,
     cumulativeUsage: undefined,
     conversation: undefined,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1267,7 +1267,6 @@ describe('CLI TUI row allocation', () => {
     expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
       kind: 'accept',
       streamId: child1,
-      shouldAnnounceQueuedFollowUp: false,
     });
   });
 
@@ -1291,7 +1290,6 @@ describe('CLI TUI row allocation', () => {
     expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
       kind: 'accept',
       streamId: child1,
-      shouldAnnounceQueuedFollowUp: true,
     });
   });
 
@@ -1354,7 +1352,6 @@ describe('CLI TUI row allocation', () => {
       expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
         kind: 'accept',
         streamId: child1,
-        shouldAnnounceQueuedFollowUp: true,
       });
     } finally {
       dispose();
@@ -1550,6 +1547,37 @@ describe('CLI transcript state', () => {
         text: 'Model request failed',
         finalized: true,
       });
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('tracks hidden thinking activity without rendering thinking text', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
+      thinking.append('private reasoning summary');
+
+      syncStreamLog(root);
+
+      let slice = cliState.streams.get().get(root);
+      expect(slice?.thinkingActive).toBe(true);
+      expect(slice?.entries).toEqual([]);
+
+      const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+      output.append('Visible answer.');
+
+      syncStreamLog(root);
+
+      slice = cliState.streams.get().get(root);
+      expect(slice?.thinkingActive).toBe(false);
+      expect(slice?.entries.map((entry) => entry.text)).toEqual([
+        'Visible answer.',
+      ]);
     } finally {
       setDefaultStreamLogStore(previousStore);
     }


### PR DESCRIPTION
## Summary
- avoid rendering queued follow-up text twice in the CLI transcript
- keep inquiry continuation row budgeting aligned with the row that actually renders
- show a lightweight `thinking` status when hidden provider-side thinking is the current live activity, without rendering thinking text in the transcript

## Verification
- `vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/ResumeHint.vitest.mts`
- `tsc --noEmit -p tsconfig.test-kernel.json`
- `npm --prefix packages/cli run build`
- GitHub CI