### PR TITLE
SDK 7d F-2: per-run control handle (onRun + handle.trace + handle.result)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,10 @@ export {
   AgentFlowResultSchema,
   type WorkflowFlowResult,
 } from '@agent/runtime/AgentFlowResult';
+// Per-run control handle (F-2): the run's live handle, exposed via `onRun`.
+// Its `.result` promise settles with the terminal `ResultEvent` (always
+// resolves), and `.trace` is the run's discriminated-event channel.
+export { type AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 
 // ── 5. Host port (consumer-injected progress-event sink) ──
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,7 +77,10 @@ export {
 // Per-run control handle (F-2): the run's live handle, exposed via `onRun`.
 // Its `.result` promise settles with the terminal `ResultEvent` (always
 // resolves), and `.trace` is the run's discriminated-event channel.
-export { type AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+export {
+  type AgentRunHandle,
+  type AgentRunHandle as AgentExecutionHandle,
+} from '@agent/runtime/executionRegistry';
 
 // ── 5. Host port (consumer-injected progress-event sink) ──
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,10 +77,7 @@ export {
 // Per-run control handle (F-2): the run's live handle, exposed via `onRun`.
 // Its `.result` promise settles with the terminal `ResultEvent` (always
 // resolves), and `.trace` is the run's discriminated-event channel.
-export {
-  type AgentRunHandle,
-  type AgentRunHandle as AgentExecutionHandle,
-} from '@agent/runtime/executionRegistry';
+export { type AgentRunHandle } from '@agent/runtime/executionRegistry';
 
 // ── 5. Host port (consumer-injected progress-event sink) ──
 export {

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -24,7 +24,7 @@ import {
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { agentName as baseAgentName } from '@shared/schemas/agent';
 
-import { AgentExecutionHandle } from './executionRegistry';
+import { AgentExecutionHandle, type AgentRunHandle } from './executionRegistry';
 import {
   getAgentFlowErrorResult,
   buildTerminalFlowResult,
@@ -44,7 +44,7 @@ export interface RunFlowLifecycleOptions {
    * the additive exposure of the control handle (`.trace`, `.result`, interrupt
    * via `executions`). Throwing here must not abort the run, so it is guarded.
    */
-  onRun?: (handle: AgentExecutionHandle) => void;
+  onRun?: (handle: AgentRunHandle) => void;
 }
 
 /** Map the canonical run outcome onto the terminal `result` event's outcome. */
@@ -129,11 +129,16 @@ export async function runFlowWithLifecycle(
     ctx.logger,
   );
   session.executions.track(handle);
-  // Expose the live handle to the launcher (F-2). Guarded: a throwing consumer
-  // callback must never abort the run.
+  // Expose the live handle to the launcher (F-2). Guarded: neither a synchronous
+  // throw nor an async rejection from a consumer callback may abort the run.
   if (options?.onRun) {
     try {
-      options.onRun(handle);
+      const maybePromise = options.onRun(handle) as void | Promise<void>;
+      void Promise.resolve(maybePromise).catch((err: unknown) =>
+        logger.warn(
+          `onRun callback rejected for ${agentIdentifier}: ${String(err)}`,
+        ),
+      );
     } catch (err) {
       logger.warn(
         `onRun callback threw for ${agentIdentifier}: ${String(err)}`,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -44,7 +44,7 @@ export interface RunFlowLifecycleOptions {
    * the additive exposure of the control handle (`.trace`, `.result`, interrupt
    * via `executions`). Throwing here must not abort the run, so it is guarded.
    */
-  onRun?: (handle: AgentRunHandle) => void;
+  onRun?: (handle: AgentRunHandle) => void | Promise<void>;
 }
 
 /** Map the canonical run outcome onto the terminal `result` event's outcome. */
@@ -133,7 +133,7 @@ export async function runFlowWithLifecycle(
   // throw nor an async rejection from a consumer callback may abort the run.
   if (options?.onRun) {
     try {
-      const maybePromise = options.onRun(handle) as void | Promise<void>;
+      const maybePromise = options.onRun(handle);
       void Promise.resolve(maybePromise).catch((err: unknown) =>
         logger.warn(
           `onRun callback rejected for ${agentIdentifier}: ${String(err)}`,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -39,6 +39,12 @@ export interface RunFlowLifecycleOptions {
   parentStreamId?: StreamTabId;
   onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
   onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;
+  /**
+   * Fires once with the live per-run handle, right after it is tracked (F-2) —
+   * the additive exposure of the control handle (`.trace`, `.result`, interrupt
+   * via `executions`). Throwing here must not abort the run, so it is guarded.
+   */
+  onRun?: (handle: AgentExecutionHandle) => void;
 }
 
 /** Map the canonical run outcome onto the terminal `result` event's outcome. */
@@ -60,9 +66,9 @@ function emitRunResult(
   outcome: ResultEvent['outcome'],
   isSubagent: boolean,
   error?: { kind: AgentErrorKind; message?: string },
-): void {
+): ResultEvent {
   const usage = ctx.usageMonitor.lastTotals();
-  ctx.logger.emit({
+  const event: ResultEvent = {
     type: 'result',
     outcome,
     executionId: ctx.executionId,
@@ -72,7 +78,9 @@ function emitRunResult(
     isSubagent,
     ...(error ? { error } : {}),
     ...(usage ? { usage } : {}),
-  });
+  };
+  ctx.logger.emit(event);
+  return event;
 }
 
 function endParentStageSafely(
@@ -118,8 +126,20 @@ export async function runFlowWithLifecycle(
     category,
     ctx.runtimeHost,
     ctx.coordinators,
+    ctx.logger,
   );
   session.executions.track(handle);
+  // Expose the live handle to the launcher (F-2). Guarded: a throwing consumer
+  // callback must never abort the run.
+  if (options?.onRun) {
+    try {
+      options.onRun(handle);
+    } catch (err) {
+      logger.warn(
+        `onRun callback threw for ${agentIdentifier}: ${String(err)}`,
+      );
+    }
+  }
   // Tracks whether the terminal `result` event has already been emitted, so a
   // throw in the success arm's post-emit cleanup can never fall into the catch
   // arm and publish a second, contradictory `failed` result for a finished run.
@@ -160,12 +180,15 @@ export async function runFlowWithLifecycle(
 
     endParentStageSafely(ctx, agentIdentifier, projection.endGroupStatus);
     // Emit the terminal result BEFORE untrack so the registry's terminal
-    // listener event never precedes the result event.
-    emitRunResult(
-      ctx,
-      category,
-      toResultOutcome(result.outcome),
-      options?.isSubagent ?? false,
+    // listener event never precedes the result event, and settle the handle's
+    // `result` promise with the same event (F-2: per-run control handle).
+    handle.settleResult(
+      emitRunResult(
+        ctx,
+        category,
+        toResultOutcome(result.outcome),
+        options?.isSubagent ?? false,
+      ),
     );
     resultEmitted = true;
     try {
@@ -225,12 +248,14 @@ export async function runFlowWithLifecycle(
     // Abort still carries the SDK message for event consumers; the toast mapper
     // intentionally suppresses user-facing notifications for aborts.
     if (!resultEmitted) {
-      emitRunResult(
-        ctx,
-        category,
-        toResultOutcome(outcome),
-        options?.isSubagent ?? false,
-        { kind, message: kind === 'unexpected' ? errorMsg : sdkMsg },
+      handle.settleResult(
+        emitRunResult(
+          ctx,
+          category,
+          toResultOutcome(outcome),
+          options?.isSubagent ?? false,
+          { kind, message: kind === 'unexpected' ? errorMsg : sdkMsg },
+        ),
       );
     }
     try {

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -145,6 +145,20 @@ export class AgentExecutionHandle implements ExecutionHandle {
   }
 }
 
+export type AgentRunHandle = Pick<
+  AgentExecutionHandle,
+  | 'executionId'
+  | 'parentStreamId'
+  | 'childStreamId'
+  | 'category'
+  | 'agentName'
+  | 'startedAt'
+  | 'runtimeHost'
+  | 'trace'
+  | 'result'
+  | 'getProgress'
+>;
+
 /**
  * Handle for background bash processes.
  * No `childStreamId` — processes don't have their own stream.

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -5,6 +5,7 @@
  * describe themselves. Termination policy lives with the owning registry.
  */
 
+import type { AgentTrace, ResultEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
 import {
@@ -75,6 +76,17 @@ export class AgentExecutionHandle implements ExecutionHandle {
   /** Stable tool name for UI identification (e.g. "bash", "codex"). */
   toolName?: string;
 
+  /**
+   * The run's terminal outcome, settled exactly once (by the run lifecycle, or
+   * by `finalizeChildStream` for non-lifecycle child streams) BEFORE the
+   * execution is untracked. Always resolves — never rejects — so a consumer-less
+   * failed run cannot produce an unhandled rejection. SDK consumers awaiting a
+   * specific run's outcome use this; the host-wide stream is `session.onResult`.
+   */
+  readonly result: Promise<ResultEvent>;
+  private settle!: (event: ResultEvent) => void;
+  private settled = false;
+
   constructor(
     readonly executionId: string,
     parentStreamId: StreamTabId,
@@ -83,8 +95,20 @@ export class AgentExecutionHandle implements ExecutionHandle {
     readonly category: AgentCategory,
     readonly runtimeHost: AgentRuntimeHost,
     readonly coordinators?: RunCoordinators,
+    /** The run's discriminated-event channel, for run-scoped subscribers. */
+    readonly trace?: AgentTrace,
   ) {
     this._parentStreamId = parentStreamId;
+    this.result = new Promise<ResultEvent>((resolve) => {
+      this.settle = resolve;
+    });
+  }
+
+  /** Settle {@link result} with the terminal outcome (idempotent). */
+  settleResult(event: ResultEvent): void {
+    if (this.settled) return;
+    this.settled = true;
+    this.settle(event);
   }
 
   get parentStreamId(): StreamTabId {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -48,7 +48,7 @@ import {
   type CompileFailureSummary,
   type OutputFileSummary,
 } from './AgentFlowResult';
-import type { AgentExecutionHandle } from './executionRegistry';
+import type { AgentRunHandle } from './executionRegistry';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const CHANNEL = 'executeAgent';
@@ -255,7 +255,7 @@ export interface ExecuteAgentOptions {
   /** Fires when a subagent fails and should report the failure to its orchestrator. */
   onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;
   /** Fires once with the live per-run handle right after it is tracked (F-2). */
-  onRun?: (handle: AgentExecutionHandle) => void;
+  onRun?: (handle: AgentRunHandle) => void;
 }
 
 export async function executeAgent(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -48,6 +48,7 @@ import {
   type CompileFailureSummary,
   type OutputFileSummary,
 } from './AgentFlowResult';
+import type { AgentExecutionHandle } from './executionRegistry';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const CHANNEL = 'executeAgent';
@@ -253,6 +254,8 @@ export interface ExecuteAgentOptions {
   onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
   /** Fires when a subagent fails and should report the failure to its orchestrator. */
   onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;
+  /** Fires once with the live per-run handle right after it is tracked (F-2). */
+  onRun?: (handle: AgentExecutionHandle) => void;
 }
 
 export async function executeAgent(
@@ -416,6 +419,7 @@ export async function executeAgent(
         parentStreamId: options.parentStreamId,
         onCompleted: options.onCompleted,
         onError: options.onError,
+        onRun: options.onRun,
       },
     );
   });

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -255,7 +255,7 @@ export interface ExecuteAgentOptions {
   /** Fires when a subagent fails and should report the failure to its orchestrator. */
   onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;
   /** Fires once with the live per-run handle right after it is tracked (F-2). */
-  onRun?: (handle: AgentRunHandle) => void;
+  onRun?: (handle: AgentRunHandle) => void | Promise<void>;
 }
 
 export async function executeAgent(
@@ -432,6 +432,7 @@ export interface ResumeToolUseFromSnapshotOptions {
   readonly runtimeUnavailableTools?: readonly string[];
   /** Session owning this run's coordination state. Defaults to the process session. */
   readonly session?: SessionHandle;
+  readonly onRun?: (handle: AgentRunHandle) => void | Promise<void>;
   readonly setupSession?: (session: IToolUseSession) => void;
 }
 
@@ -504,7 +505,7 @@ export async function resumeToolUseFromSnapshot(
           ctx.attachedMemoryMisses,
         );
       },
-      { isSubagent },
+      { isSubagent, onRun: options.onRun },
     );
   });
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -39,6 +39,7 @@ export {
   type ExecutionProgress,
   type ExecutionStatusInfo,
   type LiveToolUseFlowContext,
+  type AgentRunHandle,
   ACTIVE_STATUSES,
   AgentExecutionHandle,
   ProcessExecutionHandle,

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -6,6 +6,7 @@ import { generateExecutionId } from '@utils/core/executionId';
 import { executeAgent } from './executeAgent';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentFlowResult, WorkflowFlowResult } from './AgentFlowResult';
+import type { AgentExecutionHandle } from './executionRegistry';
 import type { SessionHandle } from './SessionHandle';
 
 export interface RunAgentOptions {
@@ -18,6 +19,13 @@ export interface RunAgentOptions {
   runtimeUnavailableTools?: readonly string[];
   /** Session owning this run's coordination state. Defaults to the process session. */
   session?: SessionHandle;
+  /**
+   * Fires once with the live per-run handle right after it is tracked (F-2):
+   * `handle.result` settles with the terminal outcome, `handle.trace` is the
+   * run's event channel, and the handle can interrupt via the session. The
+   * returned promise is unchanged — this is additive, post-launch exposure.
+   */
+  onRun?: (handle: AgentExecutionHandle) => void;
 }
 
 /**
@@ -59,6 +67,7 @@ export async function runAgent(
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
     runtimeUnavailableTools: options.runtimeUnavailableTools,
     session: options.session,
+    onRun: options.onRun,
   });
   if (result.category === 'workflow') {
     await options.openWorkflowOutput?.(result);

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -25,7 +25,7 @@ export interface RunAgentOptions {
    * run's event channel, and the handle can interrupt via the session. The
    * returned promise is unchanged — this is additive, post-launch exposure.
    */
-  onRun?: (handle: AgentRunHandle) => void;
+  onRun?: (handle: AgentRunHandle) => void | Promise<void>;
 }
 
 /**

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -6,7 +6,7 @@ import { generateExecutionId } from '@utils/core/executionId';
 import { executeAgent } from './executeAgent';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentFlowResult, WorkflowFlowResult } from './AgentFlowResult';
-import type { AgentExecutionHandle } from './executionRegistry';
+import type { AgentRunHandle } from './executionRegistry';
 import type { SessionHandle } from './SessionHandle';
 
 export interface RunAgentOptions {
@@ -25,7 +25,7 @@ export interface RunAgentOptions {
    * run's event channel, and the handle can interrupt via the session. The
    * returned promise is unchanged — this is additive, post-launch exposure.
    */
-  onRun?: (handle: AgentExecutionHandle) => void;
+  onRun?: (handle: AgentRunHandle) => void;
 }
 
 /**

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -16,6 +16,7 @@ import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator'
 import { RetryRequestCoordinatorImpl } from '@agent/runtime/RetryRequestCoordinator';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import type { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
@@ -213,6 +214,39 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     }
   });
 
+  it('exposes the per-run handle via onRun and settles handle.result (F-2)', async () => {
+    const logger = new TraceEmitter();
+    const { ctx, streamStatus } = createCtx({ logger });
+    let handle: AgentExecutionHandle | undefined;
+    try {
+      await runFlowWithLifecycle(
+        ctx,
+        async () => ({
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId: ctx.executionId,
+          streamId: ctx.streamId,
+        }),
+        {
+          onRun: (h) => {
+            handle = h;
+          },
+        },
+      );
+      expect(handle).toBeDefined();
+      // The handle carries the run's trace channel for run-scoped subscribers.
+      expect(handle?.trace).toBe(logger);
+      // `result` settles with the same terminal event (always resolves).
+      await expect(handle?.result).resolves.toMatchObject({
+        type: 'result',
+        outcome: 'completed',
+        executionId: ctx.executionId,
+      });
+    } finally {
+      streamStatus.clear(ctx.streamId, { emit: false });
+    }
+  });
+
   it('keeps the completed result when the completion hook throws', async () => {
     const logger = new TraceEmitter();
     const results = collectResults(logger);
@@ -291,6 +325,33 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
       expect(results[0]).toMatchObject({
         outcome: 'failed',
         executionId: ctx.executionId,
+      });
+    } finally {
+      streamStatus.clear(ctx.streamId, { emit: false });
+    }
+  });
+
+  it('settles handle.result as failed on a thrown run (always resolves)', async () => {
+    const logger = new TraceEmitter();
+    const { ctx, streamStatus } = createCtx({ logger });
+    let handle: AgentExecutionHandle | undefined;
+    try {
+      await expect(
+        runFlowWithLifecycle(
+          ctx,
+          async () => {
+            throw new Error('boom');
+          },
+          {
+            onRun: (h) => {
+              handle = h;
+            },
+          },
+        ),
+      ).rejects.toThrow('boom');
+      await expect(handle?.result).resolves.toMatchObject({
+        type: 'result',
+        outcome: 'failed',
       });
     } finally {
       streamStatus.clear(ctx.streamId, { emit: false });

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -16,7 +16,7 @@ import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator'
 import { RetryRequestCoordinatorImpl } from '@agent/runtime/RetryRequestCoordinator';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
-import type { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
 import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
@@ -217,7 +217,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   it('exposes the per-run handle via onRun and settles handle.result (F-2)', async () => {
     const logger = new TraceEmitter();
     const { ctx, streamStatus } = createCtx({ logger });
-    let handle: AgentExecutionHandle | undefined;
+    let handle: AgentRunHandle | undefined;
     try {
       await runFlowWithLifecycle(
         ctx,
@@ -334,7 +334,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   it('settles handle.result as failed on a thrown run (always resolves)', async () => {
     const logger = new TraceEmitter();
     const { ctx, streamStatus } = createCtx({ logger });
-    let handle: AgentExecutionHandle | undefined;
+    let handle: AgentRunHandle | undefined;
     try {
       await expect(
         runFlowWithLifecycle(

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -247,6 +247,73 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     }
   });
 
+  it('keeps running when onRun throws synchronously', async () => {
+    const logger = new TraceEmitter();
+    const results = collectResults(logger);
+    const { ctx, streamStatus } = createCtx({ logger });
+    try {
+      await expect(
+        runFlowWithLifecycle(
+          ctx,
+          async () => ({
+            category: 'toolUse',
+            outcome: RUN_OUTCOME.COMPLETED,
+            executionId: ctx.executionId,
+            streamId: ctx.streamId,
+          }),
+          {
+            onRun: () => {
+              throw new Error('onRun boom');
+            },
+          },
+        ),
+      ).resolves.toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        type: 'result',
+        outcome: 'completed',
+        executionId: ctx.executionId,
+      });
+    } finally {
+      streamStatus.clear(ctx.streamId, { emit: false });
+    }
+  });
+
+  it('keeps running when onRun rejects asynchronously', async () => {
+    const logger = new TraceEmitter();
+    const results = collectResults(logger);
+    const { ctx, streamStatus } = createCtx({ logger });
+    try {
+      await expect(
+        runFlowWithLifecycle(
+          ctx,
+          async () => ({
+            category: 'toolUse',
+            outcome: RUN_OUTCOME.COMPLETED,
+            executionId: ctx.executionId,
+            streamId: ctx.streamId,
+          }),
+          {
+            onRun: async () => {
+              throw new Error('onRun async boom');
+            },
+          },
+        ),
+      ).resolves.toMatchObject({ outcome: RUN_OUTCOME.COMPLETED });
+      await Promise.resolve();
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        type: 'result',
+        outcome: 'completed',
+        executionId: ctx.executionId,
+      });
+    } finally {
+      streamStatus.clear(ctx.streamId, { emit: false });
+    }
+  });
+
   it('keeps the completed result when the completion hook throws', async () => {
     const logger = new TraceEmitter();
     const results = collectResults(logger);

--- a/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
@@ -133,7 +133,7 @@ describe('child stream progress events', () => {
     });
   });
 
-  it('publishes child loop status changes through the child stream owner', () => {
+  it('publishes child loop status changes through the child stream owner', async () => {
     const active = createRecordingHost();
 
     const childStream = createChildStream(loopExecutionId, parentStreamId, {
@@ -145,6 +145,9 @@ describe('child stream progress events', () => {
       config,
       toolName: 'codex',
     });
+    const handle =
+      defaultSession().executions.getAgentHandleByStream(loopChildStreamId);
+    expect(handle).toBeDefined();
     active.events.splice(0);
 
     childStream.waitForInput();
@@ -170,9 +173,17 @@ describe('child stream progress events', () => {
       event: 'updateActiveSubagents',
       payload: { parentStreamId, children: [] },
     });
+    await expect(handle?.result).resolves.toMatchObject({
+      type: 'result',
+      outcome: 'failed',
+      error: {
+        kind: 'unexpected',
+        message: 'Child stream failed',
+      },
+    });
   });
 
-  it('preserves explicit user stops during child loop status changes', () => {
+  it('preserves explicit user stops during child loop status changes', async () => {
     const active = createRecordingHost();
 
     const childStream = createChildStream(stoppedExecutionId, parentStreamId, {
@@ -184,6 +195,9 @@ describe('child stream progress events', () => {
       config,
       toolName: 'codex',
     });
+    const handle =
+      defaultSession().executions.getAgentHandleByStream(stoppedChildStreamId);
+    expect(handle).toBeDefined();
     StreamStatusService.set(stoppedChildStreamId, STREAM_STATUS.STOPPED, {
       emit: false,
     });
@@ -200,6 +214,12 @@ describe('child stream progress events', () => {
     expect(
       active.events.filter((entry) => entry.event === 'updateStreamStatus'),
     ).toHaveLength(0);
+    await expect(handle?.result).resolves.toMatchObject({
+      type: 'result',
+      outcome: 'cancelled',
+      executionId: stoppedExecutionId,
+      streamId: stoppedChildStreamId,
+    });
   });
 
   it('settles child handle results as cancelled for stopped finalization', async () => {

--- a/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
@@ -26,6 +26,10 @@ const cancelledChildStreamId =
   'codex#exec:child-stream-cancelled' as StreamTabId;
 const failedExecutionId = 'exec:child-stream-failed' as ExecutionId;
 const failedChildStreamId = 'codex#exec:child-stream-failed' as StreamTabId;
+const normalizedErrorExecutionId =
+  'exec:child-stream-normalized-error' as ExecutionId;
+const normalizedErrorChildStreamId =
+  'codex#exec:child-stream-normalized-error' as StreamTabId;
 const config = {
   agentCategory: AgentCategory.ToolUse,
   model: 'test-model',
@@ -40,6 +44,7 @@ describe('child stream progress events', () => {
       stoppedChildStreamId,
       cancelledChildStreamId,
       failedChildStreamId,
+      normalizedErrorChildStreamId,
     ]) {
       StreamStatusService.clear(streamId, { emit: false });
     }
@@ -279,6 +284,47 @@ describe('child stream progress events', () => {
       error: {
         kind: 'unexpected',
         message: 'child process exited 1',
+      },
+    });
+  });
+
+  it('normalizes explicit non-error status when child finalization has an error', async () => {
+    const active = createRecordingHost();
+
+    const childStream = createChildStream(
+      normalizedErrorExecutionId,
+      parentStreamId,
+      {
+        runtimeHost: active.host,
+        streamPrefix: 'codex',
+        streamCategory: AgentCategory.ToolUse,
+        agentName: 'codex',
+        description: 'Run a child loop with mismatched finalization inputs',
+        config,
+        toolName: 'codex',
+      },
+    );
+    const handle = defaultSession().executions.getAgentHandleByStream(
+      normalizedErrorChildStreamId,
+    );
+    expect(handle).toBeDefined();
+
+    childStream.finalize({
+      status: STREAM_STATUS.READY,
+      errorMessage: 'tool failed after reporting ready',
+    });
+
+    expect(StreamStatusService.get(normalizedErrorChildStreamId)).toBe(
+      STREAM_STATUS.ERROR,
+    );
+    await expect(handle?.result).resolves.toMatchObject({
+      type: 'result',
+      outcome: 'failed',
+      executionId: normalizedErrorExecutionId,
+      streamId: normalizedErrorChildStreamId,
+      error: {
+        kind: 'unexpected',
+        message: 'tool failed after reporting ready',
       },
     });
   });

--- a/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
@@ -24,6 +24,8 @@ const stoppedChildStreamId = 'codex#exec:child-stream-stopped' as StreamTabId;
 const cancelledExecutionId = 'exec:child-stream-cancelled' as ExecutionId;
 const cancelledChildStreamId =
   'codex#exec:child-stream-cancelled' as StreamTabId;
+const failedExecutionId = 'exec:child-stream-failed' as ExecutionId;
+const failedChildStreamId = 'codex#exec:child-stream-failed' as StreamTabId;
 const config = {
   agentCategory: AgentCategory.ToolUse,
   model: 'test-model',
@@ -37,6 +39,7 @@ describe('child stream progress events', () => {
       loopChildStreamId,
       stoppedChildStreamId,
       cancelledChildStreamId,
+      failedChildStreamId,
     ]) {
       StreamStatusService.clear(streamId, { emit: false });
     }
@@ -227,6 +230,36 @@ describe('child stream progress events', () => {
       outcome: 'cancelled',
       executionId: cancelledExecutionId,
       streamId: cancelledChildStreamId,
+    });
+  });
+
+  it('settles failed child handle results with error details', async () => {
+    const active = createRecordingHost();
+
+    const childStream = createChildStream(failedExecutionId, parentStreamId, {
+      runtimeHost: active.host,
+      streamPrefix: 'codex',
+      streamCategory: AgentCategory.ToolUse,
+      agentName: 'codex',
+      description: 'Run a failing Codex child loop',
+      config,
+      toolName: 'codex',
+    });
+    const handle =
+      defaultSession().executions.getAgentHandleByStream(failedChildStreamId);
+    expect(handle).toBeDefined();
+
+    childStream.finalize({ errorMessage: 'child process exited 1' });
+
+    await expect(handle?.result).resolves.toMatchObject({
+      type: 'result',
+      outcome: 'failed',
+      executionId: failedExecutionId,
+      streamId: failedChildStreamId,
+      error: {
+        kind: 'unexpected',
+        message: 'child process exited 1',
+      },
     });
   });
 });

--- a/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 // Local imports
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   STREAM_STATUS,
@@ -20,6 +21,9 @@ const loopExecutionId = 'exec:child-stream-loop' as ExecutionId;
 const loopChildStreamId = 'codex#exec:child-stream-loop' as StreamTabId;
 const stoppedExecutionId = 'exec:child-stream-stopped' as ExecutionId;
 const stoppedChildStreamId = 'codex#exec:child-stream-stopped' as StreamTabId;
+const cancelledExecutionId = 'exec:child-stream-cancelled' as ExecutionId;
+const cancelledChildStreamId =
+  'codex#exec:child-stream-cancelled' as StreamTabId;
 const config = {
   agentCategory: AgentCategory.ToolUse,
   model: 'test-model',
@@ -32,6 +36,7 @@ describe('child stream progress events', () => {
       childStreamId,
       loopChildStreamId,
       stoppedChildStreamId,
+      cancelledChildStreamId,
     ]) {
       StreamStatusService.clear(streamId, { emit: false });
     }
@@ -192,5 +197,36 @@ describe('child stream progress events', () => {
     expect(
       active.events.filter((entry) => entry.event === 'updateStreamStatus'),
     ).toHaveLength(0);
+  });
+
+  it('settles child handle results as cancelled for stopped finalization', async () => {
+    const active = createRecordingHost();
+
+    const childStream = createChildStream(
+      cancelledExecutionId,
+      parentStreamId,
+      {
+        runtimeHost: active.host,
+        streamPrefix: 'codex',
+        streamCategory: AgentCategory.ToolUse,
+        agentName: 'codex',
+        description: 'Run an interrupted Codex child loop',
+        config,
+        toolName: 'codex',
+      },
+    );
+    const handle = defaultSession().executions.getAgentHandleByStream(
+      cancelledChildStreamId,
+    );
+    expect(handle).toBeDefined();
+
+    childStream.finalize({ status: STREAM_STATUS.STOPPED });
+
+    await expect(handle?.result).resolves.toMatchObject({
+      type: 'result',
+      outcome: 'cancelled',
+      executionId: cancelledExecutionId,
+      streamId: cancelledChildStreamId,
+    });
   });
 });

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -289,8 +289,13 @@ export function runAgentCliSession<TTurn>(
         () => {},
       );
 
+      const finalStatus = sawTurnFailure
+        ? STREAM_STATUS.ERROR
+        : session.isInterrupted()
+          ? STREAM_STATUS.STOPPED
+          : STREAM_STATUS.READY;
       childStream.finalize({
-        status: sawTurnFailure ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+        status: finalStatus,
       });
     }
   })();

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -48,7 +48,8 @@ interface FinalizeChildStreamOptions {
 
 type ChildStreamTerminalStatus =
   | typeof STREAM_STATUS.READY
-  | typeof STREAM_STATUS.ERROR;
+  | typeof STREAM_STATUS.ERROR
+  | typeof STREAM_STATUS.STOPPED;
 
 export interface ChildStream {
   childStreamId: StreamTabId;
@@ -101,6 +102,8 @@ export function createChildStream(
     options.agentName,
     'toolUse',
     runtimeHost,
+    undefined,
+    runTrace.trace,
   );
   if (options.toolName) handle.toolName = options.toolName;
   session.executions.trackAgentExecution(handle, {
@@ -169,12 +172,25 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
     );
   }
 
+  // The terminal status the child finishes with — the single source of truth
+  // for both the registry status and the handle's result outcome. Deriving from
+  // status (not just `hasError`) covers callers that pass ERROR without an
+  // error payload, and long-lived child loops that finalize after an interrupt.
+  const finalStatus =
+    options?.status ?? (hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY);
+  const outcome =
+    hasError || finalStatus === STREAM_STATUS.ERROR
+      ? 'failed'
+      : finalStatus === STREAM_STATUS.STOPPED
+        ? 'cancelled'
+        : 'completed';
+
   // Settle the handle's `result` before untracking (F-2): child streams never
   // traverse the run lifecycle, so this is their only settle point. Without it
   // a consumer awaiting a child handle's `result` would hang forever.
   handle.settleResult({
     type: 'result',
-    outcome: hasError ? 'failed' : 'completed',
+    outcome,
     executionId: handle.executionId,
     streamId: handle.childStreamId,
     agentName: handle.agentName,
@@ -182,10 +198,7 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
     isSubagent: handle.parentStreamId !== handle.childStreamId,
   });
 
-  session.executions.finishAgentExecution(handle, {
-    status:
-      options?.status ?? (hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY),
-  });
+  session.executions.finishAgentExecution(handle, { status: finalStatus });
   disposeTrace();
 
   if (options?.autoClose) {

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -12,11 +12,7 @@ import {
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 
 // Local imports - errors
-import {
-  classifyAgentError,
-  toErrorMessage,
-  type AgentErrorKind,
-} from '@common/errors';
+import { classifyAgentError, toErrorMessage } from '@common/errors';
 
 // Local imports - shared
 import type { ExecutionId, StreamTabId, StorageKey } from '@shared/schemas';
@@ -200,7 +196,7 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   const error =
     outcome === 'failed'
       ? {
-          kind: getChildStreamErrorKind(options?.error),
+          kind: classifyAgentError(options?.error),
           message: errorMessage ?? 'Child stream failed',
         }
       : undefined;
@@ -225,8 +221,4 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   if (options?.autoClose) {
     handle.runtimeHost.emit('removeStream', { streamId: handle.childStreamId });
   }
-}
-
-function getChildStreamErrorKind(error: unknown): AgentErrorKind {
-  return error == null ? 'unexpected' : classifyAgentError(error);
 }

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -12,7 +12,11 @@ import {
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 
 // Local imports - errors
-import { toErrorMessage } from '@common/errors';
+import {
+  classifyAgentError,
+  toErrorMessage,
+  type AgentErrorKind,
+} from '@common/errors';
 
 // Local imports - shared
 import type { ExecutionId, StreamTabId, StorageKey } from '@shared/schemas';
@@ -157,11 +161,12 @@ interface FinalizeChildStreamArgs {
 function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   const { handle, session, logger, disposeTrace, options } = args;
   const hasError = options?.error != null || options?.errorMessage != null;
+  const errorMessage =
+    options?.errorMessage ??
+    (options?.error != null ? toErrorMessage(options.error) : undefined);
 
-  if (options?.errorMessage) {
-    logger.error(options.errorMessage);
-  } else if (options?.error) {
-    logger.error(toErrorMessage(options.error));
+  if (errorMessage) {
+    logger.error(errorMessage);
   }
   if (options?.wallTimeMs != null) {
     logger.info(`Completed in ${formatDuration(options.wallTimeMs)}`);
@@ -184,6 +189,13 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
       : finalStatus === STREAM_STATUS.STOPPED
         ? 'cancelled'
         : 'completed';
+  const error =
+    outcome === 'failed' && errorMessage
+      ? {
+          kind: getChildStreamErrorKind(options?.error),
+          message: errorMessage,
+        }
+      : undefined;
 
   // Settle the handle's `result` before untracking (F-2): child streams never
   // traverse the run lifecycle, so this is their only settle point. Without it
@@ -196,6 +208,7 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
     agentName: handle.agentName,
     category: handle.category,
     isSubagent: handle.parentStreamId !== handle.childStreamId,
+    ...(error ? { error } : {}),
   });
 
   session.executions.finishAgentExecution(handle, { status: finalStatus });
@@ -204,4 +217,8 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   if (options?.autoClose) {
     handle.runtimeHost.emit('removeStream', { streamId: handle.childStreamId });
   }
+}
+
+function getChildStreamErrorKind(error: unknown): AgentErrorKind {
+  return error == null ? 'unexpected' : classifyAgentError(error);
 }

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -169,6 +169,19 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
     );
   }
 
+  // Settle the handle's `result` before untracking (F-2): child streams never
+  // traverse the run lifecycle, so this is their only settle point. Without it
+  // a consumer awaiting a child handle's `result` would hang forever.
+  handle.settleResult({
+    type: 'result',
+    outcome: hasError ? 'failed' : 'completed',
+    executionId: handle.executionId,
+    streamId: handle.childStreamId,
+    agentName: handle.agentName,
+    category: handle.category,
+    isSubagent: handle.parentStreamId !== handle.childStreamId,
+  });
+
   session.executions.finishAgentExecution(handle, {
     status:
       options?.status ?? (hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY),

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -181,19 +181,27 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   // for both the registry status and the handle's result outcome. Deriving from
   // status (not just `hasError`) covers callers that pass ERROR without an
   // error payload, and long-lived child loops that finalize after an interrupt.
-  const finalStatus =
+  const requestedStatus =
     options?.status ?? (hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY);
+  const currentStatus = session.executions.getStatus(handle).status;
+  const finalStatus =
+    currentStatus === STREAM_STATUS.STOPPED ||
+    requestedStatus === STREAM_STATUS.STOPPED
+      ? STREAM_STATUS.STOPPED
+      : hasError
+        ? STREAM_STATUS.ERROR
+        : requestedStatus;
   const outcome =
-    hasError || finalStatus === STREAM_STATUS.ERROR
+    finalStatus === STREAM_STATUS.ERROR
       ? 'failed'
       : finalStatus === STREAM_STATUS.STOPPED
         ? 'cancelled'
         : 'completed';
   const error =
-    outcome === 'failed' && errorMessage
+    outcome === 'failed'
       ? {
           kind: getChildStreamErrorKind(options?.error),
-          message: errorMessage,
+          message: errorMessage ?? 'Child stream failed',
         }
       : undefined;
 


### PR DESCRIPTION
Recovered on top of current `main` after #5975 replaced the closed #5961 F-1 stack base. Rebased again after #5977 landed.

## Summary

- expose the per-run public `AgentRunHandle` through `onRun`
- add `handle.trace` and an always-resolving `handle.result`
- settle lifecycle and child-stream handles with the same terminal result event semantics
- carry failed child-stream error details on `handle.result`, including status-only failures
- keep child-stream registry status and handle outcome aligned when explicit stops are preserved
- normalize mismatched child finalization inputs so an error indicator records an error-level final status
- keep the review fixes for child handle trace, status-derived child outcomes, cancelled child-loop outcomes, async `onRun` failures, and failed-lifecycle settle-before-status ordering
- expose SDK callers to the read-only public handle shape so they cannot call the internal `settleResult` mutator
- forward `onRun` through resumed tool-use sessions for the same handle contract

## Verification

- `corepack pnpm exec prettier --write packages/core/src/index.ts src/agent/runtime/AgentRunLifecycle.ts src/agent/runtime/executeAgent.ts src/agent/runtime/runAgent.ts src/tools/childStream.ts src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts`
- `corepack pnpm exec eslint src/agent/runtime/AgentRunLifecycle.ts src/agent/runtime/executeAgent.ts src/agent/runtime/runAgent.ts src/tools/childStream.ts src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core run and child-stream termination semantics for anyone awaiting per-run handles, though the API is additive and callbacks are guarded. Mis-settlement or outcome mapping on child finalization could leave embedders with wrong terminal events.
> 
> **Overview**
> Adds SDK **F-2**: hosts can receive a live per-run **`AgentRunHandle`** through a new **`onRun`** callback on **`runAgent`**, **`executeAgent`**, **`resumeToolUseFromSnapshot`**, and the lifecycle wrapper. The public type is re-exported from **`@texra/core`** and omits internal **`settleResult`**.
> 
> Each tracked run handle now carries **`trace`** (run-scoped event channel) and an always-resolving **`result`** promise that settles with the same terminal **`ResultEvent`** as the trace emission. The run lifecycle wires the run logger into the handle, invokes **`onRun`** after tracking (sync throws and async rejections are logged, not fatal), and calls **`settleResult`** immediately after emitting the terminal result—before untrack or terminal status cleanup.
> 
> Child streams (bash/codex tabs) attach their run trace to the execution handle and **settle `result` in `finalizeChildStream`** before untracking, since they never go through the main lifecycle. Finalization now derives **completed / failed / cancelled** from terminal stream status (including **`STOPPED`** and preserved user stops), with failed outcomes carrying classified error details; the agent-CLI session loop passes **`STOPPED`** when the session is interrupted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffe38e463085efefeeae0d581d720ad6f64f39d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->