### PR TITLE
refactor(webview): adopt native WebAwesome components (button-group, badge, divider, copy)

### DIFF
--- a/packages/extension/src/progressView/frontend/components/PermissionCard.ts
+++ b/packages/extension/src/progressView/frontend/components/PermissionCard.ts
@@ -35,6 +35,7 @@ import { permissionCardStyles } from '@shared/styles/permissionCardStyles';
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
 
 // Local imports - progress view
 import { ProgressEvents } from '../events';
@@ -295,13 +296,13 @@ export class PermissionCard extends LitElement {
         flags,
         (flag) => flag,
         (flag) =>
-          html`<span class="extract-flag"
+          html`<wa-badge variant="neutral" appearance="filled"
             ><wa-icon
               library="texra"
               name="file-media"
               aria-hidden="true"
             ></wa-icon>
-            ${flag}</span
+            ${flag}</wa-badge
           >`,
       )}
     </p>`;

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -9,6 +9,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 // Side-effect imports - register WA icon component
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
@@ -118,15 +119,12 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
       >
         <div class="workflow-proposal__details">
           <div class="workflow-proposal__header-row">
-            <span
-              class=${classMap({
-                'workflow-proposal__category-badge': true,
-                'workflow-proposal__category-badge--workflow': isWorkflow,
-                'workflow-proposal__category-badge--tool-use': !isWorkflow,
-              })}
+            <wa-badge
+              variant=${isWorkflow ? 'neutral' : 'brand'}
+              appearance="filled"
             >
               ${categoryLabel}
-            </span>
+            </wa-badge>
             ${hasAgentOptions
               ? html`
                   <div class="workflow-proposal__agent-select">
@@ -248,14 +246,13 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
         flags,
         (flag) => flag,
         (flag) =>
-          html`<span
-            class="workflow-proposal__category-badge workflow-proposal__category-badge--workflow workflow-proposal__extract-flag"
+          html`<wa-badge variant="neutral" appearance="filled"
             ><wa-icon
               library="texra"
               name="file-media"
               aria-hidden="true"
             ></wa-icon>
-            ${flag}</span
+            ${flag}</wa-badge
           >`,
       )}
     </div>`;

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -24,6 +24,7 @@ import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
+import '@awesome.me/webawesome/dist/components/button-group/button-group.js';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS, TOOLBAR_BUTTONS } from '../constants';
@@ -190,15 +191,6 @@ export class StreamHeader extends LitElement {
 
       /* Note: .is-ready and other status states from statusIndicatorStyles */
 
-      /* Replaces flex layout previously provided by vscode-toolbar-container.
-         Without this, toolbar buttons would stack vertically in block flow. */
-      .toolbar-container {
-        display: inline-flex;
-        flex-wrap: wrap;
-        gap: var(--wa-space-2xs, 4px);
-        align-items: center;
-      }
-
       .toolbar-button--hidden {
         display: none;
       }
@@ -345,9 +337,9 @@ export class StreamHeader extends LitElement {
             ${this.renderOdysseyChip()} ${this.renderProgressBadge()}
           </div>
           <div class="header-actions">
-            <div
+            <wa-button-group
               id=${ELEMENT_IDS.TOOLBAR_CONTAINER}
-              class="toolbar-container"
+              label="Stream actions"
               data-agent-mode=${agentCategory}
               @click=${this.handleToolbarClick}
             >
@@ -393,7 +385,7 @@ export class StreamHeader extends LitElement {
                   `;
                 },
               )}
-            </div>
+            </wa-button-group>
           </div>
         </div>
       </div>

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -30,6 +30,10 @@ import {
   SPINNER_ICON_NAME,
 } from '../htmlBuilders';
 
+// Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
+import '@awesome.me/webawesome/dist/components/divider/divider.js';
+
 type RenderableSection = TemplateResult | typeof nothing | undefined | null;
 type BadgeData = { iconName: string; label: string };
 type CodexToolRenderer = (input: unknown) => TemplateResult | typeof nothing;
@@ -51,7 +55,7 @@ function renderBadge({ iconName, label }: BadgeData): TemplateResult {
     ? html`<wa-spinner></wa-spinner>`
     : html`<wa-icon library="texra" name=${iconName} aria-hidden="true"></wa-icon>`;
   // prettier-ignore
-  return html`<span class="extract-flag">${iconTemplate} ${label}</span>`;
+  return html`<wa-badge variant="neutral" appearance="filled">${iconTemplate} ${label}</wa-badge>`;
 }
 
 function renderBadgeSection(
@@ -87,10 +91,7 @@ function renderSectionGroup(
     visibleSections,
     (_section, index) => index,
     (section, index) =>
-      html`${when(
-        index > 0,
-        () => html`<hr class="tool-use-separator" />`,
-      )}${section}`,
+      html`${when(index > 0, () => html`<wa-divider></wa-divider>`)}${section}`,
   )}`;
 }
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -78,6 +78,10 @@ import { codexToolRenderers } from './codexToolTemplates';
 import '@progressView/frontend/components/ToolTimer';
 import '@progressView/frontend/components/TerminalOutput';
 
+// Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
+import '@awesome.me/webawesome/dist/components/divider/divider.js';
+
 /** Known per-tool default timeouts (ms) for display in the running timer. */
 const TOOL_DEFAULT_TIMEOUTS: Record<string, number> = {
   bash: 120_000, // matches BASH_TIMEOUT_MS in src/tools/bash.ts
@@ -148,7 +152,7 @@ function joinWithSeparator(sections: TemplateResult[]): TemplateResult {
   return html`${sections.map(
     (section, i) =>
       html`${section}${i < sections.length - 1
-        ? html`<hr class="tool-use-separator" />`
+        ? html`<wa-divider></wa-divider>`
         : ''}`,
   )}`;
 }
@@ -499,7 +503,7 @@ function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
     extractFlags.push('Extract TikZ');
   if (extractFlags.length > 0) {
     // prettier-ignore
-    sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => html`<span class="extract-flag"><wa-icon library="texra" name="file-media" aria-hidden="true"></wa-icon> ${f}</span>`)}`));
+    sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => html`<wa-badge variant="neutral" appearance="filled"><wa-icon library="texra" name="file-media" aria-hidden="true"></wa-icon> ${f}</wa-badge>`)}`));
   }
 
   const fileGroups = getProposalFileGroups(delegateInput);
@@ -568,7 +572,7 @@ function buildMcpSections(ctx: ToolSectionContext): TemplateResult[] {
       ? html`<wa-spinner></wa-spinner>`
       : html`<wa-icon library="texra" name=${statusIconName} aria-hidden="true"></wa-icon>`;
     // prettier-ignore
-    sections.push(buildToolUseSection('Status:', html`<span class="extract-flag">${statusIconTemplate} ${mcpOutput.status}</span>`));
+    sections.push(buildToolUseSection('Status:', html`<wa-badge variant="neutral" appearance="filled">${statusIconTemplate} ${mcpOutput.status}</wa-badge>`));
     renderedMcpOutput = true;
   }
 

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -256,19 +256,6 @@ export const logEntryStyles = css`
     display: none;
   }
 
-  .extract-flag {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--wa-space-3xs);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold);
-    padding: var(--wa-space-3xs) var(--wa-space-2xs);
-    border-radius: var(--border-radius);
-    background: var(--wa-color-neutral-fill-quiet);
-    color: var(--wa-color-neutral-on-quiet);
-    margin-right: var(--wa-space-2xs);
-  }
-
   /* Terminal-style output: monospace font, tighter spacing, no log bullets.
      Applied to streams that proxy raw process output (e.g. bash child streams)
      so their stdout/stderr reads like a terminal instead of a logger. */

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -39,13 +39,6 @@ export const toolUseStyles = css`
     font-size: var(--font-size-sm);
   }
 
-  .tool-use-separator {
-    margin: var(--wa-space-2xs) 0;
-    border: none;
-    border-top: var(--border-thin) solid var(--color-border);
-    opacity: var(--opacity-separator);
-  }
-
   :is(.tool-use-error, .banner-details--error)
     > .details-summary
     :is(.tool-use-title, .label, wa-icon),

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -312,11 +312,7 @@ export class HistoryItemElement extends LitElement {
 
     const metaParts: Array<string | TemplateResult> = [
       timestamp,
-      html`<wa-tag
-        class="agent-category-badge"
-        variant=${categoryVariant}
-        size="small"
-      >
+      html`<wa-tag variant=${categoryVariant} size="small">
         ${decorator.icon
           ? html`<wa-icon library="texra" name=${decorator.icon}></wa-icon>`
           : nothing}

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -11,6 +11,7 @@ import {
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
+import '@awesome.me/webawesome/dist/components/button-group/button-group.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -198,7 +199,7 @@ export class MemoryItem extends LitElement {
       <div class="list-item memory-item ${this.item.pinned ? 'pinned' : ''}">
         <div class="list-item-header">
           <div class="memory-path">${this.item.displayPath}</div>
-          <div class="action-button-group">
+          <wa-button-group label="Memory actions">
             ${renderIconActionButton({
               icon: this.item.pinned ? 'thumbtack-slash' : 'thumbtack',
               label: this.item.pinned ? 'Unpin' : 'Pin',
@@ -219,7 +220,7 @@ export class MemoryItem extends LitElement {
               title: 'Delete this memory',
               onClick: this.handleDelete,
             })}
-          </div>
+          </wa-button-group>
         </div>
         <div class="text-secondary meta-strip">
           ${this.renderMeta(this.item)}

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -467,7 +467,6 @@ export const profileViewStyles: CSSResult = css`
   /**
    * Inline icon following a model row's name. Variants set --_icon-color;
    * the base resolves to secondary text when no variant is applied.
-   * Mirrors the tinted-badge --_tint pattern in shared badgeStyles.
    */
   .model-row-icon {
     font-size: var(--font-size-xs);

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -1,5 +1,6 @@
 /** Single tool group with status, description, and optional installation guide. */
 
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/switch/switch.js';
@@ -97,18 +98,9 @@ export class ToolCard extends LitElement {
         margin-bottom: var(--wa-space-2xs);
       }
 
-      .tool-id-tag {
+      wa-badge.tool-id-tag::part(base) {
         font-family: var(--wa-font-family-mono, monospace), monospace;
         font-size: var(--font-size-xs);
-        padding: var(--border-thin) var(--border-radius-large);
-        background: var(
-          --wa-color-neutral-fill-quiet,
-          rgba(128, 128, 128, 0.15)
-        );
-        border: var(--border-thin) solid
-          var(--wa-color-neutral-border-quiet, transparent);
-        color: var(--wa-color-neutral-on-quiet);
-        border-radius: var(--border-radius);
       }
 
       .tool-guide-toggle::part(base) {
@@ -477,10 +469,12 @@ export class ToolCard extends LitElement {
               <div class="tool-ids">
                 ${this.item.tools.map(
                   (tool) =>
-                    html`<span
+                    html`<wa-badge
                       class="tool-id-tag"
+                      variant="neutral"
+                      appearance="filled"
                       title=${tool.description ?? tool.name}
-                      >${tool.name}</span
+                      >${tool.name}</wa-badge
                     >`,
                 )}
               </div>

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -6,6 +6,7 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/switch/switch.js';
+import '@awesome.me/webawesome/dist/components/copy-button/copy-button.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -44,7 +45,6 @@ import {
 } from '@shared/constants/latex';
 
 // Local imports - shared utilities
-import { copyTextToClipboard } from '@shared/utils/clipboard';
 import { createEvent } from '@shared/utils/events';
 import { clamp, filterNotNullish } from '@utils/core';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
@@ -315,11 +315,6 @@ export class LaTeXTab extends LitElement {
         white-space: nowrap;
       }
 
-      .copy-success {
-        color: var(--wa-color-testing-passed, #73c991) !important;
-        border-color: var(--wa-color-testing-passed, #73c991) !important;
-      }
-
       /* Prerequisite hint uses wa-callout; only layout for actions row + the
          inline command text live here. */
       wa-callout.prerequisite-hint {
@@ -399,17 +394,6 @@ export class LaTeXTab extends LitElement {
   @property({ type: Boolean, attribute: 'desktop-host' }) desktopHost = false;
 
   @state() private expandedGuides = new Set<string>();
-  /** Command string most recently copied; clears after a brief flash. */
-  @state() private copiedCommand: string | null = null;
-  private copyResetTimer: ReturnType<typeof setTimeout> | null = null;
-
-  override disconnectedCallback(): void {
-    if (this.copyResetTimer) {
-      clearTimeout(this.copyResetTimer);
-      this.copyResetTimer = null;
-    }
-    super.disconnectedCallback();
-  }
 
   private toggleGuide(key: string): void {
     const next = new Set(this.expandedGuides);
@@ -453,17 +437,6 @@ export class LaTeXTab extends LitElement {
       options.find((cmd) => !cmd.packageManager || cmd.packageManager === pm) ??
       null
     );
-  }
-
-  private async handleCopyCommand(command: string): Promise<void> {
-    const ok = await copyTextToClipboard(command);
-    if (!ok) return;
-    this.copiedCommand = command;
-    if (this.copyResetTimer) clearTimeout(this.copyResetTimer);
-    this.copyResetTimer = setTimeout(() => {
-      this.copiedCommand = null;
-      this.copyResetTimer = null;
-    }, 2000);
   }
 
   private handleRunInTerminal(command: string): void {
@@ -532,19 +505,7 @@ export class LaTeXTab extends LitElement {
         ${!installed && installCmd
           ? html`
               <div class="dependency-install-actions">
-                <button
-                  class="tab-action-btn ${this.copiedCommand ===
-                  installCmd.command
-                    ? 'copy-success'
-                    : ''}"
-                  title=${this.copiedCommand === installCmd.command
-                    ? 'Copied!'
-                    : `Copy: ${installCmd.command}`}
-                  @click=${() => this.handleCopyCommand(installCmd.command)}
-                >
-                  <wa-icon library="texra" name="copy"></wa-icon>
-                  Copy
-                </button>
+                <wa-copy-button value=${installCmd.command}></wa-copy-button>
                 <button
                   class="tab-action-btn"
                   title="Run: ${installCmd.command}"
@@ -622,18 +583,7 @@ export class LaTeXTab extends LitElement {
         <div class="hint-description">${description}</div>
         <div class="hint-actions">
           <code class="install-command-text">${installCommand}</code>
-          <button
-            class="tab-action-btn ${this.copiedCommand === installCommand
-              ? 'copy-success'
-              : ''}"
-            title=${this.copiedCommand === installCommand
-              ? 'Copied!'
-              : `Copy ${pmName} install command`}
-            @click=${() => this.handleCopyCommand(installCommand)}
-          >
-            <wa-icon library="texra" name="copy"></wa-icon>
-            Copy
-          </button>
+          <wa-copy-button value=${installCommand}></wa-copy-button>
           <button
             class="tab-action-btn"
             title=${this.desktopHost

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -5,6 +5,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
+import '@awesome.me/webawesome/dist/components/divider/divider.js';
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { SignalWatcher, signal, Signal } from '@shared/signals';
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
@@ -1779,7 +1780,7 @@ export class MainApp extends MainAppBase {
               .handleComponentDismissGettingStarted}
           ></banner-group>
 
-          <div class="section-separator" role="presentation"></div>
+          <wa-divider></wa-divider>
           <wa-details
             class="file-selection-details"
             ?open=${this.fileSelectionOpen.get()}

--- a/packages/extension/src/webview/frontend/styles.ts
+++ b/packages/extension/src/webview/frontend/styles.ts
@@ -50,18 +50,6 @@ export const mainViewStyles: CSSResult = css`
   }
 
   /*
-   * Hairline separator between sections of the launcher. Kept subtle
-   * (single-pixel surface-border line) so the primary instruction flow
-   * stays the dominant visual element, with secondary regions like the
-   * file-select group quietly demarcated below.
-   */
-  .section-separator {
-    border-top: var(--border-thin) solid
-      var(--wa-color-surface-border, var(--color-border));
-    margin: 0 0 var(--wa-space-2xs);
-  }
-
-  /*
    * Files section sits BELOW the instruction-panel (textarea + toolbar).
    * Wrapped in a wa-details so the document slots collapse to a single
    * slim summary row by default, keeping the primary "what do you want to

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -1,30 +1,8 @@
 import { css, type CSSResult } from 'lit';
 
-const baseBadgeStyles: CSSResult = css`
-  .badge {
-    display: inline-block;
-    padding: var(--wa-space-2xs) var(--wa-space-xs);
-    border-radius: var(--border-radius-medium);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium, 500);
-  }
-`;
-
-const categoryBadgeStyles: CSSResult = css`
-  .category-badge,
-  .agent-category-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--wa-space-2xs);
-    background: var(--wa-color-neutral-fill-quiet);
-    color: var(--wa-color-neutral-on-quiet);
-  }
-
-  .category-badge wa-icon,
-  .agent-category-badge wa-icon {
-    font-size: var(--font-size-sm);
-  }
-`;
+// NOTE: the hand-rolled badge/pill rules formerly here (.badge, .category-badge,
+// .agent-category-badge, .tinted-badge) were retired in favor of native <wa-badge>.
+// What remains is search-highlight and empty-state styling shared by list views.
 
 const searchHighlightStyles: CSSResult = css`
   mark {
@@ -54,42 +32,7 @@ const emptyStateStyles: CSSResult = css`
   }
 `;
 
-/**
- * Tinted status badge — small pill with a tinted background.
- * Set `--_tint` on the element to control the color.
- *
- * Usage:
- *   <span class="tinted-badge" style="--_tint: var(--color-warning)">running</span>
- *
- * Or define a variant class:
- *   .my-badge--error { --_tint: var(--color-error); }
- */
-export const tintedBadgeStyles: CSSResult = css`
-  .tinted-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--wa-space-3xs);
-    padding: var(--border-thin) var(--wa-space-2xs);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold);
-    color: var(--_tint, var(--color-text-secondary));
-    background: color-mix(
-      in srgb,
-      var(--_tint, var(--color-text-secondary)) 12%,
-      transparent
-    );
-    border-radius: var(--border-radius-small);
-    white-space: nowrap;
-  }
-
-  .tinted-badge wa-icon {
-    font-size: var(--font-size-xs);
-  }
-`;
-
 export const badgeStyles: CSSResult[] = [
-  baseBadgeStyles,
-  categoryBadgeStyles,
   searchHighlightStyles,
   emptyStateStyles,
 ];

--- a/src/shared/styles/index.ts
+++ b/src/shared/styles/index.ts
@@ -13,8 +13,8 @@ export { permissionCardStyles } from './permissionCardStyles';
 export { requestPanelStyles } from './requestPanelStyles';
 export { viewTabStyles, waTabThemeTokenStyles } from './viewTabStyles';
 
-// Badge styles (combined array used by multiple views)
-export { badgeStyles, tintedBadgeStyles } from './badgeStyles';
+// Shared list-view styles: search highlighting + empty states
+export { badgeStyles } from './badgeStyles';
 
 // History/search styles
 export {

--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -113,18 +113,6 @@ export const permissionCardStyles: CSSResult = css`
     flex-wrap: wrap;
   }
 
-  .extract-flag {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--wa-space-3xs);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold);
-    padding: var(--wa-space-3xs) var(--wa-space-2xs);
-    border-radius: var(--border-radius);
-    background: var(--wa-color-neutral-fill-quiet);
-    color: var(--wa-color-neutral-on-quiet);
-  }
-
   .file-list {
     margin: var(--wa-space-2xs) 0;
   }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -45,9 +45,7 @@ const ACTIONS = selectorGroup(ITEM_NAMES, '__actions');
 const FEEDBACKS = selectorGroup(ITEM_NAMES, '__feedback');
 const FEEDBACK_INPUTS = selectorGroup(ITEM_NAMES, '__feedback-input');
 const FEEDBACK_ACTIVE = selectorGroup(ITEM_NAMES, '--feedback-active');
-const BADGES = unsafeCSS(
-  '.workflow-proposal__category-badge, .external-inquiry-request__mode-badge',
-);
+const BADGES = unsafeCSS('.external-inquiry-request__mode-badge');
 const SCROLLABLE_DETAILS = selectorGroup(
   ITEM_NAMES.filter((n) => n !== 'workflow-proposal'),
   '__details',
@@ -397,16 +395,6 @@ export const requestPanelStyles: CSSResult = css`
     flex-wrap: wrap;
   }
 
-  .workflow-proposal__category-badge--workflow {
-    background: var(--wa-color-neutral-fill-quiet);
-    color: var(--wa-color-neutral-on-quiet);
-  }
-
-  .workflow-proposal__category-badge--tool-use {
-    background: var(--wa-color-text-link);
-    color: var(--wa-color-surface-default);
-  }
-
   .workflow-proposal__agent {
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size);
@@ -472,14 +460,6 @@ export const requestPanelStyles: CSSResult = css`
     gap: ${sp.small};
     flex-wrap: wrap;
     margin-top: ${sp.small};
-  }
-
-  .workflow-proposal__extract-flag {
-    display: inline-flex;
-    align-items: center;
-    gap: ${sp.tiny};
-    text-transform: none;
-    letter-spacing: normal;
   }
 
   .workflow-proposal__files {


### PR DESCRIPTION
Continues the WebAwesome-native adoption sweep. A 7-agent parallel audit of the extension webviews surfaced 63 ad-hoc-CSS/JS findings; this PR lands the low-risk, high-consistency conversions and removes the dead CSS they reveal.

**Net: −182 lines (48 insertions / 230 deletions) across 18 files.**

### Conversions
- **`wa-button-group`** — progress-board toolbar (`StreamHeader`) and memory-item actions (`MemoryItem`); the bespoke `.toolbar-container` flex rule is gone (the component's host provides `inline-flex` + `flex-wrap`).
- **`wa-badge`** — unifies three separately hand-rolled pills onto one canonical `variant="neutral" appearance="filled"` form:
  - the `.extract-flag` pill (`toolFormatters`, `codexToolTemplates`, `PermissionCard`) — was duplicated CSS in 2 style files,
  - the workflow-proposal category badge (`ProposalRequestPanel`) — `variant` now maps 1:1 to the old manual color pairs,
  - the tool-id pill (`ToolCard`) — monospace kept via a single `::part(base)` override.
- **`wa-divider`** — tool-use section separators (`<hr class="tool-use-separator">`) and the launcher `.section-separator` div.
- **`wa-copy-button`** — LaTeX install-command copy buttons; drops the manual `copiedCommand` state, reset timer, `.copy-success` toggle, and handler.

### Dead CSS removed
`.badge`, `.category-badge` / `.agent-category-badge`, and `.tinted-badge` (the last had zero importers) — all superseded by `wa-badge`. The history agent-category label stays a native `wa-tag`; its `.agent-category-badge` host overrides were no-ops behind the tag's shadow DOM.

### Deliberately deferred (not in this PR)
- Status pills (OdysseyTab / StreamHeader odyssey chip / WorktreeChip) — owned by #5702.
- `wa-format-bytes` / `wa-format-date` (rank 10) — timestamp rendering is split across progressView and settings and warrants a single unified strategy (the audit flagged this); folding it in here would risk a visible format change.
- `.action-button` / `.tab-action-btn` → `wa-button` (rank 9, many consumers), and the LaTeXTab guide toggle → `wa-details` (rank 11) — medium-risk, better isolated.

### Verification
- `tsc --noEmit` green: repo root, `tsconfig.test-kernel.json`, and the `texra` extension project.
- Prettier-clean.
- Grep-verified: zero orphaned references to any removed class/state (`.extract-flag`, `.tool-use-separator`, `.section-separator`, `.workflow-proposal__category-badge`, `copiedCommand`, `handleCopyCommand`, `tintedBadgeStyles`).
- `.external-inquiry-request__mode-badge` (which shared a base selector with the proposal badge) left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor with no auth, data, or backend changes; risk is limited to minor visual or copy-button behavior differences in webviews.
> 
> **Overview**
> This PR continues adopting **native Web Awesome components** across extension webviews, replacing hand-rolled markup and CSS with shared primitives and deleting the superseded styles (~230 lines removed).
> 
> **`wa-badge`** replaces custom pill spans for extract-figure flags (permission cards, proposal panel, tool log formatters), workflow vs tool-use category labels (`variant` maps to the old color pairs), and tool ID chips in settings (monospace kept via `::part(base)`).
> 
> **`wa-button-group`** wraps the progress stream toolbar and memory-item action buttons, so the bespoke `.toolbar-container` flex rule is no longer needed.
> 
> **`wa-divider`** replaces `<hr class="tool-use-separator">` and the launcher `.section-separator` div in tool-use formatters and the main webview.
> 
> **`wa-copy-button`** replaces manual copy buttons on the LaTeX tab, removing `copiedCommand` state, timers, and `.copy-success` styling.
> 
> Shared **`badgeStyles`** is trimmed to search-highlight and empty-state rules; `.badge`, category badges, `.tinted-badge`, and related proposal/extract-flag CSS are removed. History still uses **`wa-tag`** for agent category; a redundant host class on that tag was dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044b5b53f3fc25f2bda28659b7bbf099113d30fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->