### PR TITLE
refactor: remove render-time workaround reads

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -469,6 +469,7 @@ export function App(props: AppProps): React.JSX.Element {
   const [childControlMode, setChildControlMode] = useState<
     ChildControlMode | undefined
   >(undefined);
+  const [tipHour] = useState(() => new Date().getHours());
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
   const agentSelectionAvailable = rootRunStartAvailable;
@@ -832,7 +833,10 @@ export function App(props: AppProps): React.JSX.Element {
           </Box>
         ) : null}
         {tipRowVisible ? (
-          <TipRow agentSelectionAvailable={agentSelectionAvailable} />
+          <TipRow
+            agentSelectionAvailable={agentSelectionAvailable}
+            hour={tipHour}
+          />
         ) : null}
         {queuedFollowUpPanelVisible ? (
           <QueuedFollowUpsPanel

--- a/packages/cli/src/chat/tui/panes/TipRow.tsx
+++ b/packages/cli/src/chat/tui/panes/TipRow.tsx
@@ -17,11 +17,11 @@ const AGENT_SELECTION_TIP = 'Press /agent to choose the root agent';
 
 export function tipRowText({
   agentSelectionAvailable = false,
-  hour = new Date().getHours(),
+  hour,
 }: {
   readonly agentSelectionAvailable?: boolean;
-  readonly hour?: number;
-} = {}): string {
+  readonly hour: number;
+}): string {
   const tips = agentSelectionAvailable
     ? [BASE_TIPS[0], BASE_TIPS[1], AGENT_SELECTION_TIP, ...BASE_TIPS.slice(2)]
     : BASE_TIPS;
@@ -31,11 +31,11 @@ export function tipRowText({
 
 export function TipRow(props: {
   readonly agentSelectionAvailable?: boolean;
+  readonly hour: number;
 }): React.JSX.Element {
-  // Pick a deterministic tip based on the current hour so it rotates
-  // naturally without timers or extra state.
   const tip = tipRowText({
     agentSelectionAvailable: props.agentSelectionAvailable,
+    hour: props.hour,
   });
 
   return (

--- a/packages/desktop/src/renderer/diffOverlay.ts
+++ b/packages/desktop/src/renderer/diffOverlay.ts
@@ -1,4 +1,8 @@
 import { render } from 'lit';
+import {
+  DESKTOP_THEME_KIND,
+  type DesktopThemeKind,
+} from '@shared/constants/desktopTheme';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { DesktopShowDiffMessage } from '../desktopDiffMessages';
 import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
@@ -7,11 +11,13 @@ interface DiffViewElement extends HTMLElement {
   originalText: string;
   proposedText: string;
   language: string;
+  hostTheme: string;
 }
 
 export interface DiffOverlayController {
   open(payload: DesktopShowDiffMessage): void;
   close(): void;
+  setTheme(theme: DesktopThemeKind): void;
 }
 
 export function createDiffOverlay(appRoot: HTMLElement): DiffOverlayController {
@@ -19,6 +25,7 @@ export function createDiffOverlay(appRoot: HTMLElement): DiffOverlayController {
   let viewEl: DiffViewElement | null = null;
   let titleEl: HTMLElement | null = null;
   let subtitleEl: HTMLElement | null = null;
+  let currentTheme: DesktopThemeKind = DESKTOP_THEME_KIND.DARK;
 
   function ensure(): WaDialog {
     if (dialog) return dialog;
@@ -47,6 +54,7 @@ export function createDiffOverlay(appRoot: HTMLElement): DiffOverlayController {
     // across re-opens — Lit's @property setter handles content swaps.
     const view = document.createElement('texra-diff-view') as DiffViewElement;
     view.classList.add('desktop-diff-view');
+    view.hostTheme = currentTheme;
     viewEl = view;
 
     body.append(header, view);
@@ -90,5 +98,10 @@ export function createDiffOverlay(appRoot: HTMLElement): DiffOverlayController {
     if (dialog) dialog.open = false;
   }
 
-  return { open, close };
+  function setTheme(theme: DesktopThemeKind): void {
+    currentTheme = theme;
+    if (viewEl) viewEl.hostTheme = theme;
+  }
+
+  return { open, close, setTheme };
 }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -890,4 +890,5 @@ function postWebviewReady(): void {
 
 function applyDesktopTheme(theme: DesktopThemeKind): void {
   applyHostBodyTheme(theme);
+  diffOverlay.setTheme(theme);
 }

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -1,11 +1,13 @@
 // Third-party imports
 import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { consume } from '@lit/context';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
 
-// Local imports - shared constants
+// Local imports - shared webview
+import { themeContext } from '@shared/BaseWebviewApp';
 import { DESKTOP_THEME_KIND } from '@shared/constants/desktopTheme';
 
 type MonacoModule = typeof import('monaco-editor/esm/vs/editor/editor.api.js');
@@ -83,12 +85,12 @@ async function loadMonaco(): Promise<MonacoModule> {
   return monacoLoad;
 }
 
-function monacoThemeForDocument(): 'vs' | 'vs-dark' | 'hc-black' | 'hc-light' {
-  const themeKind = document.body.dataset.vscodeThemeKind;
+function monacoThemeForHostTheme(
+  themeKind: string,
+): 'vs' | 'vs-dark' | 'hc-black' | 'hc-light' {
   if (themeKind === DESKTOP_THEME_KIND.LIGHT) return 'vs';
   if (themeKind === DESKTOP_THEME_KIND.HIGH_CONTRAST) return 'hc-black';
-  if (themeKind === DESKTOP_THEME_KIND.DARK) return 'vs-dark';
-  return document.body.classList.contains('vscode-light') ? 'vs' : 'vs-dark';
+  return 'vs-dark';
 }
 
 @customElement('texra-diff-view')
@@ -139,6 +141,9 @@ export class TexraDiffView extends LitElement {
   @property({ attribute: false }) proposedText = '';
   @property() language = 'plaintext';
 
+  @consume({ context: themeContext, subscribe: true })
+  @property({ attribute: false })
+  hostTheme: string = DESKTOP_THEME_KIND.DARK;
   @state() private loading = false;
   @state() private errorMessage = '';
 
@@ -147,18 +152,11 @@ export class TexraDiffView extends LitElement {
   private originalModel?: TextModel;
   private proposedModel?: TextModel;
   private resizeObserver?: ResizeObserver;
-  private mutationObserver?: MutationObserver;
   private loadGeneration = 0;
-
-  override connectedCallback(): void {
-    super.connectedCallback();
-    this.observeTheme();
-  }
 
   override disconnectedCallback(): void {
     this.loadGeneration += 1;
     this.resizeObserver?.disconnect();
-    this.mutationObserver?.disconnect();
     this.disposeMonacoObjects();
     super.disconnectedCallback();
   }
@@ -174,6 +172,9 @@ export class TexraDiffView extends LitElement {
       changed.has('language')
     ) {
       this.syncModels();
+    }
+    if (changed.has('hostTheme')) {
+      this.applyTheme();
     }
   }
 
@@ -253,17 +254,8 @@ export class TexraDiffView extends LitElement {
     this.editor?.layout();
   }
 
-  private observeTheme(): void {
-    if (typeof MutationObserver === 'undefined') return;
-    this.mutationObserver = new MutationObserver(() => this.applyTheme());
-    this.mutationObserver.observe(document.body, {
-      attributes: true,
-      attributeFilter: ['class', 'data-vscode-theme-kind'],
-    });
-  }
-
   private applyTheme(): void {
-    this.monaco?.editor.setTheme(monacoThemeForDocument());
+    this.monaco?.editor.setTheme(monacoThemeForHostTheme(this.hostTheme));
   }
 
   private disposeMonacoObjects(): void {

--- a/src/test-kernel/progressView/TexraDiffView.vitest.mts
+++ b/src/test-kernel/progressView/TexraDiffView.vitest.mts
@@ -47,6 +47,13 @@ class MockWorker {
   terminate = vi.fn();
 }
 
+function setHostTheme(
+  element: TexraDiffView,
+  theme: (typeof DESKTOP_THEME_KIND)[keyof typeof DESKTOP_THEME_KIND],
+): void {
+  element.hostTheme = theme;
+}
+
 function installDom(): JSDOM {
   const dom = new JSDOM('<!doctype html><body class="vscode-dark"></body>', {
     url: 'http://localhost',
@@ -140,14 +147,13 @@ describe('texra-diff-view', () => {
     });
     expect(setTheme).toHaveBeenCalledWith('vs-dark');
 
-    dom.window.document.body.dataset.vscodeThemeKind = DESKTOP_THEME_KIND.LIGHT;
+    setHostTheme(element, DESKTOP_THEME_KIND.LIGHT);
     await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('vs'));
 
-    dom.window.document.body.dataset.vscodeThemeKind =
-      DESKTOP_THEME_KIND.HIGH_CONTRAST;
+    setHostTheme(element, DESKTOP_THEME_KIND.HIGH_CONTRAST);
     await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('hc-black'));
 
-    dom.window.document.body.dataset.vscodeThemeKind = DESKTOP_THEME_KIND.DARK;
+    setHostTheme(element, DESKTOP_THEME_KIND.DARK);
     await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('vs-dark'));
   });
 });


### PR DESCRIPTION
## Summary

- make the CLI TipRow text calculation pure by requiring the already-chosen session hour
- choose the CLI tip hour once in the mounted TUI app instead of reading the clock inside the row component
- make the progress inline Monaco diff consume the shared webview theme context instead of observing document.body itself

Closes #5785.

## Verification

- corepack pnpm vitest run src/test-kernel/cli/TipRow.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts
- corepack pnpm vitest run src/test-kernel/progressView/TexraDiffView.vitest.mts src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
- npm run typecheck
- npm run lint -- --quiet
- git diff --check

## Notes

- Ran npm run check:dead-code after dependencies were installed; it still reports broad pre-existing unused-export noise plus unrelated unused files, so this PR keeps that out of scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor with explicit props/context; behavior should match prior tip rotation and diff theming, with clearer desktop theme sync for the diff overlay.
> 
> **Overview**
> Removes **render-time side effects** by pushing clock and theme inputs up to stable owners instead of reading them inside leaf UI.
> 
> **CLI:** `tipRowText` / `TipRow` now require an explicit `hour`; the TUI `App` captures the session hour once on mount and passes it down so the tip row no longer calls `new Date()` during render.
> 
> **Diff / Monaco:** `texra-diff-view` drops the `document.body` `MutationObserver` and maps Monaco themes from a `hostTheme` property fed by shared `themeContext` (VS Code webviews) or, on desktop, `diffOverlay.setTheme` wired from `applyDesktopTheme`. Tests assert theme changes via `hostTheme` instead of mutating body dataset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit debe81505ea3212591d180c2d3a2991f05c0691e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->