### PR TITLE
fix(cli): drop invisible assistant spacer rows

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -496,7 +496,7 @@ function seedLiveToolOnlyTranscript(): void {
     timestamp: timestamp + 1,
     messageType: MESSAGE_TYPES.MODEL_RESPONSE,
     text: SHOW_LIVE_INVISIBLE_ASSISTANT
-      ? `${String.fromCharCode(27)}[2m${String.fromCharCode(27)}[22m`
+      ? `${String.fromCharCode(27)}[2m${String.fromCharCode(27)}[22m\u200B\n\n`
       : '',
   });
   const tools = [

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -36,7 +36,7 @@ export function trimAssistantTranscriptLead(text: string): string {
   while (index < text.length) {
     if (text[index] === ANSI_ESCAPE_START) {
       const end = ansiEscapeEnd(text, index);
-      if (!consumedInvisibleLead) leadingAnsi += text.slice(index, end);
+      leadingAnsi += text.slice(index, end);
       index = end;
       continue;
     }

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -1,17 +1,71 @@
 import {
+  ANSI_ESCAPE_START,
+  ansiEscapeEnd,
+  stripAnsiSequences,
+} from '@cli/runtime/ansiEscapes';
+import {
   LIVE_ELAPSED_STREAM_STATUSES,
   type StreamStatus,
 } from '@shared/schemas';
-import { stripAnsiSequences } from '@cli/runtime/ansiEscapes';
 
 import type { ConversationEntry } from '../state/cliState';
+
+const INVISIBLE_TRANSCRIPT_CHARS = new Set([
+  '\u200B',
+  '\u200C',
+  '\u200D',
+  '\uFEFF',
+]);
+
+function isInvisibleTranscriptChar(char: string | undefined): boolean {
+  return char !== undefined && INVISIBLE_TRANSCRIPT_CHARS.has(char);
+}
+
+export function terminalVisibleTranscriptText(text: string): string {
+  let out = '';
+  for (const char of stripAnsiSequences(text)) {
+    if (!isInvisibleTranscriptChar(char)) out += char;
+  }
+  return out;
+}
+
+export function trimAssistantTranscriptLead(text: string): string {
+  let index = 0;
+  let consumedInvisibleLead = false;
+  let leadingAnsi = '';
+  while (index < text.length) {
+    if (text[index] === ANSI_ESCAPE_START) {
+      const end = ansiEscapeEnd(text, index);
+      if (!consumedInvisibleLead) leadingAnsi += text.slice(index, end);
+      index = end;
+      continue;
+    }
+    if (isInvisibleTranscriptChar(text[index])) {
+      index += 1;
+      consumedInvisibleLead = true;
+      continue;
+    }
+    const newline = /^[ \t]*\r?\n/.exec(text.slice(index));
+    if (newline?.[0]) {
+      index += newline[0].length;
+      consumedInvisibleLead = true;
+      continue;
+    }
+    break;
+  }
+  if (!consumedInvisibleLead) return text;
+  const tail = text.slice(index);
+  return terminalVisibleTranscriptText(tail).trim().length > 0
+    ? leadingAnsi + tail
+    : tail;
+}
 
 export function isRenderableTranscriptEntry(entry: ConversationEntry): boolean {
   switch (entry.role) {
     case 'assistant':
     case 'error':
     case 'user':
-      return stripAnsiSequences(entry.text).trim().length > 0;
+      return terminalVisibleTranscriptText(entry.text).trim().length > 0;
     case 'process':
       return entry.process !== undefined;
     case 'tool':

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -14,7 +14,10 @@ import {
 import { normalizeToolUseData } from '@shared/toolUse';
 
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
-import { isRenderableTranscriptEntry } from '../panes/transcriptEntries';
+import {
+  isRenderableTranscriptEntry,
+  trimAssistantTranscriptLead,
+} from '../panes/transcriptEntries';
 import { cliState, patchStream, type ConversationEntry } from './cliState';
 import { isFinalTranscriptStatus } from './transcript';
 
@@ -152,7 +155,7 @@ function renderLogEntryText(
 ): string {
   switch (role) {
     case 'assistant':
-      return text.replace(/^(?:[ \t]*\r?\n)+/, '');
+      return trimAssistantTranscriptLead(text);
     case 'error':
       return appendCliApiSwitchHint(text);
     case 'user':

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -416,6 +416,9 @@ describe('CLI conversation transcript splitting', () => {
     expect(trimAssistantTranscriptLead('\u001B[2m\u200B\nvisible')).toBe(
       '\u001B[2mvisible',
     );
+    expect(trimAssistantTranscriptLead('\n\u001B[31mvisible')).toBe(
+      '\u001B[31mvisible',
+    );
     expect(
       splitTranscriptEntries(
         [user, invisibleAssistant, tool],

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -7,7 +7,11 @@ import {
   isInquiryContinuationText,
 } from '@cli/chat/tui/panes/TranscriptEntry';
 import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
-import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
+import {
+  splitTranscriptEntries,
+  terminalVisibleTranscriptText,
+  trimAssistantTranscriptLead,
+} from '@cli/chat/tui/panes/transcriptEntries';
 import {
   appendStaticTranscriptItems,
   sessionHeaderIdentityLine,
@@ -392,6 +396,35 @@ describe('CLI conversation transcript splitting', () => {
     expect(
       transcriptToLines(
         sliceWithEntries(STREAM_ID, [user, emptyAssistant, tool]),
+        80,
+      ),
+    ).toEqual(['› what is this repo about', '● Bash (ls)']);
+  });
+
+  it('does not reserve rows for zero-width assistant placeholders before tools', () => {
+    const user = entry('u1', 'user', 'what is this repo about', true);
+    const invisibleAssistant = entry(
+      'a1',
+      'assistant',
+      '\u001B[2m\u001B[22m\u200B\n\n',
+      false,
+    );
+    const tool = toolEntry('t1', 'in_progress');
+
+    expect(terminalVisibleTranscriptText(invisibleAssistant.text)).toBe('\n\n');
+    expect(trimAssistantTranscriptLead(invisibleAssistant.text)).toBe('');
+    expect(trimAssistantTranscriptLead('\u001B[2m\u200B\nvisible')).toBe(
+      '\u001B[2mvisible',
+    );
+    expect(
+      splitTranscriptEntries(
+        [user, invisibleAssistant, tool],
+        STREAM_STATUS.RUNNING,
+      ).pending.map((item) => item.id),
+    ).toEqual(['t1']);
+    expect(
+      transcriptToLines(
+        sliceWithEntries(STREAM_ID, [user, invisibleAssistant, tool]),
         80,
       ),
     ).toEqual(['› what is this repo about', '● Bash (ls)']);


### PR DESCRIPTION
## Summary
- Treat ANSI-only/zero-width assistant chunks as terminal-invisible before allocating transcript rows.
- Reuse that same transcript text boundary when trimming assistant lead-in blank lines.
- Update the TUI harness spacing scenario to cover a zero-width invisible assistant chunk before tool rows.

## Validation
- corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-spacing-shot live-tool-only-spacing live-tool-stack-spacing
- corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build transcript plain-submit subagent-tab-focus-full-frame subagent-focused-own-scrollback-history
- corepack pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI transcript text normalization and rendering; no auth, API, or persistence changes.
> 
> **Overview**
> Fixes the CLI transcript treating **ANSI-only and zero-width assistant chunks** as visible content, which could reserve blank rows between a user message and the next tool row.
> 
> **`transcriptEntries`** now exposes `terminalVisibleTranscriptText` (strip ANSI, drop ZWSP/ZWNJ/ZWJ/BOM) and `trimAssistantTranscriptLead` (skip leading escapes, invisible characters, and whitespace-only newlines while preserving leading ANSI when real text follows). **`isRenderableTranscriptEntry`** uses that visibility check so empty-looking assistant placeholders are skipped for layout and static scrollback.
> 
> **`subscribeStreamLog`** trims assistant log text with `trimAssistantTranscriptLead` instead of a simple leading-newline regex. The **TUI harness** invisible-assistant fixture adds a zero-width character; **ConversationPane** tests cover the user → invisible assistant → tool spacing case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee4570a129536de7b8181a24c8e8b1197cf662f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->