### PR TITLE
fix: align chat tui guidance with run state

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -450,7 +450,7 @@ const SCENARIOS = [
       '/clear',
       'Start a fresh chat session',
       'Keyboard',
-      '`Ctrl-C` stops, twice exits',
+      '`Ctrl-C` exits idle chats; stops active responses',
       'Typing while a response is running queues your message as a follow-up.',
     ],
   },

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -5,6 +5,7 @@
 import { Box, useApp, useInput, useStdin, useWindowSize } from 'ink';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
+import { isActiveStatus } from '@common/constants/streamStatus';
 import {
   LIVE_ELAPSED_STREAM_STATUSES,
   type StreamStatus,
@@ -618,6 +619,7 @@ export function App(props: AppProps): React.JSX.Element {
   }, [onTranscriptViewportChange, viewportKey]);
 
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
+  const activeResponseRunning = isActiveStatus(activeSlice?.status);
   const queuedFollowUpMessages = activeSlice?.queuedFollowUpMessages ?? [];
   const queuedFollowUpPanelWanted =
     !foregroundOpen && queuedFollowUpMessages.length > 0;
@@ -983,6 +985,7 @@ export function App(props: AppProps): React.JSX.Element {
           <TipRow
             agentSelectionAvailable={agentSelectionAvailable}
             hour={tipHour}
+            responseRunning={activeResponseRunning}
           />
         ) : null}
         {queuedFollowUpPanelVisible ? (

--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -63,7 +63,7 @@ function keyboardSection(options: SlashCommandHelpOptions): string {
     // Generated from the editing keymap so this list can't drift from the
     // bindings that actually exist (see textInputBindings.ts).
     `- ${textInputEditingHelp()}`,
-    '- `Esc` stops the current response · `Ctrl-C` stops, twice exits',
+    '- `Esc` stops the current response · `Ctrl-C` exits idle chats; stops active responses',
     '- `Ctrl-T` opens the transcript viewer for the focused stream',
     `- \`Tab\` switches streams · \`${focusChord}\` jumps to one (when subagents are running)`,
     `- \`${tasksChord}\` opens tasks · \`${subagentsChord}\` opens subagents (when available)`,

--- a/packages/cli/src/chat/tui/panes/TipRow.tsx
+++ b/packages/cli/src/chat/tui/panes/TipRow.tsx
@@ -1,5 +1,10 @@
 import { Box, Text } from 'ink';
 
+const QUEUE_FOLLOW_UP_TIP =
+  'Type while a response is running to queue a follow-up';
+const IDLE_QUEUE_FOLLOW_UP_FALLBACK_TIP =
+  'Press Ctrl-R to search your input history';
+
 const BASE_TIPS = [
   'Use /help to see available commands',
   'Press /model to switch models',
@@ -8,7 +13,7 @@ const BASE_TIPS = [
   'Press /status to see session details',
   'Press /api to view or change API mode',
   'Press Ctrl-T to read the full transcript',
-  'Type while a response is running to queue a follow-up',
+  QUEUE_FOLLOW_UP_TIP,
   'Press Ctrl-R to search your input history',
   'Use /resume to continue a previous session',
 ] as const;
@@ -18,24 +23,31 @@ const AGENT_SELECTION_TIP = 'Press /agent to choose the root agent';
 export function tipRowText({
   agentSelectionAvailable = false,
   hour,
+  responseRunning = false,
 }: {
   readonly agentSelectionAvailable?: boolean;
   readonly hour: number;
+  readonly responseRunning?: boolean;
 }): string {
   const tips = agentSelectionAvailable
     ? [BASE_TIPS[0], BASE_TIPS[1], AGENT_SELECTION_TIP, ...BASE_TIPS.slice(2)]
     : BASE_TIPS;
   const index = ((hour % tips.length) + tips.length) % tips.length;
-  return tips[index]!;
+  const tip = tips[index]!;
+  return !responseRunning && tip === QUEUE_FOLLOW_UP_TIP
+    ? IDLE_QUEUE_FOLLOW_UP_FALLBACK_TIP
+    : tip;
 }
 
 export function TipRow(props: {
   readonly agentSelectionAvailable?: boolean;
   readonly hour: number;
+  readonly responseRunning?: boolean;
 }): React.JSX.Element {
   const tip = tipRowText({
     agentSelectionAvailable: props.agentSelectionAvailable,
     hour: props.hour,
+    responseRunning: props.responseRunning,
   });
 
   return (

--- a/src/test-kernel/cli/TipRow.vitest.mts
+++ b/src/test-kernel/cli/TipRow.vitest.mts
@@ -14,4 +14,22 @@ describe('CLI TipRow', () => {
       'Press /agent to choose the root agent',
     );
   });
+
+  it('only shows the queued follow-up tip while a response is active', () => {
+    expect(tipRowText({ hour: 7, responseRunning: true })).toBe(
+      'Type while a response is running to queue a follow-up',
+    );
+    expect(tipRowText({ hour: 7, responseRunning: false })).toBe(
+      'Press Ctrl-R to search your input history',
+    );
+  });
+
+  it('keeps unrelated tips stable when the response state changes', () => {
+    expect(tipRowText({ hour: 9, responseRunning: true })).toBe(
+      'Use /resume to continue a previous session',
+    );
+    expect(tipRowText({ hour: 9, responseRunning: false })).toBe(
+      'Use /resume to continue a previous session',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- hide the queued-follow-up tip unless the active stream is actually running/resuming
- update `/help` Ctrl-C copy to match idle exit behavior
- update focused unit coverage and the `slash-help` harness expectation

Closes #5935.
Closes #5936.

## Dogfood Evidence

- Real PTY chat run on `668946b13` showed idle footer `◆ idle ... [Ctrl-C]exit` while the tip row still said `Type while a response is running to queue a follow-up`.
- Sidecar real PTY run showed `/help` said `Ctrl-C stops, twice exits`, while a single idle Ctrl-C exited and the footer advertised `[Ctrl-C]exit`.
- Rebuilt CLI bundle and verified bundled `/help` now renders: `Ctrl-C exits idle chats; stops active responses`.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/TipRow.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SlashHelpText.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --skip-if-missing-deps slash-help slash-palette`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli run bundle`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing help and tip strings only; behavior is gated on existing stream status with unit and harness coverage.
> 
> **Overview**
> **Chat TUI copy now matches whether the focused stream is actually running**, so idle sessions no longer advertise follow-up queuing or outdated Ctrl-C behavior.
> 
> `App` derives `activeResponseRunning` from `isActiveStatus` on the active stream and passes it into `TipRow`. When the hourly tip would be “queue a follow-up” but nothing is active, `tipRowText` swaps in the Ctrl-R history tip instead.
> 
> **`/help` and rotating tips** use the same Ctrl-C wording: idle chats exit on one press; an active response is stopped first. The `slash-help` TUI harness expectation was updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 522ea9f11ec48a8dc7e8bd884422f8a388ccd451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->