### PR TITLE
SDK 7d T2-2/T3-2: consolidate result.error onto the structured ProviderErrorPartial shape

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,7 +74,7 @@ export {
   AgentFlowResultSchema,
   type WorkflowFlowResult,
 } from '@agent/runtime/AgentFlowResult';
-// Per-run control handle (F-2): the run's live handle, exposed via `onRun`.
+// Per-run control handle: the run's live handle, exposed via `onRun`.
 // Its `.result` promise settles with the terminal `ResultEvent` (always
 // resolves), and `.trace` is the run's discriminated-event channel.
 export { type AgentExecutionHandle } from '@agent/runtime/executionRegistry';

--- a/packages/extension/src/frontend/agents/remoteAgentUtils.ts
+++ b/packages/extension/src/frontend/agents/remoteAgentUtils.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 
 import { createKey, getAgent, type AgentSource } from '@agent/index';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -54,8 +53,9 @@ export async function selectAgentInMainView(
     }
 
     const entry = getAgent(agentValue);
-    const sessionType =
-      entry?.category === AgentCategory.ToolUse ? 'toolUse' : 'workflow';
+    // `category` is the `'toolUse' | 'workflow'` union; default to workflow when
+    // the agent isn't resolvable.
+    const sessionType = entry?.category ?? 'workflow';
 
     logger.info(
       CHANNEL,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -5,7 +5,6 @@ import {
 import { platform } from '@platform/platform';
 import { writeTerminalStatus } from '@agent/storage';
 import { logSdkError, type ResultEvent } from '@agent/trace';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   AGENT_ERROR_OUTCOME,
   AgentError,
@@ -14,7 +13,6 @@ import {
   normalizeProviderError,
   type AgentErrorKind,
 } from '@common/errors';
-import type { ProviderErrorPartial } from '@shared/schemas/errors';
 import { projectRunOutcome } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
@@ -23,6 +21,7 @@ import {
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
+import type { ProviderErrorPartial } from '@shared/schemas/errors';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { agentName as baseAgentName } from '@shared/schemas/agent';
 
@@ -135,10 +134,8 @@ export async function runFlowWithLifecycle(
 ): Promise<AgentFlowResult> {
   const { streamId, session } = ctx;
   const agentIdentifier = ctx.config.agent;
-  const category =
-    ctx.setting.agentCategory === AgentCategory.ToolUse
-      ? 'toolUse'
-      : 'workflow';
+  // `AgentCategory` IS the `'toolUse' | 'workflow'` union, so no remap needed.
+  const category = ctx.setting.agentCategory;
   const parentStreamId = options?.parentStreamId ?? streamId;
   const handle = new AgentExecutionHandle(
     ctx.executionId,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -71,12 +71,19 @@ function buildResultError(
   message: string,
 ): ResultError {
   const pe = normalizeProviderError(err);
+  // `missing-api-key` means the user hasn't configured credentials — retrying
+  // won't help.  Override the bare-Error default (userRetryable=true from the
+  // unrecognized-error path in normalizeProviderError) so SDK consumers that
+  // gate retry UI on userRetryable surface key setup instead of a retry button.
+  const userRetryable =
+    kind === 'missing-api-key' ? false : pe.userRetryable;
   return {
     kind,
     message,
-    userRetryable: pe.userRetryable,
+    userRetryable,
     isRelayError: pe.isRelayError,
     ...(pe.statusCode !== undefined && { statusCode: pe.statusCode }),
+    ...(pe.statusText !== undefined && { statusText: pe.statusText }),
     ...(pe.provider !== undefined && { provider: pe.provider }),
     ...(pe.requestId !== undefined && { requestId: pe.requestId }),
     ...(pe.isCredentialExhausted !== undefined && {

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -11,8 +11,10 @@ import {
   AgentError,
   classifyAgentError,
   getSdkErrorMessage,
+  normalizeProviderError,
   type AgentErrorKind,
 } from '@common/errors';
+import type { ProviderErrorPartial } from '@shared/schemas/errors';
 import { projectRunOutcome } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
@@ -54,6 +56,37 @@ function toResultOutcome(outcome: RunOutcome): ResultEvent['outcome'] {
   return 'failed';
 }
 
+type ResultError = { kind: AgentErrorKind } & ProviderErrorPartial;
+
+/**
+ * Build the `result` event's structured error from a caught error: the
+ * classified `kind` + the event-safe fields recovered by
+ * `normalizeProviderError` (T2-2/T3-2). Fully populated when the error reaches
+ * the boundary tagged; for a bare-`Error` flow failure only `message` and the
+ * always-set `userRetryable`/`isRelayError` are present until the T2-2 flow-seam
+ * attach lands. Excludes `rawErrorBody`/`streamDiagnostics` (event bloat).
+ */
+function buildResultError(
+  err: unknown,
+  kind: AgentErrorKind,
+  message: string,
+): ResultError {
+  const pe = normalizeProviderError(err);
+  return {
+    kind,
+    message,
+    userRetryable: pe.userRetryable,
+    isRelayError: pe.isRelayError,
+    ...(pe.statusCode !== undefined && { statusCode: pe.statusCode }),
+    ...(pe.provider !== undefined && { provider: pe.provider }),
+    ...(pe.requestId !== undefined && { requestId: pe.requestId }),
+    ...(pe.isCredentialExhausted !== undefined && {
+      isCredentialExhausted: pe.isCredentialExhausted,
+    }),
+    ...(pe.partialText !== undefined && { partialText: pe.partialText }),
+  };
+}
+
 /**
  * Emit the terminal `result` event on the run's trace — the single emission
  * boundary for run outcomes. Carries the classified error `kind` (when any) and
@@ -65,7 +98,7 @@ function emitRunResult(
   category: 'toolUse' | 'workflow',
   outcome: ResultEvent['outcome'],
   isSubagent: boolean,
-  error?: { kind: AgentErrorKind; message?: string },
+  error?: ResultError,
 ): ResultEvent {
   const usage = ctx.usageMonitor.lastTotals();
   const event: ResultEvent = {
@@ -241,7 +274,11 @@ export async function runFlowWithLifecycle(
           category,
           toResultOutcome(outcome),
           options?.isSubagent ?? false,
-          { kind, message: kind === 'unexpected' ? errorMsg : sdkMsg },
+          buildResultError(
+            err,
+            kind,
+            kind === 'unexpected' ? errorMsg : sdkMsg,
+          ),
         ),
       );
     }

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -18,10 +18,10 @@ import { createChannelTrace } from '@logger';
 import {
   RUN_OUTCOME,
   STREAM_STATUS,
+  type ProviderErrorPartial,
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
-import type { ProviderErrorPartial } from '@shared/schemas/errors';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { agentName as baseAgentName } from '@shared/schemas/agent';
 
@@ -41,7 +41,7 @@ export interface RunFlowLifecycleOptions {
   onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
   onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;
   /**
-   * Fires once with the live per-run handle, right after it is tracked (F-2) —
+   * Fires once with the live per-run handle, right after it is tracked —
    * the additive exposure of the control handle (`.trace`, `.result`, interrupt
    * via `executions`). Throwing here must not abort the run, so it is guarded.
    */
@@ -75,8 +75,7 @@ function buildResultError(
   // won't help.  Override the bare-Error default (userRetryable=true from the
   // unrecognized-error path in normalizeProviderError) so SDK consumers that
   // gate retry UI on userRetryable surface key setup instead of a retry button.
-  const userRetryable =
-    kind === 'missing-api-key' ? false : pe.userRetryable;
+  const userRetryable = kind === 'missing-api-key' ? false : pe.userRetryable;
   return {
     kind,
     message,
@@ -155,7 +154,7 @@ export async function runFlowWithLifecycle(
     ctx.logger,
   );
   session.executions.track(handle);
-  // Expose the live handle to the launcher (F-2). Guarded: neither a synchronous
+  // Expose the live handle to the launcher. Guarded: neither a synchronous
   // throw nor an async rejection from a consumer callback may abort the run.
   if (options?.onRun) {
     try {
@@ -213,7 +212,7 @@ export async function runFlowWithLifecycle(
     ctx.parentStage.end(projection.endGroupStatus);
     // Emit the terminal result BEFORE untrack so the registry's terminal
     // listener event never precedes the result event, and settle the handle's
-    // `result` promise with the same event (F-2: per-run control handle).
+    // `result` promise with the same event.
     handle.settleResult(
       emitRunResult(
         ctx,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -83,6 +83,9 @@ function buildResultError(
     ...(pe.isCredentialExhausted !== undefined && {
       isCredentialExhausted: pe.isCredentialExhausted,
     }),
+    ...(pe.isUpstreamCreditDepleted !== undefined && {
+      isUpstreamCreditDepleted: pe.isUpstreamCreditDepleted,
+    }),
     ...(pe.partialText !== undefined && { partialText: pe.partialText }),
   };
 }

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -224,7 +224,7 @@ export function getAllActiveExecutionIds(): string[] {
   for (const id of orphanedActiveExecutions) {
     if (live.has(id)) orphanedActiveExecutions.delete(id);
   }
-  return [...new Set([...orphanedActiveExecutions, ...live])];
+  return [...orphanedActiveExecutions, ...live];
 }
 
 let cachedDefaultSession: SessionHandle | undefined;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -254,7 +254,7 @@ export interface ExecuteAgentOptions {
   onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
   /** Fires when a subagent fails and should report the failure to its orchestrator. */
   onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;
-  /** Fires once with the live per-run handle right after it is tracked (F-2). */
+  /** Fires once with the live per-run handle right after it is tracked. */
   onRun?: (handle: AgentExecutionHandle) => void;
 }
 

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -20,7 +20,7 @@ export interface RunAgentOptions {
   /** Session owning this run's coordination state. Defaults to the process session. */
   session?: SessionHandle;
   /**
-   * Fires once with the live per-run handle right after it is tracked (F-2):
+   * Fires once with the live per-run handle right after it is tracked:
    * `handle.result` settles with the terminal outcome, `handle.trace` is the
    * run's event channel, and the handle can interrupt via the session. The
    * returned promise is unchanged — this is additive, post-launch exposure.

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -10,8 +10,7 @@
  */
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentErrorKind } from '@common/errors';
-import type { EndGroupStatus } from '@shared/schemas';
-import type { ProviderErrorPartial } from '@shared/schemas/errors';
+import type { EndGroupStatus, ProviderErrorPartial } from '@shared/schemas';
 
 /** Status assigned to a tool call when it completes. */
 export type ToolStatus = 'completed' | 'failed' | 'in_progress';
@@ -179,7 +178,9 @@ export interface ResultEvent extends StageStamp {
   readonly agentName: string;
   readonly category: 'toolUse' | 'workflow';
   readonly isSubagent: boolean;
-  readonly error?: { readonly kind: AgentErrorKind } & Readonly<ProviderErrorPartial>;
+  readonly error?: {
+    readonly kind: AgentErrorKind;
+  } & Readonly<ProviderErrorPartial>;
   readonly usage?: RunUsageTotals;
 }
 

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -179,7 +179,7 @@ export interface ResultEvent extends StageStamp {
   readonly agentName: string;
   readonly category: 'toolUse' | 'workflow';
   readonly isSubagent: boolean;
-  readonly error?: { readonly kind: AgentErrorKind } & ProviderErrorPartial;
+  readonly error?: { readonly kind: AgentErrorKind } & Readonly<ProviderErrorPartial>;
   readonly usage?: RunUsageTotals;
 }
 

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -11,6 +11,7 @@
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentErrorKind } from '@common/errors';
 import type { EndGroupStatus } from '@shared/schemas';
+import type { ProviderErrorPartial } from '@shared/schemas/errors';
 
 /** Status assigned to a tool call when it completes. */
 export type ToolStatus = 'completed' | 'failed' | 'in_progress';
@@ -160,10 +161,15 @@ export interface DomainEvent extends StageStamp {
  * Terminal run outcome as data — emitted exactly once at the run-lifecycle
  * boundary (`runFlowWithLifecycle`), never from flows or the bus. `cancelled`
  * is a sibling of `failed` (a user interrupt is not a failure). `error.kind` is
- * the classified terminal-error discriminant; the optional `RetryErrorInfo`
- * enrichment is deferred to the error-pipeline T2-2 work, so the shape carries
- * only what is genuinely populated today. `usage` is the run totals (present
- * once at least one round recorded usage, including on failures).
+ * the classified terminal-error discriminant; the rest of `error` reuses the
+ * structured {@link ProviderErrorPartial} shape (statusCode / provider /
+ * requestId / partialText / isCredentialExhausted / isRelayError / userRetryable
+ * — all optional), populated best-effort from `normalizeProviderError` at the
+ * boundary. It is FULLY populated for errors that reach the boundary tagged;
+ * flow failures currently rethrow a bare `Error`, so for those only `message`
+ * (and the always-set `userRetryable` / `isRelayError`) are present until the
+ * T2-2 flow-seam attach lands. `usage` is the run totals (present once at least
+ * one round recorded usage, including on failures).
  */
 export interface ResultEvent extends StageStamp {
   readonly type: 'result';
@@ -173,7 +179,7 @@ export interface ResultEvent extends StageStamp {
   readonly agentName: string;
   readonly category: 'toolUse' | 'workflow';
   readonly isSubagent: boolean;
-  readonly error?: { readonly kind: AgentErrorKind; readonly message?: string };
+  readonly error?: { readonly kind: AgentErrorKind } & ProviderErrorPartial;
   readonly usage?: RunUsageTotals;
 }
 

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -246,6 +246,28 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     }
   });
 
+  it('carries the structured ProviderErrorPartial fields on result.error (T2-2/T3-2)', async () => {
+    const logger = new TraceEmitter();
+    const results = collectResults(logger);
+    const { ctx, streamStatus } = createCtx({ logger });
+    try {
+      await expect(
+        runFlowWithLifecycle(ctx, async () => {
+          throw new Error('provider exploded');
+        }),
+      ).rejects.toThrow('provider exploded');
+      const err = results[0].error;
+      expect(err?.kind).toBeDefined();
+      expect(typeof err?.message).toBe('string');
+      // `result.error` reuses the structured ProviderErrorPartial shape — the
+      // always-set fields are present even for a bare-Error failure.
+      expect(typeof err?.userRetryable).toBe('boolean');
+      expect(typeof err?.isRelayError).toBe('boolean');
+    } finally {
+      streamStatus.clear(ctx.streamId, { emit: false });
+    }
+  });
+
   it('maps a returned cancellation to a cancelled result (sibling of failed)', async () => {
     const logger = new TraceEmitter();
     const results = collectResults(logger);

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -263,6 +263,44 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
       // always-set fields are present even for a bare-Error failure.
       expect(typeof err?.userRetryable).toBe('boolean');
       expect(typeof err?.isRelayError).toBe('boolean');
+      // A bare Error without provider metadata: userRetryable defaults to true
+      // (unrecognized error path) and isRelayError is false.
+      expect(err?.userRetryable).toBe(true);
+      expect(err?.isRelayError).toBe(false);
+    } finally {
+      streamStatus.clear(ctx.streamId, { emit: false });
+    }
+  });
+
+  it('fully populates result.error for a provider-tagged error (T2-2/T3-2)', async () => {
+    const { normalizeProviderError } = await import('@common/errors');
+    const logger = new TraceEmitter();
+    const results = collectResults(logger);
+    const { ctx, streamStatus } = createCtx({ logger });
+    try {
+      // Simulate a provider-boundary error: attach structured metadata via
+      // normalizeProviderError (as provider adapters do), then throw it so
+      // buildResultError detects the cached ProviderError and forwards the
+      // full set of event-safe fields.
+      const tagged = Object.assign(new Error('Too Many Requests'), {
+        statusCode: 429,
+        name: 'APIConnectionError',
+      });
+      normalizeProviderError(tagged);
+      await expect(
+        runFlowWithLifecycle(ctx, async () => {
+          throw tagged;
+        }),
+      ).rejects.toThrow('Too Many Requests');
+      const err = results[0].error;
+      expect(err?.kind).toBeDefined();
+      expect(err?.statusCode).toBe(429);
+      expect(typeof err?.statusText).toBe('string');
+      expect(err?.userRetryable).toBe(true); // HTTP 429 is retryable
+      expect(err?.isRelayError).toBe(false);
+      // Conditional fields not set for a non-relay 429 from a generic provider.
+      expect(err?.isCredentialExhausted).toBeUndefined();
+      expect(err?.isUpstreamCreditDepleted).toBeUndefined();
     } finally {
       streamStatus.clear(ctx.streamId, { emit: false });
     }

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -181,7 +181,7 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   const outcome =
     hasError || finalStatus === STREAM_STATUS.ERROR ? 'failed' : 'completed';
 
-  // Settle the handle's `result` before untracking (F-2): child streams never
+  // Settle the handle's `result` before untracking: child streams never
   // traverse the run lifecycle, so this is their only settle point. Without it
   // a consumer awaiting a child handle's `result` would hang forever.
   handle.settleResult({

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -145,7 +145,6 @@ async function update(
   if (!goal) return null;
   const final: Goal = { ...mutate(goal), updatedAt: nowIso() };
   await writeRaw(final);
-  // In-run: the active run's host (ALS), falling back to the bus.
   emitRuntimeEvent('goalStateChanged', { streamId });
   return final;
 }


### PR DESCRIPTION
## Summary

**SDK Step 7d follow-on T2-2/T3-2 (scoped): consolidate `result.error` onto the structured error shape.** Stacked on #5964 (multi-window) → … → #5960 (7d).

`ResultEvent.error` was an ad-hoc `{ kind, message? }`, while the codebase already had a full structured shape — `ProviderErrorPartial` (statusCode / provider / requestId / partialText / isCredentialExhausted / isRelayError / userRetryable, all optional, *"for event transport"*) — plus `normalizeProviderError(err)` to recover it. **Same concept, two shapes.** Consolidated:

- `ResultEvent.error` is now `{ kind: AgentErrorKind } & ProviderErrorPartial` — one structured error type, reused, so SDK consumers can build retry UI off `statusCode` / `requestId` / `isCredentialExhausted` instead of re-sniffing `message`.
- The lifecycle catch arm populates it via `buildResultError(err, kind, msg)` (`normalizeProviderError` + the event-safe fields; excludes `rawErrorBody` / `streamDiagnostics`). **Message text unchanged** (kept `getSdkErrorMessage`) → additive, no behavior change for existing consumers (`terminalResultToast` still reads `kind`/`message`).

## Scope (honest)

Fully populated for errors that reach the boundary **tagged**; flow failures still rethrow a bare `Error` (`runReflectionFlow.ts:297`, `runToolUseFlow.ts`), so for those only `message` + the always-set `userRetryable`/`isRelayError` are present. The **full T2-2** — widen the persisted `RetryErrorInfo`, reconstruct/attach the structured shape at the two flow-exit rethrows, and gate the duplicate ERROR rows — is the medium-risk, persistence-touching remainder (`PersistedFlow` structuredClones shared state; the design doc is trap-dense). It's deferred to a focused pass rather than rushed at the end of a long session; it's what makes flow failures carry the full shape. This PR lands the type consolidation + the safe best-effort enrichment.

## Tests / verification

- `SessionResultEvent.vitest.ts`: `result.error` carries the structured fields.
- root + test-kernel + extension + CLI + desktop typecheck clean; full suite **451 files / 3125** (the lone red is the pre-existing flaky `TextConnectionHelperModel`, untouched — passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public SDK `ResultEvent.error` contract and terminal error enrichment at the run boundary; behavior for existing `kind`/`message` consumers should stay compatible, but new fields and `userRetryable` overrides affect retry UI logic.
> 
> **Overview**
> **`ResultEvent.error`** is now `{ kind: AgentErrorKind } & ProviderErrorPartial` instead of `{ kind, message? }`, so SDK consumers can drive retry UI from `statusCode`, `requestId`, `userRetryable`, and related fields without parsing `message`.
> 
> Run lifecycle failures populate that shape via **`buildResultError`**, which merges classified `kind` with event-safe fields from **`normalizeProviderError`** (omitting `rawErrorBody` / `streamDiagnostics`). **`missing-api-key`** forces **`userRetryable: false`** so hosts steer users to credential setup. Tagged provider errors get fuller metadata; bare `Error` throws still only expose `message` plus the always-set retry/relay flags until a later flow-seam attach.
> 
> Smaller cleanups: **`remoteAgentUtils`** uses `entry?.category ?? 'workflow'` directly; **`AgentRunLifecycle`** uses `ctx.setting.agentCategory` without remapping; **`getAllActiveExecutionIds`** drops a redundant `Set` dedupe; comment-only F-2 label trims elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10efa63f3e7f3ec11187b1f74a9233eb7ae84a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->