### PR TITLE
[codex] Validate slash help and typo recovery

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -42,10 +42,12 @@ import {
   type TranscriptViewportChange,
 } from '../src/chat/tui/state/transcriptViewportMode';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
+import { formatSlashCommandHelp } from '../src/chat/tui/commands/helpText';
 import {
   findSlashCommand,
   listSlashCommands,
   parseSlashInput,
+  suggestSlashCommand,
 } from '../src/chat/tui/commands/slashRegistry';
 import {
   openCliSlashCommandForm,
@@ -75,6 +77,7 @@ import {
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
 import { streamStatusFromState } from '../src/chat/tui/state/streamStatus';
 import { resolveLocalTranscriptStreamId } from '../src/chat/tui/state/transcript';
+import { defaultShortcutModifierLabel } from '../src/chat/tui/shortcutLabels';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
 import {
   formatCliApiMode,
@@ -1294,9 +1297,9 @@ function defaultHarnessTranscriptStreamId(): StreamTabId {
 }
 
 function formatHarnessSlashHelp(): string {
-  return listSlashCommands()
-    .map((command) => `/${command.name} - ${command.description}`)
-    .join('\n');
+  return formatSlashCommandHelp(listSlashCommands(), {
+    shortcutModifierLabel: defaultShortcutModifierLabel(),
+  });
 }
 
 function parseHarnessApprovalPolicy(
@@ -1484,7 +1487,13 @@ function handleHarnessSlashCommand(line: string): boolean {
     default: {
       const command = findSlashCommand(commandName);
       if (!command) {
-        appendHarnessAssistantTranscript(`Unknown command: /${parsed.name}`);
+        const suggestion = suggestSlashCommand(commandName);
+        const didYouMean = suggestion
+          ? ` Did you mean /${suggestion.name}?`
+          : '';
+        appendHarnessAssistantTranscript(
+          `Unknown command: /${parsed.name}.${didYouMean} Type /help to list commands.`,
+        );
         return true;
       }
       if (openRegisteredCliSlashForm(command, rest)) return true;

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -439,6 +439,32 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'slash-help',
+    rows: 45,
+    cols: 100,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/help', '\r'],
+    frame: 'tail',
+    expect: [
+      'Session',
+      '/clear',
+      'Start a fresh chat session',
+      'Keyboard',
+      '`Ctrl-C` stops, twice exits',
+      'Typing while a response is running queues your message as a follow-up.',
+    ],
+  },
+  {
+    name: 'unknown-slash-suggestion',
+    cols: 100,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/hlp\r'],
+    frame: 'tail',
+    expect: [
+      'Unknown command: /hlp. Did you mean /help? Type /help to list commands.',
+    ],
+  },
+  {
     name: 'narrow-slash-palette-command-names',
     rows: 16,
     cols: 52,


### PR DESCRIPTION
Closes #5920.

## Summary
- make the `validate:tui` harness reuse the production grouped `/help` formatter
- make the harness unknown slash-command path use production typo suggestions
- add PTY frame scenarios for `/help` output and pasted `/hlp` typo recovery

## Why
`validate:tui` was green even though its slash-command harness path had drifted from the production chat TUI. This keeps the deterministic frame validator aligned with the user-visible slash help and typo recovery behavior.

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui -- slash-help unknown-slash-suggestion`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/SlashHelpText.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build slash-palette`
- `corepack pnpm --filter @texra-ai/cli exec tsc --noEmit`
- `npm run lint` (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness and validator-only changes; no production chat runtime path altered beyond shared helpers already used by the app.
> 
> **Overview**
> The **TUI test harness** no longer uses a flat `name - description` list for `/help` or a bare “Unknown command” line. It now calls **`formatSlashCommandHelp`** (grouped sections, keyboard hints) and **`suggestSlashCommand`** for typos, matching the real chat TUI.
> 
> **`validate:tui`** gains PTY scenarios **`slash-help`** and **`unknown-slash-suggestion`** so frame checks fail if harness slash UX drifts again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336cecc023a993ed8545e415a2c0d933306fc619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->