### PR TITLE
Extract shared agent-CLI session loop into reusable module

### DIFF
--- a/src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts
@@ -19,11 +19,8 @@ import type {
 } from '@shared/schemas';
 
 // Local imports - tools
-import {
-  publishCodexStreamUsage,
-  publishCodexTodos,
-  runStreamedTurn,
-} from '@tools/codex';
+import { publishAgentCliStreamUsage } from '@tools/agentCliShared';
+import { publishCodexTodos, runStreamedTurn } from '@tools/codex';
 
 // Local imports - test
 import { createRecordingHost } from '../progressTestUtils';
@@ -65,7 +62,7 @@ describe('codex progress events', () => {
     const active = createRecordingHost();
 
     publishCodexTodos(streamId, todos, active.host);
-    publishCodexStreamUsage(streamId, executionId, usage, active.host);
+    publishAgentCliStreamUsage(streamId, executionId, usage, active.host);
 
     expect(active.events).toEqual([
       {

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -41,7 +41,7 @@ type TurnUsage = { input_tokens?: number; output_tokens?: number };
  * through the WAITING state queue path: `sendFollowUp()` → stream is WAITING →
  * `ToolUseFollowUpQueue.enqueue()`.
  */
-export class AgentCliSession implements IInterruptible {
+class AgentCliSession implements IInterruptible {
   private interrupted = false;
   private queue: FollowUpQueue | null = null;
   private turnAbortController: AbortController | null = null;
@@ -74,6 +74,15 @@ export class AgentCliSession implements IInterruptible {
  * Provider-specific behavior for a single agent-CLI session. Created once per
  * session; its methods close over the provider's thread/session object,
  * registry, and runtime host.
+ *
+ * Per-turn call order inside the loop:
+ *   runTurn → getUsage (turn summary) → isTurnError → onTurnError (if true)
+ *   → onTurnSuccess (only when the turn did not fail) → publishUsage → format*.
+ * `onTurnError` fires only for a non-throwing turn that reports an
+ * application-level error (`isTurnError` true); a thrown turn goes through the
+ * loop's catch instead and is formatted via `formatError(null, …)`.
+ * `onSessionStart` runs once before the first turn; `onSessionCleanup` runs once
+ * in the loop's `finally`. `publishUsage` owns its own usage-presence check.
  */
 export interface AgentCliSessionStrategy<TTurn> {
   /** Stage label opened on the child trace (e.g. "Codex session"). */
@@ -88,8 +97,8 @@ export interface AgentCliSessionStrategy<TTurn> {
   /** Run one streamed turn. Throws on hard failure. */
   runTurn(prompt: string, abortController: AbortController): Promise<TTurn>;
 
-  /** Token usage for the turn summary + UI publish (null/undefined when none). */
-  getUsage(turn: TTurn): TurnUsage | null | undefined;
+  /** Token usage for the turn summary (null when none). */
+  getUsage(turn: TTurn): TurnUsage | null;
 
   /**
    * Application-level error reported by a turn that did NOT throw (e.g. the SDK
@@ -169,6 +178,7 @@ export function runAgentCliSession<TTurn>(
 
         let turn: TTurn | null = null;
         let err: unknown = null;
+        let turnIsError = false;
         try {
           turn = await strategy.runTurn(prompt, abortController);
           logTurnSummary(
@@ -176,7 +186,8 @@ export function runAgentCliSession<TTurn>(
             Date.now() - startedAt,
             strategy.getUsage(turn),
           );
-          if (strategy.isTurnError?.(turn)) {
+          turnIsError = strategy.isTurnError?.(turn) === true;
+          if (turnIsError) {
             strategy.onTurnError?.(turn, logger);
           }
         } catch (caught) {
@@ -190,15 +201,15 @@ export function runAgentCliSession<TTurn>(
         }
 
         const wallTimeMs = Date.now() - startedAt;
-        const turnFailed =
-          err != null ||
-          (turn != null && strategy.isTurnError?.(turn) === true);
+        const turnFailed = err != null || turnIsError;
 
         if (!turnFailed && turn != null) {
           strategy.onTurnSuccess?.(turn);
         }
 
-        if (turn != null && strategy.getUsage(turn)) {
+        // publishUsage owns its own usage-presence check; the loop only needs a
+        // turn to publish.
+        if (turn != null) {
           strategy.publishUsage(turn);
         }
 

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -123,8 +123,7 @@ export interface AgentCliSessionStrategy<TTurn> {
 
   /**
    * Called in the finally block to release provider-owned registry entries.
-   * Runs before this loop unregisters the child stream from InterruptRegistry;
-   * implementations must not depend on interrupt-registry membership.
+   * Runs after this loop unregisters its interrupt and follow-up queue state.
    */
   onSessionCleanup?(): void;
 }
@@ -243,9 +242,9 @@ export function runAgentCliSession<TTurn>(
       }
     } finally {
       sessionStage.end(sawTurnFailure ? 'error' : 'stopped');
-      strategy.onSessionCleanup?.();
       interruptRegistry.unregister(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
+      strategy.onSessionCleanup?.();
       // Persist terminal status before childStream.finalize() untracks and
       // notifies waiters.
       await writeTerminalStatus(

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -171,7 +171,11 @@ export function runAgentCliSession<TTurn>(
         let err: unknown = null;
         try {
           turn = await strategy.runTurn(prompt, abortController);
-          logTurnSummary(logger, Date.now() - startedAt, strategy.getUsage(turn));
+          logTurnSummary(
+            logger,
+            Date.now() - startedAt,
+            strategy.getUsage(turn),
+          );
           if (strategy.isTurnError?.(turn)) {
             strategy.onTurnError?.(turn, logger);
           }
@@ -187,7 +191,8 @@ export function runAgentCliSession<TTurn>(
 
         const wallTimeMs = Date.now() - startedAt;
         const turnFailed =
-          err != null || (turn != null && strategy.isTurnError?.(turn) === true);
+          err != null ||
+          (turn != null && strategy.isTurnError?.(turn) === true);
 
         if (!turnFailed && turn != null) {
           strategy.onTurnSuccess?.(turn);

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -1,0 +1,244 @@
+// Shared session-loop runner for the agent-CLI tool modules (codex.ts,
+// claudeAgent.ts). Both tools spin off an external CLI agent and then drive an
+// identical turn loop: drain the child's follow-up queue, run one streamed turn
+// per batch, deliver each result to the parent's follow-up queue, and finalize
+// on interruption or failure. The provider-specific pieces (how a turn runs,
+// how usage/results are formatted, which registry the session id lives in) are
+// supplied via an AgentCliSessionStrategy so the subtle interrupt/finalize
+// choreography lives in exactly one place.
+//
+// Host-agnostic, VS Code-free.
+
+import { getExecutionStore, writeTerminalStatus } from '@agent/storage';
+import type { AgentTrace } from '@agent/trace';
+import {
+  interruptRegistry,
+  type IInterruptible,
+} from '@agent/runtime/InterruptRegistry';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
+import { toErrorMessage } from '@common/errors';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { STREAM_STATUS } from '@shared/schemas';
+
+import {
+  agentCliLoopTerminalStatus,
+  isCleanInterruption,
+  logTurnSummary,
+} from './agentCliShared';
+import type { ChildStream } from './childStream';
+
+/** Minimal token usage shape consumed by the loop's turn summary. */
+type TurnUsage = { input_tokens?: number; output_tokens?: number };
+
+/**
+ * Lightweight interruptible registered with the InterruptRegistry so the stop
+ * button works on agent-CLI child streams.
+ *
+ * Does NOT implement the session duck-type (no `session.appendFollowUp`), so
+ * flow-only commands such as context compaction ignore it. Follow-ups route
+ * through the WAITING state queue path: `sendFollowUp()` → stream is WAITING →
+ * `ToolUseFollowUpQueue.enqueue()`.
+ */
+export class AgentCliSession implements IInterruptible {
+  private interrupted = false;
+  private queue: FollowUpQueue | null = null;
+  private turnAbortController: AbortController | null = null;
+
+  interrupt(): void {
+    this.interrupted = true;
+    this.queue?.cancelWait();
+    this.turnAbortController?.abort();
+  }
+
+  setQueue(q: FollowUpQueue): void {
+    this.queue = q;
+  }
+
+  isInterrupted(): boolean {
+    return this.interrupted;
+  }
+
+  startTurn(): AbortController {
+    this.turnAbortController = new AbortController();
+    return this.turnAbortController;
+  }
+
+  finishTurn(): void {
+    this.turnAbortController = null;
+  }
+}
+
+/**
+ * Provider-specific behavior for a single agent-CLI session. Created once per
+ * session; its methods close over the provider's thread/session object,
+ * registry, and runtime host.
+ */
+export interface AgentCliSessionStrategy<TTurn> {
+  /** Stage label opened on the child trace (e.g. "Codex session"). */
+  readonly stageLabel: string;
+
+  /**
+   * Called once before the loop starts. Used to register a resumed session id
+   * immediately so a concurrent call with the same id can't start a second loop.
+   */
+  onSessionStart?(): void;
+
+  /** Run one streamed turn. Throws on hard failure. */
+  runTurn(prompt: string, abortController: AbortController): Promise<TTurn>;
+
+  /** Token usage for the turn summary + UI publish (null/undefined when none). */
+  getUsage(turn: TTurn): TurnUsage | null | undefined;
+
+  /**
+   * Application-level error reported by a turn that did NOT throw (e.g. the SDK
+   * returned an error result). Omit for providers that always throw on failure.
+   */
+  isTurnError?(turn: TTurn): boolean;
+
+  /** Log a turn-level error message for a non-throwing failure. */
+  onTurnError?(turn: TTurn, logger: AgentTrace): void;
+
+  /** After a successful turn: register the session/thread id, etc. */
+  onTurnSuccess?(turn: TTurn): void;
+
+  /** Publish token usage to the UI. */
+  publishUsage(turn: TTurn): void;
+
+  /** Format the success delivery XML. */
+  formatDelivery(turn: TTurn, prompt: string, wallTimeMs: number): string;
+
+  /** Format the error delivery XML (turn is null when `runTurn` threw). */
+  formatError(turn: TTurn | null, prompt: string, err: unknown): string;
+
+  /** Called in the finally block to release registry entries. */
+  onSessionCleanup?(): void;
+}
+
+export interface RunAgentCliSessionParams<TTurn> {
+  childStream: ChildStream;
+  parentStreamId: StreamTabId;
+  executionId: ExecutionId;
+  initialPrompt: string;
+  strategy: AgentCliSessionStrategy<TTurn>;
+}
+
+/**
+ * Drive an agent-CLI session loop. The initial prompt is seeded into the child's
+ * follow-up queue so the first turn goes through the same code path as every
+ * follow-up turn. Each turn's result (or error) is delivered to the parent's
+ * follow-up queue, persisted as a report, and the child stream is finalized when
+ * the session is interrupted or a turn fails.
+ */
+export function runAgentCliSession<TTurn>(
+  params: RunAgentCliSessionParams<TTurn>,
+): void {
+  const { childStream, parentStreamId, executionId, initialPrompt, strategy } =
+    params;
+  const { childStreamId, logger } = childStream;
+
+  const session = new AgentCliSession();
+  const queue = ToolUseFollowUpQueue.acquire(childStreamId);
+  session.setQueue(queue);
+  interruptRegistry.register(childStreamId, session);
+
+  // The child session runs on its own trace, whose per-instance stage scope is
+  // empty here, so this opens as a root with no cross-trace parent.
+  const sessionStage = logger.openStage(strategy.stageLabel);
+
+  strategy.onSessionStart?.();
+
+  // Seed the initial prompt; the loop drains it as the first turn.
+  queue.enqueue({ text: initialPrompt });
+  childStream.waitForInput();
+
+  let sawTurnFailure = false;
+  void (async () => {
+    try {
+      while (!session.isInterrupted()) {
+        const messages = await queue.waitAndDrainAll(() =>
+          session.isInterrupted(),
+        );
+        if (!messages || session.isInterrupted()) break;
+
+        const prompt = messages.items.map((item) => item.text).join('\n\n');
+        childStream.beginTurn();
+        const startedAt = Date.now();
+        const abortController = session.startTurn();
+
+        let turn: TTurn | null = null;
+        let err: unknown = null;
+        try {
+          turn = await strategy.runTurn(prompt, abortController);
+          logTurnSummary(logger, Date.now() - startedAt, strategy.getUsage(turn));
+          if (strategy.isTurnError?.(turn)) {
+            strategy.onTurnError?.(turn, logger);
+          }
+        } catch (caught) {
+          if (isCleanInterruption(caught, abortController.signal, session)) {
+            break;
+          }
+          err = caught;
+          logger.error(toErrorMessage(caught));
+        } finally {
+          session.finishTurn();
+        }
+
+        const wallTimeMs = Date.now() - startedAt;
+        const turnFailed =
+          err != null || (turn != null && strategy.isTurnError?.(turn) === true);
+
+        if (!turnFailed && turn != null) {
+          strategy.onTurnSuccess?.(turn);
+        }
+
+        if (turn != null && strategy.getUsage(turn)) {
+          strategy.publishUsage(turn);
+        }
+
+        const msg =
+          turn != null && !turnFailed
+            ? strategy.formatDelivery(turn, prompt, wallTimeMs)
+            : strategy.formatError(turn, prompt, err);
+        try {
+          await getExecutionStore(executionId).writeReport(msg);
+        } catch {
+          // Best-effort; delivery must not block on storage.
+        }
+        await sendFollowUp(parentStreamId, {
+          text: msg,
+          origin: 'subagent_result',
+        });
+
+        if (turnFailed) {
+          sawTurnFailure = true;
+          childStream.failTurn();
+          break;
+        }
+
+        if (!session.isInterrupted()) {
+          childStream.waitForInput();
+        }
+      }
+    } finally {
+      sessionStage.end(sawTurnFailure ? 'error' : 'stopped');
+      strategy.onSessionCleanup?.();
+      interruptRegistry.unregister(childStreamId);
+      ToolUseFollowUpQueue.release(childStreamId);
+      // Persist terminal status before childStream.finalize() untracks and
+      // notifies waiters.
+      await writeTerminalStatus(
+        executionId,
+        agentCliLoopTerminalStatus({
+          interrupted: session.isInterrupted(),
+          sawTurnFailure,
+        }),
+      ).catch(() => {});
+
+      childStream.finalize({
+        status: sawTurnFailure ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+      });
+    }
+  })();
+}

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -121,7 +121,11 @@ export interface AgentCliSessionStrategy<TTurn> {
   /** Format the error delivery XML (turn is null when `runTurn` threw). */
   formatError(turn: TTurn | null, prompt: string, err: unknown): string;
 
-  /** Called in the finally block to release registry entries. */
+  /**
+   * Called in the finally block to release provider-owned registry entries.
+   * Runs before this loop unregisters the child stream from InterruptRegistry;
+   * implementations must not depend on interrupt-registry membership.
+   */
   onSessionCleanup?(): void;
 }
 

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -2,7 +2,15 @@
 // Host-agnostic, VS Code-free.
 
 import { type AgentTrace } from '@agent/trace';
-import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  EXECUTION_STATUS,
+  type ExecutionId,
+  type ExecutionStatus,
+  type StorageKey,
+  type StreamTabId,
+  type TokenUsageStats,
+} from '@shared/schemas';
 import { formatDuration } from '@utils/core';
 
 /** True for an AbortController-style cancellation error. */
@@ -30,6 +38,24 @@ export function agentCliLoopTerminalStatus(state: {
   return state.interrupted
     ? EXECUTION_STATUS.INTERRUPTED
     : EXECUTION_STATUS.COMPLETED;
+}
+
+/**
+ * Publish a turn's token usage to the progress UI for an agent-CLI child stream.
+ * Shared by the codex and claudeAgent session strategies.
+ */
+export function publishAgentCliStreamUsage(
+  childStreamId: StreamTabId,
+  executionId: ExecutionId,
+  usage: TokenUsageStats,
+  runtimeHost: AgentRuntimeHost,
+): void {
+  runtimeHost.emit('updateStreamUsage', {
+    streamId: childStreamId,
+    storageKey: executionId as StorageKey,
+    executionId,
+    usage,
+  });
 }
 
 /** Log a turn summary (duration + token usage) to the child stream. */

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -37,12 +37,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { toErrorMessage } from '@common/errors';
-import type {
-  StreamTabId,
-  ExecutionId,
-  StorageKey,
-  ToolUseLog,
-} from '@shared/schemas';
+import type { StreamTabId, ExecutionId, ToolUseLog } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { ToolError, type ToolResult } from '@tools/result';
@@ -63,6 +58,7 @@ import {
 } from './claudeAgentImport';
 import { createChildStream, type ChildStream } from './childStream';
 import { AgentCliSessionRegistry } from './agentCliSessionRegistry';
+import { publishAgentCliStreamUsage } from './agentCliShared';
 import {
   runAgentCliSession,
   type AgentCliSessionStrategy,
@@ -486,12 +482,12 @@ function startClaudeAgentLoop(params: {
     },
     publishUsage: (turn) => {
       if (turn.usage) {
-        runtimeHost.emit('updateStreamUsage', {
-          streamId: childStreamId,
-          storageKey: executionId as StorageKey,
+        publishAgentCliStreamUsage(
+          childStreamId,
           executionId,
-          usage: buildClaudeUsageStats(turn.usage),
-        });
+          buildClaudeUsageStats(turn.usage),
+          runtimeHost,
+        );
       }
     },
     formatDelivery: (turn, prompt, wallTimeMs) =>

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -25,11 +25,7 @@
 import { z } from 'zod';
 
 // Local imports
-import {
-  getExecutionStore,
-  registerExecution,
-  writeTerminalStatus,
-} from '@agent/storage';
+import { registerExecution } from '@agent/storage';
 import {
   emitToolUseCard,
   endToolUseCard,
@@ -39,13 +35,7 @@ import {
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
-import {
-  interruptRegistry,
-  type IInterruptible,
-} from '@agent/runtime/InterruptRegistry';
-import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
 import type {
   StreamTabId,
@@ -53,7 +43,7 @@ import type {
   StorageKey,
   ToolUseLog,
 } from '@shared/schemas';
-import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
+import { MESSAGE_TYPES } from '@shared/schemas';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { ToolError, type ToolResult } from '@tools/result';
 import { parseWorkingDirectory } from '@tools/pathResolution';
@@ -74,10 +64,9 @@ import {
 import { createChildStream, type ChildStream } from './childStream';
 import { AgentCliSessionRegistry } from './agentCliSessionRegistry';
 import {
-  agentCliLoopTerminalStatus,
-  isCleanInterruption,
-  logTurnSummary,
-} from './agentCliShared';
+  runAgentCliSession,
+  type AgentCliSessionStrategy,
+} from './agentCliSessionLoop';
 import {
   buildClaudeToolUseLog,
   buildClaudeUsageStats,
@@ -157,39 +146,6 @@ const claudeAgentSessions = new AgentCliSessionRegistry<ActiveSession>(
 
 export function interruptAllClaudeAgentSessions(): void {
   claudeAgentSessions.interruptAll();
-}
-
-// ============================================================================
-// Interruptible session — runs the SDK query loop and accepts follow-ups
-// ============================================================================
-
-class ClaudeAgentSession implements IInterruptible {
-  private interrupted = false;
-  private queue: FollowUpQueue | null = null;
-  private turnAbortController: AbortController | null = null;
-
-  interrupt(): void {
-    this.interrupted = true;
-    this.queue?.cancelWait();
-    this.turnAbortController?.abort();
-  }
-
-  setQueue(q: FollowUpQueue): void {
-    this.queue = q;
-  }
-
-  isInterrupted(): boolean {
-    return this.interrupted;
-  }
-
-  startTurn(): AbortController {
-    this.turnAbortController = new AbortController();
-    return this.turnAbortController;
-  }
-
-  finishTurn(): void {
-    this.turnAbortController = null;
-  }
 }
 
 // ============================================================================
@@ -474,148 +430,85 @@ function startClaudeAgentLoop(params: {
   pathToClaudeCodeExecutable: string | undefined;
   runtimeHost: AgentRuntimeHost;
 }): void {
-  const {
+  const { childStream, parentStreamId, executionId, initialPrompt, runtimeHost } =
+    params;
+  const { childStreamId, logger } = childStream;
+
+  // The SDK needs the prior session id to resume the same conversation across
+  // turns; it's threaded forward from each turn's result.
+  let resumeSessionId: string | undefined;
+  const storedSessionIds = new Set<string>();
+
+  const strategy: AgentCliSessionStrategy<TurnResult> = {
+    stageLabel: 'Claude Code session',
+    runTurn: async (prompt, abortController) => {
+      const turn = await runStreamedTurn({
+        prompt,
+        childStreamId,
+        logger,
+        abortController,
+        model: params.model,
+        permissionMode: params.permissionMode,
+        effort: params.effort,
+        cwd: params.cwd,
+        additionalDirectories: params.additionalDirectories,
+        env: params.env,
+        resumeSessionId,
+        pathToClaudeCodeExecutable: params.pathToClaudeCodeExecutable,
+      });
+      if (turn.sessionId) resumeSessionId = turn.sessionId;
+      return turn;
+    },
+    getUsage: (turn) => turn.usage,
+    isTurnError: (turn) => turn.isError,
+    onTurnError: (turn, log) => {
+      if (turn.errorMessage) log.error(turn.errorMessage);
+    },
+    onTurnSuccess: (turn) => {
+      if (turn.sessionId && !claudeAgentSessions.isActive(turn.sessionId)) {
+        claudeAgentSessions.register(turn.sessionId, {
+          childStreamId,
+          parentStreamId,
+          executionId,
+          model: params.model,
+          permissionMode: params.permissionMode,
+          effort: params.effort,
+          cwd: params.cwd,
+          additionalDirectories: params.additionalDirectories,
+        });
+        storedSessionIds.add(turn.sessionId);
+      }
+    },
+    publishUsage: (turn) => {
+      if (turn.usage) {
+        runtimeHost.emit('updateStreamUsage', {
+          streamId: childStreamId,
+          storageKey: executionId as StorageKey,
+          executionId,
+          usage: buildClaudeUsageStats(turn.usage),
+        });
+      }
+    },
+    formatDelivery: (turn, prompt, wallTimeMs) =>
+      formatClaudeDelivery(executionId, prompt, wallTimeMs, turn),
+    formatError: (turn, prompt, err) =>
+      formatClaudeError(
+        executionId,
+        prompt,
+        err ?? turn?.errorMessage ?? turn?.finalResponse,
+      ),
+    onSessionCleanup: () => {
+      claudeAgentSessions.releaseMany(storedSessionIds);
+    },
+  };
+
+  runAgentCliSession({
     childStream,
     parentStreamId,
     executionId,
     initialPrompt,
-    runtimeHost,
-  } = params;
-  const { childStreamId, logger } = childStream;
-
-  const session = new ClaudeAgentSession();
-  const queue = ToolUseFollowUpQueue.acquire(childStreamId);
-  session.setQueue(queue);
-  interruptRegistry.register(childStreamId, session);
-
-  // The child session runs on its own trace, whose per-instance stage scope is
-  // empty here, so this opens as a root with no cross-trace parent.
-  const sessionStage = logger.openStage('Claude Code session');
-
-  queue.enqueue({ text: initialPrompt });
-  childStream.waitForInput();
-
-  let resumeSessionId: string | undefined;
-  const storedSessionIds = new Set<string>();
-
-  let sawTurnFailure = false;
-  void (async () => {
-    try {
-      while (!session.isInterrupted()) {
-        const messages = await queue.waitAndDrainAll(() =>
-          session.isInterrupted(),
-        );
-        if (!messages || session.isInterrupted()) break;
-
-        const prompt = messages.items.map((item) => item.text).join('\n\n');
-        childStream.beginTurn();
-        const startedAt = Date.now();
-        const ac = session.startTurn();
-
-        let turn: TurnResult | null = null;
-        let err: unknown = null;
-        try {
-          turn = await runStreamedTurn({
-            prompt,
-            childStreamId,
-            logger,
-            abortController: ac,
-            model: params.model,
-            permissionMode: params.permissionMode,
-            effort: params.effort,
-            cwd: params.cwd,
-            additionalDirectories: params.additionalDirectories,
-            env: params.env,
-            resumeSessionId,
-            pathToClaudeCodeExecutable: params.pathToClaudeCodeExecutable,
-          });
-          if (turn.sessionId) resumeSessionId = turn.sessionId;
-          logTurnSummary(logger, Date.now() - startedAt, turn.usage);
-          if (turn.isError && turn.errorMessage) {
-            logger.error(turn.errorMessage);
-          }
-        } catch (caught) {
-          if (isCleanInterruption(caught, ac.signal, session)) break;
-          err = caught;
-          logger.error(toErrorMessage(caught));
-        } finally {
-          session.finishTurn();
-        }
-
-        const wallTimeMs = Date.now() - startedAt;
-        const turnFailed = err != null || turn?.isError === true;
-        if (
-          !turnFailed &&
-          turn?.sessionId &&
-          !claudeAgentSessions.isActive(turn.sessionId)
-        ) {
-          claudeAgentSessions.register(turn.sessionId, {
-            childStreamId,
-            parentStreamId,
-            executionId,
-            model: params.model,
-            permissionMode: params.permissionMode,
-            effort: params.effort,
-            cwd: params.cwd,
-            additionalDirectories: params.additionalDirectories,
-          });
-          storedSessionIds.add(turn.sessionId);
-        }
-
-        if (turn?.usage) {
-          runtimeHost.emit('updateStreamUsage', {
-            streamId: childStreamId,
-            storageKey: executionId as StorageKey,
-            executionId,
-            usage: buildClaudeUsageStats(turn.usage),
-          });
-        }
-
-        const msg =
-          turn && !turnFailed
-            ? formatClaudeDelivery(executionId, prompt, wallTimeMs, turn)
-            : formatClaudeError(
-                executionId,
-                prompt,
-                err ?? turn?.errorMessage ?? turn?.finalResponse,
-              );
-        try {
-          await getExecutionStore(executionId).writeReport(msg);
-        } catch {
-          // Best-effort; delivery must not block on storage.
-        }
-        await sendFollowUp(parentStreamId, {
-          text: msg,
-          origin: 'subagent_result',
-        });
-
-        if (turnFailed) {
-          sawTurnFailure = true;
-          childStream.failTurn();
-          break;
-        }
-
-        if (!session.isInterrupted()) {
-          childStream.waitForInput();
-        }
-      }
-    } finally {
-      sessionStage.end(sawTurnFailure ? 'error' : 'stopped');
-      claudeAgentSessions.releaseMany(storedSessionIds);
-      interruptRegistry.unregister(childStreamId);
-      ToolUseFollowUpQueue.release(childStreamId);
-      await writeTerminalStatus(
-        executionId,
-        agentCliLoopTerminalStatus({
-          interrupted: session.isInterrupted(),
-          sawTurnFailure,
-        }),
-      ).catch(() => {});
-      childStream.finalize({
-        status: sawTurnFailure ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
-      });
-    }
-  })();
+    strategy,
+  });
 }
 
 // ============================================================================

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -430,8 +430,13 @@ function startClaudeAgentLoop(params: {
   pathToClaudeCodeExecutable: string | undefined;
   runtimeHost: AgentRuntimeHost;
 }): void {
-  const { childStream, parentStreamId, executionId, initialPrompt, runtimeHost } =
-    params;
+  const {
+    childStream,
+    parentStreamId,
+    executionId,
+    initialPrompt,
+    runtimeHost,
+  } = params;
   const { childStreamId, logger } = childStream;
 
   // The SDK needs the prior session id to resume the same conversation across

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -37,9 +37,7 @@ import { toErrorMessage } from '@common/errors';
 import type {
   StreamTabId,
   ExecutionId,
-  StorageKey,
   TodoItem,
-  TokenUsageStats,
   ToolUseLog,
 } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
@@ -59,6 +57,7 @@ import { defineTool } from './core/define';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { createChildStream, type ChildStream } from './childStream';
 import { AgentCliSessionRegistry } from './agentCliSessionRegistry';
+import { publishAgentCliStreamUsage } from './agentCliShared';
 import {
   runAgentCliSession,
   type AgentCliSessionStrategy,
@@ -207,20 +206,6 @@ export function publishCodexTodos(
   runtimeHost: AgentRuntimeHost,
 ): void {
   runtimeHost.emit('updateTodos', { streamId: childStreamId, todos });
-}
-
-export function publishCodexStreamUsage(
-  childStreamId: StreamTabId,
-  executionId: ExecutionId,
-  usage: TokenUsageStats,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  runtimeHost.emit('updateStreamUsage', {
-    streamId: childStreamId,
-    storageKey: executionId as StorageKey,
-    executionId,
-    usage,
-  });
 }
 
 function toProgressTodos(item: TodoListItem): TodoItem[] {
@@ -463,7 +448,7 @@ function startCodexLoop(params: {
     onTurnSuccess: registerThread,
     publishUsage: (turn) => {
       if (turn.usage) {
-        publishCodexStreamUsage(
+        publishAgentCliStreamUsage(
           childStreamId,
           executionId,
           buildCodexUsageStats(turn.usage),

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -21,11 +21,7 @@
 import { z } from 'zod';
 
 // Local imports
-import {
-  getExecutionStore,
-  registerExecution,
-  writeTerminalStatus,
-} from '@agent/storage';
+import { registerExecution } from '@agent/storage';
 import {
   emitToolUseCard,
   endToolUseCard,
@@ -36,13 +32,7 @@ import {
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
-import {
-  interruptRegistry,
-  type IInterruptible,
-} from '@agent/runtime/InterruptRegistry';
-import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
 import type {
   StreamTabId,
@@ -52,7 +42,7 @@ import type {
   TokenUsageStats,
   ToolUseLog,
 } from '@shared/schemas';
-import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
+import { MESSAGE_TYPES } from '@shared/schemas';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { ToolError, type ToolResult } from '@tools/result';
 import { parseWorkingDirectory } from '@tools/pathResolution';
@@ -70,10 +60,9 @@ import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { createChildStream, type ChildStream } from './childStream';
 import { AgentCliSessionRegistry } from './agentCliSessionRegistry';
 import {
-  agentCliLoopTerminalStatus,
-  isCleanInterruption,
-  logTurnSummary,
-} from './agentCliShared';
+  runAgentCliSession,
+  type AgentCliSessionStrategy,
+} from './agentCliSessionLoop';
 import {
   buildCodexCommandToolLog,
   buildCodexFileChangeToolLog,
@@ -160,49 +149,6 @@ const codexThreads = new AgentCliSessionRegistry<ActiveThread>(
 /** Prevents codex streams from remaining in stale WAITING state during reload. */
 export function interruptAllCodexSessions(): void {
   codexThreads.interruptAll();
-}
-
-// ============================================================================
-// Codex follow-up session — IInterruptible only (no ToolUseFlowContext)
-// ============================================================================
-
-/**
- * Lightweight interruptible registered with the InterruptRegistry so the
- * stop button works on codex child streams.
- *
- * Does NOT implement the session duck-type (no `session.appendFollowUp`),
- * so flow-only commands such as context compaction ignore it.
- *
- * Follow-ups route through the WAITING state queue path:
- * `sendFollowUp()` → stream is WAITING → `ToolUseFollowUpQueue.enqueue()`.
- */
-class CodexFollowUpSession implements IInterruptible {
-  private interrupted = false;
-  private queue: FollowUpQueue | null = null;
-  private turnAbortController: AbortController | null = null;
-
-  interrupt(): void {
-    this.interrupted = true;
-    this.queue?.cancelWait();
-    this.turnAbortController?.abort();
-  }
-
-  setQueue(q: FollowUpQueue): void {
-    this.queue = q;
-  }
-
-  isInterrupted(): boolean {
-    return this.interrupted;
-  }
-
-  startTurn(): AbortSignal {
-    this.turnAbortController = new AbortController();
-    return this.turnAbortController.signal;
-  }
-
-  finishTurn(): void {
-    this.turnAbortController = null;
-  }
 }
 
 // ============================================================================
@@ -462,10 +408,10 @@ export async function runStreamedTurn(
 // ============================================================================
 
 /**
- * Run the Codex session loop. The loop processes prompts from the child's
- * follow-up queue one at a time and delivers each turn's result to the
- * parent's follow-up queue. The initial prompt is seeded into the queue so
- * the first turn goes through the same code path as every follow-up turn.
+ * Run the Codex session loop. The shared loop runner processes prompts from the
+ * child's follow-up queue one at a time and delivers each turn's result to the
+ * parent's follow-up queue; this strategy supplies the Codex-specific turn
+ * execution, registry bookkeeping, and result formatting.
  */
 function startCodexLoop(params: {
   thread: Thread;
@@ -485,140 +431,63 @@ function startCodexLoop(params: {
   } = params;
   const { childStreamId, logger } = childStream;
 
-  const session = new CodexFollowUpSession();
-  const queue = ToolUseFollowUpQueue.acquire(childStreamId);
-  session.setQueue(queue);
-  interruptRegistry.register(childStreamId, session);
-
-  // Start a log group so endRunningGroups() marks it as errored on reload,
-  // giving the user a visual cue that the session was interrupted.
-  // Opens as a root: the child session's own trace has a per-instance stage
-  // scope that is empty here, so there is no cross-trace parent to inherit.
-  const sessionStage = logger.openStage('Codex session');
-
-  // Register resumed threads immediately — without this, a second codex call
-  // with the same thread_id during the first turn would bypass the in-memory
-  // guard and start a concurrent loop. Fresh threads don't have thread.id
-  // yet; they're registered after the first turn completes.
-  if (thread.id) {
-    codexThreads.register(thread.id, {
-      thread,
-      childStreamId,
-      parentStreamId,
-      executionId,
-    });
-  }
-
-  // Seed the initial prompt; the loop drains it as the first turn.
-  queue.enqueue({ text: initialPrompt });
-  childStream.waitForInput();
-
-  let sawTurnFailure = false;
-  void (async () => {
-    try {
-      while (!session.isInterrupted()) {
-        const messages = await queue.waitAndDrainAll(() =>
-          session.isInterrupted(),
-        );
-        if (!messages || session.isInterrupted()) break;
-
-        const prompt = messages.items.map((item) => item.text).join('\n\n');
-        childStream.beginTurn();
-        const startedAt = Date.now();
-        const signal = session.startTurn();
-
-        let turn: RunResult | null = null;
-        let err: unknown = null;
-        try {
-          turn = await runStreamedTurn(
-            thread,
-            prompt,
-            childStreamId,
-            logger,
-            runtimeHost,
-            signal,
-          );
-          logTurnSummary(logger, Date.now() - startedAt, turn.usage);
-        } catch (caught) {
-          if (isCleanInterruption(caught, signal, session)) break;
-          err = caught;
-          logger.error(toErrorMessage(caught));
-        } finally {
-          session.finishTurn();
-        }
-
-        const wallTimeMs = Date.now() - startedAt;
-        const turnFailed = err != null;
-        const threadId = thread.id;
-        if (!turnFailed && threadId && !codexThreads.isActive(threadId)) {
-          codexThreads.register(threadId, {
-            thread,
-            childStreamId,
-            parentStreamId,
-            executionId,
-          });
-        }
-
-        if (turn?.usage) {
-          publishCodexStreamUsage(
-            childStreamId,
-            executionId,
-            buildCodexUsageStats(turn.usage),
-            runtimeHost,
-          );
-        }
-
-        const msg =
-          turn && !turnFailed
-            ? formatCodexDelivery(
-                executionId,
-                prompt,
-                wallTimeMs,
-                turn,
-                threadId,
-              )
-            : formatCodexError(executionId, prompt, err);
-        try {
-          await getExecutionStore(executionId).writeReport(msg);
-        } catch {
-          // Best-effort; delivery must not block on storage.
-        }
-        await sendFollowUp(parentStreamId, {
-          text: msg,
-          origin: 'subagent_result',
-        });
-
-        if (turnFailed) {
-          sawTurnFailure = true;
-          childStream.failTurn();
-          break;
-        }
-
-        if (!session.isInterrupted()) {
-          childStream.waitForInput();
-        }
-      }
-    } finally {
-      sessionStage.end(sawTurnFailure ? 'error' : 'stopped');
-      interruptRegistry.unregister(childStreamId);
-      ToolUseFollowUpQueue.release(childStreamId);
-      const threadId = thread.id;
-      if (threadId) codexThreads.release(threadId);
-      // Persist terminal status before childStream.finalize() untracks and
-      // notifies waiters.
-      await writeTerminalStatus(
+  // Fresh threads don't have thread.id yet; they're registered after the first
+  // turn completes. Resumed threads are registered up front (onSessionStart) so
+  // a second codex call with the same thread_id during the first turn can't
+  // bypass the in-memory guard and start a concurrent loop.
+  const registerThread = (): void => {
+    const threadId = thread.id;
+    if (threadId && !codexThreads.isActive(threadId)) {
+      codexThreads.register(threadId, {
+        thread,
+        childStreamId,
+        parentStreamId,
         executionId,
-        agentCliLoopTerminalStatus({
-          interrupted: session.isInterrupted(),
-          sawTurnFailure,
-        }),
-      ).catch(() => {});
-
-      childStream.finalize({
-        status: sawTurnFailure ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
       });
     }
-  })();
+  };
+
+  const strategy: AgentCliSessionStrategy<RunResult> = {
+    stageLabel: 'Codex session',
+    onSessionStart: registerThread,
+    runTurn: (prompt, abortController) =>
+      runStreamedTurn(
+        thread,
+        prompt,
+        childStreamId,
+        logger,
+        runtimeHost,
+        abortController.signal,
+      ),
+    getUsage: (turn) => turn.usage,
+    onTurnSuccess: registerThread,
+    publishUsage: (turn) => {
+      if (turn.usage) {
+        publishCodexStreamUsage(
+          childStreamId,
+          executionId,
+          buildCodexUsageStats(turn.usage),
+          runtimeHost,
+        );
+      }
+    },
+    formatDelivery: (turn, prompt, wallTimeMs) =>
+      formatCodexDelivery(executionId, prompt, wallTimeMs, turn, thread.id),
+    formatError: (_turn, prompt, err) =>
+      formatCodexError(executionId, prompt, err),
+    onSessionCleanup: () => {
+      const threadId = thread.id;
+      if (threadId) codexThreads.release(threadId);
+    },
+  };
+
+  runAgentCliSession({
+    childStream,
+    parentStreamId,
+    executionId,
+    initialPrompt,
+    strategy,
+  });
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Refactors the duplicated agent-CLI child-session loop shared by `claudeAgent.ts` and `codex.ts` into `src/tools/agentCliSessionLoop.ts`.

The shared runner owns the common lifecycle once: follow-up queue drain, per-turn abort controller, child stream state, report persistence, parent `subagent_result` delivery, terminal status, interrupt unregister, queue release, and finalization. `claudeAgent.ts` and `codex.ts` now provide provider-specific strategy hooks for turn execution, result formatting, thread/session registration, and usage publishing.

## Single Source Of Truth

- `src/tools/agentCliSessionLoop.ts` owns the external-agent child-session loop choreography.
- `src/tools/agentCliShared.ts` owns shared usage/status/summary helpers used by both providers.
- Provider files keep only provider-specific SDK/thread behavior.

## Review Fixes

- Kept `AgentCliSession` private to the loop module.
- Documented the strategy call order and error path contract.
- Ordered cleanup by owner: the shared loop unregisters interrupt state and releases the follow-up queue before provider registry cleanup, preventing a same-thread Codex call from slipping into the teardown window.

## Validation

Local:
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse src/test-kernel/tools src/test/tools` — 45 files, 210 tests passed.
- `npm run typecheck -- --pretty false` — passed.
- `npm run lint -- --quiet` — passed.

Remote:
- GitHub CI validation — passed.
- Format, label, Cursor Bugbot, Claude reviews, and TeXRA review — passed.