### PR TITLE
[codex] fix progress approval layout overflow

### DIFF
--- a/packages/extension/src/progressView/frontend/components/streamTabsStyles.ts
+++ b/packages/extension/src/progressView/frontend/components/streamTabsStyles.ts
@@ -6,6 +6,10 @@ export const streamTabStyles = css`
   :host {
     display: block;
     container-type: inline-size;
+    box-sizing: border-box;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
   }
 
   .tab-container {
@@ -13,8 +17,12 @@ export const streamTabStyles = css`
     align-items: center;
     position: relative;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
     gap: var(--wa-space-3xs);
     border-left: var(--border-medium) solid transparent;
+    box-sizing: border-box;
+    overflow: hidden;
   }
 
   /*
@@ -86,10 +94,12 @@ export const streamTabStyles = css`
     align-items: center;
     gap: var(--wa-space-2xs);
     width: 100%;
+    min-width: 0;
   }
 
   .tab-title {
     flex: 1;
+    min-width: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -121,6 +131,8 @@ export const streamTabStyles = css`
     color: var(--wa-color-text-normal);
     opacity: var(--opacity-subtle);
     width: 100%;
+    min-width: 0;
+    overflow: hidden;
   }
 
   .tab-meta .remote-agent,
@@ -280,6 +292,8 @@ export const streamTabsContainerStyles = css`
     flex-direction: column;
     flex: 1;
     width: 100%;
+    min-width: 0;
+    max-width: 100%;
     min-height: 0;
     overflow: hidden;
   }
@@ -301,7 +315,7 @@ export const streamTabsContainerStyles = css`
     min-width: 0;
     font-size: var(--font-size-sm);
     height: 100%;
-    overflow: visible;
+    overflow: hidden;
     background-color: var(--background-color);
   }
 
@@ -331,8 +345,15 @@ export const streamTabsContainerStyles = css`
   .tabs-content {
     flex: 1;
     overflow-y: auto;
+    overflow-x: hidden;
     min-height: 0;
     scrollbar-width: thin;
+  }
+
+  .tabs-content > div {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
   }
 
   .stream-list-footer {
@@ -386,6 +407,10 @@ export const streamTabsContainerStyles = css`
     padding-left: var(--wa-space-xs, 12px);
     border-left: var(--border-thin) solid var(--color-border);
     margin-left: var(--wa-space-2xs);
+    box-sizing: border-box;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
   }
 
   .child-streams stream-tab {

--- a/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
+++ b/packages/extension/src/webview/frontend/mocks/MocksGallery.ts
@@ -53,8 +53,25 @@ export class MocksGallery extends LitElement {
 
       .section {
         margin-bottom: var(--wa-space-l);
+        box-sizing: border-box;
         min-width: 0;
         max-width: 100%;
+        overflow-x: hidden;
+      }
+
+      .section > * {
+        box-sizing: border-box;
+        min-width: 0;
+        max-width: 100%;
+      }
+
+      texra-todo-list-mock,
+      texra-followup-controls-mock,
+      texra-progress-board-layout-mock {
+        display: block;
+        min-width: 0;
+        max-width: 100%;
+        overflow-x: hidden;
       }
 
       .section__title {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -141,6 +141,7 @@ export const requestPanelStyles: CSSResult = css`
 
   :is(${ACTIONS}) {
     display: flex;
+    align-items: center;
     flex-wrap: wrap;
     gap: ${sp.small};
     min-width: 0;
@@ -167,10 +168,13 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .approval-request__actions wa-button[data-action] {
+    display: inline-flex;
     flex: 0 0 auto;
-    width: fit-content;
+    width: auto;
+    inline-size: max-content;
     min-width: min(5.5rem, 100%);
-    max-width: min(9rem, 100%);
+    max-width: min(7rem, 100%);
+    max-inline-size: min(7rem, 100%);
   }
 
   :is(${ACTIONS}) wa-button[data-action]::part(base) {
@@ -181,6 +185,7 @@ export const requestPanelStyles: CSSResult = css`
   .approval-request__actions wa-button[data-action]::part(base) {
     justify-content: center;
     width: auto;
+    inline-size: auto;
     min-width: 0;
     max-width: 100%;
   }
@@ -282,6 +287,7 @@ export const requestPanelStyles: CSSResult = css`
     flex: 0 1 8.25rem;
     min-width: 0;
     max-width: 100%;
+    max-inline-size: 100%;
   }
 
   .approval-request__actions .diff-dropdown .diff-main-button {

--- a/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
+++ b/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
@@ -39,12 +39,15 @@ describe('request panel styles', () => {
     expect(hostRule).toContain('max-width: 100%');
     expect(actionStart).toBeGreaterThanOrEqual(0);
     expect(baseStart).toBeGreaterThan(actionStart);
+    expect(actionRule).toContain('display: inline-flex');
     expect(actionRule).toContain('flex: 0 0 auto');
-    expect(actionRule).toContain('width: fit-content');
+    expect(actionRule).toContain('inline-size: max-content');
     expect(actionRule).toContain('min-width: min(5.5rem, 100%)');
-    expect(actionRule).toContain('max-width: min(9rem, 100%)');
+    expect(actionRule).toContain('max-width: min(7rem, 100%)');
+    expect(actionRule).toContain('max-inline-size: min(7rem, 100%)');
     expect(baseRule).toContain('justify-content: center');
     expect(baseRule).toContain('width: auto');
+    expect(baseRule).toContain('inline-size: auto');
     expect(baseRule).toContain('max-width: 100%');
   });
 
@@ -67,6 +70,7 @@ describe('request panel styles', () => {
     expect(dropdownRule).toContain('flex: 0 1 8.25rem');
     expect(dropdownRule).toContain('min-width: 0');
     expect(dropdownRule).toContain('max-width: 100%');
+    expect(dropdownRule).toContain('max-inline-size: 100%');
     expect(dropdownButtonRule).toContain('flex: 1 1 auto');
     expect(dropdownButtonRule).toContain('width: auto');
     expect(dropdownButtonRule).toContain('min-width: 0');

--- a/src/test-kernel/progressView/StreamTabsStyles.vitest.mts
+++ b/src/test-kernel/progressView/StreamTabsStyles.vitest.mts
@@ -1,0 +1,92 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+function readStreamTabsStyles(): string {
+  return readFileSync(
+    resolve(
+      REPO_ROOT,
+      'packages/extension/src/progressView/frontend/components/streamTabsStyles.ts',
+    ),
+    'utf8',
+  );
+}
+
+describe('stream tabs styles', () => {
+  it('contains narrow rails at every flex boundary', () => {
+    const source = readStreamTabsStyles();
+    const tabHostStart = source.indexOf(':host {');
+    const tabContainerStart = source.indexOf('.tab-container {');
+    const tabStart = source.indexOf('.tab {');
+    const tabHeaderStart = source.indexOf('.tab-header {');
+    const tabTitleStart = source.indexOf('.tab-title {');
+    const tabMetaStart = source.indexOf('.tab-meta {');
+    const containerHostStart = source.indexOf(
+      'export const streamTabsContainerStyles',
+    );
+    const tabsStart = source.indexOf('.tabs {', containerHostStart);
+    const tabsContentStart = source.indexOf('.tabs-content {');
+    const tabsContentChildrenStart = source.indexOf('.tabs-content > div {');
+    const childStreamsStart = source.indexOf('.child-streams {');
+
+    const tabHostRule = source.slice(tabHostStart, tabContainerStart);
+    const tabContainerRule = source.slice(tabContainerStart, tabStart);
+    const tabHeaderRule = source.slice(tabHeaderStart, tabTitleStart);
+    const tabTitleRule = source.slice(tabTitleStart, tabMetaStart);
+    const tabMetaRule = source.slice(
+      tabMetaStart,
+      source.indexOf('.tab-meta .remote-agent,', tabMetaStart),
+    );
+    const containerHostRule = source.slice(
+      source.indexOf(':host {', containerHostStart),
+      source.indexOf(':host([hidden])', containerHostStart),
+    );
+    const tabsRule = source.slice(
+      tabsStart,
+      source.indexOf('.stream-tabs-header {'),
+    );
+    const tabsContentRule = source.slice(
+      tabsContentStart,
+      tabsContentChildrenStart,
+    );
+    const tabsContentChildrenRule = source.slice(
+      tabsContentChildrenStart,
+      source.indexOf('}', tabsContentChildrenStart),
+    );
+    const childStreamsRule = source.slice(
+      childStreamsStart,
+      source.indexOf('}', childStreamsStart),
+    );
+
+    expect(tabHostRule).toContain('min-width: 0');
+    expect(tabHostRule).toContain('max-width: 100%');
+    expect(tabHostRule).toContain('overflow: hidden');
+    expect(tabContainerRule).toContain('min-width: 0');
+    expect(tabContainerRule).toContain('max-width: 100%');
+    expect(tabContainerRule).toContain('overflow: hidden');
+    expect(tabHeaderRule).toContain('min-width: 0');
+    expect(tabTitleRule).toContain('min-width: 0');
+    expect(tabMetaRule).toContain('min-width: 0');
+    expect(tabMetaRule).toContain('overflow: hidden');
+    expect(containerHostRule).toContain('min-width: 0');
+    expect(containerHostRule).toContain('max-width: 100%');
+    expect(containerHostRule).toContain('overflow: hidden');
+    expect(tabsRule).toContain('overflow: hidden');
+    expect(tabsContentRule).toContain('overflow-x: hidden');
+    expect(tabsContentChildrenRule).toContain('min-width: 0');
+    expect(tabsContentChildrenRule).toContain('max-width: 100%');
+    expect(tabsContentChildrenRule).toContain('overflow-x: hidden');
+    expect(childStreamsRule).toContain('min-width: 0');
+    expect(childStreamsRule).toContain('max-width: 100%');
+    expect(childStreamsRule).toContain('overflow: hidden');
+  });
+});

--- a/src/test-kernel/webview/MocksGalleryStyles.vitest.mts
+++ b/src/test-kernel/webview/MocksGalleryStyles.vitest.mts
@@ -22,18 +22,34 @@ describe('mock gallery styles', () => {
     );
     const hostStart = source.indexOf(':host {');
     const sectionStart = source.indexOf('.section {');
+    const sectionChildrenStart = source.indexOf('.section > * {');
+    const customElementStart = source.indexOf('texra-todo-list-mock,');
     const headerStart = source.indexOf('.header-strip {');
     const labelStart = source.indexOf('.header-strip__label {');
     const hostRule = source.slice(hostStart, sectionStart);
+    const sectionRule = source.slice(sectionStart, sectionChildrenStart);
+    const customElementRule = source.slice(
+      customElementStart,
+      source.indexOf('}', customElementStart),
+    );
     const headerRule = source.slice(headerStart, labelStart);
     const labelRule = source.slice(labelStart, source.indexOf('}', labelStart));
 
     expect(hostStart).toBeGreaterThanOrEqual(0);
+    expect(sectionChildrenStart).toBeGreaterThan(sectionStart);
+    expect(customElementStart).toBeGreaterThan(sectionChildrenStart);
     expect(headerStart).toBeGreaterThan(hostStart);
     expect(labelStart).toBeGreaterThan(headerStart);
     expect(hostRule).toContain('min-width: 0');
     expect(hostRule).toContain('max-width: 100%');
     expect(hostRule).toContain('overflow-x: hidden');
+    expect(sectionRule).toContain('min-width: 0');
+    expect(sectionRule).toContain('max-width: 100%');
+    expect(sectionRule).toContain('overflow-x: hidden');
+    expect(customElementRule).toContain('display: block');
+    expect(customElementRule).toContain('min-width: 0');
+    expect(customElementRule).toContain('max-width: 100%');
+    expect(customElementRule).toContain('overflow-x: hidden');
     expect(headerRule).toContain('flex-wrap: wrap');
     expect(headerRule).toContain('min-width: 0');
     expect(headerRule).toContain('max-width: 100%');


### PR DESCRIPTION
## Summary

- constrain tool edit approval action buttons to content-sized widths instead of allowing them to stretch across the row
- add horizontal containment to the stream rail and mock gallery preview boundaries so narrow mock layouts do not paint outside their host
- add style regression coverage for request-panel sizing, stream tab containment, and mock gallery clipping

## Root cause

The approval row still allowed Web Awesome button hosts to take excessive flex width in some layouts, and the progress stream rail had an `overflow: visible` path that could bypass the mock gallery's outer clipping.

## Validation

- `corepack pnpm prettier --write src/shared/styles/requestPanelStyles.ts packages/extension/src/progressView/frontend/components/streamTabsStyles.ts packages/extension/src/webview/frontend/mocks/MocksGallery.ts src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/StreamTabsStyles.vitest.mts src/test-kernel/webview/MocksGalleryStyles.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/StreamTabsStyles.vitest.mts src/test-kernel/webview/MocksGalleryStyles.vitest.mts src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src/shared/styles/requestPanelStyles.ts packages/extension/src/progressView/frontend/components/streamTabsStyles.ts packages/extension/src/webview/frontend/mocks/MocksGallery.ts src/test-kernel/progressView/RequestPanelStyles.vitest.mts src/test-kernel/progressView/StreamTabsStyles.vitest.mts src/test-kernel/webview/MocksGalleryStyles.vitest.mts`
- `npm run typecheck`
- `corepack pnpm run smoke:webviews`

Electron smoke verified `progress-approval` at a 420px viewport with approve width 112px, reject width 100.6px, and no viewport overflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and source-string tests; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes **horizontal overflow** in narrow progress and mock layouts by tightening flex containment and approval action sizing.
> 
> **Tool edit approval row** (`requestPanelStyles`): Approve/reject buttons no longer grow across the row—they use `inline-flex`, `inline-size: max-content`, and a **7rem** cap (down from 9rem). Action rows align vertically; the diff dropdown can shrink with `max-inline-size: 100%`.
> 
> **Stream rail** (`streamTabsStyles`): Every flex boundary gets `min-width: 0`, width caps, and hidden overflow; `.tabs` switches from `overflow: visible` to **hidden**, with extra clipping on scroll content and nested child streams.
> 
> **Mock gallery** (`MocksGallery`): Sections and key mock custom elements are clipped so progress-board previews stay inside the launcher panel.
> 
> Vitest style regressions cover request-panel buttons, stream-tab rails, and mock gallery boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3750a538c695dc1f106e08d6cba0e5866649be4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->