### PR TITLE
refactor(agents): collapse delegation duplication and the dual category enum

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -17,7 +17,7 @@ import { toErrorMessage } from '@common/errors';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { platform, tryPlatform } from '@platform/platform';
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_STATUS,
@@ -272,7 +272,7 @@ function harnessOrchestrationHistory(): readonly CliHistoryEntry[] {
       model: 'harness-model',
       status: CLI_HISTORY_RESUMABLE_STATUS,
       inputBasename: '-',
-      category: AGENT_CATEGORY.TOOL_USE,
+      category: AgentCategory.ToolUse,
       parentExecutionId: 'root-session' as ExecutionId,
       delegationDepth: 1,
     },
@@ -283,7 +283,7 @@ function harnessOrchestrationHistory(): readonly CliHistoryEntry[] {
       model: 'harness-model',
       status: CLI_HISTORY_RESUMABLE_STATUS,
       inputBasename: '-',
-      category: AGENT_CATEGORY.TOOL_USE,
+      category: AgentCategory.ToolUse,
       delegationDepth: 1,
     },
     {
@@ -293,7 +293,7 @@ function harnessOrchestrationHistory(): readonly CliHistoryEntry[] {
       model: 'harness-model',
       status: CLI_HISTORY_RESUMABLE_STATUS,
       inputBasename: '-',
-      category: AGENT_CATEGORY.TOOL_USE,
+      category: AgentCategory.ToolUse,
     },
   ];
 }
@@ -710,7 +710,7 @@ function makeAgentProposalPayload() {
   return {
     proposalId: 'harness-agent-proposal',
     streamId: STREAM_ID,
-    agentCategory: AGENT_CATEGORY.TOOL_USE,
+    agentCategory: AgentCategory.ToolUse,
     agent: 'review',
     model: 'deepseekT',
     instruction: AGENT_PROPOSAL_INSTRUCTION,

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -6,7 +6,7 @@
 // holds finished subagents for the session, so no exit-time disk I/O is needed.
 
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   sumUsageStats,
   type StreamTabId,
   type TokenUsageStats,
@@ -109,7 +109,7 @@ export function collectResumeTargets({
     for (const child of slice.childStreams) {
       if (!child.childStreamId || seen.has(child.executionId)) continue;
       const childSlice = streams.get(child.childStreamId);
-      if (childSlice?.category !== AGENT_CATEGORY.TOOL_USE) continue;
+      if (childSlice?.category !== AgentCategory.ToolUse) continue;
       seen.add(child.executionId);
       targets.push({
         executionId: child.executionId,

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -1,7 +1,7 @@
 import { platform } from '@platform/platform';
 import { BUILTIN_TEAM_ROOT_AGENT_NAMES, type AgentEntry } from '@agent/index';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { agentKey } from '@shared/schemas/agent';
 import {
   AGENT_MODE_PRESETS,
@@ -552,7 +552,7 @@ function formatAvailableTeamAgentCount(count: number): string {
 }
 
 export function agentHasDelegationTools(agent: AgentEntry): boolean {
-  return agent.tools?.some((tool) => DELEGATION_TOOLS.has(tool)) ?? false;
+  return hasDelegationTool(agent.tools);
 }
 
 function toAgentKey(agent: AgentEntry): string {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -66,7 +66,7 @@ import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
-import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import {
   cleanupAllApprovals,
@@ -509,7 +509,7 @@ export class DesktopProgressBridge {
       agentCategory:
         info?.agentCategory ??
         restored?.agentCategory ??
-        AGENT_CATEGORY.WORKFLOW,
+        AgentCategory.Workflow,
       inputFile: info?.inputFile || restored?.inputFile,
       instruction: taskState?.agentConfig.instruction || restored?.instruction,
       lastKnownStatus:

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -1,6 +1,6 @@
 import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
-import { AGENT_CATEGORY, type AgentCategory } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 import { type SwitchViewTarget } from '@shared/schemas/commonViewMessages';
 import {
   MainViewInboundMessageSchema,
@@ -231,8 +231,8 @@ function dispatchMainViewInboundOnShell(
     case MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS:
       actions.showSettings(
         SETTINGS_TAB.AGENTS,
-        message.sessionType === AGENT_CATEGORY.TOOL_USE
-          ? AGENT_CATEGORY.TOOL_USE
+        message.sessionType === AgentCategory.ToolUse
+          ? AgentCategory.ToolUse
           : undefined,
       );
       return true;

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -28,7 +28,7 @@ import type {
   ToolEditPermission,
   UserQuestionPermission,
 } from '@shared/schemas';
-import { AGENT_CATEGORY } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
@@ -295,7 +295,7 @@ export class ProgressViewProvider
     // the dropdown still appears if ServerSideKeyService isn't ready. Agent
     // options have no static equivalent, so the agent dropdown is omitted
     // when the registry fetch fails.
-    const isWorkflow = proposal.agentCategory === AGENT_CATEGORY.WORKFLOW;
+    const isWorkflow = proposal.agentCategory === AgentCategory.Workflow;
     const loadAgentOptions = async () => {
       const all = await computeAgentOptionsData();
       const raw = isWorkflow ? all.workflow : all.toolUse;

--- a/packages/extension/src/progressView/frontend/components/PermissionCard.ts
+++ b/packages/extension/src/progressView/frontend/components/PermissionCard.ts
@@ -7,7 +7,7 @@ import { when } from 'lit/directives/when.js';
 
 // Local imports - shared
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import { AGENT_CATEGORY } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 import { postMessage } from '@shared/hostBridge';
 import type {
   AgentOptionData,
@@ -201,7 +201,7 @@ export class PermissionCard extends LitElement {
     if (!this.permission) return '';
 
     if (this.permission.kind === PERMISSION_KIND.PROPOSAL) {
-      return this.permission.data.agentCategory === AGENT_CATEGORY.WORKFLOW
+      return this.permission.data.agentCategory === AgentCategory.Workflow
         ? 'Approve task (Workflow)'
         : 'Approve task (Interactive)';
     }
@@ -277,7 +277,7 @@ export class PermissionCard extends LitElement {
             <span class="file-path">${data.workingDirectory}</span>
           </p>`
         : nothing}
-      ${data.agentCategory === AGENT_CATEGORY.WORKFLOW
+      ${data.agentCategory === AgentCategory.Workflow
         ? this.renderExtractFlags(data)
         : nothing}
       ${this.renderFileGroups(data)} ${this.renderFeedbackSection()}

--- a/packages/extension/src/progressView/frontend/components/PermissionCard.ts
+++ b/packages/extension/src/progressView/frontend/components/PermissionCard.ts
@@ -22,6 +22,7 @@ import type {
   WorkflowAgentProposalPermission,
 } from '@shared/schemas';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
+import { renderWorkflowExtractFlagBadges } from '@shared/wa/extractFlagBadges';
 import { getBasename } from '@shared/utils/path';
 import { getTextareaValue } from '@shared/utils/textarea';
 import {
@@ -287,25 +288,9 @@ export class PermissionCard extends LitElement {
   private renderExtractFlags(
     data: WorkflowAgentProposalPermission,
   ): TemplateResult | typeof nothing {
-    const flags: string[] = [];
-    if (data.toolConfig.autoExtractFigure) flags.push('Extract Figures');
-    if (data.toolConfig.autoExtractTikzFigure) flags.push('Extract TikZ');
-    if (flags.length === 0) return nothing;
-    return html`<p class="extract-flags">
-      ${repeat(
-        flags,
-        (flag) => flag,
-        (flag) =>
-          html`<wa-badge variant="neutral" appearance="filled"
-            ><wa-icon
-              library="texra"
-              name="file-media"
-              aria-hidden="true"
-            ></wa-icon>
-            ${flag}</wa-badge
-          >`,
-      )}
-    </p>`;
+    const badges = renderWorkflowExtractFlagBadges(data.toolConfig);
+    if (badges === nothing) return nothing;
+    return html`<p class="extract-flags">${badges}</p>`;
   }
 
   private renderPlanApprovalBody(data: PlanApprovalPermission): TemplateResult {

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -43,6 +43,7 @@ import { getProposalFileGroups } from '@shared/schemas/proposalFields';
 import { getBasename } from '@shared/utils/path';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+import { renderWorkflowExtractFlagBadges } from '@shared/wa/extractFlagBadges';
 
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
@@ -237,25 +238,9 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   private renderExtractFlags(
     data: WorkflowAgentProposalPermission,
   ): TemplateResult | typeof nothing {
-    const flags: string[] = [];
-    if (data.toolConfig.autoExtractFigure) flags.push('Extract Figures');
-    if (data.toolConfig.autoExtractTikzFigure) flags.push('Extract TikZ');
-    if (flags.length === 0) return nothing;
-    return html`<div class="workflow-proposal__extract-flags">
-      ${repeat(
-        flags,
-        (flag) => flag,
-        (flag) =>
-          html`<wa-badge variant="neutral" appearance="filled"
-            ><wa-icon
-              library="texra"
-              name="file-media"
-              aria-hidden="true"
-            ></wa-icon>
-            ${flag}</wa-badge
-          >`,
-      )}
-    </div>`;
+    const badges = renderWorkflowExtractFlagBadges(data.toolConfig);
+    if (badges === nothing) return nothing;
+    return html`<div class="workflow-proposal__extract-flags">${badges}</div>`;
   }
 
   private renderProposalFileList(

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -25,7 +25,7 @@ import {
 
 // Local imports - shared utils
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   type AgentProposalPermission,
   type WorkflowAgentProposalPermission,
 } from '@shared/schemas';
@@ -103,7 +103,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
       this.permission.kind === PERMISSION_KIND.PROPOSAL
         ? (this.permission.agentOptions ?? [])
         : [];
-    const isWorkflow = data.agentCategory === AGENT_CATEGORY.WORKFLOW;
+    const isWorkflow = data.agentCategory === AgentCategory.Workflow;
     const categoryLabel = isWorkflow ? 'Workflow' : 'Tool-Use';
     const currentModel = this.selectedModel ?? data.model;
     const currentAgent = this.selectedAgent ?? data.agent;

--- a/packages/extension/src/progressView/frontend/formatters/proposalInputStore.ts
+++ b/packages/extension/src/progressView/frontend/formatters/proposalInputStore.ts
@@ -11,7 +11,7 @@
 import { z } from 'zod';
 
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   ToolConfigSchema,
   ToolUseAgentProposalSchema,
   WorkflowAgentProposalSchema,
@@ -50,7 +50,7 @@ function parseProposalInput(
 
   if (toolName === 'delegate_agent' || toolName === 'propose_agent') {
     const result = LenientToolUseProposalSchema.safeParse({
-      agentCategory: AGENT_CATEGORY.TOOL_USE,
+      agentCategory: AgentCategory.ToolUse,
       ...spread,
     });
     return result.success ? result.data : null;
@@ -86,7 +86,7 @@ function parseProposalInput(
     };
 
     const result = LenientWorkflowProposalSchema.safeParse({
-      agentCategory: AGENT_CATEGORY.WORKFLOW,
+      agentCategory: AgentCategory.Workflow,
       ...migrated,
       toolConfig,
     });

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -1,8 +1,7 @@
 // Local imports
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   createStreamState,
-  type AgentCategory,
   type AgentCategoryFilter,
   type ContextStateData,
   type LogMessageData,
@@ -119,6 +118,6 @@ export function getStreamState(
 ): StreamState {
   return (
     state.streamStates.get(streamId) ??
-    createStreamState(agentCategory ?? AGENT_CATEGORY.WORKFLOW)
+    createStreamState(agentCategory ?? AgentCategory.Workflow)
   );
 }

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -9,7 +9,7 @@ import Mark from 'mark.js';
 // Local imports - shared
 import type { HistoryItem as HistoryItemData } from '@shared/schemas';
 import { badgeStyles, commonViewStyles, designTokens } from '@shared/styles';
-import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { getAgentCategoryDecorator } from '@shared/utils/icons';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
@@ -264,7 +264,7 @@ export class HistoryItemElement extends LitElement {
 
     const config = this.item.agentConfig;
     const timestamp = new Date(this.item.timestamp).toLocaleString();
-    const isToolUse = config.agentCategory === AGENT_CATEGORY.TOOL_USE;
+    const isToolUse = config.agentCategory === AgentCategory.ToolUse;
     const categoryVariant: 'warning' | 'brand' = isToolUse
       ? 'warning'
       : 'brand';
@@ -276,7 +276,7 @@ export class HistoryItemElement extends LitElement {
 
     const extraDetails: Array<TemplateResult> = [];
 
-    if (config.agentCategory === AGENT_CATEGORY.WORKFLOW) {
+    if (config.agentCategory === AgentCategory.Workflow) {
       const contextSection = this.renderConfigSection('Context', [
         ['ContextFiles', config.contextFiles],
       ]);
@@ -297,7 +297,7 @@ export class HistoryItemElement extends LitElement {
         );
         if (toolSection) extraDetails.push(toolSection);
       }
-    } else if (config.agentCategory === AGENT_CATEGORY.TOOL_USE) {
+    } else if (config.agentCategory === AgentCategory.ToolUse) {
       const editedSection = this.renderConfigSection('Edited Files', [
         ['Files', config.editedFiles],
       ]);
@@ -321,7 +321,7 @@ export class HistoryItemElement extends LitElement {
       `Agent: ${config.agent ?? 'Unknown'}`,
       `Model: ${config.model ?? 'Unknown'}`,
     ];
-    if (config.agentCategory === AGENT_CATEGORY.WORKFLOW) {
+    if (config.agentCategory === AgentCategory.Workflow) {
       if (config.inputFiles?.length) {
         metaParts.push(`Inputs: ${config.inputFiles.join(', ')}`);
       }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -3,7 +3,7 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentRunStateSnapshotSchema } from '@agent/core/execution/AgentState';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { buildInitialToolUsePrompts } from '@utils/prompt';
 
 import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
@@ -24,9 +24,7 @@ export class ToolUsePrepareNode<C> extends Node<
     const { userVarChannels, logger, snapshot, config, fileService } =
       this.services;
     const resolvedToolNames = this.services.resolvedTools.map((t) => t.name);
-    const hasDelegationTools = this.services.resolvedTools.some((t) =>
-      DELEGATION_TOOLS.has(t.name),
-    );
+    const hasDelegationTools = hasDelegationTool(resolvedToolNames);
     const promptOptions = {
       resolvedToolNames,
       hasDelegationTools,

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -19,7 +19,7 @@ import type { BaseFlowContextInit } from '@agent/implementations/flows/common/Ba
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import type { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
-import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
+import { evaluateCurrentDelegationGate } from '@agent/runtime/delegationPolicy';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import {
   END_GROUP_STATUS,
@@ -27,7 +27,6 @@ import {
   type EndGroupStatus,
 } from '@shared/schemas';
 import type { SubagentProgressUpdate } from '@shared/schemas';
-import { evaluateDelegationGate } from '@shared/constants/delegationPolicy';
 
 import { getDefaultToolRegistry } from '@tools/registry';
 import { TaskRunFileService } from '@utils/files';
@@ -141,11 +140,7 @@ export async function runToolUseFlow<C = unknown>(
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
   const registry = toolRegistry ?? getDefaultToolRegistry();
   const delegationDepth = input.delegationDepth ?? 0;
-  const delegationConfig = readNestedDelegationConfig();
-  const delegationGate = evaluateDelegationGate(
-    delegationDepth,
-    delegationConfig,
-  );
+  const delegationGate = evaluateCurrentDelegationGate(delegationDepth);
   const { tools: resolvedTools, delegationTrimmed } = await resolveAgentTools({
     tools: setting.tools,
     registry,

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -15,7 +15,7 @@ import type { AgentOptionData } from '@shared/schemas';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { AgentSource } from '@shared/schemas/agent';
 import { agentKey as createKey, agentName } from '@shared/schemas/agent';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { AbsoluteFS } from '@utils/files';
 import { filterNotNull } from '@utils/core';
 import {
@@ -672,7 +672,7 @@ function entryToOptionData(entry: AgentEntry): AgentOptionData {
     value: key,
     label: entry.name,
     isToolUse: entry.category === AgentCategory.ToolUse,
-    isOrchestrator: entry.tools?.some((t) => DELEGATION_TOOLS.has(t)),
+    isOrchestrator: hasDelegationTool(entry.tools),
     isRemote: entry.source === 'remote',
     isCustom: entry.source === 'custom',
     description: entry.description,

--- a/src/agent/index/streamTabInfo.ts
+++ b/src/agent/index/streamTabInfo.ts
@@ -3,12 +3,8 @@ import * as path from 'path';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import type {
-  AgentCategory,
-  StreamTabInfo,
-  WorktreeInfo,
-} from '@shared/schemas';
-import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import type { StreamTabInfo, WorktreeInfo } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas/agent';
 import { isProcessAgent } from '@shared/streams/agentKind';
 
 import { getCleanAgentName, isRemoteAgent } from './agentRegistry';
@@ -47,7 +43,7 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   const { streamId, config, hints, creationTimestamp } = inputs;
 
   const category =
-    config?.agentCategory ?? hints?.agentCategory ?? AGENT_CATEGORY.WORKFLOW;
+    config?.agentCategory ?? hints?.agentCategory ?? AgentCategory.Workflow;
 
   const inputFile = config?.inputFiles?.[0] ?? hints?.inputFile ?? '';
   const rawAgentName = config?.agent ?? hints?.agent ?? streamId.split('@')[0];
@@ -57,7 +53,7 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   // can tell parallel runs apart at a glance. Tool-use agents don't have
   // a single canonical input file, so we just show the agent name.
   const label =
-    category !== AGENT_CATEGORY.TOOL_USE && inputFile
+    category !== AgentCategory.ToolUse && inputFile
       ? `${agentName}: ${path.basename(inputFile)}`
       : agentName;
 

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -26,7 +26,10 @@ import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass'
 import * as logUtils from '@logger/logUtils';
 import type { ToolDefinition } from '@model';
 import { computeModelOptionsData } from '@model/computeModelOptions';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import {
+  DELEGATION_TOOLS,
+  hasDelegationTool,
+} from '@shared/constants/delegationTools';
 import { getDefaultToolRegistry } from '@tools/registry';
 import {
   getDisabledToolNames,
@@ -73,7 +76,7 @@ export interface ResolvedAgentTools {
 async function availableDelegationModelNamesForTools(
   tools: readonly ToolDefinition[],
 ): Promise<readonly string[] | null | undefined> {
-  if (!tools.some((tool) => DELEGATION_TOOLS.has(tool.name))) {
+  if (!hasDelegationTool(tools.map((tool) => tool.name))) {
     return undefined;
   }
 
@@ -115,20 +118,22 @@ export async function resolveAgentTools({
   const toolConfigs = Array.isArray(tools) ? tools : [];
   let delegationTrimmed = false;
 
+  /** Delegation-depth and approval gates shared by declared and injected tools. */
+  const passesRuntimeGates = (name: string): boolean => {
+    if (DELEGATION_TOOLS.has(name) && delegationBlocked) {
+      delegationTrimmed = true;
+      return false;
+    }
+    return (
+      approvalPromptsUnavailable !== true || !isApprovalGatedToolName(name)
+    );
+  };
+
   const resolved: ToolDefinition[] = [];
   const resolvedNames = new Set<string>();
   for (const config of toolConfigs) {
     const def = typeof config === 'string' ? { name: config } : config;
-    if (DELEGATION_TOOLS.has(def.name) && delegationBlocked) {
-      delegationTrimmed = true;
-      continue;
-    }
-    if (
-      approvalPromptsUnavailable === true &&
-      isApprovalGatedToolName(def.name)
-    ) {
-      continue;
-    }
+    if (!passesRuntimeGates(def.name)) continue;
     if (disabled.has(def.name)) continue;
     if (unavailable.has(def.name)) {
       missingDependency.push(def.name);
@@ -141,16 +146,7 @@ export async function resolveAgentTools({
   for (const injection of toolInjections.list()) {
     if (!injection.shouldInject()) continue;
     if (resolvedNames.has(injection.toolName)) continue;
-    if (DELEGATION_TOOLS.has(injection.toolName) && delegationBlocked) {
-      delegationTrimmed = true;
-      continue;
-    }
-    if (
-      approvalPromptsUnavailable === true &&
-      isApprovalGatedToolName(injection.toolName)
-    ) {
-      continue;
-    }
+    if (!passesRuntimeGates(injection.toolName)) continue;
     const tool = effectiveRegistry.get(injection.toolName);
     if (tool) {
       resolved.push(tool.definition);

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -14,6 +14,8 @@ import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   clampNestedDelegationDepth,
+  evaluateDelegationGate,
+  type DelegationGateResult,
   type NestedDelegationConfig,
   UNKNOWN_DELEGATION_DEPTH,
 } from '@shared/constants/delegationPolicy';
@@ -25,6 +27,13 @@ export function readNestedDelegationConfig(): NestedDelegationConfig {
     state.get<number>(WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH, undefined),
   );
   return { maxDepth };
+}
+
+/** Evaluate the delegation gate against the current workspace policy. */
+export function evaluateCurrentDelegationGate(
+  depth: number,
+): DelegationGateResult {
+  return evaluateDelegationGate(depth, readNestedDelegationConfig());
 }
 
 /**

--- a/src/shared/constants/delegationTools.ts
+++ b/src/shared/constants/delegationTools.ts
@@ -13,3 +13,14 @@ export const DELEGATION_TOOLS: ReadonlySet<string> = new Set([
   'propose_workflow',
   'propose_agent',
 ]);
+
+/** True when any of the given tool names is a delegation tool. */
+export function hasDelegationTool(
+  toolNames: Iterable<string> | undefined,
+): boolean {
+  if (!toolNames) return false;
+  for (const name of toolNames) {
+    if (DELEGATION_TOOLS.has(name)) return true;
+  }
+  return false;
+}

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -13,15 +13,6 @@ export const AgentCategory = {
 } as const;
 export type AgentCategory = (typeof AgentCategory)[keyof typeof AgentCategory];
 
-/**
- * Legacy alias preserving UPPER_SNAKE keys for call sites that already use it
- * (e.g. `AGENT_CATEGORY.WORKFLOW`). Prefer `AgentCategory.Workflow` in new code.
- */
-export const AGENT_CATEGORY = {
-  WORKFLOW: AgentCategory.Workflow,
-  TOOL_USE: AgentCategory.ToolUse,
-} as const;
-
 export const AgentCategorySchema = z.enum([
   AgentCategory.Workflow,
   AgentCategory.ToolUse,

--- a/src/shared/schemas/historyViewMessages.ts
+++ b/src/shared/schemas/historyViewMessages.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { HISTORY_VIEW_COMMANDS } from '@shared/ipc';
 import { commandOnly } from './messageFactories';
 
-import { AGENT_CATEGORY } from './agent';
+import { AgentCategory } from './agent';
 
 // ============================================================
 // Data schemas
@@ -24,7 +24,7 @@ const BaseConfigSummarySchema = z.object({
 
 /** Workflow agents carry file-related fields. */
 const WorkflowConfigSummarySchema = BaseConfigSummarySchema.extend({
-  agentCategory: z.literal(AGENT_CATEGORY.WORKFLOW),
+  agentCategory: z.literal(AgentCategory.Workflow),
   inputFiles: z.array(z.string()).optional(),
   mediaFiles: z.array(z.string()).optional(),
   contextFiles: z.array(z.string()).optional(),
@@ -34,7 +34,7 @@ const WorkflowConfigSummarySchema = BaseConfigSummarySchema.extend({
 
 /** Tool-use agents only have the base fields. */
 const ToolUseConfigSummarySchema = BaseConfigSummarySchema.extend({
-  agentCategory: z.literal(AGENT_CATEGORY.TOOL_USE),
+  agentCategory: z.literal(AgentCategory.ToolUse),
   editedFiles: z.array(z.string()).optional(),
 });
 

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { AGENT_CATEGORY } from './agent';
+import { AgentCategory } from './agent';
 import { ProviderErrorPartialSchema } from './errors';
 import { StreamTabIdSchema } from './identifiers';
 import { PlanSchema } from './plan';
@@ -50,16 +50,16 @@ export const RetryPermissionSchema = z.strictObject({
 export type RetryPermission = z.infer<typeof RetryPermissionSchema>;
 
 /** Workflow agent proposal - includes file fields for document processing */
-export const WorkflowAgentProposalSchema = BaseProposalFieldsSchema.merge(
-  WorkflowSpecificFieldsSchema,
+export const WorkflowAgentProposalSchema = BaseProposalFieldsSchema.extend(
+  WorkflowSpecificFieldsSchema.shape,
 ).extend({
-  agentCategory: z.literal(AGENT_CATEGORY.WORKFLOW),
+  agentCategory: z.literal(AgentCategory.Workflow),
 });
 export type WorkflowAgentProposal = z.infer<typeof WorkflowAgentProposalSchema>;
 
 /** Tool-use agent proposal - agents access files through their own tools */
 export const ToolUseAgentProposalSchema = BaseProposalFieldsSchema.extend({
-  agentCategory: z.literal(AGENT_CATEGORY.TOOL_USE),
+  agentCategory: z.literal(AgentCategory.ToolUse),
 });
 export type ToolUseAgentProposal = z.infer<typeof ToolUseAgentProposalSchema>;
 

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -1,11 +1,7 @@
 import { z } from 'zod';
 
 import { GoalStatusSchema } from '@tools/goal/goalMeta';
-import {
-  AGENT_CATEGORY,
-  AgentCategorySchema,
-  type AgentCategory,
-} from './agent';
+import { AgentCategory, AgentCategorySchema } from './agent';
 import { CompileFailureSchema, OutputFileInfoSchema } from './output';
 import { STREAM_STATUS, StreamStatusSchema } from './stream';
 import { TaskGroupSchema } from './taskGroup';
@@ -103,7 +99,7 @@ function RunScopedRecord<T extends z.ZodType>(valueSchema: T) {
 // Tool-Use Stream State
 
 export const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
-  kind: z.literal(AGENT_CATEGORY.TOOL_USE),
+  kind: z.literal(AgentCategory.ToolUse),
   // Frontend-owned fields updated by targeted progress-view messages
   todos: z.array(TodoItemSchema).prefault([]),
   plan: PlanSchema.nullable().prefault(null),
@@ -130,7 +126,7 @@ function RoundIndexedRecord<T extends z.ZodType>(valueSchema: T) {
 }
 
 export const WorkflowStreamStateSchema = BaseStreamStateSchema.extend({
-  kind: z.literal(AGENT_CATEGORY.WORKFLOW),
+  kind: z.literal(AgentCategory.Workflow),
   // Frontend-owned fields updated by targeted progress-view messages.
   // Per-run usage mirrors tool-use so resume correctly accumulates across
   // the original and resumed runs; sessionUsage is derived as their sum.
@@ -157,13 +153,13 @@ export type StreamState = z.infer<typeof StreamStateSchema>;
 export function isToolUseState(
   state: StreamState,
 ): state is ToolUseStreamState {
-  return state.kind === AGENT_CATEGORY.TOOL_USE;
+  return state.kind === AgentCategory.ToolUse;
 }
 
 export function isWorkflowState(
   state: StreamState,
 ): state is WorkflowStreamState {
-  return state.kind === AGENT_CATEGORY.WORKFLOW;
+  return state.kind === AgentCategory.Workflow;
 }
 
 // Factory Functions
@@ -172,7 +168,7 @@ export function createToolUseStreamState(
   partial?: Partial<ToolUseStreamState>,
 ): ToolUseStreamState {
   return ToolUseStreamStateSchema.parse({
-    kind: AGENT_CATEGORY.TOOL_USE,
+    kind: AgentCategory.ToolUse,
     ...partial,
   });
 }
@@ -181,7 +177,7 @@ export function createWorkflowStreamState(
   partial?: Partial<WorkflowStreamState>,
 ): WorkflowStreamState {
   return WorkflowStreamStateSchema.parse({
-    kind: AGENT_CATEGORY.WORKFLOW,
+    kind: AgentCategory.Workflow,
     ...partial,
   });
 }
@@ -190,7 +186,7 @@ export function createStreamState(
   agentCategory: AgentCategory,
   partial?: Partial<StreamState>,
 ): StreamState {
-  if (agentCategory === AGENT_CATEGORY.TOOL_USE) {
+  if (agentCategory === AgentCategory.ToolUse) {
     return createToolUseStreamState(partial as Partial<ToolUseStreamState>);
   }
   return createWorkflowStreamState(partial as Partial<WorkflowStreamState>);

--- a/src/shared/wa/extractFlagBadges.ts
+++ b/src/shared/wa/extractFlagBadges.ts
@@ -1,0 +1,38 @@
+// Third-party imports
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
+import { html, nothing, type TemplateResult } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared
+import type { ToolConfig } from '@shared/schemas/toolConfig';
+
+// Local imports - Web Awesome
+import { waIcon } from './webAwesomeIcons';
+
+/** User-visible labels for a workflow proposal's media-extraction flags. */
+export function workflowExtractFlagLabels(toolConfig: ToolConfig): string[] {
+  const flags: string[] = [];
+  if (toolConfig.autoExtractFigure) flags.push('Extract Figures');
+  if (toolConfig.autoExtractTikzFigure) flags.push('Extract TikZ');
+  return flags;
+}
+
+/**
+ * Render the badge row for a workflow proposal's media-extraction flags.
+ * Returns `nothing` when no flag is set; callers wrap the badges in their
+ * own container element for component-specific layout classes.
+ */
+export function renderWorkflowExtractFlagBadges(
+  toolConfig: ToolConfig,
+): TemplateResult | typeof nothing {
+  const flags = workflowExtractFlagLabels(toolConfig);
+  if (flags.length === 0) return nothing;
+  return html`${repeat(
+    flags,
+    (flag) => flag,
+    (flag) =>
+      html`<wa-badge variant="neutral" appearance="filled"
+        >${waIcon('file-media')} ${flag}</wa-badge
+      >`,
+  )}`;
+}

--- a/src/test-kernel/agent/index/StreamTabInfo.vitest.ts
+++ b/src/test-kernel/agent/index/StreamTabInfo.vitest.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildStreamTabInfo } from '@agent/index';
-import { AGENT_CATEGORY } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas';
 import { isProcessAgent } from '@shared/streams/agentKind';
 
 describe('buildStreamTabInfo', () => {
@@ -9,7 +9,7 @@ describe('buildStreamTabInfo', () => {
     const info = buildStreamTabInfo({
       streamId: 'bash@tool#exec:child-stream',
       hints: {
-        agentCategory: AGENT_CATEGORY.TOOL_USE,
+        agentCategory: AgentCategory.ToolUse,
       },
       creationTimestamp: 1,
     });

--- a/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
+++ b/src/test-kernel/agent/runtime/runCoordinators.vitest.ts
@@ -18,7 +18,7 @@ import {
   ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   TODO_STATUS,
   type AgentProposal,
   type Plan,
@@ -40,7 +40,7 @@ const plan: Plan = {
   ],
 };
 const proposal: AgentProposal = {
-  agentCategory: AGENT_CATEGORY.TOOL_USE,
+  agentCategory: AgentCategory.ToolUse,
   agent: 'reviewer',
   model: 'test-model',
   instruction: 'Review the runtime boundary.',

--- a/src/test-kernel/cli/AgentProposal.vitest.mts
+++ b/src/test-kernel/cli/AgentProposal.vitest.mts
@@ -7,7 +7,7 @@ import {
   maxAgentProposalInstructionScrollOffset,
 } from '@cli/chat/tui/modals/AgentProposal';
 import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
-import { AGENT_CATEGORY, agentProposalCategoryLabel } from '@shared/schemas';
+import { AgentCategory, agentProposalCategoryLabel } from '@shared/schemas';
 
 const LONG_AGENT_PROMPT = [
   'Review the mathematical proof in triangular_square_mod5.tex for correctness, completeness, and rigor.',
@@ -20,10 +20,10 @@ const LONG_AGENT_PROMPT = [
 
 describe('CLI agent proposal approval layout', () => {
   it('uses human-facing category labels', () => {
-    expect(agentProposalCategoryLabel(AGENT_CATEGORY.TOOL_USE)).toBe(
+    expect(agentProposalCategoryLabel(AgentCategory.ToolUse)).toBe(
       'tool-use agent',
     );
-    expect(agentProposalCategoryLabel(AGENT_CATEGORY.WORKFLOW)).toBe(
+    expect(agentProposalCategoryLabel(AgentCategory.Workflow)).toBe(
       'workflow agent',
     );
   });

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -11,7 +11,7 @@ import {
 } from '@cli/runtime/approvalAdapter';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-import { AGENT_CATEGORY, DEFAULT_TOOL_CONFIG } from '@shared/schemas';
+import { AgentCategory, DEFAULT_TOOL_CONFIG } from '@shared/schemas';
 import {
   requestToolEditApproval,
   setToolEditApprovalHandler,
@@ -180,7 +180,7 @@ describe('formatAgentProposalApprovalSummary', () => {
       instruction:
         'Please verify the proof carefully.\nReport any gaps or hidden cases.',
       memories: [],
-      agentCategory: AGENT_CATEGORY.TOOL_USE,
+      agentCategory: AgentCategory.ToolUse,
     });
 
     expect(summary).toContain(
@@ -209,7 +209,7 @@ describe('formatAgentProposalApprovalSummary', () => {
       instruction,
       memories: ['/memories/proof-style.md'],
       workingDirectory: '/tmp/project',
-      agentCategory: AGENT_CATEGORY.TOOL_USE,
+      agentCategory: AgentCategory.ToolUse,
     });
 
     expect(summary).toContain('Working directory: /tmp/project');
@@ -232,7 +232,7 @@ describe('formatAgentProposalApprovalSummary', () => {
       mediaFiles: ['figure.png'],
       outputFiles: ['draft-polished.tex'],
       toolConfig: DEFAULT_TOOL_CONFIG,
-      agentCategory: AGENT_CATEGORY.WORKFLOW,
+      agentCategory: AgentCategory.Workflow,
     });
 
     expect(summary).toContain(

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -9,7 +9,7 @@ import {
 } from '@cli/chat/tui/state/resumeHint';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   type ActiveChildInfo,
   type StreamTabId,
 } from '@shared/schemas';
@@ -79,11 +79,11 @@ describe('collectResumeTargets', () => {
     });
     const reviewer = makeSlice({
       streamId: 'reviewer@m#rev',
-      category: AGENT_CATEGORY.TOOL_USE,
+      category: AgentCategory.ToolUse,
     });
     const builder = makeSlice({
       streamId: 'builder@m#flow',
-      category: AGENT_CATEGORY.WORKFLOW,
+      category: AgentCategory.Workflow,
     });
 
     expect(

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -86,7 +86,7 @@ import {
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   MESSAGE_TYPES,
   STREAM_STATUS,
   type StorageKey,
@@ -445,7 +445,7 @@ describe('CLI TUI row allocation', () => {
           payload: {
             proposalId: 'proposal-1',
             streamId: root,
-            agentCategory: AGENT_CATEGORY.TOOL_USE,
+            agentCategory: AgentCategory.ToolUse,
             agent: 'review',
             model: 'harness-model',
             instruction: 'Review the proof.',

--- a/src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts
@@ -8,7 +8,7 @@ import { describe, it } from 'vitest';
 import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
 
 // Local imports - shared
-import { AGENT_CATEGORY, type AgentProposalPermission } from '@shared/schemas';
+import { AgentCategory, type AgentProposalPermission } from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 function createWorkflowProposal(
@@ -17,7 +17,7 @@ function createWorkflowProposal(
   return {
     proposalId: 'proposal-1',
     streamId: 'stream-1',
-    agentCategory: AGENT_CATEGORY.WORKFLOW,
+    agentCategory: AgentCategory.Workflow,
     agent: 'proofreader',
     model: 'gemini31p',
     instruction: 'Check the paper.',
@@ -59,7 +59,7 @@ describe('ProgressAgentProposalController', () => {
     ]);
     assert.deepEqual(restored[0], {
       agentConfig: {
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
         agent: 'proofreader',
         model: 'gemini31p',
         instruction: 'Check the paper.',

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports - progress schemas
 import { DESKTOP_SHELL_COMMANDS } from '@desktop/desktopShellMessages';
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   LOG_LEVELS,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_STATUS,
@@ -350,7 +350,7 @@ function workflowTaskState(): {
   agentConfig: {
     agent: string;
     model: string;
-    agentCategory: typeof AGENT_CATEGORY.WORKFLOW;
+    agentCategory: typeof AgentCategory.Workflow;
     toolConfig: typeof DEFAULT_TOOL_CONFIG;
   };
   activeFiles: Record<string, boolean>;
@@ -359,7 +359,7 @@ function workflowTaskState(): {
     agentConfig: {
       agent: 'proofreader',
       model: 'deepseekproT',
-      agentCategory: AGENT_CATEGORY.WORKFLOW,
+      agentCategory: AgentCategory.Workflow,
       toolConfig: DEFAULT_TOOL_CONFIG,
     },
     activeFiles: {},
@@ -430,7 +430,7 @@ describe('DesktopProgressBridge', () => {
     try {
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'parent',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       bridge.handleProgressEvent('updateConversationProgress', {
         streamId: 'parent',
@@ -479,7 +479,7 @@ describe('DesktopProgressBridge', () => {
     try {
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'parent',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       bridge.handleProgressEvent('updateActiveProcesses', {
         parentStreamId: 'parent',
@@ -622,7 +622,7 @@ describe('DesktopProgressBridge', () => {
         {
           streamId: 'ghost-stream',
           label: 'ghost-stream',
-          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          agentCategory: AgentCategory.Workflow,
           lastKnownStatus: STREAM_STATUS.STOPPED,
           creationTimestamp: 1_000,
           persistedAt: 2_000,
@@ -695,7 +695,7 @@ describe('DesktopProgressBridge', () => {
         {
           streamId: 'ghost-stream',
           label: 'ghost-stream',
-          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          agentCategory: AgentCategory.Workflow,
           lastKnownStatus: STREAM_STATUS.STOPPED,
           creationTimestamp: 1_000,
           persistedAt: 2_000,
@@ -752,7 +752,7 @@ describe('DesktopProgressBridge', () => {
         {
           streamId: 'ghost-stream',
           label: 'ghost-stream',
-          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          agentCategory: AgentCategory.Workflow,
           lastKnownStatus: STREAM_STATUS.STOPPED,
           creationTimestamp: 1_000,
           persistedAt: 2_000,
@@ -820,7 +820,7 @@ describe('DesktopProgressBridge', () => {
         {
           streamId: 'ghost-stream',
           label: 'ghost-stream',
-          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          agentCategory: AgentCategory.Workflow,
           lastKnownStatus: STREAM_STATUS.STOPPED,
           creationTimestamp: 1_000,
           persistedAt: 2_000,
@@ -893,7 +893,7 @@ describe('DesktopProgressBridge', () => {
         {
           streamId: 'ghost-one',
           label: 'ghost-one',
-          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          agentCategory: AgentCategory.Workflow,
           lastKnownStatus: STREAM_STATUS.STOPPED,
           creationTimestamp: 1_000,
           persistedAt: 2_000,
@@ -901,7 +901,7 @@ describe('DesktopProgressBridge', () => {
         {
           streamId: 'ghost-two',
           label: 'ghost-two',
-          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          agentCategory: AgentCategory.Workflow,
           lastKnownStatus: STREAM_STATUS.STOPPED,
           creationTimestamp: 1_100,
           persistedAt: 2_100,
@@ -947,7 +947,7 @@ describe('DesktopProgressBridge', () => {
     try {
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'child-stream',
-        agentCategory: AGENT_CATEGORY.TOOL_USE,
+        agentCategory: AgentCategory.ToolUse,
         suppressViewSwitch: true,
       });
       await settleProgressEvents();
@@ -973,11 +973,11 @@ describe('DesktopProgressBridge', () => {
     try {
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'first',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'second',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       bridge.streamLogs.append('first', {
         id: 'first-log',
@@ -1025,7 +1025,7 @@ describe('DesktopProgressBridge', () => {
       agentConfig: {
         agent: 'search',
         model: 'deepseekproT',
-        agentCategory: AGENT_CATEGORY.TOOL_USE,
+        agentCategory: AgentCategory.ToolUse,
       },
     };
     const retrieveSessionResumeData = vi.fn(async () => ({
@@ -1071,15 +1071,15 @@ describe('DesktopProgressBridge', () => {
     try {
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'first',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'second',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'third',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       await settleProgressEvents();
       bridge.setActiveStream('second');
@@ -1116,11 +1116,11 @@ describe('DesktopProgressBridge', () => {
     try {
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'first',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'second',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       await settleProgressEvents();
       bridge.setActiveStream('first');
@@ -1129,7 +1129,7 @@ describe('DesktopProgressBridge', () => {
       const deletePromise = bridge.deleteStream('second');
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'second',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       await deletePromise;
 
@@ -1161,7 +1161,7 @@ describe('DesktopProgressBridge', () => {
     try {
       bridge.handleProgressEvent('setActiveStream', {
         streamId: 'active',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
       });
       await settleProgressEvents();
       messages.length = 0;
@@ -1411,7 +1411,7 @@ describe('DesktopProgressBridge', () => {
           streamId: 'stream-1',
           label: 'proofreader',
           agent: 'proofreader',
-          agentCategory: AGENT_CATEGORY.WORKFLOW,
+          agentCategory: AgentCategory.Workflow,
           lastKnownStatus: STREAM_STATUS.STOPPED,
           executionId,
           creationTimestamp: 1_000,
@@ -1448,7 +1448,7 @@ describe('DesktopProgressBridge', () => {
         agentConfig: {
           agent: 'search',
           model: 'deepseekproT',
-          agentCategory: AGENT_CATEGORY.TOOL_USE,
+          agentCategory: AgentCategory.ToolUse,
         },
       },
     }));
@@ -1466,7 +1466,7 @@ describe('DesktopProgressBridge', () => {
       agentConfig: {
         agent: 'search',
         model: 'deepseekproT',
-        agentCategory: AGENT_CATEGORY.TOOL_USE,
+        agentCategory: AgentCategory.ToolUse,
       },
     };
 
@@ -1533,7 +1533,7 @@ describe('DesktopProgressBridge', () => {
         agentConfig: {
           agent: 'search',
           model: 'deepseekproT',
-          agentCategory: AGENT_CATEGORY.TOOL_USE,
+          agentCategory: AgentCategory.ToolUse,
         },
       },
     }));
@@ -1557,7 +1557,7 @@ describe('DesktopProgressBridge', () => {
           agentConfig: {
             agent: 'search',
             model: 'deepseekproT',
-            agentCategory: AGENT_CATEGORY.TOOL_USE,
+            agentCategory: AgentCategory.ToolUse,
           },
         },
       });
@@ -1618,7 +1618,7 @@ describe('DesktopProgressBridge', () => {
           agentConfig: {
             agent: 'search',
             model: 'deepseekproT',
-            agentCategory: AGENT_CATEGORY.TOOL_USE,
+            agentCategory: AgentCategory.ToolUse,
           },
         },
       };
@@ -1635,7 +1635,7 @@ describe('DesktopProgressBridge', () => {
           agentConfig: {
             agent: 'search',
             model: 'deepseekproT',
-            agentCategory: AGENT_CATEGORY.TOOL_USE,
+            agentCategory: AgentCategory.ToolUse,
           },
         },
       });
@@ -1660,7 +1660,7 @@ describe('DesktopProgressBridge', () => {
       bridge.handleProgressEvent('showAgentProposal', {
         proposalId: 'proposal-1',
         streamId: 'stream-1',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
         agent: 'proofreader',
         model: 'gemini31p',
         instruction: 'Check this draft.',

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - shared schemas
-import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 import { delay } from '@utils/core/async';
 
@@ -287,7 +287,7 @@ describe('desktop command palette', () => {
       {
         name: 'stream-proof',
         label: 'Spectral proof run',
-        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agentCategory: AgentCategory.Workflow,
         creationTimestamp: 1,
         description: 'Checking the main lemma',
       },

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -7,7 +7,7 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc/settingsViewCommands';
 
 // Local imports - command catalog and shared schemas
 import { commandCatalogById, type CommandId } from '@shared/commands/catalog';
-import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
@@ -288,10 +288,10 @@ describe('desktop command surface', () => {
     expect(
       buildDesktopSettingsTabMessage(
         SETTINGS_TAB.AGENTS,
-        AGENT_CATEGORY.TOOL_USE,
+        AgentCategory.ToolUse,
       ),
     ).toEqual({
-      agentSubTab: AGENT_CATEGORY.TOOL_USE,
+      agentSubTab: AgentCategory.ToolUse,
       command: SETTINGS_VIEW_COMMANDS.SET_TAB,
       tabIndex: SETTINGS_TAB.AGENTS,
     });

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc/settingsViewCommands';
-import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
@@ -198,7 +198,7 @@ describe('desktop IPC adapters', () => {
     shellIpc.handleMessage({ command: MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS });
     shellIpc.handleMessage({
       command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
-      sessionType: AGENT_CATEGORY.TOOL_USE,
+      sessionType: AgentCategory.ToolUse,
     });
     shellIpc.handleMessage({
       command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
@@ -221,7 +221,7 @@ describe('desktop IPC adapters', () => {
       route: 'settings',
     });
     expect(postToRenderer).toHaveBeenNthCalledWith(5, {
-      agentSubTab: AGENT_CATEGORY.TOOL_USE,
+      agentSubTab: AgentCategory.ToolUse,
       command: SETTINGS_VIEW_COMMANDS.SET_TAB,
       tabIndex: SETTINGS_TAB.AGENTS,
     });

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -6,7 +6,7 @@ import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc/settingsViewCommands';
-import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
@@ -283,7 +283,7 @@ describe('desktop main-view IPC', () => {
       { sender: webContents },
       {
         command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
-        sessionType: AGENT_CATEGORY.TOOL_USE,
+        sessionType: AgentCategory.ToolUse,
       },
     );
     rendererListener?.(
@@ -317,7 +317,7 @@ describe('desktop main-view IPC', () => {
       {
         channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
         message: {
-          agentSubTab: AGENT_CATEGORY.TOOL_USE,
+          agentSubTab: AgentCategory.ToolUse,
           command: SETTINGS_VIEW_COMMANDS.SET_TAB,
           tabIndex: SETTINGS_TAB.AGENTS,
         },

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -18,7 +18,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 
 // Local imports - shared schemas
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   createStreamState,
   STREAM_STATUS,
   type ProgressViewOutboundMessage,
@@ -61,7 +61,7 @@ function createProcessState(streamId: StreamTabId): ProgressState {
   state.activeStreamId = streamId;
   state.streamStates.set(
     streamId,
-    createStreamState(AGENT_CATEGORY.WORKFLOW, {
+    createStreamState(AgentCategory.Workflow, {
       activeProcesses: [
         {
           executionId: 'active-process',
@@ -160,13 +160,13 @@ describe('process output frontend state', () => {
     state.streamById.set(parent, {
       name: parent,
       label: 'parent',
-      agentCategory: AGENT_CATEGORY.WORKFLOW,
+      agentCategory: AgentCategory.Workflow,
       creationTimestamp: 1,
     });
     state.streamById.set(child, {
       name: child,
       label: 'child',
-      agentCategory: AGENT_CATEGORY.TOOL_USE,
+      agentCategory: AgentCategory.ToolUse,
       creationTimestamp: 2,
       parentStreamId: parent,
     });

--- a/src/test-kernel/settings/HistoryHandlers.vitest.ts
+++ b/src/test-kernel/settings/HistoryHandlers.vitest.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 
 const mocks = vi.hoisted(() => ({
   listExecutions: vi.fn(),
@@ -31,7 +31,7 @@ describe('settings history handlers', () => {
           agent: 'chat',
           model: 'deepseekT',
           instruction: 'Check a proof.',
-          agentCategory: AGENT_CATEGORY.TOOL_USE,
+          agentCategory: AgentCategory.ToolUse,
         },
         category: 'toolUse',
       },

--- a/src/test-kernel/shared/StreamMetadata.vitest.ts
+++ b/src/test-kernel/shared/StreamMetadata.vitest.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   STREAM_STATUS,
   type ActiveChildInfo,
 } from '@shared/schemas';
@@ -10,9 +10,9 @@ import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 describe('buildStreamMetadata', () => {
   it('fills backend-owned defaults for a stream state metadata payload', () => {
     expect(
-      buildStreamMetadata({ kind: AGENT_CATEGORY.WORKFLOW }),
+      buildStreamMetadata({ kind: AgentCategory.Workflow }),
     ).toMatchObject({
-      kind: AGENT_CATEGORY.WORKFLOW,
+      kind: AgentCategory.Workflow,
       status: STREAM_STATUS.READY,
       conversationProgress: { conversationTurns: 0, toolCallCount: 0 },
       activeSubagents: [],
@@ -31,7 +31,7 @@ describe('buildStreamMetadata', () => {
 
     expect(
       buildStreamMetadata({
-        kind: AGENT_CATEGORY.TOOL_USE,
+        kind: AgentCategory.ToolUse,
         status: STREAM_STATUS.RUNNING,
         lastTimestamp: 123,
         conversationProgress: { conversationTurns: 2, toolCallCount: 5 },
@@ -41,7 +41,7 @@ describe('buildStreamMetadata', () => {
         finishedProcessCount: 3,
       }),
     ).toEqual({
-      kind: AGENT_CATEGORY.TOOL_USE,
+      kind: AgentCategory.ToolUse,
       status: STREAM_STATUS.RUNNING,
       lastTimestamp: 123,
       conversationProgress: { conversationTurns: 2, toolCallCount: 5 },

--- a/src/test-kernel/shared/StreamMetadata.vitest.ts
+++ b/src/test-kernel/shared/StreamMetadata.vitest.ts
@@ -9,17 +9,17 @@ import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 
 describe('buildStreamMetadata', () => {
   it('fills backend-owned defaults for a stream state metadata payload', () => {
-    expect(
-      buildStreamMetadata({ kind: AgentCategory.Workflow }),
-    ).toMatchObject({
-      kind: AgentCategory.Workflow,
-      status: STREAM_STATUS.READY,
-      conversationProgress: { conversationTurns: 0, toolCallCount: 0 },
-      activeSubagents: [],
-      finishedSubagentCount: 0,
-      activeProcesses: [],
-      finishedProcessCount: 0,
-    });
+    expect(buildStreamMetadata({ kind: AgentCategory.Workflow })).toMatchObject(
+      {
+        kind: AgentCategory.Workflow,
+        status: STREAM_STATUS.READY,
+        conversationProgress: { conversationTurns: 0, toolCallCount: 0 },
+        activeSubagents: [],
+        finishedSubagentCount: 0,
+        activeProcesses: [],
+        finishedProcessCount: 0,
+      },
+    );
   });
 
   it('preserves supplied status, progress, child badges, and timestamps', () => {

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -34,12 +34,15 @@ vi.mock('@agent/runtime/executeAgent', () => ({
   executeAgent: mocks.executeAgent,
 }));
 
-vi.mock('@agent/runtime/delegationPolicy', () => ({
-  readNestedDelegationConfig: () => ({
-    enabled: true,
-    maxDepth: 3,
-  }),
-}));
+vi.mock('@agent/runtime/delegationPolicy', async () => {
+  const { evaluateDelegationGate } = await vi.importActual<
+    typeof import('@shared/constants/delegationPolicy')
+  >('@shared/constants/delegationPolicy');
+  return {
+    evaluateCurrentDelegationGate: (depth: number) =>
+      evaluateDelegationGate(depth, { maxDepth: 3 }),
+  };
+});
 
 vi.mock('@agent/storage', () => ({
   getExecutionStore: mocks.getExecutionStore,

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -24,7 +24,7 @@ import type {
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
-import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 import { StorageFS } from '@utils/files';
 
 const tempDirs: string[] = [];
@@ -368,7 +368,7 @@ describe('StreamSnapshotStore', () => {
       agentConfig: {
         agent: 'search',
         model: 'deepseekproT',
-        agentCategory: AGENT_CATEGORY.TOOL_USE,
+        agentCategory: AgentCategory.ToolUse,
       },
     }) as TaskState;
     const executionId = 'abc123' as ExecutionId;

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -19,7 +19,6 @@ import {
   AgentConfigSchema,
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
@@ -46,7 +45,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - model
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import {
-  AGENT_CATEGORY,
+  AgentCategory,
   DEFAULT_TOOL_CONFIG,
   WorkflowAgentProposalSchema,
   ToolUseAgentProposalSchema,
@@ -208,19 +207,6 @@ function getRequiredContext(): RunContext & {
   return ctx as RunContext & { streamId: StreamTabId };
 }
 
-/** Build config payload from a proposal. */
-function toConfigPayload(
-  proposal: WorkflowAgentProposal | ToolUseAgentProposal,
-): AgentConfigPayload {
-  return {
-    ...proposal,
-    agentCategory:
-      proposal.agentCategory === AGENT_CATEGORY.TOOL_USE
-        ? AgentCategory.ToolUse
-        : AgentCategory.Workflow,
-  };
-}
-
 /** Metadata about how the delegation was approved, included in the tool result. */
 interface ApprovalMeta {
   autoApproved: boolean;
@@ -230,6 +216,12 @@ interface ApprovalMeta {
   requestedAgent?: string;
 }
 
+/**
+ * Format a subagent result for delivery to the orchestrator.
+ * For workflow results, computes latexdiffs and writes them as files to the
+ * execution's run directory first — the delivery references diff file paths
+ * so the orchestrator can read them on demand via /executions/{id}/files/.
+ */
 async function subagentDeliveryMessage(
   executionId: string,
   agentName: string,
@@ -381,6 +373,7 @@ async function executeSubagent(
 
   const executionId = generateExecutionId();
   const startedAt = Date.now();
+  const workingDirectory = configPayload.workingDirectory ?? undefined;
 
   const syntheticConfig = AgentConfigSchema.parse(configPayload);
   await registerExecution(
@@ -392,7 +385,33 @@ async function executeSubagent(
     parentDelegationDepth + 1,
   );
 
+  const inheritChildStreamApprovals = (resolvedStreamId: StreamTabId): void => {
+    // Bash bypass follows the parent regardless of edit-YOLO, so a bash-only
+    // parent (CLI AUTO-BASH without AUTO-APPROVE) still propagates to the child.
+    inheritBashBypassOnChildStream(resolvedStreamId, orchestratorStreamId);
+    if (options?.enableYoloOnChild) {
+      enableYoloOnChildStream(resolvedStreamId);
+    }
+  };
+
   if (parentContext.stopAfterCycle) {
+    const failureResult = async (
+      err: unknown,
+      memoryMisses?: AgentFlowResult['memoryMisses'],
+    ): Promise<ToolResult> => {
+      const msg = formatSubagentError(executionId, agentName, err, {
+        wallTimeMs: Date.now() - startedAt,
+        workingDirectory,
+        memoryMisses,
+      });
+      await writeSubagentReport(executionId, msg);
+      return {
+        summary: `Subagent '${agentName}' failed`,
+        output: msg,
+        error: toErrorMessage(err),
+        isError: true,
+      };
+    };
     try {
       let subagentError: unknown;
       const result = await executeAgent(configPayload, executionId, {
@@ -403,52 +422,23 @@ async function executeSubagent(
         delegationDepth: parentDelegationDepth + 1,
         approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
         stopAfterCycle: true,
-        onStreamResolved: (resolvedStreamId) => {
-          // Bash bypass follows the parent regardless of edit-YOLO, so a
-          // bash-only parent (CLI AUTO-BASH without AUTO-APPROVE) still
-          // propagates to the child.
-          inheritBashBypassOnChildStream(
-            resolvedStreamId,
-            orchestratorStreamId,
-          );
-          if (options?.enableYoloOnChild) {
-            enableYoloOnChildStream(resolvedStreamId);
-          }
-        },
+        onStreamResolved: inheritChildStreamApprovals,
         onError: (err) => {
           subagentError = err;
         },
       });
       settleSubagentCost(result);
       if (result.status === 'error') {
-        const msg = formatSubagentError(
-          executionId,
-          agentName,
+        return failureResult(
           subagentError ?? 'Subagent ended with error status.',
-          {
-            wallTimeMs: Date.now() - startedAt,
-            workingDirectory: configPayload.workingDirectory ?? undefined,
-            memoryMisses: result.memoryMisses,
-          },
+          result.memoryMisses,
         );
-        await writeSubagentReport(executionId, msg);
-        return {
-          summary: `Subagent '${agentName}' failed`,
-          output: msg,
-          error: toErrorMessage(
-            subagentError ?? 'Subagent ended with error status.',
-          ),
-          isError: true,
-        };
       }
       const msg = await subagentDeliveryMessage(
         executionId,
         agentName,
         result,
-        {
-          startedAt,
-          workingDirectory: configPayload.workingDirectory ?? undefined,
-        },
+        { startedAt, workingDirectory },
       );
       await writeSubagentReport(executionId, msg);
       return {
@@ -457,17 +447,7 @@ async function executeSubagent(
       };
     } catch (err) {
       settleSubagentCost(getAgentFlowErrorResult(err));
-      const msg = formatSubagentError(executionId, agentName, err, {
-        wallTimeMs: Date.now() - startedAt,
-        workingDirectory: configPayload.workingDirectory ?? undefined,
-      });
-      await writeSubagentReport(executionId, msg);
-      return {
-        summary: `Subagent '${agentName}' failed`,
-        output: msg,
-        error: toErrorMessage(err),
-        isError: true,
-      };
+      return failureResult(err);
     }
   }
 
@@ -525,13 +505,12 @@ async function executeSubagent(
     result?: AgentFlowResult,
   ): Promise<void> {
     settleSubagentCost(result);
-    const wallTimeMs = Date.now() - startedAt;
     const msg = formatSubagentError(executionId, agentName, err, {
-      wallTimeMs,
-      workingDirectory: configPayload.workingDirectory ?? undefined,
+      wallTimeMs: Date.now() - startedAt,
+      workingDirectory,
       memoryMisses: result?.memoryMisses,
     });
-    void getExecutionStore(executionId).writeReport(msg);
+    await writeSubagentReport(executionId, msg);
     await deliverTerminalFollowUp({
       text: msg,
       origin: 'subagent_result',
@@ -547,12 +526,7 @@ async function executeSubagent(
     approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;
-      // Bash bypass follows the parent regardless of edit-YOLO, so a bash-only
-      // parent (CLI AUTO-BASH without AUTO-APPROVE) still propagates to the child.
-      inheritBashBypassOnChildStream(resolvedStreamId, orchestratorStreamId);
-      if (options?.enableYoloOnChild) {
-        enableYoloOnChildStream(resolvedStreamId);
-      }
+      inheritChildStreamApprovals(resolvedStreamId);
     },
     onProgress,
     onFollowUpConsumed: () => {
@@ -570,7 +544,6 @@ async function executeSubagent(
       const resolvedChildStreamId = childStreamId;
       if (!resolvedChildStreamId) return false;
 
-      const wallTimeMs = Date.now() - startedAt;
       const msg = formatSubagentDelivery(
         agentName,
         {
@@ -583,16 +556,12 @@ async function executeSubagent(
           memoryMisses: memoryMisses.length > 0 ? [...memoryMisses] : undefined,
         },
         {
-          wallTimeMs,
-          workingDirectory: configPayload.workingDirectory ?? undefined,
+          wallTimeMs: Date.now() - startedAt,
+          workingDirectory,
         },
       );
       // Best-effort persist — must never block delivery or abort the subagent.
-      try {
-        await getExecutionStore(executionId).writeReport(msg);
-      } catch {
-        /* storage failure is non-fatal */
-      }
+      await writeSubagentReport(executionId, msg);
       // Claim only the enqueue step: formatting/storage failures before this
       // still leave onCompleted/onError available as terminal fallbacks.
       return await deliverTerminalFollowUp({
@@ -602,28 +571,13 @@ async function executeSubagent(
     },
     onCompleted: async (result) => {
       settleSubagentCost(result);
-      // For workflow results, compute diffs and write them as files to the
-      // execution's run directory. The delivery references diff file paths
-      // so the orchestrator can read them on demand via /executions/{id}/files/.
-      let diffInfos: Map<string, DiffFileInfo> | undefined;
-      if (result.category === 'workflow' && result.outputs.length > 0) {
-        try {
-          diffInfos = await computeAndWriteWorkflowDiffs(
-            executionId,
-            result.outputs,
-          );
-        } catch {
-          // Diff computation failure is non-fatal — deliver without diffs.
-        }
-      }
-
-      const wallTimeMs = Date.now() - startedAt;
-      const msg = formatSubagentDelivery(agentName, result, {
-        diffInfos,
-        wallTimeMs,
-        workingDirectory: configPayload.workingDirectory ?? undefined,
-      });
-      void getExecutionStore(executionId).writeReport(msg);
+      const msg = await subagentDeliveryMessage(
+        executionId,
+        agentName,
+        result,
+        { startedAt, workingDirectory },
+      );
+      await writeSubagentReport(executionId, msg);
       await deliverTerminalFollowUp({
         text: msg,
         origin: 'subagent_result',
@@ -633,7 +587,6 @@ async function executeSubagent(
   });
   promise
     .catch((err: unknown) => {
-      settleSubagentCost();
       void deliverSubagentError(err);
     })
     .finally(() => {
@@ -775,7 +728,7 @@ async function proposeAndExecute(
   streamId: StreamTabId,
 ): Promise<ToolResult> {
   if (proposalApprovalState.isBypassed(streamId)) {
-    return executeSubagent(toConfigPayload(proposal), agentName, streamId, {
+    return executeSubagent(proposal, agentName, streamId, {
       enableYoloOnChild: true,
       approvalMeta: { autoApproved: true },
     });
@@ -824,25 +777,20 @@ async function proposeAndExecute(
     ...(agentOverride && { agent: agentOverride }),
   };
   const effectiveAgentName = agentOverride ?? agentName;
-  return executeSubagent(
-    toConfigPayload(effective),
-    effectiveAgentName,
-    streamId,
-    {
-      enableYoloOnChild: isApprovalBypassedForStream(streamId),
-      approvalMeta: {
-        autoApproved: false,
-        ...(modelOverride && {
-          modelOverride,
-          requestedModel: proposal.model,
-        }),
-        ...(agentOverride && {
-          agentOverride,
-          requestedAgent: proposal.agent,
-        }),
-      },
+  return executeSubagent(effective, effectiveAgentName, streamId, {
+    enableYoloOnChild: isApprovalBypassedForStream(streamId),
+    approvalMeta: {
+      autoApproved: false,
+      ...(modelOverride && {
+        modelOverride,
+        requestedModel: proposal.model,
+      }),
+      ...(agentOverride && {
+        agentOverride,
+        requestedAgent: proposal.agent,
+      }),
     },
-  );
+  });
 }
 
 // ============================================================================
@@ -965,13 +913,6 @@ Example: agent=correct, inputFiles=["paper.tex"], extractFigures=true, instructi
       requestedModel: input.model,
       parentModel: ctx.model,
     });
-
-    // Validate at least one input file is provided
-    if (input.inputFiles.length === 0) {
-      throw new Error(
-        'At least one entry in inputFiles is required for workflow agents.',
-      );
-    }
 
     // Validate all file paths exist (parallel for performance)
     const toValidate = (

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -20,7 +20,7 @@ import {
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
-import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
+import { evaluateCurrentDelegationGate } from '@agent/runtime/delegationPolicy';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
 import {
@@ -54,7 +54,6 @@ import {
   type StreamTabId,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
-import { evaluateDelegationGate } from '@shared/constants/delegationPolicy';
 import { formatBytes } from '@shared/utils/string';
 
 // Local imports - tools
@@ -277,13 +276,10 @@ function resolveDeliveryStreamId(
 
 /**
  * Runtime depth gate shared by fresh delegations and resumes.
- * Reads the current workspace delegation policy via readNestedDelegationConfig().
+ * Evaluates against the current workspace delegation policy.
  */
 function depthGateError(parentDelegationDepth: number): ToolResult | null {
-  const gate = evaluateDelegationGate(
-    parentDelegationDepth,
-    readNestedDelegationConfig(),
-  );
+  const gate = evaluateCurrentDelegationGate(parentDelegationDepth);
   if (gate.allowed) return null;
 
   const unknownDepth = gate.blockReason === 'unknown_depth';
@@ -651,11 +647,17 @@ async function resolveAvailableDelegationModel(input: {
   });
 }
 
+/** True when a visible agent of the given category matches the name. */
+function isVisibleAgent(category: AgentCategory, name: string): boolean {
+  return getVisibleAgents(category).some((a) => a.name === name);
+}
+
 /** Throw if no visible agent of the given category matches the name. */
 function assertVisibleAgent(category: AgentCategory, name: string): void {
-  const visible = getVisibleAgents(category);
-  if (visible.some((a) => a.name === name)) return;
-  const available = visible.map((a) => a.name).join(', ');
+  if (isVisibleAgent(category, name)) return;
+  const available = getVisibleAgents(category)
+    .map((a) => a.name)
+    .join(', ');
   throw new Error(
     `Unknown ${category} agent '${name}'. Available: ${available}`,
   );
@@ -760,15 +762,12 @@ async function proposeAndExecute(
   // approval the agent may have been removed/renamed, or the approval could
   // carry a malformed value. Fail fast so the orchestrator sees the problem
   // synchronously instead of after an async launch.
-  if (agentOverride) {
-    const visible = getVisibleAgents(proposal.agentCategory);
-    if (!visible.some((a) => a.name === agentOverride)) {
-      return {
-        summary: `Approved agent override '${agentOverride}' is not available`,
-        output: `Cannot launch '${agentOverride}': it is not currently a visible ${proposal.agentCategory} agent (removed, renamed, or disabled since the proposal was shown). Re-propose the delegation.`,
-        isError: true,
-      };
-    }
+  if (agentOverride && !isVisibleAgent(proposal.agentCategory, agentOverride)) {
+    return {
+      summary: `Approved agent override '${agentOverride}' is not available`,
+      output: `Cannot launch '${agentOverride}': it is not currently a visible ${proposal.agentCategory} agent (removed, renamed, or disabled since the proposal was shown). Re-propose the delegation.`,
+      isError: true,
+    };
   }
 
   const effective = {


### PR DESCRIPTION
Reduce friction in the multi-agent orchestration layer:

- Delete the AGENT_CATEGORY legacy alias; all call sites (extension,
  desktop, CLI, webviews, tests) now use the canonical AgentCategory
  const from @shared/schemas/agent.
- Drop toConfigPayload in DelegationTools — with one category enum the
  proposal-to-payload mapping was an identity transform.
- Deduplicate executeSubagent: shared inheritChildStreamApprovals
  callback for headless and async launches, a single failureResult
  helper for the two headless error paths, and onCompleted now reuses
  subagentDeliveryMessage instead of re-implementing diff computation
  and delivery formatting inline.
- Route all subagent report persistence through writeSubagentReport so
  storage failures can no longer surface as unhandled rejections from
  fire-and-forget writeReport calls.
- Remove the unreachable inputFiles-empty check in delegate_workflow
  (the Zod schema already enforces .min(1) before execute runs).
- Replace deprecated Zod .merge() with .extend(...shape) in the
  workflow proposal schema.

https://claude.ai/code/session_01YPDS6MHiiGZgpGLrheRYt1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegation tool resolution, depth gating, and subagent report persistence across the orchestration path; behavior should be equivalent but errors are now swallowed consistently on report writes.
> 
> **Overview**
> Removes the legacy **`AGENT_CATEGORY`** alias and standardizes on **`AgentCategory`** across CLI, desktop, extension, shared schemas, and tests.
> 
> **Delegation / orchestration cleanup:** adds **`hasDelegationTool`** and **`evaluateCurrentDelegationGate`**; consolidates runtime tool gating in **`resolveAgentTools`**; simplifies **`runToolUseFlow`** depth checks. **`DelegationTools`** drops redundant **`toConfigPayload`**, passes proposals straight into **`executeSubagent`**, and centralizes subagent report writes via **`writeSubagentReport`** (with **`subagentDeliveryMessage`** reused on completion). Removes a redundant **`inputFiles`** empty check in **`delegate_workflow`**.
> 
> **UI:** workflow extract-figure badges move to shared **`renderWorkflowExtractFlagBadges`** in **`PermissionCard`** and **`ProposalRequestPanel`**.
> 
> **Schemas:** workflow proposal schema uses **`.extend(...shape)`** instead of deprecated **`.merge()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cd5b4931914b2854d3415afbb3776bf0feb906a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->