### PR TITLE
fix(cli): keep compact tools form within row budget

### DIFF
--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -108,10 +108,11 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
 
   if (isCompactFormRows(props.availableRows)) {
     return (
-      <FormFrame color="cyan" title="/tools" showCloseHint={false}>
-        <Text dimColor wrap="truncate-end">
-          Toggle available external integrations.
-        </Text>
+      <FormFrame
+        color="cyan"
+        title="/tools · Toggle available external integrations."
+        showCloseHint={false}
+      >
         <Select
           items={items}
           maxVisibleItems={1}


### PR DESCRIPTION
## Summary

Fixes a current-main TUI validator failure in the compact `/tools` slash form.

In a 12-row terminal, the compact tools form rendered `/tools`, a separate explanatory line, one item, and the compact key hints. That extra body row crowded out the retained transcript row, causing the PTY validator's `compact-tools-form` scenario to fail its compactness check.

The compact form now folds the purpose text into the title row:

`/tools · Toggle available external integrations.`

This keeps the same user-facing information while reducing the compact panel by one row. The full-size `/tools` form is unchanged.

## Validation

- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-snap compact-tools-form` — passed; snapshot retained the prior transcript line.
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/CliTools.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — 3 files, 122 tests passed.
- `corepack pnpm --filter @texra-ai/cli validate:tui` — all 114 PTY scenarios passed.
- `npm run typecheck -- --pretty false` — passed.
- `npm run lint -- --quiet` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout tweak for the compact tools slash form; full-size form and toggle behavior are unchanged.
> 
> **Overview**
> Fixes compact `/tools` TUI layout so it stays within the **12-row** PTY budget used by the `compact-tools-form` validator.
> 
> The compact branch no longer renders a separate dim explanatory line under the title. That copy is folded into the `FormFrame` title as **`/tools · Toggle available external integrations.`**, saving one row so the retained transcript line is not crowded out. The full-size `/tools` form still shows the description on its own line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346f8dcb1b22e2aa00153d2fa18328daffb927c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->