### PR TITLE
test(cli): cover live tool stack spacing

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -109,6 +109,10 @@ const PLAN_APPROVAL_GOAL = process.env.HARNESS_PLAN_APPROVAL_GOAL === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
 const SHOW_LIVE_TOOL_ONLY = process.env.HARNESS_LIVE_TOOL_ONLY === '1';
+const LIVE_TOOL_COUNT = Math.max(
+  1,
+  Number.parseInt(process.env.HARNESS_LIVE_TOOL_COUNT ?? '1', 10) || 1,
+);
 const SHOW_LIVE_INVISIBLE_ASSISTANT =
   process.env.HARNESS_LIVE_INVISIBLE_ASSISTANT === '1';
 const SHOW_PROJECT_SKILL = process.env.HARNESS_PROJECT_SKILL === '1';
@@ -495,21 +499,30 @@ function seedLiveToolOnlyTranscript(): void {
       ? `${String.fromCharCode(27)}[2m${String.fromCharCode(27)}[22m`
       : '',
   });
-  store.append(STREAM_ID, {
-    id: 'live-tool-ls',
-    type: STREAM_LOG_ENTRY_TYPES.LOG,
-    level: LOG_LEVELS.INFO,
-    timestamp: timestamp + 2,
-    messageType: MESSAGE_TYPES.TOOL_USE,
-    data: {
-      toolName: 'ls',
-      input: { path: '.' },
-      output: '',
-      summary: 'Listed 36 entries in .',
-      isError: false,
-      status: TOOL_USE_STATUS.COMPLETED,
-    },
-  });
+  const tools = [
+    ['ls', { path: '.' }, 'Listed 36 entries in .'],
+    ['glob', { pattern: '*.md' }, 'Found 7 files for "*.md" in .'],
+    ['glob', { pattern: '**/*.tex' }, 'Found 6 files for "**/*.tex" in .'],
+  ] as const;
+  for (const [index, [toolName, input, summary]] of tools
+    .slice(0, LIVE_TOOL_COUNT)
+    .entries()) {
+    store.append(STREAM_ID, {
+      id: `live-tool-${toolName}-${index}`,
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: timestamp + 2 + index,
+      messageType: MESSAGE_TYPES.TOOL_USE,
+      data: {
+        toolName,
+        input,
+        output: '',
+        summary,
+        isError: false,
+        status: TOOL_USE_STATUS.COMPLETED,
+      },
+    });
+  }
   syncStreamLog(STREAM_ID);
 }
 

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -121,6 +121,38 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'live-tool-stack-spacing',
+    rows: 34,
+    env: {
+      HARNESS_LIVE_INVISIBLE_ASSISTANT: '1',
+      HARNESS_LIVE_TOOL_COUNT: '3',
+      HARNESS_LIVE_TOOL_ONLY: '1',
+    },
+    expect: [
+      'what is this repo about',
+      '● ls (Listed 36 entries in .)',
+      '● glob (Found 7 files for "*.md" in .)',
+      '● glob (Found 6 files for "**/*.tex" in .)',
+    ],
+    maxBlankLinesBetween: [
+      {
+        from: 'what is this repo about',
+        to: '● ls (Listed 36 entries in .)',
+        max: 0,
+      },
+      {
+        from: '● ls (Listed 36 entries in .)',
+        to: '● glob (Found 7 files for "*.md" in .)',
+        max: 0,
+      },
+      {
+        from: '● glob (Found 7 files for "*.md" in .)',
+        to: '● glob (Found 6 files for "**/*.tex" in .)',
+        max: 0,
+      },
+    ],
+  },
+  {
     name: 'queued-followups',
     cols: 120,
     env: {


### PR DESCRIPTION
## Summary
- extend the TUI harness live-tool scenario so it can emit a compact stack of tool rows
- add a tall-terminal regression scenario asserting zero blank rows between the submitted user prompt and the first tool row
- keep the existing single-tool scenario unchanged by default

## Notes
- Current main already renders this path tightly in the TTY harness after the earlier assistant-leading-blank fix; this PR locks that behavior down rather than adding a speculative layout change.

## Validation
- corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/tui-spacing-stack-final live-tool-only-spacing live-tool-stack-spacing
- corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts
- npm run typecheck
- npm run lint -- --quiet
- corepack pnpm exec prettier --check packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs
- git diff --check origin/main...HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to harness seed data and validate-tui scenarios; default behavior and production TUI code are unchanged.
> 
> **Overview**
> Adds **test-only** coverage for compact live-tool transcript spacing in the CLI TUI harness—no production layout changes.
> 
> The harness **`live-tool-only`** path now supports **`HARNESS_LIVE_TOOL_COUNT`** (default **1**) so it can emit a stack of **`ls`** / **`glob`** tool rows instead of a single hard-coded **`ls`** entry. **`validate-tui`** gains **`live-tool-stack-spacing`**, which asserts three consecutive tool lines appear with **zero blank lines** between the user prompt, the first tool row, and each following tool row (using a taller terminal). The existing **`live-tool-only-spacing`** scenario stays the default single-tool case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 675ad2fab788474e2f55f7ad6cd4425f956299ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->