### PR TITLE
refactor: tighten any types to native types across core

### DIFF
--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -37,7 +37,7 @@ export interface ModelInvocationConfig<TShared, TServices> {
   ) => CycleDebugFileOptions;
 }
 
-type InvocationServices = BaseFlowContextInit<any> & {
+type InvocationServices = BaseFlowContextInit<unknown> & {
   readonly client: unknown;
   readonly refreshClient?: () => Promise<void>;
 };

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -773,8 +773,8 @@ export class ModelHandlerOpenAI<
     userRequest: string,
     mediaFiles?: FileLocation[],
     systemPrompt?: string,
-  ): Promise<any[]> {
-    const messages: any[] = [];
+  ): Promise<ChatCompletionMessageParam[]> {
+    const messages: ChatCompletionMessageParam[] = [];
 
     // Handle system prompt differently for O1 models
     // O1 mini and O1 preview models do not support system prompt; use 'user' role instead.
@@ -836,10 +836,10 @@ export class ModelHandlerOpenAI<
 
   /** Adds user message content for subsequent rounds. */
   async createRoundMessages(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     userMessage: string,
     mediaFiles?: FileLocation[],
-  ): Promise<any[]> {
+  ): Promise<ChatCompletionMessageParam[]> {
     const roundContent: ChatCompletionContentPart[] = [];
 
     if (
@@ -872,9 +872,9 @@ export class ModelHandlerOpenAI<
   }
 
   async createUserFollowUpMessages(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     userMessage: string,
-  ): Promise<any[]> {
+  ): Promise<ChatCompletionMessageParam[]> {
     messages.push({
       role: 'user',
       content: [{ type: 'text', text: userMessage }],
@@ -1083,7 +1083,7 @@ export class ModelHandlerOpenAI<
 
   /** Manages continuation with prefill support (typically no-op for models with prefill). */
   addContinueMessageWithPrefill(
-    _messages: any[],
+    _messages: ChatCompletionMessageParam[],
     _workspaceState: AgentWorkspaceState,
     _agentSetting: AgentSetting,
   ): void {
@@ -1092,7 +1092,7 @@ export class ModelHandlerOpenAI<
 
   /** Manages continuation for models without prefill support by adding a continuation prompt. */
   addContinueMessageWithoutPrefill(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     workspaceState: AgentWorkspaceState,
     agentSetting: AgentSetting,
   ): void {
@@ -1116,11 +1116,11 @@ export class ModelHandlerOpenAI<
   async initializeOutputAndPrefill(
     _agentConfig: AgentConfig,
     agentSetting: AgentSetting,
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     workspaceState: AgentWorkspaceState,
     outputLocation: FileLocation,
     prefill: string,
-  ): Promise<[boolean, any[]]> {
+  ): Promise<[boolean, ChatCompletionMessageParam[]]> {
     let endTurn = false;
 
     if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
@@ -1228,7 +1228,7 @@ export class ModelHandlerOpenAI<
 
   /** Updates message content for models with prefill support. */
   updateMessageContentWithPrefill(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     bestConnector: string,
     newResponse: string,
     workspaceState: AgentWorkspaceState,
@@ -1267,7 +1267,7 @@ export class ModelHandlerOpenAI<
 
   /** Updates message content for models without prefill support. */
   updateMessageContentWithoutPrefill(
-    messages: any[],
+    messages: ChatCompletionMessageParam[],
     bestConnector: string,
     newResponse: string,
     workspaceState: AgentWorkspaceState,

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -94,7 +94,7 @@ export class PersistedFlow<
    * @param kv - Storage backend (ExecutionKVStore)
    * @param runId - Optional run identifier. Defaults to kv.getExecutionId().
    */
-  constructor(start: BaseNode<any, any>, kv: ExecutionKVStore, runId?: string) {
+  constructor(start: BaseNode, kv: ExecutionKVStore, runId?: string) {
     super(start);
     this.kv = kv;
     this.runId = runId ?? kv.getExecutionId();
@@ -160,7 +160,7 @@ export class PersistedFlow<
       throw new Error('Invalid or corrupted flow record');
     }
 
-    let cursor: BaseNode<any, any> | undefined = this.start;
+    let cursor: BaseNode | undefined = this.start;
     for (const n of flow.nodes)
       cursor = cursor?.getNextNode(n.action as Action);
 
@@ -215,7 +215,7 @@ export class PersistedFlow<
   >(
     kv: ExecutionKVStore,
     runId: string | undefined,
-    start: BaseNode<any, any>,
+    start: BaseNode,
   ): Promise<PersistedFlow<S, P, Svc>> {
     const effectiveRunId = runId ?? kv.getExecutionId();
     const flow = await kv.read<FlowRecord>(flowKey(effectiveRunId));

--- a/src/agent/node/roundPersistedFlow.ts
+++ b/src/agent/node/roundPersistedFlow.ts
@@ -98,7 +98,7 @@ export class RoundPersistedFlow<
   private currentRoundStage: StageHandle | null = null;
 
   constructor(
-    start: BaseNode<any, any>,
+    start: BaseNode,
     kv: ExecutionKVStore,
     options?: {
       callbacks?: RoundCallbacks<S>;

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -26,7 +26,7 @@ import { themeIsDark } from '@shared/wa/hostTheme';
  * instead of `unknown`.
  */
 
-export abstract class BaseWebviewApp<TMessage = any> extends LitElement {
+export abstract class BaseWebviewApp<TMessage = unknown> extends LitElement {
   @provide({ context: themeContext })
   @state()
   protected theme = '';

--- a/src/test-kernel/agent/modelHandlers/EmptyPrefill.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/EmptyPrefill.vitest.ts
@@ -29,6 +29,7 @@ import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/openrouter/mo
 
 // Local imports - utils
 import type { FileLocation } from '@utils/files';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 
 // Type imports
 import type { ChatMessages } from '@openrouter/sdk/models';
@@ -107,7 +108,7 @@ describe('model handler empty prefill behavior', () => {
     await withMissingOutput(async (outputLocation) => {
       const handler = new ModelHandlerOpenAI(buildConfig(ModelProvider.OPENAI));
       handler.setLogger(createLoggerStub() as unknown as AgentTrace);
-      const messages = [
+      const messages: ChatCompletionMessageParam[] = [
         {
           role: 'user',
           content: [{ type: 'text', text: 'revise the document' }],

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -88,7 +88,7 @@ You are a delegated subagent. The configured delegation depth does not allow you
  */
 export async function getSystemPromptWithRules(
   systemPrompt: string,
-  userVars: Record<string, any>,
+  userVars: Record<string, unknown>,
 ): Promise<string> {
   const basePrompt = await renderPrompt(systemPrompt, userVars);
   const parts = [basePrompt];
@@ -125,7 +125,7 @@ export class PromptBuilder {
   constructor(
     private readonly agentPrompt: AgentPrompt,
     private readonly agentSetting: PromptBuilderSetting,
-    private readonly userVars: Record<string, any>,
+    private readonly userVars: Record<string, unknown>,
     private readonly logger?: AgentTrace,
   ) {}
 
@@ -226,7 +226,7 @@ export type InitialPrompts = Awaited<
 
 export async function buildInitialToolUsePrompts(
   agentPrompt: AgentPrompt,
-  userVars: Record<string, any>,
+  userVars: Record<string, unknown>,
   logger?: AgentTrace,
   options?: {
     resolvedToolNames?: readonly string[];


### PR DESCRIPTION
Audit-driven replacement of `any` annotations with the concrete native
types they already represent, verified with a clean full typecheck:

- modelHandlerOpenAI: type message arrays as ChatCompletionMessageParam[]
  (the M binding the abstract base already declares) instead of any[]
- PromptBuilder: userVars Record<string, any> -> Record<string, unknown>
  (matches renderPrompt's existing signature; call sites already narrow)
- ModelInvocationNode: BaseFlowContextInit<any> -> <unknown> (the type's
  own default)
- persistedFlow/roundPersistedFlow: BaseNode<any, any> -> BaseNode, the
  bare default the parent Flow constructor already uses (BaseNode's P is
  constrained to NonIterableObject, so <unknown, unknown> is invalid)
- BaseWebviewApp: default generic TMessage = any -> unknown
- EmptyPrefill test: type the messages fixture as ChatCompletionMessageParam[]

`any` usages left in place are genuinely load-bearing (documented
per-entry command maps, citty CommandDef invariance, off-spec OpenAI
provider responses, the createMediaContent ReturnType helper, Lit mixin
constructors) and are not improved by unknown.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only refactor with no logic changes; types align with existing abstract signatures and defaults.
> 
> **Overview**
> Replaces **`any`** with concrete types across agent core, OpenAI message handling, prompt building, persisted flows, and webview base classes—no runtime behavior changes.
> 
> **`modelHandlerOpenAI`** now types conversation arrays as **`ChatCompletionMessageParam[]`** (matching the abstract handler binding) instead of **`any[]`** on initialize/round/follow-up/continuation/prefill helpers. **`PromptBuilder`** and **`getSystemPromptWithRules`** use **`Record<string, unknown>`** for template variables, aligned with **`renderPrompt`**. **`ModelInvocationNode`** uses **`BaseFlowContextInit<unknown>`**. **`PersistedFlow`** / **`RoundPersistedFlow`** take **`BaseNode`** without **`any`** type args. **`BaseWebviewApp`** defaults **`TMessage`** to **`unknown`**. The empty-prefill test fixture is explicitly **`ChatCompletionMessageParam[]`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7baa21a84eda1031ff4146e5ced300cd8d249a92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->