### PR TITLE
refactor: modernize TypeScript across the workspace

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: TeXRA-aware code review. Use for /review, PR audits, or any code review of this repo. Catches platform-coupling, Zod v4, PocketFlow, factory, and webview-render rules that generic passes miss.
+description: TeXRA-aware code review. Use for /review, PR audits, or any code review of this repo. Catches platform-coupling, Zod v4, PocketFlow, factory, modern-TypeScript, and webview-render rules that generic passes miss.
 ---
 
 # TeXRA Code Review

--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -99,6 +99,9 @@ Full pattern list with examples in `AGENTS.md` → "ES2023+ Patterns". Greps for
 - **`for (let i = 0; i < arr.length; i++)`** where the body only reads `arr[i]` → `for...of` (with `.entries()` when the index is needed). The conversion usually deletes `!` assertions and `if (!item) continue` guards too — flag those leftovers.
 - **Backwards index loops** (`for (let i = arr.length - 1; i >= 0; i--)`) that search or visit in reverse → `.findLast()` / `.findLastIndex()` / iterate `.toReversed()`.
 - **Manual pairwise-equality loops** over two arrays → `a.length === b.length && a.every((x, i) => ...)`.
+- **`.substring(`** → `.slice()` (repo is unified on `slice`).
+- **Bare `parseInt(` / `parseFloat(`** → `Number.parseInt(x, 10)` / `Number.parseFloat(x)`; flag any missing radix.
+- **`new Promise((resolve) => setTimeout(resolve, ms))`** in Node-only code → `setTimeout` from `node:timers/promises`.
 - **Don't flag** the legitimate index loops: token consumers that advance `i` by variable strides, queue/BFS loops that append mid-iteration, and `charCodeAt(i)` hash loops (code-point iteration would change persisted hash output).
 
 ## Final pass

--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -90,6 +90,17 @@ Design rules in `CLAUDE.md` → "Schema and Type Guidelines" / "Backward Compati
 - **Renamed fields in persisted state** (`TaskState`, run records, session storage) → use `.prefault()` and tolerate the old shape (canonical pattern in `c9f8b2b`).
 - **Provider-handler `switch` over a discriminated union** → default branch should `assertNever` / `satisfies never` so adding a provider compile-fails.
 
+## 12. Modern TypeScript (ES2023)
+
+Full pattern list with examples in `AGENTS.md` → "ES2023+ Patterns". Greps for the diff:
+
+- **Bare Node builtin imports** — `grep -nE "from '(assert|buffer|child_process|crypto|events|fs|fs/promises|module|os|path|url|util)'"` → use the `node:` prefix (`from 'node:path'`). The whole repo is unified on it.
+- **`[...arr].sort(` / `.slice().sort(`** on a true array → `.toSorted()`. Keep the spread when copying out of a `Set` or `Map.entries()`.
+- **`for (let i = 0; i < arr.length; i++)`** where the body only reads `arr[i]` → `for...of` (with `.entries()` when the index is needed). The conversion usually deletes `!` assertions and `if (!item) continue` guards too — flag those leftovers.
+- **Backwards index loops** (`for (let i = arr.length - 1; i >= 0; i--)`) that search or visit in reverse → `.findLast()` / `.findLastIndex()` / iterate `.toReversed()`.
+- **Manual pairwise-equality loops** over two arrays → `a.length === b.length && a.every((x, i) => ...)`.
+- **Don't flag** the legitimate index loops: token consumers that advance `i` by variable strides, queue/BFS loops that append mid-iteration, and `charCodeAt(i)` hash loops (code-point iteration would change persisted hash output).
+
 ## Final pass
 
 - Cut findings not tied to a real `path:line` in the diff.

--- a/.github/prompts/texra-code-review-prompt.md
+++ b/.github/prompts/texra-code-review-prompt.md
@@ -49,7 +49,14 @@ that affect the truth, scope, or reproducibility of the scientific content:
   and consistent with the surrounding text.
 
 Avoid style nits unless they obscure correctness or make future changes
-substantially harder. Do not invent issues merely to have comments. Prefer
+substantially harder. Do not invent issues merely to have comments. One
+repository convention is worth enforcing on changed TypeScript lines: the
+modern-TypeScript patterns in `AGENTS.md` ("ES2023+ Patterns") — `node:`
+prefixed builtin imports, `.toSorted()` over spread-then-sort, `for...of`
+(with `.entries()`) over index loops, `.findLast()`/`.toReversed()` over
+backwards loops. Flag only regressions newly introduced by this pull request,
+not pre-existing code, and respect the documented exceptions (variable-stride
+token consumers, queues appended mid-iteration, `charCodeAt` hash loops). Prefer
 inline comments for local, actionable issues on changed diff lines; put broader
 mathematical, physical, or scientific-computing concerns in the review body.
 Use the commentable line anchors file when choosing JSON `comments` line

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,31 @@ const isEnabled = config.enabled ?? false;
 
 // Iterate Sets directly without Array.from()
 for (const item of mySet) { ... }
+
+// Import Node builtins with the node: protocol
+import * as path from 'node:path';
+
+// Use .toSorted() instead of spread-then-mutate (copies from a Set/Map
+// still need the spread first)
+const sorted = items.toSorted((a, b) => a.localeCompare(b));
+
+// Use for...of — with .entries() when the index is needed — instead of
+// index-based loops; iterator values are non-undefined, so guards and
+// non-null assertions on arr[i] disappear
+for (const [i, step] of plan.steps.entries()) { ... }
+
+// Use .findLast()/.findLastIndex() or .toReversed() instead of
+// backwards index loops
+const round = segments.map(parseRound).findLast((r) => r !== null);
+
+// Use .every() for pairwise array comparison instead of manual loops
+const equal = a.length === b.length && a.every((x, i) => x === b[i]);
 ```
+
+Index-based loops are still right when the index itself is the point: token
+consumers that advance `i` by a variable stride, queue/BFS loops that append
+to the array mid-iteration, and `charCodeAt(i)` hash loops (`for...of` walks
+code points, not UTF-16 units, which changes persisted hash output).
 
 ### Refactoring for simplicity
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,17 @@ const round = segments.map(parseRound).findLast((r) => r !== null);
 
 // Use .every() for pairwise array comparison instead of manual loops
 const equal = a.length === b.length && a.every((x, i) => x === b[i]);
+
+// Use .slice() instead of .substring()
+const preview = text.slice(0, 100);
+
+// Use Number.parseInt with an explicit radix instead of bare parseInt
+const line = Number.parseInt(value, 10);
+
+// In Node-only code, sleep via node:timers/promises instead of a
+// hand-rolled Promise around setTimeout
+import { setTimeout as sleep } from 'node:timers/promises';
+await sleep(25);
 ```
 
 Index-based loops are still right when the index itself is the point: token

--- a/packages/cli/src/chat/tui/input/draftAttachments.ts
+++ b/packages/cli/src/chat/tui/input/draftAttachments.ts
@@ -133,9 +133,7 @@ export class DraftAttachmentStore {
    */
   expandText(input: string): string {
     let out = input;
-    const matches = matchChips(input);
-    for (let i = matches.length - 1; i >= 0; i--) {
-      const match = matches[i];
+    for (const match of matchChips(input).toReversed()) {
       const entry = this.entries.get(match.id);
       if (entry?.kind !== 'text') continue;
       out = out.slice(0, match.start) + entry.content + out.slice(match.end);
@@ -150,9 +148,7 @@ export class DraftAttachmentStore {
    */
   expandTextForHistory(input: string): string {
     let out = input;
-    const matches = matchChips(input);
-    for (let i = matches.length - 1; i >= 0; i--) {
-      const match = matches[i];
+    for (const match of matchChips(input).toReversed()) {
       const entry = this.entries.get(match.id);
       if (entry?.kind !== 'image') continue;
       out = removeChipRange(out, match.start, match.end);

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -154,8 +154,7 @@ function collapseMiddle(
 
   const out: StreamTabDisplayItem[] = [];
   let elided = false;
-  for (let i = 0; i < items.length; i++) {
-    const item = items[i];
+  for (const [i, item] of items.entries()) {
     if (keep.has(i)) {
       if (elided) {
         out.push(ELLIPSIS_TAB_ITEM);

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -5,6 +5,8 @@
 // non-TTY callers are pointed at `texra run` (which is what they actually
 // want for piping/scripting).
 
+import { setTimeout as sleep } from 'node:timers/promises';
+
 import { render, type Instance as InkInstance } from 'ink';
 import PQueue from 'p-queue';
 
@@ -1527,7 +1529,7 @@ export async function runChat(
           !session.stopRequested &&
           !session.runCompleted
         ) {
-          await new Promise<void>((resolve) => setTimeout(resolve, 25));
+          await sleep(25);
           followUpTarget = session.streamId;
         }
         if (!followUpTarget || session.stopRequested) return;

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -372,9 +372,7 @@ async function resolveDeepestSubCommandPath({
   if (!subCommands) {
     return { command: cmd, parent, commandPath, parentPath, rootCommand };
   }
-  for (let i = 0; i < rawArgs.length; i++) {
-    const token = rawArgs[i];
-    if (token === undefined) break;
+  for (const [i, token] of rawArgs.entries()) {
     if (token.startsWith('-')) continue;
     const next = subCommands[token];
     if (next) {

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -372,7 +372,9 @@ async function resolveDeepestSubCommandPath({
   if (!subCommands) {
     return { command: cmd, parent, commandPath, parentPath, rootCommand };
   }
-  for (const [i, token] of rawArgs.entries()) {
+  for (let i = 0; i < rawArgs.length; i++) {
+    const token = rawArgs[i];
+    if (token === undefined) break;
     if (token.startsWith('-')) continue;
     const next = subCommands[token];
     if (next) {

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import * as vscode from 'vscode';
 import * as nunjucks from 'nunjucks';

--- a/packages/extension/src/commands/agent/agentTemplateRenderer.ts
+++ b/packages/extension/src/commands/agent/agentTemplateRenderer.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import * as vscode from 'vscode';
 import * as nunjucks from 'nunjucks';

--- a/packages/extension/src/commands/latex/arXivCommands.ts
+++ b/packages/extension/src/commands/latex/arXivCommands.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import * as path from 'path';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 // Local imports

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -97,7 +97,7 @@ export async function handleExtractTikzFigures(): Promise<void> {
           ([label, tikzpicturess]: [string, string[]]) => ({
             label: `${label} (${tikzpicturess.length} TikZ ${pluralize(tikzpicturess.length, 'picture')})`,
             description: `Figure with label: ${label}`,
-            detail: `${tikzpicturess[0].substring(0, 100)}...`,
+            detail: `${tikzpicturess[0].slice(0, 100)}...`,
           }),
         );
 

--- a/packages/extension/src/commands/latex/imageCommands.ts
+++ b/packages/extension/src/commands/latex/imageCommands.ts
@@ -75,7 +75,7 @@ export async function handleEncodeImageToBase64(): Promise<string | undefined> {
     const base64String = await getBase64EncodedMedia(selection.relativePath);
     logger.debug(
       CHANNEL,
-      `Truncated base64 string (first 100 chars): ${base64String.substring(0, 100)}...`,
+      `Truncated base64 string (first 100 chars): ${base64String.slice(0, 100)}...`,
     );
     return base64String;
   } catch (err) {
@@ -110,7 +110,7 @@ export async function handleConvertPdfToImages(): Promise<
       prompt: 'Enter quality (DPI) for conversion (default: 300)',
       value: '300',
       validateInput: (value) => {
-        const num = parseInt(value);
+        const num = Number.parseInt(value, 10);
         return num > 0 && num <= 600
           ? null
           : 'Please enter a number between 1 and 600';
@@ -128,15 +128,15 @@ export async function handleConvertPdfToImages(): Promise<
         if (!value) {
           return null;
         }
-        const num = parseInt(value);
+        const num = Number.parseInt(value, 10);
         return num > 0 ? null : 'Please enter a positive number';
       },
     });
 
     const result = await processPdf2Png(
       selection.relativePath,
-      maxPages ? parseInt(maxPages) : undefined,
-      parseInt(quality),
+      maxPages ? Number.parseInt(maxPages, 10) : undefined,
+      Number.parseInt(quality, 10),
     );
 
     if (result) {

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/packages/extension/src/commands/system/sampleProjectCommands.ts
+++ b/packages/extension/src/commands/system/sampleProjectCommands.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import fsExtra from 'fs-extra';

--- a/packages/extension/src/commands/system/textEditorCommands.ts
+++ b/packages/extension/src/commands/system/textEditorCommands.ts
@@ -85,7 +85,7 @@ export async function handleTestTextEditor(): Promise<void> {
           const startLine = await vscode.window.showInputBox({
             prompt: 'Enter start line number',
             validateInput: (value) => {
-              const num = parseInt(value);
+              const num = Number.parseInt(value, 10);
               return isNaN(num) || num < 1
                 ? 'Please enter a valid line number'
                 : '';
@@ -95,13 +95,16 @@ export async function handleTestTextEditor(): Promise<void> {
           const endLine = await vscode.window.showInputBox({
             prompt: 'Enter end line number (or -1 for end of file)',
             validateInput: (value) => {
-              const num = parseInt(value);
+              const num = Number.parseInt(value, 10);
               return isNaN(num) ? 'Please enter a valid line number' : '';
             },
           });
 
           if (startLine && endLine) {
-            input.view_range = [parseInt(startLine), parseInt(endLine)];
+            input.view_range = [
+              Number.parseInt(startLine, 10),
+              Number.parseInt(endLine, 10),
+            ];
           }
         }
         break;
@@ -130,7 +133,7 @@ export async function handleTestTextEditor(): Promise<void> {
         const insertLine = await vscode.window.showInputBox({
           prompt: 'Enter line number to insert at',
           validateInput: (value) => {
-            const num = parseInt(value);
+            const num = Number.parseInt(value, 10);
             return isNaN(num) || num < 0
               ? 'Please enter a valid line number (0 or greater)'
               : '';
@@ -150,7 +153,7 @@ export async function handleTestTextEditor(): Promise<void> {
           return;
         }
 
-        input.insert_line = parseInt(insertLine);
+        input.insert_line = Number.parseInt(insertLine, 10);
         input.new_str = textToInsert;
         break;
 

--- a/packages/extension/src/commands/system/yamlCommands.ts
+++ b/packages/extension/src/commands/system/yamlCommands.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import * as fs from 'fs/promises';
-import * as path from 'path';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/packages/extension/src/frontend/approval/VscodeDiffViewHost.ts
+++ b/packages/extension/src/frontend/approval/VscodeDiffViewHost.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from 'fs';
+import { promises as fs } from 'node:fs';
 
 import * as vscode from 'vscode';
 

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -8,8 +8,8 @@
  * approval/rejection via the progress view.
  */
 
-import { promises as fs } from 'fs';
-import * as path from 'path';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
 
 import * as vscode from 'vscode';
 

--- a/packages/extension/src/frontend/files/listing.ts
+++ b/packages/extension/src/frontend/files/listing.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/packages/extension/src/frontend/git/resolveGitRoot.ts
+++ b/packages/extension/src/frontend/git/resolveGitRoot.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/packages/extension/src/frontend/latex/openBuild.ts
+++ b/packages/extension/src/frontend/latex/openBuild.ts
@@ -1,5 +1,5 @@
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import * as vscode from 'vscode';
 

--- a/packages/extension/src/frontend/lean/VscodeIntegration.ts
+++ b/packages/extension/src/frontend/lean/VscodeIntegration.ts
@@ -8,7 +8,7 @@
  * Tool implementations access it via the injectable `LeanLanguageServices`.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import { toErrorMessage } from '@common/errors';

--- a/packages/extension/src/frontend/media/audio.ts
+++ b/packages/extension/src/frontend/media/audio.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import * as vscode from 'vscode';
 import { execa, type Subprocess } from 'execa';

--- a/packages/extension/src/frontend/setup.ts
+++ b/packages/extension/src/frontend/setup.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import * as vscode from 'vscode';
 

--- a/packages/extension/src/frontend/ui/dialogs.ts
+++ b/packages/extension/src/frontend/ui/dialogs.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';

--- a/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
+++ b/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
@@ -3,7 +3,7 @@
  *
  * Wraps vscode.workspace.fs operations, converting string paths to vscode.Uri.
  */
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import * as vscode from 'vscode';
 
 import type {

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -98,7 +98,7 @@ export class QueuedFollowUps extends LitElement {
       return { display: message, full: undefined };
     }
     return {
-      display: message.substring(0, MAX_MESSAGE_LENGTH) + '...',
+      display: message.slice(0, MAX_MESSAGE_LENGTH) + '...',
       full: message,
     };
   }

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -60,8 +60,8 @@ export function planTerminalTextUpdate(
 
 export function countTerminalRows(text: string): number {
   let rows = 1;
-  for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) === 10) rows += 1;
+  for (const char of text) {
+    if (char === '\n') rows += 1;
   }
   return rows;
 }

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -43,9 +43,10 @@ export class MessageIndex {
   ): boolean {
     if (previousGroups.length !== nextGroups.length) return false;
 
-    for (const [i, next] of nextGroups.entries()) {
+    for (let i = 0; i < nextGroups.length; i++) {
       const previous = previousGroups[i];
-      if (!previous) return false;
+      const next = nextGroups[i];
+      if (!previous || !next) return false;
       if (
         previous.id !== next.id ||
         previous.parentGroupId !== next.parentGroupId ||
@@ -277,7 +278,9 @@ export class MessageIndex {
       return;
     }
 
-    for (const item of this.timeline) {
+    for (let i = this.timeline.length - 1; i >= 0; i--) {
+      const item = this.timeline[i];
+      if (!item) continue;
       if (!('msg' in item)) continue;
       const fresh = this.ungroupedById.get(item.key);
       if (fresh && fresh !== item.msg) {

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -43,10 +43,9 @@ export class MessageIndex {
   ): boolean {
     if (previousGroups.length !== nextGroups.length) return false;
 
-    for (let i = 0; i < nextGroups.length; i++) {
+    for (const [i, next] of nextGroups.entries()) {
       const previous = previousGroups[i];
-      const next = nextGroups[i];
-      if (!previous || !next) return false;
+      if (!previous) return false;
       if (
         previous.id !== next.id ||
         previous.parentGroupId !== next.parentGroupId ||
@@ -87,7 +86,7 @@ export class MessageIndex {
 
     // Sort messages by timestamp and classify by groupId.
     // JS engines use stable sort, so equal timestamps preserve original order.
-    const sortedMessages = [...messages].sort(
+    const sortedMessages = messages.toSorted(
       (a, b) =>
         (a.timestamp ?? Number.MAX_SAFE_INTEGER) -
         (b.timestamp ?? Number.MAX_SAFE_INTEGER),
@@ -157,8 +156,7 @@ export class MessageIndex {
     ].sort((a, b) => a.time - b.time);
     this.timeline = timeline;
     this.timelineMessageIndex.clear();
-    for (let i = 0; i < timeline.length; i++) {
-      const item = timeline[i];
+    for (const [i, item] of timeline.entries()) {
       if ('msg' in item) this.timelineMessageIndex.set(item.key, i);
     }
   }
@@ -279,8 +277,7 @@ export class MessageIndex {
       return;
     }
 
-    for (let i = this.timeline.length - 1; i >= 0; i--) {
-      const item = this.timeline[i];
+    for (const item of this.timeline) {
       if (!('msg' in item)) continue;
       const fresh = this.ungroupedById.get(item.key);
       if (fresh && fresh !== item.msg) {

--- a/packages/extension/src/progressView/frontend/components/terminalBuffer.ts
+++ b/packages/extension/src/progressView/frontend/components/terminalBuffer.ts
@@ -30,8 +30,7 @@ export function processTerminalText(text: string): string {
       // the erase point is still written at the cursor, so just strip the markers.
       let current = segs[0]!.split(ERASE_SENTINEL).join('');
 
-      for (let i = 1; i < segs.length; i++) {
-        const seg = segs[i]!;
+      for (const seg of segs.slice(1)) {
         const eraseAt = seg.indexOf(ERASE_SENTINEL);
         if (eraseAt >= 0) {
           // \r overlays the prefix up to the erase point; \x1b[K clears from there to EOL.

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -64,7 +64,7 @@ interface ProviderGroup {
 
 /** Stable sort: fast-first-response models bubble to the top of their provider. */
 function sortFastFirst(items: ModelSelectionItem[]): ModelSelectionItem[] {
-  return [...items].sort((a, b) => {
+  return items.toSorted((a, b) => {
     const aFast = a.isFast ? 0 : 1;
     const bFast = b.isFast ? 0 : 1;
     return aFast - bFast;

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -5,7 +5,7 @@
  * Handles agent enable/disable, create/customize/delete, YAML editing,
  * custom agent directories, and agent teams.
  */
-import * as path from 'path';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -220,7 +220,7 @@ export class LatexDiffsSection extends LitElement {
   }
 
   private renderFileOptions(options: string[]): TemplateResult {
-    const sortedOptions = [...options].sort((a, b) => a.localeCompare(b));
+    const sortedOptions = options.toSorted((a, b) => a.localeCompare(b));
     return html`
       <wa-option value="">None</wa-option>
       ${repeat(

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import * as vscode from 'vscode';
 

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, type Plugin } from 'vite';
-import { resolve } from 'path';
-import { mkdirSync, writeFileSync, existsSync } from 'fs';
+import { resolve } from 'node:path';
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
 
 // Shared path aliases from tsconfig.json (single source of truth)
 import { aliases } from '../../scripts/aliases.mjs';

--- a/src/agent/core/execution/AgentWorkspaceState.ts
+++ b/src/agent/core/execution/AgentWorkspaceState.ts
@@ -305,20 +305,18 @@ export class WorkPlanState {
   }
 
   private _todosEqual(a: TodoItem[], b: TodoItem[]): boolean {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) {
-      const ai = a[i],
-        bi = b[i];
-      if (!ai || !bi) return false;
-      if (
-        ai.content !== bi.content ||
-        ai.status !== bi.status ||
-        ai.activeForm !== bi.activeForm
-      ) {
-        return false;
-      }
-    }
-    return true;
+    return (
+      a.length === b.length &&
+      a.every((ai, i) => {
+        const bi = b[i];
+        return (
+          bi !== undefined &&
+          ai.content === bi.content &&
+          ai.status === bi.status &&
+          ai.activeForm === bi.activeForm
+        );
+      })
+    );
   }
 
   private _planEqual(a: Plan | null, b: Plan | null): boolean {

--- a/src/agent/core/execution/AgentWorkspaceState.ts
+++ b/src/agent/core/execution/AgentWorkspaceState.ts
@@ -322,23 +322,21 @@ export class WorkPlanState {
   private _planEqual(a: Plan | null, b: Plan | null): boolean {
     if (a === b) return true;
     if (!a || !b) return false;
-    if (a.summary !== b.summary) return false;
-    if (a.steps.length !== b.steps.length) return false;
-    for (let i = 0; i < a.steps.length; i++) {
-      const ai = a.steps[i],
-        bi = b.steps[i];
-      if (!ai || !bi) return false;
-      if (
-        ai.title !== bi.title ||
-        ai.description !== bi.description ||
-        ai.status !== bi.status ||
-        ai.files.length !== bi.files.length ||
-        ai.files.some((f, j) => f !== bi.files[j])
-      ) {
-        return false;
-      }
-    }
-    return true;
+    return (
+      a.summary === b.summary &&
+      a.steps.length === b.steps.length &&
+      a.steps.every((ai, i) => {
+        const bi = b.steps[i];
+        return (
+          bi !== undefined &&
+          ai.title === bi.title &&
+          ai.description === bi.description &&
+          ai.status === bi.status &&
+          ai.files.length === bi.files.length &&
+          ai.files.every((f, j) => f === bi.files[j])
+        );
+      })
+    );
   }
 
   reset(): void {

--- a/src/agent/core/execution/AgentWorkspaceState.ts
+++ b/src/agent/core/execution/AgentWorkspaceState.ts
@@ -305,38 +305,42 @@ export class WorkPlanState {
   }
 
   private _todosEqual(a: TodoItem[], b: TodoItem[]): boolean {
-    return (
-      a.length === b.length &&
-      a.every((ai, i) => {
-        const bi = b[i];
-        return (
-          bi !== undefined &&
-          ai.content === bi.content &&
-          ai.status === bi.status &&
-          ai.activeForm === bi.activeForm
-        );
-      })
-    );
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      const ai = a[i];
+      const bi = b[i];
+      if (!ai || !bi) return false;
+      if (
+        ai.content !== bi.content ||
+        ai.status !== bi.status ||
+        ai.activeForm !== bi.activeForm
+      ) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private _planEqual(a: Plan | null, b: Plan | null): boolean {
     if (a === b) return true;
     if (!a || !b) return false;
-    return (
-      a.summary === b.summary &&
-      a.steps.length === b.steps.length &&
-      a.steps.every((ai, i) => {
-        const bi = b.steps[i];
-        return (
-          bi !== undefined &&
-          ai.title === bi.title &&
-          ai.description === bi.description &&
-          ai.status === bi.status &&
-          ai.files.length === bi.files.length &&
-          ai.files.every((f, j) => f === bi.files[j])
-        );
-      })
-    );
+    if (a.summary !== b.summary) return false;
+    if (a.steps.length !== b.steps.length) return false;
+    for (let i = 0; i < a.steps.length; i++) {
+      const ai = a.steps[i];
+      const bi = b.steps[i];
+      if (!ai || !bi) return false;
+      if (
+        ai.title !== bi.title ||
+        ai.description !== bi.description ||
+        ai.status !== bi.status ||
+        ai.files.length !== bi.files.length ||
+        ai.files.some((f, j) => f !== bi.files[j])
+      ) {
+        return false;
+      }
+    }
+    return true;
   }
 
   reset(): void {

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'path';
+import { dirname } from 'node:path';
 
 import { z } from 'zod';
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { getExecutionStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -77,8 +77,8 @@ export function findLastAssistantText(
   messages: ProviderMessage[],
   extractAssistantText: (message: ProviderMessage) => string | undefined,
 ): string | undefined {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const text = extractAssistantText(messages[i]);
+  for (const message of messages.toReversed()) {
+    const text = extractAssistantText(message);
     if (text !== undefined) return text;
   }
   return undefined;

--- a/src/agent/index/AgentDirectoryService.ts
+++ b/src/agent/index/AgentDirectoryService.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports
 import { toErrorMessage } from '@common/errors';

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import fsExtra from 'fs-extra';

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -1,6 +1,6 @@
 /** Agent Registry - Flat agent metadata cache with source-priority lookup. */
 
-import * as path from 'path';
+import * as path from 'node:path';
 import { glob } from 'glob';
 import * as yaml from 'yaml';
 
@@ -691,7 +691,7 @@ function sortAgentEntries(
       .map((name, i) => [entries.find((e) => e.name === name), i] as const)
       .filter(([entry]) => entry != null),
   );
-  return [...entries].sort((a, b) => {
+  return entries.toSorted((a, b) => {
     const aIdx = preferredSet.get(a);
     const bIdx = preferredSet.get(b);
     if (aIdx != null && bIdx != null) return aIdx - bIdx;

--- a/src/agent/index/streamTabInfo.ts
+++ b/src/agent/index/streamTabInfo.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { MODEL_CONFIGS } from 'llm-zoo';
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -1116,7 +1116,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     if (thoughtContent) {
       this.logger.debug(
-        `Google GenAI thought summary preview: ${thoughtContent.substring(0, K_SLICE)}...`,
+        `Google GenAI thought summary preview: ${thoughtContent.slice(0, K_SLICE)}...`,
       );
     }
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { Buffer } from 'buffer';
+import { Buffer } from 'node:buffer';
 import { randomUUID } from 'node:crypto';
 
 // Third-party imports

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -1389,7 +1389,7 @@ export class ModelHandlerOpenAI<
     }
 
     this.logger.debug(
-      `Reasoning content preview: ${reasoning.substring(0, K_SLICE)}...`,
+      `Reasoning content preview: ${reasoning.slice(0, K_SLICE)}...`,
     );
     return reasoning;
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2154,7 +2154,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     if (thoughtContent) {
       this.logger.debug(
-        `OpenAI Responses reasoning preview (${reasoningItems.length} item(s)): ${thoughtContent.substring(0, K_SLICE)}...`,
+        `OpenAI Responses reasoning preview (${reasoningItems.length} item(s)): ${thoughtContent.slice(0, K_SLICE)}...`,
       );
     }
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2205,8 +2205,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // to satisfy both API requirements (reasoning needs following item, web_search needs preceding reasoning)
     const contentBlocks: (ResponseFunctionWebSearch | ResponseReasoningItem)[] =
       [];
-    for (let i = 0; i < output.length; i++) {
-      const item = output[i];
+    for (const [i, item] of output.entries()) {
       if (isOpenAIWebSearchCall(item)) {
         // Check if there's a reasoning item immediately before this web_search_call
         if (i > 0 && isOpenAIReasoningItem(output[i - 1])) {

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -6,7 +6,7 @@
 // caller, so they live outside the handler as stateless functions.
 
 import { Buffer } from 'node:buffer';
-import * as path from 'path';
+import * as path from 'node:path';
 
 import OpenAI, {
   APIConnectionTimeoutError,

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -859,7 +859,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       workspaceState.reasoning.thinkingAdded = true;
     }
     this.logger.debug(
-      `Reasoning content preview: ${reasoning.substring(0, K_SLICE)}...`,
+      `Reasoning content preview: ${reasoning.slice(0, K_SLICE)}...`,
     );
   }
 

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import * as path from 'path';
-import { Buffer } from 'buffer';
+import * as path from 'node:path';
+import { Buffer } from 'node:buffer';
 
 // Third-party imports
 import pMap from 'p-map';

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { platform } from '@platform/platform';
 import type { StageHandle } from '@agent/trace';

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { platform } from '@platform/platform';
 import type { AgentTrace } from '@agent/trace';

--- a/src/agent/output/compiledPdfArtifacts.ts
+++ b/src/agent/output/compiledPdfArtifacts.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - shared schemas
 import { platform } from '@platform/platform';

--- a/src/agent/output/lineageMapping.ts
+++ b/src/agent/output/lineageMapping.ts
@@ -5,7 +5,7 @@
  * enabling proper diff computation and file history tracking.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type { FileLocation } from '@shared/schemas';
 import { createFileMapping, getComparablePath } from '@utils/files';

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { ZodError } from 'zod';
 import { MODEL_CONFIGS } from 'llm-zoo';

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from 'async_hooks';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
 import { noopTrace, type AgentTrace } from '@agent/trace';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import deepmerge from 'deepmerge';
 import * as yaml from 'yaml';

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import {

--- a/src/agent/runtime/polishModel.ts
+++ b/src/agent/runtime/polishModel.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import * as nunjucks from 'nunjucks';
 import * as yaml from 'yaml';

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -6,7 +6,7 @@
  * and generic read/write for arbitrary keys.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { z } from 'zod';
 

--- a/src/agent/storage/executionWorkspaceFiles.ts
+++ b/src/agent/storage/executionWorkspaceFiles.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AbsoluteFS } from '@utils/files';

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { AsyncLocalStorage } from 'async_hooks';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
 // Type imports
 import type {

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type { AgentTrace } from '@agent/trace';
 import { toErrorMessage } from '@common/errors';

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import {
   WORKFLOW_OUTPUT_BASENAME,

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { loadRuntimeSkillCatalog } from '@skills/runtimeSkills';
 import { logFileCategory, logFilesLoaded, type AgentTrace } from '@agent/trace';

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -345,7 +345,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       }
 
       // Log token format to help diagnose auth issues (token prefix indicates type)
-      const tokenPrefix = githubSession.accessToken.substring(0, 4);
+      const tokenPrefix = githubSession.accessToken.slice(0, 4);
       const tokenType = GITHUB_TOKEN_TYPE_MAP[tokenPrefix] ?? 'unknown format';
 
       logger.info(

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -14,7 +14,7 @@
  * - free tier: Included non-premium models (up to $3/M input)
  */
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import { toErrorMessage } from '@common/errors';
 import {
   SERVER_SIDE_CACHE_TTL_MS,

--- a/src/common/errors/errorFormatUtils.ts
+++ b/src/common/errors/errorFormatUtils.ts
@@ -7,7 +7,7 @@ const MAX_ERROR_LENGTH = 500;
 export function formatError(prefix: string, err: unknown): string {
   const detail = toErrorMessage(err);
   if (detail.length > MAX_ERROR_LENGTH) {
-    return `${prefix}: ${detail.substring(0, MAX_ERROR_LENGTH)}...`;
+    return `${prefix}: ${detail.slice(0, MAX_ERROR_LENGTH)}...`;
   }
   return `${prefix}: ${detail}`;
 }

--- a/src/common/storage/KVStore.ts
+++ b/src/common/storage/KVStore.ts
@@ -7,7 +7,7 @@
  * envelope.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import Keyv, { type KeyvStoreAdapter, type StoredData } from 'keyv';
 

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';

--- a/src/controllers/settingsView/SettingsAgentFileController.ts
+++ b/src/controllers/settingsView/SettingsAgentFileController.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - shared
 import type { AgentCategory } from '@shared/schemas/agent';

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 import type { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { TaskState } from '@agent/core/execution/TaskState';

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { sync as globSync } from 'glob';

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - result types
 import { getCleanAgentName } from '@agent/index';
@@ -222,11 +222,10 @@ function buildFileListLog(movedFiles: string[], copiedFiles: string[]): string {
 function packDestinationName(file: string): string {
   const base = path.basename(file);
   const segments = path.dirname(file).split(/[\\/]+/);
-  for (let i = segments.length - 1; i >= 0; i--) {
-    const round = parseWorkflowOutputRoundDir(segments[i]);
-    if (round !== null) return `r${round}_${base}`;
-  }
-  return base;
+  const round = segments
+    .map(parseWorkflowOutputRoundDir)
+    .findLast((r) => r !== null);
+  return round != null ? `r${round}_${base}` : base;
 }
 
 async function moveAndCopyFiles(

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -222,10 +222,11 @@ function buildFileListLog(movedFiles: string[], copiedFiles: string[]): string {
 function packDestinationName(file: string): string {
   const base = path.basename(file);
   const segments = path.dirname(file).split(/[\\/]+/);
-  const round = segments
-    .map(parseWorkflowOutputRoundDir)
-    .findLast((r) => r !== null);
-  return round != null ? `r${round}_${base}` : base;
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const round = parseWorkflowOutputRoundDir(segments[i]);
+    if (round !== null) return `r${round}_${base}`;
+  }
+  return base;
 }
 
 async function moveAndCopyFiles(

--- a/src/housekeeping/runDirOps.ts
+++ b/src/housekeeping/runDirOps.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports
 import { platform } from '@platform/platform';

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { sync as globSync } from 'glob';

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import pMap from 'p-map';
 

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -171,8 +171,7 @@ export class TikzPictureManager {
           ? tikzpicturess.map((_, i) => String.fromCharCode(97 + i))
           : [undefined];
 
-      for (let i = 0; i < tikzpicturess.length; i++) {
-        const tikzpictures = tikzpicturess[i];
+      for (const [i, tikzpictures] of tikzpicturess.entries()) {
         const suffix = suffixes[i];
 
         const texLocation = await this.createStandalone(

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import path from 'path';
+import path from 'node:path';
 
 // Local imports - agent
 import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { createGunzip } from 'node:zlib';
 

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { BibEntry, parseBibFile } from 'bibtex';

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -8,7 +8,7 @@
  */
 
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports
 import { platform } from '@platform/platform';

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { sync as globSync } from 'glob';
 

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -6,7 +6,7 @@
  * bibliography directive matching.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { platform } from '@platform/platform';
 import * as logger from '@logger/logUtils';

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { z } from 'zod';
 

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 import {
   extractLastRoundMatch,

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';

--- a/src/platform/defaults/nodeFilesystem.ts
+++ b/src/platform/defaults/nodeFilesystem.ts
@@ -1,8 +1,8 @@
 /**
  * Node.js filesystem backend for CLI / Electron / tests.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import { isFileNotFoundError } from '@common/errors';
 

--- a/src/platform/defaults/nodeStorage.ts
+++ b/src/platform/defaults/nodeStorage.ts
@@ -1,6 +1,6 @@
 // Node imports
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Local imports - platform
 import { WorkspaceStorageProvider } from './workspaceStorage';

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -2,8 +2,8 @@
  * Node.js workspace provider for CLI / Electron / tests.
  * Uses process.cwd() as the workspace root.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import { minimatch } from 'minimatch';
 

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -336,14 +336,11 @@ export function replaceMathUnicode(text: string): string {
         continue;
       }
 
-      const mathContent = text.substring(envStart, envEnd);
+      const mathContent = text.slice(envStart, envEnd);
       const replacedContent = convertMathContent(mathContent);
 
       if (replacedContent !== mathContent) {
-        text =
-          text.substring(0, envStart) +
-          replacedContent +
-          text.substring(envEnd);
+        text = text.slice(0, envStart) + replacedContent + text.slice(envEnd);
       }
 
       startIdx = envStart + replacedContent.length;

--- a/src/shared/progressView/backend/persistence/StreamTabStore.ts
+++ b/src/shared/progressView/backend/persistence/StreamTabStore.ts
@@ -10,7 +10,7 @@
  * stream. It can be retired entirely once those pre-#3061 tabs age out.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 import pMap from 'p-map';
 
 import {

--- a/src/shared/schemas/diffResult.ts
+++ b/src/shared/schemas/diffResult.ts
@@ -97,7 +97,7 @@ const LegacyLocationsSchema = z
 function parseRoundFromLabel(label: string | undefined): number | null {
   if (typeof label !== 'string') return null;
   const match = label.match(/\[r(\d+)\]/);
-  return match ? parseInt(match[1], 10) : null;
+  return match ? Number.parseInt(match[1], 10) : null;
 }
 
 /** Legacy DiffResult format - transforms to DiffResultDisplay on parse */

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';

--- a/src/test-kernel/agent/modelHandlers/EmptyPrefill.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/EmptyPrefill.vitest.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
+++ b/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
@@ -1,7 +1,7 @@
 // Standard library imports
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';

--- a/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
+++ b/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
@@ -1,7 +1,7 @@
 // Node imports
-import * as fs from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
+++ b/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -1,7 +1,7 @@
 // Standard library imports
-import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -1,6 +1,6 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/src/test-kernel/tools/AgentWorkspaceOptions.vitest.ts
+++ b/src/test-kernel/tools/AgentWorkspaceOptions.vitest.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { afterEach, describe, expect, it } from 'vitest';

--- a/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
@@ -1,7 +1,7 @@
 // Third-party imports
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - model
@@ -15,16 +15,16 @@ let homedirMock: string;
 async function loadBuildClaudeAgentEnv(): Promise<
   typeof import('@tools/claudeAgentConfig').buildClaudeAgentEnv
 > {
-  vi.doMock('child_process', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('child_process')>();
+  vi.doMock('node:child_process', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:child_process')>();
     return {
       ...actual,
       execFileSync: execFileSyncMock,
     };
   });
 
-  vi.doMock('os', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('os')>();
+  vi.doMock('node:os', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:os')>();
     return {
       ...actual,
       homedir: () => homedirMock,

--- a/src/test-kernel/utils/RoundDirOwnership.vitest.ts
+++ b/src/test-kernel/utils/RoundDirOwnership.vitest.ts
@@ -8,9 +8,9 @@ import {
   stat,
   unlink,
   writeFile,
-} from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 

--- a/src/test/agent/AgentDirectoryService.test.ts
+++ b/src/test/agent/AgentDirectoryService.test.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import { strict as assert } from 'assert';
-import * as path from 'path';
+import { strict as assert } from 'node:assert';
+import * as path from 'node:path';
 
 // Local imports
 import { AgentDirectoryService } from '@agent/index';

--- a/src/test/agent/core/ConfigSchemas.test.ts
+++ b/src/test/agent/core/ConfigSchemas.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - agent core
 

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/src/test/agent/modelHandlers/ModelHandlerDeepSeek.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerDeepSeek.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import {

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import {

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // (none needed)
 

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAIResponse.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAIResponse.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import {

--- a/src/test/agent/modelHandlers/ModelHandlerOpenRouterNative.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenRouterNative.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import {

--- a/src/test/agent/modelHandlers/ModelHandlerReasoningCap.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerReasoningCap.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import {

--- a/src/test/agent/modelHandlers/OpenAIMessageUtils.test.ts
+++ b/src/test/agent/modelHandlers/OpenAIMessageUtils.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // (none needed)
 

--- a/src/test/agent/modelHandlers/stopReasonUtils.test.ts
+++ b/src/test/agent/modelHandlers/stopReasonUtils.test.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - utils
 import { isTokenLimitStopReason } from '@agent/modelHandlers/utils/stopReasonUtils';

--- a/src/test/agent/modelHandlers/support/MediaAttachmentProcessor.test.ts
+++ b/src/test/agent/modelHandlers/support/MediaAttachmentProcessor.test.ts
@@ -1,9 +1,9 @@
 // Standard library imports
-import { Buffer } from 'buffer';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { strict as assert } from 'assert';
+import { Buffer } from 'node:buffer';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import { PDFDocument, StandardFonts } from '@cantoo/pdf-lib';

--- a/src/test/agent/modelHandlers/utils/toolAttachmentUtils.test.ts
+++ b/src/test/agent/modelHandlers/utils/toolAttachmentUtils.test.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - utils
 import {

--- a/src/test/agent/runtime/PromiseCoordinators.test.ts
+++ b/src/test/agent/runtime/PromiseCoordinators.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports
 import { type AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';

--- a/src/test/agent/runtime/agentLoad.test.ts
+++ b/src/test/agent/runtime/agentLoad.test.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import { strict as assert } from 'assert';
-import * as path from 'path';
+import { strict as assert } from 'node:assert';
+import * as path from 'node:path';
 
 // Local imports - agent runtime
 import type { ResolvedAgent } from '@agent/index';

--- a/src/test/agent/runtime/sessionDescription.test.ts
+++ b/src/test/agent/runtime/sessionDescription.test.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 import { cleanSessionDescription } from '@agent/runtime/sessionDescription';
 

--- a/src/test/agent/runtime/streamTab.test.ts
+++ b/src/test/agent/runtime/streamTab.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports
 import { getStreamTabId } from '@agent/runtime/streamTab';

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - agent
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';

--- a/src/test/agent/trace/logFileCategory.test.ts
+++ b/src/test/agent/trace/logFileCategory.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports
 import {

--- a/src/test/agent/utils/debugMessageSaver.test.ts
+++ b/src/test/agent/utils/debugMessageSaver.test.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import { strict as assert } from 'assert';
-import * as path from 'path';
+import { strict as assert } from 'node:assert';
+import * as path from 'node:path';
 
 // Local imports - agent
 // Internal imports

--- a/src/test/agent/utils/promptBuilder.test.ts
+++ b/src/test/agent/utils/promptBuilder.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - prompt utilities
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - agent components
 import {

--- a/src/test/auth/ServerSideKeyService.test.ts
+++ b/src/test/auth/ServerSideKeyService.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - auth
 import { FREE_TIER, type UserTier } from '@auth/config';

--- a/src/test/auth/SupabaseClient.test.ts
+++ b/src/test/auth/SupabaseClient.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - auth
 import { SupabaseClient } from '@auth/SupabaseClient';

--- a/src/test/auth/SupabaseSession.test.ts
+++ b/src/test/auth/SupabaseSession.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - auth
 import {

--- a/src/test/auth/authCallback.test.ts
+++ b/src/test/auth/authCallback.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - auth
 import {

--- a/src/test/auth/config.test.ts
+++ b/src/test/auth/config.test.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 import {
   getExternalAuthCallbackInfo,

--- a/src/test/commands/CommandCatalog.test.ts
+++ b/src/test/commands/CommandCatalog.test.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import { strict as assert } from 'assert';
-import { createRequire } from 'module';
+import { strict as assert } from 'node:assert';
+import { createRequire } from 'node:module';
 
 // Local imports - commands
 import { commandCatalog, commandKeybindings } from '@shared/commands/catalog';

--- a/src/test/commands/history/chatExportFormatter.test.ts
+++ b/src/test/commands/history/chatExportFormatter.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - commands
 import { formatChatAsMarkdown } from '@commands/history/chatExportFormatter';

--- a/src/test/controllers/LatexConfigPersistenceController.test.ts
+++ b/src/test/controllers/LatexConfigPersistenceController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - state keys
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';

--- a/src/test/controllers/LatexRecommendedSettingsController.test.ts
+++ b/src/test/controllers/LatexRecommendedSettingsController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - controllers
 import { LatexRecommendedSettingsController } from '@controllers/settingsView/LatexRecommendedSettingsController';

--- a/src/test/controllers/LatexToolingController.test.ts
+++ b/src/test/controllers/LatexToolingController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - shared constants
 import {

--- a/src/test/controllers/MainViewInteractionController.test.ts
+++ b/src/test/controllers/MainViewInteractionController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - common
 import { MainViewInteractionController } from '@controllers/mainView/MainViewInteractionController';

--- a/src/test/controllers/MainViewStartupController.test.ts
+++ b/src/test/controllers/MainViewStartupController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - common
 import { MainViewStartupController } from '@controllers/mainView/MainViewStartupController';

--- a/src/test/controllers/ProgressFollowUpController.test.ts
+++ b/src/test/controllers/ProgressFollowUpController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - agent
 import { ProgressFollowUpController } from '@controllers/progressView/ProgressFollowUpController';

--- a/src/test/controllers/ProgressStreamLifecycleController.test.ts
+++ b/src/test/controllers/ProgressStreamLifecycleController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - test support
 import { createProgressStreamLifecycleHarness } from '../support/ProgressControllerHarnesses';

--- a/src/test/controllers/ProgressWorkflowActionsController.test.ts
+++ b/src/test/controllers/ProgressWorkflowActionsController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - agent
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';

--- a/src/test/controllers/ProgressWorkflowFileActionsController.test.ts
+++ b/src/test/controllers/ProgressWorkflowFileActionsController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - controllers
 import {

--- a/src/test/controllers/SettingsAgentCatalogController.test.ts
+++ b/src/test/controllers/SettingsAgentCatalogController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - shared
 import {

--- a/src/test/controllers/SettingsAgentDirectoryController.test.ts
+++ b/src/test/controllers/SettingsAgentDirectoryController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - controllers
 import {

--- a/src/test/controllers/SettingsAgentFileController.test.ts
+++ b/src/test/controllers/SettingsAgentFileController.test.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import { strict as assert } from 'assert';
-import * as path from 'path';
+import { strict as assert } from 'node:assert';
+import * as path from 'node:path';
 
 // Local imports - controllers
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';

--- a/src/test/controllers/SettingsAgentVisibilityController.test.ts
+++ b/src/test/controllers/SettingsAgentVisibilityController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - shared
 import {

--- a/src/test/controllers/SettingsMemoryController.test.ts
+++ b/src/test/controllers/SettingsMemoryController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - common
 import {

--- a/src/test/controllers/SettingsProfileKeyController.test.ts
+++ b/src/test/controllers/SettingsProfileKeyController.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - test support
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';

--- a/src/test/frontend/agents/register.test.ts
+++ b/src/test/frontend/agents/register.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports
 import { getAgentRegistrationSkipReason } from '@frontend/agents';

--- a/src/test/hosts/FakeHosts.test.ts
+++ b/src/test/hosts/FakeHosts.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - test support
 import { FakeTerminalHandle, createFakeUIHosts } from '../support/FakeHosts';

--- a/src/test/latex/extractBibliography.test.ts
+++ b/src/test/latex/extractBibliography.test.ts
@@ -1,6 +1,6 @@
 // Node.js built-in imports
-import * as assert from 'assert';
-import * as path from 'path';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
 
 // Local imports - latex helpers
 import {

--- a/src/test/logger/errorData.test.ts
+++ b/src/test/logger/errorData.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - test
 import {

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import {

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import { z } from 'zod';

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - platform
 import { FileType } from '@platform/interfaces/filesystem';

--- a/src/test/progressView/streamInfoUtils.test.ts
+++ b/src/test/progressView/streamInfoUtils.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports
 import type { StreamTabInfo } from '@shared/schemas';

--- a/src/test/progressView/streamTabSchemas.test.ts
+++ b/src/test/progressView/streamTabSchemas.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports
 import { selectPreferredLegacyInstruction } from '@shared/schemas';

--- a/src/test/progressView/utils.test.ts
+++ b/src/test/progressView/utils.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import { JSDOM } from 'jsdom';

--- a/src/test/replacement/captionSpacing.test.ts
+++ b/src/test/replacement/captionSpacing.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { applyReplacements } from '@replacement/engine';

--- a/src/test/replacement/equationLinebreaks.test.ts
+++ b/src/test/replacement/equationLinebreaks.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { applyReplacements } from '@replacement/engine';

--- a/src/test/replacement/equationMacros.test.ts
+++ b/src/test/replacement/equationMacros.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { applyReplacements } from '@replacement/engine';

--- a/src/test/replacement/fencedLatexBlocksRegex.test.ts
+++ b/src/test/replacement/fencedLatexBlocksRegex.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { applyReplacements } from '@replacement/engine';

--- a/src/test/replacement/htmlEntities.test.ts
+++ b/src/test/replacement/htmlEntities.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { applyReplacements } from '@replacement/engine';

--- a/src/test/replacement/latexForbiddenCommands.test.ts
+++ b/src/test/replacement/latexForbiddenCommands.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { applyReplacements } from '@replacement/engine';

--- a/src/test/replacement/personalStyleContextual.test.ts
+++ b/src/test/replacement/personalStyleContextual.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { replacementEngine } from '@replacement/engine';

--- a/src/test/replacement/referenceUnderscore.test.ts
+++ b/src/test/replacement/referenceUnderscore.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { applyReplacements } from '@replacement/engine';

--- a/src/test/replacement/stripCriticizeAnnotations.test.ts
+++ b/src/test/replacement/stripCriticizeAnnotations.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { stripCriticizeAnnotations } from '@replacement/advanced';

--- a/src/test/replacement/textttUnderscore.test.ts
+++ b/src/test/replacement/textttUnderscore.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { escapeTextttUnderscores } from '@replacement/advanced';

--- a/src/test/replacement/wrapCritiqueInAlign.test.ts
+++ b/src/test/replacement/wrapCritiqueInAlign.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Internal imports
 import { wrapCritiqueInAlign } from '@replacement/advanced';

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,8 +2,8 @@
 // This file is loaded before all tests to configure the test environment
 
 // Standard library imports
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // Third-party imports
 import { register } from 'tsconfig-paths';

--- a/src/test/shared/delegationPolicy.test.ts
+++ b/src/test/shared/delegationPolicy.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - shared constants
 import {

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import { createRequire } from 'module';
-import { strict as assert } from 'assert';
+import { createRequire } from 'node:module';
+import { strict as assert } from 'node:assert';
 
 // Local imports - schemas
 import {

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - platform
 import {

--- a/src/test/tools/ArxivDownloadTool.test.ts
+++ b/src/test/tools/ArxivDownloadTool.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - tools
 import * as arxivModule from '@latex/arxivProcessor';

--- a/src/test/tools/ArxivSearchTool.test.ts
+++ b/src/test/tools/ArxivSearchTool.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - tools
 import * as arxivShared from '@tools/latex/arxivShared';

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - agent core
 import {

--- a/src/test/tools/DelegationTools.test.ts
+++ b/src/test/tools/DelegationTools.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Platform imports
 import { FileType, type FileStat } from '@platform/interfaces/filesystem';

--- a/src/test/tools/TexcountTool.test.ts
+++ b/src/test/tools/TexcountTool.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - tools
 import * as texcountModule from '@latex/texcount';

--- a/src/test/tools/ToolEditApprovalGate.test.ts
+++ b/src/test/tools/ToolEditApprovalGate.test.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - agent types
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';

--- a/src/test/tools/codexConfig.test.ts
+++ b/src/test/tools/codexConfig.test.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import { strict as assert } from 'assert';
-import * as path from 'path';
+import { strict as assert } from 'node:assert';
+import * as path from 'node:path';
 
 // Local imports
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';

--- a/src/test/tools/codexImport.test.ts
+++ b/src/test/tools/codexImport.test.ts
@@ -1,8 +1,8 @@
 // Node.js built-in imports
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Local imports - tools
 import { findCodexBinaryInElectronResources } from '@tools/codexImport';

--- a/src/test/tools/externalToolDefs.test.ts
+++ b/src/test/tools/externalToolDefs.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - platform/test support/tools
 import { initPlatform, tryPlatform } from '@platform/platform';

--- a/src/test/tools/grep.test.ts
+++ b/src/test/tools/grep.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports
 import { buildArguments, type GrepInput } from '@tools/grep';

--- a/src/test/tools/latex/ExtractBibliographyTool.test.ts
+++ b/src/test/tools/latex/ExtractBibliographyTool.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - tools
 import * as bibliographyModule from '@latex/extractBibliography';

--- a/src/test/tools/latex/ExtractFiguresTool.test.ts
+++ b/src/test/tools/latex/ExtractFiguresTool.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - tools
 import * as figureModule from '@latex/extractFigure';

--- a/src/test/tools/latex/ExtractTikzFiguresTool.test.ts
+++ b/src/test/tools/latex/ExtractTikzFiguresTool.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - tools
 import { tikzPictureManager } from '@latex/TikzPictureManager';

--- a/src/test/tools/setup/ConfigTools.test.ts
+++ b/src/test/tools/setup/ConfigTools.test.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 import { ReadConfigTool, UpdateConfigTool } from '@tools/setup/ConfigTools';
 import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';

--- a/src/test/tools/setup/InvokeCommandTool.test.ts
+++ b/src/test/tools/setup/InvokeCommandTool.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports
 import { AUTH_COMMANDS } from '@auth/constants';

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports
 import { initPlatform, type Platform } from '@platform/platform';

--- a/src/test/tools/wolframScriptUtils.test.ts
+++ b/src/test/tools/wolframScriptUtils.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - tools
 import {

--- a/src/test/utils/files/RelativeFSJson.test.ts
+++ b/src/test/utils/files/RelativeFSJson.test.ts
@@ -1,8 +1,8 @@
 // Third-party imports
-import * as assert from 'assert';
-import * as os from 'os';
-import * as path from 'path';
-import { promises as fs } from 'fs';
+import * as assert from 'node:assert';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
 
 // Local imports - utils
 import { RelativeFS } from '@utils/files/relativeFS';

--- a/src/test/utils/files/WorkspaceFS.test.ts
+++ b/src/test/utils/files/WorkspaceFS.test.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files/workspaceFS';

--- a/src/test/utils/files/flexibleFS.test.ts
+++ b/src/test/utils/files/flexibleFS.test.ts
@@ -1,5 +1,5 @@
 // Node.js built-in imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Internal imports
 import { flexibleFS } from '@utils/files/flexibleFS';

--- a/src/test/utils/files/mimeUtils.test.ts
+++ b/src/test/utils/files/mimeUtils.test.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // Local imports - utils
 import { getMimeType } from '@utils/files';

--- a/src/test/utils/files/pathUtils.test.ts
+++ b/src/test/utils/files/pathUtils.test.ts
@@ -1,6 +1,6 @@
 // Third-party imports
-import * as assert from 'assert';
-import * as path from 'path';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
 
 // Local imports - common
 import { isTexFile } from '@common/files/fileTypeUtils';

--- a/src/test/utils/system/BinaryResolver.test.ts
+++ b/src/test/utils/system/BinaryResolver.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - utils
 import { BinaryResolverService } from '@utils/system/binaryResolver';

--- a/src/test/utils/system/execUtils.test.ts
+++ b/src/test/utils/system/execUtils.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - utils
 import { executeCommand } from '@utils/system/execUtils';

--- a/src/test/utils/text/xmlUtils.test.ts
+++ b/src/test/utils/text/xmlUtils.test.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Local imports - utils
 import {

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -10,7 +10,7 @@
  */
 
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { z } from 'zod';

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -9,7 +9,7 @@
  */
 
 // Third-party imports
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
 // Local imports - agent
@@ -119,17 +119,15 @@ const memoriesField = z
     'Memory file paths to attach (e.g. /memories/conventions.md). Content is injected into the agent prompt as read-only context. Use for project conventions, style guides, or accumulated knowledge the agent should follow.',
   )
   .superRefine((memories, ctx) => {
-    for (let i = 0; i < memories.length; i++) {
+    for (const [i, memory] of memories.entries()) {
       try {
-        displayToStoragePath(memories[i]);
+        displayToStoragePath(memory);
       } catch (e) {
         ctx.addIssue({
           code: 'custom',
           path: [i],
           message:
-            e instanceof Error
-              ? e.message
-              : `Invalid memory path: ${memories[i]}`,
+            e instanceof Error ? e.message : `Invalid memory path: ${memory}`,
         });
       }
     }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -6,7 +6,7 @@
  */
 
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { z } from 'zod';

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { z } from 'zod';

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { z } from 'zod';

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { z } from 'zod';

--- a/src/tools/agentWorkspaceOptions.ts
+++ b/src/tools/agentWorkspaceOptions.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - files
 import { WorkspaceFS } from '@utils/files';

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -3,8 +3,8 @@
  * Handles creating temp files, running latexdiff, and building PDFs.
  */
 
-import { randomUUID } from 'crypto';
-import path from 'path';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
 
 import { sync as globSync } from 'glob';
 

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -1,8 +1,8 @@
-import { execFileSync } from 'child_process';
-import { createHash } from 'crypto';
-import { existsSync } from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Local imports - agent config
 import { platform } from '@platform/platform';

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -15,7 +15,7 @@
  *    `query()`. Results are cached for the session.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { isModuleNotFoundError } from '@common/errors';
 import { pathExists, resolveBinary } from './support/externalBinaryUtils';

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -14,7 +14,7 @@
  *    are cached for the session.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { isModuleNotFoundError } from '@common/errors';
 import { pathExists, resolveBinary } from './support/externalBinaryUtils';

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -682,8 +682,7 @@ export class PRPollingSource extends PollingSourceBase<
     let madeProgress = true;
     while (madeProgress) {
       madeProgress = false;
-      for (let i = 0; i < pendingEntries.length; i += 1) {
-        const [key, state] = pendingEntries[i];
+      for (const [key, state] of pendingEntries) {
         if (!this.has(key)) continue;
         if (state.pendingAnnotationRuns.length === 0) continue;
         const claims = claimsByKey.get(key) ?? 0;

--- a/src/tools/github/prCheckRunDomain.ts
+++ b/src/tools/github/prCheckRunDomain.ts
@@ -103,8 +103,8 @@ export function planAnnotationCandidates(
   currentPendingRuns: ReadonlyArray<GhCheckRun>,
 ): AnnotationQueuePlan {
   const pendingIndexById = new Map<number, number>();
-  for (let i = 0; i < currentPendingRuns.length; i += 1) {
-    pendingIndexById.set(currentPendingRuns[i].id, i);
+  for (const [i, run] of currentPendingRuns.entries()) {
+    pendingIndexById.set(run.id, i);
   }
 
   const newCurrentKeys = new Set<string>();

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import ignore from 'ignore';

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import { randomBytes } from 'crypto';
+import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
 
 import AsyncLock from 'async-lock';
 import { z } from 'zod';

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { z } from 'zod';

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { z } from 'zod';

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -5,7 +5,7 @@
  * preview data for memory items displayed in views or terminal UI.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import pMap from 'p-map';
 

--- a/src/tools/memory/memoryMeta.ts
+++ b/src/tools/memory/memoryMeta.ts
@@ -6,7 +6,7 @@
  * no locking, no orphan cleanup — delete/rename just works.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';

--- a/src/tools/memory/memoryUtils.ts
+++ b/src/tools/memory/memoryUtils.ts
@@ -1,7 +1,7 @@
 /**
  * Shared utilities for memory tool and memory view.
  */
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { normalizeFilePath } from '@shared/utils/path';
 

--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - runtime
 import { tryUseRunContext } from '@agent/runtime/RunContext';

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -511,9 +511,7 @@ Best practices:
   private formatPlan(plan: Plan): string {
     const lines: string[] = [`Plan: ${plan.summary}`, ''];
 
-    for (let i = 0; i < plan.steps.length; i++) {
-      const step = plan.steps[i];
-      if (!step) continue;
+    for (const [i, step] of plan.steps.entries()) {
       const { icon, label } = STATUS_DISPLAY[step.status];
       lines.push(`${i + 1}. ${icon} [${label}] ${step.title}`);
       lines.push(`   ${step.description}`);

--- a/src/tools/setup/ProbeEnvironmentTool.ts
+++ b/src/tools/setup/ProbeEnvironmentTool.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Third-party imports
 import { z } from 'zod';

--- a/src/tools/subagentDiffs.ts
+++ b/src/tools/subagentDiffs.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { diff_match_patch } from 'diff-match-patch';
 
@@ -52,10 +52,10 @@ function computeReadableDiff(
     // Each chunk is one or more complete lines (with trailing \n).
     // Split and prefix each line, dropping the trailing empty entry from split.
     const chunkLines = text.split('\n');
-    for (let i = 0; i < chunkLines.length; i++) {
+    for (const [i, line] of chunkLines.entries()) {
       // Skip the empty string after the final \n
-      if (i === chunkLines.length - 1 && chunkLines[i] === '') continue;
-      lines.push(`${prefix}${chunkLines[i]}`);
+      if (i === chunkLines.length - 1 && line === '') continue;
+      lines.push(`${prefix}${line}`);
     }
   }
   return lines.join('\n');

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -448,8 +448,7 @@ function formatPlanContext(workPlan: WorkPlanSnapshot): string[] {
 
   const lines: string[] = [`<current-plan summary="${escapeAttr(summary)}">`];
   if (plan) {
-    for (let i = 0; i < plan.steps.length; i++) {
-      const step = plan.steps[i]!;
+    for (const [i, step] of plan.steps.entries()) {
       const filesAttr =
         step.files.length > 0
           ? ` files="${escapeAttr(step.files.join(', '))}"`

--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -7,8 +7,8 @@
  * path-existence helpers. Centralising them here prevents silent drift.
  */
 
-import { createRequire } from 'module';
-import * as path from 'path';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
 
 import { platform } from '@platform/platform';
 import { executeCommandSync } from '@utils/system/execUtils';

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -130,8 +130,7 @@ Best practices:
 
     const lines: string[] = ['Current todo list:', ''];
 
-    for (let i = 0; i < todos.length; i++) {
-      const todo = todos[i];
+    for (const [i, todo] of todos.entries()) {
       const { icon, label } = STATUS_DISPLAY[todo.status];
       lines.push(`${i + 1}. ${icon} [${label}] ${todo.content}`);
       if (todo.status === TODO_STATUS.IN_PROGRESS) {

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -135,7 +135,7 @@ The tool returns a JSON object whose keys are the original question texts and wh
     const requestId = `user-question-${Date.now().toString(36)}-${++questionCounter}`;
 
     logger.info(
-      `User question requested: ${input.questions[0]?.question.substring(0, 100) ?? ''}`,
+      `User question requested: ${input.questions[0]?.question.slice(0, 100) ?? ''}`,
     );
 
     try {

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -92,8 +92,7 @@ function formatTree(
 ): string[] {
   const lines: string[] = [];
 
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
+  for (const [i, node] of nodes.entries()) {
     const isLast = i === nodes.length - 1;
     const connector = indent === 0 ? '' : isLast ? '└── ' : '├── ';
     const childContinuation = indent === 0 ? '' : isLast ? '    ' : '│   ';

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -35,8 +35,7 @@ export class StreamLog {
     });
     this.seqCounter = this.entries.length;
 
-    for (let i = 0; i < this.entries.length; i++) {
-      const entry = this.entries[i];
+    for (const [i, entry] of this.entries.entries()) {
       this.indexById.set(entry.id, i);
       if (isRunningGroupEntry(entry)) {
         this.runningGroupCount += 1;

--- a/src/utils/core/executionId.ts
+++ b/src/utils/core/executionId.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto';
+import { randomBytes } from 'node:crypto';
 
 import type { ExecutionId } from '@shared/schemas';
 

--- a/src/utils/core/pathCore.ts
+++ b/src/utils/core/pathCore.ts
@@ -3,7 +3,7 @@
  */
 
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 const PATH_SEPARATORS = /[\\/]/;
 

--- a/src/utils/files/absoluteFS.ts
+++ b/src/utils/files/absoluteFS.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - filesystem
 import { BaseFS } from './baseFS';

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // Platform imports
 import { FileType, type FileStat } from '@platform/interfaces/filesystem';

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports - common
 import type { AgentTrace } from '@agent/trace';

--- a/src/utils/files/latexDiffUtils.ts
+++ b/src/utils/files/latexDiffUtils.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 /**
  * Pattern to match latex diff filenames: `basename-diffCOMMITHASH.ext`

--- a/src/utils/files/pastedImageUtils.ts
+++ b/src/utils/files/pastedImageUtils.ts
@@ -1,6 +1,6 @@
 // Standard library imports
 import { randomBytes } from 'node:crypto';
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports
 import { PASTED_PREFIX } from '@shared/files/pastedImageConstants';

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Platform imports
 import { isFile } from './fsEntryType';

--- a/src/utils/files/rulesUtils.ts
+++ b/src/utils/files/rulesUtils.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import * as path from 'path';
-import { promises as fs } from 'fs';
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
 
 import { WORKFLOW_OUTPUT_BASENAME } from '@agent/output/workflowOutputLayout';
 import { isFileNotFoundError, toErrorMessage } from '@common/errors';

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Platform imports
 import { platform } from '@platform/platform';

--- a/src/utils/files/workspaceRoot.ts
+++ b/src/utils/files/workspaceRoot.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { findExternalRoot, type MatchedExternalRoot } from './externalRoots';
 

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -112,8 +112,8 @@ async function getImageDimensions(
     throw new Error(result.stderr || 'Failed to get image dimensions');
   }
   const [widthStr, heightStr] = result.stdout.trim().split(/\s+/);
-  const width = parseInt(widthStr, 10);
-  const height = parseInt(heightStr, 10);
+  const width = Number.parseInt(widthStr, 10);
+  const height = Number.parseInt(heightStr, 10);
 
   if (Number.isNaN(width) || Number.isNaN(height)) {
     throw new Error(

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -1,7 +1,7 @@
 // Standard library imports
-import * as crypto from 'crypto';
-import * as os from 'os';
-import * as path from 'path';
+import * as crypto from 'node:crypto';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Third-party imports
 import { PDFDocument } from '@cantoo/pdf-lib';

--- a/src/utils/prompt/promptUtils.ts
+++ b/src/utils/prompt/promptUtils.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import * as nunjucks from 'nunjucks';
 

--- a/src/utils/system/binaryResolver.ts
+++ b/src/utils/system/binaryResolver.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Local imports
 import { hasExtension } from '@utils/core/pathCore';

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 import {
   execa,

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Third-party imports
 import { globSync } from 'glob';

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import * as path from 'path';
+import * as path from 'node:path';
 
 // Third-party imports
 import { execa, execaSync } from 'execa';

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -1,6 +1,6 @@
 // Standard library imports
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Third-party imports
 import { execa } from 'execa';

--- a/src/utils/system/wslDetect.ts
+++ b/src/utils/system/wslDetect.ts
@@ -5,7 +5,7 @@
  * imported from VS Code-free zones like `src/tools/`.
  */
 
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 
 /** Cached WSL detection result (null = not yet checked). */
 let wslDetected: boolean | null = null;

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -14,7 +14,7 @@ export function objectToLogString(
   try {
     const json = JSON.stringify(obj);
     return json.length > maxLength
-      ? `${json.substring(0, maxLength)}... (${json.length} chars)`
+      ? `${json.slice(0, maxLength)}... (${json.length} chars)`
       : json;
   } catch (_err) {
     return String(obj);

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -167,7 +167,7 @@ Deno.serve(async (req: Request) => {
       return errorResponse(req, 'Missing authorization token', 401);
     }
 
-    const jwtToken = authHeader.substring(7);
+    const jwtToken = authHeader.slice(7);
 
     // 2. Validate user with Supabase
     const userClient = createClient(supabaseUrl, supabaseAnonKey, {

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -201,7 +201,7 @@ function extractJwtFromRequest(req: Request): string | null {
   // OpenAI SDK: Authorization: Bearer {jwt}
   const authHeader = req.headers.get('authorization');
   if (authHeader?.startsWith('Bearer ')) {
-    return authHeader.substring(7);
+    return authHeader.slice(7);
   }
 
   // Anthropic SDK: x-api-key: {jwt}


### PR DESCRIPTION
Apply modern ES2022/ES2023 idioms where they are behavior-preserving:

- Use the `node:` protocol for Node builtin imports across the workspace and update matching `vi.doMock` specifiers.
- Replace non-mutating sort copies with `toSorted()` where the behavior is equivalent.
- Use `for...of` / `.entries()` in dense-array loops where dropping index guards does not change semantics.
- Use `toReversed()` / `findLast()` only where that preserves the original traversal semantics.
- Keep explicit loops where review found they were part of the behavior contract: sparse-array guards in CLI dispatch/message indexing, reverse timeline scanning, work-plan equality null guards, and short-circuit round-directory lookup.
- Codify the modern TypeScript style guidance in repo/review docs.

Review feedback applied after rebase onto current `main`:

- Restored the reverse scan in `MessageIndex.updateTimelineMessageRefs`.
- Restored `previous || next` sparse-array guard handling in `MessageIndex.patchGroupMetadataIfShapeStable`.
- Restored explicit `WorkPlanState` equality loops so null/undefined entries return `false` instead of throwing or being skipped.
- Restored the CLI raw-arg `token === undefined` guard.
- Restored `packDestinationName` as a reverse short-circuit loop.

Validation:

- `npm run typecheck`
- `npm run lint -- --quiet`
- `corepack pnpm vitest run src/test-kernel/progressView/TaskGroupListIndex.vitest.ts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts src/test-kernel/tools/WorkPlanGranularityFeedback.vitest.ts src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts`
- `git diff --check`