### PR TITLE
fix(progress): prevent stream header overflow

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -126,6 +126,10 @@ export class StreamHeader extends LitElement {
     css`
       :host {
         display: block;
+        box-sizing: border-box;
+        min-width: 0;
+        max-width: 100%;
+        container-type: inline-size;
       }
 
       :host([hidden]) {
@@ -141,6 +145,8 @@ export class StreamHeader extends LitElement {
         gap: var(--wa-space-2xs);
         min-height: var(--height-header);
         box-sizing: border-box;
+        min-width: 0;
+        max-width: 100%;
         color: var(--color-text-secondary);
         border-bottom: var(--border-thin) solid var(--color-border);
       }
@@ -149,6 +155,9 @@ export class StreamHeader extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--wa-space-xs);
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
       }
 
       .header-left {
@@ -157,13 +166,17 @@ export class StreamHeader extends LitElement {
         gap: var(--wa-space-xs);
         flex: 1;
         min-width: 0;
+        max-width: 100%;
       }
 
       .stream-header {
         display: flex;
         align-items: center;
         gap: var(--wa-space-2xs);
+        flex: 1 1 auto;
         min-width: 0;
+        max-width: 100%;
+        overflow: hidden;
       }
 
       .stream-header #activeStreamName {
@@ -178,8 +191,16 @@ export class StreamHeader extends LitElement {
       }
 
       .header-actions {
-        flex-shrink: 0;
+        display: flex;
+        justify-content: flex-end;
+        flex: 0 0 auto;
+        min-width: 0;
+        max-width: 100%;
         margin-left: auto;
+      }
+
+      .header-actions wa-button-group {
+        max-width: 100%;
       }
 
       /* Status indicator overrides - base styles from statusIndicatorStyles.
@@ -258,10 +279,9 @@ export class StreamHeader extends LitElement {
         font-size: var(--font-size-xs);
       }
 
-      @media (max-width: 500px) {
-        .log-header {
+      @container (max-width: 320px) {
+        .log-header__primary {
           flex-wrap: wrap;
-          gap: var(--wa-space-2xs);
         }
 
         .header-left {
@@ -269,7 +289,8 @@ export class StreamHeader extends LitElement {
         }
 
         .header-actions {
-          margin-left: auto;
+          width: 100%;
+          margin-left: 0;
         }
       }
     `,


### PR DESCRIPTION
Closes #5973.

## Summary

- constrain `stream-header` and its primary row to the available inline width
- make the stream title flex/ellipsize instead of forcing the toolbar offscreen
- replace the viewport media rule with a container query so very narrow embedded headers wrap the actions below the title row

## Verification

- `corepack pnpm --filter texra vite:webviews:dev`
- local Electron mock-gallery measurement at 390px: `bodyScrollWidth: 390`, `docScrollWidth: 390`, `offenders: []`
- `npm run smoke:webviews`
  - included `Verified progress-approval tool edit approval layout: {"approveWidth":112,"cardRight":276.09375,"rejectWidth":100.6171875,"viewportWidth":420}`
- `corepack pnpm exec prettier --check packages/extension/src/progressView/frontend/components/StreamHeader.ts`
- `corepack pnpm exec eslint packages/extension/src/progressView/frontend/components/StreamHeader.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout changes in a single Lit component with no logic or data-handling impact.
> 
> **Overview**
> Fixes horizontal overflow in the progress view **stream header** when the panel is narrow or embedded.
> 
> The host and header rows now use **`min-width: 0` / `max-width: 100%`** and the title row **`flex`** so the stream name ellipsizes instead of pushing the toolbar off-screen. **`.stream-header`** gets **`overflow: hidden`**; **`.header-actions`** is a flex row that stays shrinkable while **`wa-button-group`** is capped to full width.
> 
> Responsive behavior switches from a **500px viewport `@media`** rule to a **`@container (max-width: 320px)`** query on the host (`container-type: inline-size`), so wrapping actions below the title tracks the header’s actual width—not the whole window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 908a1ba12e204bd11782360f3e9c5e538dfa19ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->