### PR TITLE
fix(google): apply cache discount to cached prompt tokens in pricing

### DIFF
--- a/src/agent/modelHandlers/google/googleUsage.ts
+++ b/src/agent/modelHandlers/google/googleUsage.ts
@@ -13,10 +13,11 @@ import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { normalizeUsage } from '../support/UsageNormalizer';
 import type { GenerateContentResponseUsageMetadata } from '@google/genai';
 
-/** Pricing inputs the handler supplies from its `config`. */
+/** Pricing inputs the handler supplies from its `config`/`capabilities`. */
 export interface GooglePricingConfig {
   inputPrice: number;
   outputPrice: number;
+  cacheDiscountFactor: number;
 }
 
 interface GoogleTokenCounts {
@@ -73,12 +74,24 @@ export function computeGooglePrice(
   if (!responseUsage) return 0.0;
   const { inputTokens, outputTokens } = computeGoogleTokenCounts(responseUsage);
 
-  return calculateTokenPrice(
+  let basePrice = calculateTokenPrice(
     inputTokens,
     outputTokens,
     config.inputPrice,
     config.outputPrice,
   );
+
+  // cachedContentTokenCount is a subset of promptTokenCount, so cached reads
+  // are first billed at the full input rate above; rebate them down to the
+  // discounted cache-read rate (mirrors computeOpenAIPrice).
+  const cachedTokens = responseUsage.cachedContentTokenCount ?? 0;
+  if (cachedTokens) {
+    basePrice -=
+      (cachedTokens * config.inputPrice * (1 - config.cacheDiscountFactor)) /
+      1e6;
+  }
+
+  return basePrice;
 }
 
 /** Normalizes Google GenAI usage data into a unified format. */

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -893,6 +893,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return {
       inputPrice: this.config.inputPrice,
       outputPrice: this.config.outputPrice,
+      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
     };
   }
 

--- a/src/test-kernel/agent/modelHandlers/GoogleCachePricing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleCachePricing.vitest.ts
@@ -1,0 +1,42 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - agent model handlers
+import { computeGooglePrice } from '@agent/modelHandlers/google/googleUsage';
+
+const CONFIG = {
+  inputPrice: 2,
+  outputPrice: 12,
+  cacheDiscountFactor: 0.25,
+};
+
+describe('Google cache pricing', () => {
+  it('rebates cached prompt tokens down to the cache-read rate', () => {
+    // cachedContentTokenCount is a subset of promptTokenCount: the 600 cached
+    // tokens are billed at inputPrice * cacheDiscountFactor, not full rate.
+    const price = computeGooglePrice(
+      {
+        promptTokenCount: 1000,
+        cachedContentTokenCount: 600,
+        candidatesTokenCount: 100,
+      },
+      CONFIG,
+    );
+
+    const expected =
+      (1000 * 2) / 1e6 + (100 * 12) / 1e6 - (600 * 2 * (1 - 0.25)) / 1e6;
+    expect(price).toBeCloseTo(expected, 12);
+  });
+
+  it('bills the full input rate when nothing is cached', () => {
+    const price = computeGooglePrice(
+      {
+        promptTokenCount: 1000,
+        candidatesTokenCount: 100,
+      },
+      CONFIG,
+    );
+
+    expect(price).toBeCloseTo((1000 * 2) / 1e6 + (100 * 12) / 1e6, 12);
+  });
+});


### PR DESCRIPTION
## Why

`computeGooglePrice` billed Gemini's `cachedContentTokenCount` at the **full input rate**. `GooglePricingConfig` carried no `cacheDiscountFactor`, unlike the Anthropic (`anthropicUsage.ts`), OpenAI (`openAIUsage.ts`), and OpenRouter (`openRouterUsage.ts`) handlers, which all apply it.

Since `cachedContentTokenCount` is a subset of `promptTokenCount`, cached-heavy Gemini agent runs were overstated several-fold. In the June 9 free-tier incident (follow-up to #5720), a single orchestrator call reported **~$25 of input cost on 12.6M cached tokens** that should have been billed at the 0.25 cache-read rate.

## What

- `GooglePricingConfig` gains `cacheDiscountFactor`; the handler sources it from `this.capabilities.cacheDiscountFactor` (same as Anthropic/OpenAI).
- `computeGooglePrice` mirrors `computeOpenAIPrice`: price the full prompt at input rate, then rebate cached tokens down to `inputPrice * cacheDiscountFactor` (Google and OpenAI both report cached tokens as a subset of prompt tokens; Anthropic differs because its `input_tokens` excludes cache reads, hence the additive pattern there).
- New `GoogleCachePricing.vitest.ts` mirroring the existing `AnthropicCachePricing` suite: cached tokens rebated; no-cache path unchanged.

## Notes

This affects the **client-computed cost** used for usage logging / the relay spend counter, so post-fix Gemini relay costs will read lower (and correctly). No behavior change for models that report no cached tokens.

## Verification

- `npx vitest run src/test-kernel/agent/modelHandlers/GoogleCachePricing.vitest.ts` — 2/2 pass (plus the Anthropic suite still green).
- `npm run typecheck` — exit 0, all four projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-computed spend for Gemini cache-heavy runs (lower, correct costs); logic is localized to pricing but affects usage logging and relay counters.
> 
> **Overview**
> **Fixes overstated Gemini costs** when `cachedContentTokenCount` is reported: those tokens were priced at the full input rate even though they are included in prompt token counts.
> 
> `computeGooglePrice` now takes **`cacheDiscountFactor`** (wired from model capabilities in the Google handler) and **rebates** cached prompt tokens from full input price down to the cache-read rate, matching the OpenAI handler’s subset-of-prompt pattern. Runs with no cached tokens behave as before.
> 
> Adds **`GoogleCachePricing.vitest.ts`** for rebate vs no-cache billing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc58262e42a30f1e33ee6a4a75b8d670da947f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->