### PR TITLE
refactor(agent): delete dead delegationConfig carrier chain

### DIFF
--- a/src/agent/implementations/flows/common/BaseFlowServices.ts
+++ b/src/agent/implementations/flows/common/BaseFlowServices.ts
@@ -14,7 +14,6 @@ import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 
 export interface AgentCore<C = unknown> {
   modelHandler: IModelHandler<
@@ -42,12 +41,6 @@ export interface AgentCore<C = unknown> {
    * to compute the child's depth.
    */
   delegationDepth?: number;
-  /**
-   * Delegation policy snapshot for this agent run. Tool-use flows set this once
-   * so the visible tool list and runtime delegation gate derive from the same
-   * max-depth setting without carrying a second depth value.
-   */
-  delegationConfig?: NestedDelegationConfig;
   /** Whether approval or user prompts cannot be answered by the current host. */
   approvalPromptsUnavailable?: boolean;
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -152,7 +152,6 @@ export async function runToolUseFlow<C = unknown>(
     fileService: new TaskRunFileService(executionId),
     idleContinuations: input.idleContinuations ?? idleContinuationRegistry,
     delegationDepth,
-    delegationConfig,
     delegationTrimmed,
   };
   const switchedHandlers = new Set<ToolUseServices<C>['modelHandler']>();

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -116,7 +116,6 @@ export async function withExecutionRunContext<T>(
     agentName: ctx.config.agent,
     workingDirectory: ctx.workingDirectory,
     delegationDepth: ctx.delegationDepth,
-    delegationConfig: ctx.delegationConfig,
     approvalPromptsUnavailable: ctx.approvalPromptsUnavailable,
     stopAfterCycle: ctx.stopAfterCycle,
   });

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -2,7 +2,6 @@ import { AsyncLocalStorage } from 'async_hooks';
 
 import { noopTrace, type AgentTrace } from '@agent/trace';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentProposalCoordinator } from './AgentProposalCoordinator';
@@ -37,11 +36,6 @@ export interface RunContext {
    * deep. Read by delegation tools to compute the child's depth.
    */
   readonly delegationDepth?: number;
-  /**
-   * Delegation policy snapshot for this run. Keeps delegation tool enforcement
-   * aligned with the tool list shown to the model.
-   */
-  readonly delegationConfig?: NestedDelegationConfig;
   /** Whether approval or user prompts cannot be answered by the current host. */
   readonly approvalPromptsUnavailable?: boolean;
   /** Whether this run should stop after one tool-use cycle instead of idling. */
@@ -62,7 +56,6 @@ export interface CreateRunContextOptions {
   agentName?: string;
   workingDirectory?: string;
   delegationDepth?: number;
-  delegationConfig?: NestedDelegationConfig;
   approvalPromptsUnavailable?: boolean;
   stopAfterCycle?: boolean;
 }
@@ -84,7 +77,6 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     agentName: options.agentName,
     workingDirectory: options.workingDirectory,
     delegationDepth: options.delegationDepth,
-    delegationConfig: options.delegationConfig,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
     stopAfterCycle: options.stopAfterCycle,
   });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -51,10 +51,7 @@ import {
   type StreamTabId,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
-import {
-  evaluateDelegationGate,
-  type NestedDelegationConfig,
-} from '@shared/constants/delegationPolicy';
+import { evaluateDelegationGate } from '@shared/constants/delegationPolicy';
 import { formatBytes } from '@shared/utils/string';
 
 // Local imports - tools
@@ -284,17 +281,12 @@ function resolveDeliveryStreamId(
 
 /**
  * Runtime depth gate shared by fresh delegations and resumes.
- * Tool-use flows pass the same max-depth snapshot used for tool resolution so
- * prompt pruning and runtime enforcement derive from one policy snapshot.
- * Direct tool calls fall back to the current workspace policy.
+ * Reads the current workspace delegation policy via readNestedDelegationConfig().
  */
-function depthGateError(
-  parentDelegationDepth: number,
-  configSnapshot?: NestedDelegationConfig,
-): ToolResult | null {
+function depthGateError(parentDelegationDepth: number): ToolResult | null {
   const gate = evaluateDelegationGate(
     parentDelegationDepth,
-    configSnapshot ?? readNestedDelegationConfig(),
+    readNestedDelegationConfig(),
   );
   if (gate.allowed) return null;
 
@@ -369,10 +361,7 @@ async function executeSubagent(
   const parentDelegationDepth = parentContext.delegationDepth ?? 0;
   const runtimeHost = parentContext.runtimeHost;
 
-  const gated = depthGateError(
-    parentDelegationDepth,
-    parentContext.delegationConfig,
-  );
+  const gated = depthGateError(parentDelegationDepth);
   if (gated) return gated;
 
   const executionId = generateExecutionId();
@@ -1122,10 +1111,7 @@ Git worktree support: ${
   ): Promise<ToolResult> {
     const parentContext = tryUseRunContext();
     const parentDelegationDepth = parentContext?.delegationDepth ?? 0;
-    const gated = depthGateError(
-      parentDelegationDepth,
-      parentContext?.delegationConfig,
-    );
+    const gated = depthGateError(parentDelegationDepth);
     if (gated) return gated;
 
     const handle = executionRegistry.getHandle(executionId);


### PR DESCRIPTION
## What

Deletes the `delegationConfig` field that was **dual-carried** (services bag + `RunContext`) but **never read** on either path — collapsing an 8-link pass-through down to its single live owner, `readNestedDelegationConfig()`.

## Why (verified against origin/main)

`delegationConfig` had two carriers and neither was a live read:

1. **RunContext / AgentCore path was always `undefined`.** `ctx.delegationConfig` has **zero writers** anywhere in `src/agent/`, so `RunContext.delegationConfig` was always `undefined`. Both readers (`DelegationTools.executeSubagent` and `resumeAgent`) passed it into `depthGateError(depth, configSnapshot?)`, whose body is `configSnapshot ?? readNestedDelegationConfig()` — i.e. the fallback **always** fired.
2. **The services-bag field was write-only.** `runToolUseFlow` set `services.delegationConfig` from the live `readNestedDelegationConfig()` local, but **nothing reads `services.delegationConfig`** (grep-confirmed). The live local (used by `evaluateDelegationGate`) is kept; only the dead store is removed.

So delegation gating already derives entirely from `readNestedDelegationConfig()`. This PR removes the phantom field and makes that the lone, explicit owner.

## Changes

- Drop `delegationConfig` from `AgentCore` (`BaseFlowServices`), the `RunContext` interface, `CreateRunContextOptions`, and both builders + the `AgentLaunchContext` copy.
- Drop the dead `services.delegationConfig` write in `runToolUseFlow` (live local + gate untouched).
- Collapse `depthGateError`'s always-`undefined` `configSnapshot` param; it now reads the current workspace policy directly, with corrected JSDoc.
- Remove 3 now-unused `NestedDelegationConfig` imports.

## Safety

- **Behavior-neutral** — every former reader already resolved to `readNestedDelegationConfig()`; the bag field had no readers.
- **Net −31 LOC**, no new abstraction/wrapper/parameter-object.
- `npm run typecheck` green (root + test-kernel + extension + CLI); delegation vitest suites green (`DelegationHeadless`, `DelegationModelAvailability`).
- `packages/` (extension/desktop/CLI) reference `delegationConfig` nowhere — untouched.

Part of a broader "single owner per run-scoped fact + resolve-once-at-the-boundary" direction for the agent core; this is the standalone, low-risk first step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-neutral cleanup; delegation enforcement already fell back to `readNestedDelegationConfig()` when the removed field was undefined.
> 
> **Overview**
> Removes the unused **`delegationConfig`** snapshot that was threaded through **`AgentCore`**, **`RunContext`**, **`AgentLaunchContext`**, and the tool-use services bag without ever being set or read on the live paths.
> 
> **Delegation depth gating** in **`DelegationTools`** (`depthGateError` for new delegations and resumes) now always calls **`readNestedDelegationConfig()`** instead of accepting an optional run-context snapshot that was always **`undefined`**. **`runToolUseFlow`** still resolves policy locally for tool-list trimming via **`evaluateDelegationGate`**; it no longer writes a duplicate **`services.delegationConfig`** field.
> 
> Net effect: one explicit owner for workspace delegation policy—**`readNestedDelegationConfig()`**—with no change to runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092358d86deba422360b328c48249e1b96feaca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->