### PR TITLE
[codex] Stabilize agent proposal approval width

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -80,6 +80,7 @@ const LONG_BASH_APPROVAL_COMMAND = [
 ].join('\n');
 const LONG_EXTERNAL_INQUIRY_ANSWER =
   'Independent check agrees: there are 22 non-degenerate triples in the displayed list, plus exactly 61 degenerate triples of the form (0,b,b), and the bounded search over integer pairs proves completeness.';
+const FULL_WIDTH_AGENT_PROPOSAL_BORDER_80 = `╔${'═'.repeat(78)}╗`;
 const ASYNC_FORM_SETTLE_MS = 12000;
 const VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT = [
   'research',
@@ -1127,6 +1128,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Spawn review?',
+      FULL_WIDTH_AGENT_PROPOSAL_BORDER_80,
       'Category: tool-use agent',
       'Review the mathematical proof',
       'more rows',

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -16,6 +16,7 @@ import {
   scrollPageRows,
   type ScrollableDisplayLine,
 } from '../render/scrollBounds';
+import { fillRows } from '../render/terminalText';
 import { KeyHints } from '../ui/KeyHints';
 import { useScrollableOffset } from '../state/useScrollableOffset';
 import type { ApprovalDecision } from '../state/approvalQueue';
@@ -259,7 +260,7 @@ export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
       >
         {displayLines.map((line, index) => (
           <Text key={index} dimColor={line.kind === 'overflow'}>
-            {line.text}
+            {fillRows(line.text, instructionWidth)}
           </Text>
         ))}
       </Box>


### PR DESCRIPTION
## Summary

Fixes #5882.

- pads visible agent proposal prompt rows to the same width used for wrapping
- keeps the `Spawn review?` approval card at a stable width while scrolling long prompts
- adds a TUI harness assertion that the normal 80-column agent proposal frame reserves the full width immediately

## Root cause

The proposal prompt was wrapped against the modal content width, but each visible prompt row was rendered as raw text. Ink therefore measured the card from the currently visible rows, so scrolling from short rows to longer rows could widen the frame.

## Validation

- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /private/tmp/tui-snap-agent-proposal-width agent-proposal-long compact-agent-proposal-scroll`
- `corepack pnpm vitest run src/test-kernel/cli/AgentProposal.vitest.mts --config vitest.config.mjs`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/modals/AgentProposal.tsx`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`

`npm test` is currently blocked by a pre-existing latest-main failure in `src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts`; rerunning that single file on latest `main` reproduces the same three failures (`no data in serverIn yet`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only layout fix in the agent proposal modal plus a harness assertion; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes unstable width on the **Spawn review?** agent proposal approval card when scrolling long prompts.
> 
> **`AgentProposal`** now renders each visible instruction row with **`fillRows(line.text, instructionWidth)`** so every row occupies the same column width as wrapping, instead of raw shorter lines that let Ink resize the **`ConfirmCard`** frame as scroll position changes.
> 
> The TUI harness **`agent-proposal-long`** scenario (80 columns) asserts the top border is a full-width double-line frame via **`FULL_WIDTH_AGENT_PROPOSAL_BORDER_80`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eedf0f70da17f823a5b60add87246b069158a1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->