### PR TITLE
refactor(cli): require agent form selectable state

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -20,7 +20,7 @@ import { useAsyncListForm } from './_shared/useAsyncListForm';
 export interface AgentListFormProps {
   readonly currentAgent: string;
   readonly availableRows?: number;
-  readonly selectable?: boolean;
+  readonly selectable: boolean;
   readonly onSelect?: (value: string) => void;
   readonly onClose: () => void;
 }
@@ -175,7 +175,6 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   }
 
   const agents: AgentGroups = data ?? { toolUse: [], workflow: [] };
-  const selectable = props.selectable === true;
   const primarySectionTitle = agentPickerPrimarySectionTitle(agents.toolUse);
   const items = agents.toolUse.map((agent) => ({
     value: agent.label,
@@ -206,7 +205,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     selectWindow.maxVisibleWorkflows,
   );
   const handleSelectItem = (value: string): void => {
-    if (selectable) {
+    if (props.selectable) {
       props.onSelect?.(value);
       return;
     }
@@ -232,7 +231,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
         />
         <CompactFormKeyHints
           primary={
-            selectable
+            props.selectable
               ? { key: '1-9/a-z/Enter', action: 'select' }
               : { key: 'Enter', action: 'close' }
           }
@@ -244,7 +243,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   return (
     <FormFrame color="cyan" title="/agent" showCloseHint={false}>
       <Text dimColor wrap="truncate-end">
-        {selectable
+        {props.selectable
           ? 'Choose the root agent for the first message.'
           : 'Available agents. Start a new chat with texra chat --agent=<name> to choose the root agent.'}
       </Text>
@@ -285,7 +284,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
         </Box>
       ) : null}
       <Box marginTop={1}>
-        {selectable ? (
+        {props.selectable ? (
           <KeyHints
             hints={[
               { key: '↑/↓', action: 'navigate' },


### PR DESCRIPTION
## Summary

Tightens the `/agent` TUI form contract so `selectable` is required instead of optional.

The slash command registration layer already owns root-agent selection availability through `canSelectAgent`, normalizes its default once, and passes the resulting boolean into `AgentListForm`. The form no longer has a second local fallback path (`props.selectable === true`); it consumes the explicit boolean directly.

This mirrors the `/model` form contract and keeps selection ownership in the command layer without adding another helper or indirection.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — 3 files, 136 tests passed.
- `npm run typecheck -- --pretty false` — passed.
- `npm run lint -- --quiet` — passed.
- `corepack pnpm --filter @texra-ai/cli validate:tui` — all 114 PTY scenarios passed.
- `git diff --check` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only contract tightening on the `/agent` TUI form; callers already supply `selectable` explicitly.
> 
> **Overview**
> Makes **`selectable` a required prop** on `AgentListForm`, matching the `/model` form pattern.
> 
> The form no longer treats missing `selectable` as false via `props.selectable === true`; it uses the boolean passed from the slash-command layer (`canSelectAgent()` in `AgentListFormAdapter`) for selection behavior, copy, and key hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b78f801920a133961d283ebd825a00bef189be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->