### PR TITLE
[codex] fix slash palette escape recovery

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -469,6 +469,28 @@ const SCENARIOS = [
     unexpect: ['/\u0015/model', '/model - error'],
   },
   {
+    name: 'slash-palette-esc-retypes-command',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT,
+    },
+    keys: ['/', `${ESC}/agent\r`],
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: [
+      '/agent',
+      'Tool-use and delegating agents',
+      'texra chat --agent=<name>',
+    ],
+    unexpect: ['//agent', 'Harness received: //agent', '/agent - error'],
+  },
+  {
+    name: 'slash-palette-csi-escape-ignored',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/', `${ESC}[13:2u`],
+    expect: ['│ › /'],
+    unexpect: ['[13:2u', 'Harness received'],
+  },
+  {
     name: 'plain-submit',
     cols: 120,
     env: { HARNESS_ENTRIES: '2' },

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -15,6 +15,7 @@ import {
   verticalCursorMove,
   type CursorEdit,
   type TextEdit,
+  type TextInputChunkEdit,
 } from './textInputEditing';
 import { matchTextInputBinding } from './textInputBindings';
 import {
@@ -27,6 +28,8 @@ import {
 } from './inputKeys';
 import { ImagePasteQueue, withImagePasteTimeout } from './imagePasteQueue';
 import { textDisplayWidth } from '../render/terminalText';
+
+const ESC_SLASH_PREFIX = '\u001B/';
 
 export interface BaseTextInputProps {
   readonly value: string;
@@ -58,6 +61,21 @@ export interface BaseTextInputProps {
   readonly onImagePaste?: () => Promise<string | null>;
   readonly onImagePasteError?: (error: unknown) => void;
   readonly imagePasteQueue?: ImagePasteQueue;
+  /** Optional parent-owned value ref for same-tick programmatic draft changes. */
+  readonly readLatestValue?: () => string;
+  /** Optional parent-owned edit applied before a raw terminal chunk is handled. */
+  readonly prepareInputChunk?: (
+    input: string,
+    value: string,
+    cursor: number,
+  ) => TextEdit | undefined;
+  readonly shouldDropInputChunk?: (
+    input: string,
+    value: string,
+    cursor: number,
+  ) => boolean;
+  /** Apply an edit when Escape is received before normal text handling. */
+  readonly escapeEdit?: CursorEdit;
   /** Render the value as bullets (secret entry, e.g. an API key). Display-only:
    *  the captured value, edits, and paste are unaffected. */
   readonly masked?: boolean;
@@ -372,6 +390,40 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     [isControlled, onChange, onCursorChange],
   );
 
+  const syncLatestExternalValue = useCallback((): TextEdit => {
+    const externalValue = props.readLatestValue?.();
+    const latest = latestStateRef.current;
+    if (externalValue === undefined || externalValue === latest.value) {
+      return latest;
+    }
+    const cursor = clampCursor(latest.cursor, externalValue.length);
+    const next = { value: externalValue, cursor };
+    latestStateRef.current = next;
+    if (!isControlled) setInternalCursor(cursor);
+    onCursorChange?.(cursor);
+    return next;
+  }, [isControlled, onCursorChange, props.readLatestValue]);
+
+  const prepareInputChunkState = useCallback(
+    (input: string): TextEdit => {
+      const latest = syncLatestExternalValue();
+      const prepared = props.prepareInputChunk?.(
+        input,
+        latest.value,
+        latest.cursor,
+      );
+      if (prepared === undefined) return latest;
+      const next = {
+        value: prepared.value,
+        cursor: clampCursor(prepared.cursor, prepared.value.length),
+      };
+      latestStateRef.current = next;
+      lastEmittedValueRef.current = next.value;
+      return next;
+    },
+    [props.prepareInputChunk, syncLatestExternalValue],
+  );
+
   const insertIntoLatestDraft = useCallback(
     (text: string) => {
       const { value: v, cursor: c } = latestStateRef.current;
@@ -401,16 +453,43 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     [imagePasteQueue],
   );
 
+  const commitInputChunkEdit = useCallback(
+    (edit: TextInputChunkEdit, previous: TextEdit) => {
+      if (edit.submit) {
+        submitAfterImagePastes(onInputChunkSubmit ?? onSubmit, edit.value);
+        return;
+      }
+      if (edit.value === previous.value && edit.cursor === previous.cursor) {
+        return;
+      }
+      applyEdit(edit);
+    },
+    [applyEdit, onInputChunkSubmit, onSubmit, submitAfterImagePastes],
+  );
+
   useInput(
     (input, key) => {
       if (isEscapeInput(input, key)) {
         imagePasteQueue.cancelDeferredAction();
+        if (props.escapeEdit) {
+          applyLatestEdit(props.escapeEdit);
+        }
         return;
       }
       if (imagePasteQueue.hasDeferredAction) {
         // A visible Enter already committed this draft. Ignore later keystrokes
         // until clipboard probes settle so the deferred submit is neither
         // overwritten nor allowed to clear a newer draft.
+        return;
+      }
+      const latestBeforeInput = syncLatestExternalValue();
+      if (
+        props.shouldDropInputChunk?.(
+          input,
+          latestBeforeInput.value,
+          latestBeforeInput.cursor,
+        ) === true
+      ) {
         return;
       }
 
@@ -457,6 +536,30 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         imagePasteQueue.track(paste);
         return;
       }
+      if (
+        input.startsWith(ESC_SLASH_PREFIX) &&
+        !key.meta &&
+        props.escapeEdit
+      ) {
+        imagePasteQueue.cancelDeferredAction();
+        const latest = syncLatestExternalValue();
+        const escaped = props.escapeEdit(latest.value, latest.cursor);
+        const escapedState = {
+          value: escaped.value,
+          cursor: clampCursor(escaped.cursor, escaped.value.length),
+        };
+        latestStateRef.current = escapedState;
+        lastEmittedValueRef.current = escapedState.value;
+        commitInputChunkEdit(
+          applyTerminalInputChunk(
+            escapedState.value,
+            escapedState.cursor,
+            input.slice(1),
+          ),
+          escapedState,
+        );
+        return;
+      }
       // Drop unhandled control/meta combos; pass printable input through.
       if (
         key.meta ||
@@ -468,14 +571,11 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         return;
       }
       const { value: latestValue, cursor: latestCursor } =
-        latestStateRef.current;
-      const edit = applyTerminalInputChunk(latestValue, latestCursor, input);
-      if (edit.submit) {
-        submitAfterImagePastes(onInputChunkSubmit ?? onSubmit, edit.value);
-        return;
-      }
-      if (edit.value === latestValue && edit.cursor === latestCursor) return;
-      applyEdit(edit);
+        prepareInputChunkState(input);
+      commitInputChunkEdit(
+        applyTerminalInputChunk(latestValue, latestCursor, input),
+        { value: latestValue, cursor: latestCursor },
+      );
     },
     { isActive: focus },
   );

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -536,11 +536,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         imagePasteQueue.track(paste);
         return;
       }
-      if (
-        input.startsWith(ESC_SLASH_PREFIX) &&
-        !key.meta &&
-        props.escapeEdit
-      ) {
+      if (input.startsWith(ESC_SLASH_PREFIX) && !key.meta && props.escapeEdit) {
         imagePasteQueue.cancelDeferredAction();
         const latest = syncLatestExternalValue();
         const escaped = props.escapeEdit(latest.value, latest.cursor);

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -23,7 +23,10 @@ import {
   type SlashPickIntent,
 } from '../commands/slashRegistry';
 import { cliState } from '../state/cliState';
+import type { CursorEdit } from '../input/textInputEditing';
 import type { InputHistory } from '../history/inputHistory';
+
+const CSI_SEQUENCE_TAIL_RE = /^\[[0-?]*[ -/]*[@-~]$/u;
 
 export interface InputBarProps {
   /** Forwarded to BaseTextInput; called only on real (non-paste) Enter.
@@ -127,6 +130,24 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
     setValue('');
     attachmentsRef.current.clear();
   }, [setValue]);
+  const clearDraftEdit = useCallback<CursorEdit>(() => {
+    clearDraft();
+    return { value: '', cursor: 0 };
+  }, [clearDraft]);
+  const replaceSlashTriggerInput = useCallback(
+    (input: string, value: string, cursor: number) => {
+      if (value === '/' && cursor === 1 && input.startsWith('/')) {
+        return { value: '', cursor: 0 };
+      }
+      return undefined;
+    },
+    [],
+  );
+  const dropSlashPaletteControlTail = useCallback(
+    (input: string, value: string, cursor: number) =>
+      value === '/' && cursor === 1 && CSI_SEQUENCE_TAIL_RE.test(input),
+    [],
+  );
   const replaceDraft = useCallback(
     (next: string) => {
       setValue(next);
@@ -341,6 +362,14 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
             onHistoryUp={showPalette ? undefined : () => browseHistory(-1)}
             onHistoryDown={showPalette ? undefined : () => browseHistory(1)}
             imagePasteQueue={imagePasteQueue}
+            readLatestValue={() => draftValueRef.current}
+            prepareInputChunk={
+              showPalette ? replaceSlashTriggerInput : undefined
+            }
+            shouldDropInputChunk={
+              showPalette ? dropSlashPaletteControlTail : undefined
+            }
+            escapeEdit={showPalette ? clearDraftEdit : undefined}
             transformPaste={transformPaste}
             onImagePaste={onImagePaste}
             onImagePasteError={(error) =>


### PR DESCRIPTION
## Summary
- Keep the chat input editor in sync with parent-owned draft changes while the slash palette is open.
- Clear the palette trigger only for `Esc` immediately followed by a retyped slash command, avoiding broader CSI handling.
- Drop CSI-style terminal tails while the palette draft is still the lone `/`, so Kitty/modified-key sequences do not corrupt the input.
- Add PTY validator scenarios for `/` then `Esc` plus `/agent`, and for CSI Escape tails while the palette is open.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TextInputEditing.vitest.mts src/test-kernel/cli/InputBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /private/tmp/texra-cli-dogfood-0612-round5-frames-fix slash-palette-esc-retypes-command slash-palette-csi-escape-ignored slash-palette-ctrl-u-clears-raw-control agent-form`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (0 errors; existing import-order warnings remain outside touched files)
- Manual TTY: opened `/`, then sent `Esc` + `/agent` + Enter; the agent picker opened and no `//agent` prompt was submitted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to TUI chat input and slash-palette behavior with new validator coverage; no auth, API, or data-path changes.
> 
> **Overview**
> Fixes **slash palette** input bugs where Escape and Kitty-style terminal sequences could leave a stale lone `/` or produce `//agent` instead of a clean `/agent` command.
> 
> **`BaseTextInput`** gains parent hooks (`readLatestValue`, `prepareInputChunk`, `shouldDropInputChunk`, `escapeEdit`) so the editor can sync with programmatic draft clears in the same tick. Escape-then-retyped slash is handled via an `\u001B/` prefix path that clears via `escapeEdit` and applies the following characters as normal input.
> 
> **`InputBar`** wires those hooks while the palette is open: Esc clears the draft, retyping `/` on a lone trigger is normalized, and CSI tails like `[13:2u` are dropped so modified-key sequences do not corrupt the prompt.
> 
> **`validate-tui.mjs`** adds PTY scenarios for Esc + `/agent` and for ignored CSI escape tails with the palette open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b1509b507c4823807dddc3da60f50d805b19ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->