### PR TITLE
fix: reuse stopped subagent recovery hint

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -36,11 +36,12 @@ import {
 import { buildContinuationText } from '@tools/inquiry/inquiryContinuation';
 import { getDefaultStreamLogStore } from '@transcript';
 
-import { App } from '../src/chat/tui/App';
+import { App, focusedChildInputDisabledMessage } from '../src/chat/tui/App';
 import {
   transcriptViewportRepaintOptions,
   type TranscriptViewportChange,
 } from '../src/chat/tui/state/transcriptViewportMode';
+import { resolveChildControlDisplayTargets } from '../src/chat/tui/state/childControls';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
 import {
   findSlashCommand,
@@ -1287,6 +1288,26 @@ function harnessRejectsChildSubmit(childStreamId: StreamTabId): boolean {
   return status !== undefined && !isInFlightStatus(status);
 }
 
+function harnessStoppedChildMessage(childStreamId: StreamTabId): string {
+  const parentStream = cliState.parentStream.get();
+  const streams = cliState.streams.get();
+  const controls = resolveChildControlDisplayTargets({
+    activeStreamId: childStreamId,
+    parentStream,
+    streams,
+  });
+
+  return (
+    focusedChildInputDisabledMessage({
+      activeStreamId: childStreamId,
+      parentStream,
+      status: streamStatusFromState(childStreamId),
+      subagentControlsAvailable: controls.subagents.hasItems,
+      taskControlsAvailable: controls.tasks.hasItems,
+    }) ?? 'The selected subagent is no longer accepting follow-ups.'
+  );
+}
+
 function formatHarnessSlashHelp(): string {
   return listSlashCommands()
     .map((command) => `/${command.name} - ${command.description}`)
@@ -1413,7 +1434,7 @@ function handleHarnessSubmit(line: string): void {
   const childStreamId = harnessActiveChildStreamId();
   if (childStreamId && harnessRejectsChildSubmit(childStreamId)) {
     appendHarnessAssistantTranscript(
-      'The selected subagent is no longer accepting follow-ups.',
+      harnessStoppedChildMessage(childStreamId),
       childStreamId,
     );
     return;

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -111,7 +111,7 @@ import { escapeText } from '@shared/utils/xmlEscape';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 import { generateExecutionId } from '@utils/core/executionId';
 
-import { App } from './App';
+import { App, focusedChildInputDisabledMessage } from './App';
 import { assertNever } from './assertNever';
 import { formatApprovalPolicyForCli as formatApprovalPolicy } from './forms/ApprovalPolicyForm';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
@@ -134,6 +134,7 @@ import {
 } from './render/noColorOutput';
 import { formatCliSessionStatus } from './sessionStatus';
 import { clearApprovals } from './state/approvalQueue';
+import { resolveChildControlDisplayTargets } from './state/childControls';
 import { cliState, patchStream, resetCliState } from './state/cliState';
 import {
   collectResumeTargets,
@@ -462,6 +463,26 @@ export function chatTuiFocusedChildFollowUpRoute(): ChatTuiFocusedChildFollowUpR
     return { kind: 'reject', streamId: scope.streamId };
   }
   return { kind: 'accept', streamId: scope.streamId };
+}
+
+function stoppedFocusedChildFollowUpMessage(streamId: StreamTabId): string {
+  const parentStream = cliState.parentStream.get();
+  const streams = cliState.streams.get();
+  const controls = resolveChildControlDisplayTargets({
+    activeStreamId: streamId,
+    parentStream,
+    streams,
+  });
+
+  return (
+    focusedChildInputDisabledMessage({
+      activeStreamId: streamId,
+      parentStream,
+      status: streamStatusFromState(streamId),
+      subagentControlsAvailable: controls.subagents.hasItems,
+      taskControlsAvailable: controls.tasks.hasItems,
+    }) ?? 'The selected subagent is no longer accepting follow-ups.'
+  );
 }
 
 interface SlashCommandContext {
@@ -1567,7 +1588,7 @@ export async function runChat(
     const focusedChildRoute = chatTuiFocusedChildFollowUpRoute();
     if (focusedChildRoute.kind === 'reject') {
       appendLocalAssistantTranscript(
-        'The selected subagent is no longer accepting follow-ups.',
+        stoppedFocusedChildFollowUpMessage(focusedChildRoute.streamId),
         focusedChildRoute.streamId,
       );
       return;
@@ -1628,7 +1649,7 @@ export async function runChat(
             session.stopRequested = true;
           } else {
             appendLocalAssistantTranscript(
-              'The selected subagent is no longer accepting follow-ups.',
+              stoppedFocusedChildFollowUpMessage(followUpTarget),
               followUpTarget,
             );
           }


### PR DESCRIPTION
## Summary

- Reuse the focused-child disabled-input helper when rejected submissions target a stopped child stream.
- Apply the same helper in the deterministic TUI harness so PTY snapshots cover the real recovery copy.
- Keep the fallback generic only for edge state where the helper cannot produce a message.

Fixes #5895

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-snapshots-0612-fix focused-stopped-subagent-submit`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build --snapshot-dir /tmp/texra-tui-snapshots-0612-fix-slice compact-subagent-picker compact-task-picker-process-overflow focused-stopped-subagent focused-stopped-subagent-submit hidden-root-approval-tab-return`
- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/chat/tui/runChatTui.tsx packages/cli/scripts/tui-harness.tsx` (runtime file clean; harness script is outside ESLint config)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (0 errors, existing 25 warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change on an already-rejected submit path; no auth, persistence, or follow-up routing logic changes.
> 
> **Overview**
> When a user submits a follow-up while focused on a **stopped** child subagent stream, the CLI no longer always shows the generic *"The selected subagent is no longer accepting follow-ups."* transcript line.
> 
> **`runChatTui`** and the **TUI harness** now build that rejection message with the same **`focusedChildInputDisabledMessage`** helper the input bar uses (stream status, parent/child scope, and whether subagent/task pickers are available), so users get the recovery copy—e.g. switching streams with Tab and optional shortcut hints—instead of a dead-end string.
> 
> The generic fallback remains only when the helper cannot produce a message. Behavior is unchanged aside from **wording** on rejected child follow-ups and on harness submit when a stopped child is focused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1985c636437e06245f9340f8e497016ee833250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->