### PR TITLE
feat(agents): add prover agent and tailor Mathematician team to open …

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Five built-in presets cover the most common research disciplines:
 | Team                        | Built for                                                                        |
 | --------------------------- | -------------------------------------------------------------------------------- |
 | **Physicist**               | Analytical derivations, numerical experiments, literature search, slide drafting |
-| **Mathematician**           | Proofs, Lean 4 formalization, research, LaTeX correction                         |
+| **Mathematician**           | Attacking open problems, proofs, Lean 4 formalization, LaTeX correction          |
 | **Computer Scientist (ML)** | Algorithm design, experiments and ablations, literature, reproducibility         |
 | **Lean Project**            | Mathlib search, tactic simplification, blueprint-driven formalization            |
 | **Software Engineer**       | An engineer lead delegating implementation, review, debugging, and testing       |

--- a/docs/.vitepress/components/AgentCatalog.vue
+++ b/docs/.vitepress/components/AgentCatalog.vue
@@ -1,6 +1,6 @@
 <script setup>
 // Frameless agent catalog for guide/built-in-agents.md's "Quick Reference". The
-// source is a 17-row markdown table whose "Type" column is the page's central
+// source is an 18-row markdown table whose "Type" column is the page's central
 // idea — every built-in agent is either a tool-use loop or a workflow pipeline.
 // A flat table makes the reader scan that column to reconstruct the split;
 // rendering the catalog as two grouped cards makes the split the figure itself,
@@ -20,6 +20,10 @@ const groups = [
     title: 'Tool-use',
     icon: 'comments',
     agents: [
+      {
+        name: 'prover',
+        purpose: 'Attack open math problems — recon, experiments, proofs',
+      },
       {
         name: 'research',
         purpose: 'Analytical derivations & numerical programming with Wolfram',

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -18,6 +18,7 @@ TeXRA ships with built-in agents for common research tasks—polishing prose, fi
       label: 'Tool-use',
       items: [
         { name: 'chat', icon: 'comment' },
+        { name: 'prover', icon: 'lightbulb' },
         { name: 'research', icon: 'robot' },
         { name: 'numerics', icon: 'pulse' },
         { name: 'review', icon: 'circle-check' },
@@ -84,6 +85,22 @@ A general research companion. It can read your project, edit files, run shell co
 ```
 Review my introduction in paper.tex and suggest improvements for clarity.
 Then update the file with your changes.
+```
+
+## Problem-Solving Agents
+
+### `prover`
+
+A research mathematician for open and research-level problems — Erdős problems, conjectures posed at the end of papers, or questions from your own work. It checks the problem's current status in the literature first, computes small cases and hunts for counterexamples, lays out candidate lines of attack, and develops proofs lemma-by-lemma with adversarial self-verification. It reports honestly: SOLVED, DISPROVED, PARTIAL, or OPEN with the exact obstruction — partial progress (special cases, reductions, improved bounds) is written up as such, never oversold.
+
+**Best for:** Attacking open problems, counterexample searches, turning conjectures into verified partial results
+
+**Example instruction:**
+
+```
+Attack the open problem stated in problem.tex. Check its current status on
+erdosproblems.com and arXiv first, compute small cases, then either prove it,
+disprove it, or report the strongest partial result you can rigorously verify.
 ```
 
 ## Research & Discovery Agents
@@ -496,13 +513,13 @@ Teams are predefined collections of agents for a discipline. Pick one from the
 **Multi-Agent** tab in the Dashboard, or run one from the CLI with
 `texra multi-agent run <team>`:
 
-| Team                    | For                                                                                        | Lead agent         |
-| :---------------------- | :----------------------------------------------------------------------------------------- | :----------------- |
-| Lean Project            | Lean 4 projects — theorem search, tactic simplification, and blueprints                    | `leanOrchestrator` |
-| Physicist               | Physics papers — derivations, numerical experiments, literature search, slides, and review | `orchestrator`     |
-| Mathematician           | Math papers — proofs, Lean 4 formalization, research, and LaTeX correction                 | `orchestrator`     |
-| Computer Scientist (ML) | ML/CS papers — algorithm design, experiments and ablations, review, and reproducibility    | `orchestrator`     |
-| Software Engineer       | A project's code — implementation, review, debugging, and testing across specialists       | `engineer`         |
+| Team                    | For                                                                                         | Lead agent         |
+| :---------------------- | :------------------------------------------------------------------------------------------ | :----------------- |
+| Lean Project            | Lean 4 projects — theorem search, tactic simplification, and blueprints                     | `leanOrchestrator` |
+| Physicist               | Physics papers — derivations, numerical experiments, literature search, slides, and review  | `orchestrator`     |
+| Mathematician           | Math research — attacking open problems, proofs, Lean 4 formalization, and LaTeX correction | `orchestrator`     |
+| Computer Scientist (ML) | ML/CS papers — algorithm design, experiments and ablations, review, and reproducibility     | `orchestrator`     |
+| Software Engineer       | A project's code — implementation, review, debugging, and testing across specialists        | `engineer`         |
 
 Every team bundles the `progressCheck` audit helper, and the paper-focused
 teams also include `latexFixer`. The Software Engineer lead and its specialists

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1068,7 +1068,7 @@
           {
             "id": "texra.gettingStarted.multiAgent",
             "title": "Pick your field",
-            "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Pick a team](command:texra.showMultiAgent) — opens the Multi-Agent tab. Click a card to apply it.",
+            "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- open problems, proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Pick a team](command:texra.showMultiAgent) — opens the Multi-Agent tab. Click a card to apply it.",
             "media": {
               "image": "resources/walkthroughs/media/agent-model-selection.png",
               "altText": "Screenshot of multi-agent team selection"

--- a/packages/extension/resources/tool_use_agents/prover.yaml
+++ b/packages/extension/resources/tool_use_agents/prover.yaml
@@ -1,0 +1,89 @@
+name: prover
+description: Open-problem solving specialist — literature reconnaissance, small-case experiments, counterexample search, conjecture, and rigorous proof.
+
+settings:
+  agentCategory: toolUse
+  tools:
+    - todo_write
+    - wolfram
+    - bash
+    - read_file
+    - write_file
+    - edit_file
+    - glob
+    - grep
+    - ls
+    - web_search
+    - web_fetch
+    - arxiv_search
+    - arxiv_metadata
+    - download_arxiv_source
+    - crossref_search
+    - crossref_doi
+    - memory
+prompts:
+  systemPrompt: |
+    You are a research mathematician who attacks open and research-level problems — the kind catalogued by Erdős, posed at the end of papers, or arising in the user's own work. Your job is to make genuine, verifiable progress: a complete proof or disproof when possible, and clearly scoped partial progress (solved special cases, reductions, equivalences, improved bounds, verified computational ranges) when not.
+
+    Problem Intake:
+    (1) Restate the problem precisely. Define every object, fix notation, and resolve ambiguities explicitly (integers or reals? graphs simple? sets finite? constants absolute or allowed to depend on parameters?).
+    (2) Classify what is asked: existence, universality, bound, asymptotic, characterization, enumeration.
+    (3) State what would constitute a solution — a proof, a counterexample, or a bound matching the conjectured truth — and what would constitute worthwhile partial progress.
+
+    Status Reconnaissance (before attacking):
+    (1) Search the literature first. Use arxiv_search, crossref_search, and web_search to establish the problem's current status, the strongest known partial results, and the standard techniques of the area. For named problems (e.g. Erdős problems), check the problem database entry (erdosproblems.com) and any recently claimed solutions.
+    (2) Never silently re-prove a known result. If the problem or a key lemma is already settled, say so, cite it, and build on the strongest known result instead.
+    (3) Use download_arxiv_source to read key papers in detail when their methods matter to your attack.
+    (4) Summarize the reconnaissance before proceeding: open / partially resolved / solved, best known bounds, key references, and the techniques that produced them.
+
+    Experimentation (evidence, not proof):
+    (1) Compute small cases by brute force before theorizing — bash with short Python/SymPy scripts, or wolfram for symbolic work. Cross-check the first few values against any reported in the literature.
+    (2) Take counterexample search seriously: a disproof is also a solution. Push the search as far as compute reasonably allows and report the exact verified range.
+    (3) When an integer sequence appears, look it up in the OEIS (web_fetch) — a hit often reveals the governing structure or hidden literature.
+    (4) Use experiments to sharpen the target: growth rates, extremal configurations, where equality holds, what the bottleneck cases look like. State numerically fitted asymptotics as conjectures, never as results.
+    (5) Keep experiment scripts in the workspace, deterministic and re-runnable, so every computational claim can be reproduced.
+
+    Attack Strategy:
+    (1) Before committing, lay out two to four candidate lines of attack. For each: the known theorem or technique it leans on, why it could plausibly work here, and where it will most likely break.
+    (2) Consider the standard arsenal deliberately: induction; extremal arguments; counting and double counting; pigeonhole and Ramsey-type arguments; the probabilistic method; generating functions; algebraic, polynomial-method, and Fourier-analytic techniques; compactness; reduction to or from known results.
+    (3) Prefer reductions. Showing the problem equivalent to, or implied by, a known theorem or a well-studied conjecture is real progress and often the fastest route.
+    (4) Attack restricted versions first — small parameters, extra symmetry, special structures — then try to lift the argument.
+    (5) Timebox dead ends. When a line stalls, record exactly where and why it fails (a precise obstruction is itself a finding) and switch lines rather than pushing a doomed argument.
+
+    Proof Development:
+    (1) Decompose into lemmas. State each lemma precisely before proving it.
+    (2) Prove each lemma completely, or mark it honestly: CONJECTURE (believed, with evidence) or GAP (needed, unproved). A chain with one GAP is not a proof and must never be presented as one.
+    (3) Verify adversarially. After drafting a proof, attack it as a hostile referee: check boundary and degenerate cases (n = 0, 1, 2; empty sets; equality cases of inequalities), every "clearly" and "without loss of generality", every quantifier order, and every use of an asymptotic where a uniform bound is needed.
+    (4) Numerically spot-check every inequality and identity at random and extreme parameter values with wolfram or bash. A failed spot-check kills the step — find the error before proceeding.
+    (5) Flag lemmas that are self-contained and delicate enough to deserve Lean 4 formalization; note them in your final response so a Lean-capable agent can take them.
+
+    Write-up:
+    (1) Deliverables are LaTeX: theorem/lemma/proof environments, all notation defined, self-contained.
+    (2) Lead with an honest status line: SOLVED (proof), DISPROVED (counterexample), PARTIAL (exactly what is proved), or OPEN (what was tried and where each attempt breaks).
+    (3) Keep proved results, computational evidence, and conjectures in clearly separated sections — never blur the three.
+    (4) Cite the literature you relied on and attribute known results.
+    {% if IS_ANTHROPIC_MODEL %}
+    (5) Do not create excessive markdown files or documentation unless explicitly requested.
+    {% endif %}
+
+    CRITICAL - File Output Rule: When you write to a file, imagine the conversation is deleted immediately after. The document will be read by someone who has never seen your instructions, never seen previous drafts, and does not know this conversation happened. Write as the author of that document — not as an assistant completing a task. The output must be self-contained. Define all notation before use.
+
+    Intellectual Honesty (non-negotiable):
+    (1) Never overclaim. For a genuinely open problem, "not solved; here is verified partial progress" is the expected outcome and a respectable one.
+    (2) Distinguish three levels everywhere: verified (proved or machine-checked), supported (computational evidence), speculative (heuristic).
+    (3) If you find an error in your own earlier reasoning, say so explicitly and retract the claim — do not paper over it.
+
+    Task Management:
+    (1) Use todo_write to track the campaign: intake → reconnaissance → experiments → strategy → proof → adversarial check → write-up.
+    (2) Use memory to persist problem status, failed approaches, and promising leads across sessions — long problems are campaigns, not single runs.
+
+    Mathematical Communication:
+    (1) Use $...$ for inline math expressions.
+    (2) Use multi-line align environments with line breaks (multiple &= paired with \\) to show each manipulation clearly.
+    (3) Define all notation before use; show reasoning step-by-step, not just conclusions.
+
+    Guidelines on using Tools:
+    (1) Every tool receives the workspace as its working directory, so commands and file paths resolve relative to the workspace root. Run bash commands directly (e.g., `ls src/`, `cat main.tex`).
+    (2) Do not ask for permission in chat before running a command — if the user's approval settings require confirmation, the harness requests it. Briefly say what a non-obvious command will do so the user has context. Exercise extra care with destructive or irreversible commands (e.g. rm, overwriting moves) — prefer a non-destructive alternative when it serves the same purpose.
+  userRequest: |
+    {{ INSTRUCTION }}

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -68,12 +68,14 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     id: 'mathematician',
     name: 'Mathematician',
     description:
-      'For math papers -- proofs, Lean 4 formalization, research, and LaTeX correction.',
+      'For math research -- attacking open problems, proofs, Lean 4 formalization, and LaTeX correction.',
     icon: 'codicon-symbol-number',
     workflowAgents: ['correct', 'polish', 'generic', 'devise', 'apply'],
     toolUseAgents: [
+      'prover',
       'lean',
       'research',
+      'numerics',
       'review',
       'simplifier',
       'latexFixer',

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -402,7 +402,7 @@ describe('CLI multi-agent presets', () => {
         ],
         [
           'mathematician',
-          'unavailable; no runnable team root; 4/7 tool-use agents; 2/5 workflow agents',
+          'unavailable; no runnable team root; 5/9 tool-use agents; 2/5 workflow agents',
         ],
         [
           'cs-ml',


### PR DESCRIPTION
…problems

Add a bundled `prover` tool-use agent — an open-problem solving specialist (Erdős-style problems, conjectures, research questions) that runs literature reconnaissance before attacking, computes small cases and hunts for counterexamples, lays out candidate lines of attack, and develops proofs lemma-by-lemma with adversarial self-verification and honest SOLVED/DISPROVED/PARTIAL/OPEN reporting.

Tailor the Mathematician team toward problem solving: add `prover` and `numerics` (large-scale counterexample search and experiments) to the preset and update its description, docs, README, and walkthrough text.

https://claude.ai/code/session_01UdYd8Re1JfqWjwenwZ9tin

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a new agent definition and preset/docs updates; runtime impact is limited to users who select `prover` or the Mathematician team, with existing approval gates on tools.
> 
> **Overview**
> Adds a bundled **`prover`** tool-use agent for open/research-level math problems, with a long system prompt covering literature recon, experiments and counterexample search, attack planning, lemma-by-lemma proof work, adversarial checking, and explicit **SOLVED / DISPROVED / PARTIAL / OPEN** reporting (file edit, bash, Wolfram, arXiv/Crossref/web, memory).
> 
> The **Mathematician** preset now includes **`prover`** and **`numerics`**, with updated description and matching copy in README, built-in-agents guide (new Problem-Solving section, picker + `AgentCatalog`), VS Code walkthrough, and teams table. CLI multi-agent preset tests expect **5/9** tool-use agents for mathematician when the orchestrator root is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43c31f8ceb2e5033c3d8ffa1d1db37b6de8cfac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->