### PR TITLE
refactor(supabase): centralize edge function deps, dedupe shared logic, use native libs

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -21,6 +21,9 @@ export interface AuthenticatedUser {
   client: SupabaseClient;
 }
 
+const supabaseUrl = Deno.env.get('SUPABASE_URL');
+const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+
 /**
  * Validate a user JWT and return the user plus a user-scoped client.
  * Returns null when the JWT is missing, invalid, or expired (callers should
@@ -30,8 +33,6 @@ export interface AuthenticatedUser {
 export async function authenticateJwt(
   jwt: string | null,
 ): Promise<AuthenticatedUser | null> {
-  const supabaseUrl = Deno.env.get('SUPABASE_URL');
-  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
   if (!jwt || !supabaseUrl || !supabaseAnonKey) return null;
 
   const client = createClient(supabaseUrl, supabaseAnonKey, {

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,49 @@
+/** Shared user-JWT authentication for edge functions. */
+
+import {
+  createClient,
+  type SupabaseClient,
+  type User,
+} from '@supabase/supabase-js';
+
+/** Extract the bearer token from the Authorization header. */
+export function bearerToken(req: Request): string | null {
+  const authHeader = req.headers.get('Authorization');
+  return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+}
+
+export interface AuthenticatedUser {
+  user: User;
+  /**
+   * User-scoped client (anon key + the user's JWT), so RLS applies to
+   * database queries made with it.
+   */
+  client: SupabaseClient;
+}
+
+/**
+ * Validate a user JWT and return the user plus a user-scoped client.
+ * Returns null when the JWT is missing, invalid, or expired (callers should
+ * have already verified SUPABASE_URL / SUPABASE_ANON_KEY to distinguish
+ * configuration errors from auth failures).
+ */
+export async function authenticateJwt(
+  jwt: string | null,
+): Promise<AuthenticatedUser | null> {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (!jwt || !supabaseUrl || !supabaseAnonKey) return null;
+
+  const client = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: `Bearer ${jwt}` } },
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const {
+    data: { user },
+    error,
+  } = await client.auth.getUser();
+  if (error || !user) return null;
+
+  return { user, client };
+}

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -68,18 +68,18 @@ export function getCorsHeaders(req: Request): Record<string, string> {
  * Handle CORS preflight or reject disallowed origins.
  * @returns Response if handled (preflight or rejected), null if request should proceed.
  */
-export function handleCors(req: Request): { response?: Response } {
+export function handleCors(req: Request): Response | null {
   const corsHeaders = getCorsHeaders(req);
 
   // Reject requests from disallowed origins
   if (!corsHeaders['Access-Control-Allow-Origin']) {
-    return { response: new Response('Forbidden', { status: 403 }) };
+    return new Response('Forbidden', { status: 403 });
   }
 
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
-    return { response: new Response('ok', { headers: corsHeaders }) };
+    return new Response('ok', { headers: corsHeaders });
   }
 
-  return {};
+  return null;
 }

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -68,27 +68,18 @@ export function getCorsHeaders(req: Request): Record<string, string> {
  * Handle CORS preflight or reject disallowed origins.
  * @returns Response if handled (preflight or rejected), null if request should proceed.
  */
-export function handleCors(req: Request): {
-  corsHeaders: Record<string, string>;
-  response?: Response;
-} {
+export function handleCors(req: Request): { response?: Response } {
   const corsHeaders = getCorsHeaders(req);
 
   // Reject requests from disallowed origins
   if (!corsHeaders['Access-Control-Allow-Origin']) {
-    return {
-      corsHeaders,
-      response: new Response('Forbidden', { status: 403 }),
-    };
+    return { response: new Response('Forbidden', { status: 403 }) };
   }
 
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
-    return {
-      corsHeaders,
-      response: new Response('ok', { headers: corsHeaders }),
-    };
+    return { response: new Response('ok', { headers: corsHeaders }) };
   }
 
-  return { corsHeaders };
+  return {};
 }

--- a/supabase/functions/_shared/responses.ts
+++ b/supabase/functions/_shared/responses.ts
@@ -1,0 +1,16 @@
+/** Shared JSON response helper for edge functions. */
+
+import { getCorsHeaders } from './cors.ts';
+
+/** JSON response carrying CORS headers and the function's `_version` stamp. */
+export function versionedJsonResponse(
+  req: Request,
+  version: string,
+  body: Record<string, unknown>,
+  status: number,
+): Response {
+  return new Response(JSON.stringify({ _version: version, ...body }), {
+    status,
+    headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/functions/auth-github/deno.json
+++ b/supabase/functions/auth-github/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@hono/hono": "jsr:@hono/hono@4.12.24",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1",
+    "djwt": "https://deno.land/x/djwt@v3.0.2/mod.ts"
+  }
+}

--- a/supabase/functions/auth-github/deno.lock
+++ b/supabase/functions/auth-github/deno.lock
@@ -1,0 +1,86 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@hono/hono@4.12.24": "4.12.24",
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1"
+  },
+  "jsr": {
+    "@hono/hono@4.12.24": {
+      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
+    },
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+      "dependencies": [
+        "npm:@supabase/auth-js",
+        "npm:@supabase/functions-js",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    },
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    }
+  },
+  "remote": {
+    "https://deno.land/std@0.221.0/encoding/_util.ts": "beacef316c1255da9bc8e95afb1fa56ed69baef919c88dc06ae6cb7a6103d376",
+    "https://deno.land/std@0.221.0/encoding/base64.ts": "8ccae67a1227b875340a8582ff707f37b131df435b07080d3bb58e07f5f97807",
+    "https://deno.land/std@0.221.0/encoding/base64url.ts": "9cc46cf510436be63ac00ebf97a7de1993e603ca58e1853b344bf90d80ea9945",
+    "https://deno.land/x/djwt@v3.0.2/algorithm.ts": "b1c6645f9dbd6e6c47c123a3b18c28b956f91c65ed17f5b6d5d968fc3750542b",
+    "https://deno.land/x/djwt@v3.0.2/deps.ts": "a7954fe567f2097b4f6aca11d091b6df658e485a817ac4dee47257ed5c28fd6e",
+    "https://deno.land/x/djwt@v3.0.2/mod.ts": "962d8f2c4d6a4db111f45d777b152356aec31ba7db0ca664601175a422629857",
+    "https://deno.land/x/djwt@v3.0.2/signature.ts": "16238fbf558267c85dd6c0178045f006c8b914a7301db87149f3318326569272",
+    "https://deno.land/x/djwt@v3.0.2/util.ts": "5cb264d2125c553678e11446bcfa0494025d120e3f59d0a3ab38f6800def697d"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@hono/hono@4.12.24",
+      "jsr:@supabase/supabase-js@2.108.1"
+    ]
+  }
+}

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -66,7 +66,7 @@ const app = new Hono<{ Variables: Variables }>();
 
 // CORS middleware using shared utilities
 app.use('*', async (c, next) => {
-  const { response } = handleCors(c.req.raw);
+  const response = handleCors(c.req.raw);
   if (response) return response;
   await next();
 });
@@ -343,7 +343,8 @@ app.post('/exchange', async (c) => {
         userId = newUser.user.id;
       }
 
-      // Link identity (duplicate inserts are ignored)
+      // Duplicate/constraint failures are non-fatal; thrown transport/runtime
+      // failures should fail the exchange instead of leaving auth state split.
       const { error: identityError } = await supabase
         .schema('auth')
         .from('identities')

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -14,20 +14,21 @@
  * - JWTs signed with Supabase's JWT secret
  */
 
-import { Hono } from 'jsr:@hono/hono@4.12.15';
-import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
-import { create, getNumericDate } from 'https://deno.land/x/djwt@v3.0.2/mod.ts';
+import { Hono, type Context as HonoContext } from '@hono/hono';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { create, getNumericDate } from 'djwt';
 import { handleCors } from '../_shared/cors.ts';
 import {
   checkEmailDomain,
   checkGitHubAccountAge,
 } from '../_shared/emailPolicy.ts';
+import { versionedJsonResponse } from '../_shared/responses.ts';
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-const VERSION = '2.0.0';
+const VERSION = '2.0.1';
 const ACCESS_TOKEN_EXPIRY_SECONDS = 3600;
 const REFRESH_TOKEN_EXPIRY_DAYS = 7;
 
@@ -52,9 +53,9 @@ interface GitHubUser {
   created_at: string;
 }
 
+// `any` schema so `.schema('auth')` queries typecheck (service-role client).
 type Variables = {
-  supabase: ReturnType<typeof createClient>;
-  corsHeaders: Record<string, string>;
+  supabase: SupabaseClient<any>;
 };
 
 // =============================================================================
@@ -65,24 +66,25 @@ const app = new Hono<{ Variables: Variables }>();
 
 // CORS middleware using shared utilities
 app.use('*', async (c, next) => {
-  const { corsHeaders, response } = handleCors(c.req.raw);
+  const { response } = handleCors(c.req.raw);
   if (response) return response;
-  c.set('corsHeaders', corsHeaders);
   await next();
 });
 
 // Initialize Supabase client
 app.use('*', async (c, next) => {
   if (!supabaseUrl || !supabaseServiceKey || !jwtSecret) {
-    return c.json(
-      { error: 'Server configuration error', _version: VERSION },
+    return versionedJsonResponse(
+      c.req.raw,
+      VERSION,
+      { error: 'Server configuration error' },
       500,
     );
   }
 
   c.set(
     'supabase',
-    createClient(supabaseUrl, supabaseServiceKey, {
+    createClient<any>(supabaseUrl, supabaseServiceKey, {
       auth: { autoRefreshToken: false, persistSession: false },
     }),
   );
@@ -94,14 +96,14 @@ app.use('*', async (c, next) => {
 // Helpers
 // =============================================================================
 
-type Context = Parameters<Parameters<typeof app.post>[1]>[0];
+type Context = HonoContext<{ Variables: Variables }>;
 
 function jsonResponse(
   c: Context,
   body: Record<string, unknown>,
   status: number,
 ) {
-  return c.json({ _version: VERSION, ...body }, status, c.get('corsHeaders'));
+  return versionedJsonResponse(c.req.raw, VERSION, body, status);
 }
 
 function errorResponse(c: Context, error: string, status: number) {
@@ -341,8 +343,8 @@ app.post('/exchange', async (c) => {
         userId = newUser.user.id;
       }
 
-      // Link identity
-      await supabase
+      // Link identity (duplicate inserts are ignored)
+      const { error: identityError } = await supabase
         .schema('auth')
         .from('identities')
         .insert({
@@ -359,8 +361,10 @@ app.post('/exchange', async (c) => {
           last_sign_in_at: new Date().toISOString(),
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
-        })
-        .catch(() => {}); // Ignore duplicate
+        });
+      if (identityError) {
+        console.warn('[AUTH] Identity link skipped:', identityError.message);
+      }
     }
 
     // Generate tokens

--- a/supabase/functions/before-user-created/deno.json
+++ b/supabase/functions/before-user-created/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "standardwebhooks": "npm:standardwebhooks@1.0.0"
+  }
+}

--- a/supabase/functions/before-user-created/deno.lock
+++ b/supabase/functions/before-user-created/deno.lock
@@ -1,0 +1,26 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:standardwebhooks@1.0.0": "1.0.0"
+  },
+  "npm": {
+    "@stablelib/base64@1.0.1": {
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
+    },
+    "fast-sha256@1.3.0": {
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
+    },
+    "standardwebhooks@1.0.0": {
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dependencies": [
+        "@stablelib/base64",
+        "fast-sha256"
+      ]
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:standardwebhooks@1.0.0"
+    ]
+  }
+}

--- a/supabase/functions/before-user-created/index.ts
+++ b/supabase/functions/before-user-created/index.ts
@@ -102,15 +102,22 @@ Deno.serve(async (req) => {
   const rawBody = await req.text();
 
   let payload: HookRequest;
+  try {
+    payload = JSON.parse(rawBody) as HookRequest;
+  } catch {
+    return new Response('Invalid JSON', { status: 400 });
+  }
+
   if (webhook) {
     try {
       // verify() enforces the spec's timestamp tolerance (anti-replay) and
-      // returns the parsed JSON payload.
-      payload = webhook.verify(rawBody, {
+      // validates the signed raw body. JSON was already parsed above so
+      // malformed payloads remain 400 rather than looking like auth failures.
+      webhook.verify(rawBody, {
         'webhook-id': req.headers.get('webhook-id') ?? '',
         'webhook-timestamp': req.headers.get('webhook-timestamp') ?? '',
         'webhook-signature': req.headers.get('webhook-signature') ?? '',
-      }) as HookRequest;
+      });
     } catch {
       console.warn('[before-user-created] Signature verification failed');
       return new Response('Unauthorized', { status: 401 });
@@ -120,11 +127,6 @@ Deno.serve(async (req) => {
       '[before-user-created] BEFORE_USER_CREATED_HOOK_SECRET is not set; ' +
         'allowing unsigned requests. Configure the hook secret to enforce verification.',
     );
-    try {
-      payload = JSON.parse(rawBody) as HookRequest;
-    } catch {
-      return new Response('Invalid JSON', { status: 400 });
-    }
   }
 
   const user = payload.user;

--- a/supabase/functions/before-user-created/index.ts
+++ b/supabase/functions/before-user-created/index.ts
@@ -11,7 +11,10 @@
 //
 // Payload contract: https://supabase.com/docs/guides/auth/auth-hooks/before-user-created-hook
 // Signature contract: Standard Webhooks — https://www.standardwebhooks.com/
+// (verified via the reference `standardwebhooks` library, which also enforces
+// the spec's timestamp tolerance against replay).
 
+import { Webhook } from 'standardwebhooks';
 import {
   checkEmailDomain,
   checkGitHubAccountAge,
@@ -20,6 +23,9 @@ import {
 const HOOK_SECRET_RAW = Deno.env.get('BEFORE_USER_CREATED_HOOK_SECRET') ?? '';
 // Supabase stores the secret as "v1,whsec_<base64>"; strip the prefix.
 const HOOK_SECRET_BASE64 = HOOK_SECRET_RAW.replace(/^v1,whsec_/, '');
+
+// null = secret not configured; requests are allowed unsigned (with a warning).
+const webhook = HOOK_SECRET_BASE64 ? new Webhook(HOOK_SECRET_BASE64) : null;
 
 const GITHUB_FETCH_TIMEOUT_MS = 3000;
 
@@ -47,64 +53,6 @@ function block(message: string, httpCode = 400): Response {
     JSON.stringify({ error: { http_code: httpCode, message } }),
     { status: httpCode, headers: { 'content-type': 'application/json' } },
   );
-}
-
-function decodeBase64(s: string): ArrayBuffer {
-  // Return ArrayBuffer (not Uint8Array) so it satisfies WebCrypto's BufferSource
-  // under Deno's strict types (Uint8Array<ArrayBufferLike> doesn't match).
-  const decoded = atob(s);
-  const buf = new ArrayBuffer(decoded.length);
-  const view = new Uint8Array(buf);
-  for (let i = 0; i < decoded.length; i++) view[i] = decoded.charCodeAt(i);
-  return buf;
-}
-
-async function verifySignature(
-  msgId: string,
-  timestamp: string,
-  body: string,
-  signatureHeader: string,
-): Promise<boolean> {
-  if (!HOOK_SECRET_BASE64) {
-    console.warn(
-      '[before-user-created] BEFORE_USER_CREATED_HOOK_SECRET is not set; ' +
-        'allowing unsigned requests. Configure the hook secret to enforce verification.',
-    );
-    return true;
-  }
-
-  if (!msgId || !timestamp || !signatureHeader) return false;
-
-  const signedContent = `${msgId}.${timestamp}.${body}`;
-  const key = await crypto.subtle.importKey(
-    'raw',
-    decodeBase64(HOOK_SECRET_BASE64),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['verify'],
-  );
-
-  // webhook-signature is space-delimited "v1,<base64> v1,<base64>" (key rotation).
-  const candidates = signatureHeader
-    .split(' ')
-    .filter((s) => s.startsWith('v1,'))
-    .map((s) => s.slice(3));
-
-  const msgBytes = new TextEncoder().encode(signedContent);
-  for (const sigB64 of candidates) {
-    try {
-      const ok = await crypto.subtle.verify(
-        'HMAC',
-        key,
-        decodeBase64(sigB64),
-        msgBytes,
-      );
-      if (ok) return true;
-    } catch {
-      // ignore and try the next candidate
-    }
-  }
-  return false;
 }
 
 async function fetchGitHubCreatedAt(login: string): Promise<string | null> {
@@ -152,22 +100,31 @@ Deno.serve(async (req) => {
   }
 
   const rawBody = await req.text();
-  const sigOk = await verifySignature(
-    req.headers.get('webhook-id') ?? '',
-    req.headers.get('webhook-timestamp') ?? '',
-    rawBody,
-    req.headers.get('webhook-signature') ?? '',
-  );
-  if (!sigOk) {
-    console.warn('[before-user-created] Signature verification failed');
-    return new Response('Unauthorized', { status: 401 });
-  }
 
   let payload: HookRequest;
-  try {
-    payload = JSON.parse(rawBody) as HookRequest;
-  } catch {
-    return new Response('Invalid JSON', { status: 400 });
+  if (webhook) {
+    try {
+      // verify() checks the v1 HMAC signature (all rotation candidates) and
+      // timestamp tolerance, then returns the parsed JSON payload.
+      payload = webhook.verify(rawBody, {
+        'webhook-id': req.headers.get('webhook-id') ?? '',
+        'webhook-timestamp': req.headers.get('webhook-timestamp') ?? '',
+        'webhook-signature': req.headers.get('webhook-signature') ?? '',
+      }) as HookRequest;
+    } catch {
+      console.warn('[before-user-created] Signature verification failed');
+      return new Response('Unauthorized', { status: 401 });
+    }
+  } else {
+    console.warn(
+      '[before-user-created] BEFORE_USER_CREATED_HOOK_SECRET is not set; ' +
+        'allowing unsigned requests. Configure the hook secret to enforce verification.',
+    );
+    try {
+      payload = JSON.parse(rawBody) as HookRequest;
+    } catch {
+      return new Response('Invalid JSON', { status: 400 });
+    }
   }
 
   const user = payload.user;

--- a/supabase/functions/before-user-created/index.ts
+++ b/supabase/functions/before-user-created/index.ts
@@ -104,8 +104,8 @@ Deno.serve(async (req) => {
   let payload: HookRequest;
   if (webhook) {
     try {
-      // verify() checks the v1 HMAC signature (all rotation candidates) and
-      // timestamp tolerance, then returns the parsed JSON payload.
+      // verify() enforces the spec's timestamp tolerance (anti-replay) and
+      // returns the parsed JSON payload.
       payload = webhook.verify(rawBody, {
         'webhook-id': req.headers.get('webhook-id') ?? '',
         'webhook-timestamp': req.headers.get('webhook-timestamp') ?? '',

--- a/supabase/functions/get-agent-config/deno.json
+++ b/supabase/functions/get-agent-config/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1"
+  }
+}

--- a/supabase/functions/get-agent-config/deno.lock
+++ b/supabase/functions/get-agent-config/deno.lock
@@ -1,0 +1,71 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1"
+  },
+  "jsr": {
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+      "dependencies": [
+        "npm:@supabase/auth-js",
+        "npm:@supabase/functions-js",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    },
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@supabase/supabase-js@2.108.1"
+    ]
+  }
+}

--- a/supabase/functions/get-agent-config/index.ts
+++ b/supabase/functions/get-agent-config/index.ts
@@ -7,33 +7,23 @@
  * - POST /get-agent-config - Fetch agent YAML config by name
  */
 
-import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
-import { handleCors, getCorsHeaders } from '../_shared/cors.ts';
+import { createClient } from '@supabase/supabase-js';
+import { authenticateJwt, bearerToken } from '../_shared/auth.ts';
+import { handleCors } from '../_shared/cors.ts';
+import { versionedJsonResponse } from '../_shared/responses.ts';
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-const VERSION = '1.1.0';
+const VERSION = '1.1.1';
 
 // =============================================================================
 // Helpers
 // =============================================================================
 
-function jsonResponse(
-  req: Request,
-  body: Record<string, unknown>,
-  status: number,
-): Response {
-  const corsHeaders = getCorsHeaders(req);
-  return new Response(JSON.stringify({ _version: VERSION, ...body }), {
-    status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-  });
-}
-
 function errorResponse(req: Request, error: string, status: number): Response {
-  return jsonResponse(req, { error }, status);
+  return versionedJsonResponse(req, VERSION, { error }, status);
 }
 
 // =============================================================================
@@ -41,6 +31,7 @@ function errorResponse(req: Request, error: string, status: number): Response {
 // =============================================================================
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL');
+const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
 const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 
 // =============================================================================
@@ -49,7 +40,7 @@ const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 
 Deno.serve(async (req: Request) => {
   // Handle CORS
-  const { corsHeaders, response } = handleCors(req);
+  const { response } = handleCors(req);
   if (response) return response;
 
   // Only accept POST
@@ -58,35 +49,27 @@ Deno.serve(async (req: Request) => {
   }
 
   // Check environment
-  if (!supabaseUrl || !serviceRoleKey) {
+  if (!supabaseUrl || !supabaseAnonKey || !serviceRoleKey) {
     console.error('[GET_AGENT_CONFIG] Missing required environment variables');
     return errorResponse(req, 'Server configuration error', 500);
   }
 
   try {
     // 1. Extract and validate auth
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
+    const jwtToken = bearerToken(req);
+    if (!jwtToken) {
       return errorResponse(req, 'Unauthorized', 401);
     }
 
-    // User client: uses user's JWT for auth verification and RLS-protected queries
-    const userClient = createClient(supabaseUrl, serviceRoleKey, {
-      global: { headers: { Authorization: authHeader } },
-    });
+    // 2. Verify user; the returned client runs queries as the user (RLS applies)
+    const auth = await authenticateJwt(jwtToken);
+    if (!auth) {
+      return errorResponse(req, 'Invalid token', 401);
+    }
+    const userClient = auth.client;
 
     // Admin client: bypasses bucket policies for storage operations
     const adminClient = createClient(supabaseUrl, serviceRoleKey);
-
-    // 2. Verify user
-    const {
-      data: { user },
-      error: userError,
-    } = await userClient.auth.getUser();
-
-    if (userError || !user) {
-      return errorResponse(req, 'Invalid token', 401);
-    }
 
     // 3. Get agent name from request
     let body: { agentName?: string };
@@ -125,8 +108,9 @@ Deno.serve(async (req: Request) => {
     // 6. Return config (client parses YAML and extracts description)
     const yamlContent = await fileData.text();
 
-    return jsonResponse(
+    return versionedJsonResponse(
       req,
+      VERSION,
       {
         config: yamlContent,
         name: agent.name,

--- a/supabase/functions/get-agent-config/index.ts
+++ b/supabase/functions/get-agent-config/index.ts
@@ -40,7 +40,7 @@ const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 
 Deno.serve(async (req: Request) => {
   // Handle CORS
-  const { response } = handleCors(req);
+  const response = handleCors(req);
   if (response) return response;
 
   // Only accept POST

--- a/supabase/functions/log-usage/deno.json
+++ b/supabase/functions/log-usage/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1",
+    "zod": "npm:zod@^4.4.3"
+  }
+}

--- a/supabase/functions/log-usage/deno.lock
+++ b/supabase/functions/log-usage/deno.lock
@@ -1,0 +1,76 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1",
+    "npm:zod@^4.4.3": "4.4.3"
+  },
+  "jsr": {
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+      "dependencies": [
+        "npm:@supabase/auth-js",
+        "npm:@supabase/functions-js",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    },
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "zod@4.4.3": {
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@supabase/supabase-js@2.108.1",
+      "npm:zod@^4.4.3"
+    ]
+  }
+}

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -25,7 +25,7 @@ import { versionedJsonResponse } from '../_shared/responses.ts';
 // Constants
 // =============================================================================
 
-const LOG_USAGE_VERSION = '1.2.0';
+const LOG_USAGE_VERSION = '1.2.1';
 
 // =============================================================================
 // Schemas
@@ -43,9 +43,9 @@ const UsageLogEntrySchema = z.object({
   agentName: z.string().optional().catch(undefined),
   agentCategory: z.enum(['workflow', 'toolUse']).optional().catch(undefined),
   isMultipleOutput: z.boolean().optional().catch(undefined),
-  responseTimeMs: z.number().optional().catch(undefined),
-  cachedInputTokens: z.number().optional().catch(undefined),
-  reasoningTokens: z.number().optional().catch(undefined),
+  responseTimeMs: z.number().nonnegative().optional().catch(undefined),
+  cachedInputTokens: z.number().nonnegative().optional().catch(undefined),
+  reasoningTokens: z.number().nonnegative().optional().catch(undefined),
   usedRelay: z.boolean().optional().catch(undefined),
   streamId: z.string().optional().catch(undefined),
   extensionVersion: z.string().optional().catch(undefined),

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -91,7 +91,7 @@ if (!supabaseUrl || !supabaseAnonKey || !supabaseServiceKey) {
 
 Deno.serve(async (req: Request) => {
   // Handle CORS
-  const { response } = handleCors(req);
+  const response = handleCors(req);
   if (response) return response;
 
   // Only accept POST requests

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -15,37 +15,47 @@
  * - RPC: usage_logs_upsert (service role only)
  */
 
-import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
-import { handleCors, getCorsHeaders } from '../_shared/cors.ts';
+import { createClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+import { authenticateJwt, bearerToken } from '../_shared/auth.ts';
+import { handleCors } from '../_shared/cors.ts';
+import { versionedJsonResponse } from '../_shared/responses.ts';
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-const LOG_USAGE_VERSION = '1.1.0';
+const LOG_USAGE_VERSION = '1.2.0';
 
 // =============================================================================
-// Types
+// Schemas
 // =============================================================================
 
-interface UsageLogEntry {
-  timestamp: string;
-  model: string;
-  provider: string;
-  agentName?: string;
-  agentCategory?: 'workflow' | 'toolUse';
-  isMultipleOutput?: boolean;
-  inputTokens: number;
-  outputTokens: number;
-  cost: number;
-  responseTimeMs?: number;
-  cachedInputTokens?: number;
-  reasoningTokens?: number;
-  usedRelay?: boolean;
-  streamId?: string;
-  extensionVersion?: string;
-  editorType?: string;
-}
+// Invalid optional fields are dropped (`.catch(undefined)`) rather than
+// rejecting the whole entry; invalid required fields reject the entry.
+const UsageLogEntrySchema = z.object({
+  timestamp: z.string(),
+  model: z.string(),
+  provider: z.string(),
+  inputTokens: z.number().nonnegative(),
+  outputTokens: z.number().nonnegative(),
+  cost: z.number().nonnegative(),
+  agentName: z.string().optional().catch(undefined),
+  agentCategory: z.enum(['workflow', 'toolUse']).optional().catch(undefined),
+  isMultipleOutput: z.boolean().optional().catch(undefined),
+  responseTimeMs: z.number().optional().catch(undefined),
+  cachedInputTokens: z.number().optional().catch(undefined),
+  reasoningTokens: z.number().optional().catch(undefined),
+  usedRelay: z.boolean().optional().catch(undefined),
+  streamId: z.string().optional().catch(undefined),
+  extensionVersion: z.string().optional().catch(undefined),
+  editorType: z.string().optional().catch(undefined),
+});
+
+const UsageBatchSchema = z.object({
+  entries: z.array(z.unknown()),
+  batchId: z.string(),
+});
 
 // =============================================================================
 // Helpers
@@ -56,77 +66,11 @@ function jsonResponse(
   body: Record<string, unknown>,
   status: number,
 ): Response {
-  const corsHeaders = getCorsHeaders(req);
-  return new Response(
-    JSON.stringify({ _version: LOG_USAGE_VERSION, ...body }),
-    {
-      status,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    },
-  );
+  return versionedJsonResponse(req, LOG_USAGE_VERSION, body, status);
 }
 
 function errorResponse(req: Request, error: string, status: number): Response {
   return jsonResponse(req, { success: false, accepted: 0, error }, status);
-}
-
-/**
- * Validate a single usage entry.
- * Returns null if invalid, the entry if valid.
- */
-function validateEntry(entry: unknown): UsageLogEntry | null {
-  if (!entry || typeof entry !== 'object') {
-    return null;
-  }
-
-  const e = entry as Record<string, unknown>;
-
-  // Required fields
-  if (
-    typeof e.timestamp !== 'string' ||
-    typeof e.model !== 'string' ||
-    typeof e.provider !== 'string' ||
-    typeof e.inputTokens !== 'number' ||
-    typeof e.outputTokens !== 'number' ||
-    typeof e.cost !== 'number'
-  ) {
-    return null;
-  }
-
-  // Validate non-negative numbers
-  if (e.inputTokens < 0 || e.outputTokens < 0 || e.cost < 0) {
-    return null;
-  }
-
-  // Validate agentCategory enum
-  const agentCategory =
-    e.agentCategory === 'workflow' || e.agentCategory === 'toolUse'
-      ? e.agentCategory
-      : undefined;
-
-  return {
-    timestamp: e.timestamp,
-    model: e.model,
-    provider: e.provider,
-    agentName: typeof e.agentName === 'string' ? e.agentName : undefined,
-    agentCategory,
-    isMultipleOutput:
-      typeof e.isMultipleOutput === 'boolean' ? e.isMultipleOutput : undefined,
-    inputTokens: e.inputTokens,
-    outputTokens: e.outputTokens,
-    cost: e.cost,
-    responseTimeMs:
-      typeof e.responseTimeMs === 'number' ? e.responseTimeMs : undefined,
-    cachedInputTokens:
-      typeof e.cachedInputTokens === 'number' ? e.cachedInputTokens : undefined,
-    reasoningTokens:
-      typeof e.reasoningTokens === 'number' ? e.reasoningTokens : undefined,
-    usedRelay: typeof e.usedRelay === 'boolean' ? e.usedRelay : undefined,
-    streamId: typeof e.streamId === 'string' ? e.streamId : undefined,
-    extensionVersion:
-      typeof e.extensionVersion === 'string' ? e.extensionVersion : undefined,
-    editorType: typeof e.editorType === 'string' ? e.editorType : undefined,
-  };
 }
 
 // =============================================================================
@@ -162,26 +106,17 @@ Deno.serve(async (req: Request) => {
 
   try {
     // 1. Extract and validate JWT
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader?.startsWith('Bearer ')) {
+    const jwtToken = bearerToken(req);
+    if (!jwtToken) {
       return errorResponse(req, 'Missing authorization token', 401);
     }
 
-    const jwtToken = authHeader.slice(7);
-
     // 2. Validate user with Supabase
-    const userClient = createClient(supabaseUrl, supabaseAnonKey, {
-      global: { headers: { Authorization: `Bearer ${jwtToken}` } },
-    });
-
-    const {
-      data: { user },
-      error: userError,
-    } = await userClient.auth.getUser();
-
-    if (userError || !user) {
+    const auth = await authenticateJwt(jwtToken);
+    if (!auth) {
       return errorResponse(req, 'Invalid or expired token', 401);
     }
+    const { user } = auth;
 
     // 3. Parse request body
     let body: unknown;
@@ -192,27 +127,21 @@ Deno.serve(async (req: Request) => {
     }
 
     // 4. Validate batch structure
-    if (!body || typeof body !== 'object') {
-      return errorResponse(req, 'Invalid request body', 400);
-    }
-
-    const batch = body as Record<string, unknown>;
-    if (!Array.isArray(batch.entries) || typeof batch.batchId !== 'string') {
+    const batchResult = UsageBatchSchema.safeParse(body);
+    if (!batchResult.success) {
       return errorResponse(
         req,
         'Invalid batch format: expected { entries: [], batchId: string }',
         400,
       );
     }
+    const batch = batchResult.data;
 
     // 5. Validate and transform entries
-    const validEntries: UsageLogEntry[] = [];
-    for (const entry of batch.entries) {
-      const validated = validateEntry(entry);
-      if (validated) {
-        validEntries.push(validated);
-      }
-    }
+    const validEntries = batch.entries
+      .map((entry) => UsageLogEntrySchema.safeParse(entry))
+      .filter((result) => result.success)
+      .map((result) => result.data);
 
     if (validEntries.length === 0) {
       return jsonResponse(

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -138,10 +138,11 @@ Deno.serve(async (req: Request) => {
     const batch = batchResult.data;
 
     // 5. Validate and transform entries
-    const validEntries = batch.entries
-      .map((entry) => UsageLogEntrySchema.safeParse(entry))
-      .filter((result) => result.success)
-      .map((result) => result.data);
+    const validEntries: z.infer<typeof UsageLogEntrySchema>[] = [];
+    for (const entry of batch.entries) {
+      const result = UsageLogEntrySchema.safeParse(entry);
+      if (result.success) validEntries.push(result.data);
+    }
 
     if (validEntries.length === 0) {
       return jsonResponse(

--- a/supabase/functions/relay/deno.json
+++ b/supabase/functions/relay/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@hono/hono": "jsr:@hono/hono@4.12.24",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1",
+    "llm-zoo": "npm:llm-zoo@^1.9.0"
+  }
+}

--- a/supabase/functions/relay/deno.lock
+++ b/supabase/functions/relay/deno.lock
@@ -1,0 +1,81 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@hono/hono@4.12.24": "4.12.24",
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1",
+    "npm:llm-zoo@^1.9.0": "1.9.1"
+  },
+  "jsr": {
+    "@hono/hono@4.12.24": {
+      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
+    },
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+      "dependencies": [
+        "npm:@supabase/auth-js",
+        "npm:@supabase/functions-js",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    },
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "llm-zoo@1.9.1": {
+      "integrity": "sha512-86loA6jNXMnoRVyI64kQebv/hwYh/uQ29Lgkoq9mfdu0jexyKWr8yRY2JRSHlbNHfRL5ZRKfD0YMPEy6SLJArw=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@hono/hono@4.12.24",
+      "jsr:@supabase/supabase-js@2.108.1",
+      "npm:llm-zoo@^1.9.0"
+    ]
+  }
+}

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -526,10 +526,9 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     return jsonError('Missing authorization token', 401);
   }
 
-  // 3. Get Supabase config
+  // 3. Get Supabase config (authenticateJwt reads its own env internally)
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
-
-  if (!supabaseUrl || !Deno.env.get('SUPABASE_ANON_KEY')) {
+  if (!supabaseUrl) {
     console.error('Missing required Supabase environment variables');
     return jsonError('Server configuration error', 500);
   }

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -528,7 +528,8 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   // 3. Get Supabase config (authenticateJwt reads its own env internally)
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
-  if (!supabaseUrl) {
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (!supabaseUrl || !supabaseAnonKey) {
     console.error('Missing required Supabase environment variables');
     return jsonError('Server configuration error', 500);
   }

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -62,9 +62,10 @@
  * (SDKs send JWT in provider-specific headers, not the standard Authorization header).
  */
 
-import { Hono } from 'jsr:@hono/hono@4.12.15';
-import { cors } from 'jsr:@hono/hono@4.12.15/cors';
-import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
+import { Hono } from '@hono/hono';
+import { cors } from '@hono/hono/cors';
+import { createClient } from '@supabase/supabase-js';
+import { authenticateJwt } from '../_shared/auth.ts';
 import {
   TIER_CONFIG,
   TIER_SPENDING_LIMITS,
@@ -76,9 +77,9 @@ import {
   FREE_TIER,
   MAX_TIER,
 } from './models.ts';
+import { isJsonRecord } from './json.ts';
 import {
   capOpenAIReasoningEffortForTier,
-  isJsonRecord,
   type ReasoningEffortCap,
 } from './reasoning.ts';
 import {
@@ -96,7 +97,7 @@ import {
 // Constants
 // =============================================================================
 
-const RELAY_VERSION = '1.9.0';
+const RELAY_VERSION = '1.9.1';
 
 // Tier constants imported from models.ts (single source of truth)
 // CROSS-REFERENCE: Keep models.ts in sync with:
@@ -444,7 +445,6 @@ app.get('/providers', (c) => {
  */
 app.get('/tier-config', async (c) => {
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
-  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
   const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
   const jwtToken = extractJwtFromRequest(c.req.raw);
 
@@ -457,17 +457,12 @@ app.get('/tier-config', async (c) => {
   };
 
   // Try to include user status if authenticated
-  if (jwtToken && supabaseUrl && supabaseAnonKey) {
+  if (jwtToken && supabaseUrl) {
     try {
-      const supabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
-        global: { headers: { Authorization: `Bearer ${jwtToken}` } },
-      });
+      const auth = await authenticateJwt(jwtToken);
 
-      const {
-        data: { user },
-      } = await supabaseClient.auth.getUser();
-
-      if (user) {
+      if (auth) {
+        const { user, client: supabaseClient } = auth;
         const { data: profile } = await supabaseClient
           .from('profiles')
           .select('tier, access_expires_at, banned_until')
@@ -546,18 +541,11 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   }
 
   // 4. Validate user and check tier
-  const userClient = createClient(supabaseUrl, supabaseAnonKey, {
-    global: { headers: { Authorization: `Bearer ${jwtToken}` } },
-  });
-
-  const {
-    data: { user },
-    error: userError,
-  } = await userClient.auth.getUser();
-
-  if (userError || !user) {
+  const auth = await authenticateJwt(jwtToken);
+  if (!auth) {
     return jsonError('Invalid or expired token', 401);
   }
+  const { user, client: userClient } = auth;
 
   // 5. Get user profile and check ban / expiration
   const { data: profile, error: profileError } = await userClient
@@ -849,12 +837,6 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   }
 
   // 10. Forward request with timeout
-  const abortController = new AbortController();
-  const timeoutId = setTimeout(
-    () => abortController.abort(),
-    UPSTREAM_TIMEOUT_MS,
-  );
-
   let upstreamResponse: Response;
   try {
     const bodyToSend =
@@ -868,17 +850,18 @@ app.all('/:provider{[^/]+}/*', async (c) => {
       method: c.req.method,
       headers: upstreamHeaders,
       body: bodyToSend,
-      signal: abortController.signal,
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
   } catch (error) {
-    clearTimeout(timeoutId);
     await releaseRelaySlot?.();
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (
+      error instanceof Error &&
+      (error.name === 'TimeoutError' || error.name === 'AbortError')
+    ) {
       return jsonError('Upstream request timed out', 504);
     }
     throw error;
   }
-  clearTimeout(timeoutId);
 
   if (upstreamResponse.status >= 400) {
     console.error(

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -64,7 +64,7 @@
 
 import { Hono } from '@hono/hono';
 import { cors } from '@hono/hono/cors';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { authenticateJwt } from '../_shared/auth.ts';
 import {
   TIER_CONFIG,
@@ -326,8 +326,7 @@ function getCurrentMonthStartUTC(): string {
  * This is acceptable for soft limits. See migration for mitigation options.
  */
 async function checkSpendingLimit(
-  supabaseUrl: string,
-  serviceRoleKey: string,
+  adminClient: SupabaseClient,
   userId: string,
   tier: string,
 ): Promise<{
@@ -339,9 +338,6 @@ async function checkSpendingLimit(
 }> {
   const limit = getSpendingLimit(tier);
   const monthStart = getCurrentMonthStartUTC();
-
-  // Use service role to bypass RLS for admin query
-  const adminClient = createClient(supabaseUrl, serviceRoleKey);
 
   // Call database function for efficient server-side aggregation
   // Aggregates relay usage server-side, summing workflow streams and
@@ -480,8 +476,7 @@ app.get('/tier-config', async (c) => {
           let spendingStatus = null;
           if (serviceRoleKey) {
             const spending = await checkSpendingLimit(
-              supabaseUrl,
-              serviceRoleKey,
+              createClient(supabaseUrl, serviceRoleKey),
               user.id,
               profile.tier || FREE_TIER,
             );
@@ -533,9 +528,8 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   // 3. Get Supabase config
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
-  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
 
-  if (!supabaseUrl || !supabaseAnonKey) {
+  if (!supabaseUrl || !Deno.env.get('SUPABASE_ANON_KEY')) {
     console.error('Missing required Supabase environment variables');
     return jsonError('Server configuration error', 500);
   }
@@ -587,13 +581,11 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   // 5.5. Check monthly spending limit
   const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
-  if (serviceRoleKey) {
-    const spending = await checkSpendingLimit(
-      supabaseUrl,
-      serviceRoleKey,
-      user.id,
-      userTier,
-    );
+  const adminClient = serviceRoleKey
+    ? createClient(supabaseUrl, serviceRoleKey)
+    : null;
+  if (adminClient) {
+    const spending = await checkSpendingLimit(adminClient, user.id, userTier);
 
     if (!spending.allowed) {
       if (spending.spendCheckFailed) {
@@ -746,8 +738,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   // request validation so rejected requests do not consume active slots.
   let releaseRelaySlot: (() => Promise<void>) | null = null;
   let refreshRelaySlot: (() => Promise<void>) | null = null;
-  if (serviceRoleKey) {
-    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+  if (adminClient) {
     try {
       const slot = await acquireRelayRequestSlot(
         adminClient,

--- a/supabase/functions/relay/json.ts
+++ b/supabase/functions/relay/json.ts
@@ -1,0 +1,14 @@
+/** Generic JSON value helpers shared by relay modules. */
+
+export type JsonRecord = Record<string, unknown>;
+
+export function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Narrow an unknown value to a finite number, else undefined. */
+export function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}

--- a/supabase/functions/relay/modelNames.ts
+++ b/supabase/functions/relay/modelNames.ts
@@ -1,0 +1,17 @@
+/** Model-name normalization shared by relay modules. */
+
+/** Lowercase and trim an API model name. */
+export function normalizeModelName(modelName: string): string {
+  return modelName.toLowerCase().trim();
+}
+
+/** Drop an optional "provider/" prefix ("openai/gpt-4o-mini" → "gpt-4o-mini"). */
+export function stripProviderPrefix(name: string): string {
+  return name.includes('/') ? name.slice(name.indexOf('/') + 1) : name;
+}
+
+export function isGpt5Model(modelName: string | null): boolean {
+  if (!modelName) return false;
+  const modelPart = stripProviderPrefix(normalizeModelName(modelName));
+  return modelPart.startsWith('gpt-5') || modelPart.startsWith('gpt5');
+}

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -11,7 +11,8 @@
  * - Ultra: everything else
  */
 
-import { MODEL_CONFIGS, type ModelConfig } from 'npm:llm-zoo@^1.9.0';
+import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
+import { normalizeModelName, stripProviderPrefix } from './modelNames.ts';
 import { FREE_TIER, MAX_TIER, ULTRA_TIER } from './tierConstants.ts';
 
 export { FREE_TIER, MAX_TIER, ULTRA_TIER };
@@ -221,10 +222,8 @@ const BOUNDARY_RE = /^[-/:@.]/;
  * tiers for the same model). The caller decides how to interpret the set.
  */
 function resolveAllModelsByApiName(modelName: string): RelayModel[] {
-  const name = modelName.toLowerCase().trim();
-  const modelPart = name.includes('/')
-    ? name.slice(name.indexOf('/') + 1)
-    : name;
+  const name = normalizeModelName(modelName);
+  const modelPart = stripProviderPrefix(name);
 
   const exactMatches: RelayModel[] = [];
   let bestBoundaryLen = -1;

--- a/supabase/functions/relay/reasoning.ts
+++ b/supabase/functions/relay/reasoning.ts
@@ -1,3 +1,6 @@
+import { isJsonRecord, type JsonRecord } from './json.ts';
+import { isGpt5Model } from './modelNames.ts';
+
 export interface ReasoningEffortCapContext {
   provider: string;
   tier: string;
@@ -6,22 +9,6 @@ export interface ReasoningEffortCapContext {
 }
 
 export type ReasoningEffortCap = 'high' | 'medium';
-export type JsonRecord = Record<string, unknown>;
-
-export function isJsonRecord(value: unknown): value is JsonRecord {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function isGpt5Model(modelName: string | null): boolean {
-  if (!modelName) return false;
-
-  const normalized = modelName.toLowerCase().trim();
-  const modelPart = normalized.includes('/')
-    ? normalized.slice(normalized.indexOf('/') + 1)
-    : normalized;
-
-  return modelPart.startsWith('gpt-5') || modelPart.startsWith('gpt5');
-}
 
 function capForTier(
   tier: string,

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -1,3 +1,5 @@
+import { asFiniteNumber, isJsonRecord } from './json.ts';
+
 interface RpcError {
   message?: string;
 }
@@ -8,10 +10,11 @@ interface RequestLimit {
 }
 
 interface RpcClient {
+  // PromiseLike, not Promise: supabase-js rpc() returns a thenable builder.
   rpc(
     name: string,
     args: Record<string, unknown>,
-  ): Promise<{ data: unknown; error: RpcError | null }>;
+  ): PromiseLike<{ data: unknown; error: RpcError | null }>;
 }
 
 interface GateDecision {
@@ -47,17 +50,8 @@ class RelayRequestSlotLostError extends Error {
   }
 }
 
-function asNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value
-    : undefined;
-}
-
 function parseGateDecision(data: unknown): GateDecision {
-  const record =
-    typeof data === 'object' && data !== null
-      ? (data as Record<string, unknown>)
-      : {};
+  const record = isJsonRecord(data) ? data : {};
   return {
     allowed: record.allowed === true,
     slotId: typeof record.slotId === 'string' ? record.slotId : undefined,
@@ -65,20 +59,16 @@ function parseGateDecision(data: unknown): GateDecision {
       record.reason === 'rate' || record.reason === 'concurrency'
         ? record.reason
         : undefined,
-    rateLimitPerMinute: asNumber(record.rateLimitPerMinute),
-    concurrencyLimit: asNumber(record.concurrencyLimit),
-    requestsThisMinute: asNumber(record.requestsThisMinute),
-    activeRequests: asNumber(record.activeRequests),
-    retryAfterSeconds: asNumber(record.retryAfterSeconds),
+    rateLimitPerMinute: asFiniteNumber(record.rateLimitPerMinute),
+    concurrencyLimit: asFiniteNumber(record.concurrencyLimit),
+    requestsThisMinute: asFiniteNumber(record.requestsThisMinute),
+    activeRequests: asFiniteNumber(record.activeRequests),
+    retryAfterSeconds: asFiniteNumber(record.retryAfterSeconds),
   };
 }
 
 function didRefreshSlot(data: unknown): boolean {
-  const record =
-    typeof data === 'object' && data !== null
-      ? (data as Record<string, unknown>)
-      : {};
-  return record.refreshed === true;
+  return isJsonRecord(data) && data.refreshed === true;
 }
 
 function once(release: () => Promise<void>): () => Promise<void> {

--- a/supabase/functions/relay/requestLimits.ts
+++ b/supabase/functions/relay/requestLimits.ts
@@ -1,4 +1,9 @@
-import { isJsonRecord, type JsonRecord } from './reasoning.ts';
+import { asFiniteNumber, isJsonRecord, type JsonRecord } from './json.ts';
+import {
+  isGpt5Model,
+  normalizeModelName,
+  stripProviderPrefix,
+} from './modelNames.ts';
 
 const BYTES_PER_KIB = 1024;
 const BYTES_PER_MIB = BYTES_PER_KIB * 1024;
@@ -122,16 +127,12 @@ export interface MaxOutputTokenClampResult {
   originalValue: number | null;
 }
 
-function numericValue(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
 function clampRecordField(
   record: JsonRecord,
   field: string,
   limit: number,
 ): { record: JsonRecord; changed: boolean; originalValue: number | null } {
-  const current = numericValue(record[field]);
+  const current = asFiniteNumber(record[field]) ?? null;
   if (current !== null && current > 0 && current <= limit) {
     return { record, changed: false, originalValue: current };
   }
@@ -176,13 +177,9 @@ function clampGoogleGenerationConfig(
 
 function isOpenAICompletionTokenModel(model: unknown): boolean {
   if (typeof model !== 'string') return false;
-  const normalized = model.toLowerCase().trim();
-  const modelName = normalized.includes('/')
-    ? normalized.slice(normalized.indexOf('/') + 1)
-    : normalized;
+  if (isGpt5Model(model)) return true;
+  const modelName = stripProviderPrefix(normalizeModelName(model));
   return (
-    modelName.startsWith('gpt-5') ||
-    modelName.startsWith('gpt5') ||
     modelName.startsWith('o1') ||
     modelName.startsWith('o3') ||
     modelName.startsWith('o4')


### PR DESCRIPTION
## Summary

- **Versions centralized + bumped**: each function now has a `deno.json` import map pinning dependencies once (supabase-js 2.104.1 → 2.108.1, hono 4.12.15 → 4.12.24; llm-zoo/djwt unchanged-latest). No more hand-pinned version strings scattered across files.
- **New `_shared/responses.ts` + `_shared/auth.ts`**: collapse the `jsonResponse`/`errorResponse` helpers written three times and the JWT-validation boilerplate written three times. `authenticateJwt` returns the user plus a user-scoped (anon key + user JWT) client so RLS applies to queries.
- **get-agent-config hygiene**: the user-scoped client now uses the anon key instead of the service-role key as the gateway `apikey` (behavior-neutral: the user's Authorization JWT already determined the Postgres role, so RLS was and remains enforced — but a dropped header now degrades to anon, not service-role).
- **Relay dedup**: new `json.ts` (`isJsonRecord`/`asFiniteNumber`) and `modelNames.ts` (`normalizeModelName`/`stripProviderPrefix`/`isGpt5Model`) replace four copies of provider-prefix stripping and two copies each of the JSON-record/finite-number helpers across `models`/`reasoning`/`requestLimits`/`requestGate`.
- **Native over hand-rolled**:
  - `before-user-created` verifies Standard Webhooks signatures via the reference `standardwebhooks` library (Supabase's documented approach for auth hooks) instead of hand-rolled HMAC + base64 — also adds the spec's timestamp tolerance (anti-replay).
  - relay upstream timeout uses `AbortSignal.timeout()` instead of AbortController + setTimeout.
  - `log-usage` entry validation is now Zod v4 schemas (repo standard); invalid optional fields drop via `.catch(undefined)`, invalid required fields drop the entry — matching prior semantics.
- **auth-github type fixes**: native `Context`/`SupabaseClient` types replace the `Parameters<typeof app.post>` extraction trick and `ReturnType<typeof createClient>` (latent errors surfaced by `deno check` under hono 4.12.24 / supabase-js 2.108); `.catch()` on a thenable builder replaced with proper `{ error }` handling.

## Verified

- `deno check` passes for all five functions (it did not before: auth-github had 28 latent type errors)
- `vitest run src/test-kernel/supabase src/test-kernel/auth`: 75/75 pass
- Deployed to prod and probed:
  - relay `/providers` + `/tier-config` → 200, `_relay: 1.9.1`, model lists intact
  - before-user-created: bad signature → 401, GET → 405 (standardwebhooks boots + verifies)
  - log-usage no-auth → 401 `_version 1.2.0`; get-agent-config no-auth → 401 `_version 1.1.1`
  - auth-github → `Server configuration error` **pre-existing** (project migrated to JWT signing keys; `SUPABASE_JWT_SECRET` no longer exists, and origin/main has the identical env check). Path A confirmed dead at runtime; deletion is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication, signup hook verification, relay proxy JWT validation, and get-agent-config client key choice—security-sensitive paths with mostly refactor-level behavior changes plus stricter webhook replay checks.
> 
> **Overview**
> Refactors Supabase edge functions around **shared `_shared/auth.ts` and `_shared/responses.ts`**, so JWT validation and versioned JSON responses are no longer duplicated across `get-agent-config`, `log-usage`, and `relay`. **`authenticateJwt`** returns a user-scoped client (anon key + bearer JWT) so profile/agent queries run under **RLS**; **`get-agent-config`** stops using the service-role key as the user gateway client.
> 
> Each function gets a **`deno.json` import map** (and lockfiles) pinning **supabase-js 2.108.1** and **hono 4.12.24** where used. **`handleCors`** now returns **`Response | null`** instead of a wrapper object; callers short-circuit on preflight/forbidden.
> 
> **`before-user-created`** replaces hand-rolled Standard Webhooks HMAC with the **`standardwebhooks`** package (timestamp tolerance / replay protection). **`log-usage`** validates batches with **Zod v4** (optional fields drop via `.catch(undefined)`). **Relay** extracts **`json.ts`** and **`modelNames.ts`** helpers, uses **`authenticateJwt`** on proxy and tier-config paths, **`AbortSignal.timeout`** for upstream fetch, and tightens **auth-github** identity linking to surface real errors while only swallowing duplicate constraint failures.
> 
> **`auth-github`** adopts shared response/CORS helpers and fixes Hono/Supabase typing under newer deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f92bf6bb7c0e3cf6f3d83df85fdb9eaa33b748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->