### PR TITLE
[codex] keep progress approval actions compact

### DIFF
--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -64,6 +64,12 @@ export const requestPanelStyles: CSSResult = css`
    * Shared request panel layout (all panel types)
    * ================================================================ */
 
+  :host {
+    box-sizing: border-box;
+    min-width: 0;
+    max-width: 100%;
+  }
+
   :is(${CONTAINERS}) {
     margin: ${sp.medium} 0;
     padding: ${sp.medium};
@@ -73,6 +79,9 @@ export const requestPanelStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     gap: ${sp.medium};
+    box-sizing: border-box;
+    min-width: 0;
+    max-width: 100%;
   }
 
   :is(${HEADERS}) {
@@ -87,6 +96,8 @@ export const requestPanelStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     gap: ${sp.medium};
+    min-width: 0;
+    max-width: 100%;
   }
 
   :is(${ITEMS}) {
@@ -98,6 +109,9 @@ export const requestPanelStyles: CSSResult = css`
     padding: ${sp.medium};
     gap: ${sp.medium};
     position: relative;
+    box-sizing: border-box;
+    min-width: 0;
+    max-width: 100%;
   }
 
   :is(${DETAILS}) {
@@ -129,6 +143,8 @@ export const requestPanelStyles: CSSResult = css`
     display: flex;
     flex-wrap: wrap;
     gap: ${sp.small};
+    min-width: 0;
+    max-width: 100%;
   }
 
   /* The primary action buttons (which carry data-action) fill the row
@@ -151,10 +167,10 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .approval-request__actions wa-button[data-action] {
-    flex: 0 1 6.5rem;
-    width: 6.5rem;
-    min-width: 0;
-    max-width: 100%;
+    flex: 0 0 auto;
+    width: auto;
+    min-width: min(5.5rem, 100%);
+    max-width: min(7rem, 100%);
   }
 
   :is(${ACTIONS}) wa-button[data-action]::part(base) {
@@ -262,15 +278,23 @@ export const requestPanelStyles: CSSResult = css`
     position: relative;
     display: inline-flex;
     align-items: center;
-    flex: 0 1 auto;
+    flex: 0 1 8.25rem;
+    min-width: 0;
     max-width: 100%;
   }
 
   .approval-request__actions .diff-dropdown .diff-main-button {
-    flex: 0 1 auto;
+    flex: 1 1 auto;
+    width: auto;
     min-width: 0;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+  }
+
+  .approval-request__actions .diff-dropdown .diff-main-button::part(base) {
+    width: 100%;
+    min-width: 0;
+    justify-content: center;
   }
 
   .approval-request__actions .diff-dropdown .diff-dropdown-trigger {

--- a/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
+++ b/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
@@ -21,6 +21,9 @@ function readRequestPanelStyles(): string {
 describe('request panel styles', () => {
   it('keeps tool edit approval actions compact', () => {
     const source = readRequestPanelStyles();
+    const hostStart = source.indexOf(':host {');
+    const containersStart = source.indexOf(':is(${CONTAINERS}) {');
+    const hostRule = source.slice(hostStart, containersStart);
     const actionStart = source.indexOf(
       '.approval-request__actions wa-button[data-action] {',
     );
@@ -30,13 +33,42 @@ describe('request panel styles', () => {
     const actionRule = source.slice(actionStart, baseStart);
     const baseRule = source.slice(baseStart, source.indexOf('}', baseStart));
 
+    expect(hostStart).toBeGreaterThanOrEqual(0);
+    expect(containersStart).toBeGreaterThan(hostStart);
+    expect(hostRule).toContain('min-width: 0');
+    expect(hostRule).toContain('max-width: 100%');
     expect(actionStart).toBeGreaterThanOrEqual(0);
     expect(baseStart).toBeGreaterThan(actionStart);
-    expect(actionRule).toContain('flex: 0 1 6.5rem');
-    expect(actionRule).toContain('width: 6.5rem');
-    expect(actionRule).toContain('max-width: 100%');
+    expect(actionRule).toContain('flex: 0 0 auto');
+    expect(actionRule).toContain('width: auto');
+    expect(actionRule).toContain('min-width: min(5.5rem, 100%)');
+    expect(actionRule).toContain('max-width: min(7rem, 100%)');
     expect(baseRule).toContain('justify-content: center');
     expect(baseRule).toContain('width: 100%');
+  });
+
+  it('lets the tool edit diff dropdown shrink inside narrow panels', () => {
+    const source = readRequestPanelStyles();
+    const dropdownStart = source.indexOf(
+      '.approval-request__actions .diff-dropdown {',
+    );
+    const dropdownButtonStart = source.indexOf(
+      '.approval-request__actions .diff-dropdown .diff-main-button {',
+    );
+    const dropdownRule = source.slice(dropdownStart, dropdownButtonStart);
+    const dropdownButtonRule = source.slice(
+      dropdownButtonStart,
+      source.indexOf('}', dropdownButtonStart),
+    );
+
+    expect(dropdownStart).toBeGreaterThanOrEqual(0);
+    expect(dropdownButtonStart).toBeGreaterThan(dropdownStart);
+    expect(dropdownRule).toContain('flex: 0 1 8.25rem');
+    expect(dropdownRule).toContain('min-width: 0');
+    expect(dropdownRule).toContain('max-width: 100%');
+    expect(dropdownButtonRule).toContain('flex: 1 1 auto');
+    expect(dropdownButtonRule).toContain('width: auto');
+    expect(dropdownButtonRule).toContain('min-width: 0');
   });
 
   it('keeps retry error details headers compact', () => {


### PR DESCRIPTION
Closes #5914.

## Summary
- Add shrink guards to shared request panel hosts, containers, lists, cards, and action rows so progress panels fit narrow sidebar/mock layouts.
- Change tool-edit approve/reject actions from fixed/fill behavior to compact content-sized buttons with a small max width.
- Let the tool-edit diff dropdown shrink without forcing the approval action row wider than its panel.

## Validation
- `npx prettier --write src/shared/styles/requestPanelStyles.ts src/test-kernel/progressView/RequestPanelStyles.vitest.mts`
- `npx vitest run --config vitest.config.mjs src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts`
- `VITE_WEBVIEW=progressView corepack pnpm --filter texra exec vite build --mode development`
- `git diff --check`
- Browser layout fixture using the built progress-view bundle:
  - 300px container: document `scrollWidth` stayed 420 for a 420px viewport; approve button width 107px, reject width 93px.
  - 220px container: document `scrollWidth` stayed 360 for a 360px viewport; actions wrapped without overflowing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweaks for progress request panels with updated style snapshot tests; no auth, data, or API changes.
> 
> **Overview**
> Progress request panels now **shrink inside narrow sidebars** instead of forcing horizontal overflow.
> 
> Shared `requestPanelStyles` adds **flex shrink guards** (`min-width: 0`, `max-width: 100%`, `box-sizing`) on `:host`, containers, lists, cards, and action rows. **Tool-edit approve/reject** buttons move from fixed ~6.5rem row-fill sizing to **content-sized** controls capped with `min(5.5rem–7rem, 100%)`. The **diff dropdown** can flex-shrink (`flex: 0 1 8.25rem`) with the main button stretching inside the control.
> 
> Vitest source assertions in `RequestPanelStyles.vitest.mts` are updated and extended to lock in the host, action, and diff-dropdown rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34fb3de7ea634db87675b4b1dfe008b2fb43878e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->