### PR TITLE
[codex] Attach live tool rows to prompt

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -11,10 +11,17 @@ import {
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
-import { BoundedTranscriptEntry, LiveTranscriptEntry } from './TranscriptEntry';
+import {
+  BoundedTranscriptEntry,
+  LiveTranscriptEntry,
+  TranscriptEntry,
+} from './TranscriptEntry';
 import { ToolUseRow } from './ToolUseRow';
 import { splitTranscriptEntries } from './transcriptEntries';
-import { selectTranscriptEntriesForViewport } from './transcriptViewport';
+import {
+  estimateTranscriptEntryRows,
+  selectTranscriptEntriesForViewport,
+} from './transcriptViewport';
 
 const DEFAULT_TRANSCRIPT_ROWS = 24;
 const MIN_PENDING_ROWS = 1;
@@ -74,6 +81,26 @@ function renderConversationPaneEntry({
     }
     if (entry.role === 'assistant') {
       return <LiveTranscriptEntry entry={entry} width={width} />;
+    }
+    if (entry.role === 'user') {
+      return (
+        <TranscriptEntry
+          colorEnabled={colorEnabled}
+          entry={entry}
+          fillWidth
+          width={width}
+        />
+      );
+    }
+    if (entry.role === 'error') {
+      return (
+        <BoundedTranscriptEntry
+          colorEnabled={colorEnabled}
+          entry={entry}
+          maxRows={estimateTranscriptEntryRows(entry, width)}
+          width={width}
+        />
+      );
     }
     return null;
   })();

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -23,10 +23,14 @@ import { streamViewForId } from '../state/streamViews';
 import { transcriptEntryLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
-import { isRenderableTranscriptEntry } from './transcriptEntries';
+import {
+  isInquiryContinuationText,
+  isRenderableTranscriptEntry,
+  nextRenderableTranscriptEntry,
+  userPromptAwaitsLiveContinuation,
+} from './transcriptEntries';
 import {
   ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS,
-  isInquiryContinuationText,
   PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
   TranscriptEntry,
   USER_ENTRY_MARGIN_BOTTOM_ROWS,
@@ -45,6 +49,7 @@ export type StaticTranscriptItem =
       readonly id: string;
       readonly kind: 'entry';
       readonly entry: ConversationEntry;
+      readonly userBottomMarginRows?: number;
     };
 
 interface StaticTranscriptState {
@@ -178,13 +183,31 @@ function staticTranscriptItemRowCount(
   ).length;
   let marginRows = 0;
   if (isUserBand) {
-    marginRows = USER_ENTRY_MARGIN_TOP_ROWS + USER_ENTRY_MARGIN_BOTTOM_ROWS;
+    marginRows =
+      USER_ENTRY_MARGIN_TOP_ROWS +
+      (item.userBottomMarginRows ?? USER_ENTRY_MARGIN_BOTTOM_ROWS);
   } else if (item.entry.role === 'assistant') {
     marginRows = ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS;
   } else if (item.entry.role === 'process') {
     marginRows = PROCESS_ENTRY_MARGIN_BOTTOM_ROWS;
   }
   return lines + marginRows;
+}
+
+function staticUserBottomMarginRows({
+  entry,
+  nextEntry,
+}: {
+  readonly entry: ConversationEntry;
+  readonly nextEntry: ConversationEntry | undefined;
+}): number | undefined {
+  const isUserBand =
+    entry.role === 'user' && !isInquiryContinuationText(entry.text);
+  if (!isUserBand) return undefined;
+  // Tool rows are the command execution part of the same turn; keep them
+  // attached to the prompt instead of printing a gap row.
+  if (nextEntry?.role === 'tool') return 0;
+  return USER_ENTRY_MARGIN_BOTTOM_ROWS;
 }
 
 export function appendStaticTranscriptItems({
@@ -249,12 +272,24 @@ export function appendStaticTranscriptItems({
   const slice = scrollbackStreamId
     ? streams.get(scrollbackStreamId)
     : undefined;
-  for (const entry of slice?.entries ?? []) {
+  const entries = slice?.entries ?? [];
+  for (const [index, entry] of entries.entries()) {
     if (!isRenderableTranscriptEntry(entry)) continue;
+    if (userPromptAwaitsLiveContinuation(entries, index, slice?.status)) {
+      continue;
+    }
     if (!entry.finalized) continue;
     if (seen.has(entry.id)) continue;
     nextItems ??= [...currentItems];
-    nextItems.push({ id: entry.id, kind: 'entry', entry });
+    nextItems.push({
+      id: entry.id,
+      kind: 'entry',
+      entry,
+      userBottomMarginRows: staticUserBottomMarginRows({
+        entry,
+        nextEntry: nextRenderableTranscriptEntry(entries, index),
+      }),
+    });
     seen.add(entry.id);
   }
   // Same reference when nothing was appended so the `setItems` functional
@@ -362,6 +397,7 @@ export function StaticConversationTranscript({
                 entry={item.entry}
                 width={width}
                 colorEnabled={colorEnabled}
+                userBottomMarginRows={item.userBottomMarginRows}
               />
             </EntryErrorBoundary>
           )}

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -11,6 +11,7 @@ import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { fillRows } from '../render/terminalText';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
+import { isInquiryContinuationText } from './transcriptEntries';
 import { ToolUseRow } from './ToolUseRow';
 import { toolUseDisplayLines } from './toolRenderers';
 import type {
@@ -18,16 +19,10 @@ import type {
   ConversationEntry,
 } from '../state/cliState';
 
-const INQUIRY_CONTINUATION_RE =
-  /^\[inquiry\]\s+\S+\s+(?:answered|dropped by user)\.(?:\n|$)/;
 export const USER_ENTRY_MARGIN_TOP_ROWS = 1;
 export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 1;
 export const ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS = 0;
 export const PROCESS_ENTRY_MARGIN_BOTTOM_ROWS = 1;
-
-export function isInquiryContinuationText(text: string): boolean {
-  return INQUIRY_CONTINUATION_RE.test(text);
-}
 
 function prefixedWrappedLines(
   text: string,
@@ -92,10 +87,16 @@ function boundedDisplayRows({
 function UserEntryRow({
   entry,
   colorEnabled,
+  marginTopRows = USER_ENTRY_MARGIN_TOP_ROWS,
+  marginBottomRows = USER_ENTRY_MARGIN_BOTTOM_ROWS,
+  maxRows,
   width,
 }: {
   readonly entry: ConversationEntry;
   readonly colorEnabled?: boolean;
+  readonly marginTopRows?: number;
+  readonly marginBottomRows?: number;
+  readonly maxRows?: number;
   readonly width?: number;
 }): React.JSX.Element {
   // Mark a user turn with a reverse-video band (theme-adaptive via reverse
@@ -108,14 +109,11 @@ function UserEntryRow({
   // their wrapped-line count.
   const cols = Math.max(1, Math.floor(width ?? 80) - 2);
   return (
-    <Box
-      marginTop={USER_ENTRY_MARGIN_TOP_ROWS}
-      marginBottom={USER_ENTRY_MARGIN_BOTTOM_ROWS}
-      paddingX={1}
-    >
+    <Box marginTop={marginTopRows} marginBottom={marginBottomRows} paddingX={1}>
       <Text inverse={colorEnabled !== false}>
         {compactPrefixedDisplayRows({
           fillWidth: true,
+          maxRows,
           text: entry.text,
           width: cols,
         })}
@@ -128,16 +126,20 @@ function InquiryContinuationRow({
   entry,
   fillWidth,
   colorEnabled,
+  maxRows,
   width,
 }: {
   readonly entry: ConversationEntry;
   readonly fillWidth?: boolean;
   readonly colorEnabled?: boolean;
+  readonly maxRows?: number;
   readonly width?: number;
 }): React.JSX.Element {
   // Same one-column gutter as the user band so both `› ` chevrons align.
   const cols = Math.max(1, Math.floor(width ?? 80) - 2);
-  const lines = prefixedWrappedLines(entry.text, cols);
+  const wrappedLines = prefixedWrappedLines(entry.text, cols);
+  const lines =
+    maxRows === undefined ? wrappedLines : boundedLines(wrappedLines, maxRows);
   const displayLines =
     fillWidth === true ? fillRows(lines.join('\n'), cols).split('\n') : lines;
   return (
@@ -222,11 +224,13 @@ export const TranscriptEntry = memo(function TranscriptEntry({
   width,
   colorEnabled,
   fillWidth,
+  userBottomMarginRows,
 }: {
   readonly entry: ConversationEntry;
   readonly width?: number;
   readonly colorEnabled?: boolean;
   readonly fillWidth?: boolean;
+  readonly userBottomMarginRows?: number;
 }): React.JSX.Element {
   switch (entry.role) {
     case 'user':
@@ -241,7 +245,12 @@ export const TranscriptEntry = memo(function TranscriptEntry({
         );
       }
       return (
-        <UserEntryRow entry={entry} colorEnabled={colorEnabled} width={width} />
+        <UserEntryRow
+          entry={entry}
+          colorEnabled={colorEnabled}
+          marginBottomRows={userBottomMarginRows}
+          width={width}
+        />
       );
     case 'error': {
       const cols = Math.max(1, Math.floor(width ?? 80) - 2);
@@ -379,6 +388,34 @@ export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
           })}
         </Text>
       </Box>
+    );
+  }
+  if (entry.role === 'user') {
+    if (isInquiryContinuationText(entry.text)) {
+      return (
+        <InquiryContinuationRow
+          entry={entry}
+          fillWidth
+          colorEnabled={colorEnabled}
+          maxRows={rows}
+          width={width}
+        />
+      );
+    }
+
+    const includeMargins = rows >= 3;
+    const marginRows = includeMargins
+      ? USER_ENTRY_MARGIN_TOP_ROWS + USER_ENTRY_MARGIN_BOTTOM_ROWS
+      : 0;
+    return (
+      <UserEntryRow
+        entry={entry}
+        colorEnabled={colorEnabled}
+        marginTopRows={includeMargins ? USER_ENTRY_MARGIN_TOP_ROWS : 0}
+        marginBottomRows={includeMargins ? USER_ENTRY_MARGIN_BOTTOM_ROWS : 0}
+        maxRows={Math.max(1, rows - marginRows)}
+        width={width}
+      />
     );
   }
   if (entry.role === 'tool' && entry.toolUse) {

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -10,6 +10,8 @@ import {
 
 import type { ConversationEntry } from '../state/cliState';
 
+const INQUIRY_CONTINUATION_RE =
+  /^\[inquiry\]\s+\S+\s+(?:answered|dropped by user)\.(?:\n|$)/;
 const INVISIBLE_TRANSCRIPT_CHARS = new Set([
   '\u200B',
   '\u200C',
@@ -27,6 +29,10 @@ export function terminalVisibleTranscriptText(text: string): string {
     if (!isInvisibleTranscriptChar(char)) out += char;
   }
   return out;
+}
+
+export function isInquiryContinuationText(text: string): boolean {
+  return INQUIRY_CONTINUATION_RE.test(text);
 }
 
 export function trimAssistantTranscriptLead(text: string): string {
@@ -73,6 +79,36 @@ export function isRenderableTranscriptEntry(entry: ConversationEntry): boolean {
   }
 }
 
+export function nextRenderableTranscriptEntry(
+  entries: readonly ConversationEntry[],
+  index: number,
+): ConversationEntry | undefined {
+  for (let i = index + 1; i < entries.length; i += 1) {
+    const entry = entries[i];
+    if (entry && isRenderableTranscriptEntry(entry)) return entry;
+  }
+  return undefined;
+}
+
+export function userPromptAwaitsLiveContinuation(
+  entries: readonly ConversationEntry[],
+  index: number,
+  status: StreamStatus | undefined,
+): boolean {
+  const entry = entries[index];
+  if (
+    entry?.role !== 'user' ||
+    isInquiryContinuationText(entry.text) ||
+    !isRenderableTranscriptEntry(entry) ||
+    status === undefined ||
+    !LIVE_ELAPSED_STREAM_STATUSES.has(status)
+  ) {
+    return false;
+  }
+  const nextEntry = nextRenderableTranscriptEntry(entries, index);
+  return nextEntry === undefined;
+}
+
 export function splitTranscriptEntries(
   entries: readonly ConversationEntry[],
   status: StreamStatus | undefined,
@@ -92,8 +128,12 @@ export function splitTranscriptEntries(
     status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status);
   const finalized: ConversationEntry[] = [];
   const pending: ConversationEntry[] = [];
-  for (const entry of entries) {
+  for (const [index, entry] of entries.entries()) {
     if (!isRenderableTranscriptEntry(entry)) continue;
+    if (userPromptAwaitsLiveContinuation(entries, index, status)) {
+      pending.push(entry);
+      continue;
+    }
     if (entry.finalized) {
       finalized.push(entry);
       continue;

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -6,9 +6,14 @@ import {
   ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS,
   LIVE_TAIL_ROWS,
   PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
+  USER_ENTRY_MARGIN_BOTTOM_ROWS,
+  USER_ENTRY_MARGIN_TOP_ROWS,
   tailWindow,
 } from './TranscriptEntry';
-import { isRenderableTranscriptEntry } from './transcriptEntries';
+import {
+  isInquiryContinuationText,
+  isRenderableTranscriptEntry,
+} from './transcriptEntries';
 import { toolUseDisplayLines } from './toolRenderers';
 import type { ConversationEntry } from '../state/cliState';
 
@@ -62,10 +67,13 @@ export function estimateTranscriptEntryRows(
   }
   if (entry.role === 'user' || entry.role === 'error') {
     // Both roles render inside a paddingX={1} box plus a 2-col prefix
-    // (`› ` / `! `), so text wraps to `width - 4`. The static band's margins
-    // are not budgeted here: the live pane paints these rows through the
-    // margin-less bounded renderer.
-    return estimateWrappedRows(entry.text, Math.max(1, width - 4));
+    // (`› ` / `! `), so text wraps to `width - 4`.
+    const textRows = estimateWrappedRows(entry.text, Math.max(1, width - 4));
+    const marginRows =
+      entry.role === 'user' && !isInquiryContinuationText(entry.text)
+        ? USER_ENTRY_MARGIN_TOP_ROWS + USER_ENTRY_MARGIN_BOTTOM_ROWS
+        : 0;
+    return textRows + marginRows;
   }
 
   return estimateWrappedRows(entry.text, width) + 1;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -176,6 +176,10 @@ export class ToolUseWaitNode<C> extends Node<
       shared.deliveredToOrchestrator = true;
     }
 
+    streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
+      runtimeHost,
+    });
+
     // Synthesized continuations don't come from the user queue, so they
     // must not emit updateQueuedFollowUps via the consume callback. They
     // also don't need to be replayed in the chat log. Keep any prior
@@ -188,9 +192,6 @@ export class ToolUseWaitNode<C> extends Node<
         logUserMessage(logger, followUp.displayText ?? followUp.text);
       }
     }
-    streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
-      runtimeHost,
-    });
 
     for (const followUp of execRes.followUps) {
       shared.messages = await appendFollowUpAsUserMessage(

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -330,6 +330,8 @@ describe('ToolUseWaitNode', () => {
       ],
     );
     const info = vi.fn();
+    const runtimeHost = { emit: vi.fn() };
+    const streamStatus = new StreamStatusRegistry();
     const services = {
       checkInterruption: () => false,
       logger: { error: vi.fn(), info },
@@ -338,7 +340,7 @@ describe('ToolUseWaitNode', () => {
         createUserFollowUpMessages,
         extractAssistantText: () => undefined,
       },
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       session: {
         hasQueuedFollowUp: () => true,
         waitForFollowUp: async () => ({
@@ -355,7 +357,7 @@ describe('ToolUseWaitNode', () => {
           synthetic: false,
         }),
       },
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus,
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
     const node = new ToolUseWaitNode().setServices(services);
@@ -365,6 +367,13 @@ describe('ToolUseWaitNode', () => {
     const transition = await node.post(shared, prep, exec);
 
     expect(transition).toBe(FlowTransition.CONTINUE);
+    expect(runtimeHost.emit).toHaveBeenCalledWith(
+      'updateStreamStatus',
+      expect.objectContaining({ status: STREAM_STATUS.RUNNING }),
+    );
+    expect(runtimeHost.emit.mock.invocationCallOrder[0]).toBeLessThan(
+      info.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(createUserFollowUpMessages).toHaveBeenNthCalledWith(
       1,
       [],

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -4,10 +4,10 @@ import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   boundedAssistantDisplayLines,
   compactPrefixedDisplayRows,
-  isInquiryContinuationText,
 } from '@cli/chat/tui/panes/TranscriptEntry';
 import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
 import {
+  isInquiryContinuationText,
   splitTranscriptEntries,
   terminalVisibleTranscriptText,
   trimAssistantTranscriptLead,
@@ -367,10 +367,10 @@ describe('CLI conversation transcript splitting', () => {
     ).toBe('  ef  ');
   });
 
-  it('does not reserve a spacer row after finalized user turns', () => {
+  it('budgets live user prompt bands with their margin rows', () => {
     const user = entry('u1', 'user', 'why do you write as a latex?', true);
 
-    expect(estimateTranscriptEntryRows(user, 80)).toBe(1);
+    expect(estimateTranscriptEntryRows(user, 80)).toBe(3);
   });
 
   it('does not render empty assistant placeholders between user and tool rows', () => {
@@ -417,6 +417,79 @@ describe('CLI conversation transcript splitting', () => {
     ).toEqual(['› what is this repo about', '● Bash (ls)']);
   });
 
+  it('keeps a live prompt out of static scrollback until a continuation exists', () => {
+    const user = entry('u1', 'user', 'what is this repo about', true);
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        STREAM_ID,
+        sliceWithEntries(STREAM_ID, [user], {
+          status: STREAM_STATUS.RUNNING,
+        }),
+      ],
+    ]);
+
+    const split = splitTranscriptEntries([user], STREAM_STATUS.RUNNING);
+    expect(split.finalized).toEqual([]);
+    expect(split.pending.map((item) => item.id)).toEqual(['u1']);
+
+    const staticItems = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: [],
+      streams,
+      meta: SESSION_META,
+    });
+    expect(staticItems.map((item) => item.id)).toEqual(['session-header']);
+  });
+
+  it('prints a deferred live prompt compactly once a tool continuation exists', () => {
+    const user = entry('u1', 'user', 'what is this repo about', true);
+    const tool = toolEntry('t1', 'in_progress');
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        STREAM_ID,
+        sliceWithEntries(STREAM_ID, [user, tool], {
+          status: STREAM_STATUS.RUNNING,
+        }),
+      ],
+    ]);
+
+    const split = splitTranscriptEntries([user, tool], STREAM_STATUS.RUNNING);
+    expect(split.finalized.map((item) => item.id)).toEqual(['u1']);
+    expect(split.pending.map((item) => item.id)).toEqual(['t1']);
+
+    const staticItems = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: [],
+      streams,
+      meta: SESSION_META,
+    });
+    expect(staticItems.map((item) => item.id)).toEqual([
+      'session-header',
+      'u1',
+    ]);
+    expect(staticItems[1]).toMatchObject({
+      kind: 'entry',
+      userBottomMarginRows: 0,
+    });
+  });
+
+  it('keeps inquiry continuations on the finalized transcript path', () => {
+    const continuation = entry(
+      'u1',
+      'user',
+      '[inquiry] ei_123 answered.\nQ: Can this be simplified?\nA: Yes.',
+      true,
+    );
+    const assistant = entry('a1', 'assistant', 'working', false);
+
+    const split = splitTranscriptEntries(
+      [continuation, assistant],
+      STREAM_STATUS.RUNNING,
+    );
+    expect(split.finalized.map((item) => item.id)).toEqual(['u1']);
+    expect(split.pending.map((item) => item.id)).toEqual(['a1']);
+  });
+
   it('does not reserve rows for zero-width assistant placeholders before tools', () => {
     const user = entry('u1', 'user', 'what is this repo about', true);
     const invisibleAssistant = entry(
@@ -449,7 +522,7 @@ describe('CLI conversation transcript splitting', () => {
     ).toEqual(['› what is this repo about', '● Bash (ls)']);
   });
 
-  it('wraps live user rows at the padded width with no margin rows', () => {
+  it('wraps live user rows at the padded width with user band margins', () => {
     const continuation = entry(
       'u1',
       'user',
@@ -460,9 +533,9 @@ describe('CLI conversation transcript splitting', () => {
 
     // 77 chars exceeds the padded wrap width (80 - 4 = 76) by one, so the
     // row estimate must reflect the gutter + prefix geometry, not the
-    // terminal width.
+    // terminal width, and normal user prompts include the band margins.
     const long = entry('u2', 'user', 'x'.repeat(77), true);
-    expect(estimateTranscriptEntryRows(long, 80)).toBe(2);
+    expect(estimateTranscriptEntryRows(long, 80)).toBe(4);
   });
 
   it('appends only finalized entries to terminal scrollback items', () => {


### PR DESCRIPTION
Fixes #5855.

## Summary
- Defer a finalized user prompt out of `<Static>` only while a live stream has no visible continuation yet.
- Keep that short deferred prompt in the live pane with the same reverse-video user band used by static scrollback.
- Once the next visible entry is known, print the prompt into static scrollback: compactly before tool rows, and with normal spacing before assistant text.
- Set a consumed follow-up stream back to `RUNNING` before logging its `USER_MESSAGE`, so a stale `WAITING` status cannot print the prompt into `<Static>` before the live continuation ownership rule applies.

## Root cause
`transcriptToLines()` already treats prompt-to-tool turns as attached, but the terminal renderer gave every static user band an unconditional bottom margin. In real live ordering, the user prompt can otherwise be appended to `<Static>` before the first tool row exists, freezing a blank row that remains when the tool later renders below it.

A review also found the related follow-up ordering race: `ToolUseWaitNode` logged the consumed follow-up before changing the stream from `WAITING` to `RUNNING`, which could let the TUI project a new prompt under a stale non-live status.

## Validation
- `corepack pnpm vitest run src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /private/tmp/texra-cli-dogfood-0612-live-tool-spacing-snapshots-7 live-tool-only-spacing live-tool-stack-spacing transcript`
- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec prettier --check src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts packages/cli/src/chat/tui/panes/ConversationPane.tsx packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx packages/cli/src/chat/tui/panes/TranscriptEntry.tsx packages/cli/src/chat/tui/panes/transcriptEntries.ts packages/cli/src/chat/tui/panes/transcriptViewport.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/cli/ConversationPane.vitest.mts && git diff --check`
- Earlier integration dogfood before the live-ordering review adjustment: with ready TUI fixes #5842, #5851, and #5854 stacked plus this fix, `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /private/tmp/texra-cli-dogfood-0612-integrated-fixed-snapshots` passed all 118 scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TUI transcript split/static-append rules and stream-status ordering around follow-ups; wrong timing could still mis-order scrollback, but scope is display and status emission only.
> 
> **Overview**
> Fixes live-turn spacing where a user prompt could freeze into `<Static>` scrollback with a permanent gap before tool rows (#5855).
> 
> The TUI now **defers** finalized user prompts from static scrollback while the stream is live and no next visible entry exists yet—those prompts stay in the **live pane** with the reverse-video user band. Once a continuation appears (e.g. a tool row), the prompt is appended to static scrollback with **zero bottom margin** before tools and normal spacing before assistant text. `splitTranscriptEntries` and `appendStaticTranscriptItems` share `userPromptAwaitsLiveContinuation`; viewport row estimates include user band margins; `BoundedTranscriptEntry` can render compact user bands when height is tight.
> 
> **`ToolUseWaitNode`** sets stream status to `RUNNING` **before** logging consumed follow-ups, so a stale `WAITING` status cannot push the new prompt into static before the deferral rule applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c74672033691c21ef488371d673d8b6a2beb5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->