### PR TITLE
[codex] fix approval prompt status interleave

### DIFF
--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -14,6 +14,10 @@ export type ApprovalDecision = SharedApprovalDecision;
 export const CLI_PERSONAL_API_RETRY_HINT =
   'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch to personal API keys.';
 
+export interface CliApprovalPromptHooks {
+  readonly beforePrompt?: () => void;
+}
+
 const deniedApprovalContexts = new WeakSet<CliContext>();
 const cliPromptQueues = new WeakMap<CliContext, Promise<unknown>>();
 
@@ -178,9 +182,11 @@ export function immediateDecisionForApproval(
 export async function askApproval(
   context: CliContext,
   summary: string,
+  hooks: CliApprovalPromptHooks = {},
 ): Promise<ApprovalDecision> {
   let answer: string;
   try {
+    hooks.beforePrompt?.();
     answer = await queueCliApprovalQuestion(context, {
       kind: 'approval',
       summary,
@@ -195,6 +201,7 @@ export async function askApproval(
   let feedback = parsed.feedback;
   if (!parsed.accepted && parsed.shouldPromptForFeedback) {
     try {
+      hooks.beforePrompt?.();
       const feedbackAnswer = await queueCliApprovalQuestion(context, {
         kind: 'approval',
         summary: '',

--- a/packages/cli/src/runtime/approval/humanInputHandlers.ts
+++ b/packages/cli/src/runtime/approval/humanInputHandlers.ts
@@ -7,6 +7,7 @@ import { type CliContext } from '../cliContext';
 import { parseUserQuestionAnswer } from '../userQuestionAnswer';
 
 import {
+  type CliApprovalPromptHooks,
   approvalPromptAllowed,
   humanInputDenialFeedback,
   markApprovalDenied,
@@ -17,6 +18,7 @@ import { formatUserQuestionPrompt } from './approvalSummaries';
 export function handleExternalInquiry(
   payload: ProgressEventPayloads['showExternalInquiry'],
   context: CliContext,
+  hooks: CliApprovalPromptHooks = {},
 ): void {
   const threadId = payload.threadId;
   if (!threadId) {
@@ -36,6 +38,7 @@ export function handleExternalInquiry(
   void (async () => {
     let answer: string;
     try {
+      hooks.beforePrompt?.();
       answer = await queueCliApprovalQuestion(context, {
         kind: 'externalInquiry',
         summary: `External inquiry requested:\n${payload.question}`,
@@ -71,6 +74,7 @@ export function handleExternalInquiry(
 export function handleUserQuestion(
   payload: ProgressEventPayloads['showUserQuestion'],
   context: CliContext,
+  hooks: CliApprovalPromptHooks = {},
 ): void {
   if (!approvalPromptAllowed(context)) {
     const feedback = humanInputDenialFeedback(
@@ -89,6 +93,7 @@ export function handleUserQuestion(
     const answers: Record<string, string | string[]> = {};
     try {
       for (const question of payload.questions) {
+        hooks.beforePrompt?.();
         const answer = await queueCliApprovalQuestion(context, {
           kind: 'approval',
           summary: payload.context

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -15,6 +15,7 @@ import { type CliContext } from './cliContext';
 import { writeTextStderr } from './logSinks';
 
 import {
+  type CliApprovalPromptHooks,
   askApproval,
   immediateDecision,
   immediateDecisionForApproval,
@@ -53,6 +54,7 @@ export {
 async function decideToolEdit(
   request: ToolEditApprovalRequest,
   context: CliContext,
+  hooks: CliApprovalPromptHooks,
 ): Promise<ToolEditApprovalResult> {
   const immediate = immediateDecision(context);
   if (immediate) {
@@ -64,25 +66,33 @@ async function decideToolEdit(
   const decision = await askApproval(
     context,
     formatToolEditApprovalSummary(request),
+    hooks,
   );
   return decision.accepted
     ? { accepted: true, appliedContent: request.proposedContent }
     : { accepted: false, userMessage: decision.userMessage };
 }
 
-export function installCliApprovalHandlers(context: CliContext): void {
-  setToolEditApprovalHandler((request) => decideToolEdit(request, context));
+export function installCliApprovalHandlers(
+  context: CliContext,
+  hooks: CliApprovalPromptHooks = {},
+): void {
+  setToolEditApprovalHandler((request) =>
+    decideToolEdit(request, context, hooks),
+  );
 }
 
 export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
   event: K,
   payload: ProgressEventPayloads[K],
   context: CliContext,
+  hooks: CliApprovalPromptHooks = {},
 ): boolean {
   if (event === 'showExternalInquiry') {
     handleExternalInquiry(
       payload as ProgressEventPayloads['showExternalInquiry'],
       context,
+      hooks,
     );
     return true;
   }
@@ -91,6 +101,7 @@ export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
     handleUserQuestion(
       payload as ProgressEventPayloads['showUserQuestion'],
       context,
+      hooks,
     );
     return true;
   }
@@ -99,20 +110,22 @@ export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
 
   const approvalPayload = payload as ProgressEventPayloads[typeof event];
 
+  const immediate = immediateDecisionForApproval(
+    event,
+    approvalPayload,
+    context,
+  );
+
   // Surface the upstream cause of every retry request before any auto-decision.
   // Without this, non-interactive runs (--print + never/yolo) lose the only
   // place the relay/provider error appears, leaving users with an opaque
   // "Node exceeded maximum manual retry limit" after the budget runs out.
   if (event === 'showRetryRequest') {
     const data = approvalPayload as ProgressEventPayloads['showRetryRequest'];
+    if (!immediate) hooks.beforePrompt?.();
     writeTextStderr(formatRetryRequestMessage(data));
   }
 
-  const immediate = immediateDecisionForApproval(
-    event,
-    approvalPayload,
-    context,
-  );
   if (immediate) {
     dispatchApprovalDecision(event, approvalPayload, immediate);
     return true;
@@ -122,6 +135,7 @@ export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
     const decision = await askApproval(
       context,
       summarizeApprovalEvent(event, approvalPayload),
+      hooks,
     );
     dispatchApprovalDecision(event, approvalPayload, decision, {
       writeRejectionToStderr: true,

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -31,7 +31,13 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
 
   return {
     emit(event, payload) {
-      if (handleCliApprovalEvent(event, payload, context)) return;
+      if (
+        handleCliApprovalEvent(event, payload, context, {
+          beforePrompt: () => runProgress?.preserve(),
+        })
+      ) {
+        return;
+      }
 
       if (context.outputFormat === 'ndjson') {
         writeNdjsonStdout({

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -20,6 +20,7 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 const CHANNEL = 'SessionDescription';
 const MAX_DESCRIPTION_LENGTH = 80;
+const MAX_DESCRIPTION_WORDS = 12;
 
 /**
  * Normalize a model-generated session description: collapse newlines,
@@ -35,6 +36,7 @@ export function cleanSessionDescription(text: string): string {
     .replaceAll(/[.!?…]+$/g, '')
     .trim();
   if (!cleaned) return '';
+  if (cleaned.split(/\s+/).length > MAX_DESCRIPTION_WORDS) return '';
   return truncateWithEllipsis(cleaned, MAX_DESCRIPTION_LENGTH);
 }
 

--- a/src/test-kernel/agent/runtime/CleanSessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/CleanSessionDescription.vitest.ts
@@ -46,6 +46,24 @@ describe('cleanSessionDescription', () => {
     assert.equal(cleanSessionDescription('   '), '');
   });
 
+  it('rejects full-sentence helper responses instead of persisting stale prose', () => {
+    assert.equal(
+      cleanSessionDescription(
+        'Since the system environment for this run does not provide delegation tools, I cannot delegate.',
+      ),
+      '',
+    );
+  });
+
+  it('keeps compact labels within the description word budget', () => {
+    assert.equal(
+      cleanSessionDescription(
+        'Checking concise proof with one delegated review subagent',
+      ),
+      'Checking concise proof with one delegated review subagent',
+    );
+  });
+
   it('truncates with ellipsis at 80 characters', () => {
     const long = 'a'.repeat(120);
     const result = cleanSessionDescription(long);

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -6,6 +6,7 @@ import {
   formatAgentProposalApprovalSummary,
   formatRetryRequestMessage,
   formatToolEditApprovalSummary,
+  handleCliApprovalEvent,
   hasCliApprovalDenied,
   humanInputDenialFeedback,
   immediateDecisionForApproval,
@@ -114,6 +115,59 @@ describe('human input approval policy', () => {
       'Denied by CLI approval policy.',
     );
     expect(hasCliApprovalDenied(ctx)).toBe(true);
+  });
+});
+
+describe('approval prompt hooks', () => {
+  const proposal: ProgressEventPayloads['showAgentProposal'] = {
+    proposalId: 'proposal-1',
+    streamId: 'root@deepseekT#abc',
+    agent: 'review',
+    model: 'deepseekT',
+    instruction: 'Please check this proof.',
+    memories: [],
+    agentCategory: AgentCategory.ToolUse,
+  };
+
+  it('runs the before-prompt hook for interactive approval events', async () => {
+    const events: string[] = [];
+    const handled = handleCliApprovalEvent(
+      'showAgentProposal',
+      proposal,
+      context({
+        approvalPrompt: async () => {
+          events.push('prompt');
+          return 'n no review needed';
+        },
+      }),
+      {
+        beforePrompt: () => {
+          events.push('before');
+        },
+      },
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(handled).toBe(true);
+    expect(events).toEqual(['before', 'prompt']);
+  });
+
+  it('does not run the before-prompt hook for auto-approved events', () => {
+    const events: string[] = [];
+    const handled = handleCliApprovalEvent(
+      'showAgentProposal',
+      proposal,
+      context({ approvalPolicy: 'yolo' }),
+      {
+        beforePrompt: () => {
+          events.push('before');
+        },
+      },
+    );
+
+    expect(handled).toBe(true);
+    expect(events).toEqual([]);
   });
 });
 

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -581,6 +581,32 @@ describe('CLI run progress renderer', () => {
     expect(output).toContain('polish paper.tex · 0s');
   });
 
+  it('preserves the live progress line before approval prompts', async () => {
+    const output = await captureStreamWrites(process.stderr, async () => {
+      const host = createCliRuntimeHost(
+        context({
+          approvalPolicy: 'ask',
+          approvalPrompt: async () => 'n no review needed',
+        }),
+      );
+
+      host.emit('setTaskState', workflowTaskState());
+      host.emit('showAgentProposal', {
+        proposalId: 'proposal-1',
+        streamId: 'stream-1',
+        agent: 'review',
+        model: 'deepseekT',
+        instruction: 'Please check this proof.',
+        memories: [],
+        agentCategory: AgentCategory.ToolUse,
+      });
+      await Promise.resolve();
+      await host.close();
+    });
+
+    expect(output).toContain('\r\x1b[2Kpolish paper.tex · 0s\n');
+  });
+
   it('writes human progress to stderr without polluting json stdout', async () => {
     let stderr = '';
     const stdout = await captureStreamWrites(process.stdout, async () => {


### PR DESCRIPTION
## Summary

- preserve the live CLI progress renderer before interactive approval and human-input prompts write to the terminal
- keep auto-approval paths from triggering the prompt-preserve hook
- reject full-sentence helper responses as session descriptions so stale assistant prose is not persisted in history

## Root Cause

The CLI runtime handled approval events before the run-progress renderer saw them, so an active single-line status could remain live while the approval prompt wrote to stderr. Separately, session descriptions accepted long helper-model prose and truncated it into a misleading history label.

Refs #5901.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/CleanSessionDescription.vitest.ts src/test-kernel/agent/runtime/SessionDescription.vitest.ts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/approval/approvalPolicy.ts packages/cli/src/runtime/approval/humanInputHandlers.ts packages/cli/src/runtime/approvalAdapter.ts packages/cli/src/runtime/runtimeHost.ts src/agent/runtime/sessionDescription.ts src/test-kernel/agent/runtime/CleanSessionDescription.vitest.ts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (0 errors, existing import-order warnings only)
- `npm run texra-local:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI UX and session-label normalization with tests; no auth, security, or data-model changes.
> 
> **Overview**
> Fixes **terminal interleaving** when the CLI shows interactive approval or human-input prompts while a live run-progress status line is active. A new **`CliApprovalPromptHooks`** hook (with **`beforePrompt`**) is threaded through approval handling; **`runtimeHost`** wires it to **`runProgress.preserve()`** so the ANSI line is finalized before stderr prompts. The hook runs only on paths that actually prompt—**not** on yolo/auto-approved decisions—and also before interactive retry stderr output.
> 
> Separately, **`cleanSessionDescription`** now **drops** helper-model text over **12 words**, so full-sentence assistant prose is not saved as a truncated session label in history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e6dd7644ed8e62f1b698f77317ce13bcdd63df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->