### PR TITLE
Converge workspace config on `.texra/config.json` across hosts

### DIFF
--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -47,10 +47,10 @@ function commandSections(commands: readonly SlashCommand[]): string[] {
 }
 
 function keyboardSection(options: SlashCommandHelpOptions): string {
-  const focusChord = metaChordLabel(
-    options.shortcutModifierLabel ?? 'Alt',
-    '1..9',
-  );
+  const modifier = options.shortcutModifierLabel ?? 'Alt';
+  const focusChord = metaChordLabel(modifier, '1..9');
+  const tasksChord = metaChordLabel(modifier, 'p');
+  const subagentsChord = metaChordLabel(modifier, 's');
   const newline =
     options.shiftEnterNewline === true
       ? '`Shift-Enter` or `Ctrl-J` insert a newline'
@@ -62,6 +62,7 @@ function keyboardSection(options: SlashCommandHelpOptions): string {
     '- `Esc` stops the current response · `Ctrl-C` stops, twice exits',
     '- `Ctrl-T` opens the transcript viewer for the focused stream',
     `- \`Tab\` switches streams · \`${focusChord}\` jumps to one (when subagents are running)`,
+    `- \`${tasksChord}\` opens tasks · \`${subagentsChord}\` opens subagents (when available)`,
   ].join('\n');
 }
 

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,9 +1,9 @@
+import { TEXRA_CONFIG_FILE_NAME } from '@platform/defaults/nodeStorage';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
-  CLI_CONFIG_FILE,
   loadWorkspaceCliConfig,
   parseCliConfigValues,
   resolveConfiguredAgent,
@@ -64,7 +64,7 @@ async function loadWorkspaceDefaults(cwd: string): Promise<PartialDefaults> {
 async function loadUserDefaults(): Promise<PartialDefaults> {
   try {
     return defaultsFromConfigValues(
-      parseCliConfigValues(await GlobalStorageFS.readJson(CLI_CONFIG_FILE)),
+      parseCliConfigValues(await GlobalStorageFS.readJson(TEXRA_CONFIG_FILE_NAME)),
     );
   } catch {
     return {};

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -64,7 +64,9 @@ async function loadWorkspaceDefaults(cwd: string): Promise<PartialDefaults> {
 async function loadUserDefaults(): Promise<PartialDefaults> {
   try {
     return defaultsFromConfigValues(
-      parseCliConfigValues(await GlobalStorageFS.readJson(TEXRA_CONFIG_FILE_NAME)),
+      parseCliConfigValues(
+        await GlobalStorageFS.readJson(TEXRA_CONFIG_FILE_NAME),
+      ),
     );
   } catch {
     return {};

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -1,9 +1,13 @@
 import { readFile } from 'node:fs/promises';
-import path from 'node:path';
 
 import { MODEL_CONFIGS } from 'llm-zoo';
 import { z } from 'zod';
 
+import {
+  TEXRA_CONFIG_FILE_NAME,
+  TEXRA_STORAGE_DIR_NAME,
+  workspaceTexraConfigPath,
+} from '@platform/defaults/nodeStorage';
 import { isFileNotFoundError } from '@common/errors';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { isObject } from '@utils/core/typeGuards';
@@ -17,8 +21,8 @@ import {
 } from '../schemas/cliSettings';
 import { KNOWN_TEXRA_KEYS } from '../schemas/knownKeys';
 
-export const CLI_CONFIG_DIR = '.texra';
-export const CLI_CONFIG_FILE = 'config.json';
+export const CLI_CONFIG_DIR = TEXRA_STORAGE_DIR_NAME;
+export const CLI_CONFIG_FILE = TEXRA_CONFIG_FILE_NAME;
 export const CLI_BUILTIN_DEFAULT_MODEL = 'deepseekT';
 
 export interface CliCommandConfig {
@@ -196,7 +200,7 @@ export function parseCliConfigValues(value: unknown): CliConfigValues {
 }
 
 export function workspaceCliConfigPath(cwd: string): string {
-  return path.join(cwd, CLI_CONFIG_DIR, CLI_CONFIG_FILE);
+  return workspaceTexraConfigPath(cwd);
 }
 
 export async function loadWorkspaceCliConfig(

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { MODEL_CONFIGS } from 'llm-zoo';
 import { z } from 'zod';
 
+import { configKeyVariants } from '@platform/defaults/configKeyHelpers';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { isFileNotFoundError } from '@common/errors';
 import { toErrorMessage } from '@common/errors/errorMessage';
@@ -64,11 +65,6 @@ const COMMAND_SECTIONS = ['chat', 'run'] as const;
 
 const TOP_LEVEL_KEYS = new Set<string>(CLI_SETTING_PATHS);
 const COMMAND_KEYS = new Set(COMMAND_FIELD_SCHEMAS.map(([key]) => key));
-
-/** Preferred config key order: unified `texra.*` first, legacy bare key second. */
-function configKeyVariants(bareKey: string): readonly [string, string] {
-  return [`texra.${bareKey}`, bareKey];
-}
 
 function isKnownConfigKey(key: string): boolean {
   return (

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -3,11 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { MODEL_CONFIGS } from 'llm-zoo';
 import { z } from 'zod';
 
-import {
-  TEXRA_CONFIG_FILE_NAME,
-  TEXRA_STORAGE_DIR_NAME,
-  workspaceTexraConfigPath,
-} from '@platform/defaults/nodeStorage';
+import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { isFileNotFoundError } from '@common/errors';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { isObject } from '@utils/core/typeGuards';
@@ -21,8 +17,6 @@ import {
 } from '../schemas/cliSettings';
 import { KNOWN_TEXRA_KEYS } from '../schemas/knownKeys';
 
-export const CLI_CONFIG_DIR = TEXRA_STORAGE_DIR_NAME;
-export const CLI_CONFIG_FILE = TEXRA_CONFIG_FILE_NAME;
 export const CLI_BUILTIN_DEFAULT_MODEL = 'deepseekT';
 
 export interface CliCommandConfig {
@@ -199,14 +193,10 @@ export function parseCliConfigValues(value: unknown): CliConfigValues {
   return isObject(value) ? pickConfigValues(value) : {};
 }
 
-export function workspaceCliConfigPath(cwd: string): string {
-  return workspaceTexraConfigPath(cwd);
-}
-
 export async function loadWorkspaceCliConfig(
   cwd: string,
 ): Promise<LoadedCliConfig> {
-  const filePath = workspaceCliConfigPath(cwd);
+  const filePath = workspaceTexraConfigPath(cwd);
   let raw: string;
   try {
     raw = await readFile(filePath, 'utf8');

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -6,6 +6,7 @@ import { access, stat } from 'node:fs/promises';
 import { satisfies as semverSatisfies } from 'semver';
 
 // Local imports - LaTeX
+import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import {
   probeLatexToolchain,
   type LatexToolchainProbe,
@@ -17,7 +18,6 @@ import {
 import { extractErrorMessage } from '@utils/core';
 
 // Local imports - CLI runtime
-import { workspaceCliConfigPath } from './cliConfig';
 import { CliExitCode } from './exitCodes';
 import {
   writeNdjsonStdout,
@@ -311,7 +311,7 @@ async function checkConfig(context: CliContext): Promise<DoctorCheck> {
       context.configWarnings?.join(' '),
     );
   }
-  const workspaceConfig = workspaceCliConfigPath(context.cwd);
+  const workspaceConfig = workspaceTexraConfigPath(context.cwd);
   try {
     await access(workspaceConfig, fsConstants.R_OK);
     return pass('config', 'Config', `Workspace config: ${workspaceConfig}`);

--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -7,7 +7,11 @@
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { CLI_CONFIG_DIR, workspaceCliConfigPath } from './cliConfig';
+import {
+  TEXRA_STORAGE_DIR_NAME,
+  workspaceTexraConfigPath,
+} from '@platform/defaults/nodeStorage';
+
 import type {
   CliApprovalPolicy,
   CliOutputFormat,
@@ -33,7 +37,7 @@ export interface InitConfigShape {
  * storage with a different shape and loader; bootstrapping it is a follow-up.)
  */
 export function initConfigPath(cwd: string): string {
-  return workspaceCliConfigPath(cwd);
+  return workspaceTexraConfigPath(cwd);
 }
 
 /** Map wizard answers to the canonical config object. */
@@ -74,11 +78,11 @@ export async function writeInitConfig(
  * existing content and a single trailing newline.
  */
 export function gitignoreWithTexra(existing: string): string | null {
-  const entry = `${CLI_CONFIG_DIR}/`;
+  const entry = `${TEXRA_STORAGE_DIR_NAME}/`;
   const present = existing
     .split('\n')
     .map((line) => line.trim())
-    .some((line) => line === entry || line === CLI_CONFIG_DIR);
+    .some((line) => line === entry || line === TEXRA_STORAGE_DIR_NAME);
   if (present) return null;
   const trimmed = existing.replace(/\n+$/, '');
   return trimmed.length > 0 ? `${trimmed}\n${entry}\n` : `${entry}\n`;

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -16,6 +16,10 @@ import { UsageLogService } from '@telemetry/UsageLogService';
 
 // Local imports - agent index
 import { defaultSkillSources, setRuntimeSkillSources } from '@skills/index';
+import {
+  TEXRA_CONFIG_FILE_NAME,
+  workspaceTexraConfigPath,
+} from '@platform/defaults/nodeStorage';
 import { bootstrapPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 
 // Local imports - auth
@@ -41,7 +45,6 @@ import { applyCliGitAuthorConfig } from './gitAuthor';
 import { getCliSecrets } from './cliSecrets';
 import { isTexraCliEntrypointPath, readCliEntrypointPath } from './cliContext';
 import { writeTextStderr } from './logSinks';
-import { CLI_CONFIG_FILE, workspaceCliConfigPath } from './cliConfig';
 import { getCliAuthProvider, initializeCliSupabaseAuth } from './supabaseAuth';
 import { createCliStateStores } from './cliStateStores';
 import { CliExitCode } from './exitCodes';
@@ -158,7 +161,7 @@ export async function initCliPlatform(
 
   if (!tryPlatform()) {
     const configStore = await JsonStore.open(
-      workspaceCliConfigPath(cliWorkspaceCwd),
+      workspaceTexraConfigPath(cliWorkspaceCwd),
     );
     const stateStores = await createCliStateStores({
       storageRoot: context.storageRoot,
@@ -168,7 +171,10 @@ export async function initCliPlatform(
     // mirroring the desktop host: workspace values shadow global on read and
     // `update(..., 'global')` has somewhere to write instead of throwing.
     const globalConfigStore = await JsonStore.open(
-      nodePath.join(stateStores.storage.getGlobalStoragePath(), CLI_CONFIG_FILE),
+      nodePath.join(
+        stateStores.storage.getGlobalStoragePath(),
+        TEXRA_CONFIG_FILE_NAME,
+      ),
     );
     // Same severity and wording as the extension/desktop hosts: a shutdown
     // handler failure is an error everywhere, not a warning in one host.

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -1,3 +1,6 @@
+// Node imports
+import * as nodePath from 'node:path';
+
 // Local imports - platform
 import { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
 import { JsonStore } from '@platform/defaults/jsonStore';
@@ -38,7 +41,7 @@ import { applyCliGitAuthorConfig } from './gitAuthor';
 import { getCliSecrets } from './cliSecrets';
 import { isTexraCliEntrypointPath, readCliEntrypointPath } from './cliContext';
 import { writeTextStderr } from './logSinks';
-import { workspaceCliConfigPath } from './cliConfig';
+import { CLI_CONFIG_FILE, workspaceCliConfigPath } from './cliConfig';
 import { getCliAuthProvider, initializeCliSupabaseAuth } from './supabaseAuth';
 import { createCliStateStores } from './cliStateStores';
 import { CliExitCode } from './exitCodes';
@@ -70,7 +73,7 @@ type CliPlatformInitOptions = Pick<
 };
 
 function logAt(
-  level: 'debug' | 'info' | 'warn',
+  level: 'debug' | 'info' | 'warn' | 'error',
   channel: string,
   message: string,
 ): void {
@@ -161,16 +164,27 @@ export async function initCliPlatform(
       storageRoot: context.storageRoot,
       workspacePath: () => cliWorkspaceCwd,
     });
+    // User-level config (`~/.texra/config.json`) backs the global target,
+    // mirroring the desktop host: workspace values shadow global on read and
+    // `update(..., 'global')` has somewhere to write instead of throwing.
+    const globalConfigStore = await JsonStore.open(
+      nodePath.join(stateStores.storage.getGlobalStoragePath(), CLI_CONFIG_FILE),
+    );
+    // Same severity and wording as the extension/desktop hosts: a shutdown
+    // handler failure is an error everywhere, not a warning in one host.
     const lifecycle = createLifecycleHost({
       onError: (phase, error) => {
         logAt(
-          'warn',
+          'error',
           'cli.lifecycle',
-          `${phase} handler failed: ${toErrorMessage(error)}`,
+          `Lifecycle ${phase} handler failed: ${toErrorMessage(error)}`,
         );
       },
     });
-    const config = new JsonConfigProvider({ workspace: configStore });
+    const config = new JsonConfigProvider({
+      workspace: configStore,
+      global: globalConfigStore,
+    });
     initPlatform({
       config,
       globalState: stateStores.globalState,

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -167,9 +167,10 @@ export async function initCliPlatform(
       storageRoot: context.storageRoot,
       workspacePath: () => cliWorkspaceCwd,
     });
-    // User-level config (`~/.texra/config.json`) backs the global target,
-    // mirroring the desktop host: workspace values shadow global on read and
-    // `update(..., 'global')` has somewhere to write instead of throwing.
+    // User-level config (`~/.texra/global-storage/config.json`, the same file
+    // chatDefaults reads) backs the global target, mirroring the desktop host:
+    // workspace values shadow global on read and `update(..., 'global')` has
+    // somewhere to write instead of throwing.
     const globalConfigStore = await JsonStore.open(
       nodePath.join(
         stateStores.storage.getGlobalStoragePath(),

--- a/packages/desktop/src/main/desktopTerminalRunner.ts
+++ b/packages/desktop/src/main/desktopTerminalRunner.ts
@@ -2,13 +2,16 @@
 import stripAnsi from 'strip-ansi';
 
 // Local imports - hosts
-import type { TerminalRunner, TerminalRunRequest } from '@hosts/terminalHost';
+import {
+  TERMINAL_OUTPUT_MAX_CHARS,
+  type TerminalRunner,
+  type TerminalRunRequest,
+} from '@hosts/terminalHost';
 
 // Local imports - system
 import { executeCommand } from '@utils/system/execUtils';
 
-const OUTPUT_MAX_CHARS = 12_000;
-const RAW_OUTPUT_MAX_CHARS = OUTPUT_MAX_CHARS * 2;
+const RAW_OUTPUT_MAX_CHARS = TERMINAL_OUTPUT_MAX_CHARS * 2;
 
 export interface DesktopTerminalRunnerOptions {
   cwd?: string;
@@ -64,7 +67,7 @@ function normalizeEnv(
 
 function tail(output: string): string {
   const stripped = stripAnsi(output);
-  return stripped.length > OUTPUT_MAX_CHARS
-    ? stripped.slice(-OUTPUT_MAX_CHARS)
+  return stripped.length > TERMINAL_OUTPUT_MAX_CHARS
+    ? stripped.slice(-TERMINAL_OUTPUT_MAX_CHARS)
     : stripped;
 }

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -4,6 +4,7 @@ import { app } from 'electron';
 
 import { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
 import { JsonStore } from '@platform/defaults/jsonStore';
+import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import { NO_TOOL_AVAILABILITY_HOST } from '@platform/interfaces/toolAvailability';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -32,10 +33,39 @@ export interface ElectronPlatformInitResult {
   progressSnapshotStore: StreamSnapshotStore;
 }
 
+const WORKSPACE_CONFIG_MIGRATED_KEY = 'desktop.workspaceConfigMigratedToProject';
+
+/**
+ * One-time copy of workspace config from the pre-project-file internal store
+ * (`<workspace-storage>/config.json`) into the project's `.texra/config.json`.
+ * Existing project values win — a checked-in config is never overwritten.
+ */
+async function migrateLegacyWorkspaceConfig(init: {
+  legacyPath: string;
+  projectStore: JsonStore;
+  workspaceState: JsonStore;
+}): Promise<void> {
+  if (init.workspaceState.get<boolean>(WORKSPACE_CONFIG_MIGRATED_KEY) === true) {
+    return;
+  }
+  const legacyStore = await JsonStore.open(init.legacyPath);
+  for (const [key, value] of Object.entries(legacyStore.snapshot())) {
+    if (!init.projectStore.has(key)) {
+      await init.projectStore.set(key, value);
+    }
+  }
+  await init.workspaceState.update(WORKSPACE_CONFIG_MIGRATED_KEY, true);
+}
+
 export async function initializeElectronPlatform(
   mainDirname: string,
 ): Promise<ElectronPlatformInitResult> {
-  const lifecycle = createLifecycleHost();
+  // console.error is mirrored into the desktop app log; wording matches the
+  // extension and CLI hosts so support logs read the same everywhere.
+  const lifecycle = createLifecycleHost({
+    onError: (phase, error) =>
+      console.error(`[lifecycle] Lifecycle ${phase} handler failed:`, error),
+  });
   const userDataPath = app.getPath('userData');
   const globalStateStore = await JsonStore.open(
     join(userDataPath, 'state', 'global.json'),
@@ -52,9 +82,23 @@ export async function initializeElectronPlatform(
   const globalConfigStore = await JsonStore.open(
     join(userDataPath, 'config', 'global.json'),
   );
+  // Workspace config lives in the project's `.texra/config.json` — the same
+  // file the CLI reads and writes — so a checked-in config behaves
+  // identically in both hosts. Sessions without a workspace fall back to the
+  // internal per-workspace store.
+  const legacyWorkspaceConfigPath = join(storage.getStoragePath(), 'config.json');
   const workspaceConfigStore = await JsonStore.open(
-    join(storage.getStoragePath(), 'config.json'),
+    workspacePath
+      ? workspaceTexraConfigPath(workspacePath)
+      : legacyWorkspaceConfigPath,
   );
+  if (workspacePath) {
+    await migrateLegacyWorkspaceConfig({
+      legacyPath: legacyWorkspaceConfigPath,
+      projectStore: workspaceConfigStore,
+      workspaceState: workspaceStateStore,
+    });
+  }
   const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
 
   repairLaunchPath();

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -33,7 +33,8 @@ export interface ElectronPlatformInitResult {
   progressSnapshotStore: StreamSnapshotStore;
 }
 
-const WORKSPACE_CONFIG_MIGRATED_KEY = 'desktop.workspaceConfigMigratedToProject';
+const WORKSPACE_CONFIG_MIGRATED_KEY =
+  'desktop.workspaceConfigMigratedToProject';
 
 export async function initializeElectronPlatform(
   mainDirname: string,
@@ -61,7 +62,10 @@ export async function initializeElectronPlatform(
   // file the CLI reads and writes — so a checked-in config behaves
   // identically in both hosts. Sessions without a workspace fall back to the
   // internal per-workspace store.
-  const legacyWorkspaceConfigPath = join(storage.getStoragePath(), 'config.json');
+  const legacyWorkspaceConfigPath = join(
+    storage.getStoragePath(),
+    'config.json',
+  );
   const workspaceConfigStore = await JsonStore.open(
     workspacePath
       ? workspaceTexraConfigPath(workspacePath)

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -35,37 +35,12 @@ export interface ElectronPlatformInitResult {
 
 const WORKSPACE_CONFIG_MIGRATED_KEY = 'desktop.workspaceConfigMigratedToProject';
 
-/**
- * One-time copy of workspace config from the pre-project-file internal store
- * (`<workspace-storage>/config.json`) into the project's `.texra/config.json`.
- * Existing project values win — a checked-in config is never overwritten.
- */
-async function migrateLegacyWorkspaceConfig(init: {
-  legacyPath: string;
-  projectStore: JsonStore;
-  workspaceState: JsonStore;
-}): Promise<void> {
-  if (init.workspaceState.get<boolean>(WORKSPACE_CONFIG_MIGRATED_KEY) === true) {
-    return;
-  }
-  const legacyStore = await JsonStore.open(init.legacyPath);
-  for (const [key, value] of Object.entries(legacyStore.snapshot())) {
-    if (!init.projectStore.has(key)) {
-      await init.projectStore.set(key, value);
-    }
-  }
-  await init.workspaceState.update(WORKSPACE_CONFIG_MIGRATED_KEY, true);
-}
-
 export async function initializeElectronPlatform(
   mainDirname: string,
 ): Promise<ElectronPlatformInitResult> {
-  // console.error is mirrored into the desktop app log; wording matches the
-  // extension and CLI hosts so support logs read the same everywhere.
-  const lifecycle = createLifecycleHost({
-    onError: (phase, error) =>
-      console.error(`[lifecycle] Lifecycle ${phase} handler failed:`, error),
-  });
+  // The default handler's console.error is mirrored into the desktop app log,
+  // so shutdown-handler failures land at error severity like the other hosts.
+  const lifecycle = createLifecycleHost();
   const userDataPath = app.getPath('userData');
   const globalStateStore = await JsonStore.open(
     join(userDataPath, 'state', 'global.json'),
@@ -92,12 +67,20 @@ export async function initializeElectronPlatform(
       ? workspaceTexraConfigPath(workspacePath)
       : legacyWorkspaceConfigPath,
   );
-  if (workspacePath) {
-    await migrateLegacyWorkspaceConfig({
-      legacyPath: legacyWorkspaceConfigPath,
-      projectStore: workspaceConfigStore,
-      workspaceState: workspaceStateStore,
-    });
+  // One-time copy from the pre-project-file internal store into the project
+  // file; existing project values win, so a checked-in config is never
+  // overwritten.
+  if (
+    workspacePath &&
+    workspaceStateStore.get<boolean>(WORKSPACE_CONFIG_MIGRATED_KEY) !== true
+  ) {
+    const legacyStore = await JsonStore.open(legacyWorkspaceConfigPath);
+    for (const [key, value] of Object.entries(legacyStore.snapshot())) {
+      if (!workspaceConfigStore.has(key)) {
+        await workspaceConfigStore.set(key, value);
+      }
+    }
+    await workspaceStateStore.update(WORKSPACE_CONFIG_MIGRATED_KEY, true);
   }
   const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
 

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -15,6 +15,7 @@ import { initPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { StreamSnapshotStore } from '@transcript';
 import { registerAgentFeatures } from '@agent/features';
+import { toErrorMessage } from '@common/errors';
 import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
 import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 
@@ -61,37 +62,48 @@ export async function initializeElectronPlatform(
   );
   // Workspace config lives in the project's `.texra/config.json` — the same
   // file the CLI reads and writes — so a checked-in config behaves
-  // identically in both hosts. Sessions without a workspace fall back to the
-  // internal per-workspace store.
+  // identically in both hosts. Sessions without a workspace, and read-only
+  // project trees where the file cannot be created or written, fall back to
+  // the internal per-workspace store so startup never fails on config.
   const legacyWorkspaceConfigPath = join(
     storage.getStoragePath(),
     'config.json',
   );
-  const workspaceConfigStore = await JsonStore.open(
-    workspacePath
-      ? workspaceTexraConfigPath(workspacePath)
-      : legacyWorkspaceConfigPath,
-  );
-  // One-time copy from the pre-project-file internal store into the project
-  // file; existing project values win, so a checked-in config is never
-  // overwritten. Presence is checked across key variants because checked-in
-  // CLI configs use bare keys (`model`) while this store wrote canonical
-  // `texra.*` keys, which shadow bare ones on read.
-  if (
-    workspacePath &&
-    workspaceStateStore.get<boolean>(WORKSPACE_CONFIG_MIGRATED_KEY) !== true
-  ) {
-    const legacyStore = await JsonStore.open(legacyWorkspaceConfigPath);
-    for (const [key, value] of Object.entries(legacyStore.snapshot())) {
-      const inProject = configKeyVariants(key).some((variant) =>
-        workspaceConfigStore.has(variant),
+  let workspaceConfigStore: JsonStore | undefined;
+  if (workspacePath) {
+    try {
+      const projectStore = await JsonStore.open(
+        workspaceTexraConfigPath(workspacePath),
       );
-      if (!inProject) {
-        await workspaceConfigStore.set(key, value);
+      // One-time copy from the pre-project-file internal store into the
+      // project file; existing project values win, so a checked-in config is
+      // never overwritten. Presence is checked across key variants because
+      // checked-in CLI configs use bare keys (`model`) while this store wrote
+      // canonical `texra.*` keys, which shadow bare ones on read. Merge-only,
+      // so a write failure here safely retries on the next launch.
+      if (
+        workspaceStateStore.get<boolean>(WORKSPACE_CONFIG_MIGRATED_KEY) !== true
+      ) {
+        const legacyStore = await JsonStore.open(legacyWorkspaceConfigPath);
+        for (const [key, value] of Object.entries(legacyStore.snapshot())) {
+          const inProject = configKeyVariants(key).some((variant) =>
+            projectStore.has(variant),
+          );
+          if (!inProject) {
+            await projectStore.set(key, value);
+          }
+        }
+        await workspaceStateStore.update(WORKSPACE_CONFIG_MIGRATED_KEY, true);
       }
+      workspaceConfigStore = projectStore;
+    } catch (error) {
+      console.warn(
+        `[desktop] Project .texra/config.json is not writable; using the internal workspace config store. Cause: ${toErrorMessage(error)}`,
+      );
+      workspaceConfigStore = undefined;
     }
-    await workspaceStateStore.update(WORKSPACE_CONFIG_MIGRATED_KEY, true);
   }
+  workspaceConfigStore ??= await JsonStore.open(legacyWorkspaceConfigPath);
   const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
 
   repairLaunchPath();

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { app } from 'electron';
 
 import { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
+import { configKeyVariants } from '@platform/defaults/configKeyHelpers';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
@@ -73,14 +74,19 @@ export async function initializeElectronPlatform(
   );
   // One-time copy from the pre-project-file internal store into the project
   // file; existing project values win, so a checked-in config is never
-  // overwritten.
+  // overwritten. Presence is checked across key variants because checked-in
+  // CLI configs use bare keys (`model`) while this store wrote canonical
+  // `texra.*` keys, which shadow bare ones on read.
   if (
     workspacePath &&
     workspaceStateStore.get<boolean>(WORKSPACE_CONFIG_MIGRATED_KEY) !== true
   ) {
     const legacyStore = await JsonStore.open(legacyWorkspaceConfigPath);
     for (const [key, value] of Object.entries(legacyStore.snapshot())) {
-      if (!workspaceConfigStore.has(key)) {
+      const inProject = configKeyVariants(key).some((variant) =>
+        workspaceConfigStore.has(variant),
+      );
+      if (!inProject) {
         await workspaceConfigStore.set(key, value);
       }
     }

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -69,41 +69,49 @@ export async function initializeElectronPlatform(
     storage.getStoragePath(),
     'config.json',
   );
-  let workspaceConfigStore: JsonStore | undefined;
+  let projectConfigStore: JsonStore | undefined;
   if (workspacePath) {
     try {
-      const projectStore = await JsonStore.open(
+      projectConfigStore = await JsonStore.open(
         workspaceTexraConfigPath(workspacePath),
       );
-      // One-time copy from the pre-project-file internal store into the
-      // project file; existing project values win, so a checked-in config is
-      // never overwritten. Presence is checked across key variants because
-      // checked-in CLI configs use bare keys (`model`) while this store wrote
-      // canonical `texra.*` keys, which shadow bare ones on read. Merge-only,
-      // so a write failure here safely retries on the next launch.
-      if (
-        workspaceStateStore.get<boolean>(WORKSPACE_CONFIG_MIGRATED_KEY) !== true
-      ) {
-        const legacyStore = await JsonStore.open(legacyWorkspaceConfigPath);
-        for (const [key, value] of Object.entries(legacyStore.snapshot())) {
-          const inProject = configKeyVariants(key).some((variant) =>
-            projectStore.has(variant),
-          );
-          if (!inProject) {
-            await projectStore.set(key, value);
-          }
-        }
-        await workspaceStateStore.update(WORKSPACE_CONFIG_MIGRATED_KEY, true);
-      }
-      workspaceConfigStore = projectStore;
     } catch (error) {
       console.warn(
-        `[desktop] Project .texra/config.json is not writable; using the internal workspace config store. Cause: ${toErrorMessage(error)}`,
+        `[desktop] Cannot open project .texra/config.json; using the internal workspace config store. Cause: ${toErrorMessage(error)}`,
       );
-      workspaceConfigStore = undefined;
     }
   }
-  workspaceConfigStore ??= await JsonStore.open(legacyWorkspaceConfigPath);
+  const workspaceConfigStore =
+    projectConfigStore ?? (await JsonStore.open(legacyWorkspaceConfigPath));
+  // One-time copy from the pre-project-file internal store into the project
+  // file; existing project values win, so a checked-in config is never
+  // overwritten. Presence is checked across key variants because checked-in
+  // CLI configs use bare keys (`model`) while this store wrote canonical
+  // `texra.*` keys, which shadow bare ones on read. A write failure (e.g. a
+  // read-only tree) only skips the merge-only migration — the readable
+  // project file stays the config source — and retries on the next launch.
+  if (
+    projectConfigStore &&
+    workspaceStateStore.get<boolean>(WORKSPACE_CONFIG_MIGRATED_KEY) !== true
+  ) {
+    const projectStore = projectConfigStore;
+    try {
+      const legacyStore = await JsonStore.open(legacyWorkspaceConfigPath);
+      for (const [key, value] of Object.entries(legacyStore.snapshot())) {
+        const inProject = configKeyVariants(key).some((variant) =>
+          projectStore.has(variant),
+        );
+        if (!inProject) {
+          await projectStore.set(key, value);
+        }
+      }
+      await workspaceStateStore.update(WORKSPACE_CONFIG_MIGRATED_KEY, true);
+    } catch (error) {
+      console.warn(
+        `[desktop] Legacy workspace config migration failed; will retry on next launch. Cause: ${toErrorMessage(error)}`,
+      );
+    }
+  }
   const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
 
   repairLaunchPath();

--- a/packages/extension/src/MainViewProvider.ts
+++ b/packages/extension/src/MainViewProvider.ts
@@ -13,6 +13,7 @@ import {
   setActiveSidebarView,
 } from '@common/webview';
 import { consumePendingState } from '@common/state';
+import { getFilterExtensions } from '@common/files';
 
 import { agentDirectories } from '@frontend/agents';
 import { computeModelOptionsData } from '@model/computeModelOptions';
@@ -153,8 +154,15 @@ export class MainViewProvider
   }
 
   private setupFileWatcher() {
-    const filePattern =
-      '**/*.{tex,txt,md,cls,png,pdf,jpeg,jpg,svg,gif,heic,heif,webp,wav,mp3,m4a,aiff,aac,ogg,flac}';
+    // Watch exactly the categories the launcher file lists are built from
+    // (fileListingRules), including user-configured extension overrides, so
+    // the watched set cannot drift from what the lists display.
+    const extensions = new Set(
+      (['input', 'context', 'media', 'audio', 'edited'] as const).flatMap(
+        (category) => getFilterExtensions(category),
+      ),
+    );
+    const filePattern = `**/*.{${[...extensions].join(',')}}`;
     this.fileWatcher = vscode.workspace.createFileSystemWatcher(filePattern);
     this.fileWatcher.onDidCreate(this.refreshFiles.bind(this));
     this.fileWatcher.onDidDelete(this.refreshFiles.bind(this));

--- a/packages/extension/src/MainViewProvider.ts
+++ b/packages/extension/src/MainViewProvider.ts
@@ -160,7 +160,8 @@ export class MainViewProvider
     const extensions = new Set(
       EXTENSION_CATEGORIES.flatMap(getFilterExtensions),
     );
-    const filePattern = `**/*.{${[...extensions].join(',')}}`;
+    const filePattern =
+      extensions.size === 0 ? '**/*' : `**/*.{${[...extensions].join(',')}}`;
     this.fileWatcher = vscode.workspace.createFileSystemWatcher(filePattern);
     this.fileWatcher.onDidCreate(this.refreshFiles.bind(this));
     this.fileWatcher.onDidDelete(this.refreshFiles.bind(this));

--- a/packages/extension/src/MainViewProvider.ts
+++ b/packages/extension/src/MainViewProvider.ts
@@ -13,7 +13,7 @@ import {
   setActiveSidebarView,
 } from '@common/webview';
 import { consumePendingState } from '@common/state';
-import { getFilterExtensions } from '@common/files';
+import { EXTENSION_CATEGORIES, getFilterExtensions } from '@common/files';
 
 import { agentDirectories } from '@frontend/agents';
 import { computeModelOptionsData } from '@model/computeModelOptions';
@@ -158,9 +158,7 @@ export class MainViewProvider
     // (fileListingRules), including user-configured extension overrides, so
     // the watched set cannot drift from what the lists display.
     const extensions = new Set(
-      (['input', 'context', 'media', 'audio', 'edited'] as const).flatMap(
-        (category) => getFilterExtensions(category),
-      ),
+      EXTENSION_CATEGORIES.flatMap(getFilterExtensions),
     );
     const filePattern = `**/*.{${[...extensions].join(',')}}`;
     this.fileWatcher = vscode.workspace.createFileSystemWatcher(filePattern);

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -24,12 +24,6 @@ const CHANNEL = 'SetupAssistant';
 logger.initialize(CHANNEL);
 
 /**
- * Model to launch with when the user is signed in to Researcher Access
- * (server-side keys cover the shared default model).
- */
-const SIGNED_IN_SETUP_MODEL = DEFAULT_AGENT_MODEL;
-
-/**
  * Provider → model mapping used when the user only has a direct API key.
  * Each mapping points at a model routed through that same provider, so the
  * agent can actually authenticate with the key it's been given.
@@ -78,9 +72,9 @@ interface LaunchModelResolution {
  *      on AND the signed-in setup model is in the user's tier. A plain
  *      `canUseServerSideKeys()` pass is insufficient because a lower-tier
  *      user may have server-side access to *some* models but not
- *      `SIGNED_IN_SETUP_MODEL`; we'd otherwise fall through preflight
+ *      `DEFAULT_AGENT_MODEL`; we'd otherwise fall through preflight
  *      and fail at runtime when tier enforcement kicks in.
- *   2. If the user is signed in but `SIGNED_IN_SETUP_MODEL` is not in
+ *   2. If the user is signed in but `DEFAULT_AGENT_MODEL` is not in
  *      tier, scan `API_KEY_MODEL_BY_PROVIDER` for any model that IS in
  *      tier so a lower-tier signed-in user still gets a working launch.
  *   3. Any direct API key for a provider whose default model routes
@@ -108,8 +102,8 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
     };
   }
 
-  if (await serverKeys.canUseServerSideKeysForModel(SIGNED_IN_SETUP_MODEL)) {
-    return { model: SIGNED_IN_SETUP_MODEL, requiresOpenRouter: false };
+  if (await serverKeys.canUseServerSideKeysForModel(DEFAULT_AGENT_MODEL)) {
+    return { model: DEFAULT_AGENT_MODEL, requiresOpenRouter: false };
   }
 
   // Step 2: signed-in user whose tier excludes the default signed-in
@@ -127,7 +121,7 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
   }
 
   // Step 3: direct provider key. Only consider providers we know how to
-  // map to a default model — silently falling back to `SIGNED_IN_SETUP_MODEL`
+  // map to a default model — silently falling back to `DEFAULT_AGENT_MODEL`
   // (a Google model) for an unmapped provider would produce a runtime
   // auth failure with a credential that can't reach Google.
   for (const provider of SecretManager.API_PROVIDERS) {

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -4,7 +4,10 @@ import * as vscode from 'vscode';
 // Local imports
 import { loadAgents } from '@agent/index';
 import { registerExecution } from '@agent/storage';
-import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import {
+  AgentConfigSchema,
+  DEFAULT_AGENT_MODEL,
+} from '@agent/core/definition/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -22,9 +25,9 @@ logger.initialize(CHANNEL);
 
 /**
  * Model to launch with when the user is signed in to Researcher Access
- * (server-side keys cover Gemini).
+ * (server-side keys cover the shared default model).
  */
-const SIGNED_IN_SETUP_MODEL = 'gemini35f';
+const SIGNED_IN_SETUP_MODEL = DEFAULT_AGENT_MODEL;
 
 /**
  * Provider → model mapping used when the user only has a direct API key.

--- a/packages/extension/src/frontend/setupTerminalRunner.ts
+++ b/packages/extension/src/frontend/setupTerminalRunner.ts
@@ -15,12 +15,12 @@ import * as vscode from 'vscode';
 import stripAnsi from 'strip-ansi';
 
 // Local imports - hosts
-import type {
-  TerminalRunRequest,
-  TerminalRunResult,
+import {
+  TERMINAL_OUTPUT_MAX_CHARS,
+  type TerminalRunRequest,
+  type TerminalRunResult,
 } from '@hosts/terminalHost';
 
-const OUTPUT_MAX_CHARS = 12_000;
 const SHELL_INTEGRATION_WAIT_MS = 2_000;
 const READER_DRAIN_MS = 250;
 
@@ -94,7 +94,9 @@ async function captureExecution(
   // Drain the stream into a sliding-window tail. `.catch` swallows
   // late stream errors (terminal closed after we stopped awaiting)
   // so they cannot bubble up as unhandled rejections.
-  const reader = tail(execution.read(), OUTPUT_MAX_CHARS).catch(() => '');
+  const reader = tail(execution.read(), TERMINAL_OUTPUT_MAX_CHARS).catch(
+    () => '',
+  );
 
   const result = await raced;
 

--- a/packages/extension/src/frontend/vscode/vscodeSecrets.ts
+++ b/packages/extension/src/frontend/vscode/vscodeSecrets.ts
@@ -1,8 +1,9 @@
 /**
  * VS Code adapter for the platform-agnostic PlatformSecrets.
  *
- * Uses vscode.SecretStorage for secure key storage, with
- * process.env fallback for API keys.
+ * Uses vscode.SecretStorage for secure key storage. Environment variables
+ * override persisted secrets, matching ElectronSecrets and CliSecrets so a
+ * key exported in the environment behaves identically in every host.
  */
 import * as vscode from 'vscode';
 
@@ -16,6 +17,8 @@ export class VscodeSecrets implements PlatformSecrets {
   }
 
   async get(key: string): Promise<string | undefined> {
+    const envValue = process.env[key];
+    if (envValue !== undefined) return envValue;
     return this.storage.get(key);
   }
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -16,6 +16,10 @@ import type {
 import { normalizeToolUseData } from '@shared/toolUse';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import {
+  BASH_TOOL_DEFAULT_TIMEOUT_MS,
+  EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+} from '@shared/constants/toolDefaults';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
 import type { EditInput } from '@tools/EditTool';
 import type { TextEditorInput } from '@tools/TextEditorTool';
@@ -84,8 +88,8 @@ import '@awesome.me/webawesome/dist/components/divider/divider.js';
 
 /** Known per-tool default timeouts (ms) for display in the running timer. */
 const TOOL_DEFAULT_TIMEOUTS: Record<string, number> = {
-  bash: 120_000, // matches BASH_TIMEOUT_MS in src/tools/bash.ts
-  executions: 300_000, // matches code default in ExecutionsTool.ts
+  bash: BASH_TOOL_DEFAULT_TIMEOUT_MS,
+  executions: EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS * 1000,
   codex: 300_000, // generous default — Codex turns can be slow
 };
 

--- a/src/common/files/fileTypeUtils.ts
+++ b/src/common/files/fileTypeUtils.ts
@@ -29,6 +29,11 @@ const INCLUDED_EXTENSION_KEYS: Record<ExtensionCategory, string> = {
   edited: 'texra.files.included.editedExtensions',
 };
 
+/** Every configurable extension category, for callers that aggregate them all. */
+export const EXTENSION_CATEGORIES = Object.keys(
+  INCLUDED_EXTENSION_KEYS,
+) as readonly ExtensionCategory[];
+
 /** Legacy keys preserved so older user customizations carry through the rename. */
 const LEGACY_REFERENCE_EXTENSIONS_KEY =
   'texra.files.included.referenceExtensions';

--- a/src/common/files/index.ts
+++ b/src/common/files/index.ts
@@ -1,6 +1,7 @@
 // Barrel export for common file utilities
 export {
   ExtensionCategory,
+  EXTENSION_CATEGORIES,
   getFilterExtensions,
   getIncludedExtensions,
   isLatexFile,

--- a/src/hosts/terminalHost.ts
+++ b/src/hosts/terminalHost.ts
@@ -10,6 +10,13 @@ export interface TerminalRunRequest extends TerminalOptions {
   timeoutMs: number;
 }
 
+/**
+ * Length cap (chars) for {@link TerminalRunResult.output}. Every host's
+ * `TerminalRunner` keeps the same sliding-window tail so agents see identical
+ * truncation regardless of where a setup command ran.
+ */
+export const TERMINAL_OUTPUT_MAX_CHARS = 12_000;
+
 export interface TerminalRunResult {
   /** Undefined when the host cannot observe the command exit code. */
   exitCode: number | undefined;

--- a/src/platform/defaults/nodeStorage.ts
+++ b/src/platform/defaults/nodeStorage.ts
@@ -24,7 +24,11 @@ export const DEFAULT_NODE_STORAGE_ROOT = path.join(
  * a checked-in `.texra/config.json` behaves the same in both.
  */
 export function workspaceTexraConfigPath(workspaceRoot: string): string {
-  return path.join(workspaceRoot, TEXRA_STORAGE_DIR_NAME, TEXRA_CONFIG_FILE_NAME);
+  return path.join(
+    workspaceRoot,
+    TEXRA_STORAGE_DIR_NAME,
+    TEXRA_CONFIG_FILE_NAME,
+  );
 }
 
 interface NodeStorageProviderOptions {

--- a/src/platform/defaults/nodeStorage.ts
+++ b/src/platform/defaults/nodeStorage.ts
@@ -6,7 +6,26 @@ import * as path from 'node:path';
 import { WorkspaceStorageProvider } from './workspaceStorage';
 import type { StorageProvider } from '../interfaces/storage';
 
-export const DEFAULT_NODE_STORAGE_ROOT = path.join(os.homedir(), '.texra');
+/** Directory name for TeXRA data, both global (`~/.texra`) and per-project (`<workspace>/.texra`). */
+export const TEXRA_STORAGE_DIR_NAME = '.texra';
+
+/** File name of the JSON config file inside a `.texra` directory. */
+export const TEXRA_CONFIG_FILE_NAME = 'config.json';
+
+export const DEFAULT_NODE_STORAGE_ROOT = path.join(
+  os.homedir(),
+  TEXRA_STORAGE_DIR_NAME,
+);
+
+/**
+ * Project-local config file shared by the CLI and the desktop app:
+ * `<workspaceRoot>/.texra/config.json`. The VS Code extension keeps workspace
+ * config in `.vscode/settings.json`; the other hosts converge on this path so
+ * a checked-in `.texra/config.json` behaves the same in both.
+ */
+export function workspaceTexraConfigPath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, TEXRA_STORAGE_DIR_NAME, TEXRA_CONFIG_FILE_NAME);
+}
 
 interface NodeStorageProviderOptions {
   readonly storageRoot?: string;

--- a/src/shared/constants/toolDefaults.ts
+++ b/src/shared/constants/toolDefaults.ts
@@ -1,0 +1,12 @@
+/**
+ * Default tool timeouts shared between the tool implementations and the host
+ * UIs that display a running-tool countdown (extension/desktop progress view).
+ * Keep these here — not re-declared per host — so the displayed limit always
+ * matches what the tool actually enforces.
+ */
+
+/** Default `bash` tool timeout (ms) when the model omits `timeout`. */
+export const BASH_TOOL_DEFAULT_TIMEOUT_MS = 120_000;
+
+/** Default `executions wait` timeout (seconds) when the model omits `timeout`. */
+export const EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS = 300;

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -86,7 +86,7 @@ vi.mock('@cli/runtime/cliStateStores', () => ({
   createCliStateStores: vi.fn().mockResolvedValue({
     globalState: { update: vi.fn() },
     workspaceState: {},
-    storage: {},
+    storage: { getGlobalStoragePath: () => '/tmp/texra-global' },
   }),
 }));
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -34,6 +34,8 @@ import {
 import { executionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
 import { onFollowUpSent } from '@agent/toolUse/ToolUseFollowUp';
 
+// Local imports - shared
+
 // Local imports - utils
 import { toErrorMessage } from '@common/errors';
 import {
@@ -41,6 +43,7 @@ import {
   ExecutionIdSchema,
   type ExecutionId,
 } from '@shared/schemas';
+import { EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS } from '@shared/constants/toolDefaults';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { requireRunStream } from '@tools/contextHelpers';
 import { AbsoluteFS, StorageFS } from '@utils/files';
@@ -272,7 +275,10 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         );
       }
       if (input.action === 'wait')
-        await this.waitForAnyChange(input.timeout ?? 300, input.ids);
+        await this.waitForAnyChange(
+          input.timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+          input.ids,
+        );
       return this.listExecutions(input.offset ?? 0, input.limit ?? 100);
     }
 
@@ -291,7 +297,10 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         return this.handleUnsubscribe(executionId);
       }
       if (input.action === 'wait')
-        await this.waitForChange(executionId, input.timeout ?? 300);
+        await this.waitForChange(
+          executionId,
+          input.timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+        );
       return this.showSummary(executionId);
     }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -35,6 +35,7 @@ import { executionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptio
 import { onFollowUpSent } from '@agent/toolUse/ToolUseFollowUp';
 
 // Local imports - shared
+import { EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS } from '@shared/constants/toolDefaults';
 
 // Local imports - utils
 import { toErrorMessage } from '@common/errors';
@@ -43,7 +44,6 @@ import {
   ExecutionIdSchema,
   type ExecutionId,
 } from '@shared/schemas';
-import { EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS } from '@shared/constants/toolDefaults';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { requireRunStream } from '@tools/contextHelpers';
 import { AbsoluteFS, StorageFS } from '@utils/files';

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -44,7 +44,6 @@ import { defineTool } from './core/define';
 import { createChildStream } from './childStream';
 import { parseWorkingDirectory } from './pathResolution';
 
-const BASH_TIMEOUT_MS = BASH_TOOL_DEFAULT_TIMEOUT_MS;
 const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
 /** Max chars logged to the child stream tab to prevent unbounded memory growth. */
 const BACKGROUND_LOG_CAP_CHARS = 200_000;
@@ -128,7 +127,7 @@ export class BashTool extends defineTool({
     const runContext = contexts?.runContext;
     callContext?.onExecutionReady?.();
 
-    const timeoutMs = input.timeout ?? BASH_TIMEOUT_MS;
+    const timeoutMs = input.timeout ?? BASH_TOOL_DEFAULT_TIMEOUT_MS;
 
     const cwd = parseWorkingDirectory(runContext?.workingDirectory);
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -23,6 +23,7 @@ import { toErrorMessage } from '@common/errors';
 
 // Local imports - tools
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
+import { BASH_TOOL_DEFAULT_TIMEOUT_MS } from '@shared/constants/toolDefaults';
 import { ToolError, type ToolResult } from '@tools/result';
 import { formatBashDelivery, formatBashError } from '@tools/subagentResults';
 import {
@@ -43,7 +44,7 @@ import { defineTool } from './core/define';
 import { createChildStream } from './childStream';
 import { parseWorkingDirectory } from './pathResolution';
 
-const BASH_TIMEOUT_MS = 120_000; // 120 s
+const BASH_TIMEOUT_MS = BASH_TOOL_DEFAULT_TIMEOUT_MS;
 const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
 /** Max chars logged to the child stream tab to prevent unbounded memory growth. */
 const BACKGROUND_LOG_CAP_CHARS = 200_000;


### PR DESCRIPTION
## Summary

Unifies workspace configuration storage across the CLI, desktop, and extension by adopting a shared `.texra/config.json` file at the project root. Previously, each host stored workspace config in different locations (CLI: `.texra/config.json`, desktop: internal per-workspace store, extension: VS Code settings). This change makes the desktop and CLI converge on the same file, enabling checked-in project configuration to behave identically in both hosts.

The extension continues using VS Code settings (`.vscode/settings.json`) as its workspace config source, maintaining the VS Code idiom.

## Issue acceptance gates

Implements the workspace config convergence design:
- ✅ CLI reads/writes `/.texra/config.json`
- ✅ Desktop reads `/.texra/config.json` with fallback to legacy internal store
- ✅ Desktop performs one-time migration from legacy store to project file
- ✅ CLI wires user-level config (`~/.texra/global-storage/config.json`, the same file the chat-defaults loader already read) into the `global` config target, matching desktop's existing global store (`<userData>/config/global.json`)
- ✅ Shared constants and paths eliminate duplication

## Single source of truth

**Module:** `src/platform/defaults/nodeStorage.ts`

Exports `workspaceTexraConfigPath()`, `TEXRA_CONFIG_FILE_NAME`, and `TEXRA_STORAGE_DIR_NAME` as the canonical definitions of the shared project config location. All hosts (CLI, desktop) and config initialization code import from this module rather than re-declaring paths.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated `workspaceCliConfigPath()` from `packages/cli/src/runtime/cliConfig.ts`; now uses `workspaceTexraConfigPath()` from platform defaults
- Consolidated `CLI_CONFIG_DIR` and `CLI_CONFIG_FILE` constants into `TEXRA_STORAGE_DIR_NAME` and `TEXRA_CONFIG_FILE_NAME` in the platform layer
- Removed per-host magic strings for output truncation (`OUTPUT_MAX_CHARS`); now uses `TERMINAL_OUTPUT_MAX_CHARS` from `src/hosts/terminalHost.ts`
- Consolidated tool timeout defaults into `src/shared/constants/toolDefaults.ts` (used by both tool implementations and progress UI)

**New abstractions:**
- `workspaceTexraConfigPath(workspaceRoot)` — owns the invariant that workspace config lives at `/.texra/config.json`
- `TERMINAL_OUTPUT_MAX_CHARS` — ensures all hosts truncate terminal output identically
- Tool timeout constants — shared between implementations and UI so displayed limits match enforced limits

## Host impact

**Extension:**
- No change to config storage (continues using VS Code settings)
- File watcher now derives watched extensions from `EXTENSION_CATEGORIES` to stay synchronized with file listing rules
- `VscodeSecrets` now checks environment variables first (matching desktop and CLI behavior)

**Desktop:**
- Workspace config now reads from `/.texra/config.json` instead of internal per-workspace store
- One-time migration copies legacy config values into the project file (existing project values win; presence is checked across `texra.*`/bare key variants so migrated canonical keys never shadow checked-in bare keys)
- Global config unchanged (`<userData>/config/global.json`)

**CLI:**
- Config paths now use shared `workspaceTexraConfigPath()` from platform defaults
- User-level config (`~/.texra/global-storage/config.json`) now backs the `global` config target via `JsonConfigProvider`; `update(..., 'global')` no longer throws
- Lifecycle error logging severity unified with other hosts

## Scheduled refactoring

None. The migration is complete and backward-compatible (desktop migrates legacy config on first run).

## Validation

- Existing unit tests pass (mocked `getGlobalStoragePath()` in CLI platform init test)
- Desktop migration logic is defensive: only copies keys not already in the project file (checked across key variants), preserving checked-in config
- All three hosts now read from the same file when a workspace is present, enabling identical behavior for checked-in `.texra/config.json`

https://claude.ai/code/session_01SMC7r7LefBtGpgGxDyGc1u


---

&gt; [!NOTE]
&gt; **Medium Risk**
&gt; Desktop one-time config migration and shared project config path affect where settings are read/written; migration is merge-only but wrong paths could confuse users until verified.
&gt; 
&gt; **Overview**
&gt; **CLI and desktop** now share project workspace settings via `/.texra/config.json`, using `workspaceTexraConfigPath()` and related constants from `@platform/defaults/nodeStorage` instead of host-specific path helpers. **Desktop** reads that project file when a workspace is set, runs a **one-time migration** from the old internal `config.json` (project values win), and still falls back to the legacy store without a workspace. **CLI** wires **global** config into `JsonConfigProvider`, aligns lifecycle shutdown errors with other hosts, and updates init/doctor/chat defaults to the shared paths.
&gt; 
&gt; **Extension** keeps VS Code settings for workspace config but **aligns behavior**: launcher file watching follows `EXTENSION_CATEGORIES` + `getFilterExtensions`, **secrets** prefer `process.env` over stored values (like CLI/desktop), and the setup assistant uses **`DEFAULT_AGENT_MODEL`** instead of a local signed-in constant.
&gt; 
&gt; **Shared constants**: `TERMINAL_OUTPUT_MAX_CHARS` for setup terminal truncation across hosts; `toolDefaults` for bash/executions wait timeouts in tools and progress UI. **CLI `/help`** documents modifier+`p` (tasks) and modifier+`s` (subagents) shortcuts.
&gt; 
&gt; <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604f540c282f0ecd2b338800726028b594315742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Desktop one-time config migration and shared project config path affect where settings are read/written; migration is merge-only but wrong paths could confuse users until verified.
> 
> **Overview**
> **CLI and desktop** now share project workspace settings through `<workspace>/.texra/config.json`, using `workspaceTexraConfigPath()` and related constants from `@platform/defaults/nodeStorage` instead of host-specific path helpers. **Desktop** reads that project file when a workspace is set, runs a **one-time migration** from the old internal `config.json` (project values win), and still falls back to the legacy store without a workspace. **CLI** wires **global** config (`~/.texra/global-storage/config.json`) into `JsonConfigProvider`, aligns lifecycle shutdown errors with other hosts, and updates init/doctor/chat defaults to the shared paths.
> 
> **Extension** keeps VS Code settings for workspace config but **aligns behavior**: launcher file watching follows `EXTENSION_CATEGORIES` + `getFilterExtensions`, **secrets** prefer `process.env` over stored values (like CLI/desktop), and the setup assistant uses **`DEFAULT_AGENT_MODEL`** instead of a local signed-in constant.
> 
> **Shared constants**: `TERMINAL_OUTPUT_MAX_CHARS` for setup terminal truncation across hosts; `toolDefaults` for bash/executions wait timeouts in tools and progress UI. **CLI `/help`** documents modifier+`p` (tasks) and modifier+`s` (subagents) shortcuts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57921808b6a519bffa12beae2f140c76bd50fc91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->