### PR TITLE
fix: contain docs mockup activity icons

### DIFF
--- a/docs/.vitepress/components/MockupFrame.vue
+++ b/docs/.vitepress/components/MockupFrame.vue
@@ -120,16 +120,27 @@ const LOGO = withBase('/logo-icon-board.svg');
   align-items: center;
   padding: var(--mk-space-10) 0;
   gap: var(--mk-space-16);
+  box-sizing: border-box;
 }
 .activity-item {
   color: var(--mk-text-faint);
-  width: 100%;
+  width: var(--mk-size-46);
+  height: var(--mk-size-32);
+  flex: 0 0 var(--mk-size-32);
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
-  padding: var(--mk-space-2) 0;
   font-size: var(--mk-space-20);
+  line-height: 1;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+.activity-item > wa-icon {
+  display: block;
+  width: var(--mk-space-20);
+  height: var(--mk-space-20);
+  line-height: 1;
 }
 .activity-item--active {
   color: var(--mk-text);
@@ -138,8 +149,8 @@ const LOGO = withBase('/logo-icon-board.svg');
   content: '';
   position: absolute;
   left: 0;
-  top: -4px;
-  bottom: -4px;
+  top: 0;
+  bottom: 0;
   width: var(--mk-space-2);
   background: var(--mk-accent);
 }
@@ -170,10 +181,10 @@ const LOGO = withBase('/logo-icon-board.svg');
     border-bottom: 1px solid var(--mk-border-strong);
   }
   .activity-item--active::before {
-    left: -2px;
+    left: 0;
     top: auto;
     bottom: 0;
-    right: -2px;
+    right: 0;
     width: auto;
     height: var(--mk-space-2);
   }


### PR DESCRIPTION
## Summary
- Give docs mockup activity-rail items fixed square slots so Web Awesome icons cannot overflow into the window chrome.
- Clamp the active rail marker to the item bounds on desktop and mobile layouts.

## Validation
- `prettier --check docs/.vitepress/components/MockupFrame.vue && git diff --check`
- `npm run docs:build`
- Chrome headless screenshots at 390x900 and 1180x900 confirmed the mock activity icons stay inside the frame/title-bar bounds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS-only changes to a VitePress docs mockup component with no runtime or security impact.
> 
> **Overview**
> Fixes layout overflow in the docs **MockupFrame** activity rail so Web Awesome icons stay inside the mock window chrome.
> 
> **Activity items** now use fixed **46×32** slots with `box-sizing`, `overflow: hidden`, and no vertical padding; **`wa-icon`** children are explicitly sized to **20×20** with `line-height: 1`. The **active** rail indicator (`::before`) is aligned to the item edges on desktop (left bar) and in the mobile horizontal bar (bottom bar), replacing negative offsets that let markers and icons bleed into the title bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe3296273179a97af825752c0ce12033d7440d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->