### PR TITLE
Reject non-command-shaped slash inputs as chat messages

### DIFF
--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -171,7 +171,10 @@ export function slashPickIntent(
 /**
  * Parse a `"/cmd remainder"` input into `{ name, remainder }`.
  * Also accepts `\clear` as a compatibility alias.
- * Returns `undefined` if `text` is not a slash command.
+ * Returns `undefined` if `text` is not a slash command — including when the
+ * leading token contains another `/`: command names never do, so input like
+ * `/Users/me/figure.pdf` is a pasted absolute path that must reach the agent
+ * as a chat message instead of dying as "Unknown command".
  */
 export function parseSlashInput(
   text: string,
@@ -183,6 +186,8 @@ export function parseSlashInput(
   }
   const body = text.slice(1);
   const ws = body.search(/\s/);
-  if (ws === -1) return { name: body, remainder: '' };
-  return { name: body.slice(0, ws), remainder: body.slice(ws + 1) };
+  const name = ws === -1 ? body : body.slice(0, ws);
+  if (name.includes('/')) return undefined;
+  if (ws === -1) return { name, remainder: '' };
+  return { name, remainder: body.slice(ws + 1) };
 }

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -171,10 +171,13 @@ export function slashPickIntent(
 /**
  * Parse a `"/cmd remainder"` input into `{ name, remainder }`.
  * Also accepts `\clear` as a compatibility alias.
- * Returns `undefined` if `text` is not a slash command — including when the
- * leading token contains another `/`: command names never do, so input like
- * `/Users/me/figure.pdf` is a pasted absolute path that must reach the agent
- * as a chat message instead of dying as "Unknown command".
+ * Returns `undefined` if `text` is not a slash command. Only command-shaped
+ * tokens qualify: command names are plain identifiers (letters, digits, `_`,
+ * `-`), so a leading token with any other character — `/Users/me/figure.pdf`,
+ * `/notes.txt`, `/3.14` — is a pasted path or message that must reach the
+ * agent instead of dying as "Unknown command". Command-shaped near-misses
+ * (`/hlp`) still parse so the typo suggestion can catch them, and the empty
+ * name (bare `/`) still parses so the palette opens.
  */
 export function parseSlashInput(
   text: string,
@@ -187,7 +190,7 @@ export function parseSlashInput(
   const body = text.slice(1);
   const ws = body.search(/\s/);
   const name = ws === -1 ? body : body.slice(0, ws);
-  if (name.includes('/')) return undefined;
+  if (!/^[\w-]*$/.test(name)) return undefined;
   if (ws === -1) return { name, remainder: '' };
   return { name, remainder: body.slice(ws + 1) };
 }

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -651,4 +651,12 @@ describe('parseSlashInput', () => {
       remainder: ' reasoner',
     });
   });
+
+  it('treats absolute paths as chat messages, not commands', () => {
+    expect(parseSlashInput('/Users/me/poster/mpq_logo.pdf')).toBeUndefined();
+    expect(
+      parseSlashInput('/Users/me/poster/mpq_logo.pdf just use this then'),
+    ).toBeUndefined();
+    expect(parseSlashInput('/tmp/figure.png looks wrong')).toBeUndefined();
+  });
 });

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -652,11 +652,26 @@ describe('parseSlashInput', () => {
     });
   });
 
-  it('treats absolute paths as chat messages, not commands', () => {
+  it('treats non-command-shaped leading tokens as chat messages', () => {
+    // Pasted absolute paths.
     expect(parseSlashInput('/Users/me/poster/mpq_logo.pdf')).toBeUndefined();
     expect(
       parseSlashInput('/Users/me/poster/mpq_logo.pdf just use this then'),
     ).toBeUndefined();
     expect(parseSlashInput('/tmp/figure.png looks wrong')).toBeUndefined();
+    // Single-segment tokens with characters no command name contains.
+    expect(parseSlashInput('/mpq_logo.pdf')).toBeUndefined();
+    expect(parseSlashInput('/3.14 is pi')).toBeUndefined();
+    expect(parseSlashInput('/(a+b)')).toBeUndefined();
+  });
+
+  it('still parses command-shaped near-misses so typo suggestions fire', () => {
+    expect(parseSlashInput('/hlp')).toEqual({ name: 'hlp', remainder: '' });
+    expect(parseSlashInput('/my-cmd_2 arg')).toEqual({
+      name: 'my-cmd_2',
+      remainder: 'arg',
+    });
+    // Bare `/` keeps parsing so the palette opens on an empty query.
+    expect(parseSlashInput('/')).toEqual({ name: '', remainder: '' });
   });
 });


### PR DESCRIPTION
## Summary

Update `parseSlashInput()` to reject slash inputs that don't match command name syntax, treating them as chat messages instead of failed commands. This allows users to paste absolute paths (e.g., `/Users/me/file.pdf`) or other non-command text without triggering "Unknown command" errors.

Command-shaped near-misses (e.g., `/hlp`) and bare `/` still parse to enable typo suggestions and palette opening respectively.

## Issue acceptance gates

N/A — no issue referenced

## Single source of truth

`parseSlashInput()` in `packages/cli/src/chat/tui/commands/slashRegistry.ts` now owns the decision of what constitutes a valid command-shaped token.

## Duplication and abstraction budget

None — this is a focused validation change to an existing function.

## Host impact

**CLI:** Pasted paths and non-command text in slash input no longer error; they fall through to the agent as chat messages.

**Extension:** Same behavior applies to the VS Code extension's slash command parsing.

**Desktop:** Same behavior applies to the Electron desktop client.

## Scheduled refactoring

None

## Validation

Added two test suites in `src/test-kernel/cli/SlashRegistry.vitest.mts`:
- `'treats non-command-shaped leading tokens as chat messages'` — verifies that absolute paths, filenames with special characters, and numeric tokens return `undefined`
- `'still parses command-shaped near-misses so typo suggestions fire'` — verifies that typo-like commands (`/hlp`), commands with underscores and hyphens, and bare `/` still parse

All existing tests pass.

https://claude.ai/code/session_01PMewcGVWSkYMDSEDKZ66K2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to slash-input classification in the CLI TUI with explicit tests; no auth, data, or API surface changes.
> 
> **Overview**
> **`parseSlashInput()`** now treats only **command-shaped** first tokens (letters, digits, `_`, `-`) as slash commands. Inputs like pasted absolute paths (`/Users/me/file.pdf`), dotted filenames, or numeric text return **`undefined`** so they are handled as normal chat instead of **Unknown command**.
> 
> **Unchanged behavior:** typo-shaped tokens such as `/hlp`, names with `_`/`-`, and bare `/` still parse so typo suggestions and the slash palette keep working.
> 
> Tests in **`SlashRegistry.vitest.mts`** cover path-like input and the near-miss / bare-`/` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec33a33985b57cde981ed78b0774057b3b8fffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->