### PR TITLE
fix(cli): resolve ten TUI friction points across input, status, and slash UX

### DIFF
--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -5,6 +5,7 @@
 // markdown (bold section headers + list items) so each command stays on
 // its own row in the transcript.
 
+import { textInputEditingHelp } from '../input/textInputBindings';
 import { metaChordLabel } from '../panes/StatusBar';
 
 import type { SlashCommand, SlashCommandCategory } from './slashRegistry';
@@ -59,6 +60,9 @@ function keyboardSection(options: SlashCommandHelpOptions): string {
     '**Keyboard**',
     `- \`Enter\` sends · ${newline}`,
     '- `↑`/`↓` browse input history · `Ctrl-R` searches it',
+    // Generated from the editing keymap so this list can't drift from the
+    // bindings that actually exist (see textInputBindings.ts).
+    `- ${textInputEditingHelp()}`,
     '- `Esc` stops the current response · `Ctrl-C` stops, twice exits',
     '- `Ctrl-T` opens the transcript viewer for the focused stream',
     `- \`Tab\` switches streams · \`${focusChord}\` jumps to one (when subagents are running)`,

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -80,15 +80,32 @@ export function findSlashCommand(
 }
 
 /**
- * Returns registered commands whose name or an alias starts with `prefix`.
- * Results are case-insensitive and preserve registration order.
+ * Returns registered commands matching `prefix`, case-insensitively and in
+ * registration order. Prefix matches (on name or alias) win; when there are
+ * none, falls back to substring matches (`/odel` still finds `/model`), and
+ * finally to the closest typo suggestion (`/hlp` → `/help`) so the palette
+ * recovers from mistypes instead of going blank.
  */
 export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
   const lower = prefix.toLowerCase();
-  return listSlashCommands().filter((cmd) => {
-    if (cmd.name.toLowerCase().startsWith(lower)) return true;
-    return cmd.aliases?.some((a) => a.toLowerCase().startsWith(lower)) ?? false;
-  });
+  const commands = listSlashCommands();
+  const matchesBy = (
+    predicate: (candidate: string) => boolean,
+  ): readonly SlashCommand[] =>
+    commands.filter(
+      (cmd) =>
+        predicate(cmd.name.toLowerCase()) ||
+        (cmd.aliases?.some((a) => predicate(a.toLowerCase())) ?? false),
+    );
+
+  const prefixMatches = matchesBy((candidate) => candidate.startsWith(lower));
+  if (prefixMatches.length > 0 || lower.length === 0) return prefixMatches;
+
+  const substringMatches = matchesBy((candidate) => candidate.includes(lower));
+  if (substringMatches.length > 0) return substringMatches;
+
+  const suggestion = suggestSlashCommand(lower);
+  return suggestion ? [suggestion] : [];
 }
 
 /**

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -68,14 +68,19 @@ export function listSlashCommands(): readonly SlashCommand[] {
   return [...COMMANDS.values()];
 }
 
+/** Lowercased name + aliases a command can be addressed by. */
+function commandCandidates(command: SlashCommand): string[] {
+  return [command.name, ...(command.aliases ?? [])].map((name) =>
+    name.toLowerCase(),
+  );
+}
+
 export function findSlashCommand(
   nameOrAlias: string,
 ): SlashCommand | undefined {
   const lower = nameOrAlias.toLowerCase();
-  return listSlashCommands().find(
-    (cmd) =>
-      cmd.name.toLowerCase() === lower ||
-      cmd.aliases?.some((alias) => alias.toLowerCase() === lower) === true,
+  return listSlashCommands().find((cmd) =>
+    commandCandidates(cmd).includes(lower),
   );
 }
 
@@ -89,19 +94,13 @@ export function findSlashCommand(
 export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
   const lower = prefix.toLowerCase();
   const commands = listSlashCommands();
-  const matchesBy = (
-    predicate: (candidate: string) => boolean,
-  ): readonly SlashCommand[] =>
-    commands.filter(
-      (cmd) =>
-        predicate(cmd.name.toLowerCase()) ||
-        (cmd.aliases?.some((a) => predicate(a.toLowerCase())) ?? false),
-    );
+  const matching = (test: (candidate: string) => boolean) =>
+    commands.filter((cmd) => commandCandidates(cmd).some(test));
 
-  const prefixMatches = matchesBy((candidate) => candidate.startsWith(lower));
-  if (prefixMatches.length > 0 || lower.length === 0) return prefixMatches;
+  const prefixMatches = matching((candidate) => candidate.startsWith(lower));
+  if (prefixMatches.length > 0 || !lower) return prefixMatches;
 
-  const substringMatches = matchesBy((candidate) => candidate.includes(lower));
+  const substringMatches = matching((candidate) => candidate.includes(lower));
   if (substringMatches.length > 0) return substringMatches;
 
   const suggestion = suggestSlashCommand(lower);
@@ -126,16 +125,15 @@ export function suggestSlashCommand(
     | undefined;
 
   for (const command of listSlashCommands()) {
-    for (const candidate of [command.name, ...(command.aliases ?? [])]) {
-      const lower = candidate.toLowerCase();
-      const distance = editDistance(token, lower);
-      if (distance > typoSuggestionThreshold(token, lower)) continue;
+    for (const candidate of commandCandidates(command)) {
+      const distance = editDistance(token, candidate);
+      if (distance > typoSuggestionThreshold(token, candidate)) continue;
       if (
         best === undefined ||
         distance < best.distance ||
-        (distance === best.distance && lower < best.candidate)
+        (distance === best.distance && candidate < best.candidate)
       ) {
-        best = { command, candidate: lower, distance };
+        best = { command, candidate, distance };
       }
     }
   }

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -85,22 +85,33 @@ export function findSlashCommand(
 }
 
 /**
+ * Commands whose name or an alias starts with `prefix` — the palette's first
+ * tier, and the only tier safe to auto-run on a submit the user never
+ * previewed (e.g. a pasted chunk ending in a newline).
+ */
+export function prefixSlashCommands(prefix: string): readonly SlashCommand[] {
+  const lower = prefix.toLowerCase();
+  return listSlashCommands().filter((cmd) =>
+    commandCandidates(cmd).some((candidate) => candidate.startsWith(lower)),
+  );
+}
+
+/**
  * Returns registered commands matching `prefix`, case-insensitively and in
  * registration order. Prefix matches (on name or alias) win; when there are
  * none, falls back to substring matches (`/odel` still finds `/model`), and
  * finally to the closest typo suggestion (`/hlp` → `/help`) so the palette
- * recovers from mistypes instead of going blank.
+ * recovers from mistypes instead of going blank. The fallback tiers are for
+ * the palette, where the user sees the match before Enter runs it.
  */
 export function matchSlashCommands(prefix: string): readonly SlashCommand[] {
   const lower = prefix.toLowerCase();
-  const commands = listSlashCommands();
-  const matching = (test: (candidate: string) => boolean) =>
-    commands.filter((cmd) => commandCandidates(cmd).some(test));
-
-  const prefixMatches = matching((candidate) => candidate.startsWith(lower));
+  const prefixMatches = prefixSlashCommands(prefix);
   if (prefixMatches.length > 0 || !lower) return prefixMatches;
 
-  const substringMatches = matching((candidate) => candidate.includes(lower));
+  const substringMatches = listSlashCommands().filter((cmd) =>
+    commandCandidates(cmd).some((candidate) => candidate.includes(lower)),
+  );
   if (substringMatches.length > 0) return substringMatches;
 
   const suggestion = suggestSlashCommand(lower);

--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -26,6 +26,10 @@ export interface InputHistory {
     needle: string,
     from?: number,
   ): { value: string; index: number } | undefined;
+  /** Entry at `index` (0 = oldest), for ↑/↓ history browsing. */
+  at(index: number): string | undefined;
+  /** Number of stored entries. */
+  length(): number;
 }
 
 function parseRecord(raw: string): HistoryRecord | undefined {
@@ -104,6 +108,12 @@ export async function loadInputHistory(): Promise<InputHistory> {
         }
       }
       return undefined;
+    },
+    at(index) {
+      return entries[index];
+    },
+    length() {
+      return entries.length;
     },
   };
 }

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -11,12 +11,18 @@ import {
   clampCursor,
   deleteAtCursor,
   deleteBeforeCursor,
+  deleteNextWord,
   deletePreviousWord,
   deleteToEnd,
   deleteToStart,
   applyTerminalInputChunk,
   insertText,
+  lineEndCursor,
+  lineStartCursor,
   maskDisplayValue,
+  nextWordCursor,
+  previousWordCursor,
+  verticalCursorMove,
   type CursorEdit,
   type TextEdit,
 } from './textInputEditing';
@@ -46,6 +52,12 @@ export interface BaseTextInputProps {
   readonly onSubmit: (value: string) => void;
   readonly onInputChunkSubmit?: (value: string) => void;
   readonly onChange: (value: string) => void;
+  /** ↑ pressed while the caret is on the first line of the draft (where ↑ has
+   *  no in-draft meaning) — input bars use this for shell-style history
+   *  recall. Within a multiline draft, ↑/↓ move the caret between lines. */
+  readonly onHistoryUp?: () => void;
+  /** ↓ pressed while the caret is on the last line of the draft. */
+  readonly onHistoryDown?: () => void;
   /** Optionally transform pasted text before it is inserted — e.g. collapse a
    *  large paste into a `[Pasted text #N +M lines]` chip and stash the content
    *  elsewhere. Defaults to inserting the paste verbatim. */
@@ -413,6 +425,17 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         submitAfterImagePastes(onSubmit, latestStateRef.current.value);
         return;
       }
+      // Alt+Backspace (readline backward-kill-word). Terminals surface it as
+      // a meta-flagged backspace/DEL or as the raw ESC+DEL chord.
+      const chord = metaChordInput(input, key);
+      if (
+        ((key.backspace || key.delete) && key.meta) ||
+        chord === '\u007F' ||
+        chord === '\b'
+      ) {
+        applyLatestEdit(deletePreviousWord);
+        return;
+      }
       if (key.backspace) {
         applyLatestEdit(deleteBeforeCursor);
         return;
@@ -422,19 +445,51 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         return;
       }
       if (key.leftArrow) {
-        moveCursor(latestStateRef.current.cursor - 1);
+        const { value: v, cursor: c } = latestStateRef.current;
+        moveCursor(key.ctrl || key.meta ? previousWordCursor(v, c) : c - 1);
         return;
       }
       if (key.rightArrow) {
-        moveCursor(latestStateRef.current.cursor + 1);
+        const { value: v, cursor: c } = latestStateRef.current;
+        moveCursor(key.ctrl || key.meta ? nextWordCursor(v, c) : c + 1);
+        return;
+      }
+      if (key.upArrow || key.downArrow) {
+        const { value: v, cursor: c } = latestStateRef.current;
+        const moved = verticalCursorMove(v, c, key.upArrow ? -1 : 1);
+        if (moved !== undefined) {
+          moveCursor(moved);
+        } else if (key.upArrow) {
+          props.onHistoryUp?.();
+        } else {
+          props.onHistoryDown?.();
+        }
+        return;
+      }
+      // Readline word chords: Alt-B / Alt-F move by word, Alt-D kills the
+      // next word. Other meta chords fall through to the drop branch below.
+      if (chord === 'b') {
+        const { value: v, cursor: c } = latestStateRef.current;
+        moveCursor(previousWordCursor(v, c));
+        return;
+      }
+      if (chord === 'f') {
+        const { value: v, cursor: c } = latestStateRef.current;
+        moveCursor(nextWordCursor(v, c));
+        return;
+      }
+      if (chord === 'd') {
+        applyLatestEdit(deleteNextWord);
         return;
       }
       if (key.home || isCtrlInput(input, key, 'a')) {
-        moveCursor(0);
+        const { value: v, cursor: c } = latestStateRef.current;
+        moveCursor(lineStartCursor(v, c));
         return;
       }
       if (key.end || isCtrlInput(input, key, 'e')) {
-        moveCursor(latestStateRef.current.value.length);
+        const { value: v, cursor: c } = latestStateRef.current;
+        moveCursor(lineEndCursor(v, c));
         return;
       }
       if (isCtrlInput(input, key, 'u')) {

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -8,24 +8,15 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Text, useInput, usePaste } from 'ink';
 
 import {
-  clampCursor,
-  deleteAtCursor,
-  deleteBeforeCursor,
-  deleteNextWord,
-  deletePreviousWord,
-  deleteToEnd,
-  deleteToStart,
   applyTerminalInputChunk,
+  clampCursor,
   insertText,
-  lineEndCursor,
-  lineStartCursor,
   maskDisplayValue,
-  nextWordCursor,
-  previousWordCursor,
   verticalCursorMove,
   type CursorEdit,
   type TextEdit,
 } from './textInputEditing';
+import { matchTextInputBinding } from './textInputBindings';
 import {
   isPlainReturnInput,
   isCtrlInput,
@@ -433,31 +424,6 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         submitAfterImagePastes(onSubmit, latestStateRef.current.value);
         return;
       }
-      // Alt+Backspace (readline backward-kill-word). Terminals surface it as
-      // a meta-flagged backspace/DEL or as the raw ESC+DEL chord.
-      const chord = metaChordInput(input, key);
-      if (
-        ((key.backspace || key.delete) && key.meta) ||
-        chord === '\u007F' ||
-        chord === '\b'
-      ) {
-        applyLatestEdit(deletePreviousWord);
-        return;
-      }
-      if (key.backspace) {
-        applyLatestEdit(deleteBeforeCursor);
-        return;
-      }
-      if (key.delete) {
-        applyLatestEdit(deleteAtCursor);
-        return;
-      }
-      if (key.leftArrow || key.rightArrow) {
-        const word = key.leftArrow ? previousWordCursor : nextWordCursor;
-        const step = key.leftArrow ? -1 : 1;
-        moveCursorTo(key.ctrl || key.meta ? word : (_, c) => c + step);
-        return;
-      }
       if (key.upArrow || key.downArrow) {
         const { value: v, cursor: c } = latestStateRef.current;
         const moved = verticalCursorMove(v, c, key.upArrow ? -1 : 1);
@@ -468,34 +434,12 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         }
         return;
       }
-      // Readline word chords: Alt-B / Alt-F move by word, Alt-D kills the
-      // next word. Other meta chords fall through to the drop branch below.
-      if (chord === 'b' || chord === 'f') {
-        moveCursorTo(chord === 'b' ? previousWordCursor : nextWordCursor);
-        return;
-      }
-      if (chord === 'd') {
-        applyLatestEdit(deleteNextWord);
-        return;
-      }
-      if (key.home || isCtrlInput(input, key, 'a')) {
-        moveCursorTo(lineStartCursor);
-        return;
-      }
-      if (key.end || isCtrlInput(input, key, 'e')) {
-        moveCursorTo(lineEndCursor);
-        return;
-      }
-      if (isCtrlInput(input, key, 'u')) {
-        applyLatestEdit(deleteToStart);
-        return;
-      }
-      if (isCtrlInput(input, key, 'k')) {
-        applyLatestEdit(deleteToEnd);
-        return;
-      }
-      if (isCtrlInput(input, key, 'w')) {
-        applyLatestEdit(deletePreviousWord);
+      // Stateless editing chords dispatch through the declarative keymap;
+      // unmatched meta/ctrl combos fall through to the drop branch below.
+      const binding = matchTextInputBinding(input, key);
+      if (binding) {
+        if ('edit' in binding) applyLatestEdit(binding.edit);
+        else moveCursorTo(binding.move);
         return;
       }
       if (isCtrlInput(input, key, 'v') && props.onImagePaste) {

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -361,6 +361,14 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     [isControlled, onCursorChange],
   );
 
+  const moveCursorTo = useCallback(
+    (target: (value: string, cursor: number) => number) => {
+      const { value: v, cursor: c } = latestStateRef.current;
+      moveCursor(target(v, c));
+    },
+    [moveCursor],
+  );
+
   const applyEdit = useCallback(
     (edit: TextEdit) => {
       const c = clampCursor(edit.cursor, edit.value.length);
@@ -444,14 +452,10 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         applyLatestEdit(deleteAtCursor);
         return;
       }
-      if (key.leftArrow) {
-        const { value: v, cursor: c } = latestStateRef.current;
-        moveCursor(key.ctrl || key.meta ? previousWordCursor(v, c) : c - 1);
-        return;
-      }
-      if (key.rightArrow) {
-        const { value: v, cursor: c } = latestStateRef.current;
-        moveCursor(key.ctrl || key.meta ? nextWordCursor(v, c) : c + 1);
+      if (key.leftArrow || key.rightArrow) {
+        const word = key.leftArrow ? previousWordCursor : nextWordCursor;
+        const step = key.leftArrow ? -1 : 1;
+        moveCursorTo(key.ctrl || key.meta ? word : (_, c) => c + step);
         return;
       }
       if (key.upArrow || key.downArrow) {
@@ -459,23 +463,15 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         const moved = verticalCursorMove(v, c, key.upArrow ? -1 : 1);
         if (moved !== undefined) {
           moveCursor(moved);
-        } else if (key.upArrow) {
-          props.onHistoryUp?.();
         } else {
-          props.onHistoryDown?.();
+          (key.upArrow ? props.onHistoryUp : props.onHistoryDown)?.();
         }
         return;
       }
       // Readline word chords: Alt-B / Alt-F move by word, Alt-D kills the
       // next word. Other meta chords fall through to the drop branch below.
-      if (chord === 'b') {
-        const { value: v, cursor: c } = latestStateRef.current;
-        moveCursor(previousWordCursor(v, c));
-        return;
-      }
-      if (chord === 'f') {
-        const { value: v, cursor: c } = latestStateRef.current;
-        moveCursor(nextWordCursor(v, c));
+      if (chord === 'b' || chord === 'f') {
+        moveCursorTo(chord === 'b' ? previousWordCursor : nextWordCursor);
         return;
       }
       if (chord === 'd') {
@@ -483,13 +479,11 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         return;
       }
       if (key.home || isCtrlInput(input, key, 'a')) {
-        const { value: v, cursor: c } = latestStateRef.current;
-        moveCursor(lineStartCursor(v, c));
+        moveCursorTo(lineStartCursor);
         return;
       }
       if (key.end || isCtrlInput(input, key, 'e')) {
-        const { value: v, cursor: c } = latestStateRef.current;
-        moveCursor(lineEndCursor(v, c));
+        moveCursorTo(lineEndCursor);
         return;
       }
       if (isCtrlInput(input, key, 'u')) {

--- a/packages/cli/src/chat/tui/input/textInputBindings.ts
+++ b/packages/cli/src/chat/tui/input/textInputBindings.ts
@@ -1,0 +1,172 @@
+// Declarative readline-style keymap for BaseTextInput.
+//
+// One entry per editing chord: the matcher that recognizes the keypress, the
+// pure editing primitive it applies, and the label/action that document it.
+// This table is the single source of truth — BaseTextInput dispatches through
+// it and `/help` renders the advertised rows from it, so a documented chord
+// that doesn't exist (or an implemented chord nobody can discover) is
+// structurally impossible.
+//
+// Order is precedence: earlier entries win, so modified chords
+// (Alt-Backspace, Ctrl/Alt-arrows) must precede their unmodified bases. The
+// audit in TextInputBindings.vitest.mts probes every chord and fails on
+// shadowed or unreachable entries.
+//
+// Deliberately NOT in this table: stateful interactions that need component
+// context — Enter (submit), Ctrl-J/Shift-Enter (newline), Esc (cancel paste),
+// ↑/↓ (line motion falling back to history recall), and Ctrl-V (async image
+// paste). Those stay explicit in BaseTextInput.
+
+import { isCtrlInput, metaChordInput } from './inputKeys';
+import {
+  deleteAtCursor,
+  deleteBeforeCursor,
+  deleteNextWord,
+  deletePreviousWord,
+  deleteToEnd,
+  deleteToStart,
+  lineEndCursor,
+  lineStartCursor,
+  nextWordCursor,
+  previousWordCursor,
+  type CursorEdit,
+} from './textInputEditing';
+
+/** Structural subset of Ink's `Key` consulted by the keymap matchers. */
+export interface TextInputKey {
+  readonly backspace?: boolean;
+  readonly delete?: boolean;
+  readonly leftArrow?: boolean;
+  readonly rightArrow?: boolean;
+  readonly home?: boolean;
+  readonly end?: boolean;
+  readonly ctrl?: boolean;
+  readonly meta?: boolean;
+}
+
+export type TextInputBinding = {
+  /** Chord label shown in docs and audits, e.g. `Ctrl-W / Alt-Backspace`. */
+  readonly keys: string;
+  readonly action: string;
+  /** Rendered in the /help keyboard section. Omit for self-evident keys
+   *  (plain arrows, Backspace) so the docs stay short. */
+  readonly advertise?: boolean;
+  readonly matches: (input: string, key: TextInputKey) => boolean;
+} & (
+  | { readonly edit: CursorEdit }
+  | { readonly move: (value: string, cursor: number) => number }
+);
+
+const wordModified = (key: TextInputKey): boolean =>
+  key.ctrl === true || key.meta === true;
+
+export const TEXT_INPUT_BINDINGS: readonly TextInputBinding[] = [
+  {
+    keys: 'Ctrl-W / Alt-Backspace',
+    action: 'delete word left',
+    advertise: true,
+    matches: (input, key) => {
+      // Terminals surface Alt-Backspace as a meta-flagged backspace/DEL or
+      // as the raw ESC+DEL chord.
+      const chord = metaChordInput(input, key);
+      return (
+        isCtrlInput(input, key, 'w') ||
+        ((key.backspace === true || key.delete === true) &&
+          key.meta === true) ||
+        chord === '\u007F' ||
+        chord === '\b'
+      );
+    },
+    edit: deletePreviousWord,
+  },
+  {
+    keys: 'Alt-D',
+    action: 'delete word right',
+    advertise: true,
+    matches: (input, key) => metaChordInput(input, key) === 'd',
+    edit: deleteNextWord,
+  },
+  {
+    keys: 'Alt-B / Ctrl-←',
+    action: 'word left',
+    advertise: true,
+    matches: (input, key) =>
+      metaChordInput(input, key) === 'b' ||
+      (key.leftArrow === true && wordModified(key)),
+    move: previousWordCursor,
+  },
+  {
+    keys: 'Alt-F / Ctrl-→',
+    action: 'word right',
+    advertise: true,
+    matches: (input, key) =>
+      metaChordInput(input, key) === 'f' ||
+      (key.rightArrow === true && wordModified(key)),
+    move: nextWordCursor,
+  },
+  {
+    keys: 'Backspace',
+    action: 'delete left',
+    matches: (_input, key) => key.backspace === true,
+    edit: deleteBeforeCursor,
+  },
+  {
+    keys: 'Delete',
+    action: 'delete right',
+    matches: (_input, key) => key.delete === true,
+    edit: deleteAtCursor,
+  },
+  {
+    keys: '←',
+    action: 'left',
+    matches: (_input, key) => key.leftArrow === true,
+    move: (_value, cursor) => cursor - 1,
+  },
+  {
+    keys: '→',
+    action: 'right',
+    matches: (_input, key) => key.rightArrow === true,
+    move: (_value, cursor) => cursor + 1,
+  },
+  {
+    keys: 'Home / Ctrl-A',
+    action: 'line start',
+    matches: (input, key) => key.home === true || isCtrlInput(input, key, 'a'),
+    move: lineStartCursor,
+  },
+  {
+    keys: 'End / Ctrl-E',
+    action: 'line end',
+    matches: (input, key) => key.end === true || isCtrlInput(input, key, 'e'),
+    move: lineEndCursor,
+  },
+  {
+    keys: 'Ctrl-U',
+    action: 'delete to line start',
+    advertise: true,
+    matches: (input, key) => isCtrlInput(input, key, 'u'),
+    edit: deleteToStart,
+  },
+  {
+    keys: 'Ctrl-K',
+    action: 'delete to line end',
+    advertise: true,
+    matches: (input, key) => isCtrlInput(input, key, 'k'),
+    edit: deleteToEnd,
+  },
+];
+
+export function matchTextInputBinding(
+  input: string,
+  key: TextInputKey,
+): TextInputBinding | undefined {
+  return TEXT_INPUT_BINDINGS.find((binding) => binding.matches(input, key));
+}
+
+/** `/help` row for the advertised editing chords — generated from the keymap
+ *  so the docs can never drift from the implemented bindings. */
+export function textInputEditingHelp(): string {
+  return TEXT_INPUT_BINDINGS.filter((binding) => binding.advertise)
+    .map((binding) => `\`${binding.keys}\` ${binding.action}`)
+    .join(' · ');
+}

--- a/packages/cli/src/chat/tui/input/textInputEditing.ts
+++ b/packages/cli/src/chat/tui/input/textInputEditing.ts
@@ -67,18 +67,38 @@ export function deleteAtCursor(value: string, cursor: number): TextEdit {
   };
 }
 
+/** Home / Ctrl-A target: start of the current logical line (readline
+ *  behavior in a multiline draft; index 0 for single-line values). */
+export function lineStartCursor(value: string, cursor: number): number {
+  const c = clampCursor(cursor, value.length);
+  return value.lastIndexOf('\n', c - 1) + 1;
+}
+
+/** End / Ctrl-E target: end of the current logical line. */
+export function lineEndCursor(value: string, cursor: number): number {
+  const c = clampCursor(cursor, value.length);
+  const nextBreak = value.indexOf('\n', c);
+  return nextBreak === -1 ? value.length : nextBreak;
+}
+
+/** Ctrl-U: delete from the start of the current line to the cursor. */
 export function deleteToStart(value: string, cursor: number): TextEdit {
   const c = clampCursor(cursor, value.length);
+  const start = lineStartCursor(value, c);
   return {
-    value: value.slice(c),
-    cursor: 0,
+    value: value.slice(0, start) + value.slice(c),
+    cursor: start,
   };
 }
 
+/** Ctrl-K: delete from the cursor to the end of the current line; at the
+ *  end of a line it kills the newline, joining the next line (readline). */
 export function deleteToEnd(value: string, cursor: number): TextEdit {
   const c = clampCursor(cursor, value.length);
+  const lineEnd = lineEndCursor(value, c);
+  const end = lineEnd === c && c < value.length ? c + 1 : lineEnd;
   return {
-    value: value.slice(0, c),
+    value: value.slice(0, c) + value.slice(end),
     cursor: c,
   };
 }
@@ -91,6 +111,64 @@ export function deletePreviousWord(value: string, cursor: number): TextEdit {
     value: trimmed + value.slice(c),
     cursor: trimmed.length,
   };
+}
+
+/** Alt-D / readline `kill-word`: delete from the cursor through the end of
+ *  the next word (skipping any whitespace in between). */
+export function deleteNextWord(value: string, cursor: number): TextEdit {
+  const c = clampCursor(cursor, value.length);
+  const right = value.slice(c);
+  const removed = /^\s*\S*/.exec(right)?.[0].length ?? 0;
+  return {
+    value: value.slice(0, c) + value.slice(c + removed),
+    cursor: c,
+  };
+}
+
+/** Alt-B / Ctrl-← target: start of the word at (or before) the cursor. */
+export function previousWordCursor(value: string, cursor: number): number {
+  const c = clampCursor(cursor, value.length);
+  return value.slice(0, c).replace(/\S*\s*$/, '').length;
+}
+
+/** Alt-F / Ctrl-→ target: end of the word at (or after) the cursor. */
+export function nextWordCursor(value: string, cursor: number): number {
+  const c = clampCursor(cursor, value.length);
+  const advanced = /^\s*\S*/.exec(value.slice(c))?.[0].length ?? 0;
+  return c + advanced;
+}
+
+/**
+ * ↑/↓ within a multiline draft: cursor position one logical line up or down,
+ * preserving the column where the target line is long enough. Returns
+ * `undefined` when the cursor is already on the boundary line — the caller
+ * decides what the key means then (e.g. ↑ on the first line recalls history).
+ */
+export function verticalCursorMove(
+  value: string,
+  cursor: number,
+  direction: -1 | 1,
+): number | undefined {
+  const c = clampCursor(cursor, value.length);
+  const lines = value.split('\n');
+
+  let lineStart = 0;
+  let lineIndex = 0;
+  for (; lineIndex < lines.length; lineIndex += 1) {
+    const lineEnd = lineStart + (lines[lineIndex]?.length ?? 0);
+    if (c <= lineEnd) break;
+    lineStart = lineEnd + 1;
+  }
+
+  const targetIndex = lineIndex + direction;
+  if (targetIndex < 0 || targetIndex >= lines.length) return undefined;
+
+  let targetStart = 0;
+  for (let i = 0; i < targetIndex; i += 1) {
+    targetStart += (lines[i]?.length ?? 0) + 1;
+  }
+  const column = c - lineStart;
+  return targetStart + Math.min(column, lines[targetIndex]?.length ?? 0);
 }
 
 export function applyTerminalInputChunk(
@@ -120,11 +198,17 @@ export function applyTerminalInputChunk(
 
     const ctrl = normalizedCtrlInput(ch, {});
     if (ctrl === 'a') {
-      edit = { value: edit.value, cursor: 0 };
+      edit = {
+        value: edit.value,
+        cursor: lineStartCursor(edit.value, edit.cursor),
+      };
       continue;
     }
     if (ctrl === 'e') {
-      edit = { value: edit.value, cursor: edit.value.length };
+      edit = {
+        value: edit.value,
+        cursor: lineEndCursor(edit.value, edit.cursor),
+      };
       continue;
     }
     if (ctrl === 'u') {

--- a/packages/cli/src/chat/tui/input/textInputEditing.ts
+++ b/packages/cli/src/chat/tui/input/textInputEditing.ts
@@ -49,24 +49,6 @@ export function insertText(
   };
 }
 
-export function deleteBeforeCursor(value: string, cursor: number): TextEdit {
-  const c = clampCursor(cursor, value.length);
-  if (c === 0) return { value, cursor: c };
-  return {
-    value: value.slice(0, c - 1) + value.slice(c),
-    cursor: c - 1,
-  };
-}
-
-export function deleteAtCursor(value: string, cursor: number): TextEdit {
-  const c = clampCursor(cursor, value.length);
-  if (c >= value.length) return { value, cursor: c };
-  return {
-    value: value.slice(0, c) + value.slice(c + 1),
-    cursor: c,
-  };
-}
-
 /** Home / Ctrl-A target: start of the current logical line (readline
  *  behavior in a multiline draft; index 0 for single-line values). */
 export function lineStartCursor(value: string, cursor: number): number {
@@ -81,50 +63,6 @@ export function lineEndCursor(value: string, cursor: number): number {
   return nextBreak === -1 ? value.length : nextBreak;
 }
 
-/** Ctrl-U: delete from the start of the current line to the cursor. */
-export function deleteToStart(value: string, cursor: number): TextEdit {
-  const c = clampCursor(cursor, value.length);
-  const start = lineStartCursor(value, c);
-  return {
-    value: value.slice(0, start) + value.slice(c),
-    cursor: start,
-  };
-}
-
-/** Ctrl-K: delete from the cursor to the end of the current line; at the
- *  end of a line it kills the newline, joining the next line (readline). */
-export function deleteToEnd(value: string, cursor: number): TextEdit {
-  const c = clampCursor(cursor, value.length);
-  const lineEnd = lineEndCursor(value, c);
-  const end = lineEnd === c && c < value.length ? c + 1 : lineEnd;
-  return {
-    value: value.slice(0, c) + value.slice(end),
-    cursor: c,
-  };
-}
-
-export function deletePreviousWord(value: string, cursor: number): TextEdit {
-  const c = clampCursor(cursor, value.length);
-  const left = value.slice(0, c);
-  const trimmed = left.replace(/\S*\s*$/, '');
-  return {
-    value: trimmed + value.slice(c),
-    cursor: trimmed.length,
-  };
-}
-
-/** Alt-D / readline `kill-word`: delete from the cursor through the end of
- *  the next word (skipping any whitespace in between). */
-export function deleteNextWord(value: string, cursor: number): TextEdit {
-  const c = clampCursor(cursor, value.length);
-  const right = value.slice(c);
-  const removed = /^\s*\S*/.exec(right)?.[0].length ?? 0;
-  return {
-    value: value.slice(0, c) + value.slice(c + removed),
-    cursor: c,
-  };
-}
-
 /** Alt-B / Ctrl-← target: start of the word at (or before) the cursor. */
 export function previousWordCursor(value: string, cursor: number): number {
   const c = clampCursor(cursor, value.length);
@@ -134,8 +72,53 @@ export function previousWordCursor(value: string, cursor: number): number {
 /** Alt-F / Ctrl-→ target: end of the word at (or after) the cursor. */
 export function nextWordCursor(value: string, cursor: number): number {
   const c = clampCursor(cursor, value.length);
-  const advanced = /^\s*\S*/.exec(value.slice(c))?.[0].length ?? 0;
-  return c + advanced;
+  return c + (/^\s*\S*/.exec(value.slice(c))?.[0].length ?? 0);
+}
+
+/** Delete the span [from, to) and park the caret at its start. */
+function deleteSpan(value: string, from: number, to: number): TextEdit {
+  return { value: value.slice(0, from) + value.slice(to), cursor: from };
+}
+
+export function deleteBeforeCursor(value: string, cursor: number): TextEdit {
+  const c = clampCursor(cursor, value.length);
+  return deleteSpan(value, Math.max(0, c - 1), c);
+}
+
+export function deleteAtCursor(value: string, cursor: number): TextEdit {
+  const c = clampCursor(cursor, value.length);
+  return deleteSpan(value, c, Math.min(value.length, c + 1));
+}
+
+/** Ctrl-U: delete from the start of the current line to the cursor. */
+export function deleteToStart(value: string, cursor: number): TextEdit {
+  const c = clampCursor(cursor, value.length);
+  return deleteSpan(value, lineStartCursor(value, c), c);
+}
+
+/** Ctrl-K: delete from the cursor to the end of the current line; at the
+ *  end of a line it kills the newline, joining the next line (readline). */
+export function deleteToEnd(value: string, cursor: number): TextEdit {
+  const c = clampCursor(cursor, value.length);
+  const lineEnd = lineEndCursor(value, c);
+  return deleteSpan(
+    value,
+    c,
+    lineEnd === c && c < value.length ? c + 1 : lineEnd,
+  );
+}
+
+/** Ctrl-W / Alt-Backspace: delete back to the start of the previous word. */
+export function deletePreviousWord(value: string, cursor: number): TextEdit {
+  const c = clampCursor(cursor, value.length);
+  return deleteSpan(value, previousWordCursor(value, c), c);
+}
+
+/** Alt-D / readline `kill-word`: delete from the cursor through the end of
+ *  the next word (skipping any whitespace in between). */
+export function deleteNextWord(value: string, cursor: number): TextEdit {
+  const c = clampCursor(cursor, value.length);
+  return deleteSpan(value, c, nextWordCursor(value, c));
 }
 
 /**
@@ -151,25 +134,29 @@ export function verticalCursorMove(
 ): number | undefined {
   const c = clampCursor(cursor, value.length);
   const lines = value.split('\n');
+  let offset = 0;
+  const starts = lines.map((line) => {
+    const start = offset;
+    offset += line.length + 1;
+    return start;
+  });
 
-  let lineStart = 0;
-  let lineIndex = 0;
-  for (; lineIndex < lines.length; lineIndex += 1) {
-    const lineEnd = lineStart + (lines[lineIndex]?.length ?? 0);
-    if (c <= lineEnd) break;
-    lineStart = lineEnd + 1;
-  }
+  const lineIndex = starts.findLastIndex((start) => start <= c);
+  const target = lineIndex + direction;
+  if (target < 0 || target >= lines.length) return undefined;
 
-  const targetIndex = lineIndex + direction;
-  if (targetIndex < 0 || targetIndex >= lines.length) return undefined;
-
-  let targetStart = 0;
-  for (let i = 0; i < targetIndex; i += 1) {
-    targetStart += (lines[i]?.length ?? 0) + 1;
-  }
-  const column = c - lineStart;
-  return targetStart + Math.min(column, lines[targetIndex]?.length ?? 0);
+  const column = c - (starts[lineIndex] ?? 0);
+  return (starts[target] ?? 0) + Math.min(column, lines[target]?.length ?? 0);
 }
+
+/** Readline edits honored inside batched terminal input chunks. */
+const CHUNK_CTRL_EDITS: Readonly<Record<string, CursorEdit>> = {
+  a: (v, c) => ({ value: v, cursor: lineStartCursor(v, c) }),
+  e: (v, c) => ({ value: v, cursor: lineEndCursor(v, c) }),
+  u: deleteToStart,
+  k: deleteToEnd,
+  w: deletePreviousWord,
+};
 
 export function applyTerminalInputChunk(
   value: string,
@@ -197,30 +184,9 @@ export function applyTerminalInputChunk(
     }
 
     const ctrl = normalizedCtrlInput(ch, {});
-    if (ctrl === 'a') {
-      edit = {
-        value: edit.value,
-        cursor: lineStartCursor(edit.value, edit.cursor),
-      };
-      continue;
-    }
-    if (ctrl === 'e') {
-      edit = {
-        value: edit.value,
-        cursor: lineEndCursor(edit.value, edit.cursor),
-      };
-      continue;
-    }
-    if (ctrl === 'u') {
-      edit = deleteToStart(edit.value, edit.cursor);
-      continue;
-    }
-    if (ctrl === 'k') {
-      edit = deleteToEnd(edit.value, edit.cursor);
-      continue;
-    }
-    if (ctrl === 'w') {
-      edit = deletePreviousWord(edit.value, edit.cursor);
+    const ctrlEdit = ctrl ? CHUNK_CTRL_EDITS[ctrl] : undefined;
+    if (ctrlEdit) {
+      edit = ctrlEdit(edit.value, edit.cursor);
       continue;
     }
     if (ctrl || isEscapeInput(ch, {}) || isUnhandledControlInput(ch)) {

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -83,12 +83,66 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   const [reverseSearchOpen, setReverseSearchOpen] = useState(false);
   const [attachNotice, setAttachNotice] = useState<string | null>(null);
   const draftValueRef = useRef(value);
+  // ↑/↓ history browsing (shell-style). `index` walks the persisted entries;
+  // `savedDraft` restores whatever was typed before browsing began. Any edit
+  // that diverges from the recalled entry ends the browse.
+  const historyBrowseRef = useRef<
+    { index: number; savedDraft: string } | undefined
+  >(undefined);
+  const appliedHistoryValueRef = useRef<string | undefined>(undefined);
   const setValue = useCallback((next: string) => {
     draftValueRef.current = next;
+    if (
+      appliedHistoryValueRef.current !== undefined &&
+      next !== appliedHistoryValueRef.current
+    ) {
+      historyBrowseRef.current = undefined;
+      appliedHistoryValueRef.current = undefined;
+    }
     setValueState(next);
   }, []);
   const historyRef = useRef(history);
   historyRef.current = history;
+  const recallHistoryValue = useCallback((next: string) => {
+    draftValueRef.current = next;
+    appliedHistoryValueRef.current = next;
+    setValueState(next);
+  }, []);
+  const handleHistoryUp = useCallback(() => {
+    const entries = historyRef.current;
+    if (!entries) return;
+    const count = entries.length();
+    if (count === 0) return;
+    const browse = historyBrowseRef.current;
+    const nextIndex = browse === undefined ? count - 1 : browse.index - 1;
+    if (nextIndex < 0) return;
+    const entry = entries.at(nextIndex);
+    if (entry === undefined) return;
+    historyBrowseRef.current = {
+      index: nextIndex,
+      savedDraft: browse?.savedDraft ?? draftValueRef.current,
+    };
+    recallHistoryValue(entry);
+  }, [recallHistoryValue]);
+  const handleHistoryDown = useCallback(() => {
+    const entries = historyRef.current;
+    const browse = historyBrowseRef.current;
+    if (!entries || browse === undefined) return;
+    const nextIndex = browse.index + 1;
+    if (nextIndex >= entries.length()) {
+      // Walked past the newest entry — restore the pre-browse draft.
+      historyBrowseRef.current = undefined;
+      appliedHistoryValueRef.current = undefined;
+      const restored = browse.savedDraft;
+      draftValueRef.current = restored;
+      setValueState(restored);
+      return;
+    }
+    const entry = entries.at(nextIndex);
+    if (entry === undefined) return;
+    historyBrowseRef.current = { ...browse, index: nextIndex };
+    recallHistoryValue(entry);
+  }, [recallHistoryValue]);
   const imagePasteQueueRef = useRef<ImagePasteQueue | null>(null);
   imagePasteQueueRef.current ??= new ImagePasteQueue();
   const imagePasteQueue = imagePasteQueueRef.current;
@@ -303,6 +357,10 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           value={value}
           focus={!disabled && !reverseSearchOpen}
           onChange={setValue}
+          // While the slash palette is open it owns ↑/↓ for row selection;
+          // history recall would clobber the draft mid-navigation.
+          onHistoryUp={showPalette ? undefined : handleHistoryUp}
+          onHistoryDown={showPalette ? undefined : handleHistoryDown}
           imagePasteQueue={imagePasteQueue}
           transformPaste={transformPaste}
           onImagePaste={onImagePaste}

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -17,6 +17,7 @@ import { SlashPalette } from '../commands/SlashPalette';
 import {
   matchSlashCommands,
   parseSlashInput,
+  prefixSlashCommands,
   slashPickIntent,
   type SlashCommand,
   type SlashPickIntent,
@@ -238,7 +239,11 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
     (submitted: string) => {
       const slash = parseSlashInput(submitted);
       if (slash !== undefined && !/\s/.test(submitted.slice(1))) {
-        const chosen = matchSlashCommands(slash.name)[0];
+        // Batched chunks (e.g. a paste ending in a newline) never showed the
+        // palette, so only auto-run prefix matches here — the substring/typo
+        // fallbacks are palette-only, where the user previews the match.
+        // Unmatched input falls through to the unknown-command suggestion.
+        const chosen = prefixSlashCommands(slash.name)[0];
         if (chosen !== undefined) {
           acceptSlashCommand(
             chosen,

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -83,66 +83,35 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   const [reverseSearchOpen, setReverseSearchOpen] = useState(false);
   const [attachNotice, setAttachNotice] = useState<string | null>(null);
   const draftValueRef = useRef(value);
-  // ↑/↓ history browsing (shell-style). `index` walks the persisted entries;
-  // `savedDraft` restores whatever was typed before browsing began. Any edit
-  // that diverges from the recalled entry ends the browse.
+  // ↑/↓ history browsing (shell-style). `index` walks the persisted entries,
+  // `savedDraft` restores whatever was typed before browsing began, and
+  // `applied` detects edits to a recalled entry, which end the browse.
   const historyBrowseRef = useRef<
-    { index: number; savedDraft: string } | undefined
+    { index: number; savedDraft: string; applied: string } | undefined
   >(undefined);
-  const appliedHistoryValueRef = useRef<string | undefined>(undefined);
   const setValue = useCallback((next: string) => {
     draftValueRef.current = next;
-    if (
-      appliedHistoryValueRef.current !== undefined &&
-      next !== appliedHistoryValueRef.current
-    ) {
+    if (next !== historyBrowseRef.current?.applied) {
       historyBrowseRef.current = undefined;
-      appliedHistoryValueRef.current = undefined;
     }
     setValueState(next);
   }, []);
   const historyRef = useRef(history);
   historyRef.current = history;
-  const recallHistoryValue = useCallback((next: string) => {
-    draftValueRef.current = next;
-    appliedHistoryValueRef.current = next;
-    setValueState(next);
+  const browseHistory = useCallback((direction: -1 | 1) => {
+    const entries = historyRef.current;
+    const browse = historyBrowseRef.current;
+    if (!entries || (!browse && direction === 1)) return;
+    const index = (browse?.index ?? entries.length()) + direction;
+    if (index < 0) return;
+    const savedDraft = browse?.savedDraft ?? draftValueRef.current;
+    // Walking ↓ past the newest entry restores the pre-browse draft.
+    const entry = entries.at(index);
+    historyBrowseRef.current =
+      entry === undefined ? undefined : { index, savedDraft, applied: entry };
+    draftValueRef.current = entry ?? savedDraft;
+    setValueState(entry ?? savedDraft);
   }, []);
-  const handleHistoryUp = useCallback(() => {
-    const entries = historyRef.current;
-    if (!entries) return;
-    const count = entries.length();
-    if (count === 0) return;
-    const browse = historyBrowseRef.current;
-    const nextIndex = browse === undefined ? count - 1 : browse.index - 1;
-    if (nextIndex < 0) return;
-    const entry = entries.at(nextIndex);
-    if (entry === undefined) return;
-    historyBrowseRef.current = {
-      index: nextIndex,
-      savedDraft: browse?.savedDraft ?? draftValueRef.current,
-    };
-    recallHistoryValue(entry);
-  }, [recallHistoryValue]);
-  const handleHistoryDown = useCallback(() => {
-    const entries = historyRef.current;
-    const browse = historyBrowseRef.current;
-    if (!entries || browse === undefined) return;
-    const nextIndex = browse.index + 1;
-    if (nextIndex >= entries.length()) {
-      // Walked past the newest entry — restore the pre-browse draft.
-      historyBrowseRef.current = undefined;
-      appliedHistoryValueRef.current = undefined;
-      const restored = browse.savedDraft;
-      draftValueRef.current = restored;
-      setValueState(restored);
-      return;
-    }
-    const entry = entries.at(nextIndex);
-    if (entry === undefined) return;
-    historyBrowseRef.current = { ...browse, index: nextIndex };
-    recallHistoryValue(entry);
-  }, [recallHistoryValue]);
   const imagePasteQueueRef = useRef<ImagePasteQueue | null>(null);
   imagePasteQueueRef.current ??= new ImagePasteQueue();
   const imagePasteQueue = imagePasteQueueRef.current;
@@ -359,8 +328,8 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           onChange={setValue}
           // While the slash palette is open it owns ↑/↓ for row selection;
           // history recall would clobber the draft mid-navigation.
-          onHistoryUp={showPalette ? undefined : handleHistoryUp}
-          onHistoryDown={showPalette ? undefined : handleHistoryDown}
+          onHistoryUp={showPalette ? undefined : () => browseHistory(-1)}
+          onHistoryDown={showPalette ? undefined : () => browseHistory(1)}
           imagePasteQueue={imagePasteQueue}
           transformPaste={transformPaste}
           onImagePaste={onImagePaste}

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -336,29 +336,38 @@ function fitStatusBarLeftSegments(
     ),
   ].sort((a, b) => a - b);
 
-  // First pass: shrink segments to their compactText (lowest priority first)
-  // before removing anything — a narrowed segment beats a missing one.
-  for (const priority of priorities) {
-    for (let index = compacted.length - 1; index >= 0; index -= 1) {
-      const segment = compacted[index];
-      if (segment?.compactPriority !== priority) continue;
+  // Lowest-priority segments compact first; returns as soon as the row fits.
+  const sweep = (
+    apply: (index: number, segment: StatusBarSegment) => boolean,
+  ): readonly StatusBarSegment[] | undefined => {
+    for (const priority of priorities) {
+      for (let index = compacted.length - 1; index >= 0; index -= 1) {
+        const segment = compacted[index];
+        if (segment?.compactPriority !== priority || !apply(index, segment)) {
+          continue;
+        }
+        if (statusBarSegmentsWidth(compacted) <= innerWidth) return compacted;
+      }
+    }
+    return undefined;
+  };
+
+  return (
+    // Shrink segments to their compactText before removing anything — a
+    // narrowed segment beats a missing one.
+    sweep((index, segment) => {
       if (!segment.compactText || segment.compactText === segment.text) {
-        continue;
+        return false;
       }
       compacted[index] = { ...segment, text: segment.compactText };
-      if (statusBarSegmentsWidth(compacted) <= innerWidth) return compacted;
-    }
-  }
-
-  for (const priority of priorities) {
-    for (let index = compacted.length - 1; index >= 0; index -= 1) {
-      if (compacted[index]?.compactPriority !== priority) continue;
+      return true;
+    }) ??
+    sweep((index) => {
       compacted.splice(index, 1);
-      if (statusBarSegmentsWidth(compacted) <= innerWidth) return compacted;
-    }
-  }
-
-  return compacted;
+      return true;
+    }) ??
+    compacted
+  );
 }
 
 export function defaultShortcutModifierLabel(

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -45,6 +45,9 @@ export interface StatusBarSegment {
   readonly badge?: boolean;
   readonly badgeColor?: 'red' | 'yellow';
   readonly compactPriority?: number;
+  /** Shorter replacement text tried (in priority order) before the segment
+   *  is removed outright when the bar overflows the terminal width. */
+  readonly compactText?: string;
   /** Purely visual glyphs hidden from screen readers (`aria-hidden`). */
   readonly decorative?: boolean;
 }
@@ -139,6 +142,9 @@ function formatUsage(
     text: `${formatCompactNumber(total)}/${formatCompactNumber(
       contextWindow,
     )} (${percent}%)`,
+    // Keep context visibility on narrow terminals: degrade to the bare
+    // percentage instead of dropping the segment entirely.
+    compactText: `${percent}%`,
     color,
   };
 }
@@ -329,6 +335,20 @@ function fitStatusBarLeftSegments(
         .filter(filterNotNullish),
     ),
   ].sort((a, b) => a - b);
+
+  // First pass: shrink segments to their compactText (lowest priority first)
+  // before removing anything — a narrowed segment beats a missing one.
+  for (const priority of priorities) {
+    for (let index = compacted.length - 1; index >= 0; index -= 1) {
+      const segment = compacted[index];
+      if (segment?.compactPriority !== priority) continue;
+      if (!segment.compactText || segment.compactText === segment.text) {
+        continue;
+      }
+      compacted[index] = { ...segment, text: segment.compactText };
+      if (statusBarSegmentsWidth(compacted) <= innerWidth) return compacted;
+    }
+  }
 
   for (const priority of priorities) {
     for (let index = compacted.length - 1; index >= 0; index -= 1) {
@@ -597,6 +617,17 @@ export function buildStatusBarDisplay(
 
   if (input.pendingExitHint) {
     left.push({ text: PENDING_EXIT_HINT_TEXT, color: 'yellow' });
+    const queuedCount = input.queuedFollowUpMessages.length;
+    if (queuedCount > 0) {
+      // Exiting drops queued follow-ups silently — warn before the user
+      // confirms with the second Ctrl-C.
+      left.push({
+        text: `${queuedCount} queued follow-up${
+          queuedCount === 1 ? '' : 's'
+        } will be discarded`,
+        color: 'red',
+      });
+    }
   } else {
     left.push({ text: formatCliStatusLabel(input.status), color: 'dim' });
     if (

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -18,11 +18,29 @@ import {
   editPatchGroups,
   type InlinePatchGroup,
 } from '../render/DiffView';
+import { textDisplayWidth } from '../render/terminalText';
 
 const STATUS_DOT = '●';
 const OUTPUT_CORNER = '⎿';
 const MAX_HEADER_PREVIEW = 80;
 const MAX_ERROR_PREVIEW = 240;
+// Header chrome around the preview: `● ` plus ` (` and `)`.
+const HEADER_CHROME_COLS = 5;
+const MIN_HEADER_PREVIEW = 24;
+
+/** Preview budget for live tool rows: fill the terminal row instead of the
+ *  historical fixed 80 columns, so wide terminals show the whole command and
+ *  narrow ones truncate to fit a single row. */
+export function toolHeaderPreviewBudget(
+  columns: number | undefined,
+  displayName: string,
+): number {
+  if (columns === undefined || columns <= 0) return MAX_HEADER_PREVIEW;
+  return Math.max(
+    MIN_HEADER_PREVIEW,
+    columns - textDisplayWidth(displayName) - HEADER_CHROME_COLS,
+  );
+}
 
 // Tool output can be arbitrarily large (a 50 KB bash dump, a long grep). The
 // finalized `<Static>` scrollback and the live region show a head+tail slice
@@ -411,6 +429,7 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     showExitCode = false,
     preferInputPreview = false,
   } = props;
+  const { columns } = useWindowSize();
   const color = statusColor(toolUse);
   const name =
     (props.displayName ?? displayToolName(toolUse.toolName)) ||
@@ -424,14 +443,17 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
       ? previewInput(toolUse.input) || toolUse.headerSummary || ''
       : toolUse.headerSummary || previewInput(toolUse.input) || '';
     const previewText = sourceText
-      ? truncateWithEllipsis(collapseWhitespace(sourceText), MAX_HEADER_PREVIEW)
+      ? truncateWithEllipsis(
+          collapseWhitespace(sourceText),
+          toolHeaderPreviewBudget(columns, name),
+        )
       : '';
     return {
       patchGroups: showPatch ? toolUsePatchGroups(toolUse) : undefined,
       preview: previewText,
       visibleOutput: showOutput ? visibleOutputLines(toolUse) : [],
     };
-  }, [toolUse, showPatch, showOutput, preferInputPreview]);
+  }, [toolUse, showPatch, showOutput, preferInputPreview, columns, name]);
 
   const errorText = errorTextForDisplay(toolUse);
   const exitCode = showExitCode ? extractExitCode(toolUse) : undefined;

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -18,7 +18,10 @@ import {
   editPatchGroups,
   type InlinePatchGroup,
 } from '../render/DiffView';
-import { textDisplayWidth } from '../render/terminalText';
+import {
+  textDisplayWidth,
+  truncateSummaryToWidth,
+} from '../render/terminalText';
 
 const STATUS_DOT = '●';
 const OUTPUT_CORNER = '⎿';
@@ -26,20 +29,22 @@ const MAX_HEADER_PREVIEW = 80;
 const MAX_ERROR_PREVIEW = 240;
 // Header chrome around the preview: `● ` plus ` (` and `)`.
 const HEADER_CHROME_COLS = 5;
-const MIN_HEADER_PREVIEW = 24;
+// Below this many remaining columns, drop the preview instead of overflowing
+// the row.
+const MIN_HEADER_PREVIEW = 4;
 
-/** Preview budget for live tool rows: fill the terminal row instead of the
- *  historical fixed 80 columns, so wide terminals show the whole command and
- *  narrow ones truncate to fit a single row. */
+/** Preview budget (in display columns) for live tool rows: fill the terminal
+ *  row instead of the historical fixed 80 columns, so wide terminals show the
+ *  whole command and narrow ones truncate to fit a single row. Returns 0 (no
+ *  preview) when the tool name plus chrome already eat the row. */
 export function toolHeaderPreviewBudget(
   columns: number | undefined,
   displayName: string,
 ): number {
   if (columns === undefined || columns <= 0) return MAX_HEADER_PREVIEW;
-  return Math.max(
-    MIN_HEADER_PREVIEW,
-    columns - textDisplayWidth(displayName) - HEADER_CHROME_COLS,
-  );
+  const available =
+    columns - textDisplayWidth(displayName) - HEADER_CHROME_COLS;
+  return available >= MIN_HEADER_PREVIEW ? available : 0;
 }
 
 // Tool output can be arbitrarily large (a 50 KB bash dump, a long grep). The
@@ -175,7 +180,8 @@ export function toolUsePatchDisplayLines(
   ]);
 }
 
-/** One-line input/summary preview for a tool header, truncated to fit.
+/** One-line input/summary preview for a tool header, truncated to
+ *  `maxPreview` display columns (so wide glyphs cannot overflow the budget).
  *  Bash rows prefer the command text (input) over the generic header summary;
  *  all other tools prefer the curated per-tool summary first. */
 function toolHeaderPreview(
@@ -183,12 +189,11 @@ function toolHeaderPreview(
   maxPreview = MAX_HEADER_PREVIEW,
   preferInputPreview = false,
 ): string {
+  if (maxPreview <= 0) return '';
   const sourceText = preferInputPreview
     ? previewInput(toolUse.input) || toolUse.headerSummary || ''
     : toolUse.headerSummary || previewInput(toolUse.input) || '';
-  return sourceText
-    ? truncateWithEllipsis(collapseWhitespace(sourceText), maxPreview)
-    : '';
+  return sourceText ? truncateSummaryToWidth(sourceText, maxPreview) : '';
 }
 
 function formatHeader(

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -175,14 +175,27 @@ export function toolUsePatchDisplayLines(
   ]);
 }
 
+/** One-line input/summary preview for a tool header, truncated to fit.
+ *  Bash rows prefer the command text (input) over the generic header summary;
+ *  all other tools prefer the curated per-tool summary first. */
+function toolHeaderPreview(
+  toolUse: NormalizedToolUse,
+  maxPreview = MAX_HEADER_PREVIEW,
+  preferInputPreview = false,
+): string {
+  const sourceText = preferInputPreview
+    ? previewInput(toolUse.input) || toolUse.headerSummary || ''
+    : toolUse.headerSummary || previewInput(toolUse.input) || '';
+  return sourceText
+    ? truncateWithEllipsis(collapseWhitespace(sourceText), maxPreview)
+    : '';
+}
+
 function formatHeader(
   toolUse: NormalizedToolUse,
   displayName = displayToolName(toolUse.toolName) || 'tool',
 ): string {
-  const sourceText = toolUse.headerSummary || previewInput(toolUse.input) || '';
-  const preview = sourceText
-    ? truncateWithEllipsis(collapseWhitespace(sourceText), MAX_HEADER_PREVIEW)
-    : '';
+  const preview = toolHeaderPreview(toolUse);
   return `${STATUS_DOT} ${displayName}${preview ? ` (${preview})` : ''}`;
 }
 
@@ -436,24 +449,18 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     props.fallbackName ||
     'tool';
 
-  const { patchGroups, preview, visibleOutput } = useMemo(() => {
-    // Bash rows prefer the command text (input) over the generic header summary;
-    // all other tools prefer the summary (which is curated per-tool) first.
-    const sourceText = preferInputPreview
-      ? previewInput(toolUse.input) || toolUse.headerSummary || ''
-      : toolUse.headerSummary || previewInput(toolUse.input) || '';
-    const previewText = sourceText
-      ? truncateWithEllipsis(
-          collapseWhitespace(sourceText),
-          toolHeaderPreviewBudget(columns, name),
-        )
-      : '';
-    return {
+  const { patchGroups, preview, visibleOutput } = useMemo(
+    () => ({
       patchGroups: showPatch ? toolUsePatchGroups(toolUse) : undefined,
-      preview: previewText,
+      preview: toolHeaderPreview(
+        toolUse,
+        toolHeaderPreviewBudget(columns, name),
+        preferInputPreview,
+      ),
       visibleOutput: showOutput ? visibleOutputLines(toolUse) : [],
-    };
-  }, [toolUse, showPatch, showOutput, preferInputPreview, columns, name]);
+    }),
+    [toolUse, showPatch, showOutput, preferInputPreview, columns, name],
+  );
 
   const errorText = errorTextForDisplay(toolUse);
   const exitCode = showExitCode ? extractExitCode(toolUse) : undefined;

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -862,6 +862,7 @@ async function handleTuiSlashCommand(
           approval: formatApprovalPolicy(context.getApprovalPolicy()),
           approvalBypasses: slice?.bypass,
           status: slice?.status ?? 'not started',
+          sessionId: context.session.executionId,
           queuedFollowUpMessages:
             activeStreamId === undefined
               ? []

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -862,7 +862,9 @@ async function handleTuiSlashCommand(
           approval: formatApprovalPolicy(context.getApprovalPolicy()),
           approvalBypasses: slice?.bypass,
           status: slice?.status ?? 'not started',
-          sessionId: context.session.executionId,
+          // Only surface the resume id once a stream exists — never next to
+          // a "not started" status.
+          sessionId: slice ? context.session.executionId : undefined,
           queuedFollowUpMessages:
             activeStreamId === undefined
               ? []

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -15,6 +15,9 @@ export interface CliSessionStatusInput {
   readonly approvalBypasses?: Partial<BypassState>;
   readonly status: string;
   readonly queuedFollowUpMessages: readonly string[];
+  /** Root execution id, when a run has started. Surfaces the resume command
+   *  mid-session instead of only in the exit hint. */
+  readonly sessionId?: string;
 }
 
 export function formatCliStatusLabel(status: string | undefined): string {
@@ -62,6 +65,12 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
       ? [`auto-approvals: ${bypassLabels.join(', ')}`]
       : []),
     `status: ${formatCliStatusLabel(input.status)}`,
+    ...(input.sessionId
+      ? [
+          `session: ${input.sessionId}`,
+          `resume later with: texra --resume ${input.sessionId}`,
+        ]
+      : []),
     ...queuedFollowUpStatusLines(input.queuedFollowUpMessages),
   ].join('\n');
 }

--- a/src/test-kernel/cli/InputHistory.vitest.mts
+++ b/src/test-kernel/cli/InputHistory.vitest.mts
@@ -1,0 +1,76 @@
+// Persistent ↑/↓ + Ctrl-R input history for the chat TUI input bar.
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadInputHistory } from '@cli/chat/tui/history/inputHistory';
+
+describe('CLI TUI input history', () => {
+  let storageDir: string;
+
+  beforeEach(async () => {
+    // GlobalStorageFS resolves paths through the platform but writes with the
+    // real node fs, so the fake platform needs a real temp directory.
+    storageDir = await mkdtemp(path.join(tmpdir(), 'texra-input-history-'));
+    const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
+      await Promise.all([
+        import('@platform/platform'),
+        import('@platform/defaults/nodeFilesystem'),
+        import('@test/support/FakePlatform'),
+      ]);
+    initPlatform(
+      createFakePlatform(
+        { globalStoragePath: storageDir },
+        { fs: nodeFilesystem },
+      ),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(storageDir, { recursive: true, force: true });
+  });
+
+  it('exposes indexed entries for ↑/↓ history browsing', async () => {
+    const history = await loadInputHistory();
+
+    expect(history.length()).toBe(0);
+    expect(history.at(0)).toBeUndefined();
+
+    await history.push('first message');
+    await history.push('second message');
+
+    expect(history.length()).toBe(2);
+    expect(history.at(0)).toBe('first message');
+    expect(history.at(1)).toBe('second message');
+    expect(history.at(2)).toBeUndefined();
+  });
+
+  it('persists entries across loads and skips adjacent duplicates', async () => {
+    const history = await loadInputHistory();
+    await history.push('alpha');
+    await history.push('alpha');
+    await history.push('beta');
+
+    const reloaded = await loadInputHistory();
+
+    expect(reloaded.length()).toBe(2);
+    expect(reloaded.at(0)).toBe('alpha');
+    expect(reloaded.at(1)).toBe('beta');
+  });
+
+  it('reverse-finds the most recent matching entry first', async () => {
+    const history = await loadInputHistory();
+    await history.push('build the project');
+    await history.push('run the tests');
+    await history.push('build the docs');
+
+    const newest = history.reverseFind('build');
+    expect(newest).toEqual({ value: 'build the docs', index: 2 });
+
+    const older = history.reverseFind('build', newest?.index);
+    expect(older).toEqual({ value: 'build the project', index: 0 });
+  });
+});

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -88,6 +88,35 @@ describe('CLI session status formatter', () => {
     expect(status).toContain('1. (empty follow-up)');
   });
 
+  it('surfaces the session id and resume command once a run has started', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'personal',
+      approval: 'ask',
+      status: 'running',
+      sessionId: 'abc123',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).toContain('session: abc123');
+    expect(status).toContain('resume later with: texra --resume abc123');
+  });
+
+  it('omits session lines before the first run starts', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'personal',
+      approval: 'ask',
+      status: 'not started',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).not.toContain('session:');
+    expect(status).not.toContain('--resume');
+  });
+
   it('reports an empty follow-up queue explicitly', () => {
     expect(
       formatCliSessionStatus({

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -534,6 +534,24 @@ describe('slashRegistry', () => {
     expect(matchSlashCommands('us').map((c) => c.name)).toEqual(['help']);
   });
 
+  it('falls back to substring matches when no prefix matches', () => {
+    registerSlashCommand({ name: 'model', description: 'pick a model' });
+    registerSlashCommand({ name: 'agent', description: 'pick an agent' });
+
+    expect(matchSlashCommands('odel').map((c) => c.name)).toEqual(['model']);
+    expect(matchSlashCommands('gen').map((c) => c.name)).toEqual(['agent']);
+    // Prefix matches still win outright when present.
+    expect(matchSlashCommands('mo').map((c) => c.name)).toEqual(['model']);
+  });
+
+  it('falls back to the typo suggestion when nothing matches literally', () => {
+    registerSlashCommand({ name: 'help', description: 'show help' });
+    registerSlashCommand({ name: 'model', description: 'pick a model' });
+
+    expect(matchSlashCommands('hlp').map((c) => c.name)).toEqual(['help']);
+    expect(matchSlashCommands('frobnicate')).toEqual([]);
+  });
+
   it('finds exact command names and aliases case-insensitively', () => {
     registerSlashCommand({
       name: 'agent',

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -7,6 +7,7 @@ import {
   listSlashCommands,
   matchSlashCommands,
   parseSlashInput,
+  prefixSlashCommands,
   registerSlashCommand,
   slashPickIntent,
   suggestSlashCommand,
@@ -550,6 +551,16 @@ describe('slashRegistry', () => {
 
     expect(matchSlashCommands('hlp').map((c) => c.name)).toEqual(['help']);
     expect(matchSlashCommands('frobnicate')).toEqual([]);
+  });
+
+  it('keeps the auto-run tier prefix-only so fallbacks never fire blind', () => {
+    registerSlashCommand({ name: 'help', description: 'show help' });
+    registerSlashCommand({ name: 'model', description: 'pick a model' });
+
+    expect(prefixSlashCommands('mo').map((c) => c.name)).toEqual(['model']);
+    // Substring ('odel') and typo ('hlp') matches are palette-only.
+    expect(prefixSlashCommands('odel')).toEqual([]);
+    expect(prefixSlashCommands('hlp')).toEqual([]);
   });
 
   it('finds exact command names and aliases case-insensitively', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1159,6 +1159,75 @@ describe('CLI StatusBar display model', () => {
     );
   });
 
+  it('warns that queued follow-ups are discarded while exit is armed', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: true,
+      pendingExitResumeId: 'abc123',
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [
+        'Keep the proof under one page.',
+        'Also mention the finite monoid argument.',
+      ],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+    });
+
+    expect(display.left.map(statusBarSegmentText)).toContain(
+      '2 queued follow-ups will be discarded',
+    );
+    expect(
+      display.left.find(
+        (segment) =>
+          statusBarSegmentText(segment) ===
+          '2 queued follow-ups will be discarded',
+      ),
+    ).toMatchObject({ color: 'red' });
+  });
+
+  it('compacts token usage to a percentage before dropping it on narrow widths', () => {
+    const input = {
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: { inputTokens: 80_000, outputTokens: 25_000, cost: 0 },
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+    } as const;
+
+    // Wide: the full usage segment fits.
+    expect(
+      buildStatusBarDisplay({ ...input, width: 80 }).left.map(
+        statusBarSegmentText,
+      ),
+    ).toContain('105k/1M (10%)');
+
+    // Narrow: the segment degrades to the bare percentage instead of
+    // disappearing, keeping context pressure visible.
+    const narrow = buildStatusBarDisplay({ ...input, width: 24 }).left.map(
+      statusBarSegmentText,
+    );
+    expect(narrow).not.toContain('105k/1M (10%)');
+    expect(narrow).toContain('10%');
+  });
+
   it('keeps the exit confirmation visible in very narrow footers', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,

--- a/src/test-kernel/cli/TextInputBindings.vitest.mts
+++ b/src/test-kernel/cli/TextInputBindings.vitest.mts
@@ -1,0 +1,170 @@
+// Audit of the declarative text-input keymap: every chord routes to exactly
+// the binding that declares it, every table entry is reachable (no dead or
+// shadowed "excessive" entries), and the /help docs render from the same
+// table so they cannot drift from the implementation.
+
+import { describe, expect, it } from 'vitest';
+
+import { formatSlashCommandHelp } from '@cli/chat/tui/commands/helpText';
+import {
+  matchTextInputBinding,
+  TEXT_INPUT_BINDINGS,
+  textInputEditingHelp,
+  type TextInputKey,
+} from '@cli/chat/tui/input/textInputBindings';
+
+interface Probe {
+  readonly chord: string;
+  readonly input: string;
+  readonly key: TextInputKey;
+  /** Expected binding label, or undefined when the chord must stay unbound
+   *  (owned by a stateful handler or passed through as text). */
+  readonly binding: string | undefined;
+}
+
+const PROBES: readonly Probe[] = [
+  // Word deletes — alias spellings must shadow the plain deletes.
+  {
+    chord: 'Ctrl-W',
+    input: 'w',
+    key: { ctrl: true },
+    binding: 'Ctrl-W / Alt-Backspace',
+  },
+  {
+    chord: 'Ctrl-W raw byte',
+    input: '\u0017',
+    key: {},
+    binding: 'Ctrl-W / Alt-Backspace',
+  },
+  {
+    chord: 'Alt-Backspace meta flag',
+    input: '',
+    key: { backspace: true, meta: true },
+    binding: 'Ctrl-W / Alt-Backspace',
+  },
+  {
+    chord: 'Alt-Backspace raw ESC+DEL',
+    input: '\u001B\u007F',
+    key: {},
+    binding: 'Ctrl-W / Alt-Backspace',
+  },
+  { chord: 'Alt-D', input: 'd', key: { meta: true }, binding: 'Alt-D' },
+  { chord: 'Alt-D raw ESC d', input: '\u001Bd', key: {}, binding: 'Alt-D' },
+  // Word moves — modified arrows must shadow the plain arrows.
+  {
+    chord: 'Alt-B',
+    input: 'b',
+    key: { meta: true },
+    binding: 'Alt-B / Ctrl-←',
+  },
+  {
+    chord: 'Ctrl-←',
+    input: '',
+    key: { leftArrow: true, ctrl: true },
+    binding: 'Alt-B / Ctrl-←',
+  },
+  {
+    chord: 'Alt-←',
+    input: '',
+    key: { leftArrow: true, meta: true },
+    binding: 'Alt-B / Ctrl-←',
+  },
+  {
+    chord: 'Alt-F',
+    input: 'f',
+    key: { meta: true },
+    binding: 'Alt-F / Ctrl-→',
+  },
+  {
+    chord: 'Ctrl-→',
+    input: '',
+    key: { rightArrow: true, ctrl: true },
+    binding: 'Alt-F / Ctrl-→',
+  },
+  // Plain editing keys.
+  {
+    chord: 'Backspace',
+    input: '',
+    key: { backspace: true },
+    binding: 'Backspace',
+  },
+  { chord: 'Delete', input: '', key: { delete: true }, binding: 'Delete' },
+  { chord: '←', input: '', key: { leftArrow: true }, binding: '←' },
+  { chord: '→', input: '', key: { rightArrow: true }, binding: '→' },
+  { chord: 'Home', input: '', key: { home: true }, binding: 'Home / Ctrl-A' },
+  {
+    chord: 'Ctrl-A raw byte',
+    input: '\u0001',
+    key: {},
+    binding: 'Home / Ctrl-A',
+  },
+  { chord: 'End', input: '', key: { end: true }, binding: 'End / Ctrl-E' },
+  {
+    chord: 'Ctrl-E raw byte',
+    input: '\u0005',
+    key: {},
+    binding: 'End / Ctrl-E',
+  },
+  { chord: 'Ctrl-U raw byte', input: '\u0015', key: {}, binding: 'Ctrl-U' },
+  { chord: 'Ctrl-K', input: 'k', key: { ctrl: true }, binding: 'Ctrl-K' },
+  { chord: 'Ctrl-K raw byte', input: '\u000B', key: {}, binding: 'Ctrl-K' },
+  // Chords the keymap must NOT own.
+  { chord: 'printable a', input: 'a', key: {}, binding: undefined },
+  {
+    chord: 'Ctrl-V (image paste)',
+    input: '\u0016',
+    key: {},
+    binding: undefined,
+  },
+  {
+    chord: 'Ctrl-B (unbound)',
+    input: 'b',
+    key: { ctrl: true },
+    binding: undefined,
+  },
+  {
+    chord: 'Alt-P (stream shortcut)',
+    input: 'p',
+    key: { meta: true },
+    binding: undefined,
+  },
+];
+
+describe('text input keymap', () => {
+  it('routes every probe chord to exactly its declared binding', () => {
+    const routed = PROBES.map((probe) => ({
+      chord: probe.chord,
+      binding: matchTextInputBinding(probe.input, probe.key)?.keys,
+    }));
+
+    expect(routed).toEqual(
+      PROBES.map((probe) => ({ chord: probe.chord, binding: probe.binding })),
+    );
+  });
+
+  it('has no unreachable (excessive) entries — every binding is probed', () => {
+    const probed = new Set(PROBES.map((probe) => probe.binding));
+    const unreachable = TEXT_INPUT_BINDINGS.map((b) => b.keys).filter(
+      (keys) => !probed.has(keys),
+    );
+
+    expect(unreachable).toEqual([]);
+  });
+
+  it('declares each chord label once', () => {
+    const labels = TEXT_INPUT_BINDINGS.map((binding) => binding.keys);
+
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it('renders the advertised bindings into /help from the same table', () => {
+    const help = formatSlashCommandHelp([]);
+
+    expect(help).toContain(textInputEditingHelp());
+    for (const binding of TEXT_INPUT_BINDINGS) {
+      if (binding.advertise) {
+        expect(textInputEditingHelp()).toContain(`\`${binding.keys}\``);
+      }
+    }
+  });
+});

--- a/src/test-kernel/cli/TextInputEditing.vitest.mts
+++ b/src/test-kernel/cli/TextInputEditing.vitest.mts
@@ -4,10 +4,16 @@ import {
   applyTerminalInputChunk,
   deleteAtCursor,
   deleteBeforeCursor,
+  deleteNextWord,
   deletePreviousWord,
   deleteToEnd,
   deleteToStart,
   insertText,
+  lineEndCursor,
+  lineStartCursor,
+  nextWordCursor,
+  previousWordCursor,
+  verticalCursorMove,
 } from '@cli/chat/tui/input/textInputEditing';
 import {
   isCtrlInput,
@@ -280,5 +286,61 @@ describe('CLI TUI text input editing', () => {
       value: 'one three',
       cursor: 4,
     });
+  });
+
+  it('scopes Ctrl-U and Ctrl-K to the current line in multiline drafts', () => {
+    expect(deleteToStart('alpha\nbeta gamma\ndelta', 10)).toEqual({
+      value: 'alpha\n gamma\ndelta',
+      cursor: 6,
+    });
+    expect(deleteToEnd('alpha\nbeta gamma\ndelta', 10)).toEqual({
+      value: 'alpha\nbeta\ndelta',
+      cursor: 10,
+    });
+    // Ctrl-K at the end of a line kills the newline (joins the next line).
+    expect(deleteToEnd('alpha\nbeta', 5)).toEqual({
+      value: 'alphabeta',
+      cursor: 5,
+    });
+  });
+
+  it('moves Home/End (Ctrl-A/E) to the current line boundaries', () => {
+    expect(lineStartCursor('one two', 4)).toBe(0);
+    expect(lineEndCursor('one two', 4)).toBe(7);
+    expect(lineStartCursor('alpha\nbeta gamma', 10)).toBe(6);
+    expect(lineEndCursor('alpha\nbeta gamma\ndelta', 10)).toBe(16);
+  });
+
+  it('implements word-wise movement for Alt-B/F and Ctrl-arrows', () => {
+    expect(previousWordCursor('one two three', 8)).toBe(4);
+    expect(previousWordCursor('one two three', 6)).toBe(4);
+    expect(previousWordCursor('one two three', 0)).toBe(0);
+    expect(nextWordCursor('one two three', 8)).toBe(13);
+    expect(nextWordCursor('one two three', 3)).toBe(7);
+    expect(nextWordCursor('one two three', 13)).toBe(13);
+  });
+
+  it('implements Alt-D forward word kill', () => {
+    expect(deleteNextWord('one two three', 4)).toEqual({
+      value: 'one  three',
+      cursor: 4,
+    });
+    expect(deleteNextWord('one two three', 3)).toEqual({
+      value: 'one three',
+      cursor: 3,
+    });
+    expect(deleteNextWord('one', 3)).toEqual({ value: 'one', cursor: 3 });
+  });
+
+  it('moves the caret between logical lines on ↑/↓, preserving the column', () => {
+    // "alpha\nbe\ngamma": ↓ from column 3 of line 0 clamps to line 1's end.
+    expect(verticalCursorMove('alpha\nbe\ngamma', 3, 1)).toBe(8);
+    expect(verticalCursorMove('alpha\nbe\ngamma', 7, 1)).toBe(10);
+    expect(verticalCursorMove('alpha\nbe\ngamma', 10, -1)).toBe(7);
+    // Boundary lines yield undefined so the caller can recall history.
+    expect(verticalCursorMove('alpha\nbe', 2, -1)).toBeUndefined();
+    expect(verticalCursorMove('alpha\nbe', 7, 1)).toBeUndefined();
+    expect(verticalCursorMove('single line', 4, -1)).toBeUndefined();
+    expect(verticalCursorMove('single line', 4, 1)).toBeUndefined();
   });
 });

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -248,8 +248,9 @@ describe('CLI tool renderer registry', () => {
     expect(toolHeaderPreviewBudget(200, 'bash')).toBe(191);
     // Narrow terminals truncate to fit one row instead of wrapping.
     expect(toolHeaderPreviewBudget(60, 'bash')).toBe(51);
-    // Never collapse below a readable floor.
-    expect(toolHeaderPreviewBudget(20, 'a-rather-long-tool-name')).toBe(24);
+    // When the name + chrome already eat the row, drop the preview entirely
+    // instead of overflowing into a second row.
+    expect(toolHeaderPreviewBudget(20, 'a-rather-long-tool-name')).toBe(0);
     // Unknown width falls back to the historical fixed budget.
     expect(toolHeaderPreviewBudget(undefined, 'bash')).toBe(80);
   });

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 // Local imports - shared schemas
 import {
   pickToolRenderer,
+  toolHeaderPreviewBudget,
   toolUseDisplayLines,
 } from '@cli/chat/tui/panes/toolRenderers';
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
@@ -240,5 +241,16 @@ describe('CLI tool renderer registry', () => {
         "● read_file (paper.tex)",
       ]
     `);
+  });
+
+  it('sizes live header previews to the terminal width', () => {
+    // Wide terminals show more of the command than the historical 80 columns.
+    expect(toolHeaderPreviewBudget(200, 'bash')).toBe(191);
+    // Narrow terminals truncate to fit one row instead of wrapping.
+    expect(toolHeaderPreviewBudget(60, 'bash')).toBe(51);
+    // Never collapse below a readable floor.
+    expect(toolHeaderPreviewBudget(20, 'a-rather-long-tool-name')).toBe(24);
+    // Unknown width falls back to the historical fixed budget.
+    expect(toolHeaderPreviewBudget(undefined, 'bash')).toBe(80);
   });
 });


### PR DESCRIPTION
Input editing (BaseTextInput / textInputEditing / InputBar):
- Add shell-style ↑/↓ input history recall (was documented in /help but
  never implemented; history was only reachable via Ctrl-R), with the
  pre-browse draft saved and restored when walking past the newest entry
- Move the caret between logical lines with ↑/↓ inside multiline drafts
- Add word-wise cursor movement: Alt-B/Alt-F and Ctrl/Alt+←/→
- Add word deletes: Alt-D (kill next word) and Alt-Backspace (kill
  previous word)
- Scope Home/End/Ctrl-A/E/U/K to the current line in multiline drafts
  (readline behavior); Ctrl-K at a line end joins the next line

Status bar (StatusBar):
- Degrade the token-usage segment to a bare percentage on narrow
  terminals instead of dropping it, keeping context pressure visible
- Warn that queued follow-ups will be discarded while the Ctrl-C exit
  confirmation is armed

Slash commands (slashRegistry):
- Fall back to substring matches and then the typo suggestion when no
  prefix matches, so /odel and /hlp recover instead of going blank

Session visibility (sessionStatus / runChatTui):
- /status now shows the session id and the texra --resume command
  mid-session instead of only in the exit hint

Tool rows (toolRenderers):
- Size live tool header previews to the terminal width instead of a
  fixed 80 columns, so wide terminals show the whole command and narrow
  ones truncate to a single row

https://claude.ai/code/session_0143qtFLqdWkEKfHxtw7dUWx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly local CLI TUI behavior with new tests; slash auto-run is intentionally restricted to prefix matches to avoid surprising pasted commands.
> 
> **Overview**
> **Chat TUI input** gets readline-style editing and history that match what `/help` already promised: shell-style **↑/↓** history recall (with draft save/restore), **↑/↓** moving between lines in multiline drafts, word motion/deletes (**Alt-B/F**, **Ctrl/Alt arrows**, **Alt-D**, **Alt-Backspace**), and **Home/End/Ctrl-A/E/U/K** scoped to the current line. Stateless chords move into a new **`textInputBindings`** keymap; **`BaseTextInput`** dispatches through it and **`/help`** pulls advertised chords from the same table so docs cannot drift.
> 
> **Slash UX:** the palette can recover via **substring** and **typo** matches when prefix search is empty; **pasted/auto-submit** paths use **`prefixSlashCommands`** only so fuzzy matches never run blind.
> 
> **Status bar:** narrow widths **compact** token usage to a **%** before dropping it; **Ctrl-C exit confirm** shows a **red warning** if queued follow-ups would be discarded.
> 
> **`/status`** surfaces **session id** and **`texra --resume`** once a run has started. **Live tool headers** size their one-line preview to **terminal width** instead of a fixed 80 columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4556568d264ddd76deee87886f7c99b7cb1585cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->