### PR TITLE
[codex] Suppress chat TUI resize listener warning

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -59,7 +59,10 @@ import {
 } from '../src/chat/tui/state/cliState';
 import { formatCliSessionStatus } from '../src/chat/tui/sessionStatus';
 import { notify } from '../src/chat/tui/notifications/terminalNotifier';
-import { tuiOutputStreamForColor } from '../src/chat/tui/render/noColorOutput';
+import {
+  installTuiStdoutListenerLimit,
+  tuiOutputStreamForColor,
+} from '../src/chat/tui/render/noColorOutput';
 import {
   enqueueApproval,
   type ApprovalDecision,
@@ -1533,6 +1536,9 @@ function handleHarnessCtrlC(): void {
   void exitHarness(0);
 }
 
+const restoreStdoutListenerLimit = installTuiStdoutListenerLimit(
+  process.stdout,
+);
 const ink = render(
   <App
     onSubmit={handleHarnessSubmit}
@@ -1561,6 +1567,7 @@ async function exitHarness(exitCode: number): Promise<void> {
   try {
     await tryPlatform()?.lifecycle.runShutdown();
   } finally {
+    restoreStdoutListenerLimit();
     process.exit(exitCode);
   }
 }

--- a/packages/cli/src/chat/tui/render/noColorOutput.ts
+++ b/packages/cli/src/chat/tui/render/noColorOutput.ts
@@ -1,5 +1,12 @@
 import { ANSI_ESCAPE_START } from '@cli/runtime/ansiEscapes';
 
+const TUI_STDOUT_MAX_LISTENERS = 64;
+
+interface ListenerLimitStream {
+  getMaxListeners(): number;
+  setMaxListeners(n: number): unknown;
+}
+
 interface SgrStripState {
   pending: string;
 }
@@ -102,4 +109,23 @@ export function tuiOutputStreamForColor<T extends NodeJS.WriteStream>(
   colorEnabled: boolean,
 ): T {
   return colorEnabled ? stream : sgrStrippingWriteStream(stream);
+}
+
+export function installTuiStdoutListenerLimit(
+  stream: ListenerLimitStream,
+): () => void {
+  const previous = stream.getMaxListeners();
+  if (previous === 0 || previous >= TUI_STDOUT_MAX_LISTENERS) {
+    return () => undefined;
+  }
+
+  stream.setMaxListeners(TUI_STDOUT_MAX_LISTENERS);
+  let restored = false;
+  return () => {
+    if (restored) return;
+    restored = true;
+    if (stream.getMaxListeners() === TUI_STDOUT_MAX_LISTENERS) {
+      stream.setMaxListeners(previous);
+    }
+  };
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -128,7 +128,10 @@ import {
 } from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
-import { tuiOutputStreamForColor } from './render/noColorOutput';
+import {
+  installTuiStdoutListenerLimit,
+  tuiOutputStreamForColor,
+} from './render/noColorOutput';
 import { formatCliSessionStatus } from './sessionStatus';
 import { clearApprovals } from './state/approvalQueue';
 import { cliState, patchStream, resetCliState } from './state/cliState';
@@ -1121,6 +1124,10 @@ export async function runChat(
   const snapshotStore = new StreamSnapshotStore();
 
   const disposers: Array<() => void> = [];
+  // Ink registers one stdout "resize" listener per mounted useWindowSize()
+  // hook. The chat TUI can legitimately mount more than Node's default ten
+  // while approvals, status, stream tabs, and child-stream views are visible.
+  disposers.push(installTuiStdoutListenerLimit(process.stdout));
   // Crash safety: if the process dies outside the orderly teardown below
   // (uncaught exception, stray process.exit), still restore the terminal so
   // the user's shell isn't left in raw/kitty/mouse mode with a hidden cursor.

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1,5 +1,7 @@
 // Phase 4 state + focus-cycle smoke.
 
+import { EventEmitter } from 'node:events';
+
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -69,6 +71,7 @@ import {
   clearTuiSessionRunState,
   markChatTuiRunPending,
 } from '@cli/chat/tui/runChatTui';
+import { installTuiStdoutListenerLimit } from '@cli/chat/tui/render/noColorOutput';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import {
   appendAssistantTranscriptIfMissing,
@@ -284,6 +287,34 @@ describe('cliState Phase 4 fields', () => {
         transcriptViewerStreamId: child1,
       }),
     ).toBe(`viewer:${child1}`);
+  });
+});
+
+describe('chat TUI stdout listener limit', () => {
+  it('raises and restores the listener ceiling for the mounted TUI lifetime', () => {
+    const stream = new EventEmitter();
+    stream.setMaxListeners(10);
+
+    const restore = installTuiStdoutListenerLimit(stream);
+
+    expect(stream.getMaxListeners()).toBeGreaterThan(10);
+
+    restore();
+    expect(stream.getMaxListeners()).toBe(10);
+
+    restore();
+    expect(stream.getMaxListeners()).toBe(10);
+  });
+
+  it('does not lower a listener ceiling changed after installation', () => {
+    const stream = new EventEmitter();
+    stream.setMaxListeners(10);
+    const restore = installTuiStdoutListenerLimit(stream);
+
+    stream.setMaxListeners(128);
+    restore();
+
+    expect(stream.getMaxListeners()).toBe(128);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a shared TUI stdout listener-limit guard for Ink-mounted screens
- install it in the real chat TUI and the PTY validation harness
- cover restore/idempotency behavior with a focused unit test

Fixes #5843.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /private/tmp/texra-dogfood-frames-0612-listener-fix subagents subagent-picker task-picker bash-approval approval-form`
- `corepack pnpm --filter @texra-ai/cli run typecheck`
- `npm run typecheck`
- `git diff --check`

## Dogfood Evidence
- Live TTY on `origin/main` (`6dd911700`): `TERM=xterm-256color texra-local chat --agent assistant --api-mode included --approval-policy ask`
- Prompted the assistant to enumerate primitive Pythagorean triples with `c <= 50`, approve bash, and delegate an independent check to `research`
- Approval modals, stream cycling, subagent focus, Wolfram execution, parent report readback, and final answer all worked
- During the run, Node printed `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 resize listeners added to [WriteStream]` into the TUI, which this PR addresses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped stdout listener-limit tweak with restore on teardown; no auth, persistence, or agent-runtime behavior changes.
> 
> **Overview**
> Adds **`installTuiStdoutListenerLimit`** in `noColorOutput.ts`, which temporarily raises `process.stdout`’s EventEmitter listener cap to **64** (from Node’s default of 10) while the Ink TUI is mounted. Ink registers one **resize** listener per `useWindowSize()` hook; a busy chat session (approvals, forms, stream tabs, child views) can exceed ten and trigger **`MaxListenersExceededWarning`** in the terminal.
> 
> The guard is wired into the **real chat TUI** (`runChatTui.tsx`, registered with other session disposers) and the **PTY validation harness** (`tui-harness.tsx`, restored in `exitHarness`). Restore is **idempotent** and does not clobber a higher limit set after install.
> 
> Unit tests in `TuiStateAndFocus.vitest.mts` cover raise/restore and the post-install ceiling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2b0f40cb50db5783db88dc3049271e77399444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->