### PR TITLE
Update CS team roster in launcher PRD

### DIFF
--- a/docs/prd/launcher-and-onboarding.md
+++ b/docs/prd/launcher-and-onboarding.md
@@ -803,13 +803,15 @@ removed, not what stays.
 │ │ Lean 4 formalization     │ │ CS research workflow. │            │
 │ │ workflow.                │ │                          │            │
 │ │ Lead: 🎯 leanOrchestrator│ │ Lead: 🎯 orchestrator    │            │
-│ │ Specialists: lean,       │ │ Specialists: numerics,   │            │
-│ │  leanSearch, leanBlue-   │ │  search, review, present │            │
-│ │  print, leanSimplifier,  │ │  simplifier, latexFixer, │            │
-│ │  latexFixer, progress-   │ │  progressCheck           │            │
-│ │  Check                   │ │ Workflows: criticize,    │            │
-│ │ Workflows: (none)        │ │  generic, devise, apply, │            │
-│ │  [Use]  [Duplicate]      │ │  polish                  │            │
+│ │ Specialists: lean,       │ │ Specialists: research,   │            │
+│ │  leanSearch, leanBlue-   │ │  numerics, coder,        │            │
+│ │  print, leanSimplifier,  │ │  testEngineer, search,   │            │
+│ │  latexFixer, progress-   │ │  review, presenter,      │            │
+│ │  Check                   │ │  simplifier, latexFixer, │            │
+│ │ Workflows: (none)        │ │  progressCheck           │            │
+│ │  [Use]  [Duplicate]      │ │ Workflows: criticize,    │            │
+│ │                          │ │  generic, devise, apply, │            │
+│ │                          │ │  polish                  │            │
 │ │                          │ │  [Use]  [Duplicate]      │            │
 │ └──────────────────────────┘ └──────────────────────────┘            │
 │                                                                      │
@@ -1410,7 +1412,7 @@ Shipped as `builtIn: true` records in code, not in workspace state:
 | `mathematician` | Mathematician      | 🎓   | `orchestrator`     | `chat`, `research`, `review`, `lean`, `simplifier`, `latexFixer`, `progressCheck`                    | `correct`, `polish`, `merge`, `devise`, `apply`     |
 | `physicist`     | Physicist          | ⚛    | `orchestrator`     | `research`, `numerics`, `review`, `search`, `presenter`, `simplifier`, `latexFixer`, `progressCheck` | `criticize`, `generic`, `devise`, `apply`           |
 | `lean-project`  | Lean Project       | ⚙    | `leanOrchestrator` | `lean`, `leanSearch`, `leanBlueprint`, `leanSimplifier`, `latexFixer`, `progressCheck`               | (none)                                              |
-| `cs-ml`         | Computer Scientist | 💻   | `orchestrator`     | `numerics`, `search`, `review`, `presenter`, `simplifier`, `latexFixer`, `progressCheck`             | `criticize`, `generic`, `devise`, `apply`, `polish` |
+| `cs-ml`         | Computer Scientist | 💻   | `orchestrator`     | `research`, `numerics`, `coder`, `testEngineer`, `search`, `review`, `presenter`, `simplifier`, `latexFixer`, `progressCheck` | `criticize`, `generic`, `devise`, `apply`, `polish` |
 | `onboarding`    | Onboarding         | 🛠   | `setup`            | `latexFixer`                                                                                         | (none)                                              |
 
 Each id is stable across upgrades; renaming a built-in team requires a

--- a/docs/prd/launcher-and-onboarding.md
+++ b/docs/prd/launcher-and-onboarding.md
@@ -1407,13 +1407,13 @@ launcher render path.
 
 Shipped as `builtIn: true` records in code, not in workspace state:
 
-| id              | name               | icon | lead               | specialists                                                                                          | workflows                                           |
-| --------------- | ------------------ | ---- | ------------------ | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `mathematician` | Mathematician      | 🎓   | `orchestrator`     | `chat`, `research`, `review`, `lean`, `simplifier`, `latexFixer`, `progressCheck`                    | `correct`, `polish`, `merge`, `devise`, `apply`     |
-| `physicist`     | Physicist          | ⚛    | `orchestrator`     | `research`, `numerics`, `review`, `search`, `presenter`, `simplifier`, `latexFixer`, `progressCheck` | `criticize`, `generic`, `devise`, `apply`           |
-| `lean-project`  | Lean Project       | ⚙    | `leanOrchestrator` | `lean`, `leanSearch`, `leanBlueprint`, `leanSimplifier`, `latexFixer`, `progressCheck`               | (none)                                              |
+| id              | name               | icon | lead               | specialists                                                                                                                   | workflows                                           |
+| --------------- | ------------------ | ---- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `mathematician` | Mathematician      | 🎓   | `orchestrator`     | `chat`, `research`, `review`, `lean`, `simplifier`, `latexFixer`, `progressCheck`                                             | `correct`, `polish`, `merge`, `devise`, `apply`     |
+| `physicist`     | Physicist          | ⚛    | `orchestrator`     | `research`, `numerics`, `review`, `search`, `presenter`, `simplifier`, `latexFixer`, `progressCheck`                          | `criticize`, `generic`, `devise`, `apply`           |
+| `lean-project`  | Lean Project       | ⚙    | `leanOrchestrator` | `lean`, `leanSearch`, `leanBlueprint`, `leanSimplifier`, `latexFixer`, `progressCheck`                                        | (none)                                              |
 | `cs-ml`         | Computer Scientist | 💻   | `orchestrator`     | `research`, `numerics`, `coder`, `testEngineer`, `search`, `review`, `presenter`, `simplifier`, `latexFixer`, `progressCheck` | `criticize`, `generic`, `devise`, `apply`, `polish` |
-| `onboarding`    | Onboarding         | 🛠   | `setup`            | `latexFixer`                                                                                         | (none)                                              |
+| `onboarding`    | Onboarding         | 🛠   | `setup`            | `latexFixer`                                                                                                                  | (none)                                              |
 
 Each id is stable across upgrades; renaming a built-in team requires a
 migration entry that maps the old id to the new one.


### PR DESCRIPTION
## Summary

- Updates the launcher PRD ASCII team card for `cs-ml` to include `research`, `coder`, and `testEngineer`.
- Updates the `cs-ml` reference table specialists list to match `src/shared/schemas/agentPresets.ts`.

Fixes #5810.

## Validation

```bash
rg -n '(`numerics`, `search`, `review`, `presenter`, `simplifier`, `latexFixer`, `progressCheck`|Specialists: numerics)' docs/prd/launcher-and-onboarding.md || true
git diff --check
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> PRD documentation only; no application code or preset behavior changes.
> 
> **Overview**
> Aligns the **Computer Scientist** (`cs-ml`) built-in team in `docs/prd/launcher-and-onboarding.md` with `src/shared/schemas/agentPresets.ts`.
> 
> The PRD **ASCII team card** and **built-in teams table** now list specialists as `research`, `numerics`, `coder`, `testEngineer`, `search`, `review`, `presenter`, `simplifier`, `latexFixer`, and `progressCheck` (adding **`research`**, **`coder`**, and **`testEngineer`** and dropping the outdated roster). Workflows for `cs-ml` are unchanged.
> 
> Documentation-only; no runtime or schema changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d598539aa2626e994fe28e80c28d8e9dff31105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->