### PR TITLE
fix(desktop): shim __filename in esbuild ESM banner to prevent startup crash

### DIFF
--- a/packages/desktop/esbuild.main.mjs
+++ b/packages/desktop/esbuild.main.mjs
@@ -22,10 +22,20 @@ const result = await esbuild.build({
   external: ['electron', 'fsevents'],
   tsconfig: 'tsconfig.main.json',
   target: 'node22',
+  // ESM output has no CJS globals. Bundled CommonJS deps still reference them:
+  //   - `require` (createRequire) — needed by several deps.
+  //   - `__filename` — write-file-atomic's getTmpname() reads it; without this
+  //     shim the app fatally crashes on startup ("__filename is not defined")
+  //     in bootstrapPlatformAgentDirectories -> JsonStore.flush.
+  // Do NOT also shim `__dirname` here: esbuild already emits a `var __dirname`
+  // in the one chunk that needs it, so a banner `const __dirname` collides
+  // ("Identifier '__dirname' has already been declared").
   banner: {
     js:
       `import { createRequire as __texraCreateRequire } from 'node:module';\n` +
-      `const require = __texraCreateRequire(import.meta.url);`,
+      `import { fileURLToPath as __texraFileURLToPath } from 'node:url';\n` +
+      `const require = __texraCreateRequire(import.meta.url);\n` +
+      `const __filename = __texraFileURLToPath(import.meta.url);`,
   },
 });
 


### PR DESCRIPTION
## Problem
The packaged desktop app **fatally crashes on first launch** — no window ever opens:

```
Fatal TeXRA desktop error:
ReferenceError: __filename is not defined
    at getTmpname (.../dist/main/chunks/main-*.js)   # write-file-atomic
    at writeFileAsync (...)
    at _JsonStore.flush (...)
    at BundledAgentDirectorySync.reconcile (...)
    at bootstrapPlatformAgentDirectories (...)
    at initializeElectronPlatform (...)
```

The main bundle is built as ESM (`format: 'esm'` in `esbuild.main.mjs`), which has no CommonJS `__filename` global. The bundled `write-file-atomic` dependency reads `__filename` inside `getTmpname()`, so the very first atomic JSON write during **agent-directory bootstrap** throws — before any `BrowserWindow` is created.

This only affects the **packaged / esbuild-bundled** path (electron-builder). `pnpm dev` is fine because main runs as TypeScript there, not the bundle. The existing banner already shims `require` (via `createRequire`) but not `__filename`.

## Fix
Add `const __filename = fileURLToPath(import.meta.url)` to the esbuild banner, next to the existing `createRequire` shim.

Deliberately **not** shimming `__dirname`: esbuild already emits a `var __dirname` in the one chunk that needs it, so adding a banner `const __dirname` collides (`Identifier '__dirname' has already been declared`). Only `__filename` is genuinely missing — a code comment in the file records why.

## Verification
Rebuilt the main bundle and launched the packaged Electron app on a fresh profile + temp workspace:
- **Before:** crashes on startup with the trace above.
- **After:** boots cleanly through `bootstrapPlatformAgentDirectories` and renders the app (verified via the `packages/desktop/tests/e2e` Playwright harness — it now reaches `firstWindow()` and screenshots the UI).

One-line change to a build script; no runtime/source code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only banner change in the desktop main bundle; no application runtime source logic is modified.
> 
> **Overview**
> Fixes a **fatal packaged-desktop startup crash** (`ReferenceError: __filename is not defined`) when the esbuild ESM main bundle first runs atomic JSON writes during agent-directory bootstrap.
> 
> The main esbuild config in `esbuild.main.mjs` already injects a `require` shim for bundled CommonJS deps; this change **adds a matching `__filename` shim** via `fileURLToPath(import.meta.url)` and documents why **`__dirname` is intentionally omitted** (esbuild already declares it in a chunk, so a banner would collide). Dev/unbundled runs are unchanged; only the bundled electron-builder path is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a1f1b915fc501995c3c623226c6f11e4eca85b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->