### PR TITLE
Make CLI NDJSON output and enum settings Zod-native shared contracts

### DIFF
--- a/packages/cli/src/commands/_helpers/output.ts
+++ b/packages/cli/src/commands/_helpers/output.ts
@@ -1,8 +1,6 @@
 import { writeNdjsonStdout, writeTextStdout } from '@cli/runtime/logSinks';
 import { pageStdout } from '@cli/runtime/pager';
 import type { CliContext } from '@cli/runtime/cliContext';
-
-export type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 
 /**

--- a/packages/cli/src/commands/_helpers/output.ts
+++ b/packages/cli/src/commands/_helpers/output.ts
@@ -2,7 +2,8 @@ import { writeNdjsonStdout, writeTextStdout } from '@cli/runtime/logSinks';
 import { pageStdout } from '@cli/runtime/pager';
 import type { CliContext } from '@cli/runtime/cliContext';
 
-export type CliNdjsonRecord = object;
+export type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
+import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 
 /**
  * Single home for the `json` / `ndjson` / `text` switch every headless command

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -11,6 +11,7 @@ import {
   type ResultMeta,
 } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import { isFileNotFoundError } from '@common/errors';
 import {
   EXECUTION_STATUS,
@@ -277,7 +278,7 @@ export function formatCliHistoryText(
 export function cliHistoryNdjsonRecords(
   entries: readonly CliHistoryEntry[],
   ts = new Date().toISOString(),
-): object[] {
+): CliNdjsonRecord[] {
   return entries.map((entry) => ({ kind: 'history-entry', ts, entry }));
 }
 

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -1,6 +1,10 @@
 // Standard library imports
 import { createInterface } from 'node:readline/promises';
 
+// Local imports - CLI schemas
+import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
+
+// Local imports - errors
 import { toErrorMessage } from '@common/errors/errorMessage';
 import type { LogLevel } from '@shared/schemas';
 
@@ -178,7 +182,8 @@ class NdjsonStdoutSink implements LogSink {
       while (!this.stdoutClosed && this.queue.length > 0) {
         const record = this.queue.shift();
         if (!record) continue;
-        const line = `${JSON.stringify({ kind: 'log', ...record })}\n`;
+        const lineRecord: CliNdjsonRecord = { kind: 'log', ...record };
+        const line = `${JSON.stringify(lineRecord)}\n`;
         let canContinue: boolean;
         try {
           canContinue = process.stdout.write(line);

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -1,5 +1,6 @@
 import { platform } from '@platform/platform';
 import { BUILTIN_TEAM_ROOT_AGENT_NAMES, type AgentEntry } from '@agent/index';
+import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { agentKey } from '@shared/schemas/agent';
@@ -241,7 +242,7 @@ export function formatCliMultiAgentPresetInspection(
 
 export function cliMultiAgentPresetNdjsonRecords(
   plans: readonly CliMultiAgentPresetRunPlan[],
-): object[] {
+): CliNdjsonRecord[] {
   const ts = new Date().toISOString();
   return plans.map((plan) => ({
     kind: 'multi-agent-preset',

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -1,5 +1,6 @@
 // Local imports - runtime
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local imports - CLI runtime
@@ -46,12 +47,13 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       }
 
       if (context.outputFormat === 'ndjson') {
-        writeNdjsonStdout({
+        const record: CliNdjsonRecord = {
           kind: 'progress',
           event,
           ts: new Date().toISOString(),
           payload,
-        });
+        };
+        writeNdjsonStdout(record);
         return;
       }
 

--- a/packages/cli/src/schemas/cliOutput.ts
+++ b/packages/cli/src/schemas/cliOutput.ts
@@ -54,6 +54,10 @@ export const CliNdjsonRecordSchema = z.discriminatedUnion('kind', [
   z.looseObject({ kind: z.literal('result'), result: payload }),
   z.looseObject({ kind: z.literal('skill'), skill: payload }),
   z.looseObject({ kind: z.literal('skill-issue'), issue: payload }),
+  z.looseObject({ kind: z.literal('doctor-check') }),
+  z.looseObject({ kind: z.literal('doctor-summary') }),
+  z.looseObject({ kind: z.literal('progress') }),
+  z.looseObject({ kind: z.literal('log') }),
 ]);
 
 /** A single `--output-format ndjson` line record. */

--- a/packages/cli/src/schemas/cliOutput.ts
+++ b/packages/cli/src/schemas/cliOutput.ts
@@ -1,0 +1,60 @@
+/**
+ * Contract for the CLI's `--output-format ndjson` line records.
+ *
+ * Every headless command emits one JSON object per line through
+ * {@link emitCliResult} (a few stream records directly via `writeNdjsonStdout`).
+ * Each record is tagged with a `kind` discriminator and carries a command-
+ * specific payload; a `ts` ISO timestamp is stamped on the way out. This file
+ * is the single source of truth for that wire shape:
+ *
+ * - The {@link CliNdjsonRecord} type is derived from the schema, so the
+ *   `ndjson` argument of every `emitCliResult` call is checked against the
+ *   registered `kind` set at compile time (the previous `object` type checked
+ *   nothing — a typo'd or unregistered `kind` slipped through silently).
+ * - `CliNdjsonRecordContract.vitest.mts` parses representative records against
+ *   {@link CliNdjsonRecordSchema}, locking the contract so downstream consumers
+ *   that key on `kind` don't break under a silent rename.
+ *
+ * Members are intentionally *loose*: the discriminator and the primary nested
+ * field are pinned, but extra keys pass through. Several commands spread a
+ * typed payload at the top level (`{ kind: 'auth-status', ...profile }`) and
+ * `ts` is added downstream, so over-constraining here would reject valid output
+ * and break headless byte-parity for no contract gain. The value is in the
+ * exhaustive, named `kind` registry, not in re-validating each payload field.
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+/** A payload field carried verbatim from the command (already shaped upstream). */
+const payload = z.unknown();
+
+export const CliNdjsonRecordSchema = z.discriminatedUnion('kind', [
+  z.looseObject({ kind: z.literal('agent'), agent: payload }),
+  z.looseObject({ kind: z.literal('tool-status'), tool: payload }),
+  z.looseObject({ kind: z.literal('model'), model: payload }),
+  z.looseObject({ kind: z.literal('memory'), memory: payload }),
+  z.looseObject({ kind: z.literal('memory-detail') }),
+  z.looseObject({ kind: z.literal('auth') }),
+  z.looseObject({ kind: z.literal('auth-status') }),
+  z.looseObject({ kind: z.literal('relay-usage') }),
+  z.looseObject({ kind: z.literal('relay-token') }),
+  z.looseObject({ kind: z.literal('relay-token-info') }),
+  z.looseObject({ kind: z.literal('relay-token-revoked') }),
+  z.looseObject({ kind: z.literal('history-entry'), entry: payload }),
+  z.looseObject({ kind: z.literal('history-detail'), detail: payload }),
+  z.looseObject({ kind: z.literal('history-delete'), result: payload }),
+  z.looseObject({ kind: z.literal('multi-agent-result') }),
+  z.looseObject({ kind: z.literal('multi-agent-preset'), preset: payload }),
+  z.looseObject({
+    kind: z.literal('multi-agent-preset-inspection'),
+    plan: payload,
+  }),
+  z.looseObject({ kind: z.literal('agent-result'), result: payload }),
+  z.looseObject({ kind: z.literal('result'), result: payload }),
+  z.looseObject({ kind: z.literal('skill'), skill: payload }),
+  z.looseObject({ kind: z.literal('skill-issue'), issue: payload }),
+]);
+
+/** A single `--output-format ndjson` line record. */
+export type CliNdjsonRecord = z.infer<typeof CliNdjsonRecordSchema>;

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -15,6 +15,7 @@ import * as path from 'node:path';
 
 // Third-party imports
 import * as vscode from 'vscode';
+import { z } from 'zod';
 
 // Local imports
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
@@ -23,7 +24,6 @@ import {
   buildFixInstruction,
   buildReviewInstruction,
   createReviewIssue,
-  type ReviewApproach,
   type ReviewIssue,
   type ReviewIssueReport,
   type ReviewSeverity,
@@ -35,8 +35,9 @@ import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
+import { AGENT_REVIEW_APPROACHES } from '@shared/schemas/coreSettings';
 import { WorkspaceFS } from '@utils/files';
-import { getConfig } from '@utils/config/configUtils';
+import { getConfig, getValidatedConfig } from '@utils/config/configUtils';
 
 const CHANNEL = 'AgentReview';
 const COLLECTION_NAME = 'texra-agent-review';
@@ -281,7 +282,11 @@ class AgentReviewServiceImpl {
         changedFiles,
         diff,
         truncated,
-        approach: getConfig<ReviewApproach>('agentReview.approach', 'quick'),
+        approach: getValidatedConfig(
+          'agentReview.approach',
+          z.enum(AGENT_REVIEW_APPROACHES),
+          'quick',
+        ),
       });
       const model = getConfig<string>('agentReview.model', '').trim();
       const config = AgentConfigSchema.parse({

--- a/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
+++ b/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CliNdjsonRecordSchema,
+  type CliNdjsonRecord,
+} from '@cli/schemas/cliOutput';
+
+/**
+ * Locks the `--output-format ndjson` wire contract. One representative record
+ * per `kind` a command emits — mirroring the shapes built in
+ * `packages/cli/src/commands/*` and the `cli*NdjsonRecords` helpers — must parse
+ * against the shared schema. If a command starts emitting a new `kind` (or
+ * renames one) without registering it here and in `cliOutput.ts`, this fails.
+ */
+const REPRESENTATIVE_RECORDS: CliNdjsonRecord[] = [
+  { kind: 'agent', agent: { name: 'coder' } },
+  { kind: 'tool-status', tool: { name: 'bash', available: true } },
+  { kind: 'model', model: { value: 'sonnet45', label: 'Sonnet 4.5' } },
+  { kind: 'memory', memory: { id: 'm1', text: 'remember' } },
+  { kind: 'memory-detail', id: 'm1', text: 'remember', scope: 'workspace' },
+  { kind: 'auth', authenticated: true, account: 'a@b.c', expiresAt: 1 },
+  { kind: 'auth', authenticated: false, relayTokenConfigured: true },
+  { kind: 'auth-status', authenticated: true, tier: 'pro' },
+  { kind: 'relay-usage', tier: 'pro', costUsd: 1, limitUsd: 10 },
+  { kind: 'relay-token', name: 'ci', token: 'secret' },
+  { kind: 'relay-token-info', name: 'ci', createdAt: 1 },
+  { kind: 'relay-token-revoked', name: 'ci' },
+  { kind: 'history-entry', entry: { id: 'e1' } },
+  { kind: 'history-detail', detail: { id: 'e1' } },
+  { kind: 'history-delete', result: { deleted: 3 } },
+  { kind: 'multi-agent-result', agent: 'team', outputFiles: [] },
+  { kind: 'multi-agent-preset', preset: { id: 'p1' } },
+  { kind: 'multi-agent-preset-inspection', plan: { id: 'p1' } },
+  { kind: 'agent-result', result: { outputFiles: [] } },
+  { kind: 'result', result: { category: 'workflow' } },
+  { kind: 'skill', ts: '2026-01-01T00:00:00.000Z', skill: { name: 's1' } },
+  { kind: 'skill-issue', ts: '2026-01-01T00:00:00.000Z', issue: { code: 'x' } },
+];
+
+describe('CLI NDJSON record contract', () => {
+  it.each(REPRESENTATIVE_RECORDS)('accepts %o', (record) => {
+    expect(CliNdjsonRecordSchema.safeParse(record).success).toBe(true);
+  });
+
+  it('tolerates the downstream `ts` stamp on every record', () => {
+    for (const record of REPRESENTATIVE_RECORDS) {
+      const stamped = { ...record, ts: '2026-06-14T00:00:00.000Z' };
+      expect(CliNdjsonRecordSchema.safeParse(stamped).success).toBe(true);
+    }
+  });
+
+  it('rejects an unregistered kind', () => {
+    expect(
+      CliNdjsonRecordSchema.safeParse({ kind: 'not-a-real-kind' }).success,
+    ).toBe(false);
+  });
+});

--- a/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
+++ b/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
@@ -35,6 +35,10 @@ const REPRESENTATIVE_RECORDS: CliNdjsonRecord[] = [
   { kind: 'result', result: { category: 'workflow' } },
   { kind: 'skill', ts: '2026-01-01T00:00:00.000Z', skill: { name: 's1' } },
   { kind: 'skill-issue', ts: '2026-01-01T00:00:00.000Z', issue: { code: 'x' } },
+  { kind: 'doctor-check', ts: '2026-01-01T00:00:00.000Z', id: 'node' },
+  { kind: 'doctor-summary', ts: '2026-01-01T00:00:00.000Z', ok: true },
+  { kind: 'progress', ts: '2026-01-01T00:00:00.000Z', event: 'setTaskState' },
+  { kind: 'log', ts: '2026-01-01T00:00:00.000Z', level: 'info' },
 ];
 
 describe('CLI NDJSON record contract', () => {

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -86,6 +86,9 @@ async function loadApprovalModules(workspacePath = '/workspace') {
   };
   vi.doMock('@utils/config/configUtils', () => ({
     getConfig: vi.fn(() => 'sameDirectory'),
+    getValidatedConfig: vi.fn(
+      <T,>(_path: string, _schema: unknown, defaultValue: T) => defaultValue,
+    ),
   }));
   vi.doMock('@agent/runtime/RunContext', async () => {
     const actual = await vi.importActual<

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 
 import { sync as globSync } from 'glob';
 import { nanoid } from 'nanoid';
+import { z } from 'zod';
 
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
@@ -14,12 +15,13 @@ import { TEMP_EXTENSIONS } from '@housekeeping/constants';
 import { LaTeXdiffService } from '@latex/latexdiff';
 import { debug } from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
+import { LATEXDIFF_TEMP_FILE_LOCATIONS } from '@shared/schemas/coreSettings';
 import {
   createExternalLocation,
   createWorkspaceLocation,
   WorkspaceFS,
 } from '@utils/files';
-import { getConfig } from '@utils/config/configUtils';
+import { getValidatedConfig } from '@utils/config/configUtils';
 
 export type BuildDisplayFn = (
   location: FileLocation,
@@ -49,9 +51,6 @@ export interface LatexPreviewEntry {
   /** Platform-specific error reporter, injected by the caller. */
   onError: (message: string) => void;
 }
-
-/** Temp file location options */
-type TempFileLocation = 'sameDirectory' | 'workspaceTemp';
 
 const TEXRA_TEMP_DIR = '.texra-temp';
 /** Length of the random suffix for temp file names (8 nanoid chars ≈ 2^47 combinations, sufficient for uniqueness) */
@@ -145,8 +144,9 @@ async function createTempFileWithCleanup(
     throw new Error('No workspace folder open');
   }
 
-  const location = getConfig<TempFileLocation>(
+  const location = getValidatedConfig(
     'texra.latexdiff.tempFileLocation',
+    z.enum(LATEXDIFF_TEMP_FILE_LOCATIONS),
     'sameDirectory',
   );
 

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -1,6 +1,7 @@
 // Local imports
 import { tryPlatform } from '@platform/platform';
 import { ensureArray } from '@utils/core';
+import type { ZodType } from 'zod';
 import type { ConfigTarget } from '@platform/interfaces/config';
 import type { Disposable } from '@platform/interfaces/disposable';
 
@@ -35,6 +36,28 @@ function configProvider() {
 export function getConfig<T>(path: string, defaultValue?: T): T {
   const provider = configProvider();
   return provider ? provider.get(path, defaultValue) : (defaultValue as T);
+}
+
+/**
+ * Reads a configuration value and validates it against a Zod schema, returning
+ * `defaultValue` when the setting is unset or fails validation.
+ *
+ * Prefer this over `getConfig<T>(path, default)` whenever the value has a
+ * constrained shape (enums, bounded numbers, structured records). `getConfig`
+ * only *asserts* the type at the call site — a stale or hand-edited
+ * `settings.json` can still feed through a value that violates it. Passing the
+ * authoritative schema (e.g. the `z.enum(...)` built from a `coreSettings.ts`
+ * constant) makes that schema the single shared contract for both the type and
+ * the runtime check, so drift surfaces as a clean fallback rather than an
+ * invalid value flowing downstream.
+ */
+export function getValidatedConfig<T>(
+  path: string,
+  schema: ZodType<T>,
+  defaultValue: T,
+): T {
+  const result = schema.safeParse(getConfig<unknown>(path));
+  return result.success ? result.data : defaultValue;
 }
 
 /**


### PR DESCRIPTION
Two Zod-integration wins from the contract audit, turning hand-asserted
types into single shared schemas validated at their boundary.

CLI `--output-format ndjson` contract: the per-line record type was
`object`, so a typo'd or unregistered `kind` slipped through unchecked.
Add `CliNdjsonRecordSchema` (a discriminated union over `kind`, loose so
spread payloads and the downstream `ts` stamp pass) as the single source
of truth, derive `CliNdjsonRecord` from it, and type every `emitCliResult`
call and the `cli*NdjsonRecords` helpers against it. A new contract test
locks one representative record per emitted `kind`.

Validated settings reads: `CoreSettingsSchema` was the source of truth for
types but config reads cast through `getConfig<T>` with no runtime check,
so a stale `settings.json` enum value flowed through as-is. Add
`getValidatedConfig(path, schema, default)` and use it for the
`latexdiff.tempFileLocation` and `agentReview.approach` enum reads, sharing
the `coreSettings.ts` enum constants as both the type and the validator.

https://claude.ai/code/session_01NoFvezToRpK1XwYwjPS4WD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly typing and validation at output/config boundaries; behavior falls back to defaults on bad settings and does not change NDJSON wire shapes beyond stricter compile-time checks.
> 
> **Overview**
> Introduces **shared Zod contracts** at two boundaries that previously relied on loose `object` / `getConfig<T>` typing.
> 
> **CLI `--output-format ndjson`:** Adds `CliNdjsonRecordSchema` (discriminated union on `kind`, loose payloads) and derives `CliNdjsonRecord` from it. `emitCliResult`, `cli*NdjsonRecords` helpers, progress/log streaming, and related call sites now type against that registry so unregistered or mistyped `kind` values fail at compile time. A contract test parses one representative record per `kind` and rejects unknown kinds.
> 
> **Settings reads:** Adds `getValidatedConfig(path, schema, default)` and switches enum reads for `agentReview.approach` and `texra.latexdiff.tempFileLocation` to Zod enums built from `coreSettings` constants, falling back to defaults when `settings.json` is invalid. Desktop approval tests mock `getValidatedConfig` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b03ebe68d93fe642970590fd3d0e116696b7246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->