### PR TITLE
Surface model thinking phase with deferred stream starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 #### Improvements
 
+- **Thinking indicator** — while the model is in its reasoning phase, the chat TUI now shows an animated `Thinking…` row in the conversation area instead of sitting silent. The phase is detected from provider stream signals where available, so it also works for models whose reasoning never streams any text (e.g. GPT-5 with reasoning summaries disabled).
 - **Honest history statuses** — runs that never reached a terminal state (e.g. the process was killed) now show `unknown` in `texra history` instead of being reported as `completed`, and interrupted chat sessions are checked for a resumable record like unfinished ones.
 
 ## [0.38.7] - 2026-06-09

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -2,8 +2,15 @@
 // Finalized history is owned by the static scrollback renderer.
 
 import { Box } from 'ink';
+import { Spinner } from '@inkjs/ui';
 
-import { cliState, type ConversationEntry } from '../state/cliState';
+import { STREAM_STATUS } from '@shared/schemas';
+
+import {
+  cliState,
+  type ConversationEntry,
+  type StreamSlice,
+} from '../state/cliState';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import { BoundedTranscriptEntry, LiveTranscriptEntry } from './TranscriptEntry';
@@ -13,6 +20,28 @@ import { selectTranscriptEntriesForViewport } from './transcriptViewport';
 
 const DEFAULT_TRANSCRIPT_ROWS = 24;
 const MIN_PENDING_ROWS = 1;
+
+/**
+ * True while the stream's live activity is a hidden reasoning phase: the
+ * model is working but nothing streams into the transcript, so the pane
+ * shows an explicit liveness row instead of sitting silent. The thinking
+ * text itself is never rendered — only the fact that thinking is happening.
+ */
+export function thinkingRowVisible(
+  slice: Pick<StreamSlice, 'status' | 'thinkingActive'> | undefined,
+): boolean {
+  return (
+    slice?.thinkingActive === true && slice.status === STREAM_STATUS.RUNNING
+  );
+}
+
+function ThinkingRow(): React.JSX.Element {
+  return (
+    <Box>
+      <Spinner label="Thinking…" />
+    </Box>
+  );
+}
 
 export interface ConversationPaneProps {
   readonly width?: number;
@@ -72,6 +101,7 @@ export function ConversationPane(
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
   const displayEntries = splitTranscriptEntries(entries, slice?.status).pending;
+  const showThinking = thinkingRowVisible(slice);
   if (props.allowNativeScrollbackOverflow) {
     return (
       <Box flexDirection="column">
@@ -82,20 +112,25 @@ export function ConversationPane(
             width: props.width,
           }),
         )}
+        {showThinking ? <ThinkingRow /> : null}
       </Box>
     );
   }
 
   const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;
+  // The thinking liveness row is budgeted like any other live content: it
+  // takes one row off the entry viewport so the pane's explicit height never
+  // exceeds maxRows (an overflow would leak live rows into scrollback).
+  const thinkingRows = showThinking ? 1 : 0;
   const visibleEntries = selectTranscriptEntriesForViewport(
     displayEntries,
-    maxRows,
+    maxRows - thinkingRows,
     props.width,
   );
   const visibleRows =
-    displayEntries.length > 0
+    (visibleEntries.entries.length > 0
       ? Math.max(MIN_PENDING_ROWS, visibleEntries.usedRows)
-      : 0;
+      : 0) + thinkingRows;
 
   // Keep stream order intact so in-flight text stays interleaved with tool rows.
   // The explicit height keeps the input bar pinned and prevents bursts from
@@ -110,6 +145,7 @@ export function ConversationPane(
           width: props.width,
         });
       })}
+      {thinkingRows > 0 ? <ThinkingRow /> : null}
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -1,16 +1,14 @@
 // Transcript region for the current stream's in-flight assistant/tool rows.
 // Finalized history is owned by the static scrollback renderer.
 
-import { Box } from 'ink';
-import { Spinner } from '@inkjs/ui';
-
-import { STREAM_STATUS } from '@shared/schemas';
+import { Box, Text } from 'ink';
 
 import {
   cliState,
+  thinkingIndicatorVisible,
   type ConversationEntry,
-  type StreamSlice,
 } from '../state/cliState';
+import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import { BoundedTranscriptEntry, LiveTranscriptEntry } from './TranscriptEntry';
@@ -22,23 +20,19 @@ const DEFAULT_TRANSCRIPT_ROWS = 24;
 const MIN_PENDING_ROWS = 1;
 
 /**
- * True while the stream's live activity is a hidden reasoning phase: the
- * model is working but nothing streams into the transcript, so the pane
- * shows an explicit liveness row instead of sitting silent. The thinking
- * text itself is never rendered — only the fact that thinking is happening.
+ * Liveness row for the hidden reasoning phase: the model is working but
+ * nothing streams into the transcript, so the pane shows that thinking is
+ * happening (never the thinking text itself). Animated off the shared 1 Hz
+ * ticker — an autonomous 80 ms spinner would repaint the whole live region
+ * at ~12 Hz during exactly the phase where nothing else is streaming, while
+ * the shared tick batches with the StatusBar's elapsed-seconds render.
  */
-export function thinkingRowVisible(
-  slice: Pick<StreamSlice, 'status' | 'thinkingActive'> | undefined,
-): boolean {
-  return (
-    slice?.thinkingActive === true && slice.status === STREAM_STATUS.RUNNING
-  );
-}
-
 function ThinkingRow(): React.JSX.Element {
+  const now = useLiveNowMs(true);
+  const dots = '.'.repeat((Math.floor(now / 1000) % 3) + 1);
   return (
     <Box>
-      <Spinner label="Thinking…" />
+      <Text dimColor>✻ Thinking{dots}</Text>
     </Box>
   );
 }
@@ -101,7 +95,7 @@ export function ConversationPane(
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
   const displayEntries = splitTranscriptEntries(entries, slice?.status).pending;
-  const showThinking = thinkingRowVisible(slice);
+  const showThinking = thinkingIndicatorVisible(slice);
   if (props.allowNativeScrollbackOverflow) {
     return (
       <Box flexDirection="column">
@@ -145,7 +139,7 @@ export function ConversationPane(
           width: props.width,
         });
       })}
-      {thinkingRows > 0 ? <ThinkingRow /> : null}
+      {showThinking ? <ThinkingRow /> : null}
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -26,6 +26,7 @@ import { terminalCapabilities } from '../state/terminalCapabilities';
 import {
   cliState,
   NO_BYPASS,
+  thinkingIndicatorVisible,
   type BypassState,
   type StreamSlice,
 } from '../state/cliState';
@@ -650,8 +651,10 @@ export function buildStatusBarDisplay(
       });
     }
     if (
-      input.status === STREAM_STATUS.RUNNING &&
-      input.thinkingActive === true
+      thinkingIndicatorVisible({
+        status: input.status,
+        thinkingActive: input.thinkingActive === true,
+      })
     ) {
       left.push({
         text: 'thinking...',

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -116,6 +116,22 @@ export interface StreamSlice {
   readonly bypass: BypassState;
 }
 
+/**
+ * Shared gate for the "model is thinking" indicators (the StatusBar segment
+ * and the conversation pane's liveness row) so the two can never disagree:
+ * the hidden reasoning phase is only worth surfacing while the stream is
+ * actually running — any final or waiting status supersedes it.
+ */
+export function thinkingIndicatorVisible(
+  slice:
+    | { readonly status: string | undefined; readonly thinkingActive: boolean }
+    | undefined,
+): boolean {
+  return (
+    slice?.thinkingActive === true && slice.status === STREAM_STATUS.RUNNING
+  );
+}
+
 const EMPTY_SESSION_META: SessionMeta = {
   agent: '',
   model: '',

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -231,26 +231,35 @@ export abstract class ModelHandler<
   /**
    * Convenience wrapper for thinking streams.
    *
-   * Subscribers read the stream's start as "the model began its thinking
-   * phase" (the CLI shows a thinking indicator from it). Call sites that
-   * open the stream exactly when the provider signals that phase (Anthropic
-   * `content_block_start`, OpenAI Responses reasoning items) open eagerly;
-   * call sites that open at request setup must pass `deferStart` so the
-   * start is only emitted once a reasoning delta proves the phase happened.
+   * Stream-timing contract: subscribers read `stream.start` as "this phase
+   * began" (the CLI lights its thinking indicator from it; a started output
+   * stream means the model response is underway). By default the start is
+   * deferred to the first content chunk — the only universally available
+   * signal — so a stream opened at request setup never announces a phase
+   * that doesn't happen. A handler that sees an explicit provider phase
+   * signal (Anthropic `content_block_start`, OpenAI Responses output items)
+   * opens the stream AT that signal with `atPhaseSignal: true`, which emits
+   * the start immediately. The safe polarity is the default: a mis-placed
+   * call site degrades to first-chunk timing instead of a false indicator.
    */
-  protected createThinkingStream(options?: { deferStart?: boolean }) {
+  protected createThinkingStream(options?: { atPhaseSignal?: boolean }) {
     return this.logger.openStream(MESSAGE_TYPES.THINKING, {
       progressViewEnabled: this.progressViewEnabled,
-      deferStart: options?.deferStart,
+      deferStart: !options?.atPhaseSignal,
     });
   }
 
   /**
-   * Convenience wrapper for output streams.
+   * Convenience wrapper for output streams (timing contract above). When
+   * output streaming is disabled the stream still announces the response
+   * phase (start/end) but withholds the content — workflow runs extract and
+   * log the output separately instead of streaming it.
    */
-  protected createOutputStream() {
+  protected createOutputStream(options?: { atPhaseSignal?: boolean }) {
     return this.logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE, {
       progressViewEnabled: this.progressViewEnabled,
+      deferStart: !options?.atPhaseSignal,
+      phaseOnly: !this.outputStreaming,
     });
   }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -230,10 +230,18 @@ export abstract class ModelHandler<
 
   /**
    * Convenience wrapper for thinking streams.
+   *
+   * Subscribers read the stream's start as "the model began its thinking
+   * phase" (the CLI shows a thinking indicator from it). Call sites that
+   * open the stream exactly when the provider signals that phase (Anthropic
+   * `content_block_start`, OpenAI Responses reasoning items) open eagerly;
+   * call sites that open at request setup must pass `deferStart` so the
+   * start is only emitted once a reasoning delta proves the phase happened.
    */
-  protected createThinkingStream() {
+  protected createThinkingStream(options?: { deferStart?: boolean }) {
     return this.logger.openStream(MESSAGE_TYPES.THINKING, {
       progressViewEnabled: this.progressViewEnabled,
+      deferStart: options?.deferStart,
     });
   }
 

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -614,12 +614,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
       const streamHandler = new AnthropicStreamHandler(
         this.logger,
         {
-          outputEnabled: this.isOutputStreamingEnabled(),
           progressViewEnabled: this.progressViewEnabled,
         },
         {
-          createThinkingStream: () => this.createThinkingStream(),
-          createOutputStream: () => this.createOutputStream(),
+          // The stream handler opens these at `content_block_start` — the
+          // provider's explicit phase signal — so the starts emit eagerly.
+          createThinkingStream: () =>
+            this.createThinkingStream({ atPhaseSignal: true }),
+          createOutputStream: () =>
+            this.createOutputStream({ atPhaseSignal: true }),
         },
       );
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -554,7 +554,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         };
         const stream = await chat.sendMessageStream(streamParams);
 
-        const thinking = this.createThinkingStream();
+        // Deferred: opened before the request, but the thinking phase only
+        // starts (if ever) at the first thought part.
+        const thinking = this.createThinkingStream({ deferStart: true });
         const output = this.isOutputStreamingEnabled()
           ? this.createOutputStream()
           : undefined;

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -554,12 +554,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         };
         const stream = await chat.sendMessageStream(streamParams);
 
-        // Deferred: opened before the request, but the thinking phase only
-        // starts (if ever) at the first thought part.
-        const thinking = this.createThinkingStream({ deferStart: true });
-        const output = this.isOutputStreamingEnabled()
-          ? this.createOutputStream()
-          : undefined;
+        // Opened before the request; the deferred starts fire (if ever) at
+        // the first thought/text part — the phase signal for this API.
+        const thinking = this.createThinkingStream();
+        const output = this.createOutputStream();
 
         let baseResponse: GenerateContentResponse | undefined;
         let latestCandidate:
@@ -587,7 +585,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
             : '';
           if (chunkText) {
             aggregatedText += chunkText;
-            output?.append(chunkText);
+            output.append(chunkText);
           }
 
           if (chunk.usageMetadata) {
@@ -646,7 +644,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           baseResponse.candidates?.[0]?.content?.parts ?? [];
         const finalOutputText =
           aggregatedText || extractNonThinkingText(responseParts);
-        output?.finalize(finalOutputText);
+        output.finalize(finalOutputText);
 
         // Ensure text field excludes thinking content
         // Part.thought is a native property of the Google GenAI SDK Part interface

--- a/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
+++ b/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
@@ -16,6 +16,7 @@ import {
   isFunctionCallArgumentsDoneEvent,
   isOutputItemDoneEvent,
   isReasoningDeltaEvent,
+  isReasoningItemAddedEvent,
   isTextDeltaEvent,
   isWebSearchInProgressEvent,
   isWebSearchItem,
@@ -42,13 +43,17 @@ export interface ResponseStreamProcessorDeps {
 }
 
 export class ResponseStreamProcessor {
-  private thinkingStream: StreamHandle;
+  /**
+   * Open only while the model is inside a reasoning phase. Opening on the
+   * reasoning output item — not the first summary delta — lets subscribers
+   * surface "the model is thinking" even when no summary text ever streams
+   * (e.g. gpt-5 with reasoning summaries disabled).
+   */
+  private thinkingStream: StreamHandle | null = null;
   private readonly outputStream: StreamHandle | null;
   private readonly emittedWebSearchIds = new Set<string>();
-  private hasThinkingContent = false;
 
   constructor(private readonly deps: ResponseStreamProcessorDeps) {
-    this.thinkingStream = deps.createThinkingStream();
     this.outputStream = deps.outputStreamingEnabled
       ? deps.createOutputStream()
       : null;
@@ -60,25 +65,28 @@ export class ResponseStreamProcessor {
    */
   process(event: ResponseStreamEvent): void {
     if (isReasoningDeltaEvent(event)) {
-      this.thinkingStream.append(event.delta);
-      this.hasThinkingContent = true;
+      this.openThinkingStream().append(event.delta);
+    } else if (isReasoningItemAddedEvent(event)) {
+      this.openThinkingStream();
     } else if (isTextDeltaEvent(event)) {
       this.outputStream?.append(event.delta);
     } else if (isWebSearchInProgressEvent(event)) {
-      this.rotateThinkingStream();
+      this.closeThinkingStream();
     } else if (isFunctionCallArgumentsDoneEvent(event)) {
-      // Function call arguments complete - finalize streams since no more
-      // text/thinking deltas will arrive after tool calls begin.
-      this.rotateThinkingStream();
+      // Function call arguments complete - finalize the thinking stream since
+      // no more thinking deltas will arrive after tool calls begin.
+      this.closeThinkingStream();
       this.deps.logger.debug(`Tool call ready during streaming: ${event.name}`);
     } else if (isOutputItemDoneEvent(event)) {
       const item = event.item;
-      if (
+      if (item.type === 'reasoning') {
+        this.closeThinkingStream();
+      } else if (
         isWebSearchItem(item) &&
         !this.emittedWebSearchIds.has(item.id) &&
         hasOpenAIWebSearchData(item)
       ) {
-        this.rotateThinkingStream();
+        this.closeThinkingStream();
         this.emitWebSearch(item);
         this.emittedWebSearchIds.add(item.id);
       }
@@ -91,23 +99,24 @@ export class ResponseStreamProcessor {
    * reflects the completed response, not the pre-poll snapshot.
    */
   finalize(response: Response): void {
-    if (this.hasThinkingContent) {
-      this.thinkingStream.finalize();
-    }
+    this.closeThinkingStream();
     const finalText = this.deps.extractText(response);
     if (this.outputStream) this.outputStream.finalize(finalText);
     this.emitWebSearchesFromResponse(response);
   }
 
+  private openThinkingStream(): StreamHandle {
+    return (this.thinkingStream ??= this.deps.createThinkingStream());
+  }
+
   /**
-   * Finalize and reset the thinking stream if it has content.
-   * Keeps interleaved thinking/web-search/text segments visually separated.
+   * Finalize and clear the active thinking stream at a phase boundary.
+   * Keeps interleaved thinking/web-search/text segments visually separated;
+   * the next reasoning signal opens a fresh stream.
    */
-  private rotateThinkingStream(): void {
-    if (!this.hasThinkingContent) return;
-    this.thinkingStream.finalize();
-    this.hasThinkingContent = false;
-    this.thinkingStream = this.deps.createThinkingStream();
+  private closeThinkingStream(): void {
+    this.thinkingStream?.finalize();
+    this.thinkingStream = null;
   }
 
   /** Emit a single web-search result to the progress view. */

--- a/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
+++ b/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
@@ -29,12 +29,10 @@ import type {
 
 /** Collaborators the processor borrows from the owning handler. */
 export interface ResponseStreamProcessorDeps {
-  /** Open a fresh thinking stream (used on creation and after each rotation). */
+  /** Open a thinking stream for the current reasoning phase (one per phase). */
   createThinkingStream(): StreamHandle;
-  /** Open the output stream (only called when output streaming is enabled). */
+  /** Open the output stream for the response text. */
   createOutputStream(): StreamHandle;
-  /** Whether the final text should be streamed to an output stream. */
-  outputStreamingEnabled: boolean;
   /** Extract the final assistant text from a completed response. */
   extractText(response: Response): string;
   /** Emit a web-search result to the progress view. */
@@ -50,13 +48,14 @@ export class ResponseStreamProcessor {
    * (e.g. gpt-5 with reasoning summaries disabled).
    */
   private thinkingStream: StreamHandle | null = null;
-  private readonly outputStream: StreamHandle | null;
+  private readonly outputStream: StreamHandle;
   private readonly emittedWebSearchIds = new Set<string>();
 
   constructor(private readonly deps: ResponseStreamProcessorDeps) {
-    this.outputStream = deps.outputStreamingEnabled
-      ? deps.createOutputStream()
-      : null;
+    // Deferred start: announces the response phase at the first text delta.
+    // Whether content streams or only the phase boundaries is the handler's
+    // output-stream policy, not this processor's concern.
+    this.outputStream = deps.createOutputStream();
   }
 
   /**
@@ -69,7 +68,7 @@ export class ResponseStreamProcessor {
     } else if (isReasoningItemAddedEvent(event)) {
       this.openThinkingStream();
     } else if (isTextDeltaEvent(event)) {
-      this.outputStream?.append(event.delta);
+      this.outputStream.append(event.delta);
     } else if (isWebSearchInProgressEvent(event)) {
       this.closeThinkingStream();
     } else if (isFunctionCallArgumentsDoneEvent(event)) {
@@ -100,8 +99,7 @@ export class ResponseStreamProcessor {
    */
   finalize(response: Response): void {
     this.closeThinkingStream();
-    const finalText = this.deps.extractText(response);
-    if (this.outputStream) this.outputStream.finalize(finalText);
+    this.outputStream.finalize(this.deps.extractText(response));
     this.emitWebSearchesFromResponse(response);
   }
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -448,14 +448,14 @@ export class ModelHandlerOpenAI<
 
   protected finalizeStreams(
     thinking: ReturnType<ModelHandler['createThinkingStream']>,
-    output: ReturnType<ModelHandler['createOutputStream']> | undefined,
+    output: ReturnType<ModelHandler['createOutputStream']>,
     finalResponse: ChatCompletion,
   ): void {
     const finalReasoning = this.processThinkingBlock(finalResponse);
     thinking.finalize(finalReasoning ?? undefined);
 
     const finalOutput = finalResponse.choices?.[0]?.message?.content ?? '';
-    output?.finalize(finalOutput);
+    output.finalize(finalOutput);
   }
 
   protected async executeStreamingChat(
@@ -463,12 +463,10 @@ export class ModelHandlerOpenAI<
     baseParams: ChatCompletionRequestBase,
     signal?: AbortSignal,
   ): Promise<ChatCompletion> {
-    // Deferred: opened before the request, but the thinking phase only
-    // starts (if ever) at the first reasoning delta.
-    const thinking = this.createThinkingStream({ deferStart: true });
-    const output = this.isOutputStreamingEnabled()
-      ? this.createOutputStream()
-      : undefined;
+    // Opened before the request; the deferred starts fire (if ever) at the
+    // first reasoning/content delta — the phase signal for this API.
+    const thinking = this.createThinkingStream();
+    const output = this.createOutputStream();
 
     const streamParams: ChatCompletionStreamParams = {
       ...baseParams,
@@ -483,7 +481,7 @@ export class ModelHandlerOpenAI<
 
     const onContentDelta = ({ delta }: ContentDeltaEvent): void => {
       if (delta) {
-        output?.append(delta);
+        output.append(delta);
         streamingAggregator?.appendContent(delta);
       }
     };

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -463,7 +463,9 @@ export class ModelHandlerOpenAI<
     baseParams: ChatCompletionRequestBase,
     signal?: AbortSignal,
   ): Promise<ChatCompletion> {
-    const thinking = this.createThinkingStream();
+    // Deferred: opened before the request, but the thinking phase only
+    // starts (if ever) at the first reasoning delta.
+    const thinking = this.createThinkingStream({ deferStart: true });
     const output = this.isOutputStreamingEnabled()
       ? this.createOutputStream()
       : undefined;

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -270,9 +270,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    */
   private createStreamProcessor(): ResponseStreamProcessor {
     return new ResponseStreamProcessor({
-      createThinkingStream: () => this.createThinkingStream(),
+      // The processor opens this at the reasoning output item — the
+      // provider's explicit phase signal — so the start emits eagerly.
+      createThinkingStream: () =>
+        this.createThinkingStream({ atPhaseSignal: true }),
       createOutputStream: () => this.createOutputStream(),
-      outputStreamingEnabled: this.isOutputStreamingEnabled(),
       extractText: (response) => this.extractResponse(response, '').text,
       emitWebSearchResult: (result) => this.emitWebSearchResult(result),
       logger: this.logger,

--- a/src/agent/modelHandlers/openai/responseStreamEvents.ts
+++ b/src/agent/modelHandlers/openai/responseStreamEvents.ts
@@ -13,6 +13,7 @@ import type {
   ResponseTextDeltaEvent,
   ResponseReasoningTextDeltaEvent,
   ResponseReasoningSummaryTextDeltaEvent,
+  ResponseOutputItemAddedEvent,
   ResponseOutputItemDoneEvent,
   ResponseWebSearchCallInProgressEvent,
   ResponseFunctionCallArgumentsDoneEvent,
@@ -34,6 +35,20 @@ export function isReasoningDeltaEvent(
   return (
     event.type === 'response.reasoning_text.delta' ||
     event.type === 'response.reasoning_summary_text.delta'
+  );
+}
+
+/**
+ * Type guard for the start of a reasoning output item. This fires even when
+ * no reasoning summary text will ever stream (e.g. gpt-5 with summaries
+ * disabled), so it is the reliable "model started thinking" signal.
+ */
+export function isReasoningItemAddedEvent(
+  event: ResponseStreamEvent,
+): event is ResponseOutputItemAddedEvent {
+  return (
+    event.type === 'response.output_item.added' &&
+    event.item.type === 'reasoning'
   );
 }
 

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -369,27 +369,24 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         { signal },
       );
       const aggregator = new OpenRouterStreamAggregator();
-      // Deferred: opened before the request, but the thinking phase only
-      // starts (if ever) at the first reasoning delta.
-      const thinking = this.createThinkingStream({ deferStart: true });
-      const output = this.isOutputStreamingEnabled()
-        ? this.createOutputStream()
-        : undefined;
+      // Opened before the request; the deferred starts fire (if ever) at the
+      // first reasoning/content delta — the phase signal for this API.
+      const thinking = this.createThinkingStream();
+      const output = this.createOutputStream();
 
       try {
         for await (const chunk of stream) {
           const { contentDelta, reasoningDelta } =
             aggregator.consumeChunk(chunk);
           if (reasoningDelta) thinking.append(reasoningDelta);
-          if (contentDelta) output?.append(contentDelta);
+          if (contentDelta) output.append(contentDelta);
         }
 
         const response = aggregator.buildResponse();
         const finalReasoning = this.processThinkingBlock(response);
         thinking.finalize(finalReasoning ?? undefined);
         const finalOutput = response.choices?.[0]?.message?.content ?? '';
-        if (output)
-          output.finalize(typeof finalOutput === 'string' ? finalOutput : '');
+        output.finalize(typeof finalOutput === 'string' ? finalOutput : '');
 
         if (response.usage?.promptTokens) {
           this.lastKnownInputTokens = response.usage.promptTokens;
@@ -403,7 +400,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         // Ensure progress streams are finalized on error to prevent
         // the progress view from being stuck in a loading state
         thinking.finalize(undefined);
-        output?.finalize('');
+        output.finalize('');
         // Lift the accumulated partial text onto the error so the retry UI
         // can show the tail (parity with the other streaming providers).
         const partialTail = takeTail(

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -369,7 +369,9 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         { signal },
       );
       const aggregator = new OpenRouterStreamAggregator();
-      const thinking = this.createThinkingStream();
+      // Deferred: opened before the request, but the thinking phase only
+      // starts (if ever) at the first reasoning delta.
+      const thinking = this.createThinkingStream({ deferStart: true });
       const output = this.isOutputStreamingEnabled()
         ? this.createOutputStream()
         : undefined;

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -80,8 +80,6 @@ interface StreamDiagnosticsState extends Omit<
  * Configuration for the stream handler.
  */
 interface StreamHandlerConfig {
-  /** Whether output streaming is enabled */
-  outputEnabled: boolean;
   /** Whether progress view is enabled */
   progressViewEnabled: boolean;
 }
@@ -270,7 +268,6 @@ export class AnthropicStreamHandler {
     // (we null it for thinking/tool blocks).
     const isConsecutiveText =
       blockType === 'text' &&
-      this.config.outputEnabled &&
       this.state.outputStream !== null &&
       blockIndex === this.state.lastBlockIndex + 1;
 
@@ -286,7 +283,7 @@ export class AnthropicStreamHandler {
       );
     } else if (blockType === 'compaction') {
       this.logger.debug('Compaction block started in stream');
-    } else if (blockType === 'text' && this.config.outputEnabled) {
+    } else if (blockType === 'text') {
       if (!isConsecutiveText) {
         this.state.outputStream = this.factories.createOutputStream();
       }

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -82,6 +82,15 @@ export interface StreamOptions {
    * content emits nothing at all.
    */
   readonly deferStart?: boolean;
+  /**
+   * Emit only the phase boundaries (`stream.start` / `stream.end`); chunk
+   * text and the finalize text never reach subscribers (`finalize` still
+   * returns the locally buffered text). Used when a phase should be visible
+   * as liveness — "the model response has started" — while its content is
+   * withheld, e.g. workflow runs that extract and log the output separately
+   * instead of streaming it.
+   */
+  readonly phaseOnly?: boolean;
 }
 
 /** Handle returned by `openStream` — append chunks then finalize. */
@@ -163,5 +172,12 @@ export interface AgentTrace {
 
   // ─── Stage + stream handles ─────────────────────────────────────────
   openStage(label: string, options?: StageOptions): StageHandle;
+  /**
+   * Open a streaming message. `stream.start` marks the moment the phase the
+   * stream represents actually began — emit it at the provider's phase
+   * signal, or use `deferStart` when the first content chunk is the only
+   * signal — so subscribers can surface liveness ("thinking…", "responding…")
+   * from the start event alone.
+   */
   openStream(kind: StreamKind, options?: StreamOptions): StreamHandle;
 }

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -73,6 +73,15 @@ export interface StreamOptions {
    * still returns the buffered text. Useful for tests / off-progress paths.
    */
   readonly progressViewEnabled?: boolean;
+  /**
+   * Defer the `stream.start` emission until the first non-empty chunk (or a
+   * finalize that carries text). Subscribers treat `stream.start` as "this
+   * phase began" — e.g. thinking streams drive a "model is thinking" liveness
+   * indicator — so a stream opened eagerly at request setup must not announce
+   * a phase that may never happen. A deferred stream that ends without
+   * content emits nothing at all.
+   */
+  readonly deferStart?: boolean;
 }
 
 /** Handle returned by `openStream` — append chunks then finalize. */

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -219,15 +219,15 @@ export class TraceEmitter implements AgentTrace {
       return new BufferOnlyStreamHandle(this, id);
     }
 
+    const phaseOnly = options.phaseOnly === true;
+
     if (options.deferStart) {
       // Capture the stage now so the deferred start lands in the same group
       // an eager start would have used, not whatever scope is active when
       // the first chunk finally arrives.
-      return new DeferredStartStreamHandle(
-        this,
-        id,
-        kind,
-        options.stageId ?? this.activeStageId(),
+      const stageId = options.stageId ?? this.activeStageId();
+      return new StreamHandleImpl(this, id, phaseOnly, () =>
+        this.emit({ type: 'stream.start', id, kind, stageId }),
       );
     }
 
@@ -235,16 +235,14 @@ export class TraceEmitter implements AgentTrace {
     // right stageId without forcing the caller to await.
     if (options.stageId && options.stageId !== this.activeStageId()) {
       const nextStack = [...this.currentStageStack(), options.stageId];
-      let handle!: StreamHandle;
       this.stageScope.run(nextStack, () => {
         this.emit({ type: 'stream.start', id, kind });
-        handle = new StreamHandleImpl(this, id);
       });
-      return handle;
+      return new StreamHandleImpl(this, id, phaseOnly, null);
     }
 
     this.emit({ type: 'stream.start', id, kind });
-    return new StreamHandleImpl(this, id);
+    return new StreamHandleImpl(this, id, phaseOnly, null);
   }
 }
 
@@ -323,15 +321,35 @@ class StreamHandleImpl implements StreamHandle {
   // stream costs O(n) instead of repeated full-buffer string copies.
   private readonly chunks: string[] = [];
   private finalText: string | undefined;
+  /**
+   * Deferred `stream.start` emission (see `StreamOptions.deferStart`); null
+   * once started — eager streams are constructed already started. A deferred
+   * stream finalized without content emits no events at all, while a
+   * finalize that carries text emits the start/end pair so reasoning that
+   * only arrives in the final response still lands as a single entry.
+   */
+  private pendingStart: (() => void) | null;
 
   constructor(
     private readonly trace: TraceEmitter,
     readonly id: string,
-  ) {}
+    private readonly phaseOnly: boolean,
+    pendingStart: (() => void) | null,
+  ) {
+    this.pendingStart = pendingStart;
+  }
+
+  private start(): void {
+    const pending = this.pendingStart;
+    this.pendingStart = null;
+    pending?.();
+  }
 
   append(text: string): void {
     if (this.finalText !== undefined || !text) return;
+    this.start();
     this.chunks.push(text);
+    if (this.phaseOnly) return;
     this.trace.emit({ type: 'stream.chunk', id: this.id, text });
   }
 
@@ -339,70 +357,19 @@ class StreamHandleImpl implements StreamHandle {
     if (this.finalText !== undefined) return this.finalText;
     this.finalText =
       typeof finalText === 'string' ? finalText : this.chunks.join('');
-    this.trace.emit({
-      type: 'stream.end',
-      id: this.id,
-      finalText: typeof finalText === 'string' ? finalText : undefined,
-    });
-    return this.finalText;
-  }
-}
-
-/**
- * Stream that holds back `stream.start` until content proves the phase
- * happened (see `StreamOptions.deferStart`). A deferred stream finalized
- * without content emits no events; a finalize that carries text emits the
- * start/end pair so reasoning that only arrives in the final response still
- * lands as a single entry.
- */
-class DeferredStartStreamHandle implements StreamHandle {
-  private readonly chunks: string[] = [];
-  private started = false;
-  private finalText: string | undefined;
-
-  constructor(
-    private readonly trace: TraceEmitter,
-    readonly id: string,
-    private readonly kind: StreamKind,
-    private readonly stageId: string | undefined,
-  ) {}
-
-  private start(): void {
-    if (this.started) return;
-    this.started = true;
-    this.trace.emit({
-      type: 'stream.start',
-      id: this.id,
-      kind: this.kind,
-      stageId: this.stageId,
-    });
-  }
-
-  append(text: string): void {
-    if (this.finalText !== undefined || !text) return;
-    this.start();
-    this.chunks.push(text);
-    this.trace.emit({
-      type: 'stream.chunk',
-      id: this.id,
-      text,
-      stageId: this.stageId,
-    });
-  }
-
-  finalize(finalText?: string): string {
-    if (this.finalText !== undefined) return this.finalText;
-    this.finalText =
-      typeof finalText === 'string' ? finalText : this.chunks.join('');
-    // Never started and nothing to say: the phase never happened, so the
-    // stream leaves no trace at all.
-    if (!this.started && this.finalText.length === 0) return this.finalText;
+    // Deferred and nothing to say: the phase never happened, so the stream
+    // leaves no trace at all.
+    if (this.pendingStart !== null && this.finalText.length === 0) {
+      return this.finalText;
+    }
     this.start();
     this.trace.emit({
       type: 'stream.end',
       id: this.id,
-      finalText: typeof finalText === 'string' ? finalText : undefined,
-      stageId: this.stageId,
+      finalText:
+        !this.phaseOnly && typeof finalText === 'string'
+          ? finalText
+          : undefined,
     });
     return this.finalText;
   }

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -219,6 +219,18 @@ export class TraceEmitter implements AgentTrace {
       return new BufferOnlyStreamHandle(this, id);
     }
 
+    if (options.deferStart) {
+      // Capture the stage now so the deferred start lands in the same group
+      // an eager start would have used, not whatever scope is active when
+      // the first chunk finally arrives.
+      return new DeferredStartStreamHandle(
+        this,
+        id,
+        kind,
+        options.stageId ?? this.activeStageId(),
+      );
+    }
+
     // Open inside the explicit stage scope so the start event carries the
     // right stageId without forcing the caller to await.
     if (options.stageId && options.stageId !== this.activeStageId()) {
@@ -331,6 +343,66 @@ class StreamHandleImpl implements StreamHandle {
       type: 'stream.end',
       id: this.id,
       finalText: typeof finalText === 'string' ? finalText : undefined,
+    });
+    return this.finalText;
+  }
+}
+
+/**
+ * Stream that holds back `stream.start` until content proves the phase
+ * happened (see `StreamOptions.deferStart`). A deferred stream finalized
+ * without content emits no events; a finalize that carries text emits the
+ * start/end pair so reasoning that only arrives in the final response still
+ * lands as a single entry.
+ */
+class DeferredStartStreamHandle implements StreamHandle {
+  private readonly chunks: string[] = [];
+  private started = false;
+  private finalText: string | undefined;
+
+  constructor(
+    private readonly trace: TraceEmitter,
+    readonly id: string,
+    private readonly kind: StreamKind,
+    private readonly stageId: string | undefined,
+  ) {}
+
+  private start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.trace.emit({
+      type: 'stream.start',
+      id: this.id,
+      kind: this.kind,
+      stageId: this.stageId,
+    });
+  }
+
+  append(text: string): void {
+    if (this.finalText !== undefined || !text) return;
+    this.start();
+    this.chunks.push(text);
+    this.trace.emit({
+      type: 'stream.chunk',
+      id: this.id,
+      text,
+      stageId: this.stageId,
+    });
+  }
+
+  finalize(finalText?: string): string {
+    if (this.finalText !== undefined) return this.finalText;
+    this.finalText =
+      typeof finalText === 'string' ? finalText : this.chunks.join('');
+    // Never started and nothing to say: the phase never happened, so the
+    // stream leaves no trace at all.
+    if (!this.started && this.finalText.length === 0) return this.finalText;
+    this.start();
+    this.trace.emit({
+      type: 'stream.end',
+      id: this.id,
+      finalText: typeof finalText === 'string' ? finalText : undefined,
+      stageId: this.stageId,
     });
     return this.finalText;
   }

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -113,7 +113,13 @@ export interface ContextStateEvent extends StageStamp {
   readonly contextWindow: number;
 }
 
-/** Streaming message opened — subsequent stream.chunk events append text. */
+/**
+ * Streaming message opened — subsequent stream.chunk events append text.
+ * Marks the moment the phase the stream represents actually began (emitters
+ * fire it at the provider's phase signal, or at the first content chunk via
+ * `StreamOptions.deferStart`), so subscribers may surface liveness — "the
+ * model is thinking / responding" — from this event alone.
+ */
 export interface StreamStartEvent extends StageStamp {
   readonly type: 'stream.start';
   readonly id: string;

--- a/src/test-kernel/agent/modelHandlers/ResponseStreamProcessor.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ResponseStreamProcessor.vitest.ts
@@ -1,0 +1,163 @@
+// Reasoning-phase boundaries for the OpenAI Responses stream processor.
+//
+// The thinking stream must open on the reasoning output item — not the first
+// summary delta — so subscribers can surface "the model is thinking" even
+// when no summary text ever streams (gpt-5 with summaries disabled), and it
+// must close at every phase boundary so the indicator turns off.
+
+import { describe, expect, it } from 'vitest';
+
+import { noopTrace, type StreamHandle } from '@agent/trace';
+import { ResponseStreamProcessor } from '@agent/modelHandlers/openai/ResponseStreamProcessor';
+import type {
+  Response,
+  ResponseStreamEvent,
+} from 'openai/resources/responses/responses';
+
+interface RecordedStream extends StreamHandle {
+  readonly appended: string[];
+  finalized: boolean;
+}
+
+function recordedStream(id: string): RecordedStream {
+  const appended: string[] = [];
+  return {
+    id,
+    appended,
+    finalized: false,
+    append(text: string) {
+      appended.push(text);
+    },
+    finalize(finalText?: string) {
+      this.finalized = true;
+      return finalText ?? appended.join('');
+    },
+  };
+}
+
+function createProcessor() {
+  const thinkingStreams: RecordedStream[] = [];
+  const processor = new ResponseStreamProcessor({
+    createThinkingStream: () => {
+      const stream = recordedStream(`thinking-${thinkingStreams.length}`);
+      thinkingStreams.push(stream);
+      return stream;
+    },
+    createOutputStream: () => recordedStream('output'),
+    outputStreamingEnabled: false,
+    extractText: () => '',
+    emitWebSearchResult: () => undefined,
+    logger: noopTrace,
+  });
+  return { processor, thinkingStreams };
+}
+
+function event(partial: Record<string, unknown>): ResponseStreamEvent {
+  return partial as unknown as ResponseStreamEvent;
+}
+
+const reasoningAdded = event({
+  type: 'response.output_item.added',
+  item: { type: 'reasoning', id: 'rs_1', summary: [] },
+  output_index: 0,
+  sequence_number: 1,
+});
+const reasoningDone = event({
+  type: 'response.output_item.done',
+  item: { type: 'reasoning', id: 'rs_1', summary: [] },
+  output_index: 0,
+  sequence_number: 2,
+});
+const summaryDelta = event({
+  type: 'response.reasoning_summary_text.delta',
+  delta: 'weighing options',
+  item_id: 'rs_1',
+  output_index: 0,
+  summary_index: 0,
+  sequence_number: 3,
+});
+const functionArgsDone = event({
+  type: 'response.function_call_arguments.done',
+  name: 'search',
+  arguments: '{}',
+  item_id: 'fc_1',
+  output_index: 1,
+  sequence_number: 4,
+});
+const emptyResponse = { output: [] } as unknown as Response;
+
+describe('ResponseStreamProcessor reasoning phases', () => {
+  it('opens the thinking stream on the reasoning item, without any delta', () => {
+    const { processor, thinkingStreams } = createProcessor();
+
+    processor.process(reasoningAdded);
+
+    expect(thinkingStreams).toHaveLength(1);
+    expect(thinkingStreams[0]?.appended).toEqual([]);
+    expect(thinkingStreams[0]?.finalized).toBe(false);
+
+    processor.process(reasoningDone);
+
+    expect(thinkingStreams[0]?.finalized).toBe(true);
+  });
+
+  it('appends summary deltas to the stream opened by the reasoning item', () => {
+    const { processor, thinkingStreams } = createProcessor();
+
+    processor.process(reasoningAdded);
+    processor.process(summaryDelta);
+
+    expect(thinkingStreams).toHaveLength(1);
+    expect(thinkingStreams[0]?.appended).toEqual(['weighing options']);
+  });
+
+  it('opens a stream lazily when only deltas arrive', () => {
+    const { processor, thinkingStreams } = createProcessor();
+
+    processor.process(summaryDelta);
+
+    expect(thinkingStreams).toHaveLength(1);
+    expect(thinkingStreams[0]?.appended).toEqual(['weighing options']);
+  });
+
+  it('closes the phase when tool-call arguments complete', () => {
+    const { processor, thinkingStreams } = createProcessor();
+
+    processor.process(reasoningAdded);
+    processor.process(functionArgsDone);
+
+    expect(thinkingStreams[0]?.finalized).toBe(true);
+
+    // A later reasoning segment opens a fresh stream.
+    processor.process(reasoningAdded);
+    expect(thinkingStreams).toHaveLength(2);
+    expect(thinkingStreams[1]?.finalized).toBe(false);
+  });
+
+  it('closes any open phase at finalize', () => {
+    const { processor, thinkingStreams } = createProcessor();
+
+    processor.process(reasoningAdded);
+    processor.finalize(emptyResponse);
+
+    expect(thinkingStreams[0]?.finalized).toBe(true);
+  });
+
+  it('never opens a thinking stream when no reasoning happens', () => {
+    const { processor, thinkingStreams } = createProcessor();
+
+    processor.process(
+      event({
+        type: 'response.output_text.delta',
+        delta: 'plain answer',
+        item_id: 'msg_1',
+        output_index: 0,
+        content_index: 0,
+        sequence_number: 1,
+      }),
+    );
+    processor.finalize(emptyResponse);
+
+    expect(thinkingStreams).toHaveLength(0);
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/ResponseStreamProcessor.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ResponseStreamProcessor.vitest.ts
@@ -44,7 +44,6 @@ function createProcessor() {
       return stream;
     },
     createOutputStream: () => recordedStream('output'),
-    outputStreamingEnabled: false,
     extractText: () => '',
     emitWebSearchResult: () => undefined,
     logger: noopTrace,

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -82,6 +82,104 @@ describe('AgentTrace stream output', () => {
     }
   });
 
+  it('materializes thinking streams at stream start, before any delta', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace('stream').trace;
+      const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
+
+      // The running entry exists immediately — the CLI keys its "model is
+      // thinking" indicator off it, and hidden reasoning may never emit a
+      // first chunk.
+      let entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.messageType).toBe(MESSAGE_TYPES.THINKING);
+      expect(entries[0]?.text).toBe('');
+      expect(entries[0]?.data).toEqual({ status: 'running' });
+
+      thinking.finalize();
+      entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.data).toEqual({ status: 'completed' });
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('emits nothing for a deferred stream until the first chunk', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace('stream').trace;
+      const thinking = logger.openStream(MESSAGE_TYPES.THINKING, {
+        deferStart: true,
+      });
+
+      expect(store.get('stream')).toBeUndefined();
+
+      thinking.append('reasoning delta');
+      flushPendingRunTraces();
+
+      const entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.messageType).toBe(MESSAGE_TYPES.THINKING);
+      expect(entries[0]?.text).toBe('reasoning delta');
+
+      expect(thinking.finalize()).toBe('reasoning delta');
+      expect((store.get('stream')?.getRange(0) ?? [])[0]?.data).toEqual({
+        status: 'completed',
+      });
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('leaves no trace for a deferred stream finalized without content', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace('stream').trace;
+      const thinking = logger.openStream(MESSAGE_TYPES.THINKING, {
+        deferStart: true,
+      });
+
+      expect(thinking.finalize()).toBe('');
+      expect(store.get('stream')).toBeUndefined();
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('materializes a deferred stream finalized with reasoning text', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace('stream').trace;
+      const thinking = logger.openStream(MESSAGE_TYPES.THINKING, {
+        deferStart: true,
+      });
+
+      // Mirrors providers that only return reasoning in the final response.
+      expect(thinking.finalize('final reasoning')).toBe('final reasoning');
+
+      const entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.text).toBe('final reasoning');
+      expect(entries[0]?.data).toEqual({ status: 'completed' });
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
   it('accumulates disabled progress streams without scheduled updates', () => {
     vi.useFakeTimers();
 

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -7,8 +7,26 @@ import {
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
-import { endToolUseCard, startToolUseCard } from '@agent/trace';
+import {
+  endToolUseCard,
+  startToolUseCard,
+  type AgentTrace,
+} from '@agent/trace';
 import { MESSAGE_TYPES } from '@shared/schemas';
+
+/** Swap in a fresh default store (restored afterwards) around `run`. */
+function withStore(
+  run: (store: StreamLogStore, logger: AgentTrace) => void,
+): void {
+  const previousStore = getDefaultStreamLogStore();
+  const store = new StreamLogStore();
+  setDefaultStreamLogStore(store);
+  try {
+    run(store, createRunTrace('stream').trace);
+  } finally {
+    setDefaultStreamLogStore(previousStore);
+  }
+}
 
 describe('AgentTrace stream output', () => {
   afterEach(() => {
@@ -82,13 +100,8 @@ describe('AgentTrace stream output', () => {
     }
   });
 
-  it('materializes thinking streams at stream start, before any delta', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
-
-    try {
-      const logger = createRunTrace('stream').trace;
+  it('materializes streams at stream start, before any delta', () => {
+    withStore((store, logger) => {
       const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
 
       // The running entry exists immediately — the CLI keys its "model is
@@ -104,18 +117,11 @@ describe('AgentTrace stream output', () => {
       entries = store.get('stream')?.getRange(0) ?? [];
       expect(entries).toHaveLength(1);
       expect(entries[0]?.data).toEqual({ status: 'completed' });
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    });
   });
 
   it('emits nothing for a deferred stream until the first chunk', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
-
-    try {
-      const logger = createRunTrace('stream').trace;
+    withStore((store, logger) => {
       const thinking = logger.openStream(MESSAGE_TYPES.THINKING, {
         deferStart: true,
       });
@@ -134,36 +140,22 @@ describe('AgentTrace stream output', () => {
       expect((store.get('stream')?.getRange(0) ?? [])[0]?.data).toEqual({
         status: 'completed',
       });
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    });
   });
 
   it('leaves no trace for a deferred stream finalized without content', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
-
-    try {
-      const logger = createRunTrace('stream').trace;
+    withStore((store, logger) => {
       const thinking = logger.openStream(MESSAGE_TYPES.THINKING, {
         deferStart: true,
       });
 
       expect(thinking.finalize()).toBe('');
       expect(store.get('stream')).toBeUndefined();
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    });
   });
 
   it('materializes a deferred stream finalized with reasoning text', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
-
-    try {
-      const logger = createRunTrace('stream').trace;
+    withStore((store, logger) => {
       const thinking = logger.openStream(MESSAGE_TYPES.THINKING, {
         deferStart: true,
       });
@@ -175,9 +167,34 @@ describe('AgentTrace stream output', () => {
       expect(entries).toHaveLength(1);
       expect(entries[0]?.text).toBe('final reasoning');
       expect(entries[0]?.data).toEqual({ status: 'completed' });
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    });
+  });
+
+  it('announces phase boundaries without content for phase-only streams', () => {
+    withStore((store, logger) => {
+      // Workflow runs hide the response text (it is extracted and logged
+      // separately) but still announce that the response phase started.
+      const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE, {
+        deferStart: true,
+        phaseOnly: true,
+      });
+
+      expect(store.get('stream')).toBeUndefined();
+
+      output.append('hidden partial output');
+
+      let entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.messageType).toBe(MESSAGE_TYPES.MODEL_RESPONSE);
+      expect(entries[0]?.text).toBe('');
+      expect(entries[0]?.data).toEqual({ status: 'running' });
+
+      // finalize returns the locally buffered text but never publishes it.
+      expect(output.finalize('full output')).toBe('full output');
+      entries = store.get('stream')?.getRange(0) ?? [];
+      expect(entries[0]?.text).toBe('');
+      expect(entries[0]?.data).toEqual({ status: 'completed' });
+    });
   });
 
   it('accumulates disabled progress streams without scheduled updates', () => {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -6,6 +6,7 @@ import {
   compactPrefixedDisplayRows,
   isInquiryContinuationText,
 } from '@cli/chat/tui/panes/TranscriptEntry';
+import { thinkingRowVisible } from '@cli/chat/tui/panes/ConversationPane';
 import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
 import {
   splitTranscriptEntries,
@@ -835,6 +836,36 @@ describe('CLI conversation transcript splitting', () => {
       clearScrollback: true,
       preserveStatic: false,
     });
+  });
+
+  it('shows the thinking liveness row only while a running stream is thinking', () => {
+    expect(thinkingRowVisible(undefined)).toBe(false);
+    expect(
+      thinkingRowVisible(
+        sliceWithEntries(STREAM_ID, [], {
+          thinkingActive: true,
+          status: STREAM_STATUS.RUNNING,
+        }),
+      ),
+    ).toBe(true);
+    // Off once visible activity (or a final status) takes over — the row is
+    // a liveness signal for the silent reasoning phase only.
+    expect(
+      thinkingRowVisible(
+        sliceWithEntries(STREAM_ID, [], {
+          thinkingActive: false,
+          status: STREAM_STATUS.RUNNING,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      thinkingRowVisible(
+        sliceWithEntries(STREAM_ID, [], {
+          thinkingActive: true,
+          status: STREAM_STATUS.WAITING,
+        }),
+      ),
+    ).toBe(false);
   });
 
   it('detects generated inquiry continuation rows only', () => {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -6,7 +6,6 @@ import {
   compactPrefixedDisplayRows,
   isInquiryContinuationText,
 } from '@cli/chat/tui/panes/TranscriptEntry';
-import { thinkingRowVisible } from '@cli/chat/tui/panes/ConversationPane';
 import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
 import {
   splitTranscriptEntries,
@@ -31,6 +30,7 @@ import {
   cliState,
   patchStream,
   resetCliState,
+  thinkingIndicatorVisible,
   type ConversationEntry,
   type StreamSlice,
 } from '@cli/chat/tui/state/cliState';
@@ -839,9 +839,9 @@ describe('CLI conversation transcript splitting', () => {
   });
 
   it('shows the thinking liveness row only while a running stream is thinking', () => {
-    expect(thinkingRowVisible(undefined)).toBe(false);
+    expect(thinkingIndicatorVisible(undefined)).toBe(false);
     expect(
-      thinkingRowVisible(
+      thinkingIndicatorVisible(
         sliceWithEntries(STREAM_ID, [], {
           thinkingActive: true,
           status: STREAM_STATUS.RUNNING,
@@ -851,7 +851,7 @@ describe('CLI conversation transcript splitting', () => {
     // Off once visible activity (or a final status) takes over — the row is
     // a liveness signal for the silent reasoning phase only.
     expect(
-      thinkingRowVisible(
+      thinkingIndicatorVisible(
         sliceWithEntries(STREAM_ID, [], {
           thinkingActive: false,
           status: STREAM_STATUS.RUNNING,
@@ -859,7 +859,7 @@ describe('CLI conversation transcript splitting', () => {
       ),
     ).toBe(false);
     expect(
-      thinkingRowVisible(
+      thinkingIndicatorVisible(
         sliceWithEntries(STREAM_ID, [], {
           thinkingActive: true,
           status: STREAM_STATUS.WAITING,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1555,11 +1555,20 @@ describe('CLI transcript state', () => {
     try {
       const logger = createRunTrace(root).trace;
       const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
+
+      // Opening the stream alone marks the phase — hidden reasoning (e.g.
+      // gpt-5 without summaries) may never produce a text delta.
+      syncStreamLog(root);
+
+      let slice = cliState.streams.get().get(root);
+      expect(slice?.thinkingActive).toBe(true);
+      expect(slice?.entries).toEqual([]);
+
       thinking.append('private reasoning summary');
 
       syncStreamLog(root);
 
-      let slice = cliState.streams.get().get(root);
+      slice = cliState.streams.get().get(root);
       expect(slice?.thinkingActive).toBe(true);
       expect(slice?.entries).toEqual([]);
 

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -252,8 +252,8 @@ export function attachTranscriptRecorder(
         return;
       }
 
-      case 'stream.start':
-        streams.set(event.id, {
+      case 'stream.start': {
+        const state: StreamSinkState = {
           buffer: '',
           pending: [],
           created: false,
@@ -263,8 +263,18 @@ export function attachTranscriptRecorder(
           level: 'info',
           messageType: asMessageType(event.kind),
           updateTimer: null,
-        });
+        };
+        streams.set(event.id, state);
+        // A thinking stream's start IS the signal consumers care about: the
+        // CLI keys its "model is thinking" liveness indicator off a running
+        // THINKING entry, and hidden reasoning (e.g. gpt-5 without summaries)
+        // may never produce a first chunk to create one. Materialize the
+        // entry at phase start — renderers already skip empty thinking text.
+        if (state.messageType === MESSAGE_TYPES.THINKING) {
+          flushStream(state, event.id);
+        }
         return;
+      }
 
       case 'stream.chunk': {
         const state = streams.get(event.id);

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -8,8 +8,10 @@
  * one of many possible subscribers.
  *
  * Streaming behavior mirrors the `AgentTrace` stream pattern:
- *   - first chunk creates the entry (with empty text if no chunks yet)
- *   - subsequent chunks are buffered + flushed on an interval
+ *   - stream.start creates the entry (empty text, status running) — it marks
+ *     the moment the phase began, so consumers can surface liveness from it
+ *   - the first content chunk flushes immediately; later chunks are
+ *     buffered + flushed on an interval
  *   - finalize flushes any pending chunks immediately
  */
 import { nanoid } from 'nanoid';
@@ -265,14 +267,14 @@ export function attachTranscriptRecorder(
           updateTimer: null,
         };
         streams.set(event.id, state);
-        // A thinking stream's start IS the signal consumers care about: the
-        // CLI keys its "model is thinking" liveness indicator off a running
-        // THINKING entry, and hidden reasoning (e.g. gpt-5 without summaries)
-        // may never produce a first chunk to create one. Materialize the
-        // entry at phase start — renderers already skip empty thinking text.
-        if (state.messageType === MESSAGE_TYPES.THINKING) {
-          flushStream(state, event.id);
-        }
+        // The start IS the signal consumers care about — it marks the moment
+        // the phase began: a running THINKING entry drives the CLI's "model
+        // is thinking" indicator, and a running MODEL_RESPONSE entry says
+        // the response has started even when its content is withheld
+        // (phase-only workflow streams, hidden reasoning that never emits a
+        // chunk). Materialize the entry immediately; renderers already skip
+        // entries with empty text.
+        flushStream(state, event.id);
         return;
       }
 
@@ -280,7 +282,10 @@ export function attachTranscriptRecorder(
         const state = streams.get(event.id);
         if (!state || !state.enabled) return;
         state.pending.push(event.text);
-        if (!state.created) {
+        // First content flushes immediately — the entry was materialized
+        // empty at stream.start, so without this the first paint would wait
+        // out the coalescing interval. Later chunks coalesce.
+        if (!state.created || state.buffer.length === 0) {
           flushStream(state, event.id);
         } else {
           scheduleStreamUpdate(state, event.id);


### PR DESCRIPTION
## Summary

This change enables the CLI to surface "the model is thinking" as a liveness indicator during the reasoning phase, even when no reasoning text streams. It introduces deferred stream starts (`deferStart` option) so phases that may never produce content don't announce themselves prematurely, and adds phase-only streams (`phaseOnly` option) for cases where phase boundaries should be visible but content is withheld.

The key insight: `stream.start` now marks the moment a phase actually began (at the provider's explicit signal or the first content chunk), allowing subscribers to surface liveness from the start event alone. This is especially important for hidden reasoning phases where no summary text may ever stream.

## Issue acceptance gates

Implements the thinking indicator feature:
- ✅ CLI shows animated "Thinking…" row during reasoning phase
- ✅ Indicator appears only while stream is running and thinking is active
- ✅ Works with providers that emit explicit phase signals (OpenAI Responses, Anthropic)
- ✅ Works with providers that only signal via content deltas (OpenRouter, Google)
- ✅ Handles reasoning that only arrives in final response (deferred finalize)

## Single source of truth

**`StreamOptions` in `AgentTrace.ts`** now owns the stream timing contract:
- `deferStart`: defers `stream.start` until first content or finalize-with-text
- `phaseOnly`: emits phase boundaries but withholds content from subscribers

**`ResponseStreamProcessor`** owns reasoning phase boundaries for OpenAI Responses:
- Opens thinking stream at `response.output_item.added` (reasoning item)
- Closes at phase boundaries (tool calls, web search, reasoning done)

**`thinkingIndicatorVisible()` in `cliState.ts`** gates both CLI thinking indicators (StatusBar + ConversationPane) so they never disagree.

## Duplication and abstraction budget

**Removed:**
- `outputStreamingEnabled` parameter from `ResponseStreamProcessorDeps` — output stream is always created; handlers control content via `phaseOnly` instead
- `hasThinkingContent` flag in `ResponseStreamProcessor` — replaced with nullable `thinkingStream` (null = closed)
- `rotateThinkingStream()` method — split into `openThinkingStream()` (lazy) and `closeThinkingStream()` (explicit)

**Added:**
- `StreamHandleImpl` now tracks `pendingStart` callback for deferred emission
- `isReasoningItemAddedEvent()` type guard for OpenAI reasoning output items
- `thinkingIndicatorVisible()` shared gate for CLI thinking indicators
- `ThinkingRow` component in ConversationPane for the liveness animation

**Abstraction:** `StreamOptions.deferStart` and `phaseOnly` are general-purpose stream timing controls that work across all providers and handlers, avoiding provider-specific timing logic in the trace layer.

## Host impact

**CLI:**
- ConversationPane now shows animated "Thinking…" row during reasoning
- StatusBar thinking indicator uses shared `thinkingIndicatorVisible()` gate
- Both indicators turn off when stream exits RUNNING status or thinking closes
- Transcript entries materialize at `stream.start` (empty text, status running) so phase boundaries are visible even without content

**Extension:**
- No visible changes; stream timing is transparent to webview consumers
- Deferred starts prevent false "thinking" indicators for non-reasoning requests

**Desktop:**
- No visible changes; same as extension

## Scheduled refactoring

None. The deferred-start and phase-only patterns are general enough to support future providers without further changes.

## Validation

- ✅ Added `ResponseStreamProcessor.vitest.ts` with 6 tests covering reasoning phase boundaries
- ✅ Added `RunTraceStream.vitest.ts` tests for deferred/phase-only stream behavior (4 new tests)
- ✅ Updated `ConversationPane.vitest.mts` with thinking indicator visibility test
- ✅ Updated `TuiStateAndFocus.vitest.mts` to verify `thinkingActive` state at stream start
- ✅ All existing tests pass; no breaking changes to public APIs

https://claude.ai/code/session_011d7CfAuumtByDHkVNXsppX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared trace/stream emission and all major model handlers; behavior changes when thinking and output phases are announced, though tests cover deferred streams and OpenAI reasoning boundaries.
> 
> **Overview**
> Adds a **CLI thinking liveness** experience during hidden reasoning: an animated `Thinking…` row in the conversation pane and a matching StatusBar segment, both gated by shared `thinkingIndicatorVisible()` so they only show while the stream is **running** and reasoning is active.
> 
> Reworks **stream phase timing** across the agent trace layer: `StreamOptions` gains `deferStart` (no `stream.start` until first content or finalize-with-text) and `phaseOnly` (phase boundaries without publishing chunks). Handlers open thinking/output streams at provider phase signals where available (`atPhaseSignal`), and always create output streams—non-streaming workflow output uses `phaseOnly` instead of skipping the stream. **OpenAI Responses** opens thinking on `reasoning` output-item added (not only summary deltas) and closes at phase boundaries.
> 
> **Transcript recording** materializes entries on `stream.start` (empty, running) and flushes the first chunk immediately so liveness and early text paint without waiting on coalescing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab8ad6276b4e5e5301e2b7aa4c023a75d396c2bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->