### PR TITLE
[codex] Clarify stopped subagent input state

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2229,6 +2229,7 @@ const SCENARIOS = [
   },
   {
     name: 'focused-stopped-subagent-esc-s-picker',
+    platforms: ['darwin'],
     env: {
       HARNESS_ENTRIES: '4',
       HARNESS_CHILDREN: '1',
@@ -2251,6 +2252,7 @@ const SCENARIOS = [
   },
   {
     name: 'focused-stopped-subagent-esc-tab-focus',
+    platforms: ['darwin'],
     env: {
       HARNESS_ENTRIES: '4',
       HARNESS_CHILDREN: '1',
@@ -2882,6 +2884,19 @@ function writeSnapshotReport(results) {
 }
 
 async function runScenario(scenario) {
+  if (scenario.platforms && !scenario.platforms.includes(process.platform)) {
+    const skipReason = `scenario is only supported on ${scenario.platforms.join(', ')}`;
+    return {
+      name: scenario.name,
+      ok: true,
+      skipped: true,
+      skipReason,
+      failures: [],
+      frame: skipReason,
+      rows: scenarioRows(scenario),
+    };
+  }
+
   const fakeClipboard = scenario.fakeClipboard ? makeFakeClipboard() : null;
   if (scenario.fakeClipboard && !fakeClipboard) {
     const skipReason = `fake clipboard is not supported on ${process.platform}`;

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2250,6 +2250,32 @@ const SCENARIOS = [
     unexpect: ['Tasks and sub-workflows', '◆ running', '2 sub 1 proc'],
   },
   {
+    name: 'focused-stopped-subagent-esc-tab-focus',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [
+      ESC + 'p',
+      'k',
+      ESC + 's',
+      DOWN,
+      DOWN,
+      'f',
+      { input: ESC, delayMs: 40 },
+      '\t',
+    ],
+    frame: 'tail',
+    expect: ['[main]*', '◆ running', '2 sub 1 proc'],
+    unexpect: [
+      'Harness interrupt requested.',
+      STOPPED_SUBAGENT_INPUT_MESSAGE_START,
+      '[3:strategy](stopped)',
+    ],
+  },
+  {
     name: 'focused-stopped-subagent-submit',
     cols: 120,
     env: {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -55,6 +55,14 @@ const UP = ESC + '[A';
 const DOWN = ESC + '[B';
 const PAGE_DOWN = ESC + '[6~';
 const ANSI_SGR_PATTERN = new RegExp(`${ESC}\\[[0-?]*[ -/]*m`, 'g');
+const shortcutModifierLabel = process.platform === 'darwin' ? 'Esc' : 'Alt';
+const metaChordLabel = (key) =>
+  `${shortcutModifierLabel}${shortcutModifierLabel === 'Esc' ? ' ' : '-'}${key}`;
+const STOPPED_SUBAGENT_INPUT_MESSAGE_START =
+  'Subagent is no longer accepting follow-ups; press Tab to switch streams';
+const STOPPED_SUBAGENT_PICKER_MESSAGE = `${metaChordLabel('s')} to choose another`;
+const STOPPED_SUBAGENT_TASKS_MESSAGE = `${metaChordLabel('p')} to review tasks.`;
+const STOPPED_SUBAGENT_INPUT_MESSAGE = `${STOPPED_SUBAGENT_INPUT_MESSAGE_START} or ${STOPPED_SUBAGENT_PICKER_MESSAGE}, or ${STOPPED_SUBAGENT_TASKS_MESSAGE}`;
 const LONG_BASH_APPROVAL_COMMAND = [
   "python3 << 'EOF'",
   'solutions = []',
@@ -2213,9 +2221,33 @@ const SCENARIOS = [
       '[3:strategy](stopped)',
       '◆ stopped',
       'root active',
+      STOPPED_SUBAGENT_INPUT_MESSAGE_START,
       '[Ctrl-C]stop root',
     ],
+    expectCollapsed: [STOPPED_SUBAGENT_INPUT_MESSAGE],
     unexpect: ['◆ running', '2 sub 1 proc'],
+  },
+  {
+    name: 'focused-stopped-subagent-esc-s-picker',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: [
+      ESC + 'p',
+      'k',
+      ESC + 's',
+      DOWN,
+      DOWN,
+      'f',
+      { input: ESC, delayMs: 40 },
+      's',
+    ],
+    frame: 'tail',
+    expect: ['Subagents', 'strategy', '3. strategy — stopped', 'root active'],
+    unexpect: ['Tasks and sub-workflows', '◆ running', '2 sub 1 proc'],
   },
   {
     name: 'focused-stopped-subagent-submit',
@@ -2241,9 +2273,11 @@ const SCENARIOS = [
       '[3:strategy](stopped)',
       '◆ stopped',
       'root active',
-      'The selected subagent is no longer accepting follow-ups.',
+      STOPPED_SUBAGENT_INPUT_MESSAGE_START,
     ],
+    expectCollapsed: [STOPPED_SUBAGENT_INPUT_MESSAGE],
     unexpect: [
+      'The selected subagent is no longer accepting follow-ups.',
       'Harness received: can you still receive this?',
       '◆ running',
       '2 sub 1 proc',
@@ -2569,7 +2603,17 @@ function scenarioFrame(scenario, fullFrame, rows) {
 }
 
 function expectedFrameTextVisible(scenario, frame) {
-  return (scenario.expect ?? []).every((text) => frame.includes(text));
+  const collapsedFrame = collapseFrameText(frame);
+  return (
+    (scenario.expect ?? []).every((text) => frame.includes(text)) &&
+    (scenario.expectCollapsed ?? []).every((text) =>
+      collapsedFrame.includes(text),
+    )
+  );
+}
+
+function collapseFrameText(frame) {
+  return frame.replaceAll(/[│╭╮╰╯─]/g, ' ').replaceAll(/\s+/g, ' ');
 }
 
 const FAKE_CLIPBOARD_COMMANDS_BY_PLATFORM = {
@@ -2909,8 +2953,9 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
   }
 
   for (const key of scenario.keys ?? []) {
-    child.write(key);
-    await sleep(500);
+    const input = typeof key === 'string' ? key : key.input;
+    child.write(input);
+    await sleep(Number(key.delayMs ?? scenario.keyDelayMs ?? 500));
   }
   for (const resize of scenario.resizes ?? []) {
     child.resize(Number(resize.cols ?? cols), Number(resize.rows ?? rows));
@@ -2953,12 +2998,18 @@ async function runScenarioWithResources(scenario, fakeClipboard) {
     } catch {}
   }
 
+  const collapsedFrame = collapseFrameText(frame);
   const missing = (scenario.expect ?? []).filter((t) => !frame.includes(t));
+  const missingCollapsed = (scenario.expectCollapsed ?? []).filter(
+    (t) => !collapsedFrame.includes(t),
+  );
   const present = (scenario.unexpect ?? []).filter((t) => frame.includes(t));
   const failures = [];
   if (!booted) failures.push('input prompt never rendered (boot timeout)');
   for (const t of missing)
     failures.push(`expected text missing: ${JSON.stringify(t)}`);
+  for (const t of missingCollapsed)
+    failures.push(`expected collapsed text missing: ${JSON.stringify(t)}`);
   for (const t of present)
     failures.push(`unexpected text present: ${JSON.stringify(t)}`);
   for (const check of scenario.maxOccurrences ?? []) {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -886,7 +886,12 @@ export function App(props: AppProps): React.JSX.Element {
       pendingEscapeInterruptTimer.current !== undefined;
     if (pendingEscapeInterrupt) {
       clearPendingEscapeInterrupt();
-      if (!key.ctrl && !isEscapeInput(input, key) && input.length > 0) {
+      if (
+        !key.ctrl &&
+        !key.tab &&
+        !isEscapeInput(input, key) &&
+        input.length > 0
+      ) {
         if (handleMetaShortcut(input)) return;
         triggerEscapeInterrupt(escapeInterruptStateRef.current);
         return;

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -598,13 +598,21 @@ export function App(props: AppProps): React.JSX.Element {
     canInterruptActiveRun: props.canInterruptActiveRun,
     onInterruptActive: props.onInterruptActive,
   });
-  escapeInterruptStateRef.current = {
-    inputDisabled: appInputDisabled,
+  useLayoutEffect(() => {
+    escapeInterruptStateRef.current = {
+      inputDisabled: appInputDisabled,
+      reverseSearchOpen,
+      slashPaletteOpen,
+      canInterruptActiveRun: props.canInterruptActiveRun,
+      onInterruptActive: props.onInterruptActive,
+    };
+  }, [
+    appInputDisabled,
+    props.canInterruptActiveRun,
+    props.onInterruptActive,
     reverseSearchOpen,
     slashPaletteOpen,
-    canInterruptActiveRun: props.canInterruptActiveRun,
-    onInterruptActive: props.onInterruptActive,
-  };
+  ]);
   const inputBarVisible = !foregroundOpen;
   const viewportKey = transcriptViewportKey({
     activeStreamId,

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -5,6 +5,7 @@
 import { Box, useApp, useInput, useStdin, useWindowSize } from 'ink';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import {
   LIVE_ELAPSED_STREAM_STATUSES,
   type StreamStatus,
@@ -24,7 +25,11 @@ import {
   QueuedFollowUpsPanel,
   queuedFollowUpPanelRowCount,
 } from './panes/QueuedFollowUpsPanel';
-import { StatusBar } from './panes/StatusBar';
+import {
+  defaultShortcutModifierLabel,
+  metaChordLabel,
+  StatusBar,
+} from './panes/StatusBar';
 import {
   StreamTabsStrip,
   streamTabsDisplayItems,
@@ -39,7 +44,6 @@ import {
 } from './state/approvalQueue';
 import {
   isEscapeInput,
-  metaChordDigit,
   metaChordInput,
   rewriteKittyEnterInput,
 } from './input/inputKeys';
@@ -51,7 +55,7 @@ import {
 } from './state/childControls';
 import { cliState } from './state/cliState';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
-import { streamDisplayLabel } from './state/streamViews';
+import { activeStreamScope, streamDisplayLabel } from './state/streamViews';
 import {
   isScopedTranscriptViewport,
   transcriptViewportChange,
@@ -83,6 +87,7 @@ const APPROVAL_FOREGROUND_MAX_ROWS = 18;
 // conversation or push the input bar off-screen.
 const BOTTOM_PANEL_MAX_ROWS = 10;
 const COMPACT_STATIC_TRANSCRIPT_MAX_ROWS = 14;
+const ESC_META_CHORD_INTERRUPT_DELAY_MS = 125;
 const COMPACT_LIVE_TRANSCRIPT_RESERVE_ROWS = 2;
 
 const PINNED_CHROME_ROWS = {
@@ -339,6 +344,52 @@ export function appEscapeInterruptActive({
   );
 }
 
+export function shouldDeferEscapeInterruptForMetaChord({
+  childInputDisabled,
+  shortcutModifierLabel,
+  subagentControlsAvailable,
+  taskControlsAvailable,
+}: {
+  readonly childInputDisabled: boolean;
+  readonly shortcutModifierLabel: string;
+  readonly subagentControlsAvailable: boolean;
+  readonly taskControlsAvailable: boolean;
+}): boolean {
+  return (
+    childInputDisabled &&
+    shortcutModifierLabel === 'Esc' &&
+    (subagentControlsAvailable || taskControlsAvailable)
+  );
+}
+
+export interface EscapeInterruptState {
+  readonly inputDisabled: boolean;
+  readonly reverseSearchOpen: boolean;
+  readonly slashPaletteOpen: boolean;
+  readonly canInterruptActiveRun: () => boolean;
+  readonly onInterruptActive: () => void;
+}
+
+export function triggerEscapeInterrupt(state: EscapeInterruptState): boolean {
+  if (
+    !appEscapeInterruptActive({
+      inputDisabled: state.inputDisabled,
+      reverseSearchOpen: state.reverseSearchOpen,
+      runPending: state.canInterruptActiveRun(),
+      slashPaletteOpen: state.slashPaletteOpen,
+    })
+  ) {
+    return false;
+  }
+
+  state.onInterruptActive();
+  return true;
+}
+
+export function digitFromMetaShortcut(value: string): number | undefined {
+  return /^[1-9]$/.test(value) ? Number.parseInt(value, 10) : undefined;
+}
+
 export type ForegroundSurfaceKind =
   | 'transcript'
   | 'childControls'
@@ -432,6 +483,45 @@ export function approvalForegroundMaxRows(
   }
 }
 
+export function focusedChildInputDisabledMessage(init: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly shortcutModifierLabel?: string;
+  readonly status: StreamStatus | undefined;
+  readonly subagentControlsAvailable?: boolean;
+  readonly taskControlsAvailable?: boolean;
+}): string | undefined {
+  const scope = activeStreamScope({
+    activeStreamId: init.activeStreamId,
+    parentStream: init.parentStream,
+  });
+  if (
+    scope.kind !== 'child' ||
+    init.status === undefined ||
+    isInFlightStatus(init.status)
+  ) {
+    return undefined;
+  }
+  const shortcutModifierLabel =
+    init.shortcutModifierLabel ?? defaultShortcutModifierLabel();
+  const alternateActions: string[] = [];
+  if (init.subagentControlsAvailable !== false) {
+    alternateActions.push(
+      `${metaChordLabel(shortcutModifierLabel, 's')} to choose another`,
+    );
+  }
+  if (init.taskControlsAvailable === true) {
+    alternateActions.push(
+      `${metaChordLabel(shortcutModifierLabel, 'p')} to review tasks`,
+    );
+  }
+  const base =
+    'Subagent is no longer accepting follow-ups; press Tab to switch streams';
+  if (alternateActions.length === 0) return `${base}.`;
+  const alternateText = alternateActions.join(', or ');
+  return `${base} or ${alternateText}.`;
+}
+
 export interface AppProps {
   readonly onSubmit: (line: string, mediaFiles?: readonly string[]) => void;
   readonly onKillExecution: (executionId: string) => void;
@@ -477,6 +567,13 @@ export function App(props: AppProps): React.JSX.Element {
     activeStreamId,
     pending,
   });
+  const childControlTargets = resolveChildControlDisplayTargets({
+    activeStreamId,
+    parentStream,
+    streams,
+  });
+  const taskControlsAvailable = childControlTargets.tasks.hasItems;
+  const subagentControlsAvailable = childControlTargets.subagents.hasItems;
 
   const stdin = useStdin();
   const foregroundOpen =
@@ -484,7 +581,30 @@ export function App(props: AppProps): React.JSX.Element {
     activeForm !== undefined ||
     childControlMode !== undefined ||
     transcriptViewerOpen;
-  const inputDisabled = props.inputDisabled === true || foregroundOpen;
+  const childInputDisabledMessage = focusedChildInputDisabledMessage({
+    activeStreamId,
+    parentStream,
+    status: activeStreamId ? streams.get(activeStreamId)?.status : undefined,
+    subagentControlsAvailable,
+    taskControlsAvailable,
+  });
+  const appInputDisabled = props.inputDisabled === true || foregroundOpen;
+  const inputDisabled =
+    appInputDisabled || childInputDisabledMessage !== undefined;
+  const escapeInterruptStateRef = useRef<EscapeInterruptState>({
+    inputDisabled: appInputDisabled,
+    reverseSearchOpen,
+    slashPaletteOpen,
+    canInterruptActiveRun: props.canInterruptActiveRun,
+    onInterruptActive: props.onInterruptActive,
+  });
+  escapeInterruptStateRef.current = {
+    inputDisabled: appInputDisabled,
+    reverseSearchOpen,
+    slashPaletteOpen,
+    canInterruptActiveRun: props.canInterruptActiveRun,
+    onInterruptActive: props.onInterruptActive,
+  };
   const inputBarVisible = !foregroundOpen;
   const viewportKey = transcriptViewportKey({
     activeStreamId,
@@ -568,13 +688,6 @@ export function App(props: AppProps): React.JSX.Element {
         rows,
         tipVisible: tipRowVisible,
       });
-  const childControlTargets = resolveChildControlDisplayTargets({
-    activeStreamId,
-    parentStream,
-    streams,
-  });
-  const taskControlsAvailable = childControlTargets.tasks.hasItems;
-  const subagentControlsAvailable = childControlTargets.subagents.hasItems;
   const hasSubagentPanel =
     !foregroundOpen && hasChildControlItems(activeSlice, 'tasks');
   const hasTodosPlanPanel = shouldShowTodosPlanPanel({
@@ -701,12 +814,77 @@ export function App(props: AppProps): React.JSX.Element {
     reverseSearchOpen,
     slashPaletteOpen,
   });
+  const pendingEscapeInterruptTimer = useRef<
+    ReturnType<typeof setTimeout> | undefined
+  >(undefined);
+
+  const clearPendingEscapeInterrupt = () => {
+    if (pendingEscapeInterruptTimer.current === undefined) return;
+    clearTimeout(pendingEscapeInterruptTimer.current);
+    pendingEscapeInterruptTimer.current = undefined;
+  };
+
+  useEffect(
+    () => () => {
+      if (pendingEscapeInterruptTimer.current !== undefined) {
+        clearTimeout(pendingEscapeInterruptTimer.current);
+        pendingEscapeInterruptTimer.current = undefined;
+      }
+    },
+    [],
+  );
+
+  const handleMetaShortcut = (value: string): boolean => {
+    const lower = value.toLowerCase();
+    if (lower === 's') {
+      if (!subagentControlsAvailable) return false;
+      setChildControlMode('subagents');
+      return true;
+    }
+    if (lower === 'p') {
+      if (!taskControlsAvailable) return false;
+      setChildControlMode('tasks');
+      return true;
+    }
+    const digit = digitFromMetaShortcut(value);
+    if (digit !== undefined) {
+      const target = numericFocusTargetForActiveStream({
+        activeStreamId,
+        parentStream,
+        streams,
+        zeroBasedIndex: digit - 1,
+      });
+      if (!target) return false;
+      cliState.activeStreamId.set(target);
+      return true;
+    }
+    return false;
+  };
+
+  const scheduleEscapeInterrupt = () => {
+    clearPendingEscapeInterrupt();
+    pendingEscapeInterruptTimer.current = setTimeout(() => {
+      pendingEscapeInterruptTimer.current = undefined;
+      triggerEscapeInterrupt(escapeInterruptStateRef.current);
+    }, ESC_META_CHORD_INTERRUPT_DELAY_MS);
+  };
 
   // Single App-level keyboard entry point. Ink broadcasts every keystroke to all
   // mounted useInput handlers, so keeping the App's shortcuts in one always-on
   // handler (gating internally) is clearer than several hooks racing on the same
   // chord. Stays mounted so Ctrl+C works even while a modal/form owns the input.
   useInput((input, key) => {
+    const pendingEscapeInterrupt =
+      pendingEscapeInterruptTimer.current !== undefined;
+    if (pendingEscapeInterrupt) {
+      clearPendingEscapeInterrupt();
+      if (!key.ctrl && !isEscapeInput(input, key) && input.length > 0) {
+        if (handleMetaShortcut(input)) return;
+        triggerEscapeInterrupt(escapeInterruptStateRef.current);
+        return;
+      }
+    }
+
     // Ctrl+C is owned here even over foreground surfaces. We render with
     // exitOnCtrlC: false (see runChatTui), so Ink neither auto-exits nor filters
     // Ctrl+C out of useInput. The full CLI wires onCtrlC to the same SIGINT
@@ -752,25 +930,7 @@ export function App(props: AppProps): React.JSX.Element {
     // Esc/Alt chords: s → subagent controls, p → tasks, 1-9 → focus stream.
     const metaInput = metaChordInput(input, key);
     if (metaInput) {
-      const lower = metaInput.toLowerCase();
-      if (lower === 's') {
-        if (subagentControlsAvailable) setChildControlMode('subagents');
-        return;
-      }
-      if (lower === 'p') {
-        if (taskControlsAvailable) setChildControlMode('tasks');
-        return;
-      }
-      const digit = metaChordDigit(input, key);
-      if (digit !== undefined) {
-        const target = numericFocusTargetForActiveStream({
-          activeStreamId,
-          parentStream,
-          streams,
-          zeroBasedIndex: digit - 1,
-        });
-        if (target) cliState.activeStreamId.set(target);
-      }
+      handleMetaShortcut(metaInput);
       return;
     }
 
@@ -778,13 +938,24 @@ export function App(props: AppProps): React.JSX.Element {
     if (
       isEscapeInput(input, key) &&
       appEscapeInterruptActive({
-        inputDisabled,
-        reverseSearchOpen,
-        runPending: props.canInterruptActiveRun(),
-        slashPaletteOpen,
+        inputDisabled: escapeInterruptStateRef.current.inputDisabled,
+        reverseSearchOpen: escapeInterruptStateRef.current.reverseSearchOpen,
+        runPending: escapeInterruptStateRef.current.canInterruptActiveRun(),
+        slashPaletteOpen: escapeInterruptStateRef.current.slashPaletteOpen,
       })
     ) {
-      props.onInterruptActive();
+      if (
+        shouldDeferEscapeInterruptForMetaChord({
+          childInputDisabled: childInputDisabledMessage !== undefined,
+          shortcutModifierLabel: defaultShortcutModifierLabel(),
+          subagentControlsAvailable,
+          taskControlsAvailable,
+        })
+      ) {
+        scheduleEscapeInterrupt();
+        return;
+      }
+      triggerEscapeInterrupt(escapeInterruptStateRef.current);
     }
   });
 
@@ -848,6 +1019,7 @@ export function App(props: AppProps): React.JSX.Element {
         <InputBar
           onSubmit={props.onSubmit}
           collapseWhenDisabled={!inputBarVisible}
+          disabledMessage={childInputDisabledMessage}
           disabled={inputDisabled}
           history={props.history}
         />

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -31,6 +31,8 @@ export interface InputBarProps {
   readonly onSubmit: (value: string, mediaFiles?: readonly string[]) => void;
   /** Disable the input while an approval modal is owning the screen. */
   readonly disabled?: boolean;
+  /** Inline reason shown when the disabled input remains visible. */
+  readonly disabledMessage?: string;
   /** Preserve component state while giving foreground panels the input rows. */
   readonly collapseWhenDisabled?: boolean;
   /** Prompt prefix (e.g. `>`). */
@@ -327,23 +329,27 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         <Text aria-hidden color="cyan">
           {prompt ?? '›'}{' '}
         </Text>
-        <BaseTextInput
-          value={value}
-          focus={!disabled && !reverseSearchOpen}
-          onChange={setValue}
-          // While the slash palette is open it owns ↑/↓ for row selection;
-          // history recall would clobber the draft mid-navigation.
-          onHistoryUp={showPalette ? undefined : () => browseHistory(-1)}
-          onHistoryDown={showPalette ? undefined : () => browseHistory(1)}
-          imagePasteQueue={imagePasteQueue}
-          transformPaste={transformPaste}
-          onImagePaste={onImagePaste}
-          onImagePasteError={(error) =>
-            setAttachNotice(`Image paste failed: ${toErrorMessage(error)}`)
-          }
-          onInputChunkSubmit={handleInputChunkSubmit}
-          onSubmit={showPalette ? () => undefined : handleSubmit}
-        />
+        {disabled && props.disabledMessage ? (
+          <Text dimColor>{props.disabledMessage}</Text>
+        ) : (
+          <BaseTextInput
+            value={value}
+            focus={!disabled && !reverseSearchOpen}
+            onChange={setValue}
+            // While the slash palette is open it owns ↑/↓ for row selection;
+            // history recall would clobber the draft mid-navigation.
+            onHistoryUp={showPalette ? undefined : () => browseHistory(-1)}
+            onHistoryDown={showPalette ? undefined : () => browseHistory(1)}
+            imagePasteQueue={imagePasteQueue}
+            transformPaste={transformPaste}
+            onImagePaste={onImagePaste}
+            onImagePasteError={(error) =>
+              setAttachNotice(`Image paste failed: ${toErrorMessage(error)}`)
+            }
+            onInputChunkSubmit={handleInputChunkSubmit}
+            onSubmit={showPalette ? () => undefined : handleSubmit}
+          />
+        )}
       </Box>
     </Box>
   );

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -25,11 +25,15 @@ import {
   approvalForegroundMaxRows,
   approvalVisibleForActiveStream,
   childControlForegroundMaxRows,
+  digitFromMetaShortcut,
+  focusedChildInputDisabledMessage,
   foregroundEscapeAction,
   foregroundSurfaceKind,
+  shouldDeferEscapeInterruptForMetaChord,
   shouldShowTipRow,
   shouldShowTodosPlanPanel,
   staticTranscriptRowBudget,
+  triggerEscapeInterrupt,
 } from '@cli/chat/tui/App';
 import type { PendingApproval } from '@cli/chat/tui/state/approvalQueue';
 import {
@@ -756,6 +760,86 @@ describe('CLI TUI row allocation', () => {
     ).toBe(false);
   });
 
+  it('defers Escape interrupt only when stopped child Esc chords are visible', () => {
+    expect(
+      shouldDeferEscapeInterruptForMetaChord({
+        childInputDisabled: true,
+        shortcutModifierLabel: 'Esc',
+        subagentControlsAvailable: true,
+        taskControlsAvailable: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferEscapeInterruptForMetaChord({
+        childInputDisabled: true,
+        shortcutModifierLabel: 'Esc',
+        subagentControlsAvailable: false,
+        taskControlsAvailable: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferEscapeInterruptForMetaChord({
+        childInputDisabled: false,
+        shortcutModifierLabel: 'Esc',
+        subagentControlsAvailable: true,
+        taskControlsAvailable: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldDeferEscapeInterruptForMetaChord({
+        childInputDisabled: true,
+        shortcutModifierLabel: 'Alt',
+        subagentControlsAvailable: true,
+        taskControlsAvailable: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldDeferEscapeInterruptForMetaChord({
+        childInputDisabled: true,
+        shortcutModifierLabel: 'Esc',
+        subagentControlsAvailable: false,
+        taskControlsAvailable: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('parses stripped meta shortcut digits', () => {
+    expect(digitFromMetaShortcut('1')).toBe(1);
+    expect(digitFromMetaShortcut('9')).toBe(9);
+    expect(digitFromMetaShortcut('0')).toBeUndefined();
+    expect(digitFromMetaShortcut('10')).toBeUndefined();
+    expect(digitFromMetaShortcut('p')).toBeUndefined();
+  });
+
+  it('runs Escape interrupt from the supplied current state', () => {
+    let interrupts = 0;
+    expect(
+      triggerEscapeInterrupt({
+        inputDisabled: false,
+        reverseSearchOpen: false,
+        slashPaletteOpen: false,
+        canInterruptActiveRun: () => true,
+        onInterruptActive: () => {
+          interrupts += 1;
+        },
+      }),
+    ).toBe(true);
+    expect(interrupts).toBe(1);
+
+    expect(
+      triggerEscapeInterrupt({
+        inputDisabled: false,
+        reverseSearchOpen: false,
+        slashPaletteOpen: false,
+        canInterruptActiveRun: () => false,
+        onInterruptActive: () => {
+          interrupts += 1;
+        },
+      }),
+    ).toBe(false);
+    expect(interrupts).toBe(1);
+  });
+
   it('keeps user-opened foreground surfaces ahead of new approvals', () => {
     expect(
       foregroundSurfaceKind({
@@ -1306,6 +1390,93 @@ describe('CLI TUI row allocation', () => {
       kind: 'reject',
       streamId: child1,
     });
+  });
+
+  it('explains disabled input when a focused child stream cannot accept follow-ups', () => {
+    setParentStream(child1, root);
+
+    expect(
+      focusedChildInputDisabledMessage({
+        activeStreamId: root,
+        parentStream: cliState.parentStream.get(),
+        status: STREAM_STATUS.STOPPED,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      focusedChildInputDisabledMessage({
+        activeStreamId: child1,
+        parentStream: cliState.parentStream.get(),
+        status: undefined,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      focusedChildInputDisabledMessage({
+        activeStreamId: child1,
+        parentStream: cliState.parentStream.get(),
+        status: STREAM_STATUS.RUNNING,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      focusedChildInputDisabledMessage({
+        activeStreamId: child1,
+        parentStream: cliState.parentStream.get(),
+        shortcutModifierLabel: 'Esc',
+        status: STREAM_STATUS.STOPPED,
+      }),
+    ).toBe(
+      'Subagent is no longer accepting follow-ups; press Tab to switch streams or Esc s to choose another.',
+    );
+
+    expect(
+      focusedChildInputDisabledMessage({
+        activeStreamId: child1,
+        parentStream: cliState.parentStream.get(),
+        shortcutModifierLabel: 'Alt',
+        status: STREAM_STATUS.STOPPED,
+      }),
+    ).toBe(
+      'Subagent is no longer accepting follow-ups; press Tab to switch streams or Alt-s to choose another.',
+    );
+
+    expect(
+      focusedChildInputDisabledMessage({
+        activeStreamId: child1,
+        parentStream: cliState.parentStream.get(),
+        shortcutModifierLabel: 'Esc',
+        status: STREAM_STATUS.STOPPED,
+        subagentControlsAvailable: false,
+      }),
+    ).toBe(
+      'Subagent is no longer accepting follow-ups; press Tab to switch streams.',
+    );
+
+    expect(
+      focusedChildInputDisabledMessage({
+        activeStreamId: child1,
+        parentStream: cliState.parentStream.get(),
+        shortcutModifierLabel: 'Esc',
+        status: STREAM_STATUS.STOPPED,
+        subagentControlsAvailable: false,
+        taskControlsAvailable: true,
+      }),
+    ).toBe(
+      'Subagent is no longer accepting follow-ups; press Tab to switch streams or Esc p to review tasks.',
+    );
+
+    expect(
+      focusedChildInputDisabledMessage({
+        activeStreamId: child1,
+        parentStream: cliState.parentStream.get(),
+        shortcutModifierLabel: 'Esc',
+        status: STREAM_STATUS.STOPPED,
+        taskControlsAvailable: true,
+      }),
+    ).toBe(
+      'Subagent is no longer accepting follow-ups; press Tab to switch streams or Esc s to choose another, or Esc p to review tasks.',
+    );
   });
 
   it('mirrors running child status events into focused child routing', () => {


### PR DESCRIPTION
Fixes #5853.

## Summary
- disable the visible chat input when the focused stream is a child stream that is no longer in flight
- show an inline reason pointing users back to the main stream or subagent picker instead of rendering an editable-looking blank prompt
- update focused stopped-subagent TUI validator coverage and add a helper unit test

## Root Cause
A focused stopped child stream already rejected submitted follow-ups in `runChatTui`, but `App` still rendered the normal input box because input disabled state only considered foreground surfaces and caller-provided root input state. The UI therefore looked writable until the user typed and submitted.

## Validation
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npx prettier --check packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/InputBar.tsx packages/cli/scripts/validate-tui.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `git diff --check`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /private/tmp/texra-cli-dogfood-0612-stopped-input-snapshots focused-stopped-subagent focused-stopped-subagent-submit`
- `npx eslint packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/InputBar.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run compile:fast`
- `npm run format`
- `npm run lint` (passes with existing import-order warnings outside this touched scope)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI input and keyboard routing changes only; no auth, persistence, or submit-path logic beyond gating the input earlier.
> 
> **Overview**
> When a **stopped child subagent stream** is focused, the chat input is now **disabled** and shows an **inline explanation** (Tab to switch streams, plus platform-specific **Esc/Alt** hints for subagent picker and tasks) instead of a blank editable prompt. Submit-time rejection in `runChatTui` remains, but users no longer get a writable-looking box until they hit Enter.
> 
> On **macOS**, a lone **Escape** while that message is shown **waits briefly** (~125ms) so **Esc+s** / **Esc+p** can open pickers without accidentally interrupting the root run; **Tab** during that window switches streams without interrupting.
> 
> **`validate-tui`** gains **`expectCollapsed`** matching (box-drawing stripped), **darwin-only** scenarios for those chords, and **per-keystroke delays**; unit tests cover the new helpers and disabled-message copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e93dd2b7d1b06b238f09d52938f2550a0b1011be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->