### PR TITLE
fix: keep latex fixer off generated diffs

### DIFF
--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -11,9 +11,11 @@ import { withLaTeXGuard } from '@frontend/editor/activeFileGuards';
 import { indentLatexFilesInDirectory } from '@housekeeping';
 import { runLatexFormatter } from '@latex/texFormatter';
 import { getTeXCount, type TexcountMode } from '@latex/texcount';
+import { detectGeneratedLatexdiffArtifact } from '@latex/latexdiff/diffFileNameManager';
 import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
 import { delay, filterNotNull } from '@utils/core';
+import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 
 import { getIndentTeXNotification } from './latexHousekeepingNotifications';
 
@@ -64,7 +66,16 @@ export async function handleFixCompilation(): Promise<void> {
   try {
     await withLaTeXGuard(
       { channel: CHANNEL, action: 'fix compilation', saveDocument: true },
-      async ({ relativePath }) => {
+      async ({ editor, relativePath }) => {
+        if (
+          await showGeneratedLatexdiffTargetWarning(
+            editor.document.fileName,
+            relativePath,
+          )
+        ) {
+          return;
+        }
+
         logger.info(
           CHANNEL,
           `Launching tool-use agent to fix compilation for: ${relativePath}`,
@@ -83,6 +94,53 @@ export async function handleFixCompilation(): Promise<void> {
       err,
     );
   }
+}
+
+async function showGeneratedLatexdiffTargetWarning(
+  activeFilePath: string,
+  activeRelativePath: string,
+): Promise<boolean> {
+  const artifact = detectGeneratedLatexdiffArtifact(activeFilePath);
+  if (!artifact) return false;
+
+  const sourceExists = await AbsoluteFS.exists(artifact.sourcePath);
+  // A user may legitimately keep a source file named chapter_diff.tex. Treat
+  // a plain `_diff` suffix in the workspace as generated only when the inferred
+  // source exists. Shadow/temp diffs live outside the workspace and still need
+  // to be blocked even when their source is elsewhere.
+  if (
+    artifact.kind === 'workspaceDiff' &&
+    !sourceExists &&
+    isInsideWorkspace(activeFilePath)
+  ) {
+    return false;
+  }
+
+  const sourceRelativePath = WorkspaceFS.relativePath(artifact.sourcePath);
+  const message = sourceExists
+    ? `Cannot run latexFixer on generated LaTeXdiff artifact ${activeRelativePath}. Open ${sourceRelativePath} and fix the source, then regenerate the diff.`
+    : `Cannot run latexFixer on generated LaTeXdiff artifact ${activeRelativePath}. Fix the source document, then regenerate the diff.`;
+
+  logger.warn(CHANNEL, message);
+  const openSource = 'Open Source';
+  const selection = sourceExists
+    ? await vscode.window.showWarningMessage(message, openSource)
+    : await vscode.window.showWarningMessage(message);
+  if (selection === openSource) {
+    await openSourceDocument(artifact.sourcePath);
+  }
+  return true;
+}
+
+function isInsideWorkspace(filePath: string): boolean {
+  return vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath)) != null;
+}
+
+async function openSourceDocument(sourcePath: string): Promise<void> {
+  const document = await vscode.workspace.openTextDocument(
+    vscode.Uri.file(sourcePath),
+  );
+  await vscode.window.showTextDocument(document);
 }
 
 export async function handleApplyReplacements(): Promise<void> {

--- a/src/latex/index.ts
+++ b/src/latex/index.ts
@@ -40,10 +40,13 @@ export { LaTeXdiffService } from './latexdiff';
 export {
   DEFAULT_MATH_MARKUP,
   describeMathMarkupOption,
+  detectGeneratedLatexdiffArtifact,
   DiffCommandExecutor,
   DiffFileProcessor,
   generateDiffFileName,
   MATH_MARKUP_OPTIONS,
+  type GeneratedLatexdiffArtifact,
+  type GeneratedLatexdiffArtifactKind,
   type MathMarkupOption,
 } from './latexdiff/index';
 

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -6,6 +6,16 @@ import {
   extractLastRoundModelMatch,
 } from '@agent/utils/mergeFileUtils';
 
+export type GeneratedLatexdiffArtifactKind =
+  | 'workspaceDiff'
+  | 'versionControlDiff'
+  | 'betweenRoundDiff';
+
+export interface GeneratedLatexdiffArtifact {
+  kind: GeneratedLatexdiffArtifactKind;
+  sourcePath: string;
+}
+
 /**
  * Generate a diff filename based on input and edited file names.
  * Uses round-based naming only for between-round diffs (same operation chain).
@@ -59,4 +69,36 @@ export function generateDiffFileName(
   }
 
   return `${editedBaseName}${suffix}.tex`;
+}
+
+/**
+ * Recognize filenames TeXRA/latexdiff generates so source-editing commands can
+ * avoid treating diff artifacts as editable paper sources.
+ */
+export function detectGeneratedLatexdiffArtifact(
+  filePath: string,
+): GeneratedLatexdiffArtifact | null {
+  const parsed = path.parse(filePath);
+  if (parsed.ext.toLowerCase() !== '.tex') return null;
+
+  const patterns: Array<{
+    kind: GeneratedLatexdiffArtifactKind;
+    regex: RegExp;
+  }> = [
+    { kind: 'versionControlDiff', regex: /^(.+)-diff[0-9a-f]{6,40}$/i },
+    { kind: 'betweenRoundDiff', regex: /^(.+)_diffr\d+r\d+$/i },
+    { kind: 'workspaceDiff', regex: /^(.+)_diff$/i },
+  ];
+
+  for (const pattern of patterns) {
+    const match = pattern.regex.exec(parsed.name);
+    const sourceStem = match?.[1];
+    if (!sourceStem) continue;
+    return {
+      kind: pattern.kind,
+      sourcePath: path.join(parsed.dir, `${sourceStem}${parsed.ext}`),
+    };
+  }
+
+  return null;
 }

--- a/src/latex/latexdiff/index.ts
+++ b/src/latex/latexdiff/index.ts
@@ -1,5 +1,10 @@
 export { DiffCommandExecutor } from './diffCommandExecutor';
-export { generateDiffFileName } from './diffFileNameManager';
+export {
+  detectGeneratedLatexdiffArtifact,
+  generateDiffFileName,
+  type GeneratedLatexdiffArtifact,
+  type GeneratedLatexdiffArtifactKind,
+} from './diffFileNameManager';
 export { DiffFileProcessor } from './diffFileProcessor';
 export {
   DEFAULT_MATH_MARKUP,

--- a/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
+++ b/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
@@ -1,0 +1,44 @@
+import * as path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { detectGeneratedLatexdiffArtifact } from '@latex/latexdiff/diffFileNameManager';
+
+describe('detectGeneratedLatexdiffArtifact', () => {
+  it('recognizes latexdiff-vc files and infers their source', () => {
+    expect(
+      detectGeneratedLatexdiffArtifact('/paper/main-diffea268c1.tex'),
+    ).toEqual({
+      kind: 'versionControlDiff',
+      sourcePath: path.join('/paper', 'main.tex'),
+    });
+  });
+
+  it('recognizes between-round TeXRA diff files', () => {
+    expect(
+      detectGeneratedLatexdiffArtifact('/paper/output_diffr2r1.tex'),
+    ).toEqual({
+      kind: 'betweenRoundDiff',
+      sourcePath: path.join('/paper', 'output.tex'),
+    });
+  });
+
+  it('recognizes workspace-side diff files', () => {
+    expect(detectGeneratedLatexdiffArtifact('/paper/revised_diff.tex')).toEqual(
+      {
+        kind: 'workspaceDiff',
+        sourcePath: path.join('/paper', 'revised.tex'),
+      },
+    );
+  });
+
+  it('ignores non-generated TeX files', () => {
+    expect(detectGeneratedLatexdiffArtifact('/paper/main.tex')).toBeNull();
+  });
+
+  it('ignores non-TeX files', () => {
+    expect(detectGeneratedLatexdiffArtifact('/paper/main-diffabc123.pdf')).toBe(
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a shared LaTeXdiff artifact classifier for TeXRA-generated diff filenames
- stop the direct `texra.fixCompilation` command from launching `latexFixer` on generated diff artifacts
- show a source-oriented warning and offer to open the inferred source when it exists

Closes #5716.

## Validation

- `corepack pnpm vitest run src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the fix-compilation command path and filename heuristics; low impact beyond preventing mistaken agent edits on diff files.
> 
> **Overview**
> Adds **`detectGeneratedLatexdiffArtifact`** to classify TeXRA/latexdiff output names (`-diff{hash}`, `_diffrNrM`, `_diff`) and infer the source `.tex` path, with new types exported from the LaTeX diff module.
> 
> **`texra.fixCompilation`** now checks the active file before launching **`latexFixer`**: generated diff artifacts are blocked with a warning that points users at the source file, plus an **Open Source** action when that file exists. Workspace `*_diff.tex` files are only treated as generated when the inferred source is present, so legitimate names like `chapter_diff.tex` are not blocked.
> 
> Unit tests cover the classifier for each pattern and non-matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a858c351f8d8f1e12aa46cc51b49e3086024bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->