### PR TITLE
fix: re-enqueue follow-ups with force:true on resume failure

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1048,7 +1048,7 @@ export class DesktopProgressBridge {
           });
         } catch (error) {
           for (const item of queuedFollowUps) {
-            ToolUseFollowUpQueue.enqueue(streamId, item);
+            ToolUseFollowUpQueue.enqueue(streamId, item, { force: true });
           }
           if (queuedFollowUps.length > 0) {
             this.runtimeHost.emit('updateQueuedFollowUps', { streamId });

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -79,7 +79,7 @@ async function resumeFromSnapshot(
         ? [{ text: followUp, origin: 'user' as const }, ...queuedFollowUps]
         : queuedFollowUps;
     for (const item of requeued) {
-      ToolUseFollowUpQueue.enqueue(streamId, item);
+      ToolUseFollowUpQueue.enqueue(streamId, item, { force: true });
     }
     if (requeued.length > 0) {
       runtimeHost.emit('updateQueuedFollowUps', { streamId });


### PR DESCRIPTION
When a tool-use flow crashes, dispose() already releases the queue and adds the stream to the released set. The catch block's enqueue() call would then silently discard items because released.has(streamId) was true. Passing { force: true } clears released status and re-creates the queue so a later resume can replay the items.

Fixes: #5825

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to error-path follow-up requeueing in desktop and extension resume flows; no auth or data-model changes.
> 
> **Overview**
> When **tool-use resume** fails after follow-ups were drained from `ToolUseFollowUpQueue`, the error handlers in the **desktop** bridge and **VS Code** `resumeCommand` now call `enqueue(..., { force: true })` instead of a plain enqueue.
> 
> That bypasses the “released stream” guard that could drop requeued items after crash cleanup, so drained follow-ups (and any explicit resume follow-up on extension) are restored for a later resume and the UI still gets `updateQueuedFollowUps` when anything was requeued.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f2acb633df4e495bdfe35fd8677a6f7c47fb10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->