### PR TITLE
[codex] clarify CLI headless tool-use docs

### DIFF
--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -176,6 +176,8 @@ Code extension.
 texra chat                          # default chat agent and model
 texra chat --agent research         # pick a tool-use agent for the session
 texra chat --model deepseekT        # override the session model
+# headless tool-use run for scripts and CI
+texra agents run review --input main.tex --instruction "Check the proof." --print
 ```
 
 Slash commands inside the session: `/tools` lists and toggles integrations,
@@ -184,7 +186,11 @@ another model from the same provider mid-session (the change applies
 immediately and persists on resume), `/skills` lists available skills and
 applies one to your next request, and `/resume` restores a stored execution.
 Chat requires an interactive terminal — for scripted, non-TTY runs use
-`texra run` with `--print` or `--output-format json|ndjson`.
+`texra agents run <agent>` with `--print` or
+`--output-format json|ndjson`. It accepts workspace `--input` and `--context`
+files plus an `--instruction` prompt for the tool-use agent. Use `texra run`
+for workflow agents that take input files and produce document-oriented
+outputs.
 
 ## Multi-Agent Teams
 

--- a/docs/prd/cli-tui-ink/00-overview.md
+++ b/docs/prd/cli-tui-ink/00-overview.md
@@ -4,7 +4,12 @@
 
 Replace the `texra chat` plain-ANSI line renderer with an Ink-based TUI that mirrors the VS Code Progress View's component topology, reuses the workspace's existing markdown and syntax-highlighting pipelines, and lets a keyboard-only user drive multi-agent sessions with the same fidelity they get in the extension.
 
-The headless path (`texra run`, `--print/-p`, `--output-format json|ndjson`, non-TTY, CI) is preserved byte-for-byte. The new TUI runs only when the chat command is invoked on an interactive terminal; when stdout is piped while stdin/stderr remain TTYs, chrome degrades to plain streaming text rather than refusing to run — see [20-implementation.md § Headless](./20-implementation.md#13-headless--legacy-preserved).
+The headless paths (`texra run`, `texra agents run`, `--print/-p`,
+`--output-format json|ndjson`, non-TTY, CI) are preserved byte-for-byte. The new
+TUI runs only when `texra chat` or the bare interactive launcher is invoked on
+an interactive terminal; when stdout is piped while stdin/stderr remain TTYs,
+chrome degrades to plain streaming text rather than refusing to run — see
+[20-implementation.md § Headless](./20-implementation.md#13-headless--legacy-preserved).
 
 ## 2. Problem
 

--- a/docs/prd/cli-tui-ink/10-architecture.md
+++ b/docs/prd/cli-tui-ink/10-architecture.md
@@ -161,7 +161,12 @@ Per-phase frame timings (render / diff / write / yoga-layout) and flicker contex
 
 ### Entrypoint default
 
-`texra` invoked with no subcommand defaults to `texra chat` when stdin / stdout are TTYs (the TUI path); otherwise it falls through to `--help`. Named subcommands (`texra run`, `texra config`, etc.) keep their explicit names. Wired through citty's default-subcommand mechanism, no shim. Pattern matches Claude Code's `claude` (bare command → REPL).
+`texra` invoked with no subcommand defaults to the interactive launcher
+(`texra orchestrate`) when stdin / stdout are TTYs; otherwise it falls through
+to `--help`. The launcher lets users pick a chat, resume a session, or run a
+team preset. Named subcommands (`texra chat`, `texra run`, `texra setup`,
+etc.) keep their explicit names. Wired through citty's default-subcommand
+mechanism, no shim.
 
 **Default agent + model resolution.** When `texra` starts the TUI without `--agent` / `--model` overrides, the agent and model are resolved in this order:
 

--- a/docs/prd/cli-tui-ink/20-implementation.md
+++ b/docs/prd/cli-tui-ink/20-implementation.md
@@ -40,7 +40,10 @@ The new streaming-text mode is exactly the gap created by gating chrome on `stdo
 
 ### What's preserved
 
-- `texra run`, `--print/-p`, `CI=true`, and `--output-format ndjson` — Ink chrome never loads. `NdjsonStdoutSink` and its drain/backpressure logic remain in `logSinks.ts` for the headless `--output-format ndjson` path; they are not touched by this PRD.
+- `texra run`, `texra agents run`, `--print/-p`, `CI=true`, and
+  `--output-format ndjson` — Ink chrome never loads. `NdjsonStdoutSink` and its
+  drain/backpressure logic remain in `logSinks.ts` for the headless
+  `--output-format ndjson` path; they are not touched by this PRD.
 - `--legacy-renderer` flag retains today's plain renderer (also auto-forced on `TERM=dumb` or `NO_COLOR` + narrow `COLUMNS`). The legacy renderer becomes the only consumer of `picocolors` after migration; everything else lives in Ink.
 - `--output-format json|ndjson` output byte-identical. Golden test in `packages/cli/scripts/validate-run.mjs`.
 
@@ -53,8 +56,15 @@ Every phase is independently mergeable. Each adds a `--tui` flag, default-off, u
 - Add `react@19`, `ink@6`, `@inkjs/ui`, `citty`, `picocolors`, `string-width`, `wrap-ansi`.
 - **Wire React Compiler.** Add `babel-plugin-react-compiler` and run a Babel pre-pass over `packages/cli/src/chat/tui/**/*.tsx` before esbuild. Validate output by smoke-running a hello-world `<App>` and confirming `react/compiler-runtime` is the only added import. Risk R12.
 - Migrate `cliContext.ts` arg parsing to `citty` (no UI change). Drop `ANSI_TONES` for `picocolors` in legacy renderer.
-- **Default subcommand:** wire `texra` (no args) to invoke `texra chat` when stdin / stdout are TTYs, fall through to `--help` otherwise. Citty's `defaultSubCommand` field.
-- **Default agent + model resolution.** Implement the four-step lookup (workspace → user → last-used → built-in) per [§ Entrypoint default](./10-architecture.md#entrypoint-default). `texra` with no args reaches this resolver before mounting `<App>`, so the header always shows a concrete agent + model.
+- **Default subcommand:** wire `texra` (no args) to invoke the interactive
+  launcher (`texra orchestrate`) when stdin / stdout are TTYs, falling through
+  to `--help` otherwise. Citty's `defaultSubCommand` field.
+- **Default agent + model resolution.** Implement the four-step lookup
+  (workspace → user → last-used → built-in) per
+  [§ Entrypoint default](./10-architecture.md#entrypoint-default). `texra chat`
+  reaches this resolver before mounting `<App>`, so the header always shows a
+  concrete agent + model; bare `texra` reaches it after the launcher starts a
+  new chat.
 - Verify headless tests + `validate-run.mjs` pass.
 
 ### Phase 1 — Skeleton + input + telemetry (2–3 d)


### PR DESCRIPTION
Closes #5910.

## Summary
- Point scripted tool-use chat users at `texra agents run <agent>` instead of workflow-only `texra run`.
- Update the CLI TUI architecture note so bare `texra` reflects the current interactive launcher default (`texra orchestrate`).

## Dogfood evidence
- Rebuilt and relinked local CLI with `npm run texra-local:build && npm run texra-local:link`.
- Ran `texra-local doctor --output-format json` successfully.
- Ran a real PTY `texra-local chat --cwd /tmp/texra-cli-dogfood --approval-policy=ask --agent chat` session on a tiny LaTeX/math task:
  - submitted a prompt via TUI keystrokes,
  - approved an `edit_file` diff,
  - approved a `pdflatex` bash command,
  - produced a compiling `main.pdf`,
  - exited cleanly with a resumable session id.
- Ran `corepack pnpm --filter @texra-ai/cli run validate:tui -- --snapshot-dir /tmp/texra-tui-frames`; all 124 TUI scenarios passed and snapshot report was written to `/tmp/texra-tui-frames/index.html`.

## Validation
- `npx prettier --write docs/guide/texra-cli.md docs/prd/cli-tui-ink/10-architecture.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or CLI behavior changes.
> 
> **Overview**
> Documentation now separates **workflow** headless runs (`texra run`) from **tool-use** headless runs (`texra agents run` with `--input`, `--context`, `--instruction`, and `--print` / JSON output).
> 
> The user guide adds a `texra agents run` example and tells scripted users to prefer that command over `texra run` for interactive-style agents in CI.
> 
> The CLI TUI Ink PRD is aligned with current behavior: headless preservation explicitly includes `texra agents run`; the TUI applies to `texra chat` and the bare launcher; **bare `texra` on a TTY** defaults to **`texra orchestrate`** (session picker), not directly to `texra chat`, with agent/model resolution described for launcher-started chat vs `texra chat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276976545b037260d6e0b46bb8cae1feb2d2b320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->