### PR TITLE
refactor: consolidate duplicate utilities and replace custom impls with shared functions

### DIFF
--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -91,14 +91,15 @@ async function waitForRenderedElement(window, view) {
           }
         }
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-        const unregisteredVscodeElements = [
-          ...document.querySelectorAll('*'),
-          ...[...document.querySelectorAll('*')]
-            .flatMap((node) => [...(node.shadowRoot?.querySelectorAll('*') ?? [])]),
-        ]
-          .map((node) => node.localName)
-          .filter((name) => name.startsWith('vscode-'))
-          .filter((name, index, names) => names.indexOf(name) === index)
+        const unregisteredVscodeElements = [...new Set(
+          [
+            ...document.querySelectorAll('*'),
+            ...[...document.querySelectorAll('*')]
+              .flatMap((node) => [...(node.shadowRoot?.querySelectorAll('*') ?? [])]),
+          ]
+            .map((node) => node.localName)
+            .filter((name) => name.startsWith('vscode-'))
+        )]
           .filter((name) => customElements.get(name) === undefined);
         if (unregisteredVscodeElements.length > 0) {
           throw new Error(

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -8,6 +8,7 @@
  */
 
 import { isNonEmptyString } from '@utils/core';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
 import type { GhIssueComment } from './prTypes';
 
@@ -63,9 +64,7 @@ export function sections(
 }
 
 export function truncate(s: string | null | undefined, max: number): string {
-  const body = (s ?? '').trim();
-  if (body.length <= max) return body;
-  return body.slice(0, max) + '…';
+  return truncateWithEllipsis((s ?? '').trim(), max);
 }
 
 /**

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -23,7 +23,7 @@ import type {
   InquiryResumeOutcome,
   StreamTabId,
 } from '@shared/schemas';
-import { collapseWhitespace } from '@utils/text/stringUtils';
+import { truncateSummary, truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import {
   getThreadSummary,
@@ -39,15 +39,6 @@ export type InjectionOutcome = 'sent' | 'queued' | 'resumed' | 'archived';
 const QUESTION_TRUNCATION = 400;
 const ANSWER_TRUNCATION = 2000;
 
-function truncate(text: string, limit: number): string {
-  if (text.length <= limit) return text;
-  return text.slice(0, limit).trimEnd() + ' …';
-}
-
-function previewText(text: string, limit: number): string {
-  return truncate(collapseWhitespace(text), limit);
-}
-
 function readThreadCommand(threadId: ExternalInquiryThreadId): string {
   return `inquiry { command: 'read', thread_id: '${threadId}' }`;
 }
@@ -58,7 +49,7 @@ function formatStillOpen(threads: ExternalInquiryThreadSummary[]): string[] {
   for (const t of threads) {
     const since = formatRelativeTime(t.lastActivityIso);
     lines.push(
-      `  - ${t.threadId}  "${truncate(t.lastQuestionPreview, 60)}"  (dispatched ${since})`,
+      `  - ${t.threadId}  "${truncateWithEllipsis(t.lastQuestionPreview, 60)}"  (dispatched ${since})`,
     );
   }
   return lines;
@@ -87,10 +78,10 @@ export function buildContinuationText(params: {
 
   if (event === 'answered') {
     lines.push(`[inquiry] ${threadId} answered.`);
-    lines.push(`Q: ${previewText(question, QUESTION_TRUNCATION)}`);
+    lines.push(`Q: ${truncateSummary(question, QUESTION_TRUNCATION)}`);
     if (answer !== undefined) {
       lines.push(
-        `A: ${previewText(answer, ANSWER_TRUNCATION)}` +
+        `A: ${truncateSummary(answer, ANSWER_TRUNCATION)}` +
           (answer.length > ANSWER_TRUNCATION
             ? ` (full text via ${readThreadCommand(threadId)})`
             : ''),
@@ -112,7 +103,7 @@ export function buildContinuationText(params: {
 
   // dropped
   lines.push(`[inquiry] ${threadId} dropped by user.`);
-  lines.push(`Q: ${previewText(question, QUESTION_TRUNCATION)}`);
+  lines.push(`Q: ${truncateSummary(question, QUESTION_TRUNCATION)}`);
   lines.push(`Full thread: ${readThreadCommand(threadId)}`);
   lines.push(...formatStillOpen(stillOpen));
   lines.push(

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -56,10 +56,10 @@ import {
   STREAM_DATA_KEYS,
   streamDataDir,
 } from './streamDataPaths';
+import { mapToRecord } from '@shared/progressView/backend/persistence/serializationUtils';
 import {
   assembleSnapshot,
   EMPTY_WORK_PLAN,
-  mapToRecord,
   readStreamData,
   type StreamData,
 } from './streamSnapshotRead';

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -35,6 +35,8 @@ import {
 } from '@shared/schemas';
 import { isObject } from '@utils/core';
 
+import { mapToRecord } from '@shared/progressView/backend/persistence/serializationUtils';
+
 import { STREAM_DATA_KEYS } from './streamDataPaths';
 
 const CHANNEL = 'StreamSnapshotStore';
@@ -58,13 +60,6 @@ export interface StreamData {
   workPlan: WorkPlanSnapshot;
   /** Category keys whose on-disk file was legacy-nested (need a one-time flat rewrite). */
   legacyKeys: string[];
-}
-
-/** Map → string-keyed Record for JSON persistence / the snapshot's record fields. */
-export function mapToRecord<K extends string | number, V>(
-  map: Map<K, V>,
-): Record<string, V> {
-  return Object.fromEntries(Array.from(map, ([k, v]) => [String(k), v]));
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`mapToRecord` deduplication** — identical function was defined in both `streamSnapshotRead.ts` and `serializationUtils.ts`; the definition is removed from `streamSnapshotRead.ts` and both `streamSnapshotRead` and `StreamSnapshotStore` now import from the single canonical location (`@shared/progressView/backend/persistence/serializationUtils`)
- **`formatUtils.ts:truncate` delegates to shared utility** — the inline `length check + slice + '…'` is replaced by a call to `truncateWithEllipsis` from `@utils/text/stringUtils`, keeping null/trim handling in the wrapper
- **`inquiryContinuation.ts` drops local `truncate`/`previewText` pair** — `previewText` was a local re-implementation of the existing `truncateSummary` (collapseWhitespace + truncateWithEllipsis); both are replaced by imports from `@utils/text/stringUtils`
- **Smoke script: O(n²) dedup → Set** — `.filter((n,i,a) => a.indexOf(n) === i)` replaced with `[...new Set(...)]` in `smoke-webviews-electron-runner.cjs`

## Test plan

- [ ] `npm run compile:fast` passes (verified: all 3 build targets succeeded)
- [ ] `npm run lint` passes (verified: exit 0)
- [ ] Truncation changes are display-only: shared helpers cap output at the requested length and use a bare ellipsis, so previews can be one character shorter and omit the pre-ellipsis space

https://claude.ai/code/session_017hzZLt1s4KE5qhY2a7heEM

---
_Generated by [Claude Code](https://claude.ai/code/session_017hzZLt1s4KE5qhY2a7heEM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication and import rewiring with no auth, persistence, or API surface changes; only minor risk if inquiry/GitHub preview ellipsis formatting differed from the shared helpers (claimed equivalent).
> 
> **Overview**
> This PR **deduplicates small helpers** so truncation and Map→Record serialization go through one shared implementation.
> 
> **`mapToRecord`** is removed from `streamSnapshotRead.ts`; `streamSnapshotRead` and `StreamSnapshotStore` now import it from `@shared/progressView/backend/persistence/serializationUtils`.
> 
> **GitHub `formatUtils.truncate`** delegates to `truncateWithEllipsis` from `@utils/text/stringUtils` (still trims/null-coalesces in the wrapper). **Inquiry continuation** drops local `truncate` / `previewText` in favor of `truncateSummary` and `truncateWithEllipsis` for Q/A previews and thread list snippets.
> 
> In **`smoke-webviews-electron-runner.cjs`**, unique `vscode-*` tag names are deduped with `[...new Set(...)]` instead of an O(n²) `indexOf` filter before the unregistered-custom-element check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d172e6f734a37af6efca096866900d7dce1e1b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

