### PR TITLE
[codex] fix idle chat Ctrl-C exit code

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -405,6 +405,7 @@ export function chatTuiCanSelectModel(input: {
 export type ChatTuiSigintAction =
   | 'clean-exit'
   | 'force-exit'
+  | 'preserve-exit'
   | 'interrupt-and-arm-exit';
 
 export function chatTuiSigintAction(input: {
@@ -416,9 +417,9 @@ export function chatTuiSigintAction(input: {
   if (input.canStopActiveRun) return 'interrupt-and-arm-exit';
   // Resumable-idle (interruptible but not actively running): exit WITHOUT
   // interrupting so the suspended tool-use flow record survives for resume —
-  // interrupting would clear it in runToolUseFlow's finally. force-exit calls
-  // process.exit, leaving the suspended flow on disk for `texra --resume`.
-  if (input.canInterruptActiveRun) return 'force-exit';
+  // interrupting would clear it in runToolUseFlow's finally. preserve-exit
+  // calls process.exit, leaving the suspended flow on disk for `texra --resume`.
+  if (input.canInterruptActiveRun) return 'preserve-exit';
   return 'clean-exit';
 }
 
@@ -1813,12 +1814,17 @@ export async function runChat(
         requestInputExit();
         return;
       case 'force-exit':
-        // exitArmed OR resumable-idle: exit WITHOUT interrupting. For an
-        // idle/WAITING session this preserves the suspended tool-use flow
-        // record (executions/<id>/flow-*.json) so `texra --resume` can
-        // continue it — interrupting would clear it in runToolUseFlow's
-        // finally. exitNow() calls process.exit, leaving the flow on disk.
-        exitNow(130);
+        exitNow(CliExitCode.Interrupted);
+        return;
+      case 'preserve-exit':
+        // Resumable-idle: exit WITHOUT interrupting. This preserves the
+        // suspended tool-use flow record (executions/<id>/flow-*.json) so
+        // `texra --resume` can continue it. Preserve the session's current
+        // terminal status too; an intentional idle exit after a successful turn
+        // should not report SIGINT/130.
+        //
+        // exitNow() calls process.exit, leaving the flow on disk.
+        exitNow(session.runExitCode);
         return;
       case 'interrupt-and-arm-exit':
         session.stopRequested = true;

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1338,13 +1338,13 @@ describe('CLI TUI row allocation', () => {
 
     expect(
       // Idle/WAITING (interruptible, not stoppable): exit WITHOUT interrupting
-      // so the suspended tool-use flow record survives for `texra --resume`.
+      // so the suspended tool-use flow record and terminal status survive.
       chatTuiSigintAction({
         exitArmed: false,
         canStopActiveRun: false,
         canInterruptActiveRun: true,
       }),
-    ).toBe('force-exit');
+    ).toBe('preserve-exit');
 
     expect(
       chatTuiSigintAction({


### PR DESCRIPTION
Closes #5905.

## Summary

- split the chat TUI SIGINT policy so resumable-idle exits use a distinct `preserve-exit` action instead of sharing the hard `force-exit` path
- keep the existing resume-preservation behavior, but return the session's current terminal status when the footer presents Ctrl-C as idle `exit`
- update the focused TUI state test to lock the idle/WAITING action to `preserve-exit`

## Dogfood evidence

After rebuilding and relinking `texra-local`, I ran a real TTY chat in `/tmp/texra-chat-exit-6kPwLa`:

1. `texra-local chat --agent review --model deepseekT --approval-policy=ask`
2. Submitted: `In one sentence, prove that the sum of two even integers is even. Do not use tools.`
3. Waited for the footer to return to `idle` with `[Ctrl-C]exit`.
4. Pressed Ctrl-C.

The wrapper observed `__EXIT:0`, the CLI printed the resume hint, and `texra-local history list --cwd /tmp/texra-chat-exit-6kPwLa --output-format json --quiet --limit 5` showed the session as `resumable`.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `git diff --check`
- `npm run lint` (passes with pre-existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI TUI SIGINT/exit-code behavior change with no auth or data-path impact; resume preservation is unchanged aside from exit code.
> 
> **Overview**
> Fixes **idle chat Ctrl-C** reporting exit **130** after a successful turn when the footer shows `[Ctrl-C]exit`.
> 
> The SIGINT policy now splits **resumable-idle** (interruptible but not stoppable) into a dedicated **`preserve-exit`** action instead of reusing **`force-exit`**. **`force-exit`** remains for the armed double–Ctrl-C path and still exits with **`CliExitCode.Interrupted`**. **`preserve-exit`** still skips interrupting the suspended tool-use flow (so **`texra --resume`** works) but calls **`exitNow(session.runExitCode)`**, so a normal idle exit can return **0** instead of SIGINT.
> 
> The TUI test locks idle/WAITING **`chatTuiSigintAction`** to **`preserve-exit`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c515bb49e2953a93d5ff53ed8fff4bc4eb49b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->