### PR TITLE
refactor: replace array/record lookup bridges with native maps

### DIFF
--- a/src/controllers/onboarding/defaultTeamSeeding.ts
+++ b/src/controllers/onboarding/defaultTeamSeeding.ts
@@ -19,7 +19,7 @@ import {
 } from '@controllers/settingsView/SettingsAgentCatalogController';
 import { getAgentsByCategory } from '@agent/index/agentRegistry';
 import {
-  AGENT_MODE_PRESETS,
+  AGENT_MODE_PRESETS_BY_ID,
   STARTER_AGENT_MODE_PRESET,
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
@@ -32,7 +32,7 @@ import type { StateStore } from '@platform/interfaces/state';
 /** Resolve a team id to its built-in preset (the hidden 'starter' included). */
 export function resolveTeamPreset(teamId: string): AgentModePreset | undefined {
   if (teamId === STARTER_AGENT_MODE_PRESET.id) return STARTER_AGENT_MODE_PRESET;
-  return AGENT_MODE_PRESETS.find((preset) => preset.id === teamId);
+  return AGENT_MODE_PRESETS_BY_ID.get(teamId);
 }
 
 /**

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -1,7 +1,7 @@
 // Local imports - shared
 import type { AgentModePreset } from '@shared/schemas/agentPresets';
 import {
-  AGENT_MODE_PRESETS,
+  AGENT_MODE_PRESETS_BY_ID,
   AgentModePresetSchema,
 } from '@shared/schemas/agentPresets';
 import {
@@ -214,8 +214,7 @@ export class SettingsAgentCatalogController {
 
   private getPreset(presetId: string): AgentModePreset | null {
     return (
-      AGENT_MODE_PRESETS.find((preset) => preset.id === presetId) ??
-      this.getCustomPreset(presetId)
+      AGENT_MODE_PRESETS_BY_ID.get(presetId) ?? this.getCustomPreset(presetId)
     );
   }
 }

--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -428,7 +428,7 @@ export class WebviewUpdater {
     const allStates = state.getAllStreamStates();
     const streamMetadata: Record<StreamTabId, StreamMetadata> = {};
     for (const { name, agentCategory } of streams) {
-      const current = allStates[name];
+      const current = allStates.get(name);
       streamMetadata[name] = buildStreamMetadata({
         kind: agentCategory,
         status: statuses?.get(name),

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -286,8 +286,8 @@ export class ProgressViewState {
     return this._streamStates.get(stream);
   }
 
-  getAllStreamStates(): Record<StreamTabId, StreamExecutionState> {
-    return Object.fromEntries(this._streamStates.entries());
+  getAllStreamStates(): ReadonlyMap<StreamTabId, StreamExecutionState> {
+    return this._streamStates;
   }
 
   async endRunningTaskGroups(

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -148,3 +148,12 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     ],
   },
 ];
+
+/**
+ * Built-in presets indexed by id. {@link AGENT_MODE_PRESETS} stays the ordered
+ * source of truth (the settings UI renders team cards in declaration order);
+ * this map is the native lookup structure for id resolution, so callers don't
+ * linear-scan the array on every resolve.
+ */
+export const AGENT_MODE_PRESETS_BY_ID: ReadonlyMap<string, AgentModePreset> =
+  new Map(AGENT_MODE_PRESETS.map((preset) => [preset.id, preset]));

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -615,7 +615,16 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   // LaTeX settings tab — see LaTeXTab.ts and SettingsViewMessageHandler.ts.
 ];
 
+/**
+ * Tool definitions indexed by id. The array above stays the ordered source of
+ * truth (dashboard renders in declaration order); this map is the native
+ * lookup structure for id resolution.
+ */
+const EXTERNAL_TOOL_DEFS_BY_ID: ReadonlyMap<string, ExternalToolDef> = new Map(
+  EXTERNAL_TOOL_DEFS.map((d) => [d.id, d]),
+);
+
 /** Look up a tool definition by id. */
 export function findExternalToolDef(id: string): ExternalToolDef | undefined {
-  return EXTERNAL_TOOL_DEFS.find((d) => d.id === id);
+  return EXTERNAL_TOOL_DEFS_BY_ID.get(id);
 }


### PR DESCRIPTION
Eliminate data-structure "bridges" — code that repeatedly converts between
representations instead of storing data in its natural shape — in favor of
native lookup structures:

- agentPresets: add AGENT_MODE_PRESETS_BY_ID map; built-in preset resolution
  in SettingsAgentCatalogController.getPreset and resolveTeamPreset now does
  O(1) map lookups instead of linear `.find(p => p.id === id)` scans. The
  array stays the ordered source of truth for UI rendering.
- externalToolDefs: add EXTERNAL_TOOL_DEFS_BY_ID map; findExternalToolDef
  resolves by map lookup instead of scanning the array on every call.
- ProgressViewState.getAllStreamStates: return the internal ReadonlyMap
  directly instead of rebuilding a Record via Object.fromEntries on every
  call; WebviewUpdater consumes it with .get(name).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving performance refactor with a narrow API tweak (`getAllStreamStates` now returns a Map); only `WebviewUpdater` was updated to match.
> 
> **Overview**
> Replaces repeated **linear array scans** and **per-call Record rebuilds** with **Map-backed lookups**, while keeping ordered arrays as the source of truth for UI ordering.
> 
> **Agent presets:** adds `AGENT_MODE_PRESETS_BY_ID`; `resolveTeamPreset` and `SettingsAgentCatalogController.getPreset` use `.get(id)` instead of `AGENT_MODE_PRESETS.find(...)`.
> 
> **External tools:** adds `EXTERNAL_TOOL_DEFS_BY_ID`; `findExternalToolDef` uses map lookup instead of scanning `EXTERNAL_TOOL_DEFS`.
> 
> **Progress view:** `ProgressViewState.getAllStreamStates()` now returns the internal `ReadonlyMap` directly (no `Object.fromEntries` on each call); `WebviewUpdater` reads stream state via `allStates.get(name)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af5999d9c89bd20f32a3bb4fb7c49b638cd56cc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->