### PR TITLE
refactor(cli): project status bar stream target once

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -539,45 +539,40 @@ interface StatusBarVisibleStream {
   readonly status: StreamStatus | undefined;
 }
 
-export function statusBarCanStopVisibleRun({
-  activeStreamId,
-  parentStream,
-  status,
-  streams,
-}: {
-  readonly activeStreamId: StreamTabId | undefined;
-  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
-  readonly status: StreamStatus | undefined;
-  readonly streams: ReadonlyMap<StreamTabId, StatusBarVisibleStream>;
-}): boolean {
-  if (isLiveStreamStatus(status)) return true;
-  return (
-    nearestActiveStreamAncestor({
-      activeStreamId,
-      parentStream,
-      values: streams,
-      canUseValue: (stream) => isLiveStreamStatus(stream.status),
-    }) !== undefined
-  );
+export interface StatusBarStreamTarget {
+  readonly ctrlCAction: CtrlCAction;
+  readonly displaySlice: StreamSlice | undefined;
 }
 
-export function statusBarDisplaySlice({
+export function statusBarStreamTarget({
   activeStreamId,
+  canStopActiveRun,
   parentStream,
   streams,
 }: {
   readonly activeStreamId: StreamTabId | undefined;
+  readonly canStopActiveRun: boolean;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
-}): StreamSlice | undefined {
+}): StatusBarStreamTarget {
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  if (activeSlice) return activeSlice;
-  return nearestActiveStreamAncestor({
+  const liveAncestor = nearestActiveStreamAncestor({
     activeStreamId,
     parentStream,
     values: streams,
-    canUseValue: (stream) => isLiveStreamStatus(stream.status),
-  })?.value;
+    canUseValue: (stream: StatusBarVisibleStream) =>
+      isLiveStreamStatus(stream.status),
+  });
+  const canStopVisibleRun =
+    isLiveStreamStatus(activeSlice?.status) || liveAncestor !== undefined;
+  return {
+    ctrlCAction: ctrlCActionForFocus({
+      activeStreamId,
+      canStopActiveRun: canStopActiveRun || canStopVisibleRun,
+      parentStream,
+    }),
+    displaySlice: activeSlice ?? liveAncestor?.value,
+  };
 }
 
 // Bypass badges, in emission order. One row per BypassState flag.
@@ -728,12 +723,13 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const approvals = useSignal(approvalQueueStatus);
   const caps = useSignal(terminalCapabilities);
   const { columns } = useWindowSize();
-  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  const statusSlice = statusBarDisplaySlice({
+  const target = statusBarStreamTarget({
     activeStreamId,
+    canStopActiveRun: props.canStopActiveRun?.() === true,
     parentStream,
     streams,
   });
+  const statusSlice = target.displaySlice;
 
   const runStartedAt =
     statusSlice?.status === STREAM_STATUS.RUNNING
@@ -765,18 +761,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     shiftEnterNewline: caps.kittyKeyboard,
     transcriptAvailable: props.transcriptAvailable,
     width: columns,
-    ctrlCAction: ctrlCActionForFocus({
-      activeStreamId,
-      canStopActiveRun:
-        props.canStopActiveRun?.() === true ||
-        statusBarCanStopVisibleRun({
-          activeStreamId,
-          parentStream,
-          status: slice?.status,
-          streams,
-        }),
-      parentStream,
-    }),
+    ctrlCAction: target.ctrlCAction,
     foregroundEscapeAction: props.foregroundEscapeAction,
     shortcutsActive: props.shortcutsActive,
   });

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -5,9 +5,8 @@ import {
   ctrlCActionForFocus,
   defaultShortcutModifierLabel,
   queuedFollowUpsSummary,
-  statusBarCanStopVisibleRun,
-  statusBarDisplaySlice,
   statusBarSegmentText,
+  statusBarStreamTarget,
 } from '@cli/chat/tui/panes/StatusBar';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
@@ -713,53 +712,80 @@ describe('CLI StatusBar display model', () => {
     );
   });
 
-  it('treats visible live stream status as stoppable', () => {
+  it('projects the focused status target and visible stoppable run once', () => {
     const root = 'root';
     const child = 'child';
     const grandchild = 'grandchild';
-    const streams = new Map([
-      [root, { streamId: root, status: STREAM_STATUS.RUNNING }],
-      [child, { streamId: child, status: STREAM_STATUS.STOPPED }],
-      [grandchild, { streamId: grandchild, status: STREAM_STATUS.STOPPED }],
+    const rootSlice = {
+      streamId: root,
+      status: STREAM_STATUS.RUNNING,
+    } as StreamSlice;
+    const childSlice = {
+      streamId: child,
+      status: STREAM_STATUS.STOPPED,
+    } as StreamSlice;
+    const grandchildSlice = {
+      streamId: grandchild,
+      status: STREAM_STATUS.STOPPED,
+    } as StreamSlice;
+    const streams = new Map<StreamSlice['streamId'], StreamSlice>([
+      [root, rootSlice],
+      [child, childSlice],
+      [grandchild, grandchildSlice],
     ]);
 
     expect(
-      statusBarCanStopVisibleRun({
+      statusBarStreamTarget({
         activeStreamId: root,
+        canStopActiveRun: false,
         parentStream: new Map([[child, root]]),
-        status: STREAM_STATUS.RUNNING,
         streams,
       }),
-    ).toBe(true);
+    ).toMatchObject({
+      ctrlCAction: 'stop',
+      displaySlice: rootSlice,
+    });
     expect(
-      statusBarCanStopVisibleRun({
+      statusBarStreamTarget({
         activeStreamId: child,
+        canStopActiveRun: false,
         parentStream: new Map([[child, root]]),
-        status: STREAM_STATUS.STOPPED,
         streams,
       }),
-    ).toBe(true);
+    ).toMatchObject({
+      ctrlCAction: 'stop root',
+      displaySlice: childSlice,
+    });
     expect(
-      statusBarCanStopVisibleRun({
+      statusBarStreamTarget({
         activeStreamId: grandchild,
+        canStopActiveRun: false,
         parentStream: new Map([
           [child, root],
           [grandchild, child],
         ]),
-        status: STREAM_STATUS.STOPPED,
         streams,
       }),
-    ).toBe(true);
+    ).toMatchObject({
+      ctrlCAction: 'stop root',
+      displaySlice: grandchildSlice,
+    });
     expect(
-      statusBarCanStopVisibleRun({
+      statusBarStreamTarget({
         activeStreamId: root,
+        canStopActiveRun: false,
         parentStream: new Map([[child, root]]),
-        status: STREAM_STATUS.WAITING,
-        streams: new Map([
-          [root, { streamId: root, status: STREAM_STATUS.WAITING }],
+        streams: new Map<StreamSlice['streamId'], StreamSlice>([
+          [
+            root,
+            { streamId: root, status: STREAM_STATUS.WAITING } as StreamSlice,
+          ],
         ]),
       }),
-    ).toBe(false);
+    ).toMatchObject({
+      ctrlCAction: 'exit',
+      displaySlice: { streamId: root, status: STREAM_STATUS.WAITING },
+    });
   });
 
   it('uses focused stream status when a stopped child stream is focused', () => {
@@ -779,25 +805,28 @@ describe('CLI StatusBar display model', () => {
     ]);
 
     expect(
-      statusBarDisplaySlice({
+      statusBarStreamTarget({
         activeStreamId: 'child',
+        canStopActiveRun: false,
         parentStream: new Map([['child', 'root']]),
         streams,
-      }),
+      }).displaySlice,
     ).toBe(childSlice);
     expect(
-      statusBarDisplaySlice({
+      statusBarStreamTarget({
         activeStreamId: 'waiting-child',
+        canStopActiveRun: false,
         parentStream: new Map([['waiting-child', 'root']]),
         streams,
-      }),
+      }).displaySlice,
     ).toBe(waitingChildSlice);
     expect(
-      statusBarDisplaySlice({
+      statusBarStreamTarget({
         activeStreamId: 'root',
+        canStopActiveRun: false,
         parentStream: new Map([['child', 'root']]),
         streams,
-      }),
+      }).displaySlice,
     ).toBe(rootSlice);
   });
 


### PR DESCRIPTION
## Summary
- replace separate status-bar display/stoppable helper paths with one statusBarStreamTarget projection
- keep focused stopped child streams visible while allowing Ctrl-C to stop the live root ancestor
- update tests to assert the shared target contract instead of split helper behavior

## Validation
- corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/tui-statusbar-target-2 subagent-focused-status-stays-scoped
- npm run typecheck
- npm run lint -- --quiet
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only refactor with tests covering multi-stream focus and Ctrl-C labeling; no auth, data, or API surface changes.
> 
> **Overview**
> Replaces the split **status bar** helpers (`statusBarCanStopVisibleRun` and `statusBarDisplaySlice`) with a single **`statusBarStreamTarget`** projection that returns both the **display stream slice** and **Ctrl-C action** in one pass.
> 
> **`StatusBar`** now calls that helper once instead of recomputing stoppable-run visibility and focus separately. Behavior is unchanged in intent: the bar still shows the **focused** stream’s status (including stopped children) while **Ctrl-C** can offer **stop** / **stop root** when the focused stream or a live ancestor is in a stoppable state.
> 
> Tests assert the combined **`StatusBarStreamTarget`** contract rather than the removed helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3d198f9bd0fc75e4a1247274b46641c001f64c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->