### PR TITLE
refactor: consolidate duplicate clampIndex and collapseWhitespace patterns

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -9,10 +9,11 @@ import { Box, Text, useInput } from 'ink';
 import type { StreamTabId } from '@shared/schemas';
 
 // Local imports - CLI state and UI
+import { clampIndex } from '@utils/core';
+
 import {
   buildChildControlItems,
   childPickerKeyAction,
-  clampPickerIndex,
   liveChildExecutionElapsedKey,
   nextPickerIndex,
   subagentPickerSelection,
@@ -981,7 +982,7 @@ export function ChildControlPicker({
     undefined,
   );
   const streamScopeLabel = streamLabel ?? activeStreamId;
-  const selectedIndex = clampPickerIndex(highlight, items.length);
+  const selectedIndex = clampIndex(highlight, items.length);
   const selectedItem = items[selectedIndex];
   const hasItems = items.length > 0;
   const tailItem = tailExecutionId
@@ -1014,7 +1015,7 @@ export function ChildControlPicker({
     : framedPickerHintColumns(availableColumns);
 
   useEffect(() => {
-    setHighlight((current) => clampPickerIndex(current, items.length));
+    setHighlight((current) => clampIndex(current, items.length));
   }, [items.length]);
 
   useEffect(() => {

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -7,7 +7,7 @@ import {
   type ActiveChildInfo,
   type StreamTabId,
 } from '@shared/schemas';
-import { clamp, formatDuration } from '@utils/core';
+import { formatDuration } from '@utils/core';
 
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
@@ -420,11 +420,6 @@ export function numericFocusTargetForActiveStream(init: {
     parentStream: init.parentStream,
     streams: init.streams,
   })[init.zeroBasedIndex];
-}
-
-export function clampPickerIndex(index: number, length: number): number {
-  if (length <= 0) return 0;
-  return clamp(index, 0, length - 1);
 }
 
 export function nextPickerIndex(

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -11,7 +11,7 @@
 import { Box, Text, useInput } from 'ink';
 import { useEffect, useState } from 'react';
 
-import { clamp } from '@utils/core';
+import { clampIndex } from '@utils/core';
 
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 
@@ -34,11 +34,6 @@ export interface SelectProps<T> {
   readonly initialIndex?: number;
   readonly maxVisibleItems?: number;
   readonly showOverflow?: boolean;
-}
-
-function clampIndex(index: number, length: number): number {
-  if (length <= 0) return 0;
-  return clamp(index, 0, length - 1);
 }
 
 function firstEnabledSelectIndex<T>(

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -11,6 +11,8 @@
  * Returns an `InjectionOutcome` so the caller (action handler) can
  * forward it to the UI via the `inquiryThreadUpdated` event.
  */
+import { collapseWhitespace } from '@utils/text/stringUtils';
+
 import { platform } from '@platform/platform';
 
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
@@ -43,8 +45,7 @@ function truncate(text: string, limit: number): string {
 }
 
 function previewText(text: string, limit: number): string {
-  const collapsed = text.replaceAll(/\s+/g, ' ').trim();
-  return truncate(collapsed, limit);
+  return truncate(collapseWhitespace(text), limit);
 }
 
 function readThreadCommand(threadId: ExternalInquiryThreadId): string {

--- a/src/tools/workPlanGranularityFeedback.ts
+++ b/src/tools/workPlanGranularityFeedback.ts
@@ -1,7 +1,9 @@
+import { collapseWhitespace } from '@utils/text/stringUtils';
+
 import { type Plan, type TodoItem } from '@shared/schemas';
 
 function taskKey(value: string): string {
-  return value.trim().replaceAll(/\s+/g, ' ').toLowerCase();
+  return collapseWhitespace(value).toLowerCase();
 }
 
 export function formatWorkPlanGranularityWarning(

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -22,4 +22,4 @@ export {
   ensureArray,
 } from './typeGuards';
 export { debounce, delay } from './async';
-export { clamp } from './math';
+export { clamp, clampIndex } from './math';

--- a/src/utils/core/math.ts
+++ b/src/utils/core/math.ts
@@ -5,3 +5,12 @@
 export function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
+
+/**
+ * Clamp `index` into `[0, length - 1]`.
+ * Returns 0 when `length <= 0` so the result is always a valid array index.
+ */
+export function clampIndex(index: number, length: number): number {
+  if (length <= 0) return 0;
+  return clamp(index, 0, length - 1);
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Add `clampIndex` to `@utils/core/math`**: exports a shared `clampIndex(index, length)` helper from the barrel. Removes two identical private helpers that existed independently:
  - `function clampIndex` in `Select.tsx` (file-local)
  - `export function clampPickerIndex` in `childControls.ts` (and its consumer `ChildControlPicker.tsx`)
  Both were `if (length <= 0) return 0; return clamp(index, 0, length - 1)`.

- **Use existing `collapseWhitespace`** in two call sites that re-implemented it inline:
  - `inquiryContinuation.ts`: `text.replaceAll(/\s+/g, ' ').trim()` → `collapseWhitespace(text)`
  - `workPlanGranularityFeedback.ts`: `value.trim().replaceAll(/\s+/g, ' ')` → `collapseWhitespace(value)`

No behaviour changes — purely mechanical substitution of identical logic with the canonical shared utility.

## Test plan

- [ ] `npm run typecheck` passes (pre-existing env errors unrelated to this PR)
- [ ] `npm run lint` passes
- [ ] `npm run format` produces no changes

https://claude.ai/code/session_01BZQwDhfKW2d8V5M6KQCA38
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZQwDhfKW2d8V5M6KQCA38)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication with equivalent helpers; no auth, data, or control-flow changes.
> 
> **Overview**
> Centralizes two small utilities that were duplicated across the CLI TUI and tools.
> 
> **`clampIndex`** is added to `@utils/core/math` and exported from the core barrel. TUI pickers (`Select`, `ChildControlPicker`) and `childControls` drop their local `clampIndex` / `clampPickerIndex` helpers and import the shared helper instead.
> 
> **`collapseWhitespace`** from `@utils/text/stringUtils` replaces inline `trim` + `/\s+/g` normalization in inquiry continuation previews and work-plan granularity task keys.
> 
> No intended behavior change—same logic, one canonical implementation per pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33354f3fba672906c63501ea0a37a6d43da0786c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->