### PR TITLE
docs: add Homebrew install instructions for the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ code --install-extension texra-ai.texra
 
 # Terminal — requires Node.js >=22.9.0
 npm install -g @texra-ai/cli
+
+# Or via Homebrew (macOS / Linux)
+brew install texra-ai/tap/texra
 ```
 
 Sign in with GitHub or Google for hosted access (no key management

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -49,6 +49,12 @@ Node.js >=22.9.0):
 npm install -g @texra-ai/cli
 ```
 
+Or with [Homebrew](https://github.com/texra-ai/homebrew-tap) on macOS and Linux:
+
+```bash
+brew install texra-ai/tap/texra
+```
+
 See [TeXRA CLI](./texra-cli.md) for usage, shell completion, and workspace defaults.
 
 ### From VSIX File

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -89,10 +89,10 @@ Run `texra doctor` to see what TeXRA found — the LaTeX toolchain, runtime and 
 
 <p class="hero-caption"><code>texra doctor</code> groups its findings: the full LaTeX toolchain and runtime/auth are verified up front, while the optional image tools and Wolfram are checked on demand the first time a feature needs them.</p>
 
-### Homebrew (macOS only) {#homebrew}
+### Homebrew {#homebrew}
 
 ::: info WHAT IS HOMEBREW?
-[Homebrew](https://brew.sh/) is a free package manager for macOS that makes it easy to install command-line tools and applications from the terminal. Many of the macOS instructions below use `brew install` commands, which require Homebrew to be installed first.
+[Homebrew](https://brew.sh/) is a free package manager for macOS and Linux that makes it easy to install command-line tools and applications from the terminal. Many of the macOS instructions below use `brew install` commands, which require Homebrew to be installed first.
 :::
 
 If you're on macOS and don't have Homebrew yet, open the **Terminal** app (found in Applications → Utilities) and paste this command:

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -157,7 +157,8 @@ For details on how LaTeX diff works, see the [LaTeX Diff guide](./latex-diff.md)
 ## From the CLI
 
 The same agents are one command away from the terminal. After
-`npm install -g @texra-ai/cli` (Node.js >=22.9.0):
+`npm install -g @texra-ai/cli` (Node.js >=22.9.0) or
+`brew install texra-ai/tap/texra`:
 
 ```bash
 # Sign in for included hosted access, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in your shell:

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -10,12 +10,19 @@ import ConfigPrecedenceStack from '../.vitepress/components/ConfigPrecedenceStac
 The TeXRA CLI provides a local `texra` command for running TeXRA agents from a
 terminal. It is published to npm as [`@texra-ai/cli`](https://www.npmjs.com/package/@texra-ai/cli).
 
-## Install From npm
+## Install
 
-Install the CLI globally (requires Node.js >=22.9.0):
+Install the CLI globally from npm (requires Node.js >=22.9.0):
 
 ```bash
 npm install -g @texra-ai/cli
+```
+
+Or with [Homebrew](https://github.com/texra-ai/homebrew-tap) on macOS and
+Linux, which installs Node.js for you if needed:
+
+```bash
+brew install texra-ai/tap/texra
 ```
 
 Verify the command:


### PR DESCRIPTION
The CLI is now installable via the new Homebrew tap ([texra-ai/homebrew-tap](https://github.com/texra-ai/homebrew-tap)):

```bash
brew install texra-ai/tap/texra
```

This adds the Homebrew option alongside the existing npm instructions in:

- `docs/guide/texra-cli.md` (install section, retitled **Install From npm** → **Install**)
- `docs/guide/installation.md` (CLI section)
- `docs/guide/quick-start.md` (From the CLI section)
- `README.md` (root readme — also published as the npm package readme via `copy-docs.mjs`)

The tap formula installs `@texra-ai/cli` from the npm registry (Homebrew brings its own Node), and a daily workflow in the tap repo keeps the formula synced to the latest npm release. Verified locally: `brew install texra-ai/tap/texra` → `texra --version` reports 0.38.7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime, packaging, or authentication code changes.
> 
> **Overview**
> Documents **Homebrew** as an alternative way to install the `texra` CLI alongside the existing **npm** global install.
> 
> The new command `brew install texra-ai/tap/texra` is added in the root **README**, **installation**, **quick-start**, and **texra-cli** guides, with links to the **texra-ai/homebrew-tap** repo. The CLI doc’s install heading is broadened from npm-only to a general **Install** section, and the Homebrew dependency section is retitled from macOS-only to **macOS and Linux** in copy that still walks through macOS Homebrew setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60b055f054141d095b8525497e479302116c464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->