### PR TITLE
Replace title attributes with wa-tooltip components

### DIFF
--- a/docs/.vitepress/theme/webAwesomeIcons.js
+++ b/docs/.vitepress/theme/webAwesomeIcons.js
@@ -97,6 +97,7 @@ import { faPencil } from '@fortawesome/free-solid-svg-icons/faPencil';
 import { faPictureInPicture } from '@fortawesome/free-solid-svg-icons/faPictureInPicture';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { faPlusMinus } from '@fortawesome/free-solid-svg-icons/faPlusMinus';
 import { faReply } from '@fortawesome/free-solid-svg-icons/faReply';
 import { faRightFromBracket } from '@fortawesome/free-solid-svg-icons/faRightFromBracket';
 import { faRightToBracket } from '@fortawesome/free-solid-svg-icons/faRightToBracket';
@@ -226,6 +227,7 @@ const icons = {
   'picture-in-picture': faPictureInPicture,
   play: faPlay,
   plus: faPlus,
+  'plus-minus': faPlusMinus,
   reply: faReply,
   'right-from-bracket': faRightFromBracket,
   'right-to-bracket': faRightToBracket,
@@ -285,8 +287,8 @@ const CODICON_ALIASES = {
   'device-camera-video': 'video',
   diff: 'code-compare',
   'diff-added': 'plus',
-  'diff-multiple': 'code-compare',
-  'diff-single': 'code-compare',
+  'diff-multiple': 'plus-minus',
+  'diff-single': 'plus-minus',
   discard: 'arrow-rotate-left',
   edit: 'pencil',
   error: 'circle-exclamation',

--- a/docs/guide/latex-diff.md
+++ b/docs/guide/latex-diff.md
@@ -107,7 +107,7 @@ TeXRA runs the same five-stage pipeline shown above — only this route uses the
 
 ### Step 3: Manage Diff Outputs
 
-After generating a Git-based diff using the "latexdiff-vc" button, you can manage the resulting files from the Commit section's **Pack** (<wa-icon library="texra" name="archive"></wa-icon>) and **Clean** (<wa-icon library="texra" name="trash"></wa-icon>) buttons. Pack archives the diff files; Clean removes them.
+After generating a Git-based diff using the **Diff** button beneath the Commit dropdown, you can manage the resulting files from the Commit section's **Pack** (<wa-icon library="texra" name="archive"></wa-icon>) and **Clean** (<wa-icon library="texra" name="trash"></wa-icon>) buttons. Pack archives the diff files; Clean removes them.
 
 Each diff route writes its own predictably-named artifacts alongside the source pair — `latexdiff` produces `_diff.tex`, `latexdiff-vc` appends the commit hash (`_diff_rev<hash>.tex`), and between-round runs use `_diff_rN-rM.tex` — and every `.tex` compiles to a matching `.pdf`. Pack and Clean act on this whole set:
 

--- a/docs/guide/latex-diff.md
+++ b/docs/guide/latex-diff.md
@@ -66,7 +66,7 @@ The "Current" button (<wa-icon library="texra" name="file-code"></wa-icon>) allo
 
 ### Step 2: Generate the Diff
 
-Click the "latexdiff" button with the <wa-icon library="texra" name="diff-single"></wa-icon> icon. TeXRA then runs the same five-stage pipeline for every diff route — only the tool and output name change:
+Click the **Diff** button (<wa-icon library="texra" name="diff-single"></wa-icon>) beneath the Edited dropdown. TeXRA then runs the same five-stage pipeline for every diff route — only the tool and output name change:
 
 <FlowSteps :steps="[
   { n: 1, icon: 'diff-single', title: 'Run latexdiff', desc: 'Invokes the latexdiff tool on your selected base and edited files.' },
@@ -101,7 +101,7 @@ The commit dropdown shows recent commits. Click the refresh icon (<wa-icon libra
 
 ### Step 2: Generate the Diff
 
-Click the "latexdiff-vc" button (<wa-icon library="texra" name="diff-single"></wa-icon> icon) to compare your file with its version at the selected commit.
+Click the **Diff** button (<wa-icon library="texra" name="diff-single"></wa-icon>) beneath the Commit dropdown to compare your file with its version at the selected commit.
 
 TeXRA runs the same five-stage pipeline shown above — only this route uses the `latexdiff-vc` tool and names its output with the commit hash (e.g., `original_diff_rev[commit_hash].tex`).
 

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -183,7 +183,8 @@ export class StreamHeader extends LitElement {
       }
 
       /* Status indicator overrides - base styles from statusIndicatorStyles.
-         The hover label is a native <wa-tooltip> wrapping this dot. */
+         The hover label is a native <wa-tooltip> anchored to this dot via
+         its "for" attribute. */
       .status-indicator {
         width: var(--wa-space-xs);
         height: var(--wa-space-xs);
@@ -311,14 +312,15 @@ export class StreamHeader extends LitElement {
                 ${this.stream.label || this.stream.name}
               </span>
             </div>
-            <wa-tooltip content=${statusLabel}>
-              <span
-                id=${ELEMENT_IDS.STATUS_INDICATOR}
-                class=${classMap({
-                  'status-indicator': true,
-                  [`is-${status}`]: Boolean(status),
-                })}
-              ></span>
+            <span
+              id=${ELEMENT_IDS.STATUS_INDICATOR}
+              class=${classMap({
+                'status-indicator': true,
+                [`is-${status}`]: Boolean(status),
+              })}
+            ></span>
+            <wa-tooltip for=${ELEMENT_IDS.STATUS_INDICATOR}>
+              ${statusLabel}
             </wa-tooltip>
             ${this.renderGoalChip()} ${this.renderProgressBadge()}
           </div>

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -6,6 +6,7 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/divider/divider.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { SignalWatcher, signal, Signal } from '@shared/signals';
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
@@ -1706,11 +1707,11 @@ export class MainApp extends MainAppBase {
                   <wa-tab-panel name="progress"></wa-tab-panel>
                 </wa-tab-group>
                 <wa-button
+                  id="openDashboardButton"
                   class="header-action"
                   aria-label="Open dashboard"
                   appearance="plain"
                   size="small"
-                  title="Open dashboard"
                   @click=${this.onOpenDashboard}
                 >
                   <wa-icon
@@ -1719,12 +1720,15 @@ export class MainApp extends MainAppBase {
                     variant="solid"
                   ></wa-icon>
                 </wa-button>
+                <wa-tooltip for="openDashboardButton">
+                  Open dashboard
+                </wa-tooltip>
                 <wa-button
+                  id="popOutProgressButton"
                   class="header-action"
                   aria-label="Open progress sessions in editor"
                   appearance="plain"
                   size="small"
-                  title="Open progress sessions in editor"
                   @click=${this.onPopOutProgress}
                 >
                   <wa-icon
@@ -1733,6 +1737,9 @@ export class MainApp extends MainAppBase {
                     variant="solid"
                   ></wa-icon>
                 </wa-button>
+                <wa-tooltip for="popOutProgressButton">
+                  Open progress sessions in editor
+                </wa-tooltip>
               </div>
             `}
 

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -6,6 +6,7 @@ import { repeat } from 'lit/directives/repeat.js';
 
 import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
 import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 import { SortableController } from '@shared/controllers';
 import { designTokens } from '@shared/styles';
@@ -166,7 +167,6 @@ export class FileSelectGroup extends LitElement {
           size="small"
           type="button"
           aria-label="Tool configuration options"
-          title="Tool configuration options"
         >
           ${waIcon('tools')}
         </wa-button>
@@ -179,6 +179,7 @@ export class FileSelectGroup extends LitElement {
           Attach TeX Count
         </wa-dropdown-item>
       </wa-dropdown>
+      <wa-tooltip for="toggleToolConfig">Tool configuration options</wa-tooltip>
     `;
   }
 
@@ -203,7 +204,6 @@ export class FileSelectGroup extends LitElement {
           size="small"
           type="button"
           aria-label="Auto-extract options"
-          title="Auto-extract options"
         >
           ${waIcon('wand')}
         </wa-button>
@@ -229,6 +229,7 @@ export class FileSelectGroup extends LitElement {
           Compile Input PDF
         </wa-dropdown-item>
       </wa-dropdown>
+      <wa-tooltip for="toggleAutoExtract">Auto-extract options</wa-tooltip>
     `;
   }
 
@@ -303,7 +304,8 @@ export class FileSelectGroup extends LitElement {
             <span class="file-select-icon" aria-hidden="true">
               ${waIcon(config.icon as TeXRAIconName)}
             </span>
-            <label title=${config.tooltip}>${config.label}</label>
+            <label id="${this.listId}Label">${config.label}</label>
+            <wa-tooltip for="${this.listId}Label">${config.tooltip}</wa-tooltip>
             ${config.toolConfig === 'tool'
               ? this.renderToolConfigMenu()
               : nothing}
@@ -323,7 +325,7 @@ export class FileSelectGroup extends LitElement {
               )}FilesButton`,
               icon: 'folder-opened',
               label: config.addOpenedLabel,
-              title: config.addOpenedLabel,
+              tooltip: config.addOpenedLabel,
               onClick: this.handleAddOpenedFiles,
             })}
             ${renderIconActionButton({
@@ -332,7 +334,7 @@ export class FileSelectGroup extends LitElement {
               )}FilesButton`,
               icon: 'trash',
               label: config.emptyListLabel,
-              title: config.emptyListLabel,
+              tooltip: config.emptyListLabel,
               onClick: this.handleEmptyFiles,
             })}
             ${renderIconActionButton({
@@ -341,7 +343,7 @@ export class FileSelectGroup extends LitElement {
               )}FilesButton`,
               icon: 'add',
               label: config.selectListLabel,
-              title: config.selectListLabel,
+              tooltip: config.selectListLabel,
               onClick: this.handleSelectMultipleFiles,
             })}
           </div>

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -46,6 +46,7 @@ import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 type SessionHintKey = SessionType | 'orchestrator';
@@ -151,9 +152,10 @@ export class InstructionPanel extends LitElement {
             <span class="session-hint-time">${copy.time}</span>
           </span>
           ${renderIconActionButton({
+            id: 'dismissSessionHintButton',
             icon: 'close',
             label: 'Dismiss this reminder',
-            title: 'Dismiss this reminder',
+            tooltip: 'Dismiss this reminder',
             className: 'session-hint-dismiss',
             onClick: this.handleDismissSessionHint,
           })}
@@ -294,20 +296,26 @@ export class InstructionPanel extends LitElement {
                 @change=${this.handleSessionTypeChange}
               >
                 <wa-radio
+                  id="sessionTypeToolUse"
                   value="toolUse"
                   data-session-type="toolUse"
-                  title=${getSessionTitle(SESSION_TYPES.TOOL_USE)}
                 >
                   Interactive
                 </wa-radio>
                 <wa-radio
+                  id="sessionTypeWorkflow"
                   value="workflow"
                   data-session-type="workflow"
-                  title=${getSessionTitle(SESSION_TYPES.WORKFLOW)}
                 >
                   Workflow
                 </wa-radio>
               </wa-radio-group>
+              <wa-tooltip for="sessionTypeToolUse">
+                ${getSessionTitle(SESSION_TYPES.TOOL_USE)}
+              </wa-tooltip>
+              <wa-tooltip for="sessionTypeWorkflow">
+                ${getSessionTitle(SESSION_TYPES.WORKFLOW)}
+              </wa-tooltip>
             </div>
           </div>
           <div
@@ -320,7 +328,7 @@ export class InstructionPanel extends LitElement {
                     id: 'packButton',
                     icon: 'archive',
                     label: 'Pack output to History',
-                    title:
+                    tooltip:
                       'Pack the output for this agent into the History folder',
                     action: 'pack',
                   })}
@@ -328,7 +336,7 @@ export class InstructionPanel extends LitElement {
                     id: 'cleanButton',
                     icon: 'trash',
                     label: 'Clean output',
-                    title: 'Clean the output for this agent',
+                    tooltip: 'Clean the output for this agent',
                     action: 'clean',
                   })}
                 `
@@ -337,7 +345,7 @@ export class InstructionPanel extends LitElement {
               id: 'magicPolishButton',
               icon: 'sparkle',
               label: 'Polish instruction',
-              title: 'Polish instruction text with AI',
+              tooltip: 'Polish instruction text with AI',
               busy: session.isPolishing,
               action: 'polish',
             })}
@@ -345,7 +353,7 @@ export class InstructionPanel extends LitElement {
               id: 'recordInstructionButton',
               icon: session.isRecording ? 'stop-circle' : 'mic',
               label: 'Record instruction',
-              title: session.isRecording
+              tooltip: session.isRecording
                 ? 'Stop recording'
                 : 'Record instruction with microphone',
               className: session.isRecording ? 'recording' : '',
@@ -355,7 +363,7 @@ export class InstructionPanel extends LitElement {
               id: 'eraseInstructionButton',
               icon: 'clear-all',
               label: 'Erase instruction',
-              title: 'Erase instruction',
+              tooltip: 'Erase instruction',
               action: 'erase',
             })}
           </div>
@@ -379,7 +387,7 @@ export class InstructionPanel extends LitElement {
                 id: 'agentSettingsButton',
                 icon: 'sparkle',
                 label: 'Agent settings',
-                title: 'Agent settings',
+                tooltip: 'Agent settings',
                 className: 'settings-button',
                 onClick: this.handleAgentSettings,
               })}
@@ -426,7 +434,7 @@ export class InstructionPanel extends LitElement {
                 id: 'modelSettingsButton',
                 icon: 'robot',
                 label: 'Model settings',
-                title: 'Model settings',
+                tooltip: 'Model settings',
                 className: 'settings-button',
                 onClick: this.handleModelSettings,
               })}
@@ -451,7 +459,6 @@ export class InstructionPanel extends LitElement {
           <wa-button
             id="executeButton"
             class="execute-button"
-            title="Execute (${this.executeShortcutLabel})"
             appearance="filled"
             variant="brand"
             @click=${this.handleExecute}
@@ -459,6 +466,9 @@ export class InstructionPanel extends LitElement {
             <wa-icon slot="start" library="texra" name="play"></wa-icon>
             <span class="execute-button__label">Run</span>
           </wa-button>
+          <wa-tooltip for="executeButton">
+            Execute (${this.executeShortcutLabel})
+          </wa-tooltip>
         </div>
       </div>
     `;

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -439,7 +439,10 @@ export class LatexDiffsSection extends LitElement {
                   tooltip: 'Refresh edited files',
                   onClick: this.handleRefreshEditedFiles,
                 })}
-                <label for="editedFile">Edited</label>
+                <label id="editedFileLabel" for="editedFile">Edited</label>
+                <wa-tooltip for="editedFileLabel">
+                  File containing edits to merge into the base file
+                </wa-tooltip>
               </div>
               <div
                 class="file-select-actions"

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -1,17 +1,20 @@
 /** LaTeXDiff section with base/edited file selectors, commit selector, and diff actions. */
 
 // Side-effect imports - register WA select & option components
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/button-group/button-group.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - main view
+import type { LatexDiffsActionDetail } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
@@ -22,6 +25,86 @@ import {
   fileSelectLayoutStyles,
 } from '../styles/fileSelectStyles';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
+
+type LatexDiffsAction = LatexDiffsActionDetail['action'];
+
+/** A labeled diff operation button rendered inside a wa-button-group. */
+interface DiffActionSpec {
+  readonly id: string;
+  readonly icon: TeXRAIconName;
+  readonly label: string;
+  readonly tooltip: string;
+  readonly action: LatexDiffsAction;
+}
+
+/** Review the base ↔ edited pair without touching either file. */
+const EDITED_REVIEW_ACTIONS: readonly DiffActionSpec[] = [
+  {
+    id: 'latexdiffButton',
+    icon: 'diff-single',
+    label: 'Diff',
+    tooltip:
+      'Run latexdiff on the base and edited files and open the marked-up result',
+    action: 'latexdiff',
+  },
+  {
+    id: 'compareButton',
+    icon: 'diff',
+    label: 'Compare',
+    tooltip: 'Open the base and edited files side by side in the diff editor',
+    action: 'compare',
+  },
+];
+
+/** Apply the edited file's changes onto the base file. */
+const EDITED_APPLY_ACTIONS: readonly DiffActionSpec[] = [
+  {
+    id: 'mergeButton',
+    icon: 'merge',
+    label: 'Merge',
+    tooltip:
+      'Create a new version of the base file by merging the edits suggested by the edited file',
+    action: 'merge',
+  },
+  {
+    id: 'acceptButton',
+    icon: 'check',
+    label: 'Accept',
+    tooltip:
+      'Accept the changes from the edited file and overwrite the base file',
+    action: 'accept',
+  },
+];
+
+/** Diff the base file against its version at the selected commit. */
+const COMMIT_DIFF_ACTIONS: readonly DiffActionSpec[] = [
+  {
+    id: 'latexdiffvcButton',
+    icon: 'diff-single',
+    label: 'Diff',
+    tooltip:
+      'Run latexdiff-vc on the base file against its version at the selected commit',
+    action: 'latexdiffvc',
+  },
+];
+
+/** Manage the artifacts a latexdiff-vc run leaves behind. */
+const COMMIT_MANAGE_ACTIONS: readonly DiffActionSpec[] = [
+  {
+    id: 'packLatexdiffvcButton',
+    icon: 'archive',
+    label: 'Pack',
+    tooltip: 'Pack the latexdiff-vc output into the History folder',
+    action: 'packLatexdiffvc',
+  },
+  {
+    id: 'cleanLatexdiffvcButton',
+    icon: 'trash',
+    label: 'Clean',
+    tooltip: 'Delete the latexdiff-vc output files',
+    action: 'cleanLatexdiffvc',
+  },
+];
 
 @customElement('latexdiffs-section')
 export class LatexDiffsSection extends LitElement {
@@ -83,6 +166,28 @@ export class LatexDiffsSection extends LitElement {
 
       #commit::part(listbox) {
         max-height: var(--height-large);
+      }
+
+      /* Operation rows: native small WA buttons in button groups beneath the
+         select they act on. Density comes from WA's published form-control
+         tokens, not ::part overrides, so hover/focus/active chrome stays
+         stock Web Awesome. */
+      .diff-actions {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-2xs);
+      }
+
+      .diff-actions wa-button {
+        font-size: var(--font-size-sm);
+        --wa-form-control-height: var(--height-control);
+        --wa-form-control-padding-inline: var(--wa-space-xs);
+      }
+
+      .diff-actions wa-button wa-icon {
+        font-size: var(--font-size-xs);
       }
     `,
   ];
@@ -153,14 +258,7 @@ export class LatexDiffsSection extends LitElement {
     if (diffButton?.dataset.diffAction) {
       this.dispatchEvent(
         MainViewEvents.latexDiffsAction({
-          action: diffButton.dataset.diffAction as
-            | 'latexdiff'
-            | 'latexdiffvc'
-            | 'packLatexdiffvc'
-            | 'cleanLatexdiffvc'
-            | 'merge'
-            | 'compare'
-            | 'accept',
+          action: diffButton.dataset.diffAction as LatexDiffsAction,
         }),
       );
       return;
@@ -183,22 +281,19 @@ export class LatexDiffsSection extends LitElement {
     }
   }
 
-  private renderDatasetButton({
+  /** Icon-only header utility (set current / clear) with a native tooltip. */
+  private renderFileUtilityButton({
     id,
     icon,
     label,
-    title,
-    diffAction,
     fileAction,
     fileType,
   }: {
     id: string;
     icon: TeXRAIconName;
     label: string;
-    title?: string;
-    diffAction?: string;
-    fileAction?: string;
-    fileType?: string;
+    fileAction: 'current' | 'empty';
+    fileType: 'base' | 'edited';
   }): TemplateResult {
     return html`
       <wa-button
@@ -209,13 +304,49 @@ export class LatexDiffsSection extends LitElement {
         size="small"
         type="button"
         aria-label=${label}
-        title=${title ?? label}
-        data-diff-action=${ifDefined(diffAction)}
-        data-file-action=${ifDefined(fileAction)}
-        data-file-type=${ifDefined(fileType)}
+        data-file-action=${fileAction}
+        data-file-type=${fileType}
       >
         ${waIcon(icon)}
       </wa-button>
+      <wa-tooltip for=${id}>${label}</wa-tooltip>
+    `;
+  }
+
+  /**
+   * A cluster of labeled operation buttons. Tooltips render after the group:
+   * wa-button-group fuses corners via CSS :first/:last-child on its slotted
+   * children, so a slotted wa-tooltip would break the segmenting.
+   */
+  private renderDiffActionGroup(
+    label: string,
+    actions: readonly DiffActionSpec[],
+  ): TemplateResult {
+    return html`
+      <wa-button-group label=${label}>
+        ${repeat(
+          actions,
+          (action) => action.id,
+          (action) => html`
+            <wa-button
+              id=${action.id}
+              appearance="outlined"
+              variant="neutral"
+              size="small"
+              type="button"
+              data-diff-action=${action.action}
+            >
+              ${waIcon(action.icon, { slot: 'start' })} ${action.label}
+            </wa-button>
+          `,
+        )}
+      </wa-button-group>
+      ${repeat(
+        actions,
+        (action) => action.id,
+        (action) =>
+          html`<wa-tooltip for=${action.id}>${action.tooltip}</wa-tooltip>`,
+      )}
     `;
   }
 
@@ -273,19 +404,17 @@ export class LatexDiffsSection extends LitElement {
                 class="file-select-actions"
                 @click=${this.handleToolbarClick}
               >
-                ${this.renderDatasetButton({
+                ${this.renderFileUtilityButton({
                   id: 'currentBaseFileButton',
                   icon: 'file-code',
                   label: 'Set current file as base',
-                  title: 'Set current file as base',
                   fileAction: 'current',
                   fileType: 'base',
                 })}
-                ${this.renderDatasetButton({
+                ${this.renderFileUtilityButton({
                   id: 'emptyBaseFileButton',
                   icon: 'close',
                   label: 'Clear base file',
-                  title: 'Clear base file',
                   fileAction: 'empty',
                   fileType: 'base',
                 })}
@@ -307,65 +436,26 @@ export class LatexDiffsSection extends LitElement {
                   id: 'refreshEditedFileButton',
                   icon: 'edit',
                   label: 'Refresh edited files',
-                  title: 'Refresh edited files',
+                  tooltip: 'Refresh edited files',
                   onClick: this.handleRefreshEditedFiles,
                 })}
-                <label
-                  for="editedFile"
-                  title="File containing edits to merge into the base file"
-                >
-                  Edited
-                </label>
+                <label for="editedFile">Edited</label>
               </div>
               <div
                 class="file-select-actions"
                 @click=${this.handleToolbarClick}
               >
-                ${this.renderDatasetButton({
-                  id: 'acceptButton',
-                  icon: 'check',
-                  label: 'Accept changes',
-                  title:
-                    'Accept changes from edited file and overwrite base file',
-                  diffAction: 'accept',
-                })}
-                ${this.renderDatasetButton({
-                  id: 'compareButton',
-                  icon: 'diff',
-                  label: 'Compare files',
-                  title:
-                    'Compare the selected edited file with the selected base file',
-                  diffAction: 'compare',
-                })}
-                ${this.renderDatasetButton({
-                  id: 'mergeButton',
-                  icon: 'merge',
-                  label: 'Merge edits',
-                  title:
-                    'Create a new version of the base file by merging the edits suggested by the edited file',
-                  diffAction: 'merge',
-                })}
-                ${this.renderDatasetButton({
-                  id: 'latexdiffButton',
-                  icon: 'diff-single',
-                  label: 'LaTeXdiff',
-                  title:
-                    'LaTeXdiff the selected edited file with the selected base file',
-                  diffAction: 'latexdiff',
-                })}
-                ${this.renderDatasetButton({
+                ${this.renderFileUtilityButton({
                   id: 'currentEditedFileButton',
                   icon: 'file-code',
                   label: 'Set current file as edited',
-                  title: 'Set current file as edited',
                   fileAction: 'current',
                   fileType: 'edited',
                 })}
-                ${this.renderDatasetButton({
+                ${this.renderFileUtilityButton({
                   id: 'emptyEditedFileButton',
                   icon: 'close',
                   label: 'Clear edited file',
-                  title: 'Clear edited file',
                   fileAction: 'empty',
                   fileType: 'edited',
                 })}
@@ -379,6 +469,16 @@ export class LatexDiffsSection extends LitElement {
             >
               ${this.renderFileOptions(this.editedFileOptions)}
             </wa-select>
+            <div class="diff-actions" @click=${this.handleToolbarClick}>
+              ${this.renderDiffActionGroup(
+                'Review changes',
+                EDITED_REVIEW_ACTIONS,
+              )}
+              ${this.renderDiffActionGroup(
+                'Apply changes',
+                EDITED_APPLY_ACTIONS,
+              )}
+            </div>
           </div>
           <div class="file-select">
             <div class="file-select-header">
@@ -387,37 +487,10 @@ export class LatexDiffsSection extends LitElement {
                   id: 'refreshCommitsButton',
                   icon: 'git-commit',
                   label: 'Refresh commit list',
-                  title: 'Refresh commit list',
+                  tooltip: 'Refresh commit list',
                   onClick: this.handleRefreshCommits,
                 })}
                 <label for="commit">Commit</label>
-              </div>
-              <div
-                class="file-select-actions"
-                @click=${this.handleToolbarClick}
-              >
-                ${this.renderDatasetButton({
-                  id: 'latexdiffvcButton',
-                  icon: 'diff-single',
-                  label: 'LaTeXdiff with commit',
-                  title:
-                    'LaTeXdiff the selected base file with another git commit',
-                  diffAction: 'latexdiffvc',
-                })}
-                ${this.renderDatasetButton({
-                  id: 'packLatexdiffvcButton',
-                  icon: 'archive',
-                  label: 'Pack latexdiff output',
-                  title: 'Pack the latexdiff-vc output into the History folder',
-                  diffAction: 'packLatexdiffvc',
-                })}
-                ${this.renderDatasetButton({
-                  id: 'cleanLatexdiffvcButton',
-                  icon: 'trash',
-                  label: 'Clean latexdiff output',
-                  title: 'Clean the latexdiff-vc output',
-                  diffAction: 'cleanLatexdiffvc',
-                })}
               </div>
             </div>
             <wa-select
@@ -429,6 +502,16 @@ export class LatexDiffsSection extends LitElement {
             >
               ${this.renderCommitOptions()}
             </wa-select>
+            <div class="diff-actions" @click=${this.handleToolbarClick}>
+              ${this.renderDiffActionGroup(
+                'Diff against commit',
+                COMMIT_DIFF_ACTIONS,
+              )}
+              ${this.renderDiffActionGroup(
+                'Manage diff output',
+                COMMIT_MANAGE_ACTIONS,
+              )}
+            </div>
           </div>
         </div>
       </wa-details>

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -31,9 +31,9 @@ export interface IconActionButtonOptions {
    */
   readonly busy?: boolean;
   /**
-   * Native Web Awesome tooltip text. Requires `id` — the `<wa-tooltip>`
-   * anchors via `for` within the same shadow root. Replaces the `title`
-   * attribute so the browser tooltip never doubles up with the WA one.
+   * Native Web Awesome tooltip text. When `id` is present, the `<wa-tooltip>`
+   * anchors via `for` within the same shadow root. Without an anchor, this
+   * falls back to the native `title` attribute so the hint is still visible.
    */
   readonly tooltip?: string;
   readonly onClick?: (event: MouseEvent) => void;
@@ -78,11 +78,12 @@ function renderActionButtonBase({
     .filter(Boolean)
     .join(' ');
   const ariaLabel = label ?? text ?? '';
+  const useWebAwesomeTooltip = Boolean(tooltip && id);
   // wa-tooltip is position:absolute, so the sibling never affects flex flow.
-  const tooltipTemplate =
-    tooltip && id
-      ? html`<wa-tooltip for=${id}>${tooltip}</wa-tooltip>`
-      : nothing;
+  const tooltipTemplate = useWebAwesomeTooltip
+    ? html`<wa-tooltip for=${id}>${tooltip}</wa-tooltip>`
+    : nothing;
+  const nativeTitle = tooltip && !id ? tooltip : (title ?? ariaLabel);
 
   const button = html`
     <wa-button
@@ -93,9 +94,7 @@ function renderActionButtonBase({
       size="small"
       type="button"
       aria-label=${ariaLabel}
-      title=${ifDefined(
-        tooltipTemplate === nothing ? (title ?? ariaLabel) : undefined,
-      )}
+      title=${ifDefined(useWebAwesomeTooltip ? undefined : nativeTitle)}
       data-action=${ifDefined(action)}
       ?disabled=${disabled || busy}
       @click=${onClick}

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -2,6 +2,7 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 import { html, nothing, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
@@ -29,6 +30,12 @@ export interface IconActionButtonOptions {
    * makes sense over a square icon button.
    */
   readonly busy?: boolean;
+  /**
+   * Native Web Awesome tooltip text. Requires `id` — the `<wa-tooltip>`
+   * anchors via `for` within the same shadow root. Replaces the `title`
+   * attribute so the browser tooltip never doubles up with the WA one.
+   */
+  readonly tooltip?: string;
   readonly onClick?: (event: MouseEvent) => void;
 }
 
@@ -60,6 +67,7 @@ function renderActionButtonBase({
   variant = 'neutral',
   disabled,
   busy,
+  tooltip,
   onClick,
 }: ActionButtonBaseOptions): TemplateResult {
   const classes = [
@@ -70,6 +78,11 @@ function renderActionButtonBase({
     .filter(Boolean)
     .join(' ');
   const ariaLabel = label ?? text ?? '';
+  // wa-tooltip is position:absolute, so the sibling never affects flex flow.
+  const tooltipTemplate =
+    tooltip && id
+      ? html`<wa-tooltip for=${id}>${tooltip}</wa-tooltip>`
+      : nothing;
 
   const button = html`
     <wa-button
@@ -80,7 +93,9 @@ function renderActionButtonBase({
       size="small"
       type="button"
       aria-label=${ariaLabel}
-      title=${title ?? ariaLabel}
+      title=${ifDefined(
+        tooltipTemplate === nothing ? (title ?? ariaLabel) : undefined,
+      )}
       data-action=${ifDefined(action)}
       ?disabled=${disabled || busy}
       @click=${onClick}
@@ -91,7 +106,7 @@ function renderActionButtonBase({
 
   // `busy` undefined → plain button (unchanged for every other caller).
   // `busy` defined → stable overlay wrapper so toggling never reflows the row.
-  if (busy === undefined) return button;
+  if (busy === undefined) return html`${button}${tooltipTemplate}`;
   return html`
     <span class="action-icon-busy">
       ${button}
@@ -102,6 +117,7 @@ function renderActionButtonBase({
           ></wa-spinner>`
         : nothing}
     </span>
+    ${tooltipTemplate}
   `;
 }
 

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -80,13 +80,13 @@ import { faMagnifyingGlassChart } from '@fortawesome/free-solid-svg-icons/faMagn
 import { faMicrophone } from '@fortawesome/free-solid-svg-icons/faMicrophone';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faNoteSticky } from '@fortawesome/free-solid-svg-icons/faNoteSticky';
-import { faNotEqual } from '@fortawesome/free-solid-svg-icons/faNotEqual';
 import { faPalette } from '@fortawesome/free-solid-svg-icons/faPalette';
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane';
 import { faPencil } from '@fortawesome/free-solid-svg-icons/faPencil';
 import { faPictureInPicture } from '@fortawesome/free-solid-svg-icons/faPictureInPicture';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { faPlusMinus } from '@fortawesome/free-solid-svg-icons/faPlusMinus';
 import { faReply } from '@fortawesome/free-solid-svg-icons/faReply';
 import { faRightFromBracket } from '@fortawesome/free-solid-svg-icons/faRightFromBracket';
 import { faRightToBracket } from '@fortawesome/free-solid-svg-icons/faRightToBracket';
@@ -220,13 +220,13 @@ const icons = {
   microphone: faMicrophone,
   minus: faMinus,
   'note-sticky': faNoteSticky,
-  'not-equal': faNotEqual,
   palette: faPalette,
   'paper-plane': faPaperPlane,
   pencil: faPencil,
   'picture-in-picture': faPictureInPicture,
   play: faPlay,
   plus: faPlus,
+  'plus-minus': faPlusMinus,
   reply: faReply,
   'right-from-bracket': faRightFromBracket,
   'right-to-bracket': faRightToBracket,
@@ -282,8 +282,10 @@ const CODICON_ALIASES = {
   'device-camera-video': 'video',
   diff: 'code-compare',
   'diff-added': 'plus',
-  'diff-multiple': 'not-equal',
-  'diff-single': 'not-equal',
+  // latexdiff marks additions/deletions — ± reads as that markup, where the
+  // previous not-equal (≠) glyph read as a math comparison.
+  'diff-multiple': 'plus-minus',
+  'diff-single': 'plus-minus',
   discard: 'arrow-rotate-left',
   edit: 'pencil',
   error: 'circle-exclamation',


### PR DESCRIPTION
## Summary

Systematically replace native HTML `title` attributes with Web Awesome `<wa-tooltip>` components across the extension and shared UI code. This improves tooltip styling consistency, positioning, and accessibility by using the framework's native tooltip component instead of browser defaults.

The change affects icon action buttons, file utility buttons, diff action buttons, radio controls, and various utility buttons throughout the webview UI. Tooltips now anchor to their target elements via the `for` attribute rather than wrapping them, which simplifies DOM structure and prevents layout issues with flex containers.

## Issue acceptance gates

N/A — this is a refactoring to improve UI consistency and framework adoption.

## Single source of truth

The `IconActionButtonOptions` interface in `src/shared/wa/actionButtons.ts` now owns the tooltip contract: it accepts an optional `tooltip` string that replaces the `title` attribute. The `renderActionButtonBase` function handles rendering the `<wa-tooltip>` component alongside the button.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated redundant `title` attributes that duplicated label text or tooltip content
- Consolidated tooltip rendering logic in `renderActionButtonBase` so all icon action buttons follow the same pattern

**Abstraction added:**
- `DiffActionSpec` interface in `LatexDiffsSection.ts` encapsulates diff operation metadata (id, icon, label, tooltip, action), eliminating repetitive button definitions
- Four action group constants (`EDITED_REVIEW_ACTIONS`, `EDITED_APPLY_ACTIONS`, `COMMIT_DIFF_ACTIONS`, `COMMIT_MANAGE_ACTIONS`) centralize action definitions and make them reusable
- `renderDiffActionGroup()` method abstracts the pattern of rendering a labeled button group with associated tooltips

**Refactored methods:**
- `renderDatasetButton()` → `renderFileUtilityButton()` with stricter typing (removed optional `diffAction` parameter, made `fileAction` and `fileType` required)
- Diff action buttons moved from inline toolbar buttons to organized button groups beneath their respective selectors

## Host impact

**Extension:**
- Webview UI tooltips now use Web Awesome component styling instead of browser defaults
- Diff action buttons reorganized into labeled groups ("Review changes", "Apply changes", "Diff against commit", "Manage diff output") for better UX
- File utility buttons (Set/Clear base/edited) retain their icon-only appearance with tooltips
- Session type radio buttons in InstructionPanel now use `<wa-tooltip>` instead of `title` attributes

**Desktop:**
- No direct changes; inherits tooltip improvements from shared UI code

**CLI:**
- No impact

## Scheduled refactoring

None — this completes the tooltip migration for the affected components.

## Validation

- TypeScript compilation passes (no type errors)
- Existing component tests remain valid; tooltip rendering is additive and does not break event handling
- Visual inspection confirms tooltips render correctly with `for` attribute anchoring
- Icon action buttons in InstructionPanel, FileSelectGroup, MainApp, and StreamHeader all render tooltips without layout side effects

https://claude.ai/code/session_01WCoCZ3Rn3BfqTx3k6H4RJi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only webview and docs changes; diff/merge IPC handlers are unchanged.
> 
> **Overview**
> Replaces native **`title`** tooltips with Web Awesome **`<wa-tooltip for="…">`** across the main webview, progress stream header, and shared **`renderIconActionButton`** (new **`tooltip`** option; drops **`title`** on anchored controls).
> 
> **LaTeXDiffs** moves diff/compare/merge/accept and commit pack/clean out of crowded header icon rows into labeled **`wa-button-group`** rows under the Edited and Commit selectors, with action metadata centralized in **`DiffActionSpec`** constants. Docs in **`latex-diff.md`** now describe the **Diff** buttons beneath those dropdowns.
> 
> **`diff-single`** / **`diff-multiple`** icons switch from not-equal to **`plus-minus`** in the shared icon registry and VitePress theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa5aadadd2ee5b64ea20de4d928e7f4538c5436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->