### PR TITLE
refactor(webview-styles): remove dead CSS selectors from profile/styles.ts

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -11,25 +11,6 @@ export const profileViewStyles: CSSResult = css`
     padding-bottom: var(--wa-space-2xs);
   }
 
-  .profile-container {
-    max-width: 1000px;
-    margin: 0 auto;
-  }
-
-  .not-authenticated {
-    text-align: center;
-    padding: var(--wa-space-l);
-  }
-
-  .not-authenticated p {
-    margin-bottom: var(--wa-space-l);
-    color: var(--color-text-secondary);
-  }
-
-  .remote-agents-section {
-    margin-top: var(--wa-space-l);
-  }
-
   /* ============================================
    * Provider Keys Table
    * ============================================ */
@@ -55,29 +36,6 @@ export const profileViewStyles: CSSResult = css`
     top: 0;
   }
 
-  /* Profile-specific badge modifiers (base category styles from @shared/styles) */
-  .category-badge {
-    text-transform: capitalize;
-  }
-
-  .visibility-badge {
-    text-transform: lowercase;
-  }
-
-  .badge.visibility-badge.public {
-    background: var(--wa-color-success-fill-loud);
-    color: var(--wa-color-brand-on-loud);
-  }
-
-  .badge.visibility-badge.custom {
-    background: var(--wa-color-neutral-fill-quiet);
-    color: var(--wa-color-neutral-on-quiet);
-  }
-
-  .select-btn {
-    white-space: nowrap;
-  }
-
   /* ============================================
    * API Access Options
    * ============================================ */
@@ -85,12 +43,6 @@ export const profileViewStyles: CSSResult = css`
   .api-access-section {
     margin-top: var(--wa-space-l);
     margin-bottom: var(--wa-space-l);
-  }
-
-  .api-access-description {
-    color: var(--color-text-secondary);
-    margin-bottom: var(--wa-space-xs);
-    line-height: var(--line-height-normal);
   }
 
   /* wa-radio-group provides layout + keyboard navigation; the per-option card
@@ -315,12 +267,6 @@ export const profileViewStyles: CSSResult = css`
 
   .model-selection-section h2 {
     margin-top: 0;
-  }
-
-  .model-selection-description {
-    color: var(--color-text-secondary);
-    margin-bottom: var(--wa-space-xs);
-    line-height: var(--line-height-normal);
   }
 
   .helper-model-row {


### PR DESCRIPTION
Follow-up from #5624.

Removes 11 dead CSS selectors from `profile/styles.ts` that were identified during the dead-CSS audit but deferred to keep #5624 bounded.

Each selector was confirmed dead via adversarial grep — zero matches in rendered markup across all 7 profile components and the parent `ModelsTab`.

### Removed
- `.profile-container`
- `.not-authenticated` (+ `p` child)
- `.remote-agents-section`
- `.category-badge`
- `.visibility-badge` (+ `.badge.visibility-badge.public`, `.badge.visibility-badge.custom`)
- `.select-btn`
- `.api-access-description`
- `.model-selection-description`

### Verification
- `npm run compile:fast` — ✅ clean
- `npm run lint` — ✅ 0 errors

Closes #5629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style-only deletion of unused selectors; no runtime logic or markup changes.
> 
> **Overview**
> Follow-up cleanup in **`profile/styles.ts`** that deletes **11 unused CSS rules** left over from a dead-CSS audit (after #5624).
> 
> Removed layout/auth/section hooks (`.profile-container`, `.not-authenticated`, `.remote-agents-section`), badge and button styling (`.category-badge`, `.visibility-badge` variants, `.select-btn`), and secondary description text classes (`.api-access-description`, `.model-selection-description`). **No markup or component changes**—only shrinking the Lit `profileViewStyles` sheet so it matches what profile UI actually renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5e7a132e07399faa85696ccea753f5f24ecec2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->