### PR TITLE
[codex] Keep run context model live

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -113,15 +113,10 @@ const STATUS_MESSAGES: Record<string, string> = {
  * designed independently:
  *  - `AgentCore.logger`   → `RunContext.trace`
  *  - `AgentConfig.agent`  → `RunContext.agentName`
- *  - `AgentConfig.model`  → `RunContext.model`  (snapshotted — see note below)
+ *  - `AgentConfig.model`  → `RunContext.model`
  *
- * NOTE — `RunContext.model` staleness: `model` is snapshotted here at the
- * start of execution. If the agent switches models mid-session via
- * `onModelChanged` (which updates `AgentLaunchContext.config.model`), the
- * ambient `RunContext.model` seen by tools via `tryUseRunContext()` will lag
- * behind. Code that delegates subagents and needs the current model should
- * prefer `AgentLaunchContext.config.model` via explicit context; the ALS
- * value is a best-effort hint.
+ * `RunContext.model` reads through `getModel` so tools observe model switches
+ * applied to `AgentLaunchContext.config.model` during an interactive session.
  */
 function agentContextToRunContext(
   ctx: AgentLaunchContext,
@@ -132,7 +127,7 @@ function agentContextToRunContext(
     executionId: ctx.executionId,
     trace: ctx.logger,
     coordinators: ctx.coordinators,
-    model: ctx.config.model,
+    getModel: () => ctx.config.model,
     agentName: ctx.config.agent,
     workingDirectory: ctx.workingDirectory,
     delegationDepth: ctx.delegationDepth,

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -18,10 +18,10 @@ export interface RunCoordinators {
  * Ambient per-run context stored in an {@link AsyncLocalStorage} scope.
  *
  * Tools and utilities that cannot take explicit parameters reach host services
- * via `tryUseRunContext()`. The canonical source of truth for all of these
- * fields is {@link AgentLaunchContext} / {@link AgentCore}; the values here
- * are projected once by `agentContextToRunContext` in `AgentLaunchContext.ts`
- * at the moment `withExecutionRunContext` is entered.
+ * via `tryUseRunContext()`. The canonical source of truth for these fields is
+ * {@link AgentLaunchContext} / {@link AgentCore}; the ambient context exposes
+ * the subset that tool-side code needs without importing the full launch
+ * context.
  *
  * **Field naming mismatches with AgentCore** (unavoidable — interfaces were
  * designed independently):
@@ -29,11 +29,9 @@ export interface RunCoordinators {
  *   - `AgentConfig.agent` → `RunContext.agentName`
  *   - `AgentConfig.model` → `RunContext.model`
  *
- * **Staleness**: `model` is snapshotted at run start. After a mid-session
- * model switch (`onModelChanged` in `executeAgent`), `RunContext.model` lags
- * behind `AgentLaunchContext.config.model`. Tools that delegate subagents
- * and inherit the parent model (e.g. `delegate_agent`) will use the stale
- * value. This is a known limitation of the snapshot approach.
+ * `model` is a live property when the context is projected from an
+ * {@link AgentLaunchContext}, so mid-session model switches are visible to
+ * delegation tools that inherit the parent model.
  */
 export interface RunContext {
   readonly runtimeHost: AgentRuntimeHost;
@@ -49,10 +47,7 @@ export interface RunContext {
    */
   readonly trace: AgentTrace;
   readonly coordinators?: RunCoordinators;
-  /**
-   * Model short name snapshotted at run start (e.g. "opus46T"). May be stale
-   * after `onModelChanged` — see interface-level note above.
-   */
+  /** Current model short name for this run (e.g. "opus46T"). */
   readonly model?: string;
   /** Agent name (e.g. "orchestrator", "search-agent"). */
   readonly agentName?: string;
@@ -79,7 +74,10 @@ export interface CreateRunContextOptions {
    */
   trace?: AgentTrace;
   coordinators?: RunCoordinators;
+  /** Static model fallback for manually-created run contexts. */
   model?: string;
+  /** Live model provider for contexts backed by mutable launch state. */
+  getModel?: () => string | undefined;
   agentName?: string;
   workingDirectory?: string;
   delegationDepth?: number;
@@ -94,19 +92,25 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     throw new Error('createRunContext requires an explicit runtimeHost');
   }
 
-  return Object.freeze({
+  const { getModel, model } = options;
+
+  const context: RunContext = {
     runtimeHost: options.runtimeHost,
     streamId: options.streamId,
     executionId: options.executionId,
     trace: options.trace ?? noopTrace,
     coordinators: options.coordinators,
-    model: options.model,
+    get model() {
+      return getModel?.() ?? model;
+    },
     agentName: options.agentName,
     workingDirectory: options.workingDirectory,
     delegationDepth: options.delegationDepth,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
     stopAfterCycle: options.stopAfterCycle,
-  });
+  };
+
+  return Object.freeze(context);
 }
 
 /**

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -2,7 +2,13 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import { getAgentPath } from '@agent/runtime/AgentLaunchContext';
+import { noopTrace } from '@agent/trace';
+import {
+  getAgentPath,
+  withExecutionRunContext,
+  type AgentLaunchContext,
+} from '@agent/runtime/AgentLaunchContext';
+import { useRunContext } from '@agent/runtime/RunContext';
 
 import { createRecordingHost } from '../progressTestUtils';
 
@@ -22,5 +28,25 @@ describe('AgentLaunchContext', () => {
         },
       },
     ]);
+  });
+
+  it('projects model changes into the active run context', async () => {
+    const explicit = createRecordingHost();
+    const ctx = {
+      runtimeHost: explicit.host,
+      logger: noopTrace,
+      config: {
+        agent: 'chat',
+        model: 'deepseekT',
+      },
+    } as unknown as AgentLaunchContext;
+
+    await withExecutionRunContext(ctx, async () => {
+      expect(useRunContext().model).toBe('deepseekT');
+
+      ctx.config.model = 'sonnet46T';
+
+      expect(useRunContext().model).toBe('sonnet46T');
+    });
   });
 });

--- a/src/test-kernel/agent/runtime/RunContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunContext.vitest.ts
@@ -50,6 +50,27 @@ describe('RunContext', () => {
     expect(resolved).toBe(runtimeHost);
   });
 
+  it('reads the current model from a live provider', () => {
+    let currentModel: string | undefined = 'deepseekT';
+    const context = createRunContext({
+      runtimeHost: createRuntimeHost(),
+      model: 'fallback-model',
+      getModel: () => currentModel,
+    });
+
+    expect(context.model).toBe('deepseekT');
+
+    currentModel = 'sonnet46T';
+
+    const resolved = withRunContext(context, () => useRunContext().model);
+
+    expect(resolved).toBe('sonnet46T');
+
+    currentModel = undefined;
+
+    expect(context.model).toBe('fallback-model');
+  });
+
   it('requires an active context for owned runtime state', () => {
     expect(() => useRunContext()).toThrow(/outside withRunContext/);
   });


### PR DESCRIPTION
Fixes #5867.

## Summary
- Keep the existing `RunContext.model` property API, but allow `createRunContext` to back it with a live model provider.
- Project `AgentLaunchContext.config.model` into `RunContext` through that getter so mid-session `/model` changes are visible to delegation tools.
- Replace the stale snapshot documentation with the new ownership rule and add focused regression coverage.

## Root cause
`agentContextToRunContext` copied `ctx.config.model` once when entering the async run scope. `executeAgent` later updates `ctx.config.model` in `onModelChanged`, but `delegate_agent` and `delegate_workflow` inherit the parent model through `tryUseRunContext().model`, so subagents could inherit the old model after a switch.

## Validation
- `corepack pnpm vitest run src/test-kernel/agent/runtime/RunContext.vitest.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts src/test-kernel/tools/DelegationModelAvailability.vitest.mts src/test-kernel/tools/DelegationHeadless.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm exec prettier --check src/agent/runtime/RunContext.ts src/agent/runtime/AgentLaunchContext.ts src/test-kernel/agent/runtime/RunContext.vitest.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts && git diff --check`
- `npm run compile:fast`

## Dogfood context
Before this fix pass, `texra-local` was rebuilt from current `origin/main`; `texra-local doctor --output-format json` was green, `validate:tui` passed the transcript/slash/approval/subagent/task/launcher snapshot scenarios, and a real TTY `texra-local chat` session handled `/help`, `/status`, a small prime-number proof prompt, and clean exit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core per-run ALS context used by delegation tools; behavior change is intentional but affects model inheritance for subagents.
> 
> **Overview**
> **`RunContext.model` is no longer snapshotted at run start.** `createRunContext` can wire the property through an optional `getModel` callback (with a static `model` fallback for hand-built contexts). `agentContextToRunContext` now passes `getModel: () => ctx.config.model` instead of copying the model once, so tools that read ambient context—especially delegation paths that inherit the parent model—see mid-session `/model` updates on `AgentLaunchContext.config.model`.
> 
> Documentation that described stale `RunContext.model` after `onModelChanged` is replaced with the live-read behavior. Regression tests cover the getter/fallback in `RunContext` and projection through `withExecutionRunContext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1f390391e4f6e99df8c8fe8de34b7e0e492be58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->