### PR TITLE
fix(cli): trim leading blank assistant rows

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -151,6 +151,8 @@ function renderLogEntryText(
   text: string,
 ): string {
   switch (role) {
+    case 'assistant':
+      return text.replace(/^(?:[ \t]*\r?\n)+/, '');
     case 'error':
       return appendCliApiSwitchHint(text);
     case 'user':

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1619,6 +1619,30 @@ describe('CLI transcript state', () => {
     }
   });
 
+  it('trims leading blank assistant rows at turn start', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info('Why?', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+      logger.info('\n\n  The answer starts here.', {
+        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+      });
+
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        'Why?',
+        '  The answer starts here.',
+      ]);
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
   // Regression: a sync tick that fires after `finalizeAssistantTranscriptEntries`
   // must not roll the entry back to `finalized: false`. Cursor Bugbot flagged
   // this when `entriesEqual` started comparing `finalized` — without this


### PR DESCRIPTION
## Summary
- trim leading blank-only rows from assistant stream-log text before the TUI renders it
- preserve indentation on the first real assistant line
- add a regression test for user-turn spacing when an assistant response starts with blank lines

## Validation
- corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/tui-spacing-after live-tool-only-spacing
- npm run typecheck
- npm run lint -- --quiet
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in CLI transcript rendering with a focused unit test; no auth, persistence, or streaming protocol changes.
> 
> **Overview**
> Fixes extra vertical spacing in the chat TUI when an assistant turn begins with blank lines from the stream log.
> 
> **Assistant transcript text** is normalized in `renderLogEntryText` by stripping only a leading run of whitespace-only lines (`[ \t]*` plus newlines). The first non-empty line keeps its indentation (e.g. leading spaces on the answer).
> 
> A **regression test** asserts that after a user message, a model response like `\n\n  The answer starts here.` syncs to two transcript rows without empty assistant rows above the content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 362838f5c311f67a5f8b65ae5b6cf1a2bb823e3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->