### PR TITLE
fix(cli): skip invisible transcript rows

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -109,6 +109,8 @@ const PLAN_APPROVAL_GOAL = process.env.HARNESS_PLAN_APPROVAL_GOAL === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
 const SHOW_LIVE_TOOL_ONLY = process.env.HARNESS_LIVE_TOOL_ONLY === '1';
+const SHOW_LIVE_INVISIBLE_ASSISTANT =
+  process.env.HARNESS_LIVE_INVISIBLE_ASSISTANT === '1';
 const SHOW_PROJECT_SKILL = process.env.HARNESS_PROJECT_SKILL === '1';
 const WIDE_TRANSCRIPT_SUFFIX =
   ' hidden-middle wide-column-A wide-column-B wide-column-C wide-column-D wide-column-E wide-column-F';
@@ -489,7 +491,9 @@ function seedLiveToolOnlyTranscript(): void {
     level: LOG_LEVELS.INFO,
     timestamp: timestamp + 1,
     messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-    text: '',
+    text: SHOW_LIVE_INVISIBLE_ASSISTANT
+      ? `${String.fromCharCode(27)}[2m${String.fromCharCode(27)}[22m`
+      : '',
   });
   store.append(STREAM_ID, {
     id: 'live-tool-ls',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -111,7 +111,10 @@ const SCENARIOS = [
   },
   {
     name: 'live-tool-only-spacing',
-    env: { HARNESS_LIVE_TOOL_ONLY: '1' },
+    env: {
+      HARNESS_LIVE_INVISIBLE_ASSISTANT: '1',
+      HARNESS_LIVE_TOOL_ONLY: '1',
+    },
     expect: ['what is this repo about', '● ls (Listed 36 entries in .)'],
     maxBlankLinesBetween: [
       { from: 'what is this repo about', to: '● ls', max: 0 },

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -2,6 +2,7 @@ import {
   LIVE_ELAPSED_STREAM_STATUSES,
   type StreamStatus,
 } from '@shared/schemas';
+import { stripAnsiSequences } from '@cli/runtime/ansiEscapes';
 
 import type { ConversationEntry } from '../state/cliState';
 
@@ -10,7 +11,7 @@ export function isRenderableTranscriptEntry(entry: ConversationEntry): boolean {
     case 'assistant':
     case 'error':
     case 'user':
-      return entry.text.trim().length > 0;
+      return stripAnsiSequences(entry.text).trim().length > 0;
     case 'process':
       return entry.process !== undefined;
     case 'tool':


### PR DESCRIPTION
## What

- Treat transcript text rows as renderable only when they still have visible text after ANSI escape stripping.
- Extend the PTY TUI harness so `live-tool-only-spacing` reproduces invisible assistant output between a user turn and the first tool row.
- Keep the zero-blank-line assertion between the user message and first tool row.

## Why

Invisible model chunks could still claim terminal rows, leaving a visible gap after the user message before tool output appeared. The existing `isRenderableTranscriptEntry` contract is now the single place that strips ANSI/control styling before deciding whether text rows render.

## Verification

- `corepack pnpm --filter @texra-ai/cli validate:tui live-tool-only-spacing`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `git diff --check`
