### PR TITLE
SDK 7d polish: consolidate redundant AgentCategory→string remaps

### DIFF
--- a/packages/extension/src/frontend/agents/remoteAgentUtils.ts
+++ b/packages/extension/src/frontend/agents/remoteAgentUtils.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 
 import { createKey, getAgent, type AgentSource } from '@agent/index';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -54,8 +53,9 @@ export async function selectAgentInMainView(
     }
 
     const entry = getAgent(agentValue);
-    const sessionType =
-      entry?.category === AgentCategory.ToolUse ? 'toolUse' : 'workflow';
+    // `category` is the `'toolUse' | 'workflow'` union; default to workflow when
+    // the agent isn't resolvable.
+    const sessionType = entry?.category ?? 'workflow';
 
     logger.info(
       CHANNEL,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -5,7 +5,6 @@ import {
 import { platform } from '@platform/platform';
 import { writeTerminalStatus } from '@agent/storage';
 import { logSdkError, type ResultEvent } from '@agent/trace';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   AGENT_ERROR_OUTCOME,
   AgentError,
@@ -14,7 +13,6 @@ import {
   normalizeProviderError,
   type AgentErrorKind,
 } from '@common/errors';
-import type { ProviderErrorPartial } from '@shared/schemas/errors';
 import { projectRunOutcome } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
@@ -23,6 +21,7 @@ import {
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
+import type { ProviderErrorPartial } from '@shared/schemas/errors';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { agentName as baseAgentName } from '@shared/schemas/agent';
 
@@ -135,10 +134,8 @@ export async function runFlowWithLifecycle(
 ): Promise<AgentFlowResult> {
   const { streamId, session } = ctx;
   const agentIdentifier = ctx.config.agent;
-  const category =
-    ctx.setting.agentCategory === AgentCategory.ToolUse
-      ? 'toolUse'
-      : 'workflow';
+  // `AgentCategory` IS the `'toolUse' | 'workflow'` union, so no remap needed.
+  const category = ctx.setting.agentCategory;
   const parentStreamId = options?.parentStreamId ?? streamId;
   const handle = new AgentExecutionHandle(
     ctx.executionId,


### PR DESCRIPTION
## Summary

**SDK Step 7d follow-on: polish — consolidate redundant `AgentCategory`→string remaps.** Final stage of the sequence. Stacked on #5965 (T2-2/T3-2) → … → #5960 (7d).

`AgentCategory` **is** the `'toolUse' | 'workflow'` union (`const AgentCategory = { Workflow: 'workflow', ToolUse: 'toolUse' }`), so `x === AgentCategory.ToolUse ? 'toolUse' : 'workflow'` re-derives `x` itself — the same value in two forms.

- `AgentRunLifecycle`: `const category = ctx.setting.agentCategory` (drops the ternary + the now-unused `AgentCategory` import).
- `remoteAgentUtils`: `sessionType = entry?.category ?? 'workflow'` (drops the ternary + import; `??` keeps the workflow default for an unresolved agent).

**Left as-is (not redundant):** `UsageMonitor` maps to `'tool-use'` (hyphen — a real backend transform); `MainViewStateRestoreController` maps a reused local boolean; the genuine `=== AgentCategory.ToolUse` boolean checks; `ResultEvent.category` keeps its inline literal (deliberate SDK-contract decoupling).

Net **−3 LOC**. Full suite **451 files / 3125**; typecheck + eslint + prettier clean.

## Remaining optional polish (not done — flagged honestly)

- Relocate the 232-LOC `modelHandlerValidation` stub out of the production `modelHandlers/` dir via an injection seam (audit §2.6) — touches the env-gated `ModelFactory` import + CLI reachability; its own small PR.
- `@agent/runtime` facade barrel + `no-restricted-imports` rule (audit §3.1) — low value; `@texra/core` already shields the package surface, and the rule would fire on ~287 existing imports.
- The full **T2-2** flow-seam structured-error attach (the remainder noted in #5965).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, behavior-preserving refactors in agent routing and webview messaging with no auth, data, or API contract changes.
> 
> **Overview**
> Removes **identity ternaries** that re-mapped `AgentCategory` to the same `'toolUse' | 'workflow'` strings the type already uses.
> 
> In **`AgentRunLifecycle`**, run lifecycle now passes `ctx.setting.agentCategory` straight through as `category` (execution handle, result events) instead of `=== AgentCategory.ToolUse ? 'toolUse' : 'workflow'`, and drops the unused `AgentCategory` import.
> 
> In **`remoteAgentUtils`**, remote agent selection sets `sessionType` from `entry?.category ?? 'workflow'` for the main webview `SET_SELECTED_AGENT` message, replacing the same ternary and import.
> 
> Behavior should be unchanged: workflow remains the default when an agent entry cannot be resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49474a142e8c655367ec54f47ed3c7221bc39eef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->