### PR TITLE
[codex] Centralize subagent panel target selection

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -48,7 +48,6 @@ import {
   rewriteKittyEnterInput,
 } from './input/inputKeys';
 import {
-  hasChildControlItems,
   numericFocusTargetForActiveStream,
   resolveChildControlDisplayTargets,
   type ChildControlMode,
@@ -696,8 +695,8 @@ export function App(props: AppProps): React.JSX.Element {
         rows,
         tipVisible: tipRowVisible,
       });
-  const hasSubagentPanel =
-    !foregroundOpen && hasChildControlItems(activeSlice, 'tasks');
+  const subagentPanelTarget = childControlTargets.tasks;
+  const hasSubagentPanel = !foregroundOpen && subagentPanelTarget.hasItems;
   const hasTodosPlanPanel = shouldShowTodosPlanPanel({
     foregroundOpen,
     hasPlan: activeSlice?.plan != null,
@@ -743,7 +742,9 @@ export function App(props: AppProps): React.JSX.Element {
   // reservation would leave a dead gap above the input whenever the lists are
   // shorter than the cap.
   const subagentContentRows =
-    hasSubagentPanel && activeSlice ? subagentPanelRowCount(activeSlice) : 0;
+    hasSubagentPanel && subagentPanelTarget.slice
+      ? subagentPanelRowCount(subagentPanelTarget.slice)
+      : 0;
   const todosPlanContentRows =
     hasTodosPlanPanel && activeSlice
       ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)
@@ -1012,7 +1013,10 @@ export function App(props: AppProps): React.JSX.Element {
         </Box>
         {bottomPanelBudget > 0 ? (
           <Box flexDirection="column" overflowY="hidden">
-            <SubagentList maxRows={subagentRows} />
+            <SubagentList
+              maxRows={subagentRows}
+              slice={subagentPanelTarget.slice}
+            />
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>
         ) : null}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -14,10 +14,9 @@ import {
   processTailLines,
 } from '../state/childControls';
 import { visibleSubagentRows } from '../state/childStreamMerge';
-import { cliState, type ProcessOutputTail } from '../state/cliState';
 import { useLiveNowMs } from '../state/useLiveNowMs';
-import { useSignal } from '../state/useSignal';
 import { CHILD_STATUS_MARKER, childStatusColor } from './SubagentListDisplay';
+import type { ProcessOutputTail, StreamSlice } from '../state/cliState';
 
 interface RowProps {
   readonly child: ActiveChildInfo;
@@ -150,14 +149,16 @@ export function subagentPanelRowCount(slice: {
 
 export interface SubagentListProps {
   readonly maxRows?: number;
+  readonly slice?: Pick<
+    StreamSlice,
+    'activeProcesses' | 'activeSubagents' | 'childStreams' | 'processOutput'
+  >;
 }
 
 export function SubagentList(
   props: SubagentListProps = {},
 ): React.JSX.Element | null {
-  const activeStreamId = useSignal(cliState.activeStreamId);
-  const streams = useSignal(cliState.streams);
-  const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const slice = props.slice;
   const activeProcesses = slice?.activeProcesses ?? [];
   const processOutput = slice?.processOutput;
   const subagents = slice ? visibleSubagentRows(slice) : [];


### PR DESCRIPTION
## Summary

- Make `SubagentList` a presentational component that renders the slice passed by `App` instead of reading `cliState` directly.
- Reuse App's fallback-aware child-control task target for the compact bottom subagent/tasks panel.
- Keep the foreground picker and passive bottom panel aligned when focus is inside a leaf child stream.

## Root Cause

`App` already resolved child-control targets through `resolveChildControlDisplayTargets`, including fallback to the nearest ancestor stream when the focused child stream had no rows. The foreground picker used that resolved target, but the compact bottom `SubagentList` independently read `cliState.activeStreamId` and `cliState.streams`, so target ownership was split and the passive panel could disagree with picker availability.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npx prettier --check packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/SubagentList.tsx`
- `npx eslint packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/SubagentList.tsx`
- `git diff --check`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- task-picker-parent-fallback subagents subagent-focused-status-stays-scoped`
- `npm run compile:fast`
- `npm run lint` (passed with existing warnings outside this touched scope; local touched-file warning was fixed and targeted ESLint is clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI layout and data-flow refactor only; no auth, persistence, or API changes. Behavior change is aligning two UI surfaces to the same existing resolver.
> 
> **Overview**
> **Centralizes which stream slice drives the compact bottom subagent/tasks panel** so it matches the foreground child-control picker instead of always using `activeStreamId`.
> 
> `App` now uses `childControlTargets.tasks` (from `resolveChildControlDisplayTargets`, including ancestor fallback when the focused child has no rows) for panel visibility, row budgeting, and the `slice` passed into `SubagentList`. **`SubagentList` is presentational**: it takes an optional `slice` prop and no longer subscribes to `cliState.activeStreamId` / `cliState.streams`.
> 
> This removes split ownership where the passive bottom panel could disagree with picker availability when focus is on a leaf child stream with no local task rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26cf1b5dddf680759d6d319b0bd340f6c4d670b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->