### PR TITLE
test(cli): require compact user-to-tool spacing

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -114,7 +114,7 @@ const SCENARIOS = [
     env: { HARNESS_LIVE_TOOL_ONLY: '1' },
     expect: ['what is this repo about', '● ls (Listed 36 entries in .)'],
     maxBlankLinesBetween: [
-      { from: 'what is this repo about', to: '● ls', max: 1 },
+      { from: 'what is this repo about', to: '● ls', max: 0 },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- tighten the live-tool-only TUI validator so the first tool row must render immediately below the user message
- preserves the current renderer behavior with a stricter product-facing snapshot assertion

## Verification
- corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-spacing-zero live-tool-only-spacing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion change in the CLI TUI validator; no runtime or product code modified.
> 
> **Overview**
> Tightens the **`live-tool-only-spacing`** PTY TUI scenario in `validate-tui.mjs` so the first tool line (`● ls`) must sit **directly under** the user line (`what is this repo about`) with **no blank lines** between them (`maxBlankLinesBetween` **1 → 0**).
> 
> This is a stricter regression guard for live-tool-only transcript layout; it does not change renderer or harness code in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ea6c760a0a62262044fce6a59c20f65f771ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->