### PR TITLE
fix: skip empty CLI transcript placeholders

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -23,6 +23,7 @@ import { streamViewForId } from '../state/streamViews';
 import { transcriptEntryLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
+import { isRenderableTranscriptEntry } from './transcriptEntries';
 import {
   isInquiryContinuationText,
   TranscriptEntry,
@@ -231,6 +232,7 @@ export function appendStaticTranscriptItems({
     ? streams.get(scrollbackStreamId)
     : undefined;
   for (const entry of slice?.entries ?? []) {
+    if (!isRenderableTranscriptEntry(entry)) continue;
     if (!entry.finalized) continue;
     if (seen.has(entry.id)) continue;
     nextItems ??= [...currentItems];

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -5,6 +5,19 @@ import {
 
 import type { ConversationEntry } from '../state/cliState';
 
+export function isRenderableTranscriptEntry(entry: ConversationEntry): boolean {
+  switch (entry.role) {
+    case 'assistant':
+    case 'error':
+    case 'user':
+      return entry.text.trim().length > 0;
+    case 'process':
+      return entry.process !== undefined;
+    case 'tool':
+      return entry.toolUse !== undefined;
+  }
+}
+
 export function splitTranscriptEntries(
   entries: readonly ConversationEntry[],
   status: StreamStatus | undefined,
@@ -25,6 +38,7 @@ export function splitTranscriptEntries(
   const finalized: ConversationEntry[] = [];
   const pending: ConversationEntry[] = [];
   for (const entry of entries) {
+    if (!isRenderableTranscriptEntry(entry)) continue;
     if (entry.finalized) {
       finalized.push(entry);
       continue;

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -8,6 +8,7 @@ import {
   USER_ENTRY_MARGIN_BOTTOM_ROWS,
   tailWindow,
 } from './TranscriptEntry';
+import { isRenderableTranscriptEntry } from './transcriptEntries';
 import { toolUseDisplayLines } from './toolRenderers';
 import type { ConversationEntry } from '../state/cliState';
 
@@ -111,6 +112,7 @@ export function selectTranscriptEntriesForViewport(
   let usedRows = 0;
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index];
+    if (!isRenderableTranscriptEntry(entry)) continue;
     const entryRows = estimateLiveTranscriptEntryRows(entry, width);
     if (usedRows + entryRows > maxRows) {
       if (selected.length === 0) {

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -14,6 +14,7 @@ import {
 import { normalizeToolUseData } from '@shared/toolUse';
 
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
+import { isRenderableTranscriptEntry } from '../panes/transcriptEntries';
 import { cliState, patchStream, type ConversationEntry } from './cliState';
 import { isFinalTranscriptStatus } from './transcript';
 
@@ -203,12 +204,6 @@ function renderLogEntry(
   const text = entry.text ?? '';
   const role = logEntryRole(entry.messageType);
   const renderedText = renderLogEntryText(role, text);
-  if (
-    entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE &&
-    renderedText.trim().length === 0
-  ) {
-    return null;
-  }
   // Assistant text is promoted by `finalizeSettledPrefix` once the model
   // moves on to a later entry; inherit the prior flag here so a re-sync
   // can't de-finalize an already-promoted block. User/error rows can't
@@ -220,6 +215,7 @@ function renderLogEntry(
     text: renderedText,
     finalized,
   };
+  if (!isRenderableTranscriptEntry(next)) return null;
   return prev && entriesEqual(prev, next) ? prev : next;
 }
 

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -5,6 +5,7 @@
 
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { completedProcessDisplayLines } from './completedProcessTranscript';
+import { isRenderableTranscriptEntry } from '../panes/transcriptEntries';
 import { toolUseDisplayLines } from '../panes/toolRenderers';
 import type { ConversationEntry, StreamSlice } from './cliState';
 
@@ -129,6 +130,7 @@ export function transcriptToLines(
   let previousEntry: ConversationEntry | undefined;
   let previousLines: readonly string[] = [];
   for (const entry of slice.entries) {
+    if (!isRenderableTranscriptEntry(entry)) continue;
     const lines = transcriptEntryLines(entry, cols);
     if (lines.length === 0) continue;
     if (

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -353,6 +353,50 @@ describe('CLI conversation transcript splitting', () => {
     expect(estimateTranscriptEntryRows(user, 80)).toBe(1);
   });
 
+  it('does not render empty assistant placeholders between user and tool rows', () => {
+    const user = entry('u1', 'user', 'what is this repo about', true);
+    const emptyAssistant = entry('a1', 'assistant', '\n  \n', false);
+    const tool = toolEntry('t1', 'in_progress');
+
+    const split = splitTranscriptEntries(
+      [user, emptyAssistant, tool],
+      STREAM_STATUS.RUNNING,
+    );
+    expect(split.finalized.map((item) => item.id)).toEqual(['u1']);
+    expect(split.pending.map((item) => item.id)).toEqual(['t1']);
+
+    expect(
+      selectTranscriptEntriesForViewport(
+        [emptyAssistant, tool],
+        4,
+        80,
+      ).entries.map((item) => item.id),
+    ).toEqual(['t1']);
+
+    const staticItems = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: [],
+      streams: streamsFromEntries(STREAM_ID, [
+        user,
+        { ...emptyAssistant, finalized: true },
+        { ...tool, finalized: true },
+      ]),
+      meta: SESSION_META,
+    });
+    expect(staticItems.map((item) => item.id)).toEqual([
+      'session-header',
+      'u1',
+      't1',
+    ]);
+
+    expect(
+      transcriptToLines(
+        sliceWithEntries(STREAM_ID, [user, emptyAssistant, tool]),
+        80,
+      ),
+    ).toEqual(['› what is this repo about', '', '● Bash (ls)']);
+  });
+
   it('does not budget regular user margin for inquiry continuations', () => {
     const continuation = entry(
       'u1',


### PR DESCRIPTION
## Summary
- add a single CLI transcript renderability contract for empty assistant placeholders
- use it in stream projection, live/static transcript splitting, viewport row budgeting, and transcript flattening
- add a regression for user -> empty assistant placeholder -> tool rows so the placeholder cannot reserve vertical space

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui live-tool-only-spacing --snapshot-dir /tmp/texra-spacing-snapshots`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only filtering of display entries; stream log data is unchanged and behavior is covered by a targeted regression test.
> 
> **Overview**
> Introduces **`isRenderableTranscriptEntry`** in `transcriptEntries.ts` as the single rule for whether a conversation row should appear in the CLI transcript: text roles need non-whitespace text; tool/process rows need their payload fields.
> 
> That helper replaces the ad hoc “drop empty model responses” check in **`subscribeStreamLog`** and is applied everywhere entries are split, budgeted, or flattened—**`splitTranscriptEntries`**, static **`<Static>`** scrollback, live viewport selection, and **`transcriptToLines`** (Ctrl+T viewer)—so whitespace-only assistant placeholders no longer consume rows or sit between user and tool lines.
> 
> Adds a regression test for **user → empty assistant → tool** across split, viewport, static items, and transcript lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d8ca12f2e1bf1cc997fa7cc34fd348240d2ae27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->