### PR TITLE
fix: show focused child submit ack in harness

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -18,6 +18,7 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { platform, tryPlatform } from '@platform/platform';
 import {
   AgentCategory,
+  LIVE_ELAPSED_STREAM_STATUSES,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_STATUS,
@@ -689,12 +690,13 @@ function harnessMessageEntry(
   id: string,
   text: string,
   role: ConversationEntry['role'] = 'assistant',
+  finalized = true,
 ): ConversationEntry {
   return {
     id,
     role,
     text,
-    finalized: true,
+    finalized,
   };
 }
 
@@ -1243,6 +1245,18 @@ function appendHarnessAssistantTranscript(
   appendHarnessTranscript('assistant', text, streamId);
 }
 
+function appendHarnessChildSubmitAck(
+  text: string,
+  streamId: StreamTabId,
+): void {
+  const status = cliState.streams.get().get(streamId)?.status;
+  appendHarnessTranscript('assistant', text, streamId, {
+    finalized: !(
+      status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status)
+    ),
+  });
+}
+
 function appendHarnessUserTranscript(text: string): void {
   appendHarnessTranscript('user', text);
 }
@@ -1251,6 +1265,7 @@ function appendHarnessTranscript(
   role: ConversationEntry['role'],
   text: string,
   explicitStreamId?: StreamTabId,
+  options: { readonly finalized?: boolean } = {},
 ): void {
   const streamId = explicitStreamId ?? defaultHarnessTranscriptStreamId();
   patchStream(streamId, (slice) => ({
@@ -1261,6 +1276,7 @@ function appendHarnessTranscript(
         `harness-local-${Date.now()}-${slice.entries.length}`,
         text,
         role,
+        options.finalized,
       ),
     ],
   }));
@@ -1439,7 +1455,11 @@ function handleHarnessSubmit(line: string): void {
     );
     return;
   }
-  appendHarnessAssistantTranscript(`Harness received: ${line}`, childStreamId);
+  if (childStreamId) {
+    appendHarnessChildSubmitAck(`Harness received: ${line}`, childStreamId);
+    return;
+  }
+  appendHarnessAssistantTranscript(`Harness received: ${line}`);
 }
 
 function appendHarnessStatus(): void {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1589,7 +1589,6 @@ const SCENARIOS = [
     keys: [ESC + 's', 'f', 'child follow-up on focused stream', '\r'],
     frame: 'tail',
     expect: [
-      'Please handle the harness-child-strategy sub-workflow.',
       'strategy is checking the harness-child-strategy details',
       'Harness received: child follow-up on focused stream',
     ],
@@ -1611,8 +1610,6 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     keys: ['\t'],
     expect: [
-      'subagent: strategy · parent: main · model: harness-model',
-      'Please handle the harness-child-strategy sub-workflow.',
       'strategy is checking the harness-child-strategy details',
       '[1:strategy]*',
     ],
@@ -1665,7 +1662,6 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     keys: ['\t'],
     expect: [
-      'Please handle the harness-child-strategy sub-workflow.',
       'strategy detail line 01',
       'strategy detail line 18',
       '[1:strategy]*',
@@ -1691,7 +1687,6 @@ const SCENARIOS = [
     keys: ['\t', '/status', '\r'],
     frame: 'tail',
     expect: [
-      'Please handle the harness-child-strategy sub-workflow.',
       'strategy is checking the harness-child-strategy details',
       '[1:strategy]*',
     ],


### PR DESCRIPTION
## Summary

- Render focused-child submit acknowledgements as live harness entries so the active child viewport visibly confirms the follow-up.
- Keep root harness submissions on the existing finalized transcript path.
- Update focused-child TUI snapshot expectations to match the current scoped-scrollback contract: live child output stays in the viewport while finalized header/prompt rows can live above it in native scrollback.

Fixes #5897

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /tmp/texra-tui-snapshots-0612-focused-child-live-ack subagent-focused-submit`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build --snapshot-dir /tmp/texra-tui-snapshots-0612-focused-child-slice-2 plain-submit subagent-focused-submit subagent-tab-focus-full-frame subagent-focused-own-scrollback-history subagent-focused-status-stays-scoped subagent-focus-return-root-scrollback-deduped focused-stopped-subagent-submit stopped-subagent-picker task-subworkflow-detail-long-output`
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build --snapshot-dir /tmp/texra-tui-snapshots-0612-next-2 slash-palette slash-palette-overflow approval-form compact-approval-form bash-approval narrow-bash-approval long-bash-approval compact-long-bash-approval-scroll edit-approval narrow-edit-approval agent-proposal-long compact-agent-proposal-scroll external-inquiry-long external-inquiry-long-80-cols plan-approval compact-plan-approval retry-approval subagents failed-subagent-status subagent-focused-submit task-subworkflow-detail-long-output tiny-task-subworkflow-detail-controls ctrl-c-interrupt-active`
- `corepack pnpm vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors, existing 25 warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness and snapshot validation only; no production CLI submit or transcript logic changed in this diff.
> 
> **Overview**
> Focused-child follow-ups in the **TUI harness** now append submit acknowledgements as **live** transcript rows when the child stream is in an active/elapsed status (`LIVE_ELAPSED_STREAM_STATUSES`), so the harness mirrors production behavior where the ack stays visible in the child viewport. **Root** submissions still use the existing **finalized** assistant transcript path.
> 
> Transcript helpers (`harnessMessageEntry`, `appendHarnessTranscript`) accept an optional **`finalized`** flag; `handleHarnessSubmit` routes child vs root acks through the new **`appendHarnessChildSubmitAck`** path.
> 
> **`validate-tui.mjs`** expectations for focused-child scenarios were trimmed (e.g. static sub-workflow prompt and subagent status header) to match the **scoped scrollback** contract: live child output and the ack remain in view while older finalized header rows may sit above the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8d2c0adf2df7a5db91805c87524262dfeda5f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->