### PR TITLE
feat(cli): reduce TUI cognitive overhead in /help and command discovery

### DIFF
--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -5,19 +5,21 @@
 // markdown (bold section headers + list items) so each command stays on
 // its own row in the transcript.
 
+import { metaChordLabel } from '../panes/StatusBar';
+
 import type { SlashCommand, SlashCommandCategory } from './slashRegistry';
 
-const CATEGORY_ORDER: readonly SlashCommandCategory[] = [
-  'session',
-  'configuration',
-  'account',
+// Help sections in display order; `undefined` collects uncategorized
+// (plugin-style) registrations into a trailing "Other" section.
+const CATEGORY_SECTIONS: ReadonlyArray<{
+  readonly category: SlashCommandCategory | undefined;
+  readonly label: string;
+}> = [
+  { category: 'session', label: 'Session' },
+  { category: 'configuration', label: 'Configuration' },
+  { category: 'account', label: 'Account' },
+  { category: undefined, label: 'Other' },
 ];
-
-const CATEGORY_LABELS: Record<SlashCommandCategory, string> = {
-  session: 'Session',
-  configuration: 'Configuration',
-  account: 'Account',
-};
 
 export interface SlashCommandHelpOptions {
   /** Chord modifier shown for stream-focus shortcuts: `Alt` on most
@@ -36,28 +38,19 @@ function commandListItem(command: SlashCommand): string {
 }
 
 function commandSections(commands: readonly SlashCommand[]): string[] {
-  const grouped = new Map<string, string[]>();
-  for (const command of commands) {
-    const label = command.category
-      ? CATEGORY_LABELS[command.category]
-      : 'Other';
-    const items = grouped.get(label) ?? [];
-    items.push(commandListItem(command));
-    grouped.set(label, items);
-  }
-
-  const labels = [
-    ...CATEGORY_ORDER.map((category) => CATEGORY_LABELS[category]),
-    'Other',
-  ];
-  return labels
-    .filter((label) => grouped.has(label))
-    .map((label) => [`**${label}**`, ...grouped.get(label)!].join('\n'));
+  return CATEGORY_SECTIONS.flatMap(({ category, label }) => {
+    const items = commands.filter((command) => command.category === category);
+    return items.length === 0
+      ? []
+      : [[`**${label}**`, ...items.map(commandListItem)].join('\n')];
+  });
 }
 
 function keyboardSection(options: SlashCommandHelpOptions): string {
-  const modifier = options.shortcutModifierLabel ?? 'Alt';
-  const focusChord = `${modifier}${modifier === 'Esc' ? ' ' : '-'}1..9`;
+  const focusChord = metaChordLabel(
+    options.shortcutModifierLabel ?? 'Alt',
+    '1..9',
+  );
   const newline =
     options.shiftEnterNewline === true
       ? '`Shift-Enter` or `Ctrl-J` insert a newline'

--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -1,0 +1,84 @@
+// Grouped `/help` output for the chat TUI.
+//
+// The transcript renders assistant text as markdown with `breaks: false`,
+// so plain newline-joined lines collapse into one paragraph. Emit real
+// markdown (bold section headers + list items) so each command stays on
+// its own row in the transcript.
+
+import type { SlashCommand, SlashCommandCategory } from './slashRegistry';
+
+const CATEGORY_ORDER: readonly SlashCommandCategory[] = [
+  'session',
+  'configuration',
+  'account',
+];
+
+const CATEGORY_LABELS: Record<SlashCommandCategory, string> = {
+  session: 'Session',
+  configuration: 'Configuration',
+  account: 'Account',
+};
+
+export interface SlashCommandHelpOptions {
+  /** Chord modifier shown for stream-focus shortcuts: `Alt` on most
+   *  platforms, `Esc` on macOS (see `defaultShortcutModifierLabel`). */
+  readonly shortcutModifierLabel?: string;
+  /** Advertise Shift+Enter for newline when the Kitty keyboard protocol is
+   *  active; Ctrl-J is the universal fallback. */
+  readonly shiftEnterNewline?: boolean;
+}
+
+function commandListItem(command: SlashCommand): string {
+  const aliases = (command.aliases ?? [])
+    .map((alias) => ` (\`/${alias}\`)`)
+    .join('');
+  return `- \`/${command.name}\`${aliases} — ${command.description}`;
+}
+
+function commandSections(commands: readonly SlashCommand[]): string[] {
+  const grouped = new Map<string, string[]>();
+  for (const command of commands) {
+    const label = command.category
+      ? CATEGORY_LABELS[command.category]
+      : 'Other';
+    const items = grouped.get(label) ?? [];
+    items.push(commandListItem(command));
+    grouped.set(label, items);
+  }
+
+  const labels = [
+    ...CATEGORY_ORDER.map((category) => CATEGORY_LABELS[category]),
+    'Other',
+  ];
+  return labels
+    .filter((label) => grouped.has(label))
+    .map((label) => [`**${label}**`, ...grouped.get(label)!].join('\n'));
+}
+
+function keyboardSection(options: SlashCommandHelpOptions): string {
+  const modifier = options.shortcutModifierLabel ?? 'Alt';
+  const focusChord = `${modifier}${modifier === 'Esc' ? ' ' : '-'}1..9`;
+  const newline =
+    options.shiftEnterNewline === true
+      ? '`Shift-Enter` or `Ctrl-J` insert a newline'
+      : '`Ctrl-J` inserts a newline';
+  return [
+    '**Keyboard**',
+    `- \`Enter\` sends · ${newline}`,
+    '- `↑`/`↓` browse input history · `Ctrl-R` searches it',
+    '- `Esc` stops the current response · `Ctrl-C` stops, twice exits',
+    '- `Ctrl-T` opens the transcript viewer for the focused stream',
+    `- \`Tab\` switches streams · \`${focusChord}\` jumps to one (when subagents are running)`,
+  ].join('\n');
+}
+
+export function formatSlashCommandHelp(
+  commands: readonly SlashCommand[],
+  options: SlashCommandHelpOptions = {},
+): string {
+  return [
+    ...commandSections(commands),
+    keyboardSection(options),
+    'Typing while a response is running queues your message as a follow-up.',
+  ].join('\n\n');
+}

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -265,82 +265,99 @@ export function registerBuiltinSlashCommands(options?: {
   registerSlashCommand({
     name: 'help',
     description: 'Show available slash commands',
+    category: 'session',
   });
   registerSlashCommand({
     name: 'clear',
     description: 'Start a fresh chat session',
+    category: 'session',
   });
   registerSlashCommand({
     name: 'agent',
     description: 'List or choose the root agent',
     aliases: ['agents'],
+    category: 'configuration',
     formComponent: AgentListFormAdapter,
   });
   registerSlashCommand({
     name: 'model',
     description: 'List available models',
     aliases: ['models'],
+    category: 'configuration',
     formComponent: ModelListFormAdapter,
   });
   registerSlashCommand({
     name: 'api',
     description: 'Switch between included relay and personal API keys',
+    category: 'configuration',
     formComponent: ApiModeFormAdapter,
   });
   registerSlashCommand({
     name: 'auth',
     description: 'Show TeXRA login status',
+    category: 'account',
   });
   registerSlashCommand({
     name: 'login',
     description: 'Sign in to TeXRA included access',
+    category: 'account',
   });
   registerSlashCommand({
     name: 'logout',
     description: 'Sign out of TeXRA',
+    category: 'account',
   });
   registerSlashCommand({
     name: 'approval',
     description: 'Switch approval policy',
+    category: 'configuration',
     formComponent: ApprovalPolicyFormAdapter,
     formEscapeAction: 'cancel',
   });
   registerSlashCommand({
     name: 'yolo',
     description: 'Auto-approve privileged actions',
+    category: 'configuration',
   });
   registerSlashCommand({
     name: 'status',
     description: 'Show session details',
+    category: 'session',
   });
   registerSlashCommand({
     name: 'resume',
     description: 'Resume a previous session',
+    category: 'session',
     formComponent: ResumeListFormAdapter,
   });
   registerSlashCommand({
     name: 'memory',
     description: 'List stored memories',
+    category: 'configuration',
     formComponent: MemoryListFormAdapter,
   });
   registerSlashCommand({
     name: 'skills',
     description: 'List available skills',
     aliases: ['skill'],
+    category: 'configuration',
     formComponent: SkillsListFormAdapter,
   });
   registerSlashCommand({
     name: 'tools',
     description: 'List or toggle external integrations',
+    category: 'configuration',
     formComponent: ToolsListFormAdapter,
   });
   registerSlashCommand({
     name: 'compact',
     description: 'Request context compaction',
+    category: 'session',
   });
   registerSlashCommand({
     name: 'exit',
     description: 'Exit the CLI session',
     aliases: ['quit'],
+    category: 'session',
   });
 }

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -1,5 +1,14 @@
 // In-tree slash command registry.
 
+import {
+  editDistance,
+  typoSuggestionThreshold,
+} from '@utils/text/editDistance';
+
+/** Help-screen grouping. Uncategorized commands land in a trailing
+ *  "Other" section, so plugin-style registrations stay visible. */
+export type SlashCommandCategory = 'session' | 'configuration' | 'account';
+
 /** A structured-form component renders inline when the user picks a slash
  *  command that declares one (e.g. `/api`). Calls `onDone(result)` to
  *  commit the user's selection or `onDone(undefined)` on cancel. */
@@ -15,6 +24,8 @@ export interface SlashCommand {
   readonly description: string;
   /** Optional alias list for autocomplete (matches both `name` and aliases). */
   readonly aliases?: readonly string[];
+  /** Where the command appears in the grouped `/help` listing. */
+  readonly category?: SlashCommandCategory;
   /**
    * Fire-and-forget handler. Receives the raw remainder of the command line
    * (everything after the command name + whitespace).
@@ -78,6 +89,41 @@ export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
     if (cmd.name.toLowerCase().startsWith(lower)) return true;
     return cmd.aliases?.some((a) => a.toLowerCase().startsWith(lower)) ?? false;
   });
+}
+
+/**
+ * Best "did you mean" candidate for a mistyped command name: the registered
+ * command (matching by name or alias) within the shared typo threshold,
+ * closest first, alphabetical on ties.
+ */
+export function suggestSlashCommand(
+  nameOrAlias: string,
+): SlashCommand | undefined {
+  const token = nameOrAlias.toLowerCase();
+  let best:
+    | {
+        readonly command: SlashCommand;
+        readonly candidate: string;
+        readonly distance: number;
+      }
+    | undefined;
+
+  for (const command of listSlashCommands()) {
+    for (const candidate of [command.name, ...(command.aliases ?? [])]) {
+      const lower = candidate.toLowerCase();
+      const distance = editDistance(token, lower);
+      if (distance > typoSuggestionThreshold(token, lower)) continue;
+      if (
+        best === undefined ||
+        distance < best.distance ||
+        (distance === best.distance && lower < best.candidate)
+      ) {
+        best = { command, candidate: lower, distance };
+      }
+    }
+  }
+
+  return best?.command;
 }
 
 export function slashPickIntent(

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -14,6 +14,12 @@ import {
   maxScrollableRowOffset,
   scrollBoundedRows,
 } from '../render/scrollBounds';
+import {
+  hiddenRowsText,
+  moreRowsText,
+  previousRowsText,
+  scrollStatusText,
+} from '../render/overflowText';
 import { clipToWidth, textDisplayWidth } from '../render/terminalText';
 import { KeyHints } from '../ui/KeyHints';
 import type { ApprovalDecision } from '../state/approvalQueue';
@@ -120,10 +126,8 @@ function agentProposalInstructionPageRows(maxInstructionRows: number): number {
     : Math.max(1, maxInstructionRows - 2);
 }
 
-function overflowText(kind: 'more' | 'previous' | 'hidden', count: number) {
-  if (kind === 'previous') return `... ${count} previous rows`;
-  if (kind === 'hidden') return `... ${count} prompt rows hidden`;
-  return `... ${count} more rows`;
+function hiddenPromptRowsText(count: number): string {
+  return hiddenRowsText(count, 'prompt rows');
 }
 
 function compactHiddenInstructionText({
@@ -135,36 +139,18 @@ function compactHiddenInstructionText({
   readonly hiddenLines: number;
   readonly width: number;
 }): string {
-  const suffix = ` ${overflowText('hidden', hiddenLines)}`;
+  const suffix = ` ${hiddenPromptRowsText(hiddenLines)}`;
   const prefixWidth = width - textDisplayWidth(suffix);
   if (prefixWidth <= 0) {
-    return clipToWidth(overflowText('hidden', hiddenLines), width);
+    return clipToWidth(hiddenPromptRowsText(hiddenLines), width);
   }
 
   const prefix = clipToWidth(firstLine, prefixWidth).trimEnd();
   if (prefix.length === 0) {
-    return clipToWidth(overflowText('hidden', hiddenLines), width);
+    return clipToWidth(hiddenPromptRowsText(hiddenLines), width);
   }
 
   return `${prefix}${suffix}`;
-}
-
-function compactScrollStatusText({
-  hiddenAfter,
-  hiddenBefore,
-  width,
-}: {
-  readonly hiddenAfter: number;
-  readonly hiddenBefore: number;
-  readonly width: number;
-}): string {
-  const text =
-    hiddenBefore > 0 && hiddenAfter > 0
-      ? `... ${hiddenBefore} previous, ${hiddenAfter} more rows`
-      : hiddenBefore > 0
-        ? overflowText('previous', hiddenBefore)
-        : overflowText('more', hiddenAfter);
-  return clipToWidth(text, width);
 }
 
 function wrappedRows(text: string, width: number): number {
@@ -253,11 +239,7 @@ export function boundedAgentProposalInstructionLines({
       ...visible,
       {
         kind: 'overflow',
-        text: compactScrollStatusText({
-          hiddenAfter,
-          hiddenBefore,
-          width,
-        }),
+        text: clipToWidth(scrollStatusText(hiddenBefore, hiddenAfter), width),
       },
     ];
   }
@@ -274,7 +256,7 @@ export function boundedAgentProposalInstructionLines({
       ? [
           {
             kind: 'overflow' as const,
-            text: overflowText('previous', hiddenBefore),
+            text: previousRowsText(hiddenBefore),
           },
         ]
       : []),
@@ -283,7 +265,7 @@ export function boundedAgentProposalInstructionLines({
       ? [
           {
             kind: 'overflow' as const,
-            text: overflowText('more', hiddenAfter),
+            text: moreRowsText(hiddenAfter),
           },
         ]
       : []),

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -10,6 +10,12 @@ import {
   maxScrollableRowOffset,
   scrollBoundedRows,
 } from '../render/scrollBounds';
+import {
+  hiddenRowsText,
+  moreRowsText,
+  previousRowsText,
+  scrollStatusText,
+} from '../render/overflowText';
 import { clipToWidth, textDisplayWidth } from '../render/terminalText';
 import { KeyHints } from '../ui/KeyHints';
 import type { ApprovalDecision } from '../state/approvalQueue';
@@ -103,12 +109,6 @@ export function bashApprovalPageRows(maxCommandRows: number): number {
     : Math.max(1, maxCommandRows - 2);
 }
 
-function overflowText(kind: 'more' | 'previous' | 'hidden', count: number) {
-  if (kind === 'previous') return `... ${count} previous rows`;
-  if (kind === 'hidden') return `... ${count} rows hidden`;
-  return `... ${count} more rows`;
-}
-
 function compactHiddenCommandText({
   firstLine,
   hiddenLines,
@@ -118,30 +118,11 @@ function compactHiddenCommandText({
   readonly hiddenLines: number;
   readonly width: number;
 }): string {
-  const suffix = ` ${overflowText('hidden', hiddenLines)}`;
+  const suffix = ` ${hiddenRowsText(hiddenLines)}`;
   const prefixWidth = width - textDisplayWidth(suffix);
-  if (prefixWidth <= 0)
-    return clipToWidth(overflowText('hidden', hiddenLines), width);
+  if (prefixWidth <= 0) return clipToWidth(hiddenRowsText(hiddenLines), width);
 
   return `${clipToWidth(firstLine, prefixWidth).trimEnd()}${suffix}`;
-}
-
-function compactScrollStatusText({
-  hiddenAfter,
-  hiddenBefore,
-  width,
-}: {
-  readonly hiddenAfter: number;
-  readonly hiddenBefore: number;
-  readonly width: number;
-}): string {
-  const text =
-    hiddenBefore > 0 && hiddenAfter > 0
-      ? `... ${hiddenBefore} previous, ${hiddenAfter} more rows`
-      : hiddenBefore > 0
-        ? overflowText('previous', hiddenBefore)
-        : overflowText('more', hiddenAfter);
-  return clipToWidth(text, width);
 }
 
 export function boundedBashCommandDisplayLines({
@@ -186,11 +167,7 @@ export function boundedBashCommandDisplayLines({
       ...visible,
       {
         kind: 'overflow',
-        text: compactScrollStatusText({
-          hiddenAfter,
-          hiddenBefore,
-          width,
-        }),
+        text: clipToWidth(scrollStatusText(hiddenBefore, hiddenAfter), width),
       },
     ];
   }
@@ -207,7 +184,7 @@ export function boundedBashCommandDisplayLines({
       ? [
           {
             kind: 'overflow' as const,
-            text: overflowText('previous', hiddenBefore),
+            text: previousRowsText(hiddenBefore),
           },
         ]
       : []),
@@ -216,7 +193,7 @@ export function boundedBashCommandDisplayLines({
       ? [
           {
             kind: 'overflow' as const,
-            text: overflowText('more', hiddenAfter),
+            text: moreRowsText(hiddenAfter),
           },
         ]
       : []),

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -10,6 +10,11 @@ import { BaseTextInput } from '../input/BaseTextInput';
 import { isEscapeInput } from '../input/inputKeys';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import {
+  moreRowsText,
+  previousRowsText,
+  scrollStatusText,
+} from '../render/overflowText';
+import {
   maxScrollableRowOffset,
   scrollBoundedRows,
 } from '../render/scrollBounds';
@@ -137,22 +142,6 @@ export function externalInquiryQuestionRowsBudget({
   return Math.max(0, availableRows - EXTERNAL_INQUIRY_FIXED_ROWS - answerRows);
 }
 
-function overflowText(kind: 'previous' | 'more', count: number) {
-  if (kind === 'previous') return `... ${count} previous rows`;
-  return `... ${count} more rows`;
-}
-
-function compactOverflowText(
-  hiddenBefore: number,
-  hiddenAfter: number,
-): string {
-  if (hiddenBefore > 0 && hiddenAfter > 0) {
-    return `... ${hiddenBefore} previous, ${hiddenAfter} more rows`;
-  }
-  if (hiddenBefore > 0) return overflowText('previous', hiddenBefore);
-  return overflowText('more', hiddenAfter);
-}
-
 export function externalInquiryQuestionLines({
   question,
   width,
@@ -215,7 +204,7 @@ export function boundedExternalInquiryQuestionLines({
         ? [
             {
               kind: 'overflow' as const,
-              text: compactOverflowText(hiddenBefore, hiddenAfter),
+              text: scrollStatusText(hiddenBefore, hiddenAfter),
             },
           ]
         : []),
@@ -234,7 +223,7 @@ export function boundedExternalInquiryQuestionLines({
       ? [
           {
             kind: 'overflow' as const,
-            text: overflowText('previous', hiddenBefore),
+            text: previousRowsText(hiddenBefore),
           },
         ]
       : []),
@@ -243,7 +232,7 @@ export function boundedExternalInquiryQuestionLines({
       ? [
           {
             kind: 'overflow' as const,
-            text: overflowText('more', hiddenAfter),
+            text: moreRowsText(hiddenAfter),
           },
         ]
       : []),

--- a/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
@@ -2,7 +2,8 @@ import { Box, Text } from 'ink';
 import stringWidth from 'string-width';
 
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
-import { collapseWhitespace } from '@utils/text/stringUtils';
+
+import { truncateSummaryToWidth } from '../render/terminalText';
 
 export const QUEUED_FOLLOW_UP_PANEL_MAX_ROWS = 3;
 
@@ -15,23 +16,6 @@ export interface QueuedFollowUpPanelDisplay {
   readonly title: string | undefined;
   readonly rows: readonly QueuedFollowUpPanelRow[];
   readonly hiddenCount: number;
-}
-
-function truncateToColumns(text: string, maxColumns: number): string {
-  const summary = collapseWhitespace(text);
-  if (stringWidth(summary) <= maxColumns) return summary;
-
-  const ellipsis = '…';
-  const contentColumns = Math.max(0, maxColumns - stringWidth(ellipsis));
-  let width = 0;
-  let truncated = '';
-  for (const char of summary) {
-    const charWidth = stringWidth(char);
-    if (width + charWidth > contentColumns) break;
-    truncated += char;
-    width += charWidth;
-  }
-  return `${truncated}${ellipsis}`;
 }
 
 export function queuedFollowUpPanelRowCount(
@@ -55,7 +39,7 @@ export function queuedFollowUpPanelDisplay({
   }
 
   const contentWidth = Math.max(0, width - 2);
-  const title = truncateToColumns(
+  const title = truncateSummaryToWidth(
     `Queued follow-ups (${messages.length})`,
     contentWidth,
   );
@@ -75,7 +59,7 @@ export function queuedFollowUpPanelDisplay({
       const bodyWidth = Math.max(0, contentWidth - stringWidth(prefix));
       return {
         kind: 'message',
-        text: `${prefix}${truncateToColumns(
+        text: `${prefix}${truncateSummaryToWidth(
           summarizeFollowupMessage(message),
           bodyWidth,
         )}`,
@@ -86,7 +70,10 @@ export function queuedFollowUpPanelDisplay({
   if (hiddenCount > 0) {
     rows.push({
       kind: 'overflow',
-      text: truncateToColumns(`… ${hiddenCount} more queued`, contentWidth),
+      text: truncateSummaryToWidth(
+        `… ${hiddenCount} more queued`,
+        contentWidth,
+      ),
     });
   }
 

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -7,6 +7,7 @@ import stringWidth from 'string-width';
 
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
+  LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
   type ConversationProgress,
   type StreamStatus,
@@ -14,8 +15,8 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { filterNotNullish } from '@utils/core';
-import { collapseWhitespace } from '@utils/text/stringUtils';
 
+import { truncateSummaryToWidth } from '../render/terminalText';
 import { formatCliStatusLabel } from '../sessionStatus';
 import {
   approvalQueueStatus,
@@ -175,23 +176,6 @@ const STATUS_BAR_COMPACT_PRIORITY = {
   thinking: 75,
 } as const;
 
-function truncateSummaryToColumns(text: string, maxColumns: number): string {
-  const summary = collapseWhitespace(text);
-  if (stringWidth(summary) <= maxColumns) return summary;
-
-  const ellipsis = '…';
-  const contentColumns = Math.max(0, maxColumns - stringWidth(ellipsis));
-  let width = 0;
-  let truncated = '';
-  for (const char of summary) {
-    const charWidth = stringWidth(char);
-    if (width + charWidth > contentColumns) break;
-    truncated += char;
-    width += charWidth;
-  }
-  return `${truncated}${ellipsis}`;
-}
-
 function numberedQueuedFollowUpPreview(
   message: string,
   index: number,
@@ -199,7 +183,7 @@ function numberedQueuedFollowUpPreview(
 ): string {
   const prefix = `${index + 1}. `;
   const bodyColumns = Math.max(0, maxColumns - stringWidth(prefix));
-  return `${prefix}${truncateSummaryToColumns(message, bodyColumns)}`;
+  return `${prefix}${truncateSummaryToWidth(message, bodyColumns)}`;
 }
 
 function queuedFollowUpsListSummary(
@@ -239,7 +223,7 @@ export function queuedFollowUpsSummary(
   if (messages.length > 1) {
     return queuedFollowUpsListSummary(messages, previewLength);
   }
-  return truncateSummaryToColumns(messages[0] ?? '', previewLength);
+  return truncateSummaryToWidth(messages[0] ?? '', previewLength);
 }
 
 function queuedFollowUpsCountSegment(
@@ -303,7 +287,7 @@ function fitPendingExitStatusBarLeftSegments(
     const iconAndGapWidth = statusBarSegmentWidth(icon) + 1;
     fitted[1] = {
       ...prompt,
-      text: truncateSummaryToColumns(
+      text: truncateSummaryToWidth(
         prompt.text,
         Math.max(0, innerWidth - iconAndGapWidth),
       ),
@@ -511,35 +495,22 @@ export function ctrlCActionForFocus({
     : 'stop';
 }
 
-function statusBarCanStopStatus(status: string | undefined): boolean {
-  return (
-    status === STREAM_STATUS.INITIALIZING ||
-    status === STREAM_STATUS.RUNNING ||
-    status === STREAM_STATUS.RESUMING
-  );
+/** In-flight run statuses — stoppable, and live enough to represent a
+ *  focused child's ancestor in the bar. */
+function isLiveStreamStatus(status: string | undefined): boolean {
+  return status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status);
 }
 
 function rootActiveSegment(
   input: StatusBarDisplayInput,
 ): StatusBarSegment | undefined {
-  return input.ctrlCAction === 'stop root' &&
-    !statusBarCanStopStatus(input.status)
+  return input.ctrlCAction === 'stop root' && !isLiveStreamStatus(input.status)
     ? {
         text: 'root active',
         color: 'yellow',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.rootActive,
       }
     : undefined;
-}
-
-function statusBarCanRepresentLiveAncestor(
-  status: StreamStatus | undefined,
-): boolean {
-  return (
-    status === STREAM_STATUS.INITIALIZING ||
-    status === STREAM_STATUS.RUNNING ||
-    status === STREAM_STATUS.RESUMING
-  );
 }
 
 interface StatusBarVisibleStream {
@@ -576,13 +547,13 @@ export function statusBarCanStopVisibleRun({
   readonly status: StreamStatus | undefined;
   readonly streams: ReadonlyMap<StreamTabId, StatusBarVisibleStream>;
 }): boolean {
-  if (statusBarCanStopStatus(status)) return true;
+  if (isLiveStreamStatus(status)) return true;
   return (
     statusBarFindAncestorStream({
       activeStreamId,
       parentStream,
       streams,
-      canUseStream: (stream) => statusBarCanStopStatus(stream.status),
+      canUseStream: (stream) => isLiveStreamStatus(stream.status),
     }) !== undefined
   );
 }
@@ -602,7 +573,7 @@ export function statusBarDisplaySlice({
     activeStreamId,
     parentStream,
     streams,
-    canUseStream: (stream) => statusBarCanRepresentLiveAncestor(stream.status),
+    canUseStream: (stream) => isLiveStreamStatus(stream.status),
   });
 }
 

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -361,9 +361,15 @@ export function defaultShortcutModifierLabel(
   return platform === 'darwin' ? 'Esc' : 'Alt';
 }
 
-function metaShortcutLabel(modifierLabel: string, key: string): string {
+/** Bare modifier chord (`Alt-p` / `Esc p`) — also feeds the /help keyboard
+ *  section, so the Esc-vs-Alt separator rule lives in one place. */
+export function metaChordLabel(modifierLabel: string, key: string): string {
   const separator = modifierLabel === 'Esc' ? ' ' : '-';
-  return `[${modifierLabel}${separator}${key}]`;
+  return `${modifierLabel}${separator}${key}`;
+}
+
+function metaShortcutLabel(modifierLabel: string, key: string): string {
+  return `[${metaChordLabel(modifierLabel, key)}]`;
 }
 
 function statusBarBindingRow(

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from 'ink';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 
-import { truncateToWidth } from '../render/terminalText';
+import { textDisplayWidth, truncateToWidth } from '../render/terminalText';
 import { cliState, type StreamSlice } from '../state/cliState';
 import { activeStreamTreeViews } from '../state/streamViews';
 import { useSignal } from '../state/useSignal';
@@ -88,7 +88,7 @@ function buildLineSegments(
   for (const [index, item] of items.entries()) {
     const leadingSpace = index > 0;
     const text = streamTabSegmentText(item);
-    const totalWidth = text.length + (leadingSpace ? 1 : 0);
+    const totalWidth = textDisplayWidth(text) + (leadingSpace ? 1 : 0);
     if (totalWidth <= remaining) {
       segments.push({ item, leadingSpace, text });
       remaining -= totalWidth;
@@ -133,7 +133,7 @@ export function streamTabsLineSegments(
 }
 
 function streamTabsTextLength(items: readonly StreamTabDisplayItem[]): number {
-  return streamTabsLineText(items).length;
+  return textDisplayWidth(streamTabsLineText(items));
 }
 
 function collapseMiddle(

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from 'ink';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 
+import { truncateToWidth } from '../render/terminalText';
 import { cliState, type StreamSlice } from '../state/cliState';
 import { activeStreamTreeViews } from '../state/streamViews';
 import { useSignal } from '../state/useSignal';
@@ -17,12 +18,6 @@ export interface StreamTabDisplayItem {
 }
 
 const MAX_LABEL_WIDTH = 18;
-
-function truncate(value: string, maxWidth: number): string {
-  if (value.length <= maxWidth) return value;
-  if (maxWidth <= 1) return '…';
-  return `${value.slice(0, maxWidth - 1)}…`;
-}
 
 export function streamTabSegmentText(item: StreamTabDisplayItem): string {
   if (item.id === 'ellipsis') return '…';
@@ -105,7 +100,7 @@ function buildLineSegments(
     segments.push({
       item,
       leadingSpace,
-      text: textWidth <= 1 ? '…' : `${text.slice(0, textWidth - 1)}…`,
+      text: truncateToWidth(text, textWidth),
     });
     break;
   }
@@ -188,7 +183,7 @@ export function streamTabsDisplayItems(init: {
     });
     return {
       id: view.id,
-      label: truncate(view.label, MAX_LABEL_WIDTH),
+      label: truncateToWidth(view.label, MAX_LABEL_WIDTH),
       active: view.active,
       running: slice?.status === STREAM_STATUS.RUNNING,
       shortcutIndex: view.shortcutIndex,

--- a/packages/cli/src/chat/tui/panes/TipRow.tsx
+++ b/packages/cli/src/chat/tui/panes/TipRow.tsx
@@ -7,6 +7,10 @@ const BASE_TIPS = [
   'Use /clear to start fresh',
   'Press /status to see session details',
   'Press /api to view or change API mode',
+  'Press Ctrl-T to read the full transcript',
+  'Type while a response is running to queue a follow-up',
+  'Press Ctrl-R to search your input history',
+  'Use /resume to continue a previous session',
 ] as const;
 
 const AGENT_SELECTION_TIP = 'Press /agent to choose the root agent';

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -1,14 +1,9 @@
-import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+import {
+  LIVE_ELAPSED_STREAM_STATUSES,
+  type StreamStatus,
+} from '@shared/schemas';
 
 import type { ConversationEntry } from '../state/cliState';
-
-function isAppending(status: StreamStatus | undefined): boolean {
-  return (
-    status === STREAM_STATUS.INITIALIZING ||
-    status === STREAM_STATUS.RUNNING ||
-    status === STREAM_STATUS.RESUMING
-  );
-}
 
 export function splitTranscriptEntries(
   entries: readonly ConversationEntry[],
@@ -25,7 +20,8 @@ export function splitTranscriptEntries(
    *  fixed. */
   readonly pending: ConversationEntry[];
 } {
-  const showLiveAssistant = isAppending(status);
+  const showLiveAssistant =
+    status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status);
   const finalized: ConversationEntry[] = [];
   const pending: ConversationEntry[] = [];
   for (const entry of entries) {

--- a/packages/cli/src/chat/tui/render/overflowText.ts
+++ b/packages/cli/src/chat/tui/render/overflowText.ts
@@ -1,0 +1,28 @@
+// Shared "... N previous / more rows" markers for scrollable modal bodies
+// (bash approvals, agent proposals, external inquiries).
+
+export function previousRowsText(count: number): string {
+  return `... ${count} previous rows`;
+}
+
+export function moreRowsText(count: number): string {
+  return `... ${count} more rows`;
+}
+
+/** `noun` lets callers qualify what is hidden (e.g. `prompt rows`). */
+export function hiddenRowsText(count: number, noun = 'rows'): string {
+  return `... ${count} ${noun} hidden`;
+}
+
+/** One-line scroll position: both sides when the window is in the middle,
+ *  otherwise whichever side overflows. */
+export function scrollStatusText(
+  hiddenBefore: number,
+  hiddenAfter: number,
+): string {
+  if (hiddenBefore > 0 && hiddenAfter > 0) {
+    return `... ${hiddenBefore} previous, ${hiddenAfter} more rows`;
+  }
+  if (hiddenBefore > 0) return previousRowsText(hiddenBefore);
+  return moreRowsText(hiddenAfter);
+}

--- a/packages/cli/src/chat/tui/render/terminalText.ts
+++ b/packages/cli/src/chat/tui/render/terminalText.ts
@@ -1,5 +1,7 @@
 import stringWidth from 'string-width';
 
+import { collapseWhitespace } from '@utils/text/stringUtils';
+
 export function textDisplayWidth(text: string): number {
   return stringWidth(text);
 }
@@ -11,6 +13,24 @@ export function clipToWidth(text: string, width: number): string {
     clipped += char;
   }
   return clipped;
+}
+
+const ELLIPSIS = '…';
+
+/** Truncate to `maxColumns` display columns, ending with `…` when cut. */
+export function truncateToWidth(text: string, maxColumns: number): string {
+  if (textDisplayWidth(text) <= maxColumns) return text;
+  const contentColumns = Math.max(0, maxColumns - textDisplayWidth(ELLIPSIS));
+  return `${clipToWidth(text, contentColumns)}${ELLIPSIS}`;
+}
+
+/** Collapse whitespace, then truncate — the one-line-summary form used by
+ *  status rows and side panels. */
+export function truncateSummaryToWidth(
+  text: string,
+  maxColumns: number,
+): string {
+  return truncateToWidth(collapseWhitespace(text), maxColumns);
 }
 
 /**

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -913,10 +913,11 @@ async function handleTuiSlashCommand(
         );
       } else {
         const suggestion = suggestSlashCommand(command);
+        const didYouMean = suggestion
+          ? ` Did you mean /${suggestion.name}?`
+          : '';
         appendLocalAssistantTranscript(
-          suggestion
-            ? `Unknown command: /${parsed.name}. Did you mean /${suggestion.name}? Type /help to list commands.`
-            : `Unknown command: /${parsed.name}. Type /help to list commands.`,
+          `Unknown command: /${parsed.name}.${didYouMean} Type /help to list commands.`,
         );
       }
       return true;

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1138,9 +1138,8 @@ export async function runChat(
 
     if (
       (isRunPending && activeStatus !== STREAM_STATUS.WAITING) ||
-      activeStatus === STREAM_STATUS.INITIALIZING ||
-      activeStatus === STREAM_STATUS.RUNNING ||
-      activeStatus === STREAM_STATUS.RESUMING
+      (activeStatus !== undefined &&
+        LIVE_ELAPSED_STREAM_STATUSES.has(activeStatus))
     ) {
       appendLocalAssistantTranscript(
         'Wait for the active response to finish, or press Ctrl-C before /clear.',

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -106,10 +106,12 @@ import {
   openCliSlashCommandForm,
   openRegisteredCliSlashForm,
 } from './commands/slashForms';
+import { formatSlashCommandHelp } from './commands/helpText';
 import {
   findSlashCommand,
   listSlashCommands,
   parseSlashInput,
+  suggestSlashCommand,
 } from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
@@ -131,7 +133,11 @@ import {
   streamStatusFromState,
 } from './state/streamStatus';
 import { activeStreamScope } from './state/streamViews';
-import { discoverTerminalCapabilities } from './state/terminalCapabilities';
+import { defaultShortcutModifierLabel } from './panes/StatusBar';
+import {
+  discoverTerminalCapabilities,
+  terminalCapabilities,
+} from './state/terminalCapabilities';
 import { requestCliCompaction } from './state/compactionRequest';
 import {
   appendLocalAssistantTranscript,
@@ -768,10 +774,12 @@ async function handleTuiSlashCommand(
   }
   switch (command) {
     case 'help': {
-      const commands = listSlashCommands()
-        .map((cmd) => `/${cmd.name} - ${cmd.description}`)
-        .join('\n');
-      appendLocalAssistantTranscript(commands);
+      appendLocalAssistantTranscript(
+        formatSlashCommandHelp(listSlashCommands(), {
+          shortcutModifierLabel: defaultShortcutModifierLabel(),
+          shiftEnterNewline: terminalCapabilities.get().kittyKeyboard,
+        }),
+      );
       return true;
     }
     case 'clear':
@@ -904,7 +912,12 @@ async function handleTuiSlashCommand(
           `/${parsed.name} is registered but is not available in this CLI view yet.`,
         );
       } else {
-        appendLocalAssistantTranscript(`Unknown command: /${parsed.name}`);
+        const suggestion = suggestSlashCommand(command);
+        appendLocalAssistantTranscript(
+          suggestion
+            ? `Unknown command: /${parsed.name}. Did you mean /${suggestion.name}? Type /help to list commands.`
+            : `Unknown command: /${parsed.name}. Type /help to list commands.`,
+        );
       }
       return true;
     }

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -9,6 +9,10 @@ import {
 import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
 import { readCliAmbientState } from '@cli/runtime/cliContext';
 import { stripAnsiSequences } from '@cli/runtime/ansiEscapes';
+import {
+  editDistance,
+  typoSuggestionThreshold,
+} from '@utils/text/editDistance';
 
 import {
   GLOBAL_ARGS,
@@ -404,30 +408,6 @@ function isPureSubCommandContainer(
   );
 }
 
-function editDistance(a: string, b: string): number {
-  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
-  let current = new Array<number>(b.length + 1);
-
-  for (let i = 1; i <= a.length; i += 1) {
-    current[0] = i;
-    for (let j = 1; j <= b.length; j += 1) {
-      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
-      current[j] = Math.min(
-        previous[j] + 1,
-        current[j - 1] + 1,
-        previous[j - 1] + substitutionCost,
-      );
-    }
-    [previous, current] = [current, previous];
-  }
-
-  return previous[b.length];
-}
-
-function suggestionThreshold(token: string, candidate: string): number {
-  return Math.max(1, Math.floor(Math.max(token.length, candidate.length) / 3));
-}
-
 function suggestSubCommand(
   token: string,
   subCommands: Record<string, AnyCommand>,
@@ -436,7 +416,7 @@ function suggestSubCommand(
 
   for (const name of Object.keys(subCommands)) {
     const distance = editDistance(token, name);
-    if (distance > suggestionThreshold(token, name)) continue;
+    if (distance > typoSuggestionThreshold(token, name)) continue;
     if (
       best === undefined ||
       distance < best.distance ||

--- a/src/test-kernel/cli/SlashHelpText.vitest.mts
+++ b/src/test-kernel/cli/SlashHelpText.vitest.mts
@@ -1,0 +1,77 @@
+// Grouped /help formatting for the chat TUI.
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { formatSlashCommandHelp } from '@cli/chat/tui/commands/helpText';
+import {
+  listSlashCommands,
+  unregisterSlashCommand,
+  type SlashCommand,
+} from '@cli/chat/tui/commands/slashRegistry';
+import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
+import { resetCliState } from '@cli/chat/tui/state/cliState';
+
+afterEach(() => {
+  for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
+  resetCliState();
+});
+
+describe('formatSlashCommandHelp', () => {
+  it('groups builtin commands into ordered sections with one list item each', () => {
+    registerBuiltinSlashCommands();
+    const help = formatSlashCommandHelp(listSlashCommands());
+
+    const sessionIndex = help.indexOf('**Session**');
+    const configurationIndex = help.indexOf('**Configuration**');
+    const accountIndex = help.indexOf('**Account**');
+    const keyboardIndex = help.indexOf('**Keyboard**');
+    expect(sessionIndex).toBeGreaterThanOrEqual(0);
+    expect(configurationIndex).toBeGreaterThan(sessionIndex);
+    expect(accountIndex).toBeGreaterThan(configurationIndex);
+    expect(keyboardIndex).toBeGreaterThan(accountIndex);
+    expect(help).not.toContain('**Other**');
+
+    // Each command renders as its own markdown list item — single newlines
+    // collapse in the transcript's markdown renderer, list items do not.
+    expect(help).toContain('- `/clear` — Start a fresh chat session');
+    expect(help).toContain('- `/exit` (`/quit`) — Exit the CLI session');
+    expect(help).toContain('- `/model` (`/models`) — List available models');
+  });
+
+  it('collects uncategorized commands under a trailing Other section', () => {
+    const plugin: SlashCommand = {
+      name: 'plugin-thing',
+      description: 'A plugin command',
+    };
+    const help = formatSlashCommandHelp([plugin]);
+
+    expect(help.indexOf('**Other**')).toBeGreaterThanOrEqual(0);
+    expect(help).toContain('- `/plugin-thing` — A plugin command');
+    expect(help.indexOf('**Other**')).toBeLessThan(
+      help.indexOf('**Keyboard**'),
+    );
+  });
+
+  it('adapts keyboard hints to the platform modifier and Kitty support', () => {
+    const altHelp = formatSlashCommandHelp([], {
+      shortcutModifierLabel: 'Alt',
+      shiftEnterNewline: false,
+    });
+    expect(altHelp).toContain('`Alt-1..9`');
+    expect(altHelp).toContain('`Ctrl-J` inserts a newline');
+    expect(altHelp).not.toContain('Shift-Enter');
+
+    const macKittyHelp = formatSlashCommandHelp([], {
+      shortcutModifierLabel: 'Esc',
+      shiftEnterNewline: true,
+    });
+    expect(macKittyHelp).toContain('`Esc 1..9`');
+    expect(macKittyHelp).toContain('`Shift-Enter` or `Ctrl-J`');
+  });
+
+  it('mentions that typing during a run queues a follow-up', () => {
+    expect(formatSlashCommandHelp([])).toContain(
+      'queues your message as a follow-up',
+    );
+  });
+});

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -9,6 +9,7 @@ import {
   parseSlashInput,
   registerSlashCommand,
   slashPickIntent,
+  suggestSlashCommand,
   unregisterSlashCommand,
 } from '@cli/chat/tui/commands/slashRegistry';
 import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
@@ -559,6 +560,30 @@ describe('slashRegistry', () => {
 
     expect(slashPickIntent(foo, 'enter')).toBe('complete');
     expect(slashPickIntent(foo, 'tab')).toBe('complete');
+  });
+
+  it('suggests the closest command for a typo within the shared threshold', () => {
+    registerBuiltinSlashCommands();
+
+    expect(suggestSlashCommand('modle')?.name).toBe('model');
+    expect(suggestSlashCommand('aprooval')?.name).toBe('approval');
+    expect(suggestSlashCommand('sttus')?.name).toBe('status');
+  });
+
+  it('matches typo suggestions against aliases too', () => {
+    registerSlashCommand({
+      name: 'exit',
+      description: 'Exit the CLI session',
+      aliases: ['quit'],
+    });
+
+    expect(suggestSlashCommand('quitt')?.name).toBe('exit');
+  });
+
+  it('returns no suggestion for input far from every command', () => {
+    registerBuiltinSlashCommands();
+
+    expect(suggestSlashCommand('frobnicate')).toBeUndefined();
   });
 
   it('does not directly submit structured-form commands from the palette', () => {

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -565,7 +565,7 @@ describe('slashRegistry', () => {
   it('suggests the closest command for a typo within the shared threshold', () => {
     registerBuiltinSlashCommands();
 
-    expect(suggestSlashCommand('modle')?.name).toBe('model');
+    expect(suggestSlashCommand('modl')?.name).toBe('model');
     expect(suggestSlashCommand('aprooval')?.name).toBe('approval');
     expect(suggestSlashCommand('sttus')?.name).toBe('status');
   });

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -12,6 +12,7 @@ import {
   streamTabsLineText,
   streamTabsDisplayItems,
 } from '@cli/chat/tui/panes/StreamTabsStrip';
+import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
 import {
   STREAM_STATUS,
   type ActiveChildInfo,
@@ -485,6 +486,23 @@ describe('CLI stream tabs strip', () => {
       fullText.length - 1,
     );
     expect(streamTabsLineText(items, fullText.length - 1)).toMatch(/…$/);
+  });
+
+  it('fits stream tab text by display width, not character count', () => {
+    const line = streamTabsLineText(
+      [
+        {
+          id: streamId('wide'),
+          label: '研究',
+          active: true,
+          running: false,
+        },
+      ],
+      5,
+    );
+
+    expect(textDisplayWidth(line)).toBeLessThanOrEqual(5);
+    expect(line).toMatch(/…$/);
   });
 
   it('keeps truncation attached to styled tab segments', () => {

--- a/src/utils/text/editDistance.ts
+++ b/src/utils/text/editDistance.ts
@@ -1,0 +1,32 @@
+/** Levenshtein edit distance between two strings (two-row DP, O(min memory)). */
+export function editDistance(a: string, b: string): number {
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  let current = new Array<number>(b.length + 1);
+
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        previous[j] + 1,
+        current[j - 1] + 1,
+        previous[j - 1] + substitutionCost,
+      );
+    }
+    [previous, current] = [current, previous];
+  }
+
+  return previous[b.length];
+}
+
+/**
+ * Maximum edit distance at which `candidate` still counts as a plausible typo
+ * of `token` — a third of the longer string, but at least 1. Shared by the
+ * CLI subcommand and slash-command "did you mean" suggestions.
+ */
+export function typoSuggestionThreshold(
+  token: string,
+  candidate: string,
+): number {
+  return Math.max(1, Math.floor(Math.max(token.length, candidate.length) / 3));
+}


### PR DESCRIPTION
- /help now renders grouped markdown sections (Session, Configuration,
  Account) with one list item per command instead of newline-joined lines
  that the markdown renderer (breaks: false) collapsed into a single
  run-on paragraph. Includes a keyboard-shortcuts section adapted to the
  platform modifier and Kitty Shift-Enter support, and notes that typing
  during a run queues a follow-up.
- Mistyped slash commands now get a "Did you mean /model?" suggestion
  (names and aliases, shared typo threshold) plus a /help pointer,
  matching the headless CLI's subcommand behavior. The Levenshtein
  helpers move from commands/_helpers/dispatch.ts into
  @utils/text/editDistance for reuse.
- Tip row gains rotating tips for Ctrl-T transcript viewing, queueing
  follow-ups while a response runs, Ctrl-R history search, and /resume.

https://claude.ai/code/session_015CzRQVuWydHTT449hMpb3N

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UX, help formatting, and refactors with tests; behavior changes are limited to help text, typo hints, and display-width truncation.
> 
> **Overview**
> The chat TUI **`/help`** output is reworked into **grouped markdown** (Session, Configuration, Account, plus an **Other** bucket for uncategorized commands), with a **keyboard** section that reflects platform modifier (`Alt` vs `Esc`) and Kitty **Shift-Enter**, and a note about **queuing follow-ups** while a run is active. Built-in slash commands gain **`category`** metadata to drive that layout.
> 
> **Command discovery** improves via **`suggestSlashCommand`** (shared Levenshtein helpers in `@utils/text/editDistance`, also used by headless subcommand suggestions) so unknown commands get a **“Did you mean …?”** line and a **`/help`** pointer.
> 
> Supporting polish: **tip row** adds Ctrl-T, follow-up queueing, Ctrl-R, and `/resume`; scrollable approval modals share **`overflowText`** helpers; status bar, queued follow-ups, and stream tabs use centralized **`truncateToWidth` / `truncateSummaryToWidth`** (display-width aware); **`LIVE_ELAPSED_STREAM_STATUSES`** replaces duplicated “in-flight” status checks for transcript splitting, `/clear` guards, and the status bar; **`metaChordLabel`** is exported for consistent shortcut labeling in help.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c24c0e2ad58766263294c66c90cb81bd81f400c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->