### PR TITLE
refactor: consolidate clamp/roundTo helpers and use replaceAll consistently

### DIFF
--- a/packages/cli/src/chat/tui/render/scrollBounds.ts
+++ b/packages/cli/src/chat/tui/render/scrollBounds.ts
@@ -1,3 +1,4 @@
+import { clamp } from '@utils/core';
 import {
   hiddenRowsText,
   moreRowsText,
@@ -173,7 +174,7 @@ export function boundedScrollableLines<K extends string>({
 
   if (maxDisplayLines <= compactRows) {
     const contentRows = Math.max(1, maxDisplayLines - 1);
-    const offset = Math.max(0, Math.min(scrollOffset, maxOffset));
+    const offset = clamp(scrollOffset, 0, maxOffset);
 
     if (maxDisplayLines === 1) {
       return [

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -4,6 +4,7 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import xtermStyles from '@xterm/xterm/css/xterm.css?inline';
+import { clamp } from '@utils/core';
 
 const DEFAULT_THEME = {
   background: '#1e1e1e',
@@ -187,7 +188,7 @@ export class TerminalOutput extends LitElement {
     // Size rows to content instead of filling the container
     const buffer = this.terminal.buffer.active;
     const contentRows = buffer.baseY + buffer.cursorY + 1;
-    const rows = Math.max(1, Math.min(contentRows, MAX_VISIBLE_ROWS));
+    const rows = clamp(contentRows, 1, MAX_VISIBLE_ROWS);
 
     if (cols !== this.terminal.cols || rows !== this.terminal.rows) {
       this.terminal.resize(cols, rows);

--- a/packages/extension/src/progressView/frontend/components/terminalBuffer.ts
+++ b/packages/extension/src/progressView/frontend/components/terminalBuffer.ts
@@ -18,8 +18,7 @@ export function processTerminalText(text: string): string {
   // the line from that column onward instead of preserving the stale tail characters.
 
   const preprocessed = text
-    .split(ERASE_SENTINEL)
-    .join('')
+    .replaceAll(ERASE_SENTINEL, '')
     .replaceAll(ANSI_ERASE_LINE_PATTERN, ERASE_SENTINEL);
   return stripAnsi(preprocessed)
     .replaceAll('\r\n', '\n')
@@ -28,17 +27,14 @@ export function processTerminalText(text: string): string {
       const segs = line.split('\r');
       // On a fresh line (no preceding \r), \x1b[K has nothing to clear; text after
       // the erase point is still written at the cursor, so just strip the markers.
-      let current = segs[0]!.split(ERASE_SENTINEL).join('');
+      let current = segs[0]!.replaceAll(ERASE_SENTINEL, '');
 
       for (const seg of segs.slice(1)) {
         const eraseAt = seg.indexOf(ERASE_SENTINEL);
         if (eraseAt >= 0) {
           // \r overlays the prefix up to the erase point; \x1b[K clears from there to EOL.
           const pre = seg.slice(0, eraseAt);
-          const post = seg
-            .slice(eraseAt + 1)
-            .split(ERASE_SENTINEL)
-            .join('');
+          const post = seg.slice(eraseAt + 1).replaceAll(ERASE_SENTINEL, '');
           current = pre + post;
         } else {
           // \r moves cursor to column 0 without clearing; shorter writes preserve the tail
@@ -46,7 +42,7 @@ export function processTerminalText(text: string): string {
             seg.length < current.length ? seg + current.slice(seg.length) : seg;
         }
       }
-      return current.split(ERASE_SENTINEL).join('');
+      return current.replaceAll(ERASE_SENTINEL, '');
     })
     .join('\n');
 }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -31,7 +31,7 @@ import type { ToolDefinition } from '@model';
 // Local imports - tools and utils
 import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@tools/result';
-import { isNonEmptyString } from '@utils/core';
+import { isNonEmptyString, roundTo } from '@utils/core';
 import { flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { extractMimeSubtype, objectToLogString } from '@utils/text/stringUtils';
@@ -280,8 +280,8 @@ export class ModelHandlerOpenAI<
           tokensBefore,
           tokensAfter: estimatedTokensAfter,
           contextWindow,
-          utilizationBefore: Number(utilizationBefore.toFixed(1)),
-          utilizationAfter: Number(utilizationAfter.toFixed(1)),
+          utilizationBefore: roundTo(utilizationBefore, 1),
+          utilizationAfter: roundTo(utilizationAfter, 1),
           details: `Client-side compaction: ${conversationMessages.length} messages summarized`,
         },
       );

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -36,7 +36,7 @@ import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@tools/result';
 
 // Local imports - utils
-import { delay, filterNotNullish } from '@utils/core';
+import { clamp, delay, filterNotNullish, roundTo } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
 import {
   getWebSocketEnabled,
@@ -802,8 +802,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           tokensBefore,
           tokensAfter,
           contextWindow,
-          utilizationBefore: Number(utilizationBefore.toFixed(1)),
-          utilizationAfter: Number(utilizationAfter.toFixed(1)),
+          utilizationBefore: roundTo(utilizationBefore, 1),
+          utilizationAfter: roundTo(utilizationAfter, 1),
           details: `OpenAI Responses API compaction: ${compactedResponse.output.length} items`,
         },
       );
@@ -1301,7 +1301,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         if (inputEstimate > 0) {
           const buffer = this.getTokenSafetyBuffer();
           const available = this.config.contextWindow - inputEstimate - buffer;
-          const capped = Math.min(maxOutputTokens, Math.max(0, available));
+          const capped = clamp(available, 0, maxOutputTokens);
           if (capped !== maxOutputTokens) {
             this.logger.debug(
               `Fallback: max_output_tokens ${maxOutputTokens} → ${capped} (estimate: ${inputEstimate})`,

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -8,6 +8,7 @@ import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
 import { shouldUseOpenRouter } from '@agent/modelHandlers/support/ProxyConfigResolver';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { toErrorMessage } from '@common/errors';
+import { roundTo } from '@utils/core';
 import type {
   ExtendedTokenUsageStats,
   StorageKey,
@@ -126,10 +127,8 @@ export class UsageMonitor {
       const payload: ExtendedTokenUsageStats = {
         inputTokens: roundInputTokens,
         outputTokens: roundOutputTokens,
-        cost: Number(roundCost.toFixed(3)),
-        elapsedTime: Number(
-          (stateGlobal.totalResponseTimeMs / 1000).toFixed(1),
-        ),
+        cost: roundTo(roundCost, 3),
+        elapsedTime: roundTo(stateGlobal.totalResponseTimeMs / 1000, 1),
         ...(roundCacheReadTokens > 0 && {
           cacheReadInputTokens: roundCacheReadTokens,
         }),
@@ -140,7 +139,7 @@ export class UsageMonitor {
           cacheCreationInputTokens: roundCacheCreationTokens,
         }),
         ...(supportsCaching && {
-          percentageCached: Number(percentageCached.toFixed(2)),
+          percentageCached: roundTo(percentageCached, 2),
         }),
         ...(capabilities.supportsReasoning && {
           reasoningTokens: roundReasoningTokens,
@@ -244,7 +243,7 @@ export class UsageMonitor {
         agentCategory: this.metadata.agentCategory,
         inputTokens: cacheMissInputTokens,
         outputTokens: usage.outputTokens,
-        cost: Number(usage.cost.toFixed(6)),
+        cost: roundTo(usage.cost, 6),
         responseTimeMs: Math.round(totalResponseTimeMs),
         cachedInputTokens,
         ...(usage.cacheMissInputTokens != null && {

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -12,6 +12,7 @@ import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { toErrorMessage } from '@common/errors';
 import { isInFlightStatus } from '@common/constants/streamStatus';
+import { clamp } from '@utils/core';
 import { createChannelTrace } from '@logger';
 import {
   AgentCategoryFilterSchema,
@@ -428,7 +429,7 @@ export class ProgressViewState {
         const timestamp =
           firstTimestamp == null
             ? baseTimestamp
-            : Math.max(0, Math.min(baseTimestamp, firstTimestamp - 1));
+            : clamp(baseTimestamp, 0, firstTimestamp - 1);
 
         this.streamLogs.append(streamId, {
           id: `legacy-instruction:${streamId}:${timestamp}`,

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -21,5 +21,5 @@ export {
   ensureArray,
 } from './typeGuards';
 export { debounce, delay, withTimeout } from './async';
-export { clamp, clampIndex } from './math';
+export { clamp, clampIndex, roundTo } from './math';
 export { tryParseUrl } from './urlCore';

--- a/src/utils/core/math.ts
+++ b/src/utils/core/math.ts
@@ -14,3 +14,11 @@ export function clampIndex(index: number, length: number): number {
   if (length <= 0) return 0;
   return clamp(index, 0, length - 1);
 }
+
+/**
+ * Round `value` to `decimals` decimal places, returning a number.
+ * Equivalent to `Number(value.toFixed(decimals))` but expresses intent clearly.
+ */
+export function roundTo(value: number, decimals: number): number {
+  return Number(value.toFixed(decimals));
+}


### PR DESCRIPTION
## Summary

- **Add `roundTo(value, decimals)` utility** to `src/utils/core/math.ts` and export via `@utils/core`. Replaces the `Number(x.toFixed(n))` idiom in 7 call sites across `UsageMonitor` and two OpenAI model handlers, making the rounding intent explicit.
- **Adopt existing `clamp()` utility** in four files that were inlining `Math.max(min, Math.min(max, value))`: `ProgressViewState`, OpenAI Responses handler, CLI `scrollBounds`, and the xterm `TerminalOutput` component. The utility already existed in `@utils/core`; these sites were unaware of it.
- **Normalise `terminalBuffer.ts`** to use `.replaceAll(ERASE_SENTINEL, '')` for all four ERASE_SENTINEL removals, consistent with the `.replaceAll()` calls already in the same function (lines 23–25).

## Files changed

| File | Change |
|------|--------|
| `src/utils/core/math.ts` | Add `roundTo()` |
| `src/utils/core/index.ts` | Export `roundTo` |
| `src/agent/utils/UsageMonitor.ts` | Use `roundTo` (3 sites) |
| `src/agent/modelHandlers/openai/modelHandlerOpenAI.ts` | Use `roundTo` (2 sites) |
| `src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts` | Use `roundTo` (2 sites) + `clamp` (1 site) |
| `src/shared/progressView/backend/state/ProgressViewState.ts` | Use `clamp` |
| `packages/cli/src/chat/tui/render/scrollBounds.ts` | Use `clamp` |
| `packages/extension/src/progressView/frontend/components/TerminalOutput.ts` | Use `clamp` |
| `packages/extension/src/progressView/frontend/components/terminalBuffer.ts` | Use `replaceAll` (4 sites) |

## Test plan

- [x] `npm test` — 439 test files, 2994 tests, all pass
- [x] No logic changes: `roundTo(v, n)` is `Number(v.toFixed(n))`; `clamp(v, lo, hi)` is `Math.max(lo, Math.min(hi, v))`; `replaceAll(s, '')` is `split(s).join('')`

https://claude.ai/code/session_019vnj8v3hTEaZ9VKm3B85cU

---
_Generated by [Claude Code](https://claude.ai/code/session_019vnj8v3hTEaZ9VKm3B85cU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactors only; no auth, data, or API contract changes.
> 
> **Overview**
> Adds **`roundTo(value, decimals)`** in `@utils/core/math` and exports it from `@utils/core`, replacing scattered **`Number(x.toFixed(n))`** in usage telemetry (`UsageMonitor`) and OpenAI compaction logging (chat + Responses handlers).
> 
> Replaces inline **`Math.max(min, Math.min(max, value))`** with the existing **`clamp()`** helper for CLI scroll offset, xterm visible row sizing, Responses API fallback **`max_output_tokens`** capping, and legacy instruction backfill timestamps in **`ProgressViewState`**.
> 
> In **`terminalBuffer.ts`**, ERASE_SENTINEL removal now consistently uses **`.replaceAll(ERASE_SENTINEL, '')`** instead of **`split().join('')`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5548c2f34dc2b31b70d58616f60b18e88492604b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->