### PR TITLE
refactor(cli): use shared stream ancestor lookup

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -539,25 +539,6 @@ interface StatusBarVisibleStream {
   readonly status: StreamStatus | undefined;
 }
 
-function statusBarFindAncestorStream<T extends StatusBarVisibleStream>({
-  activeStreamId,
-  parentStream,
-  streams,
-  canUseStream,
-}: {
-  readonly activeStreamId: StreamTabId | undefined;
-  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
-  readonly streams: ReadonlyMap<StreamTabId, T>;
-  readonly canUseStream: (stream: T) => boolean;
-}): T | undefined {
-  return nearestActiveStreamAncestor({
-    activeStreamId,
-    parentStream,
-    values: streams,
-    canUseValue: canUseStream,
-  })?.value;
-}
-
 export function statusBarCanStopVisibleRun({
   activeStreamId,
   parentStream,
@@ -571,11 +552,11 @@ export function statusBarCanStopVisibleRun({
 }): boolean {
   if (isLiveStreamStatus(status)) return true;
   return (
-    statusBarFindAncestorStream({
+    nearestActiveStreamAncestor({
       activeStreamId,
       parentStream,
-      streams,
-      canUseStream: (stream) => isLiveStreamStatus(stream.status),
+      values: streams,
+      canUseValue: (stream) => isLiveStreamStatus(stream.status),
     }) !== undefined
   );
 }
@@ -591,12 +572,12 @@ export function statusBarDisplaySlice({
 }): StreamSlice | undefined {
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
   if (activeSlice) return activeSlice;
-  return statusBarFindAncestorStream({
+  return nearestActiveStreamAncestor({
     activeStreamId,
     parentStream,
-    streams,
-    canUseStream: (stream) => isLiveStreamStatus(stream.status),
-  });
+    values: streams,
+    canUseValue: (stream) => isLiveStreamStatus(stream.status),
+  })?.value;
 }
 
 // Bypass badges, in emission order. One row per BypassState flag.


### PR DESCRIPTION
## Summary
- remove the status-bar-only ancestor lookup pass-through
- call the shared stream focus helper directly from status bar ownership points
- keep active-slice preference unchanged while making ancestor fallback ownership explicit

## Validation
- corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts
- npm run typecheck
- npm run lint -- --quiet
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with equivalent ancestor lookup behavior; covered by existing StatusBar and stream tab tests.
> 
> **Overview**
> **Status bar** no longer wraps `nearestActiveStreamAncestor` in a local `statusBarFindAncestorStream` helper. `statusBarCanStopVisibleRun` and `statusBarDisplaySlice` call the shared `streamViews` helper directly with `values` / `canUseValue` and the same live-status predicate.
> 
> Ancestor fallback for stop visibility and display slice selection is unchanged: active slice still wins when present; otherwise the nearest ancestor with a live stream status supplies the slice (via `?.value` on the ancestor result).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e071ba506e4165ddf3f04679b38e3f91bf64f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->