### PR TITLE
docs: replace stale AgentLogger references with AgentTrace, fix commands file path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,7 @@ For good separation of concerns and platform independence, core business logic s
 
 **Logging and telemetry**
 
-- Route logging through `@logger/logUtils`. Agent flows should wrap the logger with `AgentLogger` (`src/logger/AgentLogger.ts`) to get grouped output and tool-use aware channels.
+- Route logging through `@logger/logUtils`. Agent flows should use `AgentTrace` (`@agent/trace`) to get grouped output and tool-use aware channels.
 - Always pass structured payloads via the `data` argument (file lists, missing outputs, latexdiff results, usage statistics) so the progress view can render rich entries without custom parsing.
 - Publish progress updates with the event bus (`bus.emit`/`bus.on` from `src/eventBus/ProgressEventBus.ts`) and keep non-agent logs on the shared `TeXRA` output channel.
 
@@ -333,7 +333,7 @@ See `docs/pocketflow/` for full framework documentation.
 
 - **Base Classes**: All webviews (webview, progressView, settingsView) extend `BaseViewContentProvider` and `BaseViewMessageHandler` from `src/common/webview/` for consistent error handling, logging, and cleanup.
 - **Naming Convention**: Follow `[Domain]View[Component]` pattern (e.g., `MainViewContentProvider`, `SettingsViewMessageHandler`, `ProgressViewContentProvider`)
-- **Command Constants**: Define all commands in `src/common/webview/commands.ts` - use constants, not string literals
+- **Command Constants**: Define commands in `src/shared/ipc/commonCommands.ts` (plus per-view `*ViewCommands.ts` files under `src/shared/ipc/`) — use constants, not string literals
 - **Message Handlers**: Delegate to domain-specific manager classes (FileManager, SettingsManager, etc.) for separation of concerns
 - **Client-Side State**: Add empty handlers with `/* State saved client-side */` comment for checkbox/toggle operations
 - **Resource Access**: Include all common module paths in `localResourceRoots` to prevent 401 errors

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1194,7 +1194,7 @@ export async function runChat(
         } else {
           session.runExitCode = CliExitCode.AgentError;
         }
-        // Pull any final MODEL_RESPONSE chunks out of the AgentLogger
+        // Pull any final MODEL_RESPONSE chunks out of the AgentTrace
         // buffer before falling back to `result.lastResponse`. Without
         // this, a reply that finalized between sync ticks would never
         // hit the transcript.

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -10,7 +10,7 @@ import {
 import { endToolUseCard, startToolUseCard } from '@agent/trace';
 import { MESSAGE_TYPES } from '@shared/schemas';
 
-describe('AgentLogger stream output', () => {
+describe('AgentTrace stream output', () => {
   afterEach(() => {
     vi.useRealTimers();
   });

--- a/src/test/logger/errorData.test.ts
+++ b/src/test/logger/errorData.test.ts
@@ -9,7 +9,7 @@ import {
   StreamLogStore,
 } from '@transcript';
 
-describe('AgentLogger error data', () => {
+describe('AgentTrace error data', () => {
   beforeEach(async () => {
     const store = new StreamLogStore();
     setDefaultStreamLogStore(store);

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -93,7 +93,7 @@ export class StreamLog {
 
     // Direct merge — no Zod parse. update() is on the streaming hot path
     // (tool output chunks at ~200/sec) and receives trusted data from
-    // AgentLogger. Persisted entries are parsed when loaded from storage.
+    // AgentTrace. Persisted entries are parsed when loaded from storage.
     const updated: StreamLogEntry = {
       ...current,
       ...patch,

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -7,7 +7,7 @@
  * channel itself is platform-neutral, and TeXRA's transcript persistence is
  * one of many possible subscribers.
  *
- * Streaming behavior mirrors the legacy `AgentLogger.createStream`:
+ * Streaming behavior mirrors the `AgentTrace` stream pattern:
  *   - first chunk creates the entry (with empty text if no chunks yet)
  *   - subsequent chunks are buffered + flushed on an interval
  *   - finalize flushes any pending chunks immediately


### PR DESCRIPTION
Replace all stale `AgentLogger` references with `AgentTrace` and correct the commands file path in AGENTS.md.

- AGENTS.md:277: replace `AgentLogger` with `AgentTrace`, correct import path to `@agent/trace`
- AGENTS.md:336: correct commands file path to `src/shared/ipc/commonCommands.ts`
- src/transcript/StreamLog.ts:96: update comment from `AgentLogger` to `AgentTrace`
- src/transcript/TexraTranscriptRecorder.ts:10: update comment from `AgentLogger` to `AgentTrace`
- src/test/logger/errorData.test.ts:12: update test description
- src/test-kernel/agent/trace/RunTraceStream.vitest.ts:13: update test description
- packages/cli/src/chat/tui/runChatTui.tsx:1197: update code comment

Note: .claude/skills/code-review/references/review-checklist.md:33 needs a manual edit (the .claude/ directory is write-protected in this environment).

Closes #5635

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation-only edits with no runtime or API behavior changes.
> 
> **Overview**
> Updates contributor docs and in-repo comments so they match the **`AgentTrace`** (`@agent/trace`) naming and the current IPC layout.
> 
> **AGENTS.md** now tells agent flows to use `AgentTrace` instead of the old `AgentLogger` / `src/logger/AgentLogger.ts` path, and points webview command constants at `src/shared/ipc/commonCommands.ts` (with per-view `*ViewCommands.ts` under `src/shared/ipc/`).
> 
> Inline comments in **`StreamLog.ts`**, **`TexraTranscriptRecorder.ts`**, the CLI TUI **`runChatTui.tsx`** transcript flush note, and two test **`describe`** blocks are aligned to **AgentTrace** wording only—no logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2704e23bdb6606b24284451928a1678db643b033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->