### PR TITLE
refactor(webview-styles): tokenize remaining opacity/tracking/compact-height literals

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -171,7 +171,7 @@ export class BackgroundTasksPanel extends LitElement {
         font-weight: var(--font-weight-semibold);
         color: var(--color-text-secondary);
         text-transform: uppercase;
-        letter-spacing: 0.05em;
+        letter-spacing: var(--letter-spacing-caps);
         cursor: pointer;
         list-style: none;
         user-select: none;

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -237,7 +237,7 @@ export class SettingsApp extends SettingsAppBase {
 
       wa-tab .settings-tab-icon {
         margin-inline-end: 0.45em;
-        opacity: 0.85;
+        opacity: var(--opacity-normal);
       }
 
       wa-tab[active] .settings-tab-icon {

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryToggle.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryToggle.ts
@@ -24,7 +24,7 @@ export class MemoryToggle extends LitElement {
       .memory-settings {
         display: flex;
         align-items: center;
-        min-height: 22px;
+        min-height: var(--height-control-compact);
       }
     `,
   ];

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -86,7 +86,7 @@ export class AgentSelectionPanel extends LitElement {
         font-weight: var(--font-weight-semibold);
         color: var(--color-text-secondary);
         text-transform: uppercase;
-        letter-spacing: 0.06em;
+        letter-spacing: var(--letter-spacing-caps);
         background: color-mix(
           in srgb,
           var(--wa-color-surface-default) 92%,

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -165,7 +165,7 @@ export class InstructionPanel extends LitElement {
         margin-bottom: var(--wa-space-3xs);
         line-height: var(--line-height-normal);
         flex-wrap: wrap;
-        min-height: 22px;
+        min-height: var(--height-control-compact);
       }
 
       .instruction-header-leading {
@@ -235,7 +235,7 @@ export class InstructionPanel extends LitElement {
 
       .session-hint-time {
         color: var(--wa-color-text-quiet);
-        opacity: 0.85;
+        opacity: var(--opacity-normal);
       }
 
       .session-hint-dismiss {

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -39,13 +39,13 @@ export class LoginBanner extends LitElement {
 
       .banner-lead {
         font-size: var(--font-size-sm);
-        opacity: 0.85;
+        opacity: var(--opacity-normal);
         line-height: var(--line-height-normal, 1.4);
       }
 
       .banner-fineprint {
         font-size: var(--font-size-xs);
-        opacity: 0.6;
+        opacity: var(--opacity-muted);
         line-height: var(--line-height-normal, 1.4);
       }
 

--- a/packages/extension/src/webview/frontend/styles.ts
+++ b/packages/extension/src/webview/frontend/styles.ts
@@ -83,7 +83,7 @@ export const mainViewStyles: CSSResult = css`
 
   wa-details.file-selection-details::part(header) {
     padding: var(--wa-space-3xs) var(--wa-space-2xs);
-    min-height: 22px;
+    min-height: var(--height-control-compact);
     font-size: var(--font-size-sm);
     color: var(--wa-color-text-quiet);
   }

--- a/packages/extension/src/webview/frontend/styles/bannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/bannerStyles.ts
@@ -56,7 +56,7 @@ export const bannerStyles: CSSResult = css`
   .banner-row .hint {
     width: 100%;
     font-size: var(--font-size-sm);
-    opacity: 0.7;
+    opacity: var(--opacity-subtle);
     line-height: var(--line-height-relaxed, 1.5);
   }
 

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -83,8 +83,8 @@ export const fileSelectLayoutStyles = css`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 22px;
-    height: 22px;
+    width: var(--height-control-compact);
+    height: var(--height-control-compact);
     color: var(--color-text-secondary);
     flex-shrink: 0;
   }
@@ -129,7 +129,7 @@ export const toggleStyles = css`
     min-width: calc(var(--width-button-min) * 2);
     display: flex;
     align-items: center;
-    height: 22px;
+    height: var(--height-control-compact);
   }
 
   .toggle-icon {
@@ -141,7 +141,7 @@ export const toggleStyles = css`
     color: var(--text-color);
     display: flex;
     align-items: center;
-    height: 22px;
+    height: var(--height-control-compact);
     background: none;
     border: none;
   }


### PR DESCRIPTION
## What

The final **design-token straggler sweep** flagged by a discovery subagent — routes the last hardcoded opacity / letter-spacing / compact-height literals through the existing tokens. **No visual change** (the token values are identical; the one exception is BackgroundTasksPanel's `0.05em`→`--letter-spacing-caps` `0.06em`, a deliberate 0.01em normalisation onto the shared uppercase-label tracking).

- `opacity: 0.85/0.7/0.6` → `--opacity-normal` / `--opacity-subtle` / `--opacity-muted` (LoginBanner, bannerStyles, SettingsApp, InstructionPanel).
- uppercase-label `letter-spacing` → `--letter-spacing-caps` (AgentSelectionPanel, BackgroundTasksPanel).
- compact-control `22px` → `--height-control-compact` (InstructionPanel header, webview `styles.ts`, fileSelectStyles, MemoryToggle).

## Verification
- `prettier --check` clean; no `0.85/0.7/0.6` opacity, `0.05em/0.06em` tracking, or `22px` literals remain in the touched files.
- Off latest `main`. Pure token swaps, safe to merge without an eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only token substitutions with matching values; only minor visual delta is caps letter-spacing on BackgroundTasksPanel (0.05em → 0.06em).
> 
> **Overview**
> Replaces remaining hardcoded **opacity**, **letter-spacing**, and **compact height** values in extension webview/settings/progress Lit CSS with shared design tokens (`--opacity-normal`, `--opacity-subtle`, `--opacity-muted`, `--letter-spacing-caps`, `--height-control-compact`).
> 
> Touches banners, settings tabs, instruction/file-select chrome, memory toggle, agent list headers, and background-tasks section labels. **BackgroundTasksPanel** uppercase label tracking moves from `0.05em` to `--letter-spacing-caps` (`0.06em`)—a small deliberate alignment with other caps labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3a66bad0218019d51d7e3804755e0302475bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->