### PR TITLE
fix: show cwd in bash approvals

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -739,6 +739,7 @@ function makeBashApprovalPayload() {
   return {
     requestId: 'harness-bash-approval',
     command: BASH_APPROVAL_COMMAND,
+    cwd: HARNESS_CWD,
     allowBypass: true,
     streamId: STREAM_ID,
   };

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1001,6 +1001,7 @@ const SCENARIOS = [
       'agent: chat · model: harness-model',
       'Run bash command?',
       '$ npm run compile:safe',
+      'Directory:',
       'y approve',
       'a approve session',
       'Use foreground panel shortcuts',
@@ -1031,6 +1032,7 @@ const SCENARIOS = [
     expect: [
       'Run bash command?',
       '$ npm run compile:safe',
+      'Directory:',
       'y approve',
       'n reject',
       'Esc cancel',
@@ -1048,6 +1050,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Run bash command?',
+      'Directory:',
       "$ python3 << 'EOF'",
       'more rows',
       'scroll command',
@@ -1068,6 +1071,7 @@ const SCENARIOS = [
     frame: 'tail',
     expect: [
       'Run bash command?',
+      'Directory:',
       "$ python3 << 'EOF'",
       'more rows',
       'scroll command',
@@ -1089,6 +1093,7 @@ const SCENARIOS = [
     frame: 'tail',
     expect: [
       'Run bash command?',
+      'Directory:',
       'x2 = 1 + 2 * y * y',
       'previous',
       'more rows',
@@ -1110,13 +1115,13 @@ const SCENARIOS = [
     frame: 'tail',
     expect: [
       'Run bash command?',
+      'Directory:',
       'for y in range(1, 100):',
-      'x2 = 1 + 2 * y * y',
       'previous',
       'more rows',
       'PgUp/PgDn page',
     ],
-    unexpect: ["$ python3 << 'EOF'", 'solutions = []', '[Option-p]tasks'],
+    unexpect: ["$ python3 << 'EOF'", '[Option-p]tasks'],
   },
   {
     name: 'tiny-compact-long-bash-approval',
@@ -1128,7 +1133,7 @@ const SCENARIOS = [
     },
     bootExpect: '[Ctrl-C]',
     frame: 'tail',
-    expect: ['Run bash command?', 'more rows', 'scroll command', 'y approve'],
+    expect: ['Run bash command?', 'Directory:', 'rows hidden', 'y approve'],
     unexpect: ['[Option-p]tasks'],
   },
   {

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -12,6 +12,7 @@ import {
   scrollPageRows,
   type ScrollableDisplayLine,
 } from '../render/scrollBounds';
+import { truncateToWidth } from '../render/terminalText';
 import { KeyHints } from '../ui/KeyHints';
 import { useScrollableOffset } from '../state/useScrollableOffset';
 import type { ApprovalDecision } from '../state/approvalQueue';
@@ -34,10 +35,12 @@ const BASH_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE = 5;
 export function bashApprovalCommandRowsBudget({
   availableRows,
   columns,
+  extraFixedRows = 0,
   title = BASH_APPROVAL_TITLE,
 }: {
   readonly availableRows?: number;
   readonly columns: number;
+  readonly extraFixedRows?: number;
   readonly title?: string;
 }): number {
   return confirmCardContentRowsBudget({
@@ -49,6 +52,7 @@ export function bashApprovalCommandRowsBudget({
     compactMaxRows: COMPACT_BASH_COMMAND_ROWS,
     spaciousFixedRows: BASH_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE,
     compactFixedRows: BASH_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE,
+    extraFixedRows,
   });
 }
 
@@ -64,6 +68,22 @@ export function bashCommandDisplayLines({
     wrapAnsiToWidth(`${index === 0 ? '$ ' : '  '}${line}`, commandWidth)
       .split('\n')
       .map((text): BashCommandDisplayLine => ({ kind: 'command', text })),
+  );
+}
+
+export function bashCwdDisplayLine({
+  cwd,
+  width,
+}: {
+  readonly cwd?: string;
+  readonly width: number;
+}): string | undefined {
+  const trimmedCwd = cwd?.trim();
+  if (!trimmedCwd) return undefined;
+
+  return truncateToWidth(
+    `Directory: ${trimmedCwd}`,
+    Math.max(MIN_BASH_COMMAND_WIDTH, width),
   );
 }
 
@@ -111,9 +131,14 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
     MIN_BASH_COMMAND_WIDTH,
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
   );
+  const cwdLine = useMemo(
+    () => bashCwdDisplayLine({ cwd: props.payload.cwd, width: commandWidth }),
+    [commandWidth, props.payload.cwd],
+  );
   const maxCommandRows = bashApprovalCommandRowsBudget({
     availableRows: props.availableRows,
     columns,
+    extraFixedRows: cwdLine ? 1 : 0,
   });
   const commandRows = useMemo(
     () =>
@@ -148,8 +173,9 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
       alwaysAllow={{ kind: 'bash', label: 'approve session' }}
       onDecide={props.onDecide}
     >
+      {cwdLine ? <Text dimColor>{cwdLine}</Text> : null}
       <Box
-        marginY={scrollable || compactCommandLayout ? 0 : 1}
+        marginY={scrollable || compactCommandLayout || cwdLine ? 0 : 1}
         flexDirection="column"
       >
         {displayLines.map((line, index) => (

--- a/packages/cli/src/runtime/approval/eventDispatch.ts
+++ b/packages/cli/src/runtime/approval/eventDispatch.ts
@@ -16,7 +16,8 @@ export function summarizeApprovalEvent<K extends CliDecisionApprovalEvent>(
   switch (event) {
     case 'showBashPermission': {
       const data = payload as ProgressEventPayloads['showBashPermission'];
-      return `Bash command requested:\n${data.command}`;
+      const cwd = data.cwd ? `Directory: ${data.cwd}\n` : '';
+      return `Bash command requested:\n${cwd}${data.command}`;
     }
     case 'showPlanApproval': {
       const data = payload as ProgressEventPayloads['showPlanApproval'];

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -41,6 +41,11 @@ export class BashRequestPanel extends BaseFeedbackPanel {
     return this.renderRequestShell({
       prefix: 'bash-approval-request',
       details: html`
+        ${data.cwd
+          ? html`<div class="bash-approval-request__cwd">
+              Directory: <span>${data.cwd}</span>
+            </div>`
+          : ''}
         <div class="bash-approval-request__command">
           ${buildCodeBlock(data.command ?? '', { language: 'bash' })}
         </div>

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -37,6 +37,7 @@ export type ToolEditPermission = z.infer<typeof ToolEditPermissionSchema>;
 
 export const BashPermissionSchema = PermissionBaseSchema.extend({
   command: z.string(),
+  cwd: z.string().optional(),
 });
 export type BashPermission = z.infer<typeof BashPermissionSchema>;
 

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -336,6 +336,18 @@ export const requestPanelStyles: CSSResult = css`
     font-size: var(--font-size-sm);
   }
 
+  .bash-approval-request__cwd {
+    color: var(--text-muted);
+    font-family: var(--wa-font-family-mono);
+    font-size: var(--font-size-xs);
+    margin-bottom: var(--spacing-xs);
+    overflow-wrap: anywhere;
+  }
+
+  .bash-approval-request__cwd span {
+    color: var(--text-secondary);
+  }
+
   .bash-approval-request__command .code-block {
     border-left: var(--border-medium) solid var(--wa-color-terminal-ansi-yellow);
   }

--- a/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
@@ -52,7 +52,10 @@ describe('human prompt progress events', () => {
       createRunContext({ runtimeHost: explicit.host, streamId }),
       () =>
         withToolFileInteractionContext({ tracker: {} as never }, () =>
-          requestBashApproval({ command: 'echo hello' }),
+          requestBashApproval({
+            command: 'echo hello',
+            cwd: '/tmp/texra-project',
+          }),
         ),
     );
 
@@ -75,6 +78,7 @@ describe('human prompt progress events', () => {
         payload: {
           requestId: show.payload.requestId,
           command: 'echo hello',
+          cwd: '/tmp/texra-project',
           allowBypass: true,
           streamId,
         },

--- a/src/test-kernel/cli/BashApproval.vitest.mts
+++ b/src/test-kernel/cli/BashApproval.vitest.mts
@@ -4,6 +4,7 @@ import {
   bashApprovalPageRows,
   bashApprovalCommandRowsBudget,
   bashCommandDisplayLines,
+  bashCwdDisplayLine,
   boundedBashCommandDisplayLines,
   maxBashCommandScrollOffset,
 } from '@cli/chat/tui/modals/BashApproval';
@@ -26,6 +27,43 @@ const HEREDOC_COMMAND = [
 ].join('\n');
 
 describe('CLI bash approval layout', () => {
+  it('includes the working directory when one is available', () => {
+    const line = bashCwdDisplayLine({
+      cwd: '/tmp/texra-project',
+      width: 76,
+    });
+
+    expect(line).toBe('Directory: /tmp/texra-project');
+  });
+
+  it('keeps cwd out of the scrollable command rows', () => {
+    const visible = boundedBashCommandDisplayLines({
+      command: HEREDOC_COMMAND,
+      maxDisplayLines: 3,
+      width: 76,
+    });
+
+    expect(visible).toHaveLength(3);
+    expect(visible.some((line) => line.text.startsWith('Directory:'))).toBe(
+      false,
+    );
+  });
+
+  it('counts the fixed cwd row before clamping command rows', () => {
+    const withoutCwd = bashApprovalCommandRowsBudget({
+      availableRows: 8,
+      columns: 80,
+    });
+    const withCwd = bashApprovalCommandRowsBudget({
+      availableRows: 8,
+      columns: 80,
+      extraFixedRows: 1,
+    });
+
+    expect(withoutCwd).toBe(2);
+    expect(withCwd).toBe(1);
+  });
+
   it('caps long commands so the approval footer stays visible', () => {
     const budget = bashApprovalCommandRowsBudget({
       availableRows: 16,

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -12,6 +12,7 @@ import { createStreamApprovalController } from './streamApprovalQueue';
 
 const BashApprovalRequestSchema = z.object({
   command: z.string(),
+  cwd: z.string().optional(),
   streamId: StreamTabIdSchema.optional(),
 });
 export type BashApprovalRequest = z.infer<typeof BashApprovalRequestSchema>;
@@ -121,6 +122,7 @@ async function showApprovalPrompt(
       runtimeHost.emit('showBashPermission', {
         requestId,
         command: request.command,
+        ...(request.cwd ? { cwd: request.cwd } : {}),
         allowBypass: true,
         streamId: streamId ?? '',
       });

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { z } from 'zod';
 
+// Local imports - platform
+import { tryPlatform } from '@platform/platform';
+
 // Local imports - agent
 import {
   getExecutionStore,
@@ -19,11 +22,11 @@ import {
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import { toErrorMessage } from '@common/errors';
 import {
   deriveRunOutcome,
   projectRunOutcome,
 } from '@common/constants/streamStatus';
-import { toErrorMessage } from '@common/errors';
 
 // Local imports - tools
 import { type StreamTabId, type ExecutionId } from '@shared/schemas';
@@ -121,8 +124,15 @@ export class BashTool extends defineTool({
       throw new ToolError(SHELL_BACKGROUNDING_MESSAGE);
     }
 
-    // Request approval before executing the command
-    const approval = await requestBashApproval({ command: input.command });
+    const contexts = getCurrentToolContexts();
+    const callContext = contexts?.callContext;
+    const runContext = contexts?.runContext;
+    const cwd =
+      parseWorkingDirectory(runContext?.workingDirectory) ??
+      tryPlatform()?.workspace.getWorkspacePath();
+
+    // Request approval before executing the command.
+    const approval = await requestBashApproval({ command: input.command, cwd });
 
     if (!approval.accepted) {
       return buildBashApprovalRejectedResult(
@@ -132,14 +142,9 @@ export class BashTool extends defineTool({
     }
 
     // Signal execution starting (triggers in-progress log after approval)
-    const contexts = getCurrentToolContexts();
-    const callContext = contexts?.callContext;
-    const runContext = contexts?.runContext;
     callContext?.onExecutionReady?.();
 
     const timeoutMs = input.timeout ?? BASH_TOOL_DEFAULT_TIMEOUT_MS;
-
-    const cwd = parseWorkingDirectory(runContext?.workingDirectory);
 
     if (input.run_in_background) {
       return this.executeBackground(


### PR DESCRIPTION
## Summary

- include optional `cwd` on bash approval requests and shared permission payloads
- pass the bash tool's effective working directory into the approval prompt before execution starts, including the workspace-root fallback
- render `Directory: ...` in CLI approval modals as a fixed row above the scrollable command body, plus text-mode approval summaries and the progress view bash panel
- cover the cwd line in unit tests and TUI harness validation

Fixes #5926

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/BashApproval.vitest.mts src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli run typecheck`
- `corepack pnpm --filter @texra-ai/cli run bundle:harness`
- `node packages/cli/scripts/validate-tui.mjs --no-build bash-approval narrow-bash-approval long-bash-approval compact-long-bash-approval compact-long-bash-approval-scroll compact-long-bash-approval-page tiny-compact-long-bash-approval`
- `npm run compile:fast`
- `npm run lint` (passes with 25 existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional display field on approval UX; execution cwd logic is aligned with existing resolution, not a new security boundary.
> 
> **Overview**
> Bash command approvals now surface the **effective working directory** alongside the command, so reviewers can see where a shell command would run before approving.
> 
> An optional `cwd` is added to shared `BashPermission` payloads and threaded through `requestBashApproval` / `showBashPermission`. The bash tool supplies it from the run’s working directory, with a **workspace-root fallback**, at approval time (same path used for execution).
> 
> **CLI TUI** shows a fixed `Directory: …` row above the scrollable command body, with row budgeting adjusted so footers stay visible in compact layouts. **Text-mode** approval summaries and the **VS Code progress view** bash panel render the same directory line. Harness and TUI validation scenarios expect `Directory:` in bash-approval frames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1676c5615212551cf610e157d37bf7869acfef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->