### PR TITLE
fix: keep guide mockup within narrow frames

### DIFF
--- a/docs/.vitepress/components/GuideIntroHero.vue
+++ b/docs/.vitepress/components/GuideIntroHero.vue
@@ -259,7 +259,7 @@ const view = ref('search');
 
 <style scoped>
 .board {
-  width: var(--mk-size-256);
+  width: min(var(--mk-size-256), 100%);
 }
 /* This hero's header carries an extra Goal chip on top of the shared
    name/badge/tools, which overflows the 256px sidebar. Let it wrap to a second
@@ -270,14 +270,47 @@ const view = ref('search');
   white-space: normal;
   height: auto;
   row-gap: var(--mk-space-4);
+  min-width: 0;
+  overflow: hidden;
+}
+.stream-head .sh-name {
+  flex: 1 1 auto;
+}
+.stream-head .sh-badge {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .stream-head .sh-tools {
   margin-left: auto;
+}
+.board-tabs,
+.tcard,
+.tcard-sum,
+.tc-row,
+.todo {
+  min-width: 0;
+}
+.bt,
+.tc-v,
+.td-tx {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tc-v {
+  overflow-wrap: anywhere;
 }
 /* Three editor tabs are tight at content width — shrink them to fit. */
 .tabs .tab {
   font-size: var(--mk-fs-69);
   padding: var(--mk-space-8) var(--mk-space-8);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Orchestrator Goal chip (header) */
@@ -291,7 +324,8 @@ const view = ref('search');
   border: 1px solid color-mix(in srgb, var(--mk-accent) 30%, transparent);
   border-radius: var(--mk-radius-pill);
   padding: 1px var(--mk-space-7);
-  flex-shrink: 0;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 .goal-ic {
   font-size: var(--mk-space-10);

--- a/docs/.vitepress/components/MockupFrame.vue
+++ b/docs/.vitepress/components/MockupFrame.vue
@@ -60,8 +60,12 @@ const LOGO = withBase('/logo-icon-board.svg');
   background: var(--editor-bg);
   border: 1px solid var(--mk-border-strong);
   border-radius: var(--mk-radius-window);
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
   overflow: hidden;
   position: relative;
+  container: mockup-frame / inline-size;
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.04) inset,
     0 24px 60px -20px rgba(0, 0, 0, 0.55),
@@ -102,11 +106,14 @@ const LOGO = withBase('/logo-icon-board.svg');
 .win-body {
   display: flex;
   min-height: var(--mk-size-470);
+  min-width: 0;
+  max-width: 100%;
 }
 .win-content {
   display: flex;
   flex: 1;
   min-width: 0;
+  max-width: 100%;
 }
 
 /* Activity bar */
@@ -179,6 +186,41 @@ const LOGO = withBase('/logo-icon-board.svg');
     height: var(--mk-size-40);
     border-right: none;
     border-bottom: 1px solid var(--mk-border-strong);
+  }
+  .activity-item--active::before {
+    left: 0;
+    top: auto;
+    bottom: 0;
+    right: 0;
+    width: auto;
+    height: var(--mk-space-2);
+  }
+  .win-title {
+    margin-right: 0;
+  }
+}
+
+@container mockup-frame (max-width: 640px) {
+  .win-body {
+    flex-direction: column;
+  }
+  .win-content {
+    flex-direction: column;
+  }
+  .activity-bar {
+    flex-direction: row;
+    width: auto;
+    justify-content: flex-start;
+    gap: var(--mk-space-8);
+    padding: 0 var(--mk-space-10);
+    height: var(--mk-size-40);
+    border-right: none;
+    border-bottom: 1px solid var(--mk-border-strong);
+    overflow: hidden;
+  }
+  .activity-item {
+    width: var(--mk-size-36);
+    flex: 0 1 var(--mk-size-36);
   }
   .activity-item--active::before {
     left: 0;

--- a/docs/.vitepress/theme/mockup.css
+++ b/docs/.vitepress/theme/mockup.css
@@ -267,7 +267,8 @@
 
 /* Sidebar shell (board). Width is set per hero (content differs). */
 .mockup .board {
-  flex-shrink: 0;
+  flex: 0 1 auto;
+  max-width: 100%;
   background: var(--mk-bg);
   border-right: 1px solid var(--mk-border-strong);
   display: flex;
@@ -676,8 +677,9 @@
 /* Editor body — terminal-style artifact (Wolfram / Lean / BibTeX) */
 .mockup .term {
   flex: 1;
+  min-width: 0;
   min-height: 0;
-  overflow-y: auto;
+  overflow: auto;
   margin: var(--mk-space-16);
   padding: var(--mk-space-16) var(--mk-space-18);
   background: var(--mk-bg-deep);
@@ -1201,6 +1203,14 @@
 
 /* Stack the sidebar above the editor on narrow screens. */
 @media (max-width: 820px) {
+  .mockup .board {
+    width: auto !important;
+    border-right: none;
+    border-bottom: 1px solid var(--mk-border-strong);
+  }
+}
+
+@container mockup-frame (max-width: 640px) {
   .mockup .board {
     width: auto !important;
     border-right: none;


### PR DESCRIPTION
Closes #5899.

## Summary

- make `MockupFrame` a width-aware container so product mockups respond to their own embedded width, not only the viewport
- let guide mockup sidebars shrink/stack in narrow frames
- constrain the dense Guide intro stream header, todo text, delegate cards, and tabs so long labels stay inside the mockup frame

## Validation

- `corepack pnpm prettier --write docs/.vitepress/components/MockupFrame.vue docs/.vitepress/components/GuideIntroHero.vue docs/.vitepress/theme/mockup.css`
- `git diff --check`
- `corepack pnpm --dir docs run docs:build`
- Chrome DevTools 390px emulation of `/guide/`: `pageWidth == viewport == 390`; `.win`, `.win-content`, `.board`, `.stream-head`, `.sh-badge`, `.umsg`, `.tcard`, `.tc-row`, and `.term` all stayed within their client width
- captured `/tmp/texra-guide-mobile-cdp-fixed.png` and `/tmp/texra-guide-desktop-fixed.png` for visual inspection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to VitePress mockup components and theme styles; no runtime app, auth, or data handling impact.
> 
> **Overview**
> **Makes VitePress product mockups respect their embedded width** so guide heroes don’t spill past narrow layouts (e.g. ~390px mobile), not only full-viewport breakpoints.
> 
> `MockupFrame` is now a **width-aware container** (`container: mockup-frame`, `width`/`max-width: 100%`, `min-width: 0` on the body/content). A **`@container mockup-frame (max-width: 640px)`** block stacks the activity bar horizontally and flips the main layout to a column—the same behavior that used to depend on viewport `@media (max-width: 820px)`.
> 
> Shared **`mockup.css`** lets sideboards **shrink** (`flex: 0 1 auto`, `max-width: 100%`) and stacks the **`.board`** above the editor under the same container query. Terminal panes get **`min-width: 0`** and **`overflow: auto`** so horizontal overflow is contained.
> 
> **`GuideIntroHero`** caps the sidebar at **`min(256px, 100%)`** and adds flex/ellipsis/`overflow-wrap` on the stream header (Goal chip, turn badge), todos, delegate cards, board tabs, and editor tabs so long labels stay inside the frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea56a7f224a67cf5c8da035ff1138cf4c4323dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->