### PR TITLE
fix: deliver subagent terminal follow-ups

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -246,8 +246,7 @@ export async function runToolUseFlow<C = unknown>(
     },
     interrupt(): void {
       onInterrupt?.();
-      runCoordinatorBridge.clearRetryRequest(streamId);
-      runCoordinatorBridge.clearPlanApprovalForStream(streamId);
+      runCoordinatorBridge.cleanupRequestsForStream(streamId);
       sessionLifecycle.interrupt();
     },
     requestImmediateCompaction(): void {
@@ -363,7 +362,7 @@ export async function runToolUseFlow<C = unknown>(
     }
 
     sessionLifecycle.dispose();
-    runCoordinatorBridge.clearPlanApprovalForStream(streamId);
+    runCoordinatorBridge.cleanupRequestsForStream(streamId);
     interruptRegistry.unregister(streamId);
     for (const handler of switchedHandlers) {
       handler.dispose();

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -93,7 +93,6 @@ export async function runFlowWithLifecycle(
     const streamStatus =
       kind === 'abort' ? STREAM_STATUS.STOPPED : STREAM_STATUS.ERROR;
     await writeTerminalStatus(ctx.executionId, terminalStatus).catch(() => {});
-    executionRegistry.untrack(ctx.executionId);
     const sdkMsg = getSdkErrorMessage(err);
     const errorMsg = `Error executing agent ${agentName}: ${sdkMsg}`;
 
@@ -151,9 +150,11 @@ export async function runFlowWithLifecycle(
           `Failed to deliver subagent error for ${agentName}: ${getSdkErrorMessage(deliveryError)}`,
         );
       }
+      executionRegistry.untrack(ctx.executionId);
       return result;
     }
 
+    executionRegistry.untrack(ctx.executionId);
     if (kind === 'abort') {
       return buildTerminalFlowResult(
         category,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -137,19 +137,10 @@ export async function runFlowWithLifecycle(
       }
     }
 
-    if (kind === 'abort') {
-      return buildTerminalFlowResult(
-        category,
-        END_GROUP_STATUS.STOPPED,
-        ctx.executionId,
-        streamId,
-      );
-    }
-
     if (options?.isSubagent) {
       const result = buildTerminalFlowResult(
         category,
-        END_GROUP_STATUS.ERROR,
+        status,
         ctx.executionId,
         streamId,
       );
@@ -161,6 +152,15 @@ export async function runFlowWithLifecycle(
         );
       }
       return result;
+    }
+
+    if (kind === 'abort') {
+      return buildTerminalFlowResult(
+        category,
+        END_GROUP_STATUS.STOPPED,
+        ctx.executionId,
+        streamId,
+      );
     }
 
     throw new AgentError(errorMsg, { cause: err });

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -69,6 +69,16 @@ export function notifyFollowUpSent(
  *
  * Items queued for WAITING sessions are picked up when user resumes.
  */
+export function sendFollowUp(
+  streamId: StreamTabId,
+  followUp: FollowUpQueueInput,
+): Promise<SendFollowUpResult>;
+export function sendFollowUp(
+  streamId: StreamTabId,
+  followUp: string,
+  mediaFiles?: readonly string[],
+  displayText?: string,
+): Promise<SendFollowUpResult>;
 export async function sendFollowUp(
   streamId: StreamTabId,
   followUp: string | FollowUpQueueInput,

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -18,6 +18,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
+import type { FollowUpQueueInput } from './FollowUpQueue';
 
 /**
  * Result of sending a follow-up message to a tool-use session.
@@ -70,15 +71,18 @@ export function notifyFollowUpSent(
  */
 export async function sendFollowUp(
   streamId: StreamTabId,
-  text: string,
+  followUp: string | FollowUpQueueInput,
   mediaFiles?: readonly string[],
   displayText?: string,
 ): Promise<SendFollowUpResult> {
   const target = executionRegistry.getToolUseFollowUpTarget(streamId);
-  const followUp = { text, mediaFiles, displayText };
+  const item =
+    typeof followUp === 'string'
+      ? { text: followUp, mediaFiles, displayText }
+      : followUp;
 
   if (target.kind === 'active') {
-    target.context.session.appendFollowUp(followUp);
+    target.context.session.appendFollowUp(item);
     notifyFollowUpSent(streamId, target.context.runtimeHost);
     return { status: 'sent' };
   }
@@ -89,7 +93,7 @@ export async function sendFollowUp(
     const force = target.reason === 'children_running';
     ToolUseFollowUpQueue.enqueue(
       streamId,
-      followUp,
+      item,
       force ? { force: true } : undefined,
     );
     return { status: 'queued', reason: target.reason };

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -184,7 +184,8 @@ describe('runFlowWithLifecycle', () => {
   it('keeps subagent errors registered until terminal delivery runs', async () => {
     const executionId =
       'execution-lifecycle-subagent-error-registered' as ExecutionId;
-    const streamId = 'stream-lifecycle-subagent-error-registered' as StreamTabId;
+    const streamId =
+      'stream-lifecycle-subagent-error-registered' as StreamTabId;
     const streamStatus = new StreamStatusRegistry();
     const ctx = createLifecycleContext({
       executionId,

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -148,4 +148,35 @@ describe('runFlowWithLifecycle', () => {
       StreamStatusService.clear(streamId, { emit: false });
     }
   });
+
+  it('delivers subagent aborts through the terminal callback', async () => {
+    const executionId = 'execution-lifecycle-subagent-abort' as ExecutionId;
+    const streamId = 'stream-lifecycle-subagent-abort' as StreamTabId;
+    const streamStatus = new StreamStatusRegistry();
+    const ctx = createLifecycleContext({
+      executionId,
+      streamId,
+      streamStatus,
+    });
+    const onError = vi.fn();
+
+    try {
+      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async () => {
+          throw new DOMException('Request aborted', 'AbortError');
+        },
+        { isSubagent: true, onError },
+      );
+
+      expect(result.status).toBe(END_GROUP_STATUS.STOPPED);
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onError.mock.calls[0][1]).toEqual(result);
+    } finally {
+      streamStatus.clear(streamId, { emit: false });
+    }
+  });
 });

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -15,6 +15,7 @@ import {
   StreamStatusRegistry,
   StreamStatusService,
 } from '@agent/runtime/StreamStatusService';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
 import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { RetryRequestCoordinatorImpl } from '@agent/runtime/RetryRequestCoordinator';
@@ -176,6 +177,41 @@ describe('runFlowWithLifecycle', () => {
       expect(onError).toHaveBeenCalledOnce();
       expect(onError.mock.calls[0][1]).toEqual(result);
     } finally {
+      streamStatus.clear(streamId, { emit: false });
+    }
+  });
+
+  it('keeps subagent errors registered until terminal delivery runs', async () => {
+    const executionId =
+      'execution-lifecycle-subagent-error-registered' as ExecutionId;
+    const streamId = 'stream-lifecycle-subagent-error-registered' as StreamTabId;
+    const streamStatus = new StreamStatusRegistry();
+    const ctx = createLifecycleContext({
+      executionId,
+      streamId,
+      streamStatus,
+    });
+    const onError = vi.fn(() => {
+      expect(executionRegistry.getHandle(executionId)).toBeDefined();
+    });
+
+    try {
+      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async () => {
+          throw new Error('subagent failed');
+        },
+        { isSubagent: true, onError },
+      );
+
+      expect(result.status).toBe(END_GROUP_STATUS.ERROR);
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.ERROR);
+      expect(onError).toHaveBeenCalledOnce();
+      expect(executionRegistry.getHandle(executionId)).toBeUndefined();
+    } finally {
+      executionRegistry.untrack(executionId);
       streamStatus.clear(streamId, { emit: false });
     }
   });

--- a/src/test-kernel/tools/SubagentDeliveryState.vitest.ts
+++ b/src/test-kernel/tools/SubagentDeliveryState.vitest.ts
@@ -19,6 +19,24 @@ describe('subagent delivery state', () => {
     );
   });
 
+  it('does not mark a failed delivery as delivered', () => {
+    const state = new SubagentDeliveryState();
+
+    expect(state.beginDelivery()).toBe(true);
+    expect(state.beginDelivery()).toBe(false);
+    expect(state.resolveBeforeWaiting('child-stream')).toBe(
+      SUBAGENT_DELIVERY_DECISION.AlreadyDelivered,
+    );
+
+    state.failDelivery();
+
+    expect(state.resolveBeforeWaiting('child-stream')).toBe(
+      SUBAGENT_DELIVERY_DECISION.Deliver,
+    );
+    expect(state.markDelivered()).toBe(true);
+    expect(state.markDelivered()).toBe(false);
+  });
+
   it('distinguishes missing child streams from deliverable cycles', () => {
     const state = new SubagentDeliveryState();
 

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@agent/runtime/executionRegistry';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -87,6 +88,23 @@ describe('ToolUseFollowUp', () => {
     assert.deepEqual(result, { status: 'sent' });
   });
 
+  it('preserves explicit follow-up item origin for active flow contexts', async () => {
+    const calls: FollowUpQueueInput[] = [];
+    trackToolUseFlow(streamId, (followUp) => {
+      calls.push(followUp);
+    });
+
+    const result = await sendFollowUp(streamId, {
+      text: 'subagent result',
+      origin: 'subagent_result',
+    });
+
+    assert.deepEqual(result, { status: 'sent' });
+    assert.deepEqual(calls, [
+      { text: 'subagent result', origin: 'subagent_result' },
+    ]);
+  });
+
   it('queues follow-ups when children are still running', async () => {
     const parentStreamId = 'parent-stream-children' as StreamTabId;
     const childStreamId = 'child-stream-children' as StreamTabId;
@@ -145,6 +163,44 @@ describe('ToolUseFollowUp', () => {
       });
       assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
         'after release',
+      ]);
+    } finally {
+      executionRegistry.untrack(executionId);
+      ToolUseFollowUpQueue.release(parentStreamId);
+    }
+  });
+
+  it('queues subagent result follow-ups through the released parent queue', async () => {
+    const parentStreamId = 'parent-stream-subagent-result' as StreamTabId;
+    const childStreamId = 'child-stream-subagent-result' as StreamTabId;
+    const executionId = 'exec-subagent-result';
+
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+      noopAgentRuntimeHost,
+    );
+    executionRegistry.track(handle);
+    ToolUseFollowUpQueue.release(parentStreamId);
+
+    try {
+      const result = await sendFollowUp(parentStreamId, {
+        text: 'child done',
+        origin: 'subagent_result',
+      });
+
+      assert.deepEqual(result, {
+        status: 'queued',
+        reason: 'children_running',
+      });
+      assert.deepEqual(ToolUseFollowUpQueue.drainItems(parentStreamId), [
+        {
+          text: 'child done',
+          origin: 'subagent_result',
+        },
       ]);
     } finally {
       executionRegistry.untrack(executionId);

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -31,7 +31,7 @@ import {
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
 
 // Local imports - logger
 import { toErrorMessage } from '@common/errors';
@@ -457,24 +457,43 @@ async function executeSubagent(
   const deliveryState = subagentDeliveryRegistry.start(executionId);
   let childStreamId: StreamTabId | undefined;
 
+  async function deliverFollowUp(followUp: FollowUpQueueInput): Promise<boolean> {
+    const result = await sendFollowUp(orchestratorStreamId, followUp);
+    if (result.status !== 'no_session') return true;
+    logger.warn(
+      'subagentDelivery',
+      `Unable to deliver subagent result for ${executionId}: parent stream ${orchestratorStreamId} has no active session (status: ${result.streamStatus ?? 'unknown'}).`,
+    );
+    return false;
+  }
+
+  async function deliverTerminalFollowUp(
+    followUp: FollowUpQueueInput,
+  ): Promise<boolean> {
+    if (!deliveryState.beginDelivery()) return false;
+    const delivered = await deliverFollowUp(followUp);
+    if (delivered) {
+      deliveryState.completeDelivery();
+    } else {
+      deliveryState.failDelivery();
+    }
+    return delivered;
+  }
+
   function onProgress(update: SubagentProgressUpdate): void {
     if (deliveryState.isDelivered()) return;
     const msg = formatSubagentProgress(executionId, agentName, update);
-    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, {
-      text: msg,
-      origin: 'subagent_result',
-    });
+    void deliverFollowUp({ text: msg, origin: 'subagent_result' });
   }
 
-  function deliverSubagentError(err: unknown): void {
-    if (!deliveryState.markDelivered()) return;
+  async function deliverSubagentError(err: unknown): Promise<void> {
     const wallTimeMs = Date.now() - startedAt;
     const msg = formatSubagentError(executionId, agentName, err, {
       wallTimeMs,
       workingDirectory: configPayload.workingDirectory ?? undefined,
     });
     void getExecutionStore(executionId).writeReport(msg);
-    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, {
+    await deliverTerminalFollowUp({
       text: msg,
       origin: 'subagent_result',
     });
@@ -534,18 +553,15 @@ async function executeSubagent(
       } catch {
         /* storage failure is non-fatal */
       }
-      // Mark delivered and enqueue only after the write attempt so that
-      // onCompleted can still act as a fallback if we somehow never reach here.
-      if (!deliveryState.markDelivered()) return true;
-      ToolUseFollowUpQueue.enqueue(orchestratorStreamId, {
+      // Claim only the enqueue step: formatting/storage failures before this
+      // still leave onCompleted/onError available as terminal fallbacks.
+      await deliverTerminalFollowUp({
         text: msg,
         origin: 'subagent_result',
       });
       return true;
     },
     onCompleted: async (result) => {
-      if (!deliveryState.markDelivered()) return;
-
       // For workflow results, compute diffs and write them as files to the
       // execution's run directory. The delivery references diff file paths
       // so the orchestrator can read them on demand via /executions/{id}/files/.
@@ -568,18 +584,16 @@ async function executeSubagent(
         workingDirectory: configPayload.workingDirectory ?? undefined,
       });
       void getExecutionStore(executionId).writeReport(msg);
-      ToolUseFollowUpQueue.enqueue(orchestratorStreamId, {
+      await deliverTerminalFollowUp({
         text: msg,
         origin: 'subagent_result',
       });
     },
-    onError: (err) => {
-      deliverSubagentError(err);
-    },
+    onError: (err) => deliverSubagentError(err),
   });
   promise
     .catch((err: unknown) => {
-      deliverSubagentError(err);
+      void deliverSubagentError(err);
     })
     .finally(() => {
       subagentDeliveryRegistry.finish(executionId);

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -473,13 +473,18 @@ async function executeSubagent(
     followUp: FollowUpQueueInput,
   ): Promise<boolean> {
     if (!deliveryState.beginDelivery()) return false;
-    const delivered = await deliverFollowUp(followUp);
-    if (delivered) {
-      deliveryState.completeDelivery();
-    } else {
+    try {
+      const delivered = await deliverFollowUp(followUp);
+      if (delivered) {
+        deliveryState.completeDelivery();
+      } else {
+        deliveryState.failDelivery();
+      }
+      return delivered;
+    } catch (err) {
       deliveryState.failDelivery();
+      throw err;
     }
-    return delivered;
   }
 
   function onProgress(update: SubagentProgressUpdate): void {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -457,7 +457,9 @@ async function executeSubagent(
   const deliveryState = subagentDeliveryRegistry.start(executionId);
   let childStreamId: StreamTabId | undefined;
 
-  async function deliverFollowUp(followUp: FollowUpQueueInput): Promise<boolean> {
+  async function deliverFollowUp(
+    followUp: FollowUpQueueInput,
+  ): Promise<boolean> {
     const result = await sendFollowUp(orchestratorStreamId, followUp);
     if (result.status !== 'no_session') return true;
     logger.warn(

--- a/src/tools/subagentDeliveryState.ts
+++ b/src/tools/subagentDeliveryState.ts
@@ -11,6 +11,7 @@ import type { StreamTabId } from '@shared/schemas';
  */
 export class SubagentDeliveryState {
   private hasDelivered = false;
+  private deliveryInFlight = false;
 
   isDelivered(): boolean {
     return this.hasDelivered;
@@ -18,18 +19,34 @@ export class SubagentDeliveryState {
 
   markPending(): void {
     this.hasDelivered = false;
+    this.deliveryInFlight = false;
   }
 
   markDelivered(): boolean {
-    if (this.hasDelivered) return false;
-    this.hasDelivered = true;
+    if (!this.beginDelivery()) return false;
+    this.completeDelivery();
     return true;
+  }
+
+  beginDelivery(): boolean {
+    if (this.hasDelivered || this.deliveryInFlight) return false;
+    this.deliveryInFlight = true;
+    return true;
+  }
+
+  completeDelivery(): void {
+    this.hasDelivered = true;
+    this.deliveryInFlight = false;
+  }
+
+  failDelivery(): void {
+    this.deliveryInFlight = false;
   }
 
   resolveBeforeWaiting(
     childStreamId: StreamTabId | undefined,
   ): SubagentDeliveryDecision {
-    if (this.hasDelivered) {
+    if (this.hasDelivered || this.deliveryInFlight) {
       return SUBAGENT_DELIVERY_DECISION.AlreadyDelivered;
     }
     if (!childStreamId) {


### PR DESCRIPTION
## Summary

- route subagent progress/results through the shared `sendFollowUp` contract so released parent queues are reopened consistently for running children
- split subagent delivery claiming into in-flight vs completed states so a formatting/enqueue failure does not permanently suppress fallback delivery
- deliver subagent aborts through the lifecycle terminal callback and clear proposal/retry/plan coordinators through one cleanup path on tool-use interruption

## Root Cause

Subagent auto-delivery bypassed the same follow-up admission path used by explicit user follow-ups. It also marked a result as delivered before the terminal follow-up had actually been enqueued, so failures in formatting or delivery could block the error fallback. Separately, the abort arm in `runFlowWithLifecycle` returned a terminal result before invoking the subagent delivery callback.

Closes #5656.
Closes #5658.
Closes #5661.

Partially addresses #5657 by removing the raw queue bypass for subagent deliveries; the broader detach-target semantics remain a separate validation item.

## Validation

- `corepack pnpm vitest run src/test-kernel/tools/SubagentDeliveryState.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/runCoordinators.vitest.ts src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (existing warning-only import-order noise)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subagent-to-parent messaging and lifecycle error/abort handling in delegation flows; behavior is well-covered by new tests but affects async orchestration edge cases.
> 
> **Overview**
> Fixes subagent result delivery so parent orchestrators reliably receive terminal outcomes (completion, error, and abort) through the same **`sendFollowUp`** path as user follow-ups, including when the parent queue was sealed while children are still running.
> 
> **Delegation delivery** no longer enqueues directly on `ToolUseFollowUpQueue`. Progress and terminal messages go through `sendFollowUp`, with `FollowUpQueueInput` (e.g. `origin: 'subagent_result'`) preserved. **`SubagentDeliveryState`** now distinguishes in-flight vs completed delivery (`beginDelivery` / `completeDelivery` / `failDelivery`) so a failed enqueue does not permanently block `onCompleted` / `onError` fallbacks.
> 
> **`runFlowWithLifecycle`** invokes the subagent **`onError`** callback for aborts as well as errors, keeps the execution registered until after that delivery, and uses the correct terminal status for subagent errors. Tool-use **interrupt/teardown** clears plan, proposal, and retry coordinators via a single **`cleanupRequestsForStream`** call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f71f0c8424f95ee7621870894bb16804d2df18e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->