### PR TITLE
Honor detach setting when killing executions

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1146,15 +1146,16 @@ export async function runChat(
     chatTuiCanInterruptActiveRun(session);
   const canStopActiveRun = (): boolean =>
     chatTuiCanStopVisibleRun(session, rootStreamStatus());
+  const shouldDetachSubagentsOnStop = (): boolean =>
+    tryPlatform()?.workspaceState.get<boolean>(
+      WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+      false,
+    ) === true;
   const interruptActive = (): void => {
     clearApprovals();
     if (!session.streamId) return;
     executionRegistry.stopAgentStream(session.streamId, {
-      detachActiveChildren:
-        tryPlatform()?.workspaceState.get<boolean>(
-          WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
-          false,
-        ) === true,
+      detachActiveChildren: shouldDetachSubagentsOnStop(),
       runtimeHost: session.runtimeHost,
     });
   };
@@ -1609,7 +1610,9 @@ export async function runChat(
       onSuspend={() => handleSigtstp()}
       onKillExecution={(executionId) => {
         clearApprovals();
-        executionRegistry.kill(executionId);
+        executionRegistry.kill(executionId, {
+          detachActiveChildren: shouldDetachSubagentsOnStop(),
+        });
       }}
       history={inputHistory}
     />,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -49,6 +49,10 @@ export interface StopAgentStreamOptions {
   readonly runtimeHost?: AgentRuntimeHost;
 }
 
+export interface KillExecutionOptions {
+  readonly detachActiveChildren?: boolean;
+}
+
 export interface TrackAgentExecutionOptions {
   readonly status?: StreamStatus;
 }
@@ -355,11 +359,22 @@ export class ExecutionRegistry {
   }
 
   /** Terminate an execution via its handle. Returns true on success. */
-  kill(executionId: string): boolean {
+  kill(executionId: string, options: KillExecutionOptions = {}): boolean {
     const handle = this.handles.get(executionId);
     if (!handle) return false;
-    const result = this.terminate(handle, new Set(), {
-      cascadeChildren: true,
+    const visited = new Set<string>();
+    if (
+      options.detachActiveChildren === true &&
+      handle instanceof AgentExecutionHandle
+    ) {
+      this.detachActiveChildren(
+        handle.childStreamId,
+        handle.runtimeHost,
+        visited,
+      );
+    }
+    const result = this.terminate(handle, visited, {
+      cascadeChildren: options.detachActiveChildren !== true,
     });
     // Always notify waiters — even if terminate() returned false (e.g. PID not
     // yet assigned), callers blocking on this execution should be unblocked.

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -168,6 +168,70 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('detaches descendants when killing with detached subagents', () => {
+    const explicit = createRecordingHost();
+    const interrupts = new InterruptRegistry();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const rootStreamId = 'root-detach-kill-test' as StreamTabId;
+    const childStreamId = 'child-detach-kill-test' as StreamTabId;
+    const grandchildStreamId = 'grandchild-detach-kill-test' as StreamTabId;
+    const childInterrupt = vi.fn();
+    const grandchildInterrupt = vi.fn();
+
+    try {
+      interrupts.register(childStreamId, { interrupt: childInterrupt });
+      interrupts.register(grandchildStreamId, {
+        interrupt: grandchildInterrupt,
+      });
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-child-detach-kill-test',
+          rootStreamId,
+          childStreamId,
+          'test-subagent',
+          'toolUse',
+          explicit.host,
+        ),
+      );
+      registry.track(
+        new AgentExecutionHandle(
+          'exec-grandchild-detach-kill-test',
+          childStreamId,
+          grandchildStreamId,
+          'test-grandchild',
+          'toolUse',
+          explicit.host,
+        ),
+      );
+
+      expect(
+        registry.kill('exec-child-detach-kill-test', {
+          detachActiveChildren: true,
+        }),
+      ).toBe(true);
+
+      expect(childInterrupt).toHaveBeenCalledOnce();
+      expect(grandchildInterrupt).not.toHaveBeenCalled();
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(grandchildStreamId)).toBeUndefined();
+      expect(
+        registry.getAgentHandleByStream(grandchildStreamId)?.parentStreamId,
+      ).toBe(grandchildStreamId);
+      expect(explicit.events).toContainEqual({
+        event: 'setParentStream',
+        payload: {
+          childStreamId: grandchildStreamId,
+          parentStreamId: null,
+        },
+      });
+    } finally {
+      registry.dispose();
+      interrupts.unregister(childStreamId);
+      interrupts.unregister(grandchildStreamId);
+    }
+  });
+
   it('detaches children when stopping a stream with detached subagents', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -575,7 +575,12 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       };
     }
 
-    const success = executionRegistry.kill(executionId);
+    const success = executionRegistry.kill(executionId, {
+      detachActiveChildren: platform().workspaceState.get<boolean>(
+        WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+        false,
+      ),
+    });
     if (success) {
       return { output: `Execution ${executionId} terminated.` };
     }


### PR DESCRIPTION
## Summary

- Extends `ExecutionRegistry.kill()` with the same `detachActiveChildren` policy already owned by `stopAgentStream()`.
- Wires CLI foreground execution kills and the `executions` tool kill action to the existing `texra.detachSubagentsOnStop` workspace preference.
- Keeps the default behavior unchanged: execution kills still cascade unless the detach preference is enabled.

Fixes #5793.

## Design

No new setting or parallel cascade resolver. The registry remains the owner of termination policy; callers only pass the existing workspace preference.

## Validation

```bash
vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
tsc --noEmit -p tsconfig.json
npm run lint -- --quiet
git diff --check
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-agent termination when detach is enabled (children may survive kills), but mirrors existing stop policy; default cascade behavior is unchanged.
> 
> **Overview**
> **Execution kills** now honor the same **`DETACH_SUBAGENTS_ON_STOP`** workspace preference as stream stop, instead of always cascading into descendant subagents.
> 
> `ExecutionRegistry.kill()` accepts optional **`detachActiveChildren`**: when enabled it detaches direct children (grandchildren keep running and are promoted), then stops only the targeted execution; when disabled, behavior stays **cascade kill** as before.
> 
> The chat TUI shares a **`shouldDetachSubagentsOnStop()`** helper for **interrupt/stop** and **foreground execution kill**; the **`executions`** tool **kill** action reads the same preference. A registry test covers detach-on-kill semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6539165164e993edbef1d7fb93e3655f0545f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->