### PR TITLE
test: fix root-environment failure and first-test import flake

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -19,7 +19,6 @@ import { compactIconActionButtonStyles } from '@shared/styles';
 import { decodeXmlEntities } from '@shared/subagentFollowup';
 import { designTokens } from '@shared/styles/litStyles';
 import { markdownStyles } from '@shared/styles/markdownStyles';
-// Shared, host-neutral entity decoding for subagent/structured-delivery bodies.
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - formatter helpers

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -16,10 +16,10 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 // Local imports - shared styles
 import { CopyButtonController } from '@shared/controllers';
 import { compactIconActionButtonStyles } from '@shared/styles';
+import { decodeXmlEntities } from '@shared/subagentFollowup';
 import { designTokens } from '@shared/styles/litStyles';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 // Shared, host-neutral entity decoding for subagent/structured-delivery bodies.
-import { decodeXmlEntities } from '@shared/subagentFollowup';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - formatter helpers

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -14,7 +14,6 @@ import type {
   LogMessageData,
 } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
-import { isObject } from '@utils/core';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
@@ -32,6 +31,7 @@ import {
   type CodexMcpToolOutput,
 } from '@tools/codexShared';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
+import { isObject } from '@utils/core';
 import {
   collapseWhitespace,
   truncateWithEllipsis,

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -54,9 +54,9 @@ import {
 } from '@shared/wa/webAwesomeIcons';
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 import { agentName } from '@shared/schemas/agent';
+import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
 import { capitalize } from '@utils/text/stringUtils';
 import '@shared/wa/tabs';
-import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
 
 import './components/FileSelectGroup';
 import './components/BannerGroup';

--- a/src/agent/core/execution/AgentWorkspaceState.ts
+++ b/src/agent/core/execution/AgentWorkspaceState.ts
@@ -9,8 +9,8 @@ import {
   type FileLocation,
   type WorkPlanSnapshot,
 } from '@shared/schemas';
-import { isObject } from '@utils/core';
 import { FlattenedEditRecordSchema } from '@tools/result';
+import { isObject } from '@utils/core';
 import { pathToLocation } from '@utils/files';
 
 /** Schema for thinking blocks (used by model handlers). */

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -27,7 +27,6 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - common
-import { getConfig } from '@utils/config/configUtils';
 import {
   getSdkErrorMessage,
   attachStreamDiagnostics,
@@ -43,6 +42,7 @@ import type { ToolFileAttachment } from '@tools/result';
 
 // Local imports - utils
 import { AbsoluteFS, flexibleFS, type FileLocation } from '@utils/files';
+import { getConfig } from '@utils/config/configUtils';
 import { getAnthropicDynamicFiltering } from '@utils/config/providerConfig';
 import { objectToLogString } from '@utils/text/stringUtils';
 import {

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -10,7 +10,6 @@ import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
-import { getConfig } from '@utils/config/configUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Local imports - tools and utils
@@ -18,6 +17,7 @@ import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString } from '@utils/core';
 import type { FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
+import { getConfig } from '@utils/config/configUtils';
 import { extractMimeSubtype } from '@utils/text/stringUtils';
 import {
   computeOpenRouterPrice,

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -1,7 +1,7 @@
 import { ModelProvider } from 'llm-zoo';
-import { getConfig } from '@utils/config/configUtils';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
+import { getConfig } from '@utils/config/configUtils';
 import {
   getProviderEndpoint,
   getDashScopeUseChina,

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -1,10 +1,10 @@
 import * as path from 'path';
 
 import type { AgentTrace } from '@agent/trace';
-import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceFS, StorageFS } from '@utils/files';
+import { getConfig } from '@utils/config/configUtils';
 import { ensureRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 
 export interface DebugContext {

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -2,7 +2,6 @@
 import * as path from 'path';
 
 // Local imports - log
-import { getConfig } from '@utils/config/configUtils';
 import * as logger from '@logger/logUtils';
 import { renderPrompt } from '@utils/prompt';
 import {
@@ -11,6 +10,7 @@ import {
   pathToLocation,
   type FileLocation,
 } from '@utils/files';
+import { getConfig } from '@utils/config/configUtils';
 
 // Local imports - latex utils
 import { compileLatex2Pdf } from './texTools';

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -5,13 +5,13 @@ import path from 'path';
 import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
 
 // Local imports - utilities
-import { getExtensionLowercase } from '@utils/core/pathCore';
 import {
   createExternalLocation,
   createRunStorageLocation,
   createWorkspaceLocation,
   type FileLocation,
 } from '@utils/files';
+import { getExtensionLowercase } from '@utils/core/pathCore';
 
 export type AcceptedFileTarget = {
   targetLocation: FileLocation;

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -2,12 +2,12 @@ import * as path from 'path';
 
 import { sync as globSync } from 'glob';
 
-import { getConfig } from '@utils/config/configUtils';
 import { isFileNotFoundError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { delay } from '@utils/core';
 import { runToolWithCheck } from '@utils/system';
+import { getConfig } from '@utils/config/configUtils';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -1,8 +1,8 @@
 // Local imports - log
-import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { runToolWithCheck } from '@utils/system';
+import { getConfig } from '@utils/config/configUtils';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -2,7 +2,6 @@
 import * as path from 'path';
 
 // Local imports - common
-import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import {
   LaTeXCompileOptionsSchema,
@@ -16,6 +15,7 @@ import * as logger from '@logger/logUtils';
 import { WorkspaceFS, flexibleFS, pathToLocation } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';
+import { getConfig } from '@utils/config/configUtils';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -5,10 +5,10 @@
 // Local imports - common
 
 // Local imports - log
-import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
+import { getConfig } from '@utils/config/configUtils';
 
 const CHANNEL = 'ReplacementEngine';
 logger.initialize(CHANNEL);

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { CliContext } from '@cli/runtime/cliContext';
@@ -58,6 +58,12 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
 }
 
 describe('CLI agents command', () => {
+  // Warm the module graph so the first test isn't charged the import cost,
+  // which can exceed the per-test timeout on slow machines.
+  beforeAll(async () => {
+    await import('@cli/commands/agents');
+  }, 30_000);
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getToolUseAgents.mockReturnValue([]);

--- a/src/test-kernel/skills/LoadSkills.vitest.mts
+++ b/src/test-kernel/skills/LoadSkills.vitest.mts
@@ -279,27 +279,35 @@ description: A project-specific skill.
     ]);
   });
 
-  it('reports required source read errors as source failures', async () => {
-    const root = await createTempRoot();
-    const required = path.join(root, 'blocked-skills');
-    await fs.mkdir(required);
-    await fs.chmod(required, 0o000);
+  // Skip on Windows (no POSIX chmod semantics) and when running as root, where
+  // mode-0 doesn't restrict reads.
+  const skipPermissionTest =
+    process.platform === 'win32' ||
+    (typeof process.getuid === 'function' && process.getuid() === 0);
+  (skipPermissionTest ? it.skip : it)(
+    'reports required source read errors as source failures',
+    async () => {
+      const root = await createTempRoot();
+      const required = path.join(root, 'blocked-skills');
+      await fs.mkdir(required);
+      await fs.chmod(required, 0o000);
 
-    try {
-      const result = await discoverSkillSources([
-        { scope: 'custom', path: required, required: true },
-      ]);
+      try {
+        const result = await discoverSkillSources([
+          { scope: 'custom', path: required, required: true },
+        ]);
 
-      expect(result.skills).toEqual([]);
-      expect(result.errors).toEqual([
-        expect.objectContaining({
-          severity: 'error',
-          code: 'source_read_error',
-          path: required,
-        }),
-      ]);
-    } finally {
-      await fs.chmod(required, 0o700);
-    }
-  });
+        expect(result.skills).toEqual([]);
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            severity: 'error',
+            code: 'source_read_error',
+            path: required,
+          }),
+        ]);
+      } finally {
+        await fs.chmod(required, 0o700);
+      }
+    },
+  );
 });

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
 
 // Local imports - agent state
-import * as agentConfig from '@utils/config/configUtils';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 
 // Local imports - model handlers
@@ -14,6 +13,7 @@ import type { OpenAIResponseToolCall } from '@agent/modelHandlers/types/IModelHa
 // Local imports - tools
 import { BashTool } from '@tools/bash';
 import { BASH_APPROVAL_CONFIG_KEY } from '@tools/approval/bashApproval';
+import * as agentConfig from '@utils/config/configUtils';
 
 // Local imports - system utilities
 import * as execUtils from '@utils/system/execUtils';

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
@@ -10,8 +10,8 @@ import {
 
 // Local imports - agent
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import * as configModule from '@utils/config/configUtils';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
+import * as configModule from '@utils/config/configUtils';
 
 class UnsupportedBackgroundHandler extends ModelHandlerOpenAIResponse {
   protected override backgroundModeSupported = false;

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -18,13 +18,13 @@ import {
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local imports - utilities
-import { hasExtension } from '@utils/core/pathCore';
 import {
   AbsoluteFS,
   createRunStorageLocation,
   getRunDir,
   pathToLocation,
 } from '@utils/files';
+import { hasExtension } from '@utils/core/pathCore';
 
 // Local file imports
 import { defineTool } from './core/define';

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -19,8 +19,8 @@ import {
   requestApprovedEditContent,
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
-import { countLines } from '@utils/text/stringUtils';
 import { WorkspaceFS } from '@utils/files';
+import { countLines } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import { getConfig } from '@utils/config/configUtils';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { requireRuntimeHost } from '@tools/contextHelpers';
 import { type ToolResult } from '@tools/result';
+import { getConfig } from '@utils/config/configUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import { createStreamApprovalController } from './streamApprovalQueue';

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -8,7 +8,6 @@ import { z } from 'zod';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import { getConfig } from '@utils/config/configUtils';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import {
   LineChangesSchema,
@@ -16,6 +15,7 @@ import {
   type ToolResult,
 } from '@tools/result';
 import { WorkspaceFS } from '@utils/files';
+import { getConfig } from '@utils/config/configUtils';
 import { countLines } from '@utils/text/stringUtils';
 
 import { bashApprovalController } from './bashApproval';

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -17,7 +17,6 @@
 
 import * as path from 'path';
 
-
 import { isModuleNotFoundError } from '@common/errors';
 import { pathExists, resolveBinary } from './support/externalBinaryUtils';
 import type { Options, Query } from '@anthropic-ai/claude-agent-sdk';

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -17,10 +17,10 @@
 
 import * as path from 'path';
 
-import type { Options, Query } from '@anthropic-ai/claude-agent-sdk';
 
 import { isModuleNotFoundError } from '@common/errors';
 import { pathExists, resolveBinary } from './support/externalBinaryUtils';
+import type { Options, Query } from '@anthropic-ai/claude-agent-sdk';
 
 type QueryFn = (params: {
   prompt: string | AsyncIterable<unknown>;

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -11,7 +11,6 @@
  * Returns an `InjectionOutcome` so the caller (action handler) can
  * forward it to the UI via the `inquiryThreadUpdated` event.
  */
-import { collapseWhitespace } from '@utils/text/stringUtils';
 
 import { platform } from '@platform/platform';
 
@@ -24,6 +23,7 @@ import type {
   InquiryResumeOutcome,
   StreamTabId,
 } from '@shared/schemas';
+import { collapseWhitespace } from '@utils/text/stringUtils';
 
 import {
   getThreadSummary,

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -2,7 +2,6 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { getConfig } from '@utils/config/configUtils';
 import {
   extractBibliographyContext,
   loadBibliographyEntries,
@@ -13,6 +12,7 @@ import { formatToolOutput } from '@tools/formatting';
 import { resolveAndFormat } from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';
 import { WorkspaceFS } from '@utils/files';
+import { getConfig } from '@utils/config/configUtils';
 
 const ExtractBibliographyInputSchema = z.strictObject({
   texPath: z

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -11,10 +11,10 @@
 import axios from 'axios';
 
 // Local imports - core
-import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@common/errors';
 import { ToolError } from '@tools/result';
 import { isTimeoutErrorCode } from '@tools/timeouts';
+import { getConfig } from '@utils/config/configUtils';
 
 const ZOTERO_BBT_TIMEOUT_MS = 10_000; // 10 s
 


### PR DESCRIPTION
- Skip the chmod-0 source-read-error test in LoadSkills when running as
  root (mode bits don't restrict root) or on Windows, matching the
  existing pattern in OutputGuards and CliRootArgs.
- Warm the @cli/commands/agents module graph in a beforeAll so the first
  AgentsCommand test isn't charged the import cost, which exceeded the
  5s per-test timeout on slow machines.

https://claude.ai/code/session_01LwSFKrRe7SNndywCXSNw6C

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only behavior changes plus cosmetic import ordering; no production logic modified.
> 
> **Overview**
> **Test stability** is the substantive change: the LoadSkills test that chmods a directory to `000` and expects a `source_read_error` is now skipped on **Windows** (no POSIX chmod) and when running as **root** (mode bits do not block reads), aligning with patterns used elsewhere in the suite.
> 
> The CLI **agents command** tests add a **`beforeAll`** that imports `@cli/commands/agents` with a 30s timeout so the first test is not charged the full module-graph load and tripping the 5s per-test limit on slow machines.
> 
> The remaining diff is **import reordering only** (e.g. moving `@utils/config/configUtils` and other locals within existing import groups) across extension UI, agent handlers, LaTeX, tools, and tests—no logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f25ad1ec66e10b7efc07f3a81949b045631815b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->