### PR TITLE
fix: allow latexFixer to run on generated latexdiff artifacts

### DIFF
--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -59,15 +59,6 @@ export async function handleFixCompilation(): Promise<void> {
     await withLaTeXGuard(
       { channel: CHANNEL, action: 'fix compilation', saveDocument: true },
       async ({ editor, relativePath }) => {
-        if (
-          await showGeneratedLatexdiffTargetWarning(
-            editor.document.fileName,
-            relativePath,
-          )
-        ) {
-          return;
-        }
-
         logger.info(
           CHANNEL,
           `Launching tool-use agent to fix compilation for: ${relativePath}`,
@@ -75,7 +66,10 @@ export async function handleFixCompilation(): Promise<void> {
 
         await vscode.commands.executeCommand('texra.execute', {
           agent: 'latexFixer',
-          instruction: `Fix the LaTeX compilation errors in ${relativePath}.`,
+          instruction: await buildFixCompilationInstruction(
+            editor.document.fileName,
+            relativePath,
+          ),
         });
       },
     );
@@ -88,51 +82,37 @@ export async function handleFixCompilation(): Promise<void> {
   }
 }
 
-async function showGeneratedLatexdiffTargetWarning(
+/**
+ * Generated latexdiff artifacts are valid fixer targets — latexdiff itself
+ * often emits non-compiling markup that regenerating the diff would only
+ * reproduce — but the fixer should know the file is a diff so it repairs the
+ * markup in place, and should propagate source-rooted fixes to the source so
+ * they survive regeneration.
+ */
+async function buildFixCompilationInstruction(
   activeFilePath: string,
-  activeRelativePath: string,
-): Promise<boolean> {
+  relativePath: string,
+): Promise<string> {
+  const base = `Fix the LaTeX compilation errors in ${relativePath}.`;
   const artifact = detectGeneratedLatexdiffArtifact(activeFilePath);
-  if (!artifact) return false;
+  if (!artifact) return base;
 
   const sourceExists = await AbsoluteFS.exists(artifact.sourcePath);
   // A user may legitimately keep a source file named chapter_diff.tex. Treat
-  // a plain `_diff` suffix in the workspace as generated only when the inferred
-  // source exists. Shadow/temp diffs live outside the workspace and still need
-  // to be blocked even when their source is elsewhere.
-  if (
-    artifact.kind === 'workspaceDiff' &&
-    !sourceExists &&
-    isInsideWorkspace(activeFilePath)
-  ) {
-    return false;
+  // a plain `_diff` suffix as generated only when the inferred source exists.
+  if (artifact.kind === 'workspaceDiff' && !sourceExists) {
+    return base;
   }
 
-  const sourceRelativePath = WorkspaceFS.relativePath(artifact.sourcePath);
-  const message = sourceExists
-    ? `Cannot run latexFixer on generated LaTeXdiff artifact ${activeRelativePath}. Open ${sourceRelativePath} and fix the source, then regenerate the diff.`
-    : `Cannot run latexFixer on generated LaTeXdiff artifact ${activeRelativePath}. Fix the source document, then regenerate the diff.`;
-
-  logger.warn(CHANNEL, message);
-  const openSource = 'Open Source';
-  const selection = sourceExists
-    ? await vscode.window.showWarningMessage(message, openSource)
-    : await vscode.window.showWarningMessage(message);
-  if (selection === openSource) {
-    await openSourceDocument(artifact.sourcePath);
-  }
-  return true;
-}
-
-function isInsideWorkspace(filePath: string): boolean {
-  return vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath)) != null;
-}
-
-async function openSourceDocument(sourcePath: string): Promise<void> {
-  const document = await vscode.workspace.openTextDocument(
-    vscode.Uri.file(sourcePath),
-  );
-  await vscode.window.showTextDocument(document);
+  const sourceHint = sourceExists
+    ? ` generated from ${WorkspaceFS.relativePath(artifact.sourcePath)}`
+    : '';
+  return [
+    base,
+    `This file is a latexdiff artifact${sourceHint}.`,
+    'If an error comes from broken latexdiff markup (\\DIFadd/\\DIFdel or the DIF preamble blocks), repair the markup in place and keep the diff annotations intact.',
+    'If an error originates in the original source document, fix the source too so a regenerated diff stays fixed.',
+  ].join(' ');
 }
 
 export async function handleApplyReplacements(): Promise<void> {


### PR DESCRIPTION
## Summary

- Remove the hard block (from #5716 / #5717) that stopped `texra.fixCompilation` from running on generated latexdiff artifacts
- When the active file matches a generated diff pattern (`-diff<hash>`, `_diffrNrM`, `_diff`), the latexFixer instruction now explains the file is a latexdiff artifact: repair broken DIF markup (`\DIFadd`/`\DIFdel`, DIF preamble blocks) in place and keep the diff annotations intact
- When an error originates in the original source rather than the diff markup, the fixer is told to fix the source too, so a regenerated diff stays fixed
- Keep the `chapter_diff.tex` carve-out: a plain `_diff` suffix only gets the artifact framing when the inferred source exists

## Why

The #5716 guard assumed the right fix always lives in the source ("fix the source, then regenerate the diff"). That premise fails in the most common case: latexdiff itself routinely emits non-compiling markup (DIF commands inside math, around `\cite`, in macro definitions) even when both input revisions compile cleanly. Regenerating just reproduces the same broken file, so patching the artifact is the only way to get a compilable diff for review — and the artifact being throwaway makes that low-risk.

The real problem behind #5716 was the fixer not knowing what kind of file it was editing (it chased `\DIFadd` corruption as if it were paper source). Framing the instruction fixes that without removing the capability.

The progress-view compile fixer (`ProgressFollowUpController`) is intentionally unchanged: that automated path already maps failed generated outputs back to their recorded sources, which is the right default when nobody is choosing the target.

## Validation

- `npm run typecheck`
- `npx eslint packages/extension/src/commands/latex/latexCommands.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to fix-compilation command messaging and gating; no auth, data, or automated progress-path behavior changes.
> 
> **Overview**
> **`texra.fixCompilation`** no longer blocks on generated latexdiff files. Instead of warning and refusing to run **latexFixer**, it always launches the agent with a tailored instruction.
> 
> When **`detectGeneratedLatexdiffArtifact`** matches (with the existing **`chapter_diff.tex`** carve-out: plain **`_diff`** only gets artifact framing if the inferred source exists), the instruction tells the fixer the file is a latexdiff artifact, to repair broken **`\DIFadd`/`\DIFdel`** and DIF preamble markup **in place** while keeping annotations, and to fix the **source** when errors come from the original document so regeneration stays fixed.
> 
> Removed helpers that only supported the block: **`showGeneratedLatexdiffTargetWarning`**, **`isInsideWorkspace`**, and **`openSourceDocument`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 421ed6f9d784b4a30b249c3a9f694e924e9ae193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->