### PR TITLE
docs: give the CLI equal visual weight across the docs site

### DIFF
--- a/docs/.vitepress/components/CliAgentShowHero.vue
+++ b/docs/.vitepress/components/CliAgentShowHero.vue
@@ -1,0 +1,98 @@
+<script setup>
+// Terminal card for custom-agents.md Step 4 — verifying and smoke-testing a
+// new custom agent from a terminal instead of the reload-window → check the
+// dropdown round-trip. Beat 1: `texra agents show <name>` printing the real
+// detail lines `name:` / `category:` / `source:` / `path:`
+// (packages/cli/src/runtime/agents.ts formatCliAgentDetails; `source: custom`
+// is the AGENT_SOURCE.CUSTOM literal from src/shared/schemas/agent.ts).
+// Beat 2: a one-shot `texra run` against the new agent, ending with the
+// printed run-storage path. The agent name matches the page's own example
+// filename (literature_review_generator.yaml).
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
+const details = [
+  { key: 'name', value: 'literature_review_generator' },
+  { key: 'category', value: 'workflow' },
+  { key: 'source', value: 'custom' },
+  { key: 'path', value: '…/custom_agents/literature_review_generator.yaml' },
+];
+</script>
+
+<template>
+  <TermWindow
+    title="texra agents show"
+    aria-label="Verify and smoke-test a custom agent from the terminal"
+  >
+    <!-- Beat 1: the agent is registered, with its source and path -->
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra agents show literature_review_generator</span
+      >
+    </div>
+    <dl class="cas-details">
+      <div v-for="d in details" :key="d.key" class="cas-line">
+        <dt class="cas-key">{{ d.key }}:</dt>
+        <dd class="cas-value" :class="{ 'cas-value--hot': d.key === 'source' }">
+          {{ d.value }}
+        </dd>
+      </div>
+    </dl>
+
+    <!-- Beat 2: smoke-test it on a real file -->
+    <div class="mk-term-prompt cas-run">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra run literature_review_generator
+        <span class="mk-term-flag">--input</span> notes.tex
+        <span class="mk-term-flag">--instruction</span> "Draft the related-work
+        section."</span
+      >
+    </div>
+    <div class="cas-out">.texra/runs/e2c70a94b18f/r0/notes.tex</div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes in theme/mockup.css. */
+.cas-details {
+  margin: var(--mk-space-7) 0 0;
+  padding-left: var(--mk-space-16);
+  display: flex;
+  flex-direction: column;
+  gap: var(--mk-space-2);
+  font-size: var(--mk-fs-74);
+}
+.cas-line {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mk-space-7);
+}
+.cas-key {
+  color: var(--mk-syn-keyword);
+  flex-shrink: 0;
+  font-weight: 400;
+}
+.cas-value {
+  margin: 0;
+  color: var(--mk-text);
+  min-width: 0;
+  word-break: break-all;
+}
+.cas-value--hot {
+  color: var(--mk-accent);
+  font-weight: 600;
+}
+
+.cas-run {
+  margin-top: var(--mk-space-10);
+  flex-wrap: wrap;
+}
+.cas-out {
+  margin-top: var(--mk-space-5);
+  color: var(--color-text-link);
+  font-size: var(--mk-fs-72);
+  word-break: break-all;
+}
+</style>

--- a/docs/.vitepress/components/CliAgentsListHero.vue
+++ b/docs/.vitepress/components/CliAgentsListHero.vue
@@ -1,0 +1,99 @@
+<script setup>
+// Terminal card for `texra agents list` — built-in-agents.md. The same catalog
+// the GUI agent picker shows, enumerated from a terminal in the real text
+// format: one `<category>\t<name>\t<description>` row per visible agent
+// (packages/cli/src/runtime/agents.ts formatCliAgentList; the guide documents
+// the column order). Names and categories match the bundled agent YAMLs under
+// packages/extension/resources/; descriptions are abridged from them for card
+// width (the real command prints them in full).
+//
+// Built on <TermWindow>; .mockup-scoped and token-only, so it flips with the
+// docs theme. A believable static slice of the catalog, not the full roster.
+const rows = [
+  {
+    category: 'workflow',
+    name: 'polish',
+    description:
+      'Rewrites and restructures text to improve clarity, flow, and readability.',
+  },
+  {
+    category: 'workflow',
+    name: 'correct',
+    description:
+      'Fixes typos, grammar, and LaTeX formatting without changing your style.',
+  },
+  {
+    category: 'workflow',
+    name: 'merge',
+    description: 'Merges partial edits back into the full original document.',
+  },
+  {
+    category: 'toolUse',
+    name: 'assistant',
+    description:
+      'General-purpose scientific assistant covering the full research workflow.',
+  },
+  {
+    category: 'toolUse',
+    name: 'research',
+    description:
+      'Research assistant for analytical derivations and numerical programming.',
+  },
+  {
+    category: 'toolUse',
+    name: 'lean',
+    description:
+      'Lean 4 proof assistant with VS Code integration and CLI fallback.',
+  },
+];
+</script>
+
+<template>
+  <TermWindow title="texra agents list" aria-label="texra agents list output">
+    <div class="cal-scroll">
+      <div class="mk-term-prompt cal-prompt">
+        <span class="mk-term-sigil">$</span>
+        <span class="mk-term-cmd">texra agents list</span>
+      </div>
+      <div v-for="r in rows" :key="r.name" class="cal-row">
+        <span class="cal-cat">{{ r.category }}</span>
+        <span class="cal-name">{{ r.name }}</span>
+        <span class="cal-desc">{{ r.description }}</span>
+      </div>
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes. Column-aligned output scrolls horizontally instead of reflowing. */
+.cal-scroll {
+  overflow-x: auto;
+  font-size: var(--mk-fs-76);
+}
+.cal-prompt {
+  margin-bottom: var(--mk-space-8);
+}
+.cal-row {
+  display: grid;
+  grid-template-columns: 0.5fr 0.6fr 3fr;
+  min-width: var(--mk-size-470);
+  gap: var(--mk-space-10);
+  padding: var(--mk-space-3) 0;
+  align-items: baseline;
+}
+.cal-cat {
+  color: var(--mk-syn-keyword);
+}
+.cal-name {
+  color: var(--mk-syn-fn);
+  font-weight: 600;
+}
+.cal-desc {
+  color: var(--mk-text-faint);
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/docs/.vitepress/components/CliChatHero.vue
+++ b/docs/.vitepress/components/CliChatHero.vue
@@ -1,196 +1,169 @@
 <script setup>
-// Frameless terminal-window card for `texra chat` — the interactive tool-use
-// TUI described in guide/texra-cli.md. The CLI is a terminal product, so this
-// shows what a compressed session actually looks like: a faux prompt line, a
-// user turn, a streaming "reasoning" line with a bridged <wa-spinner>, two
-// tool-call rows (the MemoryCommandsHero status-dot + tool + verb-chip + path
-// vocabulary), an inline diff hunk (CompareHero's ins/del styling), and a
-// bottom hint strip listing the slash commands `/tools` `/api` `/resume`.
+// Terminal-window card for `texra chat` — the interactive tool-use TUI
+// described in guide/texra-cli.md. Built on the <TermWindow> primitive and
+// fact-checked against the real TUI sources so the figure shows what the
+// session actually renders (packages/cli/src/chat/tui/panes/
+// StaticConversationTranscript.tsx, toolRenderers.tsx, StatusBar.tsx):
+// the once-printed session header (`{ T } TeXRA` + version + api mode over a
+// rule, then `agent: … · model: …`), a reverse-video user band prefixed `› `
+// (no speaker chips), plain assistant text, `● tool (preview)` call rows whose
+// status dot is dim while running and green when done, dim `⎿ ` output lines,
+// and an edit rendered as full-width +/− diff bands (never strikethrough).
+// The bottom strip mirrors the status bar: ◆ status · api mode · round
+// counter · token usage.
 //
-// Standalone (no MockupFrame) — just the terminal card on the .mockup surface,
-// so the shared --mk-* tokens resolve here and the whole thing flips with the
-// docs light / dark theme. Believable static strings only; no live dates.
-
-// Tool-call rows mirror MemoryCommandsHero: status dot + tool + verb chip +
-// path + one-line effect. The last row is `active` (in-flight spinner).
+// .mockup-scoped, so the shared --mk-* tokens resolve here and the whole card
+// flips with the docs light / dark theme. Believable static strings only.
 const calls = [
   {
     state: 'done',
     tool: 'read_file',
-    verb: 'read',
-    path: 'sections/intro.tex',
-    effect: 'Reads the opening paragraph',
+    preview: 'sections/intro.tex',
+    output: 'In this paper we present a novel… +41 lines (ctrl + t to view)',
   },
   {
-    state: 'active',
+    state: 'running',
     tool: 'edit_file',
-    verb: 'edit',
-    path: 'sections/intro.tex',
-    effect: 'Tightens the motivating sentence',
+    preview: 'sections/intro.tex',
   },
 ];
 </script>
 
 <template>
-  <div class="mockup cli-chat" role="group" aria-label="texra chat session">
-    <!-- Faux terminal titlebar: traffic-light dots + window title -->
-    <div class="mk-term-bar">
-      <span class="mk-term-light mk-term-light--r"></span>
-      <span class="mk-term-light mk-term-light--y"></span>
-      <span class="mk-term-light mk-term-light--g"></span>
-      <span class="mk-term-title">texra chat</span>
+  <TermWindow title="texra chat" aria-label="texra chat session">
+    <!-- Shell prompt that launched the session -->
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra chat <span class="mk-term-flag">--agent</span> research</span
+      >
     </div>
 
-    <div class="cc-body">
-      <!-- Prompt line that launched the session -->
-      <div class="cc-prompt">
-        <span class="cc-sigil">$</span>
-        <span class="cc-cmd"
-          >texra chat <span class="cc-flag">--agent</span> research</span
-        >
+    <!-- Session header: printed once at the top of every chat session -->
+    <div class="cc-header">
+      <div class="cc-brand-row">
+        <span class="cc-brand">{ T } TeXRA</span>
+        <span class="cc-meta">v0.38.8</span>
+        <span class="cc-meta">relay</span>
       </div>
+      <div class="cc-identity">agent: research · model: deepseekT</div>
+    </div>
 
-      <!-- User turn -->
-      <div class="cc-turn cc-turn--user">
-        <span class="cc-who cc-who--user">you</span>
-        <span class="cc-msg"
-          >Polish the introduction and fix the awkward opener.</span
-        >
-      </div>
+    <!-- User turn: reverse-video band with the `› ` chevron, no name chip -->
+    <div class="cc-user">
+      <span class="cc-chevron">›</span>
+      <span class="cc-user-msg"
+        >Polish the introduction and fix the awkward opener.</span
+      >
+    </div>
 
-      <!-- Streaming assistant reasoning line (in-flight spinner) -->
-      <div class="cc-turn cc-turn--ai">
-        <span class="cc-who cc-who--ai">research</span>
-        <wa-spinner class="cc-spin mk-spinner"></wa-spinner>
-        <span class="cc-reasoning"
-          >Reading the section, then rewriting the first sentence…</span
-        >
-      </div>
+    <!-- Assistant turn: plain unlabeled text -->
+    <p class="cc-assistant">Reading the section, then tightening the opener.</p>
 
-      <!-- Tool-call rows -->
-      <ul class="cc-tools">
-        <li
-          v-for="(c, i) in calls"
-          :key="i"
-          class="cc-tool-row"
-          :class="{ active: c.state === 'active' }"
-        >
-          <wa-spinner
-            v-if="c.state === 'active'"
-            class="cc-tspin mk-spinner"
-          ></wa-spinner>
-          <span v-else class="cc-dot"></span>
-          <span class="cc-tname">{{ c.tool }}</span>
-          <code class="cc-verb">{{ c.verb }}</code>
-          <span class="cc-path">{{ c.path }}</span>
-          <span class="cc-effect">{{ c.effect }}</span>
-        </li>
-      </ul>
-
-      <!-- Inline diff hunk (the change edit_file is making) -->
-      <div class="cc-diff">
-        <div class="cc-dl cc-dl--del">
-          <span class="cc-gut">−</span>
-          <span class="cc-code"
-            ><del>In this paper we present a novel approach to</del></span
+    <!-- Tool-call rows: ● tool (preview); dot dim while running, green done -->
+    <ul class="cc-tools">
+      <li v-for="c in calls" :key="c.tool" class="cc-call">
+        <div class="cc-call-row">
+          <span
+            class="cc-dot"
+            :class="c.state === 'done' ? 'cc-dot--done' : 'cc-dot--running'"
+            >●</span
           >
+          <span class="cc-tname">{{ c.tool }}</span>
+          <span class="cc-preview">({{ c.preview }})</span>
         </div>
-        <div class="cc-dl cc-dl--add">
-          <span class="cc-gut">+</span>
-          <span class="cc-code"><ins>We introduce</ins></span>
+        <div v-if="c.output" class="cc-out">
+          <span class="cc-corner">⎿</span>
+          <span class="cc-out-text">{{ c.output }}</span>
         </div>
+      </li>
+    </ul>
+
+    <!-- The edit in flight, as the TUI's full-width diff bands -->
+    <div class="cc-diff">
+      <div class="cc-out">
+        <span class="cc-corner">⎿</span>
+        <span class="cc-out-text">sections/intro.tex</span>
+      </div>
+      <div class="cc-dl cc-dl--del">
+        <span class="cc-gut">-</span>
+        <span class="cc-code"
+          >In this paper we present a novel approach to</span
+        >
+      </div>
+      <div class="cc-dl cc-dl--add">
+        <span class="cc-gut">+</span>
+        <span class="cc-code">We introduce</span>
       </div>
     </div>
 
-    <!-- Slash-command hint strip -->
-    <div class="cc-hint">
-      <span class="cc-hint-label">slash commands</span>
-      <code class="cc-slash">/tools</code>
-      <code class="cc-slash">/api</code>
-      <code class="cc-slash">/resume</code>
-    </div>
-  </div>
+    <!-- Status-bar strip: ◆ status · elapsed · api mode · round · tokens -->
+    <template #hint>
+      <span class="cc-diamond">◆</span>
+      <span class="cc-status">working</span>
+      <span class="cc-seg">8s</span>
+      <span class="cc-seg">relay</span>
+      <span class="cc-seg">r1</span>
+      <span class="cc-seg">12.3k/200k (6%)</span>
+      <span class="cc-bindings"
+        >[/model]models&ensp;[/api]api&ensp;[Ctrl-C]stop</span
+      >
+    </template>
+  </TermWindow>
 </template>
 
 <style scoped>
-/* Standalone terminal card. Tokens come from `.mockup` (theme/mockup.css). */
-.cli-chat {
-  background: var(--mk-bg);
-  border: 1px solid var(--mk-border-soft);
-  border-radius: var(--mk-radius-lg);
-  margin: var(--mk-space-12) 0;
-  overflow: hidden;
-  font-family: var(--vp-font-family-base);
+/* Card shell, body, prompt line, and hint strip come from TermWindow and the
+   shared .mk-term-* classes in theme/mockup.css. */
+
+/* Session header */
+.cc-header {
+  margin-top: var(--mk-space-9);
+  padding-top: var(--mk-space-7);
+  border-top: 1px solid var(--mk-border);
 }
-
-/* Titlebar comes from the shared `.mk-term-*` classes in theme/mockup.css. */
-
-/* Terminal body */
-.cc-body {
-  padding: var(--mk-space-12) var(--mk-space-14);
-  background: var(--mk-bg-deep);
-  font-family: var(--vp-font-family-mono);
-  font-size: var(--mk-fs-78);
-  line-height: 1.6;
-  color: var(--wa-color-text-normal);
-}
-
-.cc-prompt {
+.cc-brand-row {
   display: flex;
   align-items: baseline;
-  gap: var(--mk-space-7);
+  gap: var(--mk-space-10);
 }
-.cc-sigil {
-  color: var(--mk-syn-fn);
-  font-weight: 600;
-  flex-shrink: 0;
+.cc-brand {
+  color: var(--mk-accent);
+  font-weight: 700;
 }
-.cc-cmd {
-  color: var(--mk-text);
+.cc-meta {
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
 }
-.cc-flag {
-  color: var(--mk-syn-comment);
+.cc-identity {
+  color: var(--mk-text-dim);
+  font-size: var(--mk-fs-74);
 }
 
-/* Conversation turns */
-.cc-turn {
+/* User band: the TUI's reverse-video message highlight */
+.cc-user {
   display: flex;
   align-items: baseline;
-  flex-wrap: wrap;
   gap: var(--mk-space-7);
   margin-top: var(--mk-space-9);
-}
-.cc-who {
-  flex-shrink: 0;
-  font-size: var(--mk-fs-70);
-  font-weight: 600;
-  padding: 0 var(--mk-space-5);
+  padding: var(--mk-space-4) var(--mk-space-8);
   border-radius: var(--mk-radius-sm);
+  background: var(--mk-bg-raised);
 }
-.cc-who--user {
-  color: var(--color-text-secondary);
-  background: color-mix(in srgb, var(--mk-accent) 5%, transparent);
+.cc-chevron {
+  color: var(--mk-accent);
+  font-weight: 700;
+  flex-shrink: 0;
 }
-.cc-who--ai {
-  color: var(--mk-syn-fn);
-  background: color-mix(in srgb, var(--mk-accent) 12%, transparent);
-}
-.cc-msg {
+.cc-user-msg {
   color: var(--mk-text);
   min-width: 0;
-  flex: 1;
 }
-.cc-reasoning {
-  color: var(--mk-text-faint);
-  font-style: italic;
-  min-width: 0;
-  flex: 1;
-}
-/* Bridged Web Awesome spinner; track/indicator colors flip with the theme. */
-.cc-spin {
-  align-self: center;
-  font-size: var(--mk-space-11);
-  flex-shrink: 0;
+
+/* Assistant text */
+.cc-assistant {
+  margin: var(--mk-space-9) 0 0;
+  color: var(--mk-text);
 }
 
 /* Tool-call rows */
@@ -200,129 +173,108 @@ const calls = [
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--mk-space-2);
+  gap: var(--mk-space-4);
 }
-.cc-tool-row {
+.cc-call-row {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
   gap: var(--mk-space-7);
-  padding: var(--mk-space-5) var(--mk-space-6);
-  border-radius: var(--mk-radius-md);
-  font-size: var(--mk-fs-74);
-  line-height: 1.5;
-}
-.cc-tool-row.active {
-  background: color-mix(in srgb, var(--mk-accent) 8%, transparent);
 }
 .cc-dot {
-  align-self: center;
-  width: var(--mk-space-8);
-  height: var(--mk-space-8);
-  border-radius: 50%;
-  background: var(--color-success);
   flex-shrink: 0;
 }
-.cc-tspin {
-  align-self: center;
-  font-size: var(--mk-space-11);
-  flex-shrink: 0;
+.cc-dot--done {
+  color: var(--color-success);
+}
+.cc-dot--running {
+  color: var(--mk-text-faint);
 }
 .cc-tname {
-  color: var(--mk-syn-fn);
+  color: var(--mk-text);
   font-weight: 600;
-  flex-shrink: 0;
 }
-.cc-verb {
-  color: var(--mk-accent);
-  background: color-mix(in srgb, var(--mk-accent) 12%, transparent);
-  border-radius: var(--mk-radius-sm);
-  padding: 0 var(--mk-space-5);
-  font-size: var(--mk-fs-72);
-  flex-shrink: 0;
-}
-.cc-path {
-  color: var(--color-text-link);
+.cc-preview {
+  color: var(--mk-text-faint);
   word-break: break-all;
   min-width: 0;
 }
-.cc-effect {
+
+/* Dim output line under a call, hanging off the ⎿ corner glyph */
+.cc-out {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mk-space-7);
+  padding-left: var(--mk-space-16);
   color: var(--mk-text-faint);
-  font-family: var(--vp-font-family-base);
-  font-size: var(--mk-fs-72);
-  flex: 1;
+  font-size: var(--mk-fs-74);
+}
+.cc-corner {
+  flex-shrink: 0;
+}
+.cc-out-text {
   min-width: 0;
 }
 
-/* Inline diff hunk */
+/* Diff bands: full-width colored rows, no strikethrough */
 .cc-diff {
-  margin-top: var(--mk-space-9);
-  padding: var(--mk-space-6) 0;
-  border-top: 1px solid var(--mk-border);
+  margin-top: var(--mk-space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--mk-space-2);
 }
 .cc-dl {
   display: flex;
   align-items: baseline;
   gap: var(--mk-space-10);
+  padding-left: var(--mk-space-16);
   white-space: pre-wrap;
   font-size: var(--mk-fs-74);
   line-height: 1.7;
 }
 .cc-dl--del {
   background: color-mix(in srgb, var(--color-error) 10%, transparent);
+  color: var(--mk-del-text);
 }
 .cc-dl--add {
   background: color-mix(in srgb, var(--color-success) 12%, transparent);
+  color: var(--mk-ins-text);
 }
 .cc-gut {
   flex-shrink: 0;
-  width: var(--mk-size-21);
-  text-align: center;
-  color: var(--color-text-tertiary);
   user-select: none;
 }
 .cc-code {
   min-width: 0;
 }
-.cc-dl del {
-  color: var(--mk-del-text);
-  text-decoration: line-through;
-}
-.cc-dl ins {
-  color: var(--mk-ins-text);
-  text-decoration: none;
-}
 
-/* Slash-command hint strip */
-.cc-hint {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--mk-space-7);
-  padding: var(--mk-space-8) var(--mk-space-14);
-  background: var(--mk-bg-soft);
-  border-top: 1px solid var(--mk-border);
-}
-.cc-hint-label {
+/* Status-bar strip segments (inside the shared .mk-term-hint) */
+.cc-diamond {
+  color: var(--mk-accent);
   font-size: var(--mk-fs-70);
-  color: var(--mk-text-faint);
-  margin-right: var(--mk-space-4);
 }
-.cc-slash {
+.cc-status {
   font-family: var(--vp-font-family-mono);
   font-size: var(--mk-fs-72);
-  color: var(--mk-accent);
-  background: color-mix(in srgb, var(--mk-accent) 12%, transparent);
-  border: 1px solid var(--mk-border-soft);
-  border-radius: var(--mk-radius-pill);
-  padding: 0 var(--mk-space-8);
+  color: var(--mk-text);
+}
+.cc-seg {
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--mk-fs-70);
+  color: var(--mk-text-faint);
+}
+.cc-bindings {
+  margin-left: auto;
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--mk-fs-68);
+  color: var(--mk-text-faint);
 }
 
-/* Stack effect under verb/path on narrow screens. */
+/* Let the bindings wrap under the segments on narrow screens. */
 @media (max-width: 560px) {
-  .cc-effect {
+  .cc-bindings {
+    margin-left: 0;
     flex-basis: 100%;
-    padding-left: var(--mk-space-16);
   }
 }
 </style>

--- a/docs/.vitepress/components/CliHistoryHero.vue
+++ b/docs/.vitepress/components/CliHistoryHero.vue
@@ -1,0 +1,119 @@
+<script setup>
+// Terminal card for `texra history list` — guide/progress-board.md's proof
+// that run history is shared across surfaces. Rows reproduce the real
+// tab-separated format (packages/cli/src/runtime/history.ts
+// formatCliHistoryText): id, timestamp, agent, status, primary input — the
+// same runs the ProgressBoard shows as streams. Ids are the compact 12-char
+// hex execution ids; `texra resume <id>` reopens a stored tool-use session in
+// the interactive chat TUI.
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
+const rows = [
+  {
+    id: '9f3a6c81d24e',
+    ts: '2025-11-04T14:31:08',
+    agent: 'polish',
+    status: 'completed',
+    input: 'draft.tex',
+  },
+  {
+    id: 'c4e19b07a52d',
+    ts: '2025-11-04T11:02:44',
+    agent: 'research',
+    status: 'completed',
+    input: 'sections/intro.tex',
+  },
+  {
+    id: 'e2c70a94b18f',
+    ts: '2025-11-03T17:45:13',
+    agent: 'correct',
+    status: 'failed',
+    input: 'appendices.tex',
+  },
+];
+</script>
+
+<template>
+  <TermWindow title="texra history" aria-label="texra history list output">
+    <div class="chh-scroll">
+      <div class="mk-term-prompt chh-prompt">
+        <span class="mk-term-sigil">$</span>
+        <span class="mk-term-cmd"
+          >texra history list <span class="mk-term-flag">-n</span> 3</span
+        >
+      </div>
+      <div v-for="r in rows" :key="r.id" class="chh-row">
+        <span class="chh-id">{{ r.id }}</span>
+        <span class="chh-ts">{{ r.ts }}</span>
+        <span class="chh-agent">{{ r.agent }}</span>
+        <span
+          class="chh-status"
+          :class="r.status === 'failed' ? 'chh-status--bad' : ''"
+          >{{ r.status }}</span
+        >
+        <span class="chh-input">{{ r.input }}</span>
+      </div>
+
+      <div class="mk-term-prompt chh-resume">
+        <span class="mk-term-sigil">$</span>
+        <span class="mk-term-cmd">texra resume c4e19b07a52d</span>
+      </div>
+      <div class="chh-note">
+        reopens the stored session in the chat TUI, on the saved agent and model
+      </div>
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes. Column-aligned output scrolls instead of reflowing. */
+.chh-scroll {
+  overflow-x: auto;
+  font-size: var(--mk-fs-74);
+}
+.chh-prompt {
+  margin-bottom: var(--mk-space-7);
+}
+.chh-row {
+  display: grid;
+  grid-template-columns: 0.9fr 1.2fr 0.6fr 0.7fr 1fr;
+  min-width: var(--mk-size-520);
+  gap: var(--mk-space-10);
+  padding: var(--mk-space-3) 0;
+  align-items: baseline;
+}
+.chh-id {
+  color: var(--mk-accent);
+}
+.chh-ts {
+  color: var(--mk-text-faint);
+}
+.chh-agent {
+  color: var(--mk-syn-fn);
+  font-weight: 600;
+}
+.chh-status {
+  color: var(--color-success);
+}
+.chh-status--bad {
+  color: var(--color-error);
+}
+.chh-input {
+  color: var(--mk-text);
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chh-resume {
+  margin-top: var(--mk-space-10);
+}
+.chh-note {
+  padding-left: var(--mk-space-16);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-70);
+  font-style: italic;
+}
+</style>

--- a/docs/.vitepress/components/CliInitHero.vue
+++ b/docs/.vitepress/components/CliInitHero.vue
@@ -1,0 +1,105 @@
+<script setup>
+// Terminal card for `texra init` — guide/configuration.md "Where Settings
+// Live". Beat 1 reproduces the real scaffold output
+// (packages/cli/src/commands/init.ts): `Wrote .texra/config.json` followed by
+// the chosen defaults and the next-step hint; `--yes` accepts defaults
+// non-interactively, `--gitignore` adds `.texra/` to .gitignore. Beat 2 is the
+// doctor's config row (packages/cli/src/runtime/doctor.ts checkConfig)
+// confirming which workspace config file is loaded.
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
+</script>
+
+<template>
+  <TermWindow
+    title="texra init"
+    aria-label="texra init scaffolding .texra/config.json"
+  >
+    <!-- Beat 1: scaffold workspace defaults -->
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra init
+        <span class="cih-hint-flags"
+          >(--yes accepts defaults, --gitignore ignores .texra/)</span
+        ></span
+      >
+    </div>
+    <div class="cih-block">
+      <div class="cih-wrote">Wrote .texra/config.json</div>
+      <div class="cih-kv"><span class="cih-k">agent:</span> assistant</div>
+      <div class="cih-kv"><span class="cih-k">model:</span> deepseekT</div>
+      <div class="cih-kv"><span class="cih-k">approval:</span> ask</div>
+      <div class="cih-kv"><span class="cih-k">output:</span> text</div>
+      <div class="cih-next">
+        Next: run `texra` for the launcher, or `texra chat` to start.
+      </div>
+    </div>
+
+    <!-- Beat 2: doctor confirms what's loaded -->
+    <div class="mk-term-prompt cih-beat">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd">texra doctor</span>
+    </div>
+    <div class="cih-doctor">
+      <span class="cih-pass">PASS</span>
+      <span class="cih-name">Config:</span>
+      <span class="cih-msg">Workspace config: .texra/config.json</span>
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes in theme/mockup.css. */
+.cih-hint-flags {
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-70);
+}
+.cih-block {
+  margin-top: var(--mk-space-5);
+  padding-left: var(--mk-space-16);
+  font-size: var(--mk-fs-74);
+}
+.cih-wrote {
+  color: var(--mk-text);
+  font-weight: 600;
+}
+.cih-kv {
+  color: var(--mk-text-dim);
+  padding-left: var(--mk-space-12);
+}
+.cih-k {
+  color: var(--mk-syn-keyword);
+}
+.cih-next {
+  margin-top: var(--mk-space-6);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
+}
+
+.cih-beat {
+  margin-top: var(--mk-space-10);
+}
+.cih-doctor {
+  margin-top: var(--mk-space-4);
+  padding-left: var(--mk-space-16);
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--mk-space-7);
+  font-size: var(--mk-fs-74);
+}
+.cih-pass {
+  color: var(--color-success);
+  font-weight: 700;
+}
+.cih-name {
+  color: var(--mk-text);
+  font-weight: 600;
+}
+.cih-msg {
+  color: var(--mk-text-dim);
+  min-width: 0;
+}
+</style>

--- a/docs/.vitepress/components/CliLeanHero.vue
+++ b/docs/.vitepress/components/CliLeanHero.vue
@@ -1,0 +1,114 @@
+<script setup>
+// Compact terminal card for guide/lean.md "In the CLI" — what Lean work looks
+// like without the VS Code extension underneath: the CLI spawns its own
+// `lake env lean --server` (one per Lake project, as the section explains),
+// then the same lean_* tools run against it. The tool name and the chat-TUI
+// row vocabulary (`● tool (preview)` + dim `⎿ ` output) are real
+// (packages/extension/resources/tool_use_agents/lean.yaml,
+// packages/cli/src/chat/tui/panes/toolRenderers.tsx).
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
+</script>
+
+<template>
+  <TermWindow
+    title="texra chat"
+    aria-label="A Lean check running in the CLI against lake env lean --server"
+  >
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra chat <span class="mk-term-flag">--agent</span> lean</span
+      >
+    </div>
+
+    <div class="cln-user">
+      <span class="cln-chevron">›</span>
+      <span class="cln-msg">Check Proofs/GroupTheory.lean for errors.</span>
+    </div>
+
+    <div class="cln-status">
+      starting lake env lean --server (one per Lake project)
+    </div>
+
+    <div class="cln-call">
+      <div class="cln-row">
+        <span class="cln-dot">●</span>
+        <span class="cln-tname">lean_diagnostics</span>
+        <span class="cln-preview">(Proofs/GroupTheory.lean)</span>
+      </div>
+      <div class="cln-out">
+        <span class="cln-corner">⎿</span>
+        <span class="cln-out-text"
+          >1 error — line 42: unknown identifier 'mul_com'</span
+        >
+      </div>
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes in theme/mockup.css. */
+.cln-user {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mk-space-7);
+  margin-top: var(--mk-space-8);
+  padding: var(--mk-space-4) var(--mk-space-8);
+  border-radius: var(--mk-radius-sm);
+  background: var(--mk-bg-raised);
+}
+.cln-chevron {
+  color: var(--mk-accent);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.cln-msg {
+  color: var(--mk-text);
+  min-width: 0;
+}
+
+.cln-status {
+  margin-top: var(--mk-space-7);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
+  font-style: italic;
+}
+
+.cln-call {
+  margin-top: var(--mk-space-7);
+}
+.cln-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--mk-space-7);
+}
+.cln-dot {
+  color: var(--color-success);
+  flex-shrink: 0;
+}
+.cln-tname {
+  color: var(--mk-text);
+  font-weight: 600;
+}
+.cln-preview {
+  color: var(--mk-text-faint);
+  min-width: 0;
+}
+.cln-out {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mk-space-7);
+  padding-left: var(--mk-space-16);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-74);
+}
+.cln-corner {
+  flex-shrink: 0;
+}
+.cln-out-text {
+  min-width: 0;
+}
+</style>

--- a/docs/.vitepress/components/CliMemoryHero.vue
+++ b/docs/.vitepress/components/CliMemoryHero.vue
@@ -1,0 +1,114 @@
+<script setup>
+// Terminal card for `texra memory list` / `memory show` — guide/memory.md's
+// "Managing memories from the Dashboard" section, terminal counterpart. The
+// real list output (packages/cli/src/runtime/memory.ts formatCliMemoryList)
+// is a `Memories (N):` header then one `<displayPath>\t<description>` row per
+// note, where the description joins `pinned; <size>; modified: <date>; by
+// <agent>`; `memory show memories/<file>` previews one note. File names match
+// the page's Dashboard mockups (project-conventions.md) so both surfaces tell
+// one story.
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
+const rows = [
+  {
+    path: '/memories/project-conventions.md',
+    desc: 'pinned; 1.2 KB; modified: 11/4/2025, 2:31 PM; by research',
+    pinned: true,
+  },
+  {
+    path: '/memories/notation.md',
+    desc: '0.8 KB; modified: 10/28/2025, 10:04 AM; by assistant',
+    pinned: false,
+  },
+  {
+    path: '/memories/related-work.md',
+    desc: '2.4 KB; modified: 10/21/2025, 4:48 PM; by research',
+    pinned: false,
+  },
+];
+</script>
+
+<template>
+  <TermWindow
+    title="texra memory"
+    aria-label="texra memory list and show output"
+  >
+    <!-- Beat 1: list the store -->
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd">texra memory list</span>
+    </div>
+    <div class="cmh-head">Memories (3):</div>
+    <ul class="cmh-rows">
+      <li v-for="r in rows" :key="r.path" class="cmh-row">
+        <span class="cmh-path" :class="{ 'cmh-path--pinned': r.pinned }">{{
+          r.path
+        }}</span>
+        <span class="cmh-desc">{{ r.desc }}</span>
+      </li>
+    </ul>
+
+    <!-- Beat 2: preview one note -->
+    <div class="mk-term-prompt cmh-show">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra memory show memories/project-conventions.md</span
+      >
+    </div>
+    <div class="cmh-preview">
+      <div># Project conventions</div>
+      <div>- Use \lambda_2 (not \mu) for the second eigenvalue.</div>
+      <div>- Cite the journal version of Chung (1997), not the preprint.</div>
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes in theme/mockup.css. */
+.cmh-head {
+  margin-top: var(--mk-space-7);
+  color: var(--mk-text-dim);
+  font-weight: 600;
+  font-size: var(--mk-fs-74);
+}
+.cmh-rows {
+  list-style: none;
+  margin: var(--mk-space-3) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mk-space-3);
+}
+.cmh-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--mk-space-10);
+  font-size: var(--mk-fs-72);
+}
+.cmh-path {
+  color: var(--color-text-link);
+  flex-shrink: 0;
+}
+.cmh-path--pinned {
+  color: var(--mk-accent);
+  font-weight: 600;
+}
+.cmh-desc {
+  color: var(--mk-text-faint);
+  min-width: 0;
+}
+
+.cmh-show {
+  margin-top: var(--mk-space-10);
+  flex-wrap: wrap;
+}
+.cmh-preview {
+  margin-top: var(--mk-space-5);
+  padding-left: var(--mk-space-16);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
+  line-height: 1.7;
+}
+</style>

--- a/docs/.vitepress/components/CliModelsHero.vue
+++ b/docs/.vitepress/components/CliModelsHero.vue
@@ -1,0 +1,104 @@
+<script setup>
+// Terminal card for `texra models list` / `models show` — guide/models.md
+// "Customizing the Model List". The real list prints one
+// `<value>\t<label>\t<status>` row per model for the current api mode
+// (packages/cli/src/runtime/modelAccess.ts); `models show <id>` prints
+// `id:` / `label:` / `provider:` / `status:` detail lines
+// (formatCliModelDetails). Short ids and labels match the page's own model
+// tables — the id column is exactly what `--model` takes.
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
+const rows = [
+  { id: 'fable5', label: 'Claude Fable 5', status: 'available' },
+  { id: 'opus48T', label: 'Claude Opus 4.8 (thinking)', status: 'available' },
+  {
+    id: 'sonnet46T',
+    label: 'Claude Sonnet 4.6 (thinking)',
+    status: 'available',
+  },
+  {
+    id: 'deepseekT',
+    label: 'DeepSeek V4 Flash (thinking)',
+    status: 'available',
+  },
+];
+</script>
+
+<template>
+  <TermWindow
+    title="texra models"
+    aria-label="texra models list and show output"
+  >
+    <div class="cmo-scroll">
+      <!-- Beat 1: the roster for the current api mode -->
+      <div class="mk-term-prompt cmo-prompt">
+        <span class="mk-term-sigil">$</span>
+        <span class="mk-term-cmd">texra models list</span>
+      </div>
+      <div v-for="r in rows" :key="r.id" class="cmo-row">
+        <span class="cmo-id">{{ r.id }}</span>
+        <span class="cmo-label">{{ r.label }}</span>
+        <span class="cmo-status">{{ r.status }}</span>
+      </div>
+
+      <!-- Beat 2: one model's details -->
+      <div class="mk-term-prompt cmo-show">
+        <span class="mk-term-sigil">$</span>
+        <span class="mk-term-cmd">texra models show fable5</span>
+      </div>
+      <div class="cmo-details">
+        <div><span class="cmo-k">id:</span> fable5</div>
+        <div><span class="cmo-k">label:</span> Claude Fable 5</div>
+        <div><span class="cmo-k">provider:</span> anthropic</div>
+        <div><span class="cmo-k">status:</span> available</div>
+      </div>
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes. Column-aligned output scrolls instead of reflowing. */
+.cmo-scroll {
+  overflow-x: auto;
+  font-size: var(--mk-fs-74);
+}
+.cmo-prompt {
+  margin-bottom: var(--mk-space-7);
+}
+.cmo-row {
+  display: grid;
+  grid-template-columns: 0.7fr 2fr 0.7fr;
+  min-width: var(--mk-size-420);
+  gap: var(--mk-space-10);
+  padding: var(--mk-space-3) 0;
+  align-items: baseline;
+}
+.cmo-id {
+  color: var(--mk-accent);
+  font-weight: 600;
+}
+.cmo-label {
+  color: var(--mk-text);
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cmo-status {
+  color: var(--color-success);
+}
+
+.cmo-show {
+  margin-top: var(--mk-space-10);
+}
+.cmo-details {
+  margin-top: var(--mk-space-4);
+  padding-left: var(--mk-space-16);
+  color: var(--mk-text-dim);
+  font-size: var(--mk-fs-72);
+}
+.cmo-k {
+  color: var(--mk-syn-keyword);
+}
+</style>

--- a/docs/.vitepress/components/CliMultiAgentHero.vue
+++ b/docs/.vitepress/components/CliMultiAgentHero.vue
@@ -1,0 +1,177 @@
+<script setup>
+// Terminal card for `texra multi-agent run` — the Multi-Agent Teams section of
+// guide/texra-cli.md. Shows the orchestrator-and-delegates shape the TUI
+// actually renders: the team's lead agent at work, then the subagent panel's
+// numbered child rows (status marker colored by child state, agent label,
+// status, elapsed, one dim output tail line — packages/cli/src/chat/tui's
+// subagent panel), with the stream-focus bindings in the bottom strip. Team id
+// and agent names match the built-in Software Engineer preset (lead `engineer`
+// delegating to `coder`, `testEngineer`, …) quoted in the surrounding prose.
+//
+// Built on <TermWindow>; .mockup-scoped, so the shared --mk-* tokens resolve
+// here and the card flips with the docs theme. Believable static strings only.
+const children = [
+  {
+    n: 1,
+    agent: 'coder',
+    status: 'done',
+    elapsed: '48s',
+    tail: 'optimized the inner loop in scripts/simulate.py',
+  },
+  {
+    n: 2,
+    agent: 'testEngineer',
+    status: 'running',
+    elapsed: '21s',
+    tail: 'pytest -q  ·  17 passed, 3 to go',
+  },
+];
+</script>
+
+<template>
+  <TermWindow
+    title="texra multi-agent"
+    aria-label="texra multi-agent run with delegating subagents"
+  >
+    <!-- Prompt line -->
+    <div class="mk-term-prompt cma-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra multi-agent run software-engineer
+        <span class="mk-term-flag">--instruction</span> "Profile and speed up
+        scripts/simulate.py"</span
+      >
+    </div>
+
+    <!-- Orchestrator row: the team's lead plans and delegates -->
+    <div class="cma-root">
+      <wa-spinner class="cma-spin mk-spinner"></wa-spinner>
+      <span class="cma-agent">engineer</span>
+      <span class="cma-status">delegating</span>
+      <span class="cma-elapsed">1m12s</span>
+    </div>
+
+    <!-- Subagent panel rows: numbered children with status + output tail -->
+    <ul class="cma-children">
+      <li v-for="c in children" :key="c.n" class="cma-child">
+        <div class="cma-child-row">
+          <span class="cma-n">{{ c.n }}.</span>
+          <span
+            class="cma-marker"
+            :class="
+              c.status === 'done' ? 'cma-marker--done' : 'cma-marker--run'
+            "
+            >●</span
+          >
+          <span class="cma-agent">{{ c.agent }}</span>
+          <span class="cma-status">{{ c.status }}</span>
+          <span class="cma-elapsed">{{ c.elapsed }}</span>
+        </div>
+        <div class="cma-tail">
+          <span class="cma-corner">⎿</span>
+          <span class="cma-tail-text">{{ c.tail }}</span>
+        </div>
+      </li>
+    </ul>
+
+    <!-- Stream-focus bindings: each child is a focusable scoped transcript -->
+    <template #hint>
+      <span class="cma-bindings"
+        >[Tab]streams&ensp;[Esc 1..9]focus&ensp;[Esc s]subagents</span
+      >
+      <span class="cma-hint-note">each subagent keeps its own transcript</span>
+    </template>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, prompt, and hint strip come from TermWindow + the shared
+   .mk-term-* classes in theme/mockup.css. */
+.cma-prompt {
+  flex-wrap: wrap;
+}
+
+.cma-root {
+  display: flex;
+  align-items: center;
+  gap: var(--mk-space-8);
+  margin-top: var(--mk-space-9);
+}
+.cma-spin {
+  font-size: var(--mk-space-11);
+  flex-shrink: 0;
+}
+.cma-agent {
+  color: var(--mk-syn-fn);
+  font-weight: 600;
+}
+.cma-status {
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
+}
+.cma-elapsed {
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-70);
+}
+
+.cma-children {
+  list-style: none;
+  margin: var(--mk-space-7) 0 0;
+  padding: 0 0 0 var(--mk-space-16);
+  display: flex;
+  flex-direction: column;
+  gap: var(--mk-space-4);
+}
+.cma-child-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mk-space-7);
+}
+.cma-n {
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
+  flex-shrink: 0;
+}
+.cma-marker {
+  flex-shrink: 0;
+}
+.cma-marker--done {
+  color: var(--color-success);
+}
+.cma-marker--run {
+  color: var(--mk-text-faint);
+}
+.cma-tail {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mk-space-7);
+  padding-left: var(--mk-space-26);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
+}
+.cma-corner {
+  flex-shrink: 0;
+}
+.cma-tail-text {
+  min-width: 0;
+}
+
+.cma-bindings {
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--mk-fs-68);
+  color: var(--mk-text-faint);
+}
+.cma-hint-note {
+  margin-left: auto;
+  font-size: var(--mk-fs-70);
+  color: var(--mk-text-faint);
+  font-style: italic;
+}
+
+@media (max-width: 560px) {
+  .cma-hint-note {
+    margin-left: 0;
+    flex-basis: 100%;
+  }
+}
+</style>

--- a/docs/.vitepress/components/CliRemoteHero.vue
+++ b/docs/.vitepress/components/CliRemoteHero.vue
@@ -1,0 +1,89 @@
+<script setup>
+// Terminal card for guide/remote-agents.md "3. Use Remote Agents" — the full
+// remote loop from a terminal: sign in once, the remote definition resolves by
+// name, then it runs like any local agent. `texra login` confirms with the
+// real `Signed in as <label>.` line (packages/cli/src/commands/auth.ts);
+// `texra agents show` prints the detail lines from formatCliAgentDetails with
+// `source: remote` (the AGENT_SOURCE.REMOTE literal in
+// src/shared/schemas/agent.ts) marking the cloud-delivered definition.
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
+</script>
+
+<template>
+  <TermWindow
+    title="texra login"
+    aria-label="Sign in once and use remote agents by name from the terminal"
+  >
+    <!-- Beat 1: sign in -->
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd">texra login</span>
+    </div>
+    <div class="crm-block">
+      <div class="crm-dim">
+        Pick a provider: GitHub / Google → browser opens
+      </div>
+      <div class="crm-ok">Signed in as ada@lab.edu.</div>
+    </div>
+
+    <!-- Beat 2: the remote agent resolves by name -->
+    <div class="mk-term-prompt crm-beat">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd">texra agents show search</span>
+    </div>
+    <div class="crm-block">
+      <div><span class="crm-k">name:</span> search</div>
+      <div><span class="crm-k">category:</span> toolUse</div>
+      <div>
+        <span class="crm-k">source:</span>
+        <span class="crm-hot"> remote</span>
+      </div>
+    </div>
+
+    <!-- Beat 3: run it like any local agent -->
+    <div class="mk-term-prompt crm-beat">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra chat <span class="mk-term-flag">--agent</span> search</span
+      >
+    </div>
+    <div class="crm-note">
+      runs like any local agent — same chat, same run history
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes in theme/mockup.css. */
+.crm-block {
+  margin-top: var(--mk-space-4);
+  padding-left: var(--mk-space-16);
+  font-size: var(--mk-fs-72);
+  color: var(--mk-text-dim);
+}
+.crm-beat {
+  margin-top: var(--mk-space-9);
+}
+.crm-dim {
+  color: var(--mk-text-faint);
+}
+.crm-ok {
+  color: var(--color-success);
+  font-weight: 600;
+}
+.crm-k {
+  color: var(--mk-syn-keyword);
+}
+.crm-hot {
+  color: var(--mk-accent);
+  font-weight: 600;
+}
+.crm-note {
+  padding-left: var(--mk-space-16);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-70);
+  font-style: italic;
+}
+</style>

--- a/docs/.vitepress/components/CliRunHero.vue
+++ b/docs/.vitepress/components/CliRunHero.vue
@@ -1,0 +1,152 @@
+<script setup>
+// Shared streaming-run card for headless `texra run` — the one terminal figure
+// several guide pages reuse (quick-start, first-run, polish-a-draft,
+// agent-architecture, multiple-output, working-with-figures, texra-cli), each
+// with its own command and snapshot state. Workflow runs stream round progress
+// and, in text mode, end by printing a filesystem path on stdout (the copied
+// --output / --output-dir path, else the generated file in run storage) — so
+// the card shows: prompt line, per-round progress rows, printed result lines,
+// and an optional dim annotation.
+//
+// Built on the <TermWindow> primitive; .mockup-scoped, so the shared --mk-*
+// tokens resolve here and the card flips with the docs light / dark theme.
+// Props carry believable static page-specific strings — never live data:
+// - command: full command line after `$ ` (flags are auto-tinted)
+// - rounds:  [{ label, state: 'done' | 'active' }]
+// - outputs: printed stdout result lines (paths), shown when the run finished
+// - note:    optional dim trailing annotation
+import { computed } from 'vue';
+
+const props = defineProps({
+  command: {
+    type: String,
+    default: 'texra run polish --input draft.tex',
+  },
+  rounds: {
+    type: Array,
+    default: () => [
+      { label: 'r0 — draft revision', state: 'done' },
+      { label: 'r1 — critique and revise', state: 'active' },
+    ],
+  },
+  outputs: { type: Array, default: () => [] },
+  note: { type: String, default: '' },
+});
+
+// Window title = the command's leading words ("texra run"), house convention.
+const title = computed(() => props.command.split(' ').slice(0, 2).join(' '));
+
+// Tint flag tokens without breaking quoted arguments apart.
+const segments = computed(() => {
+  const out = [];
+  let cur = '';
+  let quote = null;
+  for (const ch of props.command) {
+    if (quote) {
+      cur += ch;
+      if (ch === quote) quote = null;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+      cur += ch;
+    } else if (ch === ' ') {
+      if (cur) out.push(cur);
+      out.push(' ');
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur) out.push(cur);
+  return out.map((text) => ({ text, flag: text.startsWith('-') }));
+});
+</script>
+
+<template>
+  <TermWindow :title="title" :aria-label="`${title} streaming output`">
+    <!-- Prompt line, flags tinted -->
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd crh-cmd"
+        ><template v-for="(s, i) in segments" :key="i"
+          ><span v-if="s.flag" class="mk-term-flag">{{ s.text }}</span
+          ><template v-else>{{ s.text }}</template></template
+        ></span
+      >
+    </div>
+
+    <!-- Round progress rows -->
+    <ul class="crh-rounds">
+      <li v-for="r in rounds" :key="r.label" class="crh-round">
+        <wa-spinner
+          v-if="r.state === 'active'"
+          class="crh-spin mk-spinner"
+        ></wa-spinner>
+        <span v-else class="crh-dot"></span>
+        <span class="crh-label">{{ r.label }}</span>
+      </li>
+    </ul>
+
+    <!-- Printed result lines (text mode prints the output path on stdout) -->
+    <div v-if="outputs.length" class="crh-outputs">
+      <div v-for="line in outputs" :key="line" class="crh-out">{{ line }}</div>
+    </div>
+
+    <!-- Optional dim annotation -->
+    <div v-if="note" class="crh-note">{{ note }}</div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt line come from TermWindow + the shared
+   .mk-term-* classes in theme/mockup.css. */
+.crh-cmd {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.crh-rounds {
+  list-style: none;
+  margin: var(--mk-space-9) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mk-space-4);
+}
+.crh-round {
+  display: flex;
+  align-items: center;
+  gap: var(--mk-space-8);
+}
+.crh-dot {
+  width: var(--mk-space-8);
+  height: var(--mk-space-8);
+  border-radius: 50%;
+  background: var(--color-success);
+  flex-shrink: 0;
+}
+.crh-spin {
+  font-size: var(--mk-space-11);
+  flex-shrink: 0;
+}
+.crh-label {
+  color: var(--mk-text-dim);
+  font-size: var(--mk-fs-74);
+}
+
+.crh-outputs {
+  margin-top: var(--mk-space-9);
+}
+.crh-out {
+  color: var(--color-text-link);
+  font-size: var(--mk-fs-74);
+  word-break: break-all;
+}
+
+.crh-note {
+  margin-top: var(--mk-space-8);
+  color: var(--mk-text-faint);
+  font-family: var(--vp-font-family-base);
+  font-size: var(--mk-fs-72);
+  font-style: italic;
+}
+</style>

--- a/docs/.vitepress/components/CliSearchChatHero.vue
+++ b/docs/.vitepress/components/CliSearchChatHero.vue
@@ -1,0 +1,168 @@
+<script setup>
+// Terminal card for guide/research-tools.md "Find Papers" — the page's postdoc
+// user story, streaming in a terminal. Uses the real chat-TUI vocabulary
+// (packages/cli/src/chat/tui/panes/): session header with `agent: … ·
+// model: …`, a `› ` reverse-video user band, `● tool (preview)` rows (dot dim
+// while running, green when done) and a dim `⎿ ` result line. Tool names are
+// the real grounded-search tools (src/tools/arxiv/ArxivSearchTool.ts
+// `arxiv_search`, src/tools/citation/CrossrefSearchTool.ts `crossref_search`).
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings; the
+// quoted paper is a real arXiv preprint, not fabricated.
+</script>
+
+<template>
+  <TermWindow
+    title="texra chat"
+    aria-label="A literature search streaming in texra chat"
+  >
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra chat <span class="mk-term-flag">--agent</span> search</span
+      >
+    </div>
+
+    <div class="csr-identity">agent: search · model: deepseekT</div>
+
+    <div class="csr-user">
+      <span class="csr-chevron">›</span>
+      <span class="csr-msg"
+        >Find recent papers on efficient self-attention for long
+        documents.</span
+      >
+    </div>
+
+    <ul class="csr-tools">
+      <li class="csr-call">
+        <div class="csr-row">
+          <span class="csr-dot csr-dot--done">●</span>
+          <span class="csr-tname">arxiv_search</span>
+          <span class="csr-preview"
+            >(efficient self-attention long documents)</span
+          >
+        </div>
+        <div class="csr-out">
+          <span class="csr-corner">⎿</span>
+          <span class="csr-out-text"
+            >12 results — "Longformer: The Long-Document Transformer"
+            (arXiv:2004.05150) …</span
+          >
+        </div>
+      </li>
+      <li class="csr-call">
+        <div class="csr-row">
+          <span class="csr-dot csr-dot--running">●</span>
+          <span class="csr-tname">crossref_search</span>
+          <span class="csr-preview">(efficient attention published)</span>
+        </div>
+      </li>
+    </ul>
+
+    <template #hint>
+      <span class="csr-diamond">◆</span>
+      <span class="csr-seg">working</span>
+      <span class="csr-seg">relay</span>
+      <span class="csr-seg-dim"
+        >every row a real lookup — arXiv + Crossref</span
+      >
+    </template>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, prompt, and hint strip come from TermWindow + the shared
+   .mk-term-* classes in theme/mockup.css. */
+.csr-identity {
+  margin-top: var(--mk-space-5);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
+}
+.csr-user {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mk-space-7);
+  margin-top: var(--mk-space-8);
+  padding: var(--mk-space-4) var(--mk-space-8);
+  border-radius: var(--mk-radius-sm);
+  background: var(--mk-bg-raised);
+}
+.csr-chevron {
+  color: var(--mk-accent);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.csr-msg {
+  color: var(--mk-text);
+  min-width: 0;
+}
+
+.csr-tools {
+  list-style: none;
+  margin: var(--mk-space-8) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mk-space-4);
+}
+.csr-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--mk-space-7);
+}
+.csr-dot {
+  flex-shrink: 0;
+}
+.csr-dot--done {
+  color: var(--color-success);
+}
+.csr-dot--running {
+  color: var(--mk-text-faint);
+}
+.csr-tname {
+  color: var(--mk-text);
+  font-weight: 600;
+}
+.csr-preview {
+  color: var(--mk-text-faint);
+  min-width: 0;
+}
+.csr-out {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mk-space-7);
+  padding-left: var(--mk-space-16);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-74);
+}
+.csr-corner {
+  flex-shrink: 0;
+}
+.csr-out-text {
+  min-width: 0;
+}
+
+.csr-diamond {
+  color: var(--mk-accent);
+  font-size: var(--mk-fs-70);
+}
+.csr-seg {
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--mk-fs-70);
+  color: var(--mk-text-faint);
+}
+.csr-seg-dim {
+  margin-left: auto;
+  font-size: var(--mk-fs-68);
+  color: var(--mk-text-faint);
+  font-style: italic;
+}
+
+@media (max-width: 560px) {
+  .csr-seg-dim {
+    margin-left: 0;
+    flex-basis: 100%;
+  }
+}
+</style>

--- a/docs/.vitepress/components/CliStorageHero.vue
+++ b/docs/.vitepress/components/CliStorageHero.vue
@@ -1,0 +1,104 @@
+<script setup>
+// Terminal card for guide/file-management.md "Task Run Storage" —
+// StorageLifecycleFlow's terminal twin. Three beats showing the same
+// storage-first lifecycle from the CLI: (1) a bare run prints its run-storage
+// path (outputs land in storage first, never over workspace files), (2)
+// `--output` copies the final artifact out — the CLI's "Accept", (3)
+// `texra history show <id>` lists the run's stored artifacts with the real
+// `Files (N):` `<size>\t<path>` format (packages/cli/src/runtime/history.ts
+// formatCliHistoryDetailsText). The CLI's run store lives under
+// `.texra/runs/<run-id>/` (see First run); ids are 12-char hex.
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
+const files = [
+  { size: '4128', path: 'r0/paper.tex' },
+  { size: '4310', path: 'r1/paper.tex' },
+];
+</script>
+
+<template>
+  <TermWindow
+    title="texra run"
+    aria-label="Run storage lifecycle from the terminal"
+  >
+    <!-- Beat 1: storage first -->
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra run polish
+        <span class="mk-term-flag">--input</span> paper.tex</span
+      >
+    </div>
+    <div class="csh-out">.texra/runs/9f3a6c81d24e/r1/paper.tex</div>
+    <div class="csh-note">outputs land in the run's storage folder first</div>
+
+    <!-- Beat 2: copy out on request (the CLI's "Accept") -->
+    <div class="mk-term-prompt csh-beat">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra run polish <span class="mk-term-flag">--input</span> paper.tex
+        <span class="mk-term-flag">--output</span> paper.polished.tex</span
+      >
+    </div>
+    <div class="csh-out">paper.polished.tex</div>
+    <div class="csh-note">
+      --output copies the final artifact next to your input
+    </div>
+
+    <!-- Beat 3: browse a run's stored artifacts -->
+    <div class="mk-term-prompt csh-beat">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd">texra history show 9f3a6c81d24e</span>
+    </div>
+    <div class="csh-files">
+      <div class="csh-files-head">Files (2):</div>
+      <div v-for="f in files" :key="f.path" class="csh-file">
+        <span class="csh-size">{{ f.size }}</span>
+        <span class="csh-path">{{ f.path }}</span>
+      </div>
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes in theme/mockup.css. */
+.csh-beat {
+  margin-top: var(--mk-space-10);
+  flex-wrap: wrap;
+}
+.csh-out {
+  margin-top: var(--mk-space-4);
+  color: var(--color-text-link);
+  font-size: var(--mk-fs-72);
+  word-break: break-all;
+}
+.csh-note {
+  color: var(--mk-text-faint);
+  font-family: var(--vp-font-family-base);
+  font-size: var(--mk-fs-70);
+  font-style: italic;
+}
+
+.csh-files {
+  margin-top: var(--mk-space-5);
+  padding-left: var(--mk-space-16);
+  font-size: var(--mk-fs-72);
+}
+.csh-files-head {
+  color: var(--mk-text-dim);
+  font-weight: 600;
+}
+.csh-file {
+  display: flex;
+  gap: var(--mk-space-12);
+}
+.csh-size {
+  color: var(--mk-text-faint);
+  min-width: var(--mk-size-32);
+  text-align: right;
+}
+.csh-path {
+  color: var(--color-text-link);
+}
+</style>

--- a/docs/.vitepress/components/CliToolsLifecycleHero.vue
+++ b/docs/.vitepress/components/CliToolsLifecycleHero.vue
@@ -1,0 +1,100 @@
+<script setup>
+// Terminal card for guide/agent-integrations.md "Quick Start" — the
+// IntegrationCard flow (Not Found → Install → Sign in → Recheck → Available)
+// beat for beat, from a terminal. Output lines reproduce the real shapes:
+// `texra tools show codex` prints `key: value` detail lines including the
+// registered installCommand / authCommand (packages/cli/src/runtime/tools.ts
+// formatCliToolStatus); `tools install --run` prints the install guide then
+// executes the registered command; `tools auth` runs `codex login`. The codex
+// id, commands, and guide text match src/tools/externalToolDefs.ts verbatim.
+//
+// Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
+</script>
+
+<template>
+  <TermWindow
+    title="texra tools"
+    aria-label="Detect, install, authenticate, and recheck an integration from the terminal"
+  >
+    <!-- Beat 1: detect -->
+    <div class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd">texra tools show codex</span>
+    </div>
+    <div class="ctf-block">
+      <div><span class="ctf-k">name:</span> OpenAI Codex CLI</div>
+      <div>
+        <span class="ctf-k">detected:</span>
+        <span class="ctf-no"> no</span>
+      </div>
+      <div>
+        <span class="ctf-k">installCommand:</span> npm install -g @openai/codex
+      </div>
+      <div><span class="ctf-k">authCommand:</span> codex login</div>
+    </div>
+
+    <!-- Beat 2: install -->
+    <div class="mk-term-prompt ctf-beat">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >texra tools install codex <span class="mk-term-flag">--run</span></span
+      >
+    </div>
+    <div class="ctf-block ctf-dim">
+      <div>Install the Codex CLI (choose one):</div>
+      <div class="ctf-indent">npm install -g @openai/codex</div>
+    </div>
+
+    <!-- Beat 3: sign in -->
+    <div class="mk-term-prompt ctf-beat">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd">texra tools auth codex</span>
+    </div>
+    <div class="ctf-block ctf-dim">
+      <div>codex login — sign in with ChatGPT account</div>
+    </div>
+
+    <!-- Beat 4: recheck -->
+    <div class="mk-term-prompt ctf-beat">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd">texra tools show codex</span>
+    </div>
+    <div class="ctf-block">
+      <div>
+        <span class="ctf-k">detected:</span>
+        <span class="ctf-yes"> yes</span>
+      </div>
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes in theme/mockup.css. */
+.ctf-block {
+  margin-top: var(--mk-space-4);
+  padding-left: var(--mk-space-16);
+  font-size: var(--mk-fs-72);
+  color: var(--mk-text-dim);
+}
+.ctf-beat {
+  margin-top: var(--mk-space-9);
+}
+.ctf-k {
+  color: var(--mk-syn-keyword);
+}
+.ctf-no {
+  color: var(--color-warning);
+  font-weight: 600;
+}
+.ctf-yes {
+  color: var(--color-success);
+  font-weight: 600;
+}
+.ctf-dim {
+  color: var(--mk-text-faint);
+}
+.ctf-indent {
+  padding-left: var(--mk-space-12);
+}
+</style>

--- a/docs/.vitepress/components/CliToolsListHero.vue
+++ b/docs/.vitepress/components/CliToolsListHero.vue
@@ -1,70 +1,67 @@
 <script setup>
-// Frameless terminal-output card for `texra tools list`. The Tools and
-// Integrations section of guide/texra-cli.md describes the command as reporting
-// "each integration id, name, category, enabled state, and detection result" —
-// five structured columns the reader currently has to imagine. This renders that
-// tabular output so the columns, the enabled-vs-disabled state (status dot), and
-// the detected-vs-not state (check / x glyph) are concrete at a glance.
+// Terminal-output card for `texra tools list`. The real command prints six
+// tab-separated columns — ID NAME CATEGORY ENABLED DETECTED NOTE, booleans as
+// yes / no / - and NOTE carrying the registered install command when a tool is
+// not detected (packages/cli/src/runtime/tools.ts formatCliToolList /
+// noteForTool). This renders that table so the columns and the
+// enabled-vs-detected distinction are concrete at a glance.
 //
-// Standalone (no MockupFrame) — a terminal card on the .mockup surface, mirroring
-// CliChatHero's titlebar + mono body, so the shared --mk-* tokens resolve here
-// and the whole thing flips with the docs light / dark theme. Integration ids,
-// names, and categories match resources/externalToolDefs verbatim; the
-// enabled/detection mix is a believable static snapshot showing both states.
+// Built on the <TermWindow> primitive; the shared --mk-* tokens resolve here
+// and the card flips with the docs light / dark theme. Integration ids, names,
+// categories, and the claude-agent install command match
+// src/tools/externalToolDefs.ts verbatim; the enabled / detection mix is a
+// believable static snapshot showing all three states.
 const rows = [
   {
     id: 'codex',
     name: 'OpenAI Codex CLI',
     category: 'ai-agents',
-    enabled: true,
-    detected: true,
+    enabled: 'yes',
+    detected: 'yes',
+    note: '',
   },
   {
     id: 'claude-agent',
     name: 'Claude Code CLI',
     category: 'ai-agents',
-    enabled: true,
-    detected: true,
+    enabled: 'yes',
+    detected: 'no',
+    note: 'npm install -g @anthropic-ai/claude-code',
   },
   {
     id: 'wolfram',
     name: 'Wolfram Language',
     category: 'computation',
-    enabled: true,
-    detected: false,
+    enabled: 'yes',
+    detected: 'no',
+    note: '',
   },
   {
     id: 'lean4',
     name: 'Lean 4',
     category: 'lean',
-    enabled: false,
-    detected: true,
+    enabled: 'no',
+    detected: 'yes',
+    note: '',
   },
   {
     id: 'texcount',
     name: 'TeXcount',
     category: 'latex',
-    enabled: true,
-    detected: true,
+    enabled: 'yes',
+    detected: 'yes',
+    note: '',
   },
 ];
 </script>
 
 <template>
-  <div class="mockup ctl" role="group" aria-label="texra tools list output">
-    <!-- Faux terminal titlebar -->
-    <div class="mk-term-bar">
-      <span class="mk-term-light mk-term-light--r"></span>
-      <span class="mk-term-light mk-term-light--y"></span>
-      <span class="mk-term-light mk-term-light--g"></span>
-      <span class="mk-term-title">texra tools list</span>
-    </div>
-
-    <div class="ctl-body">
+  <TermWindow title="texra tools list" aria-label="texra tools list output">
+    <div class="ctl-scroll">
       <!-- Prompt line -->
-      <div class="ctl-prompt">
-        <span class="ctl-sigil">$</span>
-        <span class="ctl-cmd">texra tools list</span>
+      <div class="mk-term-prompt ctl-prompt">
+        <span class="mk-term-sigil">$</span>
+        <span class="mk-term-cmd">texra tools list</span>
       </div>
 
       <!-- Column header -->
@@ -74,6 +71,7 @@ const rows = [
         <span class="ctl-c ctl-c--cat">CATEGORY</span>
         <span class="ctl-c ctl-c--enabled">ENABLED</span>
         <span class="ctl-c ctl-c--detected">DETECTED</span>
+        <span class="ctl-c ctl-c--note">NOTE</span>
       </div>
 
       <!-- Integration rows -->
@@ -84,70 +82,47 @@ const rows = [
         <span class="ctl-c ctl-c--enabled">
           <span
             class="ctl-dot"
-            :class="r.enabled ? 'ctl-dot--on' : 'ctl-dot--off'"
+            :class="r.enabled === 'yes' ? 'ctl-dot--on' : 'ctl-dot--off'"
           ></span>
-          {{ r.enabled ? 'enabled' : 'disabled' }}
+          {{ r.enabled }}
         </span>
         <span
           class="ctl-c ctl-c--detected"
-          :class="r.detected ? 'ctl-det--yes' : 'ctl-det--no'"
+          :class="r.detected === 'yes' ? 'ctl-det--yes' : 'ctl-det--no'"
         >
           <wa-icon
             library="texra"
-            :name="r.detected ? 'check' : 'close'"
+            :name="r.detected === 'yes' ? 'check' : 'close'"
           ></wa-icon>
-          {{ r.detected ? 'detected' : 'not found' }}
+          {{ r.detected }}
         </span>
+        <span class="ctl-c ctl-c--note">{{ r.note }}</span>
       </div>
     </div>
-  </div>
+  </TermWindow>
 </template>
 
 <style scoped>
-.ctl {
-  background: var(--mk-bg);
-  border: 1px solid var(--mk-border-soft);
-  border-radius: var(--mk-radius-lg);
-  margin: var(--mk-space-12) 0;
-  overflow: hidden;
-  font-family: var(--vp-font-family-base);
-}
-
-/* Titlebar comes from the shared `.mk-term-*` classes in theme/mockup.css. */
-
-/* Body */
-.ctl-body {
-  padding: var(--mk-space-12) var(--mk-space-14);
-  background: var(--mk-bg-deep);
-  font-family: var(--vp-font-family-mono);
-  font-size: var(--mk-fs-76);
-  line-height: 1.6;
-  color: var(--wa-color-text-normal);
+/* Card shell, titlebar, and body come from TermWindow + the shared .mk-term-*
+   classes in theme/mockup.css. The table is denser than prose terminal cards,
+   so it tightens the body font a step and scrolls horizontally on narrow
+   columns rather than reflowing — terminal output is intrinsically
+   column-aligned. */
+.ctl-scroll {
   overflow-x: auto;
+  font-size: var(--mk-fs-76);
 }
 .ctl-prompt {
-  display: flex;
-  align-items: baseline;
-  gap: var(--mk-space-7);
   margin-bottom: var(--mk-space-8);
 }
-.ctl-sigil {
-  color: var(--mk-syn-fn);
-  font-weight: 600;
-}
-.ctl-cmd {
-  color: var(--mk-text);
-}
 
-/* Table rows: a fixed grid so columns align like fixed-width terminal output. */
+/* Table rows: a fixed grid so columns align like fixed-width terminal output.
+   The tokenized floor keeps columns readable; .ctl-scroll provides the
+   horizontal scroll instead of reflowing. */
 .ctl-row {
   display: grid;
-  grid-template-columns:
-    minmax(96px, 0.9fr)
-    minmax(120px, 1.4fr)
-    minmax(80px, 0.9fr)
-    minmax(86px, 0.8fr)
-    minmax(92px, 0.8fr);
+  grid-template-columns: 0.8fr 1.3fr 0.8fr 0.55fr 0.6fr 1.4fr;
+  min-width: var(--mk-size-520);
   gap: var(--mk-space-8);
   align-items: center;
   padding: var(--mk-space-3) 0;
@@ -206,18 +181,8 @@ const rows = [
 .ctl-c--detected wa-icon {
   font-size: var(--mk-space-11);
 }
-
-/* On a narrow column, the body scrolls horizontally (overflow-x:auto) rather
-   than reflowing — terminal output is intrinsically column-aligned. */
-@media (max-width: 560px) {
-  .ctl-row {
-    grid-template-columns:
-      minmax(88px, 0.9fr)
-      minmax(110px, 1.3fr)
-      minmax(74px, 0.8fr)
-      minmax(82px, 0.8fr)
-      minmax(86px, 0.8fr);
-    min-width: 460px;
-  }
+.ctl-c--note {
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
 }
 </style>

--- a/docs/.vitepress/components/DoctorSliceHero.vue
+++ b/docs/.vitepress/components/DoctorSliceHero.vue
@@ -1,0 +1,95 @@
+<script setup>
+// Compact, props-driven slice of the real `texra doctor` text report — the
+// terminal twin of DoctorReportCard (installation.md), for pages that need a
+// few toolchain rows rather than the whole stylized report. Rows reproduce the
+// CLI's literal output format (packages/cli/src/runtime/doctor.ts
+// formatDoctorText): `PASS <name>: <message>` with a dim indented hint line
+// under WARN/FAIL rows, exactly as the command prints them. LaTeX row names
+// and purposes come from src/latex/latexToolchain.ts TOOL_PURPOSES.
+//
+// Built on <TermWindow>; .mockup-scoped and token-only, so it flips with the
+// docs theme. Pages pass their own rows: { state: 'pass'|'warn'|'fail',
+// name, message, hint? }.
+defineProps({
+  rows: { type: Array, required: true },
+});
+</script>
+
+<template>
+  <TermWindow title="texra doctor" aria-label="texra doctor report excerpt">
+    <div class="mk-term-prompt dsh-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd">texra doctor</span>
+    </div>
+    <ul class="dsh-rows">
+      <li v-for="r in rows" :key="r.name" class="dsh-row">
+        <div class="dsh-line">
+          <span class="dsh-state" :class="`dsh-state--${r.state}`">{{
+            r.state.toUpperCase()
+          }}</span>
+          <span class="dsh-name">{{ r.name }}:</span>
+          <span class="dsh-msg">{{ r.message }}</span>
+        </div>
+        <div v-if="r.hint" class="dsh-hint">{{ r.hint }}</div>
+      </li>
+    </ul>
+    <div class="dsh-more">
+      … plus Node, auth, model access, and storage checks
+    </div>
+  </TermWindow>
+</template>
+
+<style scoped>
+/* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
+   classes in theme/mockup.css. */
+.dsh-prompt {
+  margin-bottom: var(--mk-space-8);
+}
+.dsh-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mk-space-3);
+}
+.dsh-line {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--mk-space-7);
+  font-size: var(--mk-fs-74);
+}
+.dsh-state {
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.dsh-state--pass {
+  color: var(--color-success);
+}
+.dsh-state--warn {
+  color: var(--color-warning);
+}
+.dsh-state--fail {
+  color: var(--color-error);
+}
+.dsh-name {
+  color: var(--mk-text);
+  font-weight: 600;
+}
+.dsh-msg {
+  color: var(--mk-text-dim);
+  min-width: 0;
+}
+.dsh-hint {
+  padding-left: var(--mk-space-26);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-72);
+}
+.dsh-more {
+  margin-top: var(--mk-space-8);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-70);
+  font-style: italic;
+}
+</style>

--- a/docs/.vitepress/components/LandingCliStrip.vue
+++ b/docs/.vitepress/components/LandingCliStrip.vue
@@ -1,0 +1,46 @@
+<script setup>
+// Tiny terminal strip for the landing page's bottom CTA — the visual answer to
+// "Can I use it without VS Code?". Three real commands (install, sign in, run)
+// and the printed output path; nothing else. The editor-shaped hero carries the
+// rest of the page, so this stays deliberately small.
+//
+// Built on the <TermWindow> primitive; .mockup-scoped and token-only, so it
+// flips with the docs theme. Believable static strings.
+const lines = [
+  { cmd: 'npm install ', flag: '-g', rest: ' @texra-ai/cli' },
+  { cmd: 'texra login', flag: '', rest: '' },
+  { cmd: 'texra run polish ', flag: '--input', rest: ' paper.tex' },
+];
+</script>
+
+<template>
+  <TermWindow
+    title="terminal"
+    aria-label="Install, sign in, and run TeXRA from a terminal"
+    class="lcs"
+  >
+    <div v-for="l in lines" :key="l.cmd" class="mk-term-prompt">
+      <span class="mk-term-sigil">$</span>
+      <span class="mk-term-cmd"
+        >{{ l.cmd }}<span v-if="l.flag" class="mk-term-flag">{{ l.flag }}</span
+        >{{ l.rest }}</span
+      >
+    </div>
+    <div class="lcs-out">.texra/runs/9f3a6c81d24e/r1/paper.tex</div>
+  </TermWindow>
+</template>
+
+<style scoped>
+.lcs {
+  max-width: var(--mk-size-520);
+  margin-left: auto;
+  margin-right: auto;
+  text-align: left;
+}
+.lcs-out {
+  margin-top: var(--mk-space-5);
+  color: var(--color-text-link);
+  font-size: var(--mk-fs-72);
+  word-break: break-all;
+}
+</style>

--- a/docs/.vitepress/components/RunParityHero.vue
+++ b/docs/.vitepress/components/RunParityHero.vue
@@ -1,0 +1,185 @@
+<script setup>
+// Parity card for guide/index.md "Two surfaces, one system" — the page's
+// strongest CLI claim ("A run started in the CLI shows up in the extension's
+// Progress Board, and vice versa") made visible: the SAME run, identified by
+// the same 12-char hex execution id, seen from both surfaces. Left half is a
+// slim terminal strip (shared .mk-term-* chrome from theme/mockup.css); right
+// half is a single Progress-Board-style stream row (GuideIntroHero's
+// stream-head vocabulary, reduced to one row). The shared id chip is the
+// visual tie.
+//
+// .mockup-scoped and token-only, so both halves flip with the docs theme.
+// Halves stack under the shared 820px breakpoint. Believable static strings.
+const RUN_ID = '9f3a6c81d24e';
+</script>
+
+<template>
+  <div
+    class="mockup rph"
+    role="group"
+    aria-label="One run visible from both the CLI and the extension's Progress Board"
+  >
+    <!-- Terminal half: the run as the CLI shows it -->
+    <section class="mk-term-card rph-term">
+      <div class="mk-term-bar">
+        <span class="mk-term-light mk-term-light--r"></span>
+        <span class="mk-term-light mk-term-light--y"></span>
+        <span class="mk-term-light mk-term-light--g"></span>
+        <span class="mk-term-title">terminal</span>
+      </div>
+      <div class="mk-term-body rph-term-body">
+        <div class="mk-term-prompt">
+          <span class="mk-term-sigil">$</span>
+          <span class="mk-term-cmd"
+            >texra run polish
+            <span class="mk-term-flag">--input</span> draft.tex</span
+          >
+        </div>
+        <div class="rph-done">
+          <span class="rph-dot"></span>
+          <span>run complete</span>
+          <code class="rph-id">{{ RUN_ID }}</code>
+        </div>
+        <div class="rph-path">.texra/runs/{{ RUN_ID }}/r1/draft.tex</div>
+      </div>
+    </section>
+
+    <!-- Connector: same run, either surface -->
+    <div class="rph-link" aria-hidden="true">
+      <span class="rph-link-glyph">⇄</span>
+      <span class="rph-link-label">same run</span>
+    </div>
+
+    <!-- Progress-Board half: the same run as the extension shows it -->
+    <section class="mk-term-card rph-board">
+      <div class="rph-board-head">
+        <wa-icon library="texra" name="robot"></wa-icon>
+        <span>Progress</span>
+      </div>
+      <div class="rph-row">
+        <span class="rph-dot"></span>
+        <span class="rph-agent">polish</span>
+        <span class="rph-file">draft.tex</span>
+        <code class="rph-id">{{ RUN_ID }}</code>
+      </div>
+      <div class="rph-row-sub">completed — diff ready on r1/draft.tex</div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.rph {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: stretch;
+  gap: var(--mk-space-10);
+  margin: var(--mk-space-12) 0;
+}
+
+/* Both halves take their shell from the shared .mk-term-card class
+   (theme/mockup.css); only layout-specific bits live here. */
+.rph-term-body {
+  font-size: var(--mk-fs-74);
+}
+.rph-done {
+  display: flex;
+  align-items: center;
+  gap: var(--mk-space-7);
+  margin-top: var(--mk-space-8);
+  color: var(--mk-text-dim);
+}
+.rph-path {
+  margin-top: var(--mk-space-5);
+  color: var(--color-text-link);
+  word-break: break-all;
+  font-size: var(--mk-fs-72);
+}
+
+/* Connector */
+.rph-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--mk-space-3);
+  color: var(--mk-text-faint);
+}
+.rph-link-glyph {
+  color: var(--mk-accent);
+  font-size: var(--mk-fs-105);
+}
+.rph-link-label {
+  font-size: var(--mk-fs-66);
+  white-space: nowrap;
+}
+
+/* Progress-Board half */
+.rph-board {
+  display: flex;
+  flex-direction: column;
+}
+.rph-board-head {
+  display: flex;
+  align-items: center;
+  gap: var(--mk-space-6);
+  padding: var(--mk-space-7) var(--mk-space-12);
+  background: var(--mk-bg-soft);
+  border-bottom: 1px solid var(--mk-border);
+  font-size: var(--mk-fs-72);
+  font-weight: 600;
+  color: var(--mk-text-dim);
+}
+.rph-board-head wa-icon {
+  font-size: var(--mk-space-12);
+  color: var(--mk-accent);
+}
+.rph-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--mk-space-7);
+  padding: var(--mk-space-9) var(--mk-space-12) 0;
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--mk-fs-74);
+}
+.rph-agent {
+  color: var(--mk-syn-fn);
+  font-weight: 600;
+}
+.rph-file {
+  color: var(--mk-text);
+}
+.rph-row-sub {
+  padding: var(--mk-space-4) var(--mk-space-12) var(--mk-space-10);
+  color: var(--mk-text-faint);
+  font-size: var(--mk-fs-70);
+}
+
+/* Shared vocabulary across both halves */
+.rph-dot {
+  width: var(--mk-space-8);
+  height: var(--mk-space-8);
+  border-radius: 50%;
+  background: var(--color-success);
+  flex-shrink: 0;
+}
+.rph-id {
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--mk-fs-68);
+  color: var(--mk-accent);
+  background: color-mix(in srgb, var(--mk-accent) 12%, transparent);
+  border-radius: var(--mk-radius-sm);
+  padding: 0 var(--mk-space-5);
+}
+
+/* Stack the halves on narrow screens; rotate the connector inline. */
+@media (max-width: 820px) {
+  .rph {
+    grid-template-columns: 1fr;
+  }
+  .rph-link {
+    flex-direction: row;
+    gap: var(--mk-space-7);
+  }
+}
+</style>

--- a/docs/.vitepress/components/TermWindow.vue
+++ b/docs/.vitepress/components/TermWindow.vue
@@ -1,0 +1,36 @@
+<script setup>
+// Thin terminal-window primitive — MockCard's sibling for figures that ARE
+// terminal output. Renders the shared faux-macOS titlebar (.mk-term-bar:
+// traffic-light dots + mono command title), the recessed mono body
+// (.mk-term-body) around the default slot, and a bottom strip (.mk-term-hint)
+// only when a #hint slot is passed. All chrome comes from the shared
+// .mk-term-* classes in theme/mockup.css, so the card flips with the docs
+// light / dark theme; consumers keep only their own row vocabulary.
+//
+// Deliberately prop-poor: `title` is the command being demonstrated (the house
+// convention for .mk-term-title) and `ariaLabel` defaults to it. No density or
+// variant props — prompt lines, tool rows, tables, and diff hunks belong to
+// the consumer. Frameless comparisons (CliAuthModesHero, ConfigPrecedenceStack)
+// should NOT be forced through this primitive.
+defineProps({
+  title: { type: String, required: true },
+  ariaLabel: { type: String, default: '' },
+});
+</script>
+
+<template>
+  <div
+    class="mockup mk-term-card"
+    role="group"
+    :aria-label="ariaLabel || title"
+  >
+    <div class="mk-term-bar">
+      <span class="mk-term-light mk-term-light--r"></span>
+      <span class="mk-term-light mk-term-light--y"></span>
+      <span class="mk-term-light mk-term-light--g"></span>
+      <span class="mk-term-title">{{ title }}</span>
+    </div>
+    <div class="mk-term-body"><slot /></div>
+    <div v-if="$slots.hint" class="mk-term-hint"><slot name="hint" /></div>
+  </div>
+</template>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -25,6 +25,7 @@ import MemoryPinHero from '../components/MemoryPinHero.vue';
 // blocks, so a page can show ONE component without the full VS Code window.
 import MockupPanel from '../components/MockupPanel.vue';
 import MockCard from '../components/MockCard.vue';
+import TermWindow from '../components/TermWindow.vue';
 import StatusPill from '../components/StatusPill.vue';
 import MockSwitch from '../components/MockSwitch.vue';
 import AgentClasses from '../components/AgentClasses.vue';
@@ -103,6 +104,7 @@ export default {
     // Frameless mock-UI primitives (also usable directly in markdown).
     app.component('MockupPanel', MockupPanel);
     app.component('MockCard', MockCard);
+    app.component('TermWindow', TermWindow);
     app.component('StatusPill', StatusPill);
     app.component('MockSwitch', MockSwitch);
     app.component('AgentClasses', AgentClasses);

--- a/docs/.vitepress/theme/mockup.css
+++ b/docs/.vitepress/theme/mockup.css
@@ -555,6 +555,60 @@
   color: var(--mk-text-faint);
 }
 
+/* Standalone terminal card — shell, recessed mono body, optional bottom hint
+   strip, and the prompt line every terminal figure opens with. Extracted from
+   CliChatHero / CliToolsListHero (which previously each re-rolled this CSS) and
+   served to consumers through the <TermWindow> primitive, so heroes keep only
+   their own row vocabulary. */
+.mockup.mk-term-card,
+.mockup .mk-term-card {
+  background: var(--mk-bg);
+  border: 1px solid var(--mk-border-soft);
+  border-radius: var(--mk-radius-lg);
+  overflow: hidden;
+  font-family: var(--vp-font-family-base);
+}
+/* Root-level cards space themselves off the prose; nested shells (e.g. the
+   halves of RunParityHero) leave spacing to their layout container. */
+.mockup.mk-term-card {
+  margin: var(--mk-space-12) 0;
+}
+.mockup .mk-term-body {
+  padding: var(--mk-space-12) var(--mk-space-14);
+  background: var(--mk-bg-deep);
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--mk-fs-78);
+  line-height: 1.6;
+  color: var(--wa-color-text-normal);
+}
+.mockup .mk-term-hint {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--mk-space-7);
+  padding: var(--mk-space-8) var(--mk-space-14);
+  background: var(--mk-bg-soft);
+  border-top: 1px solid var(--mk-border);
+}
+/* Prompt line: `$` sigil + typed command; flags read in the comment color. */
+.mockup .mk-term-prompt {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mk-space-7);
+}
+.mockup .mk-term-sigil {
+  color: var(--mk-syn-fn);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.mockup .mk-term-cmd {
+  color: var(--mk-text);
+  min-width: 0;
+}
+.mockup .mk-term-flag {
+  color: var(--mk-syn-comment);
+}
+
 /* Code / terminal output surface (editor body) */
 .mockup .surface {
   flex: 1;

--- a/docs/design/cli-terminal-mockups.md
+++ b/docs/design/cli-terminal-mockups.md
@@ -1,0 +1,185 @@
+# CLI terminal mockups — design brief and style contract
+
+Internal brief (srcExcluded) for the docs-wide CLI mockup pass. The docs site
+explains concepts through live Vue mockup components, but ~87 of them serve the
+VS Code extension and only 3 served the CLI. This pass gives the `texra` CLI
+equal explanatory weight where it genuinely carries the concept — one terminal
+card per endorsed page, nothing on pages where a CLI mockup would be clutter.
+
+## Balance philosophy
+
+- One CLI mockup per page, placed where the page's CLI claim is actually made.
+- Never replace a GUI mockup; the CLI card complements it (parity, not takeover).
+- Pages whose surface is genuinely GUI-only (progress-board webview internals,
+  merge pairing, drag-and-drop) keep their GUI mockups unchallenged.
+- Cross-link instead of duplicating: if a concept already has its CLI visual on
+  another page, a caption link suffices.
+
+## House rules (non-negotiable)
+
+1. **Mockup-native**: live DOM components, never screenshots or images.
+2. **Theme-adaptive**: every color from `--mk-*` tokens (or the sanctioned
+   aliases `--color-success/-warning/-error`, `--color-text-*`, `--brand`,
+   `--wa-color-text-normal`) or `color-mix()` over them. No hex/rgb literals,
+   no `html.dark` selectors in components — dark mode must come for free.
+3. **No hardcoded dimensions**: padding/gap/margin/size/radius/font-size from
+   `--mk-space-N` / `--mk-size-N` / `--mk-radius-*` / `--mk-fs-NN` /
+   `--vp-font-family-*`. Sanctioned literals only: `1px` hairlines, `@media`
+   breakpoints (560px component-level, 820px shared), unitless line-heights,
+   font weights, `50%` for circles.
+4. **Static figures**: no `Date.now()`, no current-looking timestamps, no
+   random ids, no component-local reactive state/watchers/lifecycle. Motion
+   only via shared keyframes (`mk-spin`, `mk-shpulse`, `mk-blink`) and the
+   bridged `<wa-spinner class="… mk-spinner">`.
+5. **Compose, don't re-roll**: titlebar via `.mk-term-*`; terminal cards via
+   `<TermWindow>`; pills via `<StatusPill>`; inline-header cards via
+   `<MockCard>`. Never copy-paste shared chrome CSS.
+6. **Root contract**: `<div class="mockup <prefix>" role="group"
+aria-label="…">` (TermWindow provides this for terminal cards). Unique
+   short class prefix per component; all styles `<style scoped>`.
+7. **Header comment contract**: each component opens `<script setup>` with a
+   comment stating what it shows, which doc section/prose it makes concrete,
+   and that it is `.mockup`-scoped / theme-adaptive. Believable static strings
+   copied from real product output; never invented flags or commands.
+8. **Frameless preferred**: terminal titlebar chrome only when the figure IS
+   terminal output. Comparisons/stacks stay frameless (cf. CliAuthModesHero).
+9. **Registration**: page-specific heroes are imported per-page in the .md
+   `<script setup>` with relative paths (`../.vitepress/components/X.vue`).
+   Only reusable primitives (TermWindow) are registered globally in
+   `theme/index.js`.
+
+## Shared terminal primitives
+
+CSS in `docs/.vitepress/theme/mockup.css` (added by the foundation pass,
+next to `.mk-term-bar`):
+
+- `.mk-term-card` — card shell: `--mk-bg` background, 1px `--mk-border-soft`
+  border, `--mk-radius-lg`, `margin: var(--mk-space-12) 0`, overflow hidden,
+  base font `--vp-font-family-base`.
+- `.mk-term-body` — recessed mono body: `--mk-bg-deep`, padding
+  `--mk-space-12/14`, `--vp-font-family-mono`, `--mk-fs-78`, line-height 1.6.
+- `.mk-term-hint` — bottom strip: flex, `--mk-bg-soft`, 1px top hairline.
+- `.mk-term-prompt` / `.mk-term-sigil` / `.mk-term-cmd` / `.mk-term-flag` —
+  prompt line: `$` sigil in `--mk-syn-fn` bold; command `--mk-text`; flags
+  `--mk-syn-comment`.
+
+`<TermWindow>` (globally registered, MockCard's terminal sibling):
+
+```vue
+<TermWindow title="texra run" aria-label="texra run streaming output">
+  <!-- default slot renders inside .mk-term-body -->
+  <template #hint><!-- optional .mk-term-hint strip --></template>
+</TermWindow>
+```
+
+Props: `title` (mono window title = the command being demonstrated),
+optional `ariaLabel` (defaults to title). No density/variant props — body
+content (prompt lines, rows, tables, diffs) is per-hero.
+
+## Real CLI vocabulary (fact-checked against packages/cli source)
+
+Use ONLY these; never invent flags, commands, or output shapes.
+
+**Headless text output**: `texra run <agent> --input/-i <file> [--context/-c]
+[--output | --output-dir] [--model/-m] [--instruction]` prints progress to
+stderr and, in text mode, a final filesystem path on stdout (the copied
+`--output`/`--output-dir` path, else the generated file in run storage under
+`…/executions/<id>/r0/…`). Repeated `--input` for multi-file; `--output` is
+single-input only. `--print/-p`, `--output-format text|json|ndjson`,
+`--no-input` (forces approval policy `never`). Exit codes: 0 ok, 1 agent,
+2 usage, 3 model/network, 4 approval denied.
+
+**Rounds**: workflow runs show round progress (r0 draft → r1 critique for
+polish). Run storage tree: `.texra/runs/<run-id>/r{n}/` (PolishRunTree shows
+this on first-run.md). Round folders keep the INPUT filename (`r1/draft.tex`,
+not `output.tex`). Execution/run ids are compact 12-char hex
+(`src/utils/core/executionId.ts`), e.g. `9f3a6c81d24e` — use that shape in
+mockups, never `run-123` or named ids.
+
+**List output formats** (tab-separated, stable):
+
+- `texra agents list` → `<category>\t<name>\t<description>` (workflow/toolUse)
+- `texra agents show <name>` → `name:`, `category:`, `source:`, `path:` lines
+- `texra history list [-n N]` → `<id>\t<timestamp>\t<agent>\t<status>\t<input>`
+- `texra history show <id>` → details + `Files (N):` listing with sizes
+- `texra models list` → `<value>\t<label>\t<status>` (e.g. `fable5  Claude
+Fable 5  available`); `texra models show <id>` → detail lines
+- `texra memory list` → `Memories (N):` header then `/memories/<file>` rows
+  with pinned state + size; `texra memory show memories/<file>` previews one
+- `texra tools list` → SIX columns `ID NAME CATEGORY ENABLED DETECTED NOTE`,
+  booleans as `yes`/`no`/`-`; subcommands `show|status|enable|disable|
+install [--run]|auth`
+- `texra multi-agent list|show|inspect|run` — teams: Lean Project, Physicist,
+  Mathematician, Computer Scientist, Software Engineer; inspect shows lead +
+  specialists
+- `texra doctor` → grouped PASS/WARN/FAIL rows (Node, dirs, auth, model
+  access, LaTeX toolchain: latexmk, pdflatex, latexdiff, latexindent…)
+
+**Auth**: `texra login [--device] [--no-browser] [--provider github|google]`;
+`texra auth` = status (`Signed in as <label> (<tier>).`); `texra setup-token
+[--name --expires --print-env]` (CI relay token → `TEXRA_RELAY_TOKEN`);
+BYOK via `ANTHROPIC_API_KEY` etc.; `--api-mode personal|included`.
+
+**Interactive TUI** (`texra chat [--agent X] [--model Y]`) — REAL elements:
+
+- Session header: cyan rule, bold cyan `{ T } TeXRA` + dim `v0.x` + dim
+  api-mode (`relay`/`keys`), printed once at top.
+- User turn: reverse-video band with `› ` chevron prefix. NO name chips.
+- Assistant turn: plain markdown text, unlabeled. "thinking…" lives in the
+  status bar (yellow), never inline next to text.
+- Tool-call row: `● <ToolName> (<preview>)` — dot dim while running, green
+  done, red error; tool name bold; preview = command/path/query in parens.
+  An in-flight row keeps the dim ● dot (no spinner in the row).
+- Tool output: indented under `⎿ ` corner glyph, dim, elided to head/tail
+  with `… +N lines (ctrl + t to view transcript)`.
+- Diffs: full-width colored bands — green `+` added, red `-` removed, dim
+  context. NEVER strikethrough.
+- Status bar: cyan `◆`, status label, `Ns` elapsed, dim api-mode, `rN` round
+  counter, token usage `12.3k/200k (6%)`; second row = bracketed bindings
+  like `[/status]details  [/model]models  [/api]api  [Ctrl-J]newline
+[Ctrl-C]exit`.
+- Input bar: rounded gray-bordered box with cyan `›` prompt; dim
+  `Tip: …` row above when idle.
+- Subagents: numbered child rows with status marker, label, elapsed, dim
+  output tail lines; `[Tab]streams` to focus.
+- Slash commands (real set): /help /clear /agent /model /api /auth /login
+  /logout /approval /yolo /status /resume /memory /skills /tools /compact
+  /exit.
+- Defaults: chat agent `assistant`, model `deepseekT`. `--agent research`
+  valid (tool-use). `texra resume <id>` is interactive-only (reopens the TUI;
+  never depict it as headless).
+
+**Status colors in mockups**: done dot `--color-success`; warn
+`--color-warning`; error `--color-error`; in-flight = dim dot or
+`<wa-spinner class="… mk-spinner">` where the real UI shows elapsed motion
+(status bar / round rows), per existing component precedent.
+
+## Component roster
+
+Foundation: `TermWindow.vue` (+ mockup.css classes), `CliRunHero.vue` (shared
+streaming-run card; props `command`, `rounds` `[{label, state:
+'done'|'active'}]`, `outputs` `string[]`, optional `note`), rebuilt
+`CliChatHero.vue` (real TUI vocabulary), `CliToolsListHero.vue` (TermWindow +
+NOTE column).
+
+Per-page heroes (one page each unless noted): `RunParityHero` (guide/index),
+`CliInitHero` (configuration), `DoctorSliceHero` (props-driven; troubleshooting
+
+- latex-compilation + latex-tools), `CliAgentsListHero` (built-in-agents),
+  `CliAgentShowHero` (custom-agents), `CliMemoryHero` (memory), `CliHistoryHero`
+  (progress-board), `CliStorageHero` (file-management), `CliToolsLifecycleHero`
+  (agent-integrations), `CliModelsHero` (models), `CliRemoteHero`
+  (remote-agents), `CliSearchChatHero` (research-tools), `CliLeanHero` (lean),
+  `CliMultiAgentHero` (texra-cli), landing CLI strip (root index.md).
+
+CliRunHero reuse: quick-start, first-run, polish-a-draft, texra-cli,
+agent-architecture, multiple-output (multi-input variant), working-with-figures
+(figure-caption variant: vision reaches the model via figures auto-extracted
+from the _input_ document on round 0 — `--context` is text-only; never imply
+vision via `--context`).
+
+Explicit skips (decided, don't revisit): best-practices, intelligent-merge,
+code-review, open-source, acknowledgments, providers.md, launch.md,
+installation (DoctorReportCard already serves it), tikz-figures (bash-block tip
+only), built-in-agents Teams section, troubleshooting history card
+(cross-link to progress-board instead), texra-cli device-login card.

--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -2,6 +2,7 @@
 import AgentYamlHero from '../.vitepress/components/AgentYamlHero.vue'
 import RoundOutputTree from '../.vitepress/components/RoundOutputTree.vue'
 import AgentModesCompare from '../.vitepress/components/AgentModesCompare.vue'
+import CliRunHero from '../.vitepress/components/CliRunHero.vue'
 </script>
 
 # Workflow Agents: How They Work
@@ -17,7 +18,7 @@ If you want a snappier turnaround (e.g. quick polishes, small corrections), pick
 The `settings.agentCategory` key decides which of these two modes an agent runs in:
 
 <AgentModesCompare />
-<p class="hero-caption">Workflow agents reason once and write a versioned, diffable file; tool-use agents converse and call tools turn by turn—it is the first thing to pick for any task.</p>
+<p class="hero-caption">Workflow agents reason once and write a versioned, diffable file; tool-use agents converse and call tools turn by turn—it is the first thing to pick for any task. The split maps one-to-one onto the CLI's two entry points: <code>texra run polish …</code> for workflow agents, <code>texra chat --agent research</code> for tool-use agents.</p>
 
 ## Agent Definition Files (`.yaml`)
 
@@ -74,6 +75,20 @@ sequenceDiagram
 2.  **Prompt Construction:** It combines the agent's `systemPrompt`, `userPrefix` (filled with your files and instruction), and `userRequest` templates into a full prompt for the LLM.
 3.  **LLM Interaction (Round 0):** TeXRA sends the prompt to the selected LLM API. The LLM generates a response, typically including reasoning (`<scratchpad>`) and the final answer wrapped in XML tags (e.g., `<document>...</document>`).
 4.  **Processing:** TeXRA saves the raw LLM response (often as an `.xml` file internally, e.g., `r{round}/output.xml`). It then parses this file, extracts the content from the primary XML tag (defined by `settings.documentTag`), and saves _that extracted content_ to the final output file in task storage (e.g., `r{round}/output.tex`, so Round 0 is `r0/output.tex`, the first reflection is `r1/output.tex`, and so on). You can monitor this in the [ProgressBoard](./progress-board.md). For LaTeX files, TeXRA can also automatically generate a `latexdiff` file comparing the output to the input, enhancing observability. See the [LaTeX Diff guide](./latex-diff.md) for details.
+
+Clicking **Execute** is not the only way in — the same
+load-definition → prompt → rounds → save-to-run-storage pipeline runs
+headlessly from the terminal:
+
+<CliRunHero
+  command="texra run polish --input paper.tex --output paper.polished.tex"
+  :rounds="[
+    { label: 'r0 — draft revision', state: 'done' },
+    { label: 'r1 — reflection pass', state: 'done' },
+  ]"
+  :outputs="['paper.polished.tex']"
+  note="Same agent definition, same rounds, same run storage — no UI attached."
+/>
 
 Each round lands in its own folder under task storage:
 

--- a/docs/guide/agent-integrations.md
+++ b/docs/guide/agent-integrations.md
@@ -1,6 +1,7 @@
 <script setup>
 import IntegrationCard from '../.vitepress/components/IntegrationCard.vue';
 import DelegatedStreamHero from '../.vitepress/components/DelegatedStreamHero.vue';
+import CliToolsLifecycleHero from '../.vitepress/components/CliToolsLifecycleHero.vue';
 </script>
 
 # Agent Integrations
@@ -30,6 +31,13 @@ Both integrations follow the same setup flow from the TeXRA Dashboard.
 
 <IntegrationCard />
 <p class="hero-caption">Each integration has its own card: a <strong>Not Found</strong> card expands its setup actions, and <strong>Recheck</strong> flips it to <strong>Available</strong> with a settings summary.</p>
+
+The same flow runs beat for beat in a terminal — detect, install, sign in,
+recheck:
+
+<CliToolsLifecycleHero />
+
+<p class="hero-caption"><code>texra tools</code> drives the full lifecycle: <code>show</code> reports the registered install and auth commands, <code>install --run</code> executes the installer after printing it, and <code>auth</code> hands off to the tool's own sign-in.</p>
 
 Each integration's options live on its card and are scoped to the current workspace. Per-call approval prompts are governed by the global **Require approval for shell commands & agent sessions** switch under **Dashboard → Tools → Approval & Safety** (on by default); turn it off to let agents call Codex or Claude Code without confirming each time.
 

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -1,6 +1,7 @@
 <script setup>
 import DropdownMenu from '../.vitepress/components/DropdownMenu.vue';
 import AgentModeShapes from '../.vitepress/components/AgentModeShapes.vue';
+import CliAgentsListHero from '../.vitepress/components/CliAgentsListHero.vue';
 </script>
 
 # Built-in Agent Reference
@@ -46,6 +47,12 @@ TeXRA ships with built-in agents for common research tasks—polishing prose, fi
 />
 
 <p class="hero-caption">The agent picker, split by the two agent classes — <code>tool-use</code> (left) and <code>workflow</code> (right) — with the selected agent (<code>polish</code>) highlighted.</p>
+
+The same catalog is enumerable from any terminal:
+
+<CliAgentsListHero />
+
+<p class="hero-caption">One <code>category &nbsp;name&nbsp; description</code> row per agent — tab-separated, stable for scripts; <code>--category workflow</code> filters, <code>--all</code> includes hidden agents.</p>
 
 ## Quick Reference
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -5,6 +5,7 @@ import DashboardTabsCard from '../.vitepress/components/DashboardTabsCard.vue';
 import InstructionHeaderCard from '../.vitepress/components/InstructionHeaderCard.vue';
 import AgentOutputToolbarCard from '../.vitepress/components/AgentOutputToolbarCard.vue';
 import GitTabCard from '../.vitepress/components/GitTabCard.vue';
+import CliInitHero from '../.vitepress/components/CliInitHero.vue';
 </script>
 
 TeXRA provides extensive configuration options that allow you to customize its behavior to match your workflow (don't worry, the defaults are sensible!). This guide explains the available settings and how to adjust them for optimal performance.
@@ -45,6 +46,10 @@ The Dashboard tabs are the recommended way to manage agents, models, tools, and 
 Most configuration happens in the **Dashboard** (above) — open it with `TeXRA: Show Settings Dashboard`. The CLI keeps project defaults in a per-project `.texra/config.json` (`texra init` scaffolds one).
 
 Many `texra.*` keys share the same **name** across the VS Code extension and the CLI's `.texra/config.json` (most of the file-, LaTeX-, and model-connection settings below), so the same documentation applies to both. They don't share storage, though — the extension persists settings in VS Code's config/global state, while the CLI reads `.texra/config.json`. Some keys are extension-only (for example the LaTeX formatter and extension model visibility settings); the CLI warns on any key it doesn't recognize.
+
+<CliInitHero />
+
+<p class="hero-caption"><code>texra init</code> scaffolds the workspace file with sensible defaults, and <code>texra doctor</code> confirms exactly which config file a run will load — no guessing about what applies.</p>
 
 VS Code's built-in Settings UI remains available for power users — open it with `Ctrl+,` (`Cmd+,` on macOS), search for "TeXRA", and edit in the UI or the JSON. It's no longer the primary path, so reach for the Dashboard or CLI config first.
 
@@ -322,6 +327,11 @@ For project-specific configurations in the VS Code extension, use workspace sett
 ```
 
 For personal preferences that apply to all projects, use user settings.
+
+When several levels set the same option, the CLI resolves them in a fixed
+order — an explicit flag always wins, then environment variables, then the
+project file, then built-in defaults. See the
+[precedence figure on the CLI page](./texra-cli.md#workspace-defaults).
 
 ### OS-Specific Configuration
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -4,6 +4,7 @@
 import ToolCategoriesHero from '../.vitepress/components/ToolCategoriesHero.vue';
 import AgentAnatomyHero from '../.vitepress/components/AgentAnatomyHero.vue';
 import OutputMappingHero from '../.vitepress/components/OutputMappingHero.vue';
+import CliAgentShowHero from '../.vitepress/components/CliAgentShowHero.vue';
 </script>
 
 Every lab has its own writing style, formatting quirks, and recurring tasks. Maybe your group always needs a "rewrite the abstract for a Nature-style letter" pass, or you want an agent that converts your internal notes into arXiv-ready LaTeX. Custom agents let you encode these workflows once and reuse them with a single click.
@@ -261,6 +262,13 @@ See [Handling Multiple Files](./multiple-output.md) for more details.
 1. Save your `.yaml` file.
 2. Reload the VS Code window (Command Palette → `Developer: Reload Window`).
 3. Your new custom agent should now appear in the **Agent** dropdown (<wa-icon library="texra" name="sparkle"></wa-icon>) of the TeXRA UI.
+
+From a terminal the iteration loop is faster — no window reload needed.
+Verify the agent registered, then smoke-test it in one go:
+
+<CliAgentShowHero />
+
+<p class="hero-caption"><code>agents show</code> confirms the registration — <code>source: custom</code> plus the file it loaded — and a one-shot <code>texra run</code> proves the prompts work before you polish the YAML further.</p>
 
 ### <wa-icon library="texra" name="shield"></wa-icon> Strict XML Extraction
 

--- a/docs/guide/file-management.md
+++ b/docs/guide/file-management.md
@@ -1,5 +1,6 @@
 <script setup>
 import StorageLifecycleFlow from '../.vitepress/components/StorageLifecycleFlow.vue';
+import CliStorageHero from '../.vitepress/components/CliStorageHero.vue';
 </script>
 
 # File Management
@@ -212,7 +213,9 @@ editor.
 To browse the whole run folder, use the
 <wa-icon library="texra" name="folder-opened"></wa-icon> **Open in task storage** toolbar
 button. This reveals the task-run storage folder with generated files, compile
-logs, mirrored LaTeX dependencies, and intermediate artifacts.
+logs, mirrored LaTeX dependencies, and intermediate artifacts. (From a
+terminal, `texra history show <id>` lists the same stored artifacts — see the
+card below.)
 
 ### Task Run Storage
 
@@ -229,6 +232,13 @@ files. Three commands then move that run's artifacts to three different places:
 <StorageLifecycleFlow />
 
 <p class="hero-caption">Accept copies reviewed outputs into the workspace, Pack archives the run into History, and Clean deletes the run folder — your input files are never touched.</p>
+
+The CLI follows the same storage-first lifecycle — its run store lives at
+`.texra/runs/<run-id>/`, and `--output` plays the role of **Accept**:
+
+<CliStorageHero />
+
+<p class="hero-caption">Three beats of the same lifecycle: storage-first output, <code>--output</code> as Accept, and <code>history show</code> to browse a run's stored files.</p>
 
 The folder also stores intermediate artifacts such as optional
 debug JSON files written when `texra.debug.saveDebugObjects` is enabled.

--- a/docs/guide/first-run.md
+++ b/docs/guide/first-run.md
@@ -1,6 +1,7 @@
 <script setup>
 import FlowSteps from '../.vitepress/components/FlowSteps.vue';
 import PolishRunTree from '../.vitepress/components/PolishRunTree.vue';
+import CliRunHero from '../.vitepress/components/CliRunHero.vue';
 </script>
 
 # First run
@@ -67,6 +68,16 @@ texra run polish \
   --input draft.tex \
   --instruction "Tighten the prose. Preserve all math and citations."
 ```
+
+<CliRunHero
+  command='texra run polish --input draft.tex --instruction "Tighten the prose. Preserve all math and citations."'
+  :rounds="[
+    { label: 'Round 0 — draft  ·  r0/draft.tex written', state: 'done' },
+    { label: 'Round 1 — critique, rereading its own output', state: 'active' },
+  ]"
+/>
+
+<p class="hero-caption">What you should see while it runs: Round 0 has written the first revision, Round 1 is critiquing and revising it. When the run completes, the path to the final document prints on stdout.</p>
 
 The run streams reasoning, tool calls, and the assembled output.
 When it completes, polish has written one folder per round under

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,3 +1,7 @@
+<script setup>
+import RunParityHero from '../.vitepress/components/RunParityHero.vue';
+</script>
+
 # TeXRA
 
 An AI theorist for VS Code and the terminal. Multi-agent
@@ -58,6 +62,10 @@ output.
 The VS Code extension and the `texra` CLI share the same agents, the
 same sign-in, and the same run history. A run started in the CLI shows
 up in the extension's Progress Board, and vice versa.
+
+<RunParityHero />
+
+<p class="hero-caption">One run, two surfaces: the same execution id lands in the terminal's output and the extension's Progress view.</p>
 
 ```mermaid
 graph TB

--- a/docs/guide/latex-compilation.md
+++ b/docs/guide/latex-compilation.md
@@ -1,3 +1,7 @@
+<script setup>
+import DoctorSliceHero from '../.vitepress/components/DoctorSliceHero.vue';
+</script>
+
 # LaTeX Compilation Environment
 
 While TeXRA focuses on AI-assisted editing and generation of LaTeX source code, several features rely on having a working LaTeX distribution installed on your system for tasks like compiling previews or processing generated `latexdiff` files.
@@ -12,7 +16,18 @@ You need a functional LaTeX distribution installed, such as:
 
 Getting LaTeX set up correctly can sometimes feel like wrestling an octopus, but it's necessary for features like compiling diffs and TikZ previews.
 
-Ensure that the `latexmk` command is available (preferred for TeXRA) or at least `pdflatex`. These should be accessible from your system's command line.
+Ensure that the `latexmk` command is available (preferred for TeXRA) or at least `pdflatex`. These should be accessible from your system's command line. `texra doctor` verifies the whole toolchain in one go, on any platform:
+
+<DoctorSliceHero
+  :rows="[
+    { state: 'pass', name: 'LaTeX latexmk', message: 'LaTeX build orchestration' },
+    { state: 'pass', name: 'LaTeX pdflatex', message: 'PDFLaTeX compiler' },
+    { state: 'pass', name: 'LaTeX bibtex', message: 'BibTeX bibliography processing' },
+    { state: 'pass', name: 'LaTeX latexdiff', message: 'LaTeX diff generation' },
+  ]"
+/>
+
+<p class="hero-caption">The doctor's LaTeX rows confirm each binary is on PATH — the same check works for extension and CLI users alike.</p>
 
 See the main [Installation Guide](./installation.md) for more details on installing LaTeX and other essential dependencies like Perl (required for `latexdiff`).
 

--- a/docs/guide/latex-tools.md
+++ b/docs/guide/latex-tools.md
@@ -2,6 +2,7 @@
 import ToolStatusPanel from '../.vitepress/components/ToolStatusPanel.vue';
 import ToolConfigHero from '../.vitepress/components/ToolConfigHero.vue';
 import TikzDepsHero from '../.vitepress/components/TikzDepsHero.vue';
+import DoctorSliceHero from '../.vitepress/components/DoctorSliceHero.vue';
 </script>
 
 # LaTeX Tools
@@ -25,6 +26,22 @@ All are configured from **Dashboard → Tools** (<wa-icon library="texra" name="
 <ToolStatusPanel />
 
 <p class="hero-caption">Dashboard → Tools — ready tools show a green <strong>Available</strong> check; missing dependencies show an amber <strong>Not Found</strong> with a one-click <strong>Install</strong>.</p>
+
+The same status is one command away in any terminal — `texra doctor` probes
+the identical toolchain:
+
+<DoctorSliceHero
+  :rows="[
+    { state: 'pass', name: 'LaTeX latexmk', message: 'LaTeX build orchestration' },
+    { state: 'pass', name: 'LaTeX latexdiff', message: 'LaTeX diff generation' },
+    {
+      state: 'warn',
+      name: 'LaTeX latexindent',
+      message: 'latexindent was not found on PATH.',
+      hint: 'Install latexindent or a TeX distribution that provides it.',
+    },
+  ]"
+/>
 
 ## <wa-icon library="texra" name="symbol-keyword"></wa-icon> Formatting Tools
 

--- a/docs/guide/lean.md
+++ b/docs/guide/lean.md
@@ -2,6 +2,7 @@
 import LeanToolsHero from '../.vitepress/components/LeanToolsHero.vue';
 import LeanProofHero from '../.vitepress/components/LeanProofHero.vue';
 import LeanProjectCommands from '../.vitepress/components/LeanProjectCommands.vue';
+import CliLeanHero from '../.vitepress/components/CliLeanHero.vue';
 </script>
 
 # Lean 4 Proofs
@@ -39,6 +40,10 @@ There's no Lean 4 extension to lean on, so TeXRA spawns its own server (`lake en
    lake --version
    ```
 3. Open a folder containing a `lakefile.lean` or `lakefile.toml`.
+
+<CliLeanHero />
+
+<p class="hero-caption">No extension underneath: the CLI talks to Lake directly, and the same <code>lean_*</code> tools run against its own server process.</p>
 
 If you don't have elan yet, see the [Lean community install guide](https://leanprover-community.github.io/install/).
 

--- a/docs/guide/memory.md
+++ b/docs/guide/memory.md
@@ -1,5 +1,6 @@
 <script setup>
 import MemoryItemAnatomy from '../.vitepress/components/MemoryItemAnatomy.vue';
+import CliMemoryHero from '../.vitepress/components/CliMemoryHero.vue';
 </script>
 
 # Memory
@@ -76,6 +77,13 @@ The toolbar above the list has **Refresh** and **Open Folder** — the latter re
 <MemoryItemAnatomy />
 
 <p class="hero-caption">One expanded note, part by part: the <code>/memories/...</code> path, the metadata strip, the pin / open / delete actions, and the collapsible Contents preview — with Refresh and Open Folder in the toolbar above.</p>
+
+The same store is inspectable from a terminal — memory is shared state, not a
+Dashboard feature:
+
+<CliMemoryHero />
+
+<p class="hero-caption"><code>memory list</code> prints each note with its pinned state, size, and last writer; <code>memory show</code> previews one note. In chat, <code>/memory</code> does the same.</p>
 
 ## Memory is shared across the run
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -2,6 +2,7 @@
 import ModelPickerHero from '../.vitepress/components/ModelPickerHero.vue';
 import ProviderConfigRow from '../.vitepress/components/ProviderConfigRow.vue';
 import ModelChoiceMatrix from '../.vitepress/components/ModelChoiceMatrix.vue';
+import CliModelsHero from '../.vitepress/components/CliModelsHero.vue';
 </script>
 
 # AI Models
@@ -130,7 +131,11 @@ Choose which models appear in the extension picker from the **Dashboard → Mode
 
 In the CLI TUI, use `/model` after a chat starts to switch among models that are runnable in the active API mode. Startup also asks for a model when the launcher flow needs one after the agent or team choice.
 
-For headless CLI runs, list what's available with `texra models list` (or `texra models show <id>` for details), then pick a default for your project by setting the `model` key in `.texra/config.json`, or override per run with `--model <id>`.
+For headless CLI runs, list what's available with `texra models list` (or `texra models show <id>` for details), then pick a default for your project by setting the `model` key in `.texra/config.json`, or override per run with `--model <id>`:
+
+<CliModelsHero />
+
+<p class="hero-caption">The id column is exactly what <code>--model</code> takes — the same short ids used in the tables above; <code>--all</code> includes models your current access mode can't run, with the reason.</p>
 
 ## Using OpenRouter
 

--- a/docs/guide/multiple-output.md
+++ b/docs/guide/multiple-output.md
@@ -2,6 +2,7 @@
 import MultiOutputMatchHero from '../.vitepress/components/MultiOutputMatchHero.vue'
 import MultiInputOrderHero from '../.vitepress/components/MultiInputOrderHero.vue'
 import MultiOutputModesHero from '../.vitepress/components/MultiOutputModesHero.vue'
+import CliRunHero from '../.vitepress/components/CliRunHero.vue'
 </script>
 
 # Handling Multiple Files (Inputs & Outputs)
@@ -27,6 +28,20 @@ The TeXRA UI provides dedicated sections for managing multiple input files.
 <MultiInputOrderHero />
 
 <p class="hero-caption">The Input group is an ordered list — drag to reorder. For editing agents the row order is the output order, and each input filename is reused as its output filename.</p>
+
+Multi-file runs are not webview-only. In the terminal, repeated `--input`
+flags are the same ordered Input list, and `--output-dir` collects the
+per-file artifacts:
+
+<CliRunHero
+  command="texra run polish --input chapter1.tex --input chapter2.tex --output-dir polished"
+  :rounds="[
+    { label: 'r0 — draft revision', state: 'done' },
+    { label: 'r1 — critique and revise', state: 'done' },
+  ]"
+  :outputs="['polished/chapter1.tex', 'polished/chapter2.tex']"
+  note="One copied path per output — relative document paths are preserved under the directory."
+/>
 
 _(See [File Management](./file-management.md) for general UI controls.)_
 

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -3,6 +3,7 @@ import StreamHeaderActions from '../.vitepress/components/StreamHeaderActions.vu
 import StatusDotLegend from '../.vitepress/components/StatusDotLegend.vue';
 import TodoLifecycle from '../.vitepress/components/TodoLifecycle.vue';
 import ProgressLogHero from '../.vitepress/components/ProgressLogHero.vue';
+import CliHistoryHero from '../.vitepress/components/CliHistoryHero.vue';
 </script>
 
 # ProgressBoard
@@ -15,6 +16,10 @@ streaming reasoning, tool calls, and diffs in its `texra chat` terminal UI. Past
 runs are shared across surfaces — browse them with `texra history` or **Show
 Agent Execution History** in VS Code.
 :::
+
+<CliHistoryHero />
+
+<p class="hero-caption">The board's runs, from a terminal: the same executions, one tab-separated row each — and <code>texra resume</code> picks a stored session back up.</p>
 
 ## Accessing the ProgressBoard
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,6 +1,7 @@
 <script setup>
 import TaskRecipeCards from '../.vitepress/components/TaskRecipeCards.vue';
 import OutputArtifactsTree from '../.vitepress/components/OutputArtifactsTree.vue';
+import CliRunHero from '../.vitepress/components/CliRunHero.vue';
 </script>
 
 # Quick Start Guide
@@ -50,6 +51,12 @@ Expand a provider's row (click the chevron) to toggle streaming or, for provider
 :::
 
 You can also place a `.env` file in your workspace with variables like `OPENAI_API_KEY`. TeXRA loads this automatically so you don't need to enter keys every time.
+
+::: tip CLI credentials
+The terminal uses the same two paths — `texra login` for included hosted
+access, or provider env vars for your own keys. See
+[Authentication](./texra-cli.md#authentication) on the CLI page.
+:::
 
 ## Basic Workflow
 
@@ -164,13 +171,24 @@ The same agents are one command away from the terminal. After
 # Sign in for included hosted access, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in your shell:
 texra login
 
-# One-shot run (writes output next to the input):
+# One-shot run (prints the revised file's path; --output copies it next to the input):
 texra run polish --input draft.tex \
   --instruction "Improve clarity; preserve math and citations."
 
 # Or open an interactive tool-use session:
 texra chat
 ```
+
+<CliRunHero
+  command='texra run polish --input draft.tex --instruction "Improve clarity; preserve math and citations."'
+  :rounds="[
+    { label: 'r0 — draft revision', state: 'done' },
+    { label: 'r1 — critique and revise', state: 'done' },
+  ]"
+  :outputs="['.texra/runs/9f3a6c81d24e/r1/draft.tex']"
+/>
+
+<p class="hero-caption">What a one-shot run looks like: rounds stream as progress, then the path to the revised document prints on stdout.</p>
 
 Run history is shared with VS Code, so a run started in the CLI shows up in the
 extension's ProgressBoard (and vice versa). See [TeXRA CLI](./texra-cli.md) for
@@ -280,7 +298,9 @@ folder per round. Each round holds three artifacts, and the document keeps your
 <p class="hero-caption">One folder per round under <code>r{round}/&lt;input-filename&gt;</code>: the revised <strong>Output</strong>, a <strong>Log</strong> of the run, and the <strong>Diff</strong> PDF. Round 1 (and any further reflection rounds) repeat the same trio.</p>
 
 So if your input file is `paper.tex`, the first round's output lands at
-`r0/paper.tex` — the filename you started with, never `output.tex`.
+`r0/paper.tex` — the filename you started with, never `output.tex`. The CLI
+writes the same per-round tree under `.texra/runs/<run-id>/` — see
+[First run](./first-run.md) for the terminal walkthrough.
 
 ## Next Steps
 

--- a/docs/guide/remote-agents.md
+++ b/docs/guide/remote-agents.md
@@ -2,6 +2,7 @@
 
 <script setup>
 import RemoteAgentsProfile from '../.vitepress/components/RemoteAgentsProfile.vue';
+import CliRemoteHero from '../.vitepress/components/CliRemoteHero.vue';
 </script>
 
 Remote agents are cloud-hosted AI agents maintained by the TeXRA team that extend your extension's capabilities with specialized functionality. They're automatically updated with the latest improvements and optimizations without requiring extension updates.
@@ -81,6 +82,12 @@ In the agent dropdown, your local agents sit above a **Remote** group whose entr
 />
 
 <p class="hero-caption">The agent dropdown: remote agents (<code>search</code>, <code>discuss</code>, <code>simplifier</code>) carry a cloud marker that sets them apart from local agents like <code>polish</code> and <code>correct</code>.</p>
+
+None of this is VS Code-only — the whole loop works from a terminal too:
+
+<CliRemoteHero />
+
+<p class="hero-caption">Sign in once and remote agents resolve by name everywhere: <code>agents show</code> reports <code>source: remote</code>, and <code>texra chat --agent search</code> runs it like any local agent.</p>
 
 ## Researcher Access Program
 

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -3,6 +3,7 @@
 <script setup>
 import InquiryFlowHero from '../.vitepress/components/InquiryFlowHero.vue';
 import SearchResultsHero from '../.vitepress/components/SearchResultsHero.vue';
+import CliSearchChatHero from '../.vitepress/components/CliSearchChatHero.vue';
 </script>
 
 You're deep in a manuscript and realise you need to cite "that attention paper from 2017" but can't remember the title. Or you want to verify an integral in your appendix. Or you need to pull twenty BibTeX entries from your Zotero library into a new project. TeXRA's research agents handle all of this without leaving your editor — in VS Code or the `texra` CLI.
@@ -28,6 +29,13 @@ Focus on work from 2023-2024 that handles mathematical equations.
 <SearchResultsHero />
 
 <p class="hero-caption">A typical <code>search</code> result set: each preprint carries its title, authors, an arXiv or Crossref source tag, and a one-click <strong>Cite</strong> — every row a real lookup, never fabricated.</p>
+
+The same search streams in a terminal, each lookup surfacing as a tool call
+you can watch:
+
+<CliSearchChatHero />
+
+<p class="hero-caption">The postdoc's search in <code>texra chat --agent search</code>: each grounded lookup surfaces as a tool-call row, with results streaming under it.</p>
 
 ### <wa-icon library="texra" name="link"></wa-icon> Look Up Citations
 

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -2,6 +2,8 @@
 import CliChatHero from '../.vitepress/components/CliChatHero.vue';
 import CliAuthModesHero from '../.vitepress/components/CliAuthModesHero.vue';
 import CliToolsListHero from '../.vitepress/components/CliToolsListHero.vue';
+import CliRunHero from '../.vitepress/components/CliRunHero.vue';
+import CliMultiAgentHero from '../.vitepress/components/CliMultiAgentHero.vue';
 import ConfigPrecedenceStack from '../.vitepress/components/ConfigPrecedenceStack.vue';
 </script>
 
@@ -40,6 +42,17 @@ Run a workflow agent from a project directory:
 ```bash
 texra run polish --input paper.tex --output paper.polished.tex --print
 ```
+
+<CliRunHero
+  command="texra run polish --input paper.tex --output paper.polished.tex --print"
+  :rounds="[
+    { label: 'r0 — draft revision', state: 'done' },
+    { label: 'r1 — critique and revise', state: 'done' },
+  ]"
+  :outputs="['paper.polished.tex']"
+/>
+
+<p class="hero-caption">Command in, rounds stream as progress, and the printed path is the success signal: the copied <code>--output</code> destination, or the generated file in run storage when no copy was requested.</p>
 
 Pass read-only context files with repeated `--context` flags. The agent can
 read these files through `{{ ALL_CONTEXTS }}`, but it should only emit revised
@@ -191,6 +204,10 @@ to `coder`, `codeReviewer`, `testEngineer`, `codeSimplifier`, and
 `progressCheck`. Pass `--input` and `--context` files as with `texra run`;
 read-only context files are included in the instruction the team receives.
 
+<CliMultiAgentHero />
+
+<p class="hero-caption">The lead delegates while child agents stream below it as numbered subagent rows — each one a focusable stream with its own scoped transcript.</p>
+
 In an interactive team session, focusing a subagent shows only its own
 transcript — scroll back through its earlier output with normal terminal
 scrolling and search. Each subagent keeps its own scoped history that persists
@@ -260,16 +277,19 @@ texra history show <id>
 texra history delete <id>
 ```
 
-Resume a stored execution configuration headlessly:
+Reopen a stored tool-use session in the interactive chat, on the saved agent
+and model:
 
 ```bash
 texra resume <id>
 texra --resume <id>
 ```
 
-The interactive chat also accepts `/resume`. With no id it prints recent
-executions; with an id it starts from the stored execution configuration. A
-missing or malformed id exits with code 2 in headless commands.
+Resume is interactive-only — a resumed session waits for your next message, so
+without a terminal it exits with a usage error that points scripting at
+`texra run`. The interactive chat also accepts `/resume`: with no id it prints
+recent executions, with an id it continues the stored session. A missing or
+malformed id exits with code 2.
 
 ## Tools and Integrations
 
@@ -290,7 +310,7 @@ detection result.
 
 <CliToolsListHero />
 
-<p class="hero-caption"><code>tools list</code> reports five fields per integration: a status dot marks enabled vs disabled, and a check or cross marks whether the backing tool was detected on this machine.</p>
+<p class="hero-caption"><code>tools list</code> reports six columns per integration: a status dot marks the enabled state, a check or cross marks whether the backing tool was detected on this machine, and the note carries the registered install command when something is missing.</p>
 
 Use `--output-format json` or `--output-format ndjson` for
 scripts. `tools install <id>` prints the install guide and registered command;

--- a/docs/guide/tikz-figures.md
+++ b/docs/guide/tikz-figures.md
@@ -70,7 +70,14 @@ Because these are tool-use agents, they can compile the figure and inspect the r
 3. Provide a detailed description of the figure you want.
 4. Click Execute (<wa-icon library="texra" name="play"></wa-icon>).
 
-From the CLI, the same task runs with `texra chat` (then describe the figure) or, headlessly, with `texra agents run research --input figures.tex --instruction "Create a TikZ figure of ..."`. (`texra run` is for workflow agents only; tool-use agents like `research` use `texra agents run`.)
+From the CLI, the same draw → compile → inspect loop shown below runs
+headlessly (`texra run` is for workflow agents only; tool-use agents like
+`research` use `texra agents run`):
+
+```bash
+texra agents run research --input figures.tex \
+  --instruction "Create a TikZ flowchart of the ML pipeline in Section 2."
+```
 
 **Example instruction:**
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -2,6 +2,7 @@
 import ProgressLogHero from '../.vitepress/components/ProgressLogHero.vue';
 import XmlRepairCard from '../.vitepress/components/XmlRepairCard.vue';
 import ToolPathSearchOrder from '../.vitepress/components/ToolPathSearchOrder.vue';
+import DoctorSliceHero from '../.vitepress/components/DoctorSliceHero.vue';
 </script>
 
 # Troubleshooting
@@ -46,10 +47,26 @@ to confirm available models, and `texra tools status` to check tool availability
 
 **Problem**: Error messages about missing dependencies like LaTeX, Perl, or GraphicsMagick.
 
+One command checks them all — `texra doctor` probes the LaTeX toolchain (plus
+Node, auth, and model access) and says exactly what is missing and how to fix
+it:
+
+<DoctorSliceHero
+  :rows="[
+    { state: 'pass', name: 'LaTeX latexmk', message: 'LaTeX build orchestration' },
+    { state: 'pass', name: 'LaTeX pdflatex', message: 'PDFLaTeX compiler' },
+    {
+      state: 'warn',
+      name: 'LaTeX latexdiff',
+      message: 'latexdiff was not found on PATH.',
+      hint: 'Install latexdiff or a TeX distribution that provides it.',
+    },
+  ]"
+/>
+
 **Solutions**:
 
-1. **Verify dependencies**:
-   Run these commands in your terminal to check installations:
+1. **Verify dependencies manually**:
 
    ```bash
    latexmk --version  # or pdflatex --version

--- a/docs/guide/workflows/polish-a-draft.md
+++ b/docs/guide/workflows/polish-a-draft.md
@@ -1,6 +1,7 @@
 <script setup>
 import CritiquePassCard from '../../.vitepress/components/CritiquePassCard.vue';
 import PolishRoundsTree from '../../.vitepress/components/PolishRoundsTree.vue';
+import CliRunHero from '../../.vitepress/components/CliRunHero.vue';
 </script>
 
 # Polish a draft
@@ -36,6 +37,17 @@ texra run polish \
   --input intro.tex \
   --instruction "Tighten prose. Preserve all math and citations."
 ```
+
+<CliRunHero
+  command='texra run polish --input intro.tex --instruction "Tighten prose. Preserve all math and citations."'
+  :rounds="[
+    { label: 'r0 — first revision', state: 'done' },
+    { label: 'r1 — critique-and-revise pass', state: 'done' },
+  ]"
+  :outputs="['.texra/runs/c4e19b07a52d/r1/intro.tex']"
+/>
+
+<p class="hero-caption">Rounds stream as progress, then the path to the final revision prints on stdout — that printed path is the success signal.</p>
 
 Each round writes its output into the run's task storage, using the
 **input filename** as the document name:

--- a/docs/guide/working-with-figures.md
+++ b/docs/guide/working-with-figures.md
@@ -3,15 +3,17 @@
 <script setup>
 import MediaSectionPanel from '../.vitepress/components/MediaSectionPanel.vue';
 import AutoExtractMenu from '../.vitepress/components/AutoExtractMenu.vue';
+import CliRunHero from '../.vitepress/components/CliRunHero.vue';
 </script>
 
 TeXRA lets AI agents analyse, reference, and generate figures inside your documents — from `.png` screenshots to embedded TikZ diagrams and PDFs.
 
 ::: tip CLI
 This page covers the VS Code **Media** selector. From the [`texra` CLI](./texra-cli.md),
-pass image and PDF files to an agent with `--input` / `--context` (a
-vision-capable model reads them directly), or describe the figure to a tool-use
-agent in `texra chat`.
+figures referenced by your input documents are auto-extracted and attached for
+vision-capable models on workflow runs — or work with a figure conversationally
+in `texra chat`. (`--context` files are read as text, so they're for `.tex` and
+`.bib` sources, not images.)
 :::
 
 ## <wa-icon library="texra" name="rocket"></wa-icon> Quick Task: Add a Figure Caption
@@ -21,6 +23,21 @@ agent in `texra chat`.
 3. Select your figure in the **Media** (<wa-icon library="texra" name="file-media"></wa-icon>) section.
 4. Type the instruction: "Write a detailed caption for this figure."
 5. Click Execute (<wa-icon library="texra" name="play"></wa-icon>).
+
+In the terminal, the same five steps collapse to one command. Pick a
+vision-capable model, and the figures your document references are
+auto-extracted and attached for it:
+
+<CliRunHero
+  command='texra run polish --input draft.tex --model sonnet46T --instruction "Write a detailed caption for the pipeline figure."'
+  :rounds="[
+    { label: 'r0 — draft revision', state: 'done' },
+    { label: 'r1 — critique and revise', state: 'done' },
+  ]"
+  :outputs="['.texra/runs/b81d4f29e6a3/r1/draft.tex']"
+/>
+
+<p class="hero-caption">No media picker needed: on a vision model, round 0 extracts the figures referenced by <code>draft.tex</code> and sends them alongside the text.</p>
 
 ## <wa-icon library="texra" name="file-media"></wa-icon> The Media Section
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,10 @@ title: TeXRA — Multi-agent AI for theorists
 titleTemplate: false
 ---
 
+<script setup>
+import LandingCliStrip from './.vitepress/components/LandingCliStrip.vue';
+</script>
+
 <LandingHero />
 
 <section class="trust-row">
@@ -178,6 +182,7 @@ titleTemplate: false
     <a href="/guide/built-in-agents" class="cta-button cta-secondary">Browse All Agents</a>
     <a href="/guide/texra-cli" class="cta-button cta-secondary">Use the CLI</a>
   </div>
+  <LandingCliStrip />
 </section>
 
 <section class="faq-section">


### PR DESCRIPTION
## Summary

The docs site explains concepts through ~87 live mockup components, but only 3 served the CLI — all on one page. This PR is a comprehensive-but-balanced sweep so the `texra` CLI carries the same explanatory weight as the extension GUI, with one terminal card per endorsed page and deliberate skips where a CLI mockup would be clutter.

### Consolidated terminal window
- Shared `.mk-term-card` / `.mk-term-body` / `.mk-term-hint` / `.mk-term-prompt` classes extracted into `mockup.css` (the two existing CLI heroes previously duplicated this CSS verbatim).
- New thin `TermWindow.vue` primitive (MockCard's terminal sibling), globally registered; every terminal mockup composes it.

### Realism fixes (fact-checked against `packages/cli/src`)
- `CliChatHero` rebuilt on the real TUI vocabulary: `{ T } TeXRA` session header, `›` reverse-video user band, `● tool (preview)` rows with `⎿` output lines, full-width band diffs (no strikethrough), status-bar strip. The old version showed invented verb-chips, speaker chips, and a fake slash-command strip.
- `CliToolsListHero` now shows the real six-column table (ID NAME CATEGORY ENABLED DETECTED NOTE, yes/no/- booleans, install-command notes).
- Stale prose fixed: `texra resume` is interactive-only (was documented as headless); working-with-figures no longer claims `--context` carries images (it is text-only — vision comes from round-0 figure extraction of input documents).

### New coverage (15 components, 21 pages)
- Shared `CliRunHero` (props-driven streaming-run card) reused on 7 pages: quick-start, first-run, polish-a-draft, texra-cli, agent-architecture, multiple-output, working-with-figures.
- `RunParityHero` (guide landing: one run id visible from both surfaces), `LandingCliStrip` (root landing CTA), `DoctorSliceHero` (troubleshooting / latex-compilation / latex-tools), and per-page heroes for agents list/show, memory, history, storage lifecycle, `texra init`, tools lifecycle, models, remote agents, literature search, Lean, and multi-agent teams.
- All output shapes lifted from the real formatters (`formatCliAgentList`, `formatCliHistoryText`, `formatCliToolList`, `formatDoctorText`, …); run ids use the real 12-char hex shape.

### Balance
13 pages deliberately untouched per the audit (best-practices, intelligent-merge, code-review, open-source, acknowledgments, providers, launch, installation, …). Multi-agent review verdict: "balanced, not cluttered — one card per page, each anchored at the sentence making the page's CLI claim; GUI mockups stay primary."

Internal style brief at `docs/design/cli-terminal-mockups.md` (srcExcluded) records the contract and real-CLI vocabulary for future mockups.

## Validation
- `vitepress build` green (client + server bundles, all pages render).
- Three-lens adversarial review (token discipline / realism / balance); all blockers and should-fixes applied. The realism lens was cut short by a session limit, but its scope was covered by inline source fact-checks during authoring plus the balance reviewer (which caught the one factual bug).
- Docs-only change — no extension/CLI runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and VitePress Vue mockups only; no extension or CLI runtime changes. Large surface area but low blast radius for product behavior.
> 
> **Overview**
> Adds **shared terminal mockup infrastructure** and wires **CLI terminal figures** across the docs so the `texra` CLI is illustrated alongside existing GUI heroes—without replacing them.
> 
> **Foundation:** Extracts `.mk-term-card` / body / hint / prompt styles into `mockup.css`, introduces globally registered **`TermWindow.vue`**, and documents the contract in `docs/design/cli-terminal-mockups.md`.
> 
> **Components:** Many new page-specific `Cli*Hero` cards (agents, memory, history, storage, init, models, remote, search, Lean, multi-agent, tools lifecycle, etc.), reusable **`CliRunHero`** (props-driven `texra run` streaming), **`DoctorSliceHero`**, **`RunParityHero`** (one run id on CLI + Progress Board), and **`LandingCliStrip`** on the home page.
> 
> **Realism fixes:** **`CliChatHero`** rebuilt to match the real chat TUI (session header, `›` user band, tool rows, band diffs, status strip). **`CliToolsListHero`** updated to the real six-column `tools list` output including **NOTE**.
> 
> **Guide updates:** ~20 guide pages and `docs/index.md` import heroes and add captions; prose corrections (e.g. **`texra resume`** interactive-only, **`--context`** text-only for figures/vision).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c1da4f8f6e232758f1eea2d9805ef6aab59176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->