### PR TITLE
perf(cli): cut per-frame work in the TUI render hot path

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -6,7 +6,7 @@
 
 import path from 'node:path';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Static, Text } from 'ink';
 
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
@@ -317,13 +317,16 @@ export function StaticConversationTranscript({
     width,
   ]);
 
-  // Cast instead of copying: `<Static>` declares `items: T[]` but only ever
-  // reads it (`items.slice(index)`), and a fresh spread here would allocate
-  // an O(history) array on every render.
+  // Keep our scrollback state readonly and adapt once at the Ink boundary.
+  // `<Static>` declares `items: T[]`; memoizing the defensive copy avoids the
+  // old O(history) spread on unrelated renders without exposing state to a
+  // mutable third-party prop.
+  const staticItems = useMemo(() => [...items], [items]);
+
   return (
     <Static
       key={`transcript:${ownerKey}`}
-      items={items as StaticTranscriptItem[]}
+      items={staticItems}
     >
       {(item: StaticTranscriptItem) => (
         <Box key={item.id} flexDirection="column">

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -186,11 +186,9 @@ export function appendStaticTranscriptItems({
   readonly width?: number;
 }): readonly StaticTranscriptItem[] {
   const seen = new Set(currentItems.map((item) => item.id));
-  const nextItems: StaticTranscriptItem[] = [...currentItems];
-  let currentRows = nextItems.reduce(
-    (total, item) => total + staticTranscriptItemRowCount(item, width),
-    0,
-  );
+  // Copied lazily: this runs on every stream-sync tick and most ticks append
+  // nothing.
+  let nextItems: StaticTranscriptItem[] | undefined;
   if (!seen.has(SESSION_HEADER_ID)) {
     const header: StaticTranscriptItem = {
       id: SESSION_HEADER_ID,
@@ -203,10 +201,17 @@ export function appendStaticTranscriptItems({
       }),
       meta,
     };
-    if (
+    // The row budget only applies on compact terminals (maxRows defined), and
+    // counting rows wraps every item's full text — O(history) — so it must
+    // stay behind the maxRows gate rather than run eagerly per tick.
+    const fitsBudget =
       maxRows === undefined ||
-      currentRows + staticTranscriptItemRowCount(header, width) <= maxRows
-    ) {
+      currentItems.reduce(
+        (total, item) => total + staticTranscriptItemRowCount(item, width),
+        staticTranscriptItemRowCount(header, width),
+      ) <= maxRows;
+    if (fitsBudget) {
+      nextItems = [...currentItems];
       const firstEntryIndex = nextItems.findIndex(
         (item) => item.kind === 'entry',
       );
@@ -215,7 +220,6 @@ export function appendStaticTranscriptItems({
         0,
         header,
       );
-      currentRows += staticTranscriptItemRowCount(header, width);
       seen.add(SESSION_HEADER_ID);
     }
   }
@@ -223,18 +227,19 @@ export function appendStaticTranscriptItems({
   // Only the selected scrollback owner feeds `<Static>` output. Root focus owns
   // root history; child focus owns that child's history. Other streams stay
   // available through their own focus or the transcript viewer.
-  if (!scrollbackStreamId) return nextItems;
-  const slice = streams.get(scrollbackStreamId);
+  const slice = scrollbackStreamId
+    ? streams.get(scrollbackStreamId)
+    : undefined;
   for (const entry of slice?.entries ?? []) {
     if (!entry.finalized) continue;
     if (seen.has(entry.id)) continue;
-    const item: StaticTranscriptItem = { id: entry.id, kind: 'entry', entry };
-    nextItems.push(item);
+    nextItems ??= [...currentItems];
+    nextItems.push({ id: entry.id, kind: 'entry', entry });
     seen.add(entry.id);
   }
   // Same reference when nothing was appended so the `setItems` functional
   // update doesn't schedule a re-render on every stream-sync tick.
-  return nextItems.length === currentItems.length ? currentItems : nextItems;
+  return nextItems ?? currentItems;
 }
 
 export function StaticConversationTranscript({
@@ -312,8 +317,14 @@ export function StaticConversationTranscript({
     width,
   ]);
 
+  // Cast instead of copying: `<Static>` declares `items: T[]` but only ever
+  // reads it (`items.slice(index)`), and a fresh spread here would allocate
+  // an O(history) array on every render.
   return (
-    <Static key={`transcript:${ownerKey}`} items={[...items]}>
+    <Static
+      key={`transcript:${ownerKey}`}
+      items={items as StaticTranscriptItem[]}
+    >
       {(item: StaticTranscriptItem) => (
         <Box key={item.id} flexDirection="column">
           {item.kind === 'header' ? (

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -324,10 +324,7 @@ export function StaticConversationTranscript({
   const staticItems = useMemo(() => [...items], [items]);
 
   return (
-    <Static
-      key={`transcript:${ownerKey}`}
-      items={staticItems}
-    >
+    <Static key={`transcript:${ownerKey}`} items={staticItems}>
       {(item: StaticTranscriptItem) => (
         <Box key={item.id} flexDirection="column">
           {item.kind === 'header' ? (

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -364,6 +364,14 @@ function statusBarBindingRow(
   );
 }
 
+// Single-slot memo for the bindings cascade below: it eagerly builds ~13
+// candidate rows and stringWidth-measures them until one fits, yet its
+// inputs are a handful of flags that change far less often than the
+// StatusBar re-renders (every stream-sync tick plus every elapsed-seconds
+// tick). Keyed on all inputs, so a changed flag just recomputes.
+let lastBindingsKey: string | undefined;
+let lastBindingsText = '';
+
 export function statusBarBindingsText(
   taskControlsAvailable = true,
   agentSelectionAvailable = false,
@@ -375,6 +383,18 @@ export function statusBarBindingsText(
   ctrlCAction: CtrlCAction = 'exit',
   maxColumns?: number,
 ): string {
+  const memoKey = [
+    taskControlsAvailable,
+    agentSelectionAvailable,
+    subagentControlsAvailable,
+    hasMultipleStreams,
+    modifierLabel,
+    shiftEnterNewline,
+    transcriptAvailable,
+    ctrlCAction,
+    maxColumns,
+  ].join('|');
+  if (memoKey === lastBindingsKey) return lastBindingsText;
   const focusBinding = metaShortcutLabel(modifierLabel, '1..9');
   const tasksBinding = metaShortcutLabel(modifierLabel, 'p');
   const subagentsBinding = metaShortcutLabel(modifierLabel, 's');
@@ -447,13 +467,15 @@ export function statusBarBindingsText(
     transcriptAvailable && statusBarBindingRow([transcript, ctrlC]),
   ];
 
-  return (
+  const text =
     candidates.find(
       (candidate): candidate is string =>
         typeof candidate === 'string' &&
         fitsStatusBindings(candidate, maxColumns),
-    ) ?? ctrlC
-  );
+    ) ?? ctrlC;
+  lastBindingsKey = memoKey;
+  lastBindingsText = text;
+  return text;
 }
 
 function joinStatusBindings(bindings: readonly string[]): string {

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -560,12 +560,35 @@ export function pickToolRenderer(
   return REGISTRY.find((renderer) => renderer.matches(toolUse));
 }
 
+// Memoized per NormalizedToolUse object. `subscribeStreamLog` keeps the
+// toolUse reference stable across sync ticks unless its content changed, so
+// the derived lines (including diff hunks for edit tools) can be shared by
+// the live row estimator, the bounded renderer, and static row counting
+// instead of being recomputed for every visible tool row on every frame.
+interface ToolUseDisplayLinesCacheEntry {
+  elided?: readonly string[];
+  full?: readonly string[];
+}
+const displayLinesCache = new WeakMap<
+  NormalizedToolUse,
+  ToolUseDisplayLinesCacheEntry
+>();
+
 export function toolUseDisplayLines(
   toolUse: NormalizedToolUse,
   options?: DisplayLineOptions,
 ): readonly string[] {
-  return (
+  const slot = options?.elide === false ? 'full' : 'elided';
+  let cached = displayLinesCache.get(toolUse);
+  const hit = cached?.[slot];
+  if (hit) return hit;
+  const lines =
     pickToolRenderer(toolUse)?.displayLines(toolUse, options) ??
-    universalToolUseDisplayLines(toolUse, { elide: options?.elide })
-  );
+    universalToolUseDisplayLines(toolUse, { elide: options?.elide });
+  if (!cached) {
+    cached = {};
+    displayLinesCache.set(toolUse, cached);
+  }
+  cached[slot] = lines;
+  return lines;
 }

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -399,13 +399,49 @@ function formatAnsiLatexReference(
   return style.dim(style.underline(text));
 }
 
-let cachedProcessor: MarkdownProcessor | null = null;
 // Table layout needs the terminal width baked into the renderer (the shared
-// processor caches by content only), so the processor is bound to one width
-// and rebuilt when the width changes — a rare event (resize), unlike the
-// per-delta streaming calls the cache exists to serve.
-let cachedWidth: number | undefined;
-let cachedColorEnabled: boolean | undefined;
+// processor caches by content only), so each processor is bound to one
+// (width, colorEnabled) pair. Keep a small LRU of processors rather than a
+// single slot: the live-region row estimator renders with the default color
+// setting while a NO_COLOR painter renders without, and a single slot would
+// rebuild the processor — discarding its content LRU — on every alternation,
+// re-parsing all pending markdown each frame.
+const PROCESSOR_CACHE_MAX = 4;
+const processorCache = new Map<string, MarkdownProcessor>();
+
+function processorFor(
+  width: number | undefined,
+  colorEnabled: boolean,
+): MarkdownProcessor {
+  const key = `${width ?? 'auto'}:${colorEnabled ? 'color' : 'plain'}`;
+  const cached = processorCache.get(key);
+  if (cached) {
+    // Re-insert to mark as most recently used.
+    processorCache.delete(key);
+    processorCache.set(key, cached);
+    return cached;
+  }
+  const style = ansiMarkdownStyle(colorEnabled);
+  const renderer = createMarkdownRenderer({
+    highlight: (code, lang) => highlightForTui(code, lang, style),
+    configure: (md) => configureAnsi(md, width, style),
+  });
+  const processor = createMarkdownProcessor({
+    renderer,
+    formatLatexReference: (refType, label) =>
+      formatAnsiLatexReference(refType, label, style),
+    // The CLI shows LaTeX source verbatim (math rendering is disabled), so
+    // shield `$…$` / `$$…$$` / `\(…\)` / `\[…\]` spans from markdown-it, which
+    // would otherwise strip `\(`→`(`, `\;`→`;` and eat `_{…}` subscripts.
+    protectLatexMath: true,
+  });
+  if (processorCache.size >= PROCESSOR_CACHE_MAX) {
+    const oldest = processorCache.keys().next().value;
+    if (oldest !== undefined) processorCache.delete(oldest);
+  }
+  processorCache.set(key, processor);
+  return processor;
+}
 
 export interface RenderAnsiMarkdownOptions {
   readonly width?: number;
@@ -421,50 +457,25 @@ export function renderAnsiMarkdown(
   content: string,
   options: RenderAnsiMarkdownOptions = {},
 ): string {
-  const colorEnabled = options.colorEnabled ?? true;
-  if (
-    !cachedProcessor ||
-    cachedWidth !== options.width ||
-    cachedColorEnabled !== colorEnabled
-  ) {
-    const style = ansiMarkdownStyle(colorEnabled);
-    const renderer = createMarkdownRenderer({
-      highlight: (code, lang) => highlightForTui(code, lang, style),
-      configure: (md) => configureAnsi(md, options.width, style),
-    });
-    cachedProcessor = createMarkdownProcessor({
-      renderer,
-      formatLatexReference: (refType, label) =>
-        formatAnsiLatexReference(refType, label, style),
-      // The CLI shows LaTeX source verbatim (math rendering is disabled), so
-      // shield `$…$` / `$$…$$` / `\(…\)` / `\[…\]` spans from markdown-it, which
-      // would otherwise strip `\(`→`(`, `\;`→`;` and eat `_{…}` subscripts.
-      protectLatexMath: true,
-    });
-    cachedWidth = options.width;
-    cachedColorEnabled = colorEnabled;
-  }
-  return wrapAnsiToWidth(
-    cachedProcessor(content),
-    options.width,
-    true,
-  ).trimEnd();
+  const processor = processorFor(options.width, options.colorEnabled ?? true);
+  return wrapAnsiToWidth(processor(content), options.width, true).trimEnd();
 }
 
-/** Test seam: drop the cached processor so tests can re-init cleanly. */
+/** Test seam: drop the cached processors so tests can re-init cleanly. */
 export function _resetAnsiMarkdownForTests(): void {
-  cachedProcessor = null;
-  cachedWidth = undefined;
-  cachedColorEnabled = undefined;
+  processorCache.clear();
 }
 
-/** Test seam: returns cache hit/miss counters for the active processor. */
+/** Test seam: returns cache hit/miss counters across cached processors. */
 export function _ansiMarkdownStatsForTests(): {
   hits: number;
   misses: number;
 } {
-  return {
-    hits: cachedProcessor?.stats.hits() ?? 0,
-    misses: cachedProcessor?.stats.misses() ?? 0,
-  };
+  let hits = 0;
+  let misses = 0;
+  for (const processor of processorCache.values()) {
+    hits += processor.stats.hits();
+    misses += processor.stats.misses();
+  }
+  return { hits, misses };
 }

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -402,10 +402,10 @@ function formatAnsiLatexReference(
 // Table layout needs the terminal width baked into the renderer (the shared
 // processor caches by content only), so each processor is bound to one
 // (width, colorEnabled) pair. Keep a small LRU of processors rather than a
-// single slot: the live-region row estimator renders with the default color
-// setting while a NO_COLOR painter renders without, and a single slot would
-// rebuild the processor — discarding its content LRU — on every alternation,
-// re-parsing all pending markdown each frame.
+// single slot: callers are not guaranteed to agree on the pair (the row
+// estimator defaults color on while a NO_COLOR painter passes false), and
+// with a single slot any alternation would rebuild the processor and discard
+// its content LRU — re-parsing every visible markdown body per frame.
 const PROCESSOR_CACHE_MAX = 4;
 const processorCache = new Map<string, MarkdownProcessor>();
 

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -196,14 +196,27 @@ function buildProcessItem(
   };
 }
 
+const EMPTY_TAIL_LINES: readonly string[] = [];
+// Tail objects are immutable and replaced wholesale by updateProcessOutput,
+// so the split is cached per object: the subagent panel re-renders on every
+// stream-sync tick and would otherwise re-split up to 16 KB per process row.
+const processTailLinesCache = new WeakMap<
+  ProcessOutputTail,
+  readonly string[]
+>();
+
 export function processTailLines(
   tail: ProcessOutputTail | undefined,
 ): readonly string[] {
-  if (!tail) return [];
-  return `${tail.stdout}\n${tail.stderr}`
+  if (!tail) return EMPTY_TAIL_LINES;
+  const cached = processTailLinesCache.get(tail);
+  if (cached) return cached;
+  const lines = `${tail.stdout}\n${tail.stderr}`
     .split('\n')
     .map((line) => line.trimEnd())
     .filter((line) => line.length > 0);
+  processTailLinesCache.set(tail, lines);
+  return lines;
 }
 
 export function buildChildControlItems(

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -294,23 +294,54 @@ type TranscriptCandidate = {
   readonly tieBreak: number;
 };
 
+function compareTranscriptCandidates(
+  left: TranscriptCandidate,
+  right: TranscriptCandidate,
+): number {
+  return left.sortSeq - right.sortSeq || left.tieBreak - right.tieBreak;
+}
+
+// Log entries already arrive in seqNo order, so the per-tick common case is
+// fully sorted — only synthetic rows (spliced in by syntheticAfterSeq) can
+// land out of order. Detect sortedness in O(N) instead of paying the sort's
+// comparator churn on every streaming delta.
+function sortTranscriptCandidatesIfNeeded(
+  candidates: TranscriptCandidate[],
+): TranscriptCandidate[] {
+  for (let index = 1; index < candidates.length; index += 1) {
+    if (
+      compareTranscriptCandidates(candidates[index - 1], candidates[index]) > 0
+    ) {
+      return candidates.sort(compareTranscriptCandidates);
+    }
+  }
+  return candidates;
+}
+
 export function subscribeStreamLog(): () => void {
   const store = getDefaultStreamLogStore();
-  const pendingTimers = new Map<StreamTabId, ReturnType<typeof setTimeout>>();
+  const pendingStreams = new Set<StreamTabId>();
+  let timer: ReturnType<typeof setTimeout> | undefined;
 
+  // One trailing timer shared by every stream: during a multi-subagent burst
+  // the root and each child emit within the same window, and per-stream
+  // timers would fire staggered — one sync→render pass per stream. A shared
+  // flush coalesces them into a single pass; syncStreamLog reads the full
+  // log at flush time, so batching loses nothing.
   const dispose = store.onChange((streamId) => {
-    if (pendingTimers.has(streamId)) return;
-    const timer = setTimeout(() => {
-      pendingTimers.delete(streamId);
-      syncStreamLog(streamId);
+    pendingStreams.add(streamId);
+    timer ??= setTimeout(() => {
+      timer = undefined;
+      const streamIds = [...pendingStreams];
+      pendingStreams.clear();
+      for (const id of streamIds) syncStreamLog(id);
     }, STREAM_SYNC_THROTTLE_MS);
-    pendingTimers.set(streamId, timer);
   });
 
   return () => {
     dispose();
-    for (const timer of pendingTimers.values()) clearTimeout(timer);
-    pendingTimers.clear();
+    if (timer !== undefined) clearTimeout(timer);
+    pendingStreams.clear();
   };
 }
 
@@ -336,21 +367,16 @@ export function syncStreamLog(streamId: StreamTabId): void {
     const existing = new Map(slice.entries.map((e) => [e.id, e]));
     const syntheticEntries = slice.entries.filter((entry) => entry.synthetic);
     const streamFinal = isFinalTranscriptStatus(slice.status);
-    const logEntries: { entry: StreamLogEntry; rendered: ConversationEntry }[] =
-      [];
+    const logCandidates: TranscriptCandidate[] = [];
     for (const entry of responses) {
       const rendered = renderLogEntry(entry, existing.get(entry.id));
       if (!rendered) continue;
-      logEntries.push({ entry, rendered });
+      logCandidates.push({ rendered, sortSeq: entry.seqNo, tieBreak: 0 });
     }
-    const logCandidates: TranscriptCandidate[] = logEntries.map(
-      ({ entry, rendered }) => ({
-        rendered,
-        sortSeq: entry.seqNo,
-        tieBreak: 0,
-      }),
-    );
-    const candidates: TranscriptCandidate[] = [...logCandidates];
+    // The synthetic loop's duplicate check scans `logCandidates`, so synthetics
+    // push into a copy; without synthetics the log list is used as-is.
+    const candidates: TranscriptCandidate[] =
+      syntheticEntries.length === 0 ? logCandidates : [...logCandidates];
 
     for (const [index, entry] of syntheticEntries.entries()) {
       if (entry.syntheticKind !== 'local') {
@@ -370,12 +396,9 @@ export function syncStreamLog(streamId: StreamTabId): void {
       });
     }
 
-    const ordered = candidates
-      .sort(
-        (left, right) =>
-          left.sortSeq - right.sortSeq || left.tieBreak - right.tieBreak,
-      )
-      .map((candidate) => candidate.rendered);
+    const ordered = sortTranscriptCandidatesIfNeeded(candidates).map(
+      (candidate) => candidate.rendered,
+    );
     // Promote the settled prefix only after sorting: "is there a later
     // entry" and Static append order are both defined on the final stream
     // order, not the per-entry render order.

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -44,25 +44,29 @@ function wrapLines(lines: readonly string[], cols: number): string[] {
 }
 
 // Wrapped-line cache keyed by the immutable entry object. Entries are
-// replaced (never mutated in place) when their content changes, so a hit is
-// always current. One slot per entry suffices: every caller wraps at the
-// transcript width, and after a resize the next call recomputes. This keeps
-// the open transcript viewer's per-tick re-flatten proportional to the
-// entries that actually changed (usually just the streaming tail) instead of
-// re-wrapping the full history.
+// replaced (never mutated in place) when their content changes, so hits are
+// always current. Each entry can be rendered at several widths in the same
+// frame (terminal transcript, static row budget, task-detail panel), so keep
+// the width dimension inside the entry cache instead of letting callers thrash
+// a single slot.
 const entryLinesCache = new WeakMap<
   ConversationEntry,
-  { readonly cols: number; readonly lines: readonly string[] }
+  Map<number, readonly string[]>
 >();
 
 export function transcriptEntryLines(
   entry: ConversationEntry,
   cols: number,
 ): readonly string[] {
-  const cached = entryLinesCache.get(entry);
-  if (cached && cached.cols === cols) return cached.lines;
+  const cachedByCols = entryLinesCache.get(entry);
+  const cached = cachedByCols?.get(cols);
+  if (cached) return cached;
   const lines = computeTranscriptEntryLines(entry, cols);
-  entryLinesCache.set(entry, { cols, lines });
+  if (cachedByCols) {
+    cachedByCols.set(cols, lines);
+  } else {
+    entryLinesCache.set(entry, new Map([[cols, lines]]));
+  }
   return lines;
 }
 

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -43,7 +43,30 @@ function wrapLines(lines: readonly string[], cols: number): string[] {
   return lines.flatMap((line) => wrapDisplayLine(line, cols));
 }
 
+// Wrapped-line cache keyed by the immutable entry object. Entries are
+// replaced (never mutated in place) when their content changes, so a hit is
+// always current. One slot per entry suffices: every caller wraps at the
+// transcript width, and after a resize the next call recomputes. This keeps
+// the open transcript viewer's per-tick re-flatten proportional to the
+// entries that actually changed (usually just the streaming tail) instead of
+// re-wrapping the full history.
+const entryLinesCache = new WeakMap<
+  ConversationEntry,
+  { readonly cols: number; readonly lines: readonly string[] }
+>();
+
 export function transcriptEntryLines(
+  entry: ConversationEntry,
+  cols: number,
+): readonly string[] {
+  const cached = entryLinesCache.get(entry);
+  if (cached && cached.cols === cols) return cached.lines;
+  const lines = computeTranscriptEntryLines(entry, cols);
+  entryLinesCache.set(entry, { cols, lines });
+  return lines;
+}
+
+function computeTranscriptEntryLines(
   entry: ConversationEntry,
   cols: number,
 ): readonly string[] {

--- a/packages/cli/src/chat/tui/state/useLiveNowMs.ts
+++ b/packages/cli/src/chat/tui/state/useLiveNowMs.ts
@@ -1,13 +1,35 @@
 import { useEffect, useState } from 'react';
 
+// One shared interval for every live-elapsed display. StatusBar, the
+// subagent panel, and the child-control picker can all tick at once; with
+// per-component intervals each would fire at its own phase, producing up to
+// one render burst per component per second. Subscribers of the shared
+// ticker fire in the same callback, so React batches them into one pass.
+type SharedTickSubscriber = () => void;
+const tickSubscribers = new Set<SharedTickSubscriber>();
+let tickTimer: ReturnType<typeof setInterval> | undefined;
+
+function subscribeToSharedTick(subscriber: SharedTickSubscriber): () => void {
+  tickSubscribers.add(subscriber);
+  tickTimer ??= setInterval(() => {
+    for (const tick of tickSubscribers) tick();
+  }, 1000);
+  return () => {
+    tickSubscribers.delete(subscriber);
+    if (tickSubscribers.size === 0 && tickTimer !== undefined) {
+      clearInterval(tickTimer);
+      tickTimer = undefined;
+    }
+  };
+}
+
 export function useLiveNowMs(shouldTick: boolean, resetKey?: unknown): number {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
     if (!shouldTick) return;
     setNowMs(Date.now());
-    const timer = setInterval(() => setNowMs(Date.now()), 1000);
-    return () => clearInterval(timer);
+    return subscribeToSharedTick(() => setNowMs(Date.now()));
   }, [resetKey, shouldTick]);
 
   return nowMs;

--- a/packages/cli/src/chat/tui/state/useSignal.ts
+++ b/packages/cli/src/chat/tui/state/useSignal.ts
@@ -2,7 +2,7 @@
 // the primitive the webview's `progressState` uses so the CLI host can read
 // the same signals without pulling in a second state-management library.
 
-import { useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { Signal } from '@lit-labs/signals';
 
 type ReadableSignal<T> = Signal.State<T> | Signal.Computed<T>;
@@ -13,10 +13,15 @@ type ReadableSignal<T> = Signal.State<T> | Signal.Computed<T>;
  * `Signal.subtle.Watcher` fires exactly once per change and must be re-armed
  * in the notify callback — the wrapper does that here so consumers see every
  * update.
+ *
+ * The subscribe callback is memoized per signal: `useSyncExternalStore`
+ * unsubscribes and resubscribes whenever the subscribe reference changes, so
+ * an inline closure would tear down and rebuild the Watcher on every render
+ * — per signal, per component, at streaming cadence.
  */
 export function useSignal<T>(signal: ReadableSignal<T>): T {
-  return useSyncExternalStore(
-    (notify) => {
+  const subscribe = useCallback(
+    (notify: () => void) => {
       const watcher = new Signal.subtle.Watcher(() => {
         notify();
         watcher.watch();
@@ -24,6 +29,7 @@ export function useSignal<T>(signal: ReadableSignal<T>): T {
       watcher.watch(signal);
       return () => watcher.unwatch(signal);
     },
-    () => signal.get(),
+    [signal],
   );
+  return useSyncExternalStore(subscribe, () => signal.get());
 }


### PR DESCRIPTION
Four targeted optimizations in the Ink TUI's streaming render path:

- useSignal: memoize the useSyncExternalStore subscribe callback per
  signal. The inline closure changed reference every render, so React
  tore down and rebuilt a Signal Watcher per signal, per component, on
  every streaming frame.
- appendStaticTranscriptItems: stop row-counting (full-text wrapping)
  the entire finalized history on every stream-sync tick. The count is
  only needed once — when inserting the session header under a
  compact-terminal row budget — so it now runs only behind the maxRows
  gate. The items array is also copied lazily, only when something is
  actually appended.
- StaticConversationTranscript: pass the items array to <Static> via a
  readonly cast instead of spreading, avoiding an O(history) copy per
  render (Static only ever slices the array).
- toolUseDisplayLines: memoize derived display lines (including diff
  hunk computation for edit tools) per NormalizedToolUse object, which
  subscribeStreamLog already keeps reference-stable across ticks. The
  row estimator, bounded renderer, and static row counting now share
  one computation instead of redoing it for every visible tool row on
  every frame.
- renderAnsiMarkdown: replace the single-slot processor cache with a
  small keyed LRU per (width, colorEnabled). In NO_COLOR sessions the
  row estimator (default color) and the painter (plain) alternated per
  frame, rebuilding the markdown-it processor and discarding its
  content LRU each time — re-parsing all pending markdown every frame.

https://claude.ai/code/session_01URxrwuTbACfABdFZJyD8vR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rendering-performance only: caches, lazy copies, and batched timers; no changes to auth, persistence, or agent/runtime behavior.
> 
> **Overview**
> **Reduces per-frame work** in the Ink CLI chat TUI during streaming by caching, lazy work, and coalescing updates—behavior should match prior rendering; only cost paths change.
> 
> **Transcript & scrollback:** `appendStaticTranscriptItems` copies the static items list only when appending, skips full-history row wrapping unless a compact `maxRows` budget needs it, and `StaticConversationTranscript` memoizes the defensive copy passed to `<Static>`. Wrapped transcript lines and tool display lines (including edit diffs) are cached per immutable entry/`NormalizedToolUse` via `WeakMap`s.
> 
> **Markdown & status:** `renderAnsiMarkdown` keeps up to four markdown processors in an LRU keyed by `(width, colorEnabled)` so alternating color/plain callers no longer thrash a single cache. `statusBarBindingsText` uses a module-level memo so the width-fitting candidate cascade is not rebuilt every tick.
> 
> **Sync & React:** Stream log sync uses one shared 16ms throttle for all streams (not one timer per stream), skips sorting transcript candidates when already ordered, and `useSignal` memoizes the external-store subscribe callback. `useLiveNowMs` shares one 1s interval across components; `processTailLines` caches stdout/stderr splits per tail object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb0978a1d4c2df8957f67db6337cc1880ebff2a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->