### PR TITLE
[codex] Allow CLI approval rejection feedback

### DIFF
--- a/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
+++ b/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
@@ -19,11 +19,13 @@ export function formatMultiAgentRunInstruction(
     readonly contextFiles: readonly string[];
     readonly instruction: string;
     readonly approvalContext: ApprovalInstructionContext;
+    readonly workingDirectory: string;
   },
 ): string {
   const parts = [
     `Run the "${preset.name}" multi-agent team preset.`,
     preset.description,
+    `Workspace root for this run: ${JSON.stringify(init.workingDirectory)}. Resolve relative file paths against this directory, and tell delegated agents to use these same relative paths instead of inventing container roots such as /workspace.`,
     'Use the visible workflow and tool-use agents as the team available for delegation.',
     COMPLETENESS_GUIDANCE,
     TERMINAL_RUN_GUIDANCE,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -365,6 +365,7 @@ export async function runMultiAgentPreset(
         contextFiles,
         instruction,
         approvalContext: runContext,
+        workingDirectory: runContext.cwd,
       }),
       workingDirectory: runContext.cwd,
       agentCategory: AgentCategory.ToolUse,

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -80,7 +80,43 @@ async function askCliApprovalQuestion(
   if (context.approvalPrompt) {
     return context.approvalPrompt(request);
   }
-  return askCliQuestion(`${request.summary}\n${request.prompt}`);
+  return askCliQuestion(
+    request.summary ? `${request.summary}\n${request.prompt}` : request.prompt,
+  );
+}
+
+interface ParsedApprovalAnswer {
+  readonly accepted: boolean;
+  readonly feedback?: string;
+  readonly shouldPromptForFeedback: boolean;
+}
+
+function parseApprovalAnswer(answer: string): ParsedApprovalAnswer {
+  const trimmed = answer.trim();
+  const normalized = trimmed.toLowerCase();
+  if (normalized === 'y' || normalized === 'yes') {
+    return { accepted: true, shouldPromptForFeedback: false };
+  }
+
+  if (normalized === '') {
+    return { accepted: false, shouldPromptForFeedback: false };
+  }
+
+  const rejectMatch = /^(?:n|no)(?:\s+(.+))?$/i.exec(trimmed);
+  if (rejectMatch) {
+    const feedback = rejectMatch[1]?.trim();
+    return {
+      accepted: false,
+      ...(feedback ? { feedback } : {}),
+      shouldPromptForFeedback: feedback == null,
+    };
+  }
+
+  return {
+    accepted: false,
+    feedback: trimmed,
+    shouldPromptForFeedback: false,
+  };
 }
 
 /**
@@ -148,19 +184,35 @@ export async function askApproval(
     answer = await queueCliApprovalQuestion(context, {
       kind: 'approval',
       summary,
-      prompt: 'Approve? [y/N] ',
+      prompt: 'Approve? [y/N, or n <feedback>] ',
     });
   } catch {
     markApprovalDenied(context);
     return { accepted: false, userMessage: 'CLI approval prompt failed.' };
   }
 
-  const normalized = answer.trim().toLowerCase();
-  const accepted = normalized === 'y' || normalized === 'yes';
+  const parsed = parseApprovalAnswer(answer);
+  let feedback = parsed.feedback;
+  if (!parsed.accepted && parsed.shouldPromptForFeedback) {
+    try {
+      const feedbackAnswer = await queueCliApprovalQuestion(context, {
+        kind: 'approval',
+        summary: '',
+        prompt: 'Rejection feedback (optional, Enter to skip): ',
+      });
+      feedback = feedbackAnswer.trim() || undefined;
+    } catch {
+      feedback = undefined;
+    }
+  }
+
+  const accepted = parsed.accepted;
   if (!accepted) markApprovalDenied(context);
   return {
     accepted,
-    userMessage: accepted ? undefined : 'Rejected from CLI approval prompt.',
+    userMessage: accepted
+      ? undefined
+      : feedback || 'Rejected from CLI approval prompt.',
   };
 }
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -138,7 +138,7 @@ describe('formatToolEditApprovalSummary', () => {
       context({
         approvalPrompt: async (request) => {
           promptSummary = request.summary;
-          return 'n';
+          return 'n needs revision';
         },
       }),
     );
@@ -154,6 +154,59 @@ describe('formatToolEditApprovalSummary', () => {
     expect(promptSummary).toContain('Tool edit requested by write_file');
     expect(promptSummary).toContain('+\\section{Proof}');
     expect(promptSummary).toContain('+A concise proof.');
+  });
+
+  it('passes one-line rejection feedback to the tool result', async () => {
+    installCliApprovalHandlers(
+      context({
+        approvalPrompt: async () => 'n proof misses the p = 5 case',
+      }),
+    );
+
+    const result = await requestToolEditApproval({
+      path: '/tmp/new-proof.tex',
+      originalContent: '',
+      proposedContent: '\\section{Proof}\nA concise proof.\n',
+      sourceTool: 'write_file',
+    });
+
+    expect(result).toMatchObject({
+      accepted: false,
+      userMessage: 'proof misses the p = 5 case',
+    });
+  });
+
+  it('prompts for rejection feedback after an explicit no', async () => {
+    const prompts: string[] = [];
+    const summaries: string[] = [];
+    const answers = ['n', 'use the workspace-local file path'];
+    installCliApprovalHandlers(
+      context({
+        approvalPrompt: async (request) => {
+          prompts.push(request.prompt);
+          summaries.push(request.summary);
+          return answers.shift() ?? '';
+        },
+      }),
+    );
+
+    const result = await requestToolEditApproval({
+      path: '/tmp/new-proof.tex',
+      originalContent: '',
+      proposedContent: '\\section{Proof}\nA concise proof.\n',
+      sourceTool: 'write_file',
+    });
+
+    expect(prompts).toEqual([
+      'Approve? [y/N, or n <feedback>] ',
+      'Rejection feedback (optional, Enter to skip): ',
+    ]);
+    expect(summaries[0]).toContain('Tool edit requested by write_file');
+    expect(summaries[1]).toBe('');
+    expect(result).toMatchObject({
+      accepted: false,
+      userMessage: 'use the workspace-local file path',
+    });
   });
 
   it('bounds long diff lines before prompting', () => {

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -6,6 +6,8 @@ import { formatCliRunFileInstruction } from '@cli/commands/_helpers/runFileInstr
 import { formatToolUseAgentRunInstruction } from '@cli/commands/_helpers/toolUseRunInstruction';
 import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
 
+const workingDirectory = '/tmp/texra-workspace';
+
 const preset = {
   id: 'mathematician',
   name: 'Mathematician',
@@ -111,6 +113,7 @@ describe('formatMultiAgentRunInstruction', () => {
           contextFiles: [],
           instruction: 'Solve x^2 - 2y^2 = 1 for integer x and 0 < y < 20.',
           approvalContext: { mode, approvalPolicy },
+          workingDirectory,
         });
 
         expect(instruction).toContain(
@@ -123,12 +126,31 @@ describe('formatMultiAgentRunInstruction', () => {
     }
   });
 
+  it('anchors the team on the CLI workspace root', () => {
+    const instruction = formatMultiAgentRunInstruction(preset, {
+      inputFiles: ['problem.md'],
+      contextFiles: [],
+      instruction: '',
+      approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+      workingDirectory,
+    });
+
+    expect(instruction).toContain(
+      `Workspace root for this run: ${JSON.stringify(workingDirectory)}`,
+    );
+    expect(instruction).toContain(
+      'Resolve relative file paths against this directory',
+    );
+    expect(instruction).toContain('instead of inventing container roots');
+  });
+
   it('warns the orchestrator when approval policy never denies tools', () => {
     const instruction = formatMultiAgentRunInstruction(preset, {
       inputFiles: ['problem.md'],
       contextFiles: [],
       instruction: 'Solve the problem.',
       approvalContext: { mode: 'headless', approvalPolicy: 'never' },
+      workingDirectory,
     });
 
     expect(instruction).toContain('Approval policy for this run is "never"');
@@ -144,6 +166,7 @@ describe('formatMultiAgentRunInstruction', () => {
       contextFiles: [],
       instruction: 'Solve x^2 - 2y^2 = 1 for integer x and 0 < y < 20.',
       approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+      workingDirectory,
     });
 
     expect(instruction).toContain(
@@ -158,6 +181,7 @@ describe('formatMultiAgentRunInstruction', () => {
       contextFiles: [],
       instruction: 'Solve the problem.',
       approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+      workingDirectory,
     });
 
     expect(instruction).not.toContain('were attached to this run');
@@ -169,6 +193,7 @@ describe('formatMultiAgentRunInstruction', () => {
       contextFiles: [],
       instruction: '',
       approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+      workingDirectory,
     });
 
     expect(instruction).toContain('Primary user input files:');
@@ -185,6 +210,7 @@ describe('formatMultiAgentRunInstruction', () => {
       contextFiles: ['notes.md'],
       instruction: 'Solve the problem.',
       approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+      workingDirectory,
     });
 
     expect(instruction).toContain('Primary user input files:');
@@ -201,6 +227,7 @@ describe('formatMultiAgentRunInstruction', () => {
       contextFiles: [],
       instruction: '',
       approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+      workingDirectory,
     });
 
     expect(instruction).toContain(
@@ -217,6 +244,7 @@ describe('formatMultiAgentRunInstruction', () => {
       contextFiles: [],
       instruction: 'Solve the problem.',
       approvalContext: { mode: 'headless', approvalPolicy: 'ask' },
+      workingDirectory,
     });
 
     expect(instruction).toContain('headless run with approval policy "ask"');
@@ -230,6 +258,7 @@ describe('formatMultiAgentRunInstruction', () => {
       contextFiles: [],
       instruction: '',
       approvalContext: { mode: 'headless', approvalPolicy: 'yolo' },
+      workingDirectory,
     });
 
     expect(instruction).not.toContain('approval prompts cannot be answered');


### PR DESCRIPTION
## Summary

Fixes #5891.

- Allow interactive CLI approval prompts to carry rejection feedback with `n <feedback>`.
- Prompt for optional rejection feedback after an explicit `n` / `no`.
- Include the multi-agent run workspace root in the orchestrator instruction so delegated agents are less likely to invent paths like `/workspace`.

## Root Cause

The raw CLI approval path collapsed every rejection to `Rejected from CLI approval prompt.` even though the shared approval decision type already supports `userMessage`. During dogfood, that meant the orchestrator could not learn why a generated report was rejected and later delegated a child that guessed `/workspace` and requested a broad `find /` fallback.

## Validation

- `pnpm vitest run src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/MultiAgentInstruction.vitest.ts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/commands/_helpers/multiAgentInstruction.ts packages/cli/src/commands/multiAgent.ts packages/cli/src/runtime/approval/approvalPolicy.ts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/MultiAgentInstruction.vitest.ts`
- `npm run compile:fast`
- `npm run lint` completed with existing warnings and no errors.
- `npm test` has unrelated existing failures in `src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts` (`no data in serverIn yet`); rerunning that file alone reproduces the same 3 failures.
- Rebuilt `texra-local`, then live-tested `texra-local agents run numerics --approval-policy ask`: rejecting `echo 'draft' > draft.txt` with `n use final.txt containing exactly final instead` caused the agent to request `echo 'final' > final.txt`, and the temp workspace contained only `final.txt` with `final`.

## Dogfood Evidence

Observed in `texra-local multi-agent run mathematician --approval-policy ask` against a temp totient task: the original raw prompt only offered `Approve? [y/N]`, so rejecting a flawed report gave the agent no actionable correction. The follow-up child agent then requested `cat /workspace/totient_check.py ... || find / -name ...`, confirming both the missing feedback path and weak workspace-root context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive approval parsing and what agents see after denials; multi-agent path guidance affects delegation behavior but not auth or persistence.
> 
> **Overview**
> Interactive CLI approvals now return **actionable rejection feedback** instead of a generic denial. Users can reject with `n <feedback>` on one line, or answer `n`/`no` and get an optional follow-up prompt; that text becomes the tool result `userMessage` (with a fallback when empty). Approval prompts omit a blank summary line when no summary is shown.
> 
> **Multi-agent runs** inject the CLI **workspace root** into the orchestrator instruction so delegated agents resolve relative paths against the real cwd and are discouraged from guessing paths like `/workspace`. `multi-agent run` passes `runContext.cwd` into that formatter.
> 
> Tests cover one-line feedback, the two-step rejection flow, and workspace-root wording in team instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7d832f7d73e92527adb3c772ccf2603df24499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->