### PR TITLE
[codex] Show approval policy in CLI status bar

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -188,7 +188,9 @@ const SHOW_IDLE_TODOS = process.env.HARNESS_TODOS_IDLE === '1';
 const FAILED_CHILD_AGENT = process.env.HARNESS_FAILED_CHILD?.trim();
 const TEAM_NAME = process.env.HARNESS_TEAM_NAME?.trim() || undefined;
 let canInterrupt = process.env.HARNESS_CAN_INTERRUPT === '1';
-let harnessApprovalPolicy: CliApprovalPolicy = 'ask';
+let harnessApprovalPolicy: CliApprovalPolicy =
+  parseHarnessApprovalPolicy(process.env.HARNESS_APPROVAL_POLICY ?? '') ??
+  'ask';
 const EDIT_APPROVAL_DELAY_MS = Number(
   process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
 );
@@ -897,6 +899,7 @@ cliState.sessionMeta.set({
   model: 'harness-model',
   cwd: HARNESS_CWD,
   apiMode: HARNESS_API_MODE,
+  approvalPolicy: harnessApprovalPolicy,
   canDelegate: CAN_DELEGATE,
   teamName: TEAM_NAME,
   version: '0.0.0-harness',
@@ -1330,6 +1333,10 @@ function parseHarnessApprovalPolicy(
 
 function setHarnessApprovalPolicy(policy: CliApprovalPolicy): void {
   harnessApprovalPolicy = policy;
+  cliState.sessionMeta.set({
+    ...cliState.sessionMeta.get(),
+    approvalPolicy: policy,
+  });
   appendHarnessAssistantTranscript(
     `Approval mode set to ${formatApprovalPolicyForCli(policy)}.`,
   );

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -693,6 +693,12 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'approval-policy-status-bar',
+    env: { HARNESS_APPROVAL_POLICY: 'never', HARNESS_ENTRIES: '4' },
+    expect: ['deny', '[/status]details'],
+    unexpect: ['approval: deny privileged actions'],
+  },
+  {
     name: 'tools-form',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/tools', '\r'],

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -6,6 +6,7 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import stringWidth from 'string-width';
 
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
+import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import {
   LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
@@ -80,6 +81,7 @@ export interface StatusBarDisplayInput {
   readonly hasMultipleStreams: boolean;
   readonly model: string;
   readonly apiMode: string;
+  readonly approvalPolicy?: CliApprovalPolicy;
   readonly shortcutModifierLabel?: string;
   /** Advertise Shift+Enter for newline when the Kitty keyboard protocol is
    *  active; otherwise the universal Ctrl-J is the only reliable binding. */
@@ -179,6 +181,7 @@ const STATUS_BAR_COMPACT_PRIORITY = {
   round: 30,
   usage: 40,
   queuedFollowUp: 50,
+  approvalPolicy: 55,
   approvalDepth: 60,
   rootActive: 65,
   elapsed: 70,
@@ -567,6 +570,30 @@ function rootActiveSegment(
     : undefined;
 }
 
+function approvalPolicySegment(
+  policy: CliApprovalPolicy | undefined,
+): StatusBarSegment | undefined {
+  switch (policy) {
+    case undefined:
+    case 'ask':
+      return undefined;
+    case 'never':
+      return {
+        text: 'deny',
+        color: 'yellow',
+        compactPriority: STATUS_BAR_COMPACT_PRIORITY.approvalPolicy,
+      };
+    case 'yolo':
+      return {
+        text: 'yolo',
+        color: 'red',
+        compactPriority: STATUS_BAR_COMPACT_PRIORITY.approvalPolicy,
+      };
+    default:
+      return policy satisfies never;
+  }
+}
+
 interface StatusBarVisibleStream {
   readonly status: StreamStatus | undefined;
 }
@@ -668,6 +695,8 @@ export function buildStatusBarDisplay(
   if (rootActive) left.push(rootActive);
 
   left.push({ text: input.apiMode, color: 'dim' });
+  const policy = approvalPolicySegment(input.approvalPolicy);
+  if (policy) left.push(policy);
 
   const round = roundSegment(input.conversation);
   if (round) left.push(round);
@@ -805,6 +834,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     hasMultipleStreams: streams.size > 1,
     model: sessionMeta.model,
     apiMode: shortCliApiMode(sessionMeta.apiMode),
+    approvalPolicy: sessionMeta.approvalPolicy,
     shiftEnterNewline: caps.kittyKeyboard,
     transcriptAvailable: props.transcriptAvailable,
     width: columns,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1059,6 +1059,10 @@ export async function runChat(
   const getApprovalPolicy = (): CliApprovalPolicy => activeApprovalPolicy;
   const setApprovalPolicy = (policy: CliApprovalPolicy): void => {
     activeApprovalPolicy = policy;
+    cliState.sessionMeta.set({
+      ...cliState.sessionMeta.get(),
+      approvalPolicy: policy,
+    });
   };
   // The slash-command context is identical at every call site; build it once
   // lazily so the closures it captures (interruptActive, resetSessionForClear,
@@ -1082,6 +1086,7 @@ export async function runChat(
     modelSource: defaults.modelSource,
     cwd: context.cwd,
     apiMode,
+    approvalPolicy: activeApprovalPolicy,
     canDelegate: agentSupportsDelegation(agent),
     teamName: init.teamName,
     version,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -9,6 +9,7 @@ import { signal, Signal } from '@lit-labs/signals';
 
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { CliModelSelectionSource } from '@cli/runtime/modelAccess';
+import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import {
   STREAM_STATUS,
   type ActiveChildInfo,
@@ -57,6 +58,7 @@ export interface SessionMeta {
   readonly modelSource: CliModelSelectionSource;
   readonly cwd: string;
   readonly apiMode: CliApiMode;
+  readonly approvalPolicy: CliApprovalPolicy;
   readonly canDelegate: boolean;
   readonly teamName?: string;
   readonly version: string;
@@ -138,6 +140,7 @@ const EMPTY_SESSION_META: SessionMeta = {
   modelSource: 'builtin',
   cwd: '',
   apiMode: 'personal',
+  approvalPolicy: 'ask',
   canDelegate: false,
   version: '',
 };

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -54,6 +54,7 @@ const SESSION_META = {
   modelSource: 'builtin',
   cwd: '/tmp/project',
   apiMode: 'personal',
+  approvalPolicy: 'ask',
   canDelegate: false,
   version: '0.38.0',
 } as const;

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -167,6 +167,7 @@ describe('slashRegistry', () => {
       modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
+      approvalPolicy: 'ask',
       canDelegate: false,
       version: 'test',
     });
@@ -203,6 +204,7 @@ describe('slashRegistry', () => {
       modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
+      approvalPolicy: 'ask',
       canDelegate: false,
       version: 'test',
     });
@@ -233,6 +235,7 @@ describe('slashRegistry', () => {
       modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
+      approvalPolicy: 'ask',
       canDelegate: false,
       version: 'test',
     });
@@ -261,6 +264,7 @@ describe('slashRegistry', () => {
       modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
+      approvalPolicy: 'ask',
       canDelegate: false,
       version: 'test',
     });
@@ -294,6 +298,7 @@ describe('slashRegistry', () => {
       modelSource: 'override',
       cwd: '/tmp/workspace',
       apiMode: 'personal',
+      approvalPolicy: 'ask',
       canDelegate: false,
       version: 'test',
     });
@@ -380,6 +385,7 @@ describe('slashRegistry', () => {
       modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
+      approvalPolicy: 'ask',
       canDelegate: false,
       version: 'test',
     });
@@ -415,6 +421,7 @@ describe('slashRegistry', () => {
       modelSource: 'builtin',
       cwd: '/tmp/workspace',
       apiMode: 'included',
+      approvalPolicy: 'ask',
       canDelegate: false,
       version: 'test',
     });

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -54,6 +54,58 @@ describe('CLI StatusBar display model', () => {
     expect(shortCliApiMode('personal')).toBe('keys');
   });
 
+  it('surfaces non-default approval policies in the durable status row', () => {
+    const input = {
+      status: STREAM_STATUS.WAITING,
+      pendingExitHint: false,
+      pendingExitResumeId: undefined,
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      approvalPolicy: 'ask',
+      shortcutModifierLabel: 'Alt',
+    } as const;
+    const ask = buildStatusBarDisplay(input);
+
+    expect(ask.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'idle',
+      PERSONAL_API_MODE_LABEL,
+    ]);
+
+    const deny = buildStatusBarDisplay({
+      ...input,
+      approvalPolicy: 'never',
+    });
+    expect(deny.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'idle',
+      PERSONAL_API_MODE_LABEL,
+      'deny',
+    ]);
+    expect(deny.left.at(-1)).toMatchObject({ color: 'yellow' });
+
+    const yolo = buildStatusBarDisplay({
+      ...input,
+      approvalPolicy: 'yolo',
+    });
+    expect(yolo.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'idle',
+      PERSONAL_API_MODE_LABEL,
+      'yolo',
+    ]);
+    expect(yolo.left.at(-1)).toMatchObject({ color: 'red' });
+  });
+
   it('keeps queued follow-up counts in the durable left status segments', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,


### PR DESCRIPTION
## Summary
- store the current CLI approval policy in TUI session metadata
- show compact `deny` / `yolo` status-bar segments for non-default approval modes, while omitting default `ask`
- add harness support for `HARNESS_APPROVAL_POLICY` plus validator/unit coverage

## Root Cause
`texra chat --approval-policy never` changed tool and delegation behavior immediately, but the idle TUI status bar did not show that state. The policy was only visible after running `/status`, which made denied privileged actions easy to misread as broken tools or delegation.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ApprovalPolicyForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui approval-policy-status-bar approval-form bash-approval-session-status`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm run typecheck`
- `npx prettier --check src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ApprovalPolicyForm.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npm run format`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

## Known Local Test Blocker
- `npm test` currently fails locally in unrelated `src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts` tests with `no data in serverIn yet`; the run had 438 test files passing and 3 tests failing in that one suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and session-meta wiring; approval behavior is unchanged, only visibility improves for security-sensitive modes.
> 
> **Overview**
> Surfaces the active CLI **approval policy** in the idle TUI status bar so non-default modes are visible without running `/status`.
> 
> **Session metadata** now carries `approvalPolicy`; chat startup and `/approval` changes keep `cliState.sessionMeta` in sync (including the TUI harness via `HARNESS_APPROVAL_POLICY`).
> 
> The status bar adds compact left-row segments for **`never`** (`deny`, yellow) and **`yolo`** (`yolo`, red); default **`ask`** stays hidden. Narrow layouts can drop the segment via existing compact-priority rules.
> 
> Coverage: `StatusBar` unit tests, a `validate-tui` `approval-policy-status-bar` scenario, and test fixtures updated with `approvalPolicy: 'ask'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7824c035af624147f90053bea261fc381ba18c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->