### PR TITLE
fix(cli): tighten spacing after user messages

### DIFF
--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -19,7 +19,7 @@ import type {
 
 const INQUIRY_CONTINUATION_RE =
   /^\[inquiry\]\s+\S+\s+(?:answered|dropped by user)\.(?:\n|$)/;
-export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 1;
+export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 0;
 
 export function isInquiryContinuationText(text: string): boolean {
   return INQUIRY_CONTINUATION_RE.test(text);

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -347,10 +347,10 @@ describe('CLI conversation transcript splitting', () => {
     ).toBe('  ef  ');
   });
 
-  it('budgets the visual gap after finalized user turns', () => {
+  it('does not reserve a spacer row after finalized user turns', () => {
     const user = entry('u1', 'user', 'why do you write as a latex?', true);
 
-    expect(estimateTranscriptEntryRows(user, 80)).toBe(2);
+    expect(estimateTranscriptEntryRows(user, 80)).toBe(1);
   });
 
   it('does not budget regular user margin for inquiry continuations', () => {


### PR DESCRIPTION
## Summary
- remove the extra blank row reserved after finalized CLI user messages
- keep transcript row budgeting aligned with the rendered user row

## Verification
- corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-spacing transcript long-tool-output-elided
- inspected /tmp/texra-tui-spacing/02-long-tool-output-elided.txt: the user message is immediately followed by the bash row

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only spacing and transcript row estimates; no logic, auth, or data paths touched.
> 
> **Overview**
> Removes the extra blank row after finalized CLI user messages by setting **`USER_ENTRY_MARGIN_BOTTOM_ROWS`** from `1` to `0`, so **`UserEntryRow`** no longer applies bottom margin and viewport/static row estimators stop budgeting that spacer.
> 
> Inquiry continuation user rows are unchanged; only regular finalized user turns get tighter spacing (e.g. the next tool/bash row sits directly under the user band).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d38952ca13d49d4f446e7be74f30c66080f328da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->