### PR TITLE
refactor: consolidate ten more ad hoc implementations onto shared helpers

### DIFF
--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -63,7 +63,7 @@ export function slashPaletteWindow({
     return { start: 0, end: 0, hiddenBefore: 0, hiddenAfter: 0 };
   }
 
-  const visibleAtEdge = Math.min(Math.max(1, maxVisibleCommands), itemCount);
+  const visibleAtEdge = clamp(maxVisibleCommands, 1, itemCount);
   if (itemCount <= visibleAtEdge) {
     return { start: 0, end: itemCount, hiddenBefore: 0, hiddenAfter: 0 };
   }

--- a/packages/cli/src/chat/tui/input/imagePasteQueue.ts
+++ b/packages/cli/src/chat/tui/input/imagePasteQueue.ts
@@ -1,16 +1,9 @@
+import { withTimeout } from '@utils/core';
+
 export const IMAGE_PASTE_TIMEOUT_MS = 15_000;
 
 export function withImagePasteTimeout<T>(promise: Promise<T>): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timeout = setTimeout(
-      () => reject(new Error('Image paste timed out.')),
-      IMAGE_PASTE_TIMEOUT_MS,
-    );
-  });
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeout) clearTimeout(timeout);
-  });
+  return withTimeout(promise, IMAGE_PASTE_TIMEOUT_MS, 'Image paste timed out.');
 }
 
 export class ImagePasteQueue {

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -9,7 +9,7 @@ import { Box, Text, useInput } from 'ink';
 import type { StreamTabId } from '@shared/schemas';
 
 // Local imports - CLI state and UI
-import { clampIndex } from '@utils/core';
+import { clamp, clampIndex } from '@utils/core';
 
 import {
   buildChildControlItems,
@@ -242,7 +242,7 @@ export function taskDetailVisibleLineCountFromOffsetForColumns({
   const outputColumns = taskDetailOutputColumnCount(availableColumns);
   if (outputColumns === undefined) return visibleRowBudget;
 
-  const start = Math.min(Math.max(0, offset), tailLines.length - 1);
+  const start = clamp(offset, 0, tailLines.length - 1);
   let usedRows = 0;
   let visibleLines = 0;
   for (let index = start; index < tailLines.length; index += 1) {
@@ -572,7 +572,7 @@ function taskDetailScrollOffsetFromAnchor(
     offset += taskDetailLineRowCount(context, index);
   }
   const rowCount = taskDetailLineRowCount(context, lineIndex);
-  offset += Math.min(Math.max(0, anchor.wrappedRowOffset), rowCount - 1);
+  offset += clamp(anchor.wrappedRowOffset, 0, rowCount - 1);
   return Math.min(offset, maxOffset);
 }
 

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -11,7 +11,7 @@
 import { Box, Text, useInput } from 'ink';
 import { useEffect, useState } from 'react';
 
-import { clampIndex } from '@utils/core';
+import { clamp, clampIndex } from '@utils/core';
 
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 
@@ -113,9 +113,7 @@ export function visibleSelectRange({
 }): { readonly start: number; readonly end: number } {
   if (itemCount <= 0) return { start: 0, end: 0 };
   const visibleCount =
-    maxVisibleItems == null
-      ? itemCount
-      : Math.min(Math.max(0, maxVisibleItems), itemCount);
+    maxVisibleItems == null ? itemCount : clamp(maxVisibleItems, 0, itemCount);
   if (visibleCount <= 0) return { start: 0, end: 0 };
   const clampedHighlight = clampIndex(highlight, itemCount);
   const centerOffset = Math.floor(visibleCount / 2);

--- a/packages/cli/src/runtime/supabaseAuthBrowser.ts
+++ b/packages/cli/src/runtime/supabaseAuthBrowser.ts
@@ -1,6 +1,8 @@
 // Standard library imports
 import { spawn, type ChildProcess } from 'node:child_process';
 
+import { IS_WINDOWS } from '@utils/system/platformPaths';
+
 import type { LogBackend } from './supabaseAuth';
 
 function quoteWindowsStartUrl(url: string): string {
@@ -33,7 +35,7 @@ export function openBrowser(
     try {
       child = spawn(command, args, {
         stdio: 'ignore',
-        windowsVerbatimArguments: process.platform === 'win32',
+        windowsVerbatimArguments: IS_WINDOWS,
       });
     } catch (error) {
       rejectBrowserLaunch(error);

--- a/packages/desktop/src/desktopDiffMessages.ts
+++ b/packages/desktop/src/desktopDiffMessages.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { getBasename } from '@shared/utils/path';
+
 // IPC plumbing for the in-app diff overlay (audit item C, trajectory #18).
 //
 // The desktop main process used to satisfy `DiffViewHost.openDiff` by
@@ -95,14 +97,9 @@ export function monacoLanguageForFilePath(
   filePath: string | undefined,
 ): string {
   if (!filePath) return 'plaintext';
-  // Use `lastIndexOf` rather than path.extname so this works in the
-  // renderer (no node:path) too. We accept any segment after the last
-  // dot in the basename.
-  const slashIndex = Math.max(
-    filePath.lastIndexOf('/'),
-    filePath.lastIndexOf('\\'),
-  );
-  const basename = filePath.slice(slashIndex + 1);
+  // Browser-safe (no node:path): getBasename handles both separators. We
+  // accept any segment after the last dot in the basename.
+  const basename = getBasename(filePath);
   const dotIndex = basename.lastIndexOf('.');
   if (dotIndex < 0) return 'plaintext';
   const ext = basename.slice(dotIndex).toLowerCase();

--- a/packages/extension/src/commands/history/chatExportFormatter.ts
+++ b/packages/extension/src/commands/history/chatExportFormatter.ts
@@ -20,6 +20,7 @@ import {
 import { assertToolCallsAreChatCompletionFunctionToolCalls } from 'openai/lib/parser';
 import latexPreamble from '@resources/templates/chatExport.tex';
 import { filterNotNullish } from '@utils/core';
+import { isoDateOnly } from '@utils/text/stringUtils';
 import type { Part } from '@google/genai';
 import type {
   ChatCompletionMessageParam,
@@ -818,7 +819,7 @@ export function generateExportFolderName(input: ChatExportInput): string {
 
 function generateExportStem(input: ChatExportInput): string {
   const date = new Date(input.timestamp);
-  const datePart = date.toISOString().slice(0, 10);
+  const datePart = isoDateOnly(date);
 
   const parts = ['texra-chat', datePart];
 

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -14,13 +14,10 @@ import { extractFigurePathsFromLatex } from '@latex/extractFigure';
 import { tikzPictureManager } from '@latex/TikzPictureManager';
 import * as logger from '@logger/logUtils';
 import { pathToLocation } from '@utils/files';
+import { pluralize } from '@utils/text/stringUtils';
 
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);
-
-function pluralize(count: number, singular: string): string {
-  return count === 1 ? singular : `${singular}s`;
-}
 
 async function runLaTeXCommand(
   action: string,

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -19,6 +19,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { normalizeFilePath } from '@shared/utils/path';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { ELEMENT_IDS } from '../constants';
@@ -71,7 +72,7 @@ interface ParsedPath {
 
 /** Parse a path into directory and basename components */
 function parsePath(path: string): ParsedPath {
-  const normalized = path.replaceAll('\\', '/');
+  const normalized = normalizeFilePath(path);
   const lastSlash = normalized.lastIndexOf('/');
   return {
     dir: lastSlash >= 0 ? normalized.slice(0, lastSlash + 1) : '',

--- a/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
@@ -13,13 +13,10 @@ import {
 import type { Goal, GoalStatus } from '@shared/schemas';
 import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
 import type { MetaPart } from '@shared/wa/metaStrip';
+import { capitalize } from '@utils/text/stringUtils';
 
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
-
-function statusLabel(status: GoalStatus): string {
-  return status[0].toUpperCase() + status.slice(1);
-}
 
 /** Map a Goal status to a wa-badge variant. */
 function statusVariant(status: GoalStatus): 'success' | 'warning' {
@@ -171,7 +168,7 @@ export class GoalTab extends LitElement {
           class="status-chip"
           variant=${statusVariant(item.status)}
           appearance="filled"
-          >${statusLabel(item.status)}</wa-badge
+          >${capitalize(item.status)}</wa-badge
         >
         <div>
           <div class="objective" title=${item.objective}>${item.objective}</div>

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -56,6 +56,7 @@ import type { FileLocation } from '@utils/files';
 
 // Local imports - utils
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
+import { pluralize } from '@utils/text/stringUtils';
 import {
   computeGooglePrice,
   normalizeGoogleUsage,
@@ -714,13 +715,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     if (mediaFiles?.length && this.supportsFileUploads()) {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
       if (formattedMedia.length > 0) {
-        const pluralSuffix = mediaFiles.length > 1 ? 's' : '';
         const attachmentLabel = mediaFiles
           .map((loc) => getShortDisplayPath(loc))
           .join(', ');
         userContentParts.push(
           createPartFromText(
-            `\nAttached file${pluralSuffix}: ${attachmentLabel}`,
+            `\nAttached ${pluralize(mediaFiles.length, 'file')}: ${attachmentLabel}`,
           ),
         );
         userContentParts.push(...formattedMedia);
@@ -743,13 +743,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     if (mediaFiles?.length && this.supportsFileUploads()) {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
       if (formattedMedia.length > 0) {
-        const pluralSuffix = mediaFiles.length > 1 ? 's' : '';
         const attachmentLabel = mediaFiles
           .map((loc) => getShortDisplayPath(loc))
           .join(', ');
         roundParts.push(
           createPartFromText(
-            `\nProcessing file${pluralSuffix}: ${attachmentLabel}`,
+            `\nProcessing ${pluralize(mediaFiles.length, 'file')}: ${attachmentLabel}`,
           ),
         );
         roundParts.push(...formattedMedia);

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -20,6 +20,7 @@ import {
   TaskRunFileService,
   type FileLocation,
 } from '@utils/files';
+import { formatResultCount } from '@utils/text/stringUtils';
 import {
   addCdataToTagsMultiple,
   DOCUMENT_NAME_REGEX,
@@ -89,7 +90,7 @@ export class XmlOutputManager {
         EXTRACTION_METHOD_MESSAGES[result.method] ?? 'using fallback method';
       logInternal(
         this.logger,
-        `Recovered ${documentTag} ${suffix} (${result.documents.length} document${result.documents.length === 1 ? '' : 's'})`,
+        `Recovered ${documentTag} ${suffix} (${formatResultCount(result.documents.length, 'document')})`,
       );
       return result.documents;
     }

--- a/src/agent/trace/helpers.ts
+++ b/src/agent/trace/helpers.ts
@@ -19,6 +19,7 @@ import {
   type ErrorContext,
   type FileListEntry,
 } from '@shared/schemas';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import type { AgentTrace } from './AgentTrace';
 
@@ -174,7 +175,7 @@ export function logMissingOutputs(
   const count = Array.isArray(info.missing) ? info.missing.length : 0;
   trace.domain({
     key: 'missingOutputs',
-    text: `${count} output file${count === 1 ? '' : 's'} missing`,
+    text: `${formatResultCount(count, 'output file')} missing`,
     data: info,
     stageId,
   });

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { isAbortError } from '@common/errors';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import {
   parseAuthCallbackTokens,
@@ -156,7 +157,7 @@ export async function fetchWithTimeout(
   try {
     return await fetchImpl(url, { ...options, signal });
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (isAbortError(error)) {
       if (options.signal?.aborted && !controller.signal.aborted) {
         throw error;
       }

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -18,6 +18,7 @@ import {
   SpendingStatusSchema,
   type SpendingStatus,
 } from '@shared/schemas/spendingStatus';
+import { formatResultCount } from '@utils/text/stringUtils';
 import { SERVER_SIDE_CACHE_TTL_MS, type UserTier } from '../sharedConfig';
 import {
   NOOP_AUTH_SERVICE_LOGGER,
@@ -284,7 +285,7 @@ export class TierService {
     if (tierConfig.models === '*') return 'All models included';
     const modelCount = tierConfig.models.length;
     if (modelCount === 0) return 'No included model access';
-    return `${modelCount} model${modelCount === 1 ? '' : 's'} included`;
+    return `${formatResultCount(modelCount, 'model')} included`;
   }
 
   // ===========================================================================

--- a/src/common/errors/errorPredicates.ts
+++ b/src/common/errors/errorPredicates.ts
@@ -1,3 +1,8 @@
+/** True for an AbortController-style cancellation error. */
+export function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
 /** Check if an error represents a file-not-found condition. */
 export function isFileNotFoundError(err: unknown): boolean {
   const code = (err as { code?: string })?.code;

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -9,6 +9,7 @@
 export { formatError, formatZodError } from './errorFormatUtils';
 export { toErrorMessage, ensureError } from './errorMessage';
 export {
+  isAbortError,
   isDiskFullError,
   isFileNotFoundError,
   isModuleNotFoundError,

--- a/src/common/files/fileListingRules.ts
+++ b/src/common/files/fileListingRules.ts
@@ -1,5 +1,9 @@
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
-import { normalizeFilePath } from '@shared/utils/path';
+import {
+  getBasename,
+  getFileStem,
+  normalizeFilePath,
+} from '@shared/utils/path';
 
 import {
   LEGACY_AUXILIARY_KEYWORDS_KEY,
@@ -42,16 +46,6 @@ type ConfigReader = (key: string, fallback: string[]) => string[];
 
 function getPathSegments(filePath: string): string[] {
   return normalizeFilePath(filePath).split('/');
-}
-
-function getPathFileName(filePath: string): string {
-  return getPathSegments(filePath).at(-1) ?? '';
-}
-
-export function getFileBaseName(filePath: string): string {
-  const fileName = getPathFileName(filePath);
-  const dotIndex = fileName.lastIndexOf('.');
-  return dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName;
 }
 
 function normalizeList(values: readonly string[]): string[] {
@@ -206,7 +200,7 @@ export function passesFileFilters(
     return false;
 
   const lowerPath = relativePath.toLowerCase();
-  const fileNameLower = getPathFileName(lowerPath);
+  const fileNameLower = getBasename(lowerPath);
   if (filters.excludeFiles.includes(fileNameLower)) return false;
   if (
     filters.includeExt.length > 0 &&
@@ -238,8 +232,8 @@ export function matchesEditedFile(
   filePath: string,
   baseFileName: string,
 ): boolean {
-  const baseName = getFileBaseName(baseFileName);
-  const fileBase = getFileBaseName(filePath);
+  const baseName = getFileStem(baseFileName);
+  const fileBase = getFileStem(filePath);
   if (fileBase === baseName) return false;
   const baseNameWithoutRound = getBaseNameWithoutRound(baseName);
   return (

--- a/src/common/files/index.ts
+++ b/src/common/files/index.ts
@@ -12,7 +12,6 @@ export {
   containsHiddenSegment,
   getBaseNameWithoutRound,
   getEditedFileListConfig,
-  getFileBaseName,
   getFileListConfig,
   loadFileListSettings,
   matchesEditedFile,

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -21,6 +21,7 @@ import type {
   OutputFileInfo,
   StreamTabId,
 } from '@shared/schemas';
+import { pluralize } from '@utils/text/stringUtils';
 
 export interface ProgressFollowUpModelOption {
   value: string;
@@ -236,7 +237,7 @@ export class ProgressFollowUpController {
     executionId: string | undefined,
   ): string {
     const executionHint = executionId ? `Execution: ${executionId}` : undefined;
-    const editableHint = `Editable workspace target${editableFiles.length === 1 ? '' : 's'}: ${editableFiles.join(', ')}`;
+    const editableHint = `Editable workspace ${pluralize(editableFiles.length, 'target')}: ${editableFiles.join(', ')}`;
     const failureLines = compileFailures.map((failure) => {
       const outputPath =
         executionId && failure.output.kind === 'runStorage'

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -11,6 +11,7 @@ import { toErrorMessage } from '@common/errors';
 import { indentLatexFilesInDirectory } from '@housekeeping/indent';
 import * as logger from '@logger/logUtils';
 import { normaliseArxivIdentifier } from '@tools/latex/arxivShared';
+import { withTimeout } from '@utils/core';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 
 export interface ExtractResult {
@@ -202,15 +203,7 @@ export class ArxivSourceProcessor {
     try {
       const extraction = tar.x({ file: tarPath, cwd: destDir });
       if (options.timeout) {
-        await Promise.race([
-          extraction,
-          new Promise((_, reject) =>
-            setTimeout(
-              () => reject(new Error('Extraction timed out')),
-              options.timeout,
-            ),
-          ),
-        ]);
+        await withTimeout(extraction, options.timeout, 'Extraction timed out');
       } else {
         await extraction;
       }

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -8,11 +8,11 @@ import * as path from 'node:path';
 import { minimatch } from 'minimatch';
 
 import { normalizeFilePath } from '@shared/utils/path';
+import { IS_MACOS, IS_WINDOWS } from '@utils/system/platformPaths';
 
 import type { WorkspaceProvider } from '../interfaces/workspace';
 
-const CASE_INSENSITIVE_GLOBS =
-  process.platform === 'win32' || process.platform === 'darwin';
+const CASE_INSENSITIVE_GLOBS = IS_WINDOWS || IS_MACOS;
 
 function shouldTraverseDirectory(
   root: string,

--- a/src/shared/utils/path.ts
+++ b/src/shared/utils/path.ts
@@ -25,3 +25,13 @@ export function getBasename(filePath: string | undefined | null): string {
 
   return cleaned.split('/').at(-1) ?? '';
 }
+
+/**
+ * Basename without its final extension (`'paper'` for `'dir/paper.tex'`).
+ * Dotfiles keep their name (`'.gitignore'` → `'.gitignore'`).
+ */
+export function getFileStem(filePath: string | undefined | null): string {
+  const fileName = getBasename(filePath);
+  const dotIndex = fileName.lastIndexOf('.');
+  return dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName;
+}

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -27,7 +27,6 @@ import type { ExecutionId, FileLocation } from '@shared/schemas';
 // Local imports - tools
 import { requireRuntimeHost } from '@tools/contextHelpers';
 import { ToolError, type ToolResult } from '@tools/result';
-import { formatResultCount, pluralize } from '@tools/formatting';
 import { defineTool } from '@tools/core/define';
 import {
   buildApprovalRejectedResult,
@@ -46,6 +45,7 @@ import {
   createWorkspaceLocation,
 } from '@utils/files';
 import { filterNotNull } from '@utils/core';
+import { formatResultCount, pluralize } from '@utils/text/stringUtils';
 import {
   getOriginalSnapshotPath,
   resolveStoragePath,

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -7,7 +7,6 @@ import {
   recordToolFileRead,
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
-import { pluralize } from '@tools/formatting';
 import {
   assertWritable,
   resolveAndFormat,
@@ -20,6 +19,7 @@ import {
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
+import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -47,7 +47,11 @@ import { AbsoluteFS, StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
-import { formatTimestamp, splitContentLines } from '@utils/text/stringUtils';
+import {
+  formatResultCount,
+  formatTimestamp,
+  splitContentLines,
+} from '@utils/text/stringUtils';
 import { formatSize } from './memory/memoryUtils';
 import {
   formatListingLine,
@@ -440,7 +444,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     ).length;
     const bgSuffix =
       bgCount > 0
-        ? `, ${bgCount} background process${bgCount > 1 ? 'es' : ''} running`
+        ? `, ${formatResultCount(bgCount, 'background process', 'background processes')} running`
         : '';
 
     const header = `Executions (showing ${start}\u2013${end} of ${total}${bgSuffix}, most recent first):`;

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -3,6 +3,7 @@
 
 import { type AgentTrace } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { isAbortError } from '@common/errors';
 import {
   EXECUTION_STATUS,
   type ExecutionId,
@@ -12,11 +13,6 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { formatDuration } from '@utils/core';
-
-/** True for an AbortController-style cancellation error. */
-export function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === 'AbortError';
-}
 
 /**
  * True when an error/abort represents a clean, caller-initiated interruption

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -11,7 +11,6 @@ import { z } from 'zod';
 
 // Local imports
 import { warn } from '@logger/logUtils';
-import { pluralize } from '@tools/formatting';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
@@ -22,6 +21,7 @@ import {
   extractBasePaperMetadata,
   normaliseArxivIdentifier,
 } from '@tools/latex/arxivShared';
+import { pluralize } from '@utils/text/stringUtils';
 
 type Category = Parameters<typeof catQuery>[0];
 

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -9,9 +9,9 @@ import { z } from 'zod';
 
 // Local imports
 import { ToolError } from '@tools/result';
-import { pluralize } from '@tools/formatting';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
+import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
 import { CROSSREF_CONSTANTS, crossrefClient } from './constants';

--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -18,7 +18,9 @@
 import * as path from 'node:path';
 
 import { isModuleNotFoundError } from '@common/errors';
-import { pathExists, resolveBinary } from './support/externalBinaryUtils';
+import { AbsoluteFS } from '@utils/files';
+import { IS_WINDOWS } from '@utils/system/platformPaths';
+import { resolveBinary } from './support/externalBinaryUtils';
 import type { Options, Query } from '@anthropic-ai/claude-agent-sdk';
 
 type QueryFn = (params: {
@@ -102,8 +104,7 @@ const PLATFORM_INFO: Record<string, PlatformInfo> = {
 };
 
 /** Native CLI binary filename for the current platform. */
-const CLAUDE_BINARY_NAME =
-  process.platform === 'win32' ? 'claude.exe' : 'claude';
+const CLAUDE_BINARY_NAME = IS_WINDOWS ? 'claude.exe' : 'claude';
 
 /** Cached result — found paths are cached; misses are retried. */
 let cachedBinaryPath: string | undefined;
@@ -127,7 +128,7 @@ export async function findClaudeBinaryPath(): Promise<string | undefined> {
     platformPkgDir: string,
   ): Promise<string | undefined> => {
     const binary = path.join(platformPkgDir, CLAUDE_BINARY_NAME);
-    return (await pathExists(binary)) ? binary : undefined;
+    return (await AbsoluteFS.exists(binary)) ? binary : undefined;
   };
 
   const result = await resolveBinary({

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -17,7 +17,9 @@
 import * as path from 'node:path';
 
 import { isModuleNotFoundError } from '@common/errors';
-import { pathExists, resolveBinary } from './support/externalBinaryUtils';
+import { AbsoluteFS } from '@utils/files';
+import { IS_WINDOWS } from '@utils/system/platformPaths';
+import { resolveBinary } from './support/externalBinaryUtils';
 
 type CodexConstructor = new (options?: any) => any;
 type PlatformInfo = { pkg: string; triple: string };
@@ -100,7 +102,7 @@ const PLATFORM_INFO: Record<string, PlatformInfo> = {
 let cachedBinaryPath: string | undefined;
 
 /** Native CLI binary filename for the current platform. */
-const CODEX_BINARY_NAME = process.platform === 'win32' ? 'codex.exe' : 'codex';
+const CODEX_BINARY_NAME = IS_WINDOWS ? 'codex.exe' : 'codex';
 
 /**
  * Locate the native Codex binary inside a resolved platform-package directory.
@@ -117,7 +119,7 @@ async function codexBinaryInPlatformPackage(
     'codex',
     CODEX_BINARY_NAME,
   );
-  return (await pathExists(binary)) ? binary : undefined;
+  return (await AbsoluteFS.exists(binary)) ? binary : undefined;
 }
 
 /**

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -35,6 +35,7 @@ import {
   summarizeLeanServers,
 } from '@tools/lean/leanServerRegistry';
 import { getZoteroPort } from '@tools/zotero/bbtClient';
+import { formatResultCount } from '@utils/text/stringUtils';
 import { isGitRepository } from '@utils/system/isGitRepository';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import { isWSL } from '@utils/system/wslDetect';
@@ -334,7 +335,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       if (!extensionAvailable && !lakeAvailable) return 'Needs setup';
       const activeCount = listLeanServers().filter(isLeanServerActive).length;
       return activeCount > 0
-        ? `${activeCount} server${activeCount > 1 ? 's' : ''} active`
+        ? `${formatResultCount(activeCount, 'server')} active`
         : undefined;
     },
     detailCheck: async (probeResult) => {

--- a/src/tools/formatting.ts
+++ b/src/tools/formatting.ts
@@ -115,30 +115,6 @@ export function formatFileView({
 }
 
 /**
- * Pluralize a word based on count.
- * Returns the singular form for count === 1, plural form otherwise.
- */
-export function pluralize(
-  count: number,
-  singular: string,
-  plural?: string,
-): string {
-  return count === 1 ? singular : (plural ?? `${singular}s`);
-}
-
-/**
- * Format a result count with proper pluralization.
- * Example: formatResultCount(3, 'result') returns "3 results"
- */
-export function formatResultCount(
-  count: number,
-  singular: string,
-  plural?: string,
-): string {
-  return `${count} ${pluralize(count, singular, plural)}`;
-}
-
-/**
  * Format tool output with a header and content.
  */
 export function formatToolOutput(

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -9,6 +9,8 @@
  * conclusion is a one-line table edit.
  */
 
+import { formatResultCount } from '@utils/text/stringUtils';
+
 import {
   authorOf,
   formatCommentEvent,
@@ -212,9 +214,7 @@ export function formatCIStarted(
   const body = [
     ...shownNames.map((name) => `- ${name}`),
     ...(remainingNames > 0
-      ? [
-          `…and ${remainingNames} more check name${remainingNames === 1 ? '' : 's'}.`,
-        ]
+      ? [`…and ${formatResultCount(remainingNames, 'more check name')}.`]
       : []),
   ].join('\n');
 

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 // Local imports - tools
 import { toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult } from '@tools/result';
-import { formatToolOutput, pluralize } from '@tools/formatting';
+import { formatToolOutput } from '@tools/formatting';
 import {
   joinWorkspaceRelativePath,
   resolveAndFormat,
@@ -13,6 +13,7 @@ import {
 } from '@tools/pathResolution';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { WorkspaceFS } from '@utils/files';
+import { pluralize } from '@utils/text/stringUtils';
 import { toPosixPath } from '@utils/core/pathCore';
 
 // Local file imports

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -29,6 +29,7 @@ import {
 import { ToolError, type ToolResult } from '@tools/result';
 import { requireRuntimeHost } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import { collectKnownSessionLinks } from './externalInquiryResultFormatter';
 import {
@@ -219,7 +220,7 @@ function buildReadOutput(manifest: ExternalInquiryThreadManifest): ToolResult {
   }
 
   return {
-    summary: `Inquiry thread ${manifest.threadId} (${manifest.status}, ${manifest.turns.length} turn${manifest.turns.length === 1 ? '' : 's'})`,
+    summary: `Inquiry thread ${manifest.threadId} (${manifest.status}, ${formatResultCount(manifest.turns.length, 'turn')})`,
     output: lines.join('\n'),
   };
 }

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -24,10 +24,7 @@ import type {
   StreamTabId,
 } from '@shared/schemas';
 import { formatRelativeTime } from '@shared/utils/string';
-import {
-  truncateSummary,
-  truncateWithEllipsis,
-} from '@utils/text/stringUtils';
+import { truncateSummary, truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import {
   getThreadSummary,

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -23,7 +23,11 @@ import type {
   InquiryResumeOutcome,
   StreamTabId,
 } from '@shared/schemas';
-import { truncateSummary, truncateWithEllipsis } from '@utils/text/stringUtils';
+import { formatRelativeTime } from '@shared/utils/string';
+import {
+  truncateSummary,
+  truncateWithEllipsis,
+} from '@utils/text/stringUtils';
 
 import {
   getThreadSummary,
@@ -47,23 +51,12 @@ function formatStillOpen(threads: ExternalInquiryThreadSummary[]): string[] {
   if (!threads.length) return [];
   const lines = ['', 'Still open on this stream:'];
   for (const t of threads) {
-    const since = formatRelativeTime(t.lastActivityIso);
+    const since = formatRelativeTime(Date.parse(t.lastActivityIso));
     lines.push(
       `  - ${t.threadId}  "${truncateWithEllipsis(t.lastQuestionPreview, 60)}"  (dispatched ${since})`,
     );
   }
   return lines;
-}
-
-function formatRelativeTime(iso: string): string {
-  const elapsedMs = Math.max(0, Date.now() - Date.parse(iso));
-  const minutes = Math.floor(elapsedMs / 60_000);
-  if (minutes < 1) return 'just now';
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }
 
 export function buildContinuationText(params: {

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -12,6 +12,7 @@ import { formatToolOutput } from '@tools/formatting';
 import { resolveAndFormat } from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';
 import { WorkspaceFS } from '@utils/files';
+import { formatResultCount } from '@utils/text/stringUtils';
 import { getConfig } from '@utils/config/configUtils';
 
 const ExtractBibliographyInputSchema = z.strictObject({
@@ -112,15 +113,16 @@ export class ExtractBibliographyTool extends defineTool({
     );
 
     const entryCount = entries.size;
-    const citationCount = citationKeys.length;
-    const keyPlural = citationCount === 1 ? '' : 's';
-    const entryWord = entryCount === 1 ? 'entry' : 'entries';
+    const citationKeyCount = formatResultCount(
+      citationKeys.length,
+      'citation key',
+    );
 
     let summary: string;
     if (entryCount === 0) {
-      summary = `No matching bibliography entries found for ${citationCount} citation key${keyPlural} in ${display}.`;
+      summary = `No matching bibliography entries found for ${citationKeyCount} in ${display}.`;
     } else {
-      summary = `Resolved ${entryCount} bibliography ${entryWord} for ${citationCount} citation key${keyPlural} in ${display}.`;
+      summary = `Resolved ${formatResultCount(entryCount, 'bibliography entry', 'bibliography entries')} for ${citationKeyCount} in ${display}.`;
     }
 
     const instructions = [

--- a/src/tools/latex/ExtractFiguresTool.ts
+++ b/src/tools/latex/ExtractFiguresTool.ts
@@ -7,6 +7,7 @@ import { formatToolOutput } from '@tools/formatting';
 import { resolveAndFormat } from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';
 import { pathToLocation } from '@utils/files';
+import { formatResultCount } from '@utils/text/stringUtils';
 import {
   buildLimitedAttachments,
   resolveLatexFileOrThrow,
@@ -56,9 +57,7 @@ export class ExtractLatexFiguresTool extends defineTool({
     );
     const header = `Figures referenced in ${display}`;
     const output = formatToolOutput(header, formattedList);
-    const summary = `Found ${limitedPaths.length} figure file${
-      limitedPaths.length === 1 ? '' : 's'
-    } in ${display}.`;
+    const summary = `Found ${formatResultCount(limitedPaths.length, 'figure file')} in ${display}.`;
 
     const fullOutput = limitReached
       ? `${output}\n\nNote: Limited attachments to ${attachments.length} files.`

--- a/src/tools/latex/ExtractTikzFiguresTool.ts
+++ b/src/tools/latex/ExtractTikzFiguresTool.ts
@@ -4,9 +4,10 @@ import { z } from 'zod';
 // Local imports - tools
 import { tikzPictureManager } from '@latex/TikzPictureManager';
 import { type ToolFileAttachment } from '@tools/result';
-import { formatResultCount, formatToolOutput } from '@tools/formatting';
+import { formatToolOutput } from '@tools/formatting';
 import { defineTool } from '@tools/core/define';
 import { pathToLocation } from '@utils/files';
+import { formatResultCount } from '@utils/text/stringUtils';
 import {
   buildLimitedAttachments,
   resolveLatexFileOrThrow,

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -17,6 +17,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { toErrorMessage } from '@common/errors';
 import { debug, info, warn } from '@logger/logUtils';
+import { withTimeout } from '@utils/core';
 import {
   registerLeanServer,
   unregisterLeanServer,
@@ -459,21 +460,4 @@ export function fileUriToPath(uri: string): string | null {
     debug(LOG_CHANNEL, `Ignoring unmappable file URI ${uri}`, { data: err });
     return null;
   }
-}
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  ms: number,
-  message: string,
-): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => reject(new Error(message)), ms);
-  });
-  return Promise.race([
-    promise.finally(() => {
-      if (timer) clearTimeout(timer);
-    }),
-    timeout,
-  ]);
 }

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 // Local imports - tools
 import { toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult } from '@tools/result';
-import { formatToolOutput, pluralize } from '@tools/formatting';
+import { formatToolOutput } from '@tools/formatting';
 import {
   joinWorkspaceRelativePath,
   resolveAndFormat,
@@ -16,6 +16,7 @@ import {
 import { createGlobMatcher } from '@tools/utils';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { WorkspaceFS } from '@utils/files';
+import { pluralize } from '@utils/text/stringUtils';
 import { isFile, isDirectory } from '@utils/files/fsEntryType';
 import { toPosixPath } from '@utils/core/pathCore';
 

--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -10,8 +10,9 @@
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 
-import { platform } from '@platform/platform';
+import { AbsoluteFS } from '@utils/files';
 import { executeCommandSync } from '@utils/system/execUtils';
+import { IS_WINDOWS } from '@utils/system/platformPaths';
 
 type ElectronProcess = NodeJS.Process & {
   defaultApp?: boolean;
@@ -29,17 +30,6 @@ export function getPackagedElectronResourcesPath(): string | undefined {
   if (electronProcess.versions.electron == null) return undefined;
   if (electronProcess.defaultApp === true) return undefined;
   return electronProcess.resourcesPath;
-}
-
-/**
- * Check whether a file-system path exists using the platform FS abstraction.
- * Returns `true` if `stat()` succeeds, `false` on any error (including ENOENT).
- */
-export async function pathExists(target: string): Promise<boolean> {
-  return platform()
-    .fs.stat(target)
-    .then(() => true)
-    .catch(() => false);
 }
 
 // ---------------------------------------------------------------------------
@@ -135,7 +125,7 @@ export async function resolveBinary(
   // Fallback — may find an older version that doesn't match the SDK.
   {
     const lookupResult = executeCommandSync(
-      [process.platform === 'win32' ? 'where' : 'which', config.pathCommand],
+      [IS_WINDOWS ? 'where' : 'which', config.pathCommand],
       {
         timeout: 5000,
       },
@@ -148,8 +138,8 @@ export async function resolveBinary(
       const p = hit.trim();
       if (!p) continue;
       // The SDK spawns the binary directly, so skip shell-only npm shims.
-      if (process.platform === 'win32' && /\.(cmd|ps1)$/i.test(p)) continue;
-      if (await pathExists(p)) return p;
+      if (IS_WINDOWS && /\.(cmd|ps1)$/i.test(p)) continue;
+      if (await AbsoluteFS.exists(p)) return p;
     }
   }
 

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -6,6 +6,7 @@ import { getTeXCount } from '@latex/texcount';
 import { ToolError, type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 import { ensureArray } from '@utils/core';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 const TexcountInputSchema = z.strictObject({
   files: z
@@ -61,7 +62,7 @@ export class TexcountTool extends defineTool({
       };
     }
 
-    const summary = `Analyzed: ${files.length} file${files.length === 1 ? '' : 's'}`;
+    const summary = `Analyzed: ${formatResultCount(files.length, 'file')}`;
 
     return {
       summary,

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -25,10 +25,11 @@ import { z } from 'zod';
 import { toErrorMessage } from '@common/errors';
 import { ToolError } from '@tools/result';
 import { isTimeoutErrorCode } from '@tools/timeouts';
-import { pluralize } from '@tools/formatting';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { CROSSREF_CONSTANTS, crossrefClient } from '@tools/citation/constants';
 import { defineTool } from '@tools/core/define';
+import { withTimeout } from '@utils/core';
+import { pluralize } from '@utils/text/stringUtils';
 
 // Local imports - zotero
 import { type CslCreator, getZoteroPort } from './bbtClient';
@@ -225,15 +226,11 @@ async function resolveDOI(
     await waitForRateLimit('crossref', CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS);
 
     // The CrossrefClient has no timeout support, so we race against one.
-    const response = await Promise.race([
+    const response = await withTimeout(
       crossrefClient.work(doi),
-      new Promise<never>((_, reject) =>
-        setTimeout(
-          () => reject(new Error('Crossref lookup timed out')),
-          CROSSREF_RESOLVE_TIMEOUT_MS,
-        ),
-      ),
-    ]);
+      CROSSREF_RESOLVE_TIMEOUT_MS,
+      'Crossref lookup timed out',
+    );
 
     if (!response.ok || !response.content?.message) return null;
 

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -17,6 +17,7 @@ import { defineTool } from '@tools/core/define';
 
 // Local imports - zotero
 import { filterNotNull } from '@utils/core';
+import { formatResultCount } from '@utils/text/stringUtils';
 import {
   callBetterBibTeX,
   getZoteroPort,
@@ -219,7 +220,7 @@ export class ZoteroCollectionsTool extends defineTool({
 
     const context = query ? ` matching "${query}"` : '';
     return {
-      summary: `Found ${totalCollections} collection${totalCollections === 1 ? '' : 's'}${context} across ${librariesWithResults} ${librariesWithResults === 1 ? 'library' : 'libraries'}.`,
+      summary: `Found ${formatResultCount(totalCollections, 'collection')}${context} across ${formatResultCount(librariesWithResults, 'library', 'libraries')}.`,
       output: outputParts.join('\n'),
     };
   }

--- a/src/tools/zotero/ZoteroExportTool.ts
+++ b/src/tools/zotero/ZoteroExportTool.ts
@@ -10,8 +10,8 @@ import { z } from 'zod';
 
 // Local imports - core
 import { ToolError } from '@tools/result';
-import { pluralize } from '@tools/formatting';
 import { defineTool } from '@tools/core/define';
+import { pluralize } from '@utils/text/stringUtils';
 
 // Local imports - zotero
 import { callBetterBibTeX, getZoteroPort } from './bbtClient';

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -7,9 +7,10 @@
 
 // Third-party imports
 import { z } from 'zod';
+import { defineTool } from '@tools/core/define';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local imports - core
-import { defineTool } from '@tools/core/define';
 
 // Local imports - zotero
 import {
@@ -189,7 +190,7 @@ export class ZoteroSearchTool extends defineTool({
     });
 
     return {
-      summary: `Found ${result.length} item${result.length === 1 ? '' : 's'} matching ${label}`,
+      summary: `Found ${formatResultCount(result.length, 'item')} matching ${label}`,
       output: items.join('\n'),
     };
   }

--- a/src/utils/core/async.ts
+++ b/src/utils/core/async.ts
@@ -7,3 +7,26 @@ export { debounce } from 'perfect-debounce';
 
 // Re-export delay for AbortSignal-aware sleeping: delay(ms, { signal })
 export { default as delay } from 'delay';
+
+/**
+ * Reject with `new Error(message)` if `promise` doesn't settle within `ms`.
+ * The timer is always cleared once the race settles, so a long timeout never
+ * keeps the process alive after the underlying promise finishes.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -21,5 +21,5 @@ export {
   filterNotNullish,
   ensureArray,
 } from './typeGuards';
-export { debounce, delay } from './async';
+export { debounce, delay, withTimeout } from './async';
 export { clamp, clampIndex } from './math';

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -15,6 +15,9 @@ import { hasExtension } from '@utils/core/pathCore';
 /** Whether the current platform is Windows (cached at module load). */
 export const IS_WINDOWS = process.platform === 'win32';
 
+/** Whether the current platform is macOS (cached at module load). */
+export const IS_MACOS = process.platform === 'darwin';
+
 // Common LaTeX tool names used across the system
 const TEX_TOOLS = ['latexdiff', 'latexindent', 'latexmk'] as const;
 

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -9,6 +9,8 @@ import { execa } from 'execa';
 import { escapeTextStrict } from '@shared/utils/xmlEscape';
 import { WorkspaceFS } from '@utils/files';
 import { listExternalRoots } from '@utils/files/externalRoots';
+import { isoDateOnly } from '@utils/text/stringUtils';
+import { IS_WINDOWS } from './platformPaths';
 import { isWSL } from './wslDetect';
 
 /** Timeout for git commands in milliseconds. */
@@ -31,7 +33,7 @@ interface GitInfo {
 
 /** Detect the user's default shell basename (e.g., "bash", "zsh", "PowerShell"). */
 function detectShell(): string | undefined {
-  if (process.platform === 'win32') {
+  if (IS_WINDOWS) {
     const comspec = process.env.ComSpec;
     if (!comspec) return undefined;
     const name = path.basename(comspec).toLowerCase();
@@ -109,7 +111,7 @@ async function gatherWorkspaceInfo(
     workspacePath: wsPath,
     platform: getPlatformLabel(),
     shell: detectShell(),
-    date: new Date().toISOString().slice(0, 10), // YYYY-MM-DD
+    date: isoDateOnly(),
     git: wsPath ? await getGitInfo(wsPath) : null,
   };
 }

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -7,6 +7,35 @@ export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+/**
+ * Pluralize a word based on count.
+ * Returns the singular form for count === 1, plural form otherwise.
+ */
+export function pluralize(
+  count: number,
+  singular: string,
+  plural?: string,
+): string {
+  return count === 1 ? singular : (plural ?? `${singular}s`);
+}
+
+/**
+ * Format a result count with proper pluralization.
+ * Example: formatResultCount(3, 'result') returns "3 results"
+ */
+export function formatResultCount(
+  count: number,
+  singular: string,
+  plural?: string,
+): string {
+  return `${count} ${pluralize(count, singular, plural)}`;
+}
+
+/** UTC calendar date (`YYYY-MM-DD`) of a Date; defaults to now. */
+export function isoDateOnly(date: Date = new Date()): string {
+  return date.toISOString().slice(0, 10);
+}
+
 export function objectToLogString(
   obj: unknown,
   maxLength: number = 1000,


### PR DESCRIPTION
## Summary

Second consolidation batch (follow-up to the first "top 10 ad hoc implementations" round, already merged as 036aaf3). Ten more hand-rolled duplicates replaced with shared helpers — 53 files, net −1 line. Behavior-preserving except three deliberate changes called out below.

1. **`withTimeout` in `@utils/core/async`** — replaces four hand-rolled `Promise.race`-with-timer patterns (lean LSP session, CLI image-paste queue, Zotero Crossref lookup, arXiv tar extraction). The inline races in the Zotero and arXiv paths never cleared their timers; the shared helper always does.
2. **Pluralization consolidated** — `pluralize`/`formatResultCount` move from `@tools/formatting` to `@utils/text/stringUtils` (they were needed outside `src/tools`); existing importers repointed; ~16 inline `${n} thing${n === 1 ? '' : 's'}` ternaries converted across tools, agent trace, tier service, controllers, and the Google handler; a third local `pluralize` copy in `figCommands.ts` deleted.
3. **`formatRelativeTime`** — `inquiryContinuation` drops its hand-rolled "5m ago" formatter for the canonical Intl-based one in `@shared/utils/string`.
4. **`isAbortError`** — promoted to `@common/errors/errorPredicates`; `agentCliShared` and `SupabaseSession` now share it.
5. **`getFileStem` in `@shared/utils/path`** — `fileListingRules` drops its local basename/stem pair; `desktopDiffMessages` and the `FileList` webview reuse `getBasename`/`normalizeFilePath` instead of hand-rolled slash arithmetic.
6. **`pathExists`** — the tools wrapper duplicated `AbsoluteFS.exists` (same `platform().fs.stat` probe); deleted, three users repointed.
7. **`IS_WINDOWS`/`IS_MACOS`** — `IS_MACOS` added beside `IS_WINDOWS` in `platformPaths`; seven inline `process.platform === '…'` comparisons standardized. The CLI's `initConfig` is deliberately left alone (its node-fs purity is documented design).
8. **`capitalize`** — GoalTab's local `statusLabel` replaced with the shared helper.
9. **`isoDateOnly`** — new helper for the duplicated `toISOString().slice(0, 10)` date stamps (workspace info, chat export).
10. **`clamp`** — four `Math.min(Math.max(…))` chains in the TUI (Select, ChildControlPicker ×2, SlashPalette) converted; each call site is guarded against the empty-list edge where the two forms differ.

### Intentional behavior changes

- **Timer leaks fixed** (item 1): the arXiv and Zotero inline timeout races kept their timers alive after the underlying promise settled; `withTimeout` always clears them.
- **Inquiry relative-time wording** (item 3): the "Still open on this stream" continuation lines change from the hand-rolled compact form (`just now` / `5m ago` / `3h ago` / `2d ago`) to the canonical `Intl.RelativeTimeFormat` output (`now` / `5 minutes ago` / `3 hours ago` / `2 days ago`, plus week/month/year buckets). Display-only text, not machine-parsed; unparseable timestamps now render as `''` instead of `NaNd ago`.
- **Truncation styling** (item 2 adjacent): converted plural phrases are byte-identical; the `0`-count edge in two `> 1`-style ternaries (`ExecutionsTool`, `externalToolDefs`) is unreachable behind existing `> 0` guards.

Considered and rejected: `formatSize` vs `formatBytes` (intentionally different display styles), `formatGoalTime` (documented as deliberately frontend-safe), the CLI ANSI parser (genuinely needed for position-aware wrapping).

## Verification

- `npm run typecheck` green across root, test-kernel, extension, CLI, and desktop (all four desktop tsconfigs)
- Full Vitest suite after rebasing onto latest main: **2813 passed, 3 skipped**
- `npm run lint`: 0 errors; the 6 warnings are pre-existing in files this PR doesn't touch

https://claude.ai/code/session_01QDbHWCxR14A9WmNTc4gqc1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Broad but behavior-preserving refactors with small, documented display and timer-cleanup changes; no auth, payment, or data-model changes.
> 
> **Overview**
> Second consolidation pass: **~50 files** replace hand-rolled helpers with shared utilities from `@utils/core`, `@utils/text/stringUtils`, `@shared/utils/path`, `@common/errors`, and `@utils/system/platformPaths`.
> 
> **New or promoted shared APIs:** `withTimeout` (replaces four `Promise.race`+timer patterns), `isAbortError`, `getFileStem`, `isoDateOnly`, `IS_MACOS`, and pluralization helpers moved from `@tools/formatting` to `@utils/text/stringUtils` with widespread call-site updates.
> 
> **Mechanical refactors:** TUI scroll windows use `clamp`; binary resolution uses `AbsoluteFS.exists` and `IS_WINDOWS`; file listing and Monaco language detection use `getBasename`/`normalizeFilePath`/`getFileStem`; many inline plural and date strings use `formatResultCount` / `pluralize` / `capitalize` / `isoDateOnly`.
> 
> **Notable behavior changes:** arXiv/Zotero timeouts now clear timers after settle; inquiry “still open” lines use `Intl.RelativeTimeFormat` instead of compact `5m ago` strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2a6d1e4d263cb66f3a3de279cdc4524852ff81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->