### PR TITLE
[codex] Avoid terminal follow-up prompts in multi-agent runs

### DIFF
--- a/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
+++ b/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
@@ -10,6 +10,8 @@ interface MultiAgentInstructionPreset {
 
 const COMPLETENESS_GUIDANCE =
   'Before claiming a result is complete, check the full domain stated by the user, including sign choices, zero and boundary cases, and symmetry branches.';
+const TERMINAL_RUN_GUIDANCE =
+  'This CLI team run exits after your final response. Do not end by asking the user whether to perform more work; either complete the requested work now or state the exact artifacts and next command/action for a future run.';
 
 export function formatMultiAgentRunInstruction(
   preset: MultiAgentInstructionPreset,
@@ -25,6 +27,7 @@ export function formatMultiAgentRunInstruction(
     preset.description,
     'Use the visible workflow and tool-use agents as the team available for delegation.',
     COMPLETENESS_GUIDANCE,
+    TERMINAL_RUN_GUIDANCE,
   ];
   const approvalInstruction = formatUnavailableApprovalInstruction(
     init.approvalContext,

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -245,6 +245,12 @@ describe('CLI multi-agent run command', () => {
     const request = mocks.executeCliRequest.mock.calls[0]?.[0];
     expect(request?.config.instruction).toContain('Primary user input files:');
     expect(request?.config.instruction).toContain('- "problem.tex"');
+    expect(request?.config.instruction).toContain(
+      'This CLI team run exits after your final response.',
+    );
+    expect(request?.config.instruction).toContain(
+      'Do not end by asking the user whether to perform more work',
+    );
     expect(mocks.stdinInputFile.cleanup).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

- add terminal-run guidance to the multi-agent root instruction
- make CLI team runs avoid final questions that cannot be answered after the process exits
- cover the guidance in the multi-agent run command test

## Context

During a real `texra-local multi-agent run mathematician` dogfood session, the team completed the requested math workflow and then ended by asking whether it should clean up generated working files. The command exited immediately afterward, so the user had no in-process way to answer that follow-up.

The CLI root instruction now makes the terminal lifecycle explicit: complete the requested work in the run, or leave exact artifacts and next actions for a future run.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `npm run compile:fast`
- `npm run lint` passed with 0 errors and existing warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to multi-agent root instructions plus test assertions; no execution, auth, or delegation behavior changes.
> 
> **Overview**
> Adds **terminal-run guidance** to the multi-agent CLI root instruction built by `formatMultiAgentRunInstruction`, so team runs treat the process as **one-shot**: finish the work in-run or document artifacts and the exact next command for a later run—**not** closing with questions the user cannot answer after exit.
> 
> This addresses dogfood cases where the mathematician preset finished work then asked about cleanup while the CLI had already exited. The multi-agent run command test now asserts the composed instruction includes the new lifecycle wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b647e64d06c7bd33dcdae2f6129e4fded355d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->