### PR TITLE
refactor: simplify code changed since v0.38.7

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1258,11 +1258,9 @@ function appendHarnessChildSubmitAck(
   streamId: StreamTabId,
 ): void {
   const status = cliState.streams.get().get(streamId)?.status;
-  appendHarnessTranscript('assistant', text, streamId, {
-    finalized: !(
-      status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status)
-    ),
-  });
+  const isLive =
+    status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status);
+  appendHarnessTranscript('assistant', text, streamId, { finalized: !isLive });
 }
 
 function appendHarnessUserTranscript(text: string): void {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -51,7 +51,7 @@ import {
 import { cliState } from './state/cliState';
 import { focusedChildInputDisabledMessage } from './state/focusedChildFollowUp';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
-import { activeStreamScope, streamDisplayLabel } from './state/streamViews';
+import { streamDisplayLabel } from './state/streamViews';
 import { defaultShortcutModifierLabel } from './shortcutLabels';
 import {
   isScopedTranscriptViewport,
@@ -794,15 +794,7 @@ export function App(props: AppProps): React.JSX.Element {
     pendingEscapeInterruptTimer.current = undefined;
   };
 
-  useEffect(
-    () => () => {
-      if (pendingEscapeInterruptTimer.current !== undefined) {
-        clearTimeout(pendingEscapeInterruptTimer.current);
-        pendingEscapeInterruptTimer.current = undefined;
-      }
-    },
-    [],
-  );
+  useEffect(() => clearPendingEscapeInterrupt, []);
 
   const handleMetaShortcut = (value: string): boolean => {
     const lower = value.toLowerCase();
@@ -844,9 +836,7 @@ export function App(props: AppProps): React.JSX.Element {
   // handler (gating internally) is clearer than several hooks racing on the same
   // chord. Stays mounted so Ctrl+C works even while a modal/form owns the input.
   useInput((input, key) => {
-    const pendingEscapeInterrupt =
-      pendingEscapeInterruptTimer.current !== undefined;
-    if (pendingEscapeInterrupt) {
+    if (pendingEscapeInterruptTimer.current !== undefined) {
       clearPendingEscapeInterrupt();
       if (
         !key.ctrl &&

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -794,7 +794,9 @@ export function App(props: AppProps): React.JSX.Element {
     pendingEscapeInterruptTimer.current = undefined;
   };
 
-  useEffect(() => clearPendingEscapeInterrupt, []);
+  useEffect(() => {
+    return clearPendingEscapeInterrupt;
+  }, []);
 
   const handleMetaShortcut = (value: string): boolean => {
     const lower = value.toLowerCase();

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -83,11 +83,7 @@ export function nextRenderableTranscriptEntry(
   entries: readonly ConversationEntry[],
   index: number,
 ): ConversationEntry | undefined {
-  for (let i = index + 1; i < entries.length; i += 1) {
-    const entry = entries[i];
-    if (entry && isRenderableTranscriptEntry(entry)) return entry;
-  }
-  return undefined;
+  return entries.slice(index + 1).find(isRenderableTranscriptEntry);
 }
 
 export function userPromptAwaitsLiveContinuation(
@@ -105,8 +101,7 @@ export function userPromptAwaitsLiveContinuation(
   ) {
     return false;
   }
-  const nextEntry = nextRenderableTranscriptEntry(entries, index);
-  return nextEntry === undefined;
+  return nextRenderableTranscriptEntry(entries, index) === undefined;
 }
 
 export function splitTranscriptEntries(

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -60,6 +60,7 @@ import {
 import {
   githubSelectAccountWarning,
   parseChatLoginSlashArgs,
+  type CliLoginSlashArgs,
 } from '@cli/runtime/loginOptions';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { writeTextStderr, writeTextStdout } from '@cli/runtime/logSinks';
@@ -669,6 +670,12 @@ const CHAT_STARTUP_MODEL_RECOVERY = {
   personalModeAction: 'retry with `texra chat --api-mode personal`',
 } satisfies CliNoAvailableModelsRecoveryOptions;
 
+function loginStartMessage(args: CliLoginSlashArgs): string {
+  if (args.device) return 'Starting TeXRA device-code sign-in.';
+  if (args.noBrowser) return `Starting TeXRA ${args.provider} sign-in.`;
+  return `Opening browser for TeXRA ${args.provider} sign-in...`;
+}
+
 async function loginFromChat(input: string): Promise<void> {
   const args = parseChatLoginSlashArgs(input);
   if (!args) {
@@ -678,13 +685,7 @@ async function loginFromChat(input: string): Promise<void> {
 
   const accountWarning = githubSelectAccountWarning(args);
   if (accountWarning) appendLocalAssistantTranscript(accountWarning);
-  appendLocalAssistantTranscript(
-    args.device
-      ? 'Starting TeXRA device-code sign-in.'
-      : args.noBrowser
-        ? `Starting TeXRA ${args.provider} sign-in.`
-        : `Opening browser for TeXRA ${args.provider} sign-in...`,
-  );
+  appendLocalAssistantTranscript(loginStartMessage(args));
 
   try {
     const session = args.device

--- a/packages/cli/src/commands/loginProviderPicker.tsx
+++ b/packages/cli/src/commands/loginProviderPicker.tsx
@@ -26,6 +26,7 @@ function LoginProviderPicker(props: {
   readonly onSelect: (provider: LoginPickerChoice | undefined) => void;
 }): React.JSX.Element {
   const app = useApp();
+  const remoteSession = isLikelyRemoteSession();
   const finish = (provider: LoginPickerChoice | undefined): void => {
     props.onSelect(provider);
     app.exit();
@@ -42,7 +43,7 @@ function LoginProviderPicker(props: {
         TeXRA login
       </Text>
       <Text dimColor>Choose how to sign in:</Text>
-      {isLikelyRemoteSession() ? (
+      {remoteSession ? (
         <Text dimColor>
           Remote session detected — the device code option works without a
           callback port.
@@ -51,9 +52,7 @@ function LoginProviderPicker(props: {
       <Box marginTop={1} flexDirection="column">
         <Select<LoginPickerChoice>
           items={LOGIN_PICKER_ITEMS}
-          activeValue={
-            isLikelyRemoteSession() ? 'device' : DEFAULT_OAUTH_PROVIDER
-          }
+          activeValue={remoteSession ? 'device' : DEFAULT_OAUTH_PROVIDER}
           onSelect={finish}
           onCancel={() => finish(undefined)}
         />

--- a/packages/cli/src/commands/relayTokens.ts
+++ b/packages/cli/src/commands/relayTokens.ts
@@ -74,21 +74,22 @@ export function formatMintedTokenText(minted: MintedRelayToken): string {
   ].join('\n');
 }
 
+function relayTokenStateLabel(token: RelayTokenInfo): string {
+  if (token.revoked_at) return 'revoked';
+  if (new Date(token.expires_at).getTime() <= Date.now()) return 'expired';
+  return `expires ${token.expires_at.slice(0, 10)}`;
+}
+
 export function formatTokenListText(tokens: readonly RelayTokenInfo[]): string {
   if (tokens.length === 0) {
     return 'No CI relay tokens. Mint one with `texra setup-token`.';
   }
   return tokens
     .map((token) => {
-      const state = token.revoked_at
-        ? 'revoked'
-        : new Date(token.expires_at).getTime() <= Date.now()
-          ? 'expired'
-          : `expires ${token.expires_at.slice(0, 10)}`;
       const lastUsed = token.last_used_at
         ? `last used ${token.last_used_at.slice(0, 10)}`
         : 'never used';
-      return `${token.id}  ${token.name} (${token.token_hint})  ${state}, ${lastUsed}`;
+      return `${token.id}  ${token.name} (${token.token_hint})  ${relayTokenStateLabel(token)}, ${lastUsed}`;
     })
     .join('\n');
 }

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -213,11 +213,10 @@ export async function askApproval(
     }
   }
 
-  const accepted = parsed.accepted;
-  if (!accepted) markApprovalDenied(context);
+  if (!parsed.accepted) markApprovalDenied(context);
   return {
-    accepted,
-    userMessage: accepted
+    accepted: parsed.accepted,
+    userMessage: parsed.accepted
       ? undefined
       : feedback || 'Rejected from CLI approval prompt.',
   };

--- a/packages/cli/src/runtime/supabaseAuthDeviceCode.ts
+++ b/packages/cli/src/runtime/supabaseAuthDeviceCode.ts
@@ -96,7 +96,7 @@ export async function pollForDeviceSession(
   hooks: DeviceAuthPollHooks = {},
 ): Promise<GitHubTokenExchangeResponse> {
   const now = hooks.now ?? Date.now;
-  const sleep = hooks.sleep ?? ((ms: number) => sleepMs(ms));
+  const sleep = hooks.sleep ?? sleepMs;
   const deadline = now() + authorization.expires_in * 1000;
   let intervalSeconds = authorization.interval;
   let transientFailures = 0;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1229,7 +1229,7 @@ export class DesktopProgressBridge {
   }
 
   private releasePendingPermissionsForStream(streamId: StreamTabId): void {
-    for (const [key, pending] of this.pendingPermissionStreams.entries()) {
+    for (const [key, pending] of this.pendingPermissionStreams) {
       if (pending === streamId) {
         this.pendingPermissionStreams.delete(key);
       }

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -46,13 +46,16 @@ async function resumeFromSnapshot(
     runtimeHost,
   });
 
-  let followUps: readonly FollowUpQueueInput[] = [];
+  // Seed with the explicit follow-up so the catch path still re-enqueues it
+  // even if the drain below throws before the full list is assigned.
+  const explicitFollowUp: readonly FollowUpQueueInput[] =
+    followUp !== undefined ? [{ text: followUp, origin: 'user' as const }] : [];
+  let followUps: readonly FollowUpQueueInput[] = explicitFollowUp;
   try {
-    const queuedFollowUps = ToolUseFollowUpQueue.drainItems(streamId);
-    followUps =
-      followUp !== undefined
-        ? [{ text: followUp, origin: 'user' as const }, ...queuedFollowUps]
-        : queuedFollowUps;
+    followUps = [
+      ...explicitFollowUp,
+      ...ToolUseFollowUpQueue.drainItems(streamId),
+    ];
     runtimeHost.emit('updateQueuedFollowUps', {
       streamId,
     });

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -6,10 +6,7 @@ import { z } from 'zod';
 import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import type {
-  DrainedFollowUpItem,
-  FollowUpQueueInput,
-} from '@agent/toolUse/FollowUpQueue';
+import type { FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
@@ -49,21 +46,20 @@ async function resumeFromSnapshot(
     runtimeHost,
   });
 
-  let queuedFollowUps: DrainedFollowUpItem[] = [];
+  let followUps: readonly FollowUpQueueInput[] = [];
   try {
-    queuedFollowUps = ToolUseFollowUpQueue.drainItems(streamId);
+    const queuedFollowUps = ToolUseFollowUpQueue.drainItems(streamId);
+    followUps =
+      followUp !== undefined
+        ? [{ text: followUp, origin: 'user' as const }, ...queuedFollowUps]
+        : queuedFollowUps;
     runtimeHost.emit('updateQueuedFollowUps', {
       streamId,
     });
 
     await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
       setupSession: (session) => {
-        const allFollowUps: readonly FollowUpQueueInput[] =
-          followUp !== undefined
-            ? [{ text: followUp, origin: 'user' as const }, ...queuedFollowUps]
-            : queuedFollowUps;
-
-        for (const item of allFollowUps) {
+        for (const item of followUps) {
           session.appendFollowUp(item);
         }
       },
@@ -74,14 +70,10 @@ async function resumeFromSnapshot(
     // Re-enqueue the drained follow-ups (and the explicit one, ahead of
     // them) so a later resume picks them up instead of dropping them —
     // matching the desktop bridge's failure path.
-    const requeued: readonly FollowUpQueueInput[] =
-      followUp !== undefined
-        ? [{ text: followUp, origin: 'user' as const }, ...queuedFollowUps]
-        : queuedFollowUps;
-    for (const item of requeued) {
+    for (const item of followUps) {
       ToolUseFollowUpQueue.enqueue(streamId, item, { force: true });
     }
-    if (requeued.length > 0) {
+    if (followUps.length > 0) {
       runtimeHost.emit('updateQueuedFollowUps', { streamId });
     }
 

--- a/packages/extension/src/commands/review/agentReviewCommands.ts
+++ b/packages/extension/src/commands/review/agentReviewCommands.ts
@@ -84,12 +84,13 @@ export function registerAgentReviewCommands(
   });
   const syncView = () => {
     const state = AgentReviewService.getState();
+    const count = state.issues.length;
     treeView.message = state.summary;
     treeView.badge =
-      state.issues.length > 0
+      count > 0
         ? {
-            value: state.issues.length,
-            tooltip: `${state.issues.length} agent review issue${state.issues.length === 1 ? '' : 's'}`,
+            value: count,
+            tooltip: `${count} agent review issue${count === 1 ? '' : 's'}`,
           }
         : undefined;
   };

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -699,10 +699,9 @@ export async function activate(context: vscode.ExtensionContext) {
       // palette, walkthrough, welcome card), so the onboarding funnel must
       // recompute too: the State 0 card has no other signal when a key is
       // added outside the main view's own round-trip.
-      const mainViewProvider = getMainViewProvider();
-      if (mainViewProvider) {
-        await mainViewProvider.refreshOnboardingFunnel().catch(() => {});
-      }
+      await getMainViewProvider()
+        ?.refreshOnboardingFunnel()
+        .catch(() => {});
     }),
   );
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -699,9 +699,10 @@ export async function activate(context: vscode.ExtensionContext) {
       // palette, walkthrough, welcome card), so the onboarding funnel must
       // recompute too: the State 0 card has no other signal when a key is
       // added outside the main view's own round-trip.
-      await getMainViewProvider()
-        ?.refreshOnboardingFunnel()
-        .catch(() => {});
+      const mainViewProvider = getMainViewProvider();
+      if (mainViewProvider) {
+        await mainViewProvider.refreshOnboardingFunnel().catch(() => {});
+      }
     }),
   );
 

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -335,11 +335,13 @@ class AgentReviewServiceImpl {
       // while the snapshot describes an older tree. The snapshot is only
       // restored when the session reported nothing at all.
       const restored = this.restorePreviousResults(previous);
-      const suffix = restored
-        ? ' · showing previous results'
-        : this.issues.length > 0
-          ? ` · showing the ${this.issues.length} issue${this.issues.length === 1 ? '' : 's'} reported before the session ended`
-          : '';
+      let suffix = '';
+      if (restored) {
+        suffix = ' · showing previous results';
+      } else if (this.issues.length > 0) {
+        const plural = this.issues.length === 1 ? '' : 's';
+        suffix = ` · showing the ${this.issues.length} issue${plural} reported before the session ended`;
+      }
       this.summary = `Review ${verb}${suffix}`;
       logger.warn(CHANNEL, `Agent review session ${verb}`);
       return;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -88,10 +88,7 @@ export function getToolTimeoutMs(
     return getExecutionsWaitTimeoutSeconds(input.timeout) * 1000;
   }
 
-  if (typeof input.timeout === 'number') {
-    return input.timeout;
-  }
-  return defaultTimeout;
+  return typeof input.timeout === 'number' ? input.timeout : defaultTimeout;
 }
 
 /** Truncate a prompt string for display in collapsed headers. */

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -681,16 +681,7 @@ export class LaTeXTab extends LitElement {
           title="Toggle"
         ></wa-switch>
         ${isCustom
-          ? html`<wa-button
-              appearance="outlined"
-              variant="neutral"
-              size="small"
-              aria-label="Reset to default"
-              title="Reset to default (${opts.defaultValue ? 'On' : 'Off'})"
-              @click=${() => this.dispatchSetConfigValue(opts.field, undefined)}
-            >
-              <wa-icon library="texra" name="discard"></wa-icon>
-            </wa-button>`
+          ? this.renderResetButton(opts.field, opts.defaultValue ? 'On' : 'Off')
           : nothing}
       </div>
     `;
@@ -708,6 +699,23 @@ export class LaTeXTab extends LitElement {
       class="setting-status-icon ${isCustom ? 'is-set' : 'is-default'}"
       title=${isCustom ? 'Customized' : 'Using default'}
     ></wa-icon>`;
+  }
+
+  /** Reset-to-default button shown when a config value has been customized. */
+  private renderResetButton(
+    field: LatexConfigField,
+    defaultDisplay: string,
+  ): TemplateResult {
+    return html`<wa-button
+      appearance="outlined"
+      variant="neutral"
+      size="small"
+      aria-label="Reset to default"
+      title="Reset to default (${defaultDisplay})"
+      @click=${() => this.dispatchSetConfigValue(field, undefined)}
+    >
+      <wa-icon library="texra" name="discard"></wa-icon>
+    </wa-button>`;
   }
 
   private renderNumberSetting(opts: {
@@ -752,16 +760,7 @@ export class LaTeXTab extends LitElement {
           ></wa-input>
         </div>
         ${isCustom
-          ? html`<wa-button
-              appearance="outlined"
-              variant="neutral"
-              size="small"
-              aria-label="Reset to default"
-              title="Reset to default (${opts.defaultValue})"
-              @click=${() => this.dispatchSetConfigValue(opts.field, undefined)}
-            >
-              <wa-icon library="texra" name="discard"></wa-icon>
-            </wa-button>`
+          ? this.renderResetButton(opts.field, String(opts.defaultValue))
           : nothing}
       </div>
     `;
@@ -801,16 +800,7 @@ export class LaTeXTab extends LitElement {
           </wa-select>
         </div>
         ${isCustom
-          ? html`<wa-button
-              appearance="outlined"
-              variant="neutral"
-              size="small"
-              aria-label="Reset to default"
-              title="Reset to default (${opts.defaultValue})"
-              @click=${() => this.dispatchSetConfigValue(opts.field, undefined)}
-            >
-              <wa-icon library="texra" name="discard"></wa-icon>
-            </wa-button>`
+          ? this.renderResetButton(opts.field, String(opts.defaultValue))
           : nothing}
       </div>
     `;

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1484,13 +1484,10 @@ export class MainApp extends MainAppBase {
     postMessage(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER);
   }
 
-  // Welcome-card choices reuse the existing host flows: sign-in invokes
-  // texra.auth.signIn (SIGN_IN_FROM_BANNER), API key invokes texra.setApiKey
-  // (OPEN_SET_API_KEY); only skip is onboarding-specific (declined flag).
-  private handleWelcomeSignIn(): void {
-    postMessage(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER);
-  }
-
+  // Welcome-card choices reuse the existing host flows: sign-in reuses
+  // handleComponentSignIn (SIGN_IN_FROM_BANNER → texra.auth.signIn), API key
+  // invokes texra.setApiKey (OPEN_SET_API_KEY); only skip is onboarding-specific
+  // (declined flag).
   private handleWelcomeApiKey(): void {
     postMessage(MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY);
   }
@@ -1800,7 +1797,7 @@ export class MainApp extends MainAppBase {
           ${this.renderViewHeader()}
           <div class="main-content">
             <onboarding-welcome-card
-              @welcome-sign-in=${this.handleWelcomeSignIn}
+              @welcome-sign-in=${this.handleComponentSignIn}
               @welcome-api-key=${this.handleWelcomeApiKey}
               @welcome-skip=${this.handleWelcomeSkip}
             ></onboarding-welcome-card>

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -62,12 +62,12 @@ interface ToolExecutionResult {
   parsedInput: unknown;
   /** Pre-extracted attachments and sanitized result (avoids re-extraction in post). */
   extracted: ExtractedToolAttachments;
-  editedFiles: Array<{
+  editedFiles: {
     path: string;
     ok: boolean;
     source: string;
     sourceDisplay: string;
-  }>;
+  }[];
   /** Log reference for consistent grouping. logId only set for slow tools. */
   logRef: { logId: string | undefined; groupId: string | undefined };
 }

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -119,21 +119,29 @@ async function detectBaseBranch(cwd: string): Promise<BaseBranch | null> {
     return { ref, shortName: ref.replace(/^origin\//, '') };
   }
   const verified = await Promise.all(
-    BASE_BRANCH_CANDIDATES.flatMap((candidate) => [
-      git(cwd, ['rev-parse', '--verify', '--quiet', `refs/heads/${candidate}`]),
-      git(cwd, [
-        'rev-parse',
-        '--verify',
-        '--quiet',
-        `refs/remotes/origin/${candidate}`,
-      ]),
-    ]),
+    BASE_BRANCH_CANDIDATES.map(async (candidate) => {
+      const [local, origin] = await Promise.all([
+        git(cwd, [
+          'rev-parse',
+          '--verify',
+          '--quiet',
+          `refs/heads/${candidate}`,
+        ]),
+        git(cwd, [
+          'rev-parse',
+          '--verify',
+          '--quiet',
+          `refs/remotes/origin/${candidate}`,
+        ]),
+      ]);
+      return { candidate, local, origin };
+    }),
   );
-  for (const [index, candidate] of BASE_BRANCH_CANDIDATES.entries()) {
-    if (verified[index * 2] !== null) {
+  for (const { candidate, local, origin } of verified) {
+    if (local !== null) {
       return { ref: candidate, shortName: candidate };
     }
-    if (verified[index * 2 + 1] !== null) {
+    if (origin !== null) {
       return { ref: `origin/${candidate}`, shortName: candidate };
     }
   }

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -93,8 +93,9 @@ export async function runFlowWithLifecycle(
       baseAgentName(agentIdentifier) !== SETUP_AGENT_NAME
     ) {
       try {
-        if (!getFirstRunDone(platform().globalState)) {
-          await setFirstRunDone(platform().globalState, true);
+        const { globalState } = platform();
+        if (!getFirstRunDone(globalState)) {
+          await setFirstRunDone(globalState, true);
         }
       } catch {
         // Ignore: the flag is a UX nicety, never run-critical.

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -102,7 +102,7 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
 
   const { getModel, model } = options;
 
-  const context: RunContext = {
+  return Object.freeze<RunContext>({
     runtimeHost: options.runtimeHost,
     streamId: options.streamId,
     executionId: options.executionId,
@@ -117,9 +117,7 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
     runtimeUnavailableTools: options.runtimeUnavailableTools,
     stopAfterCycle: options.stopAfterCycle,
-  };
-
-  return Object.freeze(context);
+  });
 }
 
 /**

--- a/src/auth/relayToken.ts
+++ b/src/auth/relayToken.ts
@@ -79,6 +79,20 @@ export function resetRelayTokenTierCacheForTests(): void {
   cachedStatus = null;
 }
 
+/** Fresh (within TTL) cached status for `token`, or undefined. */
+function getFreshCachedStatus(
+  token: string,
+): SettledRelayTokenStatus | undefined {
+  if (
+    cachedStatus &&
+    cachedStatus.token === token &&
+    Date.now() - cachedStatus.timestamp < SERVER_SIDE_CACHE_TTL_MS
+  ) {
+    return cachedStatus.result;
+  }
+  return undefined;
+}
+
 /**
  * Last settled status of a token, without any network I/O. Lets synchronous
  * credential checks (SupabaseClient.isAuthenticated / getRelayAccessToken)
@@ -88,14 +102,7 @@ export function resetRelayTokenTierCacheForTests(): void {
 export function getCachedRelayTokenState(
   token: string,
 ): SettledRelayTokenStatus['state'] | undefined {
-  if (
-    cachedStatus &&
-    cachedStatus.token === token &&
-    Date.now() - cachedStatus.timestamp < SERVER_SIDE_CACHE_TTL_MS
-  ) {
-    return cachedStatus.result.state;
-  }
-  return undefined;
+  return getFreshCachedStatus(token)?.state;
 }
 
 /**
@@ -113,13 +120,8 @@ export async function fetchRelayTokenStatus(
   token: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<RelayTokenStatus> {
-  if (
-    cachedStatus &&
-    cachedStatus.token === token &&
-    Date.now() - cachedStatus.timestamp < SERVER_SIDE_CACHE_TTL_MS
-  ) {
-    return cachedStatus.result;
-  }
+  const cached = getFreshCachedStatus(token);
+  if (cached) return cached;
   const result = await probeRelayTokenStatus(token, fetchImpl);
   if (result.state !== 'unknown') {
     cachedStatus = { token, result, timestamp: Date.now() };

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -6,11 +6,11 @@ import axios from 'axios';
 import { StatusCodes } from 'http-status-codes';
 import * as arxivIdentifiers from 'identifiers-arxiv';
 import pRetry, { AbortError } from 'p-retry';
+import pTimeout from 'p-timeout';
 import * as tar from 'tar';
 
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import pTimeout from 'p-timeout';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { normaliseArxivIdentifier } from './arxivIdentifier';
 import { indentLatexFilesInDirectory } from './formatter/indentDirectory';

--- a/src/shared/schemas/workPlan.ts
+++ b/src/shared/schemas/workPlan.ts
@@ -24,11 +24,12 @@ function normalizeWorkPlanSnapshot(input: unknown): unknown {
   // Legacy structured plans fail to parse and read back as "no plan";
   // their stored planSummary string still carries the one-line label.
   const plan = parsePlan(record.plan);
-  const planSummary = plan
-    ? planSummaryLine(plan.objective)
-    : isNonEmptyString(record.planSummary)
-      ? record.planSummary
-      : null;
+  let planSummary: string | null = null;
+  if (plan) {
+    planSummary = planSummaryLine(plan.objective);
+  } else if (isNonEmptyString(record.planSummary)) {
+    planSummary = record.planSummary;
+  }
 
   return {
     todos: record.todos,

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -75,14 +75,7 @@ describe('buildUntrackedFileDiff', () => {
 describe('collectReviewDiff (real git repository)', () => {
   let repo: string;
 
-  async function git(...args: string[]): Promise<void> {
-    const result = await executeCommand(['git', ...args], { cwd: repo });
-    expect(result.success, `git ${args.join(' ')}: ${result.stderr}`).toBe(
-      true,
-    );
-  }
-
-  async function gitOutput(...args: string[]): Promise<string> {
+  async function git(...args: string[]): Promise<string> {
     const result = await executeCommand(['git', ...args], { cwd: repo });
     expect(result.success, `git ${args.join(' ')}: ${result.stderr}`).toBe(
       true,
@@ -235,7 +228,7 @@ describe('collectReviewDiff (real git repository)', () => {
     await writeFile(path.join(repo, 'notes.txt'), 'notes before\n');
     await git('add', '.');
     await git('commit', '-m', 'add notes');
-    const previousHead = await gitOutput('rev-parse', 'HEAD');
+    const previousHead = await git('rev-parse', 'HEAD');
 
     await writeFile(path.join(repo, 'paper.tex'), 'committed on main\n');
     await git('commit', '-am', 'second');

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -139,61 +139,53 @@ function createLifecycleContext({
 }
 
 describe('runFlowWithLifecycle', () => {
-  it('does not complete first-run onboarding for qualified setup sessions', async () => {
-    const fake = await initLifecycleTestPlatform(false);
-    const executionId = 'execution-lifecycle-setup-agent' as ExecutionId;
-    const streamId = 'stream-lifecycle-setup-agent' as StreamTabId;
-    const streamStatus = new StreamStatusRegistry();
-    const ctx = createLifecycleContext({
-      executionId,
-      streamId,
-      streamStatus,
+  // A completed session marks first-run onboarding done, except for the
+  // built-in setup agent, which must leave the flag untouched.
+  const onboardingCases = [
+    {
+      label:
+        'does not complete first-run onboarding for qualified setup sessions',
+      slug: 'setup-agent',
       agent: agentKey('builtInToolUse', SETUP_AGENT_NAME),
-    });
-
-    try {
-      await runFlowWithLifecycle(ctx, async () => ({
-        category: 'toolUse',
-        outcome: RUN_OUTCOME.COMPLETED,
-        executionId,
-        streamId,
-      }));
-
-      expect(
-        fake.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE),
-      ).toBe(false);
-    } finally {
-      streamStatus.clear(streamId, { emit: false });
-    }
-  });
-
-  it('completes first-run onboarding for non-setup completed sessions', async () => {
-    const fake = await initLifecycleTestPlatform(false);
-    const executionId = 'execution-lifecycle-non-setup-agent' as ExecutionId;
-    const streamId = 'stream-lifecycle-non-setup-agent' as StreamTabId;
-    const streamStatus = new StreamStatusRegistry();
-    const ctx = createLifecycleContext({
-      executionId,
-      streamId,
-      streamStatus,
+      expectedDone: false,
+    },
+    {
+      label: 'completes first-run onboarding for non-setup completed sessions',
+      slug: 'non-setup-agent',
       agent: 'assistant',
-    });
+      expectedDone: true,
+    },
+  ] as const;
 
-    try {
-      await runFlowWithLifecycle(ctx, async () => ({
-        category: 'toolUse',
-        outcome: RUN_OUTCOME.COMPLETED,
+  for (const { label, slug, agent, expectedDone } of onboardingCases) {
+    it(label, async () => {
+      const fake = await initLifecycleTestPlatform(false);
+      const executionId = `execution-lifecycle-${slug}` as ExecutionId;
+      const streamId = `stream-lifecycle-${slug}` as StreamTabId;
+      const streamStatus = new StreamStatusRegistry();
+      const ctx = createLifecycleContext({
         executionId,
         streamId,
-      }));
+        streamStatus,
+        agent,
+      });
 
-      expect(
-        fake.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE),
-      ).toBe(true);
-    } finally {
-      streamStatus.clear(streamId, { emit: false });
-    }
-  });
+      try {
+        await runFlowWithLifecycle(ctx, async () => ({
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId,
+          streamId,
+        }));
+
+        expect(
+          fake.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE),
+        ).toBe(expectedDone);
+      } finally {
+        streamStatus.clear(streamId, { emit: false });
+      }
+    });
+  }
 
   it('finalizes the stream status owner from the launch context', async () => {
     const executionId = 'execution-lifecycle-status-owner' as ExecutionId;

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -22,6 +22,23 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
+async function withRelayTokenEnv(
+  token: string,
+  run: () => Promise<void>,
+): Promise<void> {
+  const previous = process.env[RELAY_TOKEN_ENV_VAR];
+  process.env[RELAY_TOKEN_ENV_VAR] = token;
+  try {
+    await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[RELAY_TOKEN_ENV_VAR];
+    } else {
+      process.env[RELAY_TOKEN_ENV_VAR] = previous;
+    }
+  }
+}
+
 describe('SupabaseClient', () => {
   afterEach(() => {
     SupabaseClient.resetForTests();
@@ -47,8 +64,7 @@ describe('SupabaseClient', () => {
   });
 
   it('keeps session tokens separate from CI relay bearer tokens', async () => {
-    const previousRelayToken = process.env[RELAY_TOKEN_ENV_VAR];
-    process.env[RELAY_TOKEN_ENV_VAR] = `${RELAY_CI_TOKEN_PREFIX}abcdef`;
+    const relayToken = `${RELAY_CI_TOKEN_PREFIX}abcdef`;
     const provider: AuthTokenProvider = {
       whenReady: async () => {},
       ensureFreshToken: async () => 'session-token',
@@ -58,28 +74,17 @@ describe('SupabaseClient', () => {
       }),
     };
 
-    try {
+    await withRelayTokenEnv(relayToken, async () => {
       SupabaseClient.setAuthProvider(provider);
 
       assert.equal(await SupabaseClient.getAccessToken(), 'session-token');
-      assert.equal(
-        await SupabaseClient.getRelayAccessToken(),
-        `${RELAY_CI_TOKEN_PREFIX}abcdef`,
-      );
+      assert.equal(await SupabaseClient.getRelayAccessToken(), relayToken);
       assert.equal(await SupabaseClient.isAuthenticated(), true);
-    } finally {
-      if (previousRelayToken === undefined) {
-        delete process.env[RELAY_TOKEN_ENV_VAR];
-      } else {
-        process.env[RELAY_TOKEN_ENV_VAR] = previousRelayToken;
-      }
-    }
+    });
   });
 
   it('falls back to the session once the relay token is known-rejected', async () => {
-    const previousRelayToken = process.env[RELAY_TOKEN_ENV_VAR];
     const relayToken = `${RELAY_CI_TOKEN_PREFIX}rejected`;
-    process.env[RELAY_TOKEN_ENV_VAR] = relayToken;
     const provider: AuthTokenProvider = {
       whenReady: async () => {},
       ensureFreshToken: async () => 'session-token',
@@ -89,7 +94,7 @@ describe('SupabaseClient', () => {
       }),
     };
 
-    try {
+    await withRelayTokenEnv(relayToken, async () => {
       SupabaseClient.setAuthProvider(provider);
 
       // Observe the rejection (tier-config answers without userStatus for
@@ -106,26 +111,18 @@ describe('SupabaseClient', () => {
       // the stored session instead of presenting a credential that will 401.
       assert.equal(await SupabaseClient.getRelayAccessToken(), 'session-token');
       assert.equal(await SupabaseClient.isAuthenticated(), true);
-    } finally {
-      if (previousRelayToken === undefined) {
-        delete process.env[RELAY_TOKEN_ENV_VAR];
-      } else {
-        process.env[RELAY_TOKEN_ENV_VAR] = previousRelayToken;
-      }
-    }
+    });
   });
 
   it('treats a relay-401 refresh as rejection of a static CI token', async () => {
-    const previousRelayToken = process.env[RELAY_TOKEN_ENV_VAR];
     const relayToken = `${RELAY_CI_TOKEN_PREFIX}got401`;
-    process.env[RELAY_TOKEN_ENV_VAR] = relayToken;
     const provider: AuthTokenProvider = {
       whenReady: async () => {},
       ensureFreshToken: async () => 'session-token',
       getSessionTokens: async () => null,
     };
 
-    try {
+    await withRelayTokenEnv(relayToken, async () => {
       SupabaseClient.setAuthProvider(provider);
 
       // The 401-recovery path (forceRefresh) presented the CI token; a static
@@ -137,13 +134,7 @@ describe('SupabaseClient', () => {
       );
       // Subsequent relay calls keep skipping the rejected token.
       assert.equal(await SupabaseClient.getRelayAccessToken(), 'session-token');
-    } finally {
-      if (previousRelayToken === undefined) {
-        delete process.env[RELAY_TOKEN_ENV_VAR];
-      } else {
-        process.env[RELAY_TOKEN_ENV_VAR] = previousRelayToken;
-      }
-    }
+    });
   });
 
   it('returns null when the token provider throws while reading session tokens', async () => {

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -49,6 +49,20 @@ import * as execUtils from '@utils/system/execUtils';
 // Type imports
 import type OpenAI from 'openai';
 
+const testModelConfig: ModelConfig = {
+  name: 'test',
+  label: 'Test',
+  fullName: 'test',
+  shortName: 'test',
+  provider: ModelProvider.OPENAI,
+  maxOutputTokens: 10,
+  inputPrice: 0,
+  outputPrice: 0,
+  contextWindow: 1000,
+  capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+  openRouterOnly: false,
+};
+
 class BashMockHandler extends ModelHandlerOpenAIResponse {
   private callCount = 0;
 
@@ -160,25 +174,12 @@ describe('BashTool', () => {
       'Bash tool should return the full stdout text',
     );
 
-    const config: ModelConfig = {
-      name: 'test',
-      label: 'Test',
-      fullName: 'test',
-      shortName: 'test',
-      provider: ModelProvider.OPENAI,
-      maxOutputTokens: 10,
-      inputPrice: 0,
-      outputPrice: 0,
-      contextWindow: 1000,
-      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
-      openRouterOnly: false,
-    };
-    const handler = new BashMockHandler(config);
+    const handler = new BashMockHandler(testModelConfig);
     const workspaceState = AgentWorkspaceState.create();
     const run = AgentRunStateSnapshotSchema.parse({});
     const options: ToolUseRoundServices<OpenAI> = {
       modelHandler: handler,
-      config: config as any,
+      config: testModelConfig as any,
       setting: {
         agentCategory: AgentCategory.ToolUse,
         documentTag: 'doc',
@@ -269,20 +270,6 @@ describe('BashTool', () => {
       },
     );
 
-    const config: ModelConfig = {
-      name: 'test',
-      label: 'Test',
-      fullName: 'test',
-      shortName: 'test',
-      provider: ModelProvider.OPENAI,
-      maxOutputTokens: 10,
-      inputPrice: 0,
-      outputPrice: 0,
-      contextWindow: 1000,
-      capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
-      openRouterOnly: false,
-    };
-
     const runTrace = createRunTrace('BashToolAbortTest' as StreamTabId);
     const events: AgentEvent[] = [];
     const unsubscribe = runTrace.trace.subscribe((event) => {
@@ -294,8 +281,8 @@ describe('BashTool', () => {
     const workspaceState = AgentWorkspaceState.create();
     const run = AgentRunStateSnapshotSchema.parse({});
     const options: ToolUseRoundServices<OpenAI> = {
-      modelHandler: new BashMockHandler(config),
-      config: config as any,
+      modelHandler: new BashMockHandler(testModelConfig),
+      config: testModelConfig as any,
       setting: {
         agentCategory: AgentCategory.ToolUse,
         documentTag: 'doc',

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -43,6 +43,7 @@ import { AbsoluteFS, StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
+import { clamp } from '@utils/core';
 import {
   formatResultCount,
   formatTimestamp,
@@ -155,11 +156,9 @@ const ExecutionsToolInputSchema = z.strictObject({
 export type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
 
 const normalizeWaitTimeout = (timeout: number | null | undefined): number =>
-  Math.min(
-    Math.max(
-      timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
-      EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
-    ),
+  clamp(
+    timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+    EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
     EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
   );
 
@@ -169,19 +168,17 @@ const normalizeExecutionsToolInput = (input: unknown): unknown => {
   }
 
   const record = input as Record<string, unknown>;
-  if (
-    typeof record.timeout !== 'number' ||
-    !Number.isFinite(record.timeout) ||
-    (record.timeout >= EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS &&
-      record.timeout <= EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS)
-  ) {
+  const { timeout } = record;
+  const outOfRange =
+    typeof timeout === 'number' &&
+    Number.isFinite(timeout) &&
+    (timeout < EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS ||
+      timeout > EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS);
+  if (!outOfRange) {
     return input;
   }
 
-  return {
-    ...record,
-    timeout: normalizeWaitTimeout(record.timeout),
-  };
+  return { ...record, timeout: normalizeWaitTimeout(timeout) };
 };
 
 export class ExecutionsTool extends defineTool({

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -15,9 +15,10 @@ import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import pTimeout from 'p-timeout';
+
 import { toErrorMessage } from '@common/errors';
 import { debug, info, warn } from '@logger/logUtils';
-import pTimeout from 'p-timeout';
 import {
   registerLeanServer,
   unregisterLeanServer,

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -93,12 +93,12 @@ ${describeTeams()}`,
     const unresolved = new Set(unresolvedNames);
     const activeWorkflow = workflowKeys.filter((key) => !unresolved.has(key));
     const activeToolUse = toolUseKeys.filter((key) => !unresolved.has(key));
-    const remoteLeadNames: readonly string[] = REMOTE_ORCHESTRATOR_AGENT_NAMES;
+    const remoteLeadNames = new Set<string>(REMOTE_ORCHESTRATOR_AGENT_NAMES);
     const pendingRemoteLeads = unresolvedNames.filter((name) =>
-      remoteLeadNames.includes(name),
+      remoteLeadNames.has(name),
     );
     const pendingOther = unresolvedNames.filter(
-      (name) => !remoteLeadNames.includes(name),
+      (name) => !remoteLeadNames.has(name),
     );
 
     const signInNote =

--- a/supabase/functions/_shared/relayCiToken.ts
+++ b/supabase/functions/_shared/relayCiToken.ts
@@ -31,9 +31,9 @@ export async function sha256Hex(value: string): Promise<string> {
     'SHA-256',
     new TextEncoder().encode(value),
   );
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
 }
 
 export type CiTokenAuthResult =

--- a/supabase/functions/relay-tokens/index.ts
+++ b/supabase/functions/relay-tokens/index.ts
@@ -134,9 +134,7 @@ app.post('/mint', async (c) => {
 
     const rawExpires = body?.expires_in_days;
     const expiresInDays =
-      rawExpires === undefined || rawExpires === null
-        ? DEFAULT_EXPIRES_IN_DAYS
-        : Number(rawExpires);
+      rawExpires == null ? DEFAULT_EXPIRES_IN_DAYS : Number(rawExpires);
     if (
       !Number.isInteger(expiresInDays) ||
       expiresInDays < 1 ||


### PR DESCRIPTION
## Summary

Behavior-preserving simplification sweep over **every TS/TSX file changed since the last release (`v0.38.7`)** — 90 commits / 287 source files reviewed, applying the repo's modern-TypeScript idioms (AGENTS.md). Touched **34 files, net −67 LOC**. The other ~253 changed files were already clean; cross-file extractions that would net-add lines were deliberately **not** done (see below).

## What changed

- **Nested ternaries → if/else or named helpers** (repo bans nested ternaries): `AgentReviewService`, `workPlan` schema, `relayTokens` (`relayTokenStateLabel`), `runChatTui` (`loginStartMessage`).
- **Within-file dedup** (extract-when-repeated, no new shared modules): `LaTeXTab` triple-duplicated reset button → `renderResetButton`; `relayToken` cache-freshness check → `getFreshCachedStatus`; `SupabaseClient.vitest` env save/restore → `withRelayTokenEnv`; `BashTool.vitest` duplicated `ModelConfig`; `AgentReviewDiff.vitest` merged `git`/`gitOutput`; `resumeCommand` duplicated follow-up array; `MainApp` deleted a duplicate `handleWelcomeSignIn`.
- **Modern idioms**: `clamp()` over nested `Math.min/max` (`ExecutionsTool`); `Set.has()` over `string[].includes()` (`ApplyTeamTool`); `Array.from(x, fn)` (`relayCiToken`); `== null` (`relay-tokens`); `for…of` over `.entries()` (`desktopAgentExecution`); optional chaining (`extension.ts`); `T[]` over `Array<T>`; `.slice().find()` over index loops; a table-driven onboarding test (coverage unchanged).

## Bonus: pre-existing broken test fixed

`BashTool.vitest.ts` imported the stale path `@agent/core/flows/toolUseCycle/ToolUseDispatchNode` — a leftover from the `toolUseCycle → toolUseRound` rename (`3366202b6`). The path no longer resolved, so Vitest could not load the file. It was invisible to `npm run typecheck` (which excludes `*.vitest.ts`). Fixed → the suite goes 442 → 443 passing files.

## Deliberately not done (deferred)

Cross-file extractions that would net-add lines / span files were reported, not built — e.g. a shared `isUserBandEntry` predicate across `StaticConversationTranscript`/`TranscriptEntry`, and folding `BaseTextInput`'s two input-chunk branches (risks reordering escape-edit logic).

## Verification

- `npm run typecheck` — clean
- `npm run format` — applied
- Full Vitest suite — **443/443 files, 3093/3093 tests pass**
- All 34 diffs manually reviewed for behavior preservation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly stylistic refactors with tests passing; the resume follow-up seeding is a narrow error-path hardening change with low blast radius.
> 
> **Overview**
> **Refactor sweep** over recently changed TS/TSX: nested ternaries become **if/else or named helpers** (`loginStartMessage`, `relayTokenStateLabel`, `AgentReviewService` suffix, `workPlan` snapshot), and repeated UI/logic is **deduped within files** (LaTeX settings `renderResetButton`, relay token cache `getFreshCachedStatus`, Vitest `withRelayTokenEnv` / shared `testModelConfig`).
> 
> **CLI/TUI** tweaks are mostly readability: escape-interrupt cleanup effect, transcript helpers use `.slice().find()`, unused `activeStreamScope` import removed, login picker caches `remoteSession`.
> 
> **Extension resume** (`resumeCommand`) now **seeds the explicit follow-up before draining** the queue so a failure during drain still re-enqueues the user’s follow-up; welcome onboarding reuses `handleComponentSignIn` instead of a duplicate handler.
> 
> **Small API/idiom updates**: `ExecutionsTool` uses shared `clamp`, `ApplyTeamTool` uses `Set.has`, `reviewDiff` base-branch detection maps candidates in parallel, `RunContext` returns a single frozen object, `BashTool.vitest` fixes the stale `ToolUseDispatchNode` import path from the `toolUseRound` rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad6ea989b47e694c65872b3c977edd7071cbca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->