### PR TITLE
[codex] Keep approval panel controls compact

### DIFF
--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -203,7 +203,13 @@ export class ProgressBoardLayoutMock extends LitElement {
 
       .board {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) minmax(200px, 240px);
+        grid-template-columns: minmax(0, 1fr) minmax(
+            56px,
+            clamp(56px, 30%, 240px)
+          );
+        box-sizing: border-box;
+        width: 100%;
+        max-width: 100%;
         min-height: 360px;
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--wa-border-radius-m);
@@ -238,6 +244,10 @@ export class ProgressBoardLayoutMock extends LitElement {
 
       task-group-list {
         height: 100%;
+      }
+
+      stream-tabs {
+        min-width: 0;
       }
 
       .files-block {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -151,8 +151,10 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .approval-request__actions wa-button[data-action] {
-    flex: 0 0 auto;
-    min-width: 6.5rem;
+    flex: 0 1 6.5rem;
+    width: 6.5rem;
+    min-width: 0;
+    max-width: 100%;
   }
 
   :is(${ACTIONS}) wa-button[data-action]::part(base) {
@@ -162,6 +164,8 @@ export const requestPanelStyles: CSSResult = css`
 
   .approval-request__actions wa-button[data-action]::part(base) {
     justify-content: center;
+    width: 100%;
+    min-width: 0;
   }
 
   /* Shared action button colors */

--- a/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
+++ b/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
@@ -32,9 +32,11 @@ describe('request panel styles', () => {
 
     expect(actionStart).toBeGreaterThanOrEqual(0);
     expect(baseStart).toBeGreaterThan(actionStart);
-    expect(actionRule).toContain('flex: 0 0 auto');
-    expect(actionRule).toContain('min-width: 6.5rem');
+    expect(actionRule).toContain('flex: 0 1 6.5rem');
+    expect(actionRule).toContain('width: 6.5rem');
+    expect(actionRule).toContain('max-width: 100%');
     expect(baseRule).toContain('justify-content: center');
+    expect(baseRule).toContain('width: 100%');
   });
 
   it('keeps retry error details headers compact', () => {


### PR DESCRIPTION
## Summary
- Keep tool edit approval/reject Web Awesome buttons at a compact fixed width instead of letting them stretch across the action row.
- Let the progress-board design mock use a responsive stream rail so narrow embeddings do not overflow.
- Update the focused style regression test for the compact button rule.

## Validation
- `corepack pnpm vitest run src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes in shared request panel styles and a webview layout mock, with matching test updates; no auth, data, or runtime logic changes.
> 
> **Overview**
> Tightens **tool edit approval** action buttons so Approve/Reject stay at a **~6.5rem** footprint instead of growing with the flex row: `flex: 0 1 6.5rem`, explicit width, `max-width: 100%`, and full-width centered button bases for narrow panels.
> 
> Updates the **progress board layout mock** so the stream rail column uses a **responsive `clamp(56px, 30%, 240px)`** grid track, constrains the board to **100% width**, and sets **`stream-tabs { min-width: 0 }`** to avoid horizontal overflow in narrow embeddings.
> 
> The **request panel styles** regression test now asserts the new compact button rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0681f41d3f1193ac58c2ebb0275d8fb1eed34d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->