### PR TITLE
Extract IToolUseSession to core/flows module

### DIFF
--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -6,7 +6,7 @@ import type {
 } from '@agent/core/execution/AgentState';
 import type { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
-import type { IToolUseSession } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
+import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { TaskRunFileService } from '@utils/files';
 

--- a/src/agent/core/flows/IToolUseSession.ts
+++ b/src/agent/core/flows/IToolUseSession.ts
@@ -1,0 +1,15 @@
+import type {
+  FollowUpQueueBatch,
+  FollowUpQueueInput,
+} from '@agent/toolUse/FollowUpQueue';
+
+/** Contract for injecting queued user messages into an active tool-use cycle. */
+export interface IToolUseSession {
+  appendFollowUp(followUp: FollowUpQueueInput): void;
+  appendSyntheticFollowUp(text: string): void;
+  hasQueuedFollowUp(): boolean;
+  /** Wait for the next follow-up items. Returns null if interrupted. */
+  waitForFollowUp(
+    checkInterruption: () => boolean,
+  ): Promise<FollowUpQueueBatch | null>;
+}

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -9,7 +9,7 @@ import type {
 import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
-import type { IToolUseSession } from './ToolUseSessionLifecycle';
+import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 
 export type ToolUseBeforeWaitingCallback = (

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -1,19 +1,7 @@
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import type {
-  FollowUpQueueBatch,
-  FollowUpQueueInput,
-} from '@agent/toolUse/FollowUpQueue';
+import type { FollowUpQueueBatch, FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
+import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { StreamTabId } from '@shared/schemas';
-
-export interface IToolUseSession {
-  appendFollowUp(followUp: FollowUpQueueInput): void;
-  appendSyntheticFollowUp(text: string): void;
-  hasQueuedFollowUp(): boolean;
-  /** Wait for the next follow-up items. Returns null if interrupted. */
-  waitForFollowUp(
-    checkInterruption: () => boolean,
-  ): Promise<FollowUpQueueBatch | null>;
-}
 
 export class ToolUseSessionLifecycle implements IToolUseSession {
   private readonly followUps = ToolUseFollowUpQueue.acquire(this.streamTabId);

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -1,5 +1,8 @@
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import type { FollowUpQueueBatch, FollowUpQueueInput } from '@agent/toolUse/FollowUpQueue';
+import type {
+  FollowUpQueueBatch,
+  FollowUpQueueInput,
+} from '@agent/toolUse/FollowUpQueue';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { StreamTabId } from '@shared/schemas';
 

--- a/src/agent/implementations/flows/tooluse/index.ts
+++ b/src/agent/implementations/flows/tooluse/index.ts
@@ -13,7 +13,7 @@ export {
   type ToolUseFlowSetupCallback,
 } from './runToolUseFlow';
 
-export { type IToolUseSession } from './ToolUseSessionLifecycle';
+export { type IToolUseSession } from '@agent/core/flows/IToolUseSession';
 
 export { type ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 


### PR DESCRIPTION
## Summary

Move the `IToolUseSession` interface from `ToolUseSessionLifecycle.ts` to a dedicated module at `src/agent/core/flows/IToolUseSession.ts`. This establishes a clearer separation between the interface contract (core concern) and its implementation (flow-specific concern), improving modularity and reducing circular dependency risks.

## Issue acceptance gates

N/A

## Single source of truth

The `IToolUseSession` interface now lives in `src/agent/core/flows/IToolUseSession.ts`, establishing it as the canonical location for the tool-use session contract within the core flows module.

## Duplication and abstraction budget

Removed the interface definition from the implementation file (`ToolUseSessionLifecycle.ts`), eliminating the conflation of contract and implementation. The interface is now properly housed in the core module where it belongs as a boundary contract.

## Host impact

Extension: No impact

Desktop: No impact

CLI: No impact

## Scheduled refactoring

None

## Validation

- Type imports updated in `CycleServices.ts`, `ToolUseServices.ts`, and `index.ts` to reference the new location
- All import paths verified to use the new canonical location
- No functional changes to the interface or its implementations

https://claude.ai/code/session_018Vji7QqXHjgZJcxDeJNYxN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only relocation with import path updates; no logic or API changes.
> 
> **Overview**
> Moves **`IToolUseSession`** out of `ToolUseSessionLifecycle.ts` into **`src/agent/core/flows/IToolUseSession.ts`**, so core cycle/round services can depend on the contract without pulling in the tool-use implementation module.
> 
> `ToolUseSessionLifecycle` now only implements the interface; **`CycleServices`**, **`ToolUseServices`**, and the tool-use **`index`** re-export import the type from the new core path. No method signatures or runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc02846a87995a6eee1d08cd962187fdd6107ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->