### PR TITLE
Rebrand TeXRA from "LaTeX research assistant" to "AI theorist"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ For `/review` or any code review on this repo, load [.claude/skills/code-review/
 
 ## Project Overview
 
-TeXRA is a VS Code extension that serves as an AI-powered LaTeX research assistant. It uses Large Language Models to help academics with writing, research, and document processing.
+TeXRA is a VS Code extension that serves as an AI theorist. It uses Large Language Models to help academics with writing, research, and document processing.
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![npm version](https://img.shields.io/npm/v/@texra-ai/cli?label=%40texra-ai%2Fcli)](https://www.npmjs.com/package/@texra-ai/cli)
 [![CLI downloads](https://img.shields.io/npm/dm/@texra-ai/cli?label=CLI%20downloads)](https://www.npmjs.com/package/@texra-ai/cli)
 
-A LaTeX research assistant for VS Code and the terminal. Multi-agent
+An AI theorist for VS Code and the terminal. Multi-agent
 workflows for writing, reviewing, formalizing, and rendering academic
 work — with every change returned as a diff you approve.
 

--- a/docs/blog/launch-blog-post.md
+++ b/docs/blog/launch-blog-post.md
@@ -1,4 +1,4 @@
-# Launching TeXRA: The AI Theorist That Understands LaTeX
+# Launching TeXRA: Your 24/7 AI Theorist
 
 **TL;DR**: We built specialized AI agents that live in VS Code and understand research workflows. TeXRA handles the LaTeX grunt work—notation fixes, TikZ compilation, parallel drafts, paper-to-slides conversion—while you stay in control.
 

--- a/docs/blog/launch-blog-post.md
+++ b/docs/blog/launch-blog-post.md
@@ -1,4 +1,4 @@
-# Launching TeXRA: The AI Research Assistant That Understands LaTeX
+# Launching TeXRA: The AI Theorist That Understands LaTeX
 
 **TL;DR**: We built specialized AI agents that live in VS Code and understand research workflows. TeXRA handles the LaTeX grunt work—notation fixes, TikZ compilation, parallel drafts, paper-to-slides conversion—while you stay in control.
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,6 +1,6 @@
 # TeXRA
 
-A LaTeX research assistant for VS Code and the terminal. Multi-agent
+An AI theorist for VS Code and the terminal. Multi-agent
 workflows for writing, reviewing, formalizing, and rendering academic
 work — with every change returned as a diff you approve.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -6,7 +6,7 @@ import ToolPathSearchOrder from '../.vitepress/components/ToolPathSearchOrder.vu
 
 # Troubleshooting
 
-Even the best research assistants (human or AI) have off days. This guide helps you diagnose and resolve common issues you might encounter when using TeXRA. We've organized troubleshooting tips by category to help you quickly find solutions to specific problems.
+Even the best theorists (human or AI) have off days. This guide helps you diagnose and resolve common issues you might encounter when using TeXRA. We've organized troubleshooting tips by category to help you quickly find solutions to specific problems.
 
 ::: tip CLI users
 Most steps below describe the VS Code extension, but the underlying causes

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "TeXRA Team",
   "license": "MIT",
-  "description": "Documentation for TeXRA - AI-powered academic research assistant",
+  "description": "Documentation for TeXRA - an AI theorist for VS Code and the terminal",
   "devDependencies": {
     "@awesome.me/webawesome": "^3.6.0",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@texra-ai/cli",
   "version": "0.38.8",
-  "description": "TeXRA CLI — AI-powered LaTeX research assistant for the terminal.",
+  "description": "TeXRA CLI — your AI theorist in the terminal.",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",
   "homepage": "https://texra.ai",

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -71,7 +71,7 @@ export const rootCommand = withUsageSections(
     // (see `readCliVersion` in cliContext.ts).
     meta: async () => ({
       name: 'texra',
-      description: 'TeXRA CLI — AI LaTeX research assistant',
+      description: 'TeXRA CLI — your AI theorist in the terminal',
       version: await readCliVersion(),
     }),
     // Global flags are duplicated here so citty's `findSubCommandIndex` knows

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "texra",
   "displayName": "TeXRA",
-  "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
+  "description": "TeXRA: Your 24/7 AI Theorist.",
   "version": "0.38.8",
   "publisher": "texra-ai",
   "engines": {

--- a/packages/extension/src/frontend/ui/welcomeView.ts
+++ b/packages/extension/src/frontend/ui/welcomeView.ts
@@ -61,7 +61,7 @@ function renderWelcomeHtml(): string {
 </head>
 <body>
   <p>
-    <strong>Welcome to TeXRA</strong> — an AI research assistant for LaTeX. It
+    <strong>Welcome to TeXRA</strong> — an AI theorist for your LaTeX work. It
     coordinates specialized agents to edit manuscripts, derive results, draw
     figures, and verify proofs.
   </p>

--- a/packages/extension/src/frontend/ui/welcomeView.ts
+++ b/packages/extension/src/frontend/ui/welcomeView.ts
@@ -61,9 +61,9 @@ function renderWelcomeHtml(): string {
 </head>
 <body>
   <p>
-    <strong>Welcome to TeXRA</strong> — an AI theorist for your LaTeX work. It
-    coordinates specialized agents to edit manuscripts, derive results, draw
-    figures, and verify proofs.
+    <strong>Welcome to TeXRA</strong> — an AI theorist. It coordinates
+    specialized agents to edit manuscripts, derive results, draw figures,
+    and verify proofs.
   </p>
   <p><strong>To get started:</strong></p>
   <ol>

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -2,7 +2,7 @@
   "manifest": {
     "name": "texra",
     "displayName": "TeXRA",
-    "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
+    "description": "TeXRA: Your 24/7 AI Theorist.",
     "publisher": "texra-ai",
     "engines": {
       "vscode": "^1.105.0"

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -38,7 +38,7 @@ export function cleanSessionDescription(text: string): string {
   return truncateWithEllipsis(cleaned, MAX_DESCRIPTION_LENGTH);
 }
 
-const SYSTEM_PROMPT = `You generate very short session labels for a LaTeX research assistant tool. Given an agent name, its description, and the user's instruction, write a single short phrase (max ~10 words, no trailing period) that captures what the session aims to accomplish. Be specific but terse — no full sentences, no meta-commentary, no quotes. Use present-tense verb phrases (e.g. "Reviewing introduction for clarity", "Fixing TikZ arrow alignment").`;
+const SYSTEM_PROMPT = `You generate very short session labels for an AI theorist tool that works on LaTeX and academic research. Given an agent name, its description, and the user's instruction, write a single short phrase (max ~10 words, no trailing period) that captures what the session aims to accomplish. Be specific but terse — no full sentences, no meta-commentary, no quotes. Use present-tense verb phrases (e.g. "Reviewing introduction for clarity", "Fixing TikZ arrow alignment").`;
 
 /**
  * Build a user prompt for session description generation.

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -38,7 +38,7 @@ export function cleanSessionDescription(text: string): string {
   return truncateWithEllipsis(cleaned, MAX_DESCRIPTION_LENGTH);
 }
 
-const SYSTEM_PROMPT = `You generate very short session labels for an AI theorist tool that works on LaTeX and academic research. Given an agent name, its description, and the user's instruction, write a single short phrase (max ~10 words, no trailing period) that captures what the session aims to accomplish. Be specific but terse — no full sentences, no meta-commentary, no quotes. Use present-tense verb phrases (e.g. "Reviewing introduction for clarity", "Fixing TikZ arrow alignment").`;
+const SYSTEM_PROMPT = `You generate very short session labels for an AI theorist tool. Given an agent name, its description, and the user's instruction, write a single short phrase (max ~10 words, no trailing period) that captures what the session aims to accomplish. Be specific but terse — no full sentences, no meta-commentary, no quotes. Use present-tense verb phrases (e.g. "Reviewing introduction for clarity", "Fixing TikZ arrow alignment").`;
 
 /**
  * Build a user prompt for session description generation.


### PR DESCRIPTION
## Summary

Updates TeXRA's product messaging across all user-facing documentation, package metadata, and system prompts to rebrand from "AI-powered LaTeX research assistant" to "AI theorist." This reflects a broader positioning of the tool as a general academic research assistant rather than one narrowly focused on LaTeX.

## Issue acceptance gates

No issue referenced. This is a messaging/branding update.

## Single source of truth

Product descriptions are now consistently positioned as "AI theorist" across:
- Extension manifest (`packages/extension/package.json`)
- CLI package metadata (`packages/cli/package.json`)
- Documentation (`docs/guide/index.md`, `docs/blog/launch-blog-post.md`, `docs/package.json`)
- Welcome UI (`packages/extension/src/frontend/ui/welcomeView.ts`)
- System prompts (`src/agent/runtime/sessionDescription.ts`)
- Project documentation (`CLAUDE.md`, `README.md`)

## Duplication and abstraction budget

No new abstractions added. This is a straightforward text replacement across configuration and documentation files to maintain consistent messaging.

## Host impact

**Extension:** Updated welcome view and package description to reflect new branding.

**Desktop:** No changes (inherits extension messaging).

**CLI:** Updated package description and command metadata to reflect new branding.

## Scheduled refactoring

None.

## Validation

- All changes are documentation and metadata updates with no functional code changes
- Package manifests and snapshot files updated consistently
- System prompt updated to reflect new positioning while maintaining functional intent

https://claude.ai/code/session_0171k7BomVzrpC4pK8tGDUd5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and metadata-only changes with no functional logic; the only runtime-adjacent change is wording in the session-description LLM prompt.
> 
> **Overview**
> Repositions TeXRA from a **LaTeX-focused research assistant** to an **AI theorist** across user-visible copy only—no runtime or API behavior changes.
> 
> **Messaging surfaces updated:** `README.md`, `CLAUDE.md`, docs (`docs/guide/index.md`, `docs/guide/troubleshooting.md`, launch blog title), extension marketplace description (`packages/extension/package.json` + `scripts/extension-package-invariants.snapshot.json`), CLI npm description and root `--help` text (`packages/cli/package.json`, `packages/cli/src/commands/root.ts`), docs site `package.json`, and the no-workspace **welcome webview** in `welcomeView.ts`.
> 
> **Product behavior touch:** `sessionDescription.ts` system prompt now tells the helper model the product is an “AI theorist tool” so auto-generated session labels match the new positioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dfcc5d4929ae3e96519cfdb07a2e1e061c72dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->