### PR TITLE
fix(progress): keep latexFixer off generated latexdiff artifacts

### DIFF
--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -12,6 +12,9 @@ import {
   type WorkflowTaskState,
 } from '@agent/core/execution/TaskState';
 
+// Local imports - latex
+import { detectGeneratedLatexdiffArtifact } from '@latex/latexdiff/diffFileNameManager';
+
 // Local imports - shared
 import type {
   CompileFailure,
@@ -293,12 +296,42 @@ export class ProgressFollowUpController {
     for (const candidate of preferred) {
       const location = this.deps.workspace.locatePath(candidate);
       if (location.kind === 'external') continue;
-      if (seen.has(location.relativePath)) continue;
-      if (!(await this.deps.workspace.exists(location.relativePath))) continue;
-      seen.add(location.relativePath);
-      targets.push(location.relativePath);
+      const editablePath = await this.editableCompileFixerCandidate(
+        location.relativePath,
+      );
+      if (!editablePath) continue;
+      if (seen.has(editablePath)) continue;
+      seen.add(editablePath);
+      targets.push(editablePath);
     }
     return targets;
+  }
+
+  private async editableCompileFixerCandidate(
+    relativePath: string,
+  ): Promise<string | null> {
+    const artifact = detectGeneratedLatexdiffArtifact(relativePath);
+    if (!artifact) {
+      return (await this.deps.workspace.exists(relativePath))
+        ? relativePath
+        : null;
+    }
+
+    const sourcePath = artifact.sourcePath;
+    if (await this.deps.workspace.exists(sourcePath)) {
+      return sourcePath;
+    }
+
+    // A user may legitimately name a source file `chapter_diff.tex`; only the
+    // stronger generated diff patterns are always excluded.
+    if (
+      artifact.kind === 'workspaceDiff' &&
+      (await this.deps.workspace.exists(relativePath))
+    ) {
+      return relativePath;
+    }
+
+    return null;
   }
 
   /**

--- a/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
@@ -71,7 +71,9 @@ function createCompileFailure(): CompileFailure {
   };
 }
 
-function createController(existingFiles: Set<string>): ProgressFollowUpController {
+function createController(
+  existingFiles: Set<string>,
+): ProgressFollowUpController {
   return new ProgressFollowUpController({
     getAgentCategory: () => AgentCategory.ToolUse,
     workspace: {
@@ -107,19 +109,20 @@ describe('ProgressFollowUpController', () => {
   });
 
   it('does not edit generated latexdiff artifacts when source is absent', async () => {
-    const plan = await createController(new Set(['main-diffea268c1.tex']))
-      .planCompileFixer({
-        streamId: 'stream-a',
-        taskState: createWorkflowTaskState({
-          inputFiles: ['main-diffea268c1.tex'],
-        }),
-        compileFailures: [createCompileFailure()],
-        runOutputs: new Map([
-          [2, [createRunStorageOutputFile('main-diffea268c1.tex')]],
-        ]),
-        modelOptions: [{ value: 'gemini31p' }],
-        executionId: 'exec-123',
-      });
+    const plan = await createController(
+      new Set(['main-diffea268c1.tex']),
+    ).planCompileFixer({
+      streamId: 'stream-a',
+      taskState: createWorkflowTaskState({
+        inputFiles: ['main-diffea268c1.tex'],
+      }),
+      compileFailures: [createCompileFailure()],
+      runOutputs: new Map([
+        [2, [createRunStorageOutputFile('main-diffea268c1.tex')]],
+      ]),
+      modelOptions: [{ value: 'gemini31p' }],
+      executionId: 'exec-123',
+    });
 
     expect(plan).toEqual({
       kind: 'warning',

--- a/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
@@ -1,0 +1,130 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - controllers
+import { ProgressFollowUpController } from '@controllers/progressView/ProgressFollowUpController';
+
+// Local imports - agent
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import {
+  AgentConfigSchema,
+  type AgentConfig,
+} from '@agent/core/definition/AgentConfig';
+import type { WorkflowTaskState } from '@agent/core/execution/TaskState';
+
+// Local imports - shared
+import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
+
+function createWorkflowTaskState(
+  overrides: Omit<Partial<AgentConfig>, 'agentCategory'> = {},
+): WorkflowTaskState {
+  return {
+    agentConfig: AgentConfigSchema.parse({
+      agent: 'writer',
+      model: 'gemini31p',
+      inputFiles: ['main.tex'],
+      outputFiles: ['answer.tex'],
+      agentCategory: AgentCategory.Workflow,
+      ...overrides,
+    }) as AgentConfig & { agentCategory: typeof AgentCategory.Workflow },
+    activeFiles: {
+      input: true,
+      context: false,
+      media: false,
+      output: true,
+    },
+  };
+}
+
+function createRunStorageOutputFile(source: string): OutputFileInfo {
+  return {
+    source,
+    round: 2,
+    lineage: null,
+    diff: null,
+    location: {
+      kind: 'runStorage',
+      absolutePath: '/tmp/exec/answer.tex',
+      relativePath: 'answer.tex',
+      executionId: 'exec-old',
+    },
+  };
+}
+
+function createCompileFailure(): CompileFailure {
+  return {
+    round: 2,
+    displayName: 'answer.tex',
+    output: {
+      kind: 'runStorage',
+      absolutePath: '/tmp/exec/answer.tex',
+      relativePath: 'answer.tex',
+      executionId: 'exec-old',
+    },
+    log: {
+      kind: 'runStorage',
+      absolutePath: '/tmp/exec/answer.log',
+      relativePath: 'answer.log',
+      executionId: 'exec-old',
+    },
+    logRelativePath: 'answer.log',
+  };
+}
+
+function createController(existingFiles: Set<string>): ProgressFollowUpController {
+  return new ProgressFollowUpController({
+    getAgentCategory: () => AgentCategory.ToolUse,
+    workspace: {
+      locatePath: (candidate) =>
+        candidate.startsWith('/external/')
+          ? { kind: 'external' }
+          : { kind: 'workspace', relativePath: candidate },
+      exists: async (relativePath) => existingFiles.has(relativePath),
+    },
+  });
+}
+
+describe('ProgressFollowUpController', () => {
+  it('maps generated latexdiff candidates back to editable sources', async () => {
+    const plan = await createController(
+      new Set(['main.tex', 'main-diffea268c1.tex']),
+    ).planCompileFixer({
+      streamId: 'stream-a',
+      taskState: createWorkflowTaskState({
+        inputFiles: ['main-diffea268c1.tex'],
+      }),
+      compileFailures: [createCompileFailure()],
+      runOutputs: new Map([
+        [2, [createRunStorageOutputFile('main-diffea268c1.tex')]],
+      ]),
+      modelOptions: [{ value: 'gemini31p' }],
+      executionId: 'exec-123',
+    });
+
+    expect(plan.kind).toBe('execute');
+    if (plan.kind !== 'execute') return;
+    expect(plan.request.config.inputFiles).toEqual(['main.tex']);
+  });
+
+  it('does not edit generated latexdiff artifacts when source is absent', async () => {
+    const plan = await createController(new Set(['main-diffea268c1.tex']))
+      .planCompileFixer({
+        streamId: 'stream-a',
+        taskState: createWorkflowTaskState({
+          inputFiles: ['main-diffea268c1.tex'],
+        }),
+        compileFailures: [createCompileFailure()],
+        runOutputs: new Map([
+          [2, [createRunStorageOutputFile('main-diffea268c1.tex')]],
+        ]),
+        modelOptions: [{ value: 'gemini31p' }],
+        executionId: 'exec-123',
+      });
+
+    expect(plan).toEqual({
+      kind: 'warning',
+      message:
+        'No editable workspace source file matched the compile failure. Accept the output into the workspace first, then run latexFixer.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Reuse the generated-latexdiff artifact detector in progress compile-fixer planning
- Map generated diff candidates back to their inferred source when it exists
- Exclude generated diff artifacts from editable latexFixer targets when no source exists
- Add CI-visible controller regression coverage

## Tests
- corepack pnpm vitest run src/test-kernel/controllers/ProgressFollowUpController.vitest.ts src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
- npx tsc --noEmit && npx tsc --noEmit -p tsconfig.test-kernel.json
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized follow-up planning logic with regression tests; no auth, persistence, or broad API surface changes.
> 
> **Overview**
> **latexFixer** planning in progress view now treats **generated latexdiff** filenames as non-editable artifacts instead of passing them through as `inputFiles`.
> 
> When resolving compile-fixer targets, candidates go through `editableCompileFixerCandidate`, which uses `detectGeneratedLatexdiffArtifact` to **redirect** to the inferred **source** (e.g. `main-diffea268c1.tex` → `main.tex`) when that source exists in the workspace. If only the generated diff exists and no source is present, the path is **dropped** so latexFixer does not target the artifact; the existing warning path still applies when no editable files remain. A narrow exception keeps **workspaceDiff** artifacts editable when the source is missing, so user-named `*_diff.tex` files are not always blocked.
> 
> New **Vitest** coverage in `ProgressFollowUpController.vitest.ts` locks in source remapping and the no-source warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1664ea01a0a050a1d4f6abcbdc4df970ff43d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->