### PR TITLE
fix(cli): give the user-message band margins

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -30,6 +30,7 @@ import {
   PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
   TranscriptEntry,
   USER_ENTRY_MARGIN_BOTTOM_ROWS,
+  USER_ENTRY_MARGIN_TOP_ROWS,
 } from './TranscriptEntry';
 
 export type StaticTranscriptItem =
@@ -163,16 +164,18 @@ function staticTranscriptItemRowCount(
   }
   // Compact budgeting can over-count tool rows because the transcript viewer
   // keeps full tool output while the static scrollback renderer elides it.
+  const cols = Math.max(1, Math.floor(width ?? 80));
+  const isUser = item.entry.role === 'user';
+  const isUserBand = isUser && !isInquiryContinuationText(item.entry.text);
+  // User rows render inside a 1-col padded box, so their text wraps two
+  // columns narrower than the flush rows the viewer renderer assumes.
   const lines = transcriptEntryLines(
     item.entry,
-    Math.max(1, Math.floor(width ?? 80)),
+    isUser ? Math.max(1, cols - 2) : cols,
   ).length;
   let marginRows = 0;
-  if (
-    item.entry.role === 'user' &&
-    !isInquiryContinuationText(item.entry.text)
-  ) {
-    marginRows = USER_ENTRY_MARGIN_BOTTOM_ROWS;
+  if (isUserBand) {
+    marginRows = USER_ENTRY_MARGIN_TOP_ROWS + USER_ENTRY_MARGIN_BOTTOM_ROWS;
   } else if (item.entry.role === 'assistant') {
     marginRows = ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS;
   } else if (item.entry.role === 'process') {

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -20,7 +20,8 @@ import type {
 
 const INQUIRY_CONTINUATION_RE =
   /^\[inquiry\]\s+\S+\s+(?:answered|dropped by user)\.(?:\n|$)/;
-export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 0;
+export const USER_ENTRY_MARGIN_TOP_ROWS = 1;
+export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 1;
 export const ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS = 0;
 export const PROCESS_ENTRY_MARGIN_BOTTOM_ROWS = 1;
 
@@ -97,14 +98,21 @@ function UserEntryRow({
   readonly colorEnabled?: boolean;
   readonly width?: number;
 }): React.JSX.Element {
-  // Mark a user turn with a full-width reverse-video band (theme-adaptive via
-  // reverse video). Static transcript rows are print-once terminal scrollback:
-  // a row keeps the width it had when it was appended, while later rows render
-  // at the latest width. The `› ` chevron is 2 cols; row estimators add the
-  // exported margin constant alongside their wrapped-line count.
-  const cols = Math.max(1, Math.floor(width ?? 80));
+  // Mark a user turn with a reverse-video band (theme-adaptive via reverse
+  // video), inset one column from each terminal edge — the same gutter the
+  // error/tool/process rows get from their padded boxes — with a blank row
+  // above and below so the turn breathes. Static transcript rows are
+  // print-once terminal scrollback: a row keeps the width it had when it was
+  // appended, while later rows render at the latest width. The `› ` chevron
+  // is 2 cols; row estimators add the exported margin constants alongside
+  // their wrapped-line count.
+  const cols = Math.max(1, Math.floor(width ?? 80) - 2);
   return (
-    <Box marginBottom={USER_ENTRY_MARGIN_BOTTOM_ROWS}>
+    <Box
+      marginTop={USER_ENTRY_MARGIN_TOP_ROWS}
+      marginBottom={USER_ENTRY_MARGIN_BOTTOM_ROWS}
+      paddingX={1}
+    >
       <Text inverse={colorEnabled !== false}>
         {compactPrefixedDisplayRows({
           fillWidth: true,
@@ -127,12 +135,13 @@ function InquiryContinuationRow({
   readonly colorEnabled?: boolean;
   readonly width?: number;
 }): React.JSX.Element {
-  const cols = Math.max(1, Math.floor(width ?? 80));
+  // Same one-column gutter as the user band so both `› ` chevrons align.
+  const cols = Math.max(1, Math.floor(width ?? 80) - 2);
   const lines = prefixedWrappedLines(entry.text, cols);
   const displayLines =
     fillWidth === true ? fillRows(lines.join('\n'), cols).split('\n') : lines;
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" paddingX={1}>
       {displayLines.map((line, index) => (
         <Text
           key={index}

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -4,10 +4,8 @@ import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
 import {
   ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS,
-  isInquiryContinuationText,
   LIVE_TAIL_ROWS,
   PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
-  USER_ENTRY_MARGIN_BOTTOM_ROWS,
   tailWindow,
 } from './TranscriptEntry';
 import { isRenderableTranscriptEntry } from './transcriptEntries';
@@ -63,10 +61,12 @@ export function estimateTranscriptEntryRows(
     });
   }
   if (entry.role === 'user') {
-    const rows = estimateWrappedRows(entry.text, Math.max(1, width - 2));
-    return isInquiryContinuationText(entry.text)
-      ? rows
-      : rows + USER_ENTRY_MARGIN_BOTTOM_ROWS;
+    // User rows — band and inquiry continuation alike — render inside a
+    // padded box plus the `› ` prefix, so long text wraps to `width - 4`
+    // (the same geometry as error rows). The static band's margins are not
+    // budgeted here: the live pane paints user rows through the margin-less
+    // bounded renderer.
+    return estimateWrappedRows(entry.text, Math.max(1, width - 4));
   }
   if (entry.role === 'error') {
     // Error rows render inside a padded box plus the `! ` prefix, so long text


### PR DESCRIPTION
## Summary

The TUI's user-message highlight band was the only transcript element rendered edge-to-edge, which made the whole transcript feel cramped next to Claude Code's layout. This insets the band one column from each terminal edge — the same gutter error/tool/process rows already get from their `paddingX={1}` boxes — and adds a blank row above and below the band so turns breathe.

- `UserEntryRow` renders inside a padded box with `marginTop`/`marginBottom` of 1 (`USER_ENTRY_MARGIN_TOP_ROWS` is new; `USER_ENTRY_MARGIN_BOTTOM_ROWS` goes 0 → 1).
- Inquiry continuation rows get the same one-column gutter so both `› ` chevrons align.
- The live-pane row estimator wraps user rows at `width - 4`, matching the padded geometry `BoundedTranscriptEntry` always had (it previously assumed `width - 2`), and no longer budgets the static-only margins — the live pane paints user rows through the margin-less bounded renderer, so the "no spacer row after user turns" behavior there is unchanged.
- The static row budget (`staticTranscriptItemRowCount`) counts the narrower wrap plus the band margins so compact-terminal header insertion stays accurate.

Before/after on a 100-col terminal (band shown as ▐…▌):

```
 /private/tmp/coauthor                      /private/tmp/coauthor
▐› what is happening in this branch       ▌
 ! Tool-use call failed: …                  ▐› what is happening in this branch     ▌

                                            ! Tool-use call failed: …
```

## Verification

- `vitest run` on ConversationPane, TuiStateAndFocus, TuiNoColorOutput, CliStyle suites: 133/133 pass.
- `tsc --noEmit` on packages/cli: clean.
- Built the bundle and drove `texra chat` under tmux at 100×32: ANSI capture confirms the inverse band is exactly 98 columns starting at column 1 (one column of terminal background on each side) with blank rows above and below; the headless `texra run`/`--print` paths don't touch these renderers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI layout and viewport row estimates only; no auth, data, or API behavior changes.
> 
> **Overview**
> Insets the TUI **user-message** reverse-video band with the same one-column gutter as error/tool/process rows, and adds **blank rows above and below** full user turns so the transcript feels less edge-to-edge.
> 
> **Rendering:** `UserEntryRow` uses `paddingX={1}`, narrower wrap width, and new `USER_ENTRY_MARGIN_TOP_ROWS` plus `USER_ENTRY_MARGIN_BOTTOM_ROWS` (0→1). Inquiry continuation rows get the same horizontal padding so `›` chevrons line up.
> 
> **Viewport math:** Static scrollback row budgeting wraps user text two columns narrower and counts top+bottom margins for non-continuation user bands. The live bounded pane estimator wraps all user rows at `width - 4` (padded box + prefix) and no longer adds static-only margin rows or special-cases inquiry continuation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49717e4640e6c12ec3b6d0c3d2e69cd88702995f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->