### PR TITLE
refactor: consolidate top 10 ad hoc implementations onto shared helpers

### DIFF
--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -2,6 +2,13 @@ export const ANSI_ESCAPE_START = String.fromCharCode(27);
 
 const ANSI_BEL = String.fromCharCode(7);
 
+/** A CSI sequence (`ESC [`) ends at its final byte, in the range `@`–`~`. */
+const CSI_FINAL_BYTE_MIN = 0x40; // '@'
+const CSI_FINAL_BYTE_MAX = 0x7e; // '~'
+
+/** An OSC sequence (`ESC ]`) ends with BEL or the two-char ST (`ESC \`). */
+const OSC_STRING_TERMINATOR = `${ANSI_ESCAPE_START}\\`;
+
 export function ansiEscapeEnd(text: string, index: number): number {
   if (text[index] !== ANSI_ESCAPE_START) return index;
 
@@ -9,17 +16,19 @@ export function ansiEscapeEnd(text: string, index: number): number {
   if (next === '[') {
     for (let end = index + 2; end < text.length; end += 1) {
       const code = text.charCodeAt(end);
-      if (code >= 0x40 && code <= 0x7e) return end + 1;
+      if (code >= CSI_FINAL_BYTE_MIN && code <= CSI_FINAL_BYTE_MAX) {
+        return end + 1;
+      }
     }
     return text.length;
   }
 
   if (next === ']') {
     const belEnd = text.indexOf(ANSI_BEL, index + 2);
-    const stEnd = text.indexOf(`${ANSI_ESCAPE_START}\\`, index + 2);
+    const stEnd = text.indexOf(OSC_STRING_TERMINATOR, index + 2);
     if (belEnd === -1 && stEnd === -1) return text.length;
     if (belEnd !== -1 && (stEnd === -1 || belEnd < stEnd)) return belEnd + 1;
-    return stEnd + 2;
+    return stEnd + OSC_STRING_TERMINATOR.length;
   }
 
   return Math.min(index + 2, text.length);

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 
 import { isFileNotFoundError } from '@common/errors';
 import { toErrorMessage } from '@common/errors/errorMessage';
+import { isObject } from '@utils/core/typeGuards';
 
 import {
   CLI_APPROVAL_POLICIES,
@@ -71,10 +72,6 @@ function configKeyVariants(bareKey: string): readonly [string, string] {
   return [`texra.${bareKey}`, bareKey];
 }
 
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 function isKnownConfigKey(key: string): boolean {
   return (
     TOP_LEVEL_KEYS.has(key) ||
@@ -133,7 +130,7 @@ function collectValidationWarnings(
     for (const sectionKey of configKeyVariants(section)) {
       if (!Object.hasOwn(record, sectionKey)) continue;
       const sectionValue = record[sectionKey];
-      if (!isPlainRecord(sectionValue)) {
+      if (!isObject(sectionValue)) {
         warnings.push(`Ignoring invalid ${filePath} key "${sectionKey}".`);
         continue;
       }
@@ -176,7 +173,7 @@ function pickRecord(
 ): Record<string, unknown> | undefined {
   for (const key of configKeyVariants(bareKey)) {
     const value = record[key];
-    if (isPlainRecord(value)) return value;
+    if (isObject(value)) return value;
   }
   return undefined;
 }
@@ -195,7 +192,7 @@ function pickConfigValues(record: Record<string, unknown>): CliConfigValues {
 }
 
 export function parseCliConfigValues(value: unknown): CliConfigValues {
-  return isPlainRecord(value) ? pickConfigValues(value) : {};
+  return isObject(value) ? pickConfigValues(value) : {};
 }
 
 export function workspaceCliConfigPath(cwd: string): string {
@@ -231,7 +228,7 @@ export async function loadWorkspaceCliConfig(
     };
   }
 
-  if (!isPlainRecord(parsed)) {
+  if (!isObject(parsed)) {
     return {
       path: filePath,
       values: {},

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -3,7 +3,6 @@ import { platform as osPlatform } from 'node:os';
 import { toErrorMessage } from '@common/errors';
 import type { ChildProcess } from 'node:child_process';
 
-
 export type ClipboardTextWriteResult =
   | { readonly ok: true }
   | { readonly ok: false; readonly reason: string };

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -1,6 +1,8 @@
 import { spawn } from 'node:child_process';
 import { platform as osPlatform } from 'node:os';
+import { toErrorMessage } from '@common/errors';
 import type { ChildProcess } from 'node:child_process';
+
 
 export type ClipboardTextWriteResult =
   | { readonly ok: true }
@@ -84,7 +86,7 @@ function writeWithCommand(
     } catch (error) {
       resolve({
         ok: false,
-        reason: error instanceof Error ? error.message : String(error),
+        reason: toErrorMessage(error),
       });
       return;
     }

--- a/packages/cli/src/runtime/completionBash.ts
+++ b/packages/cli/src/runtime/completionBash.ts
@@ -1,9 +1,10 @@
+import { quotePosixShellArg as shellQuote } from '@utils/system/shellQuote';
+
 import {
   CLI_COMPLETION_SHELLS,
   commandKey,
   completionFlagTokens,
   completionFlagVariants,
-  shellQuote,
   type CompletionCommand,
   type CompletionFlag,
 } from './completionCommandTree';

--- a/packages/cli/src/runtime/completionCommandTree.ts
+++ b/packages/cli/src/runtime/completionCommandTree.ts
@@ -179,10 +179,6 @@ export async function collectCommands(
   return [current, ...children.flat()];
 }
 
-export function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
 export function commandKey(path: readonly string[]): string {
   return path.join(' ');
 }

--- a/packages/cli/src/runtime/completionZsh.ts
+++ b/packages/cli/src/runtime/completionZsh.ts
@@ -1,8 +1,9 @@
+import { quotePosixShellArg as shellQuote } from '@utils/system/shellQuote';
+
 import {
   CLI_COMPLETION_SHELLS,
   commandKey,
   completionFlagVariants,
-  shellQuote,
   type CompletionCommand,
   type CompletionFlag,
 } from './completionCommandTree';

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -18,6 +18,7 @@ import {
   type ExecutionId,
 } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
+import { isObject } from '@utils/core/typeGuards';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 
@@ -377,7 +378,7 @@ function toConversationPreviewMessage(
   message: unknown,
   index: number,
 ): CliHistoryConversationPreviewMessage {
-  const raw = isRecord(message) ? message : {};
+  const raw = isObject(message) ? message : {};
   const role = typeof raw.role === 'string' ? raw.role : 'unknown';
   const content = formatConversationMessageContent(raw.content);
   const truncated = content.length > CONVERSATION_PREVIEW_CONTENT_LIMIT;
@@ -418,7 +419,7 @@ function formatConversationMessageContent(content: unknown): string {
 
 function formatConversationContentBlock(block: unknown): string {
   if (typeof block === 'string') return block;
-  if (!isRecord(block)) return formatJsonish(block);
+  if (!isObject(block)) return formatJsonish(block);
   if (typeof block.text === 'string') return block.text;
 
   switch (block.type) {
@@ -437,10 +438,6 @@ function formatJsonish(value: unknown): string {
   } catch {
     return String(value);
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 async function listGeneratedFiles(id: ExecutionId): Promise<CliHistoryFile[]> {
@@ -504,7 +501,7 @@ function extractWorkspaceFileToolPaths(
 ): string[] {
   const paths: string[] = [];
   for (const message of conversation) {
-    if (!isRecord(message)) continue;
+    if (!isObject(message)) continue;
 
     const responseToolPath = extractResponseFunctionCallFilePath(message);
     if (responseToolPath) paths.push(responseToolPath);
@@ -546,8 +543,8 @@ function extractResponseFunctionCallFilePath(
 }
 
 function extractOpenAiToolCallFilePath(toolCall: unknown): string | undefined {
-  if (!isRecord(toolCall)) return undefined;
-  const fn = isRecord(toolCall.function) ? toolCall.function : {};
+  if (!isObject(toolCall)) return undefined;
+  const fn = isObject(toolCall.function) ? toolCall.function : {};
   if (typeof fn.name !== 'string' || !WORKSPACE_FILE_TOOL_NAMES.has(fn.name)) {
     return undefined;
   }
@@ -555,7 +552,7 @@ function extractOpenAiToolCallFilePath(toolCall: unknown): string | undefined {
 }
 
 function extractContentToolUseFilePath(block: unknown): string | undefined {
-  if (!isRecord(block) || block.type !== 'tool_use') return undefined;
+  if (!isObject(block) || block.type !== 'tool_use') return undefined;
   if (
     typeof block.name !== 'string' ||
     !WORKSPACE_FILE_TOOL_NAMES.has(block.name)
@@ -566,7 +563,7 @@ function extractContentToolUseFilePath(block: unknown): string | undefined {
 }
 
 function extractGoogleFunctionCallFilePath(part: unknown): string | undefined {
-  if (!isRecord(part) || !isRecord(part.functionCall)) return undefined;
+  if (!isObject(part) || !isObject(part.functionCall)) return undefined;
   const { functionCall } = part;
   if (
     typeof functionCall.name !== 'string' ||
@@ -588,11 +585,11 @@ function extractToolArgumentsFilePath(
 function parseToolArguments(
   argumentsValue: unknown,
 ): Record<string, unknown> | undefined {
-  if (isRecord(argumentsValue)) return argumentsValue;
+  if (isObject(argumentsValue)) return argumentsValue;
   if (typeof argumentsValue !== 'string') return undefined;
   try {
     const parsed: unknown = JSON.parse(argumentsValue);
-    return isRecord(parsed) ? parsed : undefined;
+    return isObject(parsed) ? parsed : undefined;
   } catch {
     return undefined;
   }

--- a/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
+++ b/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
@@ -13,6 +13,7 @@ import {
   type SupabaseSessionCoordinator,
 } from '@auth/SupabaseSession';
 import { toErrorMessage } from '@common/errors/errorMessage';
+import { escapeHtml } from '@shared/utils/xmlEscape';
 
 const LOOPBACK_HOST = '127.0.0.1';
 const CALLBACK_PATH = '/auth-callback';
@@ -264,15 +265,6 @@ function failureHtml(message: string): string {
 <body>
   <p>Sign-in failed: ${escapeHtml(message)}</p>
 </body>`;
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
 }
 
 function closeServer(server: ReturnType<typeof createServer>): Promise<void> {

--- a/packages/desktop/src/main/desktopSetupTerminal.ts
+++ b/packages/desktop/src/main/desktopSetupTerminal.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { spawn } from 'node:child_process';
 
+// Local imports - shared utilities
+import { quotePosixShellArg } from '@utils/system/shellQuote';
+
 const OPEN_TERMINAL_TIMEOUT_MS = 10_000;
 
 export function setupCommandNeedsInteractiveTerminal(command: string): boolean {
@@ -60,10 +63,6 @@ export async function openMacTerminalCommand(
 
 export function buildMacTerminalCommand(command: string, cwd: string): string {
   return `cd ${quotePosixShellArg(cwd)} && ${command}`;
-}
-
-function quotePosixShellArg(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function escapeAppleScriptString(value: string): string {

--- a/src/agent/goal/promptLoader.ts
+++ b/src/agent/goal/promptLoader.ts
@@ -16,6 +16,7 @@ import * as path from 'path';
 import * as yaml from 'yaml';
 import { z } from 'zod';
 
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
 
@@ -111,9 +112,9 @@ async function loadPrompts(): Promise<GoalPrompts> {
     // goal.yaml is detectable rather than silently masked.
     logger.warn(
       'GoalPromptLoader',
-      `Failed to load bundled goal.yaml; using inline prompt templates: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `Failed to load bundled goal.yaml; using inline prompt templates: ${toErrorMessage(
+        err,
+      )}`,
     );
     cached = inlineTemplates;
   }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -6,7 +6,7 @@ import {
   type ToolUseCycleShared,
 } from '@agent/core/flows/ToolUseCycleFlow';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import { normalizeProviderError } from '@common/errors';
+import { normalizeProviderError, toErrorMessage } from '@common/errors';
 import { MESSAGE_TYPES } from '@shared/schemas';
 
 import {
@@ -97,9 +97,7 @@ export class ToolUseCycleNode<C> extends Node<
             // are diagnosable without disrupting the update stream.
             .catch((err: unknown) => {
               this.services.logger.debug(
-                `Failed to persist todos: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
+                `Failed to persist todos: ${toErrorMessage(err)}`,
               );
             });
         }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -38,6 +38,7 @@ import {
 // Local imports - model
 import { createChannelTrace } from '@logger';
 import { getApiKey, type ApiProvider } from '@model/apiProviders';
+import { isGpt5ModelName } from '@model/modelNames';
 
 // Local imports - logger
 import { MESSAGE_TYPES } from '@shared/schemas';
@@ -529,7 +530,7 @@ export abstract class ModelHandler<
     // Providers map it to their minimum effort level (e.g. Anthropic → 'low').
     // Returning null here would silently fall back to high/default effort.
 
-    const isGpt5 = this.config.name.startsWith('gpt5');
+    const isGpt5 = isGpt5ModelName(this.config.name);
     if (
       isGpt5 &&
       (reasoningEffort === ReasoningEffort.XHIGH ||

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -29,6 +29,7 @@ import {
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
+import { isGpt5ModelName, isGptFamilyModelName } from '@model/modelNames';
 
 // Type imports
 import type { ToolFileAttachment } from '@tools/result';
@@ -205,8 +206,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * on per-step streaming.
    */
   private isBackgroundModeEligible(): boolean {
-    const isGpt = this.config.name.toLowerCase().startsWith('gpt');
-    return isGpt && this.isWorkflowMode();
+    return isGptFamilyModelName(this.config.name) && this.isWorkflowMode();
   }
 
   private static readonly BACKGROUND_POLL_INTERVAL_MS = 15000;
@@ -1351,7 +1351,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Extend reasoning with summary option for API call (not needed for token counting)
     if (this.capabilities.supportsReasoning) {
-      const isGpt5 = this.config.name.startsWith('gpt5');
+      const isGpt5 = isGpt5ModelName(this.config.name);
       const includeSummary =
         !isGpt5 ||
         getConfig<boolean>('texra.model.gpt5ReasoningSummary', false);

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -10,6 +10,7 @@
 
 import { z } from 'zod';
 
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 
 // SDK type imports - using native types for better type safety
@@ -497,9 +498,7 @@ export function extractDomain(url: string): string {
     // isn't silently rendered as an empty domain.
     logger.debug(
       'ServerTools',
-      `extractDomain: unparseable URL "${url}": ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `extractDomain: unparseable URL "${url}": ${toErrorMessage(err)}`,
     );
     return '';
   }

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -7,6 +7,7 @@ import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import * as logger from '@logger/logUtils';
+import { isGpt5ModelName } from '@model/modelNames';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { getConfig } from '@utils/config/configUtils';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
@@ -168,7 +169,7 @@ function requiresOpenAIResponsesAPI(
 
   const { capabilities } = config;
   return (
-    config.fullName.startsWith('gpt-5') &&
+    isGpt5ModelName(config.fullName) &&
     capabilities.supportsReasoningEffort !== false &&
     capabilities.supportsFunctionCalling !== false
   );

--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -3,6 +3,7 @@ import { StringDecoder } from 'node:string_decoder';
 import pMap from 'p-map';
 
 import { platform } from '@platform/platform';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -195,9 +196,9 @@ export class ProcessOutputPoller {
         // Log at debug so a persistent read failure is still observable.
         logger.debug(
           'ProcessOutputPoller',
-          `Process output read failed for ${executionId}: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
+          `Process output read failed for ${executionId}: ${toErrorMessage(
+            err,
+          )}`,
         );
       }
     })();

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -23,6 +23,7 @@
 
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
+import { toErrorMessage } from '@common/errors';
 import * as logUtils from '@logger/logUtils';
 import type { ToolDefinition } from '@model';
 import { computeModelOptionsData } from '@model/computeModelOptions';
@@ -87,9 +88,9 @@ async function availableDelegationModelNamesForTools(
     // fail the run, but log so the missing "Available models:" line is traceable.
     logUtils.warn(
       'AgentToolResolution',
-      `Could not load model options for delegation annotation: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `Could not load model options for delegation annotation: ${toErrorMessage(
+        err,
+      )}`,
     );
     return null;
   }

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -9,6 +9,7 @@
 import { platform } from '@platform/platform';
 import { getExecutionStore } from '@agent/storage';
 import type { ExecutionMeta } from '@agent/storage/ExecutionKVStore';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -61,9 +62,9 @@ async function readMetaSafely(
     // unreadable ancestor isn't an invisible cause of blocked delegation.
     logger.warn(
       'DelegationPolicy',
-      `Failed to read execution meta for ${executionId}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `Failed to read execution meta for ${executionId}: ${toErrorMessage(
+        err,
+      )}`,
     );
     return 'error';
   }

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -6,6 +6,7 @@
  */
 
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { filterNotNull } from '@utils/core';
@@ -37,9 +38,9 @@ export async function hasPersistedFlowRecord(
     // no record, but log so silent KV-read failures are diagnosable.
     logger.debug(
       'DetectWaitingStreams',
-      `Failed to read persisted flow record for ${executionId}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `Failed to read persisted flow record for ${executionId}: ${toErrorMessage(
+        err,
+      )}`,
     );
     return false;
   }

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -13,6 +13,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomUUID } from 'node:crypto';
 
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { END_GROUP_STATUS, type EndGroupStatus } from '@shared/schemas';
 
@@ -82,9 +83,7 @@ export class TraceEmitter implements AgentTrace {
         // sink is diagnosable without recursing into the trace stream.
         logger.debug(
           'TraceEmitter',
-          `Trace subscriber threw while handling event: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
+          `Trace subscriber threw while handling event: ${toErrorMessage(err)}`,
         );
       }
     }

--- a/src/common/files/fileListingRules.ts
+++ b/src/common/files/fileListingRules.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
+import { normalizeFilePath } from '@shared/utils/path';
 
 import {
   LEGACY_AUXILIARY_KEYWORDS_KEY,
@@ -39,12 +40,8 @@ export interface PreparedFileFilters {
 
 type ConfigReader = (key: string, fallback: string[]) => string[];
 
-function normalizePathSeparators(filePath: string): string {
-  return filePath.replaceAll('\\', '/');
-}
-
 function getPathSegments(filePath: string): string[] {
-  return normalizePathSeparators(filePath).split('/');
+  return normalizeFilePath(filePath).split('/');
 }
 
 function getPathFileName(filePath: string): string {
@@ -162,9 +159,7 @@ export function sanitizeDirectories(directories: readonly string[]): string[] {
   return directories
     .map((dir) => dir.trim())
     .filter((dir) => dir.length > 0)
-    .map((dir) =>
-      normalizePathSeparators(dir).replace(/^\//, '').replace(/\/$/, ''),
-    );
+    .map((dir) => normalizeFilePath(dir).replace(/^\//, '').replace(/\/$/, ''));
 }
 
 export function prepareFileFilters(
@@ -191,7 +186,7 @@ export function containsExcludedDirectory(
   relativePath: string,
   excludeDirs: readonly string[],
 ): boolean {
-  const normalizedPath = normalizePathSeparators(relativePath).toLowerCase();
+  const normalizedPath = normalizeFilePath(relativePath).toLowerCase();
   const pathSegments = normalizedPath.split('/');
 
   return excludeDirs.some((dir) => {

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -9,6 +9,7 @@ import {
 import { LEVEL_TO_EFFORT } from '@agent/runtime/reasoningEffort';
 import { FREE_TIER, MAX_TIER } from '@auth/sharedConfig';
 import { computeModelOptionsData } from '@model/computeModelOptions';
+import { isGpt5ModelName } from '@model/modelNames';
 import { DEFAULT_MODELS } from '@model/modelOptionsBasic';
 import type { ModelOptionData } from '@shared/schemas';
 import {
@@ -215,7 +216,7 @@ export class SettingsModelSelectionController {
   ): ReasoningLevel | undefined {
     if (
       !this.deps.useIncludedAccess?.() ||
-      !config.name.startsWith('gpt5') ||
+      !isGpt5ModelName(config.name) ||
       config.capabilities.reasoningEffort !== ReasoningEffort.XHIGH
     ) {
       return undefined;

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -4,7 +4,7 @@ import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
-import { findFilesFromPatterns } from './utils';
+import { findFilesFromPatterns, generateTimestamp } from './utils';
 import { TEMP_EXTENSIONS } from './constants';
 
 const CHANNEL = 'Housekeeping';
@@ -69,7 +69,7 @@ export async function runPackLatexdiffvc(
     return { status: 'cleaned', inputFile };
   }
 
-  const now = new Date().toISOString().replaceAll(/[-:]/g, '').split('.')[0];
+  const now = generateTimestamp();
   const outputFolder = path.join(
     inputDir,
     'Diffs',

--- a/src/model/modelNames.ts
+++ b/src/model/modelNames.ts
@@ -1,0 +1,15 @@
+/**
+ * Model-family predicates over model names. Centralizes the scattered
+ * `startsWith` checks so short config names (e.g. `gpt5high`) and full API
+ * ids (e.g. `gpt-5`) are classified consistently everywhere.
+ */
+
+/** True for GPT-5 family models — matches short names (`gpt5*`) and full ids (`gpt-5*`). */
+export function isGpt5ModelName(name: string): boolean {
+  return name.startsWith('gpt5') || name.startsWith('gpt-5');
+}
+
+/** True for any GPT-family model name (`gpt4*`, `gpt5*`, `gpt-oss*`, …). */
+export function isGptFamilyModelName(name: string): boolean {
+  return name.toLowerCase().startsWith('gpt');
+}

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -7,21 +7,19 @@ import * as path from 'node:path';
 
 import { minimatch } from 'minimatch';
 
+import { normalizeFilePath } from '@shared/utils/path';
+
 import type { WorkspaceProvider } from '../interfaces/workspace';
 
 const CASE_INSENSITIVE_GLOBS =
   process.platform === 'win32' || process.platform === 'darwin';
-
-function normalizeRelativePath(filePath: string): string {
-  return filePath.replaceAll('\\', '/');
-}
 
 function shouldTraverseDirectory(
   root: string,
   directory: string,
   globPattern: string,
 ): boolean {
-  const relativePath = normalizeRelativePath(path.relative(root, directory));
+  const relativePath = normalizeFilePath(path.relative(root, directory));
   if (!relativePath) return true;
   return minimatch(relativePath, globPattern, {
     dot: true,
@@ -35,7 +33,7 @@ function shouldNotify(
   relativePath: string | null,
 ): boolean {
   if (relativePath == null) return false;
-  return minimatch(normalizeRelativePath(relativePath), globPattern, {
+  return minimatch(normalizeFilePath(relativePath), globPattern, {
     dot: true,
     nocase: CASE_INSENSITIVE_GLOBS,
   });
@@ -167,7 +165,7 @@ export function createNodeWorkspace(
       if (relative.startsWith('..') || path.isAbsolute(relative)) {
         return filePath;
       }
-      return normalizeRelativePath(relative);
+      return normalizeFilePath(relative);
     },
 
     watch(globPattern: string, listener: () => void): { dispose(): void } {

--- a/src/shared/utils/xmlEscape.ts
+++ b/src/shared/utils/xmlEscape.ts
@@ -24,3 +24,11 @@ export function escapeText(s: string): string {
 export function escapeTextStrict(s: string): string {
   return escapeText(s).replaceAll('>', '&gt;');
 }
+
+/**
+ * Escape for arbitrary HTML interpolation — safe in text nodes and inside
+ * single- or double-quoted attribute values (escapes `&`, `<`, `>`, `"`, `'`).
+ */
+export function escapeHtml(s: string): string {
+  return escapeTextStrict(s).replaceAll('"', '&quot;').replaceAll("'", '&#39;');
+}

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -19,6 +19,7 @@ import {
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - tools
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
@@ -301,7 +302,7 @@ export class BashTool extends defineTool({
 
     const logBackgroundFailure = (action: string, err: unknown): void => {
       logger.error(
-        `Failed to ${action} background bash result: ${err instanceof Error ? err.message : String(err)}`,
+        `Failed to ${action} background bash result: ${toErrorMessage(err)}`,
       );
     };
 

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -9,6 +9,7 @@
 
 import { isNonEmptyString } from '@utils/core';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import type { GhIssueComment } from './prTypes';
 
 const WEBHOOK_TAG = 'github-webhook-activity';
@@ -63,9 +64,7 @@ export function sections(
 }
 
 export function truncate(s: string | null | undefined, max: number): string {
-  const body = (s ?? '').trim();
-  if (body.length <= max) return body;
-  return body.slice(0, max) + '…';
+  return truncateWithEllipsis((s ?? '').trim(), max);
 }
 
 /**

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -23,7 +23,10 @@ import type {
   InquiryResumeOutcome,
   StreamTabId,
 } from '@shared/schemas';
-import { collapseWhitespace } from '@utils/text/stringUtils';
+import {
+  collapseWhitespace,
+  truncateWithEllipsis,
+} from '@utils/text/stringUtils';
 
 import {
   getThreadSummary,
@@ -39,13 +42,8 @@ export type InjectionOutcome = 'sent' | 'queued' | 'resumed' | 'archived';
 const QUESTION_TRUNCATION = 400;
 const ANSWER_TRUNCATION = 2000;
 
-function truncate(text: string, limit: number): string {
-  if (text.length <= limit) return text;
-  return text.slice(0, limit).trimEnd() + ' …';
-}
-
 function previewText(text: string, limit: number): string {
-  return truncate(collapseWhitespace(text), limit);
+  return truncateWithEllipsis(collapseWhitespace(text), limit);
 }
 
 function readThreadCommand(threadId: ExternalInquiryThreadId): string {
@@ -58,7 +56,7 @@ function formatStillOpen(threads: ExternalInquiryThreadSummary[]): string[] {
   for (const t of threads) {
     const since = formatRelativeTime(t.lastActivityIso);
     lines.push(
-      `  - ${t.threadId}  "${truncate(t.lastQuestionPreview, 60)}"  (dispatched ${since})`,
+      `  - ${t.threadId}  "${truncateWithEllipsis(t.lastQuestionPreview, 60)}"  (dispatched ${since})`,
     );
   }
   return lines;

--- a/src/utils/system/index.ts
+++ b/src/utils/system/index.ts
@@ -1,5 +1,6 @@
 export * from './execUtils';
 export * from './gitAuthorEnv';
+export * from './shellQuote';
 export * from './toolUtils';
 export * from './platformPaths';
 export * from './binaryResolver';

--- a/src/utils/system/shellQuote.ts
+++ b/src/utils/system/shellQuote.ts
@@ -1,0 +1,7 @@
+/**
+ * Quote a value for safe use as a single POSIX shell word: wrap in single
+ * quotes and escape embedded single quotes via the `'\''` idiom.
+ */
+export function quotePosixShellArg(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}


### PR DESCRIPTION
- Consolidate duplicate POSIX shell quoting through `quotePosixShellArg` in `@utils/system/shellQuote`.
- Move the CLI auth callback page to the shared `escapeHtml` helper in `@shared/utils/xmlEscape`.
- Centralize GPT model-family checks in `@model/modelNames` so short config names and full API ids classify consistently.
- Reuse housekeeping `generateTimestamp` in latexdiff instead of keeping an inlined copy.
- Reuse `normalizeFilePath` for duplicate backslash-to-slash normalization in file listing and node workspace code.
- Replace CLI-local record guards with the shared `isObject` guard where callers expect keyed objects.
- Replace repeated `err instanceof Error ? err.message : String(err)` branches with `toErrorMessage`.
- Name ANSI parser byte-range / terminator constants in the CLI runtime.

After merging current `main`, the inquiry-continuation truncation cleanup is no longer part of this PR's effective diff; main already owns that shared helper behavior. This body intentionally omits the stale `applyLatexQuotesFormatting` item from the original description because it is not in this diff.

Validation:
- `npm run typecheck`
- `corepack pnpm exec prettier --check src/tools/inquiry/inquiryContinuation.ts src/tools/github/formatUtils.ts && git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical deduplication with equivalent behavior; the main nuance is stricter object guards (`isObject` vs prior `isRecord`) and centralized GPT name matching, which could slightly change edge-case classification.
> 
> **Overview**
> This refactor **deduplicates ad hoc helpers** across CLI, desktop, agent runtime, and shared utilities so behavior stays consistent in one place.
> 
> **New or expanded shared modules:** `@utils/system/shellQuote` (`quotePosixShellArg`) replaces local quoting in bash/zsh completion and Mac Terminal setup; `@shared/utils/xmlEscape` gains **`escapeHtml`** used by the CLI OAuth callback pages; **`@model/modelNames`** centralizes **`isGpt5ModelName`** / **`isGptFamilyModelName`** for reasoning caps, Responses API routing, and OpenAI background mode; path handling moves to **`normalizeFilePath`** in file listing and Node workspace code.
> 
> **Call-site cleanups:** CLI config and history parsing drop local record guards in favor of **`isObject`**; many catch blocks use **`toErrorMessage`** instead of inline `instanceof Error` ternaries; **`latexdiff`** uses housekeeping **`generateTimestamp`**. The CLI ANSI escape parser names CSI/OSC terminator constants and uses the OSC terminator length when advancing the index.
> 
> **Model behavior note:** GPT-5 / GPT-family checks now treat both short config names (`gpt5*`) and API ids (`gpt-5*`) the same everywhere those helpers are used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ca72546300c013bd5778140eea113df1755e3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->