### PR TITLE
[codex] Relax orchestrate launcher TUI assertion

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -297,7 +297,7 @@ const SCENARIOS = [
       'no runnable team root',
       '2/7 tool-use agents',
       'Team Physicist',
-      'Team Computer Scientist…',
+      'Team Computer Scientist',
       'Help',
       'Team setup: run texra multi-agent inspect <preset>.',
       'Relay teams may unlock more agents after texra login.',


### PR DESCRIPTION
## Summary
- relax the `orchestrate-launcher` TUI validator expectation so it checks the stable `Team Computer Scientist` label without requiring the obsolete truncation glyph

## Root Cause
`orchestrate-launcher` now renders the row as `Team Computer Scientist — unavailable; ...`, so the stale expected text `Team Computer Scientist…` fails even though the launcher screen is readable and contains the intended team label.

## Validation
- `npm run format`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build orchestrate-launcher`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build --snapshot-dir /private/tmp/texra-cli-dogfood-0612-next-snapshots-fixed orchestrate-launcher orchestrate-delegated-history orchestrate-relay-model-pick orchestrate-personal-model-pick orchestrate-no-runnable-models slash-palette model-form tools-form skills-form`
- `corepack pnpm vitest run src/test-kernel/cli/TuiValidatorArgs.vitest.mts`

## Known Local Test Blocker
- `npm test` currently fails in unrelated `src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts` tests with `no data in serverIn yet`; rerunning that suite alone reproduces the same three failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only expectation tweak in the CLI TUI validator; no runtime product behavior changes.
> 
> **Overview**
> Updates the **`orchestrate-launcher`** scenario in `validate-tui.mjs` so the expected on-screen string is **`Team Computer Scientist`** instead of **`Team Computer Scientist…`**.
> 
> The launcher now shows the full team name (with status text on the same row), so the old ellipsis expectation was a false failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b5ac093d0469db96651707fa1b5521aa33cac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->