### PR TITLE
fix: buffer model picker hotkeys while loading

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -568,6 +568,22 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'model-form-buffered-hotkey',
+    env: {
+      HARNESS_CAN_SELECT_MODEL: '1',
+      HARNESS_ENTRIES: '4',
+    },
+    keys: ['/model', '\r', '21'],
+    frame: 'tail',
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: ['Harness model selected. Future turns:'],
+    unexpect: [
+      'Finish the active response before switching models.',
+      'Platform not initialized',
+      '/model - error',
+    ],
+  },
+  {
     name: 'model-form-included-empty',
     env: {
       HARNESS_AUTHENTICATED: '1',

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -5,6 +5,7 @@
 
 import { Box, Text, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
+import { useEffect, useRef } from 'react';
 
 import {
   emptyModelListMessageForCliMode,
@@ -15,7 +16,7 @@ import {
   type GetModelSwitchDisabledReason,
 } from '@cli/runtime/modelAccess';
 import { formatCliApiMode, type CliApiMode } from '@cli/runtime/apiAccessMode';
-import { Select } from '../ui/Select';
+import { Select, selectIndexForHotkeyInput } from '../ui/Select';
 import { KeyHints } from '../ui/KeyHints';
 import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
 import {
@@ -84,26 +85,13 @@ function EmptyModelListState(props: {
 }
 
 export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
-  const { data, loading, error } = useAsyncListForm<readonly CliModelAccess[]>({
-    load: () => getCliModelAccessList({ apiMode: props.apiMode }),
-    onClose: props.onClose,
-    isEmpty: (models) => !models.some((model) => model.available),
-  });
-
-  if (loading) {
-    return (
-      <FormFrame color="cyan" title="/model">
-        <Spinner label="Loading model registry..." />
-      </FormFrame>
-    );
-  }
-  if (error) {
-    return (
-      <FormFrame color="red" title="/model - error">
-        <Text>{error}</Text>
-      </FormFrame>
-    );
-  }
+  const { data, loading, error, pendingInput, clearPendingInput } =
+    useAsyncListForm<readonly CliModelAccess[]>({
+      load: () => getCliModelAccessList({ apiMode: props.apiMode }),
+      onClose: props.onClose,
+      isEmpty: (models) => !models.some((model) => model.available),
+    });
+  const appliedPendingInput = useRef<string | undefined>(undefined);
 
   const models = data ?? [];
   const items = modelSelectItemsForCliMode(
@@ -127,6 +115,42 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
       return;
     }
     props.onClose();
+  }
+
+  useEffect(() => {
+    if (loading || error || !selectable || !pendingInput) return;
+    if (appliedPendingInput.current === pendingInput) return;
+    appliedPendingInput.current = pendingInput;
+
+    const index = selectIndexForHotkeyInput(pendingInput);
+    clearPendingInput();
+    if (index == null) return;
+
+    const choice = items[index];
+    if (choice && !choice.disabled) props.onSelect?.(choice.value);
+  }, [
+    clearPendingInput,
+    error,
+    items,
+    loading,
+    pendingInput,
+    props.onSelect,
+    selectable,
+  ]);
+
+  if (loading) {
+    return (
+      <FormFrame color="cyan" title="/model">
+        <Spinner label="Loading model registry..." />
+      </FormFrame>
+    );
+  }
+  if (error) {
+    return (
+      <FormFrame color="red" title="/model - error">
+        <Text>{error}</Text>
+      </FormFrame>
+    );
   }
 
   if (isCompactFormRows(props.availableRows) && items.length > 0) {

--- a/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
@@ -4,10 +4,11 @@
 // copied verbatim across every list form; it lives here once.
 
 import { useInput } from 'ink';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import {
   isEscapeInput,
+  isPlainReturnInput,
   type ReturnKeyInput,
 } from '@cli/chat/tui/input/inputKeys';
 
@@ -15,6 +16,12 @@ export interface AsyncListFormState<T> {
   readonly data: T | undefined;
   readonly loading: boolean;
   readonly error: string | undefined;
+  /**
+   * First non-navigation key pressed while the async list was loading. Forms
+   * can apply it once their actionable items are mounted, then clear it.
+   */
+  readonly pendingInput: string | undefined;
+  readonly clearPendingInput: () => void;
   /**
    * Replace the loaded data after mount. Used by forms whose loaded list is
    * mutable in place (e.g. `/tools` re-reading statuses after a toggle).
@@ -48,6 +55,30 @@ export function shouldCloseAsyncListFormOnInput(args: {
   );
 }
 
+export function shouldBufferAsyncListFormInput(args: {
+  readonly input: string;
+  readonly key: Pick<ReturnKeyInput, 'ctrl' | 'escape' | 'meta' | 'return'> & {
+    readonly downArrow?: boolean;
+    readonly leftArrow?: boolean;
+    readonly rightArrow?: boolean;
+    readonly upArrow?: boolean;
+  };
+  readonly loading: boolean;
+}): boolean {
+  return (
+    args.loading &&
+    args.input.length > 0 &&
+    !args.key.ctrl &&
+    !args.key.meta &&
+    !args.key.downArrow &&
+    !args.key.leftArrow &&
+    !args.key.rightArrow &&
+    !args.key.upArrow &&
+    !isEscapeInput(args.input, args.key) &&
+    !isPlainReturnInput(args.input, args.key)
+  );
+}
+
 /**
  * Run the form's loader on mount, expose `loading` / `error` / `data`, and wire
  * `Esc` to close while the panel is loading, errored, or empty. Matches the
@@ -60,6 +91,8 @@ export function useAsyncListForm<T>(
   const [data, setData] = useState<T | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | undefined>(undefined);
+  const [pendingInput, setPendingInput] = useState<string | undefined>();
+  const clearPendingInput = useCallback(() => setPendingInput(undefined), []);
 
   const empty =
     data !== undefined && options.isEmpty ? options.isEmpty(data) : false;
@@ -75,6 +108,10 @@ export function useAsyncListForm<T>(
       })
     ) {
       options.onClose();
+      return;
+    }
+    if (shouldBufferAsyncListFormInput({ input, key, loading })) {
+      setPendingInput((current) => current ?? input);
     }
   });
 
@@ -98,5 +135,5 @@ export function useAsyncListForm<T>(
     // Load once on mount, matching the original per-form `useEffect(..., [])`.
   }, []);
 
-  return { data, loading, error, setData };
+  return { data, loading, error, pendingInput, clearPendingInput, setData };
 }

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -4,7 +4,10 @@ import {
   modelListDescription,
   modelSelectWindow,
 } from '@cli/chat/tui/forms/ModelListForm';
-import { shouldCloseAsyncListFormOnInput } from '@cli/chat/tui/forms/_shared/useAsyncListForm';
+import {
+  shouldBufferAsyncListFormInput,
+  shouldCloseAsyncListFormOnInput,
+} from '@cli/chat/tui/forms/_shared/useAsyncListForm';
 import {
   COMPACT_FORM_MAX_ROWS,
   isCompactFormRows,
@@ -74,6 +77,66 @@ describe('CLI async list form close input', () => {
         loading: false,
         error: undefined,
         empty: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('CLI async list form buffered input', () => {
+  it('captures ordinary keys while loading', () => {
+    expect(
+      shouldBufferAsyncListFormInput({
+        input: '6',
+        key: {},
+        loading: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldBufferAsyncListFormInput({
+        input: '21',
+        key: {},
+        loading: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores navigation, enter, escape, and modified keys', () => {
+    expect(
+      shouldBufferAsyncListFormInput({
+        input: '2',
+        key: { downArrow: true },
+        loading: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBufferAsyncListFormInput({
+        input: '\r',
+        key: { return: true },
+        loading: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBufferAsyncListFormInput({
+        input: '\u001B',
+        key: { escape: true },
+        loading: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBufferAsyncListFormInput({
+        input: 'c',
+        key: { ctrl: true },
+        loading: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('only buffers while loading', () => {
+    expect(
+      shouldBufferAsyncListFormInput({
+        input: '6',
+        key: {},
+        loading: false,
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary
- buffer one ordinary key pressed while async slash-list forms are loading
- apply that buffered key in `/model` once the model rows mount, using the existing Select hotkey and disabled-row rules
- add unit coverage plus a PTY TUI harness scenario for fast `/model` hotkey input

## Root Cause
Dogfooding found that fast input like `/model` + `6` could be swallowed when the model registry was still loading. `Select` already handles buffered chunks once mounted, but `/model` rendered only a spinner during loading, so the hotkey was lost before the rows existed.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/SelectHotkeys.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run validate:tui -- model-form-buffered-hotkey`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts packages/cli/src/chat/tui/forms/ModelListForm.tsx src/test-kernel/cli/ModelListForm.vitest.mts packages/cli/scripts/validate-tui.mjs`
- `corepack pnpm typecheck`
- `git diff --check`
- `npm run lint` (passes with pre-existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI input buffering and `/model` selection only; scoped changes with targeted tests and no auth or data-path impact.
> 
> **Overview**
> Fixes **fast `/model` hotkeys being lost** while the model registry is still loading. During the spinner, `Select` is not mounted, so keys like `6` were dropped before rows appeared.
> 
> **`useAsyncListForm`** now buffers the **first non-navigation key** pressed while `loading` (via `shouldBufferAsyncListFormInput`), exposing `pendingInput` and `clearPendingInput`. Navigation, Enter, Escape, and modified keys are not buffered.
> 
> **`ModelListForm`** applies that buffered input after the list mounts: it maps it with `selectIndexForHotkeyInput` and calls `onSelect` for enabled rows, matching existing Select hotkey rules.
> 
> Adds **unit tests** for the buffer predicate and a **PTY TUI scenario** (`model-form-buffered-hotkey`) that drives `/model`, Enter, and `21` during load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac7c4719cf4aa815283e20632a241676a667754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->