### PR TITLE
[codex] fix wide tool edit approval buttons

### DIFF
--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -139,9 +139,8 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   /* Per-panel basis tunes how many action buttons fit per row before wrapping.
-     Default 8rem (retry / inquiry / question); approval / bash / plan want
-     wider rows, the workflow proposal narrower. */
-  .approval-request__actions,
+     Default 8rem (retry / inquiry / question); bash / plan want wider rows,
+     the workflow proposal narrower. Tool edit approvals stay compact below. */
   .bash-approval-request__actions,
   .plan-approval-request__actions {
     --action-button-basis: 12rem;
@@ -151,9 +150,18 @@ export const requestPanelStyles: CSSResult = css`
     --action-button-basis: 6rem;
   }
 
+  .approval-request__actions wa-button[data-action] {
+    flex: 0 0 auto;
+    min-width: 6.5rem;
+  }
+
   :is(${ACTIONS}) wa-button[data-action]::part(base) {
     justify-content: flex-start;
     gap: ${sp.small};
+  }
+
+  .approval-request__actions wa-button[data-action]::part(base) {
+    justify-content: center;
   }
 
   /* Shared action button colors */

--- a/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
+++ b/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
@@ -19,6 +19,24 @@ function readRequestPanelStyles(): string {
 }
 
 describe('request panel styles', () => {
+  it('keeps tool edit approval actions compact', () => {
+    const source = readRequestPanelStyles();
+    const actionStart = source.indexOf(
+      '.approval-request__actions wa-button[data-action] {',
+    );
+    const baseStart = source.indexOf(
+      '.approval-request__actions wa-button[data-action]::part(base)',
+    );
+    const actionRule = source.slice(actionStart, baseStart);
+    const baseRule = source.slice(baseStart, source.indexOf('}', baseStart));
+
+    expect(actionStart).toBeGreaterThanOrEqual(0);
+    expect(baseStart).toBeGreaterThan(actionStart);
+    expect(actionRule).toContain('flex: 0 0 auto');
+    expect(actionRule).toContain('min-width: 6.5rem');
+    expect(baseRule).toContain('justify-content: center');
+  });
+
   it('keeps retry error details headers compact', () => {
     const source = readRequestPanelStyles();
     const headerStart = source.indexOf(


### PR DESCRIPTION
## Summary
- Keep tool-edit approval `Approve`/`Reject` buttons compact instead of stretching across the full action row.
- Center the compact tool-edit approval button contents while leaving other request panels on the existing shared layout.
- Add a regression guard for the tool-edit approval action CSS.

Fixes #5875

## Validation
- `corepack pnpm vitest run src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts`
- `npm run typecheck`
- `npm run lint` (0 errors, existing 25 warnings)
- `npm run compile:fast`
- `npm test` (fails only in existing local `src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts` with `no data in serverIn yet`; 439 files / 3051 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweaks for one panel type plus a source-string regression test; no auth, data, or API changes.
> 
> **Overview**
> **Tool-edit approval panels** no longer use the shared “stretch to fill row” action-button flex rules. **Approve/Reject** stay compact (`flex: 0 0 auto`, `min-width: 6.5rem`) with centered label content, while bash/plan/workflow and other request panels keep the existing shared layout.
> 
> Comments in `requestPanelStyles.ts` are updated to reflect that only bash/plan get the wider `--action-button-basis`. A **RequestPanelStyles** vitest asserts those approval-specific CSS rules remain in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c2fb25a84fe7c8a6e37d43db7c2032d511c819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->