### PR TITLE
fix(latex): restore BibTeX refs in latexdiff output

### DIFF
--- a/packages/extension/resources/tool_use_agents/latexDiff.yaml
+++ b/packages/extension/resources/tool_use_agents/latexDiff.yaml
@@ -27,9 +27,10 @@ prompts:
     (2) Run `latexdiff` to produce the diff .tex file:
         - `latexdiff <old.tex> <new.tex> > <name>_diff.tex`.
         - For math-heavy documents, pass `--math-markup=whole` or `--math-markup=coarse` to avoid noisy token-level diffs.
-        - For citation-heavy text, pass `--exclude-safecmd="cite[a-z]*"` if bibliography refs balloon the diff.
+        - For citation-heavy text, pass `--exclude-textcmd="cite[a-z]*"` so citation commands stay BibTeX-readable.
     (3) Compile the diff file:
         - `latexmk -pdf -interaction=nonstopmode <name>_diff.tex`.
+        - If latexdiff expanded a `.bbl` block and diff markup corrupted bibliography macros, restore the source document's `\bibliography{...}` directive and rerun BibTeX rather than editing generated BibTeX macro definitions.
         - If latexdiff's auto-merged preamble conflicts with the document's packages, report the error and ask the user before editing the generated diff file.
     (4) Report the generated diff paths (.tex and .pdf) and note anything notable (unusual hunks, missing references, compilation warnings).
 

--- a/packages/extension/resources/tool_use_agents/latexFixer.yaml
+++ b/packages/extension/resources/tool_use_agents/latexFixer.yaml
@@ -12,6 +12,7 @@ settings:
     - ls
     - diagnostics
     - executions
+    - extract_bib_entries
 
 prompts:
   systemPrompt: |
@@ -22,7 +23,7 @@ prompts:
     Workflow:
     (1) Use `grep` and `glob` to understand the project structure (find all .tex, .bib, .cls, .sty files). Use `ls` to inspect directories when file paths are unclear.
     (2) Compile the document to produce a log. Use `bash` to run `latexmk -pdf -interaction=nonstopmode <file>` or an equivalent compilation command. If latexmk is unavailable, fall back to `pdflatex -interaction=nonstopmode <file>` (run twice for references).
-    (3) Parse the log output to identify every error, warning, and bad box. Group them by type and severity. Use `diagnostics` to check for linter warnings in addition to compilation errors.
+    (3) Parse the log output to identify every error, warning, and bad box. Group them by type and severity. Treat hyperlink/hyperref errors and BibTeX/citation failures as default repair targets, not optional polish. Use `diagnostics` to check for linter warnings in addition to compilation errors.
     (4) For each issue, locate the offending source line using `read_file` and the line numbers from the log.
     (5) Fix issues one at a time using `edit_file`. Prefer minimal, targeted edits — change only what is needed to resolve the issue.
     (6) After fixing a batch of related issues, recompile and verify the fixes resolved them without introducing new problems.
@@ -30,7 +31,7 @@ prompts:
 
     Prioritization:
     - Fix errors first (the document cannot compile).
-    - Fix undefined references and missing citations next.
+    - Fix hyperlink/hyperref failures, undefined references, and missing citations next.
     - Fix warnings (e.g., font substitution, package conflicts) next.
     - Fix bad boxes (overfull/underfull hbox/vbox) last.
 
@@ -41,6 +42,10 @@ prompts:
     - Mismatched braces/environments: trace the nesting and close the correct environment.
     - Missing files (images, bib): check for typos in paths; use `glob` to find the actual file.
     - Bibliography errors: check `.bib` syntax and ensure `\bibliographystyle` / `\bibliography` match.
+    - Missing citation keys: use `extract_bib_entries` and `grep` to find the intended key in `.bib` files; fix typos in `\cite{...}` or bibliography entries, but do not invent new references.
+    - Hyperlink/hyperref errors: fix duplicate labels, empty or malformed anchors, fragile commands in section titles/captions, unsafe URL text, and missing `\label` targets. Prefer `\texorpdfstring`, `\url{...}`, stable label names, and correct `\ref`/`\autoref`/`\cref` targets over suppressing warnings globally.
+    - Latexdiff bibliography errors: if a generated diff file contains a corrupted `thebibliography` / `.bbl` block, prefer restoring the source document's `\bibliography{...}` directive and rerunning BibTeX over editing BibTeX's generated macro definitions.
+    - Latexdiff hyperlink errors: inspect the generated diff log, then fix duplicate labels, fragile section titles, malformed URLs, or missing reference targets in the editable source that produced the diff.
 
     Overflow and Bad-Box Fixes:
     - Overfull hbox in text: rephrase slightly, add `~` or `\-` hyphenation hints, or use `\sloppy` locally via `\begin{sloppypar}...\end{sloppypar}` as a last resort.

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -150,7 +150,7 @@ export class LaTeXdiffService {
       await flexibleFS.ensureDir(pathToLocation(outputDirectory));
       const outputLocation = pathToLocation(outputPath);
       await flexibleFS.write(outputLocation, result.stdout);
-      await this.fileProcessor.processDiffFile(outputLocation);
+      await this.fileProcessor.processDiffFile(outputLocation, editedLocation);
 
       logger.debug(
         this.channel,
@@ -203,7 +203,10 @@ export class LaTeXdiffService {
       // latexdiff-vc writes output alongside the input, relative to cwd
       const diffFilePath = filePath.replace('.tex', `-diff${commitHash}.tex`);
       const outputPath = path.join(cwd, diffFilePath);
-      await this.fileProcessor.processDiffFile(pathToLocation(outputPath));
+      await this.fileProcessor.processDiffFile(
+        pathToLocation(outputPath),
+        inputLocation,
+      );
 
       const diffFileName = path.basename(diffFilePath);
 

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -41,13 +41,51 @@ export class DiffFileProcessor {
   // means the diff output is missing or corrupt, so it must propagate to the
   // caller (LaTeXdiffService.runDiff*/), whose catch turns it into a
   // `{ success: false }` result. Swallowing it would falsely report success.
-  async processDiffFile(diffFileLocation: FileLocation): Promise<void> {
+  async processDiffFile(
+    diffFileLocation: FileLocation,
+    editedFileLocation?: FileLocation,
+  ): Promise<void> {
     const content = await flexibleFS.read(diffFileLocation);
-    let processedContent = this.processStarEnvironments(content);
+    const editedContent = editedFileLocation
+      ? await flexibleFS.read(editedFileLocation)
+      : undefined;
+    let processedContent = this.restoreFlattenedBibliography(
+      content,
+      editedContent,
+    );
+    processedContent = this.processStarEnvironments(processedContent);
     processedContent = this.processLineByLine(processedContent);
     processedContent = replacementEngine.applyAll(processedContent);
     await flexibleFS.write(diffFileLocation, processedContent);
     await this.processTikzPictureEndings(diffFileLocation);
+  }
+
+  private restoreFlattenedBibliography(
+    content: string,
+    editedContent?: string,
+  ): string {
+    const bibliography = this.findBibliographyDirective(editedContent);
+    if (!bibliography) {
+      return content;
+    }
+
+    return content.replace(
+      /\\begin\{thebibliography\}\{[^}]*\}[\s\S]*?\\end\{thebibliography\}/g,
+      bibliography,
+    );
+  }
+
+  private findBibliographyDirective(content?: string): string | undefined {
+    for (const line of content?.split('\n') ?? []) {
+      if (line.trimStart().startsWith('%')) {
+        continue;
+      }
+      const bibliography = line.match(/\\bibliography\s*\{[^}]+\}/);
+      if (bibliography) {
+        return bibliography[0];
+      }
+    }
+    return undefined;
   }
 
   private processStarEnvironments(content: string): string {

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -112,6 +112,73 @@ describe('LaTeXdiffService shadow output', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('restores flattened BibTeX blocks to the source bibliography directive', async () => {
+    const { LaTeXdiffService } = await import('@latex/latexdiff');
+    const tempDir = await makeTempDir('texra-latexdiff-bib-');
+    const sourceDir = path.join(tempDir, 'workspace');
+    const shadowDir = path.join(tempDir, 'executions', 'run-1', 'diff', 'r1');
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      path.join(sourceDir, 'base.tex'),
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'old \\cite{a}',
+        '\\bibliographystyle{plain}',
+        '\\bibliography{library}',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      path.join(sourceDir, 'revised.tex'),
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'new \\cite{a}',
+        '\\bibliographystyle{plain}',
+        '\\bibliography{library}',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+    await installNodeBackedPlatform(sourceDir, path.join(tempDir, 'storage'));
+    mocks.executeCommand.mockResolvedValueOnce({
+      success: true,
+      stdout: [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'new \\cite{a}',
+        '\\bibliographystyle{plain}',
+        '\\begin{thebibliography}{}',
+        '\\providecommand \\@ifxundefined [\\DIFadd{1}]{% corrupted bbl macro',
+        '\\end{thebibliography}',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+      stderr: '',
+    });
+
+    const service = new LaTeXdiffService('test');
+    const result = await service.runDiff(
+      createExternalLocation(path.join(sourceDir, 'base.tex')),
+      createExternalLocation(path.join(sourceDir, 'revised.tex')),
+      '_diff',
+      false,
+      undefined,
+      { outputDirectory: shadowDir },
+    );
+
+    expect(result).toMatchObject({ success: true });
+    const diff = await readFile(
+      path.join(shadowDir, 'revised_diff.tex'),
+      'utf8',
+    );
+    expect(diff).toContain('\\bibliography{library}');
+    expect(diff).not.toContain('\\begin{thebibliography}');
+    expect(diff).not.toContain('\\DIFadd{1}');
+  });
+
   it('mirrors workspace dependencies into diff round storage', async () => {
     const tempDir = await makeTempDir('texra-diff-mirror-');
     const workspaceDir = path.join(tempDir, 'workspace');


### PR DESCRIPTION
## Summary
- restore flattened `thebibliography` blocks in generated latexdiff output back to the edited source's `\bibliography{...}` directive when the source uses BibTeX
- make latexFixer treat citation/BibTeX and hyperlink/hyperref failures as default repair targets, including latexdiff logs
- align the latexDiff agent prompt with the existing citation-safe `--exclude-textcmd` behavior

## Root Cause
`latexdiff --flatten` expands existing `.bbl` output into the generated diff. Some bibliography styles define internal macros in that `.bbl`; latexdiff can then insert `\DIFadd{...}` into macro parameter syntax such as `#1` or `[1]`, producing invalid LaTeX. Online reports describe the same class of failure for latexdiff over `.bbl` / bibliography output, so the deterministic fix is to let BibTeX regenerate references from `\bibliography{...}` instead of diffing generated `.bbl` internals.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts src/test-kernel/latex/LatexdiffBibQuality.vitest.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized post-processing on generated diff files plus prompt/tool guidance; behavior is additive when the edited source has `\bibliography`, with a focused test covering the bib-restore path.
> 
> **Overview**
> Fixes a common latexdiff failure where expanded **`thebibliography` / `.bbl`** blocks get diff markup inside BibTeX-generated macros and break compilation.
> 
> **Post-processing** in `DiffFileProcessor` now takes the edited/new `.tex` path, finds its `\bibliography{...}` directive, and **replaces** any flattened `\begin{thebibliography}...\end{thebibliography}` in the diff output with that directive so BibTeX can regenerate refs. `LaTeXdiffService` passes the edited file into this step for both normal and VC diffs.
> 
> **Agent prompts** are aligned: **latexDiff** uses `--exclude-textcmd="cite[a-z]*"` and documents restoring `\bibliography` when `.bbl` diff markup is corrupt; **latexFixer** treats citation/BibTeX and hyperref issues as default fixes, adds **`extract_bib_entries`**, and documents latexdiff-specific bib/hyperlink repair.
> 
> A **kernel test** asserts corrupted mock latexdiff stdout is rewritten to `\bibliography{library}` without `thebibliography` or `\DIFadd` in macros.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88981aaae9cbd24d9f38bb0766b67cc9cb4c9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->