### PR TITLE
[codex] validate CLI TUI smoke frames in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,22 @@ jobs:
       - name: Kernel tests
         run: pnpm run test
 
+      - name: Validate CLI TUI smoke frames
+        if: runner.os == 'Linux'
+        run: >-
+          pnpm --filter @texra-ai/cli validate:tui --
+          --snapshot-dir artifacts/tui-frames
+          edit-approval subagent-picker hidden-root-approval-tab-return
+
+      - name: Upload CLI TUI smoke frames
+        if: runner.os == 'Linux' && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: texra-cli-tui-smoke-frames
+          path: artifacts/tui-frames
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Compile
         run: pnpm run compile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,11 @@ jobs:
 
       - name: Validate CLI TUI smoke frames
         if: runner.os == 'Linux'
-        run: >-
-          pnpm --filter @texra-ai/cli validate:tui --
-          --snapshot-dir artifacts/tui-frames
-          edit-approval subagent-picker hidden-root-approval-tab-return
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/artifacts"
+          pnpm --filter @texra-ai/cli validate:tui -- \
+            --snapshot-dir "$GITHUB_WORKSPACE/artifacts/tui-frames" \
+            edit-approval subagent-picker hidden-root-approval-tab-return
 
       - name: Upload CLI TUI smoke frames
         if: runner.os == 'Linux' && always()
@@ -110,7 +111,7 @@ jobs:
         with:
           name: texra-cli-tui-smoke-frames
           path: artifacts/tui-frames
-          if-no-files-found: ignore
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Compile


### PR DESCRIPTION
## Summary
- add a Linux CI smoke step for the CLI TUI frame validator
- run the approval and subagent-picker scenarios that catch high-risk interactive regressions
- upload generated TUI frame snapshots as workflow artifacts for inspection

## Why
The CLI has a deterministic PTY frame validator, but CI did not run it. That left approval modal and subagent picker regressions dependent on manual dogfood runs.

Closes #5916.

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-ci-smoke-frames edit-approval subagent-picker hidden-root-approval-tab-return`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-ci-smoke-frames-build edit-approval subagent-picker hidden-root-approval-tab-return`
- `git diff --check -- .github/workflows/ci.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; no application runtime behavior, only adds an existing local validator to the CI matrix on Ubuntu.
> 
> **Overview**
> **Linux CI** now runs the existing `@texra-ai/cli` `validate:tui` smoke after kernel tests, before compile. It exercises three PTY frame scenarios (`edit-approval`, `subagent-picker`, `hidden-root-approval-tab-return`) and writes snapshots under `artifacts/tui-frames`.
> 
> A follow-up step uploads those frames as `texra-cli-tui-smoke-frames` (14-day retention, `if-no-files-found: warn`), gated to Linux and `always()` so failures still preserve artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c79683ee990bb44913abafd70e92746ca271c01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->