### PR TITLE
fix(cli): use session API mode for TUI status

### DIFF
--- a/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
@@ -22,7 +22,7 @@ export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
 
   useEffect(() => {
     let cancelled = false;
-    void loadCliApiStatusLines()
+    void loadCliApiStatusLines({ apiMode: props.currentMode })
       .then((lines) => {
         if (!cancelled) setStatusLines(lines);
       })
@@ -32,7 +32,7 @@ export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [props.currentMode]);
 
   const items = [
     {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -566,6 +566,13 @@ async function reconcileRootModelAfterApiModeChange(
   return selection.notice;
 }
 
+function setCliSessionApiMode(apiMode: CliApiMode): void {
+  cliState.sessionMeta.set({
+    ...cliState.sessionMeta.get(),
+    apiMode,
+  });
+}
+
 async function applyCliApiModeSelection(
   mode: string | CliApiMode,
   context?: SlashCommandContext,
@@ -573,7 +580,9 @@ async function applyCliApiModeSelection(
   const normalized = mode.trim().toLowerCase();
 
   if (!normalized || normalized === 'status') {
-    const lines = await loadCliApiStatusLines();
+    const lines = await loadCliApiStatusLines({
+      apiMode: cliState.sessionMeta.get().apiMode,
+    });
     appendLocalAssistantTranscript(
       [...lines, 'Usage: /api personal | /api included'].join('\n'),
     );
@@ -583,10 +592,7 @@ async function applyCliApiModeSelection(
   const apiMode = parseCliApiMode(normalized);
   if (apiMode) {
     await setCliApiMode(apiMode);
-    cliState.sessionMeta.set({
-      ...cliState.sessionMeta.get(),
-      apiMode,
-    });
+    setCliSessionApiMode(apiMode);
     let modelNotice: string | undefined;
     try {
       modelNotice = await reconcileRootModelAfterApiModeChange(
@@ -609,7 +615,13 @@ async function applyCliApiModeSelection(
 }
 
 async function showCliAuthStatus(): Promise<void> {
-  appendLocalAssistantTranscript((await loadCliApiStatusLines()).join('\n'));
+  appendLocalAssistantTranscript(
+    (
+      await loadCliApiStatusLines({
+        apiMode: cliState.sessionMeta.get().apiMode,
+      })
+    ).join('\n'),
+  );
 }
 
 export const CHAT_LOGIN_USAGE =
@@ -654,10 +666,11 @@ async function loginFromChat(input: string): Promise<void> {
         }
       },
     });
+    setCliSessionApiMode('included');
     appendLocalAssistantTranscript(
       [
         `Signed in as ${session.account.label}.`,
-        ...(await loadCliApiStatusLines()),
+        ...(await loadCliApiStatusLines({ apiMode: 'included' })),
       ].join('\n'),
     );
   } catch (error: unknown) {
@@ -668,8 +681,12 @@ async function loginFromChat(input: string): Promise<void> {
 async function logoutFromChat(): Promise<void> {
   try {
     await signOutCliSupabase();
+    setCliSessionApiMode('personal');
     appendLocalAssistantTranscript(
-      ['Signed out.', ...(await loadCliApiStatusLines())].join('\n'),
+      [
+        'Signed out.',
+        ...(await loadCliApiStatusLines({ apiMode: 'personal' })),
+      ].join('\n'),
     );
   } catch (error: unknown) {
     appendLocalAssistantTranscript(toErrorMessage(error));

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -39,5 +39,6 @@ describe('loadCliApiStatusLines', () => {
       'auth: signed out',
       'actions: `texra login` enables included relay; `--api-mode personal` uses provider keys',
     ]);
+    expect(mocks.getCliApiMode).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- make the `/api` form load status for the mode it is currently displaying instead of re-reading persisted global mode
- make `/api status` and `/auth` status in chat read the active TUI session mode
- update the TUI session mode immediately after `/login` and `/logout`, where auth changes the credential mode

## Why
The chat TUI already stores the effective API mode in session metadata so headers, `/status`, model recovery, and command execution agree. A few API-status paths were still re-reading global persisted mode, which could make `/api`, `/auth`, and the footer/header disagree when the session was started with an override or auth changed during the session.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ApiStatusLoad.vitest.mts src/test-kernel/cli/ApiStatus.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run typecheck -- --pretty false`
- `./node_modules/.bin/eslint packages/cli/src/chat/tui/forms/ApiModeForm.tsx packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/ApiStatusLoad.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI status/display wiring with no auth or credential persistence changes beyond syncing in-memory session metadata after login/logout.
> 
> **Overview**
> Aligns chat TUI API/auth status with the **active session** API mode instead of re-reading persisted global mode.
> 
> **`/api` form** now calls `loadCliApiStatusLines({ apiMode: props.currentMode })` and refreshes when `currentMode` changes, so the status block matches the mode being shown.
> 
> **Slash commands** (`/api status`, `/auth`) pass `cliState.sessionMeta.get().apiMode` into `loadCliApiStatusLines`. **`setCliSessionApiMode`** centralizes updating session metadata when mode changes.
> 
> After **`/login`** and **`/logout`**, the session mode is set immediately (`included` / `personal`) and status lines use that mode, keeping the header, footer, and transcript consistent when auth changes mid-session or when the session started with `--api-mode`.
> 
> Test coverage confirms an explicit `apiMode` override skips `getCliApiMode()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3423efa7d55017d752b38fb9011a5d39a637b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->