### PR TITLE
refactor(webview): use native wa-badge for status pills

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -24,6 +24,7 @@ import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS, TOOLBAR_BUTTONS } from '../constants';
@@ -218,31 +219,16 @@ export class StreamHeader extends LitElement {
         color: var(--color-success);
       }
 
+      /* Native wa-badge (brand=active / warning=paused, quiet 'filled'
+         appearance), compacted to the prior chip padding. */
       .odyssey-chip {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-3xs);
         flex-shrink: 0;
-        padding: 0 var(--wa-space-2xs);
-        border-radius: var(--border-radius-pill);
-        font-size: var(--font-size-xs);
-        font-weight: var(--font-weight-medium);
-        cursor: default;
-        color: var(--wa-color-brand-on-quiet, var(--color-info));
-        background-color: color-mix(
-          in srgb,
-          var(--wa-color-brand-fill-loud, var(--color-info)) 15%,
-          transparent
-        );
       }
 
-      .odyssey-chip.is-paused {
-        color: var(--wa-color-warning-on-quiet, var(--color-warning));
-        background-color: color-mix(
-          in srgb,
-          var(--wa-color-warning-fill-loud, var(--color-warning)) 15%,
-          transparent
-        );
+      .odyssey-chip::part(base) {
+        gap: var(--wa-space-3xs);
+        padding: 0 var(--wa-space-2xs);
+        font-weight: var(--font-weight-medium);
       }
 
       .odyssey-chip wa-icon {
@@ -418,14 +404,15 @@ export class StreamHeader extends LitElement {
     const tooltip = this.odysseyObjective
       ? `${label}: ${this.odysseyObjective}`
       : label;
-    return html`<span
-      class=${classMap({ 'odyssey-chip': true, 'is-paused': isPaused })}
+    return html`<wa-badge
+      class="odyssey-chip"
+      variant=${isPaused ? 'warning' : 'brand'}
+      appearance="filled"
       title=${tooltip}
       aria-label=${tooltip}
     >
-      <wa-icon library="texra" name="compass" aria-hidden="true"></wa-icon>
-      ${label}
-    </span>`;
+      ${waIcon('compass')} ${label}
+    </wa-badge>`;
   }
 
   private renderProgressBadge(): TemplateResult | typeof nothing {

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -13,12 +13,24 @@ import { designTokens } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
 
 const PR_STATE_LABEL: Record<WorktreePRState, string> = {
   [WORKTREE_PR_STATE.OPEN]: 'Open',
   [WORKTREE_PR_STATE.MERGED]: 'Merged',
   [WORKTREE_PR_STATE.CLOSED]: 'Closed',
   [WORKTREE_PR_STATE.DRAFT]: 'Draft',
+};
+
+/** PR state → wa-badge variant (WA has no purple, so merged maps to brand). */
+const PR_STATE_VARIANT: Record<
+  WorktreePRState,
+  'brand' | 'neutral' | 'success' | 'danger'
+> = {
+  [WORKTREE_PR_STATE.OPEN]: 'success',
+  [WORKTREE_PR_STATE.MERGED]: 'brand',
+  [WORKTREE_PR_STATE.CLOSED]: 'danger',
+  [WORKTREE_PR_STATE.DRAFT]: 'neutral',
 };
 
 const CI_ICON: Record<WorktreeCIState, string> = {
@@ -57,51 +69,15 @@ export class WorktreeChip extends LitElement {
         max-width: 100%;
       }
 
+      /* Native wa-badge per PR state (quiet 'filled' appearance); compacted to
+         the prior pill padding. Colour comes from the variant. */
       .pill {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-3xs);
-        padding: 0 var(--wa-space-2xs);
-        border-radius: var(--wa-border-radius-pill);
-        background-color: color-mix(
-          in srgb,
-          var(--color-text-secondary) 12%,
-          transparent
-        );
-        color: var(--wa-color-text-normal);
-        white-space: nowrap;
         flex-shrink: 0;
       }
 
-      .pill.state-open {
-        color: var(--wa-color-success-on-quiet, var(--color-success));
-        background-color: color-mix(
-          in srgb,
-          var(--color-success) 14%,
-          transparent
-        );
-      }
-
-      .pill.state-merged {
-        color: var(--wa-color-chart-purple, var(--wa-color-text-link, #8957e5));
-        background-color: color-mix(
-          in srgb,
-          var(--wa-color-chart-purple, #8957e5) 14%,
-          transparent
-        );
-      }
-
-      .pill.state-closed {
-        color: var(--wa-color-danger-on-quiet, var(--color-error));
-        background-color: color-mix(
-          in srgb,
-          var(--color-error) 14%,
-          transparent
-        );
-      }
-
-      .pill.state-draft {
-        color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
+      .pill::part(base) {
+        gap: var(--wa-space-3xs);
+        padding: 0 var(--wa-space-2xs);
       }
 
       .branch {

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -181,10 +181,12 @@ export class WorktreeChip extends LitElement {
   }
 
   private renderPRPill(state: WorktreePRState): TemplateResult {
-    return html`<span
-      class=${classMap({ pill: true, [`state-${state}`]: true })}
+    return html`<wa-badge
+      class="pill"
+      variant=${PR_STATE_VARIANT[state]}
+      appearance="filled"
       title=${`PR ${PR_STATE_LABEL[state]}`}
-      >${PR_STATE_LABEL[state]}</span
+      >${PR_STATE_LABEL[state]}</wa-badge
     >`;
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/OdysseyTab.ts
@@ -15,9 +15,26 @@ import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
 import type { MetaPart } from '@shared/wa/metaStrip';
 
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
 
 function statusLabel(status: OdysseyStatus): string {
   return status[0].toUpperCase() + status.slice(1);
+}
+
+/** Map an Odyssey status to a wa-badge variant. */
+function statusVariant(
+  status: OdysseyStatus,
+): 'brand' | 'neutral' | 'success' | 'warning' {
+  switch (status) {
+    case 'active':
+      return 'success';
+    case 'paused':
+      return 'warning';
+    case 'complete':
+      return 'brand';
+    default:
+      return 'neutral';
+  }
 }
 
 @customElement('odyssey-tab')
@@ -57,31 +74,14 @@ export class OdysseyTab extends LitElement {
         background: var(--wa-color-surface-raised);
       }
 
-      .status-chip {
-        font-size: var(--wa-font-size-xs);
+      /* Native wa-badge (variant per status, quiet 'filled' appearance),
+         compacted to the prior 2px chip padding. */
+      .status-chip::part(base) {
+        padding: 2px var(--wa-space-2xs);
         font-weight: var(--wa-font-weight-semibold);
-        padding: 2px 8px;
-        border-radius: var(--wa-border-radius-pill);
-        background: var(--_chip-bg, var(--wa-color-neutral-fill-quiet));
-        color: var(--_chip-fg, var(--wa-color-neutral-on-quiet));
       }
 
-      .status-chip[data-status='active'] {
-        --_chip-bg: var(--wa-color-success-fill-quiet);
-        --_chip-fg: var(--wa-color-success-on-quiet);
-      }
-
-      .status-chip[data-status='paused'] {
-        --_chip-bg: var(--wa-color-warning-fill-quiet);
-        --_chip-fg: var(--wa-color-warning-on-quiet);
-      }
-
-      .status-chip[data-status='complete'] {
-        --_chip-bg: var(--wa-color-brand-fill-quiet);
-        --_chip-fg: var(--wa-color-brand-on-quiet);
-      }
-
-      .status-chip[data-status='abandoned'] {
+      .status-chip[data-status='abandoned']::part(base) {
         text-decoration: line-through;
       }
 
@@ -176,8 +176,12 @@ export class OdysseyTab extends LitElement {
         role=${inFlight ? 'button' : 'group'}
         tabindex=${inFlight ? 0 : -1}
       >
-        <span class="status-chip" data-status=${item.status}
-          >${statusLabel(item.status)}</span
+        <wa-badge
+          class="status-chip"
+          variant=${statusVariant(item.status)}
+          appearance="filled"
+          data-status=${item.status}
+          >${statusLabel(item.status)}</wa-badge
         >
         <div>
           <div class="objective" title=${item.objective}>${item.objective}</div>

--- a/src/test-kernel/progressView/ToolbarIconConsistency.vitest.mts
+++ b/src/test-kernel/progressView/ToolbarIconConsistency.vitest.mts
@@ -26,8 +26,9 @@ describe('progress toolbar icon consistency', () => {
     const iconRegistry = readSource('src/shared/wa/webAwesomeIcons.ts');
 
     // Compass: Odyssey is no longer a toolbar toggle button — it's a passive
-    // header chip surfaced when the agent enters Odyssey mode.
-    expect(streamHeader).toContain('name="compass"');
+    // header chip surfaced when the agent enters Odyssey mode through the
+    // shared Web Awesome icon helper.
+    expect(streamHeader).toContain("waIcon('compass')");
     expect(iconRegistry).toContain('compass: faCompass');
 
     expect(constants).toContain("icon: 'compress'");


### PR DESCRIPTION
## What

Replace three hand-rolled status-pill recipes with the native **`wa-badge`**, used declaratively — colour comes from `variant`, the quiet tint from `appearance="filled"`, and only the compact padding is overridden via `::part(base)`. Deletes the per-state ad-hoc tint CSS (`--_chip-bg/-fg` swaps, `color-mix` blocks).

- **OdysseyTab** `.status-chip` → `<wa-badge variant=...>` per `OdysseyStatus` (active→success, paused→warning, complete→brand, abandoned→neutral + line-through).
- **WorktreeChip** `.pill` → `<wa-badge variant=...>` per PR state (open→success, merged→**brand** — WA has no purple variant; flag if you want the GitHub-purple kept via an override, closed→danger, draft→neutral).
- **StreamHeader** `.odyssey-chip` → `<wa-badge variant=...>` (brand=active / warning=paused); icon now via `waIcon()`.

## Verification
- `prettier --check` clean. Rebased on latest `main` (so it stacks cleanly after #5694's StreamHeader tooltip change).
- **Visual:** `wa-badge appearance="filled"` is a quiet tint (matches the old `fill-quiet` chips) but the exact shade/radius is WA's — please eyeball the Odyssey settings list, worktree PR chips, and the Progress header Odyssey chip.

## Context
This is the genuine wa-badge family from a multi-subagent discovery pass. Remaining queued (separate, distinct PRs — not fragmentation): the request-panel label badges (`.workflow-proposal__category-badge`, `.extract-flag`), and the bigger **wa-button-group** (toolbar/action-button clusters, low-risk) + **wa-tree** (StreamTabs child-stream nesting, medium-risk) that the subagents surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI refactor with no auth, data, or business-logic changes; merged PR color shifts from purple to brand variant.
> 
> **Overview**
> Replaces hand-rolled status **pills** in three webviews with native **`wa-badge`** (`appearance="filled"`), using **`variant`** for state color and slim **`::part(base)`** overrides for the old compact padding. Custom **`color-mix`** / per-state chip CSS is removed.
> 
> **StreamHeader** Odyssey chip is now **`wa-badge`** (brand vs warning when paused); the compass icon uses **`waIcon('compass')`**. **WorktreeChip** PR state pills map to badge variants (open→success, merged→**brand** instead of GitHub purple, closed→danger, draft→neutral). **OdysseyTab** list rows use **`statusVariant()`** for each Odyssey status; abandoned keeps line-through on **`::part(base)`**.
> 
> **ToolbarIconConsistency** test now asserts **`waIcon('compass')`** in StreamHeader instead of a raw **`wa-icon`** name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daa2ac34776e75576569ca1fdaba8f5daa683209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->