### PR TITLE
[codex] Require substantive subagent handoffs

### DIFF
--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -139,7 +139,7 @@ describe('headless delegation', () => {
       expect.objectContaining({
         agent: 'review',
         agentCategory: AgentCategory.ToolUse,
-        instruction: 'Check the proof.',
+        instruction: expect.stringContaining('Check the proof.'),
         model: 'deepseekT',
       }),
       expect.any(String),
@@ -154,6 +154,45 @@ describe('headless delegation', () => {
     expect(result.output).toContain('<response>');
     expect(result.output).toContain('The proof is correct.');
     expect(mocks.writeReport).toHaveBeenCalledWith(result.output);
+  });
+
+  it('adds a substantive handoff requirement to tool-use subagent instructions', async () => {
+    await withRunContext(
+      createRunContext({
+        runtimeHost: runtimeHost(),
+        streamId: 'parent-stream',
+        executionId: 'parent-exec',
+        model: 'deepseekT',
+      }),
+      () =>
+        new DelegateAgentTool().call({
+          agent: 'review',
+          model: null,
+          instruction: 'Check the proof.',
+          memories: [],
+          working_directory: null,
+          execution_id: null,
+        }),
+    );
+
+    expect(mocks.executeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instruction: expect.stringContaining(
+          'Your final response is delivered verbatim to the parent orchestrator.',
+        ),
+      }),
+      expect.any(String),
+      expect.anything(),
+    );
+    expect(mocks.executeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instruction: expect.stringContaining(
+          'Do not finish with only status/process notes',
+        ),
+      }),
+      expect.any(String),
+      expect.anything(),
+    );
   });
 
   it('formats returned child error results as subagent errors', async () => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -137,6 +137,19 @@ const memoriesField = z
 
 const WORKTREE_DISABLED_MESSAGE =
   "git worktree support is disabled in this workspace. Omit working_directory, or enable 'Allow agents to work in git worktrees' on the Multi-Agent settings tab.";
+const TOOL_USE_SUBAGENT_HANDOFF_INSTRUCTION = [
+  'Delegated task handoff:',
+  '- Your final response is delivered verbatim to the parent orchestrator.',
+  '- Include the substantive result requested: answer, findings, evidence/checks, and unresolved caveats.',
+  '- Do not finish with only status/process notes such as "done", "complete", or "no files were edited"; if no files were edited, state that after the task result.',
+].join('\n');
+
+function withToolUseSubagentHandoffInstruction(instruction: string): string {
+  const trimmed = instruction.trimEnd();
+  return trimmed
+    ? `${trimmed}\n\n${TOOL_USE_SUBAGENT_HANDOFF_INSTRUCTION}`
+    : TOOL_USE_SUBAGENT_HANDOFF_INSTRUCTION;
+}
 
 function ensureWorkingDirectoryExists(dir: string): void {
   try {
@@ -1105,7 +1118,7 @@ Git worktree support: ${
       agentCategory: AgentCategory.ToolUse,
       agent: agentName,
       model,
-      instruction: input.instruction,
+      instruction: withToolUseSubagentHandoffInstruction(input.instruction),
       memories: input.memories,
       workingDirectory: input.working_directory,
     } satisfies ToolUseAgentProposal);


### PR DESCRIPTION
## Summary

- append a delegation-boundary handoff contract to new `delegate_agent` instructions
- preserve the caller's original instruction while making the parent-facing result requirement explicit
- add focused coverage that delegated tool-use agents receive the substantive handoff requirement

Closes #5863.

## Validation

- `corepack pnpm vitest run src/test-kernel/tools/DelegationHeadless.vitest.mts`
- `corepack pnpm exec prettier --check src/tools/DelegationTools.ts src/test-kernel/tools/DelegationHeadless.vitest.mts`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change on new delegations with no auth or data-path changes; resume and workflow delegation are untouched.
> 
> **Overview**
> **New `delegate_agent` tool-use delegations** now append a fixed **delegated task handoff** block to the caller’s instruction (via `withToolUseSubagentHandoffInstruction` in `DelegationTools.ts`). The parent still sees the original task text; the extra lines tell the subagent that its final reply is passed verbatim to the orchestrator and must include substantive findings—not only “done” or process status.
> 
> **Resume** paths (`execution_id`) are unchanged. **Tests** in `DelegationHeadless.vitest.mts` assert the composed instruction contains both the user text and the handoff contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 956ea4b8e37537df3e9666f51ccf4baa6c764e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->