### PR TITLE
refactor: let execution registry own process output poller

### DIFF
--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -228,5 +228,3 @@ async function readTail(path: string, state: FileReadState): Promise<string> {
   state.offset += buf.length;
   return state.decoder.write(buf);
 }
-
-export const processOutputPoller = new ProcessOutputPoller();

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -32,10 +32,7 @@ import {
   ProcessExecutionHandle,
   isChildExecution,
 } from './ExecutionHandle';
-import {
-  processOutputPoller,
-  type ProcessOutputPoller,
-} from './ProcessOutputPoller';
+import { ProcessOutputPoller } from './ProcessOutputPoller';
 
 export type { ExecutionHandle } from './ExecutionHandle';
 export {
@@ -102,7 +99,7 @@ export class ExecutionRegistry {
 
   constructor({
     interrupts = interruptRegistry,
-    processOutput = processOutputPoller,
+    processOutput = new ProcessOutputPoller(),
     streamStatus = StreamStatusService,
   }: {
     readonly interrupts?: InterruptRegistry;
@@ -138,8 +135,11 @@ export class ExecutionRegistry {
 
   dispose(): void {
     this.disposeStatusListener();
-    for (const executionId of [...this.handles.keys()]) {
-      this.untrack(executionId);
+    const executionIds = [...this.handles.keys()];
+    this.handles.clear();
+    this.processOutput.dispose();
+    for (const executionId of executionIds) {
+      this.notifyWaiters(executionId);
     }
     this.changeCallbacks.clear();
     this.persistentListeners.clear();

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -5,15 +5,38 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   AgentExecutionHandle,
   ExecutionRegistry,
+  ProcessExecutionHandle,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
+import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
 import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
 describe('executionRegistry', () => {
+  it('owns process-output poller teardown', () => {
+    const explicit = createRecordingHost();
+    const processOutput = new ProcessOutputPoller();
+    const dispose = vi.spyOn(processOutput, 'dispose');
+    const flush = vi.spyOn(processOutput, 'flush');
+    const registry = new ExecutionRegistry({ processOutput });
+    const handle = new ProcessExecutionHandle(
+      'exec-process-output-dispose-test',
+      'stream-process-output-dispose-test' as StreamTabId,
+      'bash',
+      () => true,
+      explicit.host,
+    );
+
+    registry.track(handle);
+    registry.dispose();
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(flush).not.toHaveBeenCalled();
+  });
+
   it('uses its interrupt registry when terminating agent handles', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();


### PR DESCRIPTION
## Summary
- construct the process-output poller inside `ExecutionRegistry` instead of through a separate module singleton
- dispose the poller from `ExecutionRegistry.dispose()` so the registry owns its lifecycle consistently
- add a focused regression test for the teardown ownership

## Design note
This keeps the compatibility singleton at the `executionRegistry` composition point and removes the unused lower-level `processOutputPoller` singleton. It avoids adding a cleanup pass-through; the owner that registers process output now also tears it down.

Contributes to #4737.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npx eslint src/agent/runtime/executionRegistry.ts src/agent/runtime/ProcessOutputPoller.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm run lint -- --quiet`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes teardown order for active process executions (no flush on registry dispose) and removes the shared poller singleton, which could affect shutdown behavior if callers relied on the old export.
> 
> **Overview**
> **`ExecutionRegistry` now owns the process-output poller lifecycle** instead of importing a module-level `processOutputPoller` singleton from `ProcessOutputPoller.ts` (that export is removed).
> 
> The registry **constructs** a `ProcessOutputPoller` by default (still injectable for tests) and **`dispose()`** clears handles, calls **`processOutput.dispose()`**, and notifies waiters—without per-handle **`untrack`** on shutdown. A regression test asserts **`dispose`** runs on the injected poller and **`flush`** is not invoked during registry teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b25cb15939ca722ad51123cbacc992bafa2ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->