### PR TITLE
refactor(agent-runtime): centralize tool progress emits

### DIFF
--- a/src/agent/runtime/emitRuntimeEvent.ts
+++ b/src/agent/runtime/emitRuntimeEvent.ts
@@ -1,0 +1,32 @@
+/**
+ * Single emit path for run/host progress events (SDK Step 7d follow-on F-1).
+ *
+ * Replaces scattered `bus.emit(...)` in `src/tools` so one fact has one emit
+ * path and one name, resolving the target in priority order:
+ *
+ * 1. a host-path caller's `session.hostChannel` (set only by hosts that own a
+ *    non-default session, e.g. a desktop window) — when present;
+ * 2. otherwise the active run's `runtimeHost`, resolved from the ambient
+ *    {@link RunContext} (the in-run case — tools firing inside a run's ALS);
+ * 3. otherwise the process {@link bus} — the single-session fallback that keeps
+ *    the extension byte-identical (its run `runtimeHost.emit` is `bus.emit`
+ *    anyway) and host-path callers that pass no session unchanged.
+ *
+ * In-run callers pass no `session` (the ALS supplies the run host). Host-path
+ * callers — reachable outside any run ALS — MUST pass their owning `session`,
+ * or the event resolves to the bus and a non-default session never sees it.
+ */
+import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+import { tryUseRunContext } from './RunContext';
+import type { SessionHandle } from './SessionHandle';
+
+export function emitRuntimeEvent<K extends keyof ProgressEventPayloads>(
+  event: K,
+  payload: ProgressEventPayloads[K],
+  session?: SessionHandle,
+): void {
+  const host = session?.hostChannel ?? tryUseRunContext()?.runtimeHost;
+  if (host) host.emit(event, payload);
+  else bus.emit(event, payload);
+}

--- a/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
@@ -1,0 +1,69 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - runtime
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
+import { bus } from '@eventBus/ProgressEventBus';
+import type { StreamTabId } from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+const streamId = (s: string): StreamTabId => s as StreamTabId;
+
+describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
+  it('falls back to the process bus with no session and no run context', () => {
+    const seen: unknown[] = [];
+    const off = bus.on('goalStateChanged', (p) => seen.push(p));
+    try {
+      emitRuntimeEvent('goalStateChanged', { streamId: streamId('s:bus') });
+      expect(seen).toEqual([{ streamId: 's:bus' }]);
+    } finally {
+      off();
+    }
+  });
+
+  it("emits through the active run's runtimeHost when inside a run context", () => {
+    const run = createRecordingHost();
+    const busSeen: unknown[] = [];
+    const off = bus.on('goalStateChanged', (p) => busSeen.push(p));
+    try {
+      withRunContext(createRunContext({ runtimeHost: run.host }), () => {
+        emitRuntimeEvent('goalStateChanged', { streamId: streamId('s:run') });
+      });
+      expect(run.events).toEqual([
+        { event: 'goalStateChanged', payload: { streamId: 's:run' } },
+      ]);
+      // Not double-emitted onto the bus.
+      expect(busSeen).toEqual([]);
+    } finally {
+      off();
+    }
+  });
+
+  it('prefers an explicit session hostChannel over the run context and bus', () => {
+    const channel = createRecordingHost();
+    const run = createRecordingHost();
+    const session = new SessionHandle({ hostChannel: channel.host });
+    const busSeen: unknown[] = [];
+    const off = bus.on('goalStateChanged', (p) => busSeen.push(p));
+    try {
+      withRunContext(createRunContext({ runtimeHost: run.host }), () => {
+        emitRuntimeEvent(
+          'goalStateChanged',
+          { streamId: streamId('s:chan') },
+          session,
+        );
+      });
+      expect(channel.events).toEqual([
+        { event: 'goalStateChanged', payload: { streamId: 's:chan' } },
+      ]);
+      expect(run.events).toEqual([]);
+      expect(busSeen).toEqual([]);
+    } finally {
+      off();
+      session.dispose();
+    }
+  });
+});

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { platform } from '@platform/platform';
 import { tryGetWorkspaceState } from '@agent/core/stateStore';
-import { bus } from '@eventBus/ProgressEventBus';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import {
   type ExecutionId,
   StreamTabIdSchema,
@@ -145,7 +145,8 @@ async function update(
   if (!goal) return null;
   const final: Goal = { ...mutate(goal), updatedAt: nowIso() };
   await writeRaw(final);
-  bus.emit('goalStateChanged', { streamId });
+  // In-run: the active run's host (ALS), falling back to the bus.
+  emitRuntimeEvent('goalStateChanged', { streamId });
   return final;
 }
 
@@ -203,7 +204,7 @@ export const GoalStore = {
       updatedAt: now,
     };
     await Promise.all([writeRaw(goal), addToIndex(streamId)]);
-    bus.emit('goalStateChanged', { streamId });
+    emitRuntimeEvent('goalStateChanged', { streamId });
     return goal;
   },
 
@@ -272,7 +273,9 @@ export const GoalStore = {
       state.update(legacyStreamKey(streamId), undefined),
       removeFromIndex(streamId),
     ]);
-    bus.emit('goalStateChanged', { streamId });
+    // Dual-context: PlanTool forgets in-run (→ run host via ALS); the
+    // progress-view lifecycle controller forgets host-path (→ bus fallback).
+    emitRuntimeEvent('goalStateChanged', { streamId });
   },
 
   /**
@@ -306,7 +309,8 @@ export const GoalStore = {
         ? state.update(LEGACY_INDEX_KEY, undefined)
         : Promise.resolve(),
     ]);
-    for (const id of toRemove) bus.emit('goalStateChanged', { streamId: id });
+    for (const id of toRemove)
+      emitRuntimeEvent('goalStateChanged', { streamId: id });
   },
 
   /**

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -19,7 +19,7 @@ import { z } from 'zod';
 
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import { bus } from '@eventBus/ProgressEventBus';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { createChannelTrace } from '@logger';
 import {
   ExternalInquiryThreadIdSchema,
@@ -158,7 +158,11 @@ export async function handleExternalInquiryAction(
     // this the request would replay on next webview load and the stream would
     // be reported as having pending permissions forever. Emit even for stale
     // submits so duplicate/delayed UI actions do not leave a leaked permission.
-    bus.emit('resolveExternalInquiry', { requestId: payload.threadId });
+    emitRuntimeEvent(
+      'resolveExternalInquiry',
+      { requestId: payload.threadId },
+      options.session,
+    );
     if (!persisted) {
       logger.warn(
         `Inquiry submit ignored: thread ${payload.threadId} has no open turn.`,
@@ -184,7 +188,11 @@ export async function handleExternalInquiryAction(
     );
   }
   const droppedManifest = await markDropped({ threadId: payload.threadId });
-  bus.emit('resolveExternalInquiry', { requestId: payload.threadId });
+  emitRuntimeEvent(
+    'resolveExternalInquiry',
+    { requestId: payload.threadId },
+    options.session,
+  );
   if (droppedManifest) {
     await injectContinuationForDroppedThread(
       payload.threadId,

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -16,7 +16,7 @@ import { platform } from '@platform/platform';
 
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import { bus } from '@eventBus/ProgressEventBus';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { createChannelTrace } from '@logger';
 import type {
   ExternalInquiryThreadId,
@@ -108,10 +108,11 @@ export function buildContinuationText(params: {
 async function emitInquiryThreadUpdate(
   threadId: ExternalInquiryThreadId,
   extra: { resumeOutcome: InquiryResumeOutcome },
+  session?: SessionHandle,
 ): Promise<void> {
   const summary = await getThreadSummary(threadId);
   if (!summary) return;
-  bus.emit('inquiryThreadUpdated', { ...summary, ...extra });
+  emitRuntimeEvent('inquiryThreadUpdated', { ...summary, ...extra }, session);
 }
 
 async function deliverContinuation(params: {
@@ -130,7 +131,11 @@ async function deliverContinuation(params: {
 
   switch (result.status) {
     case 'sent':
-      await emitInquiryThreadUpdate(params.threadId, { resumeOutcome: 'sent' });
+      await emitInquiryThreadUpdate(
+        params.threadId,
+        { resumeOutcome: 'sent' },
+        params.session,
+      );
       return 'sent';
     case 'queued': {
       if (result.reason === 'waiting' || result.reason === 'children_running') {
@@ -138,23 +143,35 @@ async function deliverContinuation(params: {
           params.parentStreamId,
         );
         const outcome: InjectionOutcome = resumed ? 'resumed' : 'queued';
-        await emitInquiryThreadUpdate(params.threadId, {
-          resumeOutcome: outcome,
-        });
+        await emitInquiryThreadUpdate(
+          params.threadId,
+          {
+            resumeOutcome: outcome,
+          },
+          params.session,
+        );
         return outcome;
       }
-      await emitInquiryThreadUpdate(params.threadId, {
-        resumeOutcome: 'queued',
-      });
+      await emitInquiryThreadUpdate(
+        params.threadId,
+        {
+          resumeOutcome: 'queued',
+        },
+        params.session,
+      );
       return 'queued';
     }
     case 'no_session':
       logger.warn(
         `Inquiry continuation for ${params.threadId}: parent stream ${params.parentStreamId} has no session.`,
       );
-      await emitInquiryThreadUpdate(params.threadId, {
-        resumeOutcome: 'parent_finished',
-      });
+      await emitInquiryThreadUpdate(
+        params.threadId,
+        {
+          resumeOutcome: 'parent_finished',
+        },
+        params.session,
+      );
       return 'archived';
   }
 }
@@ -176,9 +193,13 @@ export async function injectContinuationForAnsweredThread(
   const lastTurn = manifest.turns.at(-1);
   if (!lastTurn || !lastTurn.answer) return 'archived';
   if (manifest.parentStreamId == null) {
-    await emitInquiryThreadUpdate(threadId, {
-      resumeOutcome: 'parent_finished',
-    });
+    await emitInquiryThreadUpdate(
+      threadId,
+      {
+        resumeOutcome: 'parent_finished',
+      },
+      session,
+    );
     return 'archived';
   }
 
@@ -213,9 +234,13 @@ export async function injectContinuationForDroppedThread(
   const manifest = manifestHint ?? (await readExternalInquiryThread(threadId));
   if (!manifest) return 'archived';
   if (manifest.parentStreamId == null) {
-    await emitInquiryThreadUpdate(threadId, {
-      resumeOutcome: 'parent_finished',
-    });
+    await emitInquiryThreadUpdate(
+      threadId,
+      {
+        resumeOutcome: 'parent_finished',
+      },
+      session,
+    );
     return 'archived';
   }
 


### PR DESCRIPTION
Replacement for the closed/stale #5961 branch, recovered as one focused commit on current `main`.

## Summary

- add `emitRuntimeEvent(event, payload, session?)` as the single progress-event emit path for tool/runtime callers
- replace direct `bus.emit(...)` calls in `goalStore`, `ExternalInquiryTool`, and `inquiryContinuation`
- preserve current `main`'s explicit `SessionHandle` threading for inquiry host-path events, so desktop-owned sessions can receive `resolveExternalInquiry` and `inquiryThreadUpdated` without falling back to the process bus
- add coverage for bus fallback, active run context routing, and explicit session precedence

## Why This Replaces #5961

#5961 was closed when its old base was merged/deleted, and the branch now carries stale lower-stack history. This PR cherry-picks only the F-1 event-routing change and resolves it against current `main`.

## Verification

- `corepack pnpm exec prettier --check src/agent/runtime/emitRuntimeEvent.ts src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts src/tools/goal/goalStore.ts src/tools/inquiry/ExternalInquiryTool.ts src/tools/inquiry/inquiryContinuation.ts`
- `corepack pnpm exec eslint src/agent/runtime/emitRuntimeEvent.ts src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts src/tools/goal/goalStore.ts src/tools/inquiry/ExternalInquiryTool.ts src/tools/inquiry/inquiryContinuation.ts`
- `corepack pnpm vitest run src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts src/test-kernel/agent/runtime/SessionHandle.vitest.ts src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how progress events reach UI listeners across run vs host contexts; wrong or missing `SessionHandle` on host-path inquiry actions could mis-route events, though extension single-session behavior is intended to stay equivalent via bus fallback.
> 
> **Overview**
> Introduces **`emitRuntimeEvent`** as the single typed path for run/host progress events, replacing direct **`bus.emit`** in **`goalStore`**, **`ExternalInquiryTool`**, and **`inquiryContinuation`**.
> 
> Routing is **session `hostChannel` → active run `runtimeHost` (ALS) → process `bus`**, so in-run goal updates use the run host without a session, while inquiry submit/drop and continuation UI updates still pass **`options.session`** so desktop-owned sessions get **`resolveExternalInquiry`** and **`inquiryThreadUpdated`** instead of only the global bus.
> 
> Adds **`EmitRuntimeEvent.vitest.ts`** to lock in bus fallback, run-context routing (no double-emit on the bus), and explicit session precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4f0b61ea510c3032f9f0b8ff657efd807b051c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->