### PR TITLE
fix(cli): drop empty assistant transcript rows

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -108,6 +108,7 @@ const SHOW_AGENT_PROPOSAL = process.env.HARNESS_AGENT_PROPOSAL === '1';
 const PLAN_APPROVAL_GOAL = process.env.HARNESS_PLAN_APPROVAL_GOAL === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
+const SHOW_LIVE_TOOL_ONLY = process.env.HARNESS_LIVE_TOOL_ONLY === '1';
 const SHOW_PROJECT_SKILL = process.env.HARNESS_PROJECT_SKILL === '1';
 const WIDE_TRANSCRIPT_SUFFIX =
   ' hidden-middle wide-column-A wide-column-B wide-column-C wide-column-D wide-column-E wide-column-F';
@@ -471,6 +472,43 @@ function makeLongToolOutputEntries(): ConversationEntry[] {
   ];
 }
 
+function seedLiveToolOnlyTranscript(): void {
+  const store = getDefaultStreamLogStore();
+  const timestamp = Date.now();
+  store.append(STREAM_ID, {
+    id: 'live-tool-user',
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp,
+    messageType: MESSAGE_TYPES.USER_MESSAGE,
+    text: 'what is this repo about',
+  });
+  store.append(STREAM_ID, {
+    id: 'live-tool-empty-assistant',
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp: timestamp + 1,
+    messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    text: '',
+  });
+  store.append(STREAM_ID, {
+    id: 'live-tool-ls',
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp: timestamp + 2,
+    messageType: MESSAGE_TYPES.TOOL_USE,
+    data: {
+      toolName: 'ls',
+      input: { path: '.' },
+      output: '',
+      summary: 'Listed 36 entries in .',
+      isError: false,
+      status: TOOL_USE_STATUS.COMPLETED,
+    },
+  });
+  syncStreamLog(STREAM_ID);
+}
+
 function makeRejectedBashToolEntries(): ConversationEntry[] {
   const command = "printf 'approval-reject-live\\n'";
   const message = `User rejected bash command: ${command}`;
@@ -826,10 +864,16 @@ patchStream(STREAM_ID, (slice) => ({
     ? makeRejectedBashToolEntries()
     : SHOW_LONG_TOOL_OUTPUT
       ? makeLongToolOutputEntries()
-      : makeEntries(ENTRY_COUNT),
+      : SHOW_LIVE_TOOL_ONLY
+        ? []
+        : makeEntries(ENTRY_COUNT),
   queuedFollowUps: QUEUED_FOLLOW_UPS.length,
   queuedFollowUpMessages: QUEUED_FOLLOW_UPS,
 }));
+
+if (SHOW_LIVE_TOOL_ONLY) {
+  seedLiveToolOnlyTranscript();
+}
 
 if (SHOW_SUBAGENT_FOLLOWUPS) {
   seedSubagentFollowupTranscript();

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -110,6 +110,14 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'live-tool-only-spacing',
+    env: { HARNESS_LIVE_TOOL_ONLY: '1' },
+    expect: ['what is this repo about', '● ls (Listed 36 entries in .)'],
+    maxBlankLinesBetween: [
+      { from: 'what is this repo about', to: '● ls', max: 1 },
+    ],
+  },
+  {
     name: 'queued-followups',
     cols: 120,
     env: {

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -203,6 +203,12 @@ function renderLogEntry(
   const text = entry.text ?? '';
   const role = logEntryRole(entry.messageType);
   const renderedText = renderLogEntryText(role, text);
+  if (
+    entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE &&
+    renderedText.trim().length === 0
+  ) {
+    return null;
+  }
   // Assistant text is promoted by `finalizeSettledPrefix` once the model
   // moves on to a later entry; inherit the prior flag here so a re-sync
   // can't de-finalize an already-promoted block. User/error rows can't

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1590,6 +1590,35 @@ describe('CLI transcript state', () => {
     }
   });
 
+  it('does not project empty assistant responses into transcript rows', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info('', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+
+      syncStreamLog(root);
+
+      let slice = cliState.streams.get().get(root);
+      expect(slice?.entries ?? []).toEqual([]);
+
+      logger.info('Visible answer.', {
+        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+      });
+
+      syncStreamLog(root);
+
+      slice = cliState.streams.get().get(root);
+      expect(slice?.entries.map((entry) => entry.text)).toEqual([
+        'Visible answer.',
+      ]);
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
   // Regression: a sync tick that fires after `finalizeAssistantTranscriptEntries`
   // must not roll the entry back to `finalized: false`. Cursor Bugbot flagged
   // this when `entriesEqual` started comparing `finalized` — without this


### PR DESCRIPTION
## Summary

Closes #5741.

- Skip empty assistant/model-response log entries at the CLI TUI stream-log projection boundary.
- Add a TUI harness mode for a real user -> empty model response -> tool sequence.
- Add a validator scenario that checks the submitted prompt and first tool row stay visually tight.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-live-tool-spacing live-tool-only-spacing`
- `npm run typecheck`
- `npm run lint -- --quiet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Transcript projection change is narrow (empty model responses only) with targeted tests; no auth, persistence, or API behavior changes.
> 
> **Overview**
> Fixes extra vertical gap in the CLI TUI when a turn goes **user message → empty model response → tool call** by **not projecting** whitespace-only `MODEL_RESPONSE` log entries into `cliState` transcript rows in `subscribeStreamLog` (`renderLogEntry` returns `null` when trimmed assistant text is empty).
> 
> Adds regression coverage: a **TUI harness** path (`HARNESS_LIVE_TOOL_ONLY`) that seeds that sequence through the real stream-log sync, a **`validate-tui`** scenario (`live-tool-only-spacing`) that asserts at most one blank line between the user line and the first tool row, and a **Vitest** case that empty model responses produce no entries until real assistant text arrives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c907f9c947f0e0add988052f3f76b8a4a73e680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->