### PR TITLE
[codex] Fix TUI plan approval harness fixtures

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -28,6 +28,7 @@ import {
   type ExecutionId,
   type ExternalInquiryThreadId,
   type NormalizedToolUse,
+  type PlanApprovalPermission,
   type RetryPermission,
   type StreamTabId,
   type UserQuestionPermission,
@@ -734,28 +735,17 @@ function makeRetryApprovalPayload(): RetryPermission {
   };
 }
 
-function makePlanApprovalPayload() {
+function makePlanApprovalPayload(): PlanApprovalPermission {
   return {
     approvalId: 'harness-plan-approval',
     streamId: STREAM_ID,
     goalEnabled: PLAN_APPROVAL_GOAL,
     plan: {
-      summary: 'Coordinate a short math proof through CLI chat.',
-      steps: [
-        {
-          title: 'Split the finite and symbolic cases',
-          description:
-            'Separate the bounded search from the algebraic simplification.',
-          files: ['proof.md'],
-          status: TODO_STATUS.PENDING,
-        },
-        {
-          title: 'Ask a checker to verify the enumeration',
-          description: 'Use a delegated agent before writing the final answer.',
-          files: [],
-          status: TODO_STATUS.PENDING,
-        },
-      ],
+      objective: [
+        'Coordinate a short math proof through CLI chat.',
+        'Split the finite and symbolic cases.',
+        'Ask a checker to verify the enumeration before writing the final answer.',
+      ].join('\n'),
     },
   };
 }
@@ -1089,21 +1079,11 @@ if (SHOW_TODOS) {
       },
     ],
     plan: {
-      summary: 'Coordinate a small math proof through nested CLI work.',
-      steps: [
-        {
-          title: 'Route proof obligations',
-          description: 'Choose the right specialist for each proof branch.',
-          files: [],
-          status: TODO_STATUS.COMPLETED,
-        },
-        {
-          title: 'Check formalizable parts',
-          description: 'Have a subagent inspect the Lean-style finite case.',
-          files: [],
-          status: TODO_STATUS.IN_PROGRESS,
-        },
-      ],
+      objective: [
+        'Coordinate a small math proof through nested CLI work.',
+        'Route proof obligations to the right specialist.',
+        'Have a subagent inspect the Lean-style finite case.',
+      ].join('\n'),
     },
   }));
 }

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2289,7 +2289,7 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
     expect: [
       'Split theorem into algebraic and analytic checks',
-      'Route proof obligations',
+      'Coordinate a small math proof through nested CLI work.',
     ],
   },
   {
@@ -2303,7 +2303,7 @@ const SCENARIOS = [
     expect: ['idle', '[Ctrl-C]exit'],
     unexpect: [
       'Split theorem into algebraic and analytic checks',
-      'Route proof obligations',
+      'Coordinate a small math proof through nested CLI work.',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- update TUI harness plan fixtures to the current `{ objective }` plan schema
- type the plan approval fixture as `PlanApprovalPermission` so schema drift is harder to miss
- update the todos validator expectation to the visible `planSummaryLine(plan.objective)` output

Fixes #5841.

## Validation
- `corepack pnpm --filter @texra-ai/cli run typecheck`
- `corepack pnpm exec prettier --check packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs`
- `git diff --check`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /private/tmp/texra-dogfood-frames-0612-fix2 plan-approval plan-approval-goal compact-plan-approval compact-plan-approval-goal plan-approval-approve-goal todos idle-todos-hidden approval-form bash-approval subagents subagent-picker task-picker compact-task-picker empty-task-shortcut-hidden retry-approval`
- Live TTY: `TERM=xterm-256color texra-local chat --api-mode included --approval-policy ask`, `/status`, Pell-equation prompt, bash approval with `y`, tool output and answer rendered, Ctrl-C exit/resume hint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness and snapshot-validator-only changes; no production TUI or runtime plan logic is modified.
> 
> **Overview**
> Aligns CLI TUI test fixtures with the current plan shape: plans are **`{ objective }`** text instead of **`summary` + `steps`**.
> 
> In **`tui-harness.tsx`**, plan-approval and todos harness data use multi-line **`objective`** strings, and **`makePlanApprovalPayload`** is typed as **`PlanApprovalPermission`** so fixture drift fails typecheck. In **`validate-tui.mjs`**, the **`todos`** / **`idle-todos-hidden`** scenarios now expect the first line of **`planSummaryLine(plan.objective)`** instead of a legacy step title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df4d9ad2d846483f65a5a5ea833c708bedcd2f01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->