### PR TITLE
[codex] fix foreground bash cancellation on stop

### DIFF
--- a/src/agent/core/flows/toolUseCycle/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseCycle/ToolUseDispatchNode.ts
@@ -296,6 +296,20 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     }
 
     if (controller.signal.aborted || options.checkInterruption()) {
+      if (logRef.logId) {
+        endToolUseCard(
+          options.logger,
+          { logId: logRef.logId, groupId: logRef.groupId },
+          {
+            toolName: call.name,
+            input: parsedInput ?? call.raw,
+            output:
+              result.error ?? result.output ?? 'Tool execution cancelled.',
+            isError: true,
+          },
+          'failed',
+        );
+      }
       return null;
     }
 

--- a/src/agent/core/flows/toolUseCycle/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseCycle/ToolUseDispatchNode.ts
@@ -185,6 +185,7 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     workPlanState: WorkPlanState,
     onExecutionReady?: () => void,
     onToolOutput?: (chunk: string) => void,
+    signal?: AbortSignal,
   ): Promise<ToolResult> {
     if (!tool) {
       return { error: `Unknown tool ${call.name}`, isError: true };
@@ -198,6 +199,7 @@ export class ToolUseDispatchNode<C> extends BatchNode<
           toolCallId: call.callId,
           onExecutionReady,
           onToolOutput,
+          signal,
           // Subagent cost lands in the parent's totals only (no normalized
           // snapshot), so per-round usage reporting doesn't double-count it —
           // the child's own run already reported its rounds.
@@ -221,7 +223,7 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     options: ToolUseCycleServices<C>,
     tracker: FileInteractionState,
     workPlanState: WorkPlanState,
-  ): Promise<ToolExecutionResult> {
+  ): Promise<ToolExecutionResult | null> {
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
     const tool = options.toolRegistry.get(call.name);
     const isDeferred = DEFERRED_LOG_TOOLS.has(call.name);
@@ -271,16 +273,31 @@ export class ToolUseDispatchNode<C> extends BatchNode<
       };
     }
 
-    const result = await this.invokeToolSafely(
-      call,
-      tool,
-      parsedInput,
-      options,
-      tracker,
-      workPlanState,
-      onExecutionReady,
-      onToolOutput,
-    );
+    const controller = new AbortController();
+    this.signal = controller.signal;
+    options.setAbortController(controller);
+
+    let result: ToolResult;
+    try {
+      result = await this.invokeToolSafely(
+        call,
+        tool,
+        parsedInput,
+        options,
+        tracker,
+        workPlanState,
+        onExecutionReady,
+        onToolOutput,
+        controller.signal,
+      );
+    } finally {
+      options.setAbortController(null);
+      this.signal = undefined;
+    }
+
+    if (controller.signal.aborted || options.checkInterruption()) {
+      return null;
+    }
 
     const trackedEdits = tracker.recordEdits(result.edits);
     if (!result.lineChanges && trackedEdits.lineChanges) {

--- a/src/agent/core/flows/toolUseCycle/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseCycle/ToolUseDispatchNode.ts
@@ -274,7 +274,6 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     }
 
     const controller = new AbortController();
-    this.signal = controller.signal;
     options.setAbortController(controller);
 
     let result: ToolResult;
@@ -292,7 +291,6 @@ export class ToolUseDispatchNode<C> extends BatchNode<
       );
     } finally {
       options.setAbortController(null);
-      this.signal = undefined;
     }
 
     if (controller.signal.aborted || options.checkInterruption()) {

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -24,6 +24,8 @@ export interface ToolCallContext {
   onExecutionReady?: () => void;
   /** Called by tools to push partial output for live streaming to the UI. */
   onToolOutput?: (chunk: string) => void;
+  /** Aborts when the current tool call is cancelled by the owning agent run. */
+  signal?: AbortSignal;
   /**
    * Roll a completed subagent's model cost (USD) into the parent run's usage
    * totals. Delegation tools call this when a child run finishes so parent

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -141,7 +141,13 @@ describe('BashTool', () => {
       timedOut: false,
     };
 
-    vi.spyOn(execUtils, 'executeCommand').mockResolvedValue(execResult);
+    let receivedSignal: AbortSignal | undefined;
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        receivedSignal = options.signal;
+        return execResult;
+      },
+    );
 
     const bashTool = new BashTool();
     const directResult = await bashTool.call({ command: 'echo long' });
@@ -234,5 +240,10 @@ describe('BashTool', () => {
         toolOutputMessage.output.includes(longOutput),
       'Model follow-up payload should contain the complete stdout text',
     );
+    assert.ok(
+      receivedSignal,
+      'Bash command should receive the active tool-call abort signal',
+    );
+    assert.equal(receivedSignal.aborted, false);
   });
 });

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -14,6 +14,7 @@ import {
   ModelProvider,
 } from 'llm-zoo';
 import { createRunTrace } from '@transcript';
+import type { AgentEvent } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type {
   AgentPrompt,
@@ -21,6 +22,7 @@ import type {
 } from '@agent/core/definition/AgentDataclass';
 import { AgentRunStateSnapshotSchema } from '@agent/core/execution/AgentState';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
+import { ToolUseDispatchNode } from '@agent/core/flows/toolUseCycle/ToolUseDispatchNode';
 import {
   createToolUseCycleFlow,
   type ToolUseCycleShared,
@@ -34,6 +36,7 @@ import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 // Type imports
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 
 // Internal imports
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
@@ -245,5 +248,128 @@ describe('BashTool', () => {
       'Bash command should receive the active tool-call abort signal',
     );
     assert.equal(receivedSignal.aborted, false);
+  });
+
+  it('finalizes deferred progress card when foreground bash is aborted', async () => {
+    let activeController: AbortController | null = null;
+    let receivedSignal: AbortSignal | undefined;
+
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        receivedSignal = options.signal;
+        options.onStdout?.('started\n');
+        activeController?.abort();
+        return {
+          success: false,
+          stdout: null,
+          stderr: 'Command aborted by user',
+          timedOut: false,
+          exitCode: 130,
+        };
+      },
+    );
+
+    const config: ModelConfig = {
+      name: 'test',
+      label: 'Test',
+      fullName: 'test',
+      shortName: 'test',
+      provider: ModelProvider.OPENAI,
+      maxOutputTokens: 10,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 1000,
+      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+      openRouterOnly: false,
+    };
+
+    const runTrace = createRunTrace('BashToolAbortTest' as StreamTabId);
+    const events: AgentEvent[] = [];
+    const unsubscribe = runTrace.trace.subscribe((event) => {
+      events.push(event);
+    });
+
+    const node = new ToolUseDispatchNode<OpenAI>();
+    const bashTool = new BashTool();
+    const workspaceState = AgentWorkspaceState.create();
+    const run = AgentRunStateSnapshotSchema.parse({});
+    const options: ToolUseCycleServices<OpenAI> = {
+      modelHandler: new BashMockHandler(config),
+      config: config as any,
+      setting: {
+        agentCategory: AgentCategory.ToolUse,
+        documentTag: 'doc',
+        temperature: 0,
+        endTag: '</doc>',
+        requiredFiles: {},
+        requiredFilesInternal: {},
+        defaultOutputFiles: [],
+        filePatternsContain: [],
+        tools: [{ name: 'bash' }],
+      } satisfies AgentSetting,
+      prompt: {
+        systemPrompt: '',
+        userPrefix: '',
+        userRequest: '',
+      } satisfies AgentPrompt,
+      userVarChannels: { input: {}, transient: {} },
+      logger: runTrace.trace,
+      runtimeHost: noopAgentRuntimeHost,
+      streamStatus: new StreamStatusRegistry(),
+      client: {} as OpenAI,
+      fileService: new TaskRunFileService('test-execution-id'),
+      toolRegistry: new MapToolRegistry({ bash: bashTool }),
+      checkInterruption: () => activeController?.signal.aborted ?? false,
+      setAbortController: (controller) => {
+        activeController = controller;
+      },
+      streamId: 'bash-tool' as StreamTabId,
+      executionId: 'test-execution-id',
+      run,
+      workspace: workspaceState,
+    };
+
+    const call = {
+      provider: 'google',
+      callId: 'bash-abort-1',
+      name: 'bash',
+      input: { command: 'echo long' },
+      raw: { name: 'bash', args: { command: 'echo long' } },
+    } as SdkToolCall;
+
+    try {
+      node.setServices(options);
+      const result = await node.exec(call);
+
+      assert.equal(result, null);
+      assert.ok(receivedSignal, 'Bash command should receive an abort signal');
+      assert.equal(receivedSignal.aborted, true);
+
+      const toolEvents = events.filter(
+        (event) => event.type === 'tool.start' || event.type === 'tool.end',
+      );
+      assert.equal(toolEvents[0]?.type, 'tool.start');
+
+      const startedLogId =
+        toolEvents[0]?.type === 'tool.start' ? toolEvents[0].logId : null;
+      const progressEvent = toolEvents.find(
+        (event) => event.type === 'tool.end' && event.status === 'in_progress',
+      );
+      const failedEvent = toolEvents.findLast(
+        (event) => event.type === 'tool.end' && event.status === 'failed',
+      );
+
+      assert.ok(progressEvent, 'Streaming output should update the card');
+      assert.ok(failedEvent, 'Abort should close the progress card as failed');
+      if (progressEvent?.type === 'tool.end') {
+        assert.equal(progressEvent.logId, startedLogId);
+      }
+      if (failedEvent?.type === 'tool.end') {
+        assert.equal(failedEvent.logId, startedLogId);
+      }
+    } finally {
+      unsubscribe();
+      runTrace.dispose();
+    }
   });
 });

--- a/src/test-kernel/utils/system/execUtils.vitest.ts
+++ b/src/test-kernel/utils/system/execUtils.vitest.ts
@@ -1,8 +1,12 @@
-// Third-party imports
+// Node imports
 import { strict as assert } from 'node:assert';
-import { beforeAll, describe, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
 
-// Standard library imports
+// Third-party imports
+import { afterEach, beforeAll, describe, it } from 'vitest';
 
 // Local imports - test support
 import { createFakePlatform } from '@test/support/FakePlatform';
@@ -10,12 +14,40 @@ import { createFakePlatform } from '@test/support/FakePlatform';
 // Local imports - utils
 import { executeCommand } from '@utils/system/execUtils';
 
+const tempDirs: string[] = [];
+
 beforeAll(async () => {
   // executeCommand resolves its cwd from the workspace; point the fake
   // platform at a directory that exists on disk so spawning succeeds.
   const { initPlatform } = await import('@platform/platform');
   initPlatform(createFakePlatform({ workspacePath: process.cwd() }));
 });
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+async function waitForFile(filePath: string): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (existsSync(filePath)) return;
+    await sleep(20);
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+async function waitForProcessExit(pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await sleep(20);
+  }
+  throw new Error(`Process ${pid} was still running after abort`);
+}
 
 describe('executeCommand', () => {
   it('runs string commands with shell operators intact', async () => {
@@ -36,5 +68,32 @@ describe('executeCommand', () => {
     assert.ok(result.success);
     assert.strictEqual(result.stdout, 'fallback');
     assert.strictEqual(result.stderr, null);
+  });
+
+  it('aborts shell command process groups including children', async () => {
+    if (process.platform === 'win32') return;
+
+    const dir = mkdtempSync(join(tmpdir(), 'texra-exec-abort-'));
+    tempDirs.push(dir);
+    const pidFile = join(dir, 'sleep.pid');
+    const controller = new AbortController();
+    const promise = executeCommand('sleep 60 & echo $! > "$PID_FILE"; wait', {
+      cwd: dir,
+      env: { PID_FILE: pidFile },
+      signal: controller.signal,
+      timeout: 60_000,
+    });
+
+    await waitForFile(pidFile);
+    const childPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10);
+    assert.ok(Number.isInteger(childPid) && childPid > 0);
+
+    controller.abort();
+    const result = await promise;
+
+    assert.equal(result.success, false);
+    assert.equal(result.timedOut, false);
+    assert.equal(result.stderr, 'Command aborted by user');
+    await waitForProcessExit(childPid);
   });
 });

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -173,6 +173,7 @@ export class BashTool extends defineTool({
       timeout: timeoutMs,
       onStdout: ctx?.onToolOutput,
       onStderr: ctx?.onToolOutput,
+      signal: ctx?.signal,
     });
 
     if (result.timedOut) {

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -177,13 +177,25 @@ export async function executeCommand(
     onPid?: (pid: number) => void;
     /** Set to false to skip buffering stdout/stderr in memory (use with onStdout/onStderr). */
     buffer?: boolean;
+    /** Abort signal used to terminate the subprocess and any shell children. */
+    signal?: AbortSignal;
   } = {},
 ): Promise<ExecResult> {
   // Hoisted so the finally block can clear them on both success and error paths.
   let shellTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let forceKillTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let removeAbortListener: (() => void) | undefined;
 
   try {
+    if (options.signal?.aborted) {
+      return resultFromProcessOutput(
+        null,
+        'Command aborted by user',
+        130,
+        false,
+      );
+    }
+
     const workspacePath = options.cwd ?? WorkspaceFS.getPath();
     if (!workspacePath) {
       throw new Error('No workspace path found');
@@ -205,6 +217,37 @@ export async function executeCommand(
 
     let subprocess: ResultPromise;
     let shellTimedOut = false;
+    let shellAborted = false;
+
+    const terminateSubprocess = (signal: NodeJS.Signals): void => {
+      const pid = subprocess.pid;
+      if (!pid) return;
+
+      signalProcessGroup(pid, signal);
+
+      // Force-kill after FORCE_KILL_DELAY_MS if SIGTERM didn't work,
+      // and destroy streams as a last resort to unblock `await subprocess`.
+      if (signal === 'SIGTERM' && forceKillTimeoutId === undefined) {
+        forceKillTimeoutId = setTimeout(() => {
+          signalProcessGroup(pid, 'SIGKILL');
+          subprocess.stdout?.destroy();
+          subprocess.stderr?.destroy();
+        }, FORCE_KILL_DELAY_MS);
+      }
+    };
+
+    const installAbortListener = (): void => {
+      if (!options.signal) return;
+      const onAbort = (): void => {
+        shellAborted = true;
+        terminateSubprocess('SIGTERM');
+      };
+      options.signal.addEventListener('abort', onAbort, { once: true });
+      removeAbortListener = () => {
+        options.signal?.removeEventListener('abort', onAbort);
+      };
+      if (options.signal.aborted) onAbort();
+    };
 
     if (Array.isArray(command)) {
       const [cmd, ...args] = command;
@@ -214,6 +257,7 @@ export async function executeCommand(
       );
       subprocess = execa(cmd, args, execaOptions);
       if (subprocess.pid && options.onPid) options.onPid(subprocess.pid);
+      installAbortListener();
     } else {
       logger.debug(logChannel, `Running command: ${command}`);
       // Shell commands with pipes (e.g. "find / | head -2") create child
@@ -231,36 +275,27 @@ export async function executeCommand(
       //
       // Tradeoff: `detached` means the process group is NOT automatically
       // cleaned up if the extension host is hard-killed (SIGKILL / crash) --
-      // long-running shell commands would be orphaned.  This only affects the
-      // bash tool (all other callers use array-form commands which skip this
-      // path).  Acceptable because the alternative is `await` hanging forever.
+      // long-running shell commands would be orphaned. This only affects
+      // shell-form commands that opt into timeout/cancel handling, primarily
+      // the bash tool. Acceptable because the alternative is `await` hanging
+      // forever or leaving approved children running after a user stop.
       const { timeout: _shellTimeout, ...execaNoTimeout } = execaOptions;
-      // Only use detached when we have a timeout and need process-group killing.
+      // Only use detached when we have a timeout/signal and need process-group killing.
       // On POSIX, detached creates a process group we can kill as a unit.
       // On Windows, detached opens a new console window so we always skip it.
-      const useDetached = !!_shellTimeout && !IS_WINDOWS;
+      const useDetached = (!!_shellTimeout || !!options.signal) && !IS_WINDOWS;
       subprocess = execa(command, {
         ...execaNoTimeout,
         shell: true,
         ...(useDetached ? { detached: true } : {}),
       });
       if (subprocess.pid && options.onPid) options.onPid(subprocess.pid);
+      installAbortListener();
 
       if (_shellTimeout) {
         shellTimeoutId = setTimeout(() => {
           shellTimedOut = true;
-          const pid = subprocess.pid;
-          if (!pid) return;
-
-          signalProcessGroup(pid, 'SIGTERM');
-
-          // Force-kill after FORCE_KILL_DELAY_MS if SIGTERM didn't work,
-          // and destroy streams as a last resort to unblock `await subprocess`.
-          forceKillTimeoutId = setTimeout(() => {
-            signalProcessGroup(pid, 'SIGKILL');
-            subprocess.stdout?.destroy();
-            subprocess.stderr?.destroy();
-          }, FORCE_KILL_DELAY_MS);
+          terminateSubprocess('SIGTERM');
         }, _shellTimeout);
       }
     }
@@ -281,12 +316,19 @@ export async function executeCommand(
 
     const stdout = (result.stdout as string) ?? '';
     const stderr = (result.stderr as string) ?? '';
-    const exitCode = result.exitCode ?? 1;
+    const exitCode = result.exitCode ?? (shellAborted ? 130 : 1);
     const timedOut = (result.timedOut ?? false) || shellTimedOut;
+    const normalizedStderr =
+      shellAborted && !stderr ? 'Command aborted by user' : stderr;
 
-    logCommandStderr(logChannel, stderr, options.truncate);
+    logCommandStderr(logChannel, normalizedStderr, options.truncate);
 
-    return resultFromProcessOutput(stdout, stderr, exitCode, timedOut);
+    return resultFromProcessOutput(
+      stdout,
+      normalizedStderr,
+      exitCode,
+      timedOut,
+    );
   } catch (err) {
     logger.error(
       options.channel ?? CHANNEL,
@@ -297,6 +339,7 @@ export async function executeCommand(
   } finally {
     if (shellTimeoutId !== undefined) clearTimeout(shellTimeoutId);
     if (forceKillTimeoutId !== undefined) clearTimeout(forceKillTimeoutId);
+    removeAbortListener?.();
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #5942.

- threads the active tool-call abort signal through `ToolFileInteractionContext`
- registers an abort controller around each tool dispatch so user stops reach foreground tools
- makes `executeCommand` terminate shell process groups on abort, matching the existing timeout cleanup path
- passes the signal from the foreground `bash` tool into `executeCommand`

## Root Cause

Tool-use interruption already aborted model calls through `setAbortController`, but tool dispatch did not install a controller for the currently executing tool. Foreground bash commands therefore kept running after the TUI marked the stream stopped. When those commands spawned children, only the UI/session stopped; the child process could continue as an orphan.

## Validation

- `npm run typecheck`
- `corepack pnpm vitest run src/test-kernel/utils/system/execUtils.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/tools/BashTool.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/progressView/RequestPanelStyles.vitest.mts`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subprocess lifecycle and process-group killing for shell commands on user stop; incorrect signaling could leave orphans or kill too aggressively, but scope is limited to abort/timeout paths and is covered by new tests.
> 
> **Overview**
> Fixes foreground **bash** (and other tools) continuing after the user stops the stream by wiring cancellation through the tool dispatch path end-to-end.
> 
> **Tool dispatch** now registers an `AbortController` per tool call via `setAbortController`, passes its signal through `ToolFileInteractionContext`, and on abort or interruption returns `null` from execution (stopping the cycle) while closing deferred/streaming tool cards as **failed**.
> 
> **`executeCommand`** gains an optional `signal` that terminates the shell and child process groups (POSIX detached spawn when timeout or signal is set), reusing the same SIGTERM → SIGKILL path as timeouts, and returns exit 130 with `Command aborted by user` when cancelled.
> 
> **Foreground `bash`** forwards `ctx.signal` into `executeCommand`. Tests cover signal plumbing, aborted progress UI, and killing backgrounded shell children on abort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c39d2918bd76533d9729d220846260ca98e2d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->