### PR TITLE
fix(cli): let default chat delegate subagents

### DIFF
--- a/packages/extension/resources/tool_use_agents/chat.yaml
+++ b/packages/extension/resources/tool_use_agents/chat.yaml
@@ -19,6 +19,7 @@ settings:
     - download_arxiv_source
     - crossref_search
     - crossref_doi
+    - delegate_agent
     - inquiry
     - ask_user_question
 prompts:
@@ -50,7 +51,8 @@ prompts:
       (2) For bash operations, distinguish between safe and potentially risky commands. Safe commands (execute without confirmation): ls, cat, echo, grep, find, which, date, whoami. Potentially complicated operations: Ask for confirmation before executing (e.g., rm, mv, cp with wildcards, curl/wget, npm/pip install, git operations beyond status/log). 
       (3) Clearly explain what any command will do before executing it.
       (4) Use `extract_figures` to gather image assets referenced in LaTeX documents, `extract_bib_entries` to pull BibTeX records for cited references, and `extract_tikz_figures` to compile TikZ diagrams when the user needs visual outputs. 
-      (5) For some tool use users have the options to reject or edit the changes before they are applied. Pay attention to the user's feedback and adjust your behavior accordingly.
+      (5) Use `delegate_agent` when the user asks for a TeXRA subagent, specialist, parallel check, or independent internal verification. Reserve `inquiry` for external human-mediated checks where the user will copy a question to another AI system and paste the answer back later.
+      (6) For some tool use users have the options to reject or edit the changes before they are applied. Pay attention to the user's feedback and adjust your behavior accordingly.
 
     Scientific Code Quality: (1) Never hardcode expected phenomena or behaviors directly in code. Instead, use tests to verify expected behavior or explicit conditional checks with clear intent. (2) Follow the Unix philosophy: maintain a single source of truth for constants, parameters, and configuration. Avoid duplicating values across files. (3) Conduct regular code reviews - verify that implementations match their mathematical specifications. (4) When working with TikZ diagrams connected to mathematical formulas, always reflect whether the visual representation accurately matches the underlying equations and relationships.
   userRequest: |

--- a/src/test-kernel/agent/ChatAgentPrompt.vitest.mts
+++ b/src/test-kernel/agent/ChatAgentPrompt.vitest.mts
@@ -1,0 +1,45 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+import * as yaml from 'yaml';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+interface ChatAgentYaml {
+  settings: {
+    tools: string[];
+  };
+  prompts: {
+    systemPrompt: string;
+  };
+}
+
+function readChatAgent(): ChatAgentYaml {
+  const text = readFileSync(
+    resolve(
+      REPO_ROOT,
+      'packages/extension/resources/tool_use_agents/chat.yaml',
+    ),
+    'utf8',
+  );
+  return yaml.parse(text) as ChatAgentYaml;
+}
+
+describe('chat agent prompt', () => {
+  it('uses TeXRA delegation for internal subagents instead of inquiry', () => {
+    const agent = readChatAgent();
+    const systemPrompt = agent.prompts.systemPrompt;
+
+    expect(agent.settings.tools).toContain('delegate_agent');
+    expect(agent.settings.tools).toContain('inquiry');
+    expect(systemPrompt).toContain('Use `delegate_agent`');
+    expect(systemPrompt).toContain('Reserve `inquiry`');
+  });
+});


### PR DESCRIPTION
## Summary
- add `delegate_agent` to the built-in `chat` tool-use agent
- clarify that TeXRA subagents/internal parallel checks should use `delegate_agent`, while `inquiry` is for external human-mediated checks
- add a regression test for the default chat agent prompt/tools

## Dogfood Evidence
In a real `texra-local chat` TTY session, asking default chat to "launch one search subagent" caused the model to use `inquiry` instead. The TUI then showed an `Agent asks` external-inquiry panel instead of a visible TeXRA subagent stream. The root cause is that the built-in `chat` agent had `inquiry` but not `delegate_agent` in its tool list.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/ChatAgentPrompt.vitest.mts src/test-kernel/agent/ReviewAgentPrompt.vitest.mts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and tool-list changes for the built-in chat agent YAML plus a small regression test; no runtime auth or data-path changes.
> 
> **Overview**
> Enables the default **chat** tool-use agent to spawn internal TeXRA subagents instead of misrouting those requests through external **inquiry** flows.
> 
> **`delegate_agent`** is added to the built-in chat agent tool list, and the system prompt now directs the model to use **`delegate_agent`** for TeXRA subagents, specialists, parallel checks, and internal verification, while **`inquiry`** is reserved for human-mediated external AI checks.
> 
> A **Vitest** regression test asserts that `chat.yaml` exposes both tools and that the prompt contains the new delegation guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0d6729fded0ea0cd6508cf93126114eeab2cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->