### PR TITLE
[codex] Clarify TUI harness build failures

### DIFF
--- a/packages/cli/scripts/build-harness.mjs
+++ b/packages/cli/scripts/build-harness.mjs
@@ -2,9 +2,6 @@
 // Bundles scripts/tui-harness.tsx into dist/bin/tui-harness.js for PTY tests.
 import { chmod } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { build } from 'esbuild';
-import { reactCompilerPlugin } from './reactCompilerPlugin.mjs';
-import { esmCjsGlobalsBanner } from '../../../scripts/esm-cjs-globals-banner.mjs';
 
 const reactDevtoolsStub = fileURLToPath(
   new URL('./react-devtools-core-stub.mjs', import.meta.url),
@@ -12,22 +9,39 @@ const reactDevtoolsStub = fileURLToPath(
 
 const outfile = 'dist/bin/tui-harness.js';
 
-await build({
-  entryPoints: ['scripts/tui-harness.tsx'],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  target: 'node20',
-  external: ['fsevents'],
-  jsx: 'automatic',
-  loader: { '.tsx': 'tsx', '.ts': 'ts' },
-  alias: { 'react-devtools-core': reactDevtoolsStub },
-  outfile,
-  banner: {
-    js: esmCjsGlobalsBanner,
-  },
-  plugins: [reactCompilerPlugin()],
-  logLevel: 'info',
-});
+try {
+  const [{ build }, { reactCompilerPlugin }, { esmCjsGlobalsBanner }] =
+    await Promise.all([
+      import('esbuild'),
+      import('./reactCompilerPlugin.mjs'),
+      import('../../../scripts/esm-cjs-globals-banner.mjs'),
+    ]);
 
-await chmod(outfile, 0o755);
+  await build({
+    entryPoints: ['scripts/tui-harness.tsx'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    external: ['fsevents'],
+    jsx: 'automatic',
+    loader: { '.tsx': 'tsx', '.ts': 'ts' },
+    alias: { 'react-devtools-core': reactDevtoolsStub },
+    outfile,
+    banner: {
+      js: esmCjsGlobalsBanner,
+    },
+    plugins: [reactCompilerPlugin()],
+    logLevel: 'info',
+  });
+
+  await chmod(outfile, 0o755);
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[build-harness] failed to build TUI harness.');
+  console.error(
+    '[build-harness] If dependencies are missing, run `corepack pnpm install` from the repo root.',
+  );
+  console.error(`[build-harness] ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Catch TUI harness dependency, bundling, and executable-permission failures in `build-harness.mjs`.
- Print a concise `[build-harness]` diagnostic with a `corepack pnpm install` recovery hint instead of letting Node dump an uncaught stack.
- Keep the existing esbuild diagnostics visible before the summary line when bundling reaches esbuild.

## Root Cause

During CLI dogfooding of the TUI screenshot workflow, `validate-tui --snapshot-dir ...` failed in a checkout with stale/missing local dependencies. The underlying missing dependency was real, but the builder let the top-level build/import failure escape as an uncaught exception, making the recovery path noisier than necessary.

## Validation

- `node packages/cli/scripts/build-harness.mjs` in a dependency-missing worktree now prints a concise `[build-harness]` failure without a Node stack.
- `corepack pnpm install`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-snapshots-0612-branch-2 transcript bash-approval`
- `corepack pnpm vitest run src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `npx prettier --check packages/cli/scripts/build-harness.mjs`
- `git diff --check`