### PR TITLE
docs: update CLI model picker guidance

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -44,7 +44,7 @@ The Dashboard tabs are the recommended way to manage agents, models, tools, and 
 
 Most configuration happens in the **Dashboard** (above) — open it with `TeXRA: Show Settings Dashboard`. The CLI keeps project defaults in a per-project `.texra/config.json` (`texra init` scaffolds one).
 
-Many `texra.*` keys share the same **name** across the VS Code extension and the CLI's `.texra/config.json` (most of the file-, LaTeX-, and model-connection settings below), so the same documentation applies to both. They don't share storage, though — the extension persists settings in VS Code's config/global state, while the CLI reads `.texra/config.json`. Some keys are extension-only (for example the LaTeX formatter and the model picker, which live in extension state); the CLI warns on any key it doesn't recognize.
+Many `texra.*` keys share the same **name** across the VS Code extension and the CLI's `.texra/config.json` (most of the file-, LaTeX-, and model-connection settings below), so the same documentation applies to both. They don't share storage, though — the extension persists settings in VS Code's config/global state, while the CLI reads `.texra/config.json`. Some keys are extension-only (for example the LaTeX formatter and extension model visibility settings); the CLI warns on any key it doesn't recognize.
 
 VS Code's built-in Settings UI remains available for power users — open it with `Ctrl+,` (`Cmd+,` on macOS), search for "TeXRA", and edit in the UI or the JSON. It's no longer the primary path, so reach for the Dashboard or CLI config first.
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -121,9 +121,11 @@ GLM models support thinking mode (reasoning is shown inline). The API uses a non
 
 ## Customizing the Model List
 
-Choose which models appear in the picker from the **Dashboard → Models** tab — toggle them on or off per provider, no JSON required (the choice is saved in the extension).
+Choose which models appear in the extension picker from the **Dashboard → Models** tab — toggle them on or off per provider, no JSON required (the choice is saved in the extension).
 
-The CLI has no picker. List what's available with `texra models list` (or `texra models show <id>` for details), then pick a default for your project by setting the `model` key in `.texra/config.json`, or override per run with `--model <id>`.
+In the CLI TUI, use `/model` after a chat starts to switch among models that are runnable in the active API mode. Startup also asks for a model when the launcher flow needs one after the agent or team choice.
+
+For headless CLI runs, list what's available with `texra models list` (or `texra models show <id>` for details), then pick a default for your project by setting the `model` key in `.texra/config.json`, or override per run with `--model <id>`.
 
 ## Using OpenRouter
 


### PR DESCRIPTION
## Summary
- replace stale guidance that said the CLI has no model picker
- document the TUI /model path separately from headless CLI model selection
- scope Dashboard model visibility settings to the extension picker

## Validation
- corepack pnpm exec prettier --check docs/guide/models.md docs/guide/configuration.md
- git diff --check -- docs/guide/models.md docs/guide/configuration.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime or configuration behavior impact.
> 
> **Overview**
> **Documentation-only** updates so model-selection guidance matches how the CLI and extension work today.
> 
> In **models.md**, Dashboard model toggles are scoped to the **extension** picker. The guide adds a **CLI TUI** path: `/model` after chat starts (models limited to the active API mode) and launcher prompts when a model is still needed after agent/team selection. **Headless** CLI selection is split out: `texra models list` / `show`, `.texra/config.json` `model`, and `--model`.
> 
> In **configuration.md**, extension-only settings are described as **extension model visibility** instead of referring to an extension-only “model picker,” consistent with the models page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df816cf49f208ed87293bb96a57a423a0a1192a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->