### PR TITLE
fix: note non-git CLI workspaces in prompts

### DIFF
--- a/src/test-kernel/utils/system/WorkspaceInfo.vitest.ts
+++ b/src/test-kernel/utils/system/WorkspaceInfo.vitest.ts
@@ -1,0 +1,24 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildWorkspaceInfoBlock } from '@utils/system/workspaceInfo';
+
+describe('buildWorkspaceInfoBlock', () => {
+  it('tells agents when the workspace is not a git repository', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'texra-workspace-info-'));
+    try {
+      const block = await buildWorkspaceInfoBlock(workspace);
+
+      expect(block).toContain(`Workspace: ${workspace}`);
+      expect(block).toContain(
+        'Git: no repository detected or git could not be checked',
+      );
+      expect(block).toContain('avoid git history/status checks');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -153,6 +153,10 @@ export async function buildWorkspaceInfoBlock(
     const parts = ['Git: yes', branchPart];
     if (info.git.dirty) parts.push('uncommitted changes');
     lines.push(parts.join(', '));
+  } else if (info.workspacePath) {
+    lines.push(
+      'Git: no repository detected or git could not be checked for this workspace; avoid git history/status checks unless you first confirm a repository exists.',
+    );
   }
 
   const externalRoots = listExternalRoots();


### PR DESCRIPTION
## Summary

- add an explicit negative git signal to the shared `workspace_info` block when the CLI workspace is not a repository
- cover the non-git workspace prompt output with a focused test

Closes #5945.

## Dogfood Evidence

A real `texra-local multi-agent run mathematician` session in `/private/tmp/texra-cli-dogfood-0613-Q2cm8M` completed the math task, but the final `progressCheck` subagent still ran `git log`/`git status` in that non-git workspace. The prompt helper already reports branch/dirty state when git exists; this adds the missing negative case.

## Validation

- `corepack pnpm vitest run src/test-kernel/utils/system/WorkspaceInfo.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentInstruction.vitest.ts`
- `npm run lint` (passes; existing import-order warnings remain)
- `npm run typecheck`
- `node --max-old-space-size=4096 ./node_modules/prettier/bin/prettier.cjs --check src/utils/system/workspaceInfo.ts src/test-kernel/utils/system/WorkspaceInfo.vitest.ts`
- `git diff --check -- src/utils/system/workspaceInfo.ts src/test-kernel/utils/system/WorkspaceInfo.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only wording in `buildWorkspaceInfoBlock` plus a new test; no runtime behavior or security-sensitive logic changes.
> 
> **Overview**
> When a workspace path is known but **git** cannot be detected, the shared `<workspace_info>` prompt block now includes an explicit **Git: no repository…** line that tells agents to avoid `git log` / `git status` unless they first confirm a repo exists. Previously that case was silent, which could mislead subagents in CLI temp workspaces.
> 
> A focused Vitest suite exercises `buildWorkspaceInfoBlock` on a non-git temp directory and asserts the workspace line and negative git guidance appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce1617e1cbb826dc38bcf18e6c696616bcdd4ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->