### PR TITLE
[codex] Clarify multi-agent remote load status

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -303,12 +303,13 @@ export async function runMultiAgentPreset(
   const { plan, remoteAgentLoadAttempted } =
     await loadCliMultiAgentRunPlan(init);
   if (remoteAgentLoadAttempted) {
+    const inspectAdvice = `Run \`texra multi-agent inspect ${plan.preset.id}\` to view the resolved team.`;
     // Otherwise the silent second load makes runs behave differently from a
     // signed-out shell with no visible reason.
     writeTextStderr(
       cliMultiAgentPlanHasGaps(plan)
-        ? `Preset ${plan.preset.id} referenced agents not available locally; a remote agent load did not fill all the gaps.`
-        : `Preset ${plan.preset.id} referenced agents not available locally; loaded remote agents to fill the gaps.`,
+        ? `Preset ${plan.preset.id} attempted to load relay-served agents before launch, but some team members are still unavailable. ${inspectAdvice}`
+        : `Preset ${plan.preset.id} loaded relay-served agents before launch. ${inspectAdvice}`,
     );
   }
   if (plan.missingAgentOverride) {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -310,6 +310,30 @@ describe('CLI multi-agent run command', () => {
     expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(2);
   });
 
+  it('reports resolved remote agent loads without implying final missing agents', async () => {
+    const remoteLoadMessage =
+      'Preset mathematician loaded relay-served agents before launch. Run `texra multi-agent inspect mathematician` to view the resolved team.';
+    mocks.cliMultiAgentPlanHasGaps
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+    mocks.isAuthenticated.mockResolvedValueOnce(true);
+    const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
+
+    const exitCode = await runMultiAgentPreset(cliContext(), {
+      preset: 'mathematician',
+      inputFiles: ['problem.tex'],
+      contextFiles: [],
+      model: 'deepseekT',
+      instruction: 'Solve the problem with the team.',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(remoteLoadMessage);
+    expect(mocks.writeTextStderr).not.toHaveBeenCalledWith(
+      expect.stringContaining('not available locally'),
+    );
+  });
+
   it('warns when approval policy never blocks team delegation', async () => {
     const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
 


### PR DESCRIPTION
## Summary

- clarify the signed-in multi-agent run status when relay-served agents are loaded before launch
- point users to `texra multi-agent inspect <preset>` for the resolved team
- add a focused regression test that prevents the resolved reload path from implying final missing local agents

Rebased onto `main` after #5858 merged.

Closes #5861.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm exec prettier --check packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `git diff --check`
- `node packages/cli/dist/bin/texra.js multi-agent run mathematician --cwd /private/tmp/texra-cli-dogfood-0612-live-math --input convex-note.tex --instruction 'Return under 40 words: confirm the note is now mathematically sound.' --agent orchestrator --model deepseekT --approval-policy never --no-input --print`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing stderr copy and a focused test only; no changes to agent loading or run logic.
> 
> **Overview**
> **Updates stderr messaging** when a signed-in `multi-agent run` performs the pre-launch relay agent reload (`remoteAgentLoadAttempted`). Wording now describes **relay-served agents loaded before launch** (or that a load was attempted but some members remain unavailable) instead of implying agents are **not available locally** after a successful reload.
> 
> Both success and partial-gap paths append guidance to run **`texra multi-agent inspect <preset>`** to see the resolved team.
> 
> Adds a regression test that covers the reload path where gaps clear after replanning: it expects the new success message and asserts the old **"not available locally"** text is never written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c6c976e8d7a3f5f3d003ac343acf11463bb015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->