### PR TITLE
fix: report subagent memory attachment misses

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -2,6 +2,7 @@ import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass'
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { IdleContinuationRegistry } from '@agent/runtime/idleContinuation';
+import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
@@ -11,6 +12,12 @@ import type {
 } from '../common/BaseFlowServices';
 import type { IToolUseSession } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
+
+export type ToolUseBeforeWaitingCallback = (
+  lastResponse: string | undefined,
+  touchedFiles: string[],
+  memoryMisses: readonly AttachedMemoryMiss[],
+) => boolean | void | Promise<boolean | void>;
 
 export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly setting: AgentToolUseSetting;
@@ -26,10 +33,8 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
    *  current cycle is purely internal). `true` or `void` indicates a result
    *  was delivered; on interruption the wait node uses this to mark the flow
    *  as completed rather than aborted. */
-  readonly onBeforeWaiting?: (
-    lastResponse: string | undefined,
-    touchedFiles: string[],
-  ) => boolean | void | Promise<boolean | void>;
+  readonly onBeforeWaiting?: ToolUseBeforeWaitingCallback;
+  readonly attachedMemoryMisses?: readonly AttachedMemoryMiss[];
   readonly onProgress?: (update: SubagentProgressUpdate) => void;
   /** Stop after one cycle instead of waiting for a conversational follow-up. */
   readonly stopAfterCycle?: boolean;

--- a/src/agent/implementations/flows/tooluse/index.ts
+++ b/src/agent/implementations/flows/tooluse/index.ts
@@ -15,3 +15,5 @@ export {
 export { type IToolUseSession } from './ToolUseSessionLifecycle';
 
 export { type ToolUseSessionSnapshot } from './ToolUseSessionTypes';
+
+export { type ToolUseBeforeWaitingCallback } from './ToolUseServices';

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -79,6 +79,7 @@ export class ToolUseWaitNode<C> extends Node<
       const delivered = await onBeforeWaiting?.(
         prepRes.lastResponse,
         prepRes.touchedFiles,
+        this.services.attachedMemoryMisses ?? [],
       );
       prepRes.deliveredToOrchestrator =
         onBeforeWaiting !== undefined && delivered !== false;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -47,7 +47,10 @@ import {
 import { setToolUseSharedModel } from './modelSwitchState';
 import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
-import type { ToolUseServices } from './ToolUseServices';
+import type {
+  ToolUseBeforeWaitingCallback,
+  ToolUseServices,
+} from './ToolUseServices';
 
 export interface RunToolUseFlowInput<
   C = unknown,
@@ -60,10 +63,7 @@ export interface RunToolUseFlowInput<
   /** When true, approval-gated tools are filtered out before model invocation. */
   approvalPromptsUnavailable?: boolean;
   /** Fires before the subagent enters WAITING, delivering the last response to the orchestrator. */
-  onBeforeWaiting?: (
-    lastResponse: string | undefined,
-    touchedFiles: string[],
-  ) => boolean | void | Promise<boolean | void>;
+  onBeforeWaiting?: ToolUseBeforeWaitingCallback;
   /** Fires on meaningful progress: todo changes, tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
   /** Stop after one cycle instead of waiting for a conversational follow-up. */

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { AttachedMemoryMissSchema } from '@agent/types/AttachedMemory';
 import {
   EndGroupStatusSchema,
   ExecutionIdSchema,
@@ -34,6 +35,7 @@ export type CompileFailureSummary = z.infer<typeof CompileFailureSummarySchema>;
 const AgentFlowMetaSchema = z.object({
   executionId: ExecutionIdSchema,
   streamId: StreamTabIdSchema,
+  memoryMisses: z.array(AttachedMemoryMissSchema).optional(),
 });
 
 export const WorkflowFlowResultSchema = AgentFlowMetaSchema.extend({
@@ -70,15 +72,20 @@ export function buildTerminalFlowResult(
   status: EndGroupStatus,
   executionId: ExecutionId,
   streamId: StreamTabId,
+  memoryMisses?: z.infer<typeof AttachedMemoryMissSchema>[],
 ): AgentFlowResult {
+  const meta = {
+    executionId,
+    streamId,
+    ...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {}),
+  };
   if (category === 'toolUse') {
-    return { category, status, executionId, streamId };
+    return { category, status, ...meta };
   }
   return {
     category,
     status,
-    executionId,
-    streamId,
+    ...meta,
     outputs: [],
     compileFailures: [],
   };

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -20,6 +20,10 @@ import {
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import {
+  readAttachedMemoryMisses,
+  type AttachedMemoryMiss,
+} from '@agent/types/AttachedMemory';
+import {
   ensureAgentCategoryForSource,
   loadAgentSettingAndPrompts,
 } from '@agent/runtime/agentLoad';
@@ -63,6 +67,7 @@ export interface AgentLaunchContext extends AgentCore {
   parentStage: StageHandle;
   streamStatus: StreamStatusRegistry;
   coordinators: RunCoordinators;
+  attachedMemoryMisses: AttachedMemoryMiss[];
   /** Whether approval or user prompts cannot be answered by the current host. */
   approvalPromptsUnavailable?: boolean;
   /** Whether this tool-use run exits after one cycle instead of idling. */
@@ -295,6 +300,9 @@ async function assembleAgentLaunchContext(
     input: Object.freeze(baseVars),
     transient: { ...baseVars },
   };
+  const attachedMemoryMisses = readAttachedMemoryMisses(
+    baseVars.ATTACHED_MEMORY_MISSES,
+  );
 
   const usageMonitor = new UsageMonitor(
     { capabilities: modelHandler.capabilities, config: modelHandler.config },
@@ -316,6 +324,7 @@ async function assembleAgentLaunchContext(
     parentStage,
     storageKey,
     userVarChannels,
+    attachedMemoryMisses,
     usageMonitor,
     runtimeHost,
     streamStatus,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -142,6 +142,7 @@ export async function runFlowWithLifecycle(
         status,
         ctx.executionId,
         streamId,
+        ctx.attachedMemoryMisses,
       );
       try {
         await options.onError?.(err, result);
@@ -161,6 +162,7 @@ export async function runFlowWithLifecycle(
         END_GROUP_STATUS.STOPPED,
         ctx.executionId,
         streamId,
+        ctx.attachedMemoryMisses,
       );
     }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -5,6 +5,7 @@ import {
   runToolUseFlow,
   type IToolUseSession,
   type RunToolUseFlowResult,
+  type ToolUseBeforeWaitingCallback,
 } from '@agent/implementations/flows/tooluse';
 import {
   runReflectionFlow,
@@ -94,6 +95,7 @@ function buildWorkflowFlowResult(
   result: RunReflectionFlowResult,
   executionId: ExecutionId,
   streamId: StreamTabId,
+  memoryMisses: AgentFlowResult['memoryMisses'],
 ): AgentFlowResult {
   return {
     category: 'workflow',
@@ -102,6 +104,7 @@ function buildWorkflowFlowResult(
     compileFailures: toCompileFailureSummaries(result.roundOutputs),
     executionId,
     streamId,
+    ...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {}),
   };
 }
 
@@ -110,6 +113,7 @@ function buildToolUseFlowResult(
   result: RunToolUseFlowResult,
   executionId: ExecutionId,
   streamId: StreamTabId,
+  memoryMisses: AgentFlowResult['memoryMisses'],
 ): AgentFlowResult {
   return {
     category: 'toolUse',
@@ -118,6 +122,7 @@ function buildToolUseFlowResult(
     touchedFiles: result.touchedFiles,
     executionId,
     streamId,
+    ...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {}),
   };
 }
 
@@ -211,10 +216,7 @@ export interface ExecuteAgentOptions {
   /** Fires with the real streamId before the stream is activated (before UI sync). */
   onStreamResolved?: (streamId: StreamTabId) => void;
   /** Fires before a tool-use subagent enters WAITING, delivering interim result to orchestrator. */
-  onBeforeWaiting?: (
-    lastResponse: string | undefined,
-    touchedFiles: string[],
-  ) => boolean | void | Promise<boolean | void>;
+  onBeforeWaiting?: ToolUseBeforeWaitingCallback;
   /** Fires when a tool-use session consumes queued follow-up instructions. */
   onFollowUpConsumed?: () => void;
   /** Fires on meaningful progress: todo changes, round completions, tool call milestones. */
@@ -340,7 +342,12 @@ export async function executeAgent(
               return () => handle.detachToolUseFlow(flowContext);
             },
           );
-          return buildToolUseFlowResult(result, ctx.executionId, streamId);
+          return buildToolUseFlowResult(
+            result,
+            ctx.executionId,
+            streamId,
+            ctx.attachedMemoryMisses,
+          );
         }
 
         const onRoundCompleted = createRoundProgressCallback(
@@ -358,7 +365,12 @@ export async function executeAgent(
           parentStage: ctx.parentStage,
           onRoundCompleted,
         });
-        return buildWorkflowFlowResult(result, ctx.executionId, streamId);
+        return buildWorkflowFlowResult(
+          result,
+          ctx.executionId,
+          streamId,
+          ctx.attachedMemoryMisses,
+        );
       },
       {
         isSubagent,
@@ -436,7 +448,12 @@ export async function resumeToolUseFromSnapshot(
           return () => handle.detachToolUseFlow(flowContext);
         },
       );
-      return buildToolUseFlowResult(result, ctx.executionId, streamId);
+      return buildToolUseFlowResult(
+        result,
+        ctx.executionId,
+        streamId,
+        ctx.attachedMemoryMisses,
+      );
     });
   });
 }

--- a/src/agent/types/AttachedMemory.ts
+++ b/src/agent/types/AttachedMemory.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const AttachedMemoryMissSchema = z.object({
+  path: z.string(),
+  reason: z.string(),
+});
+
+export type AttachedMemoryMiss = z.infer<typeof AttachedMemoryMissSchema>;
+
+const AttachedMemoryMissesSchema = z.array(AttachedMemoryMissSchema);
+
+export function readAttachedMemoryMisses(value: unknown): AttachedMemoryMiss[] {
+  return AttachedMemoryMissesSchema.catch([]).parse(value);
+}

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -9,17 +9,19 @@ import {
   AgentPrompt,
   AgentCategory,
 } from '@agent/core/definition/AgentDataclass';
-import { getConfig } from '@utils/config/configUtils';
+import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
+import { toErrorMessage } from '@common/errors';
 import type { FileListEntry } from '@shared/schemas';
 import { parseFrontmatter } from '@tools/memory/memoryMeta';
 import { displayToStoragePath } from '@tools/memory/memoryUtils';
+import { filterNotNull, isNonEmptyString } from '@utils/core';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import {
   getListOfFiles,
   getPromptFileName,
   getXmlFormatFromReadableFiles,
 } from '@utils/prompt';
-import { filterNotNull, isNonEmptyString } from '@utils/core';
+import { getConfig } from '@utils/config/configUtils';
 import {
   listExternalRoots,
   type ExternalRootKind,
@@ -61,6 +63,11 @@ export interface ModelProviderFlags {
 type FileVarsResult = {
   vars: UserVars;
   files: LoadedFileEntry[];
+};
+
+type AttachedMemoriesResult = {
+  xml: string | null;
+  misses: AttachedMemoryMiss[];
 };
 
 /**
@@ -116,7 +123,8 @@ export async function buildUserVars(
     ...resolveOutputFiles(agentConfig, agentSetting),
     ...getToolFlags(agentConfig, agentSetting, agentPrompt),
     LATEX_STYLE_RULES: latexStyleRules,
-    ATTACHED_MEMORIES: attachedMemories,
+    ATTACHED_MEMORIES: attachedMemories.xml,
+    ATTACHED_MEMORY_MISSES: attachedMemories.misses,
     AVAILABLE_SKILLS: availableSkills,
   };
 
@@ -436,8 +444,8 @@ async function getPatternBasedFileVars(
  */
 async function getAttachedMemories(
   memoryPaths: string[],
-): Promise<string | null> {
-  if (memoryPaths.length === 0) return null;
+): Promise<AttachedMemoriesResult> {
+  if (memoryPaths.length === 0) return { xml: null, misses: [] };
 
   const results = await Promise.all(
     memoryPaths.map(async (displayPath) => {
@@ -448,18 +456,30 @@ async function getAttachedMemories(
         const { content } = parseFrontmatter(raw);
         const trimmed = content.trim();
         if (trimmed) {
-          return `<memory name="${displayPath}">\n${trimmed}\n</memory>`;
+          return {
+            xml: `<memory name="${displayPath}">\n${trimmed}\n</memory>`,
+            miss: null,
+          };
         }
-      } catch {
-        // Skip memories that can't be read (deleted between delegation and execution)
+      } catch (error) {
+        return {
+          xml: null,
+          miss: { path: displayPath, reason: toErrorMessage(error) },
+        };
       }
-      return null;
+      return { xml: null, miss: null };
     }),
   );
 
-  const parts = results.filter(filterNotNull);
-  if (parts.length === 0) return null;
-  return `<attached_memories>\n${parts.join('\n')}\n</attached_memories>`;
+  const parts = results.map((result) => result.xml).filter(filterNotNull);
+  const misses = results.map((result) => result.miss).filter(filterNotNull);
+  return {
+    xml:
+      parts.length > 0
+        ? `<attached_memories>\n${parts.join('\n')}\n</attached_memories>`
+        : null,
+    misses,
+  };
 }
 
 export function resolveOutputFiles(

--- a/src/test-kernel/agent/UserVarsMissingFiles.vitest.mts
+++ b/src/test-kernel/agent/UserVarsMissingFiles.vitest.mts
@@ -27,6 +27,8 @@ describe('buildUserVars with missing configured files', () => {
         files: {
           '/workspace/present.tex': 'present input',
           '/workspace/context.tex': 'present context',
+          '/workspace/.texra/storage/memories/present.md':
+            '---\nmodifiedBy: user\n---\nRemember this convention.',
         },
       }),
     );
@@ -70,5 +72,34 @@ describe('buildUserVars with missing configured files', () => {
     expect(vars.LIST_OF_ALL_CONTEXTS).toBe('context.tex');
     expect(vars.CONTEXT_FILE).toBe('context.tex');
     expect(vars.CONTEXT_CONTENT).toBe('present context');
+  });
+
+  it('records attached memory read misses from the prompt-load pass', async () => {
+    const agentConfig = AgentConfigSchema.parse({
+      agent: 'generic',
+      model: 'test-model',
+      memories: ['/memories/present.md', '/memories/missing.md'],
+    });
+    const agentSetting = AgentWorkflowSettingSchema.parse({
+      agentCategory: AgentCategory.Workflow,
+    });
+    const agentPrompt = AgentPromptSchema.parse({});
+
+    const vars = await buildUserVars(
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      '/agents/generic',
+      providerFlags,
+      noopTrace,
+      '/workspace',
+    );
+
+    expect(vars.ATTACHED_MEMORIES).toBe(
+      '<attached_memories>\n<memory name="/memories/present.md">\nRemember this convention.\n</memory>\n</attached_memories>',
+    );
+    expect(vars.ATTACHED_MEMORY_MISSES).toEqual([
+      expect.objectContaining({ path: '/memories/missing.md' }),
+    ]);
   });
 });

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -91,6 +91,7 @@ function createLifecycleContext({
       input: Object.freeze({}),
       transient: {},
     },
+    attachedMemoryMisses: [],
     usageMonitor: new UsageMonitor(
       modelInfo,
       {
@@ -159,6 +160,9 @@ describe('runFlowWithLifecycle', () => {
       streamId,
       streamStatus,
     });
+    ctx.attachedMemoryMisses = [
+      { path: '/memories/missing.md', reason: 'not found' },
+    ];
     const onError = vi.fn();
 
     try {
@@ -173,6 +177,7 @@ describe('runFlowWithLifecycle', () => {
       );
 
       expect(result.status).toBe(END_GROUP_STATUS.STOPPED);
+      expect(result.memoryMisses).toEqual(ctx.attachedMemoryMisses);
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
       expect(onError).toHaveBeenCalledOnce();
       expect(onError.mock.calls[0][1]).toEqual(result);

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -6,6 +6,7 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { ToolUseWaitNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseWaitNode';
 import type { ToolUseRunShared } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
+import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import { IdleContinuationRegistry } from '@agent/runtime/idleContinuation';
 import {
   StreamStatusRegistry,
@@ -22,8 +23,12 @@ describe('ToolUseWaitNode', () => {
     };
     let interrupted = false;
     const onBeforeWaiting = vi.fn(async () => {});
+    const memoryMisses: AttachedMemoryMiss[] = [
+      { path: '/memories/missing.md', reason: 'not found' },
+    ];
 
     const services = {
+      attachedMemoryMisses: memoryMisses,
       checkInterruption: () => interrupted,
       idleContinuations: new IdleContinuationRegistry(),
       isSubagent: true,
@@ -49,6 +54,7 @@ describe('ToolUseWaitNode', () => {
     const transition = await node.post(shared, prep, exec);
 
     expect(onBeforeWaiting).toHaveBeenCalledOnce();
+    expect(onBeforeWaiting).toHaveBeenCalledWith(undefined, [], memoryMisses);
     expect(transition).toBe(FlowTransition.COMPLETE);
     expect(shared.deliveredToOrchestrator).toBe(true);
   });

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -6,6 +6,7 @@ import {
   AgentExecutionHandle,
   executionRegistry,
 } from '@agent/runtime/executionRegistry';
+import type { ToolUseBeforeWaitingCallback } from '@agent/implementations/flows/tooluse';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { StreamTabId } from '@shared/schemas';
 import { DelegateAgentTool } from '@tools/DelegationTools';
@@ -212,16 +213,51 @@ describe('headless delegation', () => {
     );
   });
 
+  it('includes memory misses in interactive early-delivered reports', async () => {
+    const childStreamId = 'child-stream' as StreamTabId;
+    let onBeforeWaiting: ToolUseBeforeWaitingCallback | undefined;
+
+    mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
+      options.onStreamResolved?.(childStreamId);
+      onBeforeWaiting = options.onBeforeWaiting;
+      return new Promise(() => {});
+    });
+
+    await withRunContext(
+      createRunContext({
+        runtimeHost: runtimeHost(),
+        streamId: 'parent-stream',
+        executionId: 'parent-exec',
+        model: 'deepseekT',
+      }),
+      () =>
+        new DelegateAgentTool().call({
+          agent: 'review',
+          model: null,
+          instruction: 'Check the proof.',
+          memories: [],
+          working_directory: null,
+          execution_id: null,
+        }),
+    );
+
+    expect(onBeforeWaiting).toBeDefined();
+    await onBeforeWaiting!('The proof is correct.', [], [
+      { path: '/memories/missing.md', reason: 'not found & unreadable' },
+    ]);
+
+    expect(mocks.writeReport).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '<memory-miss path="/memories/missing.md" reason="not found &amp; unreadable" />',
+      ),
+    );
+  });
+
   it('does not deliver detached subagent results back to the released parent', async () => {
     const parentStreamId = 'parent-stream' as StreamTabId;
     const childStreamId = 'child-stream' as StreamTabId;
     const host = runtimeHost();
-    let onBeforeWaiting:
-      | ((
-          lastResponse: string | undefined,
-          touchedFiles: string[],
-        ) => Promise<boolean>)
-      | undefined;
+    let onBeforeWaiting: ToolUseBeforeWaitingCallback | undefined;
 
     mocks.executeAgent.mockImplementationOnce(
       async (_config, executionId: string, options) => {
@@ -261,9 +297,9 @@ describe('headless delegation', () => {
 
     executionRegistry.detachActiveChildren(parentStreamId, host);
 
-    await expect(onBeforeWaiting?.('The proof is correct.', [])).resolves.toBe(
-      false,
-    );
+    expect(onBeforeWaiting).toBeDefined();
+    const delivered = await onBeforeWaiting!('The proof is correct.', [], []);
+    expect(delivered).toBe(false);
     expect(ToolUseFollowUpQueue.getAll(parentStreamId)).toEqual([]);
     expect(ToolUseFollowUpQueue.getAll(childStreamId)).toEqual([]);
     expect(mocks.writeReport).toHaveBeenCalledWith(

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -242,9 +242,11 @@ describe('headless delegation', () => {
     );
 
     expect(onBeforeWaiting).toBeDefined();
-    await onBeforeWaiting!('The proof is correct.', [], [
-      { path: '/memories/missing.md', reason: 'not found & unreadable' },
-    ]);
+    await onBeforeWaiting!(
+      'The proof is correct.',
+      [],
+      [{ path: '/memories/missing.md', reason: 'not found & unreadable' }],
+    );
 
     expect(mocks.writeReport).toHaveBeenCalledWith(
       expect.stringContaining(

--- a/src/test-kernel/tools/SubagentResults.vitest.ts
+++ b/src/test-kernel/tools/SubagentResults.vitest.ts
@@ -27,6 +27,29 @@ describe('formatSubagentDelivery', () => {
     expect(delivery).not.toContain('Keep </response> literal');
   });
 
+  it('includes attached memory misses in subagent delivery XML', () => {
+    const result = {
+      category: 'toolUse',
+      executionId: 'abc123',
+      streamId: 'child-stream',
+      status: 'stopped',
+      lastResponse: 'Checked the proof.',
+      memoryMisses: [
+        {
+          path: '/memories/missing.md',
+          reason: 'Path is missing & unreadable',
+        },
+      ],
+    } satisfies ToolUseFlowResult;
+
+    const delivery = formatSubagentDelivery('reviewer', result);
+
+    expect(delivery).toContain('<memory-misses>');
+    expect(delivery).toContain(
+      '<memory-miss path="/memories/missing.md" reason="Path is missing &amp; unreadable" />',
+    );
+  });
+
   it('keeps all content lines when a background output tail ends at the preview limit', () => {
     const outputTail = Array.from(
       { length: 20 },

--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -72,6 +72,27 @@ describe('tool status formatting', () => {
     );
   });
 
+  it('includes attached memory misses in subagent error delivery', () => {
+    const delivery = formatSubagentError(
+      'exec-1',
+      'review',
+      new Error('subagent failed'),
+      {
+        memoryMisses: [
+          {
+            path: '/memories/missing.md',
+            reason: 'Path is missing & unreadable',
+          },
+        ],
+      },
+    );
+
+    expect(delivery).toContain('<memory-misses>');
+    expect(delivery).toContain(
+      '<memory-miss path="/memories/missing.md" reason="Path is missing &amp; unreadable" />',
+    );
+  });
+
   it('renders bash execution history as a process without a model', () => {
     const entry: ExecutionListingEntry = {
       id: '16c0f3f748e4',

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -423,6 +423,7 @@ async function executeSubagent(
           {
             wallTimeMs: Date.now() - startedAt,
             workingDirectory: configPayload.workingDirectory ?? undefined,
+            memoryMisses: result.memoryMisses,
           },
         );
         await writeSubagentReport(executionId, msg);
@@ -513,11 +514,15 @@ async function executeSubagent(
     void deliverFollowUp({ text: msg, origin: 'subagent_result' });
   }
 
-  async function deliverSubagentError(err: unknown): Promise<void> {
+  async function deliverSubagentError(
+    err: unknown,
+    result?: AgentFlowResult,
+  ): Promise<void> {
     const wallTimeMs = Date.now() - startedAt;
     const msg = formatSubagentError(executionId, agentName, err, {
       wallTimeMs,
       workingDirectory: configPayload.workingDirectory ?? undefined,
+      memoryMisses: result?.memoryMisses,
     });
     void getExecutionStore(executionId).writeReport(msg);
     await deliverTerminalFollowUp({
@@ -546,7 +551,7 @@ async function executeSubagent(
     onFollowUpConsumed: () => {
       deliveryState.markPending();
     },
-    onBeforeWaiting: async (lastResponse, touchedFiles) => {
+    onBeforeWaiting: async (lastResponse, touchedFiles, memoryMisses) => {
       const deliveryDecision =
         deliveryState.resolveBeforeWaiting(childStreamId);
       if (deliveryDecision === SUBAGENT_DELIVERY_DECISION.AlreadyDelivered) {
@@ -568,6 +573,8 @@ async function executeSubagent(
           touchedFiles,
           executionId,
           streamId: resolvedChildStreamId,
+          memoryMisses:
+            memoryMisses.length > 0 ? [...memoryMisses] : undefined,
         },
         {
           wallTimeMs,
@@ -615,7 +622,7 @@ async function executeSubagent(
         origin: 'subagent_result',
       });
     },
-    onError: (err) => deliverSubagentError(err),
+    onError: (err, result) => deliverSubagentError(err, result),
   });
   promise
     .catch((err: unknown) => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -573,8 +573,7 @@ async function executeSubagent(
           touchedFiles,
           executionId,
           streamId: resolvedChildStreamId,
-          memoryMisses:
-            memoryMisses.length > 0 ? [...memoryMisses] : undefined,
+          memoryMisses: memoryMisses.length > 0 ? [...memoryMisses] : undefined,
         },
         {
           wallTimeMs,

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -12,6 +12,7 @@ import type {
   AgentFlowResult,
   OutputFileSummary,
 } from '@agent/runtime/AgentFlowResult';
+import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import type { ExecResult } from '@agent/types/ResultTypes';
 import { normalizeProviderError, toErrorMessage } from '@common/errors';
 import type {
@@ -99,6 +100,20 @@ function workingDirectoryElement(value: string | undefined): string | null {
     : null;
 }
 
+function formatMemoryMisses(
+  misses: readonly AttachedMemoryMiss[] = [],
+): string[] {
+  if (misses.length === 0) return [];
+  return [
+    '<memory-misses>',
+    ...misses.map(
+      (miss) =>
+        `<memory-miss path="${escapeAttr(miss.path)}" reason="${escapeAttr(miss.reason)}" />`,
+    ),
+    '</memory-misses>',
+  ];
+}
+
 /**
  * Format an AgentFlowResult as a delivery message.
  * Injected into the orchestrator's FollowUpQueue as a user-role message.
@@ -130,6 +145,7 @@ export function formatSubagentDelivery(
 
   const wdElement = workingDirectoryElement(options?.workingDirectory);
   if (wdElement) lines.push(wdElement);
+  lines.push(...formatMemoryMisses(result.memoryMisses));
 
   if (result.category === 'workflow') {
     if (result.outputs.length > 0) {
@@ -168,7 +184,11 @@ export function formatSubagentError(
   executionId: string,
   agentName: string,
   err: unknown,
-  options?: { wallTimeMs?: number; workingDirectory?: string },
+  options?: {
+    wallTimeMs?: number;
+    workingDirectory?: string;
+    memoryMisses?: readonly AttachedMemoryMiss[];
+  },
 ): string {
   const formatted = normalizeProviderError(err);
   const lines = [
@@ -179,6 +199,7 @@ export function formatSubagentError(
   }
   const wdElement = workingDirectoryElement(options?.workingDirectory);
   if (wdElement) lines.push(wdElement);
+  lines.push(...formatMemoryMisses(options?.memoryMisses));
   lines.push(
     `<message>${escapeText(formatted.message)}</message>`,
     '</subagent-error>',


### PR DESCRIPTION
## Summary
- record attached-memory read misses during the existing prompt memory load pass
- carry those misses through agent flow results and subagent delivery/error XML
- include the same metadata in early interactive tool-use subagent delivery

## Design note
This keeps `buildUserVars` as the single source of truth for attached-memory reads. There is no separate preflight existence check or extra resolver path; the same read that builds `<attached_memories>` also records unreadable paths.

## Validation
- `corepack pnpm vitest run src/test-kernel/agent/UserVarsMissingFiles.vitest.mts src/test-kernel/tools/SubagentResults.vitest.ts src/test-kernel/tools/ToolStatusFormatting.vitest.ts src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`

Part of #5665. The broader memo export/write-back idea from that issue remains out of scope for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and delivery-metadata changes along the existing memory load path; no new auth or persistence semantics beyond optional fields on flow results.
> 
> **Overview**
> **Attached memory read failures are now surfaced end-to-end** instead of being silently skipped when building prompt XML.
> 
> During `buildUserVars`, the same pass that loads `/memories/...` for `ATTACHED_MEMORIES` now records `{ path, reason }` misses in `ATTACHED_MEMORY_MISSES`. Launch context parses those into `attachedMemoryMisses` and optional `memoryMisses` on terminal `AgentFlowResult` (workflow and tool-use).
> 
> Orchestrators see misses in subagent delivery and error XML (`<memory-misses>` / `<memory-miss>`). Interactive tool-use subagents get them on the extended `onBeforeWaiting` callback (third argument) and in early `delegate_agent` reports. `ToolUseWaitNode` forwards launch-context misses into that hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2234f1f1bd00fea1aba6bc1ef815ab5679543d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->