### PR TITLE
refactor(desktop): dedupe overlay close-button styles

### DIFF
--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -270,14 +270,19 @@ wa-dialog.desktop-settings-overlay settings-app {
   width: 100%;
 }
 
-wa-button.desktop-settings-close {
+/* Fullscreen-overlay close buttons (settings / diff / pdf) share one skin. */
+wa-button.desktop-settings-close,
+wa-button.desktop-diff-close,
+wa-button.desktop-pdf-close {
   position: absolute;
   top: var(--wa-space-s);
   right: var(--wa-space-s);
   z-index: 10;
 }
 
-wa-button.desktop-settings-close::part(base) {
+wa-button.desktop-settings-close::part(base),
+wa-button.desktop-diff-close::part(base),
+wa-button.desktop-pdf-close::part(base) {
   width: 32px;
   height: 32px;
   padding: 0;
@@ -349,22 +354,6 @@ wa-dialog.desktop-diff-overlay .desktop-diff-view {
   width: 100%;
 }
 
-wa-button.desktop-diff-close {
-  position: absolute;
-  top: var(--wa-space-s);
-  right: var(--wa-space-s);
-  z-index: 10;
-}
-
-wa-button.desktop-diff-close::part(base) {
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border-radius: var(--wa-border-radius-m);
-  background: transparent;
-  color: var(--wa-color-text-normal);
-}
-
 /* =====================================================================
    PDF preview overlay (wa-dialog) — audit item B, trajectory #17
    --------------------------------------------------------------------- */
@@ -428,22 +417,6 @@ wa-dialog.desktop-pdf-overlay .desktop-pdf-frame {
   width: 100%;
   border: 0;
   background: var(--wa-color-surface-default);
-}
-
-wa-button.desktop-pdf-close {
-  position: absolute;
-  top: var(--wa-space-s);
-  right: var(--wa-space-s);
-  z-index: 10;
-}
-
-wa-button.desktop-pdf-close::part(base) {
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border-radius: var(--wa-border-radius-m);
-  background: transparent;
-  color: var(--wa-color-text-normal);
 }
 
 /* =====================================================================


### PR DESCRIPTION
## What

The settings / diff / pdf fullscreen-overlay close buttons each defined a **byte-identical** `wa-button.desktop-*-close` position rule + `::part(base)` skin in three separate places in `styles.css`. Collapsed into two grouped selectors — one source of truth.

- No markup change (CSS-only, grouped existing class selectors).
- No visual change (the three rule sets were identical).

From the comprehensive webview UI-consistency audit (round 3 finding). 1 file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CSS refactor with no markup or logic changes; grouped selectors preserve the same rules as before.
> 
> **Overview**
> **CSS-only deduplication** of fullscreen overlay close-button styling in `styles.css`.
> 
> Identical positioning (`absolute`, top/right, `z-index`) and `::part(base)` rules for `desktop-settings-close`, `desktop-diff-close`, and `desktop-pdf-close` were defined three times. They are now **two shared selector groups** with a short comment, and the duplicate blocks under the diff and PDF overlay sections are removed.
> 
> Markup and class names in `main.ts` / overlay modules are unchanged; behavior and appearance should match the prior duplicated rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff5f8f27e81b313e2373a75feea915cdbfa2a1d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->