### PR TITLE
fix: skip issue tracker without provider token

### DIFF
--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -52,12 +52,39 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Check tracker provider token
+        id: tracker-provider-token
+        shell: bash
+        env:
+          TRACKER_PROVIDER: ${{ env.CLAUDE_CODE_PROVIDER }}
+        run: |
+          set -euo pipefail
+
+          case "$TRACKER_PROVIDER" in
+            anthropic) provider_token="$CLAUDE_CODE_OAUTH_TOKEN" ;;
+            deepseek) provider_token="$DEEPSEEK_API_KEY" ;;
+            *)
+              echo "::error::Unsupported tracker provider: $TRACKER_PROVIDER"
+              exit 1
+              ;;
+          esac
+
+          if [[ -n "$provider_token" ]]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=$TRACKER_PROVIDER token is not configured" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping tracker agent: $TRACKER_PROVIDER token is not configured for this event."
+          fi
+
       - name: Checkout repository
+        if: steps.tracker-provider-token.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Gate tracker agent
+        if: steps.tracker-provider-token.outputs.skip != 'true'
         id: tracker-gate
         shell: bash
         env:
@@ -90,7 +117,7 @@ jobs:
           echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
 
       - name: Checkout trusted automation
-        if: steps.tracker-gate.outputs.should_run == 'true'
+        if: steps.tracker-provider-token.outputs.skip != 'true' && steps.tracker-gate.outputs.should_run == 'true'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
@@ -98,7 +125,7 @@ jobs:
           fetch-depth: 1
 
       - name: Check trusted provider wrapper
-        if: steps.tracker-gate.outputs.should_run == 'true'
+        if: steps.tracker-provider-token.outputs.skip != 'true' && steps.tracker-gate.outputs.should_run == 'true'
         id: trusted-provider-wrapper
         run: |
           # claude-code-with-provider is now external (LionSR/agent-ci-actions@v1), always available;
@@ -107,7 +134,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        if: steps.tracker-gate.outputs.should_run == 'true' && steps.trusted-provider-wrapper.outputs.available == 'true'
+        if: steps.tracker-provider-token.outputs.skip != 'true' && steps.tracker-gate.outputs.should_run == 'true' && steps.trusted-provider-wrapper.outputs.available == 'true'
         uses: LionSR/agent-ci-actions@v1
         with:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}


### PR DESCRIPTION
## Summary
- add an explicit provider-token gate to the Issue Tracker workflow
- skip tracker-agent steps when the selected provider token is unavailable on the event
- keep unsupported provider names as hard errors

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/issue-tracker.yml"); puts "yaml ok"'`
- `git diff --check`
- reran CI on #5627: `validate`, `validate (macos-latest)`, and `validate (ubuntu-latest)` now pass

## Notes
This fixes the remaining red `Issue Tracker / track` check seen on Dependabot PRs where the repo variable selects `deepseek` but `DEEPSEEK_API_KEY` is unavailable to the pull_request event.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow gating with no application, auth, or data-path changes; missing tokens become a skip rather than a hard failure.
> 
> **Overview**
> Adds an upfront **provider-token gate** to the Issue Tracker workflow so the job no longer fails when `CLAUDE_CODE_PROVIDER` is set (e.g. `deepseek`) but the matching secret is missing on events like Dependabot `pull_request`.
> 
> A new **Check tracker provider token** step maps `anthropic` → `CLAUDE_CODE_OAUTH_TOKEN` and `deepseek` → `DEEPSEEK_API_KEY`, sets `skip=true` with a workflow notice when empty, and still **fails** on unknown provider names. Checkout, the tracker diff gate, trusted automation checkout, and **Run Claude Code** now run only when `skip != 'true'`, so the track job can succeed without running the agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 516176c422f2d279f637b292a304af86deaf2199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->