### PR TITLE
[codex] Share terminal final-response guidance

### DIFF
--- a/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
+++ b/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
@@ -2,6 +2,7 @@ import type { ApprovalInstructionContext } from '@cli/runtime/approvalPolicyAvai
 
 import { formatUnavailableApprovalInstruction } from './approvalPolicyInstruction';
 import { formatCliRunFileInstruction } from './runFileInstruction';
+import { TERMINAL_RUN_GUIDANCE } from './terminalRunInstruction';
 
 interface MultiAgentInstructionPreset {
   readonly name: string;
@@ -10,8 +11,6 @@ interface MultiAgentInstructionPreset {
 
 const COMPLETENESS_GUIDANCE =
   'Before claiming a result is complete, check the full domain stated by the user, including sign choices, zero and boundary cases, and symmetry branches.';
-const TERMINAL_RUN_GUIDANCE =
-  'This CLI team run exits after your final response. Do not end by asking the user whether to perform more work; either complete the requested work now or state the exact artifacts and next command/action for a future run.';
 
 export function formatMultiAgentRunInstruction(
   preset: MultiAgentInstructionPreset,

--- a/packages/cli/src/commands/_helpers/terminalRunInstruction.ts
+++ b/packages/cli/src/commands/_helpers/terminalRunInstruction.ts
@@ -1,0 +1,2 @@
+export const TERMINAL_RUN_GUIDANCE =
+  'This CLI run exits after your final response. Do not end by asking the user whether to perform more work; either complete the requested work now or state the exact artifacts and next command/action for a future run.';

--- a/packages/cli/src/commands/_helpers/toolUseRunInstruction.ts
+++ b/packages/cli/src/commands/_helpers/toolUseRunInstruction.ts
@@ -1,11 +1,12 @@
 import { formatCliRunFileInstruction } from './runFileInstruction';
+import { TERMINAL_RUN_GUIDANCE } from './terminalRunInstruction';
 
 export function formatToolUseAgentRunInstruction(init: {
   readonly inputFiles: readonly string[];
   readonly contextFiles: readonly string[];
   readonly instruction: string;
 }): string {
-  const parts: string[] = [];
+  const parts = [TERMINAL_RUN_GUIDANCE];
   const fileInstruction = formatCliRunFileInstruction({
     inputFiles: init.inputFiles,
     contextFiles: init.contextFiles,

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -248,6 +248,9 @@ describe('formatToolUseAgentRunInstruction', () => {
     expect(instruction).toContain('Primary user input files:');
     expect(instruction).toContain('- "problem.md"');
     expect(instruction).toContain(
+      'This CLI run exits after your final response.',
+    );
+    expect(instruction).toContain(
       "Treat these files as the user's task source.",
     );
     expect(instruction).toContain('Additional user instruction:');
@@ -261,7 +264,13 @@ describe('formatToolUseAgentRunInstruction', () => {
       instruction: 'Assess the proof.',
     });
 
-    expect(instruction).toBe('User instruction:\n\nAssess the proof.');
+    expect(instruction).toContain(
+      'This CLI run exits after your final response.',
+    );
+    expect(instruction).toContain(
+      'Do not end by asking the user whether to perform more work',
+    );
+    expect(instruction).toContain('User instruction:\n\nAssess the proof.');
   });
 
   it('includes read-only context files without changing input wording', () => {
@@ -272,6 +281,9 @@ describe('formatToolUseAgentRunInstruction', () => {
     });
 
     expect(instruction).toContain('Primary user input files:');
+    expect(instruction).toContain(
+      'This CLI run exits after your final response.',
+    );
     expect(instruction).toContain('Read-only context files:');
     expect(instruction).toContain('- "notes.md"');
     expect(instruction).toContain('Use these files as supporting context');

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -246,7 +246,7 @@ describe('CLI multi-agent run command', () => {
     expect(request?.config.instruction).toContain('Primary user input files:');
     expect(request?.config.instruction).toContain('- "problem.tex"');
     expect(request?.config.instruction).toContain(
-      'This CLI team run exits after your final response.',
+      'This CLI run exits after your final response.',
     );
     expect(request?.config.instruction).toContain(
       'Do not end by asking the user whether to perform more work',


### PR DESCRIPTION
## Summary

- move one-shot CLI terminal lifecycle guidance into a shared helper
- apply the guidance to `texra run` tool-use instructions as well as multi-agent runs
- update CLI instruction tests for the shared wording

## Context

PR #5888 fixed a dogfood issue where a multi-agent terminal run ended by asking a follow-up cleanup question after the process exited. The bot review correctly pointed out that the sibling single-agent `texra run` path also uses `stopAfterCycle: true`, so it can hit the same dead-end if the agent ends with an in-process follow-up question.

This follow-up keeps the ownership simple: one shared CLI-run guidance constant, used by both one-shot run instruction builders.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentInstruction.vitest.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `npm run compile:fast`
- `npm run lint` passed with 0 errors and existing warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only changes to CLI run instructions; no auth, execution, or approval logic touched.
> 
> **Overview**
> **Extracts one-shot terminal lifecycle guidance** into `TERMINAL_RUN_GUIDANCE` in `terminalRunInstruction.ts`, so multi-agent and single-agent CLI run builders share the same text.
> 
> **Multi-agent** instructions now import that constant (wording shifts from “CLI team run” to **“CLI run”**). **`formatToolUseAgentRunInstruction`** (`texra run` tool-use path) **prepends** the same guidance so headless runs with `stopAfterCycle: true` are told not to end with in-process follow-up questions after the process exits.
> 
> Tests in `MultiAgentInstruction.vitest.ts` and `MultiAgentRunCommand.vitest.mts` assert the shared phrasing on both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edcfc640986d36dd45c5f81e069d52c38a791dae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->