### PR TITLE
refactor(cli): carry child control item availability

### DIFF
--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -42,12 +42,12 @@ export interface ChildControlItem {
 
 export interface ChildControlStreamTarget {
   readonly fallbackFromStreamId?: StreamTabId;
+  readonly hasItems: boolean;
   readonly slice: StreamSlice | undefined;
   readonly streamId: StreamTabId | undefined;
 }
 
 export interface ChildControlDisplayTarget extends ChildControlStreamTarget {
-  readonly hasItems: boolean;
   readonly streamLabel: string | undefined;
   readonly streamScopeDetail: string | undefined;
 }
@@ -288,7 +288,11 @@ export function resolveChildControlStreamTarget({
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const activeHasRows = hasChildControlItems(activeSlice, mode);
   if (!activeStreamId || activeHasRows) {
-    return { streamId: activeStreamId, slice: activeSlice };
+    return {
+      hasItems: activeHasRows,
+      streamId: activeStreamId,
+      slice: activeSlice,
+    };
   }
 
   const ancestor = nearestActiveStreamAncestor({
@@ -300,12 +304,17 @@ export function resolveChildControlStreamTarget({
   if (ancestor) {
     return {
       fallbackFromStreamId: activeStreamId,
+      hasItems: true,
       streamId: ancestor.streamId,
       slice: ancestor.value,
     };
   }
 
-  return { streamId: activeStreamId, slice: activeSlice };
+  return {
+    hasItems: false,
+    streamId: activeStreamId,
+    slice: activeSlice,
+  };
 }
 
 function childControlFallbackDetail(
@@ -352,7 +361,6 @@ export function resolveChildControlDisplayTarget({
     : undefined;
   return {
     ...target,
-    hasItems: hasChildControlItems(target.slice, mode),
     streamLabel,
     streamScopeDetail: childControlFallbackDetail(
       mode,

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -593,6 +593,7 @@ describe('CLI child execution controls', () => {
 
     expect(target.streamId).toBe('main');
     expect(target.fallbackFromStreamId).toBe('review-stream');
+    expect(target.hasItems).toBe(true);
     expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
       {
         executionId: 'agent-1',
@@ -697,6 +698,7 @@ describe('CLI child execution controls', () => {
     });
 
     expect(target.streamId).toBe('review-stream');
+    expect(target.hasItems).toBe(true);
     expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
       {
         executionId: 'agent-2',
@@ -721,6 +723,7 @@ describe('CLI child execution controls', () => {
 
     expect(target.streamId).toBe('review-stream');
     expect(target.slice).toBe(child);
+    expect(target.hasItems).toBe(false);
   });
 
   it('falls back to the nearest ancestor subagent list when a focused grandchild is a leaf', () => {
@@ -753,6 +756,7 @@ describe('CLI child execution controls', () => {
 
     expect(target.streamId).toBe('main');
     expect(target.fallbackFromStreamId).toBe('detail-stream');
+    expect(target.hasItems).toBe(true);
     expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
       {
         executionId: 'agent-1',
@@ -790,6 +794,7 @@ describe('CLI child execution controls', () => {
 
     expect(target.streamId).toBe('main');
     expect(target.fallbackFromStreamId).toBe('review-stream');
+    expect(target.hasItems).toBe(true);
     expect(buildChildControlItems(target.slice!, 'tasks')).toMatchObject([
       {
         executionId: 'agent-1',
@@ -827,6 +832,7 @@ describe('CLI child execution controls', () => {
 
     expect(target.streamId).toBe('main');
     expect(target.fallbackFromStreamId).toBe('review-stream');
+    expect(target.hasItems).toBe(true);
     expect(buildChildControlItems(target.slice!, 'tasks')).toMatchObject([
       {
         executionId: 'agent-1',
@@ -875,6 +881,7 @@ describe('CLI child execution controls', () => {
 
     expect(target.streamId).toBe('review-stream');
     expect(target.slice).toBe(child);
+    expect(target.hasItems).toBe(true);
     expect(buildChildControlItems(target.slice!, 'tasks')).toMatchObject([
       {
         executionId: 'proc-1',


### PR DESCRIPTION
## Summary
- make `ChildControlStreamTarget` carry whether the resolved stream has child-control rows
- stop recomputing child-control item availability when enriching display labels
- cover fallback, leaf, retained-row, and active-child targets with direct `hasItems` assertions

## Validation
- corepack pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts
- npm run typecheck
- npm run lint -- --quiet
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure TUI state refactor with no behavior change intended beyond a single source of truth for availability; covered by existing ChildControls unit tests.
> 
> **Overview**
> **`ChildControlStreamTarget` now includes `hasItems`**, set when `resolveChildControlStreamTarget` picks the active stream, an ancestor fallback, or a leaf with no rows. **`resolveChildControlDisplayTarget` no longer calls `hasChildControlItems`** on the resolved slice—it reuses the flag from the stream target.
> 
> Tests assert **`hasItems`** for fallback, leaf, retained-row, and active-child resolution paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3128d1d0e12895033543c92b92a4e958291485cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->