### PR TITLE
[codex] scope CLI approval handlers to runs

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -7,7 +7,6 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
-import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import {
   CliUsageError,
   readCliStdinText,
@@ -127,8 +126,6 @@ export async function runToolUseAgent(
       writeErrorStderr(error);
       return CliExitCode.Usage;
     }
-
-    installCliApprovalHandlers(runContext);
 
     const config: AgentConfigPayload = {
       agent: init.agent,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -10,7 +10,6 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
-import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import { approvalPromptsUnavailable } from '../runtime/approvalPolicyAvailability';
 import {
   CliUsageError,
@@ -352,7 +351,6 @@ export async function runMultiAgentPreset(
         stdinInputFile,
       },
     );
-    installCliApprovalHandlers(runContext);
     writeApprovalUnavailableDelegationWarning(runContext, plan);
 
     const config: AgentConfigPayload = {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -9,7 +9,6 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
-import { installCliApprovalHandlers } from '../runtime/approvalAdapter';
 import {
   CliUsageError,
   readCliStdinText,
@@ -113,8 +112,6 @@ export async function runWorkflowAgent(
         'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
       );
     }
-
-    installCliApprovalHandlers(runContext);
 
     const modelOutputFile =
       init.output && path.isAbsolute(init.output)

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -76,10 +76,13 @@ async function decideToolEdit(
 export function installCliApprovalHandlers(
   context: CliContext,
   hooks: CliApprovalPromptHooks = {},
-): void {
+): () => void {
   setToolEditApprovalHandler((request) =>
     decideToolEdit(request, context, hooks),
   );
+  return () => {
+    setToolEditApprovalHandler();
+  };
 }
 
 export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -4,6 +4,7 @@ import type { ValidatedExecutionRequest } from '@agent/core/execution/executionR
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 
 import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
+import { installCliApprovalHandlers } from './approvalAdapter';
 import { createCliRuntimeHost } from './runtimeHost';
 import {
   readCliTerminalStatus,
@@ -43,6 +44,9 @@ export async function executeCliRequest(
   options: CliExecuteOptions = {},
 ): Promise<{ result: ExecuteAgentResult; terminalStatus: ExecutionStatus }> {
   const runtimeHost = createCliRuntimeHost(runContext);
+  const uninstallApprovalHandlers = installCliApprovalHandlers(runContext, {
+    beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),
+  });
   const invoke = (): Promise<ExecuteAgentResult> =>
     runAgent(request, {
       runtimeHost,
@@ -61,6 +65,7 @@ export async function executeCliRequest(
     }
     throw error;
   } finally {
+    uninstallApprovalHandlers();
     await runtimeHost.close();
   }
 

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -15,6 +15,7 @@ import { createRunProgressRenderer } from './runProgressRenderer';
 import type { CliContext } from './cliContext';
 
 export type CliRuntimeHost = AgentRuntimeHost & {
+  prepareInteractivePrompt?: () => void;
   close(): Promise<void>;
 };
 
@@ -29,11 +30,16 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
     return logger;
   }
 
+  function prepareInteractivePrompt(): void {
+    runProgress?.preserve();
+  }
+
   return {
+    prepareInteractivePrompt,
     emit(event, payload) {
       if (
         handleCliApprovalEvent(event, payload, context, {
-          beforePrompt: () => runProgress?.preserve(),
+          beforePrompt: prepareInteractivePrompt,
         })
       ) {
         return;

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -10,7 +10,6 @@ const mocks = vi.hoisted(() => {
     executeCliRequest: vi.fn(),
     expandRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
-    installCliApprovalHandlers: vi.fn(),
     resolveCliAgent: vi.fn(),
     resolveCliRunModel: vi.fn(),
     stdinInputFile,
@@ -25,10 +24,6 @@ vi.mock('@agent/index', () => ({
 
 vi.mock('@agent/storage', () => ({
   writeTerminalStatus: vi.fn(),
-}));
-
-vi.mock('@cli/runtime/approvalAdapter', () => ({
-  installCliApprovalHandlers: mocks.installCliApprovalHandlers,
 }));
 
 vi.mock('@cli/runtime/initPlatform', () => ({

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -210,6 +210,33 @@ describe('formatToolEditApprovalSummary', () => {
     expect(promptSummary).toContain('+A concise proof.');
   });
 
+  it('runs the before-prompt hook for tool edit approvals', async () => {
+    const events: string[] = [];
+    installCliApprovalHandlers(
+      context({
+        approvalPrompt: async () => {
+          events.push('prompt');
+          return 'y';
+        },
+      }),
+      {
+        beforePrompt: () => {
+          events.push('before');
+        },
+      },
+    );
+
+    const result = await requestToolEditApproval({
+      path: '/tmp/new-proof.tex',
+      originalContent: '',
+      proposedContent: '\\section{Proof}\nA concise proof.\n',
+      sourceTool: 'write_file',
+    });
+
+    expect(result.accepted).toBe(true);
+    expect(events).toEqual(['before', 'prompt']);
+  });
+
   it('passes one-line rejection feedback to the tool result', async () => {
     installCliApprovalHandlers(
       context({

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -18,7 +18,6 @@ const mocks = vi.hoisted(() => {
     formatCliMultiAgentTeamLaunchBlockMessage: vi.fn(),
     getAgentsByCategory: vi.fn(),
     initCliPlatform: vi.fn(),
-    installCliApprovalHandlers: vi.fn(),
     isAuthenticated: vi.fn(),
     loadAgents: vi.fn(),
     planCliMultiAgentPresets: vi.fn(),
@@ -36,11 +35,6 @@ vi.mock('@agent/index', () => ({
 
 vi.mock('@agent/storage', () => ({
   writeTerminalStatus: vi.fn(),
-}));
-
-vi.mock('@cli/runtime/approvalAdapter', () => ({
-  hasCliApprovalDenied: vi.fn(() => false),
-  installCliApprovalHandlers: mocks.installCliApprovalHandlers,
 }));
 
 vi.mock('@cli/runtime/initPlatform', () => ({

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -5,6 +5,8 @@ import type { CliContext } from '@cli/runtime/cliContext';
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),
   createCliRuntimeHost: vi.fn(),
+  installCliApprovalHandlers: vi.fn(),
+  prepareInteractivePrompt: vi.fn(),
   readCliTerminalStatus: vi.fn(),
   runAgent: vi.fn(),
   writeTerminalStatus: vi.fn(),
@@ -20,6 +22,10 @@ vi.mock('@agent/storage', () => ({
 
 vi.mock('@cli/runtime/runtimeHost', () => ({
   createCliRuntimeHost: mocks.createCliRuntimeHost,
+}));
+
+vi.mock('@cli/runtime/approvalAdapter', () => ({
+  installCliApprovalHandlers: mocks.installCliApprovalHandlers,
 }));
 
 vi.mock('@cli/runtime/terminalStatus', () => ({
@@ -46,8 +52,10 @@ describe('executeCliRequest', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.close.mockResolvedValue(undefined);
+    mocks.installCliApprovalHandlers.mockReturnValue(vi.fn());
     mocks.createCliRuntimeHost.mockReturnValue({
       emit: vi.fn(),
+      prepareInteractivePrompt: mocks.prepareInteractivePrompt,
       close: mocks.close,
     });
     mocks.readCliTerminalStatus.mockResolvedValue('completed');
@@ -107,6 +115,46 @@ describe('executeCliRequest', () => {
       expect.objectContaining({
         approvalPromptsUnavailable: false,
       }),
+    );
+  });
+
+  it('installs CLI approval handlers with the runtime prompt hook', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+    const context = cliContext({ mode: 'interactive', approvalPolicy: 'ask' });
+
+    await executeCliRequest(request, context);
+
+    expect(mocks.installCliApprovalHandlers).toHaveBeenCalledWith(
+      context,
+      expect.objectContaining({ beforePrompt: expect.any(Function) }),
+    );
+
+    const hooks = mocks.installCliApprovalHandlers.mock.calls[0]?.[1] as {
+      beforePrompt?: () => void;
+    };
+    hooks.beforePrompt?.();
+    expect(mocks.prepareInteractivePrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores CLI approval handlers before closing the runtime host', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+    const uninstall = vi.fn();
+    mocks.installCliApprovalHandlers.mockReturnValue(uninstall);
+
+    await executeCliRequest(request, cliContext());
+
+    expect(uninstall).toHaveBeenCalledTimes(1);
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+    expect(uninstall.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.close.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
   });
 });

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -9,7 +9,6 @@ const mocks = vi.hoisted(() => {
     executeCliRequest: vi.fn(),
     expandRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
-    installCliApprovalHandlers: vi.fn(),
     resolveCliAgent: vi.fn(),
     resolveCliRunModel: vi.fn(),
     stdinInputFile,
@@ -18,10 +17,6 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('@agent/storage', () => ({
   writeTerminalStatus: vi.fn(),
-}));
-
-vi.mock('@cli/runtime/approvalAdapter', () => ({
-  installCliApprovalHandlers: mocks.installCliApprovalHandlers,
 }));
 
 vi.mock('@cli/runtime/initPlatform', () => ({


### PR DESCRIPTION
## Summary

- move CLI approval handler installation from individual command entrypoints into `executeCliRequest`
- pass the runtime host prompt boundary into tool-edit approvals so they share the same progress-line preservation path as event approvals
- restore the global tool-edit approval handler when the run exits
- remove duplicated setup from `run`, `agents run`, and `multi-agent run`

## Root Cause

After #5902, event approvals used `runtimeHost.prepareInteractivePrompt()` before writing interactive prompts, but tool-edit approvals still used a global handler installed by each command before the runtime host existed. That split ownership meant the tool-edit path could not use the same prompt boundary and had a less clear lifecycle.

Closes #5903.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/multiAgent.ts packages/cli/src/commands/workflow.ts packages/cli/src/runtime/approvalAdapter.ts packages/cli/src/runtime/runExecution.ts packages/cli/src/runtime/runtimeHost.ts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `npm run compile:fast`
- `npm run texra-local:build`
- `npm run lint` (0 errors, existing import-order warnings only)
- `corepack pnpm --filter @texra-ai/cli validate:tui --no-build --snapshot-dir /tmp/texra-tui-runtime-owner approval-form edit-approval narrow-edit-approval bash-approval long-bash-approval compact-long-bash-approval-scroll`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive approval and global tool-edit handler lifecycle; incorrect scoping could break prompts or leave stale handlers, but changes are centralized with explicit restore and tests.
> 
> **Overview**
> **CLI approval handler installation** moves from `agents run`, `multi-agent run`, and workflow `run` into shared **`executeCliRequest`**, so every headless run gets the same lifecycle.
> 
> **`installCliApprovalHandlers`** now returns an uninstall function that clears the global tool-edit handler in a `finally` block **before** the runtime host closes, avoiding leaked handlers between runs.
> 
> Tool-edit approvals receive **`beforePrompt`** wired to **`runtimeHost.prepareInteractivePrompt`** (run progress preservation), matching event-driven approvals instead of installing handlers before the host exists.
> 
> Command tests drop duplicated approval mocks; **`RunExecution`** and **`ApprovalAdapter`** tests cover install/uninstall order and the tool-edit **`beforePrompt`** hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4d861b5e8ebcc4040861fc869d57928a118ddf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->