### PR TITLE
Consolidate duplicated logic across hosts, model handlers, and UIs

### DIFF
--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -1,27 +1,22 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Box, Text, useInput, useWindowSize } from 'ink';
+import { useMemo } from 'react';
+import { Box, Text, useWindowSize } from 'ink';
 
 import {
   agentProposalCategoryLabel,
   getProposalFileGroups,
   type AgentProposalPermission,
 } from '@shared/schemas';
-import { clamp } from '@utils/core';
 
 import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import {
-  maxScrollableRowOffset,
-  scrollBoundedRows,
+  boundedScrollableLines,
+  compactAwareMaxScrollOffset,
+  scrollPageRows,
+  type ScrollableDisplayLine,
 } from '../render/scrollBounds';
-import {
-  hiddenRowsText,
-  moreRowsText,
-  previousRowsText,
-  scrollStatusText,
-} from '../render/overflowText';
-import { clipToWidth, textDisplayWidth } from '../render/terminalText';
 import { KeyHints } from '../ui/KeyHints';
+import { useScrollableOffset } from '../state/useScrollableOffset';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface AgentProposalProps {
@@ -37,10 +32,9 @@ const COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS = 3;
 const AGENT_PROPOSAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE = 7;
 const AGENT_PROPOSAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE = 5;
 
-export interface AgentProposalInstructionLine {
-  readonly kind: 'instruction' | 'overflow';
-  readonly text: string;
-}
+export type AgentProposalInstructionLine = ScrollableDisplayLine<'instruction'>;
+
+const AGENT_PROPOSAL_HIDDEN_NOUN = 'prompt rows';
 
 export function agentProposalInstructionRowsBudget({
   availableRows,
@@ -107,50 +101,11 @@ export function maxAgentProposalInstructionScrollOffset(
   totalLines: number,
   maxDisplayLines: number,
 ): number {
-  if (maxDisplayLines <= 0) return 0;
-  if (totalLines <= maxDisplayLines) return 0;
-  if (maxDisplayLines <= COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS) {
-    return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
-  }
-
-  return maxScrollableRowOffset({
+  return compactAwareMaxScrollOffset({
     compactRows: COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS,
     maxDisplayLines,
     totalLines,
   });
-}
-
-function agentProposalInstructionPageRows(maxInstructionRows: number): number {
-  return maxInstructionRows <= COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS
-    ? Math.max(1, maxInstructionRows - 1)
-    : Math.max(1, maxInstructionRows - 2);
-}
-
-function hiddenPromptRowsText(count: number): string {
-  return hiddenRowsText(count, 'prompt rows');
-}
-
-function compactHiddenInstructionText({
-  firstLine,
-  hiddenLines,
-  width,
-}: {
-  readonly firstLine: string;
-  readonly hiddenLines: number;
-  readonly width: number;
-}): string {
-  const suffix = ` ${hiddenPromptRowsText(hiddenLines)}`;
-  const prefixWidth = width - textDisplayWidth(suffix);
-  if (prefixWidth <= 0) {
-    return clipToWidth(hiddenPromptRowsText(hiddenLines), width);
-  }
-
-  const prefix = clipToWidth(firstLine, prefixWidth).trimEnd();
-  if (prefix.length === 0) {
-    return clipToWidth(hiddenPromptRowsText(hiddenLines), width);
-  }
-
-  return `${prefix}${suffix}`;
 }
 
 function wrappedRows(text: string, width: number): number {
@@ -206,70 +161,14 @@ export function boundedAgentProposalInstructionLines({
   readonly scrollOffset?: number;
   readonly width: number;
 }): AgentProposalInstructionLine[] {
-  const lines = agentProposalInstructionDisplayLines({ instruction, width });
-  if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
-
-  if (maxDisplayLines <= COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS) {
-    const contentRows = Math.max(1, maxDisplayLines - 1);
-    const offset = Math.max(
-      0,
-      Math.min(
-        scrollOffset,
-        maxAgentProposalInstructionScrollOffset(lines.length, maxDisplayLines),
-      ),
-    );
-
-    if (maxDisplayLines === 1) {
-      return [
-        {
-          kind: 'overflow',
-          text: compactHiddenInstructionText({
-            firstLine: lines[offset]?.text ?? '',
-            hiddenLines: lines.length - 1,
-            width,
-          }),
-        },
-      ];
-    }
-
-    const visible = lines.slice(offset, offset + contentRows);
-    const hiddenBefore = offset;
-    const hiddenAfter = Math.max(0, lines.length - (offset + visible.length));
-    return [
-      ...visible,
-      {
-        kind: 'overflow',
-        text: clipToWidth(scrollStatusText(hiddenBefore, hiddenAfter), width),
-      },
-    ];
-  }
-
-  const { hiddenAfter, hiddenBefore, visibleRows } = scrollBoundedRows({
+  return boundedScrollableLines({
     compactRows: COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS,
+    hiddenNoun: AGENT_PROPOSAL_HIDDEN_NOUN,
+    lines: agentProposalInstructionDisplayLines({ instruction, width }),
     maxDisplayLines,
-    rows: lines,
     scrollOffset,
+    width,
   });
-
-  return [
-    ...(hiddenBefore > 0
-      ? [
-          {
-            kind: 'overflow' as const,
-            text: previousRowsText(hiddenBefore),
-          },
-        ]
-      : []),
-    ...visibleRows,
-    ...(hiddenAfter > 0
-      ? [
-          {
-            kind: 'overflow' as const,
-            text: moreRowsText(hiddenAfter),
-          },
-        ]
-      : []),
-  ];
 }
 
 function FileGroup(props: {
@@ -288,7 +187,6 @@ function FileGroup(props: {
 
 export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
   const { columns } = useWindowSize();
-  const [scrollOffset, setScrollOffset] = useState(0);
   const fileGroups = getProposalFileGroups(props.payload);
   const title = `Spawn ${props.payload.agent}?`;
   const instructionWidth = Math.max(
@@ -318,8 +216,13 @@ export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
     instructionRows,
     maxInstructionRows,
   );
-  const scrollable = maxScrollOffset > 0;
-  const pageRows = agentProposalInstructionPageRows(maxInstructionRows);
+  const { scrollOffset, scrollable } = useScrollableOffset({
+    maxScrollOffset,
+    pageRows: scrollPageRows({
+      compactRows: COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS,
+      maxDisplayLines: maxInstructionRows,
+    }),
+  });
   const compactInstructionLayout =
     maxInstructionRows <= COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS;
   const showScrollHints = scrollable && maxInstructionRows > 1;
@@ -329,27 +232,6 @@ export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
     scrollOffset,
     width: instructionWidth,
   });
-
-  function scrollTo(next: number | ((currentOffset: number) => number)): void {
-    setScrollOffset((current) => {
-      const requested = typeof next === 'function' ? next(current) : next;
-      return clamp(requested, 0, maxScrollOffset);
-    });
-  }
-
-  useEffect(() => {
-    setScrollOffset((current) => clamp(current, 0, maxScrollOffset));
-  }, [maxScrollOffset]);
-
-  useInput(
-    (_input, key) => {
-      if (key.downArrow) scrollTo((current) => current + 1);
-      else if (key.upArrow) scrollTo((current) => current - 1);
-      else if (key.pageDown) scrollTo((current) => current + pageRows);
-      else if (key.pageUp) scrollTo((current) => current - pageRows);
-    },
-    { isActive: scrollable },
-  );
 
   return (
     <ConfirmCard

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Box, Text, useInput, useWindowSize } from 'ink';
+import { useMemo } from 'react';
+import { Box, Text, useWindowSize } from 'ink';
 
 import type { BashPermission } from '@shared/schemas';
 import { clamp } from '@utils/core';
@@ -7,17 +7,13 @@ import { clamp } from '@utils/core';
 import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import {
-  maxScrollableRowOffset,
-  scrollBoundedRows,
+  boundedScrollableLines,
+  compactAwareMaxScrollOffset,
+  scrollPageRows,
+  type ScrollableDisplayLine,
 } from '../render/scrollBounds';
-import {
-  hiddenRowsText,
-  moreRowsText,
-  previousRowsText,
-  scrollStatusText,
-} from '../render/overflowText';
-import { clipToWidth, textDisplayWidth } from '../render/terminalText';
 import { KeyHints } from '../ui/KeyHints';
+import { useScrollableOffset } from '../state/useScrollableOffset';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface BashApprovalProps {
@@ -26,10 +22,7 @@ export interface BashApprovalProps {
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
 
-export interface BashCommandDisplayLine {
-  readonly kind: 'command' | 'overflow';
-  readonly text: string;
-}
+export type BashCommandDisplayLine = ScrollableDisplayLine<'command'>;
 
 const BASH_APPROVAL_TITLE = 'Run bash command?';
 const MIN_BASH_COMMAND_WIDTH = 20;
@@ -88,15 +81,7 @@ export function maxBashCommandScrollOffset(
   totalLines: number,
   maxDisplayLines: number,
 ): number {
-  if (
-    maxDisplayLines <= COMPACT_BASH_COMMAND_ROWS &&
-    totalLines > maxDisplayLines
-  ) {
-    const contentRows = Math.max(1, maxDisplayLines - 1);
-    return Math.max(0, totalLines - contentRows);
-  }
-
-  return maxScrollableRowOffset({
+  return compactAwareMaxScrollOffset({
     compactRows: COMPACT_BASH_COMMAND_ROWS,
     maxDisplayLines,
     totalLines,
@@ -104,25 +89,10 @@ export function maxBashCommandScrollOffset(
 }
 
 export function bashApprovalPageRows(maxCommandRows: number): number {
-  return maxCommandRows <= COMPACT_BASH_COMMAND_ROWS
-    ? Math.max(1, maxCommandRows - 1)
-    : Math.max(1, maxCommandRows - 2);
-}
-
-function compactHiddenCommandText({
-  firstLine,
-  hiddenLines,
-  width,
-}: {
-  readonly firstLine: string;
-  readonly hiddenLines: number;
-  readonly width: number;
-}): string {
-  const suffix = ` ${hiddenRowsText(hiddenLines)}`;
-  const prefixWidth = width - textDisplayWidth(suffix);
-  if (prefixWidth <= 0) return clipToWidth(hiddenRowsText(hiddenLines), width);
-
-  return `${clipToWidth(firstLine, prefixWidth).trimEnd()}${suffix}`;
+  return scrollPageRows({
+    compactRows: COMPACT_BASH_COMMAND_ROWS,
+    maxDisplayLines: maxCommandRows,
+  });
 }
 
 export function boundedBashCommandDisplayLines({
@@ -136,73 +106,17 @@ export function boundedBashCommandDisplayLines({
   readonly scrollOffset?: number;
   readonly width: number;
 }): BashCommandDisplayLine[] {
-  const lines = bashCommandDisplayLines({ command, width });
-  if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) return lines;
-
-  if (maxDisplayLines <= COMPACT_BASH_COMMAND_ROWS) {
-    const contentRows = Math.max(1, maxDisplayLines - 1);
-    const offset = clamp(
-      scrollOffset,
-      0,
-      maxBashCommandScrollOffset(lines.length, maxDisplayLines),
-    );
-
-    if (maxDisplayLines === 1) {
-      return [
-        {
-          kind: 'overflow',
-          text: compactHiddenCommandText({
-            firstLine: lines[offset]?.text ?? '',
-            hiddenLines: lines.length - 1,
-            width,
-          }),
-        },
-      ];
-    }
-
-    const visible = lines.slice(offset, offset + contentRows);
-    const hiddenBefore = offset;
-    const hiddenAfter = Math.max(0, lines.length - (offset + visible.length));
-    return [
-      ...visible,
-      {
-        kind: 'overflow',
-        text: clipToWidth(scrollStatusText(hiddenBefore, hiddenAfter), width),
-      },
-    ];
-  }
-
-  const { hiddenAfter, hiddenBefore, visibleRows } = scrollBoundedRows({
+  return boundedScrollableLines({
     compactRows: COMPACT_BASH_COMMAND_ROWS,
+    lines: bashCommandDisplayLines({ command, width }),
     maxDisplayLines,
-    rows: lines,
     scrollOffset,
+    width,
   });
-
-  return [
-    ...(hiddenBefore > 0
-      ? [
-          {
-            kind: 'overflow' as const,
-            text: previousRowsText(hiddenBefore),
-          },
-        ]
-      : []),
-    ...visibleRows,
-    ...(hiddenAfter > 0
-      ? [
-          {
-            kind: 'overflow' as const,
-            text: moreRowsText(hiddenAfter),
-          },
-        ]
-      : []),
-  ];
 }
 
 export function BashApproval(props: BashApprovalProps): React.JSX.Element {
   const { columns } = useWindowSize();
-  const [scrollOffset, setScrollOffset] = useState(0);
   const commandWidth = Math.max(
     MIN_BASH_COMMAND_WIDTH,
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
@@ -223,8 +137,10 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
     commandRows,
     maxCommandRows,
   );
-  const scrollable = maxScrollOffset > 0;
-  const pageRows = bashApprovalPageRows(maxCommandRows);
+  const { scrollOffset, scrollable } = useScrollableOffset({
+    maxScrollOffset,
+    pageRows: bashApprovalPageRows(maxCommandRows),
+  });
   const compactCommandLayout = maxCommandRows <= COMPACT_BASH_COMMAND_ROWS;
   const showScrollHints = scrollable && maxCommandRows > 1;
   const displayLines = boundedBashCommandDisplayLines({
@@ -233,27 +149,6 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
     scrollOffset,
     width: commandWidth,
   });
-
-  function scrollTo(next: number | ((currentOffset: number) => number)): void {
-    setScrollOffset((current) => {
-      const requested = typeof next === 'function' ? next(current) : next;
-      return clamp(requested, 0, maxScrollOffset);
-    });
-  }
-
-  useEffect(() => {
-    setScrollOffset((current) => clamp(current, 0, maxScrollOffset));
-  }, [maxScrollOffset]);
-
-  useInput(
-    (_input, key) => {
-      if (key.downArrow) scrollTo((current) => current + 1);
-      else if (key.upArrow) scrollTo((current) => current - 1);
-      else if (key.pageDown) scrollTo((current) => current + pageRows);
-      else if (key.pageUp) scrollTo((current) => current - pageRows);
-    },
-    { isActive: scrollable },
-  );
 
   return (
     <ConfirmCard

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Box, Text, useInput, useWindowSize } from 'ink';
+import { useMemo, useState } from 'react';
+import { Box, Text, useWindowSize } from 'ink';
 
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 import { clamp } from '@utils/core';
@@ -15,6 +15,7 @@ import {
 } from '../render/DiffView';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { KeyHints } from '../ui/KeyHints';
+import { useScrollableOffset } from '../state/useScrollableOffset';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 const EDIT_DIFF_PADDING = 6;
@@ -105,7 +106,6 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const [feedbackMode, setFeedbackMode] = useState(false);
   const [feedbackValue, setFeedbackValue] = useState('');
-  const [scrollOffset, setScrollOffset] = useState(0);
   const title = `Apply edit to ${props.request.path}?`;
   const diffWidth = Math.max(MIN_EDIT_DIFF_WIDTH, columns - EDIT_DIFF_PADDING);
   const maxDiffLines = editApprovalDiffRowsBudget({
@@ -136,33 +136,14 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
     [diffWidth, hunks],
   );
   const maxScrollOffset = maxDiffScrollOffset(diffRows, maxDiffLines);
-  const diffScrollable = maxScrollOffset > 0;
-  const pageRows = Math.max(1, maxDiffLines - 2);
+  const { scrollOffset, scrollable: diffScrollable } = useScrollableOffset({
+    maxScrollOffset,
+    pageRows: Math.max(1, maxDiffLines - 2),
+  });
   const compactDiffLayout = maxDiffLines <= COMPACT_DIFF_DISPLAY_LINES;
   const compactCard =
     props.availableRows !== undefined &&
     props.availableRows <= COMPACT_EDIT_APPROVAL_MAX_ROWS;
-
-  function scrollTo(next: number | ((currentOffset: number) => number)): void {
-    setScrollOffset((current) => {
-      const requested = typeof next === 'function' ? next(current) : next;
-      return clamp(requested, 0, maxScrollOffset);
-    });
-  }
-
-  useEffect(() => {
-    setScrollOffset((current) => clamp(current, 0, maxScrollOffset));
-  }, [maxScrollOffset]);
-
-  useInput(
-    (_input, key) => {
-      if (key.downArrow) scrollTo((current) => current + 1);
-      else if (key.upArrow) scrollTo((current) => current - 1);
-      else if (key.pageDown) scrollTo((current) => current + pageRows);
-      else if (key.pageUp) scrollTo((current) => current - pageRows);
-    },
-    { isActive: diffScrollable },
-  );
 
   return (
     <ConfirmCard

--- a/packages/cli/src/chat/tui/render/scrollBounds.ts
+++ b/packages/cli/src/chat/tui/render/scrollBounds.ts
@@ -1,3 +1,11 @@
+import {
+  hiddenRowsText,
+  moreRowsText,
+  previousRowsText,
+  scrollStatusText,
+} from './overflowText';
+import { clipToWidth, textDisplayWidth } from './terminalText';
+
 export interface ScrollBoundedRows<T> {
   readonly hiddenAfter: number;
   readonly hiddenBefore: number;
@@ -66,4 +74,152 @@ export function scrollBoundedRows<T>({
   const hiddenAfter = Math.max(0, rows.length - (offset + visibleCount));
 
   return { hiddenAfter, hiddenBefore, visibleRows };
+}
+
+/** A renderable line that is either real content or an overflow marker row. */
+export interface ScrollableDisplayLine<K extends string = string> {
+  readonly kind: K | 'overflow';
+  readonly text: string;
+}
+
+/**
+ * Maximum scroll offset for a region that degrades to a single status row in
+ * compact layouts: below `compactRows` the last visible row is reserved for
+ * the overflow marker, so content scrolls within `maxDisplayLines - 1` rows.
+ */
+export function compactAwareMaxScrollOffset({
+  compactRows,
+  maxDisplayLines,
+  totalLines,
+}: {
+  readonly compactRows: number;
+  readonly maxDisplayLines: number;
+  readonly totalLines: number;
+}): number {
+  if (maxDisplayLines <= 0) return 0;
+  if (maxDisplayLines <= compactRows && totalLines > maxDisplayLines) {
+    return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
+  }
+
+  return maxScrollableRowOffset({ compactRows, maxDisplayLines, totalLines });
+}
+
+/** Rows advanced by PgUp/PgDn, leaving a row of context where space allows. */
+export function scrollPageRows({
+  compactRows,
+  maxDisplayLines,
+}: {
+  readonly compactRows: number;
+  readonly maxDisplayLines: number;
+}): number {
+  return maxDisplayLines <= compactRows
+    ? Math.max(1, maxDisplayLines - 1)
+    : Math.max(1, maxDisplayLines - 2);
+}
+
+function compactHiddenLineText({
+  firstLine,
+  hiddenNoun,
+  hiddenLines,
+  width,
+}: {
+  readonly firstLine: string;
+  readonly hiddenNoun: string | undefined;
+  readonly hiddenLines: number;
+  readonly width: number;
+}): string {
+  const hiddenText = hiddenRowsText(hiddenLines, hiddenNoun);
+  const suffix = ` ${hiddenText}`;
+  const prefixWidth = width - textDisplayWidth(suffix);
+  if (prefixWidth <= 0) return clipToWidth(hiddenText, width);
+
+  const prefix = clipToWidth(firstLine, prefixWidth).trimEnd();
+  if (prefix.length === 0) return clipToWidth(hiddenText, width);
+
+  return `${prefix}${suffix}`;
+}
+
+/**
+ * Bounds pre-wrapped display lines to `maxDisplayLines`, replacing hidden
+ * spans with overflow marker rows. Compact layouts reserve the last row for a
+ * combined scroll-status marker; a single-row budget collapses to one
+ * "first line ... N {hiddenNoun} hidden" row.
+ */
+export function boundedScrollableLines<K extends string>({
+  compactRows,
+  hiddenNoun,
+  lines,
+  maxDisplayLines,
+  scrollOffset = 0,
+  width,
+}: {
+  readonly compactRows: number;
+  /** Qualifies what is hidden in single-row markers (e.g. `prompt rows`). */
+  readonly hiddenNoun?: string;
+  readonly lines: readonly ScrollableDisplayLine<K>[];
+  readonly maxDisplayLines: number;
+  readonly scrollOffset?: number;
+  readonly width: number;
+}): ScrollableDisplayLine<K>[] {
+  if (maxDisplayLines <= 0 || lines.length <= maxDisplayLines) {
+    return [...lines];
+  }
+
+  const maxOffset = compactAwareMaxScrollOffset({
+    compactRows,
+    maxDisplayLines,
+    totalLines: lines.length,
+  });
+
+  if (maxDisplayLines <= compactRows) {
+    const contentRows = Math.max(1, maxDisplayLines - 1);
+    const offset = Math.max(0, Math.min(scrollOffset, maxOffset));
+
+    if (maxDisplayLines === 1) {
+      return [
+        {
+          kind: 'overflow',
+          text: compactHiddenLineText({
+            firstLine: lines[offset]?.text ?? '',
+            hiddenNoun,
+            hiddenLines: lines.length - 1,
+            width,
+          }),
+        },
+      ];
+    }
+
+    const visible = lines.slice(offset, offset + contentRows);
+    const hiddenBefore = offset;
+    const hiddenAfter = Math.max(0, lines.length - (offset + visible.length));
+    return [
+      ...visible,
+      {
+        kind: 'overflow',
+        text: clipToWidth(scrollStatusText(hiddenBefore, hiddenAfter), width),
+      },
+    ];
+  }
+
+  const { hiddenAfter, hiddenBefore, visibleRows } = scrollBoundedRows({
+    compactRows,
+    maxDisplayLines,
+    rows: lines,
+    scrollOffset,
+  });
+
+  return [
+    ...(hiddenBefore > 0
+      ? [
+          {
+            kind: 'overflow' as const,
+            text: previousRowsText(hiddenBefore),
+          },
+        ]
+      : []),
+    ...visibleRows,
+    ...(hiddenAfter > 0
+      ? [{ kind: 'overflow' as const, text: moreRowsText(hiddenAfter) }]
+      : []),
+  ];
 }

--- a/packages/cli/src/chat/tui/state/useScrollableOffset.ts
+++ b/packages/cli/src/chat/tui/state/useScrollableOffset.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useInput } from 'ink';
+
+import { clamp } from '@utils/core';
+
+/**
+ * Scroll offset for a bounded modal region (approval diffs, command previews,
+ * delegation prompts). Keeps the offset within [0, maxScrollOffset] — also
+ * re-clamping when the bound shrinks on resize — and binds ↑/↓ and
+ * PgUp/PgDn while there is anything to scroll.
+ */
+export function useScrollableOffset({
+  maxScrollOffset,
+  pageRows,
+}: {
+  readonly maxScrollOffset: number;
+  readonly pageRows: number;
+}): { scrollOffset: number; scrollable: boolean } {
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const scrollable = maxScrollOffset > 0;
+
+  function scrollBy(delta: number): void {
+    setScrollOffset((current) => clamp(current + delta, 0, maxScrollOffset));
+  }
+
+  useEffect(() => {
+    setScrollOffset((current) => clamp(current, 0, maxScrollOffset));
+  }, [maxScrollOffset]);
+
+  useInput(
+    (_input, key) => {
+      if (key.downArrow) scrollBy(1);
+      else if (key.upArrow) scrollBy(-1);
+      else if (key.pageDown) scrollBy(pageRows);
+      else if (key.pageUp) scrollBy(-pageRows);
+    },
+    { isActive: scrollable },
+  );
+
+  return { scrollOffset, scrollable };
+}

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -31,8 +31,7 @@ import { setOutputChannelFactory } from '@logger/logUtils';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 // Local imports - tool integrations
-import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
-import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
+import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 
 // Local imports - CLI runtime
 import { applyCliGitAuthorConfig } from './gitAuthor';
@@ -191,13 +190,9 @@ export async function initCliPlatform(
     if (context.installSignalHandlers !== false) {
       installCliShutdownSignalHandlers(lifecycle);
     }
-    // Direct LSP adapter for Lean tools — spawns `lake env lean --server`
-    // lazily, one server per Lake project root. Errors are surfaced via the
-    // Tools dashboard if `lake` isn't on PATH; nothing happens at startup
-    // when no Lean tools are invoked.
-    const leanAdapter = createDirectLspLeanAdapter();
-    setLeanLanguageServices(leanAdapter);
-    lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => leanAdapter.dispose());
+    // Direct LSP adapter for Lean tools. Errors are surfaced via the Tools
+    // dashboard if `lake` isn't on PATH.
+    registerDirectLeanLanguageServices(lifecycle);
 
     // Attribute agent-authored commits to the TeXRA identity by default;
     // configurable via `.texra/config.json` `texra.git.markCommits`.

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -13,16 +13,11 @@ import {
 } from 'electron';
 
 import { platform } from '@platform/platform';
-import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import type { TerminalRunResult } from '@hosts/terminalHost';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
-import {
-  interruptAllClaudeAgentSessions,
-  interruptAllCodexSessions,
-} from '@tools/agentCliSessionStores';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { setDesktopAgentResumeHandler } from './desktopAgentResume.js';
 import {
@@ -686,15 +681,7 @@ if (protocolLifecycle.shouldContinue) {
     .then(async () => {
       const platformInit = await initializeElectronPlatform(desktopMainDir);
       const { lifecycle } = platformInit;
-      lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-        executionRegistry.killBackgroundProcesses(),
-      );
-      lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-        interruptAllCodexSessions(),
-      );
-      lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-        interruptAllClaudeAgentSessions(),
-      );
+      registerAgentShutdownHandlers(lifecycle);
 
       // before-quit semantics: hold every quit event until shutdown handlers
       // have finished draining (a second Cmd+Q while we're mid-drain must NOT

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -14,8 +14,7 @@ import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { StreamSnapshotStore } from '@transcript';
 import { registerAgentFeatures } from '@agent/features';
 import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
-import { createDirectLspLeanAdapter } from '@tools/lean/direct/directLspAdapter';
-import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
+import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 
 import { bootstrapElectronAgentDirectories } from './agentDirectories.js';
 import { ElectronSecrets } from './electronSecrets.js';
@@ -86,10 +85,7 @@ export async function initializeElectronPlatform(
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => snapshotStore.flush());
 
   // Lean tools talk to `lake env lean --server` directly in the desktop build.
-  // Servers are spawned lazily per Lake project root on first request.
-  const leanAdapter = createDirectLspLeanAdapter();
-  setLeanLanguageServices(leanAdapter);
-  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => leanAdapter.dispose());
+  registerDirectLeanLanguageServices(lifecycle);
 
   await bootstrapElectronAgentDirectories(
     resolveResourcesPath(mainDirname),

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -18,7 +18,7 @@ import { loadAgents, setAgentDirectories } from '@agent/index';
 import { clearStoreCache } from '@agent/storage';
 import { registerAgentFeatures } from '@agent/features';
 import { initializeGoalPrompts } from '@agent/goal';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { initializePolishModel } from '@agent/runtime/polishModel';
 import {
   getServerSideKeyService,
@@ -75,10 +75,6 @@ import { VscodeConfigProvider } from '@frontend/vscode/vscodeConfig';
 import * as logger from '@logger/logUtils';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
-import {
-  interruptAllClaudeAgentSessions,
-  interruptAllCodexSessions,
-} from '@tools/agentCliSessionStores';
 import { setOpenPdfOpener } from '@tools/OpenPdfTool';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import { setSetupPlatform } from '@tools/setup';
@@ -194,15 +190,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   registerAgentFeatures();
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => disposeStatusListener?.());
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    executionRegistry.killBackgroundProcesses(),
-  );
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    interruptAllCodexSessions(),
-  );
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    interruptAllClaudeAgentSessions(),
-  );
+  registerAgentShutdownHandlers(lifecycle);
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => killActiveRecording());
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => UsageLogService.dispose());
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>

--- a/packages/extension/src/progressView/frontend/components/BaseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseStreamContent.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared scaffolding for stream container components: consumes the stream and
+ * permission contexts and keeps `filteredPermissions` scoped to the current
+ * stream. Subclasses narrow `streamContext.streamState` and render.
+ */
+
+// Third-party imports
+import { LitElement, css, type PropertyValues } from 'lit';
+import { consume } from '@lit/context';
+import { state } from 'lit/decorators.js';
+
+// Local imports - progress view
+import { filterPermissionsForStream } from '../stateUtils';
+import {
+  EMPTY_STREAM_CONTEXT,
+  permissionsContext,
+  streamStateContext,
+  type StreamContextValue,
+} from '../contexts/streamContexts';
+
+// Local imports - types
+import type { PermissionState } from './PermissionCard';
+
+export abstract class BaseStreamContent extends LitElement {
+  static override styles = css`
+    :host {
+      display: contents;
+    }
+  `;
+
+  @consume({ context: streamStateContext, subscribe: true })
+  @state()
+  protected streamContext: StreamContextValue = EMPTY_STREAM_CONTEXT;
+
+  @consume({ context: permissionsContext, subscribe: true })
+  @state()
+  protected permissionContext: PermissionState[] = [];
+
+  // Derived values - recomputed in willUpdate() before render.
+  protected filteredPermissions: PermissionState[] = [];
+
+  protected override willUpdate(changedProperties: PropertyValues): void {
+    if (
+      changedProperties.has('streamContext') ||
+      changedProperties.has('permissionContext')
+    ) {
+      this.filteredPermissions = filterPermissionsForStream(
+        this.permissionContext,
+        this.streamContext.streamInfo?.name,
+      );
+    }
+  }
+}

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -1,30 +1,15 @@
 /** Container component for tool-use agent streams. */
 
 // Third-party imports
-import {
-  LitElement,
-  css,
-  html,
-  nothing,
-  type PropertyValues,
-  type TemplateResult,
-} from 'lit';
-import { consume } from '@lit/context';
-import { customElement, state } from 'lit/decorators.js';
+import { html, nothing, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 // Local imports - progress view
-import { filterPermissionsForStream } from '../stateUtils';
-import {
-  EMPTY_STREAM_CONTEXT,
-  permissionsContext,
-  streamStateContext,
-  type StreamContextValue,
-} from '../contexts/streamContexts';
 import { ProgressEvents } from '../events';
+import { BaseStreamContent } from './BaseStreamContent';
 import type { ToolUseStreamState } from '../store';
 
-// Local imports - types
-import type { PermissionState } from './PermissionCard';
+// Local imports - components
 
 // Side-effect imports - sibling components
 import './StreamHeader';
@@ -38,36 +23,7 @@ import './BackgroundTasksPanel';
 import './FollowUpInput';
 
 @customElement('tool-use-stream-content')
-export class ToolUseStreamContent extends LitElement {
-  static override styles = css`
-    :host {
-      display: contents;
-    }
-  `;
-
-  @consume({ context: streamStateContext, subscribe: true })
-  @state()
-  private streamContext: StreamContextValue = EMPTY_STREAM_CONTEXT;
-
-  @consume({ context: permissionsContext, subscribe: true })
-  @state()
-  private permissionContext: PermissionState[] = [];
-
-  // Derived values - recomputed in willUpdate() before render.
-  private filteredPermissions: PermissionState[] = [];
-
-  protected override willUpdate(changedProperties: PropertyValues): void {
-    if (
-      changedProperties.has('streamContext') ||
-      changedProperties.has('permissionContext')
-    ) {
-      this.filteredPermissions = filterPermissionsForStream(
-        this.permissionContext,
-        this.streamContext.streamInfo?.name,
-      );
-    }
-  }
-
+export class ToolUseStreamContent extends BaseStreamContent {
   private get currentState(): ToolUseStreamState | null {
     const ctx = this.streamContext;
     if (!ctx.isToolUse || !ctx.streamState) return null;

--- a/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -1,29 +1,15 @@
 /** Container component for workflow agent streams. */
 
 // Third-party imports
-import {
-  LitElement,
-  css,
-  html,
-  nothing,
-  type PropertyValues,
-  type TemplateResult,
-} from 'lit';
-import { consume } from '@lit/context';
-import { customElement, state } from 'lit/decorators.js';
+import { html, nothing, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 // Local imports - progress view
-import { filterPermissionsForStream, hasOutputFiles } from '../stateUtils';
-import {
-  EMPTY_STREAM_CONTEXT,
-  permissionsContext,
-  streamStateContext,
-  type StreamContextValue,
-} from '../contexts/streamContexts';
+import { hasOutputFiles } from '../stateUtils';
+import { BaseStreamContent } from './BaseStreamContent';
 import type { WorkflowStreamState } from '../store';
 
-// Local imports - types
-import type { PermissionState } from './PermissionCard';
+// Local imports - components
 
 // Side-effect imports - sibling components
 import './StreamHeader';
@@ -37,36 +23,7 @@ import './RequestPanels';
 import './WorkflowHintBanner';
 
 @customElement('workflow-stream-content')
-export class WorkflowStreamContent extends LitElement {
-  static override styles = css`
-    :host {
-      display: contents;
-    }
-  `;
-
-  @consume({ context: streamStateContext, subscribe: true })
-  @state()
-  private streamContext: StreamContextValue = EMPTY_STREAM_CONTEXT;
-
-  @consume({ context: permissionsContext, subscribe: true })
-  @state()
-  private permissionContext: PermissionState[] = [];
-
-  // Derived values - recomputed in willUpdate() before render.
-  private filteredPermissions: PermissionState[] = [];
-
-  protected override willUpdate(changedProperties: PropertyValues): void {
-    if (
-      changedProperties.has('streamContext') ||
-      changedProperties.has('permissionContext')
-    ) {
-      this.filteredPermissions = filterPermissionsForStream(
-        this.permissionContext,
-        this.streamContext.streamInfo?.name,
-      );
-    }
-  }
-
+export class WorkflowStreamContent extends BaseStreamContent {
   private get currentState(): WorkflowStreamState | null {
     const ctx = this.streamContext;
     if (ctx.isToolUse || !ctx.streamState) return null;

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 
@@ -14,11 +14,7 @@ import { getBasename, normalizeFilePath } from '@shared/utils/path';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { MainViewEvents } from '../events';
-import {
-  extractDroppedFilePaths,
-  hasDroppedFilePayload,
-  postDroppedFiles,
-} from '../fileDropHandler';
+import { FileDropController, postDroppedFiles } from '../fileDropHandler';
 import { SESSION_TYPES } from '../constants';
 import { SESSION_DEFAULTS } from '../sessionDefaults';
 import {
@@ -59,10 +55,9 @@ export class FileSelectGroup extends LitElement {
   @query('.multiple-files-list')
   private fileListElement?: HTMLElement;
 
-  @state()
-  private isDragActive = false;
-
-  private dragDepth = 0;
+  private fileDrop = new FileDropController(this, (paths) =>
+    postDroppedFiles(paths, this.config.type),
+  );
 
   private sortableController = new SortableController(
     this,
@@ -100,51 +95,6 @@ export class FileSelectGroup extends LitElement {
   private handleSelectMultipleFiles(): void {
     this.dispatchEvent(
       MainViewEvents.selectMultipleFiles({ listId: this.listId }),
-    );
-  }
-
-  private handleDragEnter(event: DragEvent): void {
-    if (!hasDroppedFilePayload(event.dataTransfer)) return;
-    event.preventDefault();
-    this.dragDepth += 1;
-    this.isDragActive = true;
-  }
-
-  private handleDragOver(event: DragEvent): void {
-    if (!hasDroppedFilePayload(event.dataTransfer)) return;
-    event.preventDefault();
-    if (event.dataTransfer) {
-      event.dataTransfer.dropEffect = 'copy';
-    }
-  }
-
-  private handleDragLeave(event: DragEvent): void {
-    if (!hasDroppedFilePayload(event.dataTransfer)) return;
-    event.preventDefault();
-    this.dragDepth = Math.max(0, this.dragDepth - 1);
-    if (this.dragDepth === 0) {
-      this.isDragActive = false;
-    }
-  }
-
-  private handleDrop(event: DragEvent): void {
-    // Always clear the drag-active visuals on drop. `dragenter`/`dragover`
-    // can only inspect `dataTransfer.types` (protected mode), so a non-file
-    // URI such as an https link is optimistically treated as droppable and
-    // activates the outline. At drop time the payload is readable and may be
-    // rejected — but no `dragleave` follows a `drop`, so failing to reset here
-    // would leave the bucket permanently stuck in the drop-active state.
-    const wasDragActive = this.isDragActive;
-    this.dragDepth = 0;
-    this.isDragActive = false;
-    if (!hasDroppedFilePayload(event.dataTransfer)) {
-      if (wasDragActive) event.preventDefault();
-      return;
-    }
-    event.preventDefault();
-    postDroppedFiles(
-      extractDroppedFilePaths(event.dataTransfer),
-      this.config.type,
     );
   }
 
@@ -341,12 +291,12 @@ export class FileSelectGroup extends LitElement {
       <div
         class=${classMap({
           'file-select': true,
-          'drop-active': this.isDragActive,
+          'drop-active': this.fileDrop.isDragActive,
         })}
-        @dragenter=${this.handleDragEnter}
-        @dragover=${this.handleDragOver}
-        @dragleave=${this.handleDragLeave}
-        @drop=${this.handleDrop}
+        @dragenter=${this.fileDrop.handleDragEnter}
+        @dragover=${this.fileDrop.handleDragOver}
+        @dragleave=${this.fileDrop.handleDragLeave}
+        @drop=${this.fileDrop.handleDrop}
       >
         <div class="file-select-header">
           <div class="file-select-label-group">

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -8,7 +8,7 @@
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { keyed } from 'lit/directives/keyed.js';
 
@@ -30,11 +30,7 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - main view
 import { MainViewEvents } from '../events';
-import {
-  extractDroppedFilePaths,
-  hasDroppedFilePayload,
-  postDroppedFiles,
-} from '../fileDropHandler';
+import { FileDropController, postDroppedFiles } from '../fileDropHandler';
 import { handleImagePaste } from '../pasteHandler';
 import { SESSION_TYPES, type SessionType } from '../constants';
 import {
@@ -415,14 +411,13 @@ export class InstructionPanel extends LitElement {
 
   @property({ type: Boolean }) showSessionHint = true;
 
-  @state()
-  private isDragActive = false;
-
   /** Reference to instruction textarea for paste handling */
   @query('#instruction')
   private instructionTextarea?: HTMLElement;
 
-  private dragDepth = 0;
+  private fileDrop = new FileDropController(this, (paths) =>
+    postDroppedFiles(paths),
+  );
 
   /** Get the tooltip for an agent dropdown based on the selected agent's description. */
   private getAgentTooltip(
@@ -523,48 +518,6 @@ export class InstructionPanel extends LitElement {
     }
   };
 
-  private handleDragEnter(event: DragEvent): void {
-    if (!hasDroppedFilePayload(event.dataTransfer)) return;
-    event.preventDefault();
-    this.dragDepth += 1;
-    this.isDragActive = true;
-  }
-
-  private handleDragOver(event: DragEvent): void {
-    if (!hasDroppedFilePayload(event.dataTransfer)) return;
-    event.preventDefault();
-    if (event.dataTransfer) {
-      event.dataTransfer.dropEffect = 'copy';
-    }
-  }
-
-  private handleDragLeave(event: DragEvent): void {
-    if (!hasDroppedFilePayload(event.dataTransfer)) return;
-    event.preventDefault();
-    this.dragDepth = Math.max(0, this.dragDepth - 1);
-    if (this.dragDepth === 0) {
-      this.isDragActive = false;
-    }
-  }
-
-  private handleDrop(event: DragEvent): void {
-    // Always clear the drag-active visuals on drop. `dragenter`/`dragover`
-    // can only inspect `dataTransfer.types` (protected mode), so a non-file
-    // URI such as an https link is optimistically treated as droppable and
-    // activates the outline. At drop time the payload is readable and may be
-    // rejected — but no `dragleave` follows a `drop`, so failing to reset here
-    // would leave the panel permanently stuck in the drop-active state.
-    const wasDragActive = this.isDragActive;
-    this.dragDepth = 0;
-    this.isDragActive = false;
-    if (!hasDroppedFilePayload(event.dataTransfer)) {
-      if (wasDragActive) event.preventDefault();
-      return;
-    }
-    event.preventDefault();
-    postDroppedFiles(extractDroppedFilePaths(event.dataTransfer));
-  }
-
   private handleActionClick(event: MouseEvent): void {
     const button = (event.target as HTMLElement).closest<HTMLElement>(
       '[data-action]',
@@ -626,12 +579,12 @@ export class InstructionPanel extends LitElement {
       <div
         class=${classMap({
           'instruction-box': true,
-          'drop-active': this.isDragActive,
+          'drop-active': this.fileDrop.isDragActive,
         })}
-        @dragenter=${this.handleDragEnter}
-        @dragover=${this.handleDragOver}
-        @dragleave=${this.handleDragLeave}
-        @drop=${this.handleDrop}
+        @dragenter=${this.fileDrop.handleDragEnter}
+        @dragover=${this.fileDrop.handleDragOver}
+        @dragleave=${this.fileDrop.handleDragLeave}
+        @drop=${this.fileDrop.handleDrop}
       >
         <div class="instruction-header">
           <div class="instruction-header-leading">

--- a/packages/extension/src/webview/frontend/fileDropHandler.ts
+++ b/packages/extension/src/webview/frontend/fileDropHandler.ts
@@ -7,6 +7,9 @@ import { postMessage } from '@shared/hostBridge';
 // Local imports - shared schemas
 import type { MultipleDocumentFileType } from '@shared/schemas';
 
+// Third-party type imports
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
 type FileWithPath = File & {
   path?: string;
 };
@@ -111,6 +114,86 @@ export function extractDroppedFilePaths(
   }
 
   return [...paths];
+}
+
+/**
+ * Drag-and-drop lifecycle for a file drop target. Tracks nested
+ * dragenter/dragleave pairs so child elements don't flicker the highlight,
+ * and hands validated drop payloads to `onDrop`. Bind all four handlers on
+ * the drop target and drive the visual state from `isDragActive`.
+ */
+export class FileDropController implements ReactiveController {
+  private dragDepth = 0;
+  private active = false;
+
+  constructor(
+    private readonly host: ReactiveControllerHost,
+    private readonly onDrop: (paths: string[]) => void,
+  ) {
+    host.addController(this);
+  }
+
+  get isDragActive(): boolean {
+    return this.active;
+  }
+
+  hostConnected(): void {}
+
+  hostDisconnected(): void {
+    this.reset();
+  }
+
+  private setActive(active: boolean): void {
+    if (this.active === active) return;
+    this.active = active;
+    this.host.requestUpdate();
+  }
+
+  private reset(): void {
+    this.dragDepth = 0;
+    this.setActive(false);
+  }
+
+  readonly handleDragEnter = (event: DragEvent): void => {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    this.dragDepth += 1;
+    this.setActive(true);
+  };
+
+  readonly handleDragOver = (event: DragEvent): void => {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  };
+
+  readonly handleDragLeave = (event: DragEvent): void => {
+    if (!hasDroppedFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    this.dragDepth = Math.max(0, this.dragDepth - 1);
+    if (this.dragDepth === 0) {
+      this.setActive(false);
+    }
+  };
+
+  readonly handleDrop = (event: DragEvent): void => {
+    // Always clear the drag-active visuals on drop. `dragenter`/`dragover`
+    // can only inspect `dataTransfer.types` (protected mode), so a non-file
+    // URI such as an https link is optimistically treated as droppable and
+    // activates the outline. At drop time the payload is readable and may be
+    // rejected — but no `dragleave` follows a `drop`, so failing to reset here
+    // would leave the drop target permanently stuck in the drop-active state.
+    const wasDragActive = this.active;
+    this.reset();
+    if (!hasDroppedFilePayload(event.dataTransfer)) {
+      if (wasDragActive) event.preventDefault();
+      return;
+    }
+    event.preventDefault();
+    this.onDrop(extractDroppedFilePaths(event.dataTransfer));
+  };
 }
 
 export function postDroppedFiles(

--- a/src/agent/modelHandlers/google/googleUsage.ts
+++ b/src/agent/modelHandlers/google/googleUsage.ts
@@ -8,17 +8,16 @@
  */
 
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
+import {
+  computeStandardPrice,
+  type StandardPricingConfig,
+} from '@agent/utils/priceUtils';
 
 import { normalizeUsage } from '../support/UsageNormalizer';
 import type { GenerateContentResponseUsageMetadata } from '@google/genai';
 
 /** Pricing inputs the handler supplies from its `config`/`capabilities`. */
-export interface GooglePricingConfig {
-  inputPrice: number;
-  outputPrice: number;
-  cacheDiscountFactor: number;
-}
+export type GooglePricingConfig = StandardPricingConfig;
 
 interface GoogleTokenCounts {
   inputTokens: number;
@@ -74,24 +73,17 @@ export function computeGooglePrice(
   if (!responseUsage) return 0.0;
   const { inputTokens, outputTokens } = computeGoogleTokenCounts(responseUsage);
 
-  let basePrice = calculateTokenPrice(
-    inputTokens,
-    outputTokens,
-    config.inputPrice,
-    config.outputPrice,
-  );
-
+  // No reasoning surcharge: thoughtsTokenCount is already part of outputTokens.
   // cachedContentTokenCount is a subset of promptTokenCount, so cached reads
-  // are first billed at the full input rate above; rebate them down to the
-  // discounted cache-read rate (mirrors computeOpenAIPrice).
-  const cachedTokens = responseUsage.cachedContentTokenCount ?? 0;
-  if (cachedTokens) {
-    basePrice -=
-      (cachedTokens * config.inputPrice * (1 - config.cacheDiscountFactor)) /
-      1e6;
-  }
-
-  return basePrice;
+  // are billed at the full input rate and rebated by computeStandardPrice.
+  return computeStandardPrice(
+    {
+      inputTokens,
+      outputTokens,
+      cachedTokens: responseUsage.cachedContentTokenCount ?? 0,
+    },
+    config,
+  );
 }
 
 /** Normalizes Google GenAI usage data into a unified format. */

--- a/src/agent/modelHandlers/openai/openAIUsage.ts
+++ b/src/agent/modelHandlers/openai/openAIUsage.ts
@@ -8,16 +8,15 @@
  */
 import type { ExtendedCompletionUsage } from '@agent/core/usage/ResponseUsage';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
+import {
+  computeStandardPrice,
+  type StandardPricingConfig,
+} from '@agent/utils/priceUtils';
 
 import { normalizeUsage } from '../support/UsageNormalizer';
 
 /** Pricing inputs the handler supplies from its `config`/`capabilities`. */
-export interface OpenAIPricingConfig {
-  inputPrice: number;
-  outputPrice: number;
-  cacheDiscountFactor: number;
-}
+export type OpenAIPricingConfig = StandardPricingConfig;
 
 /** Computes cost based on token usage and model pricing. */
 export function computeOpenAIPrice(
@@ -33,29 +32,18 @@ export function computeOpenAIPrice(
   const promptTokens =
     responseUsage.prompt_tokens ??
     cachedTokens + (responseUsage.prompt_cache_miss_tokens ?? 0);
-  const completionTokens = responseUsage.completion_tokens ?? 0;
   // Note: OpenAI doesn't provide tool_use_tokens in their API response
 
-  let basePrice = calculateTokenPrice(
-    promptTokens,
-    completionTokens,
-    config.inputPrice,
-    config.outputPrice,
+  return computeStandardPrice(
+    {
+      inputTokens: promptTokens,
+      outputTokens: responseUsage.completion_tokens ?? 0,
+      cachedTokens,
+      reasoningTokens:
+        responseUsage.completion_tokens_details?.reasoning_tokens ?? 0,
+    },
+    config,
   );
-
-  // Retrieve nested token details if present
-  const reasoningTokens =
-    responseUsage.completion_tokens_details?.reasoning_tokens ?? 0;
-  if (reasoningTokens) {
-    basePrice += (reasoningTokens * config.outputPrice) / 1e6;
-  }
-  if (cachedTokens) {
-    basePrice -=
-      (cachedTokens * config.inputPrice * (1 - config.cacheDiscountFactor)) /
-      1e6;
-  }
-
-  return basePrice;
 }
 
 /** Normalizes OpenAI usage data into a unified format. */

--- a/src/agent/modelHandlers/openrouter/openRouterUsage.ts
+++ b/src/agent/modelHandlers/openrouter/openRouterUsage.ts
@@ -9,17 +9,16 @@
  */
 
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
+import {
+  computeStandardPrice,
+  type StandardPricingConfig,
+} from '@agent/utils/priceUtils';
 
 import { normalizeUsage } from '../support/UsageNormalizer';
 import type { ChatUsage } from '@openrouter/sdk/models';
 
 /** Pricing inputs the handler supplies from its `config`/`capabilities`. */
-export interface OpenRouterPricingConfig {
-  inputPrice: number;
-  outputPrice: number;
-  cacheDiscountFactor: number;
-}
+export type OpenRouterPricingConfig = StandardPricingConfig;
 
 /** Computes cost based on token usage and model pricing. */
 export function computeOpenRouterPrice(
@@ -28,30 +27,16 @@ export function computeOpenRouterPrice(
 ): number {
   if (!responseUsage) return 0;
 
-  const promptTokens = responseUsage.promptTokens ?? 0;
-  const completionTokens = responseUsage.completionTokens ?? 0;
-
-  let basePrice = calculateTokenPrice(
-    promptTokens,
-    completionTokens,
-    config.inputPrice,
-    config.outputPrice,
+  return computeStandardPrice(
+    {
+      inputTokens: responseUsage.promptTokens ?? 0,
+      outputTokens: responseUsage.completionTokens ?? 0,
+      cachedTokens: responseUsage.promptTokensDetails?.cachedTokens ?? 0,
+      reasoningTokens:
+        responseUsage.completionTokensDetails?.reasoningTokens ?? 0,
+    },
+    config,
   );
-
-  const reasoningTokens =
-    responseUsage.completionTokensDetails?.reasoningTokens ?? 0;
-  const cachedTokens = responseUsage.promptTokensDetails?.cachedTokens ?? 0;
-
-  if (reasoningTokens) {
-    basePrice += (reasoningTokens * config.outputPrice) / 1e6;
-  }
-  if (cachedTokens) {
-    basePrice -=
-      (cachedTokens * config.inputPrice * (1 - config.cacheDiscountFactor)) /
-      1e6;
-  }
-
-  return basePrice;
 }
 
 /** Normalizes OpenRouter usage data into a unified format. */

--- a/src/agent/runtime/agentShutdown.ts
+++ b/src/agent/runtime/agentShutdown.ts
@@ -1,0 +1,31 @@
+// Local imports - platform
+import {
+  SHUTDOWN_PHASE,
+  type LifecycleHost,
+} from '@platform/interfaces/lifecycle';
+
+// Local imports - tools
+import {
+  interruptAllClaudeAgentSessions,
+  interruptAllCodexSessions,
+} from '@tools/agentCliSessionStores';
+
+// Local imports - runtime
+import { executionRegistry } from './executionRegistry';
+
+/**
+ * Stops agent-spawned child processes and CLI-backed agent sessions before
+ * host teardown. Every long-lived host (VS Code extension, Electron desktop)
+ * registers these so agent work never outlives the host.
+ */
+export function registerAgentShutdownHandlers(lifecycle: LifecycleHost): void {
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+    executionRegistry.killBackgroundProcesses(),
+  );
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+    interruptAllCodexSessions(),
+  );
+  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
+    interruptAllClaudeAgentSessions(),
+  );
+}

--- a/src/agent/utils/priceUtils.ts
+++ b/src/agent/utils/priceUtils.ts
@@ -7,3 +7,56 @@ export function calculateTokenPrice(
 ): number {
   return (promptTokens * inputPrice + completionTokens * outputPrice) / 1e6;
 }
+
+/**
+ * Pricing inputs for providers whose cached prompt tokens are a subset of the
+ * reported input tokens (OpenAI, OpenRouter, Google). Anthropic bills cache
+ * reads/writes additively on top of input tokens and has its own formula in
+ * `anthropicUsage.ts`.
+ */
+export interface StandardPricingConfig {
+  inputPrice: number;
+  outputPrice: number;
+  cacheDiscountFactor: number;
+}
+
+export interface StandardPriceTokens {
+  inputTokens: number;
+  outputTokens: number;
+  /**
+   * Cached prompt tokens already counted inside `inputTokens`. Billed above at
+   * the full input rate, then rebated down to `inputPrice * cacheDiscountFactor`.
+   */
+  cachedTokens?: number;
+  /**
+   * Reasoning tokens billed at the output rate on top of `outputTokens`. Omit
+   * for providers (e.g. Google) whose output total already includes them.
+   */
+  reasoningTokens?: number;
+}
+
+/** Inclusive-cache token cost: base price + reasoning surcharge − cache-read rebate. */
+export function computeStandardPrice(
+  tokens: StandardPriceTokens,
+  config: StandardPricingConfig,
+): number {
+  let basePrice = calculateTokenPrice(
+    tokens.inputTokens,
+    tokens.outputTokens,
+    config.inputPrice,
+    config.outputPrice,
+  );
+
+  const reasoningTokens = tokens.reasoningTokens ?? 0;
+  if (reasoningTokens) {
+    basePrice += (reasoningTokens * config.outputPrice) / 1e6;
+  }
+  const cachedTokens = tokens.cachedTokens ?? 0;
+  if (cachedTokens) {
+    basePrice -=
+      (cachedTokens * config.inputPrice * (1 - config.cacheDiscountFactor)) /
+      1e6;
+  }
+
+  return basePrice;
+}

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import * as path from 'node:path';
-
 // Third-party imports
 import { sync as globSync } from 'glob';
 import { MODELS } from 'llm-zoo';
@@ -10,7 +7,6 @@ import type { FileOpResult } from '@agent/types/ResultTypes';
 // Internal imports
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 
 // Local file imports
@@ -18,10 +14,9 @@ import {
   EXCLUDED_DIRS,
   TEMP_EXTENSIONS,
   PACK_EXTENSIONS,
-  DEFAULT_MAX_ROUNDS,
   HISTORY_DIR,
 } from './constants';
-import { getFilePatterns, findFilesFromPatterns } from './utils';
+import { findFilesFromPatterns, resolveHousekeepingTargets } from './utils';
 
 const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);
@@ -36,26 +31,11 @@ export async function runCleanSingle(
     `Starting cleanup with model=${model}, inputFile=${inputFile}, agent=${agent}`,
   );
 
-  if (!inputFile || !model || !agent) {
-    logger.error(
-      CHANNEL,
-      `Missing required parameters: model=${model}, inputFile=${inputFile}, agent=${agent}`,
-    );
+  const targets = resolveHousekeepingTargets(model, inputFile, agent);
+  if (!targets) {
     return { status: 'missingParams' };
   }
-
-  const baseName = path.parse(inputFile).name;
-  const inputDir = path.dirname(inputFile);
-  logger.debug(
-    CHANNEL,
-    `Parsed paths: baseName=${baseName}, inputDir=${inputDir}`,
-  );
-
-  const maxRounds = getConfig<number>('texra.agent.rounds', DEFAULT_MAX_ROUNDS);
-  // Pass the raw agent; getFilePatterns derives both the legacy chunk and
-  // the new clean-agent forms internally so both disk layouts are matched.
-  const filePatterns = getFilePatterns(baseName, model, agent, maxRounds);
-  logger.debug(CHANNEL, `Generated patterns: ${filePatterns}`);
+  const { inputDir, filePatterns } = targets;
 
   const extensions = [...TEMP_EXTENSIONS, ...PACK_EXTENSIONS];
   logger.debug(CHANNEL, `Using extensions: ${extensions}`);

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -22,8 +22,8 @@ import {
 import {
   generateTimestamp,
   getAgentFirstNameChunk,
-  getFilePatterns,
   findFilesFromPatterns,
+  resolveHousekeepingTargets,
 } from './utils';
 
 const CHANNEL = 'Housekeeping';
@@ -40,29 +40,13 @@ export async function runPackSingle(
     `Starting packing with model=${model}, inputFile=${inputFile}, agent=${agent}, outputFolder=${outputFolder}`,
   );
 
-  if (!inputFile || !model || !agent) {
-    logger.error(
-      CHANNEL,
-      `Missing required parameters: model=${model}, inputFile=${inputFile}, agent=${agent}`,
-    );
+  const targets = resolveHousekeepingTargets(model, inputFile, agent);
+  if (!targets) {
     return { status: 'missingParams' };
   }
-
-  const baseName = path.parse(inputFile).name;
-  const inputDir = path.dirname(inputFile);
-  logger.debug(
-    CHANNEL,
-    `Parsed paths: baseName=${baseName}, inputDir=${inputDir}`,
-  );
-
-  const maxRounds = getConfig<number>('texra.agent.rounds', DEFAULT_MAX_ROUNDS);
-  // Pass the raw agent; getFilePatterns derives both the legacy chunk and
-  // the new clean-agent forms internally so both disk layouts are matched.
-  const filePatterns = [
-    ...getFilePatterns(baseName, model, agent, maxRounds),
-    baseName,
-  ];
-  logger.debug(CHANNEL, `Generated patterns: ${filePatterns}`);
+  const { baseName, inputDir } = targets;
+  // Pack also matches the input document itself (it is copied, not moved).
+  const filePatterns = [...targets.filePatterns, baseName];
 
   const allFiles = findFilesFromPatterns(
     inputDir,

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -12,7 +12,10 @@ import {
   normalizeLegacyModel,
 } from '@agent/output/workflowOutputLayout';
 import * as logger from '@logger/logUtils';
+import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
+
+import { DEFAULT_MAX_ROUNDS } from './constants';
 
 const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);
@@ -100,6 +103,46 @@ export function getFilePatterns(
     );
   }
   return patterns;
+}
+
+export interface HousekeepingTargets {
+  baseName: string;
+  inputDir: string;
+  filePatterns: string[];
+}
+
+/**
+ * Validates the parameters shared by clean and pack operations, then derives
+ * the parsed input path parts and round-aware file patterns for the agent's
+ * output layouts. Returns null (after logging) when a parameter is missing.
+ */
+export function resolveHousekeepingTargets(
+  model: string,
+  inputFile: string,
+  agent: string,
+): HousekeepingTargets | null {
+  if (!inputFile || !model || !agent) {
+    logger.error(
+      CHANNEL,
+      `Missing required parameters: model=${model}, inputFile=${inputFile}, agent=${agent}`,
+    );
+    return null;
+  }
+
+  const baseName = path.parse(inputFile).name;
+  const inputDir = path.dirname(inputFile);
+  logger.debug(
+    CHANNEL,
+    `Parsed paths: baseName=${baseName}, inputDir=${inputDir}`,
+  );
+
+  const maxRounds = getConfig<number>('texra.agent.rounds', DEFAULT_MAX_ROUNDS);
+  // Pass the raw agent; getFilePatterns derives both the legacy chunk and
+  // the new clean-agent forms internally so both disk layouts are matched.
+  const filePatterns = getFilePatterns(baseName, model, agent, maxRounds);
+  logger.debug(CHANNEL, `Generated patterns: ${filePatterns}`);
+
+  return { baseName, inputDir, filePatterns };
 }
 
 export function findFilesFromPatterns(

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -21,7 +21,6 @@ const mocks = vi.hoisted(() => ({
   // Collects callbacks registered via the (mocked) lifecycle host's onShutdown
   // so a test can run them and assert the usage-log dispose was wired.
   shutdownHandlers: [] as Array<() => unknown>,
-  leanAdapter: { dispose: vi.fn() },
 }));
 
 vi.mock('@agent/index/platformAgentDirectories', () => ({
@@ -94,12 +93,7 @@ vi.mock('@cli/runtime/cliStateStores', () => ({
 vi.mock('@cli/runtime/gitAuthor', () => ({ applyCliGitAuthorConfig: vi.fn() }));
 
 vi.mock('@tools/lean/direct/directLspAdapter', () => ({
-  createDirectLspLeanAdapter: () => mocks.leanAdapter,
   registerDirectLeanLanguageServices: vi.fn(),
-}));
-
-vi.mock('@tools/lean/leanLanguageServices', () => ({
-  setLeanLanguageServices: vi.fn(),
 }));
 
 function cliContext(

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -95,6 +95,7 @@ vi.mock('@cli/runtime/gitAuthor', () => ({ applyCliGitAuthorConfig: vi.fn() }));
 
 vi.mock('@tools/lean/direct/directLspAdapter', () => ({
   createDirectLspLeanAdapter: () => mocks.leanAdapter,
+  registerDirectLeanLanguageServices: vi.fn(),
 }));
 
 vi.mock('@tools/lean/leanLanguageServices', () => ({

--- a/src/test-kernel/webview/FileSelectGroupSource.vitest.mts
+++ b/src/test-kernel/webview/FileSelectGroupSource.vitest.mts
@@ -32,13 +32,20 @@ function readMainApp(): string {
   );
 }
 
+function readFileDropHandler(): string {
+  return readFileSync(
+    repoPath('packages/extension/src/webview/frontend/fileDropHandler.ts'),
+    'utf8',
+  );
+}
+
 /**
- * Extract the body of the `private handleDrop(...)` method from a component
+ * Extract the body of the `handleDrop` handler from the FileDropController
  * source so we can assert on its statement ordering.
  */
 function extractHandleDropBody(source: string): string {
-  const start = source.indexOf('private handleDrop(');
-  expect(start, 'handleDrop method should exist').toBeGreaterThan(-1);
+  const start = source.indexOf('readonly handleDrop = (');
+  expect(start, 'handleDrop handler should exist').toBeGreaterThan(-1);
   const braceStart = source.indexOf('{', start);
   let depth = 0;
   for (let i = braceStart; i < source.length; i += 1) {
@@ -83,29 +90,36 @@ describe('drop-target drag-active reset', () => {
   // drop-active outline. At drop time the payload is readable and rejected by
   // `hasDroppedFilePayload`, and no `dragleave` fires after a `drop` — so the
   // reset MUST run before the rejection early-return, or the outline sticks
-  // forever. Guard both drop targets against regressing into the old ordering
-  // where the reset lived after the `hasDroppedFilePayload` guard.
+  // forever. Guard the shared FileDropController against regressing into the
+  // old ordering where the reset lived after the `hasDroppedFilePayload` guard.
+  it('FileDropController resets drag state before the rejection early-return', () => {
+    const body = extractHandleDropBody(readFileDropHandler());
+
+    const resetAt = body.indexOf('this.reset();');
+    const guardReturnAt = body.indexOf('if (!hasDroppedFilePayload(');
+
+    expect(resetAt, 'resets drag state').toBeGreaterThan(-1);
+    expect(guardReturnAt, 'guards on hasDroppedFilePayload').toBeGreaterThan(
+      -1,
+    );
+
+    // The reset runs before the payload guard, so a rejected drop still
+    // clears the drop-active visuals.
+    expect(resetAt).toBeLessThan(guardReturnAt);
+  });
+
+  // Both drop targets must route drag events through the shared controller
+  // rather than reintroducing per-component handlers.
   for (const [name, read] of [
     ['FileSelectGroup', readFileSelectGroup],
     ['InstructionPanel', readInstructionPanel],
   ] as const) {
-    it(`${name} resets drag state before the rejection early-return`, () => {
-      const body = extractHandleDropBody(read());
+    it(`${name} binds its drop target to the FileDropController`, () => {
+      const component = read();
 
-      const resetDepthAt = body.indexOf('this.dragDepth = 0;');
-      const resetActiveAt = body.indexOf('this.isDragActive = false;');
-      const guardReturnAt = body.indexOf('if (!hasDroppedFilePayload(');
-
-      expect(resetDepthAt, 'resets dragDepth').toBeGreaterThan(-1);
-      expect(resetActiveAt, 'resets isDragActive').toBeGreaterThan(-1);
-      expect(guardReturnAt, 'guards on hasDroppedFilePayload').toBeGreaterThan(
-        -1,
-      );
-
-      // Both resets run before the payload guard, so a rejected drop still
-      // clears the drop-active visuals.
-      expect(resetDepthAt).toBeLessThan(guardReturnAt);
-      expect(resetActiveAt).toBeLessThan(guardReturnAt);
+      expect(component).toContain('new FileDropController(this,');
+      expect(component).toContain('@drop=${this.fileDrop.handleDrop}');
+      expect(component).not.toContain('private handleDrop(');
     });
   }
 });

--- a/src/tools/lean/direct/directLspAdapter.ts
+++ b/src/tools/lean/direct/directLspAdapter.ts
@@ -11,11 +11,16 @@
 import { access } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import {
+  SHUTDOWN_PHASE,
+  type LifecycleHost,
+} from '@platform/interfaces/lifecycle';
 import { toErrorMessage } from '@common/errors';
 import { warn } from '@logger/logUtils';
 
 import { runLakeCommand } from './lakeCommands';
 import { LeanSession } from './leanSession';
+import { setLeanLanguageServices } from '../leanLanguageServices';
 import type { LeanFileCommand, LeanProjectCommand } from '../leanConstants';
 import type { LeanLanguageServices } from '../leanLanguageServices';
 import type { LspHover } from '../lspTypes';
@@ -33,6 +38,20 @@ export interface DirectLspLeanAdapterOptions {
   lakeCommand?: string;
   /** Override the project-root locator (mostly for tests). */
   resolveWorkspaceRoot?: (filePath: string) => Promise<string | null>;
+}
+
+/**
+ * Wire the direct LSP adapter as the Lean language services for hosts without
+ * a VS Code extension bridge (Electron desktop, CLI). Spawns `lake env lean
+ * --server` lazily per Lake project root; nothing happens at startup when no
+ * Lean tools are invoked.
+ */
+export function registerDirectLeanLanguageServices(
+  lifecycle: LifecycleHost,
+): void {
+  const leanAdapter = createDirectLspLeanAdapter();
+  setLeanLanguageServices(leanAdapter);
+  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => leanAdapter.dispose());
 }
 
 /**


### PR DESCRIPTION
Five consolidations of copy-pasted code that had drifted (or was about
to) across different parts of the workspace:

- Pricing math: extract computeStandardPrice() into priceUtils for the
  inclusive-cache providers (OpenAI, OpenRouter, Google), replacing
  three copies of the base-price + reasoning-surcharge − cache-rebate
  formula. Anthropic keeps its additive cache formula. The per-provider
  PricingConfig interfaces collapse into StandardPricingConfig aliases.

- CLI approval modals: extract the byte-identical scroll machinery from
  AgentProposal/BashApproval/EditApproval into a useScrollableOffset
  hook, and the bounded-lines/overflow-marker rendering shared by the
  first two into scrollBounds (boundedScrollableLines,
  compactAwareMaxScrollOffset, scrollPageRows), parameterized by the
  per-modal hidden-row label.

- Webview drag-and-drop: extract the duplicated dragenter/over/leave/
  drop state machine (including the reset-before-rejection fix) from
  FileSelectGroup and InstructionPanel into a FileDropController Lit
  reactive controller next to the drop helpers.

- Progress view: extract the shared stream/permission context
  consumption and willUpdate permission filtering from
  ToolUseStreamContent and WorkflowStreamContent into an abstract
  BaseStreamContent.

- Host bootstrap: extract registerAgentShutdownHandlers() (extension +
  desktop) and registerDirectLeanLanguageServices() (desktop + CLI) so
  agent teardown and direct-Lean wiring live in one place each; extract
  resolveHousekeepingTargets() for the clean/pack preamble.

https://claude.ai/code/session_01VDP7beBFLdhohPMhdJEbWi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical extractions with existing tests updated for drag-drop ordering; pricing and shutdown wiring should behave the same but merit a quick smoke check on approvals scrolling and usage costs.
> 
> **Overview**
> This PR **deduplicates** logic that had been copy-pasted across CLI TUI, webview, progress view, model pricing, and host startup.
> 
> **CLI approval modals** (`AgentProposal`, `BashApproval`, `EditApproval`) now share **`useScrollableOffset`** for ↑/↓ and PgUp/PgDn scrolling, and **`scrollBounds`** helpers (`boundedScrollableLines`, `compactAwareMaxScrollOffset`, `scrollPageRows`) for compact overflow rows instead of per-modal copies.
> 
> **Extension webview** file drops move into a **`FileDropController`** Lit controller used by **`FileSelectGroup`** and **`InstructionPanel`**, preserving reset-before-reject so drop highlights don’t stick.
> 
> **Progress view** **`ToolUseStreamContent`** and **`WorkflowStreamContent`** extend new **`BaseStreamContent`** for stream/permission context and filtered permissions.
> 
> **Model pricing**: **`computeStandardPrice`** in **`priceUtils`** replaces repeated base + reasoning − cache-rebate math in OpenAI, OpenRouter, and Google usage modules (Anthropic unchanged).
> 
> **Hosts**: **`registerAgentShutdownHandlers`** (extension + desktop) and **`registerDirectLeanLanguageServices`** (CLI + desktop) centralize teardown/wiring; **`resolveHousekeepingTargets`** shares clean/pack parameter validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38d2c746e2538bcd785e814d9a5ef0a3cc44c7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->