### PR TITLE
Use RoundOutput schema for output state instead of local RoundData

### DIFF
--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -4,7 +4,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   type FileLocation,
   type OutputFileInfo,
-  type OutputXmlSummary,
+  type RoundOutput,
   type StorageKey,
 } from '@shared/schemas';
 import { flexibleFS, replaceInputCommands } from '@utils/files';
@@ -25,7 +25,7 @@ export interface ProcessingContext {
   logger: AgentTrace;
   xmlManager: XmlOutputManager;
   setRoundOutputs: (round: number, outputs: OutputFileInfo[]) => void;
-  ensureRoundData: (round: number) => { xmlSummary: OutputXmlSummary };
+  ensureRoundData: (round: number) => RoundOutput;
 }
 
 /** Handles processing of single and multiple output files. */

--- a/src/agent/output/outputState.ts
+++ b/src/agent/output/outputState.ts
@@ -3,9 +3,12 @@
  *
  * Manages mutable state for output files across rounds, including
  * round data, storage keys, and workspace preparation.
+ *
+ * `OutputState.rounds` stores mutable `RoundOutput` objects — the same type
+ * persisted in `ReflectionFlowShared.roundOutputs`. Each round's entry is
+ * built up in-place during processing; `OutputNode.post()` then writes the
+ * completed entry to shared state for persistence.
  */
-
-import { z } from 'zod';
 
 import type { AgentTrace, StageHandle } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -13,12 +16,10 @@ import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { normalizeRunId } from '@common/constants/runIds';
 import {
-  CompileFailureSchema,
-  FileLocationSchema,
-  OutputFileInfoSchema,
   OutputXmlSummarySchema,
   type CompileFailure,
   type OutputFileInfo,
+  type RoundOutput,
   type StorageKey,
 } from '@shared/schemas';
 import {
@@ -28,17 +29,8 @@ import {
   type FileLocation,
 } from '@utils/files';
 
-const RoundDataSchema = z.object({
-  outputs: OutputFileInfoSchema.array().prefault(() => []),
-  compileFailures: CompileFailureSchema.array().prefault(() => []),
-  rawOutput: FileLocationSchema.nullable().prefault(null),
-  xmlSummary: OutputXmlSummarySchema.prefault(() => ({})),
-});
-
-export type RoundData = z.infer<typeof RoundDataSchema>;
-
 export interface OutputState {
-  rounds: Map<number, RoundData>;
+  rounds: Map<number, RoundOutput>;
   openedOutputs: Set<string>;
   storageKey: StorageKey | null;
   runPreparation: Promise<void> | null;
@@ -81,10 +73,16 @@ export function getStorageKey(state: OutputState): StorageKey {
   return state.storageKey ?? normalizeRunId(null);
 }
 
-export function ensureRoundData(state: OutputState, round: number): RoundData {
+export function ensureRoundData(state: OutputState, round: number): RoundOutput {
   let data = state.rounds.get(round);
   if (!data) {
-    data = RoundDataSchema.parse({});
+    data = {
+      round,
+      rawOutput: null,
+      outputs: [],
+      compileFailures: [],
+      xmlSummary: OutputXmlSummarySchema.parse({}),
+    };
     state.rounds.set(round, data);
   }
   return data;

--- a/src/agent/output/outputState.ts
+++ b/src/agent/output/outputState.ts
@@ -73,7 +73,10 @@ export function getStorageKey(state: OutputState): StorageKey {
   return state.storageKey ?? normalizeRunId(null);
 }
 
-export function ensureRoundData(state: OutputState, round: number): RoundOutput {
+export function ensureRoundData(
+  state: OutputState,
+  round: number,
+): RoundOutput {
   let data = state.rounds.get(round);
   if (!data) {
     data = {

--- a/src/agent/output/roundSummary.ts
+++ b/src/agent/output/roundSummary.ts
@@ -115,11 +115,5 @@ export async function getRoundOutput(
     );
   }
 
-  return {
-    round,
-    rawOutput: data.rawOutput,
-    outputs: data.outputs,
-    compileFailures: data.compileFailures,
-    xmlSummary: data.xmlSummary,
-  };
+  return data;
 }

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -10,11 +10,26 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 
+/**
+ * Flattened projection of {@link OutputFileInfo} for use in {@link AgentFlowResult}.
+ *
+ * The internal `OutputFileInfo` carries rich `FileLocationSchema` objects, full
+ * `FileLineageSchema` chains, and complete `DiffStats`. This summary strips those
+ * down to plain strings and scalars so the result can be cleanly serialized and
+ * consumed by orchestrators or storage without dragging in location internals.
+ *
+ * Conversion: see `toOutputSummaries()` in `executeAgent.ts`.
+ */
 export const OutputFileSummarySchema = z.object({
   round: z.int().nonnegative(),
   relativePath: z.string(),
   absolutePath: z.string(),
+  /** The `kind` discriminant of the source `FileLocation`. */
   location: z.enum(['workspace', 'runStorage', 'external']),
+  /**
+   * Absolute path of the lineage base file (diffBase takes precedence over
+   * original when both are present), or null if no lineage was recorded.
+   */
   originalPath: z.string().nullable(),
   added: z.int().nonnegative().nullable(),
   removed: z.int().nonnegative().nullable(),
@@ -22,6 +37,16 @@ export const OutputFileSummarySchema = z.object({
 
 export type OutputFileSummary = z.infer<typeof OutputFileSummarySchema>;
 
+/**
+ * Flattened projection of {@link CompileFailure} for use in {@link AgentFlowResult}.
+ *
+ * `CompileFailure` stores `FileLocationSchema` objects for `output` and `log`.
+ * This summary extracts plain paths: `outputPath` is workspace-relative for
+ * non-external files (absolute for external), `logPath` is always relative,
+ * and `logAbsolutePath` is always absolute for direct opening.
+ *
+ * Conversion: see `toCompileFailureSummaries()` in `executeAgent.ts`.
+ */
 export const CompileFailureSummarySchema = z.object({
   round: z.int().nonnegative(),
   displayName: z.string(),

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -52,7 +52,13 @@ import type {
 const CHANNEL = 'executeAgent';
 const logger = createChannelTrace(CHANNEL);
 
-/** Map workflow RoundOutput[] to OutputFileSummary[] for AgentFlowResult. */
+/**
+ * Project `RoundOutput[]` → `OutputFileSummary[]` for inclusion in `AgentFlowResult`.
+ *
+ * `relativePath` falls back to `absolutePath` for `external` locations that have
+ * no relative path. `originalPath` prefers `lineage.diffBase` (the snapshot used
+ * for latexdiff) over `lineage.original` (the workspace source).
+ */
 function toOutputSummaries(roundOutputs: RoundOutput[]): OutputFileSummary[] {
   return roundOutputs.flatMap((r) =>
     r.outputs.map((o: OutputFileInfo) => ({
@@ -73,6 +79,13 @@ function toOutputSummaries(roundOutputs: RoundOutput[]): OutputFileSummary[] {
   );
 }
 
+/**
+ * Project `RoundOutput[]` → `CompileFailureSummary[]` for inclusion in `AgentFlowResult`.
+ *
+ * `outputPath` is workspace-relative for workspace/runStorage files and absolute
+ * for external files (which have no meaningful relative path). `logPath` is always
+ * relative; `logAbsolutePath` is provided separately for direct file-open calls.
+ */
 function toCompileFailureSummaries(
   roundOutputs: RoundOutput[],
 ): CompileFailureSummary[] {

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -7,7 +7,8 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { OutputNode } from '@agent/implementations/flows/reflection/nodes/OutputNode';
 import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
-import { createOutputState, type RoundData } from '@agent/output/outputState';
+import { createOutputState } from '@agent/output/outputState';
+import type { RoundOutput } from '@shared/schemas';
 import {
   OutputFileProcessor,
   type ProcessingContext,
@@ -289,7 +290,7 @@ describe('output progress events', () => {
 
   it('publishes missing-output processing events through the runtime host', async () => {
     const { events, host } = createRecordingHost();
-    const roundData = new Map<number, RoundData>();
+    const roundData = new Map<number, RoundOutput>();
     const logger = {
       debug: () => {},
       domain: () => {},
@@ -299,10 +300,11 @@ describe('output progress events', () => {
         throw new Error('invalid xml');
       },
     } as unknown as XmlOutputManager;
-    const ensureRound = (round: number): RoundData => {
+    const ensureRound = (round: number): RoundOutput => {
       let data = roundData.get(round);
       if (!data) {
         data = {
+          round,
           outputs: [],
           compileFailures: [],
           rawOutput: null,
@@ -350,7 +352,7 @@ describe('output progress events', () => {
 
   it('emits missing-output events when extraction yields no files (no exception)', async () => {
     const { events, host } = createRecordingHost();
-    const roundData = new Map<number, RoundData>();
+    const roundData = new Map<number, RoundOutput>();
     const logger = {
       debug: () => {},
       domain: () => {},
@@ -358,10 +360,11 @@ describe('output progress events', () => {
     const xmlManager = {
       splitScratchpadMultipleOutputXml: async () => [],
     } as unknown as XmlOutputManager;
-    const ensureRound = (round: number): RoundData => {
+    const ensureRound = (round: number): RoundOutput => {
       let data = roundData.get(round);
       if (!data) {
         data = {
+          round,
           outputs: [],
           compileFailures: [],
           rawOutput: null,

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -8,7 +8,6 @@ import { OutputNode } from '@agent/implementations/flows/reflection/nodes/Output
 import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
 import { createOutputState } from '@agent/output/outputState';
-import type { RoundOutput } from '@shared/schemas';
 import {
   OutputFileProcessor,
   type ProcessingContext,


### PR DESCRIPTION
## Summary

Consolidate output state management by replacing the local `RoundData` type with the shared `RoundOutput` schema from `@shared/schemas`. This eliminates type duplication and establishes a single source of truth for round output structure across the codebase.

The change removes the Zod-based `RoundDataSchema` definition from `outputState.ts` and updates all references to use `RoundOutput` instead. The `ensureRoundData` function now constructs `RoundOutput` objects directly with the required `round` field, and `getRoundOutput` in `roundSummary.ts` simplifies to return the data object as-is rather than reconstructing it.

## Issue acceptance gates

N/A — This is a refactoring to improve code organization and reduce duplication.

## Single source of truth

`RoundOutput` schema in `@shared/schemas` now owns the definition of round output structure. All code that works with round data uses this shared type instead of maintaining a parallel local definition.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated `RoundDataSchema` and `RoundData` type from `outputState.ts` (7 lines)
- Removed redundant object reconstruction in `getRoundOutput()` that was manually copying fields from `RoundData` to a new object with the same shape

**Abstraction improvement:**
- `RoundOutput` is now the single definition point for round output structure, used consistently across output processing, state management, and persistence layers
- Reduces cognitive load by having one canonical type rather than two equivalent definitions

## Host impact

Extension: No impact — internal refactoring of output state management.

Desktop: No impact — internal refactoring of output state management.

CLI: No impact — internal refactoring of output state management.

## Scheduled refactoring

None.

## Validation

- Existing test suite in `OutputProgressEvents.vitest.ts` updated to use `RoundOutput` type and verified to construct objects with the required `round` field
- Type checking passes with the new schema-based approach
- No functional behavior changes — only type consolidation and object construction simplification

https://claude.ai/code/session_01CKBZqTACj7BNpJRDmcudr9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type consolidation and documentation with no intended runtime behavior change; risk is limited to incorrect default object shape if `ensureRoundData` omits `round`.
> 
> **Overview**
> **Output state now uses the shared `RoundOutput` type** instead of a duplicate local `RoundData` definition in `outputState.ts`. The Zod `RoundDataSchema` is removed; `OutputState.rounds` and `ensureRoundData` work with `RoundOutput` objects that include the required **`round`** field when created.
> 
> `getRoundOutput` in `roundSummary.ts` **returns the mutable in-memory round object directly** instead of copying fields into a new object. `OutputFileProcessor`’s `ProcessingContext.ensureRoundData` is typed to `RoundOutput`.
> 
> **Docs only elsewhere:** `AgentFlowResult` and `toOutputSummaries` / `toCompileFailureSummaries` in `executeAgent.ts` gain JSDoc explaining flattened summary shapes; behavior is unchanged. Tests in `OutputProgressEvents.vitest.ts` construct `RoundOutput` with `round` set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd57c0be9ecb774a13f21274b0bdb2a5ff37c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->