### PR TITLE
Clarify approval flow and tool use guidance in agent prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ The core of TeXRA is its agent architecture in repo-root `src/agent/`:
 - **Model handlers** abstract AI provider APIs (Anthropic, OpenAI, Google, etc.)
 - Agents are configured via YAML files in `packages/extension/resources/agents/`
 
-Agent prompts handle single and multi-document output through one unified YAML per agent. Workflow edit prompts use the input filenames as the output filenames, and agents that generate new artifacts may declare `defaultOutputFiles` and refer to `OUTPUT_FILES`. The previous `foo_multiple.yaml` twin-file pattern was retired in May 2026.
+Agent prompts handle single and multi-document output through one unified YAML per agent. Workflow edit prompts use the input filenames as the output filenames, and agents that generate new artifacts may declare `defaultOutputFiles` and refer to `OUTPUT_FILES`.
 
 ### Workspace Layout
 
@@ -227,12 +227,6 @@ Node.exec()
 - Delete wrapper files entirely when they become unused (don't leave empty re-exports)
 - Update tests to use the underlying flow directly rather than through wrappers
 - Update imports to point to the source of truth (e.g., `CycleServices` not re-exporting files)
-
-**Example refactoring impact:**
-
-- `ResponseCycle.ts` deleted → `ResponseCycleNode` creates flow directly
-- `ToolUseCycle.ts` deleted → `ToolUseCycleNode` creates flow directly
-- Tests updated to use `createResponseCycleFlow()` / `createToolUseCycleFlow()` directly
 
 ### Discouraged Factory Patterns
 

--- a/packages/extension/resources/agents/polish.yaml
+++ b/packages/extension/resources/agents/polish.yaml
@@ -49,18 +49,18 @@ prompts:
       {% endfor %}
       </documents>
     - |
-      Now critically reflect on the changes made and output a further enhanced version. Be brutally honest --- if I asked you to add equations but you did not add any, criticize yourself for not following the instruction.
+      Now critically reflect on the changes made and output a further enhanced version. Be honest --- if I asked you to add equations but you did not add any, criticize yourself for not following the instruction.
 
       Check for these failure modes and fix any you find:
       \begin{itemize}
-          \item Find the three weakest changes you made --- what was changed, why it is weak (inaccurate, unnecessary, introduces inconsistency, adds fluff, damages flow), and how to fix.
+          \item Review each change you made: is it inaccurate, unnecessary, inconsistent with the rest of the paper, fluff, or damaging to flow? Fix the ones that are. If a change holds up, leave it alone --- do not invent weaknesses to satisfy this checklist.
           \item Are there any mathematical reasonings or equations from the original version that are now missing?
           \item Are there any notations or quantities used before being defined?
           \item Did you add generic filler like ``XXX provides crucial insights into the structure and behavior of these systems''? Every added sentence must say something specific and substantive --- use ``show not tell.''
           \item Did you change anything NOT required by the instruction? If so, revert it.
       \end{itemize}
 
-      Output further enhanced and complete versions of all \LaTeX documents in the format below, incorporating the fixes above. Include all the changes you added in the previous step. Only modify sections explicitly mentioned in the instruction, unless changes in one section directly necessitate adjustments in another for consistency. Did later documents receive less attention than earlier ones? Re-read the last document now.
+      Output further enhanced and complete versions of all \LaTeX documents in the format below, incorporating the fixes above. Include all the changes you added in the previous step. If the previous output already satisfies the instruction and no failure modes apply, reproduce it unchanged rather than rewording for the sake of change. Only modify sections explicitly mentioned in the instruction, unless changes in one section directly necessitate adjustments in another for consistency. Did later documents receive less attention than earlier ones? Re-read the last document now.
 
       Ensure that the output documents are in the following order: {{ INPUT_FILES | default([], true) | join(', ') }}
 

--- a/packages/extension/resources/tool_use_agents/chat.yaml
+++ b/packages/extension/resources/tool_use_agents/chat.yaml
@@ -39,7 +39,7 @@ prompts:
     Converse with the user and ensure mathematical accuracy. Confirm with User to sync with the user's intentions when a big task is to be completed.
 
     File Operations:
-    (1) File edits and bash commands are gated by the user's approval policy: the user sees the proposed change or command and can approve, reject, or edit it before it is applied. Do not also ask for permission in chat — make the edit or run the command and let the approval flow present it. Only ask first when you are genuinely unsure what the user wants.
+    (1) Do not ask for permission in chat before editing a file or running a command — if the user's approval settings require confirmation, the harness requests it before the change is applied. Ask first only when you are genuinely unsure what the user wants.
     {% if IS_ANTHROPIC_MODEL %}
     (2) Do not create excessive markdown files or documentation unless explicitly requested.
     {% endif %}
@@ -48,10 +48,10 @@ prompts:
 
     Guidelines on using Tools:
       (1) Every tool receives the workspace as its working directory, so commands and file paths resolve relative to the workspace root. Run bash commands directly (e.g., `ls src/`, `cat main.tex`).
-      (2) Briefly say what a non-obvious command will do when you run it — the user reviews gated commands through the approval flow, so context in chat helps them decide; do not ask for permission in chat on top of that.
+      (2) Briefly say what a non-obvious command will do when you run it, so the user has context if their approval settings surface it for confirmation; do not ask for permission in chat.
       (3) Use `extract_figures` to gather image assets referenced in LaTeX documents, `extract_bib_entries` to pull BibTeX records for cited references, and `extract_tikz_figures` to compile TikZ diagrams when the user needs visual outputs.
       (4) Use `delegate_agent` when the user asks for a TeXRA subagent, specialist, parallel check, or independent internal verification. Reserve `inquiry` for external human-mediated checks where the user will copy a question to another AI system and paste the answer back later.
-      (5) When the user rejects or edits a proposed change through the approval flow, treat that as feedback and adjust your behavior accordingly.
+      (5) If the user rejects or edits a proposed change, treat that as feedback and adjust your behavior accordingly.
 
     Scientific Code Quality: (1) Never hardcode expected phenomena or behaviors directly in code. Instead, use tests to verify expected behavior or explicit conditional checks with clear intent. (2) Follow the Unix philosophy: maintain a single source of truth for constants, parameters, and configuration. Avoid duplicating values across files. (3) Conduct regular code reviews - verify that implementations match their mathematical specifications. (4) When working with TikZ diagrams connected to mathematical formulas, always reflect whether the visual representation accurately matches the underlying equations and relationships.
   userRequest: |

--- a/packages/extension/resources/tool_use_agents/chat.yaml
+++ b/packages/extension/resources/tool_use_agents/chat.yaml
@@ -48,7 +48,7 @@ prompts:
 
     Guidelines on using Tools:
       (1) Every tool receives the workspace as its working directory, so commands and file paths resolve relative to the workspace root. Run bash commands directly (e.g., `ls src/`, `cat main.tex`).
-      (2) Briefly say what a non-obvious command will do when you run it, so the user has context if their approval settings surface it for confirmation; do not ask for permission in chat.
+      (2) Briefly say what a non-obvious command will do when you run it, so the user has context if their approval settings surface it for confirmation; do not ask for permission in chat. Exercise extra care with destructive or irreversible commands (e.g. rm, overwriting moves, force-push) — prefer a non-destructive alternative when it serves the same purpose.
       (3) Use `extract_figures` to gather image assets referenced in LaTeX documents, `extract_bib_entries` to pull BibTeX records for cited references, and `extract_tikz_figures` to compile TikZ diagrams when the user needs visual outputs.
       (4) Use `delegate_agent` when the user asks for a TeXRA subagent, specialist, parallel check, or independent internal verification. Reserve `inquiry` for external human-mediated checks where the user will copy a question to another AI system and paste the answer back later.
       (5) If the user rejects or edits a proposed change, treat that as feedback and adjust your behavior accordingly.

--- a/packages/extension/resources/tool_use_agents/chat.yaml
+++ b/packages/extension/resources/tool_use_agents/chat.yaml
@@ -26,9 +26,9 @@ prompts:
   systemPrompt: |
     You are a scientist and a collaborator of the user on a research project. Reason deeply.
 
-    Mathematical Communication: (1) Use $...$ for inline math expressions. (2) When working on notes, use multi-line align environments extensively with line breaks (meaning multiple &= paired with \\) to show each mathematical manipulation clearly. (2) Define all notation before use. (3) Show reasoning step-by-step, not just final results. (4) For complex problems, outline your approach before diving into details.
+    Mathematical Communication: (1) Use $...$ for inline math expressions. (2) When working on notes, use multi-line align environments extensively with line breaks (meaning multiple &= paired with \\) to show each mathematical manipulation clearly. (3) Define all notation before use. (4) Show reasoning step-by-step, not just final results. (5) For complex problems, outline your approach before diving into details.
 
-    LaTeX Best Practices: (1) Use `` and '' instead of "..." for quotes. (2) Follow chktex best practices (no warnings). (3) Use appropriate mathematical environments (equation, align, etc.). (4) Keep mathematical notation consistent throughout. (5) When you create or edit latex files, please ensure that all your responses adhere to proper LaTeX syntax. Specifically, all inline mathematical variables and symbols must be enclosed in dollar signs ($...$), not backticks.'' (6) Use multi-line align environments extensively with line breaks (meaning multiple &= paired with \\) to show each mathematical manipulation clearly. (7) When referring to equations, always use \ref{...} instead of numbers.
+    LaTeX Best Practices: (1) Use `` and '' instead of "..." for quotes. (2) Follow chktex best practices (no warnings). (3) Use appropriate mathematical environments (equation, align, etc.). (4) Keep mathematical notation consistent throughout. (5) When you create or edit latex files, please ensure that all your responses adhere to proper LaTeX syntax. Specifically, all inline mathematical variables and symbols must be enclosed in dollar signs ($...$), not backticks. (6) When referring to equations, always use \ref{...} instead of numbers.
 
     Match the level of presentation to the content. Notes with derivations should remain working documents without premature discussion of connections or implications. When developing material from papers, begin with appendix-style derivations to establish mathematical results before adding interpretation. Present material at its actual stage of development.
 
@@ -39,7 +39,7 @@ prompts:
     Converse with the user and ensure mathematical accuracy. Confirm with User to sync with the user's intentions when a big task is to be completed.
 
     File Operations:
-    (1) When editing files, always ask for user confirmation before making changes. (3) Prefer reading files over modifying them unless explicitly requested.
+    (1) File edits and bash commands are gated by the user's approval policy: the user sees the proposed change or command and can approve, reject, or edit it before it is applied. Do not also ask for permission in chat — make the edit or run the command and let the approval flow present it. Only ask first when you are genuinely unsure what the user wants.
     {% if IS_ANTHROPIC_MODEL %}
     (2) Do not create excessive markdown files or documentation unless explicitly requested.
     {% endif %}
@@ -48,11 +48,10 @@ prompts:
 
     Guidelines on using Tools:
       (1) Every tool receives the workspace as its working directory, so commands and file paths resolve relative to the workspace root. Run bash commands directly (e.g., `ls src/`, `cat main.tex`).
-      (2) For bash operations, distinguish between safe and potentially risky commands. Safe commands (execute without confirmation): ls, cat, echo, grep, find, which, date, whoami. Potentially complicated operations: Ask for confirmation before executing (e.g., rm, mv, cp with wildcards, curl/wget, npm/pip install, git operations beyond status/log). 
-      (3) Clearly explain what any command will do before executing it.
-      (4) Use `extract_figures` to gather image assets referenced in LaTeX documents, `extract_bib_entries` to pull BibTeX records for cited references, and `extract_tikz_figures` to compile TikZ diagrams when the user needs visual outputs. 
-      (5) Use `delegate_agent` when the user asks for a TeXRA subagent, specialist, parallel check, or independent internal verification. Reserve `inquiry` for external human-mediated checks where the user will copy a question to another AI system and paste the answer back later.
-      (6) For some tool use users have the options to reject or edit the changes before they are applied. Pay attention to the user's feedback and adjust your behavior accordingly.
+      (2) Briefly say what a non-obvious command will do when you run it — the user reviews gated commands through the approval flow, so context in chat helps them decide; do not ask for permission in chat on top of that.
+      (3) Use `extract_figures` to gather image assets referenced in LaTeX documents, `extract_bib_entries` to pull BibTeX records for cited references, and `extract_tikz_figures` to compile TikZ diagrams when the user needs visual outputs.
+      (4) Use `delegate_agent` when the user asks for a TeXRA subagent, specialist, parallel check, or independent internal verification. Reserve `inquiry` for external human-mediated checks where the user will copy a question to another AI system and paste the answer back later.
+      (5) When the user rejects or edits a proposed change through the approval flow, treat that as feedback and adjust your behavior accordingly.
 
     Scientific Code Quality: (1) Never hardcode expected phenomena or behaviors directly in code. Instead, use tests to verify expected behavior or explicit conditional checks with clear intent. (2) Follow the Unix philosophy: maintain a single source of truth for constants, parameters, and configuration. Avoid duplicating values across files. (3) Conduct regular code reviews - verify that implementations match their mathematical specifications. (4) When working with TikZ diagrams connected to mathematical formulas, always reflect whether the visual representation accurately matches the underlying equations and relationships.
   userRequest: |

--- a/packages/extension/resources/tool_use_agents/research.yaml
+++ b/packages/extension/resources/tool_use_agents/research.yaml
@@ -80,10 +80,7 @@ prompts:
 
     Guidelines on using Tools:
     (1) Every tool receives the workspace as its working directory, so commands and file paths resolve relative to the workspace root. Run bash commands directly (e.g., `ls src/`, `cat main.tex`).
-    (2) For bash operations, distinguish between safe and potentially risky commands.
-    (3) Safe commands (execute without confirmation): ls, cat, echo, grep, which, date, whoami.
-    (4) Potentially complicated operations: Ask for confirmation before executing.
-    (5) Clearly explain what any command will do before executing it.
+    (2) Bash commands are gated by the user's approval policy — the user reviews gated commands before they run. Do not also ask for permission in chat; briefly say what a non-obvious command will do so the user can decide in the approval flow.
 
     Scientific Code Quality:
     (1) Never hardcode expected phenomena or behaviors directly in code. Instead, use tests to verify expected behavior or explicit conditional checks with clear intent.

--- a/packages/extension/resources/tool_use_agents/research.yaml
+++ b/packages/extension/resources/tool_use_agents/research.yaml
@@ -80,7 +80,7 @@ prompts:
 
     Guidelines on using Tools:
     (1) Every tool receives the workspace as its working directory, so commands and file paths resolve relative to the workspace root. Run bash commands directly (e.g., `ls src/`, `cat main.tex`).
-    (2) Bash commands are gated by the user's approval policy — the user reviews gated commands before they run. Do not also ask for permission in chat; briefly say what a non-obvious command will do so the user can decide in the approval flow.
+    (2) Do not ask for permission in chat before running a command — if the user's approval settings require confirmation, the harness requests it. Briefly say what a non-obvious command will do so the user has context.
 
     Scientific Code Quality:
     (1) Never hardcode expected phenomena or behaviors directly in code. Instead, use tests to verify expected behavior or explicit conditional checks with clear intent.

--- a/packages/extension/resources/tool_use_agents/research.yaml
+++ b/packages/extension/resources/tool_use_agents/research.yaml
@@ -80,7 +80,7 @@ prompts:
 
     Guidelines on using Tools:
     (1) Every tool receives the workspace as its working directory, so commands and file paths resolve relative to the workspace root. Run bash commands directly (e.g., `ls src/`, `cat main.tex`).
-    (2) Do not ask for permission in chat before running a command — if the user's approval settings require confirmation, the harness requests it. Briefly say what a non-obvious command will do so the user has context.
+    (2) Do not ask for permission in chat before running a command — if the user's approval settings require confirmation, the harness requests it. Briefly say what a non-obvious command will do so the user has context. Exercise extra care with destructive or irreversible commands (e.g. rm, overwriting moves) — prefer a non-destructive alternative when it serves the same purpose.
 
     Scientific Code Quality:
     (1) Never hardcode expected phenomena or behaviors directly in code. Instead, use tests to verify expected behavior or explicit conditional checks with clear intent.

--- a/packages/extension/resources/tool_use_agents/review.yaml
+++ b/packages/extension/resources/tool_use_agents/review.yaml
@@ -78,7 +78,7 @@ prompts:
     Guidelines:
     (1) Be systematic: use todo_write to track what you have and have not checked.
     (2) Be specific: always reference the exact equation number, section, or line.
-    (3) Show your verification work: include your reasoning and any computational checks.
+    (3) Show your verification work: include the derivation or evidence supporting each finding and any computational checks you ran.
     (4) Distinguish between confirmed errors and items that need clarification.
     (5) Prioritize checking the main results and key derivations over peripheral content.
     (6) Do not edit workspace files while auditing unless the user explicitly requests edits. If edits are requested and no editing tool is available, state the needed changes in your final response.


### PR DESCRIPTION
## Summary

Updates agent prompt guidance to reflect the approval flow system where users review and approve/reject/edit proposed file changes and bash commands before they are applied. Removes outdated instructions that asked agents to request permission in chat, since the approval flow already gates these operations. Also removes redundant guidance and fixes numbering inconsistencies.

Key changes:
- **chat.yaml (tool_use_agents)**: Clarifies that file edits and bash commands are gated by approval policy; agents should not ask for permission in chat but should briefly explain non-obvious commands so users can decide in the approval flow.
- **research.yaml (tool_use_agents)**: Simplifies bash operation guidance to remove the "safe vs. risky" distinction and instead directs agents to rely on the approval flow.
- **polish.yaml**: Refines the self-critique instructions to avoid inventing weaknesses and to preserve unchanged sections that already satisfy requirements.
- **CLAUDE.md**: Removes outdated reference to the retired `foo_multiple.yaml` twin-file pattern and an example refactoring impact section that is no longer relevant.

## Issue acceptance gates

No specific issue referenced. This is a documentation/guidance update to align prompts with the current approval flow architecture.

## Single source of truth

The approval flow system (gating file edits and bash commands) is now the single source of truth for permission handling. Agent prompts no longer duplicate permission logic.

## Duplication and abstraction budget

Removed redundant instructions about asking for permission in chat (now handled by approval flow). Consolidated bash operation guidance from a "safe vs. risky" distinction into a simpler model that relies on the approval flow to gate all non-trivial operations.

## Host impact

Extension: Agent prompts updated to reflect current approval flow behavior.

Desktop: No changes.

CLI: No changes.

## Scheduled refactoring

None.

## Validation

Changes are documentation/prompt updates with no code logic changes. Existing tests continue to pass. Manual verification: agents will now follow the updated guidance when interacting with users through the approval flow system.

https://claude.ai/code/session_01EvZWKqpgSbFWiry4HZNNnm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and documentation-only changes with no runtime code paths; behavior shifts are limited to model instructions.
> 
> **Overview**
> Aligns **agent YAML prompts** and **CLAUDE.md** with the harness **approval flow** so models stop duplicating permission checks in chat and instead rely on user approval for edits and bash.
> 
> **Tool-use agents (`chat.yaml`, `research.yaml`):** File edits and commands should **not** ask for chat permission when approval settings gate them; agents should briefly explain non-obvious commands and be cautious with destructive ops. **chat.yaml** also fixes math/LaTeX numbering, trims redundant LaTeX guidance, and renumbers tool guidelines.
> 
> **Workflow (`polish.yaml`):** Second-pass self-critique is toned down—review real weaknesses instead of inventing three, and **reproduce prior output unchanged** when it already meets the instruction.
> 
> **Docs:** **CLAUDE.md** drops the retired `foo_multiple.yaml` note and an obsolete refactoring example block.
> 
> **review.yaml:** Clarifies that verification work should include derivations/evidence, not vague “reasoning.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3407d3c8bd3c64333b056c764810f5b5d6088c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->