### PR TITLE
refactor(cli): require workflow output terminal status

### DIFF
--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -12,7 +12,6 @@ import { getRunDir } from '@utils/files';
 
 import { CliUsageError, type CliContext } from './cliContext';
 import {
-  cliTerminalStatus,
   createCliRunResult,
   type CliRunResult,
   type ExecuteAgentResult,
@@ -84,7 +83,7 @@ export type CliWorkflowRunResult = Extract<
 export interface WorkflowOutputResolutionOptions {
   readonly expectedOutputFiles?: readonly string[];
   readonly runDirectory?: string;
-  readonly terminalStatus?: ExecutionStatus;
+  readonly terminalStatus: ExecutionStatus;
 }
 
 function outputCopyRelativePath(output: OutputFileSummary): string {
@@ -129,12 +128,12 @@ export async function resolveWorkflowOutput(
   outputDir: string | undefined,
   result: ExecuteAgentResult,
   context: CliContext,
-  options: WorkflowOutputResolutionOptions = {},
+  options: WorkflowOutputResolutionOptions,
 ): Promise<{
   copiedOutput: string | undefined;
   displayResult: CliRunResult;
 }> {
-  const terminalStatus = options.terminalStatus ?? cliTerminalStatus(result);
+  const { terminalStatus } = options;
   if (
     result.category === AgentCategory.Workflow &&
     result.outputs.length === 0 &&

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -798,6 +798,7 @@ describe('CLI root argument routing', () => {
           compileFailures: [],
         },
         cliContext(),
+        { terminalStatus: EXECUTION_STATUS.ERROR },
       ),
     ).rejects.toThrow(
       'Workflow error without a generated output; corrected.tex was not written.',


### PR DESCRIPTION
## Summary
- make `resolveWorkflowOutput` require the terminal status resolved by the CLI execution path
- remove the local fallback that re-derived status from the end-group result
- update the direct root-args test to pass the expected terminal status explicitly

## Why
`executeCliRequest` already owns persisted terminal-status lookup via `readCliTerminalStatus`. Letting workflow output resolution infer status again created a second ownership path that could drift if a future caller forgot to pass the centralized value.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts`
- `corepack pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API tightening in CLI workflow output handling with test updates; production callers already pass terminal status from the execution path.
> 
> **Overview**
> **`resolveWorkflowOutput`** now requires callers to pass **`terminalStatus`** in `WorkflowOutputResolutionOptions` (no longer optional). The function no longer falls back to **`cliTerminalStatus(result)`** when status is omitted, so workflow output messaging and copy behavior use the same terminal status the CLI execution path already resolved (e.g. via persisted lookup).
> 
> The **`cliTerminalStatus`** import was dropped from **`workflowOutput.ts`**. Direct tests that call **`resolveWorkflowOutput`** must supply **`terminalStatus`** explicitly (e.g. **`EXECUTION_STATUS.ERROR`** for error-without-output cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a982e16fc18bdbe9a6b3d512f49a027efbf02c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->