### PR TITLE
SDK 7d residues: scope desktop approval delete-all; document subagent-delivery / binder-queue

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -962,11 +962,11 @@ export class DesktopProgressBridge {
       cleanupApprovalsForStream(streamId, this.session);
       ToolUseFollowUpQueue.release(streamId);
     }
-    // Catch any pending approvals whose streamId was undefined (no concrete
-    // stream context) — the per-stream loop skips them because `undefined` ≠
-    // any StreamTabId. They are rare (every desktop agent runs in a stream),
-    // but without this they'd hang with no UI prompt left to answer.
-    cleanupUnscopedApprovals();
+    // Catch pending approvals with no concrete stream context (undefined or
+    // empty streamId) — the per-stream loop skips them because they do not
+    // equal any StreamTabId. Scope this to THIS window's runtime host so a
+    // sibling window's streamless approval is not rejected.
+    cleanupUnscopedApprovals(this.runtimeHost);
     // Child/subagent coordinator requests may be session-owned without a local
     // desktop stream entry, so clear the owning window's coordinator bridge
     // after the visible per-stream sweep. This is session-scoped and does not

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -64,6 +64,7 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import {
   cleanupApprovalsForStream,
+  cleanupUnscopedApprovals,
   handleProgressViewBashApprovalAction,
 } from '@tools/approval';
 import { GoalStore, isGoalInFlight } from '@tools/goal';
@@ -957,14 +958,15 @@ export class DesktopProgressBridge {
     // another window's pending approvals (the approval controllers are
     // process-global and streamId-keyed; the coordinator half is session-owned).
     for (const streamId of streamIds) {
-      cleanupApprovalsForStream(streamId, this.session);
-    }
-    for (const streamId of streamIds) {
       this.deletedStreams.add(streamId);
-    }
-    for (const streamId of streamIds) {
+      cleanupApprovalsForStream(streamId, this.session);
       ToolUseFollowUpQueue.release(streamId);
     }
+    // Catch any pending approvals whose streamId was undefined (no concrete
+    // stream context) — the per-stream loop skips them because `undefined` ≠
+    // any StreamTabId. They are rare (every desktop agent runs in a stream),
+    // but without this they'd hang with no UI prompt left to answer.
+    cleanupUnscopedApprovals();
     await GoalStore.forgetMany([...streamIds]);
     // Drop persisted ghosts too: a "delete all" should leave nothing
     // for the next launch to hydrate, otherwise users would see the

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -63,7 +63,6 @@ import { AgentCategory } from '@shared/schemas/agent';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import {
-  cleanupAllApprovals,
   cleanupApprovalsForStream,
   handleProgressViewBashApprovalAction,
 } from '@tools/approval';
@@ -948,12 +947,18 @@ export class DesktopProgressBridge {
   }
 
   async deleteAllStreams(): Promise<void> {
-    // Shared approval cleanup also owns retry/proposal/plan coordinator cleanup.
-    cleanupAllApprovals(this.session);
     const streamIds = new Set<StreamTabId>([
       ...this.streamLogs.keys(),
       ...this.restoredStreams.keys(),
     ]);
+    // Approval cleanup (incl. retry/proposal/plan coordinator state) is scoped
+    // to THIS window's streams via the per-stream helper, NOT the process-wide
+    // `cleanupAllApprovals` reset — so one window's "delete all" can't wipe
+    // another window's pending approvals (the approval controllers are
+    // process-global and streamId-keyed; the coordinator half is session-owned).
+    for (const streamId of streamIds) {
+      cleanupApprovalsForStream(streamId, this.session);
+    }
     for (const streamId of streamIds) {
       this.deletedStreams.add(streamId);
     }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -967,6 +967,11 @@ export class DesktopProgressBridge {
     // any StreamTabId. They are rare (every desktop agent runs in a stream),
     // but without this they'd hang with no UI prompt left to answer.
     cleanupUnscopedApprovals();
+    // Child/subagent coordinator requests may be session-owned without a local
+    // desktop stream entry, so clear the owning window's coordinator bridge
+    // after the visible per-stream sweep. This is session-scoped and does not
+    // touch sibling windows.
+    this.session.coordinators.cleanupAllRequests();
     await GoalStore.forgetMany([...streamIds]);
     // Drop persisted ghosts too: a "delete all" should leave nothing
     // for the next launch to hydrate, otherwise users would see the

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -91,6 +91,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
       this.pending.set(requestId, entry);
       registerPendingApproval(requestId, {
         streamId: request.streamId,
+        runtimeHost: this.options.runtimeHost,
         isSettled: () => settled,
         settle: (value) => this.settle(requestId, value),
       });

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -232,6 +232,7 @@ async function nativeRequestApproval(
       // Register with the pure module for rejection tracking
       registerPendingApproval(requestId, {
         streamId,
+        runtimeHost: getRuntimeHost(),
         isSettled: () => settled,
         settle,
       });

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -97,6 +97,12 @@ export class SessionHandle {
     this.interrupts = interrupts;
     this.executions = executions;
     this.coordinators = coordinators;
+    // INVARIANT (SDK Step 7d residue #9): this per-session binder reads the
+    // process-global, streamId-keyed `ToolUseFollowUpQueue` as its release
+    // source. That is coherent ONLY while the queue stays keyed by the globally-
+    // unique streamId — a session's release then touches only its own streams.
+    // If the queue is ever re-keyed (e.g. by sessionId+streamId), per-session
+    // cleanup silently breaks; the queue must move onto the session at that point.
     const subscriptions =
       init.subscriptions ??
       new ExecutionSubscriptionBinder({

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -49,6 +49,14 @@ type TestableBridge = Bridge & {
   };
 };
 
+type BridgeWithSession = TestableBridge & {
+  session: {
+    coordinators: {
+      cleanupAllRequests(): void;
+    };
+  };
+};
+
 type DesktopExecution = {
   handleExecute(message: unknown): Promise<void>;
   progress: Bridge;
@@ -1156,6 +1164,10 @@ describe('DesktopProgressBridge', () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_000);
     const messages: unknown[] = [];
     const bridge = await createBridge(messages);
+    const cleanupAllRequests = vi.spyOn(
+      (bridge as BridgeWithSession).session.coordinators,
+      'cleanupAllRequests',
+    );
 
     try {
       bridge.handleProgressEvent('setActiveStream', {
@@ -1179,6 +1191,7 @@ describe('DesktopProgressBridge', () => {
         streams: [],
         streamStates: {},
       });
+      expect(cleanupAllRequests).toHaveBeenCalledOnce();
     } finally {
       bridge.dispose();
     }

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { StreamTabId } from '@shared/schemas';
 import {
   cleanupApprovalsForStream,
-  setBashApprovalSessionBypass,
   isBashApprovalBypassedForStream,
+  setBashApprovalSessionBypass,
 } from '@tools/approval';
-import type { StreamTabId } from '@shared/schemas';
 
 const sid = (s: string): StreamTabId => s as StreamTabId;
 

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -1,0 +1,38 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  cleanupApprovalsForStream,
+  setBashApprovalSessionBypass,
+  isBashApprovalBypassedForStream,
+} from '@tools/approval';
+import type { StreamTabId } from '@shared/schemas';
+
+const sid = (s: string): StreamTabId => s as StreamTabId;
+
+describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
+  it("per-stream cleanup leaves another stream's approval state intact", () => {
+    const a = sid('s:appr-scope-a');
+    const b = sid('s:appr-scope-b');
+    setBashApprovalSessionBypass(a, true, noopAgentRuntimeHost, {
+      silent: true,
+    });
+    setBashApprovalSessionBypass(b, true, noopAgentRuntimeHost, {
+      silent: true,
+    });
+
+    try {
+      // A desktop window deleting its own stream `a` scopes the sweep to `a`
+      // (this is what `deleteAllStreams` loops, instead of the process-wide
+      // `cleanupAllApprovals` reset) — so a sibling window's stream `b` keeps
+      // its pending approval / bypass state.
+      cleanupApprovalsForStream(a);
+      expect(isBashApprovalBypassedForStream(a)).toBe(false);
+      expect(isBashApprovalBypassedForStream(b)).toBe(true);
+    } finally {
+      cleanupApprovalsForStream(b);
+    }
+  });
+});

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -2,15 +2,25 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  noopAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 import {
   cleanupApprovalsForStream,
+  cleanupUnscopedApprovals,
   isBashApprovalBypassedForStream,
   setBashApprovalSessionBypass,
 } from '@tools/approval';
+import { bashApprovalController } from '@tools/approval/bashApproval';
+import {
+  registerPendingApproval,
+  unregisterPendingApproval,
+} from '@tools/approval/toolEditApproval';
 
 const sid = (s: string): StreamTabId => s as StreamTabId;
+const host = (): AgentRuntimeHost => ({ emit: () => {} });
 
 describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
   it("per-stream cleanup leaves another stream's approval state intact", () => {
@@ -33,6 +43,52 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
       expect(isBashApprovalBypassedForStream(b)).toBe(true);
     } finally {
       cleanupApprovalsForStream(b);
+    }
+  });
+
+  it('scopes streamless cleanup to the owning runtime host', () => {
+    const hostA = host();
+    const hostB = host();
+    const settled = new Set<string>();
+    const createPending = (id: string, runtimeHost: AgentRuntimeHost) => {
+      let isSettled = false;
+      return {
+        streamId: '' as StreamTabId,
+        runtimeHost,
+        isSettled: () => isSettled,
+        settle: () => {
+          isSettled = true;
+          settled.add(id);
+        },
+      };
+    };
+
+    try {
+      registerPendingApproval('tool-a', createPending('tool-a', hostA));
+      registerPendingApproval('tool-b', createPending('tool-b', hostB));
+      bashApprovalController.registerPending(
+        'bash-a',
+        createPending('bash-a', hostA),
+      );
+      bashApprovalController.registerPending(
+        'bash-b',
+        createPending('bash-b', hostB),
+      );
+
+      cleanupUnscopedApprovals(hostA);
+
+      expect(settled).toEqual(new Set(['tool-a', 'bash-a']));
+
+      cleanupUnscopedApprovals();
+
+      expect(settled).toEqual(
+        new Set(['tool-a', 'bash-a', 'tool-b', 'bash-b']),
+      );
+    } finally {
+      unregisterPendingApproval('tool-a');
+      unregisterPendingApproval('tool-b');
+      bashApprovalController.unregisterPending('bash-a');
+      bashApprovalController.unregisterPending('bash-b');
     }
   });
 });

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -108,6 +108,7 @@ async function showApprovalPrompt(
 
       bashApprovalController.registerPending(requestId, {
         streamId,
+        runtimeHost,
         settle,
         isSettled: () => settled,
       });

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -15,6 +15,7 @@ import type { StreamTabId } from '@shared/schemas';
 import {
   _rejectAllPendingUserQuestions,
   _rejectPendingUserQuestionsForStream,
+  _rejectUnscopedUserQuestions,
 } from '@tools/userQuestion';
 
 import { bashApprovalController } from './bashApproval';
@@ -40,6 +41,24 @@ export function cleanupApprovalsForStream(
   bashApprovalController.bypass.clearForStream(streamId);
   proposalApprovalState.clearForStream(streamId);
   session.coordinators.cleanupRequestsForStream(streamId);
+}
+
+/**
+ * Reject pending tool-edit, bash, and user-question approvals that have no
+ * stream context (streamId is undefined). These would otherwise survive a
+ * per-stream {@link cleanupApprovalsForStream} loop because `undefined` ≠
+ * any concrete StreamTabId, only {@link cleanupAllApprovals} catches them.
+ * Bypass, proposal, and coordinator state are always streamId-keyed and are
+ * not affected here.
+ *
+ * Desktop `deleteAllStreams` calls this after the per-stream sweep so that
+ * an approval emitted without a concrete stream (rare, but the schema allows
+ * it) is rejected rather than left pending with no UI prompt to answer.
+ */
+export function cleanupUnscopedApprovals(): void {
+  toolEditApprovalController.rejectUnscopedPending();
+  bashApprovalController.rejectUnscopedPending();
+  _rejectUnscopedUserQuestions();
 }
 
 /**

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -43,12 +43,16 @@ export function cleanupApprovalsForStream(
 }
 
 /**
- * Clean up all approval state when deleting all streams.
- * Handles pending approvals (tool edits + bash), plan approvals, and YOLO mode state.
+ * PROCESS-WIDE reset of all approval state — rejects every pending tool-edit /
+ * bash / user-question approval, clears all bypass + proposal state, and clears
+ * `session`'s coordinator requests.
  *
- * The bridge half is scoped to `session` (its `activeCoordinators()` enumerates
- * only that session's handles); the tool/bypass controllers remain process-wide
- * (documented residue — they are not yet per-session).
+ * The tool/bypass controllers are process-global and streamId-keyed, so this
+ * `clearAll` touches EVERY session's streams. Safe only for single-session
+ * hosts (the extension's default session), test reset, and process shutdown.
+ * A MULTI-SESSION host (e.g. a desktop window) must NOT use this to delete its
+ * own streams — it would wipe sibling windows' pending approvals; it scopes the
+ * sweep to its own streams by looping {@link cleanupApprovalsForStream} instead.
  */
 export function cleanupAllApprovals(
   session: SessionHandle = defaultSession(),

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -11,6 +11,7 @@ import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 import {
   _rejectAllPendingUserQuestions,
@@ -45,20 +46,21 @@ export function cleanupApprovalsForStream(
 
 /**
  * Reject pending tool-edit, bash, and user-question approvals that have no
- * stream context (streamId is undefined). These would otherwise survive a
- * per-stream {@link cleanupApprovalsForStream} loop because `undefined` ≠
- * any concrete StreamTabId, only {@link cleanupAllApprovals} catches them.
- * Bypass, proposal, and coordinator state are always streamId-keyed and are
- * not affected here.
+ * concrete stream context (streamId is undefined or empty). These would
+ * otherwise survive a per-stream {@link cleanupApprovalsForStream} loop
+ * because they do not equal any concrete StreamTabId, only
+ * {@link cleanupAllApprovals} catches them. Bypass, proposal, and coordinator
+ * state are always streamId-keyed and are not affected here.
  *
  * Desktop `deleteAllStreams` calls this after the per-stream sweep so that
- * an approval emitted without a concrete stream (rare, but the schema allows
- * it) is rejected rather than left pending with no UI prompt to answer.
+ * an approval emitted without a concrete stream is rejected rather than left
+ * pending with no UI prompt to answer. Multi-session hosts pass their own
+ * `runtimeHost` so sibling windows' streamless approvals stay intact.
  */
-export function cleanupUnscopedApprovals(): void {
-  toolEditApprovalController.rejectUnscopedPending();
-  bashApprovalController.rejectUnscopedPending();
-  _rejectUnscopedUserQuestions();
+export function cleanupUnscopedApprovals(runtimeHost?: AgentRuntimeHost): void {
+  toolEditApprovalController.rejectUnscopedPending(runtimeHost);
+  bashApprovalController.rejectUnscopedPending(runtimeHost);
+  _rejectUnscopedUserQuestions(runtimeHost);
 }
 
 /**

--- a/src/tools/approval/streamApprovalQueue.ts
+++ b/src/tools/approval/streamApprovalQueue.ts
@@ -97,6 +97,8 @@ export interface StreamApprovalController<R extends { accepted: boolean }> {
   bypass: StreamApprovalBypass;
   enqueue<T>(run: () => Promise<T>): Promise<T>;
   rejectPendingForStream(streamId: StreamTabId): void;
+  /** Reject pending entries whose streamId is undefined (no stream context). */
+  rejectUnscopedPending(): void;
   rejectAllPending(): void;
 }
 
@@ -141,6 +143,13 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
     },
     rejectPendingForStream(streamId) {
       rejectMatching(streamId);
+    },
+    rejectUnscopedPending() {
+      for (const entry of pending.values()) {
+        if (!entry.streamId && !entry.isSettled()) {
+          entry.settle(options.rejectionResult());
+        }
+      }
     },
     rejectAllPending() {
       rejectMatching();

--- a/src/tools/approval/streamApprovalQueue.ts
+++ b/src/tools/approval/streamApprovalQueue.ts
@@ -86,6 +86,7 @@ export function createStreamApprovalBypass(
 
 export interface PendingApproval<R extends { accepted: boolean }> {
   streamId?: StreamTabId;
+  runtimeHost?: AgentRuntimeHost;
   isSettled: () => boolean;
   settle: (result: R) => void;
 }
@@ -97,8 +98,11 @@ export interface StreamApprovalController<R extends { accepted: boolean }> {
   bypass: StreamApprovalBypass;
   enqueue<T>(run: () => Promise<T>): Promise<T>;
   rejectPendingForStream(streamId: StreamTabId): void;
-  /** Reject pending entries whose streamId is undefined (no stream context). */
-  rejectUnscopedPending(): void;
+  /**
+   * Reject pending entries with no concrete stream context. When `runtimeHost`
+   * is provided, only rejects entries owned by that host.
+   */
+  rejectUnscopedPending(runtimeHost?: AgentRuntimeHost): void;
   rejectAllPending(): void;
 }
 
@@ -144,9 +148,13 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
     rejectPendingForStream(streamId) {
       rejectMatching(streamId);
     },
-    rejectUnscopedPending() {
+    rejectUnscopedPending(runtimeHost) {
       for (const entry of pending.values()) {
-        if (!entry.streamId && !entry.isSettled()) {
+        if (
+          !entry.streamId &&
+          !entry.isSettled() &&
+          (runtimeHost === undefined || entry.runtimeHost === runtimeHost)
+        ) {
           entry.settle(options.rejectionResult());
         }
       }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -75,6 +75,7 @@ export function registerPendingApproval(
   id: string,
   entry: {
     streamId?: StreamTabId;
+    runtimeHost?: AgentRuntimeHost;
     isSettled: () => boolean;
     settle: (result: ToolEditApprovalResult) => void;
   },

--- a/src/tools/subagentDeliveryState.ts
+++ b/src/tools/subagentDeliveryState.ts
@@ -83,4 +83,12 @@ export const SUBAGENT_DELIVERY_DECISION = {
 export type SubagentDeliveryDecision =
   (typeof SUBAGENT_DELIVERY_DECISION)[keyof typeof SUBAGENT_DELIVERY_DECISION];
 
+/**
+ * Process-shared by design (SDK Step 7d): keyed by globally-unique executionId
+ * with no cross-session sweep (`start`/`getActive`/`finish` touch one entry),
+ * so concurrent delegations from different sessions never collide or wipe each
+ * other — the same rationale as the shared `StreamStatusService`. Not composed
+ * onto `SessionHandle`: a per-session split would be net-add with zero isolation
+ * gain. Revisit only if a cross-session `clearAll`-style sweep is ever added.
+ */
 export const subagentDeliveryRegistry = new SubagentDeliveryRegistry();

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { createChannelTrace } from '@logger';
 import {
@@ -41,6 +42,7 @@ const pendingQuestions = new Map<
   string,
   {
     streamId?: StreamTabId;
+    runtimeHost?: AgentRuntimeHost;
     settle: (result: UserQuestionResult) => void;
     isSettled: () => boolean;
   }
@@ -49,12 +51,9 @@ const pendingQuestions = new Map<
 async function awaitUserQuestionResponse(params: {
   requestId: string;
   input: AskUserQuestionInput;
+  runtimeHost: AgentRuntimeHost;
   streamId?: StreamTabId;
 }): Promise<UserQuestionResult> {
-  const runtimeHost = requireRuntimeHost(
-    'ask_user_question',
-    tryUseRunContext(),
-  );
   return new Promise<UserQuestionResult>((resolve) => {
     let settled = false;
     const settle = (result: UserQuestionResult) => {
@@ -65,15 +64,16 @@ async function awaitUserQuestionResponse(params: {
 
     pendingQuestions.set(params.requestId, {
       streamId: params.streamId,
+      runtimeHost: params.runtimeHost,
       settle,
       isSettled: () => settled,
     });
 
-    runtimeHost.emit('requestEnsureProgressView', {});
+    params.runtimeHost.emit('requestEnsureProgressView', {});
     if (params.streamId) {
-      runtimeHost.emit('setActiveStream', { streamId: params.streamId });
+      params.runtimeHost.emit('setActiveStream', { streamId: params.streamId });
     }
-    runtimeHost.emit('showUserQuestion', {
+    params.runtimeHost.emit('showUserQuestion', {
       requestId: params.requestId,
       questions: params.input.questions,
       context: params.input.context ?? undefined,
@@ -119,10 +119,16 @@ export function _rejectAllPendingUserQuestions(): void {
   }
 }
 
-/** @internal Called by unified cleanup for unscoped (streamId-less) approvals. */
-export function _rejectUnscopedUserQuestions(): void {
+/** @internal Called by unified cleanup for questions with no concrete stream. */
+export function _rejectUnscopedUserQuestions(
+  runtimeHost?: AgentRuntimeHost,
+): void {
   for (const entry of pendingQuestions.values()) {
-    if (!entry.streamId && !entry.isSettled()) {
+    if (
+      !entry.streamId &&
+      !entry.isSettled() &&
+      (runtimeHost === undefined || entry.runtimeHost === runtimeHost)
+    ) {
       entry.settle({ submitted: false });
     }
   }
@@ -151,6 +157,7 @@ The tool returns a JSON object whose keys are the original question texts and wh
       const result = await awaitUserQuestionResponse({
         requestId,
         input,
+        runtimeHost,
         streamId,
       });
 

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -119,6 +119,15 @@ export function _rejectAllPendingUserQuestions(): void {
   }
 }
 
+/** @internal Called by unified cleanup for unscoped (streamId-less) approvals. */
+export function _rejectUnscopedUserQuestions(): void {
+  for (const entry of pendingQuestions.values()) {
+    if (!entry.streamId && !entry.isSettled()) {
+      entry.settle({ submitted: false });
+    }
+  }
+}
+
 export class AskUserQuestionTool extends defineTool({
   name: 'ask_user_question',
   description: `Ask the user one to three short clarification questions and wait for their answers.

--- a/src/tools/userQuestion/index.ts
+++ b/src/tools/userQuestion/index.ts
@@ -3,4 +3,5 @@ export {
   handleUserQuestionAction,
   _rejectAllPendingUserQuestions,
   _rejectPendingUserQuestionsForStream,
+  _rejectUnscopedUserQuestions,
 } from './UserQuestionTool';


### PR DESCRIPTION
Recovered on top of current `main` after #5962 landed, keeping only the residue cleanup commits plus the review fix for session-owned coordinator cleanup.

## Summary

- scope desktop `deleteAllStreams` approval cleanup to this window's streams instead of using the process-wide approval reset
- reject rare unscoped pending approvals after the per-stream sweep so prompts without a stream context do not hang
- clear the owning desktop window's session coordinator bridge on delete-all, covering child/subagent retry/plan/proposal requests that are not in the visible stream list
- document why `subagentDeliveryRegistry` intentionally remains process-wide and executionId-keyed
- document the invariant that `ExecutionSubscriptionBinder` depends on the streamId-keyed `ToolUseFollowUpQueue`

## Verification

- `corepack pnpm exec prettier --write packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/agent/runtime/SessionHandle.ts src/tools/approval/index.ts src/tools/subagentDeliveryState.ts src/test-kernel/tools/ApprovalCleanupScope.vitest.ts`
- `corepack pnpm exec eslint packages/desktop/src/main/desktopAgentExecution.ts src/agent/runtime/SessionHandle.ts src/tools/approval/index.ts src/tools/subagentDeliveryState.ts src/test-kernel/tools/ApprovalCleanupScope.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/tools/ApprovalCleanupScope.vitest.ts src/test-kernel/agent/runtime/SessionHandle.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process-global approval cleanup paths used on stream deletion; incorrect scoping could leave hung prompts or still affect sibling windows, though new tests target the multi-window case.
> 
> **Overview**
> Fixes **multi-window desktop** behavior where one window’s **delete all streams** used the process-wide `cleanupAllApprovals` reset and could reject pending tool/bash/user-question prompts (and related state) for **other** windows.
> 
> **Desktop `deleteAllStreams`** now loops `cleanupApprovalsForStream` only for this window’s stream IDs, then calls new **`cleanupUnscopedApprovals(this.runtimeHost)`** for pending approvals with no stream context, and **`session.coordinators.cleanupAllRequests()`** for session-owned coordinator state (retry/plan/proposal) that may not appear in the local stream list.
> 
> **Approval plumbing** adds optional **`runtimeHost`** on pending entries (bash, tool-edit, user questions) and **`rejectUnscopedPending`** on the shared stream approval controller, wired through `@tools/approval/index.ts`. Docs clarify when **`cleanupAllApprovals`** is safe (single-session / shutdown) vs per-window sweeps.
> 
> Adds **`ApprovalCleanupScope`** tests and asserts coordinator cleanup on desktop delete-all; documents SDK 7d invariants on **`ToolUseFollowUpQueue`** / **`subagentDeliveryRegistry`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023cc50e53fb2f104fac68623b8e14bc33b7169c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->