### PR TITLE
[codex] Restore CLI run validation boundaries

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -14,9 +14,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 
 const cliRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const repoRoot = path.dirname(path.dirname(cliRoot));
+const require = createRequire(import.meta.url);
 const binaryPath = path.join(cliRoot, 'dist/bin/texra.js');
 const validationEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER';
 const validationFlagEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG';

--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -599,6 +599,11 @@ async function validateOrchestrateOnboardingPickers() {
     'Sign in for included re…',
     'Use my own provider API…',
   ];
+  const truncatedOnboardingLabels = [
+    ...oldTruncatedLabels,
+    'Sign in — free for acad…',
+    'Use your own provider A…',
+  ];
 
   await validateOrchestrateOnboardingPicker({
     label: 'texra orchestrate first-run onboarding',
@@ -606,12 +611,12 @@ async function validateOrchestrateOnboardingPickers() {
     env: {},
     expected: [
       'Not signed in, and no provider API key is configured. Choose how to power model calls:',
-      'Included relay access',
-      'Provider API key',
-      'sign in, no API key needed (recommended)',
-      'paste Anthropic / OpenAI / Google',
+      'Sign in — free for academics',
+      'Use your own provider API key',
+      'Researcher Access: no API key needed (recommended)',
+      'Anthropic, OpenAI, Google, and more',
     ],
-    forbidden: oldTruncatedLabels,
+    forbidden: truncatedOnboardingLabels,
   });
   await validateOrchestrateOnboardingPicker({
     label: 'texra orchestrate included-mode onboarding',
@@ -619,13 +624,13 @@ async function validateOrchestrateOnboardingPickers() {
     env: { ANTHROPIC_API_KEY: 'texra-validation-fake-key' },
     expected: [
       'Included relay access needs sign-in for this run:',
-      'Included relay access',
-      'sign in, no API key needed (recommended)',
+      'Sign in — free for academics',
+      'Researcher Access: no API key needed (recommended)',
     ],
     forbidden: [
-      'Provider API key',
-      'paste Anthropic / OpenAI / Google',
-      ...oldTruncatedLabels,
+      'Use your own provider API key',
+      'Anthropic, OpenAI, Google, and more',
+      ...truncatedOnboardingLabels,
     ],
   });
   await validateOrchestrateOnboardingPicker({
@@ -634,13 +639,13 @@ async function validateOrchestrateOnboardingPickers() {
     env: {},
     expected: [
       'Personal API-key mode needs a provider key for this run:',
-      'Provider API key',
-      'paste Anthropic / OpenAI / Google',
+      'Use your own provider API key',
+      'Anthropic, OpenAI, Google, and more',
     ],
     forbidden: [
-      'Included relay access',
-      'sign in, no API key needed',
-      ...oldTruncatedLabels,
+      'Sign in — free for academics',
+      'Researcher Access: no API key needed',
+      ...truncatedOnboardingLabels,
     ],
   });
 }

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -32,6 +32,7 @@ export interface SelectProps<T> {
   readonly onCancel: () => void;
   /** Focus the Nth item on mount (defaults to the active value's index, or 0). */
   readonly initialIndex?: number;
+  readonly labelMaxCols?: number;
   readonly maxVisibleItems?: number;
   readonly showOverflow?: boolean;
 }
@@ -306,7 +307,10 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
               </Text>
               <Text color={focused ? 'cyan' : undefined}>{shortcut} </Text>
             </Box>
-            <Box flexShrink={0} maxWidth={SELECT_LABEL_MAX_COLS}>
+            <Box
+              flexShrink={0}
+              maxWidth={props.labelMaxCols ?? SELECT_LABEL_MAX_COLS}
+            >
               <Text
                 color={focused ? 'cyan' : undefined}
                 dimColor={item.disabled}

--- a/packages/cli/src/commands/relayTokens.ts
+++ b/packages/cli/src/commands/relayTokens.ts
@@ -107,7 +107,7 @@ async function requireSessionAccessToken(
   const canPrompt =
     context.outputFormat === 'text' &&
     interactiveTerminalFailure(context) === undefined &&
-    process.stdout.isTTY;
+    context.stdoutIsTty === true;
   if (!canPrompt) {
     writeTextStderr(
       'Not signed in. Run `texra login` first (`texra login --device` works over SSH).',

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -90,7 +90,7 @@ export interface OnboardingGateContext {
 const SKIP_SUMMARY =
   "Setup skipped — run `texra login` or `texra setup` when you're ready.";
 
-// Fits the current 29-column onboarding action labels without truncation.
+// Fits the current 30-column onboarding action labels without truncation.
 const ONBOARDING_SELECT_LABEL_MAX_COLS = 34;
 
 /** Gate returned without showing the picker (or before any choice is made). */

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -499,6 +499,7 @@ function PickerStep(props: {
     >
       <Select<OnboardingChoice>
         items={props.items}
+        labelMaxCols={34}
         onSelect={(value) => {
           if (value === 'relay') props.onRelay();
           else if (value === 'key') props.onKey();

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -90,6 +90,9 @@ export interface OnboardingGateContext {
 const SKIP_SUMMARY =
   "Setup skipped — run `texra login` or `texra setup` when you're ready.";
 
+// Fits the current 29-column onboarding action labels without truncation.
+const ONBOARDING_SELECT_LABEL_MAX_COLS = 34;
+
 /** Gate returned without showing the picker (or before any choice is made). */
 const NO_ONBOARDING_RESULT: CliOnboardingResult = {
   configured: false,
@@ -499,7 +502,7 @@ function PickerStep(props: {
     >
       <Select<OnboardingChoice>
         items={props.items}
-        labelMaxCols={34}
+        labelMaxCols={ONBOARDING_SELECT_LABEL_MAX_COLS}
         onSelect={(value) => {
           if (value === 'relay') props.onRelay();
           else if (value === 'key') props.onKey();

--- a/packages/cli/src/runtime/remoteSession.ts
+++ b/packages/cli/src/runtime/remoteSession.ts
@@ -1,10 +1,12 @@
+import { readCliEnv } from './cliContext';
+
 /**
  * Heuristic for "this terminal probably can't open a local browser or
  * receive a loopback OAuth callback": SSH sessions export one of these
  * variables. Used to recommend device-code sign-in, never to force it.
  */
 export function isLikelyRemoteSession(
-  env: NodeJS.ProcessEnv = process.env,
+  env: Record<string, string | undefined> = readCliEnv(),
 ): boolean {
   return Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY);
 }

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -19,6 +19,7 @@ import {
 import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local imports - CLI runtime
+import { readCliEnv } from './cliContext';
 import { getCliSecrets } from './cliSecrets';
 import { openBrowser } from './supabaseAuthBrowser';
 import { startLoopbackCallbackServer } from './supabaseAuthCallbackServer';
@@ -203,7 +204,7 @@ export async function signOutCliSupabase(): Promise<void> {
   // the session is gone (see relayTokenStillActiveNotice), so leave included
   // access enabled — disabling it would contradict the credential that
   // remains and silently break relay access for CI environments.
-  if (!getConfiguredRelayToken()) {
+  if (!getConfiguredRelayToken(readCliEnv())) {
     await serverSideKeyService.setUseIncludedModelAccess(false);
   }
   serverSideKeyService.clearAllCaches({ resetQuotaFlip: true });
@@ -216,7 +217,7 @@ export async function signOutCliSupabase(): Promise<void> {
  * removes the variable themselves. Say so instead of reporting a clean exit.
  */
 export function relayTokenStillActiveNotice(
-  env: NodeJS.ProcessEnv = process.env,
+  env: Record<string, string | undefined> = readCliEnv(),
 ): string | undefined {
   if (!getConfiguredRelayToken(env)) return undefined;
   return `Note: ${RELAY_TOKEN_ENV_VAR} is still set in this environment, so included relay access stays active. Unset it (and revoke the token with \`texra auth token revoke\` if it leaked) to fully sign out.`;
@@ -250,7 +251,7 @@ export async function getCliAuthProfile(): Promise<CliAuthProfile> {
   // the server has rejected (expired, revoked) must not report a signed-in
   // state the relay will 401. When the check itself fails (offline), stay
   // optimistic but say the token could not be verified.
-  const relayToken = getConfiguredRelayToken();
+  const relayToken = getConfiguredRelayToken(readCliEnv());
   let rejectedTokenNote: string | undefined;
   if (relayToken) {
     const status = await fetchRelayTokenStatus(relayToken);


### PR DESCRIPTION
## Summary

- route CLI env reads in remote/auth helpers through `runtime/cliContext.ts`
- use `CliContext.stdoutIsTty` for relay-token interactive sign-in gating instead of reading `process.stdout` in command code
- let the first-run onboarding picker use a wider label column so canonical action labels are visible at the validation width
- update `validate:run` onboarding assertions to the canonical onboarding copy and guard against the observed truncated labels

Closes #5857.

## Root Cause

The CLI architecture gate had gained three direct process-boundary reads outside the allowlisted boundary files. Running `validate:run` hit that during its post-validation rebuild. After the boundary reads were fixed locally, the same validation path exposed that the onboarding harness still expected pre-#5838 copy and that the default 24-column `Select` label cap truncated the new first-run action labels.

## Validation

- `corepack pnpm --filter @texra-ai/cli check:architecture`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm vitest run src/test-kernel/cli/RelayTokens.vitest.mts src/test-kernel/cli/OnboardingGate.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build transcript`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `corepack pnpm exec prettier --check packages/cli/src/commands/relayTokens.ts packages/cli/src/runtime/remoteSession.ts packages/cli/src/runtime/supabaseAuth.ts packages/cli/src/chat/tui/ui/Select.tsx packages/cli/src/onboarding/runOnboarding.tsx packages/cli/scripts/validate-run.mjs && git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted boundary refactors and TUI label width with test harness updates; auth behavior unchanged aside from consistent env/TTY sourcing.
> 
> **Overview**
> Restores CLI **architecture boundary** compliance by routing env reads in `remoteSession`, `supabaseAuth`, and relay-token flows through **`readCliEnv()`** instead of touching `process.env` directly. **`texra setup-token` / auth token** interactive sign-in now gates on **`CliContext.stdoutIsTty`** rather than `process.stdout.isTTY`.
> 
> **Onboarding UX + validation:** `Select` gains optional **`labelMaxCols`**; first-run onboarding uses **34 columns** so canonical action labels are not truncated at the PTY width used in `validate:run`. The **`validate-run.mjs`** harness expects the updated onboarding copy (e.g. “Sign in — free for academics”) and forbids observed truncated label strings. **`createRequire`** is added in the validation script for `node-pty` helper path resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cec08e3889f26c6371fe216c2b1b9d2661d8c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->