### PR TITLE
fix(cli): keep TUI header above transcript rows

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -851,7 +851,9 @@ const SCENARIOS = [
     name: 'bash-approval',
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
     bootExpect: '[Ctrl-C]',
+    resizes: [{ cols: 120 }],
     expect: [
+      'agent: chat · model: harness-model',
       'Run bash command?',
       '$ npm run compile:safe',
       'y approve',
@@ -859,6 +861,17 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
+    maxOccurrences: [{ text: '{ T } TeXRA', max: 1 }],
+    ordered: [
+      {
+        before: 'agent: chat · model: harness-model',
+        after: '› entry-1 chat history line',
+      },
+      {
+        before: 'agent: chat · model: harness-model',
+        after: 'Run bash command?',
+      },
+    ],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: 'Run bash command?', max: 3 },
     ],
@@ -2561,6 +2574,17 @@ function countOccurrences(text, needle) {
   }
 }
 
+function orderedTextFailure(frame, check) {
+  const afterIndex = frame.indexOf(check.after);
+  if (afterIndex < 0)
+    return `order marker missing: ${JSON.stringify(check.after)}`;
+  const beforeIndex = frame.lastIndexOf(check.before, afterIndex);
+  if (beforeIndex < 0)
+    return `${JSON.stringify(check.before)} should appear before ${JSON.stringify(check.after)}`;
+  if (beforeIndex < afterIndex) return undefined;
+  return `${JSON.stringify(check.before)} should appear before ${JSON.stringify(check.after)}`;
+}
+
 function snapshotFileName(index, name, extension = 'txt') {
   const prefix = String(index + 1).padStart(2, '0');
   return `${prefix}-${name.replace(/[^a-z0-9._-]+/gi, '-')}.${extension}`;
@@ -2827,6 +2851,11 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
     child.write(key);
     await sleep(500);
   }
+  for (const resize of scenario.resizes ?? []) {
+    child.resize(Number(resize.cols ?? cols), Number(resize.rows ?? rows));
+    term.resize(Number(resize.cols ?? cols), Number(resize.rows ?? rows));
+    await sleep(Number(resize.delayMs ?? 500));
+  }
 
   // Settle after keystrokes. A quiet PTY is not quite enough: under a full
   // suite, Ink/xterm can occasionally pause between chunks of the final frame,
@@ -2878,6 +2907,10 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
         `text appears too many times: ${JSON.stringify(check.text)} (${actual} > ${check.max})`,
       );
     }
+  }
+  for (const check of scenario.ordered ?? []) {
+    const failure = orderedTextFailure(frame, check);
+    if (failure) failures.push(failure);
   }
   const slashPaletteVisible =
     frame.includes('Tab complete') && frame.includes('↑/↓ navigate');

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -1,6 +1,8 @@
-// Live session header plus print-once transcript entries. Finalized entries
-// land in ordinary terminal scrollback through Ink `<Static>`; the header
-// stays adaptive chrome for the active scrollback owner.
+// Print-once session header plus transcript entries. The header is the first
+// static row for the active scrollback owner; finalized entries append after it
+// in ordinary terminal scrollback through Ink `<Static>`. The Static key must
+// stay stable across resize because terminal scrollback is append-only: reflowing
+// old rows by remounting Static reprints the header and finalized history.
 
 import path from 'node:path';
 
@@ -40,16 +42,6 @@ export type StaticTranscriptItem =
       readonly kind: 'entry';
       readonly entry: ConversationEntry;
     };
-
-type StaticTranscriptHeaderItem = Extract<
-  StaticTranscriptItem,
-  { readonly kind: 'header' }
->;
-
-type StaticTranscriptEntryItem = Extract<
-  StaticTranscriptItem,
-  { readonly kind: 'entry' }
->;
 
 interface StaticTranscriptState {
   readonly ownerKey: string;
@@ -176,18 +168,6 @@ function staticTranscriptItemRowCount(
     : lines;
 }
 
-function isStaticTranscriptHeaderItem(
-  item: StaticTranscriptItem,
-): item is StaticTranscriptHeaderItem {
-  return item.kind === 'header';
-}
-
-function isStaticTranscriptEntryItem(
-  item: StaticTranscriptItem,
-): item is StaticTranscriptEntryItem {
-  return item.kind === 'entry';
-}
-
 export function appendStaticTranscriptItems({
   currentItems,
   streams,
@@ -227,7 +207,14 @@ export function appendStaticTranscriptItems({
       maxRows === undefined ||
       currentRows + staticTranscriptItemRowCount(header, width) <= maxRows
     ) {
-      nextItems.push(header);
+      const firstEntryIndex = nextItems.findIndex(
+        (item) => item.kind === 'entry',
+      );
+      nextItems.splice(
+        firstEntryIndex < 0 ? nextItems.length : firstEntryIndex,
+        0,
+        header,
+      );
       currentRows += staticTranscriptItemRowCount(header, width);
       seen.add(SESSION_HEADER_ID);
     }
@@ -325,33 +312,20 @@ export function StaticConversationTranscript({
     width,
   ]);
 
-  const headerItems = items.filter(isStaticTranscriptHeaderItem);
-  const entryItems = items.filter(isStaticTranscriptEntryItem);
-
   return (
-    <>
-      {headerItems.map((item: StaticTranscriptHeaderItem) => (
+    <Static key={`transcript:${ownerKey}`} items={[...items]}>
+      {(item: StaticTranscriptItem) => (
         <Box key={item.id} flexDirection="column">
-          <EntryErrorBoundary label="session header">
-            <SessionHeaderBlock
-              compact={item.compact}
-              identityLine={item.identityLine}
-              meta={item.meta}
-              width={width}
-            />
-          </EntryErrorBoundary>
-        </Box>
-      ))}
-      {/* Remount entry <Static> on a width or owner change so Ink regenerates
-       * `fullStaticOutput` for the current stream. The header is outside this
-       * keyed region; early terminal-width settling must not print the
-       * session banner twice. */}
-      <Static
-        key={`entries:${ownerKey}:${Math.max(1, Math.floor(width ?? 80))}`}
-        items={[...entryItems]}
-      >
-        {(item: StaticTranscriptEntryItem) => (
-          <Box key={item.id} flexDirection="column">
+          {item.kind === 'header' ? (
+            <EntryErrorBoundary label="session header">
+              <SessionHeaderBlock
+                compact={item.compact}
+                identityLine={item.identityLine}
+                meta={item.meta}
+                width={width}
+              />
+            </EntryErrorBoundary>
+          ) : (
             <EntryErrorBoundary label={item.entry.role}>
               <TranscriptEntry
                 entry={item.entry}
@@ -359,9 +333,9 @@ export function StaticConversationTranscript({
                 colorEnabled={colorEnabled}
               />
             </EntryErrorBoundary>
-          </Box>
-        )}
-      </Static>
-    </>
+          )}
+        </Box>
+      )}
+    </Static>
   );
 }

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -95,12 +95,10 @@ function UserEntryRow({
   readonly width?: number;
 }): React.JSX.Element {
   // Mark a user turn with a full-width reverse-video band (theme-adaptive via
-  // reverse video). The fixed-width fill is baked at render width, so it only
-  // stays full-width across a resize because `<Static>` is remounted on a width
-  // change (key={columns} in StaticConversationTranscript) — that regenerates
-  // `fullStaticOutput` at the new width, which the resize full-repaint then
-  // reprints. The `› ` chevron is 2 cols; row estimators add the exported
-  // margin constant alongside their wrapped-line count.
+  // reverse video). Static transcript rows are print-once terminal scrollback:
+  // a row keeps the width it had when it was appended, while later rows render
+  // at the latest width. The `› ` chevron is 2 cols; row estimators add the
+  // exported margin constant alongside their wrapped-line count.
   const cols = Math.max(1, Math.floor(width ?? 80));
   return (
     <Box marginBottom={USER_ENTRY_MARGIN_BOTTOM_ROWS}>

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -442,6 +442,33 @@ describe('CLI conversation transcript splitting', () => {
     ).toEqual(['u1', 'a1']);
   });
 
+  it('inserts a newly eligible header before existing compact transcript entries', () => {
+    const user = entry('u1', 'user', 'What is a tensor network?', true);
+    const assistant = entry('a1', 'assistant', 'A decomposition.', true);
+    const compact = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: [],
+      streams: streamsFromEntries(STREAM_ID, [user, assistant]),
+      meta: SESSION_META,
+      maxRows: 0,
+      width: 80,
+    });
+
+    const expanded = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: compact,
+      streams: streamsFromEntries(STREAM_ID, [user, assistant]),
+      meta: SESSION_META,
+      width: 80,
+    });
+
+    expect(expanded.map((item) => item.id)).toEqual([
+      'session-header',
+      'u1',
+      'a1',
+    ]);
+  });
+
   it('preserves static transcript order when an entry exceeds the compact row budget', () => {
     const first = entry('u1', 'user', 'first', true);
     const large = entry('a1', 'assistant', 'line 1\nline 2\nline 3', true);

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -1,14 +1,15 @@
-// Regression test for the width-adaptive `<Static>` user-message band
-// (TranscriptEntry full-width reverse-video band + the entry Static remount in
-// StaticConversationTranscript). Renders a minimal Ink app reproducing the pattern to
-// an in-memory fake stdout, simulates a terminal resize by bumping `columns` and
-// emitting `resize`, and asserts the highlighted band reflows to the NEW width
-// instead of staying baked at the original width.
+// Regression test for the patched Ink resize repaint path. Renders a minimal
+// Ink app with a deliberately remounted `<Static>` band to an in-memory fake
+// stdout, simulates a terminal resize by bumping `columns` and emitting
+// `resize`, and asserts the highlighted band reflows to the NEW width instead
+// of staying baked at the original width.
 //
 // This exercises the patched Ink resize full-repaint + the `<Static>` remount
-// (`handleStaticChange` regenerates `fullStaticOutput` at the new width) the
-// feature depends on — without a pty (node-pty's posix_spawn is unavailable in
-// sandboxed CI; the existing InkResizePatch test uses a recording stream too).
+// (`handleStaticChange` regenerates `fullStaticOutput` at the new width) without
+// a pty (node-pty's posix_spawn is unavailable in sandboxed CI; the existing
+// InkResizePatch test uses a recording stream too). The main transcript does
+// not use this pattern for historical rows, because terminal scrollback is
+// append-only and remounting old rows duplicates finalized output.
 
 // Set before Ink/chalk load so reverse-video SGR (`ESC[7m`) is actually emitted
 // to the non-TTY fake stdout; otherwise chalk no-ops `inverse` and the band has


### PR DESCRIPTION
## Summary
- render the session header and finalized transcript rows through one ordered Ink Static item list
- remove the split live-header/static-entry path that let submitted user rows print above the TeXRA banner
- add an order-sensitive TUI harness assertion for the approval frame

## Validation
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/StaticBandResize.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- npm run lint -- --quiet
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/tui-static-header-final bash-approval
- real PTY run: HARNESS_ENTRIES=4 HARNESS_BASH_APPROVAL=1 node packages/cli/dist/bin/tui-harness.js
- ad hoc PTY resize probe: 80→120 columns, headerCount=1, headerBeforeEntry=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI scrollback/render behavior and resize semantics; wrong Static ordering or keys could duplicate or mis-order transcript output, though targeted harness and unit tests mitigate regressions.
> 
> **Overview**
> Fixes the CLI TUI so the **TeXRA session banner stays above finalized transcript rows** instead of user history printing above it (notably on bash-approval frames after resize).
> 
> **`StaticConversationTranscript`** now feeds the session header and finalized entries through **one ordered Ink `<Static>` list** keyed only by `transcript:${ownerKey}` (no width-keyed remount on entries). When a header becomes eligible after compact layout, **`appendStaticTranscriptItems` splices it before existing entry items**. Comments in **`TranscriptEntry`** clarify that static rows are print-once scrollback and do not reflow on resize.
> 
> **`validate-tui.mjs`** gains scenario **`resizes`**, **`ordered`** text-order checks, and stricter **`bash-approval`** expectations (120-col resize, single `{ T } TeXRA`, header before history and approval). Unit tests cover header insertion order; **`StaticBandResize`** docs note the main transcript intentionally avoids remounting historical static rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24184775222a03d3c0fc1b05d94c643c64fda707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->