### PR TITLE
test: update Fable default model label

### DIFF
--- a/src/test-kernel/model/ModelOptionsBasic.vitest.ts
+++ b/src/test-kernel/model/ModelOptionsBasic.vitest.ts
@@ -37,7 +37,7 @@ describe('default model list', () => {
     expect(DEFAULT_MODELS).toContain('fable5');
     expect(config).toMatchObject({
       fullName: 'claude-fable-5',
-      label: 'Fable 5',
+      label: 'Claude Fable 5',
       provider: 'anthropic',
       openRouterOnly: false,
     });


### PR DESCRIPTION
## Summary

- Updates the default model registry test to match llm-zoo's current `fable5` label, `Claude Fable 5`.
- This unblocks the shared CI failure currently hitting the refactor PR queue.

## Verification

- `corepack pnpm vitest run src/test-kernel/model/ModelOptionsBasic.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only expectation change with no production or config logic touched.
> 
> **Overview**
> Aligns the **Fable 5** default-model test with **llm-zoo**’s current display name by expecting `label: 'Claude Fable 5'` instead of `'Fable 5'` in `ModelOptionsBasic.vitest.ts`.
> 
> No runtime or registry code changes—only the assertion that was failing shared CI after the upstream label update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0f5853999934ea2f1b4b67ec060d22aab3d6d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->