### PR TITLE
fix: skip TeXRA review when PR closes

### DIFF
--- a/.github/workflows/texra-code-review.yml
+++ b/.github/workflows/texra-code-review.yml
@@ -33,8 +33,30 @@ jobs:
             echo "::notice::Skipping TeXRA review: no model provider key is configured."
           fi
 
-      - name: Checkout pull request
+      - name: Check pull request merge ref
         if: steps.keys.outputs.present == 'true'
+        id: merge-ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          ref="pull/${PR_NUMBER}/merge"
+          if ! matches="$(gh api "repos/${REPOSITORY}/git/matching-refs/${ref}" --jq 'length')"; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping TeXRA review: could not confirm that refs/${ref} is available."
+            exit 0
+          fi
+
+          if [ "$matches" != "0" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping TeXRA review: refs/${ref} is not available."
+          fi
+
+      - name: Checkout pull request
+        if: steps.keys.outputs.present == 'true' && steps.merge-ref.outputs.available == 'true'
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
@@ -42,7 +64,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout trusted review prompt
-        if: steps.keys.outputs.present == 'true'
+        if: steps.keys.outputs.present == 'true' && steps.merge-ref.outputs.available == 'true'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
@@ -52,7 +74,7 @@ jobs:
           persist-credentials: false
 
       - name: TeXRA review
-        if: steps.keys.outputs.present == 'true'
+        if: steps.keys.outputs.present == 'true' && steps.merge-ref.outputs.available == 'true'
         # texra-ai/texra-action v1.1.0; pin the reviewed release commit so
         # PR review behavior only changes through an explicit workflow update.
         # Keep the secret-bearing review job read-only: provider keys and the


### PR DESCRIPTION
## Summary
- add a runtime merge-ref preflight before TeXRA review checkout
- skip the review job cleanly when `refs/pull/<n>/merge` is unavailable, instead of letting checkout fail
- keep trusted prompt checkout and review execution behind the same single preflight output

## Root Cause
The failed `TeXRA Code Review` run for #5668 died before review execution:

```text
fatal: couldn't find remote ref refs/pull/5668/merge
```

That run started after provider keys were present, but the pull-request merge ref was no longer fetchable by checkout time.

## Validation
- `git diff --check`
- `corepack pnpm exec prettier --check .github/workflows/texra-code-review.yml`
- YAML parse with the repo `yaml` package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard around checkout; no application runtime or security logic changes.
> 
> **Overview**
> **Prevents TeXRA Code Review from failing** when `refs/pull/<n>/merge` is no longer on the remote (e.g. after a PR is closed or a stale workflow run).
> 
> A new **Check pull request merge ref** step uses `gh api` `matching-refs` for `pull/<PR>/merge`. If the ref is missing or the check fails, it sets `available=false`, logs a `::notice::`, and exits **0** so the job skips instead of erroring.
> 
> **Checkout pull request**, **Checkout trusted review prompt**, and **TeXRA review** now run only when provider keys are present **and** `merge-ref.available == 'true'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eefad44e182ef323ccc731cc0b887a16acc0722e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->