### PR TITLE
refactor(webview-styles): add --border-radius-pill token, replace hardcoded font-weight and border-radius literals

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -285,7 +285,7 @@ export class ProgressApp extends ProgressAppBase {
         margin: var(--wa-space-2xs) 0 0;
         color: var(--wa-color-text-normal);
         font-size: 24px;
-        font-weight: 600;
+        font-weight: var(--font-weight-semibold);
         letter-spacing: 0;
       }
 

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -247,7 +247,7 @@ export class StreamHeader extends LitElement {
         gap: var(--wa-space-3xs);
         flex-shrink: 0;
         padding: 0 var(--wa-space-2xs);
-        border-radius: 999px;
+        border-radius: var(--border-radius-pill);
         font-size: var(--font-size-xs);
         font-weight: var(--font-weight-medium);
         cursor: default;

--- a/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
@@ -73,7 +73,7 @@ export class RelayQuotaMeter extends LitElement {
         margin-bottom: var(--wa-space-xs);
       }
       .quota-label {
-        font-weight: 600;
+        font-weight: var(--font-weight-semibold);
         font-size: var(--wa-font-size-s);
       }
       .quota-amount {

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -76,7 +76,7 @@ export class GitTab extends LitElement {
       }
 
       .section-title {
-        font-weight: 600;
+        font-weight: var(--font-weight-semibold);
         margin: 0;
       }
 

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -152,7 +152,7 @@ export class InstructionPanel extends LitElement {
         );
         color: var(--wa-color-text-normal);
         font-size: var(--font-size-sm);
-        font-weight: 600;
+        font-weight: var(--font-weight-semibold);
         pointer-events: none;
       }
 
@@ -226,7 +226,7 @@ export class InstructionPanel extends LitElement {
 
       .session-hint-lede {
         color: var(--wa-color-text-normal);
-        font-weight: 600;
+        font-weight: var(--font-weight-semibold);
         letter-spacing: 0.01em;
         white-space: nowrap;
       }

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -56,6 +56,7 @@ export const designTokens: CSSResult = css`
     --border-radius: 3px;
     --border-radius-medium: 4px;
     --border-radius-large: 6px;
+    --border-radius-pill: 999px;
 
     /* Heights */
     --height-control: 24px;


### PR DESCRIPTION
…dcoded font-weight and border-radius literals

Add --border-radius-pill: 999px design token and replace remaining hardcoded font-weight: 600 values with var(--font-weight-semibold) in Lit CSS templates. Convert odyssey-chip's border-radius: 999px to use the new pill token.

--font-weight-semibold and --transition-* tokens were already defined in #5624; this completes the consolidation pass for font-weight and pill-radius categories. Transitions and borders were already largely tokenized — the remaining hardcoded values are in the htmlExport system (--ce-* namespace) and inline styles, which are separate styling contexts.

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only token swaps with no behavior, API, or data-path changes; visual parity is the only surface area.
> 
> **Overview**
> Adds **`--border-radius-pill: 999px`** to shared `designTokens` in `litStyles.ts` and wires it into Progress, Settings, and Main webview Lit CSS.
> 
> **`.odyssey-chip`** in `StreamHeader` now uses `var(--border-radius-pill)` instead of a literal `999px`. Remaining **`font-weight: 600`** literals in those views are replaced with **`var(--font-weight-semibold)`** (empty Progress desktop heading, relay quota label, Git tab section titles, instruction drop overlay and session-hint lede). Visual behavior should be unchanged; styling goes through the shared token set from earlier work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6148b94cfcc4db7644834bc22d4aa577cc9699c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->