### PR TITLE
refactor: eliminate ten pass-through thin layers

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -44,7 +44,7 @@ import {
   rewriteKittyEnterInput,
 } from './input/inputKeys';
 import {
-  hasChildExecutionRows,
+  hasChildControlItems,
   numericFocusTargetForActiveStream,
   resolveChildControlDisplayTargets,
   type ChildControlMode,
@@ -575,7 +575,7 @@ export function App(props: AppProps): React.JSX.Element {
   const taskControlsAvailable = childControlTargets.tasks.hasItems;
   const subagentControlsAvailable = childControlTargets.subagents.hasItems;
   const hasSubagentPanel =
-    !foregroundOpen && hasChildExecutionRows(activeSlice);
+    !foregroundOpen && hasChildControlItems(activeSlice, 'tasks');
   const hasTodosPlanPanel = shouldShowTodosPlanPanel({
     foregroundOpen,
     hasPlan: activeSlice?.plan != null,

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -414,14 +414,6 @@ export function liveChildExecutionElapsedKey(
   return liveKeys.length > 0 ? liveKeys.join(',') : undefined;
 }
 
-export function hasChildExecutionRows(
-  slice:
-    | Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'childStreams'>
-    | undefined,
-): boolean {
-  return hasChildControlItems(slice, 'tasks');
-}
-
 export function numericFocusTargetForActiveStream(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -14,11 +14,7 @@ import type {
 
 export const COMPLETED_PROCESS_TAIL_LINES = 20;
 
-export function isCompletedProcessError(status: string | undefined): boolean {
-  return isChildExecutionErrorStatus(status);
-}
-
-function completedProcessTailLines(
+export function completedProcessTailLines(
   tail: ProcessOutputTail | undefined,
 ): string[] {
   if (!tail) return [];
@@ -39,7 +35,7 @@ export function buildCompletedProcessTranscript(
     title: info.agentName || info.toolName || info.executionId,
     status,
     elapsed: info.elapsed,
-    isError: isCompletedProcessError(status),
+    isError: isChildExecutionErrorStatus(status),
     tailLines: completedProcessTailLines(tail),
   };
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,5 +1,6 @@
 import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 
 import { CLI_BUILTIN_DEFAULT_MODEL } from '../runtime/cliConfig';
 import {
@@ -18,7 +19,6 @@ import {
   buildInitConfig,
   configFileExists,
   ensureTexraGitignored,
-  initConfigPath,
   writeInitConfig,
   type InitAnswers,
 } from '../runtime/initConfig';
@@ -106,7 +106,7 @@ async function runInit(
   // included models), so the picker annotates and defaults correctly.
   await initCliPlatform({ ...context, quietLogs: true });
 
-  const filePath = initConfigPath(context.cwd);
+  const filePath = workspaceTexraConfigPath(context.cwd);
   if (!opts.force && (await configFileExists(filePath))) {
     writeTextStderr(
       `Refusing to overwrite existing config at ${filePath}. Re-run with --force to replace it.`,

--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -7,10 +7,7 @@
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import {
-  TEXRA_STORAGE_DIR_NAME,
-  workspaceTexraConfigPath,
-} from '@platform/defaults/nodeStorage';
+import { TEXRA_STORAGE_DIR_NAME } from '@platform/defaults/nodeStorage';
 
 import type {
   CliApprovalPolicy,
@@ -30,14 +27,6 @@ export interface InitConfigShape {
   readonly outputFormat: CliOutputFormat;
   readonly approvalPolicy: CliApprovalPolicy;
   readonly chat: { readonly agent: string; readonly model: string };
-}
-
-/**
- * Resolve the workspace config file path. (User-scope config lives in global
- * storage with a different shape and loader; bootstrapping it is a follow-up.)
- */
-export function initConfigPath(cwd: string): string {
-  return workspaceTexraConfigPath(cwd);
 }
 
 /** Map wizard answers to the canonical config object. */

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -5,7 +5,6 @@ import {
   createCommandPalette,
   executeCommandPaletteEntry,
   filterCommandPaletteEntries,
-  getNextCommandPaletteIndex,
   isCommandPaletteShortcut,
   type CommandPaletteController,
   type CommandPaletteEntry,
@@ -41,14 +40,6 @@ export function filterDesktopCommandPaletteEntries(
   // label). The shared helper consults `category` first, then `meta`, so the
   // existing search behaviour (label + category + id) is preserved.
   return filterCommandPaletteEntries(entries, query);
-}
-
-export function getNextDesktopCommandPaletteIndex(
-  currentIndex: number,
-  itemCount: number,
-  delta: number,
-): number {
-  return getNextCommandPaletteIndex(currentIndex, itemCount, delta);
 }
 
 export function executeDesktopCommandPaletteEntry(

--- a/packages/extension/src/commands/agent/agentTemplateRenderer.ts
+++ b/packages/extension/src/commands/agent/agentTemplateRenderer.ts
@@ -76,14 +76,6 @@ const DEFAULT_TOOLS_YAML = [
   .map((t) => `    - ${t}`)
   .join('\n');
 
-function buildRenderVars(vars: AgentTemplateVars): Record<string, string> {
-  return {
-    AGENT_NAME: vars.agentName,
-    DESCRIPTION: vars.description,
-    TOOLS_YAML: vars.toolsYaml ?? DEFAULT_TOOLS_YAML,
-  };
-}
-
 /**
  * Render a template string with agent-runtime-token passthrough applied.
  *
@@ -117,5 +109,9 @@ export async function renderAgentTemplateFromBundle(
     FILES[kind],
   );
   const raw = await AbsoluteFS.read(templatePath);
-  return renderAgentTemplateString(raw, buildRenderVars(vars));
+  return renderAgentTemplateString(raw, {
+    AGENT_NAME: vars.agentName,
+    DESCRIPTION: vars.description,
+    TOOLS_YAML: vars.toolsYaml ?? DEFAULT_TOOLS_YAML,
+  });
 }

--- a/packages/extension/src/frontend/approval/DiffViewHost.ts
+++ b/packages/extension/src/frontend/approval/DiffViewHost.ts
@@ -1,6 +1,0 @@
-export type {
-  DiffOptions,
-  DiffSession,
-  DiffSource,
-  DiffViewHost,
-} from '@hosts/diffViewHost';

--- a/packages/extension/src/frontend/approval/VscodeDiffViewHost.ts
+++ b/packages/extension/src/frontend/approval/VscodeDiffViewHost.ts
@@ -7,7 +7,7 @@ import {
   type DiffSession,
   type DiffSource,
   type DiffViewHost,
-} from '@frontend/approval/DiffViewHost';
+} from '@hosts/diffViewHost';
 import { REVEAL_TIMEOUT_MS } from '@tools/approval/toolEditApproval';
 
 export class VscodeDiffViewHost implements DiffViewHost {

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -15,12 +15,12 @@ import * as vscode from 'vscode';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { isLatexFile } from '@common/files/fileTypeUtils';
+import { VscodeDiffViewHost } from '@frontend/approval/VscodeDiffViewHost';
 import {
   type DiffSession,
   type DiffSource,
   type DiffViewHost,
-} from '@frontend/approval/DiffViewHost';
-import { VscodeDiffViewHost } from '@frontend/approval/VscodeDiffViewHost';
+} from '@hosts/diffViewHost';
 import type { StreamTabId } from '@shared/schemas';
 import type { LineChanges } from '@tools/result';
 import {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -41,11 +41,11 @@ import type {
   FileInteractionState,
   WorkPlanState,
 } from '@agent/core/execution/AgentWorkspaceState';
-import type { ToolResult } from '@agent/core/tools/ToolTypes';
 import { toErrorMessage } from '@common/errors';
 
 // Local imports - logging
 import { MESSAGE_TYPES } from '@shared/schemas';
+import type { ToolResult } from '@tools/result';
 import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesForDiagnostics,

--- a/src/agent/core/tools/ToolTypes.ts
+++ b/src/agent/core/tools/ToolTypes.ts
@@ -1,20 +1,9 @@
 /**
  * Core tool type definitions: ITool, IToolRegistry, MapToolRegistry.
- * Re-exports ToolResult types from @tools/result and ToolDefinition from @model.
  */
 
 import type { ToolDefinition as ToolDefinitionType } from '@model/ToolDefinition';
 import type { ToolResult as ToolResultType } from '@tools/result';
-
-export type {
-  ToolResult,
-  ErrorDiagnostics,
-  DiagnosticsPayload,
-  ToolFileAttachment,
-} from '@tools/result';
-export { ToolError } from '@tools/result';
-
-export type { ToolDefinition } from '@model/ToolDefinition';
 
 /**
  * Contract for tool implementations.

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { LitElement } from 'lit';
-import { provide } from '@lit/context';
+import { createContext, provide } from '@lit/context';
 import { state } from 'lit/decorators.js';
 
 // Local imports - shared handlers
@@ -9,13 +9,12 @@ import { postMessage } from '@shared/hostBridge';
 import { installToolbarTooltips } from '@shared/controllers';
 import { handleCommonMessage } from '@shared/handlers/commonMessageHandlers';
 
-// Local imports - shared contexts
-import { themeContext } from '@shared/contexts/themeContext';
-
 // Local imports - webview commands
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 import { setWaColorScheme } from '@shared/wa/waColorScheme';
 import { themeIsDark } from '@shared/wa/hostTheme';
+
+export const themeContext = createContext<string>('shared-theme');
 
 /**
  * Base class for Lit-powered webview apps.

--- a/src/shared/contexts/themeContext.ts
+++ b/src/shared/contexts/themeContext.ts
@@ -1,3 +1,0 @@
-import { createContext } from '@lit/context';
-
-export const themeContext = createContext<string>('shared-theme');

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -29,7 +29,7 @@ import {
   buildChildControlItems,
   childElapsed,
   childPickerKeyAction,
-  hasChildExecutionRows,
+  hasChildControlItems,
   liveChildExecutionElapsedKey,
   nextPickerIndex,
   numericFocusTargetForActiveStream,
@@ -550,7 +550,7 @@ describe('CLI child execution controls', () => {
         status: 'completed',
       },
     ]);
-    expect(hasChildExecutionRows(state)).toBe(true);
+    expect(hasChildControlItems(state, 'tasks')).toBe(true);
   });
 
   it('opens the child side panel when only retained subagent streams remain', () => {
@@ -565,7 +565,7 @@ describe('CLI child execution controls', () => {
       ],
     });
 
-    expect(hasChildExecutionRows(state)).toBe(true);
+    expect(hasChildControlItems(state, 'tasks')).toBe(true);
   });
 
   it('falls back to the parent subagent list when the focused child is a leaf', () => {

--- a/src/test-kernel/cli/InitConfig.vitest.mts
+++ b/src/test-kernel/cli/InitConfig.vitest.mts
@@ -2,10 +2,10 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import {
   buildInitConfig,
   gitignoreWithTexra,
-  initConfigPath,
   serializeInitConfig,
   type InitAnswers,
 } from '@cli/runtime/initConfig';
@@ -37,9 +37,9 @@ describe('serializeInitConfig', () => {
   });
 });
 
-describe('initConfigPath', () => {
+describe('workspaceTexraConfigPath', () => {
   it('resolves the workspace path under cwd', () => {
-    expect(initConfigPath('/projects/paper')).toBe(
+    expect(workspaceTexraConfigPath('/projects/paper')).toBe(
       path.join('/projects/paper', '.texra', 'config.json'),
     );
   });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -36,10 +36,7 @@ import {
   nextFocusBack,
   nextFocusForward,
 } from '@cli/chat/tui/state/focusCycle';
-import {
-  hasChildControlItems,
-  hasChildExecutionRows,
-} from '@cli/chat/tui/state/childControls';
+import { hasChildControlItems } from '@cli/chat/tui/state/childControls';
 import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
 import {
   finalizeSettledPrefix,
@@ -53,8 +50,8 @@ import {
   COMPLETED_PROCESS_TAIL_LINES,
   buildCompletedProcessTranscript,
   completedProcessDisplayLines,
-  isCompletedProcessError,
 } from '@cli/chat/tui/state/completedProcessTranscript';
+import { isChildExecutionErrorStatus } from '@cli/chat/tui/state/childExecutionStatus';
 import {
   estimateTranscriptEntryRows,
   selectTranscriptEntriesForViewport,
@@ -170,7 +167,6 @@ describe('cliState Phase 4 fields', () => {
     }));
     patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
 
-    expect(hasChildExecutionRows(cliState.streams.get().get(root))).toBe(true);
     expect(
       hasChildControlItems(cliState.streams.get().get(root), 'tasks'),
     ).toBe(true);
@@ -188,7 +184,6 @@ describe('cliState Phase 4 fields', () => {
     expect(parent.activeSubagents).toEqual([]);
     expect(parent.activeProcesses).toEqual([]);
     expect(visibleSubagentRows(parent)).toEqual([]);
-    expect(hasChildExecutionRows(parent)).toBe(false);
     expect(hasChildControlItems(parent, 'tasks')).toBe(false);
     expect(hasChildControlItems(parent, 'subagents')).toBe(false);
     expect(nextFocusForward()).toBeUndefined();
@@ -2506,11 +2501,11 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
   });
 
   it('classifies completed process error statuses', () => {
-    expect(isCompletedProcessError('running')).toBe(false);
-    expect(isCompletedProcessError('exit 0')).toBe(false);
-    expect(isCompletedProcessError('exit 1')).toBe(true);
-    expect(isCompletedProcessError('exited with code 2')).toBe(true);
-    expect(isCompletedProcessError('failed')).toBe(true);
+    expect(isChildExecutionErrorStatus('running')).toBe(false);
+    expect(isChildExecutionErrorStatus('exit 0')).toBe(false);
+    expect(isChildExecutionErrorStatus('exit 1')).toBe(true);
+    expect(isChildExecutionErrorStatus('exited with code 2')).toBe(true);
+    expect(isChildExecutionErrorStatus('failed')).toBe(true);
   });
 
   it('does not keep a stale running status after a process leaves the active list', () => {

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -36,11 +36,6 @@ interface DesktopCommandPaletteModule {
     entries: DesktopPaletteEntry[],
     query: string,
   ): DesktopPaletteEntry[];
-  getNextDesktopCommandPaletteIndex(
-    currentIndex: number,
-    itemCount: number,
-    delta: number,
-  ): number;
   executeDesktopCommandPaletteEntry(
     entry: DesktopPaletteEntry | undefined,
     actions: {
@@ -135,13 +130,13 @@ describe('desktop command palette', () => {
   });
 
   it('wraps active command selection through filtered entries', async () => {
-    const { getNextDesktopCommandPaletteIndex } =
-      await loadDesktopCommandPalette();
+    const { getNextCommandPaletteIndex } =
+      await import('@shared/wa/commandPalette');
 
-    expect(getNextDesktopCommandPaletteIndex(0, 3, 1)).toBe(1);
-    expect(getNextDesktopCommandPaletteIndex(2, 3, 1)).toBe(0);
-    expect(getNextDesktopCommandPaletteIndex(0, 3, -1)).toBe(2);
-    expect(getNextDesktopCommandPaletteIndex(0, 0, 1)).toBe(-1);
+    expect(getNextCommandPaletteIndex(0, 3, 1)).toBe(1);
+    expect(getNextCommandPaletteIndex(2, 3, 1)).toBe(0);
+    expect(getNextCommandPaletteIndex(0, 3, -1)).toBe(2);
+    expect(getNextCommandPaletteIndex(0, 0, 1)).toBe(-1);
   });
 
   it('does not dispatch disabled command palette entries', async () => {

--- a/src/tools/arxiv/index.ts
+++ b/src/tools/arxiv/index.ts
@@ -1,3 +1,0 @@
-export { ArxivDownloadTool } from './ArxivDownloadTool';
-export { ArxivMetadataTool } from './ArxivMetadataTool';
-export { ArxivSearchTool } from './ArxivSearchTool';

--- a/src/tools/citation/index.ts
+++ b/src/tools/citation/index.ts
@@ -1,2 +1,0 @@
-export { CrossrefDoiTool } from './CrossrefDoiTool';
-export { CrossrefSearchTool } from './CrossrefSearchTool';

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -2,16 +2,14 @@
 import { ZodError, type ZodType } from 'zod';
 
 // Local imports - core tool types (single source of truth)
-import type {
-  ITool,
-  ToolDefinition,
-  ToolResult,
-} from '@agent/core/tools/ToolTypes';
+import type { ITool } from '@agent/core/tools/ToolTypes';
 import { toErrorMessage } from '@common/errors';
+import type { ToolDefinition } from '@model/ToolDefinition';
 import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesAsMessage,
   formatZodIssuesForDiagnostics,
+  type ToolResult,
 } from '@tools/result';
 
 /**

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -22,7 +22,9 @@ import {
   ExtractLatexFiguresTool,
   ExtractTikzFiguresTool,
 } from './latex';
-import { ArxivDownloadTool, ArxivMetadataTool, ArxivSearchTool } from './arxiv';
+import { ArxivDownloadTool } from './arxiv/ArxivDownloadTool';
+import { ArxivMetadataTool } from './arxiv/ArxivMetadataTool';
+import { ArxivSearchTool } from './arxiv/ArxivSearchTool';
 import { ReadFileTool } from './ReadTool';
 import { TextEditorTool } from './TextEditorTool';
 import { WriteFileTool } from './WriteTool';
@@ -30,17 +32,16 @@ import { WebFetchTool } from './web/WebFetchTool';
 import { WebSearchTool } from './web/WebSearchTool';
 import { WolframTool } from './wolfram/WolframTool';
 import { TexcountTool } from './texcount/TexcountTool';
-import { CrossrefDoiTool, CrossrefSearchTool } from './citation';
+import { CrossrefDoiTool } from './citation/CrossrefDoiTool';
+import { CrossrefSearchTool } from './citation/CrossrefSearchTool';
 import { PlanTool } from './plan/PlanTool';
 import { TodoWriteTool } from './todo/TodoTool';
 import { MemoryTool } from './memory/MemoryTool';
 import { OpenPdfTool } from './OpenPdfTool';
-import {
-  ZoteroAddTool,
-  ZoteroCollectionsTool,
-  ZoteroSearchTool,
-  ZoteroExportTool,
-} from './zotero';
+import { ZoteroAddTool } from './zotero/ZoteroAddTool';
+import { ZoteroCollectionsTool } from './zotero/ZoteroCollectionsTool';
+import { ZoteroExportTool } from './zotero/ZoteroExportTool';
+import { ZoteroSearchTool } from './zotero/ZoteroSearchTool';
 import { CodexTool } from './codex';
 import { ClaudeAgentTool } from './claudeAgent';
 import { CLAUDE_AGENT_NAME } from './claudeAgentShared';

--- a/src/tools/zotero/index.ts
+++ b/src/tools/zotero/index.ts
@@ -1,4 +1,0 @@
-export { ZoteroAddTool } from './ZoteroAddTool';
-export { ZoteroCollectionsTool } from './ZoteroCollectionsTool';
-export { ZoteroSearchTool } from './ZoteroSearchTool';
-export { ZoteroExportTool } from './ZoteroExportTool';


### PR DESCRIPTION
## Summary

Third cleanup batch after #5764: eliminates pass-through thin layers by deleting wrappers and retargeting callers at the canonical owner. This branch was rebased after #5770; auth/factory flattening is intentionally out of scope here and remains owned by #5770.

Changes in the current diff:

- Remove three dead tool barrels (`tools/arxiv`, `tools/citation`, `tools/zotero`) and import concrete tool modules directly from the registry.
- Delete the `frontend/approval/DiffViewHost.ts` type re-export; approval code imports `@hosts/diffViewHost` directly.
- Drop `hasChildExecutionRows`; TUI code calls `hasChildControlItems(slice, 'tasks')` directly.
- Drop `isCompletedProcessError`; completed process transcript code uses `isChildExecutionErrorStatus` directly while keeping `completedProcessTailLines` as the owner of tail normalization.
- Drop `initConfigPath`; `texra init` uses the canonical workspace config path helper.
- Drop `getNextDesktopCommandPaletteIndex`; tests target the shared `getNextCommandPaletteIndex` helper directly.
- Remove pass-through type exports from `ToolTypes`; consumers import `ToolResult` / `ToolDefinition` from their owning modules.
- Inline single-use agent template render vars and the unused theme context module.

## Verification

- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/InitConfig.vitest.mts src/test-kernel/desktop/DesktopCommandPalette.vitest.mts`
- `corepack pnpm run typecheck`
- `npm run lint -- --quiet`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical import and alias removal with tests retargeted; no auth, data, or runtime logic changes in the diff.
> 
> **Overview**
> Removes pass-through wrappers and barrel re-exports so callers import the canonical modules directly, with no intended behavior changes.
> 
> **CLI TUI:** Drops `hasChildExecutionRows` in favor of `hasChildControlItems(slice, 'tasks')` for the subagent side panel. Drops `isCompletedProcessError` and uses `isChildExecutionErrorStatus` when building completed process transcripts; exports `completedProcessTailLines` where tests need it.
> 
> **CLI init:** Removes `initConfigPath`; `texra init` and tests use `workspaceTexraConfigPath` from `@platform/defaults/nodeStorage`.
> 
> **Desktop:** Removes `getNextDesktopCommandPaletteIndex`; palette wrap tests target shared `getNextCommandPaletteIndex`.
> 
> **Extension:** Deletes the `DiffViewHost` type re-export; VS Code approval code imports `@hosts/diffViewHost`. Inlines agent template render vars in `renderAgentTemplateFromBundle`.
> 
> **Shared / agent / tools:** Inlines `themeContext` into `BaseWebviewApp` and removes `shared/contexts/themeContext`. Strips `ToolTypes` re-exports of `ToolResult` / `ToolDefinition`; `ToolUseCycleFlow`, `BaseTool`, and the registry import `@tools/result` and concrete tool paths instead of `tools/{arxiv,citation,zotero}/index.ts` barrels.
> 
> Tests are updated to exercise the underlying helpers rather than deleted aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c9823780c776fc55c84fbaeaf9ef84c278aa133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->