### PR TITLE
fix: avoid stale CLI inquiry prompts

### DIFF
--- a/packages/cli/src/runtime/approval/humanInputHandlers.ts
+++ b/packages/cli/src/runtime/approval/humanInputHandlers.ts
@@ -15,10 +15,16 @@ import {
 } from './approvalPolicy';
 import { formatUserQuestionPrompt } from './approvalSummaries';
 
+const NON_TUI_EXTERNAL_INQUIRY_FEEDBACK =
+  'External inquiry is not available in non-TUI CLI runs: inquiry answers ' +
+  'are delivered as asynchronous continuations, and this process cannot ' +
+  'resume them after the run finalizes. Use texra chat for the inquiry ' +
+  'panel, or ask_user_question for synchronous CLI input.';
+
 export function handleExternalInquiry(
   payload: ProgressEventPayloads['showExternalInquiry'],
   context: CliContext,
-  hooks: CliApprovalPromptHooks = {},
+  _hooks: CliApprovalPromptHooks = {},
 ): void {
   const threadId = payload.threadId;
   if (!threadId) {
@@ -35,40 +41,11 @@ export function handleExternalInquiry(
     return;
   }
 
-  void (async () => {
-    let answer: string;
-    try {
-      hooks.beforePrompt?.();
-      answer = await queueCliApprovalQuestion(context, {
-        kind: 'externalInquiry',
-        summary: `External inquiry requested:\n${payload.question}`,
-        prompt: 'Answer (blank to skip): ',
-      });
-    } catch {
-      markApprovalDenied(context);
-      await handleExternalInquiryAction({
-        action: 'drop',
-        threadId,
-        feedback: 'CLI external inquiry prompt failed.',
-      });
-      return;
-    }
-
-    const trimmed = answer.trim();
-    if (trimmed.length === 0) {
-      await handleExternalInquiryAction({
-        action: 'drop',
-        threadId,
-        feedback: 'External inquiry skipped by user.',
-      });
-      return;
-    }
-    await handleExternalInquiryAction({
-      action: 'submit',
-      threadId,
-      answer: trimmed,
-    });
-  })();
+  void handleExternalInquiryAction({
+    action: 'drop',
+    threadId,
+    feedback: NON_TUI_EXTERNAL_INQUIRY_FEEDBACK,
+  });
 }
 
 export function handleUserQuestion(

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -12,6 +12,8 @@ import {
 } from './terminalStatus';
 import type { CliContext } from './cliContext';
 
+const NON_TUI_CLI_UNAVAILABLE_TOOLS = ['inquiry'] as const;
+
 export interface CliExecuteOptions {
   /** Forwarded to `runAgent`. */
   readonly enforceCategory?: boolean;
@@ -24,6 +26,8 @@ export interface CliExecuteOptions {
   readonly markErrorOnThrow?: boolean;
   /** Stop a tool-use execution after one model/tool cycle. */
   readonly stopAfterCycle?: boolean;
+  /** Additional tools unavailable in this CLI runtime. */
+  readonly runtimeUnavailableTools?: readonly string[];
   /** Wrap the run (e.g. multi-agent preset visibility) without leaking the
    *  runtime-host lifecycle into the caller. */
   readonly wrap?: (
@@ -54,6 +58,10 @@ export async function executeCliRequest(
       registerExecution: options.registerExecution,
       stopAfterCycle: options.stopAfterCycle,
       approvalPromptsUnavailable: approvalPromptsUnavailable(runContext),
+      runtimeUnavailableTools: [
+        ...NON_TUI_CLI_UNAVAILABLE_TOOLS,
+        ...(options.runtimeUnavailableTools ?? []),
+      ],
     });
 
   let result: ExecuteAgentResult;

--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -48,6 +48,8 @@ export interface AgentCore<C = unknown> {
   delegationDepth?: number;
   /** Whether approval or user prompts cannot be answered by the current host. */
   approvalPromptsUnavailable?: boolean;
+  /** Tools unavailable because the current host/runtime cannot support them. */
+  runtimeUnavailableTools?: readonly string[];
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -196,17 +196,21 @@ type ContinuationNodeResult = SkippableNodeResult<{
 export function responseCycleToolsForModel<C>(
   services: Pick<
     ResponseCycleServices<C>,
-    'approvalPromptsUnavailable' | 'modelHandler' | 'setting'
+    | 'approvalPromptsUnavailable'
+    | 'modelHandler'
+    | 'runtimeUnavailableTools'
+    | 'setting'
   >,
 ): ToolDefinition[] | undefined {
   if (!services.modelHandler.capabilities.supportsFunctionCalling) {
     return undefined;
   }
-  if (services.approvalPromptsUnavailable !== true) {
-    return services.setting.tools;
-  }
+  const runtimeUnavailable = new Set(services.runtimeUnavailableTools ?? []);
   return services.setting.tools.filter(
-    (tool) => !isApprovalGatedToolName(tool.name),
+    (tool) =>
+      !runtimeUnavailable.has(tool.name) &&
+      (services.approvalPromptsUnavailable !== true ||
+        !isApprovalGatedToolName(tool.name)),
   );
 }
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -53,6 +53,8 @@ export interface RunToolUseFlowInput<
   isSubagent?: boolean;
   /** When true, approval-gated tools are filtered out before model invocation. */
   approvalPromptsUnavailable?: boolean;
+  /** Tools unavailable because the current host/runtime cannot support them. */
+  runtimeUnavailableTools?: readonly string[];
   /** Fires before the subagent enters WAITING, delivering the last response to the orchestrator. */
   onBeforeWaiting?: ToolUseBeforeWaitingCallback;
   /** Fires on meaningful progress: todo changes, tool call milestones. */
@@ -143,6 +145,7 @@ export async function runToolUseFlow<C = unknown>(
     logger,
     delegationBlocked: !delegationGate.allowed,
     approvalPromptsUnavailable: input.approvalPromptsUnavailable,
+    runtimeUnavailableTools: input.runtimeUnavailableTools,
     toolInjections: input.toolInjections,
   });
 

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -108,8 +108,8 @@ const STATUS_MESSAGES: Record<string, string> = {
  * in the ambient {@link RunContext}.
  *
  * Centralises the mapping so new per-run flags (e.g. `stopAfterCycle`,
- * `approvalPromptsUnavailable`) live in one place and are never silently
- * dropped. Three field renames are unavoidable given the interfaces were
+ * `approvalPromptsUnavailable`, `runtimeUnavailableTools`) live in one place
+ * and are never silently dropped. Three field renames are unavoidable given the interfaces were
  * designed independently:
  *  - `AgentCore.logger`   → `RunContext.trace`
  *  - `AgentConfig.agent`  → `RunContext.agentName`
@@ -132,6 +132,7 @@ function agentContextToRunContext(
     workingDirectory: ctx.workingDirectory,
     delegationDepth: ctx.delegationDepth,
     approvalPromptsUnavailable: ctx.approvalPromptsUnavailable,
+    runtimeUnavailableTools: ctx.runtimeUnavailableTools,
     stopAfterCycle: ctx.stopAfterCycle,
   };
 }

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -60,6 +60,8 @@ export interface RunContext {
   readonly delegationDepth?: number;
   /** Whether approval or user prompts cannot be answered by the current host. */
   readonly approvalPromptsUnavailable?: boolean;
+  /** Tools unavailable because the current host/runtime cannot support them. */
+  readonly runtimeUnavailableTools?: readonly string[];
   /** Whether this run should stop after one tool-use cycle instead of idling. */
   readonly stopAfterCycle?: boolean;
 }
@@ -82,6 +84,7 @@ export interface CreateRunContextOptions {
   workingDirectory?: string;
   delegationDepth?: number;
   approvalPromptsUnavailable?: boolean;
+  runtimeUnavailableTools?: readonly string[];
   stopAfterCycle?: boolean;
 }
 
@@ -107,6 +110,7 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     workingDirectory: options.workingDirectory,
     delegationDepth: options.delegationDepth,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+    runtimeUnavailableTools: options.runtimeUnavailableTools,
     stopAfterCycle: options.stopAfterCycle,
   };
 

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -56,6 +56,8 @@ export interface ResolveAgentToolsInput {
   delegationBlocked: boolean;
   /** When true, approval-gated tools are filtered out before model invocation. */
   approvalPromptsUnavailable?: boolean;
+  /** Tools unavailable because the current host/runtime cannot support them. */
+  runtimeUnavailableTools?: readonly string[];
   /** Conditional runtime tool injections. Defaults to the shared registry. */
   toolInjections?: ToolInjectionRegistry;
 }
@@ -109,11 +111,13 @@ export async function resolveAgentTools({
   logger,
   delegationBlocked,
   approvalPromptsUnavailable,
+  runtimeUnavailableTools,
   toolInjections = toolInjectionRegistry,
 }: ResolveAgentToolsInput): Promise<ResolvedAgentTools> {
   const effectiveRegistry = registry ?? getDefaultToolRegistry();
   const disabled = getDisabledToolNames();
   const unavailable = getUnavailableToolNamesCached();
+  const runtimeUnavailable = new Set(runtimeUnavailableTools ?? []);
   const missingDependency: string[] = [];
 
   const toolConfigs = Array.isArray(tools) ? tools : [];
@@ -125,6 +129,7 @@ export async function resolveAgentTools({
       delegationTrimmed = true;
       return false;
     }
+    if (runtimeUnavailable.has(name)) return false;
     return (
       approvalPromptsUnavailable !== true || !isApprovalGatedToolName(name)
     );

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -245,6 +245,8 @@ export interface ExecuteAgentOptions {
   stopAfterCycle?: boolean;
   /** Hide tools whose approval prompts cannot be answered in this host mode. */
   approvalPromptsUnavailable?: boolean;
+  /** Hide tools unavailable because the current host/runtime cannot support them. */
+  runtimeUnavailableTools?: readonly string[];
   /** Fires after flow completes but before executionRegistry.untrack, so follow-ups are enqueued before waiters resolve. */
   onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
   /** Fires when a subagent fails and should report the failure to its orchestrator. */
@@ -271,6 +273,7 @@ export async function executeAgent(
   });
   ctx.delegationDepth = options.delegationDepth ?? 0;
   ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
+  ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
   ctx.stopAfterCycle = options.stopAfterCycle;
   return withExecutionRunContext(ctx, async () => {
     const { setting, streamId, config } = ctx;
@@ -325,6 +328,7 @@ export async function executeAgent(
                 setting,
                 isSubagent,
                 approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+                runtimeUnavailableTools: options.runtimeUnavailableTools,
                 onBeforeWaiting: options.onBeforeWaiting,
                 stopAfterCycle: options.stopAfterCycle,
                 onProgress: (update) => {
@@ -417,6 +421,8 @@ export async function executeAgent(
 export interface ResumeToolUseFromSnapshotOptions {
   /** Hide tools whose approval prompts cannot be answered in this host mode. */
   readonly approvalPromptsUnavailable?: boolean;
+  /** Hide tools unavailable because the current host/runtime cannot support them. */
+  readonly runtimeUnavailableTools?: readonly string[];
   readonly setupSession?: (session: IToolUseSession) => void;
 }
 
@@ -441,6 +447,7 @@ export async function resumeToolUseFromSnapshot(
     snapshot.executionId,
   );
   ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
+  ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
   const { setting, streamId } = ctx;
 
   await withExecutionRunContext(ctx, async () => {
@@ -464,6 +471,7 @@ export async function resumeToolUseFromSnapshot(
           // /memories protocol) that the fresh run had included.
           isSubagent: (ctx.delegationDepth ?? 0) > 0,
           approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+          runtimeUnavailableTools: options.runtimeUnavailableTools,
           onFollowUpConsumed: () =>
             ctx.runtimeHost.emit('updateQueuedFollowUps', {
               streamId: ctx.streamId,

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -14,6 +14,7 @@ export interface RunAgentOptions {
   registerExecution?: boolean;
   stopAfterCycle?: boolean;
   approvalPromptsUnavailable?: boolean;
+  runtimeUnavailableTools?: readonly string[];
 }
 
 /**
@@ -53,6 +54,7 @@ export async function runAgent(
     enforceCategory: options.enforceCategory,
     stopAfterCycle: options.stopAfterCycle,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+    runtimeUnavailableTools: options.runtimeUnavailableTools,
   });
   if (result.category === 'workflow') {
     await options.openWorkflowOutput?.(result);

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.mts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.mts
@@ -9,13 +9,16 @@ function toolNames(tools: readonly { name: string }[] | undefined): string[] {
 
 function responseServices({
   approvalPromptsUnavailable,
+  runtimeUnavailableTools,
   supportsFunctionCalling = true,
 }: {
   approvalPromptsUnavailable?: boolean;
+  runtimeUnavailableTools?: readonly string[];
   supportsFunctionCalling?: boolean;
 }) {
   return {
     approvalPromptsUnavailable,
+    runtimeUnavailableTools,
     modelHandler: {
       capabilities: { supportsFunctionCalling },
     },
@@ -23,6 +26,7 @@ function responseServices({
       tools: [
         { name: 'bash' },
         { name: 'grep' },
+        { name: 'inquiry' },
         { name: 'write_file' },
         { name: 'wolfram' },
       ],
@@ -45,6 +49,23 @@ describe('response cycle tool visibility', () => {
     const tools = responseCycleToolsForModel(
       responseServices({
         approvalPromptsUnavailable: false,
+      }) as any,
+    );
+
+    expect(toolNames(tools)).toEqual([
+      'bash',
+      'grep',
+      'inquiry',
+      'write_file',
+      'wolfram',
+    ]);
+  });
+
+  it('filters runtime-unavailable workflow tools without hiding approvals', () => {
+    const tools = responseCycleToolsForModel(
+      responseServices({
+        approvalPromptsUnavailable: false,
+        runtimeUnavailableTools: ['inquiry'],
       }) as any,
     );
 

--- a/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
@@ -42,6 +42,7 @@ describe('tool-use tool resolution', () => {
       'bash',
       'delegate_agent',
       'grep',
+      'inquiry',
       'plan',
       'send_to_terminal',
       'update_config',
@@ -56,6 +57,7 @@ describe('tool-use tool resolution', () => {
         'bash',
         'delegate_agent',
         'grep',
+        'inquiry',
         'plan',
         'send_to_terminal',
         'update_config',
@@ -80,6 +82,7 @@ describe('tool-use tool resolution', () => {
       'bash',
       'delegate_agent',
       'grep',
+      'inquiry',
       'plan',
       'update_config',
     ]);
@@ -91,6 +94,7 @@ describe('tool-use tool resolution', () => {
         'bash',
         'delegate_agent',
         'grep',
+        'inquiry',
         'plan',
         'update_config',
       ]),
@@ -107,8 +111,42 @@ describe('tool-use tool resolution', () => {
       'bash',
       'delegate_agent',
       'grep',
+      'inquiry',
       'plan',
       'update_config',
+    ]);
+  });
+
+  it('filters runtime-unavailable tools without hiding other approval-gated tools', async () => {
+    const registry = registryFor([
+      'ask_user_question',
+      'bash',
+      'grep',
+      'inquiry',
+      'write_file',
+    ]);
+
+    const { tools } = await resolveAgentTools({
+      tools: toolDefs([
+        'ask_user_question',
+        'bash',
+        'grep',
+        'inquiry',
+        'write_file',
+      ]),
+      registry,
+      logger,
+      toolInjections,
+      approvalPromptsUnavailable: false,
+      runtimeUnavailableTools: ['inquiry'],
+      delegationBlocked: false,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'ask_user_question',
+      'bash',
+      'grep',
+      'write_file',
     ]);
   });
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -1,4 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
+  handleExternalInquiryAction: handleExternalInquiryActionMock,
+}));
 
 import {
   appendCliApiSwitchHint,
@@ -50,6 +56,7 @@ const credentialExhaustedRetry: ProgressEventPayloads['showRetryRequest'] = {
 
 afterEach(() => {
   setToolEditApprovalHandler();
+  handleExternalInquiryActionMock.mockClear();
 });
 
 describe('immediateDecisionForApproval', () => {
@@ -168,6 +175,41 @@ describe('approval prompt hooks', () => {
 
     expect(handled).toBe(true);
     expect(events).toEqual([]);
+  });
+
+  it('does not prompt for external inquiry in non-TUI CLI runs', async () => {
+    const events: string[] = [];
+    const handled = handleCliApprovalEvent(
+      'showExternalInquiry',
+      {
+        requestId: 'ei_aabbccdd0011',
+        threadId: 'ei_aabbccdd0011',
+        question: 'May I ask an external model to verify this proof?',
+        allowBypass: false,
+        streamId: 'root@deepseekT#abc',
+      },
+      context({
+        approvalPrompt: async () => {
+          events.push('prompt');
+          return 'yes';
+        },
+      }),
+      {
+        beforePrompt: () => {
+          events.push('before');
+        },
+      },
+    );
+
+    await Promise.resolve();
+
+    expect(handled).toBe(true);
+    expect(events).toEqual([]);
+    expect(handleExternalInquiryActionMock).toHaveBeenCalledWith({
+      action: 'drop',
+      threadId: 'ei_aabbccdd0011',
+      feedback: expect.stringContaining('non-TUI CLI runs'),
+    });
   });
 });
 

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -118,6 +118,46 @@ describe('executeCliRequest', () => {
     );
   });
 
+  it('hides async inquiry in non-TUI CLI execution', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+
+    await executeCliRequest(
+      request,
+      cliContext({ mode: 'interactive', approvalPolicy: 'ask' }),
+    );
+
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        approvalPromptsUnavailable: false,
+        runtimeUnavailableTools: ['inquiry'],
+      }),
+    );
+  });
+
+  it('preserves caller-provided runtime tool exclusions', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+
+    await executeCliRequest(request, cliContext(), {
+      runtimeUnavailableTools: ['custom_tool'],
+    });
+
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        runtimeUnavailableTools: ['inquiry', 'custom_tool'],
+      }),
+    );
+  });
+
   it('installs CLI approval handlers with the runtime prompt hook', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = {

--- a/src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts
+++ b/src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts
@@ -17,6 +17,7 @@ function makePair(): {
   const serverIn = new PassThrough(); // what the client writes (i.e. the server reads)
   const serverOut = new PassThrough(); // what the server writes (i.e. the client reads)
   const connection = new JsonRpcConnection(serverIn, serverOut);
+  let clientFrameBuffer = '';
 
   const serverSends = (json: unknown): void => {
     const body = Buffer.from(JSON.stringify(json), 'utf8');
@@ -28,24 +29,32 @@ function makePair(): {
   const collectClientFrames = () =>
     vi.waitFor(
       (): Array<Record<string, unknown>> => {
-        const raw = serverIn.read() as Buffer | string | null;
-        if (!raw) throw new Error('no data in serverIn yet');
-        const text = Buffer.isBuffer(raw) ? raw.toString('utf8') : raw;
+        let raw = serverIn.read() as Buffer | string | null;
+        while (raw) {
+          clientFrameBuffer += Buffer.isBuffer(raw)
+            ? raw.toString('utf8')
+            : raw;
+          raw = serverIn.read() as Buffer | string | null;
+        }
+        if (!clientFrameBuffer) throw new Error('no data in serverIn yet');
         const frames: Array<Record<string, unknown>> = [];
         let offset = 0;
-        while (offset < text.length) {
-          const headerEnd = text.indexOf('\r\n\r\n', offset);
+        while (offset < clientFrameBuffer.length) {
+          const headerEnd = clientFrameBuffer.indexOf('\r\n\r\n', offset);
           if (headerEnd < 0) break;
-          const header = text.slice(offset, headerEnd);
+          const header = clientFrameBuffer.slice(offset, headerEnd);
           const lengthMatch = header.match(/Content-Length: (\d+)/i);
           if (!lengthMatch) break;
           const length = Number.parseInt(lengthMatch[1]!, 10);
           const bodyStart = headerEnd + 4;
-          const body = text.slice(bodyStart, bodyStart + length);
+          const bodyEnd = bodyStart + length;
+          if (clientFrameBuffer.length < bodyEnd) break;
+          const body = clientFrameBuffer.slice(bodyStart, bodyEnd);
           frames.push(JSON.parse(body) as Record<string, unknown>);
-          offset = bodyStart + length;
+          offset = bodyEnd;
         }
         if (frames.length === 0) throw new Error('no complete frames yet');
+        clientFrameBuffer = clientFrameBuffer.slice(offset);
         return frames;
       },
       { timeout: 500, interval: 5 },

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -448,6 +448,7 @@ async function executeSubagent(
         parentStreamId: orchestratorStreamId,
         delegationDepth: parentDelegationDepth + 1,
         approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
+        runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
         stopAfterCycle: true,
         onStreamResolved: inheritChildStreamApprovals,
         onError: (err) => {
@@ -575,6 +576,7 @@ async function executeSubagent(
     parentStreamId: orchestratorStreamId,
     delegationDepth: parentDelegationDepth + 1,
     approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
+    runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;
       inheritChildStreamApprovals(resolvedStreamId);

--- a/src/tools/approvalGatedTools.ts
+++ b/src/tools/approvalGatedTools.ts
@@ -14,6 +14,7 @@ const APPROVAL_GATED_TOOL_NAME_LIST = [
   'delegate_agent',
   'delegate_workflow',
   'edit_file',
+  'inquiry',
   'install_vscode_extension',
   'invoke_command',
   'plan',


### PR DESCRIPTION
## Summary

Fixes #5932.

- Treat `inquiry` as approval-gated so headless/no-input runs do not offer it when human prompts are unavailable.
- Add a generic runtime-unavailable tool filter and use it in the non-TUI CLI execution path to hide `inquiry` while keeping blocking approvals like `bash`, `write_file`, and `ask_user_question` available.
- Keep the non-TUI external-inquiry event handler as a fallback that drops unsupported inquiry events with explicit feedback instead of opening a stale stdin prompt.
- Buffer partial client frames in the Lean JSON-RPC test harness; full Vitest exposed that `vscode-jsonrpc` may write the header and body separately.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/agent/ResponseCycleTools.vitest.mts src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/agent/ResponseCycleTools.vitest.mts src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm vitest run src/test-kernel/cli/ExternalInquiry.vitest.mts src/test-kernel/cli/ApprovalQueue.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts`
- `corepack pnpm prettier --write packages/cli/src/runtime/approval/humanInputHandlers.ts packages/cli/src/runtime/runExecution.ts src/tools/approvalGatedTools.ts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/agent/ResponseCycleTools.vitest.mts src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts src/agent/core/flows/BaseFlowServices.ts src/agent/core/flows/ResponseCycleFlow.ts src/agent/implementations/flows/tooluse/runToolUseFlow.ts src/agent/runtime/AgentLaunchContext.ts src/agent/runtime/RunContext.ts src/agent/runtime/agentToolResolution.ts src/agent/runtime/executeAgent.ts src/agent/runtime/runAgent.ts src/tools/DelegationTools.ts`
- `npm run lint` (passes, existing import-order/naming warnings only)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tool visibility and CLI approval paths used on every headless run; behavior change is intentional but agents relying on `inquiry` in CLI will need `texra chat` or `ask_user_question`.
> 
> **Overview**
> **Fixes stale / unusable `inquiry` behavior in headless and non-TUI CLI runs** by treating external inquiry as incompatible with a process that cannot resume async answers after the run ends.
> 
> Introduces **`runtimeUnavailableTools`** on the run path (`runAgent` → `executeAgent` → tool resolution and response-cycle tool lists). This is separate from **`approvalPromptsUnavailable`**: hosts can hide tools the runtime cannot support without stripping other approval-gated tools. Non-TUI CLI execution always excludes **`inquiry`** (merged with any caller-provided exclusions). Subagents inherit the parent’s runtime exclusions via delegation.
> 
> **`inquiry`** is also listed as **approval-gated**, so it is omitted when human approval prompts are unavailable (e.g. headless CLI), in addition to the explicit CLI runtime block.
> 
> The **non-TUI CLI external-inquiry handler** no longer opens a synchronous stdin prompt; it **`drop`s** the thread with feedback to use **`texra chat`** for the inquiry panel or **`ask_user_question`** for synchronous CLI input.
> 
> **Tests:** coverage for runtime vs approval filtering, CLI inquiry drop, and a **Lean JSON-RPC harness** fix that buffers partial client frames when header and body arrive in separate writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9ccb77f1ced71135fa874d0ae02c662f9702149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->