### PR TITLE
[codex] Share human input approval policy

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -15,7 +15,8 @@
 
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
-  denyMessage,
+  approvalPromptAllowed,
+  humanInputDenialFeedback,
   immediateDecision,
   immediateDecisionForApproval,
   markApprovalDenied,
@@ -153,9 +154,8 @@ function routeApproval(
       );
       return;
     case 'showExternalInquiry':
-      // External inquiry has bespoke policy semantics (legacy adapter uses
-      // `action: 'skip'` for both yolo *and* never with different feedback
-      // strings), so it bypasses the generic `routeWithPolicy` ladder.
+      // Human-input requests cannot be auto-answered in yolo mode, so they
+      // share a policy helper with the non-TUI approval path.
       handleExternalInquiry(
         payload as ProgressEventPayloads['showExternalInquiry'],
         context,
@@ -292,12 +292,11 @@ function handleExternalInquiry(
   const threadId = payload.threadId;
   if (!threadId) return;
 
-  const policy = immediateDecision(context);
-  if (policy) {
-    const feedback =
-      context.approvalPolicy === 'yolo'
-        ? 'External inquiry requires human input; yolo mode cannot synthesize an external answer.'
-        : denyMessage(context.approvalPolicy);
+  if (!approvalPromptAllowed(context)) {
+    const feedback = humanInputDenialFeedback(
+      context,
+      'External inquiry requires human input; yolo mode cannot synthesize an external answer.',
+    );
     void handleExternalInquiryAction({ action: 'drop', threadId, feedback });
     return;
   }
@@ -328,12 +327,15 @@ function handleUserQuestion(
   context: CliContext,
   host: CliRuntimeHost,
 ): void {
-  const policy = immediateDecision(context);
-  if (policy) {
+  if (!approvalPromptAllowed(context)) {
+    const feedback = humanInputDenialFeedback(
+      context,
+      'User question requires human input; yolo mode cannot synthesize an answer.',
+    );
     void handleUserQuestionAction({
       requestId: payload.requestId,
       action: 'skip',
-      feedback: userQuestionFeedback(context),
+      feedback,
     });
     return;
   }
@@ -356,11 +358,4 @@ function handleUserQuestion(
       });
     },
   );
-}
-
-function userQuestionFeedback(context: CliContext): string {
-  if (context.approvalPolicy === 'yolo') {
-    return 'User question requires human input; yolo mode cannot synthesize an answer.';
-  }
-  return denyMessage(context.approvalPolicy);
 }

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -35,8 +35,10 @@ import {
 export {
   type ApprovalDecision,
   appendCliApiSwitchHint,
+  approvalPromptAllowed,
   denyMessage,
   hasCliApprovalDenied,
+  humanInputDenialFeedback,
   immediateDecision,
   immediateDecisionForApproval,
   isCliApiSwitchableRetry,

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   appendCliApiSwitchHint,
+  approvalPromptAllowed,
   formatAgentProposalApprovalSummary,
   formatRetryRequestMessage,
   formatToolEditApprovalSummary,
+  hasCliApprovalDenied,
+  humanInputDenialFeedback,
   immediateDecisionForApproval,
   installCliApprovalHandlers,
   isCliApiSwitchableRetry,
@@ -75,6 +78,42 @@ describe('immediateDecisionForApproval', () => {
         context({ mode: 'headless' }),
       ),
     ).toMatchObject({ accepted: false });
+  });
+});
+
+describe('human input approval policy', () => {
+  it('allows prompts only for interactive ask mode', () => {
+    expect(approvalPromptAllowed(context())).toBe(true);
+    expect(approvalPromptAllowed(context({ approvalPolicy: 'yolo' }))).toBe(
+      false,
+    );
+    expect(approvalPromptAllowed(context({ approvalPolicy: 'never' }))).toBe(
+      false,
+    );
+    expect(approvalPromptAllowed(context({ mode: 'headless' }))).toBe(false);
+  });
+
+  it('uses yolo-specific human-input feedback without marking approval denied', () => {
+    const ctx = context({ approvalPolicy: 'yolo' });
+
+    expect(
+      humanInputDenialFeedback(
+        ctx,
+        'User question requires human input; yolo mode cannot synthesize an answer.',
+      ),
+    ).toBe(
+      'User question requires human input; yolo mode cannot synthesize an answer.',
+    );
+    expect(hasCliApprovalDenied(ctx)).toBe(false);
+  });
+
+  it('uses approval denial feedback and marks denied outside yolo mode', () => {
+    const ctx = context({ approvalPolicy: 'never' });
+
+    expect(humanInputDenialFeedback(ctx, 'unused yolo message')).toBe(
+      'Denied by CLI approval policy.',
+    );
+    expect(hasCliApprovalDenied(ctx)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Export the shared human-input approval policy helpers through the CLI approval adapter surface.
- Use that shared policy in the TUI external-inquiry and user-question approval path instead of duplicating yolo/never/headless feedback logic.
- Cover the shared policy contract in `ApprovalAdapter` tests.

## Root Cause

The non-TUI human-input handlers already centralize the "human input cannot be synthesized in yolo mode" feedback and denial marking in `humanInputDenialFeedback`. The TUI approval router hand-rolled the same policy branch locally for external inquiries and user questions, which split ownership of policy feedback across two runtime paths.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/ApprovalEvents.vitest.mts src/test-kernel/cli/ApprovalQueue.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npx prettier --check packages/cli/src/chat/tui/state/subscribeApprovals.ts packages/cli/src/runtime/approvalAdapter.ts src/test-kernel/cli/ApprovalAdapter.vitest.mts`
- `git diff --check`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- external-inquiry-long external-inquiry-submit-answer compact-user-question bash-approval`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral alignment refactor with explicit tests; yolo human-input semantics differ from generic auto-approve but are now consistent across paths.
> 
> **Overview**
> **Unifies human-input approval policy** between the TUI and the legacy CLI path for external inquiries and user questions.
> 
> The TUI router no longer branches on `immediateDecision` and local yolo/never feedback strings. It now uses **`approvalPromptAllowed`** (prompts only in interactive `ask` mode) and **`humanInputDenialFeedback`** (yolo-specific messages without marking denied; policy denial elsewhere), matching `humanInputHandlers`. Those helpers are **re-exported** from `approvalAdapter`, and the duplicated **`userQuestionFeedback`** helper is removed.
> 
> **Tests** in `ApprovalAdapter.vitest.mts` document when prompts are allowed and how denial feedback interacts with `hasCliApprovalDenied`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 234dcc5a4af8c4cd7ce362649b5d2aeae9eeeaae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->