### PR TITLE
feat(cli-tui): apply five more Ink TUI best practices

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -443,6 +443,9 @@ export interface AppProps {
     change: TranscriptViewportChange,
   ) => void;
   readonly onCtrlC?: () => void;
+  /** Suspend the process (Ctrl-Z). Raw mode swallows the tty driver's own
+   *  ^Z→SIGTSTP translation, so the parsed key must be routed explicitly. */
+  readonly onSuspend?: () => void;
   readonly inputDisabled?: boolean;
   readonly history?: InputHistory;
 }
@@ -718,6 +721,14 @@ export function App(props: AppProps): React.JSX.Element {
         return;
       }
       exit();
+      return;
+    }
+
+    // Ctrl-Z suspends like a classic line-mode program would. Works over
+    // foreground surfaces for the same reason Ctrl-C does: process-level
+    // job control must not depend on which pane owns the keyboard.
+    if (key.ctrl && input === 'z' && props.onSuspend) {
+      props.onSuspend();
       return;
     }
 

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -139,13 +139,17 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
 
   // Listen for Ctrl-R *outside* the text input — Ink emits the keystroke
   // to every `useInput` consumer, and BaseTextInput drops unhandled ctrl
-  // chords so this handler still fires.
-  useInput((input, key) => {
-    if (disabled) return;
-    if (isCtrlInput(input, key, 'r') && historyRef.current) {
-      setReverseSearchOpen(true);
-    }
-  });
+  // chords so this handler still fires. `isActive` (rather than an internal
+  // early-return) releases the stdin subscription entirely while a foreground
+  // surface owns input, matching BaseTextInput's `isActive: focus`.
+  useInput(
+    (input, key) => {
+      if (isCtrlInput(input, key, 'r') && historyRef.current) {
+        setReverseSearchOpen(true);
+      }
+    },
+    { isActive: !disabled },
+  );
 
   const handleSubmit = useCallback(
     (submitted: string) => {
@@ -286,8 +290,15 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         />
       ) : null}
       {attachNotice ? <Text dimColor>{attachNotice}</Text> : null}
-      <Box borderStyle="round" borderColor="gray" paddingX={1}>
-        <Text color="cyan">{prompt ?? '›'} </Text>
+      <Box
+        borderStyle="round"
+        borderColor="gray"
+        paddingX={1}
+        aria-role="textbox"
+      >
+        <Text aria-hidden color="cyan">
+          {prompt ?? '›'}{' '}
+        </Text>
         <BaseTextInput
           value={value}
           focus={!disabled && !reverseSearchOpen}

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -116,7 +116,9 @@ function SessionHeaderBlock({
   return (
     <Box flexDirection="column">
       <Box>
-        <Text color="cyan">{'─'.repeat(columns)}</Text>
+        <Text aria-hidden color="cyan">
+          {'─'.repeat(columns)}
+        </Text>
       </Box>
       <Box flexDirection="column" paddingX={1}>
         <Box gap={2}>

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -44,6 +44,8 @@ export interface StatusBarSegment {
   readonly badge?: boolean;
   readonly badgeColor?: 'red' | 'yellow';
   readonly compactPriority?: number;
+  /** Purely visual glyphs hidden from screen readers (`aria-hidden`). */
+  readonly decorative?: boolean;
 }
 
 export interface StatusBarDisplayInput {
@@ -614,7 +616,9 @@ const BYPASS_BADGES: ReadonlyArray<{
 export function buildStatusBarDisplay(
   input: StatusBarDisplayInput,
 ): StatusBarDisplay {
-  const left: StatusBarSegment[] = [{ text: '◆', color: 'cyan' }];
+  const left: StatusBarSegment[] = [
+    { text: '◆', color: 'cyan', decorative: true },
+  ];
 
   if (input.pendingExitHint) {
     left.push({ text: PENDING_EXIT_HINT_TEXT, color: 'yellow' });
@@ -816,6 +820,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
             ) : (
               <Text
                 key={`${segment.text}-${index}`}
+                aria-hidden={segment.decorative}
                 color={segment.color === 'dim' ? undefined : segment.color}
                 dimColor={segment.color === 'dim'}
               >

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -4,6 +4,7 @@
 // structure is worth preserving in a terminal. Everything else falls back to
 // the compact universal row.
 
+import { memo } from 'react';
 import { Box, Text } from 'ink';
 
 import { type NormalizedToolUse } from '@shared/schemas';
@@ -23,7 +24,10 @@ export function filledToolUseDisplayText(
   return fillRows(toolUseDisplayLines(toolUse).join('\n'), cols);
 }
 
-export function ToolUseRow({
+// Memoized: tool-use objects stay reference-identical across stream-sync
+// ticks unless their status/result changed, so streaming text deltas skip
+// re-rendering every settled tool row in the live region.
+export const ToolUseRow = memo(function ToolUseRow({
   fillWidth,
   toolUse,
   width,
@@ -46,4 +50,4 @@ export function ToolUseRow({
   ) : (
     <UniversalToolRow toolUse={toolUse} />
   );
-}
+});

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -3,6 +3,7 @@
 // markdown renderer; the live tail stays plain text to avoid re-parsing a
 // growing document on every chunk.
 
+import { memo } from 'react';
 import { Box, Text } from 'ink';
 
 import { Markdown } from '../render/Markdown';
@@ -193,7 +194,11 @@ function ProcessEntryRow({
   );
 }
 
-export function TranscriptEntry({
+// The entry renderers are memoized: stream sync keeps unchanged entry
+// objects reference-identical across ticks (see `renderLogEntry`'s
+// `entriesEqual` reuse), so a streaming delta re-wraps only the entry that
+// actually changed instead of every pending row on each 16ms tick.
+export const TranscriptEntry = memo(function TranscriptEntry({
   entry,
   width,
   colorEnabled,
@@ -267,7 +272,7 @@ export function TranscriptEntry({
       />
     </Box>
   );
-}
+});
 
 function boundedLines(
   lines: readonly string[],
@@ -323,7 +328,7 @@ export function boundedAssistantDisplayLines({
   );
 }
 
-export function BoundedTranscriptEntry({
+export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
   colorEnabled,
   entry,
   maxRows,
@@ -402,14 +407,14 @@ export function BoundedTranscriptEntry({
       </Text>
     </Box>
   );
-}
+});
 
 // Cap the live tail so a multi-megabyte assistant buffer doesn't re-wrap
 // every chunk. The static `<Static>` transcript owns the full history; we
 // only need enough characters here to fill a typical viewport.
 export const LIVE_TAIL_ROWS = 24;
 
-export function LiveTranscriptEntry({
+export const LiveTranscriptEntry = memo(function LiveTranscriptEntry({
   entry,
   width,
 }: {
@@ -423,4 +428,4 @@ export function LiveTranscriptEntry({
       <Text>{fillRows(rows.join('\n'), cols)}</Text>
     </Box>
   );
-}
+});

--- a/packages/cli/src/chat/tui/render/Markdown.tsx
+++ b/packages/cli/src/chat/tui/render/Markdown.tsx
@@ -3,6 +3,7 @@
 // renderer cache (per-host LRU) lives in `ansiMarkdown.ts` so re-renders of
 // the same content during streaming reuse the cached ANSI string.
 
+import { memo } from 'react';
 import { Text } from 'ink';
 
 import { renderAnsiMarkdown } from './ansiMarkdown';
@@ -15,7 +16,11 @@ export interface MarkdownProps {
   readonly fillWidth?: boolean;
 }
 
-export function Markdown(props: MarkdownProps): React.JSX.Element {
+// Memoized: props are scalars, so unchanged entries skip even the LRU lookup
+// in `renderAnsiMarkdown` when an unrelated signal re-renders the pane.
+export const Markdown = memo(function Markdown(
+  props: MarkdownProps,
+): React.JSX.Element {
   // `renderAnsiMarkdown` trims trailing newlines so Ink doesn't add a blank
   // line at the bottom of each conversation entry; the parent
   // `<Box marginBottom={1}>` already provides separation between entries.
@@ -34,4 +39,4 @@ export function Markdown(props: MarkdownProps): React.JSX.Element {
         : rendered}
     </Text>
   );
-}
+});

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1591,6 +1591,10 @@ export async function runChat(
       // plain Enter stays a legacy `\r`, and Ink pops the protocol on unmount.
       kittyKeyboard: {
         mode: terminalCaps.kittyKeyboard ? 'enabled' : 'disabled',
+        // Pin the flags rather than relying on Ink's default: the SIGCONT
+        // re-push in terminalCleanup re-arms exactly this set, so the two
+        // must not drift apart.
+        flags: ['disambiguateEscapeCodes'],
       },
     },
   );

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -146,6 +146,7 @@ import {
   clearTerminalScrollback,
   installTerminalRestoreOnExit,
   restoreTuiInputModes,
+  supportsTerminalJobControl,
 } from './terminalCleanup';
 import {
   transcriptViewportRepaintOptions,
@@ -1602,6 +1603,7 @@ export async function runChat(
 
   let pendingExitTimer: ReturnType<typeof setTimeout> | undefined;
   let exitArmed = false;
+  const terminalJobControlSupported = supportsTerminalJobControl();
   // Set once a signal exit (exitNow) starts: its ink.unmount() resolves
   // waitUntilExit and re-enters the post-waitUntilExit finally, so the finally
   // guards on this to avoid draining persistence / printing the resume hint a
@@ -1618,8 +1620,10 @@ export async function runChat(
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);
     process.off('SIGHUP', handleSighup);
-    process.off('SIGTSTP', handleSigtstp);
-    process.off('SIGCONT', handleSigcont);
+    if (terminalJobControlSupported) {
+      process.off('SIGTSTP', handleSigtstp);
+      process.off('SIGCONT', handleSigcont);
+    }
   };
   // Persist the reopen hint to native scrollback: the main session plus each
   // resumable tool-use subagent, so any route can be continued by its own id.
@@ -1728,6 +1732,7 @@ export async function runChat(
   // stop with SIGSTOP — this handler replaced the default stop action, so
   // re-raising SIGTSTP would just recurse.
   const handleSigtstp = (): void => {
+    if (!terminalJobControlSupported) return;
     cleanupTerminalModes({ clearItermProgress });
     if (process.stdin.isTTY) process.stdin.setRawMode(false);
     process.kill(process.pid, 'SIGSTOP');
@@ -1750,8 +1755,10 @@ export async function runChat(
   process.on('SIGINT', handleSigint);
   process.on('SIGTERM', handleSigterm);
   process.on('SIGHUP', handleSighup);
-  process.on('SIGTSTP', handleSigtstp);
-  process.on('SIGCONT', handleSigcont);
+  if (terminalJobControlSupported) {
+    process.on('SIGTSTP', handleSigtstp);
+    process.on('SIGCONT', handleSigcont);
+  }
 
   // Interactive resume: kick off the continued tool-use run now that Ink is
   // mounted (so the rehydrated transcript + streamed continuation render) and

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -144,6 +144,8 @@ import { projectStreamTranscript } from './state/transcriptProjection';
 import {
   cleanupTerminalModes,
   clearTerminalScrollback,
+  installTerminalRestoreOnExit,
+  restoreTuiInputModes,
 } from './terminalCleanup';
 import {
   transcriptViewportRepaintOptions,
@@ -1054,6 +1056,10 @@ export async function runChat(
   const snapshotStore = new StreamSnapshotStore();
 
   const disposers: Array<() => void> = [];
+  // Crash safety: if the process dies outside the orderly teardown below
+  // (uncaught exception, stray process.exit), still restore the terminal so
+  // the user's shell isn't left in raw/kitty/mouse mode with a hidden cursor.
+  disposers.push(installTerminalRestoreOnExit({ clearItermProgress }));
   disposers.push(subscribeStreamLog());
   disposers.push(subscribeStreamStatus());
   disposers.push(snapshotStore.subscribe(bus));
@@ -1560,6 +1566,7 @@ export async function runChat(
       onInterruptActive={interruptActive}
       onTranscriptViewportChange={repaintTranscriptViewport}
       onCtrlC={() => handleSigint()}
+      onSuspend={() => handleSigtstp()}
       onKillExecution={(executionId) => {
         clearApprovals();
         executionRegistry.kill(executionId);
@@ -1607,6 +1614,8 @@ export async function runChat(
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);
     process.off('SIGHUP', handleSighup);
+    process.off('SIGTSTP', handleSigtstp);
+    process.off('SIGCONT', handleSigcont);
   };
   // Persist the reopen hint to native scrollback: the main session plus each
   // resumable tool-use subagent, so any route can be continued by its own id.
@@ -1708,6 +1717,27 @@ export async function runChat(
   };
   const handleSigterm = (): void => handleTermSignal(143);
   const handleSighup = (): void => handleTermSignal(129);
+  // Suspend/resume (Ctrl-Z / `kill -TSTP` / `fg`). Raw mode keeps the tty
+  // driver from ever turning ^Z into a signal, so App's unified useInput
+  // routes the parsed Ctrl-Z here explicitly; external SIGTSTP lands in the
+  // same handler. Restore the terminal for the shell before stopping, then
+  // stop with SIGSTOP — this handler replaced the default stop action, so
+  // re-raising SIGTSTP would just recurse.
+  const handleSigtstp = (): void => {
+    cleanupTerminalModes({ clearItermProgress });
+    if (process.stdin.isTTY) process.stdin.setRawMode(false);
+    process.kill(process.pid, 'SIGSTOP');
+  };
+  // On resume the shell restores only the termios snapshot from suspend time
+  // (non-raw, since handleSigtstp dropped raw mode first); the emulator-side
+  // modes were popped outright. Re-arm both, then repaint from a known origin
+  // — the shell prompt and `fg` echo have polluted the screen, so the same
+  // clear-and-reprint path as a width change is the only safe redraw.
+  const handleSigcont = (): void => {
+    if (process.stdin.isTTY) process.stdin.setRawMode(true);
+    restoreTuiInputModes({ kittyKeyboard: terminalCaps.kittyKeyboard });
+    inkRef.current?.repaint({ clearScrollback: true });
+  };
   function requestInputExit(): void {
     removeProcessHandlers();
     clearPendingExit();
@@ -1716,6 +1746,8 @@ export async function runChat(
   process.on('SIGINT', handleSigint);
   process.on('SIGTERM', handleSigterm);
   process.on('SIGHUP', handleSighup);
+  process.on('SIGTSTP', handleSigtstp);
+  process.on('SIGCONT', handleSigcont);
 
   // Interactive resume: kick off the continued tool-use run now that Ink is
   // mounted (so the rehydrated transcript + streamed continuation render) and

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -20,6 +20,9 @@ const CLEAR_ITERM_PROGRESS = '\x1b]9;4;0\x07';
 // Ink's own flag table and must match the `flags` runChatTui passes to
 // `render()`; bracketed paste is re-enabled unconditionally because Ink's
 // `usePaste` enables it unconditionally too — this only restores Ink's state.
+// Mouse modes are reset defensively above, but not re-armed because this TUI
+// does not enable mouse input. Add them here only if a future mouse path turns
+// them on during normal render.
 const KITTY_PUSH_DISAMBIGUATE = `\x1b[>${kittyFlags.disambiguateEscapeCodes}u`;
 const REARM_INPUT_MODES = '\x1b[?2004h\x1b[?25l';
 // Clear visible screen + erase scrollback + home cursor. Required by
@@ -30,6 +33,12 @@ const CLEAR_VISIBLE_SCREEN = '\x1b[2J\x1b[H';
 
 export interface CleanupTerminalModesOptions {
   readonly clearItermProgress?: boolean;
+}
+
+export function supportsTerminalJobControl(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform !== 'win32';
 }
 
 export function cleanupTerminalModes(

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -10,6 +10,16 @@ import { writeSync } from 'node:fs';
 // masks this by ignoring an unmatched rmcup; Ghostty/iTerm2/Terminal.app do not.
 const RESET_TERMINAL_MODES = '\x1b[?1000;1003;1006l\x1b[<u\x1b[?2004l\x1b[?25h';
 const CLEAR_ITERM_PROGRESS = '\x1b]9;4;0\x07';
+// Re-arm the emulator-side input modes after a SIGCONT resume: kitty
+// disambiguate push (matches Ink's default `CSI > 1 u`), bracketed paste, and
+// cursor hide. The tty driver state (raw mode) is restored separately — the
+// shell only restores the termios snapshot it took at suspend, never these
+// escape-sequence modes, which cleanupTerminalModes popped before stopping.
+// The kitty push stays capability-gated (the caller passes the DA1-discovered
+// flag); bracketed paste is re-enabled unconditionally because Ink's
+// `usePaste` enables it unconditionally too — this only restores Ink's state.
+const KITTY_PUSH_DISAMBIGUATE = '\x1b[>1u';
+const REARM_INPUT_MODES = '\x1b[?2004h\x1b[?25l';
 // Clear visible screen + erase scrollback + home cursor. Required by
 // `/clear` since the TUI no longer uses the alternate screen, so prior
 // `<Static>` transcript lines persist in the primary-buffer scrollback.
@@ -28,6 +38,42 @@ export function cleanupTerminalModes(
     if (options.clearItermProgress) writeSync(1, CLEAR_ITERM_PROGRESS);
   } catch {
     // Exit paths cannot surface cleanup failures usefully.
+  }
+}
+
+/**
+ * Last-resort terminal restore: an uncaught exception (or a stray
+ * `process.exit` outside the TUI's own teardown) must not strand the user's
+ * shell with mouse reporting / kitty keyboard / bracketed paste on and the
+ * cursor hidden. The `exit` event fires on every non-signal death, the writes
+ * are synchronous, and re-emitting the resets after an orderly
+ * `cleanupTerminalModes` is harmless — so install once while the TUI is
+ * mounted and dispose with the other subscriptions.
+ */
+export function installTerminalRestoreOnExit(
+  options: CleanupTerminalModesOptions = {},
+): () => void {
+  const onExit = (): void => cleanupTerminalModes(options);
+  process.on('exit', onExit);
+  return () => {
+    process.off('exit', onExit);
+  };
+}
+
+export function tuiInputModeRestoreSequence(options: {
+  readonly kittyKeyboard: boolean;
+}): string {
+  return `${options.kittyKeyboard ? KITTY_PUSH_DISAMBIGUATE : ''}${REARM_INPUT_MODES}`;
+}
+
+/** Re-enable the input modes the TUI relies on after a SIGCONT resume. */
+export function restoreTuiInputModes(options: {
+  readonly kittyKeyboard: boolean;
+}): void {
+  try {
+    writeSync(1, tuiInputModeRestoreSequence(options));
+  } catch {
+    // The terminal may have gone away across the suspend; nothing to do.
   }
 }
 

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -1,5 +1,7 @@
 import { writeSync } from 'node:fs';
 
+import { kittyFlags } from 'ink';
+
 // Undo exactly the input/display modes the TUI turns on: mouse tracking
 // (1000/1003/1006), the kitty keyboard stack (<u), bracketed paste (2004), and
 // cursor visibility (25h). The TUI deliberately never enters the alternate
@@ -11,14 +13,14 @@ import { writeSync } from 'node:fs';
 const RESET_TERMINAL_MODES = '\x1b[?1000;1003;1006l\x1b[<u\x1b[?2004l\x1b[?25h';
 const CLEAR_ITERM_PROGRESS = '\x1b]9;4;0\x07';
 // Re-arm the emulator-side input modes after a SIGCONT resume: kitty
-// disambiguate push (matches Ink's default `CSI > 1 u`), bracketed paste, and
-// cursor hide. The tty driver state (raw mode) is restored separately — the
-// shell only restores the termios snapshot it took at suspend, never these
-// escape-sequence modes, which cleanupTerminalModes popped before stopping.
-// The kitty push stays capability-gated (the caller passes the DA1-discovered
-// flag); bracketed paste is re-enabled unconditionally because Ink's
+// disambiguate push, bracketed paste, and cursor hide. The tty driver state
+// (raw mode) is restored separately — the shell only restores the termios
+// snapshot it took at suspend, never these escape-sequence modes, which
+// cleanupTerminalModes popped before stopping. The push value comes from
+// Ink's own flag table and must match the `flags` runChatTui passes to
+// `render()`; bracketed paste is re-enabled unconditionally because Ink's
 // `usePaste` enables it unconditionally too — this only restores Ink's state.
-const KITTY_PUSH_DISAMBIGUATE = '\x1b[>1u';
+const KITTY_PUSH_DISAMBIGUATE = `\x1b[>${kittyFlags.disambiguateEscapeCodes}u`;
 const REARM_INPUT_MODES = '\x1b[?2004h\x1b[?25l';
 // Clear visible screen + erase scrollback + home cursor. Required by
 // `/clear` since the TUI no longer uses the alternate screen, so prior

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -275,7 +275,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   });
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" aria-role="listbox">
       {props.showOverflow && hiddenBefore > 0 ? (
         <Text dimColor>{`... ${hiddenBefore} earlier`}</Text>
       ) : null}
@@ -289,11 +289,24 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
         const shortcut = hotkey ? `${hotkey}.` : '  ';
         const showInlineOverflow = focused && inlineOverflowText;
         return (
-          <Box key={selectItemRenderKey(item, i)} minWidth={0}>
+          <Box
+            key={selectItemRenderKey(item, i)}
+            minWidth={0}
+            aria-role="option"
+            aria-state={{
+              selected: focused,
+              checked: active,
+              disabled: item.disabled,
+            }}
+          >
+            {/* Pointer/tick glyphs are decorative for screen readers — the
+                option role + state above already announce focus/active. The
+                hotkey stays audible because it is actionable. */}
             <Box flexShrink={0}>
-              <Text color={focused ? 'cyan' : undefined}>
-                {pointer} {tick} {shortcut}{' '}
+              <Text aria-hidden color={focused ? 'cyan' : undefined}>
+                {pointer} {tick}{' '}
               </Text>
+              <Text color={focused ? 'cyan' : undefined}>{shortcut} </Text>
             </Box>
             <Box flexShrink={0} maxWidth={SELECT_LABEL_MAX_COLS}>
               <Text

--- a/src/test-kernel/cli/TerminalCleanup.vitest.mts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.mts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  installTerminalRestoreOnExit,
+  tuiInputModeRestoreSequence,
+} from '@cli/chat/tui/terminalCleanup';
+
+describe('tuiInputModeRestoreSequence', () => {
+  it('re-arms bracketed paste and cursor hide after a SIGCONT resume', () => {
+    expect(tuiInputModeRestoreSequence({ kittyKeyboard: false })).toBe(
+      '\x1b[?2004h\x1b[?25l',
+    );
+  });
+
+  it("re-pushes Ink's kitty disambiguate flag on kitty terminals", () => {
+    expect(tuiInputModeRestoreSequence({ kittyKeyboard: true })).toBe(
+      '\x1b[>1u\x1b[?2004h\x1b[?25l',
+    );
+  });
+});
+
+describe('installTerminalRestoreOnExit', () => {
+  it('registers a process exit listener and removes it on dispose', () => {
+    const before = process.listenerCount('exit');
+    const dispose = installTerminalRestoreOnExit();
+    expect(process.listenerCount('exit')).toBe(before + 1);
+    dispose();
+    expect(process.listenerCount('exit')).toBe(before);
+  });
+
+  it('tolerates double dispose', () => {
+    const before = process.listenerCount('exit');
+    const dispose = installTerminalRestoreOnExit();
+    dispose();
+    dispose();
+    expect(process.listenerCount('exit')).toBe(before);
+  });
+});

--- a/src/test-kernel/cli/TerminalCleanup.vitest.mts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.mts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   installTerminalRestoreOnExit,
+  supportsTerminalJobControl,
   tuiInputModeRestoreSequence,
 } from '@cli/chat/tui/terminalCleanup';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('tuiInputModeRestoreSequence', () => {
   it('re-arms bracketed paste and cursor hide after a SIGCONT resume', () => {
@@ -19,20 +24,33 @@ describe('tuiInputModeRestoreSequence', () => {
   });
 });
 
+describe('supportsTerminalJobControl', () => {
+  it('disables Ctrl-Z suspend on Windows where SIGSTOP is unsupported', () => {
+    expect(supportsTerminalJobControl('win32')).toBe(false);
+    expect(supportsTerminalJobControl('darwin')).toBe(true);
+    expect(supportsTerminalJobControl('linux')).toBe(true);
+  });
+});
+
 describe('installTerminalRestoreOnExit', () => {
   it('registers a process exit listener and removes it on dispose', () => {
-    const before = process.listenerCount('exit');
+    const on = vi.spyOn(process, 'on').mockReturnThis();
+    const off = vi.spyOn(process, 'off').mockReturnThis();
+
     const dispose = installTerminalRestoreOnExit();
-    expect(process.listenerCount('exit')).toBe(before + 1);
+    const listener = on.mock.calls[0]?.[1];
+
+    expect(on).toHaveBeenCalledWith('exit', expect.any(Function));
     dispose();
-    expect(process.listenerCount('exit')).toBe(before);
+    expect(off).toHaveBeenCalledWith('exit', listener);
   });
 
   it('tolerates double dispose', () => {
-    const before = process.listenerCount('exit');
+    vi.spyOn(process, 'on').mockReturnThis();
+    const off = vi.spyOn(process, 'off').mockReturnThis();
     const dispose = installTerminalRestoreOnExit();
     dispose();
     dispose();
-    expect(process.listenerCount('exit')).toBe(before);
+    expect(off).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
1. Crash-safe terminal restore: install a process 'exit' hook while the
   TUI is mounted so an uncaught exception or stray process.exit can no
   longer strand the shell in raw/kitty/mouse mode with a hidden cursor.

2. Suspend/resume support: Ctrl-Z (routed explicitly since raw mode
   swallows the tty driver's ^Z) and external SIGTSTP restore the
   terminal for the shell before stopping; SIGCONT re-arms raw mode plus
   the emulator-side modes (kitty disambiguate push, bracketed paste,
   cursor hide) and repaints from a known origin, mirroring the resize
   doctrine.

3. Memoized stateless renderers: TranscriptEntry, BoundedTranscriptEntry,
   LiveTranscriptEntry, ToolUseRow, and Markdown are wrapped in
   React.memo. Stream sync keeps unchanged entry objects
   reference-identical across ticks, so a streaming delta now re-wraps
   only the entry that changed instead of every pending row per tick.

4. useInput isActive gating: the always-mounted InputBar Ctrl-R handler
   releases its stdin subscription while a foreground surface owns input
   instead of early-returning inside the handler.

5. Screen-reader accessibility (Ink 7 ARIA): Select renders as
   listbox/option with selected/checked/disabled state and hides the
   pointer/tick glyphs; the status-bar diamond, session-header rule, and
   input prompt chevron are aria-hidden; the input bar is a textbox.
   All no-ops unless INK_SCREEN_READER is enabled.

https://claude.ai/code/session_011NtGxgWJzKUyLWmxM5D7q7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Suspend/resume and exit hooks touch raw TTY/kitty state and signals; mistakes could leave a broken terminal or mishandle job control, though changes are localized to the CLI TUI with unit tests for cleanup sequences.
> 
> **Overview**
> Improves the Ink chat TUI with **terminal lifecycle**, **render performance**, **input handling**, and **optional screen-reader semantics**.
> 
> **Terminal:** Registers a `process` `exit` hook so crashes or stray `process.exit` still reset raw/kitty/mouse modes and show the cursor. **Ctrl-Z** (and `SIGTSTP`) cleans up modes, drops raw mode, then `SIGSTOP`s; **SIGCONT** re-enables raw mode, re-pushes kitty disambiguate (aligned with `render()` flags), bracketed paste, and cursor hide, then repaints with scrollback clear. Job control is skipped on Windows.
> 
> **Performance:** Wraps `TranscriptEntry`, bounded/live variants, `ToolUseRow`, and `Markdown` in `React.memo` so streaming ticks only re-render entries whose references changed.
> 
> **Input:** `InputBar` Ctrl-R uses `useInput` `{ isActive: !disabled }` instead of an in-handler early return when modals own focus.
> 
> **A11y (Ink 7, when `INK_SCREEN_READER` is on):** `Select` as listbox/option with state; decorative glyphs `aria-hidden`; input bar `textbox`; status diamond marked decorative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50a915d81a86815dd7ac1d7ce4c3f68d48365be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->