### PR TITLE
[codex] cover progress approval layout smoke

### DIFF
--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -15,6 +15,10 @@ const RENDER_TIMEOUT_MS = readPositiveNumber(
   process.env.TEXRA_WEBVIEW_SMOKE_TIMEOUT_MS,
   10_000,
 );
+const DEFAULT_VIEWPORT = {
+  width: 1280,
+  height: 900,
+};
 
 function normalizeConsoleMessage(levelOrDetails, message) {
   if (typeof levelOrDetails === 'object' && levelOrDetails !== null) {
@@ -330,8 +334,8 @@ async function applyViewFixture(window, view) {
 
 function createSmokeWindow(errors) {
   const window = new BrowserWindow({
-    width: 1280,
-    height: 900,
+    width: DEFAULT_VIEWPORT.width,
+    height: DEFAULT_VIEWPORT.height,
     show: false,
     webPreferences: {
       backgroundThrottling: false,
@@ -360,8 +364,110 @@ function createSmokeWindow(errors) {
   return window;
 }
 
+async function assertToolEditApprovalLayout(window, view) {
+  return window.webContents.executeJavaScript(
+    `
+      (async () => {
+        function findDeep(selector, root = document) {
+          const direct = root.querySelector?.(selector);
+          if (direct) return direct;
+          for (const element of root.querySelectorAll?.('*') ?? []) {
+            const found = element.shadowRoot ? findDeep(selector, element.shadowRoot) : null;
+            if (found) return found;
+          }
+          return null;
+        }
+
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+        const panel = findDeep('tool-edit-request-panel');
+        const section = findDeep('.approval-requests');
+        const card = findDeep('.approval-request');
+        const actions = findDeep('.approval-request__actions');
+        const approveButton = findDeep('wa-button[data-action="approve"]');
+        const rejectButton = findDeep('wa-button[data-action="reject"]');
+
+        const missing = [
+          ['tool-edit-request-panel', panel],
+          ['.approval-requests', section],
+          ['.approval-request', card],
+          ['.approval-request__actions', actions],
+          ['approve button', approveButton],
+          ['reject button', rejectButton],
+        ]
+          .filter(([, element]) => !element)
+          .map(([label]) => label);
+        if (missing.length > 0) {
+          throw new Error(\`${view.name} missing approval layout elements: \${missing.join(', ')}\`);
+        }
+
+        const viewportWidth = document.documentElement.clientWidth;
+        const maxRight = viewportWidth + 1;
+        const sectionRect = section.getBoundingClientRect();
+        const cardRect = card.getBoundingClientRect();
+        const actionsRect = actions.getBoundingClientRect();
+        const approveRect = approveButton.getBoundingClientRect();
+        const rejectRect = rejectButton.getBoundingClientRect();
+
+        const overflow = [
+          ['approval section', sectionRect],
+          ['approval card', cardRect],
+          ['approval actions', actionsRect],
+          ['approve button', approveRect],
+          ['reject button', rejectRect],
+        ].filter(([, rect]) => rect.left < -1 || rect.right > maxRight);
+        if (overflow.length > 0) {
+          throw new Error(
+            \`${view.name} approval layout overflowed viewport \${viewportWidth}px: \${overflow
+              .map(([label, rect]) => \`\${label} [\${rect.left.toFixed(1)}, \${rect.right.toFixed(1)}]\`)
+              .join('; ')}\`,
+          );
+        }
+
+        const compactButtonMaxWidth = 120;
+        if (approveRect.width > compactButtonMaxWidth || rejectRect.width > compactButtonMaxWidth) {
+          throw new Error(
+            \`${view.name} approval buttons are too wide: approve=\${approveRect.width.toFixed(
+              1,
+            )}px reject=\${rejectRect.width.toFixed(1)}px\`,
+          );
+        }
+
+        return {
+          approveWidth: approveRect.width,
+          cardRight: cardRect.right,
+          rejectWidth: rejectRect.width,
+          viewportWidth,
+        };
+      })();
+    `,
+    true,
+  );
+}
+
+async function assertViewSpecificLayout(window, view) {
+  const assertions = Array.isArray(view.assertions) ? view.assertions : [];
+  for (const assertion of assertions) {
+    switch (assertion) {
+      case 'toolEditApprovalLayout': {
+        const result = await assertToolEditApprovalLayout(window, view);
+        console.log(
+          `Verified ${view.name} tool edit approval layout: ${JSON.stringify(
+            result,
+          )}`,
+        );
+        break;
+      }
+      default:
+        throw new Error(`Unknown webview smoke assertion: ${assertion}`);
+    }
+  }
+}
+
 async function smokeView(window, view, outputDir, errors) {
   errors.length = 0;
+  const viewport = view.viewport ?? DEFAULT_VIEWPORT;
+  window.setBounds({ width: viewport.width, height: viewport.height });
   await window.loadFile(view.htmlPath);
   let result;
   try {
@@ -387,6 +493,7 @@ async function smokeView(window, view, outputDir, errors) {
   }
   await assertWebviewRuntime(window, view);
   const fixtureResult = await applyViewFixture(window, view);
+  await assertViewSpecificLayout(window, view);
 
   const screenshotPath = path.join(outputDir, `${view.name}.png`);
   const image = await window.webContents.capturePage();

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -15,6 +15,11 @@ const desktopRequire = createRequire(
 );
 const nonce = 'texra-webview-smoke';
 
+const progressViewReplacements = {
+  progressBundleUri: fileUri('packages/extension/dist/progressView/bundle.js'),
+  progressStyleUri: fileUri('packages/extension/dist/progressView/index.css'),
+};
+
 const commonReplacements = {
   cspSource: 'file:',
   commonStyleUri: fileUri('packages/extension/src/common/styles/common.css'),
@@ -68,14 +73,7 @@ const views = [
     name: 'progress',
     tagName: 'progress-app',
     templatePath: join(extensionRoot, 'src', 'progressView', 'index.html'),
-    replacements: {
-      progressBundleUri: fileUri(
-        'packages/extension/dist/progressView/bundle.js',
-      ),
-      progressStyleUri: fileUri(
-        'packages/extension/dist/progressView/index.css',
-      ),
-    },
+    replacements: progressViewReplacements,
   },
   {
     name: 'progress-populated',
@@ -143,14 +141,94 @@ const views = [
         updates: [],
       },
     ],
-    replacements: {
-      progressBundleUri: fileUri(
-        'packages/extension/dist/progressView/bundle.js',
-      ),
-      progressStyleUri: fileUri(
-        'packages/extension/dist/progressView/index.css',
-      ),
+    replacements: progressViewReplacements,
+  },
+  {
+    name: 'progress-approval',
+    tagName: 'progress-app',
+    templatePath: join(extensionRoot, 'src', 'progressView', 'index.html'),
+    attributes: {
+      'data-desktop-view': 'progress',
     },
+    viewport: {
+      width: 420,
+      height: 700,
+    },
+    assertions: ['toolEditApprovalLayout'],
+    seedMessages: [
+      {
+        command: 'updateStreams',
+        streams: [
+          {
+            name: 'builtInToolUse:orchestrator',
+            label: 'orchestrator',
+            model: 'deepseekT',
+            modelLabel: 'DeepSeek V4 Flash',
+            agent: 'orchestrator',
+            agentCategory: 'toolUse',
+            creationTimestamp: 1_783_353_600_000,
+            description:
+              'Revise main.tex and ask before applying the proposed patch.',
+          },
+        ],
+        activeStream: 'builtInToolUse:orchestrator',
+        agentFilter: 'all',
+        streamStates: {
+          'builtInToolUse:orchestrator': {
+            kind: 'toolUse',
+            status: 'running',
+            lastTimestamp: 1_783_353_600_000,
+            conversationProgress: {
+              conversationTurns: 4,
+              toolCallCount: 12,
+            },
+            activeSubagents: [],
+            finishedSubagentCount: 0,
+            activeProcesses: [],
+            finishedProcessCount: 0,
+          },
+        },
+      },
+      {
+        command: 'updatePermission',
+        action: 'show',
+        permission: {
+          kind: 'toolEdit',
+          data: {
+            requestId: 'smoke-tool-edit-approval',
+            streamId: 'builtInToolUse:orchestrator',
+            allowBypass: true,
+            path: '/tmp/texra-smoke/main.tex',
+            relativePath: 'main.tex',
+            sourceTool: 'edit_file',
+            addedLines: 1,
+            removedLines: 1,
+            isLatex: true,
+            originalContent:
+              'The two expressions differ by a normalization factor.',
+            proposedContent:
+              'The two expressions match after rationalizing the denominator.',
+          },
+        },
+      },
+      {
+        command: 'logDelta',
+        streamId: 'builtInToolUse:orchestrator',
+        entries: [
+          {
+            seqNo: 1,
+            id: 'approval-smoke-msg-1',
+            type: 'log',
+            level: 'info',
+            timestamp: 1_783_353_600_000,
+            messageType: 'modelResponse',
+            text: 'I found a one-line correction and need approval before editing main.tex.',
+          },
+        ],
+        updates: [],
+      },
+    ],
+    replacements: progressViewReplacements,
   },
   {
     name: 'settings',
@@ -263,6 +341,8 @@ async function prepareViewHtml(view) {
     name: view.name,
     tagName: view.tagName,
     seedMessages: view.seedMessages ?? [],
+    assertions: view.assertions ?? [],
+    viewport: view.viewport,
   };
 }
 


### PR DESCRIPTION
## Summary
- add a narrow `progress-approval` webview smoke target seeded with a pending `toolEdit` permission
- assert the approval section, card, action row, and approve/reject buttons stay within the viewport
- keep a captured `progress-approval.png` artifact in the existing webview smoke output

## Verification
- `node --check scripts/smoke-webviews-electron-runner.cjs && node --check scripts/smoke-webviews-electron.mjs`
- `npm run smoke:webviews`
  - `Verified progress-approval tool edit approval layout: {"approveWidth":104,"cardRight":276.09375,"rejectWidth":104,"viewportWidth":420}`
- `git diff --check`
- `npm run lint` (passes with existing 25 warning baseline)

## Notes
This follows up on the approval-panel screenshot concern by making the narrow sidebar approval state renderable and asserted in smoke coverage. The current layout passes, so this PR is coverage rather than a CSS change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/smoke scripts and seeded fixtures; no production UI or auth/data paths are modified.
> 
> **Overview**
> Adds **narrow-sidebar** Electron webview smoke coverage for a pending **tool edit** approval state on the progress view, including a `progress-approval` screenshot artifact.
> 
> The smoke runner now supports **per-view viewports** and optional **layout assertions**: `toolEditApprovalLayout` walks shadow DOM for the approval panel, card, action row, and approve/reject controls, then fails if anything overflows the viewport or if those buttons exceed a compact width cap. Progress view bundle URI replacements are deduplicated via a shared `progressViewReplacements` map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0c1737300fc6046f5bc5afbe6392a422ec65c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->