### PR TITLE
[codex] Align subagent idle status label

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1505,7 +1505,7 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     expect: [
       'strategy running',
-      'leanSolver waiting',
+      'leanSolver idle',
       'reviewer error',
       '2 sub',
       '[Tab]streams',

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -780,7 +780,7 @@ function TaskDetailView({
   const metaParts = [
     item.kind === 'process' ? 'shell' : 'stream',
     item.label,
-    item.status,
+    item.statusLabel,
     item.elapsed,
   ].filter((part): part is string => Boolean(part));
   const layout = computeTaskDetailLayout({
@@ -917,7 +917,7 @@ function TaskDetailView({
         <>
           {metaLine('Type', item.kind === 'process' ? 'shell' : 'stream')}
           {metaLine('Name', item.label)}
-          {metaLine('Status', item.status)}
+          {metaLine('Status', item.statusLabel)}
           {metaLine('Runtime', item.elapsed)}
         </>
       ) : (

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -7,6 +7,7 @@
 import { Box, Text } from 'ink';
 
 import type { ActiveChildInfo } from '@shared/schemas';
+import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 
 import {
   childElapsed,
@@ -33,6 +34,10 @@ export interface ChildRow {
 
 const TAIL_LINES = 4;
 
+function childStatusLabel(status: string | undefined): string | undefined {
+  return formatStreamStatusLabel(status, { style: 'cli' });
+}
+
 export function compactChildRowText({
   child,
   nowMs,
@@ -45,8 +50,9 @@ export function compactChildRowText({
   const tailSummary = processTailLines(tail).at(-1);
   const elapsed = childElapsed(child, nowMs);
   const label = child.agentName || child.toolName || child.executionId;
+  const statusLabel = childStatusLabel(child.status);
   return [
-    `${label}${child.status ? ` ${child.status}` : ''}`,
+    `${label}${statusLabel ? ` ${statusLabel}` : ''}`,
     elapsed,
     tailSummary,
   ]
@@ -66,6 +72,7 @@ function Row({
   const tailLines = compact ? [] : processTailLines(tail).slice(-TAIL_LINES);
   const elapsed = childElapsed(child, nowMs);
   const label = child.agentName || child.toolName || child.executionId;
+  const statusLabel = childStatusLabel(child.status);
   return (
     <Box
       flexDirection="column"
@@ -84,7 +91,7 @@ function Row({
         ) : (
           <>
             <Text>{label}</Text>
-            {child.status ? <Text dimColor>{` ${child.status}`}</Text> : null}
+            {statusLabel ? <Text dimColor>{` ${statusLabel}`}</Text> : null}
             {elapsed ? <Text dimColor>{` · ${elapsed}`}</Text> : null}
           </>
         )}

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -34,7 +34,7 @@ export interface ChildControlItem {
   readonly label: string;
   readonly command: string;
   readonly description: string;
-  readonly status?: string;
+  readonly statusLabel?: string;
   readonly elapsed?: string | null;
   readonly killable: boolean;
   readonly tailLines: readonly string[];
@@ -165,17 +165,15 @@ function buildSubagentItem(
   const label = childLabel(child);
   const command = streamDescription(child, streamsById) ?? label;
   const elapsed = childElapsed(child, nowMs);
+  const statusLabel = childStatusDescription(child.status);
   return {
     executionId: child.executionId,
     childStreamId: child.childStreamId,
     kind: 'subagent',
     label,
     command,
-    description: compactParts([
-      childStatusDescription(child.status),
-      elapsed ?? undefined,
-    ]),
-    status: child.status,
+    description: compactParts([statusLabel, elapsed ?? undefined]),
+    statusLabel,
     elapsed,
     killable,
     tailLines: streamTranscriptLines(child, streamsById),
@@ -191,18 +189,15 @@ function buildProcessItem(
   const lastLine = tailLines.at(-1);
   const label = childLabel(child);
   const elapsed = childElapsed(child, nowMs);
+  const statusLabel = childStatusDescription(child.status);
   return {
     executionId: child.executionId,
     childStreamId: child.childStreamId,
     kind: 'process',
     label,
     command: label,
-    description: compactParts([
-      childStatusDescription(child.status),
-      elapsed ?? undefined,
-      lastLine,
-    ]),
-    status: child.status,
+    description: compactParts([statusLabel, elapsed ?? undefined, lastLine]),
+    statusLabel,
     elapsed,
     killable: true,
     tailLines,

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -7,6 +7,7 @@ import {
   type ActiveChildInfo,
   type StreamTabId,
 } from '@shared/schemas';
+import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { formatDuration } from '@utils/core';
 
 // Local imports - CLI state
@@ -77,6 +78,12 @@ export type PickerKeyAction =
 
 function compactParts(parts: readonly (string | null | undefined)[]): string {
   return parts.filter((part): part is string => Boolean(part)).join(' · ');
+}
+
+function childStatusDescription(
+  status: string | undefined,
+): string | undefined {
+  return formatStreamStatusLabel(status, { style: 'cliCompact' });
 }
 
 function hasLiveChildElapsed(
@@ -164,7 +171,10 @@ function buildSubagentItem(
     kind: 'subagent',
     label,
     command,
-    description: compactParts([child.status, elapsed ?? undefined]),
+    description: compactParts([
+      childStatusDescription(child.status),
+      elapsed ?? undefined,
+    ]),
     status: child.status,
     elapsed,
     killable,
@@ -187,7 +197,11 @@ function buildProcessItem(
     kind: 'process',
     label,
     command: label,
-    description: compactParts([child.status, elapsed ?? undefined, lastLine]),
+    description: compactParts([
+      childStatusDescription(child.status),
+      elapsed ?? undefined,
+      lastLine,
+    ]),
     status: child.status,
     elapsed,
     killable: true,

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -45,7 +45,11 @@ import type {
 } from '@cli/chat/tui/state/cliState';
 
 // Local imports - shared schemas
-import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  TOOL_USE_STATUS,
+  type NormalizedToolUse,
+} from '@shared/schemas';
 
 function tail(stdout: string, stderr = ''): ProcessOutputTail {
   return { stdout, stderr };
@@ -315,6 +319,46 @@ describe('CLI child execution controls', () => {
       },
     ]);
     expect(childElapsed(state.activeProcesses[0], 62_000)).toBe('1s');
+  });
+
+  it('uses CLI-facing labels in picker descriptions', () => {
+    const state = slice({
+      activeSubagents: [
+        {
+          executionId: 'agent-1',
+          agentName: 'review',
+          childStreamId: 'child-a',
+          status: STREAM_STATUS.WAITING,
+          elapsed: '20s',
+        },
+      ],
+      activeProcesses: [
+        {
+          executionId: 'proc-1',
+          agentName: 'bash',
+          status: STREAM_STATUS.WAITING,
+          elapsed: '3s',
+        },
+      ],
+      processOutput: new Map([['proc-1', tail('last line')]]),
+    });
+
+    expect(buildChildControlItems(state, 'subagents')).toMatchObject([
+      {
+        executionId: 'agent-1',
+        description: 'idle · 20s',
+      },
+    ]);
+    expect(buildChildControlItems(state, 'tasks')).toMatchObject([
+      {
+        executionId: 'agent-1',
+        description: 'idle · 20s',
+      },
+      {
+        executionId: 'proc-1',
+        description: 'idle · 3s · last line',
+      },
+    ]);
   });
 
   it('keys live child elapsed timers by active execution identity', () => {

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -347,16 +347,19 @@ describe('CLI child execution controls', () => {
       {
         executionId: 'agent-1',
         description: 'idle · 20s',
+        statusLabel: 'idle',
       },
     ]);
     expect(buildChildControlItems(state, 'tasks')).toMatchObject([
       {
         executionId: 'agent-1',
         description: 'idle · 20s',
+        statusLabel: 'idle',
       },
       {
         executionId: 'proc-1',
         description: 'idle · 3s · last line',
+        statusLabel: 'idle',
       },
     ]);
   });
@@ -883,7 +886,7 @@ describe('CLI child execution controls', () => {
         childStreamId: 'review-stream',
         kind: 'subagent',
         label: 'review',
-        status: 'stopped',
+        statusLabel: 'stopped',
         killable: false,
       },
     ]);

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -8,6 +8,7 @@ import {
   compactChildRowText,
   compactRows,
 } from '@cli/chat/tui/panes/SubagentList';
+import { STREAM_STATUS } from '@shared/schemas';
 import type { ActiveChildInfo } from '@shared/schemas';
 
 describe('CLI SubagentList display model', () => {
@@ -106,5 +107,18 @@ describe('CLI SubagentList display model', () => {
     ).toBe(
       'latex build running · 19sec · main.tex: Proof sketch needs one missing reference',
     );
+  });
+
+  it('uses CLI-facing labels for child stream statuses', () => {
+    expect(
+      compactChildRowText({
+        child: {
+          executionId: 'review',
+          agentName: 'review',
+          status: STREAM_STATUS.WAITING,
+        },
+        nowMs: Date.now(),
+      }),
+    ).toBe('review idle');
   });
 });


### PR DESCRIPTION
## Summary

Closes #5884.

- route subagent panel status text through the shared CLI stream status formatter
- route child-control picker descriptions through the compact CLI stream status formatter
- keep child status coloring unchanged while showing `waiting` as user-facing `idle`
- update compact row, picker description, and TUI harness regression coverage

## Root Cause

The dogfood run showed a completed `review` subagent as `1 ● review waiting` even though the footer rendered `[main] 1:review(idle)`. `SubagentList` was rendering the raw `child.status` while the tab/footer paths used the shared formatter.

Bot review also found the sibling child-control picker descriptions were still built from raw `child.status`, so those descriptions now use the same formatter boundary.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts --config vitest.config.mjs`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /private/tmp/texra-subagent-idle-label-snapshots failed-subagent-status`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- Earlier before the picker follow-up: `npm test` failed only in `src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts`: 3 pipe-timing tests reported `no data in serverIn yet`; unrelated to this TUI display change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label mapping in the CLI TUI; no changes to status semantics, colors, or backend stream state.
> 
> **Overview**
> Aligns **subagent panel**, **child-control picker**, and **task detail** status copy with the same shared CLI formatter already used by stream tabs and the footer, so internal values like `waiting` show as **idle** instead of raw status strings.
> 
> `ChildControlItem` now carries **`statusLabel`** (formatted) instead of exposing raw **`status`** to the picker UI. Status **colors** still key off the underlying status value.
> 
> Adds unit coverage for `STREAM_STATUS.WAITING` → `idle` and updates the **`failed-subagent-status`** TUI harness expectation (`leanSolver idle` vs `waiting`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e396a9cba69752df5edfbea932f1b06f995dcc81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->