### PR TITLE
refactor: consolidate clampOptional and joinNonEmpty into shared utilities

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
@@ -9,17 +9,11 @@ import { commonViewStyles, designTokens } from '@shared/styles';
 
 // Local imports - shared utilities
 import { createEvent } from '@shared/utils/events';
+import { clampOptional } from '@utils/core';
 
 // Local imports - shared schemas
 import type { NumberVscodeSetting } from '@shared/schemas/settingsViewMessages';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
-
-function clampSetting(value: number, min?: number, max?: number): number {
-  let result = value;
-  if (min != null) result = Math.max(min, result);
-  if (max != null) result = Math.min(max, result);
-  return result;
-}
 
 @customElement('reliability-settings-section')
 export class ReliabilitySettingsSection extends LitElement {
@@ -84,7 +78,7 @@ export class ReliabilitySettingsSection extends LitElement {
       input.value = String(setting.value);
       return;
     }
-    const value = clampSetting(parsed, setting.min, setting.max);
+    const value = clampOptional(parsed, setting.min, setting.max);
     if (value !== parsed) input.value = String(value);
     this.dispatchEvent(
       createEvent('provider-vscode-setting-set', { key: setting.key, value }),

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -45,7 +45,7 @@ import type { ToolFileAttachment } from '@tools/result';
 import { AbsoluteFS, flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { getAnthropicDynamicFiltering } from '@utils/config/providerConfig';
-import { objectToLogString } from '@utils/text/stringUtils';
+import { joinNonEmpty, objectToLogString } from '@utils/text/stringUtils';
 import {
   computeAnthropicPrice,
   normalizeAnthropicUsage,
@@ -858,14 +858,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (message.role !== 'assistant') return undefined;
     if (typeof message.content === 'string') return message.content;
     if (!Array.isArray(message.content)) return undefined;
-    const texts = message.content
-      .filter(
-        (b): b is { type: 'text'; text: string } =>
-          (b as { type?: string }).type === 'text',
-      )
-      .map((b) => b.text)
-      .filter(Boolean);
-    return texts.length > 0 ? texts.join('\n') : undefined;
+    return joinNonEmpty(
+      message.content
+        .filter(
+          (b): b is { type: 'text'; text: string } =>
+            (b as { type?: string }).type === 'text',
+        )
+        .map((b) => b.text),
+    );
   }
 
   /** Converts image/document content array into Anthropic-compatible message format with type and source metadata. */

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -47,7 +47,7 @@ import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@tools/result';
 // Local imports - utils
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
-import { pluralize } from '@utils/text/stringUtils';
+import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
 import {
   computeGooglePrice,
   normalizeGoogleUsage,
@@ -740,11 +740,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   override extractAssistantText(message: Content): string | undefined {
     if (message.role !== 'model') return undefined;
     if (!Array.isArray(message.parts)) return undefined;
-    const texts = message.parts
-      .filter(isTextPart)
-      .map((p) => p.text)
-      .filter(Boolean);
-    return texts.length > 0 ? texts.join('\n') : undefined;
+    return joinNonEmpty(message.parts.filter(isTextPart).map((p) => p.text));
   }
 
   override async createMediaMessage(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -34,7 +34,11 @@ import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString, roundTo } from '@utils/core';
 import { flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
-import { extractMimeSubtype, objectToLogString } from '@utils/text/stringUtils';
+import {
+  extractMimeSubtype,
+  joinNonEmpty,
+  objectToLogString,
+} from '@utils/text/stringUtils';
 import { prepareExistingOutputContent } from '../utils/fileContentUtils';
 import { tagOpenAISdkError } from './openAISdkError';
 
@@ -882,11 +886,11 @@ export class ModelHandlerOpenAI<
     const { content } = message;
     if (typeof content === 'string') return content;
     if (!Array.isArray(content)) return undefined;
-    const texts = content
-      .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-      .map((p) => p.text)
-      .filter(Boolean);
-    return texts.length > 0 ? texts.join('\n') : undefined;
+    return joinNonEmpty(
+      content
+        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+        .map((p) => p.text),
+    );
   }
 
   /** Builds the default content parts for inline vision requests. */

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -24,7 +24,7 @@ import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString } from '@utils/core';
 import { flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
-import { extractMimeSubtype } from '@utils/text/stringUtils';
+import { extractMimeSubtype, joinNonEmpty } from '@utils/text/stringUtils';
 import {
   computeOpenRouterPrice,
   normalizeOpenRouterUsage,
@@ -538,11 +538,11 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     const msg = message as ChatAssistantMessage;
     if (typeof msg.content === 'string') return msg.content;
     if (!Array.isArray(msg.content)) return undefined;
-    const texts = (msg.content as ChatContentItems[])
-      .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-      .map((p) => p.text)
-      .filter(Boolean);
-    return texts.length > 0 ? texts.join('\n') : undefined;
+    return joinNonEmpty(
+      (msg.content as ChatContentItems[])
+        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+        .map((p) => p.text),
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -21,5 +21,5 @@ export {
   ensureArray,
 } from './typeGuards';
 export { debounce, delay } from './async';
-export { clamp, clampIndex, roundTo } from './math';
+export { clamp, clampIndex, clampOptional, roundTo } from './math';
 export { tryParseUrl } from './urlCore';

--- a/src/utils/core/math.ts
+++ b/src/utils/core/math.ts
@@ -8,7 +8,7 @@ export function clamp(value: number, min: number, max: number): number {
 
 /**
  * Clamp `value` to optional bounds. Each bound is applied only when defined.
- * Equivalent to `clamp` when both are provided; a no-op when neither is.
+ * Equivalent to `clamp` when both are provided and `min <= max`; a no-op when neither is.
  */
 export function clampOptional(
   value: number,

--- a/src/utils/core/math.ts
+++ b/src/utils/core/math.ts
@@ -7,6 +7,21 @@ export function clamp(value: number, min: number, max: number): number {
 }
 
 /**
+ * Clamp `value` to optional bounds. Each bound is applied only when defined.
+ * Equivalent to `clamp` when both are provided; a no-op when neither is.
+ */
+export function clampOptional(
+  value: number,
+  min?: number,
+  max?: number,
+): number {
+  let result = value;
+  if (min != null) result = Math.max(min, result);
+  if (max != null) result = Math.min(max, result);
+  return result;
+}
+
+/**
  * Clamp `index` into `[0, length - 1]`.
  * Returns 0 when `length <= 0` so the result is always a valid array index.
  */

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -144,3 +144,16 @@ export function extractMimeSubtype(
 ): string {
   return mimeType.split('/').pop() ?? fallback ?? mimeType;
 }
+
+/**
+ * Join non-empty strings with `sep` (default `'\n'`).
+ * Returns `undefined` when no non-empty parts remain, so callers can
+ * distinguish "no content" from an empty string.
+ */
+export function joinNonEmpty(
+  parts: string[],
+  sep: string = '\n',
+): string | undefined {
+  const nonempty = parts.filter(Boolean);
+  return nonempty.length > 0 ? nonempty.join(sep) : undefined;
+}


### PR DESCRIPTION
## Summary

- **`clampOptional`** — `ReliabilitySettingsSection.ts` contained a private `clampSetting(value, min?, max?)` that duplicated the "optional-bounds clamp" concept not covered by the existing `clamp(value, min, max)`. The function is moved to `src/utils/core/math.ts` as `clampOptional`, exported from the core barrel, and imported in the component.

- **`joinNonEmpty`** — All four model handlers (Anthropic, OpenAI, OpenRouter, Google) ended `extractAssistantText` with an identical two-line idiom:
  ```ts
  .filter(Boolean);
  return texts.length > 0 ? texts.join('\n') : undefined;
  ```
  This is now a single `joinNonEmpty(parts, sep?)` call in `src/utils/text/stringUtils.ts`, imported via the path alias already used by each handler.

## Files changed

| File | Change |
|---|---|
| `src/utils/core/math.ts` | Add `clampOptional` |
| `src/utils/core/index.ts` | Re-export `clampOptional` |
| `src/utils/text/stringUtils.ts` | Add `joinNonEmpty` |
| `packages/…/ReliabilitySettingsSection.ts` | Remove local `clampSetting`, use `clampOptional` |
| `src/agent/modelHandlers/{anthropic,openai,openrouter,google}` | Use `joinNonEmpty` in `extractAssistantText` |

## Test plan

- [ ] `npm run compile:fast` — build passes (verified)
- [ ] `npm test` — 441 test files, 3086 tests all pass (verified)
- [ ] No logic change: `clampOptional` is a literal extraction of `clampSetting`; `joinNonEmpty` inlines the same filter-then-join-or-undefined logic

https://claude.ai/code/session_01USbmB51ZA1FLaD6GaiznHz

---
_Generated by [Claude Code](https://claude.ai/code/session_01USbmB51ZA1FLaD6GaiznHz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with equivalent logic; touches assistant text extraction in model handlers but behavior should be unchanged.
> 
> **Overview**
> **Deduplicates two small patterns** into shared helpers with no intended behavior change.
> 
> Adds **`clampOptional`** in `src/utils/core/math.ts` (exported from `@utils/core`) and switches **`ReliabilitySettingsSection`** from a local `clampSetting` to that import for numeric VS Code setting bounds.
> 
> Adds **`joinNonEmpty`** in `src/utils/text/stringUtils.ts` and uses it in **`extractAssistantText`** across the Anthropic, OpenAI, OpenRouter, and Google model handlers instead of repeated filter/join/undefined logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 117a975af82e0ecacfcf87c81a94b124920dbf8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->