### PR TITLE
SDK 7d F-1: one emit path (emitRuntimeEvent) for src/tools progress events

### DIFF
--- a/src/agent/runtime/emitRuntimeEvent.ts
+++ b/src/agent/runtime/emitRuntimeEvent.ts
@@ -1,0 +1,32 @@
+/**
+ * Single emit path for run/host progress events (SDK Step 7d follow-on F-1).
+ *
+ * Replaces scattered `bus.emit(...)` in `src/tools` so one fact has one emit
+ * path and one name, resolving the target in priority order:
+ *
+ * 1. a host-path caller's `session.hostChannel` (set only by hosts that own a
+ *    non-default session, e.g. a desktop window) — when present;
+ * 2. otherwise the active run's `runtimeHost`, resolved from the ambient
+ *    {@link RunContext} (the in-run case — tools firing inside a run's ALS);
+ * 3. otherwise the process {@link bus} — the single-session fallback that keeps
+ *    the extension byte-identical (its run `runtimeHost.emit` is `bus.emit`
+ *    anyway) and host-path callers that pass no session unchanged.
+ *
+ * In-run callers pass no `session` (the ALS supplies the run host). Host-path
+ * callers — reachable outside any run ALS — MUST pass their owning `session`,
+ * or the event resolves to the bus and a non-default session never sees it.
+ */
+import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+import { tryUseRunContext } from './RunContext';
+import type { SessionHandle } from './SessionHandle';
+
+export function emitRuntimeEvent<K extends keyof ProgressEventPayloads>(
+  event: K,
+  payload: ProgressEventPayloads[K],
+  session?: SessionHandle,
+): void {
+  const host = session?.hostChannel ?? tryUseRunContext()?.runtimeHost;
+  if (host) host.emit(event, payload);
+  else bus.emit(event, payload);
+}

--- a/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
@@ -1,0 +1,69 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - runtime
+import { bus } from '@eventBus/ProgressEventBus';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
+import type { StreamTabId } from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+const streamId = (s: string): StreamTabId => s as StreamTabId;
+
+describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
+  it('falls back to the process bus with no session and no run context', () => {
+    const seen: unknown[] = [];
+    const off = bus.on('goalStateChanged', (p) => seen.push(p));
+    try {
+      emitRuntimeEvent('goalStateChanged', { streamId: streamId('s:bus') });
+      expect(seen).toEqual([{ streamId: 's:bus' }]);
+    } finally {
+      off();
+    }
+  });
+
+  it("emits through the active run's runtimeHost when inside a run context", () => {
+    const run = createRecordingHost();
+    const busSeen: unknown[] = [];
+    const off = bus.on('goalStateChanged', (p) => busSeen.push(p));
+    try {
+      withRunContext(createRunContext({ runtimeHost: run.host }), () => {
+        emitRuntimeEvent('goalStateChanged', { streamId: streamId('s:run') });
+      });
+      expect(run.events).toEqual([
+        { event: 'goalStateChanged', payload: { streamId: 's:run' } },
+      ]);
+      // Not double-emitted onto the bus.
+      expect(busSeen).toEqual([]);
+    } finally {
+      off();
+    }
+  });
+
+  it('prefers an explicit session hostChannel over the run context and bus', () => {
+    const channel = createRecordingHost();
+    const run = createRecordingHost();
+    const session = new SessionHandle({ hostChannel: channel.host });
+    const busSeen: unknown[] = [];
+    const off = bus.on('goalStateChanged', (p) => busSeen.push(p));
+    try {
+      withRunContext(createRunContext({ runtimeHost: run.host }), () => {
+        emitRuntimeEvent(
+          'goalStateChanged',
+          { streamId: streamId('s:chan') },
+          session,
+        );
+      });
+      expect(channel.events).toEqual([
+        { event: 'goalStateChanged', payload: { streamId: 's:chan' } },
+      ]);
+      expect(run.events).toEqual([]);
+      expect(busSeen).toEqual([]);
+    } finally {
+      off();
+      session.dispose();
+    }
+  });
+});

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { platform } from '@platform/platform';
 import { tryGetWorkspaceState } from '@agent/core/stateStore';
-import { bus } from '@eventBus/ProgressEventBus';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import {
   type ExecutionId,
   StreamTabIdSchema,
@@ -145,7 +145,8 @@ async function update(
   if (!goal) return null;
   const final: Goal = { ...mutate(goal), updatedAt: nowIso() };
   await writeRaw(final);
-  bus.emit('goalStateChanged', { streamId });
+  // In-run: the active run's host (ALS), falling back to the bus.
+  emitRuntimeEvent('goalStateChanged', { streamId });
   return final;
 }
 
@@ -203,7 +204,7 @@ export const GoalStore = {
       updatedAt: now,
     };
     await Promise.all([writeRaw(goal), addToIndex(streamId)]);
-    bus.emit('goalStateChanged', { streamId });
+    emitRuntimeEvent('goalStateChanged', { streamId });
     return goal;
   },
 
@@ -272,7 +273,9 @@ export const GoalStore = {
       state.update(legacyStreamKey(streamId), undefined),
       removeFromIndex(streamId),
     ]);
-    bus.emit('goalStateChanged', { streamId });
+    // Dual-context: PlanTool forgets in-run (→ run host via ALS); the
+    // progress-view lifecycle controller forgets host-path (→ bus fallback).
+    emitRuntimeEvent('goalStateChanged', { streamId });
   },
 
   /**
@@ -306,7 +309,8 @@ export const GoalStore = {
         ? state.update(LEGACY_INDEX_KEY, undefined)
         : Promise.resolve(),
     ]);
-    for (const id of toRemove) bus.emit('goalStateChanged', { streamId: id });
+    for (const id of toRemove)
+      emitRuntimeEvent('goalStateChanged', { streamId: id });
   },
 
   /**

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -18,7 +18,7 @@
 import { z } from 'zod';
 
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import { bus } from '@eventBus/ProgressEventBus';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { createChannelTrace } from '@logger';
 import {
   ExternalInquiryThreadIdSchema,
@@ -156,7 +156,7 @@ export async function handleExternalInquiryAction(
     // this the request would replay on next webview load and the stream would
     // be reported as having pending permissions forever. Emit even for stale
     // submits so duplicate/delayed UI actions do not leave a leaked permission.
-    bus.emit('resolveExternalInquiry', { requestId: payload.threadId });
+    emitRuntimeEvent('resolveExternalInquiry', { requestId: payload.threadId });
     if (!persisted) {
       logger.warn(
         `Inquiry submit ignored: thread ${payload.threadId} has no open turn.`,
@@ -181,7 +181,7 @@ export async function handleExternalInquiryAction(
     );
   }
   const droppedManifest = await markDropped({ threadId: payload.threadId });
-  bus.emit('resolveExternalInquiry', { requestId: payload.threadId });
+  emitRuntimeEvent('resolveExternalInquiry', { requestId: payload.threadId });
   if (droppedManifest) {
     await injectContinuationForDroppedThread(payload.threadId, droppedManifest);
   } else {

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -15,7 +15,7 @@
 import { platform } from '@platform/platform';
 
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
-import { bus } from '@eventBus/ProgressEventBus';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { createChannelTrace } from '@logger';
 import type {
   ExternalInquiryThreadId,
@@ -110,7 +110,7 @@ async function emitInquiryThreadUpdate(
 ): Promise<void> {
   const summary = await getThreadSummary(threadId);
   if (!summary) return;
-  bus.emit('inquiryThreadUpdated', { ...summary, ...extra });
+  emitRuntimeEvent('inquiryThreadUpdated', { ...summary, ...extra });
 }
 
 async function deliverContinuation(params: {


### PR DESCRIPTION
## Summary

**SDK Step 7d follow-on F-1 (part 1): one emit path.** Stacked on #5960 (base `sdk-7d-session-handle`); rebases onto `main` once 7d lands.

Replaces the 7 scattered `bus.emit(...)` sites in `src/tools` with a single resolver:

```ts
emitRuntimeEvent(event, payload, session?)
//  session.hostChannel  ??  active run's runtimeHost (ALS)  ??  process bus
```

So "emit a progress event" has **one name and one resolution rule** instead of a raw `bus` reference duplicated at each site (and `bus` is dropped from `goalStore` / `ExternalInquiryTool` / `inquiryContinuation`).

## Behavior

- **In-run** sites (`goalStore.update`/`start`, and `forget` when PlanTool completes a goal): resolve the run's host via the ALS. **Extension byte-identical** (its run host emit *is* `bus.emit`). **CLI headless gains `goalStateChanged` `{kind:'progress'}` ndjson records** for goal-using runs — deliberate, release-noted (you OK'd NDJSON changes). **Desktop** routes them to the renderer like every other progress event.
- **Host-path** sites (`forget`/`forgetMany` via the lifecycle controller; the two `resolveExternalInquiry` arms; `inquiryThreadUpdated`): resolve to the **bus fallback today — byte-identical**. Threading each host's `session` into the resolver (so a desktop window's host-path events hit its own session) is the **multi-window stage**; this resolver is the seam that makes that a one-arg change.

## Honest LOC

Net **+36 production** (the resolver) — *not* the roadmap's −60..−100. That figure assumed a `UsageMonitor` / `updateConversationProgress` hub-derivation, deliberately **not** done here. Evidence: `updateStreamUsage` (host channel: `{streamId, storageKey, usage}` → sidebar / `StreamSnapshotStore.addUsage` / CLI TUI, all agents) and `logger.usage()` (trace channel: `{stats}` → transcript stats line, workflow-only) are two channels with different payloads serving different consumers — not redundancy. Consolidating to one canonical event would require a hub bridge that re-derives the host view and threads `storageKey` into it: **more** indirection, for the single benefit of one SDK-canonical usage event. Per maintainer call, kept as-is. F-1's real win is the single emit path, not a LOC cut.

## Tests / verification

- `EmitRuntimeEvent.vitest.ts` locks the 3-way precedence (bus fallback / run host / session hostChannel).
- root + test-kernel + extension + CLI + desktop typecheck clean; full suite **450 files / 3120 passing**; eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how progress events are routed for goals and inquiry lifecycle; behavior is mostly equivalent except in-run goal emits now follow the run host, which affects CLI NDJSON output.
> 
> **Overview**
> Introduces **`emitRuntimeEvent`** as the single way `src/tools` publishes progress events, replacing direct **`bus.emit`** at goal and external-inquiry sites.
> 
> Resolution order is **`session.hostChannel` → active run `runtimeHost` (ALS) → process `bus`**. Call sites in **`goalStore`** (`goalStateChanged` on update/start/forget/forgetMany) and inquiry (**`resolveExternalInquiry`**, **`inquiryThreadUpdated`**) now go through this helper; **`ExternalInquiryTool`**’s in-run **`ask`** path still uses **`runtimeHost.emit`** for panel/UI events unchanged.
> 
> **`EmitRuntimeEvent.vitest.ts`** locks the three precedence cases and that run/session paths do not double-emit on the bus. Host-path callers still omit **`session`**, so they keep the bus fallback today; passing **`SessionHandle`** is the seam for per-window routing later.
> 
> In-run goal updates route through the run host when ALS is set (extension stays equivalent where run host is the bus; headless CLI can surface **`goalStateChanged`** on the run progress channel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e3415740b9a4215c5a5c813c42236982971ef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
