### PR TITLE
fix: wrap launcher guidance text

### DIFF
--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Select } from '../chat/tui/ui/Select';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { tuiOutputStreamForColor } from '../chat/tui/render/noColorOutput';
+import { wrapAnsiToWidth } from '../chat/tui/render/ansiWrap';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import { formatCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
 import {
@@ -97,9 +98,29 @@ export function orchestrationFooterHints(
   return hints;
 }
 
-/** Rows a marginTop=1 block of lines occupies (the lines plus the margin). */
-function blockRowCost(lines: readonly string[]): number {
-  return lines.length === 0 ? 0 : lines.length + 1;
+export function orchestrationWrappedLineRows(
+  line: string,
+  columns: number,
+): number {
+  return Math.max(
+    1,
+    wrapAnsiToWidth(line, Math.max(1, columns)).split('\n').length,
+  );
+}
+
+/** Rows a marginTop=1 block of lines occupies (wrapped lines plus the margin). */
+export function orchestrationBlockRowCost(
+  lines: readonly string[],
+  columns: number,
+): number {
+  if (lines.length === 0) return 0;
+  return (
+    1 +
+    lines.reduce(
+      (rows, line) => rows + orchestrationWrappedLineRows(line, columns),
+      0,
+    )
+  );
 }
 
 function modelPickKeyHints(): readonly KeyHint[] {
@@ -114,7 +135,7 @@ export function OrchestrationApp(
   props: OrchestrationAppProps,
 ): React.JSX.Element {
   const app = useApp();
-  const { rows } = useWindowSize();
+  const { columns, rows } = useWindowSize();
   const { items, modelItems } = orchestrationModelAccessView(
     props.items,
     props.models,
@@ -129,12 +150,13 @@ export function OrchestrationApp(
     undefined,
   );
   const footerHints = pending ? [] : listFooterHints;
+  const textColumns = Math.max(1, columns - 2);
   const maxVisibleItems = Math.max(
     4,
     rows -
       8 -
-      blockRowCost(pending ? [] : statusLines) -
-      blockRowCost(footerHints),
+      orchestrationBlockRowCost(pending ? [] : statusLines, textColumns) -
+      orchestrationBlockRowCost(footerHints, textColumns),
   );
 
   const finish = (action: CliOrchestrationAction): void => {
@@ -198,7 +220,7 @@ export function OrchestrationApp(
       {statusLines.length > 0 ? (
         <Box marginTop={1} flexDirection="column">
           {statusLines.map((line, index) => (
-            <Text key={`${index}:${line}`} dimColor wrap="truncate-end">
+            <Text key={`${index}:${line}`} dimColor wrap="wrap">
               {line}
             </Text>
           ))}
@@ -216,7 +238,7 @@ export function OrchestrationApp(
       {footerHints.length > 0 ? (
         <Box marginTop={1} flexDirection="column">
           {footerHints.map((hint) => (
-            <Text key={hint} dimColor wrap="truncate-end">
+            <Text key={hint} dimColor wrap="wrap">
               {hint}
             </Text>
           ))}

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest';
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
+  orchestrationBlockRowCost,
   orchestrationFooterHints,
   orchestrationKeyHints,
   orchestrationModelAccessView,
+  orchestrationWrappedLineRows,
 } from '@cli/orchestration/runOrchestrationTui';
 import { buildCliOrchestrationItems } from '@cli/runtime/orchestration';
 
@@ -132,6 +134,16 @@ describe('CLI orchestration items', () => {
       key: 'q/Esc',
       action: 'exit',
     });
+  });
+
+  it('budgets wrapped launcher status rows instead of assuming one row per line', () => {
+    const accountHint =
+      'actions: `texra login --select-account` changes account; `--api-mode personal` uses provider keys';
+
+    expect(orchestrationWrappedLineRows(accountHint, 52)).toBeGreaterThan(1);
+    expect(orchestrationBlockRowCost([accountHint], 52)).toBe(
+      1 + orchestrationWrappedLineRows(accountHint, 52),
+    );
   });
 
   it('starts with new chat and keeps help as the final active item', () => {


### PR DESCRIPTION
## Summary

Fixes #5893.

The interactive launcher was rendering startup status and footer guidance with `truncate-end`. In a real TTY dogfood run at 100 columns, the API/account guidance was cut off:

```text
note: a provider API key is set while signed in — `--api-mode` (or `/api`) co…
actions: `texra login --select-account` changes account; `--api-mode personal…
```

This PR wraps those guidance lines instead and updates the launcher item budget to count wrapped status/footer rows, so the menu remains stable while preserving the full actionable text.

## Validation

- `corepack pnpm prettier --write packages/cli/src/orchestration/runOrchestrationTui.tsx src/test-kernel/cli/Orchestration.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/Orchestration.vitest.mts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/orchestration/runOrchestrationTui.tsx src/test-kernel/cli/Orchestration.vitest.mts`
- `npm run compile:fast`
- `npm run texra-local:build && npm run texra-local:link`
- TTY smoke: `env TERM=xterm-256color COLUMNS=100 LINES=28 texra-local --cwd /private/tmp/texra-launcher-dogfood-0612-BpYT6W --approval-policy ask`
- `npm run lint` (0 errors, existing warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI layout-only change in the orchestration launcher with a focused unit test; no auth, API, or data-path changes.
> 
> **Overview**
> Fixes launcher startup **status** and **footer** guidance being cut off in narrow terminals by switching Ink `Text` from `truncate-end` to **`wrap`**, so full API/account hints stay visible.
> 
> **`maxVisibleItems`** for the menu now subtracts vertical space using **`orchestrationBlockRowCost`** / **`orchestrationWrappedLineRows`** (via existing **`wrapAnsiToWidth`**) and **`textColumns`** from the window width, instead of assuming one terminal row per status/footer line. A vitest asserts wrapped long hints consume more than one row in the budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d8c23707c9c500ed9dd4d3b0e70b0b6f5e19d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->