### PR TITLE
refactor(cli): reuse resolved resume snapshot

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -78,6 +78,7 @@ import { parseCliHistoryId } from '@cli/runtime/history';
 import {
   explainNonResumable,
   resolveCliResumeSnapshot,
+  type CliToolUseResumeResolution,
 } from '@cli/runtime/sessionResume';
 import {
   formatCliMemoryList,
@@ -172,13 +173,11 @@ export interface RunChatInit {
   readonly teamName?: string;
   /** Multi-agent preset id when chat was launched from a team preset. */
   readonly cliMultiAgentPresetId?: string;
-  /**
-   * Continue (resume) a stored tool-use session by its execution id instead of
-   * starting fresh: the interactive `texra --resume <id>` path. Set by the
-   * resume command for TTY sessions; the prior transcript is rehydrated and the
-   * suspended tool-use flow is continued on mount (see `resumeAgentRun`).
-   */
-  readonly resumeExecutionId?: ExecutionId;
+  /** Pre-resolved startup resume from `texra --resume <id>`. */
+  readonly initialResume?: {
+    readonly id: ExecutionId;
+    readonly resolution: CliToolUseResumeResolution;
+  };
 }
 
 export interface BuildInitialChatAgentConfigInput {
@@ -965,10 +964,11 @@ export async function runChat(
     return { exitCode: CliExitCode.Success };
   }
   const apiMode = effectiveCliApiMode(context);
+  const initialResume = init.initialResume;
   const defaults = await resolveChatDefaults({
     cwd: context.cwd,
-    agentOverride: init.agentOverride,
-    modelOverride: init.modelOverride,
+    agentOverride: initialResume?.resolution.config.agent ?? init.agentOverride,
+    modelOverride: initialResume?.resolution.config.model ?? init.modelOverride,
     envAgent: context.envAgent,
     envModel: context.envModel,
   });
@@ -1275,7 +1275,10 @@ export async function runChat(
   // (b) the streamId is already known (re-derived from the prior run), so we
   // set session.streamId up front and rehydrate that stream's transcript so
   // the user sees the prior conversation before the continued turn streams in.
-  const resumeAgentRun = async (id: ExecutionId): Promise<void> => {
+  const resumeAgentRun = async (
+    id: ExecutionId,
+    preResolved?: CliToolUseResumeResolution,
+  ): Promise<void> => {
     if (!chatTuiCanStartRootRun(session)) {
       appendLocalAssistantTranscript(
         'Finish the active chat before resuming a previous session.',
@@ -1283,7 +1286,7 @@ export async function runChat(
       return;
     }
 
-    const resolution = await resolveCliResumeSnapshot(id);
+    const resolution = preResolved ?? (await resolveCliResumeSnapshot(id));
     if (resolution.kind !== 'toolUse') {
       // Workflows / missing / already-completed sessions can't continue here —
       // surface why and leave the session idle so the user can still chat.
@@ -1737,13 +1740,15 @@ export async function runChat(
   // the signal handlers are armed. Fire-and-forget — resumeAgentRun installs
   // session.runPromise, and the normal first-input path stays available so the
   // user can keep chatting (follow-ups target session.streamId as usual).
-  if (init.resumeExecutionId) {
+  if (initialResume) {
     // Guard the void: resumeAgentRun awaits snapshot resolution / ensureLoaded
     // before installing its own .then/.catch, so an early throw there would
     // otherwise surface as an unhandled rejection.
-    void resumeAgentRun(init.resumeExecutionId).catch((error: unknown) => {
-      appendLocalErrorTranscript(toErrorMessage(error));
-    });
+    void resumeAgentRun(initialResume.id, initialResume.resolution).catch(
+      (error: unknown) => {
+        appendLocalErrorTranscript(toErrorMessage(error));
+      },
+    );
   }
 
   // Auto-prompt when the active stream goes WAITING so the UI clearly

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -65,9 +65,7 @@ export async function runResumeExecution(
 
   const { runChat } = await import('../chat/tui/runChatTui');
   const result = await runChat(context, {
-    resumeExecutionId: id,
-    agentOverride: resolution.config.agent,
-    modelOverride: resolution.config.model,
+    initialResume: { id, resolution },
   });
   return result.exitCode;
 }

--- a/packages/cli/src/runtime/sessionResume.ts
+++ b/packages/cli/src/runtime/sessionResume.ts
@@ -35,6 +35,11 @@ export type CliResumeResolution =
   /** Execution metadata or resume state exists but could not be loaded. */
   | { readonly kind: 'load-failed'; readonly reason: string };
 
+export type CliToolUseResumeResolution = Extract<
+  CliResumeResolution,
+  { readonly kind: 'toolUse' }
+>;
+
 export async function resolveCliResumeSnapshot(
   id: ExecutionId,
 ): Promise<CliResumeResolution> {

--- a/src/test-kernel/cli/ResumeCommand.vitest.mts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.mts
@@ -56,7 +56,7 @@ function resumableResolution() {
       agent: 'review',
       model: 'gpt-5',
     },
-  };
+  } as const;
 }
 
 describe('runResumeExecution', () => {
@@ -68,6 +68,8 @@ describe('runResumeExecution', () => {
   });
 
   it('uses the CLI context TTY snapshot before reopening chat', async () => {
+    const resolution = resumableResolution();
+    mocks.resolveCliResumeSnapshot.mockResolvedValueOnce(resolution);
     const { runResumeExecution } = await import('@cli/commands/resume');
 
     await expect(
@@ -77,9 +79,10 @@ describe('runResumeExecution', () => {
     expect(mocks.runChat).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
-        resumeExecutionId: EXECUTION_ID,
-        agentOverride: 'review',
-        modelOverride: 'gpt-5',
+        initialResume: {
+          id: EXECUTION_ID,
+          resolution,
+        },
       }),
     );
     expect(mocks.writeTextStderr).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- pass the already-resolved `texra --resume` tool-use snapshot into the TUI startup path
- keep `/resume <id>` inside an existing TUI as the dynamic resolver path
- avoid copying resume agent/model into separate startup overrides

## Design
`texra --resume` now has one snapshot owner: the resume command resolves and validates the persisted session once, then TUI consumes that resolved startup resume. The TUI still owns interactive slash-resume lookups, where the id is chosen after the session is already running.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ResumeCommand.vitest.mts src/test-kernel/cli/SessionResumeResolution.vitest.mts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of resume wiring with the same validation order; interactive `/resume` still resolves on demand.
> 
> **Overview**
> **`texra --resume`** now passes a single pre-resolved **`initialResume`** `{ id, resolution }` into the chat TUI instead of `resumeExecutionId` plus duplicated `agentOverride` / `modelOverride`. The resume command remains the only place that calls `resolveCliResumeSnapshot` for that path; startup chat defaults and `resumeAgentRun` read agent/model from the bundled resolution.
> 
> `resumeAgentRun` accepts an optional **`preResolved`** snapshot so startup resume skips a second disk lookup. In-session **`/resume <id>`** is unchanged and still resolves dynamically when the id is chosen after the TUI is running.
> 
> Adds exported type **`CliToolUseResumeResolution`** and updates resume command tests to expect `initialResume`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32abde6ffb92b0deee7fc2e9073f08fa58dbbef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->