### PR TITLE
refactor(runtime): extract AgentLaunchContext→RunContext mapping; document overlap and staleness

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -109,7 +109,7 @@ const STATUS_MESSAGES: Record<string, string> = {
  *
  * Centralises the mapping so new per-run flags (e.g. `stopAfterCycle`,
  * `approvalPromptsUnavailable`) live in one place and are never silently
- * dropped. Two field renames are unavoidable given the interfaces were
+ * dropped. Three field renames are unavoidable given the interfaces were
  * designed independently:
  *  - `AgentCore.logger`   → `RunContext.trace`
  *  - `AgentConfig.agent`  → `RunContext.agentName`

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -47,6 +47,7 @@ import { RetryRequestCoordinatorImpl } from './RetryRequestCoordinator';
 import {
   createRunContext,
   withRunContext,
+  type CreateRunContextOptions,
   type RunCoordinators,
 } from './RunContext';
 import {
@@ -102,11 +103,28 @@ const STATUS_MESSAGES: Record<string, string> = {
   [STREAM_STATUS.WAITING]: 'waiting for retry',
 };
 
-export async function withExecutionRunContext<T>(
-  ctx: AgentLaunchContext,
-  fn: () => T | Promise<T>,
-): Promise<T> {
-  const runContext = createRunContext({
+/**
+ * Project an {@link AgentLaunchContext} onto the subset of fields that belong
+ * in the ambient {@link RunContext}.
+ *
+ * Centralises the mapping so new per-run flags (e.g. `stopAfterCycle`,
+ * `approvalPromptsUnavailable`) live in one place and are never silently
+ * dropped. Two field renames are unavoidable given the interfaces were
+ * designed independently:
+ *  - `AgentCore.logger`   → `RunContext.trace`
+ *  - `AgentConfig.agent`  → `RunContext.agentName`
+ *  - `AgentConfig.model`  → `RunContext.model`  (snapshotted — see note below)
+ *
+ * NOTE — `RunContext.model` staleness: `model` is snapshotted here at the
+ * start of execution. If the agent switches models mid-session via
+ * `onModelChanged` (which updates `AgentLaunchContext.config.model`), the
+ * ambient `RunContext.model` seen by tools via `tryUseRunContext()` will lag
+ * behind. Code that delegates subagents and needs the current model should
+ * prefer `AgentLaunchContext.config.model` via explicit context; the ALS
+ * value is a best-effort hint.
+ */
+function agentContextToRunContext(ctx: AgentLaunchContext): CreateRunContextOptions {
+  return {
     runtimeHost: ctx.runtimeHost,
     streamId: ctx.streamId,
     executionId: ctx.executionId,
@@ -118,8 +136,14 @@ export async function withExecutionRunContext<T>(
     delegationDepth: ctx.delegationDepth,
     approvalPromptsUnavailable: ctx.approvalPromptsUnavailable,
     stopAfterCycle: ctx.stopAfterCycle,
-  });
-  return await withRunContext(runContext, fn);
+  };
+}
+
+export async function withExecutionRunContext<T>(
+  ctx: AgentLaunchContext,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  return await withRunContext(createRunContext(agentContextToRunContext(ctx)), fn);
 }
 
 export async function getAgentPath(

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -123,7 +123,9 @@ const STATUS_MESSAGES: Record<string, string> = {
  * prefer `AgentLaunchContext.config.model` via explicit context; the ALS
  * value is a best-effort hint.
  */
-function agentContextToRunContext(ctx: AgentLaunchContext): CreateRunContextOptions {
+function agentContextToRunContext(
+  ctx: AgentLaunchContext,
+): CreateRunContextOptions {
   return {
     runtimeHost: ctx.runtimeHost,
     streamId: ctx.streamId,
@@ -143,7 +145,10 @@ export async function withExecutionRunContext<T>(
   ctx: AgentLaunchContext,
   fn: () => T | Promise<T>,
 ): Promise<T> {
-  return await withRunContext(createRunContext(agentContextToRunContext(ctx)), fn);
+  return await withRunContext(
+    createRunContext(agentContextToRunContext(ctx)),
+    fn,
+  );
 }
 
 export async function getAgentPath(

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -14,18 +14,45 @@ export interface RunCoordinators {
   readonly retry: RetryRequestCoordinatorImpl;
 }
 
+/**
+ * Ambient per-run context stored in an {@link AsyncLocalStorage} scope.
+ *
+ * Tools and utilities that cannot take explicit parameters reach host services
+ * via `tryUseRunContext()`. The canonical source of truth for all of these
+ * fields is {@link AgentLaunchContext} / {@link AgentCore}; the values here
+ * are projected once by `agentContextToRunContext` in `AgentLaunchContext.ts`
+ * at the moment `withExecutionRunContext` is entered.
+ *
+ * **Field naming mismatches with AgentCore** (unavoidable — interfaces were
+ * designed independently):
+ *   - `AgentCore.logger`  → `RunContext.trace`
+ *   - `AgentConfig.agent` → `RunContext.agentName`
+ *   - `AgentConfig.model` → `RunContext.model`
+ *
+ * **Staleness**: `model` is snapshotted at run start. After a mid-session
+ * model switch (`onModelChanged` in `executeAgent`), `RunContext.model` lags
+ * behind `AgentLaunchContext.config.model`. Tools that delegate subagents
+ * and inherit the parent model (e.g. `delegate_agent`) will use the stale
+ * value. This is a known limitation of the snapshot approach.
+ */
 export interface RunContext {
   readonly runtimeHost: AgentRuntimeHost;
   readonly streamId?: StreamTabId;
   readonly executionId?: ExecutionId;
   /**
-   * Discriminated-event SDK channel for this run. Subscribe with
-   * `trace.subscribe(...)` to receive every event the run emits. Defaults
-   * to `noopTrace` when callers don't provide one.
+   * Discriminated-event SDK channel for this run. Defaults to `noopTrace`
+   * when the context is created without a trace (e.g. in tests).
+   *
+   * Most tools receive the trace via explicit parameter threading rather than
+   * reading it here; this field exists for test helpers and future SDK
+   * consumers that need the trace without access to the full AgentLaunchContext.
    */
   readonly trace: AgentTrace;
   readonly coordinators?: RunCoordinators;
-  /** Model short name of the executing agent (e.g. "opus46T", "sonnet46T"). */
+  /**
+   * Model short name snapshotted at run start (e.g. "opus46T"). May be stale
+   * after `onModelChanged` — see interface-level note above.
+   */
   readonly model?: string;
   /** Agent name (e.g. "orchestrator", "search-agent"). */
   readonly agentName?: string;
@@ -85,8 +112,9 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
 /**
  * Run code with an active per-run context.
  *
- * This is the migration bridge from the older runtime-host ALS and singleton
- * coordinators toward an explicit context rooted at executeAgent().
+ * The context is populated by `withExecutionRunContext` (in
+ * `AgentLaunchContext.ts`), which projects an {@link AgentLaunchContext} into
+ * the ALS scope. Tools and utilities call `tryUseRunContext()` to read it.
  */
 export function withRunContext<T>(
   context: RunContext,


### PR DESCRIPTION
## Summary

**Problem identified:** `AgentLaunchContext` and `RunContext` both carry ambient per-run fields — `runtimeHost`, `streamId`, `executionId`, `workingDirectory`, `delegationDepth`, `approvalPromptsUnavailable`, `stopAfterCycle`, etc. The translation between the two was an inline 11-field copy block inside `withExecutionRunContext`, invisible to code reviewers and silently error-prone to extend.

**Concrete risk:** When a new runtime flag is added (e.g. `stopAfterCycle`, `approvalPromptsUnavailable`), engineers must update `AgentLaunchContext`, `RunContext`, *and* the inline copy block — with no compiler error if the copy step is forgotten. The copy block also hides three field renames (`logger`→`trace`, `config.agent`→`agentName`, `config.model`→`model`) that are otherwise invisible.

**Additional issue discovered:** `RunContext.model` is snapshotted at run start and is not updated when `onModelChanged` fires mid-session (which updates `AgentLaunchContext.config.model` but not the frozen `RunContext`). `DelegationTools` reads `parentContext.model` to inherit the parent model for subagents — so after a model switch, delegated subagents receive the old parent model. This was undocumented.

## Changes

- **Extract `agentContextToRunContext(ctx: AgentLaunchContext): CreateRunContextOptions`** — a single named function that owns the full `AgentLaunchContext → RunContext` projection. Adding a new runtime flag now has one obvious place.

- **Simplify `withExecutionRunContext`** to a one-liner calling `withRunContext(createRunContext(agentContextToRunContext(ctx)), fn)`.

- **Document the overlap** on both interfaces:
  - Which fields collide and why (`logger`/`trace`, `config.agent`/`agentName`, `config.model`/`model`)
  - The `RunContext.model` staleness limitation and what it affects (`delegate_agent` inheriting the wrong parent model after a mid-session switch)

- **Update the `withRunContext` comment** to accurately describe the relationship (replace the vague "migration bridge" note with a concrete description of who populates it and who reads it).

## What this is not

This PR does not fix the `model` staleness bug (that requires either making `RunContext` mutable for that field, or threading a getter closure). It documents the issue and its scope so a follow-up can address it with full context.

## Test plan

- [x] `corepack pnpm run typecheck` — passes (exit 0)
- [x] `corepack pnpm test` — 439 test files, 2994 tests pass
- [x] No behavior change: `agentContextToRunContext` is a pure projection; `withExecutionRunContext` produces an identical `RunContext` to before

https://claude.ai/code/session_01NEBXoWyMJPtfYfx86pgJEY