### PR TITLE
fix: stabilize CLI header and thinking indicator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,9 +323,10 @@ mouse-scroll for finalized history, so don't reinvent them.
   width-dependent: recompute live-region layout from `useWindowSize()` columns
   on every render; never cache wrapped output across a width change. On a width
   change the vendored `ink` patch (`patches/ink@7.0.5.patch`) deliberately does
-  a **full repaint** — `ansiEscapes.clearTerminal` then reprint
-  `fullStaticOutput` (header + finalized root history, reflowed), with the live
-  region drawn below — debounced so a drag-storm collapses into one redraw.
+  a **full repaint** — `ansiEscapes.clearTerminal` then reprint live chrome
+  (including the session header) plus `fullStaticOutput` (finalized history,
+  reflowed), with the live region drawn below — debounced so a drag-storm
+  collapses into one redraw.
   Any transcript viewport switch (`root` ↔ scoped child, or child ↔ child) uses
   the same known-origin pattern: clear scrollback, drop cached static output,
   then repaint the new viewport. Root viewports reprint root `<Static>` history;
@@ -333,9 +334,9 @@ mouse-scroll for finalized history, so don't reinvent them.
   Line-count erasing of the live region can't survive reflow, because the
   emulator owns the reflow/scroll geometry and a write-only stdout can't observe
   it, so any fixed erase count either strands residue or walks up and eats the
-  static header. Don't "fix" this back to line-count erasing; the no-repaint
-  rule applies to steady-state rendering, not resize or transcript viewport
-  switches.
+  live session header. Don't "fix" this back to line-count erasing; the
+  no-repaint rule applies to steady-state rendering, not resize or transcript
+  viewport switches.
 
 ### CLI design (clig.dev)
 

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -278,7 +278,7 @@ export function staticScrollbackTarget({
   // Before a root run resolves, local helper output and harness-built root
   // streams still need static scrollback. The root owner key is deliberately
   // stable across the later rootStreamId resolution so Ink's append-only
-  // <Static> cache does not remount and print the session header twice.
+  // <Static> cache does not remount and reprint pre-run root entries.
   return {
     ownerKey: 'root',
     streamId: rootStreamId ?? activeStreamId,

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -1,6 +1,6 @@
-// Print-once transcript rendered through Ink `<Static>` so finalized entries
-// land in ordinary terminal scrollback. The session header is the first
-// static item; finalized conversation entries follow as they promote.
+// Live session header plus print-once transcript entries. Finalized entries
+// land in ordinary terminal scrollback through Ink `<Static>`; the header
+// stays adaptive chrome for the active scrollback owner.
 
 import path from 'node:path';
 
@@ -40,6 +40,16 @@ export type StaticTranscriptItem =
       readonly kind: 'entry';
       readonly entry: ConversationEntry;
     };
+
+type StaticTranscriptHeaderItem = Extract<
+  StaticTranscriptItem,
+  { readonly kind: 'header' }
+>;
+
+type StaticTranscriptEntryItem = Extract<
+  StaticTranscriptItem,
+  { readonly kind: 'entry' }
+>;
 
 interface StaticTranscriptState {
   readonly ownerKey: string;
@@ -164,6 +174,18 @@ function staticTranscriptItemRowCount(
     !isInquiryContinuationText(item.entry.text)
     ? lines + USER_ENTRY_MARGIN_BOTTOM_ROWS
     : lines;
+}
+
+function isStaticTranscriptHeaderItem(
+  item: StaticTranscriptItem,
+): item is StaticTranscriptHeaderItem {
+  return item.kind === 'header';
+}
+
+function isStaticTranscriptEntryItem(
+  item: StaticTranscriptItem,
+): item is StaticTranscriptEntryItem {
+  return item.kind === 'entry';
 }
 
 export function appendStaticTranscriptItems({
@@ -303,39 +325,43 @@ export function StaticConversationTranscript({
     width,
   ]);
 
+  const headerItems = items.filter(isStaticTranscriptHeaderItem);
+  const entryItems = items.filter(isStaticTranscriptEntryItem);
+
   return (
-    // Remount <Static> on a width or owner change so Ink regenerates
-    // `fullStaticOutput` for the current stream. Without the owner key, a focus
-    // switch would keep the previous stream's append-only cache.
-    <Static
-      key={`${ownerKey}:${Math.max(1, Math.floor(width ?? 80))}`}
-      items={[...items]}
-    >
-      {(item: StaticTranscriptItem) => (
-        // Isolate per item: a throw here would otherwise crash the whole Ink
-        // tree, and `<Static>` commits each row to scrollback exactly once, so
-        // the fallback marker is printed once in place of the bad entry.
+    <>
+      {headerItems.map((item: StaticTranscriptHeaderItem) => (
         <Box key={item.id} flexDirection="column">
-          <EntryErrorBoundary
-            label={item.kind === 'header' ? 'session header' : item.entry.role}
-          >
-            {item.kind === 'header' ? (
-              <SessionHeaderBlock
-                compact={item.compact}
-                identityLine={item.identityLine}
-                meta={item.meta}
-                width={width}
-              />
-            ) : (
+          <EntryErrorBoundary label="session header">
+            <SessionHeaderBlock
+              compact={item.compact}
+              identityLine={item.identityLine}
+              meta={item.meta}
+              width={width}
+            />
+          </EntryErrorBoundary>
+        </Box>
+      ))}
+      {/* Remount entry <Static> on a width or owner change so Ink regenerates
+       * `fullStaticOutput` for the current stream. The header is outside this
+       * keyed region; early terminal-width settling must not print the
+       * session banner twice. */}
+      <Static
+        key={`entries:${ownerKey}:${Math.max(1, Math.floor(width ?? 80))}`}
+        items={[...entryItems]}
+      >
+        {(item: StaticTranscriptEntryItem) => (
+          <Box key={item.id} flexDirection="column">
+            <EntryErrorBoundary label={item.entry.role}>
               <TranscriptEntry
                 entry={item.entry}
                 width={width}
                 colorEnabled={colorEnabled}
               />
-            )}
-          </EntryErrorBoundary>
-        </Box>
-      )}
-    </Static>
+            </EntryErrorBoundary>
+          </Box>
+        )}
+      </Static>
+    </>
   );
 }

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -635,8 +635,8 @@ export function buildStatusBarDisplay(
       input.thinkingActive === true
     ) {
       left.push({
-        text: 'thinking',
-        color: 'dim',
+        text: 'thinking...',
+        color: 'yellow',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.thinking,
       });
     }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -47,6 +47,14 @@ function logEntryHasText(entry: StreamLogEntry): boolean {
   return (entry.text ?? '').trim().length > 0;
 }
 
+function logEntryStreamIsRunning(entry: StreamLogEntry): boolean {
+  const data = entry.data;
+  if (typeof data !== 'object' || data === null || !('status' in data)) {
+    return logEntryHasText(entry);
+  }
+  return data.status === 'running';
+}
+
 function latestLogActivityIsThinking(
   entries: readonly StreamLogEntry[],
 ): boolean {
@@ -56,7 +64,8 @@ function latestLogActivityIsThinking(
       continue;
     }
     return (
-      entry.messageType === MESSAGE_TYPES.THINKING && logEntryHasText(entry)
+      entry.messageType === MESSAGE_TYPES.THINKING &&
+      logEntryStreamIsRunning(entry)
     );
   }
   return false;

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -1,6 +1,6 @@
 // Regression test for the width-adaptive `<Static>` user-message band
-// (TranscriptEntry full-width reverse-video band + StaticConversationTranscript
-// `<Static key={width}>`). Renders a minimal Ink app reproducing the pattern to
+// (TranscriptEntry full-width reverse-video band + the entry Static remount in
+// StaticConversationTranscript). Renders a minimal Ink app reproducing the pattern to
 // an in-memory fake stdout, simulates a terminal resize by bumping `columns` and
 // emitting `resize`, and asserts the highlighted band reflows to the NEW width
 // instead of staying baked at the original width.

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1004,7 +1004,7 @@ describe('CLI StatusBar display model', () => {
       '◆',
       'running',
       '110s',
-      'thinking',
+      'thinking...',
       PERSONAL_API_MODE_LABEL,
     ]);
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1568,6 +1568,13 @@ describe('CLI transcript state', () => {
       expect(slice?.thinkingActive).toBe(true);
       expect(slice?.entries).toEqual([]);
 
+      thinking.finalize();
+      syncStreamLog(root);
+
+      slice = cliState.streams.get().get(root);
+      expect(slice?.thinkingActive).toBe(false);
+      expect(slice?.entries).toEqual([]);
+
       const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
       output.append('Visible answer.');
 

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -64,6 +64,7 @@ interface StreamSinkState {
   buffer: string;
   pending: string[];
   created: boolean;
+  ended: boolean;
   enabled: boolean;
   groupId: string | undefined;
   level: LogLevel;
@@ -108,6 +109,7 @@ export function attachTranscriptRecorder(
         groupId: state.groupId,
         messageType: state.messageType,
         text: state.buffer,
+        data: { status: state.ended ? 'completed' : 'running' },
         verbose: debugModeEnabled(),
       });
       state.created = !!appended;
@@ -115,7 +117,10 @@ export function attachTranscriptRecorder(
       return;
     }
 
-    store.update(streamId, id, { text: state.buffer });
+    store.update(streamId, id, {
+      text: state.buffer,
+      data: { status: state.ended ? 'completed' : 'running' },
+    });
   };
 
   const scheduleStreamUpdate = (state: StreamSinkState, id: string): void => {
@@ -252,6 +257,7 @@ export function attachTranscriptRecorder(
           buffer: '',
           pending: [],
           created: false,
+          ended: false,
           enabled: true,
           groupId: event.stageId,
           level: 'info',
@@ -279,6 +285,7 @@ export function attachTranscriptRecorder(
           state.buffer = event.finalText;
           state.pending = [];
         }
+        state.ended = true;
         flushStream(state, event.id);
         streams.delete(event.id);
         return;


### PR DESCRIPTION
## Summary
- render the CLI session header as live adaptive chrome while leaving finalized entries in the width-remounted Static transcript
- stamp stream log entries with running/completed status so the CLI thinking indicator follows stream lifecycle
- make the status bar thinking indicator visible as `thinking...`

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/StaticBandResize.vitest.mts`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npx tsc --noEmit && corepack pnpm --filter @texra-ai/cli typecheck`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx packages/cli/src/chat/tui/panes/StatusBar.tsx packages/cli/src/chat/tui/state/subscribeStreamLog.ts src/transcript/TexraTranscriptRecorder.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/StaticBandResize.vitest.mts`
- `git diff --check`
- `node scripts/validate-tui.mjs transcript subagent-tab-focus-full-frame hidden-root-approval-tab-return` (from `packages/cli`)

Note: a full `validate:tui` pass was also attempted; the targeted header scenarios above pass after the fix, while unrelated compact foreground-panel scenarios timed out waiting for the input prompt in this local run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Ink transcript layout and stream-log → TUI sync paths used on every interactive CLI session; behavior is covered by targeted Vitest but resize/header edge cases remain terminal-dependent.
> 
> **Overview**
> Fixes CLI TUI glitches where the **session header** could print twice and the **thinking** indicator could stick or stay invisible.
> 
> The session banner is **live chrome** again: it renders outside Ink’s width-keyed `<Static>` block so early column settling no longer duplicates the header, while **finalized transcript lines** still use `<Static>` with an `entries:…` remount key. Docs in `CLAUDE.md` now describe resize repaints as clearing then redrawing live chrome (header) plus static history.
> 
> **Thinking** state is tied to stream lifecycle: `TexraTranscriptRecorder` stamps open trace streams with `data.status` `running` / `completed` on append and update; `subscribeStreamLog` treats the latest `THINKING` log as active only while that status is `running` (legacy entries without `status` still fall back to non-empty text). The status bar shows **`thinking...`** in yellow instead of dim `thinking`.
> 
> Tests cover header/static resize wording, status bar copy, and thinking clearing after `thinking.finalize()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ecfcef4440188bcd89cbf0bf1dff87563ac096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->