### PR TITLE
[codex] Clarify CLI bundle build failures

### DIFF
--- a/packages/cli/scripts/build-bundle.mjs
+++ b/packages/cli/scripts/build-bundle.mjs
@@ -2,10 +2,6 @@
 
 import { chmod } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { build } from 'esbuild';
-
-import { reactCompilerPlugin } from './reactCompilerPlugin.mjs';
-import { esmCjsGlobalsBanner } from '../../../scripts/esm-cjs-globals-banner.mjs';
 
 const reactDevtoolsStub = fileURLToPath(
   new URL('./react-devtools-core-stub.mjs', import.meta.url),
@@ -18,62 +14,79 @@ const outfile = 'dist/bin/texra.js';
 const includeInternalValidationModel =
   process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL === '1';
 
-await build({
-  entryPoints: ['src/bin/texra.ts'],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  target: 'node20',
-  external: ['fsevents'],
-  define: {
-    'process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL': JSON.stringify(
-      includeInternalValidationModel ? '1' : '',
-    ),
-    'process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_ENV':
-      JSON.stringify(
-        includeInternalValidationModel
-          ? 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER'
-          : '',
-      ),
-    'process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV':
-      JSON.stringify(
-        includeInternalValidationModel
-          ? 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG'
-          : '',
-      ),
-    'process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_CONTENT':
-      JSON.stringify(
-        includeInternalValidationModel ? 'texra-cli-run-validation' : '',
-      ),
-  },
-  alias: {
-    // Ink statically imports `react-devtools-core` from its `devtools.js`,
-    // which is only reached when `process.env.DEV === 'true'`. We never
-    // attach to React DevTools from the production CLI, so alias the import
-    // to a no-op stub. Avoids pulling the (heavy) real package into the
-    // bundle while keeping ink's dynamic-import path resolvable.
-    'react-devtools-core': reactDevtoolsStub,
-    ...(!includeInternalValidationModel
-      ? {
-          '@agent/modelHandlers/modelHandlerValidation':
-            internalValidationModelStub,
-        }
-      : {}),
-  },
-  outfile,
-  minify: true,
-  sourcemap: false,
-  legalComments: 'none',
-  // The React Compiler runs as a Babel pre-pass scoped to .tsx files under
-  // packages/cli/src/chat/tui/. Confirmed addition is only
-  // `react/compiler-runtime`; see docs/prd/cli-tui-ink/20-implementation.md
-  // (Phase 0). Risk R12.
-  plugins: [reactCompilerPlugin()],
-  // JSX needs to be transformed for ink (which uses React's JSX runtime).
-  jsx: 'automatic',
-  banner: {
-    js: `#!/usr/bin/env node\n${esmCjsGlobalsBanner}`,
-  },
-});
+try {
+  const [{ build }, { reactCompilerPlugin }, { esmCjsGlobalsBanner }] =
+    await Promise.all([
+      import('esbuild'),
+      import('./reactCompilerPlugin.mjs'),
+      import('../../../scripts/esm-cjs-globals-banner.mjs'),
+    ]);
 
-await chmod(outfile, 0o755);
+  await build({
+    entryPoints: ['src/bin/texra.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    external: ['fsevents'],
+    define: {
+      'process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL': JSON.stringify(
+        includeInternalValidationModel ? '1' : '',
+      ),
+      'process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_ENV':
+        JSON.stringify(
+          includeInternalValidationModel
+            ? 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER'
+            : '',
+        ),
+      'process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV':
+        JSON.stringify(
+          includeInternalValidationModel
+            ? 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG'
+            : '',
+        ),
+      'process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_CONTENT':
+        JSON.stringify(
+          includeInternalValidationModel ? 'texra-cli-run-validation' : '',
+        ),
+    },
+    alias: {
+      // Ink statically imports `react-devtools-core` from its `devtools.js`,
+      // which is only reached when `process.env.DEV === 'true'`. We never
+      // attach to React DevTools from the production CLI, so alias the import
+      // to a no-op stub. Avoids pulling the (heavy) real package into the
+      // bundle while keeping ink's dynamic-import path resolvable.
+      'react-devtools-core': reactDevtoolsStub,
+      ...(!includeInternalValidationModel
+        ? {
+            '@agent/modelHandlers/modelHandlerValidation':
+              internalValidationModelStub,
+          }
+        : {}),
+    },
+    outfile,
+    minify: true,
+    sourcemap: false,
+    legalComments: 'none',
+    // The React Compiler runs as a Babel pre-pass scoped to .tsx files under
+    // packages/cli/src/chat/tui/. Confirmed addition is only
+    // `react/compiler-runtime`; see docs/prd/cli-tui-ink/20-implementation.md
+    // (Phase 0). Risk R12.
+    plugins: [reactCompilerPlugin()],
+    // JSX needs to be transformed for ink (which uses React's JSX runtime).
+    jsx: 'automatic',
+    banner: {
+      js: `#!/usr/bin/env node\n${esmCjsGlobalsBanner}`,
+    },
+  });
+
+  await chmod(outfile, 0o755);
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[build-bundle] failed to build CLI bundle.');
+  console.error(
+    '[build-bundle] If dependencies are missing, run `corepack pnpm install` from the repo root.',
+  );
+  console.error(`[build-bundle] ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Catch CLI bundle dependency, bundling, and executable-permission failures in `build-bundle.mjs`.
- Print a concise `[build-bundle]` diagnostic with a `corepack pnpm install` recovery hint instead of letting Node dump an uncaught import stack.
- Keep the existing esbuild bundle configuration and executable-bit behavior unchanged on the success path.

## Root Cause

During CLI dogfooding of the build and TUI screenshot workflow, the TUI harness builder exposed a missing-dependency error path. The sibling production CLI bundle script had the same top-level static imports for `esbuild`, `reactCompilerPlugin`, and `esmCjsGlobalsBanner`, so a fresh dependency-missing checkout failed before the script could print any recovery guidance.

Related: #5847 applies the same diagnostic treatment to the TUI harness builder. This PR keeps the production CLI bundle fix independent.

## Validation

- `node packages/cli/scripts/build-bundle.mjs` in a dependency-missing worktree now prints a concise `[build-bundle]` failure without a Node stack.
- `corepack pnpm install`
- `corepack pnpm --filter @texra-ai/cli bundle`
- `node scripts/build-bundle.mjs` from `packages/cli/`
- `corepack pnpm vitest run src/test-kernel/cli/CliBundleBanner.vitest.mts`
- `npx prettier --check packages/cli/scripts/build-bundle.mjs`
- `git diff --check`