### PR TITLE
docs: refresh CLAUDE.md to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,16 +16,16 @@ TeXRA is a VS Code extension that serves as an AI-powered LaTeX research assista
 # Install dependencies
 corepack pnpm install
 
-# Development build (recommended - uses esbuild + Vite, much faster)
+# Development build (esbuild + Vite)
 npm run compile:fast
 
-# Development build with watch mode (recommended)
+# Development build with watch mode
 npm run watch:fast
 
-# Production build (recommended - uses esbuild + Vite)
+# Production build
 npm run package:fast
 
-# Build VSIX extension file (recommended)
+# Build VSIX extension file
 npm run build:fast
 # Creates: releases/texra-{version}.vsix
 
@@ -42,9 +42,9 @@ npm run format
 npm test
 ```
 
-### Fast Builds (Recommended)
+### Builds and Type Checking
 
-The project supports fast builds using esbuild (for the extension host) and Vite (for webviews):
+All builds use esbuild (for the extension host) and Vite (for webviews); the legacy webpack pipeline has been removed, and `npm run compile` / `watch` / `package` are aliases for the `:fast` variants:
 
 - `npm run compile:fast` - Development build
 - `npm run watch:fast` - Watch mode for development
@@ -52,9 +52,7 @@ The project supports fast builds using esbuild (for the extension host) and Vite
 - `npm run build:fast` - Build VSIX extension file
 - `npm run build:initial` - Build desktop plus VSIX artifacts and verify both
 
-These commands are significantly faster and do not require increased memory allocation.
-
-**Important:** Fast builds do NOT perform TypeScript type checking (esbuild only strips types). To verify there are no type errors, run:
+**Important:** These builds do NOT perform TypeScript type checking (esbuild only strips types). To verify there are no type errors, run:
 
 ```bash
 npm run typecheck
@@ -82,9 +80,9 @@ needed. Re-run `texra-local:build` to refresh. Override the install dir with
 
 The core of TeXRA is its agent architecture in repo-root `src/agent/`:
 
-- **Core interfaces** define agent behavior and state management
-- **Implementations** provide reasoning strategies (Direct, Chain-of-Thought, Merge, Workflow)
-- **Model handlers** abstract AI provider APIs (Anthropic, OpenAI, Google, etc.)
+- **`core/`** holds the host-agnostic domain model, organized by bounded concern: `definition/` (what an agent is), `execution/` (run state), `usage/` (usage value objects), `tools/` (tool contracts), and `flows/` (reusable cycle primitives). See `src/agent/core/README.md` for the module map and dependency rules.
+- **`implementations/flows/`** provides the PocketFlow-based flow implementations (reflection, tooluse)
+- **`modelHandlers/`** abstracts AI provider APIs (Anthropic, OpenAI, Google, OpenRouter)
 - Agents are configured via YAML files in `packages/extension/resources/agents/`
 
 Agent prompts handle single and multi-document output through one unified YAML per agent. Workflow edit prompts use the input filenames as the output filenames, and agents that generate new artifacts may declare `defaultOutputFiles` and refer to `OUTPUT_FILES`.
@@ -97,6 +95,7 @@ This repository is a pnpm workspace:
 - `packages/extension/` holds the VS Code extension entrypoint, commands, webviews, and packaged resources.
 - `packages/desktop/` holds the Electron desktop shell and adapters around the shared core.
 - `packages/core/` exposes the shared core package surface for workspace consumers.
+- `packages/cli/` holds the `texra` terminal client (Ink TUI plus headless `texra run` / `--print` modes).
 - `src/hosts/` defines host capability ports used by both VS Code and Electron integrations.
 - `src/test-kernel/` contains Vitest suites for host-neutral and Electron-facing behavior.
 
@@ -104,9 +103,10 @@ This repository is a pnpm workspace:
 
 Key directories in `src/`:
 
-- `agent/` - Agent core, implementations, model handlers, runtime, toolUse, output, storage, remote, node
+- `agent/` - Agent core, implementations, model handlers, runtime, toolUse, output, storage, remote, node, trace, goal, features
   - `implementations/flows/` - PocketFlow-based flow implementations (reflection, tooluse)
-- `platform/` - Platform abstraction layer (composition root). Hosts (VS Code, future CLI/Electron) call `initPlatform()` once at startup; core code accesses host services via `platform()` from `@platform`. See `src/platform/platform.ts`.
+- `platform/` - Platform abstraction layer (composition root). Hosts (VS Code, CLI, Electron) call `initPlatform()` once at startup; core code accesses host services via `platform()` from `@platform`. See `src/platform/platform.ts`.
+- `controllers/` - Host-neutral orchestration for the main, progress, and settings views behind injected ports
 - `common/` - Backend-only helpers (errors, state, files, webview base classes)
 - `utils/` - Utilities shared between extension host and webviews
 - `tools/` - Tool implementations for tool-use agents
@@ -119,6 +119,9 @@ Key directories in `src/`:
 - `logger/` - Logging infrastructure
 - `eventBus/` - Progress event system
 - `replacement/` - Text cleanup rules
+- `skills/` - Skill schemas, loading, and runtime skill sources
+- `telemetry/` - Usage logging
+- `transcript/` - Stream logs, snapshots, and run transcript recording
 - `test-kernel/` - Vitest suites (run via `npm test`); shared fakes live in `test-kernel/support/`
 
 Key directories in `packages/extension/`:
@@ -128,7 +131,7 @@ Key directories in `packages/extension/`:
 - `packages/extension/src/frontend/` - Extension-host utilities for shared UI flows
 - `packages/extension/src/webview/` - Main agent interaction interface
 - `packages/extension/src/progressView/` - Task tracking board
-- `packages/extension/src/settingsView/` - Unified settings webview (History, Memory, Models, Agents, Multi-Agent, LaTeX, Tools tabs)
+- `packages/extension/src/settingsView/` - Unified settings webview (Memory, History, Models, Agents, Multi-Agent, Tools, AI Agents, Git, LaTeX, Goal tabs)
 - `packages/extension/resources/` - Packaged agents, tool-use agents, docs, templates, examples, and extension assets
 
 Key documentation in `docs/`:
@@ -137,6 +140,7 @@ Key documentation in `docs/`:
 
 ### Commands (`packages/extension/src/commands/`)
 
+- `_shared/` - Helpers shared across command domains
 - `agent/` - Running and managing agents, merge operations
 - `api/` - API key management
 - `auth/` - Authentication commands
@@ -147,6 +151,7 @@ Key documentation in `docs/`:
 - `latex/` - LaTeX operations (diff, figures, etc.)
 - `progress/` - Progress board management
 - `settings/` - Settings view commands
+- `setup/` - Setup assistant
 - `system/` - Help, tests, XML/YAML utilities, editor commands
 - `tests/` - Test commands
 
@@ -370,6 +375,7 @@ For good separation of concerns, testability, and platform independence, core bu
 - `src/shared/` (IPC schemas, message types)
 - `src/replacement/` (text cleanup rules)
 - `src/eventBus/` (progress event system)
+- `src/hosts/` (host capability ports)
 - Webview frontends (`packages/extension/src/webview/frontend/`, `packages/extension/src/progressView/frontend/`, `packages/extension/src/settingsView/frontend/`)
 
 **VS Code-allowed zones** — platform-specific wiring belongs here:
@@ -402,6 +408,8 @@ Common aliases (full list in `tsconfig.json`):
 - `@model/*`, `@latex/*`, `@logger/*`, `@tools/*`, `@webview/*`
 - `@progressView/*`, `@settingsView/*`, `@shared/*`, `@eventBus/*`
 - `@replacement/*`, `@housekeeping/*`, `@auth/*`, `@types/*`
+- `@controllers/*`, `@hosts/*`, `@skills/*`, `@telemetry/*`, `@transcript/*`
+- `@cli/*`, `@desktop/*`, `@test/*`, `@resources/*`, `@extensionSchemas/*`
 - `@platform`, `@platform/*` (platform abstraction layer)
 
 ## Adding New Components

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Run history and agent settings are shared between both surfaces.
 
 ## Teams
 
-Four built-in presets cover the most common research disciplines:
+Five built-in presets cover the most common research disciplines:
 
 | Team                        | Built for                                                                        |
 | --------------------------- | -------------------------------------------------------------------------------- |
@@ -67,6 +67,7 @@ Four built-in presets cover the most common research disciplines:
 | **Mathematician**           | Proofs, Lean 4 formalization, research, LaTeX correction                         |
 | **Computer Scientist (ML)** | Algorithm design, experiments and ablations, literature, reproducibility         |
 | **Lean Project**            | Mathlib search, tactic simplification, blueprint-driven formalization            |
+| **Software Engineer**       | An engineer lead delegating implementation, review, debugging, and testing       |
 
 Pick a team in **Settings → Multi-Agent**, or with `texra multi-agent
 run <preset>`. Or define your own roster in YAML.
@@ -79,10 +80,13 @@ run <preset>`. Or define your own roster in YAML.
 
 **Tool-use agents** work conversationally with file, shell, and search
 access: `research`, `numerics`, `review`, `presenter`, `latexFixer`,
-`latexDiff`, `creator`, `lean`, `chat`, `setup`.
+`latexDiff`, `creator`, `lean`, `chat`, `setup`, plus a
+software-engineering line — `engineer`, `coder`, `codeReviewer`,
+`testEngineer`, `codeSimplifier`.
 
 **Hosted specialists** (signed-in users): `orchestrator`, `search`,
-`simplifier`, `criticize`, `devise`, `apply`, `generic`,
+`simplifier`, `criticize`, `firstread`, `logic`, `notation`, `enhance`,
+`elevate`, `humanize`, `devise`, `apply`, `verifyFix`, `generic`,
 `progressCheck`, and the Lean line — `leanOrchestrator`,
 `leanBlueprint`, `leanSearch`, `leanSimplifier`.
 


### PR DESCRIPTION
- Drop 'fast vs regular' build framing now that the legacy webpack
  pipeline is removed; note compile/watch/package alias the :fast scripts
- Update Agent System section to describe src/agent/core bounded-concern
  layout (definition/execution/usage/tools/flows) and current providers
- Add packages/cli to the workspace layout
- Add controllers/, skills/, telemetry/, transcript/ to source organization
  and new agent subdirs (trace, goal, features)
- Update settings view tab list (adds AI Agents, Git, Goal)
- Add _shared/ and setup/ to the commands list
- Add src/hosts to VS Code-free zones (matches eslint enforcement)
- Extend path alias list with newer aliases

https://claude.ai/code/session_01VNRgmKX8jLcBMoeowhSYP4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, build, or security impact.
> 
> **Overview**
> **`CLAUDE.md`** is brought in line with the current repo layout and tooling: build docs drop the “fast vs regular” split and state that webpack is gone, with `compile` / `watch` / `package` aliasing the `:fast` scripts. The agent architecture section now points at `src/agent/core/` bounded concerns and current `modelHandlers`; the workspace map adds **`packages/cli`**, **`controllers/`**, **`skills/`**, **`telemetry/`**, **`transcript/`**, and extra agent subdirs; settings tabs, command folders (`_shared/`, `setup/`), **`src/hosts/`** in VS Code-free zones, and newer path aliases are listed.
> 
> **`README.md`** updates user-facing product copy: **Software Engineer** as a fifth built-in team preset, the software-engineering tool-use agent line, and an expanded hosted-specialist roster (e.g. `firstread`, `logic`, `notation`, `enhance`, `elevate`, `humanize`, `verifyFix`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de299c78e8d7155b9df5b99be3ca05b40e8566fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->