### PR TITLE
docs: round-2 realism fixes for CLI mockups

### DIFF
--- a/docs/.vitepress/components/CliChatHero.vue
+++ b/docs/.vitepress/components/CliChatHero.vue
@@ -19,7 +19,8 @@ const calls = [
     state: 'done',
     tool: 'read_file',
     preview: 'sections/intro.tex',
-    output: 'In this paper we present a novel… +41 lines (ctrl + t to view)',
+    output: 'In this paper we present a novel approach to',
+    more: '… +41 lines (ctrl + t to view transcript)',
   },
   {
     state: 'running',
@@ -76,6 +77,9 @@ const calls = [
           <span class="cc-corner">⎿</span>
           <span class="cc-out-text">{{ c.output }}</span>
         </div>
+        <div v-if="c.more" class="cc-out cc-out--more">
+          <span class="cc-out-text">{{ c.more }}</span>
+        </div>
       </li>
     </ul>
 
@@ -100,11 +104,11 @@ const calls = [
     <!-- Status-bar strip: ◆ status · elapsed · api mode · round · tokens -->
     <template #hint>
       <span class="cc-diamond">◆</span>
-      <span class="cc-status">working</span>
+      <span class="cc-status">running</span>
       <span class="cc-seg">8s</span>
       <span class="cc-seg">relay</span>
       <span class="cc-seg">r1</span>
-      <span class="cc-seg">12.3k/200k (6%)</span>
+      <span class="cc-seg">12.3k/1M (1%)</span>
       <span class="cc-bindings"
         >[/model]models&ensp;[/api]api&ensp;[Ctrl-C]stop</span
       >
@@ -214,6 +218,10 @@ const calls = [
 }
 .cc-out-text {
   min-width: 0;
+}
+/* Elision marker line: continuation under the corner glyph's column. */
+.cc-out--more {
+  padding-left: var(--mk-space-26);
 }
 
 /* Diff bands: full-width colored rows, no strikethrough */

--- a/docs/.vitepress/components/CliHistoryHero.vue
+++ b/docs/.vitepress/components/CliHistoryHero.vue
@@ -2,32 +2,33 @@
 // Terminal card for `texra history list` — guide/progress-board.md's proof
 // that run history is shared across surfaces. Rows reproduce the real
 // tab-separated format (packages/cli/src/runtime/history.ts
-// formatCliHistoryText): id, timestamp, agent, status, primary input — the
-// same runs the ProgressBoard shows as streams. Ids are the compact 12-char
-// hex execution ids; `texra resume <id>` reopens a stored tool-use session in
-// the interactive chat TUI.
+// formatCliHistoryText): id, ISO timestamp, agent, status, primary input —
+// the same runs the ProgressBoard shows as streams. Ids are the compact
+// 12-char hex execution ids; status words are the real set (completed /
+// error / resumable / …); `texra resume <id>` only works on a `resumable`
+// session, which it reopens in the interactive chat TUI.
 //
 // Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
 const rows = [
   {
     id: '9f3a6c81d24e',
-    ts: '2025-11-04T14:31:08',
+    ts: '2025-11-04T14:31:08.412Z',
     agent: 'polish',
     status: 'completed',
     input: 'draft.tex',
   },
   {
     id: 'c4e19b07a52d',
-    ts: '2025-11-04T11:02:44',
+    ts: '2025-11-04T11:02:44.917Z',
     agent: 'research',
-    status: 'completed',
+    status: 'resumable',
     input: 'sections/intro.tex',
   },
   {
     id: 'e2c70a94b18f',
-    ts: '2025-11-03T17:45:13',
+    ts: '2025-11-03T17:45:13.208Z',
     agent: 'correct',
-    status: 'failed',
+    status: 'error',
     input: 'appendices.tex',
   },
 ];
@@ -48,7 +49,10 @@ const rows = [
         <span class="chh-agent">{{ r.agent }}</span>
         <span
           class="chh-status"
-          :class="r.status === 'failed' ? 'chh-status--bad' : ''"
+          :class="{
+            'chh-status--bad': r.status === 'error',
+            'chh-status--resume': r.status === 'resumable',
+          }"
           >{{ r.status }}</span
         >
         <span class="chh-input">{{ r.input }}</span>
@@ -98,6 +102,9 @@ const rows = [
 }
 .chh-status--bad {
   color: var(--color-error);
+}
+.chh-status--resume {
+  color: var(--mk-accent);
 }
 .chh-input {
   color: var(--mk-text);

--- a/docs/.vitepress/components/CliInitHero.vue
+++ b/docs/.vitepress/components/CliInitHero.vue
@@ -18,12 +18,11 @@
     <!-- Beat 1: scaffold workspace defaults -->
     <div class="mk-term-prompt">
       <span class="mk-term-sigil">$</span>
-      <span class="mk-term-cmd"
-        >texra init
-        <span class="cih-hint-flags"
-          >(--yes accepts defaults, --gitignore ignores .texra/)</span
-        ></span
-      >
+      <span class="mk-term-cmd">texra init</span>
+    </div>
+    <div class="cih-hint-flags">
+      --yes accepts defaults non-interactively; --gitignore adds .texra/ to
+      .gitignore
     </div>
     <div class="cih-block">
       <div class="cih-wrote">Wrote .texra/config.json</div>
@@ -53,8 +52,12 @@
 /* Card shell, body, and prompt come from TermWindow + the shared .mk-term-*
    classes in theme/mockup.css. */
 .cih-hint-flags {
+  margin-top: var(--mk-space-3);
+  padding-left: var(--mk-space-16);
   color: var(--mk-text-faint);
+  font-family: var(--vp-font-family-base);
   font-size: var(--mk-fs-70);
+  font-style: italic;
 }
 .cih-block {
   margin-top: var(--mk-space-5);

--- a/docs/.vitepress/components/CliMemoryHero.vue
+++ b/docs/.vitepress/components/CliMemoryHero.vue
@@ -12,17 +12,17 @@
 const rows = [
   {
     path: '/memories/project-conventions.md',
-    desc: 'pinned; 1.2 KB; modified: 11/4/2025, 2:31 PM; by research',
+    desc: 'pinned; 1.2K; modified: 11/4/2025, 2:31:08 PM; by research',
     pinned: true,
   },
   {
     path: '/memories/notation.md',
-    desc: '0.8 KB; modified: 10/28/2025, 10:04 AM; by assistant',
+    desc: '819B; modified: 10/28/2025, 10:04:51 AM; by assistant',
     pinned: false,
   },
   {
     path: '/memories/related-work.md',
-    desc: '2.4 KB; modified: 10/21/2025, 4:48 PM; by research',
+    desc: '2.4K; modified: 10/21/2025, 4:48:27 PM; by research',
     pinned: false,
   },
 ];
@@ -54,6 +54,10 @@ const rows = [
       <span class="mk-term-cmd"
         >texra memory show memories/project-conventions.md</span
       >
+    </div>
+    <div class="cmh-meta">
+      <div>Memory: /memories/project-conventions.md</div>
+      <div>9 lines</div>
     </div>
     <div class="cmh-preview">
       <div># Project conventions</div>
@@ -103,6 +107,12 @@ const rows = [
 .cmh-show {
   margin-top: var(--mk-space-10);
   flex-wrap: wrap;
+}
+.cmh-meta {
+  margin-top: var(--mk-space-4);
+  padding-left: var(--mk-space-16);
+  color: var(--mk-text-dim);
+  font-size: var(--mk-fs-72);
 }
 .cmh-preview {
   margin-top: var(--mk-space-5);

--- a/docs/.vitepress/components/CliModelsHero.vue
+++ b/docs/.vitepress/components/CliModelsHero.vue
@@ -4,22 +4,26 @@
 // `<value>\t<label>\t<status>` row per model for the current api mode
 // (packages/cli/src/runtime/modelAccess.ts); `models show <id>` prints
 // `id:` / `label:` / `provider:` / `status:` detail lines
-// (formatCliModelDetails). Short ids and labels match the page's own model
-// tables — the id column is exactly what `--model` takes.
+// (formatCliModelDetails). Short ids are exactly what `--model` takes; labels
+// are the literal llm-zoo MODEL_CONFIGS labels the command prints; the status
+// column is the lowercased availability label for the current api mode —
+// 'included access' when signed in to the relay, 'api key set' /
+// 'openrouter key' in personal mode ('login required' / 'not included'
+// appear under --all). Snapshot shows a signed-in relay session.
 //
 // Built on <TermWindow>; .mockup-scoped and token-only. Static strings.
 const rows = [
-  { id: 'fable5', label: 'Claude Fable 5', status: 'available' },
-  { id: 'opus48T', label: 'Claude Opus 4.8 (thinking)', status: 'available' },
+  { id: 'fable5', label: 'Claude Fable 5', status: 'included access' },
+  { id: 'opus48T', label: 'Opus 4.8 (Thinking)', status: 'included access' },
   {
     id: 'sonnet46T',
-    label: 'Claude Sonnet 4.6 (thinking)',
-    status: 'available',
+    label: 'Sonnet 4.6 (Thinking)',
+    status: 'included access',
   },
   {
     id: 'deepseekT',
-    label: 'DeepSeek V4 Flash (thinking)',
-    status: 'available',
+    label: 'DeepSeek V4 Flash (Thinking)',
+    status: 'included access',
   },
 ];
 </script>
@@ -50,7 +54,7 @@ const rows = [
         <div><span class="cmo-k">id:</span> fable5</div>
         <div><span class="cmo-k">label:</span> Claude Fable 5</div>
         <div><span class="cmo-k">provider:</span> anthropic</div>
-        <div><span class="cmo-k">status:</span> available</div>
+        <div><span class="cmo-k">status:</span> included access</div>
       </div>
     </div>
   </TermWindow>

--- a/docs/.vitepress/components/CliMultiAgentHero.vue
+++ b/docs/.vitepress/components/CliMultiAgentHero.vue
@@ -14,7 +14,7 @@ const children = [
   {
     n: 1,
     agent: 'coder',
-    status: 'done',
+    status: 'completed',
     elapsed: '48s',
     tail: 'optimized the inner loop in scripts/simulate.py',
   },
@@ -47,28 +47,21 @@ const children = [
     <div class="cma-root">
       <wa-spinner class="cma-spin mk-spinner"></wa-spinner>
       <span class="cma-agent">engineer</span>
-      <span class="cma-status">delegating</span>
-      <span class="cma-elapsed">1m12s</span>
+      <span class="cma-status">running</span>
+      <span class="cma-elapsed">1m 12s</span>
     </div>
 
     <!-- Subagent panel rows: numbered children with status + output tail -->
     <ul class="cma-children">
       <li v-for="c in children" :key="c.n" class="cma-child">
         <div class="cma-child-row">
-          <span class="cma-n">{{ c.n }}.</span>
-          <span
-            class="cma-marker"
-            :class="
-              c.status === 'done' ? 'cma-marker--done' : 'cma-marker--run'
-            "
-            >●</span
-          >
+          <span class="cma-n">{{ c.n }}</span>
+          <span class="cma-marker">●</span>
           <span class="cma-agent">{{ c.agent }}</span>
           <span class="cma-status">{{ c.status }}</span>
           <span class="cma-elapsed">{{ c.elapsed }}</span>
         </div>
         <div class="cma-tail">
-          <span class="cma-corner">⎿</span>
           <span class="cma-tail-text">{{ c.tail }}</span>
         </div>
       </li>
@@ -132,25 +125,16 @@ const children = [
   font-size: var(--mk-fs-72);
   flex-shrink: 0;
 }
+/* Both child markers are green: childStatusColor colors running and
+   completed children alike in the real subagent panel. */
 .cma-marker {
   flex-shrink: 0;
-}
-.cma-marker--done {
   color: var(--color-success);
 }
-.cma-marker--run {
-  color: var(--mk-text-faint);
-}
 .cma-tail {
-  display: flex;
-  align-items: baseline;
-  gap: var(--mk-space-7);
   padding-left: var(--mk-space-26);
   color: var(--mk-text-faint);
   font-size: var(--mk-fs-72);
-}
-.cma-corner {
-  flex-shrink: 0;
 }
 .cma-tail-text {
   min-width: 0;

--- a/docs/.vitepress/components/CliRunHero.vue
+++ b/docs/.vitepress/components/CliRunHero.vue
@@ -6,7 +6,12 @@
 // and, in text mode, end by printing a filesystem path on stdout (the copied
 // --output / --output-dir path, else the generated file in run storage) — so
 // the card shows: prompt line, per-round progress rows, printed result lines,
-// and an optional dim annotation.
+// and an optional dim annotation. The round rows are a stylized view of the
+// real progress signal — a single throttled live status line on stderr whose
+// `[rN]` segment tracks the current round
+// (packages/cli/src/runtime/runProgressRenderer.ts) — chosen so the r0/r1
+// concept reads at a glance; captions should say rounds "stream as progress",
+// not claim literal screen output.
 //
 // Built on the <TermWindow> primitive; .mockup-scoped, so the shared --mk-*
 // tokens resolve here and the card flips with the docs light / dark theme.

--- a/docs/.vitepress/components/CliSearchChatHero.vue
+++ b/docs/.vitepress/components/CliSearchChatHero.vue
@@ -61,7 +61,7 @@
 
     <template #hint>
       <span class="csr-diamond">◆</span>
-      <span class="csr-seg">working</span>
+      <span class="csr-seg">running</span>
       <span class="csr-seg">relay</span>
       <span class="csr-seg-dim"
         >every row a real lookup — arXiv + Crossref</span

--- a/docs/.vitepress/components/CliStorageHero.vue
+++ b/docs/.vitepress/components/CliStorageHero.vue
@@ -51,6 +51,9 @@ const files = [
       <span class="mk-term-cmd">texra history show 9f3a6c81d24e</span>
     </div>
     <div class="csh-files">
+      <div class="csh-elide">
+        … Execution / Status / Agent / Model details …
+      </div>
       <div class="csh-files-head">Files (2):</div>
       <div v-for="f in files" :key="f.path" class="csh-file">
         <span class="csh-size">{{ f.size }}</span>
@@ -84,6 +87,11 @@ const files = [
   margin-top: var(--mk-space-5);
   padding-left: var(--mk-space-16);
   font-size: var(--mk-fs-72);
+}
+.csh-elide {
+  color: var(--mk-text-faint);
+  font-style: italic;
+  font-size: var(--mk-fs-70);
 }
 .csh-files-head {
   color: var(--mk-text-dim);

--- a/docs/.vitepress/components/CliToolsLifecycleHero.vue
+++ b/docs/.vitepress/components/CliToolsLifecycleHero.vue
@@ -51,7 +51,8 @@
       <span class="mk-term-cmd">texra tools auth codex</span>
     </div>
     <div class="ctf-block ctf-dim">
-      <div>codex login — sign in with ChatGPT account</div>
+      <div>Uses ChatGPT subscription (free with Plus/Pro)</div>
+      <div>Command: codex login</div>
     </div>
 
     <!-- Beat 4: recheck -->

--- a/docs/.vitepress/components/CliToolsListHero.vue
+++ b/docs/.vitepress/components/CliToolsListHero.vue
@@ -36,7 +36,7 @@ const rows = [
     category: 'ai-agents',
     enabled: 'no',
     detected: 'yes',
-    note: 'Zotero must be running with Better BibTeX installed.',
+    note: 'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
   },
   {
     id: 'wolfram',
@@ -52,7 +52,7 @@ const rows = [
     category: 'lean',
     enabled: '-',
     detected: 'yes',
-    note: 'VS Code build: requires the leanprover.lean4 extension. CLI / desktop builds: requires `lake` on PATH',
+    note: 'VS Code build: requires the leanprover.lean4 extension. CLI / desktop builds: requires `lake` on PATH; each Lake project root gets its own language server, surfaced below.',
   },
 ];
 </script>

--- a/docs/.vitepress/components/CliToolsListHero.vue
+++ b/docs/.vitepress/components/CliToolsListHero.vue
@@ -7,10 +7,12 @@
 // enabled-vs-detected distinction are concrete at a glance.
 //
 // Built on the <TermWindow> primitive; the shared --mk-* tokens resolve here
-// and the card flips with the docs light / dark theme. Integration ids, names,
-// categories, and the claude-agent install command match
-// src/tools/externalToolDefs.ts verbatim; the enabled / detection mix is a
-// believable static snapshot showing all three states.
+// and the card flips with the docs light / dark theme. Ids, names, categories,
+// and notes match src/tools/externalToolDefs.ts + noteForTool (statusLabel ??
+// authNote ?? configNotes ?? installCommand): the undetected claude-agent row
+// shows its install command, codex shows its authNote, wolfram/lean4 their
+// configNotes. ENABLED prints '-' for non-toggleable tools (wolfram, lean4),
+// exactly as formatCliBoolean does.
 const rows = [
   {
     id: 'codex',
@@ -18,7 +20,7 @@ const rows = [
     category: 'ai-agents',
     enabled: 'yes',
     detected: 'yes',
-    note: '',
+    note: 'Uses ChatGPT subscription (free with Plus/Pro)',
   },
   {
     id: 'claude-agent',
@@ -29,28 +31,28 @@ const rows = [
     note: 'npm install -g @anthropic-ai/claude-code',
   },
   {
+    id: 'zotero',
+    name: 'Zotero Integration',
+    category: 'ai-agents',
+    enabled: 'no',
+    detected: 'yes',
+    note: 'Zotero must be running with Better BibTeX installed.',
+  },
+  {
     id: 'wolfram',
     name: 'Wolfram Language',
     category: 'computation',
-    enabled: 'yes',
+    enabled: '-',
     detected: 'no',
-    note: '',
+    note: 'Requires the free Wolfram Engine (provides wolframscript).',
   },
   {
     id: 'lean4',
-    name: 'Lean 4',
+    name: 'Lean 4 Proof Assistant',
     category: 'lean',
-    enabled: 'no',
+    enabled: '-',
     detected: 'yes',
-    note: '',
-  },
-  {
-    id: 'texcount',
-    name: 'TeXcount',
-    category: 'latex',
-    enabled: 'yes',
-    detected: 'yes',
-    note: '',
+    note: 'VS Code build: requires the leanprover.lean4 extension. CLI / desktop builds: requires `lake` on PATH',
   },
 ];
 </script>
@@ -81,6 +83,7 @@ const rows = [
         <span class="ctl-c ctl-c--cat">{{ r.category }}</span>
         <span class="ctl-c ctl-c--enabled">
           <span
+            v-if="r.enabled !== '-'"
             class="ctl-dot"
             :class="r.enabled === 'yes' ? 'ctl-dot--on' : 'ctl-dot--off'"
           ></span>

--- a/docs/.vitepress/components/DoctorSliceHero.vue
+++ b/docs/.vitepress/components/DoctorSliceHero.vue
@@ -34,7 +34,7 @@ defineProps({
       </li>
     </ul>
     <div class="dsh-more">
-      … plus Node, auth, model access, and storage checks
+      … plus Node.js, workspace dirs, auth, model access, and config checks
     </div>
   </TermWindow>
 </template>

--- a/docs/.vitepress/components/RunParityHero.vue
+++ b/docs/.vitepress/components/RunParityHero.vue
@@ -81,12 +81,16 @@ const RUN_ID = '9f3a6c81d24e';
 .rph-term-body {
   font-size: var(--mk-fs-74);
 }
+/* Annotation, not terminal output: text mode prints only the path (the id is
+   inside it) — this row just names the run for the parity tie. */
 .rph-done {
   display: flex;
   align-items: center;
   gap: var(--mk-space-7);
   margin-top: var(--mk-space-8);
-  color: var(--mk-text-dim);
+  color: var(--mk-text-faint);
+  font-style: italic;
+  font-size: var(--mk-fs-72);
 }
 .rph-path {
   margin-top: var(--mk-space-5);

--- a/docs/design/cli-terminal-mockups.md
+++ b/docs/design/cli-terminal-mockups.md
@@ -102,8 +102,11 @@ mockups, never `run-123` or named ids.
 - `texra agents show <name>` → `name:`, `category:`, `source:`, `path:` lines
 - `texra history list [-n N]` → `<id>\t<timestamp>\t<agent>\t<status>\t<input>`
 - `texra history show <id>` → details + `Files (N):` listing with sizes
-- `texra models list` → `<value>\t<label>\t<status>` (e.g. `fable5  Claude
-Fable 5  available`); `texra models show <id>` → detail lines
+- `texra models list` → `<value>\t<label>\t<status>` where status is the
+  lowercased availability label for the current api mode (e.g. `fable5  Claude
+Fable 5  included access`; personal mode prints `api key set` /
+  `openrouter key`; `--all` adds `login required` / `not included`);
+  `texra models show <id>` → detail lines
 - `texra memory list` → `Memories (N):` header then `/memories/<file>` rows
   with pinned state + size; `texra memory show memories/<file>` previews one
 - `texra tools list` → SIX columns `ID NAME CATEGORY ENABLED DETECTED NOTE`,

--- a/docs/guide/first-run.md
+++ b/docs/guide/first-run.md
@@ -94,7 +94,7 @@ texra run polish \
   ]"
 />
 
-<p class="hero-caption">What you should see while it runs: Round 0 has written the first revision, Round 1 is critiquing and revising it. When the run completes, the path to the final document prints on stdout.</p>
+<p class="hero-caption">Mid-run: Round 0 has written the first revision, Round 1 is critiquing and revising it — the live status line on stderr tracks the current round. When the run completes, the path to the final document prints on stdout.</p>
 
 The run streams reasoning, tool calls, and the assembled output.
 When it completes, polish has written one folder per round under


### PR DESCRIPTION
## Summary

Follow-up to #5839 (merged before this round landed on its branch). A dedicated realism fact-checker re-audited every terminal mockup against `packages/cli` source; the bulk verified clean, and this PR applies everything it flagged plus a second inline audit pass.

### Blocker fixed
- **tools list showed an impossible row**: `texcount` is `hideFromDashboard` and the CLI never lists it — replaced with `zotero`, plus the real `Lean 4 Proof Assistant` name, `-` ENABLED state for non-toggleable tools (wolfram, lean4), and real per-row NOTE values from `noteForTool`.

### Vocabulary corrections (real words only)
- history statuses: `error` / `resumable` (not `failed`); the resume example now targets a `resumable` session — `texra resume` refuses completed ones; full ISO timestamps.
- models: real lowercased availability statuses (`included access`) and literal llm-zoo labels (`Opus 4.8 (Thinking)`, no "Claude" prefix).
- chat status bar: `running` (not `working`); token gauge `12.3k/1M (1%)` to match deepseekT's actual context window.
- multi-agent panel: `completed`/`running` child statuses, green markers, `1m 12s` pretty-ms spacing, plain dim tail lines, no list dots.
- memory: real `formatSize` output (`1.2K`/`819B`), locale times with seconds, `Memory: <path>` + line-count header on the show beat.
- tools auth beat prints the real auth guide (`authNote` + `Command: codex login`); elision marker uses the full `ctrl + t to view transcript` wording on its own line.

### Honesty refinements
- `CliRunHero`'s per-round rows documented as a stylization of the real single `[rN]` live status line; first-run caption no longer claims literal screen output.
- Parity card's "run complete" line restyled as annotation (text mode prints only the path); storage card gains an elision cue before `Files (N):`; init flag-hint moved out of the typed command.
- Brief updated with the real models-list status vocabulary.

## Validation
- `vitepress build` green on top of latest main (clean cherry-pick over #5854/#5858/#5862's docs changes).
- Token-definition audit (every `var(--mk-*)` used is defined) and SSR-render audit (all spot-checked pages emit the card markup) both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static VitePress mockup strings only; no runtime, auth, or product behavior changes.
> 
> **Overview**
> Second-pass **realism fixes** for VitePress CLI terminal mockups so static figures match `packages/cli` output and TUI vocabulary, plus small honesty tweaks so captions do not overclaim literal screen output.
> 
> **`texra tools list`**: drops **`texcount`** (dashboard-hidden / not a believable list row) in favor of **`zotero`**, uses real **`Lean 4 Proof Assistant`** naming, **`ENABLED` `-`** for non-toggleable tools, and **`NOTE`** text from **`noteForTool`** (auth/config/install strings). **History** uses **`error` / `resumable`**, full ISO timestamps, and **`texra resume`** on a resumable id. **Models** show relay **`included access`** and llm-zoo labels. **Chat / search** status bars use **`running`** and **`12.3k/1M (1%)`**. **Multi-agent**, **memory**, **tools auth**, and **init** mockups align statuses, sizes, meta headers, and flag hints with the real CLI/TUI.
> 
> **`CliRunHero`** comments and **first-run** caption clarify per-round rows are a stylization of the single stderr **`[rN]`** progress line. **Run parity**, **storage**, and **`cli-terminal-mockups.md`** document annotation vs stdout and models-list status wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c13eb79a4c485d48651ca1462704c71b6ddeb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->