### PR TITLE
fix: preserve follow-up item origins

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -906,20 +906,13 @@ export class DesktopProgressBridge {
           await resumeToolUseFromSnapshot(resume.snapshot, this.runtimeHost, {
             setupSession: (session) => {
               for (const item of queuedFollowUps) {
-                session.appendFollowUp(
-                  item.text,
-                  item.mediaFiles,
-                  item.displayText,
-                );
+                session.appendFollowUp(item);
               }
             },
           });
         } catch (error) {
           for (const item of queuedFollowUps) {
-            ToolUseFollowUpQueue.enqueue(streamId, item.text, {
-              mediaFiles: item.mediaFiles,
-              displayText: item.displayText,
-            });
+            ToolUseFollowUpQueue.enqueue(streamId, item);
           }
           if (queuedFollowUps.length > 0) {
             this.runtimeHost.emit('updateQueuedFollowUps', { streamId });

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -6,7 +6,10 @@ import { z } from 'zod';
 import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import type { DrainedFollowUpItem } from '@agent/toolUse/FollowUpQueue';
+import type {
+  DrainedFollowUpItem,
+  FollowUpQueueInput,
+} from '@agent/toolUse/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
@@ -56,13 +59,13 @@ async function resumeFromSnapshot(
 
     await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
       setupSession: (session) => {
-        const allFollowUps =
+        const allFollowUps: readonly FollowUpQueueInput[] =
           followUp !== undefined
-            ? [{ text: followUp }, ...queuedFollowUps]
+            ? [{ text: followUp, origin: 'user' as const }, ...queuedFollowUps]
             : queuedFollowUps;
 
         for (const item of allFollowUps) {
-          session.appendFollowUp(item.text, item.mediaFiles, item.displayText);
+          session.appendFollowUp(item);
         }
       },
     });

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -31,6 +31,7 @@ export interface ToolUseCycleServices<
   C = unknown,
 > extends BaseFlowContextInit<C> {
   readonly client: C;
+  readonly fileService: TaskRunFileService;
   readonly toolRegistry: IToolRegistry;
   /** Session for injecting queued user messages after tool dispatch. */
   readonly session?: IToolUseSession;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -28,12 +28,14 @@ import {
   NormalizedUsageSchema,
   type NormalizedUsage,
 } from '@agent/types/NormalizedUsage';
+import { appendFollowUpAsUserMessage } from '@agent/toolUse/followUpMessages';
 
 // Internal imports - use core ToolTypes as single source of truth
 import {
   extractToolAttachments,
   type ExtractedToolAttachments,
 } from '@agent/modelHandlers/utils/toolAttachmentUtils';
+import type { FollowUpQueueBatchItem } from '@agent/toolUse/FollowUpQueue';
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import type {
   FileInteractionState,
@@ -206,8 +208,7 @@ export interface ToolUseCycleShared extends ToolUseCycleFields {
 /** Prep result for ToolUsePrepNode - drained queued follow-up plus interrupt flag. */
 interface ToolUsePrepResult {
   interrupted: boolean;
-  queuedFollowUp: string | null;
-  queuedFollowUpDisplay: string | null;
+  queuedFollowUps: readonly FollowUpQueueBatchItem[] | null;
   synthetic: boolean;
 }
 
@@ -229,8 +230,7 @@ class ToolUsePrepNode<C> extends BaseNode<
     if (!this.services.session?.hasQueuedFollowUp()) {
       return {
         interrupted,
-        queuedFollowUp: null,
-        queuedFollowUpDisplay: null,
+        queuedFollowUps: null,
         synthetic: false,
       };
     }
@@ -239,8 +239,7 @@ class ToolUsePrepNode<C> extends BaseNode<
     const batch = await this.services.session.waitForFollowUp(() => false);
     return {
       interrupted,
-      queuedFollowUp: batch?.items.join('\n\n') ?? null,
-      queuedFollowUpDisplay: batch?.displayItems.join('\n\n') ?? null,
+      queuedFollowUps: batch?.items ?? null,
       synthetic: batch?.synthetic ?? false,
     };
   }
@@ -258,18 +257,22 @@ class ToolUsePrepNode<C> extends BaseNode<
     // Inject queued follow-up BEFORE the model call
     // This ensures user's message typed during tool execution is seen
     // before the model starts thinking/responding
-    if (prepRes.queuedFollowUp) {
+    if (prepRes.queuedFollowUps?.length) {
       if (!prepRes.synthetic) {
-        logUserMessage(
-          this.services.logger,
-          prepRes.queuedFollowUpDisplay ?? prepRes.queuedFollowUp,
+        for (const followUp of prepRes.queuedFollowUps) {
+          logUserMessage(
+            this.services.logger,
+            followUp.displayText ?? followUp.text,
+          );
+        }
+      }
+      for (const followUp of prepRes.queuedFollowUps) {
+        shared.messages = await appendFollowUpAsUserMessage(
+          shared.messages,
+          followUp,
+          this.services,
         );
       }
-      shared.messages =
-        await this.services.modelHandler.createUserFollowUpMessages(
-          shared.messages,
-          prepRes.queuedFollowUp,
-        );
       if (!prepRes.synthetic) {
         this.services.onFollowUpConsumed?.();
       }

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -1,13 +1,12 @@
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import type { FollowUpQueueBatch } from '@agent/toolUse/FollowUpQueue';
+import type {
+  FollowUpQueueBatch,
+  FollowUpQueueInput,
+} from '@agent/toolUse/FollowUpQueue';
 import type { StreamTabId } from '@shared/schemas';
 
 export interface IToolUseSession {
-  appendFollowUp(
-    text: string,
-    mediaFiles?: readonly string[],
-    displayText?: string,
-  ): void;
+  appendFollowUp(followUp: FollowUpQueueInput): void;
   appendSyntheticFollowUp(text: string): void;
   hasQueuedFollowUp(): boolean;
   /** Wait for the next follow-up items. Returns null if interrupted. */
@@ -22,12 +21,8 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
 
   constructor(private readonly streamTabId: StreamTabId) {}
 
-  appendFollowUp(
-    text: string,
-    mediaFiles?: readonly string[],
-    displayText?: string,
-  ): void {
-    this.followUps.enqueue(text, mediaFiles, displayText);
+  appendFollowUp(followUp: FollowUpQueueInput): void {
+    this.followUps.enqueue(followUp);
   }
 
   appendSyntheticFollowUp(text: string): void {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -1,11 +1,7 @@
 import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import {
-  countMediaFilesNeedingVision,
-  formatMediaNeedsVisionWarning,
-  shouldWarnMediaNeedsVision,
-} from '@agent/runtime/mediaVisionWarning';
+import { appendFollowUpAsUserMessage } from '@agent/toolUse/followUpMessages';
 import { STREAM_STATUS } from '@shared/schemas';
 
 import { findLastAssistantText, extractTouchedFiles } from './types';
@@ -109,7 +105,9 @@ export class ToolUseWaitNode<C> extends Node<
           await continuation.commit();
           return {
             kind: 'continue',
-            followUp: continuation.followUp,
+            followUps: [
+              { text: continuation.followUp, origin: 'synthetic' as const },
+            ],
             synthetic: true,
           };
         }
@@ -129,10 +127,8 @@ export class ToolUseWaitNode<C> extends Node<
 
     return {
       kind: 'continue',
-      followUp: batch.items.join('\n\n'),
-      displayFollowUp: batch.displayItems.join('\n\n'),
+      followUps: batch.items,
       synthetic: batch.synthetic,
-      mediaFiles: batch.mediaFiles,
     };
   }
 
@@ -149,15 +145,8 @@ export class ToolUseWaitNode<C> extends Node<
     prepRes: WaitPrepResult,
     execRes: WaitExecResult,
   ): Promise<string | undefined> {
-    const {
-      onFollowUpConsumed,
-      streamId,
-      logger,
-      modelHandler,
-      runtimeHost,
-      streamStatus,
-      fileService,
-    } = this.services;
+    const { onFollowUpConsumed, streamId, logger, runtimeHost, streamStatus } =
+      this.services;
 
     if (execRes.kind === 'stop') {
       if (prepRes.deliveredToOrchestrator) {
@@ -183,32 +172,19 @@ export class ToolUseWaitNode<C> extends Node<
     if (!execRes.synthetic) {
       shared.deliveredToOrchestrator = undefined;
       onFollowUpConsumed?.();
-      logUserMessage(logger, execRes.displayFollowUp ?? execRes.followUp);
+      for (const followUp of execRes.followUps) {
+        logUserMessage(logger, followUp.displayText ?? followUp.text);
+      }
     }
     streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
       runtimeHost,
     });
-    shared.messages = await modelHandler.createUserFollowUpMessages(
-      shared.messages,
-      execRes.followUp,
-    );
 
-    // Attach any media (e.g. pasted images) the user sent with this follow-up
-    // to the freshly-appended user message, reusing the same shared media path
-    // as the reflection flow. No-ops when empty or the model lacks vision.
-    if (execRes.mediaFiles?.length) {
-      const visionMediaCount = countMediaFilesNeedingVision(execRes.mediaFiles);
-      if (
-        shouldWarnMediaNeedsVision(
-          execRes.mediaFiles,
-          modelHandler.capabilities,
-        )
-      ) {
-        logger.warn(formatMediaNeedsVisionWarning(visionMediaCount, 'pasted'));
-      }
-      await modelHandler.addMediaToUserMessage(
+    for (const followUp of execRes.followUps) {
+      shared.messages = await appendFollowUpAsUserMessage(
         shared.messages,
-        execRes.mediaFiles.map((p) => fileService.createLocation(p)),
+        followUp,
+        this.services,
       );
     }
 

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -7,6 +7,7 @@ import type {
 } from '@agent/core/execution/AgentWorkspaceState';
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { FollowUpQueueBatchItem } from '@agent/toolUse/FollowUpQueue';
 import type { RetryErrorInfo } from '@shared/schemas';
 
 export interface StateSlicesSnapshot {
@@ -49,22 +50,14 @@ export interface PrepareResult {
 export type WaitExecResult =
   | {
       kind: 'continue';
-      followUp: string;
-      /** User-facing text for logs when followUp contains injected context. */
-      displayFollowUp?: string;
+      followUps: readonly FollowUpQueueBatchItem[];
       /**
-       * True when `followUp` was synthesized by an idle-continuation provider
+       * True when `followUps` were synthesized by an idle-continuation provider
        * instead of being consumed from `session.waitForFollowUp()`. The
        * post() handler uses this to skip `onFollowUpConsumed` so synthetic
        * continuations don't emit a spurious updateQueuedFollowUps event.
        */
       synthetic?: boolean;
-      /**
-       * Media file paths attached to this follow-up (from the user queue).
-       * Converted to FileLocation[] and attached to the new user message via
-       * `addMediaToUserMessage` in post(). Empty for synthetic continuations.
-       */
-      mediaFiles?: string[];
     }
   | { kind: 'stop' };
 

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import type { AgentCategory } from '@shared/schemas/agent';
 import type { RunCoordinators } from './RunContext';
@@ -44,11 +45,7 @@ export interface ExecutionHandle {
 
 export interface LiveToolUseFlowContext {
   readonly session: {
-    appendFollowUp(
-      text: string,
-      mediaFiles?: readonly string[],
-      displayText?: string,
-    ): void;
+    appendFollowUp(followUp: FollowUpQueueInput): void;
   };
   readonly modelHandler: {
     readonly supportsManualCompaction: boolean;

--- a/src/agent/toolUse/FollowUpQueue.ts
+++ b/src/agent/toolUse/FollowUpQueue.ts
@@ -5,10 +5,24 @@
  * toolUse modules, allowing it to be imported without circular dependency issues.
  */
 
+/** Preserves visible follow-up provenance across queueing and resume replay. */
+export type VisibleFollowUpQueueItemOrigin = 'user' | 'subagent_result';
+export type FollowUpQueueItemOrigin =
+  | VisibleFollowUpQueueItemOrigin
+  | 'synthetic';
+
+export interface FollowUpQueueInput {
+  readonly text: string;
+  readonly displayText?: string;
+  /** Media file paths (e.g. pasted images) attached to this user follow-up. */
+  readonly mediaFiles?: readonly string[];
+  readonly origin?: VisibleFollowUpQueueItemOrigin;
+}
+
 interface FollowUpQueueItem {
   readonly text: string;
   readonly displayText?: string;
-  readonly synthetic: boolean;
+  readonly origin: FollowUpQueueItemOrigin;
   /** Media file paths (e.g. pasted images) attached to this user follow-up. */
   readonly mediaFiles?: readonly string[];
 }
@@ -17,40 +31,67 @@ function displayTextForItem(item: FollowUpQueueItem): string {
   return item.displayText ?? item.text;
 }
 
+function isVisibleItem(item: FollowUpQueueItem): item is FollowUpQueueItem & {
+  readonly origin: VisibleFollowUpQueueItemOrigin;
+} {
+  return item.origin !== 'synthetic';
+}
+
+export interface FollowUpQueueBatchItem {
+  readonly text: string;
+  readonly displayText?: string;
+  readonly mediaFiles?: readonly string[];
+  readonly origin: FollowUpQueueItemOrigin;
+}
+
 export interface FollowUpQueueBatch {
-  readonly items: string[];
-  readonly displayItems: string[];
+  readonly items: FollowUpQueueBatchItem[];
   readonly synthetic: boolean;
-  /** Media file paths from the user follow-ups in this batch, flattened. */
-  readonly mediaFiles: string[];
 }
 
 /** A single visible follow-up drained for resume replay. */
 export interface DrainedFollowUpItem {
-  text: string;
-  displayText?: string;
-  mediaFiles?: readonly string[];
+  readonly text: string;
+  readonly displayText?: string;
+  readonly mediaFiles?: readonly string[];
+  readonly origin: VisibleFollowUpQueueItemOrigin;
+}
+
+function batchItem(item: FollowUpQueueItem): FollowUpQueueBatchItem {
+  return {
+    text: item.text,
+    displayText: item.displayText,
+    mediaFiles: item.mediaFiles,
+    origin: item.origin,
+  };
+}
+
+function drainedVisibleItem(
+  item: FollowUpQueueItem & { readonly origin: VisibleFollowUpQueueItemOrigin },
+): DrainedFollowUpItem {
+  return {
+    text: item.text,
+    displayText: item.displayText,
+    mediaFiles: item.mediaFiles,
+    origin: item.origin,
+  };
 }
 
 export class FollowUpQueue {
   private readonly queued: FollowUpQueueItem[] = [];
   private resolver: ((value: FollowUpQueueItem | null) => void) | null = null;
 
-  enqueue(
-    value: string,
-    mediaFiles?: readonly string[],
-    displayText?: string,
-  ): void {
+  enqueue(value: FollowUpQueueInput): void {
     this.enqueueItem({
-      text: value,
-      displayText,
-      synthetic: false,
-      mediaFiles,
+      text: value.text,
+      displayText: value.displayText,
+      origin: value.origin ?? 'user',
+      mediaFiles: value.mediaFiles,
     });
   }
 
   enqueueSynthetic(value: string): void {
-    this.enqueueItem({ text: value, synthetic: true });
+    this.enqueueItem({ text: value, origin: 'synthetic' });
   }
 
   private enqueueItem(value: FollowUpQueueItem): void {
@@ -68,10 +109,7 @@ export class FollowUpQueue {
   }
 
   drain(): string[] {
-    return this.queued
-      .splice(0)
-      .filter((item) => !item.synthetic)
-      .map(displayTextForItem);
+    return this.queued.splice(0).filter(isVisibleItem).map(displayTextForItem);
   }
 
   /**
@@ -80,14 +118,7 @@ export class FollowUpQueue {
    * the text-only {@link drain} stays for display/back-compat.
    */
   drainItems(): DrainedFollowUpItem[] {
-    return this.queued
-      .splice(0)
-      .filter((item) => !item.synthetic)
-      .map((item) => ({
-        text: item.text,
-        displayText: item.displayText,
-        mediaFiles: item.mediaFiles,
-      }));
+    return this.queued.splice(0).filter(isVisibleItem).map(drainedVisibleItem);
   }
 
   waitForNext(
@@ -116,27 +147,21 @@ export class FollowUpQueue {
   ): Promise<FollowUpQueueBatch | null> {
     const first = await this.waitForNext(checkInterruption);
     if (first === null) return null;
-    if (first.synthetic) {
+    if (first.origin === 'synthetic') {
       return {
-        items: [first.text],
-        displayItems: [displayTextForItem(first)],
+        items: [batchItem(first)],
         synthetic: true,
-        mediaFiles: [],
       };
     }
 
-    const items = [first.text];
-    const displayItems = [displayTextForItem(first)];
-    const mediaFiles: string[] = [...(first.mediaFiles ?? [])];
+    const items = [batchItem(first)];
     while (true) {
       const next = this.queued[0];
-      if (!next || next.synthetic) break;
+      if (!next || next.origin === 'synthetic') break;
       const item = this.queued.shift()!;
-      items.push(item.text);
-      displayItems.push(displayTextForItem(item));
-      if (item.mediaFiles?.length) mediaFiles.push(...item.mediaFiles);
+      items.push(batchItem(item));
     }
-    return { items, displayItems, synthetic: false, mediaFiles };
+    return { items, synthetic: false };
   }
 
   cancelWait(): void {
@@ -152,8 +177,6 @@ export class FollowUpQueue {
 
   /** Get a copy of all queued items for display purposes. */
   getAll(): string[] {
-    return this.queued
-      .filter((item) => !item.synthetic)
-      .map(displayTextForItem);
+    return this.queued.filter(isVisibleItem).map(displayTextForItem);
   }
 }

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -75,9 +75,10 @@ export async function sendFollowUp(
   displayText?: string,
 ): Promise<SendFollowUpResult> {
   const target = executionRegistry.getToolUseFollowUpTarget(streamId);
+  const followUp = { text, mediaFiles, displayText };
 
   if (target.kind === 'active') {
-    target.context.session.appendFollowUp(text, mediaFiles, displayText);
+    target.context.session.appendFollowUp(followUp);
     notifyFollowUpSent(streamId, target.context.runtimeHost);
     return { status: 'sent' };
   }
@@ -86,11 +87,11 @@ export async function sendFollowUp(
     // children_running reopens a queue sealed by session disposal; callers
     // must auto-resume the parent or release again to avoid stale delivery.
     const force = target.reason === 'children_running';
-    ToolUseFollowUpQueue.enqueue(streamId, text, {
-      mediaFiles,
-      displayText,
-      ...(force ? { force: true } : {}),
-    });
+    ToolUseFollowUpQueue.enqueue(
+      streamId,
+      followUp,
+      force ? { force: true } : undefined,
+    );
     return { status: 'queued', reason: target.reason };
   }
 

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -7,7 +7,11 @@
 
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
-import { FollowUpQueue, type DrainedFollowUpItem } from './FollowUpQueue';
+import {
+  FollowUpQueue,
+  type DrainedFollowUpItem,
+  type FollowUpQueueInput,
+} from './FollowUpQueue';
 
 const logger = createChannelTrace('ToolUseFollowUpQueue');
 
@@ -81,12 +85,8 @@ export class ToolUseFollowUpQueue {
    */
   static enqueue(
     streamId: StreamTabId,
-    followUp: string,
-    options?: {
-      force?: boolean;
-      mediaFiles?: readonly string[];
-      displayText?: string;
-    },
+    followUp: FollowUpQueueInput,
+    options?: { force?: boolean },
   ): boolean {
     if (this.released.has(streamId) && !options?.force) {
       logger.debug(
@@ -95,7 +95,7 @@ export class ToolUseFollowUpQueue {
       return false;
     }
     const queue = this.acquire(streamId);
-    queue.enqueue(followUp, options?.mediaFiles, options?.displayText);
+    queue.enqueue(followUp);
     logger.debug(`Queued follow-up for stream ${streamId}.`);
     return true;
   }

--- a/src/agent/toolUse/followUpMessages.ts
+++ b/src/agent/toolUse/followUpMessages.ts
@@ -1,0 +1,53 @@
+import type { AgentTrace } from '@agent/trace';
+import type {
+  IModelHandler,
+  SdkToolCall,
+} from '@agent/modelHandlers/types/IModelHandler';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import {
+  countMediaFilesNeedingVision,
+  formatMediaNeedsVisionWarning,
+  shouldWarnMediaNeedsVision,
+} from '@agent/runtime/mediaVisionWarning';
+import type { TaskRunFileService } from '@utils/files';
+import type { FollowUpQueueBatchItem } from './FollowUpQueue';
+
+interface FollowUpMessageServices<C> {
+  readonly modelHandler: Pick<
+    IModelHandler<ProviderMessage, unknown, unknown, SdkToolCall, C>,
+    'addMediaToUserMessage' | 'capabilities' | 'createUserFollowUpMessages'
+  >;
+  readonly fileService: Pick<TaskRunFileService, 'createLocation'>;
+  readonly logger: Pick<AgentTrace, 'warn'>;
+}
+
+export async function appendFollowUpAsUserMessage<C>(
+  messages: ProviderMessage[],
+  followUp: FollowUpQueueBatchItem,
+  services: FollowUpMessageServices<C>,
+): Promise<ProviderMessage[]> {
+  const nextMessages = await services.modelHandler.createUserFollowUpMessages(
+    messages,
+    followUp.text,
+  );
+
+  if (!followUp.mediaFiles?.length) return nextMessages;
+
+  const visionMediaCount = countMediaFilesNeedingVision(followUp.mediaFiles);
+  if (
+    shouldWarnMediaNeedsVision(
+      followUp.mediaFiles,
+      services.modelHandler.capabilities,
+    )
+  ) {
+    services.logger.warn(
+      formatMediaNeedsVisionWarning(visionMediaCount, 'pasted'),
+    );
+  }
+
+  await services.modelHandler.addMediaToUserMessage(
+    nextMessages,
+    followUp.mediaFiles.map((p) => services.fileService.createLocation(p)),
+  );
+  return nextMessages;
+}

--- a/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
@@ -10,14 +10,15 @@ describe('FollowUpQueue', () => {
   it('batches visible follow-ups for normal user input', async () => {
     const queue = new FollowUpQueue();
 
-    queue.enqueue('first');
-    queue.enqueue('second');
+    queue.enqueue({ text: 'first' });
+    queue.enqueue({ text: 'second' });
 
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: ['first', 'second'],
-      displayItems: ['first', 'second'],
+      items: [
+        { text: 'first', origin: 'user' },
+        { text: 'second', origin: 'user' },
+      ],
       synthetic: false,
-      mediaFiles: [],
     });
   });
 
@@ -25,53 +26,85 @@ describe('FollowUpQueue', () => {
     const queue = new FollowUpQueue();
 
     queue.enqueueSynthetic('compact now');
-    queue.enqueue('user text');
+    queue.enqueue({ text: 'user text' });
 
     expect(queue.getAll()).toEqual(['user text']);
 
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: ['compact now'],
-      displayItems: ['compact now'],
+      items: [{ text: 'compact now', origin: 'synthetic' }],
       synthetic: true,
-      mediaFiles: [],
     });
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: ['user text'],
-      displayItems: ['user text'],
+      items: [{ text: 'user text', origin: 'user' }],
       synthetic: false,
-      mediaFiles: [],
     });
   });
 
-  it('carries media file paths and flattens them across a visible batch', async () => {
+  it('carries media file paths on their own visible batch items', async () => {
     const queue = new FollowUpQueue();
 
-    queue.enqueue('look at this', ['/tmp/pasted/a.png']);
-    queue.enqueue('and this', ['/tmp/pasted/b.png']);
+    queue.enqueue({
+      text: 'look at this',
+      mediaFiles: ['/tmp/pasted/a.png'],
+    });
+    queue.enqueue({ text: 'and this', mediaFiles: ['/tmp/pasted/b.png'] });
 
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: ['look at this', 'and this'],
-      displayItems: ['look at this', 'and this'],
+      items: [
+        {
+          text: 'look at this',
+          mediaFiles: ['/tmp/pasted/a.png'],
+          origin: 'user',
+        },
+        {
+          text: 'and this',
+          mediaFiles: ['/tmp/pasted/b.png'],
+          origin: 'user',
+        },
+      ],
       synthetic: false,
-      mediaFiles: ['/tmp/pasted/a.png', '/tmp/pasted/b.png'],
     });
   });
 
   it('keeps injected text separate from display text', async () => {
     const queue = new FollowUpQueue();
 
-    queue.enqueue(
-      '<skill_activation>hidden</skill_activation>',
-      undefined,
-      'fix theorem',
-    );
+    queue.enqueue({
+      text: '<skill_activation>hidden</skill_activation>',
+      displayText: 'fix theorem',
+    });
 
     expect(queue.getAll()).toEqual(['fix theorem']);
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: ['<skill_activation>hidden</skill_activation>'],
-      displayItems: ['fix theorem'],
+      items: [
+        {
+          text: '<skill_activation>hidden</skill_activation>',
+          displayText: 'fix theorem',
+          origin: 'user',
+        },
+      ],
       synthetic: false,
-      mediaFiles: [],
+    });
+  });
+
+  it('preserves subagent-result origin on queued delivery items', async () => {
+    const queue = new FollowUpQueue();
+
+    queue.enqueue({
+      text: '<subagent-result>done</subagent-result>',
+      origin: 'subagent_result',
+    });
+    queue.enqueue({ text: 'user correction' });
+
+    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
+      items: [
+        {
+          text: '<subagent-result>done</subagent-result>',
+          origin: 'subagent_result',
+        },
+        { text: 'user correction', origin: 'user' },
+      ],
+      synthetic: false,
     });
   });
 
@@ -85,10 +118,8 @@ describe('FollowUpQueue', () => {
       session.appendSyntheticFollowUp('compact again');
 
       await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
-        items: ['compact now'],
-        displayItems: ['compact now'],
+        items: [{ text: 'compact now', origin: 'synthetic' }],
         synthetic: true,
-        mediaFiles: [],
       });
       expect(session.hasQueuedFollowUp()).toBe(false);
     } finally {
@@ -107,10 +138,8 @@ describe('FollowUpQueue', () => {
       session.appendSyntheticFollowUp('compact after interrupt');
 
       await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
-        items: ['compact after interrupt'],
-        displayItems: ['compact after interrupt'],
+        items: [{ text: 'compact after interrupt', origin: 'synthetic' }],
         synthetic: true,
-        mediaFiles: [],
       });
     } finally {
       session.dispose();
@@ -123,13 +152,20 @@ describe('FollowUpQueue', () => {
     );
 
     try {
-      session.appendFollowUp('describe the figure', ['/tmp/pasted/fig.png']);
+      session.appendFollowUp({
+        text: 'describe the figure',
+        mediaFiles: ['/tmp/pasted/fig.png'],
+      });
 
       await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
-        items: ['describe the figure'],
-        displayItems: ['describe the figure'],
+        items: [
+          {
+            text: 'describe the figure',
+            mediaFiles: ['/tmp/pasted/fig.png'],
+            origin: 'user',
+          },
+        ],
         synthetic: false,
-        mediaFiles: ['/tmp/pasted/fig.png'],
       });
     } finally {
       session.dispose();

--- a/src/test-kernel/agent/toolUse/ToolUseCycleFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseCycleFollowUpMedia.vitest.ts
@@ -1,0 +1,95 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - agent core
+import { createRunTrace } from '@transcript';
+import { AgentRunStateSnapshotSchema } from '@agent/core/execution/AgentState';
+import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
+import type { ToolUseCycleServices } from '@agent/core/flows/CycleServices';
+import {
+  createToolUseCycleFlow,
+  type ToolUseCycleShared,
+} from '@agent/core/flows/ToolUseCycleFlow';
+import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
+
+describe('ToolUseCycleFlow queued follow-ups', () => {
+  it('attaches media from follow-ups queued at cycle start', async () => {
+    const createUserFollowUpMessages = vi.fn(
+      async (messages: ProviderMessage[], userMessage: string) =>
+        [
+          ...messages,
+          { role: 'user', content: userMessage },
+        ] as ProviderMessage[],
+    );
+    const addMediaToUserMessage = vi.fn(async () => {});
+
+    const services = {
+      checkInterruption: () => false,
+      client: {},
+      config: { agent: 'test-agent', model: 'test-model' },
+      executionId: 'test-exec',
+      fileService: {
+        createLocation: (filePath: string) => ({ absolutePath: filePath }),
+      },
+      logger: createRunTrace('ToolUseCycleFollowUpMedia').trace,
+      modelHandler: {
+        addMediaToUserMessage,
+        capabilities: { supportsVision: true },
+        createResponse: vi.fn(async () => ({ response: null })),
+        createUserFollowUpMessages,
+        setOutputStreaming: vi.fn(),
+      },
+      prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
+      run: AgentRunStateSnapshotSchema.parse({}),
+      runtimeHost: noopAgentRuntimeHost,
+      session: {
+        hasQueuedFollowUp: () => true,
+        waitForFollowUp: async () => ({
+          items: [
+            {
+              text: 'inspect the pasted figure',
+              mediaFiles: ['/tmp/figure.png'],
+              origin: 'user' as const,
+            },
+          ],
+          synthetic: false,
+        }),
+      },
+      setAbortController: () => {},
+      setting: { temperature: 0, tools: [] },
+      streamId: 'test-stream',
+      streamStatus: new StreamStatusRegistry(),
+      toolRegistry: new MapToolRegistry({}),
+      userVarChannels: { input: {}, transient: {} },
+      workspace: AgentWorkspaceState.create(),
+    } as unknown as ToolUseCycleServices;
+
+    const shared: ToolUseCycleShared = {
+      messages: [],
+      shouldStop: false,
+      endTurn: false,
+      response: undefined,
+      responseTimeMs: undefined,
+      stopReason: undefined,
+      lastError: undefined,
+      toolCalls: undefined,
+      text: undefined,
+      cycleIndex: 0,
+      cycleResponseTimeMs: 0,
+      cycleNormalizedUsage: undefined,
+    };
+
+    await createToolUseCycleFlow().setServices(services).run(shared);
+
+    expect(createUserFollowUpMessages).toHaveBeenCalledWith(
+      [],
+      'inspect the pasted figure',
+    );
+    expect(addMediaToUserMessage).toHaveBeenCalledWith(shared.messages, [
+      { absolutePath: '/tmp/figure.png' },
+    ]);
+  });
+});

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -73,11 +73,11 @@ describe('tool-use follow-up progress events', () => {
     const result = await sendFollowUp(streamId, 'please continue');
 
     expect(result).toEqual({ status: 'sent' });
-    expect(appendFollowUp).toHaveBeenCalledWith(
-      'please continue',
-      undefined,
-      undefined,
-    );
+    expect(appendFollowUp).toHaveBeenCalledWith({
+      text: 'please continue',
+      mediaFiles: undefined,
+      displayText: undefined,
+    });
     expect(events).toEqual([
       {
         event: 'followUpSent',

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -83,10 +83,8 @@ describe('ToolUseWaitNode', () => {
           waitCalls += 1;
           if (waitCalls === 1) {
             return {
-              items: ['synthetic continuation'],
-              displayItems: ['synthetic continuation'],
+              items: [{ text: 'synthetic continuation', origin: 'synthetic' }],
               synthetic: true,
-              mediaFiles: [],
             };
           }
           interrupted = true;
@@ -187,9 +185,14 @@ describe('ToolUseWaitNode', () => {
         touchedFiles: [],
       },
       {
-        followUp: 'please inspect this figure',
+        followUps: [
+          {
+            text: 'please inspect this figure',
+            mediaFiles: ['/tmp/figure.png'],
+            origin: 'user',
+          },
+        ],
         kind: 'continue',
-        mediaFiles: ['/tmp/figure.png'],
       },
     );
 
@@ -221,9 +224,7 @@ describe('ToolUseWaitNode', () => {
       session: {
         hasQueuedFollowUp: () => false,
         waitForFollowUp: async () => ({
-          displayItems: ['continue'],
-          items: ['continue'],
-          mediaFiles: [],
+          items: [{ text: 'continue', origin: 'synthetic' }],
           synthetic: true,
         }),
       },
@@ -251,5 +252,70 @@ describe('ToolUseWaitNode', () => {
       streamStatus.clear(streamId, { emit: false });
       StreamStatusService.clear(streamId, { emit: false });
     }
+  });
+
+  it('appends queued subagent results and user follow-ups as separate turns', async () => {
+    const shared: ToolUseRunShared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const createUserFollowUpMessages = vi.fn(
+      async (messages: unknown[], userMessage: string) => [
+        ...messages,
+        { role: 'user', content: userMessage },
+      ],
+    );
+    const info = vi.fn();
+    const services = {
+      checkInterruption: () => false,
+      idleContinuations: new IdleContinuationRegistry(),
+      logger: { error: vi.fn(), info },
+      modelHandler: {
+        capabilities: { supportsVision: true },
+        createUserFollowUpMessages,
+        extractAssistantText: () => undefined,
+      },
+      runtimeHost: { emit: vi.fn() },
+      session: {
+        hasQueuedFollowUp: () => true,
+        waitForFollowUp: async () => ({
+          items: [
+            {
+              text: '<subagent-result>done</subagent-result>',
+              origin: 'subagent_result',
+            },
+            {
+              text: 'please revise the theorem',
+              origin: 'user',
+            },
+          ],
+          synthetic: false,
+        }),
+      },
+      streamStatus: new StreamStatusRegistry(),
+      streamId: 'test-stream',
+    } as unknown as ToolUseServices;
+    const node = new ToolUseWaitNode().setServices(services);
+
+    const prep = await node.prep(shared);
+    const exec = await node.exec(prep);
+    const transition = await node.post(shared, prep, exec);
+
+    expect(transition).toBe(FlowTransition.CONTINUE);
+    expect(createUserFollowUpMessages).toHaveBeenNthCalledWith(
+      1,
+      [],
+      '<subagent-result>done</subagent-result>',
+    );
+    expect(createUserFollowUpMessages).toHaveBeenNthCalledWith(
+      2,
+      [{ role: 'user', content: '<subagent-result>done</subagent-result>' }],
+      'please revise the theorem',
+    );
+    expect(shared.messages).toEqual([
+      { role: 'user', content: '<subagent-result>done</subagent-result>' },
+      { role: 'user', content: 'please revise the theorem' },
+    ]);
   });
 });

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -136,7 +136,7 @@ describe('CLI session status formatter', () => {
     const queue = ToolUseFollowUpQueue.acquire(STREAM_ID);
     ToolUseFollowUpQueue.drain(STREAM_ID);
     try {
-      queue.enqueue('Fresh queue message');
+      queue.enqueue({ text: 'Fresh queue message' });
 
       expect(ToolUseFollowUpQueue.getAll(STREAM_ID)).toEqual([
         'Fresh queue message',

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2282,7 +2282,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     const queue = ToolUseFollowUpQueue.acquire(root);
 
     try {
-      queue.enqueue('Keep the proof under one page.');
+      queue.enqueue({ text: 'Keep the proof under one page.' });
       wrapped.emit('followUpSent', { streamId: root });
 
       let slice = cliState.streams.get().get(root);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1476,9 +1476,11 @@ describe('DesktopProgressBridge', () => {
         executionId: 'exec-1',
         taskState,
       });
-      ToolUseFollowUpQueue.enqueue('stream-1', 'queued follow-up', {
-        force: true,
-      });
+      ToolUseFollowUpQueue.enqueue(
+        'stream-1',
+        { text: 'queued follow-up' },
+        { force: true },
+      );
 
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(true);
       expect(retrieveSessionResumeData).toHaveBeenCalledWith(
@@ -1500,21 +1502,21 @@ describe('DesktopProgressBridge', () => {
         unknown,
         {
           setupSession(session: {
-            appendFollowUp(
-              text: string,
-              mediaFiles?: readonly string[],
-              displayText?: string,
-            ): void;
+            appendFollowUp(followUp: {
+              text: string;
+              mediaFiles?: readonly string[];
+              displayText?: string;
+              origin?: 'user' | 'subagent_result';
+            }): void;
           }): void;
         },
       ];
       const appendFollowUp = vi.fn();
       resumeOptions.setupSession({ appendFollowUp });
-      expect(appendFollowUp).toHaveBeenCalledWith(
-        'queued follow-up',
-        undefined,
-        undefined,
-      );
+      expect(appendFollowUp).toHaveBeenCalledWith({
+        text: 'queued follow-up',
+        origin: 'user',
+      });
     } finally {
       ToolUseFollowUpQueue.release('stream-1');
       StreamStatusService.clear('stream-1', { emit: false });
@@ -1559,9 +1561,11 @@ describe('DesktopProgressBridge', () => {
           },
         },
       });
-      ToolUseFollowUpQueue.enqueue('stream-1', 'queued follow-up', {
-        force: true,
-      });
+      ToolUseFollowUpQueue.enqueue(
+        'stream-1',
+        { text: 'queued follow-up' },
+        { force: true },
+      );
 
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
       expect(ToolUseFollowUpQueue.getAll('stream-1')).toEqual([

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -76,8 +76,8 @@ describe('ToolUseFollowUp', () => {
 
   it('sends follow-ups to active flow contexts', async () => {
     const calls: string[] = [];
-    trackToolUseFlow(streamId, (text: string) => {
-      calls.push(text);
+    trackToolUseFlow(streamId, (followUp) => {
+      calls.push(followUp.text);
     });
 
     const result = await sendFollowUp(streamId, 'hello');

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -34,6 +34,7 @@ import type { ExecResult } from '@agent/types/ResultTypes';
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { StreamTabId } from '@shared/schemas';
 import { BashTool } from '@tools/bash';
+import { TaskRunFileService } from '@utils/files';
 import * as execUtils from '@utils/system/execUtils';
 
 // Type imports
@@ -172,6 +173,7 @@ describe('BashTool', () => {
       runtimeHost: noopAgentRuntimeHost,
       streamStatus: new StreamStatusRegistry(),
       client: {} as OpenAI,
+      fileService: new TaskRunFileService('test-execution-id'),
       toolRegistry: new MapToolRegistry({ bash: bashTool }),
       checkInterruption: () => false,
       setAbortController: () => {},

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -460,7 +460,10 @@ async function executeSubagent(
   function onProgress(update: SubagentProgressUpdate): void {
     if (deliveryState.isDelivered()) return;
     const msg = formatSubagentProgress(executionId, agentName, update);
-    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, {
+      text: msg,
+      origin: 'subagent_result',
+    });
   }
 
   function deliverSubagentError(err: unknown): void {
@@ -471,7 +474,10 @@ async function executeSubagent(
       workingDirectory: configPayload.workingDirectory ?? undefined,
     });
     void getExecutionStore(executionId).writeReport(msg);
-    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, {
+      text: msg,
+      origin: 'subagent_result',
+    });
   }
 
   const promise = executeAgent(configPayload, executionId, {
@@ -531,7 +537,10 @@ async function executeSubagent(
       // Mark delivered and enqueue only after the write attempt so that
       // onCompleted can still act as a fallback if we somehow never reach here.
       if (!deliveryState.markDelivered()) return true;
-      ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+      ToolUseFollowUpQueue.enqueue(orchestratorStreamId, {
+        text: msg,
+        origin: 'subagent_result',
+      });
       return true;
     },
     onCompleted: async (result) => {
@@ -559,7 +568,10 @@ async function executeSubagent(
         workingDirectory: configPayload.workingDirectory ?? undefined,
       });
       void getExecutionStore(executionId).writeReport(msg);
-      ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+      ToolUseFollowUpQueue.enqueue(orchestratorStreamId, {
+        text: msg,
+        origin: 'subagent_result',
+      });
     },
     onError: (err) => {
       deliverSubagentError(err);

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -313,7 +313,10 @@ export class BashTool extends defineTool({
           stderrTail,
         );
         await store.writeReport(msg);
-        ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
+        ToolUseFollowUpQueue.enqueue(parentStreamId, {
+          text: msg,
+          origin: 'subagent_result',
+        });
       })
       .catch(async (err: unknown) => {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
@@ -325,7 +328,10 @@ export class BashTool extends defineTool({
 
         const msg = formatBashError(executionId, command, err);
         await getExecutionStore(executionId).writeReport(msg);
-        ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
+        ToolUseFollowUpQueue.enqueue(parentStreamId, {
+          text: msg,
+          origin: 'subagent_result',
+        });
       });
 
     return {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -491,7 +491,7 @@ function startClaudeAgentLoop(params: {
   // empty here, so this opens as a root with no cross-trace parent.
   const sessionStage = logger.openStage('Claude Code session');
 
-  queue.enqueue(initialPrompt);
+  queue.enqueue({ text: initialPrompt });
   childStream.waitForInput();
 
   let resumeSessionId: string | undefined;
@@ -506,7 +506,7 @@ function startClaudeAgentLoop(params: {
         );
         if (!messages || session.isInterrupted()) break;
 
-        const prompt = messages.items.join('\n\n');
+        const prompt = messages.items.map((item) => item.text).join('\n\n');
         childStream.beginTurn();
         const startedAt = Date.now();
         const ac = session.startTurn();
@@ -583,7 +583,10 @@ function startClaudeAgentLoop(params: {
         } catch {
           // Best-effort; delivery must not block on storage.
         }
-        ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
+        ToolUseFollowUpQueue.enqueue(parentStreamId, {
+          text: msg,
+          origin: 'subagent_result',
+        });
 
         if (turnFailed) {
           sawTurnFailure = true;
@@ -764,7 +767,7 @@ function resumeClaudeAgentSession(
   }
 
   const queue = ToolUseFollowUpQueue.acquire(stored.childStreamId);
-  queue.enqueue(prompt);
+  queue.enqueue({ text: prompt });
 
   const preview = truncateWithEllipsis(prompt, 60);
   return {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -509,7 +509,7 @@ function startCodexLoop(params: {
   }
 
   // Seed the initial prompt; the loop drains it as the first turn.
-  queue.enqueue(initialPrompt);
+  queue.enqueue({ text: initialPrompt });
   childStream.waitForInput();
 
   let sawTurnFailure = false;
@@ -521,7 +521,7 @@ function startCodexLoop(params: {
         );
         if (!messages || session.isInterrupted()) break;
 
-        const prompt = messages.items.join('\n\n');
+        const prompt = messages.items.map((item) => item.text).join('\n\n');
         childStream.beginTurn();
         const startedAt = Date.now();
         const signal = session.startTurn();
@@ -582,7 +582,10 @@ function startCodexLoop(params: {
         } catch {
           // Best-effort; delivery must not block on storage.
         }
-        ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
+        ToolUseFollowUpQueue.enqueue(parentStreamId, {
+          text: msg,
+          origin: 'subagent_result',
+        });
 
         if (turnFailed) {
           sawTurnFailure = true;
@@ -785,7 +788,7 @@ function resumeCodexThread(
   }
 
   const queue = ToolUseFollowUpQueue.acquire(stored.childStreamId);
-  queue.enqueue(prompt);
+  queue.enqueue({ text: prompt });
 
   const preview = truncateWithEllipsis(prompt, 60);
   return {


### PR DESCRIPTION
## Summary
- add a follow-up item origin discriminant so user text, subagent results, and synthetic continuations are not collapsed into one turn
- replay queued follow-ups through a single shared item contract instead of positional pass-throughs
- tag async subagent/tool deliveries as subagent-result items and add coverage for separated turns

Closes #5666.

## Tests
- corepack pnpm vitest run src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts src/test/agent/toolUse/ToolUseFollowUp.test.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- npm run typecheck
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how queued follow-ups are turned into model messages (ordering and turn boundaries), which can alter orchestrator behavior; scope is broad but covered by targeted tests.
> 
> **Overview**
> Refactors tool-use **follow-ups** from loose `(text, mediaFiles, displayText)` arguments to a shared **`FollowUpQueueInput` / batch item** shape with an **`origin`** (`user`, `subagent_result`, `synthetic`) so provenance survives queueing, resume replay, and delivery.
> 
> **Behavior fix:** queued items are no longer merged into one string (`join('\n\n')`). **`ToolUseWaitNode`** and **`ToolUseCycleFlow`** now append **each** drained item as its own user turn via **`appendFollowUpAsUserMessage`** (text + per-item media and vision warnings). Async **bash**, **delegate**, **Codex**, and **Claude** parent deliveries are enqueued as **`subagent_result`** instead of looking like ordinary user text.
> 
> Resume/setup paths (desktop, extension) pass whole queue items through **`session.appendFollowUp`** / **`ToolUseFollowUpQueue.enqueue`**; tests cover separate subagent-result vs user turns and cycle-start media attachment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a27aaee30287098cd8818c660ad77b9a4167c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->