### PR TITLE
fix(cli): attach tool rows to prompts

### DIFF
--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -100,6 +100,13 @@ function isCompactToolEntry(
   return entry.role === 'tool' && lines.length <= 1;
 }
 
+function isPromptToToolTurn(
+  previousEntry: ConversationEntry,
+  nextEntry: ConversationEntry,
+): boolean {
+  return previousEntry.role === 'user' && nextEntry.role === 'tool';
+}
+
 function shouldSeparateEntries({
   previousEntry,
   previousLines,
@@ -112,6 +119,7 @@ function shouldSeparateEntries({
   readonly nextLines: readonly string[];
 }): boolean {
   if (!previousEntry) return false;
+  if (isPromptToToolTurn(previousEntry, nextEntry)) return false;
   return !(
     isCompactToolEntry(previousEntry, previousLines) &&
     isCompactToolEntry(nextEntry, nextLines)
@@ -119,8 +127,8 @@ function shouldSeparateEntries({
 }
 
 /** Render the active slice into a flat line array with blank separators between
- *  substantial entries. Adjacent one-line tool calls stay stacked so compact
- *  tool-heavy traces do not waste half the viewer on empty expansion space. */
+ *  substantial entries. Tool execution rows stay attached to the prompt or
+ *  adjacent compact tools so command-heavy traces do not waste vertical space. */
 export function transcriptToLines(
   slice: StreamSlice | undefined,
   cols: number,

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -394,7 +394,7 @@ describe('CLI conversation transcript splitting', () => {
         sliceWithEntries(STREAM_ID, [user, emptyAssistant, tool]),
         80,
       ),
-    ).toEqual(['› what is this repo about', '', '● Bash (ls)']);
+    ).toEqual(['› what is this repo about', '● Bash (ls)']);
   });
 
   it('does not budget regular user margin for inquiry continuations', () => {


### PR DESCRIPTION
## Summary
- stop inserting an empty transcript separator between a user prompt and the first tool row
- keep separators around prose and detailed tool output unchanged
- update the existing empty-assistant regression expectation for the compact prompt-to-tool path

## Validation
- corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui live-tool-only-spacing
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/tui-frames-user-tool-spacing --no-build live-tool-only-spacing
- npm run typecheck
- npm run lint -- --quiet
- git diff --check

Saved TTY frame: /tmp/tui-frames-user-tool-spacing/01-live-tool-only-spacing.txt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only spacing in the transcript flattening path; behavior covered by existing and updated vitest expectations.
> 
> **Overview**
> The ctrl+t **transcript viewer** no longer inserts a blank line between a **user prompt** and the **first tool row** that follows it.
> 
> `transcriptLines.ts` adds `isPromptToToolTurn` and uses it in `shouldSeparateEntries` so user→tool pairs are treated like adjacent compact tools (no separator). **Blank lines between prose, multi-line tool output, and stacked compact tools are unchanged.** The empty-assistant regression test now expects the prompt and `● Bash (ls)` on consecutive lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd03c2235c4c7caefd11e57209fa73c4020bcc96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->