### PR TITLE
fix: hint unknown multi-agent presets

### DIFF
--- a/packages/cli/src/commands/_helpers/agentLookupText.ts
+++ b/packages/cli/src/commands/_helpers/agentLookupText.ts
@@ -1,5 +1,7 @@
 const AGENT_LOOKUP_HINT =
   'Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.';
+const MULTI_AGENT_PRESET_LOOKUP_HINT =
+  'Use `texra multi-agent list` for available team presets, then run `texra multi-agent inspect <preset>` to check a team before launch.';
 
 export const AGENT_NAME_DESCRIPTION =
   'Agent name from `texra agents list` or a known launchable agent name';
@@ -13,4 +15,8 @@ export function missingAgentMessage(name: string): string {
 
 export function missingToolUseAgentMessage(name: string): string {
   return `Tool-use agent not found: ${name}. ${AGENT_LOOKUP_HINT}`;
+}
+
+export function missingMultiAgentPresetMessage(name: string): string {
+  return `Multi-agent preset not found: ${name}. ${MULTI_AGENT_PRESET_LOOKUP_HINT}`;
 }

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -46,7 +46,10 @@ import {
 } from '../runtime/runModel';
 import { getCliAuthProvider } from '../runtime/supabaseAuth';
 
-import { missingToolUseAgentMessage } from './_helpers/agentLookupText';
+import {
+  missingMultiAgentPresetMessage,
+  missingToolUseAgentMessage,
+} from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { formatMultiAgentRunInstruction } from './_helpers/multiAgentInstruction';
 import { emitCliResult } from './_helpers/output';
@@ -106,7 +109,7 @@ function planCurrentMultiAgentRun(
     init.preset,
   );
   if (!preset) {
-    throw new CliUsageError(`Multi-agent preset not found: ${init.preset}`);
+    throw new CliUsageError(missingMultiAgentPresetMessage(init.preset));
   }
   return planCliMultiAgentPresetRun(preset, {
     workflowAgents: getAgentsByCategory(AgentCategory.Workflow),
@@ -255,7 +258,7 @@ async function runMultiAgentShow(
   const presets = readCliMultiAgentPresets();
   const preset = findCliMultiAgentPreset(presets, presetIdOrName);
   if (!preset) {
-    writeTextStderr(`Multi-agent preset not found: ${presetIdOrName}`);
+    writeTextStderr(missingMultiAgentPresetMessage(presetIdOrName));
     return CliExitCode.Usage;
   }
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1390,6 +1390,33 @@ describe('runCli usage output stream routing', () => {
     expect(stderr).toBe('');
   });
 
+  it('prints recovery hints for unknown multi-agent presets', async () => {
+    const commands = [
+      ['multi-agent', 'show', 'does-not-exist'],
+      ['multi-agent', 'inspect', 'does-not-exist'],
+      [
+        'multi-agent',
+        'run',
+        'does-not-exist',
+        '--instruction',
+        'Check this derivation.',
+      ],
+    ];
+
+    for (const command of commands) {
+      stderr = '';
+      stdout = '';
+
+      const result = await runCli(command);
+
+      expect(result.exitCode).toBe(2);
+      expect(stripAnsi(stderr)).toContain(
+        'Multi-agent preset not found: does-not-exist. Use `texra multi-agent list` for available team presets, then run `texra multi-agent inspect <preset>` to check a team before launch.',
+      );
+      expect(stdout).toBe('');
+    }
+  });
+
   it('reports unknown command paths passed to help', async () => {
     const result = await runCli(['help', 'bogus']);
     expect(result.exitCode).toBe(2);


### PR DESCRIPTION
Fixes #5928.\n\n## Summary\n- add a shared recovery message for missing multi-agent presets\n- use it for multi-agent show, inspect, and run\n- cover all three command paths in CLI routing tests\n\n## Validation\n- corepack pnpm vitest run src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts\n- corepack pnpm --filter @texra-ai/cli run typecheck\n- npm run lint\n- npm run compile:fast\n- rebuilt texra-local and verified show/inspect/run missing preset outputs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only error-message and test changes with no runtime, auth, or data impact.
> 
> **Overview**
> When a **multi-agent preset id/name is missing**, `texra multi-agent show`, `inspect`, and `run` now share one recovery message instead of a bare “not found” line.
> 
> The new helper in `agentLookupText.ts` tells users to run **`texra multi-agent list`** and **`texra multi-agent inspect <preset>`** before launch. **`multi-agent run`** and **`inspect`** pick it up via preset planning (`CliUsageError`); **`show`** writes the same text to stderr.
> 
> CLI routing tests assert exit code 2 and that hint on all three command paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8192b4ec5bfe8bfb578107b5b070b15dfe9d5116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->