### PR TITLE
fix: use local launcher in CLI resume hints

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -527,6 +527,7 @@ export interface AppProps {
   readonly canInterruptActiveRun: () => boolean;
   readonly canStopActiveRun?: () => boolean;
   readonly colorEnabled?: boolean;
+  readonly commandName?: string;
   readonly onInterruptActive: () => void;
   readonly onTranscriptViewportChange?: (
     change: TranscriptViewportChange,
@@ -1044,6 +1045,7 @@ export function App(props: AppProps): React.JSX.Element {
         <StatusBar
           agentSelectionAvailable={agentSelectionAvailable}
           canStopActiveRun={canStopActiveRun}
+          commandName={props.commandName}
           foregroundEscapeAction={foregroundEscapeAction({
             activeFormEscapeAction: activeForm?.escapeAction,
             foregroundKind,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -23,6 +23,7 @@ import {
   approvalQueueStatus,
   type ApprovalQueueStatusKind,
 } from '../state/approvalQueue';
+import { formatResumeCommand } from '../state/resumeHint';
 import { terminalCapabilities } from '../state/terminalCapabilities';
 import {
   cliState,
@@ -62,6 +63,7 @@ export interface StatusBarDisplayInput {
   readonly elapsedMs?: number;
   readonly pendingExitHint: boolean;
   readonly pendingExitResumeId: string | undefined;
+  readonly commandName?: string;
   readonly bypass: BypassState;
   readonly thinkingActive?: boolean;
   readonly queuedFollowUpMessages: readonly string[];
@@ -753,7 +755,10 @@ export function buildStatusBarDisplay(
       : undefined,
     bindings:
       input.pendingExitHint && input.pendingExitResumeId
-        ? `Resume this session with: texra --resume ${input.pendingExitResumeId}`
+        ? `Resume this session with: ${formatResumeCommand(
+            input.commandName,
+            input.pendingExitResumeId,
+          )}`
         : input.shortcutsActive === false
           ? foregroundBindingsText(
               input.ctrlCAction ?? 'exit',
@@ -781,6 +786,7 @@ export function buildStatusBarDisplay(
 export interface StatusBarProps {
   readonly agentSelectionAvailable?: boolean;
   readonly canStopActiveRun?: () => boolean;
+  readonly commandName?: string;
   readonly foregroundEscapeAction?: string;
   readonly queuedFollowUpPreview?: boolean;
   readonly shortcutsActive?: boolean;
@@ -818,6 +824,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     elapsedMs: runStartedAt !== undefined ? now - runStartedAt : undefined,
     pendingExitHint,
     pendingExitResumeId,
+    commandName: props.commandName,
     bypass: statusSlice?.bypass ?? NO_BYPASS,
     thinkingActive: statusSlice?.thinkingActive ?? false,
     queuedFollowUpMessages: statusSlice?.queuedFollowUpMessages ?? [],

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -466,6 +466,7 @@ export function chatTuiFocusedChildFollowUpRoute(): ChatTuiFocusedChildFollowUpR
 
 interface SlashCommandContext {
   readonly session: TuiSession;
+  readonly commandName?: string;
   readonly initialAgent: string;
   readonly initialModel: string;
   readonly interruptActive: () => void;
@@ -901,6 +902,7 @@ async function handleTuiSlashCommand(
           // Only surface the resume id once a stream exists — never next to
           // a "not started" status.
           sessionId: slice ? context.session.executionId : undefined,
+          commandName: context.commandName,
           queuedFollowUpMessages:
             activeStreamId === undefined
               ? []
@@ -1072,6 +1074,7 @@ export async function runChat(
   // resumeAgentRun) are all defined before the first use.
   const slashCommandContext = (): SlashCommandContext => ({
     session,
+    commandName: context.commandName,
     initialAgent: agent,
     initialModel: model,
     interruptActive,
@@ -1651,6 +1654,7 @@ export async function runChat(
       canInterruptActiveRun={canInterruptActiveRun}
       canStopActiveRun={canStopActiveRun}
       colorEnabled={stdoutColorEnabled}
+      commandName={context.commandName}
       onInterruptActive={interruptActive}
       onTranscriptViewportChange={repaintTranscriptViewport}
       onCtrlC={() => handleSigint()}
@@ -1726,6 +1730,7 @@ export async function runChat(
         streams,
       }),
       collectResumeUsage(streams),
+      context.commandName,
     );
     if (hint) writeTextStdout(`\n${hint}`);
   };

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -2,6 +2,7 @@ import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { truncateSummary } from '@utils/text/stringUtils';
 
+import { formatResumeCommand } from './state/resumeHint';
 import type { BypassState } from './state/cliState';
 
 const QUEUED_FOLLOW_UP_STATUS_LENGTH = 160;
@@ -18,6 +19,7 @@ export interface CliSessionStatusInput {
   /** Root execution id, when a run has started. Surfaces the resume command
    *  mid-session instead of only in the exit hint. */
   readonly sessionId?: string;
+  readonly commandName?: string;
 }
 
 export function formatCliStatusLabel(status: string | undefined): string {
@@ -68,7 +70,10 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
     ...(input.sessionId
       ? [
           `session: ${input.sessionId}`,
-          `resume later with: texra --resume ${input.sessionId}`,
+          `resume later with: ${formatResumeCommand(
+            input.commandName,
+            input.sessionId,
+          )}`,
         ]
       : []),
     ...queuedFollowUpStatusLines(input.queuedFollowUpMessages),

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -30,6 +30,15 @@ export type ResumeUsageStats = TokenUsageStats & {
   readonly reasoningTokens?: number;
 };
 
+const DEFAULT_RESUME_COMMAND_NAME = 'texra';
+
+export function formatResumeCommand(
+  commandName: string | undefined,
+  executionId: string,
+): string {
+  return `${commandName || DEFAULT_RESUME_COMMAND_NAME} --resume ${executionId}`;
+}
+
 function formatInteger(value: number): string {
   return new Intl.NumberFormat('en-US').format(value);
 }
@@ -126,13 +135,16 @@ export function collectResumeTargets({
 export function formatResumeHint(
   targets: readonly ResumeTarget[],
   usage?: ResumeUsageStats,
+  commandName?: string,
 ): string | undefined {
   if (targets.length === 0) return undefined;
   const lines = [formatResumeUsage(usage), 'Resume this session with:'].filter(
     (line): line is string => Boolean(line),
   );
   for (const target of targets) {
-    lines.push(`  texra --resume ${target.executionId}  (${target.label})`);
+    lines.push(
+      `  ${formatResumeCommand(commandName, target.executionId)}  (${target.label})`,
+    );
   }
   return lines.join('\n');
 }

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -8,6 +8,7 @@ import {
   explainNonResumable,
   resolveCliResumeSnapshot,
 } from '../runtime/sessionResume';
+import { formatResumeCommand } from '../chat/tui/state/resumeHint';
 import {
   formatInteractiveTerminalFailure,
   interactiveTerminalFailure,
@@ -34,15 +35,23 @@ export async function runResumeExecution(
 ): Promise<number> {
   const terminalFailure = interactiveTerminalFailure(context);
   if (terminalFailure) {
+    const commandName = context.commandName || 'texra';
+    const runCommand = `${commandName} run`;
     // A resumed tool-use session goes back to WAITING for the next message;
     // headless has no input channel to provide one, so continuing here would
     // block forever. Reject before platform/snapshot work; no terminal means no
     // interactive resume regardless of whether the id is otherwise resumable.
     writeTextStderr(
       formatInteractiveTerminalFailure(terminalFailure, {
-        headlessMessage: `Resuming continues an interactive chat session — run \`texra --resume ${id}\` in a terminal. For scripting, use \`texra run\`.`,
+        headlessMessage: `Resuming continues an interactive chat session — run \`${formatResumeCommand(
+          commandName,
+          id,
+        )}\` in a terminal. For scripting, use \`${runCommand}\`.`,
         dumbTerminalCommand: 'resume',
-        dumbTerminalOptions: { nonInteractiveFallback: '`texra run`' },
+        dumbTerminalOptions: {
+          commandName,
+          nonInteractiveFallback: `\`${runCommand}\``,
+        },
       }),
     );
     return CliExitCode.Usage;

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -50,6 +50,7 @@ export interface CliContext {
   readonly stderrColorEnabled?: boolean;
   /** Back-compat alias for `stderrColorEnabled`. */
   readonly colorEnabled: boolean;
+  readonly commandName?: string;
   readonly version: string;
   readonly resourcesPath: string;
   readonly cliConfig?: CliConfigValues;
@@ -182,6 +183,12 @@ export function isTexraCliEntrypointPath(entrypointPath: string): boolean {
     name === 'texra.mjs' ||
     name === 'texra.ts'
   );
+}
+
+export function resolveCliCommandName(entrypointPath: string): string {
+  return path.basename(entrypointPath).toLowerCase() === 'texra-local'
+    ? 'texra-local'
+    : 'texra';
 }
 
 interface CliPackageManifest {
@@ -435,6 +442,7 @@ export async function buildCliContext(
     stdoutColorEnabled,
     stderrColorEnabled,
     colorEnabled: stderrColorEnabled,
+    commandName: resolveCliCommandName(readCliEntrypointPath()),
     version: await readCliVersion(),
     resourcesPath: resolveCliResourcesPath(),
     cliConfig: loadedConfig.values,

--- a/packages/cli/src/runtime/terminalRequirements.ts
+++ b/packages/cli/src/runtime/terminalRequirements.ts
@@ -14,13 +14,14 @@ export function interactiveTerminalFailure(
 
 export function dumbTerminalMessage(
   command: string,
-  options: { nonInteractiveFallback?: string } = {},
+  options: { commandName?: string; nonInteractiveFallback?: string } = {},
 ): string {
+  const commandName = options.commandName || 'texra';
   const fallback =
     options.nonInteractiveFallback == null
       ? ''
       : ` For non-interactive runs, use ${options.nonInteractiveFallback}.`;
-  return `texra ${command} needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with \`TERM=xterm-256color\`.${fallback}`;
+  return `${commandName} ${command} needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with \`TERM=xterm-256color\`.${fallback}`;
 }
 
 export function formatInteractiveTerminalFailure(
@@ -28,7 +29,10 @@ export function formatInteractiveTerminalFailure(
   options: {
     readonly headlessMessage: string;
     readonly dumbTerminalCommand: string;
-    readonly dumbTerminalOptions?: { readonly nonInteractiveFallback?: string };
+    readonly dumbTerminalOptions?: {
+      readonly commandName?: string;
+      readonly nonInteractiveFallback?: string;
+    };
   },
 ): string {
   if (reason === 'headless') return options.headlessMessage;

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -12,6 +12,7 @@ import {
   readCliEnv,
   readCliVersion,
   resolveCliCwd,
+  resolveCliCommandName,
   resolveStreamColor,
   type CliAmbientState,
 } from '@cli/runtime/cliContext';
@@ -62,6 +63,14 @@ describe('CLI entrypoint detection', () => {
       isTexraCliEntrypointPath('/repo/packages/cli/src/bin/texra.ts'),
     ).toBe(true);
     expect(isTexraCliEntrypointPath('/usr/local/bin/vitest')).toBe(false);
+  });
+
+  it('uses the local launcher name in user-facing command hints', () => {
+    expect(resolveCliCommandName('/usr/local/bin/texra')).toBe('texra');
+    expect(resolveCliCommandName('/tmp/bin/texra-local')).toBe('texra-local');
+    expect(resolveCliCommandName('/repo/packages/cli/dist/bin/texra.js')).toBe(
+      'texra',
+    );
   });
 });
 

--- a/src/test-kernel/cli/ResumeCommand.vitest.mts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.mts
@@ -106,6 +106,24 @@ describe('runResumeExecution', () => {
     );
   });
 
+  it('uses the local launcher in headless resume guidance', async () => {
+    const { runResumeExecution } = await import('@cli/commands/resume');
+
+    await expect(
+      runResumeExecution(
+        cliContext({ commandName: 'texra-local', stdoutIsTty: false }),
+        EXECUTION_ID,
+      ),
+    ).resolves.toBe(2);
+
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      expect.stringContaining(`texra-local --resume ${EXECUTION_ID}`),
+    );
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      expect.stringContaining('For scripting, use `texra-local run`.'),
+    );
+  });
+
   it('rejects resume in dumb terminals before falling through to chat', async () => {
     const { runResumeExecution } = await import('@cli/commands/resume');
 
@@ -118,6 +136,21 @@ describe('runResumeExecution', () => {
     expect(mocks.runChat).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       'texra resume needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with `TERM=xterm-256color`. For non-interactive runs, use `texra run`.',
+    );
+  });
+
+  it('uses the local launcher in dumb-terminal resume guidance', async () => {
+    const { runResumeExecution } = await import('@cli/commands/resume');
+
+    await expect(
+      runResumeExecution(
+        cliContext({ commandName: 'texra-local', termIsDumb: true }),
+        EXECUTION_ID,
+      ),
+    ).resolves.toBe(2);
+
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'texra-local resume needs a capable terminal: TERM=dumb disables the cursor controls Ink uses. If this is an interactive PTY, prefix the command with `TERM=xterm-256color`. For non-interactive runs, use `texra-local run`.',
     );
   });
 

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   collectResumeUsage,
   collectResumeTargets,
+  formatResumeCommand,
   formatResumeHint,
   formatResumeUsage,
   type ResumeUsageStats,
@@ -125,6 +126,13 @@ describe('collectResumeTargets', () => {
 });
 
 describe('formatResumeHint', () => {
+  it('formats resume commands with a local launcher when provided', () => {
+    expect(formatResumeCommand(undefined, 'root')).toBe('texra --resume root');
+    expect(formatResumeCommand('texra-local', 'root')).toBe(
+      'texra-local --resume root',
+    );
+  });
+
   it('renders one resume line per target', () => {
     expect(
       formatResumeHint([
@@ -136,6 +144,25 @@ describe('formatResumeHint', () => {
         'Resume this session with:',
         '  texra --resume root  (main)',
         '  texra --resume rev  (reviewer)',
+      ].join('\n'),
+    );
+  });
+
+  it('uses the provided command name for every resume target', () => {
+    expect(
+      formatResumeHint(
+        [
+          { executionId: 'root', label: 'main', isRoot: true },
+          { executionId: 'rev', label: 'reviewer', isRoot: false },
+        ],
+        undefined,
+        'texra-local',
+      ),
+    ).toBe(
+      [
+        'Resume this session with:',
+        '  texra-local --resume root  (main)',
+        '  texra-local --resume rev  (reviewer)',
       ].join('\n'),
     );
   });

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -103,6 +103,21 @@ describe('CLI session status formatter', () => {
     expect(status).toContain('resume later with: texra --resume abc123');
   });
 
+  it('uses the provided command name in the resume status line', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'personal',
+      approval: 'ask',
+      status: 'running',
+      sessionId: 'abc123',
+      commandName: 'texra-local',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).toContain('resume later with: texra-local --resume abc123');
+  });
+
   it('omits session lines before the first run starts', () => {
     const status = formatCliSessionStatus({
       agent: 'chat',

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1211,6 +1211,31 @@ describe('CLI StatusBar display model', () => {
     );
   });
 
+  it('uses the provided command name in the armed-exit resume command', () => {
+    const display = buildStatusBarDisplay({
+      status: STREAM_STATUS.RUNNING,
+      pendingExitHint: true,
+      pendingExitResumeId: 'abc123',
+      commandName: 'texra-local',
+      bypass: NO_BYPASS,
+      queuedFollowUpMessages: [],
+      usage: undefined,
+      conversation: undefined,
+      activeSubagents: 0,
+      activeProcesses: 0,
+      approvalDepth: 0,
+      subagentControlsAvailable: false,
+      hasMultipleStreams: false,
+      model: 'deepseekT',
+      apiMode: PERSONAL_API_MODE_LABEL,
+      shortcutModifierLabel: 'Alt',
+    });
+
+    expect(display.bindings).toBe(
+      'Resume this session with: texra-local --resume abc123',
+    );
+  });
+
   it('warns that queued follow-ups are discarded while exit is armed', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,


### PR DESCRIPTION
## Summary
- Derive the user-facing CLI command name once in `CliContext`, preserving `texra-local` only when that launcher is actually used.
- Thread the command name through `/status`, the armed-exit status bar hint, exit scrollback resume hints, and non-TTY resume guidance.
- Keep published/source entrypoints on the canonical `texra --resume ...` command.

## Dogfood Evidence
- Fresh-main `texra-local doctor --output-format json` was green.
- `validate:tui` snapshots passed for slash palette, bash approval, subagents, subagent picker, task picker, and orchestrate launcher.
- Real TTY dogfood found the bug after launching via `texra-local`: exit scrollback suggested `texra --resume ...`.
- After the fix, a real TTY run showed `/status` as `resume later with: texra-local --resume acda31a35c0f` and exit scrollback as `texra-local --resume acda31a35c0f  (main)`.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ResumeHint.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/CliContext.vitest.mts src/test-kernel/cli/ResumeCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec prettier --check ... && git diff --check`
- `npm run texra-local:build && npm run texra-local:link`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing string changes only; no runtime behavior, auth, or persistence logic is altered beyond how command hints are formatted.
> 
> **Overview**
> User-facing CLI hints no longer hard-code `texra` when the session was started via the **`texra-local`** launcher.
> 
> **`resolveCliCommandName`** is set once on **`CliContext`** from the entrypoint basename (`texra-local` only for that binary; otherwise **`texra`**). **`formatResumeCommand`** centralizes `` `<name> --resume <id>` `` formatting with a **`texra`** default when the name is omitted.
> 
> That name is passed through the TUI (**`/status`**, armed-exit status bar, exit scrollback resume lines) and non-interactive resume errors (headless / **`TERM=dumb`**, including the suggested `` `<name> run` `` fallback). **`dumbTerminalMessage`** accepts an optional **`commandName`** for the same pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf82219297c44324c11dde92f4f4bea5ed373f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->