### PR TITLE
fix(cli): tighten startup and transcript spacing

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -108,6 +108,8 @@ const SHOW_AGENT_PROPOSAL = process.env.HARNESS_AGENT_PROPOSAL === '1';
 const PLAN_APPROVAL_GOAL = process.env.HARNESS_PLAN_APPROVAL_GOAL === '1';
 const SHOW_SUBAGENT_FOLLOWUPS = process.env.HARNESS_SUBAGENT_FOLLOWUPS === '1';
 const SHOW_LONG_TOOL_OUTPUT = process.env.HARNESS_LONG_TOOL_OUTPUT === '1';
+const SHOW_ASSISTANT_TOOL_PREAMBLE =
+  process.env.HARNESS_ASSISTANT_TOOL_PREAMBLE === '1';
 const SHOW_LIVE_TOOL_ONLY = process.env.HARNESS_LIVE_TOOL_ONLY === '1';
 const LIVE_TOOL_COUNT = Math.max(
   1,
@@ -474,6 +476,41 @@ function makeLongToolOutputEntries(): ConversationEntry[] {
       text: '',
       finalized: true,
       toolUse: makeLongToolOutput(),
+    },
+  ];
+}
+
+function makeAssistantToolPreambleEntries(): ConversationEntry[] {
+  return [
+    {
+      id: 'preamble-user',
+      role: 'user',
+      text: 'what is this repo about',
+      finalized: true,
+    },
+    {
+      id: 'preamble-assistant',
+      role: 'assistant',
+      text: 'I will read the README first.',
+      finalized: true,
+    },
+    {
+      id: 'preamble-tool',
+      role: 'tool',
+      text: '',
+      finalized: true,
+      toolUse: {
+        parsed: {},
+        toolName: 'read_file',
+        errorText: '',
+        outputText: '',
+        userInstructionText: '',
+        input: { path: 'README.md' },
+        isError: false,
+        isUserFeedback: false,
+        headerSummary: 'Read README.md',
+        status: TOOL_USE_STATUS.COMPLETED,
+      },
     },
   ];
 }
@@ -881,9 +918,11 @@ patchStream(STREAM_ID, (slice) => ({
     ? makeRejectedBashToolEntries()
     : SHOW_LONG_TOOL_OUTPUT
       ? makeLongToolOutputEntries()
-      : SHOW_LIVE_TOOL_ONLY
-        ? []
-        : makeEntries(ENTRY_COUNT),
+      : SHOW_ASSISTANT_TOOL_PREAMBLE
+        ? makeAssistantToolPreambleEntries()
+        : SHOW_LIVE_TOOL_ONLY
+          ? []
+          : makeEntries(ENTRY_COUNT),
   queuedFollowUps: QUEUED_FOLLOW_UPS.length,
   queuedFollowUpMessages: QUEUED_FOLLOW_UPS,
 }));

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -153,6 +153,24 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'assistant-tool-preamble-spacing',
+    env: {
+      HARNESS_ASSISTANT_TOOL_PREAMBLE: '1',
+    },
+    expect: [
+      '› what is this repo about',
+      'I will read the README first.',
+      '● read_file (Read README.md)',
+    ],
+    maxBlankLinesBetween: [
+      {
+        from: 'I will read the README first.',
+        to: '● read_file (Read README.md)',
+        max: 0,
+      },
+    ],
+  },
+  {
     name: 'queued-followups',
     cols: 120,
     env: {

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -25,7 +25,9 @@ import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import { isRenderableTranscriptEntry } from './transcriptEntries';
 import {
+  ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS,
   isInquiryContinuationText,
+  PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
   TranscriptEntry,
   USER_ENTRY_MARGIN_BOTTOM_ROWS,
 } from './TranscriptEntry';
@@ -165,10 +167,18 @@ function staticTranscriptItemRowCount(
     item.entry,
     Math.max(1, Math.floor(width ?? 80)),
   ).length;
-  return item.entry.role === 'user' &&
+  let marginRows = 0;
+  if (
+    item.entry.role === 'user' &&
     !isInquiryContinuationText(item.entry.text)
-    ? lines + USER_ENTRY_MARGIN_BOTTOM_ROWS
-    : lines;
+  ) {
+    marginRows = USER_ENTRY_MARGIN_BOTTOM_ROWS;
+  } else if (item.entry.role === 'assistant') {
+    marginRows = ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS;
+  } else if (item.entry.role === 'process') {
+    marginRows = PROCESS_ENTRY_MARGIN_BOTTOM_ROWS;
+  }
+  return lines + marginRows;
 }
 
 export function appendStaticTranscriptItems({

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -21,6 +21,8 @@ import type {
 const INQUIRY_CONTINUATION_RE =
   /^\[inquiry\]\s+\S+\s+(?:answered|dropped by user)\.(?:\n|$)/;
 export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 0;
+export const ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS = 0;
+export const PROCESS_ENTRY_MARGIN_BOTTOM_ROWS = 1;
 
 export function isInquiryContinuationText(text: string): boolean {
   return INQUIRY_CONTINUATION_RE.test(text);
@@ -156,7 +158,11 @@ function ProcessEntryRow({
   if (fillWidth === true) {
     const cols = Math.max(1, Math.floor(width ?? 80) - 2);
     return (
-      <Box marginBottom={1} paddingX={1} flexDirection="column">
+      <Box
+        marginBottom={PROCESS_ENTRY_MARGIN_BOTTOM_ROWS}
+        paddingX={1}
+        flexDirection="column"
+      >
         <Text>
           {fillRows(completedProcessDisplayLines(process).join('\n'), cols)}
         </Text>
@@ -167,7 +173,11 @@ function ProcessEntryRow({
   const color = process.isError ? 'red' : 'green';
   const [, ...tailLines] = completedProcessDisplayLines(process);
   return (
-    <Box marginBottom={1} paddingX={1} flexDirection="column">
+    <Box
+      marginBottom={PROCESS_ENTRY_MARGIN_BOTTOM_ROWS}
+      paddingX={1}
+      flexDirection="column"
+    >
       <Box>
         <Text color={color}>● </Text>
         <Text>{process.title}</Text>
@@ -263,7 +273,7 @@ export const TranscriptEntry = memo(function TranscriptEntry({
       break;
   }
   return (
-    <Box marginBottom={1}>
+    <Box marginBottom={ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS}>
       <Markdown
         content={entry.text}
         width={width}

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -3,8 +3,10 @@
 import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
 import {
+  ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS,
   isInquiryContinuationText,
   LIVE_TAIL_ROWS,
+  PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
   USER_ENTRY_MARGIN_BOTTOM_ROWS,
   tailWindow,
 } from './TranscriptEntry';
@@ -45,13 +47,19 @@ export function estimateTranscriptEntryRows(
   if (entry.role === 'process' && entry.process) {
     const process = entry.process;
     return estimateEntryRows(() => {
-      return Math.max(1, completedProcessDisplayLines(process).length) + 1;
+      return (
+        Math.max(1, completedProcessDisplayLines(process).length) +
+        PROCESS_ENTRY_MARGIN_BOTTOM_ROWS
+      );
     });
   }
   if (entry.role === 'assistant') {
     return estimateEntryRows(() => {
       const rendered = renderAnsiMarkdown(entry.text, { width });
-      return Math.max(1, rendered.split('\n').length) + 1;
+      return (
+        Math.max(1, rendered.split('\n').length) +
+        ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS
+      );
     });
   }
   if (entry.role === 'user') {

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -8,7 +8,10 @@ import {
   formatCliMultiAgentPresetLauncherSummary,
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
-import { implicitDefaultToolUseAgents } from './defaultAgents';
+import {
+  BUILTIN_DEFAULT_CHAT_AGENT,
+  implicitDefaultToolUseAgents,
+} from './defaultAgents';
 import { formatCliHistoryResumeSummary } from './historyLabels';
 import {
   resumableCliHistoryEntries,
@@ -99,6 +102,7 @@ function recentAgentItems(
 
   for (const entry of history) {
     if (entry.category && entry.category !== AgentCategory.ToolUse) continue;
+    if (entry.agent === BUILTIN_DEFAULT_CHAT_AGENT) continue;
     if (!toolUseNames.has(entry.agent) || seen.has(entry.agent)) continue;
     seen.add(entry.agent);
     items.push({

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -112,6 +112,21 @@ function compactExecutionsEntry(id: string, path: string): ConversationEntry {
   };
 }
 
+function processEntry(id: string): ConversationEntry {
+  return {
+    id,
+    role: 'process',
+    text: '',
+    finalized: true,
+    process: {
+      executionId: 'ei_process',
+      title: 'search',
+      isError: false,
+      tailLines: [],
+    },
+  };
+}
+
 describe('CLI conversation transcript splitting', () => {
   it('keeps only explicit finalized entries in scrollback', () => {
     const user = entry('u1', 'user', '1+1', true);
@@ -547,6 +562,40 @@ describe('CLI conversation transcript splitting', () => {
       'u1',
       'a1',
     ]);
+  });
+
+  it('budgets process margins before inserting compact static headers', () => {
+    const process = processEntry('p1');
+    const compact = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: [],
+      streams: streamsFromEntries(STREAM_ID, [process]),
+      meta: SESSION_META,
+      maxRows: 0,
+      width: 80,
+    });
+
+    expect(compact.map((item) => item.id)).toEqual(['p1']);
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: STREAM_ID,
+        currentItems: compact,
+        streams: streamsFromEntries(STREAM_ID, [process]),
+        meta: SESSION_META,
+        maxRows: 5,
+        width: 80,
+      }).map((item) => item.id),
+    ).toEqual(['p1']);
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: STREAM_ID,
+        currentItems: compact,
+        streams: streamsFromEntries(STREAM_ID, [process]),
+        meta: SESSION_META,
+        maxRows: 6,
+        width: 80,
+      }).map((item) => item.id),
+    ).toEqual(['session-header', 'p1']);
   });
 
   it('preserves static transcript order when an entry exceeds the compact row budget', () => {

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -302,6 +302,21 @@ describe('CLI orchestration items', () => {
     );
   });
 
+  it('does not duplicate the default chat agent in startup recent agents', () => {
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [
+        historyEntry('aaaaaaaaaaaa', { agent: 'chat' }),
+        historyEntry('bbbbbbbbbbbb', { agent: 'review' }),
+      ],
+      toolUseAgents: [toolUseAgent('chat'), toolUseAgent('review')],
+    });
+
+    expect(items.map((item) => item.label)).toContain('New chat');
+    expect(items.map((item) => item.label)).toContain('Chat with review');
+    expect(items.map((item) => item.label)).not.toContain('Chat with chat');
+  });
+
   it('lists team presets as runnable orchestration actions', () => {
     const items = buildCliOrchestrationItems({
       presetPlans: [readyPresetPlan()],

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2131,7 +2131,7 @@ describe('CLI transcript state', () => {
       finalized: true,
     } as const;
 
-    expect(estimateTranscriptEntryRows(entry, width)).toBe(renderedRows + 1);
+    expect(estimateTranscriptEntryRows(entry, width)).toBe(renderedRows);
   });
 
   it('does not reserve spacer rows for compact one-line tool calls', () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -437,6 +437,7 @@ describe('StreamSnapshotStore', () => {
       plan: PLAN,
       planSummary: PLAN.summary,
     });
+    await store.flush();
   });
 
   it('deleteStream cancels queued writes before removing the sidecar directory', async () => {


### PR DESCRIPTION
## Summary
- hide the built-in default chat agent from startup recent-agent rows so the launcher does not show both `New chat` and `Chat with chat`
- remove the assistant transcript row trailing spacer and share that margin contract with the row estimator
- add a PTY harness scenario for a short assistant preamble immediately followed by a tool row

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run texra-local:build`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-pr-spacing-full` (117 scenarios)
- `corepack pnpm vitest run`

## Dogfood
- Real PTY startup no longer showed `Chat with chat` as a recent-agent duplicate.
- Real PTY chat showed the status-bar `thinking...` indicator during hidden thinking streams.
- New harness snapshot confirms no blank line between `I will read the README first.` and `● read_file (Read README.md)`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI spacing and launcher list filtering only; no auth, data, or API behavior changes.
> 
> **Overview**
> Tightens **CLI launcher** and **transcript spacing** so startup and chat read cleaner.
> 
> **Startup:** Recent-agent rows from history no longer include the built-in default `chat` agent, so the launcher does not show both **New chat** and **Chat with chat**.
> 
> **Transcript:** Assistant rows drop the extra trailing blank line before the next entry (e.g. a tool row). Shared margin constants (`ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS`, `PROCESS_ENTRY_MARGIN_BOTTOM_ROWS`) align **rendering**, **viewport row estimates**, and **compact static scrollback budgeting**; process rows still reserve one bottom margin row.
> 
> **Regression coverage:** A TUI harness scenario (`HARNESS_ASSISTANT_TOOL_PREAMBLE`) and a `validate-tui` case assert zero blank lines between a short assistant preamble and the following tool line; unit tests cover orchestration deduping and process margin budgeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e794b8d670c66277d145f72e20f6ec071b58040d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->