### PR TITLE
[codex] Show subagent stream model in CLI header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Subagent headers show the subagent model** — focusing a subagent in the CLI now shows that subagent's own model in the scrollback header instead of reusing the parent chat model.
 - **Terminal always restored on exit** — a crash or unexpected exit can no longer leave your shell stuck in raw mode with a hidden cursor or mouse reporting left on.
 - **Stopping honors your subagent preference** — stopping an orchestrator now respects the "Keep agents running if I stop the orchestrator" setting instead of always interrupting running subagents.
 

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -156,6 +156,22 @@ const SESSION_HEADER_ID = 'session-header';
 const FULL_SESSION_HEADER_ROWS = 4;
 const COMPACT_SESSION_HEADER_ROWS = 1;
 
+function childHeaderIdentityPending({
+  parentStream,
+  scrollbackStreamId,
+  streams,
+}: {
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly scrollbackStreamId: StreamTabId | undefined;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}): boolean {
+  return (
+    scrollbackStreamId !== undefined &&
+    parentStream.has(scrollbackStreamId) &&
+    !streams.get(scrollbackStreamId)?.model
+  );
+}
+
 function staticTranscriptItemRowCount(
   item: StaticTranscriptItem,
   width?: number,
@@ -211,6 +227,11 @@ export function appendStaticTranscriptItems({
   // Copied lazily: this runs on every stream-sync tick and most ticks append
   // nothing.
   let nextItems: StaticTranscriptItem[] | undefined;
+  const shouldWaitForChildIdentity =
+    !seen.has(SESSION_HEADER_ID) &&
+    childHeaderIdentityPending({ parentStream, scrollbackStreamId, streams });
+  if (shouldWaitForChildIdentity) return currentItems;
+
   if (!seen.has(SESSION_HEADER_ID)) {
     const header: StaticTranscriptItem = {
       id: SESSION_HEADER_ID,

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -71,11 +71,12 @@ export function sessionHeaderIdentityLine(
     readonly streams?: ReadonlyMap<StreamTabId, StreamSlice>;
   } = {},
 ): string {
-  const model = meta.model || '—';
   const parentStream = context.parentStream;
   const parentStreamId =
     context.streamId && parentStream?.get(context.streamId);
   if (context.streamId && parentStreamId && parentStream && context.streams) {
+    const slice = context.streams.get(context.streamId);
+    const model = slice?.model || meta.model || '—';
     const view = streamViewForId({
       activeStreamId: context.streamId,
       parentStream,
@@ -84,10 +85,12 @@ export function sessionHeaderIdentityLine(
     });
     return `subagent: ${view.label} · parent: ${view.parentLabel} · model: ${model}`;
   }
+  const model = meta.model || '—';
+  const agent = meta.agent || 'chat';
   if (meta.teamName) {
-    return `team: ${meta.teamName} · root: ${meta.agent || 'chat'} · model: ${model}`;
+    return `team: ${meta.teamName} · root: ${agent} · model: ${model}`;
   }
-  return `agent: ${meta.agent || 'chat'} · model: ${model}`;
+  return `agent: ${agent} · model: ${model}`;
 }
 
 function SessionHeaderBlock({

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -75,8 +75,6 @@ export interface BypassState {
 
 export interface StreamSlice {
   readonly streamId: StreamTabId;
-  /** Agent identity captured from setTaskState for this specific stream. */
-  readonly agentName?: string | undefined;
   /** Model identity captured from setTaskState for this specific stream. */
   readonly model?: string | undefined;
   /** Agent category for this stream (`toolUse` / `workflow` / …), captured
@@ -226,7 +224,6 @@ export const NO_BYPASS: BypassState = {
 function emptySlice(streamId: StreamTabId): StreamSlice {
   return {
     streamId,
-    agentName: undefined,
     model: undefined,
     category: undefined,
     status: undefined,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -75,9 +75,13 @@ export interface BypassState {
 
 export interface StreamSlice {
   readonly streamId: StreamTabId;
+  /** Agent identity captured from setTaskState for this specific stream. */
+  readonly agentName?: string | undefined;
+  /** Model identity captured from setTaskState for this specific stream. */
+  readonly model?: string | undefined;
   /** Agent category for this stream (`toolUse` / `workflow` / …), captured
-   *  from `setActiveStream`. Lets the exit hint list only resumable tool-use
-   *  subagents (workflows don't resume). Undefined until the stream activates. */
+   *  from `setTaskState` or `setActiveStream`. Lets the exit hint list only
+   *  resumable tool-use subagents (workflows don't resume). */
   readonly category: AgentCategory | undefined;
   readonly status: StreamStatus | undefined;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
@@ -222,6 +226,8 @@ export const NO_BYPASS: BypassState = {
 function emptySlice(streamId: StreamTabId): StreamSlice {
   return {
     streamId,
+    agentName: undefined,
+    model: undefined,
     category: undefined,
     status: undefined,
     runStartedAt: undefined,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -106,16 +106,11 @@ function applyToState<K extends ProgressEvent>(
       const p = payload as ProgressEventPayloads['setTaskState'];
       const config = p.taskState.agentConfig;
       patchStream(p.streamId, (s) => {
-        if (
-          s.agentName === config.agent &&
-          s.model === config.model &&
-          s.category === config.agentCategory
-        ) {
+        if (s.model === config.model && s.category === config.agentCategory) {
           return s;
         }
         return {
           ...s,
-          agentName: config.agent,
           model: config.model,
           category: config.agentCategory,
         };

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -102,6 +102,26 @@ function applyToState<K extends ProgressEvent>(
       }
       return;
     }
+    case 'setTaskState': {
+      const p = payload as ProgressEventPayloads['setTaskState'];
+      const config = p.taskState.agentConfig;
+      patchStream(p.streamId, (s) => {
+        if (
+          s.agentName === config.agent &&
+          s.model === config.model &&
+          s.category === config.agentCategory
+        ) {
+          return s;
+        }
+        return {
+          ...s,
+          agentName: config.agent,
+          model: config.model,
+          category: config.agentCategory,
+        };
+      });
+      return;
+    }
     case 'setParentStream': {
       const p = payload as ProgressEventPayloads['setParentStream'];
       setParentStream(p.childStreamId, p.parentStreamId);

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -757,7 +757,6 @@ describe('CLI conversation transcript splitting', () => {
       [
         ROOT,
         sliceWithEntries(ROOT, [], {
-          agentName: 'previous-agent',
           model: 'previous-model',
         }),
       ],
@@ -785,7 +784,6 @@ describe('CLI conversation transcript splitting', () => {
       [
         ROOT,
         sliceWithEntries(ROOT, [entry('u1', 'user', 'send scouts', true)], {
-          agentName: 'assistant',
           model: 'deepseekT',
           activeSubagents: [
             {
@@ -800,7 +798,6 @@ describe('CLI conversation transcript splitting', () => {
       [
         CHILD,
         sliceWithEntries(CHILD, [entry('a1', 'assistant', 'ok', true)], {
-          agentName: 'search',
           model: 'kimi26T',
         }),
       ],
@@ -826,6 +823,47 @@ describe('CLI conversation transcript splitting', () => {
       kind: 'header',
       identityLine: 'subagent: search · parent: main · model: kimi26T',
     });
+  });
+
+  it('waits for child task state before printing a focused subagent header', () => {
+    const ROOT = 'root-stream' as StreamTabId;
+    const CHILD = 'search-stream' as StreamTabId;
+    const parentStream = new Map<StreamTabId, StreamTabId>([[CHILD, ROOT]]);
+    const childEntry = entry('a1', 'assistant', 'checking', true);
+    const streamsWithoutChildModel = new Map<StreamTabId, StreamSlice>([
+      [ROOT, sliceWithEntries(ROOT, [])],
+      [CHILD, sliceWithEntries(CHILD, [childEntry])],
+    ]);
+
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: CHILD,
+        currentItems: [],
+        streams: streamsWithoutChildModel,
+        meta: SESSION_META,
+        parentStream,
+      }),
+    ).toEqual([]);
+
+    const streamsWithChildModel = new Map<StreamTabId, StreamSlice>([
+      [ROOT, sliceWithEntries(ROOT, [])],
+      [
+        CHILD,
+        sliceWithEntries(CHILD, [childEntry], {
+          model: 'kimi26T',
+        }),
+      ],
+    ]);
+
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: CHILD,
+        currentItems: [],
+        streams: streamsWithChildModel,
+        meta: SESSION_META,
+        parentStream,
+      }).map((item) => item.id),
+    ).toEqual(['session-header', 'a1']);
   });
 
   it('only feeds the root scrollback stream, not background subagents', () => {
@@ -1098,7 +1136,6 @@ function sliceWithEntries(
 ): StreamSlice {
   return {
     streamId,
-    agentName: undefined,
     model: undefined,
     category: undefined,
     status: undefined,

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -751,6 +751,33 @@ describe('CLI conversation transcript splitting', () => {
     );
   });
 
+  it('keeps session metadata authoritative for root stream identity', () => {
+    const ROOT = 'root-stream' as StreamTabId;
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        ROOT,
+        sliceWithEntries(ROOT, [], {
+          agentName: 'previous-agent',
+          model: 'previous-model',
+        }),
+      ],
+    ]);
+
+    expect(
+      sessionHeaderIdentityLine(
+        {
+          ...SESSION_META,
+          agent: 'current-agent',
+          model: 'current-model',
+        },
+        {
+          streamId: ROOT,
+          streams,
+        },
+      ),
+    ).toBe('agent: current-agent · model: current-model');
+  });
+
   it('labels focused subagent scrollback with the child stream identity', () => {
     const ROOT = 'root-stream' as StreamTabId;
     const CHILD = 'search-stream' as StreamTabId;
@@ -758,6 +785,8 @@ describe('CLI conversation transcript splitting', () => {
       [
         ROOT,
         sliceWithEntries(ROOT, [entry('u1', 'user', 'send scouts', true)], {
+          agentName: 'assistant',
+          model: 'deepseekT',
           activeSubagents: [
             {
               executionId: 'ei_search',
@@ -768,7 +797,13 @@ describe('CLI conversation transcript splitting', () => {
           ],
         }),
       ],
-      [CHILD, sliceWithEntries(CHILD, [entry('a1', 'assistant', 'ok', true)])],
+      [
+        CHILD,
+        sliceWithEntries(CHILD, [entry('a1', 'assistant', 'ok', true)], {
+          agentName: 'search',
+          model: 'kimi26T',
+        }),
+      ],
     ]);
 
     expect(
@@ -777,7 +812,7 @@ describe('CLI conversation transcript splitting', () => {
         streamId: CHILD,
         streams,
       }),
-    ).toBe('subagent: search · parent: main · model: deepseekT');
+    ).toBe('subagent: search · parent: main · model: kimi26T');
 
     expect(
       appendStaticTranscriptItems({
@@ -789,7 +824,7 @@ describe('CLI conversation transcript splitting', () => {
       })[0],
     ).toMatchObject({
       kind: 'header',
-      identityLine: 'subagent: search · parent: main · model: deepseekT',
+      identityLine: 'subagent: search · parent: main · model: kimi26T',
     });
   });
 
@@ -1063,6 +1098,8 @@ function sliceWithEntries(
 ): StreamSlice {
   return {
     streamId,
+    agentName: undefined,
+    model: undefined,
     category: undefined,
     status: undefined,
     runStartedAt: undefined,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -84,6 +84,7 @@ import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   AgentCategory,
+  DEFAULT_TOOL_CONFIG,
   MESSAGE_TYPES,
   STREAM_STATUS,
   type StorageKey,
@@ -2335,6 +2336,38 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
 
     expect(cliState.activeStreamId.get()).toBe(root);
     expect(cliState.streams.get().has(child1)).toBe(true);
+  });
+
+  it('captures per-stream agent and model identity from task state', () => {
+    const wrapped = wrapRuntimeHost(makeHost());
+
+    wrapped.emit('setTaskState', {
+      streamId: child1,
+      executionId: 'exec-search',
+      taskState: {
+        agentConfig: {
+          agent: 'search',
+          agentCategory: AgentCategory.ToolUse,
+          model: 'kimi26T',
+          instruction: 'Check the enumeration independently.',
+          inputFiles: [],
+          contextFiles: [],
+          mediaFiles: [],
+          outputFiles: [],
+          editedFile: null,
+          editedFiles: [],
+          toolConfig: DEFAULT_TOOL_CONFIG,
+          memories: [],
+          workingDirectory: undefined,
+        },
+      },
+    });
+
+    expect(cliState.streams.get().get(child1)).toMatchObject({
+      agentName: 'search',
+      model: 'kimi26T',
+      category: AgentCategory.ToolUse,
+    });
   });
 
   it('refreshes queued follow-up display when an active follow-up is sent', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2338,7 +2338,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     expect(cliState.streams.get().has(child1)).toBe(true);
   });
 
-  it('captures per-stream agent and model identity from task state', () => {
+  it('captures per-stream model identity from task state', () => {
     const wrapped = wrapRuntimeHost(makeHost());
 
     wrapped.emit('setTaskState', {
@@ -2364,7 +2364,6 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     });
 
     expect(cliState.streams.get().get(child1)).toMatchObject({
-      agentName: 'search',
       model: 'kimi26T',
       category: AgentCategory.ToolUse,
     });


### PR DESCRIPTION
Fixes #5845.

## Summary

- Store per-stream model identity in the CLI TUI state mirror from runtime `setTaskState` events.
- Use the stored child stream model for focused subagent headers while keeping root/team headers sourced from current session metadata.
- Delay focused child header printing until child task state supplies the model, so Ink's append-only scrollback cannot freeze a parent-model fallback.
- Cover the runtime event mirror, the focused subagent parent-vs-child model mismatch, stale root stream slice fallback, and the task-state timing race.

## Root Cause

The CLI static transcript header originally used global `sessionMeta.model` for every scrollback owner. The first fix taught subagent headers to read the child stream model from `setTaskState`, but dogfooding exposed a timing race: `setActiveStream` can focus the child before `setTaskState` arrives, and Ink static scrollback prints the header only once. That could freeze the parent model into the child header even though the child later had the correct approved model.

## Validation

- `pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts`
- `pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run texra-local:build`
- `npx prettier --check packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx packages/cli/src/chat/tui/state/cliState.ts packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `git diff --check origin/main...HEAD`