### PR TITLE
Refactor login and workflow hint banners for improved layout

### DIFF
--- a/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
@@ -29,6 +29,13 @@ export class WorkflowHintBanner extends LitElement {
       /* wa-callout ignores --padding; set the real property (its :host hardcodes 1em). */
       padding: var(--wa-space-2xs) var(--wa-space-xs);
     }
+    /* Pair the icon with the first text line instead of centering it in the
+       multi-line block. */
+    wa-callout::part(icon) {
+      align-self: flex-start;
+      margin-block-start: 0.2em;
+      padding-inline-end: var(--wa-space-2xs);
+    }
     .banner-row {
       display: flex;
       align-items: flex-start;

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -25,17 +25,21 @@ export class LoginBanner extends LitElement {
     bannerStyles,
     css`
       /* Title and actions share one row so the buttons reuse the header's
-         empty right side instead of occupying a row of their own. nowrap keeps
-         the buttons pinned to the corner in narrow sidebars (the title wraps
-         instead). */
+         empty right side instead of occupying a row of their own. The title's
+         min-content flex basis keeps the buttons pinned to the corner in
+         narrow sidebars (the title wraps instead); the row itself only wraps
+         when even the title's longest word no longer fits beside the buttons,
+         so they can't be pushed off-screen. */
       .banner-header {
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
         justify-content: space-between;
-        gap: var(--wa-space-xs);
+        gap: var(--wa-space-3xs) var(--wa-space-xs);
       }
 
       .banner-title {
+        flex: 1 1 min-content;
         font-weight: var(--font-weight-semibold);
         font-size: 1em;
         letter-spacing: -0.005em;

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -24,11 +24,15 @@ export class LoginBanner extends LitElement {
     commonViewStyles,
     bannerStyles,
     css`
-      .banner-text {
+      /* Title and actions share one row so the buttons reuse the header's
+         empty right side instead of occupying a row of their own. nowrap keeps
+         the buttons pinned to the corner in narrow sidebars (the title wraps
+         instead). */
+      .banner-header {
         display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-3xs);
-        min-width: 0;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--wa-space-xs);
       }
 
       .banner-title {
@@ -38,12 +42,16 @@ export class LoginBanner extends LitElement {
       }
 
       .banner-lead {
+        display: block;
+        margin-top: var(--wa-space-3xs);
         font-size: var(--font-size-sm);
         opacity: var(--opacity-normal);
         line-height: var(--line-height-normal, 1.4);
       }
 
       .banner-fineprint {
+        display: block;
+        margin-top: var(--wa-space-3xs);
         font-size: var(--font-size-xs);
         opacity: var(--opacity-muted);
         line-height: var(--line-height-normal, 1.4);
@@ -53,12 +61,10 @@ export class LoginBanner extends LitElement {
          taller text block. */
       #loginBanner::part(icon) {
         align-self: flex-start;
-        margin-block-start: 0.05em;
+        margin-block-start: 0.3em;
       }
 
       #loginBannerButton::part(base) {
-        min-height: 26px;
-        padding-inline: var(--wa-space-s);
         font-weight: var(--font-weight-semibold, 600);
         letter-spacing: 0.01em;
       }
@@ -86,14 +92,8 @@ export class LoginBanner extends LitElement {
       <div class="banner-frame">
         <wa-callout id="loginBanner" variant="brand">
           ${waIcon('wand-magic-sparkles', { slot: 'icon' })}
-          <div class="banner-row">
-            <div class="banner-text">
-              <span class="banner-title">Researcher Access Program</span>
-              <span class="banner-lead">${PROMO_NOTICE_SHORT.lead}</span>
-              <span class="banner-fineprint"
-                >${PROMO_NOTICE_SHORT.fineprint}</span
-              >
-            </div>
+          <div class="banner-header">
+            <span class="banner-title">Researcher Access Program</span>
             <div class="actions">
               <wa-button
                 id="loginBannerButton"
@@ -102,7 +102,7 @@ export class LoginBanner extends LitElement {
                 size="small"
                 @click=${this.handleSignIn}
               >
-                ${waIcon('right-to-bracket', { slot: 'start' })} Sign In
+                Sign In
               </wa-button>
               <wa-button
                 id="loginBannerDismissButton"
@@ -116,6 +116,8 @@ export class LoginBanner extends LitElement {
               </wa-button>
             </div>
           </div>
+          <span class="banner-lead">${PROMO_NOTICE_SHORT.lead}</span>
+          <span class="banner-fineprint">${PROMO_NOTICE_SHORT.fineprint}</span>
         </wa-callout>
       </div>
     `;


### PR DESCRIPTION
## Summary

Restructured the LoginBanner and WorkflowHintBanner components to improve layout and visual alignment:

- **LoginBanner**: Changed from a vertical column layout to a horizontal header that pairs the title with action buttons on the same row, allowing buttons to reuse the header's empty right side. Moved lead and fineprint text below the header as separate block elements. Removed the icon from the Sign In button and adjusted icon alignment.
- **WorkflowHintBanner**: Added explicit icon styling to pair it with the first text line instead of centering it vertically in the multi-line block.

These changes improve space efficiency in narrow sidebars (title wraps instead of buttons taking a full row) and provide better visual hierarchy.

## Issue acceptance gates

No issue referenced. This is a layout refactoring to improve component presentation.

## Single source of truth

Component styling and DOM structure are now the source of truth for layout behavior (flex direction, alignment, spacing).

## Duplication and abstraction budget

No new abstractions added. Simplified the LoginBanner DOM structure by removing the intermediate `banner-text` wrapper div and using direct flex layout on `banner-header`.

## Host impact

**Extension:** LoginBanner and WorkflowHintBanner webview components now render with improved layout and spacing.

**Desktop:** N/A

**CLI:** N/A

## Scheduled refactoring

None.

## Validation

Visual inspection of component layout changes. No automated tests were added as these are pure styling and DOM structure changes to existing components. The changes are straightforward CSS and template modifications with no behavioral logic changes.

https://claude.ai/code/session_01JpnK9jpJKg2B66p4d9UrqY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and template structure in extension webview banners; no auth or behavior changes.
> 
> **Overview**
> Refactors **LoginBanner** and **WorkflowHintBanner** callout layouts for narrow sidebars and clearer hierarchy.
> 
> **LoginBanner** moves from a stacked column to a **`.banner-header`** row: title and Sign In / dismiss actions sit on one line (`flex-wrap`, `space-between`), with lead and fineprint as block lines below. The intermediate **`.banner-text`** wrapper is removed. The Sign In label drops its bracket icon; callout sparkle icon alignment is tweaked (`margin-block-start` 0.3em). Custom min-height/padding on the primary button are removed.
> 
> **WorkflowHintBanner** adds **`wa-callout::part(icon)`** styling so the info icon aligns with the first line of multi-line copy instead of vertically centering in the callout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 654376e69385d0b8cf654e6147694bd6bc7601f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->