### PR TITLE
Polish webview CSS details and Lit idioms

### DIFF
--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -300,6 +300,25 @@ body {
   box-sizing: border-box;
 }
 
+/* Match light-DOM text selection to the host editor theme. Shadow-root
+   content gets the same rule from the designTokens sheet (litStyles.ts). */
+::selection {
+  background-color: var(--wa-color-editor-selection);
+}
+
+/* Honor the OS-level reduced-motion preference for light-DOM content.
+   Shadow-root content gets the same damping from the designTokens sheet. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* VS Code-compact dropdown items. WA defaults to ~0.5em padding which makes
    each option ~32px tall; VS Code menus run ~22-24px. */
 wa-option::part(base),

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -4,6 +4,7 @@ import { create } from 'mutative';
 import { html, css, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { z } from 'zod';
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -291,8 +292,8 @@ export class ProgressApp extends ProgressAppBase {
 
       .desktop-empty-progress p {
         margin: 0;
-        font-size: var(--font-size-md, 14px);
-        line-height: 1.5;
+        font-size: var(--font-size);
+        line-height: var(--line-height-relaxed);
       }
 
       .desktop-empty-progress__actions {
@@ -380,8 +381,10 @@ export class ProgressApp extends ProgressAppBase {
           >
             <wa-tab
               panel="launcher"
-              class=${isEditorMode ? 'focus-sidebar-tab' : ''}
-              title=${isEditorMode ? 'Focus Launcher sidebar' : ''}
+              class=${classMap({ 'focus-sidebar-tab': isEditorMode })}
+              title=${ifDefined(
+                isEditorMode ? 'Focus Launcher sidebar' : undefined,
+              )}
               @click=${this.onFocusLauncherTab}
             >
               <wa-icon

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -3,7 +3,8 @@
  *
  * Consumes streamLogContext to get groups and messages.
  * Renders one TaskGroupList per visited stream, hiding inactive ones with
- * display:none. Tab switching toggles visibility — zero DOM re-creation.
+ * the hidden attribute. Tab switching toggles visibility — zero DOM
+ * re-creation.
  *
  * Handles event delegation for clicks, toggles, and file links.
  *
@@ -151,7 +152,7 @@ export class LogList extends LitElement {
       ([id, data]) => html`
         <task-group-list
           ${ref(data.ref)}
-          style=${id === this.activeStreamId ? '' : 'display:none'}
+          ?hidden=${id !== this.activeStreamId}
           .groups=${data.groups}
           .messages=${data.messages}
           .updatedMessageIndices=${data.updatedMessageIndices}

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -804,7 +804,7 @@ export class StreamTabs extends LitElement {
 
     return html`
       <stream-tab
-        class=${isFinished ? 'is-finished' : ''}
+        class=${classMap({ 'is-finished': isFinished })}
         .info=${stream}
         .compact=${options.compact}
         .status=${this.getStatus(stream.name)}

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -2,7 +2,7 @@
 
 // Third-party imports
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { guard } from 'lit/directives/guard.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -114,10 +114,11 @@ export class TaskGroupList extends LitElement {
   private readonly terminalBuffer = new TerminalBuffer();
 
   /** Number of recent top-level timeline entries currently rendered. */
-  private timelineItemWindow = DEFAULT_TIMELINE_ITEM_WINDOW;
+  @state() private timelineItemWindow = DEFAULT_TIMELINE_ITEM_WINDOW;
 
-  /** Number of recent message entries rendered for each group. */
-  private groupMessageWindows = new Map<string, number>();
+  /** Number of recent message entries rendered for each group. Reassigned
+   *  (never mutated in place) so the reactive update cycle picks up changes. */
+  @state() private groupMessageWindows = new Map<string, number>();
 
   /** Reference to the scroll container */
   @query(`#${ELEMENT_IDS.LOG_CONTENT}`)
@@ -306,7 +307,7 @@ export class TaskGroupList extends LitElement {
 
   private resetRenderWindows(): void {
     this.timelineItemWindow = DEFAULT_TIMELINE_ITEM_WINDOW;
-    this.groupMessageWindows.clear();
+    this.groupMessageWindows = new Map();
   }
 
   private groupMessageScope(groupId: string): string {
@@ -382,9 +383,11 @@ export class TaskGroupList extends LitElement {
     } else if (kind === 'messages') {
       const current =
         this.groupMessageWindows.get(scope) ?? DEFAULT_GROUP_MESSAGE_WINDOW;
-      this.groupMessageWindows.set(scope, current + GROUP_MESSAGE_WINDOW_STEP);
+      this.groupMessageWindows = new Map(this.groupMessageWindows).set(
+        scope,
+        current + GROUP_MESSAGE_WINDOW_STEP,
+      );
     }
-    this.requestUpdate();
   }
 
   private visibleTimelineEntries(): typeof this.index.timeline {

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -108,7 +108,7 @@ export class TexraDiffView extends LitElement {
         height: 42vh;
         max-height: 640px;
         border: var(--border-thin) solid var(--color-border);
-        background: var(--color-background);
+        background: var(--wa-color-surface-default);
       }
 
       .editor {
@@ -125,8 +125,8 @@ export class TexraDiffView extends LitElement {
         min-height: 240px;
         padding: var(--wa-space-xs);
         border: var(--border-thin) solid var(--color-border);
-        color: var(--color-text-muted);
-        background: var(--color-background-secondary);
+        color: var(--color-text-secondary);
+        background: var(--color-bg-secondary);
       }
 
       .error {

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -39,7 +39,7 @@ import { registerCopyContent } from './copyContentStore';
 /** Build a tool-use section template. Empty label omits the label element. */
 export function buildToolUseSection(
   label: string,
-  content: TemplateResult,
+  content: TemplateResult | typeof nothing,
 ): TemplateResult {
   // prettier-ignore
   return html`<div class="tool-use-section"><div class="tool-use-subsection">${label ? html`<span class="tool-use-sublabel">${label}</span>` : nothing}${content}</div></div>`;
@@ -281,8 +281,8 @@ export function buildCodeBlock(
 export function buildFileLinkWithLines(
   filePath: string,
   options: { startLine?: number; endLine?: number } = {},
-): TemplateResult {
-  if (!filePath) return html``;
+): TemplateResult | typeof nothing {
+  if (!filePath) return nothing;
 
   const { startLine, endLine } = options;
   const fileName = getBasename(filePath) || filePath;
@@ -298,8 +298,10 @@ export function buildFileLinkWithLines(
 // ============================================================================
 
 /** Build a memory path display with database icon. Memory paths are virtual (/memories/...) and not directly openable in the editor. */
-export function buildMemoryPathDisplay(memoryPath: string): TemplateResult {
-  if (!memoryPath) return html``;
+export function buildMemoryPathDisplay(
+  memoryPath: string,
+): TemplateResult | typeof nothing {
+  if (!memoryPath) return nothing;
   const fileName = getBasename(memoryPath) || memoryPath;
   // prettier-ignore
   return html`<span class="memory-path"><wa-icon library="texra" name="database" aria-hidden="true"></wa-icon> ${fileName} <span class="file-source">(${memoryPath})</span></span>`;
@@ -310,8 +312,10 @@ export function buildMemoryPathDisplay(memoryPath: string): TemplateResult {
 // ============================================================================
 
 /** Build an executions path display with history icon. Execution paths are virtual (/executions/...) and not directly openable in the editor. */
-export function buildExecutionsPathDisplay(execPath: string): TemplateResult {
-  if (!execPath) return html``;
+export function buildExecutionsPathDisplay(
+  execPath: string,
+): TemplateResult | typeof nothing {
+  if (!execPath) return nothing;
   // prettier-ignore
   return html`<span class="memory-path"><wa-icon library="texra" name="history" aria-hidden="true"></wa-icon> ${execPath}</span>`;
 }

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -25,7 +25,12 @@ import {
 } from './logFormatters';
 
 // Local imports - Lit template utilities
-import { html, type TemplateResult, type FormatResult } from './litTemplates';
+import {
+  html,
+  nothing,
+  type TemplateResult,
+  type FormatResult,
+} from './litTemplates';
 
 // Local imports - shared schemas
 
@@ -40,7 +45,7 @@ const AUTO_EXPANDED_TYPES: Set<MessageType> = new Set([
   'scratchpad',
 ]);
 
-/** Message types that return empty template when formatter produces no result. */
+/** Message types that render nothing when the formatter produces no result. */
 const NULLABLE_TYPES: Set<MessageType> = new Set([
   'thinking',
   'scratchpad',
@@ -136,7 +141,7 @@ const TEMPLATE_FORMATTERS: Record<string, TemplateFormatterFn | null> = {
 export function formatLogEntry(
   logMessage: LogMessageData,
   options: FormatOptions = {},
-): TemplateResult {
+): TemplateResult | typeof nothing {
   const { messageType } = logMessage;
 
   // Determine if details should be open (undefined = no preference)
@@ -152,8 +157,8 @@ export function formatLogEntry(
   if (messageType && typeof formatter === 'function') {
     const result = formatter(logMessage, templateOptions);
     if (result) return result;
-    if (NULLABLE_TYPES.has(messageType)) return html``;
+    if (NULLABLE_TYPES.has(messageType)) return nothing;
   }
 
-  return formatDefaultLogMessageTemplate(logMessage) ?? html``;
+  return formatDefaultLogMessageTemplate(logMessage) ?? nothing;
 }

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -55,7 +55,7 @@ export const logEntryStyles = css`
     display: inline-flex;
     align-items: center;
     gap: var(--wa-space-3xs);
-    min-height: 24px;
+    min-height: var(--height-control);
     padding: 0 var(--wa-space-xs);
     border: var(--border-thin) solid var(--wa-color-surface-border);
     border-radius: var(--border-radius-small);
@@ -67,13 +67,13 @@ export const logEntryStyles = css`
   }
 
   .log-reveal-button:hover {
-    color: var(--color-text);
+    color: var(--wa-color-text-normal);
     border-color: var(--color-border);
   }
 
   .log-reveal-button:focus-visible {
     outline: var(--border-thin) solid var(--wa-color-focus);
-    outline-offset: 2px;
+    outline-offset: 1px;
   }
 
   .render-error-icon {
@@ -199,7 +199,11 @@ export const logEntryStyles = css`
   .banner-details:focus-within .banner-content-copy,
   .banner-content-copy:focus-visible {
     opacity: var(--opacity-full);
+  }
+
+  .banner-content-copy:focus-visible {
     outline: var(--border-thin) solid var(--wa-color-focus);
+    outline-offset: 1px;
   }
 
   .banner-content-copy.copy-success {

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -9,6 +9,7 @@ import {
   type TemplateResult,
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/button-group/button-group.js';
@@ -196,7 +197,13 @@ export class MemoryItem extends LitElement {
     const previewText = this.item.preview?.trim() ? this.item.preview : null;
 
     return html`
-      <div class="list-item memory-item ${this.item.pinned ? 'pinned' : ''}">
+      <div
+        class=${classMap({
+          'list-item': true,
+          'memory-item': true,
+          pinned: this.item.pinned === true,
+        })}
+      >
         <div class="list-item-header">
           <div class="memory-path">${this.item.displayPath}</div>
           <wa-button-group label="Memory actions">

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -11,6 +11,7 @@ import {
   type TemplateResult,
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -509,7 +510,7 @@ export class AgentSelectionPanel extends LitElement {
 
     return html`
       <div
-        class="agent-list-item ${isSelected ? 'selected' : ''}"
+        class=${classMap({ 'agent-list-item': true, selected: isSelected })}
         data-source=${sourceTone}
         role="option"
         aria-selected=${isSelected}

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -3,6 +3,7 @@
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -325,7 +326,10 @@ export class ModelSelectionList extends LitElement {
             <wa-icon
               library="texra"
               name="chevron-right"
-              class="provider-group-chevron ${isExpanded ? 'expanded' : ''}"
+              class=${classMap({
+                'provider-group-chevron': true,
+                expanded: isExpanded,
+              })}
             ></wa-icon>
             <span class="provider-group-name">${group.displayName}</span>
             <span class="provider-group-count">

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -3,6 +3,7 @@
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports - shared styles
 import { badgeStyles, commonViewStyles, designTokens } from '@shared/styles';
@@ -211,7 +212,10 @@ export class ProviderKeyList extends LitElement {
         <td>
           <div class="provider-name-cell">
             <wa-button
-              class="provider-expand-btn ${isExpanded ? 'expanded' : ''}"
+              class=${classMap({
+                'provider-expand-btn': true,
+                expanded: isExpanded,
+              })}
               appearance="plain"
               size="small"
               title="${isExpanded ? 'Collapse settings' : 'Expand settings'}"

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -3,6 +3,7 @@
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -283,7 +284,7 @@ export class MultiAgentTab extends LitElement {
     const isActive = this.activePresetId === preset.id;
     return html`
       <div
-        class="preset-card ${isActive ? 'active' : ''}"
+        class=${classMap({ 'preset-card': true, active: isActive })}
         @click=${() => this.handlePresetClick(preset)}
         title="Apply ${preset.name} team"
       >

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -153,10 +153,14 @@ export const multiFilesStyles = css`
     border-radius: var(--border-radius-small);
   }
 
+  .file-item:hover {
+    background-color: var(--wa-color-list-hover-bg);
+  }
+
+  /* Truncation lives on the .file-name-main / .file-folder children — this is
+     a flex column, where text-overflow has no effect. */
   .file-name {
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     flex: 1;
     min-width: 0;
     display: flex;

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -303,6 +303,7 @@ export const commonViewStyles: CSSResult = css`
     opacity: var(--opacity-subtle);
     font-size: var(--font-size-sm);
     display: inline-block;
+    transition: transform var(--transition-fast);
   }
 
   details[open] > summary .toggle-icon {
@@ -469,7 +470,7 @@ export const commonViewStyles: CSSResult = css`
     font-weight: var(--font-weight-medium);
     color: var(--color-text-secondary);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: var(--letter-spacing-caps);
   }
 
   /* Utility: single-line text truncation with ellipsis */

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -100,6 +100,27 @@ export const designTokens: CSSResult = css`
     /* Letter spacing for uppercase labels/badges (em scales with font-size). */
     --letter-spacing-caps: 0.06em;
   }
+
+  /* Match text selection to the host editor theme instead of the browser
+     default. ::selection does not pierce shadow roots, so this ships with the
+     token sheet every component adopts. */
+  ::selection {
+    background-color: var(--wa-color-editor-selection);
+  }
+
+  /* Honor the OS-level reduced-motion preference inside every shadow root
+     that adopts the token sheet: collapse animations and transitions to a
+     single imperceptible frame instead of removing end states. */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 `;
 
 export const animationStyles: CSSResult = css`


### PR DESCRIPTION
CSS details:
- Fix undefined tokens: --color-text (log reveal button hover was a
  no-op), --color-background/--color-text-muted/--color-background-secondary
  (TexraDiffView), --font-size-md (ProgressApp empty state)
- Honor prefers-reduced-motion in all shadow roots and light DOM
- Theme text selection via --wa-color-editor-selection
- Show the copy button's focus ring only on :focus-visible, not on
  summary hover
- Animate disclosure chevron rotation
- Add hover highlight to file list rows; drop no-op truncation props on
  the flex-column .file-name container
- Use the --letter-spacing-caps token for uppercase section headers
- Align log reveal button with control-height token and 1px focus offset

Lit nativeness:
- Return `nothing` instead of empty html`` in log formatters/builders
- Hide inactive stream lists with a ?hidden binding instead of a manual
  style string
- Make TaskGroupList reveal windows reactive @state instead of manual
  requestUpdate()
- Use classMap for conditional classes in settings/progress components
- Use ifDefined for the conditional launcher-tab tooltip

https://claude.ai/code/session_01F9F74s1cueEvbTkCW3Hvcu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only styling and Lit template/refactor changes with no backend, auth, or data-handling impact.
> 
> **Overview**
> This PR polishes **webview theming and accessibility** and tightens **Lit rendering patterns** across progress, settings, and shared styles.
> 
> **Global CSS:** Light DOM (`common.css`) and shadow roots (`litStyles.ts` design tokens) now use editor-themed `::selection` and `prefers-reduced-motion` damping. Shared view styles add a chevron **transition** and route uppercase headers through `--letter-spacing-caps`.
> 
> **Token / UI fixes:** Replaces broken or ad-hoc variables in **TexraDiffView**, **ProgressApp** empty state, and log reveal buttons (including hover text and control height). **File list** rows get list-hover background; ineffective truncation on the flex column `.file-name` is removed. Banner **copy** buttons only show a focus ring on `:focus-visible`, not on summary hover.
> 
> **Lit behavior:** Log formatters return **`nothing`** instead of empty `html```; inactive stream panes use **`?hidden`**; **TaskGroupList** “show older” windows are **`@state`** with immutable `Map` updates instead of `requestUpdate()`. Settings/progress components adopt **`classMap`** and **`ifDefined`** for conditional classes and tooltips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87863258c3adfacc7bfe2e91ed8e03f56f5edab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->