### PR TITLE
Fix CLI transcript user and error band margins

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -167,12 +167,14 @@ function staticTranscriptItemRowCount(
   const cols = Math.max(1, Math.floor(width ?? 80));
   const isUserBand =
     item.entry.role === 'user' && !isInquiryContinuationText(item.entry.text);
-  // Pass cols-2 for user entries: transcriptEntryLines subtracts the
+  const isPaddedPrefixRow =
+    item.entry.role === 'user' || item.entry.role === 'error';
+  // Pass cols-2 for user/error entries: transcriptEntryLines subtracts the
   // 2-char prefix internally, so the effective wrap width is cols-4,
   // matching the paddingX={1} + prefix geometry of the renderer.
   const lines = transcriptEntryLines(
     item.entry,
-    item.entry.role === 'user' ? Math.max(1, cols - 2) : cols,
+    isPaddedPrefixRow ? Math.max(1, cols - 2) : cols,
   ).length;
   let marginRows = 0;
   if (isUserBand) {

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -165,13 +165,14 @@ function staticTranscriptItemRowCount(
   // Compact budgeting can over-count tool rows because the transcript viewer
   // keeps full tool output while the static scrollback renderer elides it.
   const cols = Math.max(1, Math.floor(width ?? 80));
-  const isUser = item.entry.role === 'user';
-  const isUserBand = isUser && !isInquiryContinuationText(item.entry.text);
-  // User rows render inside a 1-col padded box, so their text wraps two
-  // columns narrower than the flush rows the viewer renderer assumes.
+  const isUserBand =
+    item.entry.role === 'user' && !isInquiryContinuationText(item.entry.text);
+  // Pass cols-2 for user entries: transcriptEntryLines subtracts the
+  // 2-char prefix internally, so the effective wrap width is cols-4,
+  // matching the paddingX={1} + prefix geometry of the renderer.
   const lines = transcriptEntryLines(
     item.entry,
-    isUser ? Math.max(1, cols - 2) : cols,
+    item.entry.role === 'user' ? Math.max(1, cols - 2) : cols,
   ).length;
   let marginRows = 0;
   if (isUserBand) {

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -60,17 +60,11 @@ export function estimateTranscriptEntryRows(
       );
     });
   }
-  if (entry.role === 'user') {
-    // User rows — band and inquiry continuation alike — render inside a
-    // padded box plus the `› ` prefix, so long text wraps to `width - 4`
-    // (the same geometry as error rows). The static band's margins are not
-    // budgeted here: the live pane paints user rows through the margin-less
-    // bounded renderer.
-    return estimateWrappedRows(entry.text, Math.max(1, width - 4));
-  }
-  if (entry.role === 'error') {
-    // Error rows render inside a padded box plus the `! ` prefix, so long text
-    // wraps to `width - 4`.
+  if (entry.role === 'user' || entry.role === 'error') {
+    // Both roles render inside a paddingX={1} box plus a 2-col prefix
+    // (`› ` / `! `), so text wraps to `width - 4`. The static band's margins
+    // are not budgeted here: the live pane paints these rows through the
+    // margin-less bounded renderer.
     return estimateWrappedRows(entry.text, Math.max(1, width - 4));
   }
 

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -17,10 +17,7 @@
       "Education",
       "Data Science"
     ],
-    "activationEvents": [
-      "onStartupFinished",
-      "onColorTheme"
-    ],
+    "activationEvents": ["onStartupFinished", "onColorTheme"],
     "main": "./dist/extension.js",
     "capabilities": {
       "untrustedWorkspaces": {
@@ -601,10 +598,7 @@
               "type": "array"
             },
             "texra.files.included.editedExtensions": {
-              "default": [
-                ".txt",
-                ".tex"
-              ],
+              "default": [".txt", ".tex"],
               "description": "File extensions to include when searching for edited files",
               "editPresentation": "multilineText",
               "items": {
@@ -614,11 +608,7 @@
               "type": "array"
             },
             "texra.files.included.inputExtensions": {
-              "default": [
-                ".txt",
-                ".tex",
-                ".md"
-              ],
+              "default": [".txt", ".tex", ".md"],
               "description": "File extensions to include when searching for input files",
               "editPresentation": "multilineText",
               "items": {
@@ -846,10 +836,7 @@
             "texra.latexdiff.tempFileLocation": {
               "default": "sameDirectory",
               "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
-              "enum": [
-                "sameDirectory",
-                "workspaceTemp"
-              ],
+              "enum": ["sameDirectory", "workspaceTemp"],
               "enumDescriptions": [
                 "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
                 "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
@@ -1367,9 +1354,7 @@
           "id": "texra.gettingStarted",
           "steps": [
             {
-              "completionEvents": [
-                "onCommand:texra.runSetupAssistant"
-              ],
+              "completionEvents": ["onCommand:texra.runSetupAssistant"],
               "description": "Start here. TeXRA's setup assistant agent checks your environment, installs any missing LaTeX tools, adds an API key or signs you in, and verifies that you're ready to go. It asks before every command and explains what it's doing.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The remaining steps walk you through the same checklist manually.",
               "id": "texra.gettingStarted.setupAssistant",
               "media": {
@@ -1378,9 +1363,7 @@
               "title": "Run the setup assistant agent"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.createSampleProject"
-              ],
+              "completionEvents": ["onCommand:texra.createSampleProject"],
               "description": "Not sure where to start? We've bundled a small LaTeX project you can play with.\n\n[Create the sample project](command:texra.createSampleProject)\n\nYou'll get a folder with example `.tex` files and a README that explains the layout.",
               "id": "texra.gettingStarted.sampleWorkspace",
               "media": {
@@ -1389,9 +1372,7 @@
               "title": "Try the sample project"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.setApiKey"
-              ],
+              "completionEvents": ["onCommand:texra.setApiKey"],
               "description": "You'll need an API key from a provider like Anthropic, OpenAI, or Google. Just one is enough.\n\n[Set API key](command:texra.setApiKey)\n\nHeads up: chat subscriptions (ChatGPT Plus, Claude Pro) don't come with API access. You need a separate key from the provider's developer platform.\n\n**No API key?** No problem -- sign in with the Researcher Access Program in the next step instead.",
               "id": "texra.gettingStarted.apiKeys",
               "media": {
@@ -1401,9 +1382,7 @@
               "title": "Add your API key"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.auth.signIn"
-              ],
+              "completionEvents": ["onCommand:texra.auth.signIn"],
               "description": "The **Researcher Access Program** lets you use AI models and remote agents for free -- no API key needed.\n\n[Sign In](command:texra.auth.signIn)\n\nAlready set an API key? You can skip this, but signing in still unlocks extra agents you can't get with a key alone.",
               "id": "texra.gettingStarted.signIn",
               "media": {
@@ -1413,9 +1392,7 @@
               "title": "Or just sign in"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.showMainView"
-              ],
+              "completionEvents": ["onCommand:texra.showMainView"],
               "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Context** -- bib/style files, reference papers, or any read-only context (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
               "id": "texra.gettingStarted.stageFiles",
               "media": {
@@ -1434,9 +1411,7 @@
               "title": "Use the orchestrator"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.showMultiAgent"
-              ],
+              "completionEvents": ["onCommand:texra.showMultiAgent"],
               "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- open problems, proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Pick a team](command:texra.showMultiAgent) — opens the Multi-Agent tab. Click a card to apply it.",
               "id": "texra.gettingStarted.multiAgent",
               "media": {
@@ -1459,9 +1434,7 @@
               "title": "Auto-extract figures (optional)"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.execute"
-              ],
+              "completionEvents": ["onCommand:texra.execute"],
               "description": "You're all set. Click Execute and the orchestrator will start working through your paper.\n\n[Execute](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
               "id": "texra.gettingStarted.progress",
               "media": {

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -17,7 +17,10 @@
       "Education",
       "Data Science"
     ],
-    "activationEvents": ["onStartupFinished", "onColorTheme"],
+    "activationEvents": [
+      "onStartupFinished",
+      "onColorTheme"
+    ],
     "main": "./dist/extension.js",
     "capabilities": {
       "untrustedWorkspaces": {
@@ -598,7 +601,10 @@
               "type": "array"
             },
             "texra.files.included.editedExtensions": {
-              "default": [".txt", ".tex"],
+              "default": [
+                ".txt",
+                ".tex"
+              ],
               "description": "File extensions to include when searching for edited files",
               "editPresentation": "multilineText",
               "items": {
@@ -608,7 +614,11 @@
               "type": "array"
             },
             "texra.files.included.inputExtensions": {
-              "default": [".txt", ".tex", ".md"],
+              "default": [
+                ".txt",
+                ".tex",
+                ".md"
+              ],
               "description": "File extensions to include when searching for input files",
               "editPresentation": "multilineText",
               "items": {
@@ -836,7 +846,10 @@
             "texra.latexdiff.tempFileLocation": {
               "default": "sameDirectory",
               "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
-              "enum": ["sameDirectory", "workspaceTemp"],
+              "enum": [
+                "sameDirectory",
+                "workspaceTemp"
+              ],
               "enumDescriptions": [
                 "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
                 "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
@@ -1354,7 +1367,9 @@
           "id": "texra.gettingStarted",
           "steps": [
             {
-              "completionEvents": ["onCommand:texra.runSetupAssistant"],
+              "completionEvents": [
+                "onCommand:texra.runSetupAssistant"
+              ],
               "description": "Start here. TeXRA's setup assistant agent checks your environment, installs any missing LaTeX tools, adds an API key or signs you in, and verifies that you're ready to go. It asks before every command and explains what it's doing.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The remaining steps walk you through the same checklist manually.",
               "id": "texra.gettingStarted.setupAssistant",
               "media": {
@@ -1363,7 +1378,9 @@
               "title": "Run the setup assistant agent"
             },
             {
-              "completionEvents": ["onCommand:texra.createSampleProject"],
+              "completionEvents": [
+                "onCommand:texra.createSampleProject"
+              ],
               "description": "Not sure where to start? We've bundled a small LaTeX project you can play with.\n\n[Create the sample project](command:texra.createSampleProject)\n\nYou'll get a folder with example `.tex` files and a README that explains the layout.",
               "id": "texra.gettingStarted.sampleWorkspace",
               "media": {
@@ -1372,7 +1389,9 @@
               "title": "Try the sample project"
             },
             {
-              "completionEvents": ["onCommand:texra.setApiKey"],
+              "completionEvents": [
+                "onCommand:texra.setApiKey"
+              ],
               "description": "You'll need an API key from a provider like Anthropic, OpenAI, or Google. Just one is enough.\n\n[Set API key](command:texra.setApiKey)\n\nHeads up: chat subscriptions (ChatGPT Plus, Claude Pro) don't come with API access. You need a separate key from the provider's developer platform.\n\n**No API key?** No problem -- sign in with the Researcher Access Program in the next step instead.",
               "id": "texra.gettingStarted.apiKeys",
               "media": {
@@ -1382,7 +1401,9 @@
               "title": "Add your API key"
             },
             {
-              "completionEvents": ["onCommand:texra.auth.signIn"],
+              "completionEvents": [
+                "onCommand:texra.auth.signIn"
+              ],
               "description": "The **Researcher Access Program** lets you use AI models and remote agents for free -- no API key needed.\n\n[Sign In](command:texra.auth.signIn)\n\nAlready set an API key? You can skip this, but signing in still unlocks extra agents you can't get with a key alone.",
               "id": "texra.gettingStarted.signIn",
               "media": {
@@ -1392,7 +1413,9 @@
               "title": "Or just sign in"
             },
             {
-              "completionEvents": ["onCommand:texra.showMainView"],
+              "completionEvents": [
+                "onCommand:texra.showMainView"
+              ],
               "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Context** -- bib/style files, reference papers, or any read-only context (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
               "id": "texra.gettingStarted.stageFiles",
               "media": {
@@ -1411,8 +1434,10 @@
               "title": "Use the orchestrator"
             },
             {
-              "completionEvents": ["onCommand:texra.showMultiAgent"],
-              "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Pick a team](command:texra.showMultiAgent) — opens the Multi-Agent tab. Click a card to apply it.",
+              "completionEvents": [
+                "onCommand:texra.showMultiAgent"
+              ],
+              "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- open problems, proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Pick a team](command:texra.showMultiAgent) — opens the Multi-Agent tab. Click a card to apply it.",
               "id": "texra.gettingStarted.multiAgent",
               "media": {
                 "altText": "Screenshot of multi-agent team selection",
@@ -1434,7 +1459,9 @@
               "title": "Auto-extract figures (optional)"
             },
             {
-              "completionEvents": ["onCommand:texra.execute"],
+              "completionEvents": [
+                "onCommand:texra.execute"
+              ],
               "description": "You're all set. Click Execute and the orchestrator will start working through your paper.\n\n[Execute](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
               "id": "texra.gettingStarted.progress",
               "media": {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -640,6 +640,42 @@ describe('CLI conversation transcript splitting', () => {
     ).toEqual(['session-header', 'u1']);
   });
 
+  it('budgets static error rows at the padded wrap width', () => {
+    const error = entry('e1', 'error', 'x'.repeat(77), true);
+    const compact = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: [],
+      streams: streamsFromEntries(STREAM_ID, [error]),
+      meta: SESSION_META,
+      maxRows: 0,
+      width: 80,
+    });
+
+    expect(compact.map((item) => item.id)).toEqual(['e1']);
+    // 77 chars wraps to two rows at the padded width (80 - 4 = 76);
+    // the full header needs 4 more.
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: STREAM_ID,
+        currentItems: compact,
+        streams: streamsFromEntries(STREAM_ID, [error]),
+        meta: SESSION_META,
+        maxRows: 5,
+        width: 80,
+      }).map((item) => item.id),
+    ).toEqual(['e1']);
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: STREAM_ID,
+        currentItems: compact,
+        streams: streamsFromEntries(STREAM_ID, [error]),
+        meta: SESSION_META,
+        maxRows: 6,
+        width: 80,
+      }).map((item) => item.id),
+    ).toEqual(['session-header', 'e1']);
+  });
+
   it('does not budget band margins for inquiry continuations in the static budget', () => {
     const continuation = entry(
       'u1',

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -449,15 +449,20 @@ describe('CLI conversation transcript splitting', () => {
     ).toEqual(['› what is this repo about', '● Bash (ls)']);
   });
 
-  it('does not budget regular user margin for inquiry continuations', () => {
+  it('wraps live user rows at the padded width with no margin rows', () => {
     const continuation = entry(
       'u1',
       'user',
       '[inquiry] ei_123 answered.\nQ: Can this be simplified?\nA: Yes.',
       true,
     );
-
     expect(estimateTranscriptEntryRows(continuation, 80)).toBe(3);
+
+    // 77 chars exceeds the padded wrap width (80 - 4 = 76) by one, so the
+    // row estimate must reflect the gutter + prefix geometry, not the
+    // terminal width.
+    const long = entry('u2', 'user', 'x'.repeat(77), true);
+    expect(estimateTranscriptEntryRows(long, 80)).toBe(2);
   });
 
   it('appends only finalized entries to terminal scrollback items', () => {
@@ -597,6 +602,82 @@ describe('CLI conversation transcript splitting', () => {
         width: 80,
       }).map((item) => item.id),
     ).toEqual(['session-header', 'p1']);
+  });
+
+  it('budgets user band margins before inserting compact static headers', () => {
+    const band = entry('u1', 'user', 'short prompt', true);
+    const compact = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: [],
+      streams: streamsFromEntries(STREAM_ID, [band]),
+      meta: SESSION_META,
+      maxRows: 0,
+      width: 80,
+    });
+
+    expect(compact.map((item) => item.id)).toEqual(['u1']);
+    // One text row plus the band's top and bottom margin rows = 3; the full
+    // header needs 4 more.
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: STREAM_ID,
+        currentItems: compact,
+        streams: streamsFromEntries(STREAM_ID, [band]),
+        meta: SESSION_META,
+        maxRows: 6,
+        width: 80,
+      }).map((item) => item.id),
+    ).toEqual(['u1']);
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: STREAM_ID,
+        currentItems: compact,
+        streams: streamsFromEntries(STREAM_ID, [band]),
+        meta: SESSION_META,
+        maxRows: 7,
+        width: 80,
+      }).map((item) => item.id),
+    ).toEqual(['session-header', 'u1']);
+  });
+
+  it('does not budget band margins for inquiry continuations in the static budget', () => {
+    const continuation = entry(
+      'u1',
+      'user',
+      '[inquiry] ei_123 answered.',
+      true,
+    );
+    const compact = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: [],
+      streams: streamsFromEntries(STREAM_ID, [continuation]),
+      meta: SESSION_META,
+      maxRows: 0,
+      width: 80,
+    });
+
+    expect(compact.map((item) => item.id)).toEqual(['u1']);
+    // One text row and no margin rows; the full header needs 4 more.
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: STREAM_ID,
+        currentItems: compact,
+        streams: streamsFromEntries(STREAM_ID, [continuation]),
+        meta: SESSION_META,
+        maxRows: 4,
+        width: 80,
+      }).map((item) => item.id),
+    ).toEqual(['u1']);
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: STREAM_ID,
+        currentItems: compact,
+        streams: streamsFromEntries(STREAM_ID, [continuation]),
+        meta: SESSION_META,
+        maxRows: 5,
+        width: 80,
+      }).map((item) => item.id),
+    ).toEqual(['session-header', 'u1']);
   });
 
   it('preserves static transcript order when an entry exceeds the compact row budget', () => {

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -84,7 +84,7 @@ async function waitFor(
 }
 
 describe('Static band resize', () => {
-  it('reflows the full-width user band to the new width on resize', async () => {
+  it('reflows the user band to the new width on resize', async () => {
     // Dynamic import so FORCE_COLOR is set first and the patched workspace Ink
     // (not a hoisted copy) is loaded.
     const ink = (await import(cliRequire.resolve('ink'))) as any;


### PR DESCRIPTION
## Summary

Fixes CLI transcript spacing and row budgeting for padded user and error rows. User prompts keep the intended vertical breathing room in static scrollback, and long error rows now use the same padded wrap width as the renderer.

The change also collapses duplicate user/error viewport row-estimation paths so the same width rule owns the wrap calculation. The extension package invariant snapshot is synced because CI requires the generated package metadata snapshot to match current repository metadata.

## Issue acceptance gates

- Regular user turns get top and bottom band margin rows in static scrollback.
- Inquiry continuation rows keep the chevron gutter alignment but do not add the extra static band margins.
- User and error text wrapping is estimated with the padded-band width instead of full terminal width.
- Live viewport estimates use the bounded live renderer geometry and do not include static-only margin rows.
- Extension package invariant snapshot is in sync.

## Single source of truth

- Static transcript row counts: `staticTranscriptItemRowCount()` in `packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx`
- Live viewport estimates: `estimateTranscriptEntryRows()` in `packages/cli/src/chat/tui/panes/transcriptViewport.ts`
- Extension package invariant snapshot: `scripts/extension-package-invariants.snapshot.json`

## Duplication and abstraction budget

The PR removes duplicate user/error viewport branches and keeps layout-specific row math in the transcript viewport/static transcript modules. No new pass-through layer is added.

## Host impact

Extension: generated invariant snapshot only.

Desktop: none.

CLI: visual-only TUI spacing and scrollback budgeting changes for user/error transcript rows.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/StaticBandResize.vitest.mts`
- `npm run check:extension-package-invariants`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI layout and scrollback budgeting only; behavior is covered by new vitest cases with no auth, data, or extension runtime changes beyond a generated snapshot string.
> 
> **Overview**
> Aligns **CLI transcript row budgeting** with how padded **user** and **error** rows actually render, so compact static scrollback and live viewport math stop under- or over-counting lines.
> 
> **Static scrollback** (`staticTranscriptItemRowCount`): user/error line counts now use the same padded wrap geometry as the renderer (`cols - 2` into `transcriptEntryLines` → effective `width - 4`). Regular user prompts still get top/bottom band margin rows in the static budget; **inquiry continuations** keep the chevron gutter but do not add those extra margins.
> 
> **Live viewport** (`estimateTranscriptEntryRows`): user and error share one branch that wraps at `width - 4` and does not include static-only band margins. Tests cover long user/error wrapping, user band margins vs. compact session headers, and inquiry continuation static budgeting.
> 
> Also updates the extension package invariant snapshot (Mathematician walkthrough copy) and a minor static-band resize test title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6d79b6a9fc5b9ad7adf19f1dc6038653a772cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->