### PR TITLE
[codex] fix executions wait timeout cap

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -22,6 +22,7 @@ import {
   BASH_TOOL_DEFAULT_TIMEOUT_MS,
   EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
   EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+  EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
 } from '@shared/constants/toolDefaults';
 import { isObject } from '@utils/core';
 import {
@@ -63,7 +64,10 @@ export const EXECUTIONS_DEFAULT_ACTION = 'view';
 
 export function getExecutionsWaitTimeoutSeconds(timeout: unknown): number {
   return typeof timeout === 'number' && Number.isFinite(timeout)
-    ? Math.min(timeout, EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS)
+    ? Math.min(
+        Math.max(timeout, EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS),
+        EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+      )
     : EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS;
 }
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -46,12 +46,6 @@ const TOOL_DEFAULT_TIMEOUTS: Record<string, number> = {
 };
 
 /**
- * Tools whose `timeout` input field is in seconds (converted to ms for display).
- * Most tools use milliseconds directly.
- */
-const TIMEOUT_IN_SECONDS = new Set(['executions']);
-
-/**
  * Tools where the timeout only applies to a specific action value.
  * For these tools, only show the timer limit when that action is used.
  */
@@ -95,9 +89,7 @@ export function getToolTimeoutMs(
   }
 
   if (typeof input.timeout === 'number') {
-    return TIMEOUT_IN_SECONDS.has(toolName)
-      ? input.timeout * 1000
-      : input.timeout;
+    return input.timeout;
   }
   return defaultTimeout;
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -21,6 +21,7 @@ import type { LogMessageData } from '@shared/schemas';
 import {
   BASH_TOOL_DEFAULT_TIMEOUT_MS,
   EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+  EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
 } from '@shared/constants/toolDefaults';
 import { isObject } from '@utils/core';
 import {
@@ -60,6 +61,12 @@ const TIMEOUT_GATED_BY_ACTION: Record<string, string> = {
 /** Default action for the executions tool when the model omits it. */
 export const EXECUTIONS_DEFAULT_ACTION = 'view';
 
+export function getExecutionsWaitTimeoutSeconds(timeout: unknown): number {
+  return typeof timeout === 'number' && Number.isFinite(timeout)
+    ? Math.min(timeout, EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS)
+    : EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS;
+}
+
 /**
  * Extract the effective timeout for a tool call from its input.
  * Returns undefined for tools without a configurable timeout.
@@ -78,6 +85,10 @@ export function getToolTimeoutMs(
 
   // Background tools return immediately — timeout timer is misleading
   if (input.run_in_background === true) return undefined;
+
+  if (toolName === 'executions') {
+    return getExecutionsWaitTimeoutSeconds(input.timeout) * 1000;
+  }
 
   if (typeof input.timeout === 'number') {
     return TIMEOUT_IN_SECONDS.has(toolName)

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -58,6 +58,7 @@ import { codexToolRenderers } from '../codexToolTemplates';
 import {
   buildToolSection,
   getOutputEdits,
+  getExecutionsWaitTimeoutSeconds,
   isMcpTextBlock,
   EXECUTIONS_DEFAULT_ACTION,
 } from './helpers';
@@ -220,7 +221,7 @@ function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
   }
 
   if (action === 'wait') {
-    const timeout = execInput.timeout ?? 300;
+    const timeout = getExecutionsWaitTimeoutSeconds(execInput.timeout);
     sections.push(
       buildToolUseSection('Action:', wrapInPre(`wait (timeout: ${timeout}s)`)),
     );

--- a/src/shared/constants/toolDefaults.ts
+++ b/src/shared/constants/toolDefaults.ts
@@ -10,3 +10,6 @@ export const BASH_TOOL_DEFAULT_TIMEOUT_MS = 120_000;
 
 /** Default `executions wait` timeout (seconds) when the model omits `timeout`. */
 export const EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS = 300;
+
+/** Maximum `executions wait` timeout (seconds). */
+export const EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS = 1800;

--- a/src/shared/constants/toolDefaults.ts
+++ b/src/shared/constants/toolDefaults.ts
@@ -11,5 +11,8 @@ export const BASH_TOOL_DEFAULT_TIMEOUT_MS = 120_000;
 /** Default `executions wait` timeout (seconds) when the model omits `timeout`. */
 export const EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS = 300;
 
+/** Minimum `executions wait` timeout (seconds). */
+export const EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS = 60;
+
 /** Maximum `executions wait` timeout (seconds). */
 export const EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS = 1800;

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -98,6 +98,9 @@ describe('tool-use formatter', () => {
     };
 
     expect(getToolTimeoutMs('executions', input)).toBe(1_800_000);
+    expect(getToolTimeoutMs('executions', { ...input, timeout: 30 })).toBe(
+      60_000,
+    );
 
     const container = document.createElement('div');
     render(formatToolUseTemplate(message), container);

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -73,4 +73,36 @@ describe('tool-use formatter', () => {
     expect(container.textContent).toContain('src/main.ts');
     expect(container.textContent).not.toContain('Failed to render');
   });
+
+  it('caps executions wait timeout displays at the tool maximum', async () => {
+    const { formatToolUseTemplate } =
+      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
+    const { getToolTimeoutMs } =
+      await import('@progressView/frontend/formatters/logFormatters/toolFormatters/helpers');
+    const { render } = await import('lit');
+    const input = {
+      path: '/executions/abc123',
+      action: 'wait',
+      timeout: 3600,
+    };
+    const message: LogMessageData = {
+      id: 'executions-timeout',
+      text: '',
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: 'toolUse',
+      data: {
+        toolName: 'executions',
+        input,
+      },
+    };
+
+    expect(getToolTimeoutMs('executions', input)).toBe(1_800_000);
+
+    const container = document.createElement('div');
+    render(formatToolUseTemplate(message), container);
+
+    expect(container.textContent).toContain('wait (timeout: 1800s)');
+    expect(container.textContent).not.toContain('3600s');
+  });
 });

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -43,7 +43,7 @@ const config = {
   toolConfig: DEFAULT_TOOL_CONFIG,
 } as AgentConfig;
 
-describe('ExecutionsTool workspace files', () => {
+describe('ExecutionsTool', () => {
   beforeEach(async () => {
     const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
       await Promise.all([
@@ -55,6 +55,18 @@ describe('ExecutionsTool workspace files', () => {
     vi.clearAllMocks();
     mocks.listExecutions.mockResolvedValue([]);
     mocks.readWorkspaceFiles.mockResolvedValue([]);
+  });
+
+  it('caps oversized wait timeouts instead of rejecting the tool call', async () => {
+    const result = await new ExecutionsTool().call({
+      path: '/executions',
+      action: 'wait',
+      timeout: 3600,
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.output).toBe('No execution history found.');
   });
 
   it('lists and reads persisted workspace files for tool-use executions', async () => {

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -69,6 +69,18 @@ describe('ExecutionsTool', () => {
     expect(result.output).toBe('No execution history found.');
   });
 
+  it('raises sub-minimum wait timeouts instead of rejecting the tool call', async () => {
+    const result = await new ExecutionsTool().call({
+      path: '/executions',
+      action: 'wait',
+      timeout: 30,
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.output).toBe('No execution history found.');
+  });
+
   it('rejects non-finite wait timeouts', async () => {
     const result = await new ExecutionsTool().call({
       path: '/executions',

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -69,6 +69,17 @@ describe('ExecutionsTool', () => {
     expect(result.output).toBe('No execution history found.');
   });
 
+  it('rejects non-finite wait timeouts', async () => {
+    const result = await new ExecutionsTool().call({
+      path: '/executions',
+      action: 'wait',
+      timeout: Number.NaN,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain('Invalid input');
+  });
+
   it('lists and reads persisted workspace files for tool-use executions', async () => {
     const workspace = await mkdtemp(path.join(tmpdir(), 'texra-exec-files-'));
     try {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -123,6 +123,7 @@ const ExecutionsToolInputSchema = z.strictObject({
   /** Max seconds to wait (action="wait" only). Default: 300. */
   timeout: z
     .number()
+    .finite()
     .min(60)
     .max(EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS)
     .nullish()
@@ -166,6 +167,7 @@ const normalizeExecutionsToolInput = (input: unknown): unknown => {
   const record = input as Record<string, unknown>;
   if (
     typeof record.timeout !== 'number' ||
+    !Number.isFinite(record.timeout) ||
     record.timeout <= EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS
   ) {
     return input;

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -35,6 +35,7 @@ import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
 import {
   EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
   EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+  EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
 } from '@shared/constants/toolDefaults';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { requireRunStream } from '@tools/contextHelpers';
@@ -124,7 +125,7 @@ const ExecutionsToolInputSchema = z.strictObject({
   timeout: z
     .number()
     .finite()
-    .min(60)
+    .min(EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS)
     .max(EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS)
     .nullish()
     .describe(
@@ -155,7 +156,10 @@ export type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
 
 const normalizeWaitTimeout = (timeout: number | null | undefined): number =>
   Math.min(
-    timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+    Math.max(
+      timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+      EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
+    ),
     EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
   );
 
@@ -168,14 +172,15 @@ const normalizeExecutionsToolInput = (input: unknown): unknown => {
   if (
     typeof record.timeout !== 'number' ||
     !Number.isFinite(record.timeout) ||
-    record.timeout <= EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS
+    (record.timeout >= EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS &&
+      record.timeout <= EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS)
   ) {
     return input;
   }
 
   return {
     ...record,
-    timeout: EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+    timeout: normalizeWaitTimeout(record.timeout),
   };
 };
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -32,7 +32,10 @@ import { executionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptio
 // Local imports - utils
 import { toErrorMessage } from '@common/errors';
 import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
-import { EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS } from '@shared/constants/toolDefaults';
+import {
+  EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+  EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+} from '@shared/constants/toolDefaults';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { requireRunStream } from '@tools/contextHelpers';
 import { AbsoluteFS, StorageFS } from '@utils/files';
@@ -121,10 +124,10 @@ const ExecutionsToolInputSchema = z.strictObject({
   timeout: z
     .number()
     .min(60)
-    .max(1800)
+    .max(EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS)
     .nullish()
     .describe(
-      'Max seconds to wait for a status change (action="wait" only). Default: 300, max: 1800.',
+      `Max seconds to wait for a status change (action="wait" only). Default: ${EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS}, values above ${EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS} are capped.`,
     ),
 
   /** Zero-based offset for paginating the /executions listing (action="view" only). */
@@ -148,6 +151,31 @@ const ExecutionsToolInputSchema = z.strictObject({
 });
 
 export type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
+
+const normalizeWaitTimeout = (timeout: number | null | undefined): number =>
+  Math.min(
+    timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+    EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+  );
+
+const normalizeExecutionsToolInput = (input: unknown): unknown => {
+  if (input == null || typeof input !== 'object' || Array.isArray(input)) {
+    return input;
+  }
+
+  const record = input as Record<string, unknown>;
+  if (
+    typeof record.timeout !== 'number' ||
+    record.timeout <= EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS
+  ) {
+    return input;
+  }
+
+  return {
+    ...record,
+    timeout: EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
+  };
+};
 
 export class ExecutionsTool extends defineTool({
   name: 'executions',
@@ -176,6 +204,10 @@ Use action: "kill" on /executions/{id} to terminate a running execution.
 Use action: "subscribe" on /executions/{id} to receive future status, progress, and termination events as <execution-activity> follow-ups (auto-disposes when the execution finishes or this stream is released). Use action: "unsubscribe" on /executions/{id} to stop them.`,
   schema: ExecutionsToolInputSchema,
 }) {
+  override validate(input: unknown): ExecutionsToolInput {
+    return ExecutionsToolInputSchema.parse(normalizeExecutionsToolInput(input));
+  }
+
   protected async execute(input: ExecutionsToolInput): Promise<ToolResult> {
     const segments = getPathSegments(input.path);
     const [namespace, id, resource, ...rest] = segments;
@@ -195,7 +227,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       }
       if (input.action === 'wait')
         await this.waitForAnyChange(
-          input.timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+          normalizeWaitTimeout(input.timeout),
           input.ids,
         );
       return this.listExecutions(input.offset ?? 0, input.limit ?? 100);
@@ -218,7 +250,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       if (input.action === 'wait')
         await this.waitForChange(
           executionId,
-          input.timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+          normalizeWaitTimeout(input.timeout),
         );
       return this.showSummary(executionId);
     }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -129,7 +129,7 @@ const ExecutionsToolInputSchema = z.strictObject({
     .max(EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS)
     .nullish()
     .describe(
-      `Max seconds to wait for a status change (action="wait" only). Default: ${EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS}, values above ${EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS} are capped.`,
+      `Max seconds to wait for a status change (action="wait" only). Default: ${EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS}; finite values are clamped to the ${EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS}-${EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS} range.`,
     ),
 
   /** Zero-based offset for paginating the /executions listing (action="view" only). */


### PR DESCRIPTION
## Summary
- Clamp finite `executions` wait timeouts into the documented 60s-1800s range before validation so model-generated out-of-range values do not surface as user-visible `Invalid input` errors.
- Keep JSON Schema bounds in place for compatible providers while adding a local fallback for providers that ignore them.
- Keep progress-view timeout displays aligned with the effective clamped wait.
- Add regression coverage for oversized, sub-minimum, and non-finite wait timeouts plus progress-view timeout display.

## Root Cause
During CLI dogfood, the orchestrator delegated to a review subagent, then called `executions` with a `timeout` above the schema max. The tool rejected the call before it could wait/list, showed `Invalid input: expected number to be <=1800`, and only recovered on a later call.

## Validation
- `corepack pnpm vitest run src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts src/test-kernel/progressView/ToolUseFormatter.vitest.mts`
- `npm run typecheck`
- `npm run lint` (0 errors, existing import-order/naming warnings)
- `npm run compile:fast`
- Earlier on the first commit, `npm test` still had 3 unrelated failures in `src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts` with `no data in serverIn yet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to executions wait input handling and progress-view timeout display; behavior change is intentional clamping rather than stricter rejection.
> 
> **Overview**
> **Clamps `executions` `wait` timeouts** so model-supplied values outside **60s–1800s** are adjusted before validation instead of failing with `Invalid input`. Shared min/max constants live in `toolDefaults.ts`; `ExecutionsTool` normalizes input in `validate()` and uses the same bounds when waiting. **Non-finite** timeouts (e.g. `NaN`) still fail validation.
> 
> The **progress view** shows the **effective** clamped wait timeout (timer and `wait (timeout: …s)` text) via `getExecutionsWaitTimeoutSeconds`, replacing the old seconds-vs-ms heuristic for `executions`.
> 
> Regression tests cover oversized/sub-minimum waits, non-finite rejection, and UI display at the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c538ba24323ff3cc54c20a5b26aa930825e5cac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->