### PR TITLE
[codex] Implement clear in the TUI harness

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -57,6 +57,7 @@ import { formatApprovalPolicyForCli } from '../src/chat/tui/forms/ApprovalPolicy
 import {
   cliState,
   patchStream,
+  resetCliState,
   setParentStream,
   type ConversationEntry,
 } from '../src/chat/tui/state/cliState';
@@ -71,6 +72,7 @@ import {
   tuiOutputStreamForColor,
 } from '../src/chat/tui/render/noColorOutput';
 import {
+  clearApprovals,
   enqueueApproval,
   type ApprovalDecision,
 } from '../src/chat/tui/state/approvalQueue';
@@ -1465,6 +1467,27 @@ function appendHarnessStatus(): void {
   );
 }
 
+function resetHarnessForClear(): void {
+  const meta = cliState.sessionMeta.get();
+  clearApprovals();
+  ToolUseFollowUpQueue.drain(STREAM_ID);
+  const store = getDefaultStreamLogStore();
+  for (const streamId of cliState.streams.get().keys()) {
+    store.delete(streamId).catch(() => {
+      // The harness reset is best-effort; visible cliState is reset below.
+    });
+  }
+  resetCliState({
+    ...meta,
+    approvalPolicy: harnessApprovalPolicy,
+  });
+  cliState.activeStreamId.set(STREAM_ID);
+  inkRef.current?.repaint({
+    clearScrollback: true,
+    preserveStatic: false,
+  });
+}
+
 function handleHarnessSlashCommand(line: string): boolean {
   const parsed = parseSlashInput(line);
   if (!parsed) return false;
@@ -1477,6 +1500,9 @@ function handleHarnessSlashCommand(line: string): boolean {
       return true;
     case 'status':
       appendHarnessStatus();
+      return true;
+    case 'clear':
+      resetHarnessForClear();
       return true;
     case 'approval':
       applyHarnessApprovalPolicySelection(rest, HARNESS_APPROVAL_USAGE);

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -455,6 +455,27 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'slash-clear',
+    cols: 100,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_QUEUED_FOLLOWUPS: 'queued before clear',
+    },
+    keys: ['/clear', '\r', '/status', '\r'],
+    frame: 'tail',
+    expect: [
+      'agent: chat',
+      'model: harness-model',
+      'status: not started',
+      'queued follow-ups: 0',
+    ],
+    unexpect: [
+      '/clear is registered but has no harness action.',
+      'entry-1 chat history line',
+      'queued before clear',
+    ],
+  },
+  {
     name: 'unknown-slash-suggestion',
     cols: 100,
     env: { HARNESS_ENTRIES: '4' },


### PR DESCRIPTION
Closes #5924.

## Summary

- Add a `/clear` action to the TUI harness instead of falling through to the generic registered-command placeholder.
- Reuse existing TUI owners for the reset: clear approvals, drain queued follow-ups, clear stream-log-backed state, reset `cliState` while preserving session metadata, and repaint without preserving stale static rows.
- Add a `validate-tui` `slash-clear` scenario that proves stale transcript rows and queued follow-ups disappear and `/status` remains usable afterward.

## Root Cause

The real chat TUI registered and handled `/clear`, but the PTY harness only validated the slash-help listing. Registered slash commands without explicit harness behavior fell through to `/<command> is registered but has no harness action.`, so harness validation could not cover this recovery control.

## Validation

- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- `node packages/cli/scripts/validate-tui.mjs --no-build slash-clear`
- `node packages/cli/scripts/validate-tui.mjs --no-build slash-help slash-clear unknown-slash-suggestion slash-palette-esc-retypes-command plain-submit`
- `corepack pnpm --filter @texra-ai/cli run typecheck`
- `corepack pnpm vitest run src/test-kernel/cli/SlashHelpText.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npm run lint` (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the CLI TUI harness and its validate-tui scenario; production chat TUI behavior is unchanged.
> 
> **Overview**
> The TUI **test harness** now handles **`/clear`** instead of showing the generic “registered but has no harness action” placeholder, so PTY validation can exercise the same recovery path as the real chat TUI.
> 
> **`resetHarnessForClear`** clears approvals, drains queued follow-ups on the harness stream, best-effort deletes stream-log entries for all known stream IDs, calls **`resetCliState`** while keeping session metadata and the harness approval policy, resets the active stream, and repaints with scrollback cleared and static rows not preserved.
> 
> A new **`slash-clear`** **`validate-tui`** scenario seeds transcript lines and a queued follow-up, runs `/clear` then `/status`, and asserts a fresh session (`status: not started`, `queued follow-ups: 0`) with stale history and queue text gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80bc4b2ea43d3ece87cce22e252aaecea0c83ea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->