### PR TITLE
refactor(webview): adopt native WA components (callout, progress-bar, tooltip)

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -23,6 +23,7 @@ import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS, TOOLBAR_BUTTONS } from '../constants';
@@ -179,36 +180,12 @@ export class StreamHeader extends LitElement {
         margin-left: auto;
       }
 
-      /* Status indicator overrides - base styles from statusIndicatorStyles */
+      /* Status indicator overrides - base styles from statusIndicatorStyles.
+         The hover label is a native <wa-tooltip> wrapping this dot. */
       .status-indicator {
         width: var(--wa-space-xs);
         height: var(--wa-space-xs);
         margin: 0 var(--wa-space-2xs);
-        position: relative;
-      }
-
-      /* Tooltip on hover */
-      .status-indicator::after {
-        content: attr(data-status);
-        position: absolute;
-        left: 50%;
-        top: 100%;
-        transform: translateX(-50%);
-        margin-top: var(--wa-space-3xs);
-        padding: var(--wa-space-2xs) var(--wa-space-xs);
-        background: var(--background-color);
-        border: var(--border-thin) solid var(--color-border);
-        border-radius: var(--border-radius-small);
-        font-size: var(--font-size-sm);
-        white-space: nowrap;
-        opacity: 0;
-        pointer-events: none;
-        transition: opacity var(--transition-normal);
-        z-index: 100;
-      }
-
-      .status-indicator:hover::after {
-        opacity: var(--opacity-full);
       }
 
       /* Note: .is-ready and other status states from statusIndicatorStyles */
@@ -356,14 +333,15 @@ export class StreamHeader extends LitElement {
                 ${this.stream.label || this.stream.name}
               </span>
             </div>
-            <span
-              id=${ELEMENT_IDS.STATUS_INDICATOR}
-              class=${classMap({
-                'status-indicator': true,
-                [`is-${status}`]: Boolean(status),
-              })}
-              data-status=${statusLabel}
-            ></span>
+            <wa-tooltip content=${statusLabel}>
+              <span
+                id=${ELEMENT_IDS.STATUS_INDICATOR}
+                class=${classMap({
+                  'status-indicator': true,
+                  [`is-${status}`]: Boolean(status),
+                })}
+              ></span>
+            </wa-tooltip>
             ${this.renderOdysseyChip()} ${this.renderProgressBadge()}
           </div>
           <div class="header-actions">

--- a/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
@@ -2,6 +2,7 @@
 
 import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import '@awesome.me/webawesome/dist/components/progress-bar/progress-bar.js';
 
 import { designTokens } from '@shared/styles';
 import type { SpendingStatus } from '@shared/schemas/spendingStatus';
@@ -81,23 +82,18 @@ export class RelayQuotaMeter extends LitElement {
         font-size: var(--wa-font-size-s);
         color: var(--wa-color-neutral-text-quiet);
       }
+      /* Native wa-progress-bar, compacted to a 6px track; colour the indicator
+         per quota state via its --indicator-color custom property. */
       .quota-bar {
-        position: relative;
-        height: 6px;
-        background: var(--wa-color-neutral-border-quiet);
-        border-radius: var(--border-radius);
-        overflow: hidden;
+        --track-height: 6px;
+        --track-color: var(--wa-color-neutral-border-quiet);
+        --indicator-color: var(--wa-color-brand-fill-loud);
       }
-      .quota-bar-fill {
-        height: 100%;
-        background: var(--wa-color-brand-fill-loud);
-        transition: width 200ms ease-out;
+      .quota-meter[data-state='warning'] .quota-bar {
+        --indicator-color: var(--wa-color-warning-fill-loud);
       }
-      .quota-meter[data-state='warning'] .quota-bar-fill {
-        background: var(--wa-color-warning-fill-loud);
-      }
-      .quota-meter[data-state='exhausted'] .quota-bar-fill {
-        background: var(--wa-color-danger-fill-loud);
+      .quota-meter[data-state='exhausted'] .quota-bar {
+        --indicator-color: var(--wa-color-danger-fill-loud);
       }
       .quota-note {
         margin-top: var(--wa-space-xs);
@@ -131,15 +127,11 @@ export class RelayQuotaMeter extends LitElement {
           <span class="quota-label">Relay usage this month</span>
           <span class="quota-amount">${formatPercent(percent)} used</span>
         </div>
-        <div
+        <wa-progress-bar
           class="quota-bar"
-          role="progressbar"
-          aria-valuemin="0"
-          aria-valuemax="100"
-          aria-valuenow=${Math.round(percent)}
-        >
-          <div class="quota-bar-fill" style="width: ${percent}%"></div>
-        </div>
+          value=${Math.round(percent)}
+          label="Relay usage this month"
+        ></wa-progress-bar>
         ${note ? html`<div class="quota-note">${note}</div>` : nothing}
       </div>
     `;

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -48,6 +48,7 @@ import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 import '@awesome.me/webawesome/dist/components/radio/radio.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
@@ -194,25 +195,22 @@ export class InstructionPanel extends LitElement {
         font-size: var(--font-size-sm);
       }
 
+      /* Native wa-callout (brand), compacted to IDE density. The callout
+         supplies the tinted background + border + radius; we only tighten the
+         padding/typography and lay its content out in a single row. */
       .session-hint {
-        display: flex;
-        gap: var(--wa-space-2xs);
-        align-items: flex-start;
         margin-top: var(--wa-space-2xs);
         padding: var(--wa-space-3xs) var(--wa-space-2xs);
-        border-left: 2px solid
-          color-mix(in srgb, var(--wa-color-brand-fill-loud) 70%, transparent);
-        background: color-mix(
-          in srgb,
-          var(--wa-color-brand-fill-quiet) 35%,
-          transparent
-        );
-        border-radius: 0 var(--wa-border-radius-s, 4px)
-          var(--wa-border-radius-s, 4px) 0;
-        color: var(--wa-color-text-quiet);
         font-size: var(--font-size-sm);
         line-height: var(--line-height-relaxed);
         animation: session-hint-fade 150ms ease;
+      }
+
+      .session-hint::part(message) {
+        display: flex;
+        gap: var(--wa-space-2xs);
+        align-items: flex-start;
+        color: var(--wa-color-text-quiet);
       }
 
       @keyframes session-hint-fade {
@@ -454,8 +452,9 @@ export class InstructionPanel extends LitElement {
     return keyed(
       hintKey,
       html`
-        <div
+        <wa-callout
           class="session-hint"
+          variant="brand"
           role="note"
           data-hint-key=${hintKey}
           aria-label=${copy.ariaLabel}
@@ -472,7 +471,7 @@ export class InstructionPanel extends LitElement {
             className: 'session-hint-dismiss',
             onClick: this.handleDismissSessionHint,
           })}
-        </div>
+        </wa-callout>
       `,
     );
   }


### PR DESCRIPTION
## What

Replace three hand-rolled UI recipes with the **native WebAwesome components** that already ship in 3.8.0 — used *natively* (content in the component's own slots/parts, no wrapper "mid layers"), compacted to our IDE density. Round 1 of the WA-adoption pass; one commit per component so each is independently reviewable/revertible.

- **`wa-callout`** ← `InstructionPanel`'s `.session-hint` (bespoke left-accent border + tinted bg + radius). Content sits directly in the default slot; its own `::part(message)` is the flex row. *Visual note:* the native callout is a quiet filled panel (full border) rather than the old left-accent strip — informed choice; happy to add a left-accent override if you prefer the strip.
- **`wa-progress-bar`** ← `RelayQuotaMeter`'s `.quota-bar` track + `.quota-bar-fill` width-percent div + manual `role=progressbar` ARIA. State colours move to `--indicator-color`; 6px track via `--track-height`. No inner fill layer.
- **`wa-tooltip`** ← `StreamHeader`'s `.status-indicator::after { content: attr(data-status) }` CSS-hack tooltip (clipped by `overflow`, not keyboard-accessible). Native tooltip wraps the dot; drops the pseudo-element + `data-status`.

## Verification
- `prettier --check` clean on all three.
- Off latest `main`. Independent of other open work.
- **Visual:** these are appearance changes I can't see-test — please eyeball the launcher (session hint), Settings → Models (quota meter), and the Progress header (status dot tooltip).

## Next (queued, your "all clear go")
Round 2 — `wa-relative-time` (fixes the stale-timestamp bug in StreamTabs/BackgroundTasksPanel), `wa-badge` (pills/category badges), `wa-card` (`.list-item`), `wa-format-bytes`/`wa-format-number`, `wa-skeleton`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactors in webview Lit components; behavior and element IDs are largely preserved, with minor visual differences (callout shape, tooltip implementation).
> 
> **Overview**
> Replaces three hand-rolled UI patterns with **native WebAwesome (WA) components**, styled for IDE density via CSS custom properties and shadow parts.
> 
> In **Progress** (`StreamHeader`), the stream status dot’s CSS `::after` tooltip (`data-status`, clipping/keyboard issues) is removed in favor of **`wa-tooltip`** wrapping the indicator; status coloring on the dot is unchanged.
> 
> In **Settings → Models** (`RelayQuotaMeter`), the custom track/fill div and manual `role="progressbar"` ARIA are replaced by **`wa-progress-bar`** with `value`/`label`; warning and exhausted states still drive color through **`--indicator-color`** on a 6px track.
> 
> In the launcher **`InstructionPanel`**, the bespoke left-accent session hint panel becomes **`wa-callout`** (`variant="brand"`) with hint copy in the default slot and flex layout on **`::part(message)`**—a full bordered callout instead of the old left-accent strip.
> 
> **Visual check recommended** on session hint, quota meter, and progress header tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b107c77067eca4be1aaa1a91f70f851c083c6067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->