### PR TITLE
[codex] share focused subagent follow-up routing

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -12,7 +12,6 @@ import React from 'react';
 import { getAgentsByCategory, loadAgents } from '@agent/index';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { isInFlightStatus } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { platform, tryPlatform } from '@platform/platform';
@@ -37,12 +36,11 @@ import {
 import { buildContinuationText } from '@tools/inquiry/inquiryContinuation';
 import { getDefaultStreamLogStore } from '@transcript';
 
-import { App, focusedChildInputDisabledMessage } from '../src/chat/tui/App';
+import { App } from '../src/chat/tui/App';
 import {
   transcriptViewportRepaintOptions,
   type TranscriptViewportChange,
 } from '../src/chat/tui/state/transcriptViewportMode';
-import { resolveChildControlDisplayTargets } from '../src/chat/tui/state/childControls';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
 import {
   findSlashCommand,
@@ -60,6 +58,10 @@ import {
   setParentStream,
   type ConversationEntry,
 } from '../src/chat/tui/state/cliState';
+import {
+  focusedChildFollowUpRoute,
+  stoppedFocusedChildFollowUpMessage,
+} from '../src/chat/tui/state/focusedChildFollowUp';
 import { formatCliSessionStatus } from '../src/chat/tui/sessionStatus';
 import { notify } from '../src/chat/tui/notifications/terminalNotifier';
 import {
@@ -1291,39 +1293,6 @@ function defaultHarnessTranscriptStreamId(): StreamTabId {
   });
 }
 
-function harnessActiveChildStreamId(): StreamTabId | undefined {
-  const activeStreamId = cliState.activeStreamId.get();
-  if (!activeStreamId) return undefined;
-  return cliState.parentStream.get().has(activeStreamId)
-    ? activeStreamId
-    : undefined;
-}
-
-function harnessRejectsChildSubmit(childStreamId: StreamTabId): boolean {
-  const status = streamStatusFromState(childStreamId);
-  return status !== undefined && !isInFlightStatus(status);
-}
-
-function harnessStoppedChildMessage(childStreamId: StreamTabId): string {
-  const parentStream = cliState.parentStream.get();
-  const streams = cliState.streams.get();
-  const controls = resolveChildControlDisplayTargets({
-    activeStreamId: childStreamId,
-    parentStream,
-    streams,
-  });
-
-  return (
-    focusedChildInputDisabledMessage({
-      activeStreamId: childStreamId,
-      parentStream,
-      status: streamStatusFromState(childStreamId),
-      subagentControlsAvailable: controls.subagents.hasItems,
-      taskControlsAvailable: controls.tasks.hasItems,
-    }) ?? 'The selected subagent is no longer accepting follow-ups.'
-  );
-}
-
 function formatHarnessSlashHelp(): string {
   return listSlashCommands()
     .map((command) => `/${command.name} - ${command.description}`)
@@ -1447,16 +1416,28 @@ function markHarnessExecutionStopped(executionId: string): void {
 
 function handleHarnessSubmit(line: string): void {
   if (handleHarnessSlashCommand(line)) return;
-  const childStreamId = harnessActiveChildStreamId();
-  if (childStreamId && harnessRejectsChildSubmit(childStreamId)) {
+  const focusedChildRoute = focusedChildFollowUpRoute({
+    activeStreamId: cliState.activeStreamId.get(),
+    parentStream: cliState.parentStream.get(),
+    statusForStream: streamStatusFromState,
+  });
+  if (focusedChildRoute.kind === 'reject') {
     appendHarnessAssistantTranscript(
-      harnessStoppedChildMessage(childStreamId),
-      childStreamId,
+      stoppedFocusedChildFollowUpMessage({
+        parentStream: cliState.parentStream.get(),
+        status: streamStatusFromState(focusedChildRoute.streamId),
+        streamId: focusedChildRoute.streamId,
+        streams: cliState.streams.get(),
+      }),
+      focusedChildRoute.streamId,
     );
     return;
   }
-  if (childStreamId) {
-    appendHarnessChildSubmitAck(`Harness received: ${line}`, childStreamId);
+  if (focusedChildRoute.kind === 'accept') {
+    appendHarnessChildSubmitAck(
+      `Harness received: ${line}`,
+      focusedChildRoute.streamId,
+    );
     return;
   }
   appendHarnessAssistantTranscript(`Harness received: ${line}`);

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -5,7 +5,6 @@
 import { Box, useApp, useInput, useStdin, useWindowSize } from 'ink';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import { isInFlightStatus } from '@common/constants/streamStatus';
 import {
   LIVE_ELAPSED_STREAM_STATUSES,
   type StreamStatus,
@@ -25,11 +24,7 @@ import {
   QueuedFollowUpsPanel,
   queuedFollowUpPanelRowCount,
 } from './panes/QueuedFollowUpsPanel';
-import {
-  defaultShortcutModifierLabel,
-  metaChordLabel,
-  StatusBar,
-} from './panes/StatusBar';
+import { StatusBar } from './panes/StatusBar';
 import {
   StreamTabsStrip,
   streamTabsDisplayItems,
@@ -53,8 +48,10 @@ import {
   type ChildControlMode,
 } from './state/childControls';
 import { cliState } from './state/cliState';
+import { focusedChildInputDisabledMessage } from './state/focusedChildFollowUp';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
 import { activeStreamScope, streamDisplayLabel } from './state/streamViews';
+import { defaultShortcutModifierLabel } from './shortcutLabels';
 import {
   isScopedTranscriptViewport,
   transcriptViewportChange,
@@ -480,45 +477,6 @@ export function approvalForegroundMaxRows(
     default:
       return assertNever(pending.payload, 'Unhandled approval payload kind');
   }
-}
-
-export function focusedChildInputDisabledMessage(init: {
-  readonly activeStreamId: StreamTabId | undefined;
-  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
-  readonly shortcutModifierLabel?: string;
-  readonly status: StreamStatus | undefined;
-  readonly subagentControlsAvailable?: boolean;
-  readonly taskControlsAvailable?: boolean;
-}): string | undefined {
-  const scope = activeStreamScope({
-    activeStreamId: init.activeStreamId,
-    parentStream: init.parentStream,
-  });
-  if (
-    scope.kind !== 'child' ||
-    init.status === undefined ||
-    isInFlightStatus(init.status)
-  ) {
-    return undefined;
-  }
-  const shortcutModifierLabel =
-    init.shortcutModifierLabel ?? defaultShortcutModifierLabel();
-  const alternateActions: string[] = [];
-  if (init.subagentControlsAvailable !== false) {
-    alternateActions.push(
-      `${metaChordLabel(shortcutModifierLabel, 's')} to choose another`,
-    );
-  }
-  if (init.taskControlsAvailable === true) {
-    alternateActions.push(
-      `${metaChordLabel(shortcutModifierLabel, 'p')} to review tasks`,
-    );
-  }
-  const base =
-    'Subagent is no longer accepting follow-ups; press Tab to switch streams';
-  if (alternateActions.length === 0) return `${base}.`;
-  const alternateText = alternateActions.join(', or ');
-  return `${base} or ${alternateText}.`;
 }
 
 export interface AppProps {

--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -6,7 +6,7 @@
 // its own row in the transcript.
 
 import { textInputEditingHelp } from '../input/textInputBindings';
-import { metaChordLabel } from '../panes/StatusBar';
+import { metaChordLabel } from '../shortcutLabels';
 
 import type { SlashCommand, SlashCommandCategory } from './slashRegistry';
 

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -1,5 +1,3 @@
-import process from 'node:process';
-
 import { Box, Text, useWindowSize } from 'ink';
 import { Badge } from '@inkjs/ui';
 import { MODEL_CONFIGS } from 'llm-zoo';
@@ -19,6 +17,10 @@ import { filterNotNullish } from '@utils/core';
 
 import { truncateSummaryToWidth } from '../render/terminalText';
 import { formatCliStatusLabel } from '../sessionStatus';
+import {
+  defaultShortcutModifierLabel,
+  metaChordLabel,
+} from '../shortcutLabels';
 import {
   approvalQueueStatus,
   type ApprovalQueueStatusKind,
@@ -374,19 +376,6 @@ function fitStatusBarLeftSegments(
     }) ??
     compacted
   );
-}
-
-export function defaultShortcutModifierLabel(
-  platform: NodeJS.Platform = process.platform,
-): string {
-  return platform === 'darwin' ? 'Esc' : 'Alt';
-}
-
-/** Bare modifier chord (`Alt-p` / `Esc p`) — also feeds the /help keyboard
- *  section, so the Esc-vs-Alt separator rule lives in one place. */
-export function metaChordLabel(modifierLabel: string, key: string): string {
-  const separator = modifierLabel === 'Esc' ? ' ' : '-';
-  return `${modifierLabel}${separator}${key}`;
 }
 
 function metaShortcutLabel(modifierLabel: string, key: string): string {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -93,7 +93,6 @@ import {
   formatCliMemoryList,
   formatCliMemoryPreview,
 } from '@cli/runtime/memory';
-import { isInFlightStatus } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { bus } from '@eventBus/ProgressEventBus';
 import { sumUsageStats } from '@shared/schemas';
@@ -111,7 +110,7 @@ import { escapeText } from '@shared/utils/xmlEscape';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 import { generateExecutionId } from '@utils/core/executionId';
 
-import { App, focusedChildInputDisabledMessage } from './App';
+import { App } from './App';
 import { assertNever } from './assertNever';
 import { formatApprovalPolicyForCli as formatApprovalPolicy } from './forms/ApprovalPolicyForm';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
@@ -134,8 +133,12 @@ import {
 } from './render/noColorOutput';
 import { formatCliSessionStatus } from './sessionStatus';
 import { clearApprovals } from './state/approvalQueue';
-import { resolveChildControlDisplayTargets } from './state/childControls';
 import { cliState, patchStream, resetCliState } from './state/cliState';
+import {
+  focusedChildFollowUpRoute,
+  stoppedFocusedChildFollowUpMessage as focusedChildStoppedMessage,
+  type FocusedChildFollowUpRoute,
+} from './state/focusedChildFollowUp';
 import {
   collectResumeTargets,
   collectResumeUsage,
@@ -149,8 +152,7 @@ import {
   onStreamStatusChange,
   streamStatusFromState,
 } from './state/streamStatus';
-import { activeStreamScope } from './state/streamViews';
-import { defaultShortcutModifierLabel } from './panes/StatusBar';
+import { defaultShortcutModifierLabel } from './shortcutLabels';
 import {
   discoverTerminalCapabilities,
   terminalCapabilities,
@@ -443,47 +445,25 @@ export function chatTuiIsResumableIdleOnExit(input: {
   return input.canInterruptActiveRun && !input.canStopActiveRun;
 }
 
-export type ChatTuiFocusedChildFollowUpRoute =
-  | { readonly kind: 'none' }
-  | { readonly kind: 'accept'; readonly streamId: StreamTabId }
-  | { readonly kind: 'reject'; readonly streamId: StreamTabId };
+export type ChatTuiFocusedChildFollowUpRoute = FocusedChildFollowUpRoute;
 
 export function chatTuiFocusedChildFollowUpRoute(): ChatTuiFocusedChildFollowUpRoute {
-  const scope = activeStreamScope({
+  return focusedChildFollowUpRoute({
     activeStreamId: cliState.activeStreamId.get(),
     parentStream: cliState.parentStream.get(),
+    statusForStream: streamStatusFromState,
   });
-  if (scope.kind !== 'child') {
-    return { kind: 'none' };
-  }
-
-  const status = streamStatusFromState(scope.streamId);
-  // A focused child normally has a status. Keep the previous permissive
-  // behavior during the brief edge where parent focus arrives first.
-  if (status !== undefined && !isInFlightStatus(status)) {
-    return { kind: 'reject', streamId: scope.streamId };
-  }
-  return { kind: 'accept', streamId: scope.streamId };
 }
 
 function stoppedFocusedChildFollowUpMessage(streamId: StreamTabId): string {
   const parentStream = cliState.parentStream.get();
   const streams = cliState.streams.get();
-  const controls = resolveChildControlDisplayTargets({
-    activeStreamId: streamId,
+  return focusedChildStoppedMessage({
     parentStream,
+    status: streamStatusFromState(streamId),
+    streamId,
     streams,
   });
-
-  return (
-    focusedChildInputDisabledMessage({
-      activeStreamId: streamId,
-      parentStream,
-      status: streamStatusFromState(streamId),
-      subagentControlsAvailable: controls.subagents.hasItems,
-      taskControlsAvailable: controls.tasks.hasItems,
-    }) ?? 'The selected subagent is no longer accepting follow-ups.'
-  );
 }
 
 interface SlashCommandContext {

--- a/packages/cli/src/chat/tui/shortcutLabels.ts
+++ b/packages/cli/src/chat/tui/shortcutLabels.ts
@@ -1,0 +1,13 @@
+import process from 'node:process';
+
+export function defaultShortcutModifierLabel(
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return platform === 'darwin' ? 'Esc' : 'Alt';
+}
+
+/** Bare modifier chord (`Alt-p` / `Esc p`) shared by status, help, and state copy. */
+export function metaChordLabel(modifierLabel: string, key: string): string {
+  const separator = modifierLabel === 'Esc' ? ' ' : '-';
+  return `${modifierLabel}${separator}${key}`;
+}

--- a/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
+++ b/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
@@ -1,0 +1,100 @@
+import { isInFlightStatus } from '@common/constants/streamStatus';
+import type { StreamStatus, StreamTabId } from '@shared/schemas';
+
+import {
+  defaultShortcutModifierLabel,
+  metaChordLabel,
+} from '../shortcutLabels';
+
+import { resolveChildControlDisplayTargets } from './childControls';
+import type { StreamSlice } from './cliState';
+import { activeStreamScope } from './streamViews';
+
+export type FocusedChildFollowUpRoute =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'accept'; readonly streamId: StreamTabId }
+  | { readonly kind: 'reject'; readonly streamId: StreamTabId };
+
+export function focusedChildFollowUpRoute(init: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly statusForStream: (streamId: StreamTabId) => StreamStatus | undefined;
+}): FocusedChildFollowUpRoute {
+  const scope = activeStreamScope({
+    activeStreamId: init.activeStreamId,
+    parentStream: init.parentStream,
+  });
+  if (scope.kind !== 'child') {
+    return { kind: 'none' };
+  }
+
+  const status = init.statusForStream(scope.streamId);
+  // A focused child normally has a status. Keep the previous permissive
+  // behavior during the brief edge where parent focus arrives first.
+  if (status !== undefined && !isInFlightStatus(status)) {
+    return { kind: 'reject', streamId: scope.streamId };
+  }
+  return { kind: 'accept', streamId: scope.streamId };
+}
+
+export function focusedChildInputDisabledMessage(init: {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly shortcutModifierLabel?: string;
+  readonly status: StreamStatus | undefined;
+  readonly subagentControlsAvailable?: boolean;
+  readonly taskControlsAvailable?: boolean;
+}): string | undefined {
+  const scope = activeStreamScope({
+    activeStreamId: init.activeStreamId,
+    parentStream: init.parentStream,
+  });
+  if (
+    scope.kind !== 'child' ||
+    init.status === undefined ||
+    isInFlightStatus(init.status)
+  ) {
+    return undefined;
+  }
+  const shortcutModifierLabel =
+    init.shortcutModifierLabel ?? defaultShortcutModifierLabel();
+  const alternateActions: string[] = [];
+  if (init.subagentControlsAvailable !== false) {
+    alternateActions.push(
+      `${metaChordLabel(shortcutModifierLabel, 's')} to choose another`,
+    );
+  }
+  if (init.taskControlsAvailable === true) {
+    alternateActions.push(
+      `${metaChordLabel(shortcutModifierLabel, 'p')} to review tasks`,
+    );
+  }
+  const base =
+    'Subagent is no longer accepting follow-ups; press Tab to switch streams';
+  if (alternateActions.length === 0) return `${base}.`;
+  const alternateText = alternateActions.join(', or ');
+  return `${base} or ${alternateText}.`;
+}
+
+export function stoppedFocusedChildFollowUpMessage(init: {
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly status: StreamStatus | undefined;
+  readonly streamId: StreamTabId;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+}): string {
+  const controls = resolveChildControlDisplayTargets({
+    activeStreamId: init.streamId,
+    parentStream: init.parentStream,
+    streams: init.streams,
+  });
+
+  return (
+    focusedChildInputDisabledMessage({
+      activeStreamId: init.streamId,
+      parentStream: init.parentStream,
+      status: init.status,
+      subagentControlsAvailable: controls.subagents.hasItems,
+      taskControlsAvailable: controls.tasks.hasItems,
+    }) ?? 'The selected subagent is no longer accepting follow-ups.'
+  );
+}

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -3,11 +3,11 @@ import { describe, expect, it } from 'vitest';
 import {
   buildStatusBarDisplay,
   ctrlCActionForFocus,
-  defaultShortcutModifierLabel,
   queuedFollowUpsSummary,
   statusBarSegmentText,
   statusBarStreamTarget,
 } from '@cli/chat/tui/panes/StatusBar';
+import { defaultShortcutModifierLabel } from '@cli/chat/tui/shortcutLabels';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import { STREAM_STATUS } from '@shared/schemas';

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -28,7 +28,6 @@ import {
   approvalVisibleForActiveStream,
   childControlForegroundMaxRows,
   digitFromMetaShortcut,
-  focusedChildInputDisabledMessage,
   foregroundEscapeAction,
   foregroundSurfaceKind,
   shouldDeferEscapeInterruptForMetaChord,
@@ -43,6 +42,7 @@ import {
   nextFocusForward,
 } from '@cli/chat/tui/state/focusCycle';
 import { hasChildControlItems } from '@cli/chat/tui/state/childControls';
+import { focusedChildInputDisabledMessage } from '@cli/chat/tui/state/focusedChildFollowUp';
 import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
 import {
   finalizeSettledPrefix,


### PR DESCRIPTION
## Summary
- move focused-child follow-up routing and stopped-child copy into a shared TUI state helper
- move shortcut chord labels out of `StatusBar` into a neutral helper
- wire `App`, production submit routing, and the PTY harness through the same route/message logic

## Why
Live CLI dogfood of the `mathematician` preset exercised real `review` and `latexFixer` subagent delegation. The user flow worked, but the stopped-subagent follow-up path had split ownership between `App.tsx`, `runChatTui.tsx`, and `tui-harness.tsx`.

That split is risky because `validate:tui` is intended to prove the behavior humans see. If the harness owns a separate rejection path, it can drift from production while still passing.

Closes #5918.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli exec tsc --noEmit`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- focused-stopped-subagent focused-stopped-subagent-submit focused-stopped-subagent-esc-s-picker focused-stopped-subagent-esc-tab-focus`
- `git diff --cached --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved via existing vitest and validate:tui scenarios; no auth, persistence, or API contract changes.
> 
> **Overview**
> **Centralizes focused-child follow-up behavior** so production chat, the TUI harness, and `App` all use the same accept/reject routing and stopped-subagent copy instead of parallel implementations in `App.tsx`, `runChatTui.tsx`, and `tui-harness.tsx`.
> 
> Adds `focusedChildFollowUp.ts` with `focusedChildFollowUpRoute`, `focusedChildInputDisabledMessage`, and `stoppedFocusedChildFollowUpMessage`. Submit paths call the shared route and rejection message; `runChatTui` keeps thin wrappers that re-export the shared type for existing tests.
> 
> Moves `defaultShortcutModifierLabel` and `metaChordLabel` into `shortcutLabels.ts` so `StatusBar`, `/help`, and follow-up messaging share one Esc-vs-Alt chord formatting rule. Test imports are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9259772c6edad9f1152ec620c045c66753109d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->