### PR TITLE
refactor(progress): use native wa-relative-time for live timestamps

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -22,6 +22,7 @@ import { classMap } from 'lit/directives/class-map.js';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/relative-time/relative-time.js';
 
 // Local imports
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
@@ -344,9 +345,13 @@ export class BackgroundTasksPanel extends LitElement {
             >${thread.threadId}</span
           >
           <span class="task-description" title=${preview}>${preview}</span>
-          <span class="task-elapsed" title=${thread.lastActivityIso}
-            >${formatInquiryActivity(thread.lastActivityIso)}</span
-          >
+          <wa-relative-time
+            class="task-elapsed"
+            date=${thread.lastActivityIso}
+            title=${thread.lastActivityIso}
+            format="narrow"
+            sync
+          ></wa-relative-time>
           <wa-tag
             class="task-status"
             variant=${inquiryStatusVariant(thread.status)}
@@ -543,20 +548,6 @@ function inquiryStatusVariant(
   if (status === 'open') return 'warning';
   if (status === 'answered') return 'success';
   return 'neutral';
-}
-
-function formatInquiryActivity(iso: string): string {
-  const time = Date.parse(iso);
-  if (Number.isNaN(time)) return '';
-
-  const elapsedMs = Date.now() - time;
-  if (elapsedMs < 60_000) return 'now';
-  if (elapsedMs < 3_600_000) return `${Math.floor(elapsedMs / 60_000)}m`;
-  if (elapsedMs < 86_400_000) return `${Math.floor(elapsedMs / 3_600_000)}h`;
-  return new Date(time).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-  });
 }
 
 declare global {

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -23,6 +23,7 @@ import {
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/relative-time/relative-time.js';
 import './WorktreeChip';
 import { formatRelativeTime } from '@shared/utils/string';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
@@ -474,11 +475,14 @@ export class StreamTab extends LitElement {
                     </div>`
                   : nothing}
                 <div class="tab-meta">
-                  <span class="last-active"
-                    >${this.lastTimestamp
-                      ? formatRelativeTime(this.lastTimestamp)
-                      : ''}</span
-                  >
+                  ${this.lastTimestamp
+                    ? html`<wa-relative-time
+                        class="last-active"
+                        .date=${new Date(this.lastTimestamp)}
+                        format="narrow"
+                        sync
+                      ></wa-relative-time>`
+                    : nothing}
                   <span class="model"
                     >${stream.modelLabel ?? stream.model ?? ''}</span
                   >


### PR DESCRIPTION
## What

Replace ad-hoc render-time relative-time formatting with the native **`<wa-relative-time sync>`** component, which self-updates over time — fixing a real staleness bug (round-2 audit #15/#51): the old timestamps were computed once at render with no refresh tick, so they froze until the next re-render.

- **StreamTabs** tab "last active": the `formatRelativeTime(...)` display span → `<wa-relative-time .date sync format="narrow">`.
- **BackgroundTasksPanel** task activity: the `formatInquiryActivity(...)` span → `<wa-relative-time date sync>`, and the **ad-hoc `formatInquiryActivity` helper is deleted** (it was a `Date.now()`-at-render clock).

`formatRelativeTime` is kept only where a plain string is genuinely needed (the StreamTab tooltip). The absolute timestamp stays available via the native `title` attr. No wrapper layers — the component is used directly.

## Verification
- `prettier --check` clean; no dangling `formatInquiryActivity` refs.
- Off latest `main`.
- **Visual/behavioral:** the relative-time *wording* now comes from `Intl` ("2 min. ago") and updates live — please eyeball the tab meta + background tasks; easy to tune the `format` (narrow/short/long) if you want different phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display change in progress view components; no auth, data, or API surface changes.
> 
> **Overview**
> **Live relative timestamps** in the progress UI now use **`<wa-relative-time sync>`** instead of one-shot formatting at render time, so labels keep updating without waiting for a parent re-render.
> 
> In **BackgroundTasksPanel**, inquiry **last activity** moves from `formatInquiryActivity` (removed) to `<wa-relative-time>` with `format="narrow"`; the absolute ISO time stays on `title`. In **StreamTabs**, tab meta **last active** swaps `formatRelativeTime` for the same component bound to `lastTimestamp`. **`formatRelativeTime` remains** only for the stream tab tooltip string.
> 
> Relative phrasing follows **`Intl`** (e.g. narrow “2 min. ago”) rather than the old custom buckets (`now`, `5m`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b41fe529d02b3b38a3d1e72f86ef7585d6cfbcc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->