### PR TITLE
Resolve top frictions in the multi-agent orchestration system

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -74,6 +74,7 @@ import {
   CLI_APPROVAL_POLICIES,
   type CliApprovalPolicy,
 } from '@cli/schemas/cliSettings';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { parseCliHistoryId } from '@cli/runtime/history';
 import {
   explainNonResumable,
@@ -1138,7 +1139,13 @@ export async function runChat(
   const interruptActive = (): void => {
     clearApprovals();
     if (!session.streamId) return;
-    executionRegistry.stopAgentStream(session.streamId);
+    executionRegistry.stopAgentStream(session.streamId, {
+      detachActiveChildren:
+        tryPlatform()?.workspaceState.get<boolean>(
+          WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+          false,
+        ) === true,
+    });
   };
 
   const resetSessionForClear = (): void => {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -29,6 +29,7 @@ import {
   executeAgent,
   resumeToolUseFromSnapshot,
 } from '@agent/runtime/executeAgent';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   notifyFollowUpSent,
   sendFollowUp,
@@ -285,6 +286,7 @@ export async function markRegisteredChatExecutionError(
 export interface ClearableTuiSessionState {
   streamId: StreamTabId | undefined;
   executionId: string | undefined;
+  runtimeHost?: AgentRuntimeHost;
   runPromise: Promise<void> | undefined;
   runExitCode: CliExitCode;
   runCompleted: boolean;
@@ -306,6 +308,7 @@ export function clearTuiSessionRunState(
 ): void {
   session.streamId = undefined;
   session.executionId = undefined;
+  session.runtimeHost = undefined;
   session.runPromise = undefined;
   session.runExitCode = CliExitCode.Success;
   session.runCompleted = false;
@@ -316,8 +319,10 @@ export function clearTuiSessionRunState(
 export function markChatTuiRunPending(
   session: ClearableTuiSessionState,
   runPromise: Promise<void>,
+  runtimeHost?: AgentRuntimeHost,
 ): void {
   session.streamId = undefined;
+  session.runtimeHost = runtimeHost;
   session.runPromise = runPromise;
   session.runExitCode = CliExitCode.Success;
   session.runCompleted = false;
@@ -1088,6 +1093,7 @@ export async function runChat(
   const session: TuiSession = {
     streamId: undefined,
     executionId: undefined,
+    runtimeHost: undefined,
     runPromise: undefined,
     runExitCode: CliExitCode.Success,
     runCompleted: false,
@@ -1145,6 +1151,7 @@ export async function runChat(
           WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
           false,
         ) === true,
+      runtimeHost: session.runtimeHost,
     });
   };
 
@@ -1280,10 +1287,11 @@ export async function runChat(
           : CliExitCode.AgentError;
       })
       .finally(() => {
+        if (session.runtimeHost === wrapped) session.runtimeHost = undefined;
         markChatTuiRunCompleted(session);
         void runtimeHost.close();
       });
-    markChatTuiRunPending(session, runPromise);
+    markChatTuiRunPending(session, runPromise, wrapped);
   };
 
   // Interactive resume: continue a suspended tool-use session by execution id.
@@ -1361,6 +1369,7 @@ export async function runChat(
 
     const runtimeHost = createCliRuntimeHost(sessionContext);
     const wrapped = wrapRuntimeHost(runtimeHost);
+    session.runtimeHost = wrapped;
     const unbindApprovals = installTuiApprovals(wrapped, sessionContext);
     disposers.push(unbindApprovals);
     const approvalsUnavailable = approvalPromptsUnavailable(sessionContext);
@@ -1390,6 +1399,7 @@ export async function runChat(
           : CliExitCode.AgentError;
       })
       .finally(() => {
+        if (session.runtimeHost === wrapped) session.runtimeHost = undefined;
         markChatTuiRunCompleted(session);
         void runtimeHost.close();
       });

--- a/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
+++ b/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
@@ -34,9 +34,17 @@ export function formatMultiAgentRunInstruction(
     inputFiles: init.inputFiles,
     contextFiles: init.contextFiles,
   });
-  if (inputFileInstruction) parts.push(inputFileInstruction);
-
   const instruction = init.instruction.trim();
+  if (inputFileInstruction) {
+    parts.push(inputFileInstruction);
+  } else if (instruction) {
+    // Say so explicitly — otherwise orchestrators tend to assume files were
+    // attached and delegate file rewrites with invented paths.
+    parts.push(
+      'No input or context files were attached to this run; work from the user instruction below.',
+    );
+  }
+
   if (instruction) {
     parts.push(
       inputFileInstruction

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -300,7 +300,15 @@ export async function runMultiAgentPreset(
 
   await initCliPlatform({ ...context, quietLogs: true });
 
-  const { plan } = await loadCliMultiAgentRunPlan(init);
+  const { plan, remoteAgentLoadAttempted } =
+    await loadCliMultiAgentRunPlan(init);
+  if (remoteAgentLoadAttempted) {
+    // Otherwise the silent second load makes runs behave differently from a
+    // signed-out shell with no visible reason.
+    writeTextStderr(
+      `Preset ${plan.preset.id} referenced agents not available locally; loaded remote agents to fill the gaps.`,
+    );
+  }
   if (plan.missingAgentOverride) {
     throw new CliUsageError(
       missingToolUseAgentMessage(plan.missingAgentOverride),

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -306,7 +306,9 @@ export async function runMultiAgentPreset(
     // Otherwise the silent second load makes runs behave differently from a
     // signed-out shell with no visible reason.
     writeTextStderr(
-      `Preset ${plan.preset.id} referenced agents not available locally; loaded remote agents to fill the gaps.`,
+      cliMultiAgentPlanHasGaps(plan)
+        ? `Preset ${plan.preset.id} referenced agents not available locally; a remote agent load did not fill all the gaps.`
+        : `Preset ${plan.preset.id} referenced agents not available locally; loaded remote agents to fill the gaps.`,
     );
   }
   if (plan.missingAgentOverride) {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -961,6 +961,10 @@ export class DesktopProgressBridge {
     }
   }
 
+  isResumeInFlight(streamId: StreamTabId): boolean {
+    return this.resumeAttempts.has(streamId);
+  }
+
   private async resolveResumeState(
     streamId: StreamTabId,
   ): Promise<ResumeState | undefined> {

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -1,6 +1,9 @@
 import type { StreamTabId } from '@shared/schemas';
 
-type DesktopResumeHandler = (streamId: StreamTabId) => Promise<boolean>;
+interface DesktopResumeHandler {
+  tryResumeStream(streamId: StreamTabId): Promise<boolean>;
+  isResumeInFlight(streamId: StreamTabId): boolean;
+}
 
 let activeHandler: DesktopResumeHandler | undefined;
 
@@ -18,5 +21,9 @@ export function setDesktopAgentResumeHandler(
 export async function tryResumeDesktopStream(
   streamId: StreamTabId,
 ): Promise<boolean> {
-  return activeHandler?.(streamId) ?? false;
+  return activeHandler?.tryResumeStream(streamId) ?? false;
+}
+
+export function isDesktopResumeInFlight(streamId: StreamTabId): boolean {
+  return activeHandler?.isResumeInFlight(streamId) ?? false;
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -470,8 +470,8 @@ function createWindow(options: {
       });
     return agentExecutionLoad;
   };
-  const disposeAgentResumeHandler = setDesktopAgentResumeHandler(
-    async (streamId) => {
+  const disposeAgentResumeHandler = setDesktopAgentResumeHandler({
+    async tryResumeStream(streamId) {
       try {
         return await (
           await getAgentExecution()
@@ -481,7 +481,10 @@ function createWindow(options: {
         return false;
       }
     },
-  );
+    isResumeInFlight(streamId) {
+      return agentExecution?.progress.isResumeInFlight(streamId) ?? false;
+    },
+  });
   const fileSelection = createDesktopFileSelection({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     showOpenFileDialog: async (options) => {

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -24,7 +24,10 @@ import { ElectronSecrets } from './electronSecrets.js';
 import { repairLaunchPath } from './pathFix.js';
 import { resolveResourcesPath, resolveWorkspacePath } from './paths.js';
 import { showSecretStorageWarningDialog } from './secretStorageWarningDialog.js';
-import { tryResumeDesktopStream } from '../desktopAgentResume.js';
+import {
+  isDesktopResumeInFlight,
+  tryResumeDesktopStream,
+} from '../desktopAgentResume.js';
 
 // Type imports - platform
 import type { LifecycleHost } from '@platform/interfaces/lifecycle';
@@ -129,7 +132,10 @@ export async function initializeElectronPlatform(
       showWarningMessage: showSecretStorageWarningDialog,
     }),
     lifecycle,
-    agentResume: { tryResumeStream: tryResumeDesktopStream },
+    agentResume: {
+      tryResumeStream: tryResumeDesktopStream,
+      isResumeInFlight: isDesktopResumeInFlight,
+    },
     toolAvailability: NO_TOOL_AVAILABILITY_HOST,
   });
   registerAgentFeatures();

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -289,6 +289,7 @@ export class SettingsApp extends SettingsAppBase {
 
   // Agent teams state
   private readonly customPresets = signal<AgentModePreset[]>([]);
+  private readonly orchestratorAgents = signal<string[]>([]);
 
   // Multi-agent coordination state
   private readonly reliabilitySettings = signal<NumberVscodeSetting[]>([]);
@@ -408,6 +409,7 @@ export class SettingsApp extends SettingsAppBase {
     },
     [SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS]: (data) => {
       this.customPresets.set(data.customPresets);
+      this.orchestratorAgents.set(data.orchestratorAgents ?? []);
     },
     [SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS]: (data) => {
       this.bashApprovalEnabled.set(data.bashApprovalEnabled);
@@ -1185,6 +1187,7 @@ export class SettingsApp extends SettingsAppBase {
           <wa-tab-panel name="multi-agent">
             <multi-agent-tab
               .customPresets=${this.customPresets.get()}
+              .orchestratorAgents=${this.orchestratorAgents.get()}
               .allowOrchestratorKill=${this.allowOrchestratorKill.get()}
               .detachSubagentsOnStop=${this.detachSubagentsOnStop.get()}
               .worktreeSupport=${this.gitWorktreeSupport.get()}

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -230,6 +230,8 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) nestedDelegationMaxDepth =
     NESTED_DELEGATION_DEPTH_RANGE.default;
   @property({ attribute: false }) customPresets: AgentModePreset[] = [];
+  /** Agent names that carry delegation tools, computed backend-side from the registry. */
+  @property({ attribute: false }) orchestratorAgents: string[] = [];
   @state() private activePresetId: string | null = null;
 
   private emitToggle(eventName: string, event: Event): void {
@@ -267,7 +269,13 @@ export class MultiAgentTab extends LitElement {
   }
 
   private isOrchestratorAgent(name: string): boolean {
-    return name.toLowerCase().includes('orchestrator');
+    // Prefer the capability-based list (catches roots like `engineer` that
+    // don't carry "orchestrator" in their name); keep the name heuristic as a
+    // fallback for presets referencing agents the registry hasn't loaded.
+    return (
+      this.orchestratorAgents.includes(name) ||
+      name.toLowerCase().includes('orchestrator')
+    );
   }
 
   private renderPresetCard(

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -10,6 +10,10 @@ import * as vscode from 'vscode';
 
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import { createKey, getAgent, loadAgents } from '@agent/index';
+import {
+  BUILTIN_TEAM_ROOT_AGENT_NAMES,
+  getToolUseAgents,
+} from '@agent/index/agentRegistry';
 import { EdgeFunctionResponseSchema } from '@agent/remote/types';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { ULTRA_TIER, SUPABASE_CONFIG } from '@auth/config';
@@ -21,6 +25,7 @@ import {
 } from '@frontend/ui/errorHandlingUtils';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { createSettingsAgentControllers } from '@shared/settingsView/handlers/agentControllerFactory';
 import {
   SETTINGS_VIEW_CMD,
@@ -414,6 +419,7 @@ export class AgentHandlers {
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
       customPresets: this.catalogController.getCustomPresets(),
+      orchestratorAgents: collectOrchestratorAgentNames(),
     });
   }
 
@@ -564,4 +570,18 @@ export class AgentHandlers {
       vscode.commands.executeCommand('texra.refreshAllOptions'),
     ]);
   }
+}
+
+/**
+ * Agent names that can lead a team. Combines the known built-in team roots
+ * (valid even before the registry has loaded remote agents) with any loaded
+ * tool-use agent that carries delegation tools, so custom orchestrators are
+ * recognized by capability instead of by name.
+ */
+function collectOrchestratorAgentNames(): string[] {
+  const names = new Set<string>(BUILTIN_TEAM_ROOT_AGENT_NAMES);
+  for (const agent of getToolUseAgents()) {
+    if (hasDelegationTool(agent.tools)) names.add(agent.name);
+  }
+  return [...names].sort();
 }

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -9,11 +9,14 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
-import { createKey, getAgent, loadAgents } from '@agent/index';
 import {
-  BUILTIN_TEAM_ROOT_AGENT_NAMES,
-  getToolUseAgents,
-} from '@agent/index/agentRegistry';
+  createKey,
+  getAgent,
+  getAgentsByCategory,
+  loadAgents,
+} from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { BUILTIN_TEAM_ROOT_AGENT_NAMES } from '@agent/index/agentRegistry';
 import { EdgeFunctionResponseSchema } from '@agent/remote/types';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { ULTRA_TIER, SUPABASE_CONFIG } from '@auth/config';
@@ -580,7 +583,7 @@ export class AgentHandlers {
  */
 function collectOrchestratorAgentNames(): string[] {
   const names = new Set<string>(BUILTIN_TEAM_ROOT_AGENT_NAMES);
-  for (const agent of getToolUseAgents()) {
+  for (const agent of getAgentsByCategory(AgentCategory.ToolUse)) {
     if (hasDelegationTool(agent.tools)) names.add(agent.name);
   }
   return [...names].sort();

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -466,6 +466,7 @@ export class ExecutionRegistry {
   detachActiveChildren(
     parentStreamId: StreamTabId,
     runtimeHost: AgentRuntimeHost,
+    visited: Set<string> = new Set(),
   ): void {
     for (const handle of this.handles.values()) {
       if (handle.parentStreamId !== parentStreamId) continue;
@@ -479,7 +480,9 @@ export class ExecutionRegistry {
           parentStreamId: null,
         });
       } else if (handle instanceof ProcessExecutionHandle) {
-        this.terminate(handle);
+        // Killed processes keep parentStreamId === parentStreamId, so without
+        // the shared visited set the root cascade would kill them again.
+        this.terminate(handle, visited);
       }
     }
     this.emitActiveSubagentsUpdate(parentStreamId, runtimeHost);
@@ -507,7 +510,7 @@ export class ExecutionRegistry {
           'stopAgentStream requires a runtimeHost to detach active children',
         );
       }
-      this.detachActiveChildren(streamId, runtimeHost);
+      this.detachActiveChildren(streamId, runtimeHost, visited);
     } else {
       this.interruptActiveChildren(streamId, visited);
     }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -445,11 +445,18 @@ export class ExecutionRegistry {
     });
   }
 
-  /** Interrupt all active subagents of a parent stream. */
+  /** Interrupt all active subagents of a parent stream, including descendants. */
   interruptActiveChildren(parentStreamId: StreamTabId): void {
+    this.terminateChildren(parentStreamId, new Set());
+  }
+
+  private terminateChildren(
+    parentStreamId: StreamTabId,
+    visited: Set<string>,
+  ): void {
     for (const handle of this.handles.values()) {
       if (isChildExecution(handle, parentStreamId)) {
-        this.terminate(handle);
+        this.terminate(handle, visited);
       }
     }
   }
@@ -494,6 +501,9 @@ export class ExecutionRegistry {
   ): boolean {
     const rootHandle = this.getAgentHandleByStream(streamId);
     const runtimeHost = options.runtimeHost ?? rootHandle?.runtimeHost;
+    // Shared across the child sweep and the root cascade so each execution in
+    // the chain is interrupted exactly once.
+    const visited = new Set<string>();
 
     if (options.detachActiveChildren === true) {
       if (!runtimeHost) {
@@ -503,11 +513,11 @@ export class ExecutionRegistry {
       }
       this.detachActiveChildren(streamId, runtimeHost);
     } else {
-      this.interruptActiveChildren(streamId);
+      this.terminateChildren(streamId, visited);
     }
 
     const stopped = rootHandle
-      ? this.terminate(rootHandle)
+      ? this.terminate(rootHandle, visited)
       : this.interruptRegisteredStream(streamId, runtimeHost);
     if (!stopped && runtimeHost) {
       this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, { runtimeHost });
@@ -615,8 +625,16 @@ export class ExecutionRegistry {
     return false;
   }
 
-  private terminate(handle: ExecutionHandle): boolean {
+  private terminate(
+    handle: ExecutionHandle,
+    visited: Set<string> = new Set(),
+  ): boolean {
+    if (visited.has(handle.executionId)) return false;
+    visited.add(handle.executionId);
     if (handle instanceof AgentExecutionHandle) {
+      // Interrupt the handle's own subagents first so no descendant outlives
+      // the chain — killing an orchestrator must also stop its grandchildren.
+      this.terminateChildren(handle.childStreamId, visited);
       const interruptible = this.interrupts.get(handle.childStreamId);
       if (!interruptible) return false;
       interruptible.interrupt();

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -57,6 +57,10 @@ export interface FinishAgentExecutionOptions {
   readonly status: StreamStatus;
 }
 
+interface TerminateOptions {
+  readonly cascadeChildren?: boolean;
+}
+
 export type ToolUseFollowUpQueueReason =
   | 'resuming'
   | 'waiting'
@@ -354,7 +358,9 @@ export class ExecutionRegistry {
   kill(executionId: string): boolean {
     const handle = this.handles.get(executionId);
     if (!handle) return false;
-    const result = this.terminate(handle);
+    const result = this.terminate(handle, new Set(), {
+      cascadeChildren: true,
+    });
     // Always notify waiters — even if terminate() returned false (e.g. PID not
     // yet assigned), callers blocking on this execution should be unblocked.
     this.notifyWaiters(executionId);
@@ -449,10 +455,11 @@ export class ExecutionRegistry {
   interruptActiveChildren(
     parentStreamId: StreamTabId,
     visited: Set<string> = new Set(),
+    options: TerminateOptions = { cascadeChildren: true },
   ): void {
     for (const handle of this.handles.values()) {
       if (isChildExecution(handle, parentStreamId)) {
-        this.terminate(handle, visited);
+        this.terminate(handle, visited, options);
       }
     }
   }
@@ -480,9 +487,7 @@ export class ExecutionRegistry {
           parentStreamId: null,
         });
       } else if (handle instanceof ProcessExecutionHandle) {
-        // Killed processes keep parentStreamId === parentStreamId, so without
-        // the shared visited set the root cascade would kill them again.
-        this.terminate(handle, visited);
+        this.terminate(handle, visited, { cascadeChildren: false });
       }
     }
     this.emitActiveSubagentsUpdate(parentStreamId, runtimeHost);
@@ -512,11 +517,15 @@ export class ExecutionRegistry {
       }
       this.detachActiveChildren(streamId, runtimeHost, visited);
     } else {
-      this.interruptActiveChildren(streamId, visited);
+      this.interruptActiveChildren(streamId, visited, {
+        cascadeChildren: true,
+      });
     }
 
     const stopped = rootHandle
-      ? this.terminate(rootHandle, visited)
+      ? this.terminate(rootHandle, visited, {
+          cascadeChildren: options.detachActiveChildren !== true,
+        })
       : this.interruptRegisteredStream(streamId, runtimeHost);
     if (!stopped && runtimeHost) {
       this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, { runtimeHost });
@@ -627,13 +636,14 @@ export class ExecutionRegistry {
   private terminate(
     handle: ExecutionHandle,
     visited: Set<string> = new Set(),
+    options: TerminateOptions = {},
   ): boolean {
     if (visited.has(handle.executionId)) return false;
     visited.add(handle.executionId);
     if (handle instanceof AgentExecutionHandle) {
-      // Interrupt the handle's own subagents first so no descendant outlives
-      // the chain — killing an orchestrator must also stop its grandchildren.
-      this.interruptActiveChildren(handle.childStreamId, visited);
+      if (options.cascadeChildren === true) {
+        this.interruptActiveChildren(handle.childStreamId, visited, options);
+      }
       const interruptible = this.interrupts.get(handle.childStreamId);
       if (!interruptible) return false;
       interruptible.interrupt();

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -446,13 +446,9 @@ export class ExecutionRegistry {
   }
 
   /** Interrupt all active subagents of a parent stream, including descendants. */
-  interruptActiveChildren(parentStreamId: StreamTabId): void {
-    this.terminateChildren(parentStreamId, new Set());
-  }
-
-  private terminateChildren(
+  interruptActiveChildren(
     parentStreamId: StreamTabId,
-    visited: Set<string>,
+    visited: Set<string> = new Set(),
   ): void {
     for (const handle of this.handles.values()) {
       if (isChildExecution(handle, parentStreamId)) {
@@ -513,7 +509,7 @@ export class ExecutionRegistry {
       }
       this.detachActiveChildren(streamId, runtimeHost);
     } else {
-      this.terminateChildren(streamId, visited);
+      this.interruptActiveChildren(streamId, visited);
     }
 
     const stopped = rootHandle
@@ -634,7 +630,7 @@ export class ExecutionRegistry {
     if (handle instanceof AgentExecutionHandle) {
       // Interrupt the handle's own subagents first so no descendant outlives
       // the chain — killing an orchestrator must also stop its grandchildren.
-      this.terminateChildren(handle.childStreamId, visited);
+      this.interruptActiveChildren(handle.childStreamId, visited);
       const interruptible = this.interrupts.get(handle.childStreamId);
       if (!interruptible) return false;
       interruptible.interrupt();

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -33,6 +33,9 @@ export type SendFollowUpResult =
     }
   | { status: 'no_session'; streamStatus: string | undefined };
 
+/** In-flight resume attempts per stream — see {@link wakeOrReleaseQueuedStream}. */
+const wakeAttempts = new Map<StreamTabId, Promise<boolean>>();
+
 /**
  * After a queued delivery, wake a stream whose cycle has exited (WAITING
  * snapshot or disposed-with-children) via the host resume port so the queued
@@ -54,7 +57,21 @@ export async function wakeOrReleaseQueuedStream(
   ) {
     return true;
   }
-  const resumed = await platform().agentResume.tryResumeStream(streamId);
+  // Serialize wakes per stream: hosts report an already-in-flight resume as
+  // `false`, indistinguishable from "unresumable", and may not have set
+  // RESUMING yet — so a concurrent wake must await the first attempt's
+  // outcome instead of re-poking the port and releasing the queue the
+  // in-flight resume is about to drain.
+  let attempt = wakeAttempts.get(streamId);
+  if (!attempt) {
+    attempt = platform()
+      .agentResume.tryResumeStream(streamId)
+      .finally(() => {
+        wakeAttempts.delete(streamId);
+      });
+    wakeAttempts.set(streamId, attempt);
+  }
+  const resumed = await attempt;
   if (
     resumed ||
     result.reason !== 'children_running' ||

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -63,18 +63,18 @@ export async function wakeOrReleaseQueuedStream(
   // outcome instead of re-poking the port and releasing the queue the
   // in-flight resume is about to drain.
   let attempt = wakeAttempts.get(streamId);
+  const resumePort = platform().agentResume;
   if (!attempt) {
-    attempt = platform()
-      .agentResume.tryResumeStream(streamId)
-      .finally(() => {
-        wakeAttempts.delete(streamId);
-      });
+    attempt = resumePort.tryResumeStream(streamId).finally(() => {
+      wakeAttempts.delete(streamId);
+    });
     wakeAttempts.set(streamId, attempt);
   }
   const resumed = await attempt;
   if (
     resumed ||
     result.reason !== 'children_running' ||
+    resumePort.isResumeInFlight?.(streamId) === true ||
     StreamStatusService.isActiveOrResuming(streamId)
   ) {
     return true;

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -10,10 +10,12 @@
  * showing appropriate UI notifications based on the returned result.
  */
 
+import { platform } from '@platform';
 import {
   executionRegistry,
   type ToolUseFollowUpQueueReason,
 } from '@agent/runtime/executionRegistry';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
@@ -32,18 +34,36 @@ export type SendFollowUpResult =
   | { status: 'no_session'; streamStatus: string | undefined };
 
 /**
- * True when a queued follow-up landed on a stream whose cycle has exited
- * (WAITING snapshot or disposed-with-children) — the cases where the caller
- * should try `platform().agentResume.tryResumeStream` so the queued item is
- * consumed instead of sitting until the user pokes the stream.
+ * After a queued delivery, wake a stream whose cycle has exited (WAITING
+ * snapshot or disposed-with-children) via the host resume port so the queued
+ * item is consumed instead of sitting until the user pokes the stream. When
+ * the wake fails and the stream is gone for good (`children_running` on a
+ * non-in-flight stream), re-release the force-reopened queue so late
+ * deliveries don't leak into the next run on that stream.
+ *
+ * Returns false when the queued item was dropped by the re-release; callers
+ * should treat the delivery as failed and rely on their durable copy.
  */
-export function shouldWakeQueuedStream(
+export async function wakeOrReleaseQueuedStream(
+  streamId: StreamTabId,
   result: SendFollowUpResult,
-): result is SendFollowUpResult & { status: 'queued' } {
-  return (
-    result.status === 'queued' &&
-    (result.reason === 'waiting' || result.reason === 'children_running')
-  );
+): Promise<boolean> {
+  if (
+    result.status !== 'queued' ||
+    (result.reason !== 'waiting' && result.reason !== 'children_running')
+  ) {
+    return true;
+  }
+  const resumed = await platform().agentResume.tryResumeStream(streamId);
+  if (
+    resumed ||
+    result.reason !== 'children_running' ||
+    StreamStatusService.isActiveOrResuming(streamId)
+  ) {
+    return true;
+  }
+  ToolUseFollowUpQueue.release(streamId);
+  return false;
 }
 
 const logger = createChannelTrace('ToolUseFollowUp');

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -31,6 +31,21 @@ export type SendFollowUpResult =
     }
   | { status: 'no_session'; streamStatus: string | undefined };
 
+/**
+ * True when a queued follow-up landed on a stream whose cycle has exited
+ * (WAITING snapshot or disposed-with-children) — the cases where the caller
+ * should try `platform().agentResume.tryResumeStream` so the queued item is
+ * consumed instead of sitting until the user pokes the stream.
+ */
+export function shouldWakeQueuedStream(
+  result: SendFollowUpResult,
+): result is SendFollowUpResult & { status: 'queued' } {
+  return (
+    result.status === 'queued' &&
+    (result.reason === 'waiting' || result.reason === 'children_running')
+  );
+}
+
 const logger = createChannelTrace('ToolUseFollowUp');
 const followUpSentObservers = new Set<(streamId: StreamTabId) => void>();
 

--- a/src/platform/interfaces/agentResume.ts
+++ b/src/platform/interfaces/agentResume.ts
@@ -18,4 +18,11 @@ export interface AgentResumePort {
    * the message queued for the next manual resume.
    */
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
+
+  /**
+   * Whether the host has already accepted a resume for this stream and is
+   * still preparing it. A queued-delivery wake uses this to avoid releasing a
+   * force-reopened queue while a host-initiated resume is about to drain it.
+   */
+  isResumeInFlight?(streamId: StreamTabId): boolean;
 }

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -283,6 +283,12 @@ export type UpdateSuperYoloEnabledMessage = z.infer<
 export const UpdateAgentModePresetsMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS),
   customPresets: z.array(AgentModePresetSchema),
+  /**
+   * Agent names that can lead a team (carry delegation tools), computed from
+   * the agent registry so preset cards badge orchestrators by capability
+   * instead of guessing from the agent's name.
+   */
+  orchestratorAgents: z.array(z.string()).prefault([]),
 });
 export type UpdateAgentModePresetsMessage = z.infer<
   typeof UpdateAgentModePresetsMessageSchema

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -175,12 +175,18 @@ describe('executionRegistry', () => {
     const registry = new ExecutionRegistry({ interrupts, streamStatus });
     const rootStreamId = 'root-detach-stop-policy-test' as StreamTabId;
     const childStreamId = 'child-detach-stop-policy-test' as StreamTabId;
+    const grandchildStreamId =
+      'grandchild-detach-stop-policy-test' as StreamTabId;
     const rootInterrupt = vi.fn();
     const childInterrupt = vi.fn();
+    const grandchildInterrupt = vi.fn();
 
     try {
       interrupts.register(rootStreamId, { interrupt: rootInterrupt });
       interrupts.register(childStreamId, { interrupt: childInterrupt });
+      interrupts.register(grandchildStreamId, {
+        interrupt: grandchildInterrupt,
+      });
       registry.track(
         new AgentExecutionHandle(
           'exec-root-detach-stop-policy-test',
@@ -201,6 +207,16 @@ describe('executionRegistry', () => {
           explicit.host,
         ),
       );
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-grandchild-detach-stop-policy-test',
+          childStreamId,
+          grandchildStreamId,
+          'test-grandchild',
+          'toolUse',
+          explicit.host,
+        ),
+      );
 
       expect(
         registry.stopAgentStream(rootStreamId, {
@@ -211,14 +227,22 @@ describe('executionRegistry', () => {
 
       expect(rootInterrupt).toHaveBeenCalledOnce();
       expect(childInterrupt).not.toHaveBeenCalled();
+      expect(grandchildInterrupt).not.toHaveBeenCalled();
       expect(registry.getActiveChildren(rootStreamId).subagents).toHaveLength(
         0,
       );
       expect(
         registry.getAgentHandleByStream(childStreamId)?.parentStreamId,
       ).toBe(childStreamId);
+      expect(
+        registry.getAgentHandleByStream(grandchildStreamId)?.parentStreamId,
+      ).toBe(childStreamId);
+      expect(registry.getActiveChildren(childStreamId).subagents).toEqual([
+        expect.objectContaining({ childStreamId: grandchildStreamId }),
+      ]);
       expect(streamStatus.get(rootStreamId)).toBe(STREAM_STATUS.STOPPED);
       expect(streamStatus.get(childStreamId)).toBeUndefined();
+      expect(streamStatus.get(grandchildStreamId)).toBeUndefined();
       expect(explicit.events).toContainEqual({
         event: 'setParentStream',
         payload: {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -118,6 +118,56 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('interrupts grandchildren when killing a subagent chain', () => {
+    const explicit = createRecordingHost();
+    const interrupts = new InterruptRegistry();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const rootStreamId = 'root-cascade-test' as StreamTabId;
+    const childStreamId = 'child-cascade-test' as StreamTabId;
+    const grandchildStreamId = 'grandchild-cascade-test' as StreamTabId;
+    const childInterrupt = vi.fn();
+    const grandchildInterrupt = vi.fn();
+
+    try {
+      interrupts.register(childStreamId, { interrupt: childInterrupt });
+      interrupts.register(grandchildStreamId, {
+        interrupt: grandchildInterrupt,
+      });
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-child-cascade-test',
+          rootStreamId,
+          childStreamId,
+          'test-subagent',
+          'toolUse',
+          explicit.host,
+        ),
+      );
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-grandchild-cascade-test',
+          childStreamId,
+          grandchildStreamId,
+          'test-grandchild',
+          'toolUse',
+          explicit.host,
+        ),
+      );
+
+      expect(registry.kill('exec-child-cascade-test')).toBe(true);
+
+      expect(childInterrupt).toHaveBeenCalledOnce();
+      expect(grandchildInterrupt).toHaveBeenCalledOnce();
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(grandchildStreamId)).toBe(STREAM_STATUS.STOPPED);
+    } finally {
+      registry.dispose();
+      interrupts.unregister(childStreamId);
+      interrupts.unregister(grandchildStreamId);
+    }
+  });
+
   it('detaches children when stopping a stream with detached subagents', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUp.vitest.ts
@@ -5,6 +5,7 @@ import { describe, it, afterEach } from 'vitest';
 // Standard library imports
 
 // Local imports - agent
+import { createFakePlatform } from '@test/support/FakePlatform';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import { AgentRunStateSnapshotSchema } from '@agent/core/execution/AgentState';
@@ -14,7 +15,10 @@ import {
   executionRegistry,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
-import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import {
+  sendFollowUp,
+  wakeOrReleaseQueuedStream,
+} from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
@@ -208,6 +212,111 @@ describe('ToolUseFollowUp', () => {
           mediaFiles: undefined,
         },
       ]);
+    } finally {
+      executionRegistry.untrack(executionId);
+      ToolUseFollowUpQueue.release(parentStreamId);
+    }
+  });
+
+  it('serializes concurrent wakes so an in-flight resume keeps the queue', async () => {
+    // Regression: hosts report an already-in-flight resume as `false` before
+    // RESUMING is set, so a second concurrent wake used to release the queue
+    // the first resume was about to drain.
+    const parentStreamId = 'parent-stream-wake-race' as StreamTabId;
+    const childStreamId = 'child-stream-wake-race' as StreamTabId;
+    const executionId = 'exec-wake-race';
+
+    let resumeCalls = 0;
+    let resolveResume!: (resumed: boolean) => void;
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(
+      createFakePlatform(
+        {},
+        {
+          agentResume: {
+            tryResumeStream: () => {
+              resumeCalls++;
+              return new Promise<boolean>((resolve) => {
+                resolveResume = resolve;
+              });
+            },
+          },
+        },
+      ),
+    );
+
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+      noopAgentRuntimeHost,
+    );
+    executionRegistry.track(handle);
+
+    try {
+      const first = await sendFollowUp(parentStreamId, 'result one');
+      const second = await sendFollowUp(parentStreamId, 'result two');
+      assert.deepEqual(first, { status: 'queued', reason: 'children_running' });
+      assert.deepEqual(second, {
+        status: 'queued',
+        reason: 'children_running',
+      });
+
+      const wakes = Promise.all([
+        wakeOrReleaseQueuedStream(parentStreamId, first),
+        wakeOrReleaseQueuedStream(parentStreamId, second),
+      ]);
+      resolveResume(true);
+
+      assert.deepEqual(await wakes, [true, true]);
+      assert.equal(resumeCalls, 1);
+      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
+        'result one',
+        'result two',
+      ]);
+    } finally {
+      executionRegistry.untrack(executionId);
+      ToolUseFollowUpQueue.release(parentStreamId);
+    }
+  });
+
+  it('releases the reopened queue when the parent cannot be resumed', async () => {
+    const parentStreamId = 'parent-stream-wake-dead' as StreamTabId;
+    const childStreamId = 'child-stream-wake-dead' as StreamTabId;
+    const executionId = 'exec-wake-dead';
+
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(
+      createFakePlatform(
+        {},
+        { agentResume: { tryResumeStream: async () => false } },
+      ),
+    );
+
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+      noopAgentRuntimeHost,
+    );
+    executionRegistry.track(handle);
+
+    try {
+      const result = await sendFollowUp(parentStreamId, 'late result');
+      assert.deepEqual(result, {
+        status: 'queued',
+        reason: 'children_running',
+      });
+
+      assert.equal(
+        await wakeOrReleaseQueuedStream(parentStreamId, result),
+        false,
+      );
+      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), []);
     } finally {
       executionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUp.vitest.ts
@@ -323,6 +323,54 @@ describe('ToolUseFollowUp', () => {
     }
   });
 
+  it('keeps the reopened queue while the host has a resume in flight', async () => {
+    const parentStreamId = 'parent-stream-wake-in-flight' as StreamTabId;
+    const childStreamId = 'child-stream-wake-in-flight' as StreamTabId;
+    const executionId = 'exec-wake-in-flight';
+
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(
+      createFakePlatform(
+        {},
+        {
+          agentResume: {
+            tryResumeStream: async () => false,
+            isResumeInFlight: (stream) => stream === parentStreamId,
+          },
+        },
+      ),
+    );
+
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+      noopAgentRuntimeHost,
+    );
+    executionRegistry.track(handle);
+
+    try {
+      const result = await sendFollowUp(parentStreamId, 'late result');
+      assert.deepEqual(result, {
+        status: 'queued',
+        reason: 'children_running',
+      });
+
+      assert.equal(
+        await wakeOrReleaseQueuedStream(parentStreamId, result),
+        true,
+      );
+      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
+        'late result',
+      ]);
+    } finally {
+      executionRegistry.untrack(executionId);
+      ToolUseFollowUpQueue.release(parentStreamId);
+    }
+  });
+
   it('creates valid snapshot structure', () => {
     // Test that snapshot structure is valid (used for resume operations)
     assert.equal(snapshot.version, 2);

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -138,6 +138,31 @@ describe('formatMultiAgentRunInstruction', () => {
     expect(instruction).toContain('Additional user instruction:');
   });
 
+  it('states explicitly when no files were attached to an instruction-only run', () => {
+    const instruction = formatMultiAgentRunInstruction(preset, {
+      inputFiles: [],
+      contextFiles: [],
+      instruction: 'Solve x^2 - 2y^2 = 1 for integer x and 0 < y < 20.',
+      approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+    });
+
+    expect(instruction).toContain(
+      'No input or context files were attached to this run',
+    );
+    expect(instruction).toContain('User instruction:');
+  });
+
+  it('does not claim missing files when inputs are attached', () => {
+    const instruction = formatMultiAgentRunInstruction(preset, {
+      inputFiles: ['problem.md'],
+      contextFiles: [],
+      instruction: 'Solve the problem.',
+      approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+    });
+
+    expect(instruction).not.toContain('were attached to this run');
+  });
+
   it('anchors input-only team runs on the provided files', () => {
     const instruction = formatMultiAgentRunInstruction(preset, {
       inputFiles: ['problems/pythagorean.md'],

--- a/src/test-kernel/tools/SubagentResults.vitest.ts
+++ b/src/test-kernel/tools/SubagentResults.vitest.ts
@@ -2,7 +2,10 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import type { ToolUseFlowResult } from '@agent/runtime/AgentFlowResult';
+import type {
+  ToolUseFlowResult,
+  WorkflowFlowResult,
+} from '@agent/runtime/AgentFlowResult';
 import {
   formatBashDelivery,
   formatSubagentDelivery,
@@ -47,6 +50,52 @@ describe('formatSubagentDelivery', () => {
     expect(delivery).toContain('<memory-misses>');
     expect(delivery).toContain(
       '<memory-miss path="/memories/missing.md" reason="Path is missing &amp; unreadable" />',
+    );
+  });
+
+  it('flags failed diff computation so orchestrators read outputs directly', () => {
+    const result = {
+      category: 'workflow',
+      executionId: 'abc123',
+      streamId: 'child-stream',
+      status: 'stopped',
+      outputs: [
+        {
+          round: 0,
+          relativePath: 'paper.tex',
+          absolutePath: '/ws/paper.tex',
+          location: 'workspace',
+          originalPath: '/ws/.texra/paper.orig.tex',
+          added: 3,
+          removed: 1,
+        },
+      ],
+      compileFailures: [],
+    } satisfies WorkflowFlowResult;
+
+    const delivery = formatSubagentDelivery('polish', result, {
+      diffsUnavailable: 'ENOSPC: no space left & disk full',
+    });
+
+    expect(delivery).toContain(
+      '<diffs-unavailable reason="ENOSPC: no space left &amp; disk full">',
+    );
+    expect(delivery).toContain('read the output files directly');
+    expect(delivery).toContain('<file path="paper.tex"');
+  });
+
+  it('omits the diffs-unavailable element on clean deliveries', () => {
+    const result = {
+      category: 'workflow',
+      executionId: 'abc123',
+      streamId: 'child-stream',
+      status: 'stopped',
+      outputs: [],
+      compileFailures: [],
+    } satisfies WorkflowFlowResult;
+
+    expect(formatSubagentDelivery('polish', result)).not.toContain(
+      'diffs-unavailable',
     );
   });
 

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -34,7 +34,10 @@ import {
 import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import {
+  sendFollowUp,
+  shouldWakeQueuedStream,
+} from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
 
@@ -474,52 +477,17 @@ async function executeSubagent(
   const deliveryState = subagentDeliveryRegistry.start(executionId);
   let childStreamId: StreamTabId | undefined;
 
+  /**
+   * Deliver a follow-up to the parent stream. For terminal results (`wake`),
+   * a parent whose cycle has exited is resumed via the host port so the
+   * queued result is consumed instead of sitting until the user pokes the
+   * stream; if the parent is gone for good (terminal status, resume failed),
+   * the force-reopened queue is re-released so late deliveries don't leak
+   * into the next run — the result stays readable in the execution report.
+   */
   async function deliverFollowUp(
     followUp: FollowUpQueueInput,
-  ): Promise<boolean> {
-    const targetStreamId = resolveDeliveryStreamId(
-      executionId,
-      orchestratorStreamId,
-    );
-    if (!targetStreamId) return false;
-
-    const result = await sendFollowUp(targetStreamId, followUp);
-    if (result.status !== 'no_session') return true;
-    logger.warn(
-      'subagentDelivery',
-      `Unable to deliver subagent result for ${executionId}: parent stream ${targetStreamId} has no active session (status: ${result.streamStatus ?? 'unknown'}).`,
-    );
-    return false;
-  }
-
-  async function deliverTerminalFollowUp(
-    followUp: FollowUpQueueInput,
-  ): Promise<boolean> {
-    if (!deliveryState.beginDelivery()) return false;
-    try {
-      const delivered = await deliverTerminalResult(followUp);
-      if (delivered) {
-        deliveryState.completeDelivery();
-      } else {
-        deliveryState.failDelivery();
-      }
-      return delivered;
-    } catch (err) {
-      deliveryState.failDelivery();
-      throw err;
-    }
-  }
-
-  /**
-   * Deliver a terminal result and, when the parent's cycle has exited, wake it
-   * via the host resume port so the queued result is consumed instead of
-   * sitting until the user pokes the stream. When the parent is gone for good
-   * (terminal status, no consumer, resume failed), re-release the
-   * force-reopened queue so late deliveries don't leak into the next run on
-   * that stream — the result stays readable in the execution report.
-   */
-  async function deliverTerminalResult(
-    followUp: FollowUpQueueInput,
+    options?: { wake?: boolean },
   ): Promise<boolean> {
     const targetStreamId = resolveDeliveryStreamId(
       executionId,
@@ -535,10 +503,7 @@ async function executeSubagent(
       );
       return false;
     }
-    if (
-      result.status === 'queued' &&
-      (result.reason === 'waiting' || result.reason === 'children_running')
-    ) {
+    if (options?.wake && shouldWakeQueuedStream(result)) {
       const resumed =
         await platform().agentResume.tryResumeStream(targetStreamId);
       if (
@@ -555,6 +520,24 @@ async function executeSubagent(
       }
     }
     return true;
+  }
+
+  async function deliverTerminalFollowUp(
+    followUp: FollowUpQueueInput,
+  ): Promise<boolean> {
+    if (!deliveryState.beginDelivery()) return false;
+    try {
+      const delivered = await deliverFollowUp(followUp, { wake: true });
+      if (delivered) {
+        deliveryState.completeDelivery();
+      } else {
+        deliveryState.failDelivery();
+      }
+      return delivered;
+    } catch (err) {
+      deliveryState.failDelivery();
+      throw err;
+    }
   }
 
   function onProgress(update: SubagentProgressUpdate): void {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -13,7 +13,6 @@ import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 // Local imports - agent
-import { platform } from '@platform';
 import { getExecutionStore, registerExecution } from '@agent/storage';
 import { getVisibleAgents } from '@agent/index/agentRegistry';
 import {
@@ -33,15 +32,11 @@ import {
 } from '@agent/runtime/AgentFlowResult';
 import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/toolUse/ToolFileInteractionContext';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   sendFollowUp,
-  shouldWakeQueuedStream,
+  wakeOrReleaseQueuedStream,
 } from '@agent/toolUse/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
-
-// Local imports - platform
 
 // Local imports - logger
 import { toErrorMessage } from '@common/errors';
@@ -503,21 +498,15 @@ async function executeSubagent(
       );
       return false;
     }
-    if (options?.wake && shouldWakeQueuedStream(result)) {
-      const resumed =
-        await platform().agentResume.tryResumeStream(targetStreamId);
-      if (
-        !resumed &&
-        result.reason === 'children_running' &&
-        !StreamStatusService.isActiveOrResuming(targetStreamId)
-      ) {
-        ToolUseFollowUpQueue.release(targetStreamId);
-        logger.warn(
-          'subagentDelivery',
-          `Dropped subagent result for ${executionId}: parent stream ${targetStreamId} is gone and could not be resumed. The result remains in the execution report.`,
-        );
-        return false;
-      }
+    if (
+      options?.wake &&
+      !(await wakeOrReleaseQueuedStream(targetStreamId, result))
+    ) {
+      logger.warn(
+        'subagentDelivery',
+        `Dropped subagent result for ${executionId}: parent stream ${targetStreamId} is gone and could not be resumed. The result remains in the execution report.`,
+      );
+      return false;
     }
     return true;
   }

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -13,6 +13,7 @@ import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 // Local imports - agent
+import { platform } from '@platform';
 import { getExecutionStore, registerExecution } from '@agent/storage';
 import { getVisibleAgents } from '@agent/index/agentRegistry';
 import {
@@ -32,8 +33,12 @@ import {
 } from '@agent/runtime/AgentFlowResult';
 import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/toolUse/ToolFileInteractionContext';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
+
+// Local imports - platform
 
 // Local imports - logger
 import { toErrorMessage } from '@common/errors';
@@ -228,19 +233,28 @@ async function subagentDeliveryMessage(
   },
 ): Promise<string> {
   let diffInfos: Map<string, DiffFileInfo> | undefined;
+  let diffsUnavailable: string | undefined;
   if (result.category === 'workflow' && result.outputs.length > 0) {
     try {
       diffInfos = await computeAndWriteWorkflowDiffs(
         executionId,
         result.outputs,
       );
-    } catch {
-      // Diff computation failure is non-fatal — deliver without diffs.
+    } catch (err) {
+      // Diff computation failure is non-fatal — deliver without diffs, but
+      // tell the orchestrator so it can read the output files directly
+      // instead of assuming the revision was a no-op.
+      diffsUnavailable = toErrorMessage(err);
+      logger.warn(
+        'subagentDelivery',
+        `Diff computation failed for ${executionId}: ${diffsUnavailable}`,
+      );
     }
   }
 
   return formatSubagentDelivery(agentName, result, {
     diffInfos,
+    diffsUnavailable,
     wallTimeMs: Date.now() - options.startedAt,
     workingDirectory: options.workingDirectory,
   });
@@ -252,8 +266,13 @@ async function writeSubagentReport(
 ): Promise<void> {
   try {
     await getExecutionStore(executionId).writeReport(message);
-  } catch {
-    /* storage failure is non-fatal */
+  } catch (err) {
+    // Non-fatal, but the report is the only durable copy of the result when
+    // delivery later fails — leave a trace instead of vanishing silently.
+    logger.warn(
+      'subagentDelivery',
+      `Failed to persist subagent report for ${executionId}: ${toErrorMessage(err)}`,
+    );
   }
 }
 
@@ -478,7 +497,7 @@ async function executeSubagent(
   ): Promise<boolean> {
     if (!deliveryState.beginDelivery()) return false;
     try {
-      const delivered = await deliverFollowUp(followUp);
+      const delivered = await deliverTerminalResult(followUp);
       if (delivered) {
         deliveryState.completeDelivery();
       } else {
@@ -489,6 +508,53 @@ async function executeSubagent(
       deliveryState.failDelivery();
       throw err;
     }
+  }
+
+  /**
+   * Deliver a terminal result and, when the parent's cycle has exited, wake it
+   * via the host resume port so the queued result is consumed instead of
+   * sitting until the user pokes the stream. When the parent is gone for good
+   * (terminal status, no consumer, resume failed), re-release the
+   * force-reopened queue so late deliveries don't leak into the next run on
+   * that stream — the result stays readable in the execution report.
+   */
+  async function deliverTerminalResult(
+    followUp: FollowUpQueueInput,
+  ): Promise<boolean> {
+    const targetStreamId = resolveDeliveryStreamId(
+      executionId,
+      orchestratorStreamId,
+    );
+    if (!targetStreamId) return false;
+
+    const result = await sendFollowUp(targetStreamId, followUp);
+    if (result.status === 'no_session') {
+      logger.warn(
+        'subagentDelivery',
+        `Unable to deliver subagent result for ${executionId}: parent stream ${targetStreamId} has no active session (status: ${result.streamStatus ?? 'unknown'}).`,
+      );
+      return false;
+    }
+    if (
+      result.status === 'queued' &&
+      (result.reason === 'waiting' || result.reason === 'children_running')
+    ) {
+      const resumed =
+        await platform().agentResume.tryResumeStream(targetStreamId);
+      if (
+        !resumed &&
+        result.reason === 'children_running' &&
+        !StreamStatusService.isActiveOrResuming(targetStreamId)
+      ) {
+        ToolUseFollowUpQueue.release(targetStreamId);
+        logger.warn(
+          'subagentDelivery',
+          `Dropped subagent result for ${executionId}: parent stream ${targetStreamId} is gone and could not be resumed. The result remains in the execution report.`,
+        );
+        return false;
+      }
+    }
+    return true;
   }
 
   function onProgress(update: SubagentProgressUpdate): void {
@@ -583,8 +649,14 @@ async function executeSubagent(
     onError: (err, result) => deliverSubagentError(err, result),
   });
   promise
-    .catch((err: unknown) => {
-      void deliverSubagentError(err);
+    // Await the error delivery so the registry entry is not torn down while
+    // the delivery (and any resume-based follow-up routing) is in flight.
+    .catch((err: unknown) => deliverSubagentError(err))
+    .catch((deliveryErr: unknown) => {
+      logger.warn(
+        'subagentDelivery',
+        `Failed to deliver subagent error for ${executionId}: ${toErrorMessage(deliveryErr)}`,
+      );
     })
     .finally(() => {
       subagentDeliveryRegistry.finish(executionId);
@@ -1085,6 +1157,22 @@ Git worktree support: ${
     if (handle.category !== 'toolUse') {
       throw new Error(
         `Execution '${executionId}' is a workflow agent. Only tool-use subagents can be resumed.`,
+      );
+    }
+
+    // Results route to handle.parentStreamId — a detached subagent (parent ===
+    // child) delivers nowhere, and a subagent of another orchestrator reports
+    // to that orchestrator, not the caller. Fail fast instead of silently
+    // queueing instructions whose results would never come back here.
+    if (handle.parentStreamId === handle.childStreamId) {
+      throw new Error(
+        `Execution '${executionId}' was detached from its orchestrator and now runs top-level. Its results can no longer be delivered back to this session — start a new delegation instead.`,
+      );
+    }
+    const callerStreamId = parentContext?.streamId;
+    if (callerStreamId && handle.parentStreamId !== callerStreamId) {
+      throw new Error(
+        `Execution '${executionId}' belongs to a different orchestrator session. Its results would be delivered there, not here — start a new delegation instead.`,
       );
     }
 

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -9,6 +9,7 @@
 //
 // Host-agnostic, VS Code-free.
 
+import { platform } from '@platform';
 import { getExecutionStore, writeTerminalStatus } from '@agent/storage';
 import type { AgentTrace } from '@agent/trace';
 import {
@@ -222,13 +223,30 @@ export function runAgentCliSession<TTurn>(
             : strategy.formatError(turn, prompt, err);
         try {
           await getExecutionStore(executionId).writeReport(msg);
-        } catch {
-          // Best-effort; delivery must not block on storage.
+        } catch (storageErr) {
+          // Best-effort; delivery must not block on storage. But the report is
+          // the only durable copy when delivery fails, so leave a trace.
+          logger.warn(
+            `Failed to persist report for ${executionId}: ${toErrorMessage(storageErr)}`,
+          );
         }
-        await sendFollowUp(parentStreamId, {
+        const delivery = await sendFollowUp(parentStreamId, {
           text: msg,
           origin: 'subagent_result',
         });
+        if (delivery.status === 'no_session') {
+          logger.warn(
+            `Turn result for ${executionId} not delivered: parent stream ${parentStreamId} has no active session (status: ${delivery.streamStatus ?? 'unknown'}). The result remains in the execution report.`,
+          );
+        } else if (
+          delivery.status === 'queued' &&
+          (delivery.reason === 'waiting' ||
+            delivery.reason === 'children_running')
+        ) {
+          // The parent's cycle has exited; wake it so the queued result is
+          // consumed instead of sitting until the user pokes the stream.
+          await platform().agentResume.tryResumeStream(parentStreamId);
+        }
 
         if (turnFailed) {
           sawTurnFailure = true;

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -9,7 +9,6 @@
 //
 // Host-agnostic, VS Code-free.
 
-import { platform } from '@platform';
 import { getExecutionStore, writeTerminalStatus } from '@agent/storage';
 import type { AgentTrace } from '@agent/trace';
 import {
@@ -18,7 +17,7 @@ import {
 } from '@agent/runtime/InterruptRegistry';
 import {
   sendFollowUp,
-  shouldWakeQueuedStream,
+  wakeOrReleaseQueuedStream,
 } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
@@ -241,8 +240,12 @@ export function runAgentCliSession<TTurn>(
           logger.warn(
             `Turn result for ${executionId} not delivered: parent stream ${parentStreamId} has no active session (status: ${delivery.streamStatus ?? 'unknown'}). The result remains in the execution report.`,
           );
-        } else if (shouldWakeQueuedStream(delivery)) {
-          await platform().agentResume.tryResumeStream(parentStreamId);
+        } else if (
+          !(await wakeOrReleaseQueuedStream(parentStreamId, delivery))
+        ) {
+          logger.warn(
+            `Turn result for ${executionId} dropped: parent stream ${parentStreamId} is gone and could not be resumed. The result remains in the execution report.`,
+          );
         }
 
         if (turnFailed) {

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -16,7 +16,10 @@ import {
   interruptRegistry,
   type IInterruptible,
 } from '@agent/runtime/InterruptRegistry';
-import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import {
+  sendFollowUp,
+  shouldWakeQueuedStream,
+} from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
@@ -224,8 +227,8 @@ export function runAgentCliSession<TTurn>(
         try {
           await getExecutionStore(executionId).writeReport(msg);
         } catch (storageErr) {
-          // Best-effort; delivery must not block on storage. But the report is
-          // the only durable copy when delivery fails, so leave a trace.
+          // Best-effort — but the report is the only durable copy of the
+          // result when delivery fails, so leave a trace.
           logger.warn(
             `Failed to persist report for ${executionId}: ${toErrorMessage(storageErr)}`,
           );
@@ -238,13 +241,7 @@ export function runAgentCliSession<TTurn>(
           logger.warn(
             `Turn result for ${executionId} not delivered: parent stream ${parentStreamId} has no active session (status: ${delivery.streamStatus ?? 'unknown'}). The result remains in the execution report.`,
           );
-        } else if (
-          delivery.status === 'queued' &&
-          (delivery.reason === 'waiting' ||
-            delivery.reason === 'children_running')
-        ) {
-          // The parent's cycle has exited; wake it so the queued result is
-          // consumed instead of sitting until the user pokes the stream.
+        } else if (shouldWakeQueuedStream(delivery)) {
           await platform().agentResume.tryResumeStream(parentStreamId);
         }
 

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -128,6 +128,8 @@ export function formatSubagentDelivery(
   result: AgentFlowResult,
   options?: {
     diffInfos?: Map<string, DiffFileInfo>;
+    /** Reason diff computation failed — emitted so the orchestrator can read the output files directly instead of assuming a no-op revision. */
+    diffsUnavailable?: string;
     wallTimeMs?: number;
     workingDirectory?: string;
   },
@@ -148,6 +150,11 @@ export function formatSubagentDelivery(
   lines.push(...formatMemoryMisses(result.memoryMisses));
 
   if (result.category === 'workflow') {
+    if (options?.diffsUnavailable) {
+      lines.push(
+        `<diffs-unavailable reason="${escapeAttr(options.diffsUnavailable)}">Diff computation failed — read the output files directly to review the changes.</diffs-unavailable>`,
+      );
+    }
     if (result.outputs.length > 0) {
       lines.push(...formatWorkflowOutputs(result.outputs, options?.diffInfos));
     }


### PR DESCRIPTION
Engine correctness:
- Cascade interruption to grandchildren: killing or stopping an
  orchestrator now recursively interrupts the whole delegation chain
  (visited-set guarded), instead of leaving grandchildren running
  against a dead parent.
- Subagent error delivery is awaited before the delivery registry entry
  is torn down, and delivery failures are logged instead of vanishing
  in a fire-and-forget catch.
- Queued terminal subagent deliveries now wake a WAITING parent via the
  host resume port (same pattern as inquiry continuations), so
  orchestrators learn their subagents finished without the user poking
  the stream. When the parent is gone for good, the force-reopened
  children_running queue is re-released so late deliveries don't leak
  into the next run on that stream.
- delegate_agent resume validates lineage: resuming a detached subagent
  or another orchestrator's subagent fails fast with the reason, instead
  of silently queueing instructions whose results can never route back.

Observability:
- Workflow diff-computation failures surface as <diffs-unavailable> in
  the delivery XML (plus a warn log) so orchestrators read output files
  directly instead of assuming a no-op revision.
- Report-persistence failures and dropped parent deliveries in the
  shared agent-CLI session loop are logged with execution context.

UX:
- Multi-Agent settings tab badges orchestrators by delegation-tool
  capability (computed backend-side from the registry), fixing the
  Software Engineer preset whose `engineer` root was never badged by
  the name heuristic.
- CLI team runs state explicitly when no input/context files were
  attached, preventing orchestrators from delegating rewrites with
  invented file paths.
- `texra multi-agent run` reports when remote agents were loaded to
  fill preset gaps instead of silently replanning.

https://claude.ai/code/session_01JQLGicZcPPHLyXFrAmeWK7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core execution termination, follow-up queue lifecycle, and resume coordination—bugs could leave orphan processes, drop subagent results, or mis-route resumed delegations.
> 
> **Overview**
> This PR tightens **multi-agent orchestration correctness** and **delivery reliability** across CLI, desktop, extension, and shared runtime.
> 
> **Execution stop/kill** now walks the full delegation tree: `executionRegistry` uses a shared `visited` set and **cascades interrupts to grandchildren** on kill/stop, while **detach-on-stop** still promotes direct children without killing their descendants. The CLI TUI passes **`runtimeHost`** and honors **`DETACH_SUBAGENTS_ON_STOP`** when interrupting.
> 
> **Subagent result delivery** no longer stalls on idle parents: terminal deliveries call **`wakeOrReleaseQueuedStream`**, which serializes per-stream resume attempts via the platform **`agentResume`** port (desktop adds **`isResumeInFlight`**). Failed wakes **re-release** the follow-up queue so results don’t leak into the next run; **`delegate_agent` resume** rejects detached or wrong-orchestrator executions up front.
> 
> **Observability**: workflow diff failures emit **`<diffs-unavailable>`** in delivery XML; report write failures and dropped deliveries are **logged** in delegation and agent-CLI paths.
> 
> **UX**: extension multi-agent preset cards badge orchestrators from a **registry-backed delegation-tool list**; CLI team instructions **state when no files** were attached; **`texra multi-agent run`** **stderr** when a remote agent reload was used to fill preset gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4860d4bbac25c33d37b2eb152e61fa738dc70a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->