### PR TITLE
[codex] Compact progress approval layouts

### DIFF
--- a/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
+++ b/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
@@ -33,6 +33,10 @@ export class MocksGallery extends LitElement {
       :host {
         display: block;
         padding: var(--wa-space-s);
+        box-sizing: border-box;
+        min-width: 0;
+        max-width: 100%;
+        overflow-x: hidden;
       }
 
       .heading {
@@ -49,6 +53,8 @@ export class MocksGallery extends LitElement {
 
       .section {
         margin-bottom: var(--wa-space-l);
+        min-width: 0;
+        max-width: 100%;
       }
 
       .section__title {
@@ -69,16 +75,24 @@ export class MocksGallery extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--wa-space-2xs);
+        flex-wrap: wrap;
         padding: var(--wa-space-2xs) var(--wa-space-s);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--wa-border-radius-m);
         background: var(--wa-color-surface-default, transparent);
+        box-sizing: border-box;
+        min-width: 0;
+        max-width: 100%;
       }
 
       .header-strip__label {
-        flex: 1;
+        flex: 1 1 8rem;
+        min-width: 0;
         color: var(--wa-color-text-quiet);
         font-size: var(--font-size-sm);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     `,
   ];

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -199,6 +199,10 @@ export class ProgressBoardLayoutMock extends LitElement {
     css`
       :host {
         display: block;
+        box-sizing: border-box;
+        min-width: 0;
+        max-width: 100%;
+        overflow-x: hidden;
       }
 
       .board {
@@ -227,6 +231,8 @@ export class ProgressBoardLayoutMock extends LitElement {
         display: flex;
         flex-direction: column;
         min-width: 0;
+        max-width: 100%;
+        overflow: hidden;
         border-right: var(--border-thin) solid var(--color-border);
       }
 
@@ -239,7 +245,9 @@ export class ProgressBoardLayoutMock extends LitElement {
 
       .log-body {
         min-height: 0;
+        min-width: 0;
         flex: 1;
+        overflow: hidden;
       }
 
       task-group-list {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -167,10 +167,10 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .approval-request__actions wa-button[data-action] {
-    flex: 0 0 auto;
+    flex: 0 1 auto;
     width: auto;
     min-width: min(5.5rem, 100%);
-    max-width: min(7rem, 100%);
+    max-width: fit-content;
   }
 
   :is(${ACTIONS}) wa-button[data-action]::part(base) {

--- a/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
+++ b/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
@@ -39,10 +39,10 @@ describe('request panel styles', () => {
     expect(hostRule).toContain('max-width: 100%');
     expect(actionStart).toBeGreaterThanOrEqual(0);
     expect(baseStart).toBeGreaterThan(actionStart);
-    expect(actionRule).toContain('flex: 0 0 auto');
+    expect(actionRule).toContain('flex: 0 1 auto');
     expect(actionRule).toContain('width: auto');
     expect(actionRule).toContain('min-width: min(5.5rem, 100%)');
-    expect(actionRule).toContain('max-width: min(7rem, 100%)');
+    expect(actionRule).toContain('max-width: fit-content');
     expect(baseRule).toContain('justify-content: center');
     expect(baseRule).toContain('width: 100%');
   });

--- a/src/test-kernel/webview/MocksGalleryStyles.vitest.mts
+++ b/src/test-kernel/webview/MocksGalleryStyles.vitest.mts
@@ -1,0 +1,76 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+describe('mock gallery styles', () => {
+  it('keeps mock previews inside the launcher panel', () => {
+    const source = readSource(
+      'packages/extension/src/webview/frontend/mocks/MocksGallery.ts',
+    );
+    const hostStart = source.indexOf(':host {');
+    const sectionStart = source.indexOf('.section {');
+    const headerStart = source.indexOf('.header-strip {');
+    const labelStart = source.indexOf('.header-strip__label {');
+    const hostRule = source.slice(hostStart, sectionStart);
+    const headerRule = source.slice(headerStart, labelStart);
+    const labelRule = source.slice(labelStart, source.indexOf('}', labelStart));
+
+    expect(hostStart).toBeGreaterThanOrEqual(0);
+    expect(headerStart).toBeGreaterThan(hostStart);
+    expect(labelStart).toBeGreaterThan(headerStart);
+    expect(hostRule).toContain('min-width: 0');
+    expect(hostRule).toContain('max-width: 100%');
+    expect(hostRule).toContain('overflow-x: hidden');
+    expect(headerRule).toContain('flex-wrap: wrap');
+    expect(headerRule).toContain('min-width: 0');
+    expect(headerRule).toContain('max-width: 100%');
+    expect(labelRule).toContain('min-width: 0');
+    expect(labelRule).toContain('text-overflow: ellipsis');
+  });
+
+  it('clips progress-board mock internals at the preview boundary', () => {
+    const source = readSource(
+      'packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts',
+    );
+    const hostStart = source.indexOf(':host {');
+    const boardStart = source.indexOf('.board {');
+    const conversationStart = source.indexOf('.conversation {');
+    const conversationMediaStart = source.indexOf(
+      '@media (max-width: 720px)',
+      conversationStart,
+    );
+    const logStart = source.indexOf('.log-body {');
+    const taskGroupStart = source.indexOf('task-group-list {');
+    const hostRule = source.slice(hostStart, boardStart);
+    const conversationRule = source.slice(
+      conversationStart,
+      conversationMediaStart,
+    );
+    const logRule = source.slice(logStart, taskGroupStart);
+
+    expect(hostStart).toBeGreaterThanOrEqual(0);
+    expect(conversationStart).toBeGreaterThan(boardStart);
+    expect(logStart).toBeGreaterThan(conversationStart);
+    expect(hostRule).toContain('min-width: 0');
+    expect(hostRule).toContain('max-width: 100%');
+    expect(hostRule).toContain('overflow-x: hidden');
+    expect(conversationRule).toContain('min-width: 0');
+    expect(conversationRule).toContain('max-width: 100%');
+    expect(conversationRule).toContain('overflow: hidden');
+    expect(logRule).toContain('min-width: 0');
+    expect(logRule).toContain('overflow: hidden');
+  });
+});


### PR DESCRIPTION
Closes #5922.

## Summary

- Keep tool-edit approval actions compact by letting the buttons size to their labels instead of stretching across the action row.
- Clamp and wrap the design mock gallery preview so launcher/progress mock content stays inside the webview panel boundary.
- Add focused style regression tests for the request panel action sizing and mock-gallery containment rules.

## Root Cause

The shared request-panel action rule gave approval buttons a larger flex basis before the tool-edit override applied, and the mock gallery preview did not consistently set shrink/overflow boundaries around its static preview containers.

## Validation

- `corepack pnpm vitest run src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/webview/MocksGalleryStyles.vitest.mts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src/shared/styles/requestPanelStyles.ts packages/extension/src/webview/frontend/mocks/MocksGallery.ts packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/webview/MocksGalleryStyles.vitest.mts`
- `npm run compile:fast`
- `npm run smoke:webviews:run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweaks for progress approval buttons and dev mock previews, with no auth, data, or business-logic changes.
> 
> **Overview**
> **Tool-edit approval actions** in `requestPanelStyles` now use `flex: 0 1 auto` and `max-width: fit-content` instead of fixed flex growth and a `7rem` cap, so Approve/Reject (and similar) buttons **size to their labels** instead of stretching across the action row.
> 
> **Design mock gallery** (`MocksGallery`, `ProgressBoardLayoutMock`) gains **shrink/overflow boundaries** (`min-width: 0`, `max-width: 100%`, horizontal clip on the host; wrapping and ellipsis on the launcher header strip; overflow hidden on conversation/log regions) so static previews stay inside the narrow webview panel.
> 
> **Regression tests** update expectations in `RequestPanelStyles.vitest.mts` and add `MocksGalleryStyles.vitest.mts` to lock in these layout rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e05fcfa64ceaea8ea4bfba62ddb231745cf847c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->