### PR TITLE
[codex] Prevent docs mock activity rail overflow

### DIFF
--- a/docs/.vitepress/components/MockupFrame.vue
+++ b/docs/.vitepress/components/MockupFrame.vue
@@ -22,23 +22,23 @@ const LOGO = withBase('/logo-icon-board.svg');
       <span class="win-title">{{ title }}</span>
     </div>
     <div class="win-body">
-      <nav class="act">
-        <span class="act-i"
+      <nav class="activity-bar">
+        <span class="activity-item"
           ><wa-icon library="texra" name="files"></wa-icon
         ></span>
-        <span class="act-i"
+        <span class="activity-item"
           ><wa-icon library="texra" name="search"></wa-icon
         ></span>
-        <span class="act-i"
+        <span class="activity-item"
           ><wa-icon library="texra" name="source-control"></wa-icon
         ></span>
-        <span class="act-i"
+        <span class="activity-item"
           ><wa-icon library="texra" name="debug-alt"></wa-icon
         ></span>
-        <span class="act-i act-on"
-          ><img class="act-logo" :src="LOGO" alt="TeXRA"
+        <span class="activity-item activity-item--active"
+          ><img class="activity-logo" :src="LOGO" alt="TeXRA"
         /></span>
-        <span class="act-i act-bottom"
+        <span class="activity-item activity-bottom"
           ><wa-icon library="texra" name="settings-gear"></wa-icon
         ></span>
       </nav>
@@ -110,7 +110,7 @@ const LOGO = withBase('/logo-icon-board.svg');
 }
 
 /* Activity bar */
-.act {
+.activity-bar {
   flex-shrink: 0;
   width: var(--mk-size-46);
   background: var(--mk-bg-raised);
@@ -121,7 +121,7 @@ const LOGO = withBase('/logo-icon-board.svg');
   padding: var(--mk-space-10) 0;
   gap: var(--mk-space-16);
 }
-.act-i {
+.activity-item {
   color: var(--mk-text-faint);
   width: 100%;
   display: flex;
@@ -131,10 +131,10 @@ const LOGO = withBase('/logo-icon-board.svg');
   padding: var(--mk-space-2) 0;
   font-size: var(--mk-space-20);
 }
-.act-on {
+.activity-item--active {
   color: var(--mk-text);
 }
-.act-on::before {
+.activity-item--active::before {
   content: '';
   position: absolute;
   left: 0;
@@ -143,12 +143,12 @@ const LOGO = withBase('/logo-icon-board.svg');
   width: var(--mk-space-2);
   background: var(--mk-accent);
 }
-.act-logo {
+.activity-logo {
   width: var(--mk-size-23);
   height: var(--mk-size-23);
   display: block;
 }
-.act-bottom {
+.activity-bottom {
   margin-top: auto;
 }
 
@@ -159,7 +159,7 @@ const LOGO = withBase('/logo-icon-board.svg');
   .win-content {
     flex-direction: column;
   }
-  .act {
+  .activity-bar {
     flex-direction: row;
     width: auto;
     justify-content: flex-start;
@@ -169,7 +169,7 @@ const LOGO = withBase('/logo-icon-board.svg');
     border-right: none;
     border-bottom: 1px solid var(--mk-border-strong);
   }
-  .act-on::before {
+  .activity-item--active::before {
     left: -2px;
     top: auto;
     bottom: 0;


### PR DESCRIPTION
## Summary
- Rename the `MockupFrame` activity rail classes so they no longer collide with the shared `.mockup .act` action-button styles.
- Keep the VS Code-style rail dimensions owned by the frame, preventing the reported icon/button overflow into the mock UI.

## Root cause
`MockupFrame.vue` used `.act` for the activity bar, while `docs/.vitepress/theme/mockup.css` also defines `.mockup .act` for small inline action buttons. Because the frame root carries `.mockup`, the global action-button selector styled the entire activity rail as a 22px rounded button, causing the rail content to bleed into the mock sidebar.

## Validation
- `corepack pnpm exec prettier --check docs/.vitepress/components/MockupFrame.vue && git diff --check`
- `npm run docs:build` from `docs/`
- Built docs served at `http://localhost:4173/` and captured landing screenshots at 390x844 and 1280x900.
- Playwright geometry assertion confirmed no `.activity-item` extends outside `.activity-bar` at 390x844 or 1280x900.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only scoped class renames in one Vue component; no runtime app or auth/data impact.
> 
> **Overview**
> Fixes docs **MockupFrame** activity rail layout by renaming rail-specific classes so they no longer match shared **`.mockup .act`** action-button styles in `mockup.css`.
> 
> The frame root carries **`.mockup`**, so the global **22px rounded `.act`** rules were applied to the VS Code-style rail (`nav.act` / `.act-i`), shrinking and overflowing icons into the mock sidebar. The rail is now **`activity-bar`**, **`activity-item`**, **`activity-item--active`**, **`activity-logo`**, and **`activity-bottom`**, with the same scoped layout and responsive rules updated to the new names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4aba3b073f104d7b2947811393707b776756751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->