### PR TITLE
refactor(cli): require model form selectable state

### DIFF
--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -37,7 +37,7 @@ export interface ModelListFormProps {
   readonly currentModel: string;
   readonly apiMode: CliApiMode;
   readonly availableRows?: number;
-  readonly selectable?: boolean;
+  readonly selectable: boolean;
   readonly getModelSwitchDisabledReason?: GetModelSwitchDisabledReason;
   readonly onSelect?: (value: string) => void;
   readonly onClose: () => void;
@@ -99,18 +99,17 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     props.apiMode,
     props.getModelSwitchDisabledReason,
   );
-  const selectable = props.selectable === true;
   const selectWindow = modelSelectWindow({
     availableRows: props.availableRows,
     itemCount: items.length,
   });
   const description = modelListDescription({
     itemCount: items.length,
-    selectable,
+    selectable: props.selectable,
   });
 
   function handleSelect(value: string): void {
-    if (selectable) {
+    if (props.selectable) {
       props.onSelect?.(value);
       return;
     }
@@ -118,7 +117,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
   }
 
   useEffect(() => {
-    if (loading || error || !selectable || !pendingInput) return;
+    if (loading || error || !props.selectable || !pendingInput) return;
     if (appliedPendingInput.current === pendingInput) return;
     appliedPendingInput.current = pendingInput;
 
@@ -135,7 +134,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     loading,
     pendingInput,
     props.onSelect,
-    selectable,
+    props.selectable,
   ]);
 
   if (loading) {
@@ -171,7 +170,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
         />
         <CompactFormKeyHints
           primary={
-            selectable
+            props.selectable
               ? { key: '1-9/a-z/Enter', action: 'select' }
               : { key: 'Enter', action: 'close' }
           }
@@ -206,7 +205,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
         </Box>
       )}
       <Box>
-        {selectable && items.length > 0 ? (
+        {props.selectable && items.length > 0 ? (
           <KeyHints
             hints={[
               { key: '↑/↓', action: 'navigate' },


### PR DESCRIPTION
## Summary

Tightens the `/model` TUI form contract so `selectable` is required instead of optional.

The command registration layer already owns model-selection availability through `canSelectModel`, normalizes its default once, and passes the resulting boolean into `ModelListForm`. The form no longer has a second local fallback path (`props.selectable === true`); it consumes the explicit boolean directly.

This keeps ownership clear without adding another helper or indirection.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts` — 2 files, 44 tests passed.
- `npm run typecheck -- --pretty false` — passed.
- `npm run lint -- --quiet` — passed.
- `git diff --check` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-contract and prop-threading cleanup in the CLI TUI with no auth, data, or runtime behavior change beyond making omitted `selectable` a compile error.
> 
> **Overview**
> Makes **`selectable` a required prop** on `ModelListForm` instead of optional, so the `/model` form always receives an explicit boolean from its caller (e.g. slash-command registration via `canSelectModel`).
> 
> The form **drops the local `props.selectable === true` check** and uses **`props.selectable` directly** for descriptions, hotkey hints, selection handling, and the pending-input `useEffect` dependencies—no second implicit “default false when omitted” path inside the form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e1428d5862a7771ca16258bfc13f698161cb772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->