### PR TITLE
fix: fail closed for unknown follow-up queues

### DIFF
--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -104,7 +104,9 @@ export async function sendFollowUp(
     ToolUseFollowUpQueue.enqueue(
       streamId,
       item,
-      force ? { force: true } : undefined,
+      force
+        ? { createIfMissing: true, force: true }
+        : { createIfMissing: true },
     );
     return { status: 'queued', reason: target.reason };
   }

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -21,7 +21,7 @@ const logger = createChannelTrace('ToolUseFollowUpQueue');
 export class ToolUseFollowUpQueue {
   private static readonly queues = new Map<StreamTabId, FollowUpQueue>();
   /** Streams whose queues were explicitly released (orchestrator disposed). */
-  private static readonly released = new Map<StreamTabId, true>();
+  private static readonly released = new Set<StreamTabId>();
   private static readonly RELEASED_CAP = 500;
   /** Observers notified whenever a stream's queue is released. */
   private static readonly releaseObservers = new Set<
@@ -120,9 +120,9 @@ export class ToolUseFollowUpQueue {
 
   private static rememberReleased(streamId: StreamTabId): void {
     this.released.delete(streamId);
-    this.released.set(streamId, true);
+    this.released.add(streamId);
     while (this.released.size > this.RELEASED_CAP) {
-      const oldest = this.released.keys().next().value;
+      const oldest = this.released.values().next().value;
       if (oldest === undefined) return;
       this.released.delete(oldest);
     }

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -21,7 +21,7 @@ const logger = createChannelTrace('ToolUseFollowUpQueue');
 export class ToolUseFollowUpQueue {
   private static readonly queues = new Map<StreamTabId, FollowUpQueue>();
   /** Streams whose queues were explicitly released (orchestrator disposed). */
-  private static readonly released = new Set<StreamTabId>();
+  private static readonly released = new Map<StreamTabId, true>();
   private static readonly RELEASED_CAP = 500;
   /** Observers notified whenever a stream's queue is released. */
   private static readonly releaseObservers = new Set<
@@ -56,11 +56,7 @@ export class ToolUseFollowUpQueue {
       queue.dispose();
       this.queues.delete(streamId);
     }
-    this.released.add(streamId);
-    if (this.released.size > this.RELEASED_CAP) {
-      this.released.clear();
-      this.released.add(streamId);
-    }
+    this.rememberReleased(streamId);
     logger.debug(`Released follow-up queue for stream ${streamId}.`);
     for (const observer of this.releaseObservers) {
       try {
@@ -77,7 +73,8 @@ export class ToolUseFollowUpQueue {
    * Enqueue a follow-up for a stream.
    *
    * Auto-creates the queue if it doesn't exist yet (needed for WAITING streams
-   * from prior sessions). Returns false and silently discards if the queue was
+   * from prior sessions) only when the caller has already admitted the
+   * follow-up through the registry. Returns false and silently discards if the queue was
    * explicitly released (orchestrator disposed — late-arriving subagent
    * results). Pass `{ force: true }` for explicit user actions that should
    * reopen a released queue (caller is responsible for ensuring a consumer
@@ -86,7 +83,7 @@ export class ToolUseFollowUpQueue {
   static enqueue(
     streamId: StreamTabId,
     followUp: FollowUpQueueInput,
-    options?: { force?: boolean },
+    options?: { createIfMissing?: boolean; force?: boolean },
   ): boolean {
     if (this.released.has(streamId) && !options?.force) {
       logger.debug(
@@ -94,8 +91,15 @@ export class ToolUseFollowUpQueue {
       );
       return false;
     }
-    const queue = this.acquire(streamId);
-    queue.enqueue(followUp);
+    const queue = this.queues.get(streamId);
+    if (!queue && !options?.createIfMissing && !options?.force) {
+      logger.debug(
+        `No follow-up queue for stream ${streamId}, discarding follow-up.`,
+      );
+      return false;
+    }
+    const target = queue ?? this.acquire(streamId);
+    target.enqueue(followUp);
     logger.debug(`Queued follow-up for stream ${streamId}.`);
     return true;
   }
@@ -112,5 +116,15 @@ export class ToolUseFollowUpQueue {
   /** Get all queued follow-up messages for a stream without consuming them. */
   static getAll(streamId: StreamTabId): string[] {
     return this.queues.get(streamId)?.getAll() ?? [];
+  }
+
+  private static rememberReleased(streamId: StreamTabId): void {
+    this.released.delete(streamId);
+    this.released.set(streamId, true);
+    while (this.released.size > this.RELEASED_CAP) {
+      const oldest = this.released.keys().next().value;
+      if (oldest === undefined) return;
+      this.released.delete(oldest);
+    }
   }
 }

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -22,7 +22,7 @@ export class ToolUseFollowUpQueue {
   private static readonly queues = new Map<StreamTabId, FollowUpQueue>();
   /** Streams whose queues were explicitly released (orchestrator disposed). */
   private static readonly released = new Set<StreamTabId>();
-  private static readonly RELEASED_CAP = 500;
+  static readonly RELEASED_CAP = 500;
   /** Observers notified whenever a stream's queue is released. */
   private static readonly releaseObservers = new Set<
     (streamId: StreamTabId) => void
@@ -77,8 +77,9 @@ export class ToolUseFollowUpQueue {
    * follow-up through the registry. Returns false and silently discards if the queue was
    * explicitly released (orchestrator disposed — late-arriving subagent
    * results). Pass `{ force: true }` for explicit user actions that should
-   * reopen a released queue (caller is responsible for ensuring a consumer
-   * will drain it, or releasing again on failure).
+   * reopen or create a queue even without `createIfMissing` (caller is
+   * responsible for ensuring a consumer will drain it, or releasing again on
+   * failure).
    */
   static enqueue(
     streamId: StreamTabId,

--- a/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
@@ -214,7 +214,7 @@ describe('FollowUpQueue', () => {
     ToolUseFollowUpQueue.acquire(retainedStream);
     ToolUseFollowUpQueue.release(retainedStream);
 
-    for (let i = 0; i < 499; i += 1) {
+    for (let i = 0; i < ToolUseFollowUpQueue.RELEASED_CAP - 1; i += 1) {
       ToolUseFollowUpQueue.release(`stream:released-extra-${i}` as StreamTabId);
     }
 

--- a/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import { ToolUseSessionLifecycle } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
 import { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { StreamTabId } from '@shared/schemas';
 
 describe('FollowUpQueue', () => {
@@ -169,6 +170,72 @@ describe('FollowUpQueue', () => {
       });
     } finally {
       session.dispose();
+    }
+  });
+
+  it('does not create ghost queues for unknown streams', () => {
+    const streamId = 'stream:unknown-followup' as StreamTabId;
+
+    try {
+      expect(
+        ToolUseFollowUpQueue.enqueue(streamId, { text: 'late result' }),
+      ).toBe(false);
+      expect(ToolUseFollowUpQueue.getAll(streamId)).toEqual([]);
+    } finally {
+      ToolUseFollowUpQueue.release(streamId);
+    }
+  });
+
+  it('creates queues only for explicitly admitted follow-ups', () => {
+    const streamId = 'stream:admitted-followup' as StreamTabId;
+
+    try {
+      expect(
+        ToolUseFollowUpQueue.enqueue(
+          streamId,
+          { text: 'admitted result' },
+          { createIfMissing: true },
+        ),
+      ).toBe(true);
+      expect(ToolUseFollowUpQueue.getAll(streamId)).toEqual([
+        'admitted result',
+      ]);
+    } finally {
+      ToolUseFollowUpQueue.release(streamId);
+    }
+  });
+
+  it('does not forget every released stream when the release cap is exceeded', () => {
+    const firstStream = 'stream:released-first' as StreamTabId;
+    const retainedStream = 'stream:released-retained' as StreamTabId;
+
+    ToolUseFollowUpQueue.acquire(firstStream);
+    ToolUseFollowUpQueue.release(firstStream);
+    ToolUseFollowUpQueue.acquire(retainedStream);
+    ToolUseFollowUpQueue.release(retainedStream);
+
+    for (let i = 0; i < 499; i += 1) {
+      ToolUseFollowUpQueue.release(`stream:released-extra-${i}` as StreamTabId);
+    }
+
+    try {
+      expect(
+        ToolUseFollowUpQueue.enqueue(firstStream, { text: 'late first' }),
+      ).toBe(false);
+      expect(ToolUseFollowUpQueue.getAll(firstStream)).toEqual([]);
+      expect(
+        ToolUseFollowUpQueue.enqueue(
+          retainedStream,
+          {
+            text: 'late retained',
+          },
+          { createIfMissing: true },
+        ),
+      ).toBe(false);
+      expect(ToolUseFollowUpQueue.getAll(retainedStream)).toEqual([]);
+    } finally {
+      ToolUseFollowUpQueue.release(firstStream);
+      ToolUseFollowUpQueue.release(retainedStream);
     }
   });
 });

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -16,9 +16,9 @@ import {
   interruptRegistry,
   type IInterruptible,
 } from '@agent/runtime/InterruptRegistry';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 
 // Local imports - tools
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
@@ -313,7 +313,7 @@ export class BashTool extends defineTool({
           stderrTail,
         );
         await store.writeReport(msg);
-        ToolUseFollowUpQueue.enqueue(parentStreamId, {
+        await sendFollowUp(parentStreamId, {
           text: msg,
           origin: 'subagent_result',
         });
@@ -328,7 +328,7 @@ export class BashTool extends defineTool({
 
         const msg = formatBashError(executionId, command, err);
         await getExecutionStore(executionId).writeReport(msg);
-        ToolUseFollowUpQueue.enqueue(parentStreamId, {
+        await sendFollowUp(parentStreamId, {
           text: msg,
           origin: 'subagent_result',
         });

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -288,15 +288,20 @@ export class BashTool extends defineTool({
     };
 
     const deliverParentFollowUp = async (text: string): Promise<void> => {
-      await sendFollowUp(parentStreamId, {
+      const result = await sendFollowUp(parentStreamId, {
         text,
         origin: 'subagent_result',
       });
+      if (result.status === 'no_session') {
+        logger.debug(
+          `Background bash follow-up dropped: parent stream ${parentStreamId} has no active session (${result.streamStatus ?? 'unknown'}).`,
+        );
+      }
     };
 
-    const logDeliveryFailure = (err: unknown): void => {
+    const logBackgroundFailure = (action: string, err: unknown): void => {
       logger.error(
-        `Failed to deliver background bash result: ${err instanceof Error ? err.message : String(err)}`,
+        `Failed to ${action} background bash result: ${err instanceof Error ? err.message : String(err)}`,
       );
     };
 
@@ -315,6 +320,15 @@ export class BashTool extends defineTool({
               `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
             );
 
+        const msg = formatBashDelivery(
+          executionId,
+          command,
+          wallTimeMs,
+          result,
+          stdoutTail,
+          stderrTail,
+        );
+
         try {
           const store = getExecutionStore(executionId);
           await store.writeResultMeta({
@@ -328,19 +342,15 @@ export class BashTool extends defineTool({
           await writeTerminalStatus(executionId, terminalStatus).catch(
             () => {},
           );
-
-          const msg = formatBashDelivery(
-            executionId,
-            command,
-            wallTimeMs,
-            result,
-            stdoutTail,
-            stderrTail,
-          );
           await store.writeReport(msg);
+        } catch (err: unknown) {
+          logBackgroundFailure('persist', err);
+        }
+
+        try {
           await deliverParentFollowUp(msg);
         } catch (err: unknown) {
-          logDeliveryFailure(err);
+          logBackgroundFailure('deliver', err);
         } finally {
           finalizeBackground({
             wallTimeMs,
@@ -352,13 +362,18 @@ export class BashTool extends defineTool({
       }
 
       const { error } = outcome;
+      const msg = formatBashError(executionId, command, error);
       try {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
-        const msg = formatBashError(executionId, command, error);
         await getExecutionStore(executionId).writeReport(msg);
+      } catch (err: unknown) {
+        logBackgroundFailure('persist', err);
+      }
+
+      try {
         await deliverParentFollowUp(msg);
       } catch (err: unknown) {
-        logDeliveryFailure(err);
+        logBackgroundFailure('deliver', err);
       } finally {
         finalizeBackground({
           error,

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -293,16 +293,6 @@ export class BashTool extends defineTool({
         });
         const terminalStatus = result.success ? 'completed' : 'error';
         await writeTerminalStatus(executionId, terminalStatus).catch(() => {});
-        interruptRegistry.unregister(childStreamId);
-        childStream.finalize({
-          wallTimeMs,
-          error: result.success
-            ? undefined
-            : new ToolError(
-                `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
-              ),
-          autoClose: true,
-        });
 
         const msg = formatBashDelivery(
           executionId,
@@ -317,20 +307,29 @@ export class BashTool extends defineTool({
           text: msg,
           origin: 'subagent_result',
         });
+        interruptRegistry.unregister(childStreamId);
+        childStream.finalize({
+          wallTimeMs,
+          error: result.success
+            ? undefined
+            : new ToolError(
+                `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
+              ),
+          autoClose: true,
+        });
       })
       .catch(async (err: unknown) => {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
-        interruptRegistry.unregister(childStreamId);
-        childStream.finalize({
-          error: err,
-          autoClose: true,
-        });
-
         const msg = formatBashError(executionId, command, err);
         await getExecutionStore(executionId).writeReport(msg);
         await sendFollowUp(parentStreamId, {
           text: msg,
           origin: 'subagent_result',
+        });
+        interruptRegistry.unregister(childStreamId);
+        childStream.finalize({
+          error: err,
+          autoClose: true,
         });
       });
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -280,58 +280,92 @@ export class BashTool extends defineTool({
       },
     });
 
-    void promise
-      .then(async (result) => {
-        const wallTimeMs = Date.now() - startedAt;
-        const store = getExecutionStore(executionId);
-        await store.writeResultMeta({
-          exitCode: result.exitCode,
-          wallTimeMs,
-          success: result.success,
-          timedOut: result.timedOut,
-          command,
-        });
-        const terminalStatus = result.success ? 'completed' : 'error';
-        await writeTerminalStatus(executionId, terminalStatus).catch(() => {});
+    const finalizeBackground = (
+      options?: Parameters<typeof childStream.finalize>[0],
+    ): void => {
+      interruptRegistry.unregister(childStreamId);
+      childStream.finalize(options);
+    };
 
-        const msg = formatBashDelivery(
-          executionId,
-          command,
-          wallTimeMs,
-          result,
-          stdoutTail,
-          stderrTail,
-        );
-        await store.writeReport(msg);
-        await sendFollowUp(parentStreamId, {
-          text: msg,
-          origin: 'subagent_result',
-        });
-        interruptRegistry.unregister(childStreamId);
-        childStream.finalize({
-          wallTimeMs,
-          error: result.success
-            ? undefined
-            : new ToolError(
-                `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
-              ),
-          autoClose: true,
-        });
-      })
-      .catch(async (err: unknown) => {
-        await writeTerminalStatus(executionId, 'error').catch(() => {});
-        const msg = formatBashError(executionId, command, err);
-        await getExecutionStore(executionId).writeReport(msg);
-        await sendFollowUp(parentStreamId, {
-          text: msg,
-          origin: 'subagent_result',
-        });
-        interruptRegistry.unregister(childStreamId);
-        childStream.finalize({
-          error: err,
-          autoClose: true,
-        });
+    const deliverParentFollowUp = async (text: string): Promise<void> => {
+      await sendFollowUp(parentStreamId, {
+        text,
+        origin: 'subagent_result',
       });
+    };
+
+    const logDeliveryFailure = (err: unknown): void => {
+      logger.error(
+        `Failed to deliver background bash result: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    };
+
+    void (async () => {
+      const outcome = await promise.then(
+        (result) => ({ ok: true as const, result }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+
+      if (outcome.ok) {
+        const { result } = outcome;
+        const wallTimeMs = Date.now() - startedAt;
+        const error = result.success
+          ? undefined
+          : new ToolError(
+              `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
+            );
+
+        try {
+          const store = getExecutionStore(executionId);
+          await store.writeResultMeta({
+            exitCode: result.exitCode,
+            wallTimeMs,
+            success: result.success,
+            timedOut: result.timedOut,
+            command,
+          });
+          const terminalStatus = result.success ? 'completed' : 'error';
+          await writeTerminalStatus(executionId, terminalStatus).catch(
+            () => {},
+          );
+
+          const msg = formatBashDelivery(
+            executionId,
+            command,
+            wallTimeMs,
+            result,
+            stdoutTail,
+            stderrTail,
+          );
+          await store.writeReport(msg);
+          await deliverParentFollowUp(msg);
+        } catch (err: unknown) {
+          logDeliveryFailure(err);
+        } finally {
+          finalizeBackground({
+            wallTimeMs,
+            error,
+            autoClose: true,
+          });
+        }
+        return;
+      }
+
+      const { error } = outcome;
+      try {
+        await writeTerminalStatus(executionId, 'error').catch(() => {});
+        const msg = formatBashError(executionId, command, error);
+        await getExecutionStore(executionId).writeReport(msg);
+        await deliverParentFollowUp(msg);
+      } catch (err: unknown) {
+        logDeliveryFailure(err);
+      } finally {
+        finalizeBackground({
+          error,
+          autoClose: true,
+        });
+      }
+    })();
 
     return {
       summary: `Launched background: ${preview}`,

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -43,6 +43,7 @@ import {
   interruptRegistry,
   type IInterruptible,
 } from '@agent/runtime/InterruptRegistry';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
@@ -583,7 +584,7 @@ function startClaudeAgentLoop(params: {
         } catch {
           // Best-effort; delivery must not block on storage.
         }
-        ToolUseFollowUpQueue.enqueue(parentStreamId, {
+        await sendFollowUp(parentStreamId, {
           text: msg,
           origin: 'subagent_result',
         });

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -40,6 +40,7 @@ import {
   interruptRegistry,
   type IInterruptible,
 } from '@agent/runtime/InterruptRegistry';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
@@ -582,7 +583,7 @@ function startCodexLoop(params: {
         } catch {
           // Best-effort; delivery must not block on storage.
         }
-        ToolUseFollowUpQueue.enqueue(parentStreamId, {
+        await sendFollowUp(parentStreamId, {
           text: msg,
           origin: 'subagent_result',
         });


### PR DESCRIPTION
## Summary

- make `ToolUseFollowUpQueue.enqueue` fail closed for unknown streams unless the caller explicitly admits queue creation
- replace wholesale `released.clear()` cap behavior with bounded insertion-order eviction
- route bash/Codex/Claude child-result delivery through `sendFollowUp`, keeping queue admission in the execution registry path
- add regression coverage for unknown streams, explicitly admitted queue creation, and released-stream retention under cap pressure

Closes #5659.
Partially addresses #5657 by removing additional raw parent-queue delivery bypasses for background bash, Codex, and Claude agent tools.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/toolUse/FollowUpQueue.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (existing import-order warnings only)
- `npm run compile:fast`
- `git diff --check`
- `npm run texra-local:build && npm run texra-local:link`
- `TERM=xterm-256color texra-local` startup panel renders in a PTY and exits with Esc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core follow-up routing and late subagent delivery; wrong admission could drop results or recreate queues, but behavior is gated on the execution registry and covered by new tests.
> 
> **Overview**
> Tightens **tool-use follow-up queue** admission so unknown streams no longer get implicit queues, and subagent results route through the registry-aware **`sendFollowUp`** path.
> 
> **`ToolUseFollowUpQueue.enqueue`** now discards work unless the caller passes **`createIfMissing`** (registry-approved queue path) or **`force`** (explicit reopen). **`sendFollowUp`** passes **`createIfMissing: true`** when queuing for waiting/resuming sessions, and **`force`** for **`children_running`**. Released-stream tracking no longer **`clear()`**s the whole set at the cap; **`rememberReleased`** evicts oldest entries in insertion order so disposed streams stay blocked.
> 
> **Background bash**, **Codex**, and **Claude** child completions switch from raw **`ToolUseFollowUpQueue.enqueue`** to **`await sendFollowUp`**, with bash also splitting persist/deliver/finalize and logging failures. Vitest adds coverage for unknown streams, admitted creation, and release-cap retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11e01158af3b5dc069166db538d9e38617a2286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->