### PR TITLE
fix: compact progress approval controls

### DIFF
--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -256,6 +256,8 @@ export class ProgressBoardLayoutMock extends LitElement {
 
       stream-tabs {
         min-width: 0;
+        max-width: 100%;
+        overflow: hidden;
       }
 
       .files-block {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -167,10 +167,10 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .approval-request__actions wa-button[data-action] {
-    flex: 0 1 auto;
-    width: auto;
+    flex: 0 0 auto;
+    width: fit-content;
     min-width: min(5.5rem, 100%);
-    max-width: fit-content;
+    max-width: min(9rem, 100%);
   }
 
   :is(${ACTIONS}) wa-button[data-action]::part(base) {
@@ -180,8 +180,9 @@ export const requestPanelStyles: CSSResult = css`
 
   .approval-request__actions wa-button[data-action]::part(base) {
     justify-content: center;
-    width: 100%;
+    width: auto;
     min-width: 0;
+    max-width: 100%;
   }
 
   /* Shared action button colors */

--- a/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
+++ b/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
@@ -39,12 +39,13 @@ describe('request panel styles', () => {
     expect(hostRule).toContain('max-width: 100%');
     expect(actionStart).toBeGreaterThanOrEqual(0);
     expect(baseStart).toBeGreaterThan(actionStart);
-    expect(actionRule).toContain('flex: 0 1 auto');
-    expect(actionRule).toContain('width: auto');
+    expect(actionRule).toContain('flex: 0 0 auto');
+    expect(actionRule).toContain('width: fit-content');
     expect(actionRule).toContain('min-width: min(5.5rem, 100%)');
-    expect(actionRule).toContain('max-width: fit-content');
+    expect(actionRule).toContain('max-width: min(9rem, 100%)');
     expect(baseRule).toContain('justify-content: center');
-    expect(baseRule).toContain('width: 100%');
+    expect(baseRule).toContain('width: auto');
+    expect(baseRule).toContain('max-width: 100%');
   });
 
   it('lets the tool edit diff dropdown shrink inside narrow panels', () => {

--- a/src/test-kernel/webview/MocksGalleryStyles.vitest.mts
+++ b/src/test-kernel/webview/MocksGalleryStyles.vitest.mts
@@ -54,16 +54,21 @@ describe('mock gallery styles', () => {
     );
     const logStart = source.indexOf('.log-body {');
     const taskGroupStart = source.indexOf('task-group-list {');
+    const streamTabsStart = source.indexOf('stream-tabs {');
+    const filesBlockStart = source.indexOf('.files-block {');
     const hostRule = source.slice(hostStart, boardStart);
     const conversationRule = source.slice(
       conversationStart,
       conversationMediaStart,
     );
     const logRule = source.slice(logStart, taskGroupStart);
+    const streamTabsRule = source.slice(streamTabsStart, filesBlockStart);
 
     expect(hostStart).toBeGreaterThanOrEqual(0);
     expect(conversationStart).toBeGreaterThan(boardStart);
     expect(logStart).toBeGreaterThan(conversationStart);
+    expect(streamTabsStart).toBeGreaterThan(taskGroupStart);
+    expect(filesBlockStart).toBeGreaterThan(streamTabsStart);
     expect(hostRule).toContain('min-width: 0');
     expect(hostRule).toContain('max-width: 100%');
     expect(hostRule).toContain('overflow-x: hidden');
@@ -72,5 +77,8 @@ describe('mock gallery styles', () => {
     expect(conversationRule).toContain('overflow: hidden');
     expect(logRule).toContain('min-width: 0');
     expect(logRule).toContain('overflow: hidden');
+    expect(streamTabsRule).toContain('min-width: 0');
+    expect(streamTabsRule).toContain('max-width: 100%');
+    expect(streamTabsRule).toContain('overflow: hidden');
   });
 });


### PR DESCRIPTION
Fixes #5930.

## Summary
- keep tool-edit Approve/Reject buttons content-sized with an explicit max width
- keep the progress-board mock stream rail clipped inside the preview boundary
- extend focused style tests for both constraints

## Validation
- corepack pnpm exec prettier --write packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts src/shared/styles/requestPanelStyles.ts src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/webview/MocksGalleryStyles.vitest.mts
- corepack pnpm vitest run src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts src/test-kernel/webview/MocksGalleryStyles.vitest.mts
- npm run compile:fast
- npm run lint
- npm run typecheck
- npm run smoke:webviews

Webview smoke rendered `progress-approval` at 420px wide and verified compact action widths: Approve 116.14px, Reject 100.62px.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweaks in shared request panel styles and a webview mock, with focused vitest guards and no auth or data-path changes.
> 
> **Overview**
> Tightens **tool-edit approval** action buttons so Approve/Reject stay **content-sized** instead of stretching: `flex` is now `0 0 auto`, width uses `fit-content`, and a **`max-width: min(9rem, 100%)`** cap replaces the previous `fit-content` max; the button `::part(base)` no longer forces full width.
> 
> In the **progress-board layout mock**, **`stream-tabs`** gets **`max-width: 100%`** and **`overflow: hidden`** so the stream rail stays clipped inside narrow gallery previews (alongside existing `min-width: 0`).
> 
> **Style regression tests** in `RequestPanelStyles.vitest.mts` and `MocksGalleryStyles.vitest.mts` are updated to assert the new rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe110ea554d367ac12e77eb5ceea3168e758f7a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->