### PR TITLE
Consolidate duplicate code and replace inline reimplementations with shared utilities

### DIFF
--- a/src/agent/implementations/flows/tooluse/modelSwitchState.ts
+++ b/src/agent/implementations/flows/tooluse/modelSwitchState.ts
@@ -1,4 +1,5 @@
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
+import { isNonEmptyString } from '@utils/core';
 
 import type { ToolUseRunShared } from './nodes/types';
 
@@ -10,7 +11,7 @@ export function currentModelFromUserChannels(
   const value =
     channels.transient[MODEL_USER_VARIABLE] ??
     channels.input[MODEL_USER_VARIABLE];
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+  return isNonEmptyString(value) ? value.trim() : undefined;
 }
 
 export function setToolUseSharedModel(

--- a/src/shared/schemas/workPlan.ts
+++ b/src/shared/schemas/workPlan.ts
@@ -1,13 +1,9 @@
 import { z } from 'zod';
 
-import { isObject } from '@utils/core';
+import { isNonEmptyString, isObject } from '@utils/core';
 
 import { PlanSchema, type Plan } from './plan';
 import { TodoItemSchema } from './todo';
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value : null;
-}
 
 function parsePlan(value: unknown): Plan | null {
   const result = PlanSchema.safeParse(value);
@@ -30,7 +26,7 @@ function normalizeWorkPlanSnapshot(input: unknown): unknown {
   const plan = parsePlan(record.plan);
   const planSummary = plan
     ? planSummaryLine(plan.objective)
-    : nonEmptyString(record.planSummary);
+    : isNonEmptyString(record.planSummary) ? record.planSummary : null;
 
   return {
     todos: record.todos,

--- a/src/shared/schemas/workPlan.ts
+++ b/src/shared/schemas/workPlan.ts
@@ -26,7 +26,9 @@ function normalizeWorkPlanSnapshot(input: unknown): unknown {
   const plan = parsePlan(record.plan);
   const planSummary = plan
     ? planSummaryLine(plan.objective)
-    : isNonEmptyString(record.planSummary) ? record.planSummary : null;
+    : isNonEmptyString(record.planSummary)
+      ? record.planSummary
+      : null;
 
   return {
     todos: record.todos,

--- a/src/test-kernel/support/githubClientMock.ts
+++ b/src/test-kernel/support/githubClientMock.ts
@@ -1,0 +1,32 @@
+import { vi, type Mock } from 'vitest';
+
+/**
+ * Register a vi.doMock for '@tools/github/githubClient' with the three error
+ * classes that PRPollingSource tests need to exercise, wiring up a caller-
+ * supplied ghGet stub as the module's default GET function.
+ *
+ * Call this after vi.resetModules() and before the dynamic import of the
+ * module-under-test.
+ */
+export function mockGitHubClient(ghGet: Mock): void {
+  class GitHubAuthError extends Error {}
+  class GitHubRateLimitError extends Error {
+    constructor(public readonly resetAt: number) {
+      super('GitHub rate limit exceeded');
+    }
+  }
+  class GitHubPermanentError extends Error {
+    constructor(
+      public readonly status: number,
+      message: string,
+    ) {
+      super(message);
+    }
+  }
+  vi.doMock('@tools/github/githubClient', () => ({
+    ghGet,
+    GitHubAuthError,
+    GitHubRateLimitError,
+    GitHubPermanentError,
+  }));
+}

--- a/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
@@ -7,6 +7,9 @@ import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 // Local imports - tools
 import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
 
+// Local imports - test support
+import { mockGitHubClient } from '../support/githubClientMock';
+
 interface AnnotationFetchSource {
   fetchAnnotations(
     owner: string,
@@ -67,28 +70,7 @@ async function createHarness(): Promise<{
 }> {
   vi.resetModules();
   const ghGet = vi.fn();
-  vi.doMock('@tools/github/githubClient', () => {
-    class GitHubAuthError extends Error {}
-    class GitHubRateLimitError extends Error {
-      constructor(public readonly resetAt: number) {
-        super('GitHub rate limit exceeded');
-      }
-    }
-    class GitHubPermanentError extends Error {
-      constructor(
-        public readonly status: number,
-        message: string,
-      ) {
-        super(message);
-      }
-    }
-    return {
-      ghGet,
-      GitHubAuthError,
-      GitHubRateLimitError,
-      GitHubPermanentError,
-    };
-  });
+  mockGitHubClient(ghGet);
   const { PRPollingSource } = await import('@tools/github/PRPollingSource');
   return {
     ghGet,

--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -7,6 +7,9 @@ import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 // Local imports - tools
 import type { GhCheckRun, GhPullRequest } from '@tools/github/prTypes';
 
+// Local imports - test support
+import { mockGitHubClient } from '../support/githubClientMock';
+
 interface CiStartedState {
   pr: { owner: string; repo: string; pullNumber: number };
   slug: string;
@@ -149,28 +152,7 @@ async function createHarness(
       emitCiStartedEvents ? true : defaultValue,
     ),
   }));
-  vi.doMock('@tools/github/githubClient', () => {
-    class GitHubAuthError extends Error {}
-    class GitHubRateLimitError extends Error {
-      constructor(public readonly resetAt: number) {
-        super('GitHub rate limit exceeded');
-      }
-    }
-    class GitHubPermanentError extends Error {
-      constructor(
-        public readonly status: number,
-        message: string,
-      ) {
-        super(message);
-      }
-    }
-    return {
-      ghGet,
-      GitHubAuthError,
-      GitHubRateLimitError,
-      GitHubPermanentError,
-    };
-  });
+  mockGitHubClient(ghGet);
   const { PRPollingSource } = await import('@tools/github/PRPollingSource');
   return {
     ghGet,


### PR DESCRIPTION
## Summary

- **Extract shared GitHub client mock** (`src/test-kernel/support/githubClientMock.ts`): Two `PRPollingSource` test files contained identical 18-line mock blocks defining `GitHubAuthError`, `GitHubRateLimitError`, and `GitHubPermanentError`. Both now call `mockGitHubClient(ghGet)` from the new shared helper, removing ~36 lines of duplication.
- **Remove local `nonEmptyString` helper in `workPlan.ts`**: The file defined a private function with the same semantics as the already-exported `isNonEmptyString` from `@utils/core`. Replaced with the shared utility.
- **Replace inline `typeof`/`trim` guard in `modelSwitchState.ts`**: An open-coded `typeof value === 'string' && value.trim()` check is replaced with `isNonEmptyString` from `@utils/core`, matching the codebase-wide convention.

## Test plan

- [x] All 429 test files pass (`corepack pnpm test`)
- [x] TypeScript type-checks clean (`npm run typecheck`)

https://claude.ai/code/session_01TFpHDF9dvqFLDTzQjKoBqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFpHDF9dvqFLDTzQjKoBqY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactors to shared utilities and test-only mock extraction; no new product behavior intended.
> 
> **Overview**
> This PR **deduplicates string checks and GitHub test mocks** by routing callers through shared helpers instead of local copies.
> 
> **Runtime/schema:** `currentModelFromUserChannels` and work-plan snapshot normalization now use **`isNonEmptyString` from `@utils/core`**, replacing an inline `typeof`/`trim` guard and a private `nonEmptyString` helper in `workPlan.ts` (legacy `planSummary` fallback behavior is unchanged).
> 
> **Tests:** A new **`mockGitHubClient(ghGet)`** helper in `src/test-kernel/support/githubClientMock.ts` centralizes the `vi.doMock` for `@tools/github/githubClient` (error classes + `ghGet`). **`PRPollingSourceAnnotationPages`** and **`PRPollingSourceCiStarted`** harnesses call it instead of duplicating the same mock block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897a5be04965030e749c10fa0fa8ae4b2665aff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->