### PR TITLE
fix: avoid stale subagent delivery after detach

### DIFF
--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -1,7 +1,13 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import {
+  AgentExecutionHandle,
+  executionRegistry,
+} from '@agent/runtime/executionRegistry';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { StreamTabId } from '@shared/schemas';
 import { DelegateAgentTool } from '@tools/DelegationTools';
 
 const mocks = vi.hoisted(() => ({
@@ -87,6 +93,14 @@ describe('headless delegation', () => {
       lastResponse: 'The proof is correct.',
       touchedFiles: [],
     });
+  });
+
+  afterEach(() => {
+    for (const executionId of executionRegistry.getActiveIds()) {
+      executionRegistry.untrack(executionId);
+    }
+    ToolUseFollowUpQueue.release('parent-stream' as StreamTabId);
+    ToolUseFollowUpQueue.release('child-stream' as StreamTabId);
   });
 
   it('awaits child delegation during one-shot tool-use runs', async () => {
@@ -195,6 +209,65 @@ describe('headless delegation', () => {
       expect.anything(),
       expect.any(String),
       expect.not.objectContaining({ stopAfterCycle: true }),
+    );
+  });
+
+  it('does not deliver detached subagent results back to the released parent', async () => {
+    const parentStreamId = 'parent-stream' as StreamTabId;
+    const childStreamId = 'child-stream' as StreamTabId;
+    const host = runtimeHost();
+    let onBeforeWaiting:
+      | ((
+          lastResponse: string | undefined,
+          touchedFiles: string[],
+        ) => Promise<boolean>)
+      | undefined;
+
+    mocks.executeAgent.mockImplementationOnce(
+      async (_config, executionId: string, options) => {
+        executionRegistry.track(
+          new AgentExecutionHandle(
+            executionId,
+            parentStreamId,
+            childStreamId,
+            'review',
+            'toolUse',
+            host,
+          ),
+        );
+        options.onStreamResolved?.(childStreamId);
+        onBeforeWaiting = options.onBeforeWaiting;
+        return new Promise(() => {});
+      },
+    );
+
+    await withRunContext(
+      createRunContext({
+        runtimeHost: host,
+        streamId: parentStreamId,
+        executionId: 'parent-exec',
+        model: 'deepseekT',
+      }),
+      () =>
+        new DelegateAgentTool().call({
+          agent: 'review',
+          model: null,
+          instruction: 'Check the proof.',
+          memories: [],
+          working_directory: null,
+          execution_id: null,
+        }),
+    );
+
+    executionRegistry.detachActiveChildren(parentStreamId, host);
+
+    await expect(onBeforeWaiting?.('The proof is correct.', [])).resolves.toBe(
+      false,
+    );
+    expect(ToolUseFollowUpQueue.getAll(parentStreamId)).toEqual([]);
+    expect(ToolUseFollowUpQueue.getAll(childStreamId)).toEqual([]);
+    expect(mocks.writeReport).toHaveBeenCalledWith(
+      expect.stringContaining('The proof is correct.'),
     );
   });
 });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -268,6 +268,20 @@ async function writeSubagentReport(
   }
 }
 
+function resolveDeliveryStreamId(
+  executionId: string,
+  fallbackStreamId: StreamTabId,
+): StreamTabId | undefined {
+  const handle = executionRegistry.getHandle(executionId);
+  if (!(handle instanceof AgentExecutionHandle)) return fallbackStreamId;
+  // AgentExecutionHandle.detach() promotes a child by setting
+  // parentStreamId === childStreamId. Do not enqueue the formatted result
+  // back into the detached child's own prompt as a synthetic follow-up.
+  return handle.parentStreamId === handle.childStreamId
+    ? undefined
+    : handle.parentStreamId;
+}
+
 /**
  * Runtime depth gate shared by fresh delegations and resumes.
  * Tool-use flows pass the same max-depth snapshot used for tool resolution so
@@ -460,11 +474,17 @@ async function executeSubagent(
   async function deliverFollowUp(
     followUp: FollowUpQueueInput,
   ): Promise<boolean> {
-    const result = await sendFollowUp(orchestratorStreamId, followUp);
+    const targetStreamId = resolveDeliveryStreamId(
+      executionId,
+      orchestratorStreamId,
+    );
+    if (!targetStreamId) return false;
+
+    const result = await sendFollowUp(targetStreamId, followUp);
     if (result.status !== 'no_session') return true;
     logger.warn(
       'subagentDelivery',
-      `Unable to deliver subagent result for ${executionId}: parent stream ${orchestratorStreamId} has no active session (status: ${result.streamStatus ?? 'unknown'}).`,
+      `Unable to deliver subagent result for ${executionId}: parent stream ${targetStreamId} has no active session (status: ${result.streamStatus ?? 'unknown'}).`,
     );
     return false;
   }
@@ -562,11 +582,10 @@ async function executeSubagent(
       }
       // Claim only the enqueue step: formatting/storage failures before this
       // still leave onCompleted/onError available as terminal fallbacks.
-      await deliverTerminalFollowUp({
+      return await deliverTerminalFollowUp({
         text: msg,
         origin: 'subagent_result',
       });
-      return true;
     },
     onCompleted: async (result) => {
       // For workflow results, compute diffs and write them as files to the


### PR DESCRIPTION
## Summary

- Resolve subagent result delivery from the live `AgentExecutionHandle` instead of the launch-time parent stream id.
- Treat detached children as top-level streams and avoid enqueueing formatted result XML back into the child’s own prompt.
- Return the actual terminal delivery result from `onBeforeWaiting` so failed delivery is not marked as delivered.
- Add a regression test for the detached-child path.

## Root Cause

`detachActiveChildren()` updates the execution handle and UI parent relationship, but `executeSubagent()` kept delivering through the closure-captured orchestrator stream id. After a parent stop/detach, that could target a released parent stream and still report the result as delivered.

This keeps the execution handle as the single source of truth for live parentage rather than adding another delivery-target map.

Closes #5657

## Validation

- `corepack pnpm vitest run src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside this diff)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive subagent result routing and delivery-state signaling in delegation tooling; behavior is localized but affects multi-agent follow-up delivery when parents stop with detached children.
> 
> **Overview**
> Fixes **stale subagent result delivery** after a parent stream is stopped with children detached: async follow-ups no longer use the launch-time orchestrator stream id from the closure.
> 
> **`resolveDeliveryStreamId`** reads the live **`AgentExecutionHandle`** from **`executionRegistry`**. After **`detach()`** (parent promoted to self via **`parentStreamId === childStreamId`**), delivery is skipped so formatted result XML is not enqueued on the detached child’s own prompt or a released parent.
> 
> **`onBeforeWaiting`** now **returns** the boolean from **`deliverTerminalFollowUp`**, so a failed enqueue is not treated as successfully delivered.
> 
> Adds **`afterEach`** registry/queue cleanup and a regression test for detach + **`onBeforeWaiting`** (expects **`false`**, empty follow-up queues, report still written).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79cddddbe86a8d09017f2ebd9f3c58a6ce57870c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->