### PR TITLE
refactor(cli): share active stream tree order

### DIFF
--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -13,11 +13,10 @@ import { formatDuration } from '@utils/core';
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { visibleSubagentRows } from './childStreamMerge';
 import {
-  activeStreamParentOrSelfId,
+  activeStreamTreeEntries,
   nearestActiveStreamAncestor,
   streamDisplayLabel,
 } from './streamViews';
-import { orderedDescendantsFromTree } from './focusCycle';
 import { transcriptEntryLines } from './transcriptLines';
 import type {
   ConversationEntry,
@@ -429,18 +428,13 @@ export function numericFocusTargetForActiveStream(init: {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly zeroBasedIndex: number;
 }): StreamTabId | undefined {
-  const activeStreamId = init.activeStreamId;
-  if (!activeStreamId || init.zeroBasedIndex < 0) return undefined;
-  const root = activeStreamParentOrSelfId({
-    activeStreamId,
-    parentStream: init.parentStream,
-  });
-  return orderedDescendantsFromTree({
-    parent: root,
-    parentSlice: init.streams.get(root),
+  if (!init.activeStreamId || init.zeroBasedIndex < 0) return undefined;
+  const shortcutIndex = init.zeroBasedIndex + 1;
+  return activeStreamTreeEntries({
+    activeStreamId: init.activeStreamId,
     parentStream: init.parentStream,
     streams: init.streams,
-  })[init.zeroBasedIndex];
+  }).find((entry) => entry.shortcutIndex === shortcutIndex)?.id;
 }
 
 export function nextPickerIndex(

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -35,6 +35,11 @@ export interface ActiveStreamAncestor<T> {
   readonly value: T;
 }
 
+export interface ActiveStreamTreeEntry {
+  readonly id: StreamTabId;
+  readonly shortcutIndex?: number;
+}
+
 export function activeStreamScope(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
@@ -161,19 +166,19 @@ function activeTreeRoot(init: OrderedStreamViewInput): StreamTabId | undefined {
   return activeStreamParentOrSelfId(init) ?? init.streams.keys().next().value;
 }
 
-function orderedStreamTree(init: {
-  readonly root: StreamTabId;
-  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
-  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
-}): readonly Pick<StreamView, 'id' | 'shortcutIndex'>[] {
+export function activeStreamTreeEntries(
+  init: OrderedStreamViewInput,
+): readonly ActiveStreamTreeEntry[] {
+  const root = activeTreeRoot(init);
+  if (!root) return [];
   const ordered = orderedDescendantsFromTree({
-    parent: init.root,
-    parentSlice: init.streams.get(init.root),
+    parent: root,
+    parentSlice: init.streams.get(root),
     parentStream: init.parentStream,
     streams: init.streams,
   });
-  const out: Pick<StreamView, 'id' | 'shortcutIndex'>[] = [];
-  if (init.streams.has(init.root)) out.push({ id: init.root });
+  const out: ActiveStreamTreeEntry[] = [];
+  if (init.streams.has(root)) out.push({ id: root });
   for (const [index, id] of ordered.entries()) {
     if (!init.streams.has(id)) continue;
     const position = index + 1;
@@ -186,13 +191,7 @@ function orderedStreamTree(init: {
 export function activeStreamTreeViews(
   init: OrderedStreamViewInput,
 ): readonly StreamView[] {
-  const root = activeTreeRoot(init);
-  if (!root) return [];
-  const ordered = orderedStreamTree({
-    root,
-    parentStream: init.parentStream,
-    streams: init.streams,
-  });
+  const ordered = activeStreamTreeEntries(init);
   if (ordered.length < 2) return [];
   return ordered.map((entry) =>
     streamViewForId({

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -4,6 +4,7 @@ import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
   activeStreamParentOrSelfId,
   activeStreamScope,
+  activeStreamTreeEntries,
   nearestActiveStreamAncestor,
 } from '@cli/chat/tui/state/streamViews';
 import {
@@ -223,6 +224,50 @@ describe('CLI stream tabs strip', () => {
       'main*',
       '1:setup(idle)',
       '[2:bash]*',
+    ]);
+  });
+
+  it('projects active stream tree order once for tabs and shortcuts', () => {
+    const root = streamId('root');
+    const child1 = streamId('child-1');
+    const child2 = streamId('child-2');
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        root,
+        slice('root', {
+          activeSubagents: [
+            child({
+              executionId: 'r1',
+              childStreamId: child1,
+              agentName: 'setup',
+            }),
+          ],
+          activeProcesses: [
+            child({
+              executionId: 'p1',
+              childStreamId: child2,
+              toolName: 'bash',
+            }),
+          ],
+        }),
+      ],
+      [child1, slice('child-1')],
+      [child2, slice('child-2')],
+    ]);
+
+    expect(
+      activeStreamTreeEntries({
+        activeStreamId: child2,
+        parentStream: new Map([
+          [child1, root],
+          [child2, root],
+        ]),
+        streams,
+      }),
+    ).toEqual([
+      { id: root },
+      { id: child1, shortcutIndex: 1 },
+      { id: child2, shortcutIndex: 2 },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- expose one active stream tree projection from `streamViews`
- have numeric focus shortcuts reuse the same tree order and shortcut indices as the stream tabs
- add a focused test pinning the shared tree projection used by tabs and shortcuts

## Validation
- corepack pnpm vitest run src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts
- npm run typecheck
- npm run lint -- --quiet
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of CLI TUI state projection with a regression test; no auth, persistence, or API surface changes.
> 
> **Overview**
> **Centralizes active stream tree ordering** in `streamViews` via exported `activeStreamTreeEntries` (root plus descendants with `shortcutIndex` 1–9), replacing a private helper and driving `activeStreamTreeViews` from the same projection.
> 
> **Numeric focus shortcuts** (`numericFocusTargetForActiveStream` / Meta+digit in `App.tsx`) now resolve targets by matching that shared `shortcutIndex` instead of indexing `orderedDescendantsFromTree` separately, so tab labels and keyboard jumps stay aligned.
> 
> A **StreamTabsStrip** test pins the shared tree shape (root without a shortcut, children `1` and `2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767480295f9fb82b2aaa0c796475ce38f84ab3f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->