### PR TITLE
Add Claude Fable 5 model support to agent configuration

### DIFF
--- a/docs/guide/agent-integrations.md
+++ b/docs/guide/agent-integrations.md
@@ -74,7 +74,7 @@ delivery. The new prompt joins that Codex session as the next turn.
 
 | Setting              | Options                                                                                            | Default             | What it controls                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------- |
-| **Model**            | `Sonnet 4.6`, `Opus 4.8`, `Haiku 4.5`                                                              | `Sonnet 4.6`        | Which Claude model the delegated agent runs on. Agents may override per call. |
+| **Model**            | `Sonnet 4.6`, `Fable 5`, `Opus 4.8`, `Haiku 4.5`                                                   | `Sonnet 4.6`        | Which Claude model the delegated agent runs on. Agents may override per call. |
 | **Permission mode**  | `Prompt for risky actions`, `Auto-accept edits`, `Bypass all (dangerous)`, `Plan only (read-only)` | `Auto-accept edits` | How much the Claude Code child process may do before stopping to ask.         |
 | **Reasoning effort** | `Low`, `Medium`, `High`, `Extra high`, `Maximum`                                                   | `High`              | How deeply Claude deliberates before acting.                                  |
 

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -69,6 +69,7 @@ const CLAUDE_MODEL_OPTIONS: readonly {
   label: string;
 }[] = [
   { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+  { value: 'claude-fable-5', label: 'Fable 5' },
   { value: 'claude-opus-4-8', label: 'Opus 4.8' },
   { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ] as const;

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -311,6 +311,7 @@ export type CodexApprovalPolicy = z.infer<typeof CodexApprovalPolicySchema>;
  * string, but the dropdown is fixed to the canonical Anthropic families. */
 export const ClaudeAgentModelSchema = z.enum([
   'claude-sonnet-4-6',
+  'claude-fable-5',
   'claude-opus-4-8',
   'claude-haiku-4-5-20251001',
 ]);

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -103,7 +103,7 @@ const ClaudeAgentInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe(
-      "Claude model to use (e.g. 'claude-sonnet-4-6', 'claude-opus-4-8'). Defaults to user-configured model.",
+      "Claude model to use (e.g. 'claude-sonnet-4-6', 'claude-fable-5', 'claude-opus-4-8'). Defaults to user-configured model.",
     ),
   effort: z
     .enum(CLAUDE_AGENT_EFFORT_LEVELS)

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -55,22 +55,28 @@ export const CLAUDE_AGENT_EFFORT_LEVELS = [
 /** Canonical Claude model IDs surfaced by the settings dropdown.
  * The SDK accepts arbitrary model strings; this list is what we expose in the
  * UI. Keep it in sync with `ClaudeAgentModelSchema` in settingsViewMessages.ts.
- * Sonnet and Opus use the alias form; Haiku 4.5 ships with a dated snapshot
- * suffix (its only published identifier at time of writing). */
+ * Sonnet, Fable, and Opus use the alias form; Haiku 4.5 ships with a dated
+ * snapshot suffix (its only published identifier at time of writing). */
 export const CLAUDE_AGENT_MODELS = [
   'claude-sonnet-4-6',
+  'claude-fable-5',
   'claude-opus-4-8',
   'claude-haiku-4-5-20251001',
 ] as const;
 export type ClaudeAgentModel = (typeof CLAUDE_AGENT_MODELS)[number];
 
 /**
- * Adaptive thinking is only supported on Opus 4.6+ and Sonnet 4.6+. Haiku
+ * Adaptive thinking is only supported on Fable 5, Opus 4.6+, and Sonnet 4.6+
+ * (on Fable thinking is always on; an explicit `adaptive` is accepted). Haiku
  * (and any earlier model) rejects the `thinking: { type: 'adaptive' }`
  * option — gate the SDK option on this predicate to keep Haiku usable.
  */
 export function modelSupportsAdaptiveThinking(model: string): boolean {
-  return model.startsWith('claude-opus-') || model.startsWith('claude-sonnet-');
+  return (
+    model.startsWith('claude-opus-') ||
+    model.startsWith('claude-sonnet-') ||
+    model.startsWith('claude-fable-')
+  );
 }
 
 const SUMMARY_MAX_LENGTH = 60;


### PR DESCRIPTION
## Summary

Adds support for Claude Fable 5 (`claude-fable-5`) as a selectable model option across the agent system. Fable 5 is added to the canonical model list, UI dropdowns, schema definitions, and adaptive thinking support predicate. Documentation is updated to reflect the new model option.

## Issue acceptance gates

No issue referenced. This is a straightforward feature addition to support a new Claude model variant.

## Single source of truth

`CLAUDE_AGENT_MODELS` in `src/tools/claudeAgentShared.ts` is the canonical list of supported Claude models. All other references (UI options, schema definitions, documentation) are kept in sync with this list.

## Duplication and abstraction budget

No new abstractions added. The change maintains existing patterns:
- Model string added to `CLAUDE_AGENT_MODELS` constant
- Corresponding schema enum updated in `ClaudeAgentModelSchema`
- UI dropdown option added in `CLAUDE_MODEL_OPTIONS`
- Predicate function `modelSupportsAdaptiveThinking()` extended to include Fable

## Host impact

**Extension:** Fable 5 now appears as a selectable model in the AI Agents settings tab and agent configuration dialogs.

**Desktop:** No direct impact; inherits model support from shared configuration.

**CLI:** Fable 5 can be specified via `--model claude-fable-5` in agent invocations.

## Scheduled refactoring

None.

## Validation

- Zod schema updated to include new model variant
- Adaptive thinking predicate extended to recognize Fable models
- Documentation updated to list Fable 5 alongside existing models
- No breaking changes; existing code paths unaffected
- CI type checking will verify schema consistency across all files

https://claude.ai/code/session_01FSa1PSMLi9HE4zCrmhDpRT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model enum and UI option with a small predicate change; no auth, persistence migration, or breaking API changes.
> 
> **Overview**
> Adds **Claude Fable 5** (`claude-fable-5`) as a first-class Claude Code delegated-agent model alongside Sonnet, Opus, and Haiku.
> 
> The canonical `CLAUDE_AGENT_MODELS` list, Zod `ClaudeAgentModelSchema`, and **AI Agents** settings model dropdown are updated so users can pick Fable 5 as the default delegated model. The `claude_code` tool docs mention the new ID in examples.
> 
> **Adaptive thinking** gating now treats `claude-fable-*` like Sonnet/Opus, so Fable runs get `thinking: { type: 'adaptive' }` when the SDK session is built (Haiku stays excluded). Agent integration docs list **Fable 5** in the Claude Code model table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ced8c358b7247a16a50e77393f664f9b5a0caeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->