### PR TITLE
Release 0.38.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,33 +9,33 @@ All notable changes to this project will be documented in this file.
 #### Bug Fixes
 
 - **Stopping a run is no longer recorded as an error** — interrupting an agent (stop button, Ctrl+C, closing an idle chat) now consistently records the run as _interrupted_ instead of _error_: history shows the right status, the transcript group ends neutral instead of red, orchestrators see a cancelled subagent as cancelled rather than failed, and the CLI exits with the interrupt code (130) instead of the error code (1).
-- **Fix LaTeX compilation works on latexdiff output** — running the LaTeX fixer on a generated `latexdiff` file is no longer blocked. Since `latexdiff` itself often emits non-compiling markup (DIF commands inside math, citations, or macro definitions), the fixer now treats the file as a diff artifact: it repairs broken DIF markup in place while keeping the change annotations, and when an error traces back to the original source it fixes the source too so a regenerated diff stays fixed.
-- **Orchestrators manage their team reliably** — stopping or killing an orchestrator now interrupts the entire delegation chain, including subagents of subagents, instead of leaving them running against a dead parent; a waiting orchestrator now wakes up when a queued subagent finishes instead of stalling until your next message; resuming a subagent that was detached or belongs to another orchestrator now fails fast with the reason instead of silently queueing instructions whose results can never come back; and when a subagent's output diffs cannot be computed, the orchestrator is told so instead of assuming nothing changed.
+- **Fix LaTeX Compilation Errors works on latexdiff output** — running the fixer on a generated `latexdiff` file is no longer blocked. Since `latexdiff` itself often emits non-compiling markup (DIF commands inside math, citations, or macro definitions), the fixer now treats the file as a diff artifact: it repairs broken DIF markup in place while keeping the change annotations, and when an error traces back to the original source it fixes the source too so a regenerated diff stays fixed.
+- **Orchestrators manage their team reliably** — stopping an orchestrator now stops the entire delegation chain, including subagents of subagents, instead of leaving them running; a waiting orchestrator now learns that a subagent finished without you having to send another message; and when a subagent's output diffs cannot be computed, the orchestrator is told so instead of assuming nothing changed.
 - **Goal records are cleaned up with their conversations** — deleting a conversation (or a run from CLI history) now also removes its goal record, so the Goal tab no longer accumulates entries for conversations that no longer exist.
 - **Relay streams survive transient hiccups** — a brief transient error on the included relay no longer cuts off an in-flight response.
 
 #### Improvements
 
-- **Plans are now a single objective document** — a plan states what to achieve, the approach, and a verifiable stopping condition; step-by-step tracking lives solely in the agent's todo list instead of being duplicated in the plan. Updating a plan always asks for your approval again, and Approve & Run seeds the goal with the document verbatim. The `texra.goal.costCapUsd` setting is removed — a goal is driven by its objective, not a budget — and when a goal auto-pauses after an error, the CLI now prints a notice instead of appearing to hang.
+- **Plans are now a single objective document** — a plan states what to achieve, the approach, and a verifiable stopping condition; step-by-step tracking lives solely in the agent's todo list instead of being duplicated in the plan. Updating a plan always asks for your approval again, and Approve & Run uses the document verbatim as the goal objective. Plans saved in the old step-list format are no longer displayed. The `texra.goal.costCapUsd` setting is removed — a goal is driven by its objective, not a budget — and when a goal auto-pauses after an error, the CLI now prints a notice instead of appearing to hang.
 
 ### CLI
 
 #### Features
 
 - **Suspend the chat with Ctrl+Z** — press `Ctrl+Z` to drop back to your shell mid-session and `fg` to return; the terminal is handed back cleanly on suspend and the screen repaints on resume.
-- **Screen-reader support** — with Ink's `INK_SCREEN_READER` environment variable enabled, menus and pickers expose proper option roles with selected and disabled states, the chat input reads as a text box, and decorative glyphs are hidden from the reader.
+- **Screen-reader support** — with the `INK_SCREEN_READER` environment variable set, menus and pickers announce their options with selected and disabled states, the chat input reads as a text box, and decorative glyphs are hidden from the reader.
 
 #### Bug Fixes
 
 - **Terminal always restored on exit** — a crash or unexpected exit can no longer leave your shell stuck in raw mode with a hidden cursor or mouse reporting left on.
-- **Stopping honors the detach setting** — stopping an agent now respects your detach-subagents-on-stop preference instead of always interrupting running subagents.
+- **Stopping honors your subagent preference** — stopping an orchestrator now respects the "Keep agents running if I stop the orchestrator" setting instead of always interrupting running subagents.
 
 #### Improvements
 
 - **Honest history statuses** — runs that never reached a terminal state (e.g. the process was killed) now show `unknown` in `texra history` instead of being reported as `completed`, and interrupted chat sessions are checked for a resumable record like unfinished ones.
-- **Calmer transcript layout** — your messages now render as an inset band with a blank line above and below, tool rows sit directly under the prompt that triggered them, stray blank rows at startup and between turns are gone, tool rows are sized to their content, and the status bar compacts gracefully on narrow terminals.
+- **Calmer transcript layout** — your messages now render as an inset band with a blank line above and below, tool rows sit directly under the prompt that triggered them, stray blank rows at startup and between turns are gone, and on narrow terminals the status bar shortens its segments (context usage degrades to a bare percentage) before dropping anything.
 - **Forgiving slash-command matching** — when nothing starts with what you typed, the palette falls back to substring matches (`/odel` still finds `/model`) and then to the closest typo suggestion (`/hlp` suggests `/help`) instead of going blank; only exact prefix matches run without preview, so a pasted line never triggers a command you didn't see. `/help` now also lists the text-editing shortcuts from the active keymap and the chords for the tasks and subagents panels.
-- **Lighter streaming redraws** — while a response streams, only the row that changed re-renders, reducing flicker and CPU on long transcripts.
+- **Lighter streaming redraws** — while a response streams, only the row that changed re-renders, reducing CPU usage during long responses.
 
 ### Desktop
 
@@ -47,7 +47,7 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **In-editor GitHub sign-in works again** — signing in with GitHub through the editor's account flow had been failing with a server configuration error and silently falling back to browser sign-in; it now completes and issues a standard session, and previously stored sessions migrate automatically on their next refresh.
+- **In-editor GitHub sign-in works again** — signing in with GitHub through the editor's account flow had been failing with a server configuration error and silently falling back to browser sign-in; it now completes again. Long-standing existing sessions may ask you to sign in one more time.
 
 ## [0.38.7] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,52 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.38.8] - 2026-06-10
 
 ### Shared (all surfaces)
 
 #### Bug Fixes
 
 - **Stopping a run is no longer recorded as an error** — interrupting an agent (stop button, Ctrl+C, closing an idle chat) now consistently records the run as _interrupted_ instead of _error_: history shows the right status, the transcript group ends neutral instead of red, orchestrators see a cancelled subagent as cancelled rather than failed, and the CLI exits with the interrupt code (130) instead of the error code (1).
+- **Fix LaTeX compilation works on latexdiff output** — running the LaTeX fixer on a generated `latexdiff` file is no longer blocked. Since `latexdiff` itself often emits non-compiling markup (DIF commands inside math, citations, or macro definitions), the fixer now treats the file as a diff artifact: it repairs broken DIF markup in place while keeping the change annotations, and when an error traces back to the original source it fixes the source too so a regenerated diff stays fixed.
+- **Orchestrators manage their team reliably** — stopping or killing an orchestrator now interrupts the entire delegation chain, including subagents of subagents, instead of leaving them running against a dead parent; a waiting orchestrator now wakes up when a queued subagent finishes instead of stalling until your next message; resuming a subagent that was detached or belongs to another orchestrator now fails fast with the reason instead of silently queueing instructions whose results can never come back; and when a subagent's output diffs cannot be computed, the orchestrator is told so instead of assuming nothing changed.
+- **Goal records are cleaned up with their conversations** — deleting a conversation (or a run from CLI history) now also removes its goal record, so the Goal tab no longer accumulates entries for conversations that no longer exist.
+- **Relay streams survive transient hiccups** — a brief transient error on the included relay no longer cuts off an in-flight response.
+
+#### Improvements
+
+- **Plans are now a single objective document** — a plan states what to achieve, the approach, and a verifiable stopping condition; step-by-step tracking lives solely in the agent's todo list instead of being duplicated in the plan. Updating a plan always asks for your approval again, and Approve & Run seeds the goal with the document verbatim. The `texra.goal.costCapUsd` setting is removed — a goal is driven by its objective, not a budget — and when a goal auto-pauses after an error, the CLI now prints a notice instead of appearing to hang.
 
 ### CLI
+
+#### Features
+
+- **Suspend the chat with Ctrl+Z** — press `Ctrl+Z` to drop back to your shell mid-session and `fg` to return; the terminal is handed back cleanly on suspend and the screen repaints on resume.
+- **Screen-reader support** — with Ink's `INK_SCREEN_READER` environment variable enabled, menus and pickers expose proper option roles with selected and disabled states, the chat input reads as a text box, and decorative glyphs are hidden from the reader.
+
+#### Bug Fixes
+
+- **Terminal always restored on exit** — a crash or unexpected exit can no longer leave your shell stuck in raw mode with a hidden cursor or mouse reporting left on.
+- **Stopping honors the detach setting** — stopping an agent now respects your detach-subagents-on-stop preference instead of always interrupting running subagents.
 
 #### Improvements
 
 - **Honest history statuses** — runs that never reached a terminal state (e.g. the process was killed) now show `unknown` in `texra history` instead of being reported as `completed`, and interrupted chat sessions are checked for a resumable record like unfinished ones.
+- **Calmer transcript layout** — your messages now render as an inset band with a blank line above and below, tool rows sit directly under the prompt that triggered them, stray blank rows at startup and between turns are gone, tool rows are sized to their content, and the status bar compacts gracefully on narrow terminals.
+- **Forgiving slash-command matching** — when nothing starts with what you typed, the palette falls back to substring matches (`/odel` still finds `/model`) and then to the closest typo suggestion (`/hlp` suggests `/help`) instead of going blank; only exact prefix matches run without preview, so a pasted line never triggers a command you didn't see. `/help` now also lists the text-editing shortcuts from the active keymap and the chords for the tasks and subagents panels.
+- **Lighter streaming redraws** — while a response streams, only the row that changed re-renders, reducing flicker and CPU on long transcripts.
+
+### Desktop
+
+#### Improvements
+
+- **Project settings shared with the CLI** — the desktop app now stores project-level settings in the same `.texra/config.json` the CLI uses, so configuring a project once applies to both; existing desktop workspace settings migrate automatically.
+
+### Extension (VS Code)
+
+#### Bug Fixes
+
+- **In-editor GitHub sign-in works again** — signing in with GitHub through the editor's account flow had been failing with a server configuration error and silently falling back to browser sign-in; it now completes and issues a standard session, and previously stored sessions migrate automatically on their next refresh.
 
 ## [0.38.7] - 2026-06-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "texra-workspace",
-  "version": "0.38.7",
+  "version": "0.38.8",
   "private": true,
   "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra-ai/cli",
-  "version": "0.38.7",
+  "version": "0.38.8",
   "description": "TeXRA CLI — AI-powered LaTeX research assistant for the terminal.",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/core",
-  "version": "0.38.7",
+  "version": "0.38.8",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra/desktop",
-  "version": "0.38.7",
+  "version": "0.38.8",
   "description": "TeXRA standalone desktop application",
   "author": "TeXRA.ai <contact@texra.ai>",
   "homepage": "https://texra.ai",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.38.7",
+  "version": "0.38.8",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.105.0"


### PR DESCRIPTION
## Summary

This release bumps the version to 0.38.8 across all workspace packages and updates the CHANGELOG with the release notes for this version, dated 2026-06-10.

The release includes:
- **Shared improvements**: Fixed run interruption status recording, LaTeX diff fixer now handles latexdiff output, orchestrator delegation chain management, goal record cleanup, relay stream resilience, and plans restructured as single objective documents
- **CLI features**: Ctrl+Z suspend support, screen-reader accessibility, terminal restoration on exit, honest history statuses, calmer transcript layout, forgiving slash-command matching, and lighter streaming redraws
- **Desktop improvements**: Project settings now shared with CLI via `.texra/config.json`
- **Extension fix**: GitHub sign-in in-editor flow restored

## Issue acceptance gates

N/A — this is a version bump and changelog update for a completed release cycle.

## Single source of truth

CHANGELOG.md serves as the authoritative record of changes in this release.

## Duplication and abstraction budget

N/A — no code abstractions or duplication changes in this diff.

## Host impact

**Extension:** GitHub sign-in flow restored; no breaking changes.

**Desktop:** Project settings now unified with CLI in `.texra/config.json`; existing workspace settings migrate automatically.

**CLI:** New Ctrl+Z suspend support, screen-reader accessibility, improved terminal handling, and UX refinements.

## Scheduled refactoring

None.

## Validation

Version bumps are mechanical and verified by:
- All package.json files updated consistently (root, cli, core, desktop, extension)
- CHANGELOG.md properly formatted with version tag and date
- CI will verify no build regressions

https://claude.ai/code/session_01EE2CcPhxTgyVuA83s7fwhj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and changelog-only changes with no runtime code modifications in the diff.
> 
> **Overview**
> **Release 0.38.8** — bumps the workspace version from `0.38.7` to `0.38.8` in the root and in `@texra-ai/cli`, `@texra/core`, `@texra/desktop`, and the VS Code extension `texra` package manifests.
> 
> **CHANGELOG** — closes the `[Unreleased]` section by publishing **`[0.38.8] - 2026-06-10`** with user-facing notes for shared fixes (interrupt status, latexdiff fixer, orchestrator delegation, goal cleanup, relay resilience), plan-as-objective changes, CLI features (Ctrl+Z suspend, screen reader), CLI/desktop/extension improvements and fixes documented in the changelog text.
> 
> There is **no application source diff** in this PR; it is versioning plus release documentation for work already landed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a1a673831965c28449bd290f93937a8d6d475b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->