### PR TITLE
fix(latex): sanitize latexdiff bbl macro preambles

### DIFF
--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -36,6 +36,13 @@ const DOCUMENT_END_FIXES: Array<[RegExp, string]> = [
   [/\\end\{document\}\s*\\addcontentsline/g, '\\addcontentsline'],
 ];
 
+/** Flattened .bbl blocks can contain macro definitions that latexdiff corrupts. */
+const THEBIBLIOGRAPHY_BLOCK =
+  /\\begin\{thebibliography\}\{[^}]*\}[\s\S]*?\\end\{thebibliography\}/g;
+
+/** The real bibliography entries start here; only sanitize generated macros before it. */
+const BIBITEM_START = /(?:^|\n)\s*(?:\\DIF(?:add|del)\{)?\\bibitem\b/;
+
 export class DiffFileProcessor {
   // Intentionally does not swallow failures: a read/transform/write error here
   // means the diff output is missing or corrupt, so it must propagate to the
@@ -66,13 +73,10 @@ export class DiffFileProcessor {
   ): string {
     const bibliography = this.findBibliographyDirective(editedContent);
     if (!bibliography) {
-      return content;
+      return this.sanitizeFlattenedBibliographyMacroPreamble(content);
     }
 
-    return content.replace(
-      /\\begin\{thebibliography\}\{[^}]*\}[\s\S]*?\\end\{thebibliography\}/g,
-      bibliography,
-    );
+    return content.replaceAll(THEBIBLIOGRAPHY_BLOCK, bibliography);
   }
 
   private findBibliographyDirective(content?: string): string | undefined {
@@ -86,6 +90,39 @@ export class DiffFileProcessor {
       }
     }
     return undefined;
+  }
+
+  private sanitizeFlattenedBibliographyMacroPreamble(content: string): string {
+    return content.replaceAll(THEBIBLIOGRAPHY_BLOCK, (block) => {
+      const bibitemStart = BIBITEM_START.exec(block);
+      const preambleEnd = bibitemStart?.index ?? block.length;
+      const preamble = block.slice(0, preambleEnd);
+      if (!preamble.includes('\\DIFadd') && !preamble.includes('\\DIFdel')) {
+        return block;
+      }
+
+      return (
+        this.stripLatexdiffMarkupFromMacroPreamble(preamble) +
+        block.slice(preambleEnd)
+      );
+    });
+  }
+
+  private stripLatexdiffMarkupFromMacroPreamble(content: string): string {
+    let sanitized = content
+      .replaceAll(/%DIF\s*>/g, '%')
+      .replaceAll(
+        /\\DIF(?:add|del)\{\\mbox\{%DIFAUXCMD\s*\r?\n\\([A-Za-z@]+)\s*\}\\hskip0pt%DIFAUXCMD\s*\r?\n\}/g,
+        '\\$1 ',
+      );
+
+    let previous: string;
+    do {
+      previous = sanitized;
+      sanitized = sanitized.replaceAll(/\\DIF(?:add|del)\{([^{}]*)\}/g, '$1');
+    } while (sanitized !== previous);
+
+    return sanitized;
   }
 
   private processStarEnvironments(content: string): string {

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -179,6 +179,56 @@ describe('LaTeXdiffService shadow output', () => {
     expect(diff).not.toContain('\\DIFadd{1}');
   });
 
+  it('sanitizes latexdiff markers from flattened bibliography macro preambles', async () => {
+    const { DiffFileProcessor } =
+      await import('@latex/latexdiff/diffFileProcessor');
+    const tempDir = await makeTempDir('texra-latexdiff-bbl-preamble-');
+    const sourceDir = path.join(tempDir, 'workspace');
+    await mkdir(sourceDir, { recursive: true });
+    await installNodeBackedPlatform(sourceDir, path.join(tempDir, 'storage'));
+    const diffPath = path.join(sourceDir, 'main-diff.tex');
+    await writeFile(
+      diffPath,
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '\\begin{thebibliography}{}',
+        '\\makeatletter',
+        '\\providecommand \\@ifxundefined [\\DIFadd{1}]{%DIF >',
+        ' \\@ifx{#1\\undefined}',
+        '}%DIF >',
+        '\\providecommand \\@ifnum [\\DIFadd{1}]{%DIF >',
+        ' \\ifnum \\DIFadd{#1}\\expandafter \\@firstoftwo',
+        ' \\else \\expandafter \\@secondoftwo',
+        ' \\fi',
+        '}%DIF >',
+        '\\providecommand \\DIFadd{\\mbox{%DIFAUXCMD',
+        '\\citenamefont }\\hskip0pt%DIFAUXCMD',
+        '}[\\DIFadd{1}]{\\DIFadd{#1}}%DIF >',
+        '\\providecommand \\DIFadd{\\bibinfo  }[\\DIFadd{0}]{\\@secondoftwo}%DIF >',
+        '\\bibitem{sample}',
+        '\\DIFadd{added citation text}',
+        '\\end{thebibliography}',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+
+    await new DiffFileProcessor().processDiffFile(
+      createExternalLocation(diffPath),
+    );
+
+    const diff = await readFile(diffPath, 'utf8');
+    expect(diff).toContain('\\providecommand \\@ifxundefined [1]{%');
+    expect(diff).toContain('\\ifnum #1\\expandafter \\@firstoftwo');
+    expect(diff).toContain('\\providecommand \\citenamefont [1]{#1}%');
+    expect(diff).toContain('\\providecommand \\bibinfo  [0]{\\@secondoftwo}%');
+    expect(diff).toContain('\\DIFadd{added citation text}');
+    expect(diff).not.toContain('\\DIFadd{1}');
+    expect(diff).not.toContain('DIFAUXCMD');
+    expect(diff).not.toContain('\\providecommand \\DIFadd');
+  });
+
   it('mirrors workspace dependencies into diff round storage', async () => {
     const tempDir = await makeTempDir('texra-diff-mirror-');
     const workspaceDir = path.join(tempDir, 'workspace');


### PR DESCRIPTION
## Summary
- sanitize latexdiff markers from flattened `thebibliography` macro preambles when no source `\bibliography{...}` directive is available to restore
- keep the existing whole-block `\bibliography{...}` restoration as the preferred path
- preserve real bibliography entry diff markup after the first `\bibitem`

## Root cause
`latexdiff` can flatten generated `.bbl` content into the comparison `.tex` file and then wrap low-level bibliography macro signatures in `\DIFadd{...}`. That corrupts definitions such as `[1]`, `#1`, and helper macros like `\citenamefont`, producing a generated diff file that LaTeX cannot parse.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts src/test-kernel/latex/LatexdiffBibQuality.vitest.ts`
- `npm run typecheck -- --pretty false`
- `./node_modules/.bin/eslint src/latex/latexdiff/diffFileProcessor.ts src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to post-latexdiff string cleanup in diff files; preferred `\bibliography` restoration is unchanged and entry-level diff markup is preserved.
> 
> **Overview**
> When latexdiff leaves a flattened `thebibliography` block in the diff and the revised source has no `\bibliography{...}` to swap in, **post-processing now repairs the generated macro preamble** instead of leaving broken `\DIFadd`/`\DIFdel` wrappers around `.bbl` helper definitions.
> 
> `DiffFileProcessor` still prefers replacing the whole block with `\bibliography{...}` from the edited file when that directive exists. The new path walks each `thebibliography` block, strips latexdiff markup only **before the first `\bibitem`**, and leaves real citation diff markup after entries untouched. Sanitization normalizes `%DIF >` comments, unwraps nested `\DIFadd`/`\DIFdel`, and fixes corrupted `\providecommand` lines (e.g. `\citenamefont`, `\bibinfo`).
> 
> A kernel test exercises the no-`\bibliography` case with a realistic corrupted preamble.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f03d1746cad676b6c67cb6d63fcfa384db43450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->