### PR TITLE
fix(relay): enforce server-side request limits

### DIFF
--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -375,9 +375,10 @@ describe('relay free-tier request limits', () => {
     }
   });
 
-  it('releases request slots when stream lease refresh keeps failing', async () => {
+  it('keeps streams open through transient lease refresh failures', async () => {
     vi.useFakeTimers();
     try {
+      let refreshes = 0;
       let releases = 0;
       const wrapped = await releaseWhenStreamCloses(
         byteStream([new Uint8Array([1])]),
@@ -385,6 +386,7 @@ describe('relay free-tier request limits', () => {
           releases += 1;
         },
         async () => {
+          refreshes += 1;
           throw new Error('refresh unavailable');
         },
         10,
@@ -392,13 +394,78 @@ describe('relay free-tier request limits', () => {
       if (wrapped === null) assert.fail('expected wrapped stream');
 
       await vi.advanceTimersByTimeAsync(30);
-      assert.equal(releases, 1);
+      assert.equal(refreshes, 3);
+      assert.equal(releases, 0);
 
       const reader = wrapped.getReader();
-      await assert.rejects(reader.read(), /refresh unavailable/);
+      assert.deepEqual(await reader.read(), {
+        done: false,
+        value: new Uint8Array([1]),
+      });
+      assert.deepEqual(await reader.read(), {
+        done: true,
+        value: undefined,
+      });
+      assert.equal(releases, 1);
 
       await vi.advanceTimersByTimeAsync(30);
       assert.equal(releases, 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('releases request slots when stream lease refresh loses the slot', async () => {
+    vi.useFakeTimers();
+    try {
+      const calls: string[] = [];
+      const client = {
+        async rpc(name: string, args: Record<string, unknown>) {
+          calls.push(name);
+          return {
+            data:
+              name === 'relay_request_gate'
+                ? {
+                    allowed: true,
+                    slotId: args.p_slot_id,
+                    activeRequests: 1,
+                    concurrencyLimit: 2,
+                    requestsThisMinute: 1,
+                    rateLimitPerMinute: 20,
+                  }
+                : name === 'relay_request_refresh'
+                  ? { refreshed: false }
+                  : {},
+            error: null,
+          };
+        },
+      };
+      const slot = await acquireRelayRequestSlot(client, crypto.randomUUID(), {
+        ratePerMinute: 20,
+        concurrent: 2,
+      });
+      if (!slot.allowed) assert.fail('expected slot to be allowed');
+
+      const wrapped = await releaseWhenStreamCloses(
+        byteStream([new Uint8Array([1])]),
+        slot.release,
+        slot.refresh,
+        10,
+      );
+      if (wrapped === null) assert.fail('expected wrapped stream');
+
+      await vi.advanceTimersByTimeAsync(10);
+      assert.deepEqual(calls, [
+        'relay_request_gate',
+        'relay_request_refresh',
+        'relay_request_release',
+      ]);
+
+      const reader = wrapped.getReader();
+      await assert.rejects(
+        reader.read(),
+        /relay_request_refresh did not find request slot/,
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -280,7 +280,7 @@ describe('relay free-tier request limits', () => {
                 }
               : name === 'relay_request_refresh'
                 ? { refreshed: true }
-              : {},
+                : {},
           error: null,
         };
       },
@@ -322,7 +322,7 @@ describe('relay free-tier request limits', () => {
                 }
               : name === 'relay_request_refresh'
                 ? { refreshed: false }
-              : {},
+                : {},
           error: null,
         };
       },

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -2,15 +2,21 @@
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
-import { describe, it } from 'vitest';
+import { describe, it, vi } from 'vitest';
 
 // Local imports - Supabase relay
 import {
+  FREE_TIER_MAX_OUTPUT_TOKENS,
   FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
   checkRequestBodySizeLimit,
+  clampFreeTierMaxOutputTokens,
   formatRequestBytes,
   readRequestBodyWithinSizeLimit,
 } from '../../../supabase/functions/relay/requestLimits';
+import {
+  acquireRelayRequestSlot,
+  releaseWhenStreamCloses,
+} from '../../../supabase/functions/relay/requestGate';
 
 function byteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -23,7 +29,7 @@ function byteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   });
 }
 
-describe('relay free-tier request size limits', () => {
+describe('relay free-tier request limits', () => {
   it('rejects free-tier request bodies over the byte cap', () => {
     assert.deepEqual(checkRequestBodySizeLimit('abc', 3), {
       allowed: true,
@@ -79,5 +85,348 @@ describe('relay free-tier request size limits', () => {
       formatRequestBytes(FREE_TIER_REQUEST_BODY_LIMIT_BYTES),
       '2 MiB',
     );
+  });
+
+  it('adds an OpenAI-compatible max token cap when missing', () => {
+    const result = clampFreeTierMaxOutputTokens('deepseek', '/v1/chat', {
+      model: 'deepseek-chat',
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.fieldPath, 'max_tokens');
+    assert.deepEqual(result.body, {
+      model: 'deepseek-chat',
+      max_tokens: FREE_TIER_MAX_OUTPUT_TOKENS,
+    });
+  });
+
+  it('preserves OpenAI-compatible max token requests under the cap', () => {
+    const body = { model: 'deepseek-chat', max_tokens: 1024 };
+    const result = clampFreeTierMaxOutputTokens('deepseek', '/v1/chat', body);
+
+    assert.equal(result.changed, false);
+    assert.equal(result.body, body);
+  });
+
+  it('replaces non-positive OpenAI-compatible max token requests', () => {
+    const result = clampFreeTierMaxOutputTokens('deepseek', '/v1/chat', {
+      model: 'deepseek-chat',
+      max_tokens: -1,
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.fieldPath, 'max_tokens');
+    assert.deepEqual(result.body, {
+      model: 'deepseek-chat',
+      max_tokens: FREE_TIER_MAX_OUTPUT_TOKENS,
+    });
+  });
+
+  it('caps Responses API max_output_tokens', () => {
+    const result = clampFreeTierMaxOutputTokens('openai', '/v1/responses', {
+      model: 'gpt-4.1-mini',
+      max_output_tokens: 128_000,
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.fieldPath, 'max_output_tokens');
+    assert.deepEqual(result.body, {
+      model: 'gpt-4.1-mini',
+      max_output_tokens: FREE_TIER_MAX_OUTPUT_TOKENS,
+    });
+  });
+
+  it('adds Responses API max_output_tokens when only a decoy field exists', () => {
+    const result = clampFreeTierMaxOutputTokens('openai', '/v1/responses', {
+      model: 'gpt-4.1-mini',
+      max_tokens: 1024,
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.fieldPath, 'max_output_tokens');
+    assert.deepEqual(result.body, {
+      model: 'gpt-4.1-mini',
+      max_tokens: 1024,
+      max_output_tokens: FREE_TIER_MAX_OUTPUT_TOKENS,
+    });
+  });
+
+  it('caps OpenAI-compatible max_completion_tokens', () => {
+    const result = clampFreeTierMaxOutputTokens('openai', '/v1/chat', {
+      model: 'gpt-5-mini',
+      max_completion_tokens: 128_000,
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.fieldPath, 'max_completion_tokens');
+    assert.deepEqual(result.body, {
+      model: 'gpt-5-mini',
+      max_completion_tokens: FREE_TIER_MAX_OUTPUT_TOKENS,
+    });
+  });
+
+  it('uses max_completion_tokens for GPT-5 chat requests without a cap', () => {
+    const result = clampFreeTierMaxOutputTokens(
+      'openai',
+      '/v1/chat/completions',
+      { model: 'gpt-5-mini' },
+    );
+
+    assert.equal(result.changed, true);
+    assert.equal(result.fieldPath, 'max_completion_tokens');
+    assert.deepEqual(result.body, {
+      model: 'gpt-5-mini',
+      max_completion_tokens: FREE_TIER_MAX_OUTPUT_TOKENS,
+    });
+  });
+
+  it('adds chat max_tokens when only a decoy Responses field exists', () => {
+    const result = clampFreeTierMaxOutputTokens(
+      'openai',
+      '/v1/chat/completions',
+      {
+        model: 'gpt-4.1-mini',
+        max_output_tokens: 1024,
+      },
+    );
+
+    assert.equal(result.changed, true);
+    assert.equal(result.fieldPath, 'max_tokens');
+    assert.deepEqual(result.body, {
+      model: 'gpt-4.1-mini',
+      max_output_tokens: 1024,
+      max_tokens: FREE_TIER_MAX_OUTPUT_TOKENS,
+    });
+  });
+
+  it('caps sibling OpenAI-compatible max token fields together', () => {
+    const result = clampFreeTierMaxOutputTokens('openai', '/v1/chat', {
+      model: 'gpt-4.1-mini',
+      max_completion_tokens: 1024,
+      max_tokens: 128_000,
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.fieldPath, 'max_tokens');
+    assert.deepEqual(result.body, {
+      model: 'gpt-4.1-mini',
+      max_completion_tokens: 1024,
+      max_tokens: FREE_TIER_MAX_OUTPUT_TOKENS,
+    });
+  });
+
+  it('caps Google generationConfig maxOutputTokens', () => {
+    const result = clampFreeTierMaxOutputTokens(
+      'google',
+      '/v1beta/models/gemini-3.5-flash:streamGenerateContent',
+      {
+        contents: [],
+        generationConfig: { maxOutputTokens: 128_000, temperature: 0.2 },
+      },
+    );
+
+    assert.equal(result.changed, true);
+    assert.equal(result.fieldPath, 'generationConfig.maxOutputTokens');
+    assert.deepEqual(result.body, {
+      contents: [],
+      generationConfig: {
+        maxOutputTokens: FREE_TIER_MAX_OUTPUT_TOKENS,
+        temperature: 0.2,
+      },
+    });
+  });
+
+  it('releases request slots when the upstream stream closes', async () => {
+    let releases = 0;
+    const wrapped = await releaseWhenStreamCloses(
+      byteStream([new Uint8Array([1]), new Uint8Array([2])]),
+      async () => {
+        releases += 1;
+      },
+    );
+    if (wrapped === null) assert.fail('expected wrapped stream');
+
+    const reader = wrapped.getReader();
+    assert.deepEqual(await reader.read(), {
+      done: false,
+      value: new Uint8Array([1]),
+    });
+    assert.deepEqual(await reader.read(), {
+      done: false,
+      value: new Uint8Array([2]),
+    });
+    assert.deepEqual(await reader.read(), {
+      done: true,
+      value: undefined,
+    });
+    assert.equal(releases, 1);
+  });
+
+  it('uses the same slot id for gate refresh and release RPCs', async () => {
+    const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    const client = {
+      async rpc(name: string, args: Record<string, unknown>) {
+        calls.push({ name, args });
+        return {
+          data:
+            name === 'relay_request_gate'
+              ? {
+                  allowed: true,
+                  slotId: args.p_slot_id,
+                  activeRequests: 1,
+                  concurrencyLimit: 2,
+                  requestsThisMinute: 1,
+                  rateLimitPerMinute: 20,
+                }
+              : name === 'relay_request_refresh'
+                ? { refreshed: true }
+              : {},
+          error: null,
+        };
+      },
+    };
+
+    const slot = await acquireRelayRequestSlot(client, crypto.randomUUID(), {
+      ratePerMinute: 20,
+      concurrent: 2,
+    });
+    if (!slot.allowed) assert.fail('expected slot to be allowed');
+
+    const slotId = calls[0].args.p_slot_id;
+    assert.equal(typeof slotId, 'string');
+    await slot.refresh();
+    await slot.release();
+    await slot.release();
+
+    assert.deepEqual(
+      calls.map((call) => call.name),
+      ['relay_request_gate', 'relay_request_refresh', 'relay_request_release'],
+    );
+    assert.equal(calls[1].args.p_slot_id, slotId);
+    assert.equal(calls[2].args.p_slot_id, slotId);
+  });
+
+  it('rejects refreshes when the request slot is already gone', async () => {
+    const client = {
+      async rpc(name: string, args: Record<string, unknown>) {
+        return {
+          data:
+            name === 'relay_request_gate'
+              ? {
+                  allowed: true,
+                  slotId: args.p_slot_id,
+                  activeRequests: 1,
+                  concurrencyLimit: 2,
+                  requestsThisMinute: 1,
+                  rateLimitPerMinute: 20,
+                }
+              : name === 'relay_request_refresh'
+                ? { refreshed: false }
+              : {},
+          error: null,
+        };
+      },
+    };
+
+    const slot = await acquireRelayRequestSlot(client, crypto.randomUUID(), {
+      ratePerMinute: 20,
+      concurrent: 2,
+    });
+    if (!slot.allowed) assert.fail('expected slot to be allowed');
+
+    await assert.rejects(
+      slot.refresh(),
+      /relay_request_refresh did not find request slot/,
+    );
+  });
+
+  it('refreshes request slots while the upstream stream stays open', async () => {
+    vi.useFakeTimers();
+    try {
+      let refreshes = 0;
+      let releases = 0;
+      const wrapped = await releaseWhenStreamCloses(
+        byteStream([
+          new Uint8Array([1]),
+          new Uint8Array([2]),
+          new Uint8Array([3]),
+        ]),
+        async () => {
+          releases += 1;
+        },
+        async () => {
+          refreshes += 1;
+        },
+        10,
+      );
+      if (wrapped === null) assert.fail('expected wrapped stream');
+
+      await vi.advanceTimersByTimeAsync(35);
+      assert.equal(refreshes, 3);
+
+      const reader = wrapped.getReader();
+      await reader.cancel();
+      assert.equal(releases, 1);
+
+      await vi.advanceTimersByTimeAsync(35);
+      assert.equal(refreshes, 3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('releases request slots when stream lease refresh keeps failing', async () => {
+    vi.useFakeTimers();
+    try {
+      let releases = 0;
+      const wrapped = await releaseWhenStreamCloses(
+        byteStream([new Uint8Array([1])]),
+        async () => {
+          releases += 1;
+        },
+        async () => {
+          throw new Error('refresh unavailable');
+        },
+        10,
+      );
+      if (wrapped === null) assert.fail('expected wrapped stream');
+
+      await vi.advanceTimersByTimeAsync(30);
+      assert.equal(releases, 1);
+
+      const reader = wrapped.getReader();
+      await assert.rejects(reader.read(), /refresh unavailable/);
+
+      await vi.advanceTimersByTimeAsync(30);
+      assert.equal(releases, 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('releases request slots when the upstream stream is canceled', async () => {
+    let releases = 0;
+    const wrapped = await releaseWhenStreamCloses(
+      byteStream([new Uint8Array([1])]),
+      async () => {
+        releases += 1;
+      },
+    );
+    if (wrapped === null) assert.fail('expected wrapped stream');
+
+    const reader = wrapped.getReader();
+    await reader.cancel();
+
+    assert.equal(releases, 1);
+  });
+
+  it('awaits request slot release for null upstream bodies', async () => {
+    let releases = 0;
+    const wrapped = await releaseWhenStreamCloses(null, async () => {
+      releases += 1;
+    });
+
+    assert.equal(wrapped, null);
+    assert.equal(releases, 1);
   });
 });

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -68,6 +68,7 @@ import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
 import {
   TIER_CONFIG,
   TIER_SPENDING_LIMITS,
+  getRequestLimits,
   isModelAllowedForTier,
   getSpendingLimit,
   FREE_TIER_SUGGESTED_MODEL,
@@ -81,9 +82,15 @@ import {
   type ReasoningEffortCap,
 } from './reasoning.ts';
 import {
+  clampFreeTierMaxOutputTokens,
+  FREE_TIER_MAX_OUTPUT_TOKENS,
   formatRequestBytes,
   readRequestBodyWithinSizeLimit,
 } from './requestLimits.ts';
+import {
+  acquireRelayRequestSlot,
+  releaseWhenStreamCloses,
+} from './requestGate.ts';
 
 // =============================================================================
 // Constants
@@ -705,12 +712,36 @@ app.all('/:provider{[^/]+}/*', async (c) => {
       );
     }
 
-    const cappedBody = capOpenAIReasoningEffortForTier(requestBodyJson, {
+    if (userTier === FREE_TIER && !isJsonRecord(requestBodyJson)) {
+      return jsonError(
+        'Free tier relay requests to model endpoints must use a JSON object body so server-side limits can be enforced.',
+        400,
+        { invalidRequestBody: true },
+      );
+    }
+
+    let cappedBody = capOpenAIReasoningEffortForTier(requestBodyJson, {
       provider,
       tier: userTier,
       modelName,
       tierCaps: OPENAI_GPT5_REASONING_EFFORT_CAPS,
     });
+    if (userTier === FREE_TIER) {
+      const outputClamp = clampFreeTierMaxOutputTokens(
+        provider,
+        apiPath,
+        cappedBody,
+      );
+      if (outputClamp.changed) {
+        console.info(
+          `[RELAY] Free tier ${outputClamp.fieldPath} capped at ${FREE_TIER_MAX_OUTPUT_TOKENS} tokens` +
+            (outputClamp.originalValue === null
+              ? ''
+              : ` (was ${outputClamp.originalValue})`),
+        );
+        cappedBody = outputClamp.body;
+      }
+    }
     if (cappedBody !== requestBodyJson) {
       requestBody = JSON.stringify(cappedBody);
     }
@@ -721,6 +752,57 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   if (!apiKey) {
     console.error(`[RELAY] API key not configured: ${providerConfig.envKey}`);
     return jsonError(`API key not configured for ${provider}`, 503);
+  }
+
+  // 7.5. Enforce server-side per-user request gates. This lives after local
+  // request validation so rejected requests do not consume active slots.
+  let releaseRelaySlot: (() => Promise<void>) | null = null;
+  let refreshRelaySlot: (() => Promise<void>) | null = null;
+  if (serviceRoleKey) {
+    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+    try {
+      const slot = await acquireRelayRequestSlot(
+        adminClient,
+        user.id,
+        getRequestLimits(userTier),
+      );
+      if (!slot.allowed) {
+        const decision = slot.decision;
+        if (decision.reason === 'concurrency') {
+          return jsonError(
+            `Too many concurrent relay requests. Limit: ${decision.concurrencyLimit ?? 'unknown'}.`,
+            429,
+            {
+              requestLimitReached: true,
+              reason: 'concurrency',
+              activeRequests: decision.activeRequests,
+              concurrencyLimit: decision.concurrencyLimit,
+              retryAfterSeconds: decision.retryAfterSeconds,
+            },
+          );
+        }
+        return jsonError(
+          `Relay request rate limit reached. Limit: ${decision.rateLimitPerMinute ?? 'unknown'} requests per minute.`,
+          429,
+          {
+            requestLimitReached: true,
+            reason: 'rate',
+            requestsThisMinute: decision.requestsThisMinute,
+            rateLimitPerMinute: decision.rateLimitPerMinute,
+            retryAfterSeconds: decision.retryAfterSeconds,
+          },
+        );
+      }
+      releaseRelaySlot = slot.release;
+      refreshRelaySlot = slot.refresh;
+    } catch (error) {
+      console.error('[RELAY] Failed to enforce request gate:', error);
+      return jsonError(
+        'Unable to verify relay request limits right now. Please try again shortly, or switch to your own API keys.',
+        503,
+        { requestLimitCheckFailed: true },
+      );
+    }
   }
 
   // 8. Build target URL
@@ -790,6 +872,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     });
   } catch (error) {
     clearTimeout(timeoutId);
+    await releaseRelaySlot?.();
     if (error instanceof Error && error.name === 'AbortError') {
       return jsonError('Upstream request timed out', 504);
     }
@@ -843,7 +926,15 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   // via the `messageStopReceived` diagnostic and throws a retryable error,
   // so the impact of not having keepalives is a retry, not silent data loss.
 
-  return new Response(upstreamResponse.body, {
+  const responseBody = releaseRelaySlot
+    ? await releaseWhenStreamCloses(
+        upstreamResponse.body,
+        releaseRelaySlot,
+        refreshRelaySlot ?? undefined,
+      )
+    : upstreamResponse.body;
+
+  return new Response(responseBody, {
     status: upstreamResponse.status,
     headers: responseHeaders,
   });

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -32,6 +32,19 @@ export interface TierSpendingLimits {
   Ultra: number;
 }
 
+/** Per-user request gates enforced by the relay edge function. */
+export interface TierRequestLimit {
+  /** Per clock-minute request count. */
+  ratePerMinute: number;
+  /** In-flight upstream requests for this user. */
+  concurrent: number;
+}
+
+export type TierRequestLimits = Record<
+  'free' | 'Max' | 'Ultra',
+  TierRequestLimit
+>;
+
 export interface TierModelConfig {
   /** All supported providers (same for all tiers) */
   providers: string[];
@@ -154,6 +167,16 @@ export const TIER_SPENDING_LIMITS: TierSpendingLimits = {
   Ultra: 300, // $300/month - sponsor access
 };
 
+/**
+ * Server-side fairness gates. These are deliberately loose enough for normal
+ * interactive use while blocking bulk free-tier fanout before costs are logged.
+ */
+export const TIER_REQUEST_LIMITS: TierRequestLimits = {
+  free: { ratePerMinute: 20, concurrent: 2 },
+  Max: { ratePerMinute: 60, concurrent: 4 },
+  Ultra: { ratePerMinute: 120, concurrent: 8 },
+};
+
 // =============================================================================
 // Tier Constants
 // =============================================================================
@@ -165,6 +188,14 @@ export function getSpendingLimit(tier: string): number {
   return (
     TIER_SPENDING_LIMITS[tier as keyof TierSpendingLimits] ??
     TIER_SPENDING_LIMITS.free
+  );
+}
+
+/** Get per-user request gates for a tier. */
+export function getRequestLimits(tier: string): TierRequestLimit {
+  return (
+    TIER_REQUEST_LIMITS[tier as keyof TierRequestLimits] ??
+    TIER_REQUEST_LIMITS.free
   );
 }
 

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -39,7 +39,13 @@ export type RelayRequestSlot =
     };
 
 export const RELAY_SLOT_REFRESH_INTERVAL_MS = 60_000;
-export const RELAY_SLOT_REFRESH_MAX_FAILURES = 3;
+
+class RelayRequestSlotLostError extends Error {
+  constructor() {
+    super('relay_request_refresh did not find request slot');
+    this.name = 'RelayRequestSlotLostError';
+  }
+}
 
 function asNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value)
@@ -87,24 +93,18 @@ function once(release: () => Promise<void>): () => Promise<void> {
 function startStreamLeaseRefresh(
   refresh: (() => Promise<void>) | undefined,
   intervalMs: number,
-  onFailure: (error: unknown) => void,
+  onLeaseLost: (error: unknown) => void,
 ): () => void {
   if (!refresh || intervalMs <= 0) return () => {};
 
-  let consecutiveFailures = 0;
   const timer = setInterval(() => {
-    void refresh()
-      .then(() => {
-        consecutiveFailures = 0;
-      })
-      .catch((error) => {
-        consecutiveFailures += 1;
-        console.error('[RELAY] Stream lease refresh failed:', error);
-        if (consecutiveFailures >= RELAY_SLOT_REFRESH_MAX_FAILURES) {
-          clearInterval(timer);
-          onFailure(error);
-        }
-      });
+    void refresh().catch((error) => {
+      console.error('[RELAY] Stream lease refresh failed:', error);
+      if (error instanceof RelayRequestSlotLostError) {
+        clearInterval(timer);
+        onLeaseLost(error);
+      }
+    });
   }, intervalMs);
   return () => clearInterval(timer);
 }
@@ -165,7 +165,7 @@ export async function acquireRelayRequestSlot(
       );
     }
     if (!didRefreshSlot(refreshResult.data)) {
-      throw new Error('relay_request_refresh did not find request slot');
+      throw new RelayRequestSlotLostError();
     }
   };
 
@@ -183,24 +183,25 @@ export async function releaseWhenStreamCloses(
     return null;
   }
 
+  let leaseError: Error | null = null;
+  let stopRefreshing = () => {};
   let streamController: ReadableStreamDefaultController<Uint8Array> | null =
     null;
-  let stopRefreshing = () => {};
   const releaseOnce = once(async () => {
     stopRefreshing();
     await release();
   });
   const reader = body.getReader();
-  const failStreamForLeaseError = (error: unknown) => {
-    const streamError =
-      error instanceof Error ? error : new Error(String(error));
-    streamController?.error(streamError);
+  const stopForLeaseLoss = (error: unknown) => {
+    leaseError = error instanceof Error ? error : new Error(String(error));
+    stopRefreshing();
+    streamController?.error(leaseError);
     void reader
-      .cancel(streamError)
+      .cancel(leaseError)
       .then(releaseOnce, releaseOnce)
       .catch((releaseError) => {
         console.error(
-          '[RELAY] Failed to release request slot after refresh failure:',
+          '[RELAY] Failed to release request slot after lease loss:',
           releaseError,
         );
       });
@@ -211,12 +212,15 @@ export async function releaseWhenStreamCloses(
       stopRefreshing = startStreamLeaseRefresh(
         refresh,
         refreshIntervalMs,
-        failStreamForLeaseError,
+        stopForLeaseLoss,
       );
     },
     async pull(controller) {
       try {
         const { done, value } = await reader.read();
+        if (leaseError) {
+          throw leaseError;
+        }
         if (done) {
           controller.close();
           await releaseOnce();

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -1,0 +1,239 @@
+interface RpcError {
+  message?: string;
+}
+
+interface RequestLimit {
+  ratePerMinute: number;
+  concurrent: number;
+}
+
+interface RpcClient {
+  rpc(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<{ data: unknown; error: RpcError | null }>;
+}
+
+interface GateDecision {
+  allowed: boolean;
+  slotId?: string;
+  reason?: 'rate' | 'concurrency';
+  rateLimitPerMinute?: number;
+  concurrencyLimit?: number;
+  requestsThisMinute?: number;
+  activeRequests?: number;
+  retryAfterSeconds?: number;
+}
+
+export type RelayRequestSlot =
+  | {
+      allowed: true;
+      release: () => Promise<void>;
+      refresh: () => Promise<void>;
+      decision: GateDecision;
+    }
+  | {
+      allowed: false;
+      release: null;
+      decision: GateDecision;
+    };
+
+export const RELAY_SLOT_REFRESH_INTERVAL_MS = 60_000;
+export const RELAY_SLOT_REFRESH_MAX_FAILURES = 3;
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function parseGateDecision(data: unknown): GateDecision {
+  const record =
+    typeof data === 'object' && data !== null
+      ? (data as Record<string, unknown>)
+      : {};
+  return {
+    allowed: record.allowed === true,
+    slotId: typeof record.slotId === 'string' ? record.slotId : undefined,
+    reason:
+      record.reason === 'rate' || record.reason === 'concurrency'
+        ? record.reason
+        : undefined,
+    rateLimitPerMinute: asNumber(record.rateLimitPerMinute),
+    concurrencyLimit: asNumber(record.concurrencyLimit),
+    requestsThisMinute: asNumber(record.requestsThisMinute),
+    activeRequests: asNumber(record.activeRequests),
+    retryAfterSeconds: asNumber(record.retryAfterSeconds),
+  };
+}
+
+function didRefreshSlot(data: unknown): boolean {
+  const record =
+    typeof data === 'object' && data !== null
+      ? (data as Record<string, unknown>)
+      : {};
+  return record.refreshed === true;
+}
+
+function once(release: () => Promise<void>): () => Promise<void> {
+  let released = false;
+  return () => {
+    if (released) return Promise.resolve();
+    released = true;
+    return release();
+  };
+}
+
+function startStreamLeaseRefresh(
+  refresh: (() => Promise<void>) | undefined,
+  intervalMs: number,
+  onFailure: (error: unknown) => void,
+): () => void {
+  if (!refresh || intervalMs <= 0) return () => {};
+
+  let consecutiveFailures = 0;
+  const timer = setInterval(() => {
+    void refresh()
+      .then(() => {
+        consecutiveFailures = 0;
+      })
+      .catch((error) => {
+        consecutiveFailures += 1;
+        console.error('[RELAY] Stream lease refresh failed:', error);
+        if (consecutiveFailures >= RELAY_SLOT_REFRESH_MAX_FAILURES) {
+          clearInterval(timer);
+          onFailure(error);
+        }
+      });
+  }, intervalMs);
+  return () => clearInterval(timer);
+}
+
+export async function acquireRelayRequestSlot(
+  client: RpcClient,
+  userId: string,
+  limits: RequestLimit,
+): Promise<RelayRequestSlot> {
+  const slotId = globalThis.crypto.randomUUID();
+  const now = new Date();
+  const windowStart = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      now.getUTCHours(),
+      now.getUTCMinutes(),
+    ),
+  ).toISOString();
+
+  const { data, error } = await client.rpc('relay_request_gate', {
+    p_user_id: userId,
+    p_slot_id: slotId,
+    p_window_start: windowStart,
+    p_rate_limit: limits.ratePerMinute,
+    p_concurrency_limit: limits.concurrent,
+  });
+  if (error) {
+    throw new Error(error.message ?? 'relay_request_gate failed');
+  }
+
+  const decision = parseGateDecision(data);
+  if (!decision.allowed) {
+    return { allowed: false, release: null, decision };
+  }
+
+  const release = once(async () => {
+    const releaseResult = await client.rpc('relay_request_release', {
+      p_user_id: userId,
+      p_slot_id: slotId,
+    });
+    if (releaseResult.error) {
+      console.error(
+        '[RELAY] Failed to release request slot:',
+        releaseResult.error.message,
+      );
+    }
+  });
+  const refresh = async () => {
+    const refreshResult = await client.rpc('relay_request_refresh', {
+      p_user_id: userId,
+      p_slot_id: slotId,
+    });
+    if (refreshResult.error) {
+      throw new Error(
+        refreshResult.error.message ?? 'relay_request_refresh failed',
+      );
+    }
+    if (!didRefreshSlot(refreshResult.data)) {
+      throw new Error('relay_request_refresh did not find request slot');
+    }
+  };
+
+  return { allowed: true, release, refresh, decision };
+}
+
+export async function releaseWhenStreamCloses(
+  body: ReadableStream<Uint8Array> | null,
+  release: () => Promise<void>,
+  refresh?: () => Promise<void>,
+  refreshIntervalMs = RELAY_SLOT_REFRESH_INTERVAL_MS,
+): Promise<ReadableStream<Uint8Array> | null> {
+  if (body === null) {
+    await release();
+    return null;
+  }
+
+  let streamController: ReadableStreamDefaultController<Uint8Array> | null =
+    null;
+  let stopRefreshing = () => {};
+  const releaseOnce = once(async () => {
+    stopRefreshing();
+    await release();
+  });
+  const reader = body.getReader();
+  const failStreamForLeaseError = (error: unknown) => {
+    const streamError =
+      error instanceof Error ? error : new Error(String(error));
+    streamController?.error(streamError);
+    void reader
+      .cancel(streamError)
+      .then(releaseOnce, releaseOnce)
+      .catch((releaseError) => {
+        console.error(
+          '[RELAY] Failed to release request slot after refresh failure:',
+          releaseError,
+        );
+      });
+  };
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      streamController = controller;
+      stopRefreshing = startStreamLeaseRefresh(
+        refresh,
+        refreshIntervalMs,
+        failStreamForLeaseError,
+      );
+    },
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          await releaseOnce();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        await releaseOnce();
+        throw error;
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        await releaseOnce();
+      }
+    },
+  });
+}

--- a/supabase/functions/relay/requestLimits.ts
+++ b/supabase/functions/relay/requestLimits.ts
@@ -1,3 +1,5 @@
+import { isJsonRecord, type JsonRecord } from './reasoning.ts';
+
 const BYTES_PER_KIB = 1024;
 const BYTES_PER_MIB = BYTES_PER_KIB * 1024;
 
@@ -6,6 +8,7 @@ const BYTES_PER_MIB = BYTES_PER_KIB * 1024;
  * normal research requests.
  */
 export const FREE_TIER_REQUEST_BODY_LIMIT_BYTES = 2 * BYTES_PER_MIB;
+export const FREE_TIER_MAX_OUTPUT_TOKENS = 8192;
 
 const textEncoder = new TextEncoder();
 
@@ -103,4 +106,161 @@ export function formatRequestBytes(bytes: number): string {
     return `${bytes / BYTES_PER_KIB} KiB`;
   }
   return `${bytes} bytes`;
+}
+
+const OPENAI_COMPATIBLE_MAX_OUTPUT_FIELDS = [
+  'max_tokens',
+  'max_completion_tokens',
+  'max_output_tokens',
+];
+
+export interface MaxOutputTokenClampResult {
+  body: unknown;
+  changed: boolean;
+  limit: number;
+  fieldPath: string | null;
+  originalValue: number | null;
+}
+
+function numericValue(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function clampRecordField(
+  record: JsonRecord,
+  field: string,
+  limit: number,
+): { record: JsonRecord; changed: boolean; originalValue: number | null } {
+  const current = numericValue(record[field]);
+  if (current !== null && current > 0 && current <= limit) {
+    return { record, changed: false, originalValue: current };
+  }
+
+  return {
+    record: { ...record, [field]: limit },
+    changed: true,
+    originalValue: current,
+  };
+}
+
+function describeFields(fields: string[]): string {
+  return fields.join(', ');
+}
+
+function clampGoogleGenerationConfig(
+  body: JsonRecord,
+  limit: number,
+): MaxOutputTokenClampResult {
+  const currentConfig = isJsonRecord(body.generationConfig)
+    ? body.generationConfig
+    : {};
+  const clamped = clampRecordField(currentConfig, 'maxOutputTokens', limit);
+  if (!clamped.changed) {
+    return {
+      body,
+      changed: false,
+      limit,
+      fieldPath: 'generationConfig.maxOutputTokens',
+      originalValue: clamped.originalValue,
+    };
+  }
+
+  return {
+    body: { ...body, generationConfig: clamped.record },
+    changed: true,
+    limit,
+    fieldPath: 'generationConfig.maxOutputTokens',
+    originalValue: clamped.originalValue,
+  };
+}
+
+function isOpenAICompletionTokenModel(model: unknown): boolean {
+  if (typeof model !== 'string') return false;
+  const normalized = model.toLowerCase().trim();
+  const modelName = normalized.includes('/')
+    ? normalized.slice(normalized.indexOf('/') + 1)
+    : normalized;
+  return (
+    modelName.startsWith('gpt-5') ||
+    modelName.startsWith('gpt5') ||
+    modelName.startsWith('o1') ||
+    modelName.startsWith('o3') ||
+    modelName.startsWith('o4')
+  );
+}
+
+function defaultMaxOutputFieldForProvider(
+  provider: string,
+  apiPath: string,
+  body: JsonRecord,
+): string {
+  if (provider === 'openai' && apiPath.includes('/responses')) {
+    return 'max_output_tokens';
+  }
+  if (
+    provider === 'openai' &&
+    apiPath.includes('/chat') &&
+    isOpenAICompletionTokenModel(body.model)
+  ) {
+    return 'max_completion_tokens';
+  }
+  return 'max_tokens';
+}
+
+function maxOutputFieldsForProvider(
+  provider: string,
+  apiPath: string,
+  body: JsonRecord,
+): string[] {
+  const fields = new Set(
+    OPENAI_COMPATIBLE_MAX_OUTPUT_FIELDS.filter((field) =>
+      Object.hasOwn(body, field),
+    ),
+  );
+  fields.add(defaultMaxOutputFieldForProvider(provider, apiPath, body));
+  return [...fields];
+}
+
+export function clampFreeTierMaxOutputTokens(
+  provider: string,
+  apiPath: string,
+  body: unknown,
+  limit: number = FREE_TIER_MAX_OUTPUT_TOKENS,
+): MaxOutputTokenClampResult {
+  if (!isJsonRecord(body)) {
+    return {
+      body,
+      changed: false,
+      limit,
+      fieldPath: null,
+      originalValue: null,
+    };
+  }
+
+  if (provider === 'google') {
+    return clampGoogleGenerationConfig(body, limit);
+  }
+
+  const fields = maxOutputFieldsForProvider(provider, apiPath, body);
+  let nextBody = body;
+  let changed = false;
+  let firstOriginalValue: number | null = null;
+  const changedFields: string[] = [];
+  for (const field of fields) {
+    const clamped = clampRecordField(nextBody, field, limit);
+    if (clamped.changed) {
+      nextBody = clamped.record;
+      changed = true;
+      changedFields.push(field);
+      firstOriginalValue ??= clamped.originalValue;
+    }
+  }
+
+  return {
+    body: nextBody,
+    changed,
+    limit,
+    fieldPath: describeFields(changed ? changedFields : fields),
+    originalValue: firstOriginalValue,
+  };
 }

--- a/supabase/migrations/20260610030000_relay_request_limits.sql
+++ b/supabase/migrations/20260610030000_relay_request_limits.sql
@@ -1,0 +1,230 @@
+-- Server-side relay request gates.
+--
+-- The edge function cannot rely on in-memory counters because Supabase may run
+-- multiple isolates. Keep rate windows and active request leases in Postgres.
+
+CREATE TABLE IF NOT EXISTS public.relay_request_limits (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  window_start timestamptz NOT NULL,
+  request_count integer NOT NULL DEFAULT 0 CHECK (request_count >= 0),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.relay_request_slots (
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  slot_id uuid NOT NULL,
+  acquired_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, slot_id)
+);
+
+CREATE INDEX IF NOT EXISTS relay_request_slots_user_updated_idx
+  ON public.relay_request_slots (user_id, updated_at);
+
+ALTER TABLE public.relay_request_limits ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.relay_request_slots ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.relay_request_limits FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.relay_request_slots FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.relay_request_gate(
+  p_user_id uuid,
+  p_slot_id uuid,
+  p_window_start timestamptz,
+  p_rate_limit integer,
+  p_concurrency_limit integer
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  gate_row public.relay_request_limits%ROWTYPE;
+  now_ts timestamptz := now();
+  active_count integer;
+  retry_after integer;
+BEGIN
+  IF p_rate_limit < 1 OR p_concurrency_limit < 1 THEN
+    RAISE EXCEPTION 'relay request limits must be positive';
+  END IF;
+
+  INSERT INTO public.relay_request_limits (
+    user_id,
+    window_start,
+    request_count,
+    updated_at
+  )
+  VALUES (p_user_id, p_window_start, 0, now_ts)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  SELECT *
+  INTO gate_row
+  FROM public.relay_request_limits
+  WHERE user_id = p_user_id
+  FOR UPDATE;
+
+  -- Avoid permanent lockout if an edge instance dies before streaming release.
+  -- Active concurrency is owned by per-request lease rows, not the rate row.
+  -- Healthy streams refresh their own lease while the proxy stream is open;
+  -- abandoned leases eventually expire when the edge instance cannot release.
+  DELETE FROM public.relay_request_slots
+  WHERE user_id = p_user_id
+    AND updated_at < now_ts - interval '10 minutes';
+
+  SELECT COUNT(*)::integer
+  INTO active_count
+  FROM public.relay_request_slots
+  WHERE user_id = p_user_id;
+
+  IF gate_row.window_start < p_window_start THEN
+    gate_row.window_start := p_window_start;
+    gate_row.request_count := 0;
+  END IF;
+
+  IF active_count >= p_concurrency_limit THEN
+    -- Do not refresh timestamps on denials. 429 retries must not keep leaked
+    -- slots alive indefinitely.
+    UPDATE public.relay_request_limits
+    SET window_start = gate_row.window_start,
+        request_count = gate_row.request_count
+    WHERE user_id = p_user_id;
+
+    RETURN jsonb_build_object(
+      'allowed', false,
+      'reason', 'concurrency',
+      'activeRequests', active_count,
+      'concurrencyLimit', p_concurrency_limit,
+      'retryAfterSeconds', 5
+    );
+  END IF;
+
+  IF gate_row.request_count >= p_rate_limit THEN
+    retry_after := GREATEST(
+      1,
+      CEIL(
+        EXTRACT(
+          EPOCH FROM (gate_row.window_start + interval '1 minute' - now_ts)
+        )
+      )::integer
+    );
+
+    UPDATE public.relay_request_limits
+    SET window_start = gate_row.window_start,
+        request_count = gate_row.request_count
+    WHERE user_id = p_user_id;
+
+    RETURN jsonb_build_object(
+      'allowed', false,
+      'reason', 'rate',
+      'requestsThisMinute', gate_row.request_count,
+      'rateLimitPerMinute', p_rate_limit,
+      'retryAfterSeconds', retry_after
+    );
+  END IF;
+
+  INSERT INTO public.relay_request_slots (
+    user_id,
+    slot_id,
+    acquired_at,
+    updated_at
+  )
+  VALUES (p_user_id, p_slot_id, now_ts, now_ts);
+
+  SELECT COUNT(*)::integer
+  INTO active_count
+  FROM public.relay_request_slots
+  WHERE user_id = p_user_id;
+
+  UPDATE public.relay_request_limits
+  SET request_count = gate_row.request_count + 1,
+      window_start = gate_row.window_start,
+      updated_at = now_ts
+  WHERE user_id = p_user_id
+  RETURNING *
+  INTO gate_row;
+
+  RETURN jsonb_build_object(
+    'allowed', true,
+    'slotId', p_slot_id,
+    'activeRequests', active_count,
+    'concurrencyLimit', p_concurrency_limit,
+    'requestsThisMinute', gate_row.request_count,
+    'rateLimitPerMinute', p_rate_limit
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.relay_request_release(
+  p_user_id uuid,
+  p_slot_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  released boolean;
+  active integer;
+BEGIN
+  DELETE FROM public.relay_request_slots
+  WHERE user_id = p_user_id
+    AND slot_id = p_slot_id
+  RETURNING true
+  INTO released;
+
+  SELECT COUNT(*)::integer
+  INTO active
+  FROM public.relay_request_slots
+  WHERE user_id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'released', COALESCE(released, false),
+    'activeRequests', active
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.relay_request_refresh(
+  p_user_id uuid,
+  p_slot_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  refreshed boolean;
+BEGIN
+  UPDATE public.relay_request_slots
+  SET updated_at = now()
+  WHERE user_id = p_user_id
+    AND slot_id = p_slot_id
+  RETURNING true
+  INTO refreshed;
+
+  RETURN jsonb_build_object(
+    'refreshed', COALESCE(refreshed, false)
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.relay_request_gate(
+  uuid, uuid, timestamptz, integer, integer
+)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.relay_request_gate(
+  uuid, uuid, timestamptz, integer, integer
+)
+  TO service_role;
+
+REVOKE ALL ON FUNCTION public.relay_request_release(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.relay_request_release(uuid, uuid)
+  TO service_role;
+
+REVOKE ALL ON FUNCTION public.relay_request_refresh(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.relay_request_refresh(uuid, uuid)
+  TO service_role;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,6 +76,7 @@
   "exclude": [
     "node_modules",
     "prototypes",
+    "src/test-kernel",
     "supabase",
     "packages/desktop",
     "packages/core",

--- a/tsconfig.test-kernel.json
+++ b/tsconfig.test-kernel.json
@@ -1,9 +1,15 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "module": "esnext",
     "moduleResolution": "bundler",
     "types": ["node"]
   },
-  "include": ["src/test-kernel/**/*.mts", "src/types/**/*.d.ts"]
+  "include": [
+    "src/test-kernel/**/*.mts",
+    "src/test-kernel/**/*.ts",
+    "src/types/**/*.d.ts"
+  ],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What

Closes #5724.

- Add a single tier-policy source for per-user relay request gates in `supabase/functions/relay/models.ts`.
- Add a DB-backed `relay_request_limits` table plus `relay_request_gate` / `relay_request_release` RPCs so rate/concurrency limits work across edge-function isolates instead of relying on per-process memory.
- Acquire a request slot immediately before proxying upstream and release it when the upstream response stream closes or is canceled.
- Clamp free-tier max output server-side to `8192` tokens across OpenAI-compatible, Responses API, Anthropic-style, and Google `generationConfig.maxOutputTokens` request bodies.
- Extend the existing relay request-limit tests for max-output clamping and stream-slot release behavior.

## Design Notes

The relay already owned tier/model/spend policy, so the new request limits live beside those constants rather than adding a client-side mirror. The edge function mutates the parsed request body once, after model validation and GPT-5 reasoning caps, then forwards that same body.

## Verification

- `corepack pnpm vitest run src/test-kernel/supabase/RelayRequestLimits.vitest.ts`
- `npm run typecheck`
- `corepack pnpm eslint supabase/functions/relay/index.ts supabase/functions/relay/models.ts supabase/functions/relay/requestLimits.ts supabase/functions/relay/requestGate.ts src/test-kernel/supabase/RelayRequestLimits.vitest.ts --quiet`
- `npm run lint -- --quiet`
- `git diff --check`
- `npx esbuild supabase/functions/relay/index.ts --bundle --platform=neutral --format=esm --outfile=/tmp/texra-relay.bundle.js '--external:jsr:*' '--external:npm:*'`

Supabase CLI check attempted: `supabase db lint --local --schema public --fail-on error` could not run because no local Supabase Postgres was listening on `127.0.0.1:54322`, and Docker is not running in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the relay proxy path for all tiers (429/503 behavior, streaming wrapper) and depends on a new migration/RPCs; misconfiguration or lease bugs could block or over-admit relay traffic.
> 
> **Overview**
> Adds **server-side per-user relay request gates** (per-minute rate and in-flight concurrency by tier) backed by Postgres RPCs, so limits work across edge isolates. Slots are acquired after local validation and released when the upstream stream ends, is canceled, or fails; long streams **refresh** leases periodically, with stale slots expiring after ~10 minutes.
> 
> For **free tier**, the relay now requires a JSON object on model endpoints, **clamps max output to 8192 tokens** (OpenAI chat/Responses fields, Google `generationConfig.maxOutputTokens`), and returns **429** with structured metadata on rate/concurrency denials.
> 
> Tests expand `RelayRequestLimits.vitest.ts` for clamping and slot lifecycle; `tsconfig` excludes `src/test-kernel` from the main project and enables `.ts` imports in `tsconfig.test-kernel.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit febdb6b8a5ea66fd1a2ae620087238657ed6cbfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->