### PR TITLE
fix(cli): detect Homebrew installs in the update prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### CLI
+
+#### Bug Fixes
+
+- **Homebrew installs get the right upgrade command** — the CLI's in-session update prompt now recognizes a Homebrew install (the `texra-ai/tap` formula) and offers `brew update && brew upgrade texra` instead of misdetecting it as an npm global and suggesting `npm install -g`, which would have clashed with the brew-managed copy.
+
 ## [0.38.7] - 2026-06-11
 
 ### Shared (all surfaces)

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -193,9 +193,7 @@ function parseHomebrewFormulaVersion(
         versions?: { stable?: unknown };
       };
       if (name !== formula) continue;
-      return typeof versions?.stable === 'string'
-        ? versions.stable
-        : undefined;
+      return typeof versions?.stable === 'string' ? versions.stable : undefined;
     }
   } catch {
     return undefined;

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -202,10 +202,11 @@ function parseHomebrewFormulaVersion(
 }
 
 /**
- * Refresh the Homebrew tap metadata and fetch the latest formula version, or
- * undefined. Without the explicit update, `brew info` can report stale local
- * metadata and hide an available upgrade until the user runs `brew update`
- * manually.
+ * Attempt to refresh Homebrew tap metadata and fetch the latest formula
+ * version, or undefined. Without the explicit update, `brew info` can report
+ * stale local metadata and hide an available upgrade until the user runs
+ * `brew update` manually. If the refresh fails, still read `brew info`: local
+ * metadata may already be fresh enough to offer the right prompt.
  */
 export async function fetchLatestHomebrewFormulaVersion(options?: {
   formula?: string;
@@ -215,12 +216,7 @@ export async function fetchLatestHomebrewFormulaVersion(options?: {
   const formula = options?.formula ?? CLI_HOMEBREW_FORMULA;
   const runCommand = options?.runCommand ?? readCommandStdout;
   const timeoutMs = options?.timeoutMs ?? HOMEBREW_COMMAND_TIMEOUT_MS;
-  const updateStdout = await runCommand(
-    'brew',
-    ['update', '--quiet'],
-    timeoutMs,
-  );
-  if (updateStdout == null) return undefined;
+  await runCommand('brew', ['update', '--quiet'], timeoutMs);
   const stdout = await runCommand(
     'brew',
     ['info', '--json=v2', formula],

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -27,7 +27,7 @@ const CLI_HOMEBREW_FORMULA = 'texra';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const DEFAULT_TIMEOUT_MS = 2500;
-const HOMEBREW_INFO_TIMEOUT_MS = 2500;
+const HOMEBREW_COMMAND_TIMEOUT_MS = 10000;
 const POSIX_SIGNAL_EXIT_OFFSET = 128;
 const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
 
@@ -201,7 +201,12 @@ function parseHomebrewFormulaVersion(
   return undefined;
 }
 
-/** Fetch the latest locally-known Homebrew formula version, or undefined. */
+/**
+ * Refresh the Homebrew tap metadata and fetch the latest formula version, or
+ * undefined. Without the explicit update, `brew info` can report stale local
+ * metadata and hide an available upgrade until the user runs `brew update`
+ * manually.
+ */
 export async function fetchLatestHomebrewFormulaVersion(options?: {
   formula?: string;
   timeoutMs?: number;
@@ -209,10 +214,17 @@ export async function fetchLatestHomebrewFormulaVersion(options?: {
 }): Promise<string | undefined> {
   const formula = options?.formula ?? CLI_HOMEBREW_FORMULA;
   const runCommand = options?.runCommand ?? readCommandStdout;
+  const timeoutMs = options?.timeoutMs ?? HOMEBREW_COMMAND_TIMEOUT_MS;
+  const updateStdout = await runCommand(
+    'brew',
+    ['update', '--quiet'],
+    timeoutMs,
+  );
+  if (updateStdout == null) return undefined;
   const stdout = await runCommand(
     'brew',
     ['info', '--json=v2', formula],
-    options?.timeoutMs ?? HOMEBREW_INFO_TIMEOUT_MS,
+    timeoutMs,
   );
   return stdout == null
     ? undefined
@@ -326,10 +338,11 @@ async function relaunchAfterUpdate(
 let notified = false;
 
 /**
- * Once per process: check npm for a newer release and, in an interactive
- * terminal, offer to run the matching global install. Never blocks meaningfully
- * when up to date, offline, or the check is disabled — failures are silent so a
- * flaky network never gets between the user and their session.
+ * Once per process: check the package source for a newer release and, in an
+ * interactive terminal, offer to run the matching global install. npm-like
+ * installs read the npm registry; Homebrew installs refresh local tap metadata
+ * before reading the formula version. Failures are silent so a flaky network
+ * never gets between the user and their session.
  *
  * Disable entirely with `TEXRA_NO_UPDATE_CHECK=1`.
  */

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -96,10 +96,10 @@ export function buildUpdateCommand(
     case 'bun':
       return { command: 'bun', args: ['add', '-g', target] };
     case 'brew':
-      // Refresh the tap first: a brew install upgrades through Homebrew, not the
-      // npm registry, and the local formula cache may not yet have the bump that
-      // the registry check just detected. Run via the shell chain (`runCliUpdate`
-      // and `formatUpdateCommand` both treat the result as a shell command).
+      // Brew prompts are gated on the locally-known formula version, then the
+      // tap is refreshed immediately before upgrade. Run via the shell chain
+      // (`runCliUpdate` and `formatUpdateCommand` both treat the result as a
+      // shell command).
       return {
         command: 'brew',
         args: ['update', '&&', 'brew', 'upgrade', CLI_HOMEBREW_FORMULA],

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -19,13 +19,19 @@ import { createCliStyle, type CliStyle } from './style';
 /** Published package name on npm; the `texra` bin lives here. */
 const CLI_PACKAGE_NAME = '@texra-ai/cli';
 
+/**
+ * Homebrew formula name (in the `texra-ai/tap` tap). The unqualified name is
+ * enough for `brew upgrade` once the tap is installed.
+ */
+const CLI_HOMEBREW_FORMULA = 'texra';
+
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const DEFAULT_TIMEOUT_MS = 2500;
 const POSIX_SIGNAL_EXIT_OFFSET = 128;
 const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
 
 /** Package manager the running binary was installed with. */
-export type InstallMethod = 'npm' | 'pnpm' | 'yarn' | 'bun';
+export type InstallMethod = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'brew';
 
 /**
  * True when `latest` is strictly newer than `current`, using full semver
@@ -43,14 +49,28 @@ export function isNewerVersion(latest: string, current: string): boolean {
 }
 
 /**
- * Guess the package manager from the path the binary runs out of. Global
- * pnpm/yarn/bun installs leave a recognizable segment in the path; npm's global
- * layout has none, so it is the fallback.
+ * Guess the package manager from the path the binary runs out of. Homebrew and
+ * global pnpm/yarn/bun installs each leave a recognizable segment in the path;
+ * npm's global layout has none, so it is the fallback.
+ *
+ * Homebrew's Tier-1 formula installs the npm package into the Cellar, so a brew
+ * install must NOT be treated as a plain npm global — `npm install -g` would
+ * shadow or clash with the brew-managed copy. The Cellar lives under
+ * `/opt/homebrew` (Apple Silicon), `/usr/local/Cellar` (Intel), or
+ * `/home/linuxbrew/.linuxbrew` (Linux), so a `cellar`, `homebrew`, or
+ * `linuxbrew` segment is a reliable marker.
  */
 export function detectInstallMethod(
   modulePath: string = currentModulePath(),
 ): InstallMethod {
   const segments = modulePath.toLowerCase().split(/[\\/]+/);
+  if (
+    segments.some(
+      (part) =>
+        part === 'cellar' || part === 'homebrew' || part === 'linuxbrew',
+    )
+  )
+    return 'brew';
   if (segments.some((part) => part === 'bun' || part === '.bun')) return 'bun';
   if (segments.some((part) => part === 'pnpm' || part === '.pnpm'))
     return 'pnpm';
@@ -81,6 +101,15 @@ export function buildUpdateCommand(
       return { command: 'yarn', args: ['global', 'add', target] };
     case 'bun':
       return { command: 'bun', args: ['add', '-g', target] };
+    case 'brew':
+      // Refresh the tap first: a brew install upgrades through Homebrew, not the
+      // npm registry, and the local formula cache may not yet have the bump that
+      // the registry check just detected. Run via the shell chain (`runCliUpdate`
+      // and `formatUpdateCommand` both treat the result as a shell command).
+      return {
+        command: 'brew',
+        args: ['update', '&&', 'brew', 'upgrade', CLI_HOMEBREW_FORMULA],
+      };
     case 'npm':
       return { command: 'npm', args: ['install', '-g', target] };
   }

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -186,19 +186,16 @@ function parseHomebrewFormulaVersion(
   try {
     const body = JSON.parse(stdout) as { formulae?: unknown };
     if (!Array.isArray(body.formulae)) return undefined;
-    for (const entry of body.formulae) {
-      if (typeof entry !== 'object' || entry === null) continue;
-      const { name, versions } = entry as {
-        name?: unknown;
-        versions?: { stable?: unknown };
-      };
-      if (name !== formula) continue;
-      return typeof versions?.stable === 'string' ? versions.stable : undefined;
-    }
+    const entry = body.formulae.find((candidate) => {
+      if (typeof candidate !== 'object' || candidate === null) return false;
+      return (candidate as { name?: unknown }).name === formula;
+    });
+    if (typeof entry !== 'object' || entry === null) return undefined;
+    const { versions } = entry as { versions?: { stable?: unknown } };
+    return typeof versions?.stable === 'string' ? versions.stable : undefined;
   } catch {
     return undefined;
   }
-  return undefined;
 }
 
 /**

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -27,6 +27,7 @@ const CLI_HOMEBREW_FORMULA = 'texra';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const DEFAULT_TIMEOUT_MS = 2500;
+const HOMEBREW_INFO_TIMEOUT_MS = 2500;
 const POSIX_SIGNAL_EXIT_OFFSET = 128;
 const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
 
@@ -55,22 +56,15 @@ export function isNewerVersion(latest: string, current: string): boolean {
  *
  * Homebrew's Tier-1 formula installs the npm package into the Cellar, so a brew
  * install must NOT be treated as a plain npm global — `npm install -g` would
- * shadow or clash with the brew-managed copy. The Cellar lives under
- * `/opt/homebrew` (Apple Silicon), `/usr/local/Cellar` (Intel), or
- * `/home/linuxbrew/.linuxbrew` (Linux), so a `cellar`, `homebrew`, or
- * `linuxbrew` segment is a reliable marker.
+ * shadow or clash with the brew-managed copy. Only the `Cellar` segment marks a
+ * brew formula install; broader `homebrew` / `linuxbrew` prefixes also contain
+ * npm globals when Node itself was installed by Homebrew.
  */
 export function detectInstallMethod(
   modulePath: string = currentModulePath(),
 ): InstallMethod {
   const segments = modulePath.toLowerCase().split(/[\\/]+/);
-  if (
-    segments.some(
-      (part) =>
-        part === 'cellar' || part === 'homebrew' || part === 'linuxbrew',
-    )
-  )
-    return 'brew';
+  if (segments.includes('cellar')) return 'brew';
   if (segments.some((part) => part === 'bun' || part === '.bun')) return 'bun';
   if (segments.some((part) => part === 'pnpm' || part === '.pnpm'))
     return 'pnpm';
@@ -146,6 +140,85 @@ export async function fetchLatestCliVersion(options?: {
   } finally {
     clearTimeout(timer);
   }
+}
+
+type CommandRunner = (
+  command: string,
+  args: readonly string[],
+  timeoutMs: number,
+) => Promise<string | undefined>;
+
+async function readCommandStdout(
+  command: string,
+  args: readonly string[],
+  timeoutMs: number,
+): Promise<string | undefined> {
+  return new Promise<string | undefined>((resolve) => {
+    const child = spawn(command, args, {
+      shell: false,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let stdout = '';
+    let settled = false;
+    const finish = (value: string | undefined): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(undefined);
+    }, timeoutMs);
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.on('error', () => finish(undefined));
+    child.on('close', (code) => finish(code === 0 ? stdout : undefined));
+  });
+}
+
+function parseHomebrewFormulaVersion(
+  stdout: string,
+  formula = CLI_HOMEBREW_FORMULA,
+): string | undefined {
+  try {
+    const body = JSON.parse(stdout) as { formulae?: unknown };
+    if (!Array.isArray(body.formulae)) return undefined;
+    for (const entry of body.formulae) {
+      if (typeof entry !== 'object' || entry === null) continue;
+      const { name, versions } = entry as {
+        name?: unknown;
+        versions?: { stable?: unknown };
+      };
+      if (name !== formula) continue;
+      return typeof versions?.stable === 'string'
+        ? versions.stable
+        : undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+/** Fetch the latest locally-known Homebrew formula version, or undefined. */
+export async function fetchLatestHomebrewFormulaVersion(options?: {
+  formula?: string;
+  timeoutMs?: number;
+  runCommand?: CommandRunner;
+}): Promise<string | undefined> {
+  const formula = options?.formula ?? CLI_HOMEBREW_FORMULA;
+  const runCommand = options?.runCommand ?? readCommandStdout;
+  const stdout = await runCommand(
+    'brew',
+    ['info', '--json=v2', formula],
+    options?.timeoutMs ?? HOMEBREW_INFO_TIMEOUT_MS,
+  );
+  return stdout == null
+    ? undefined
+    : parseHomebrewFormulaVersion(stdout, formula);
 }
 
 function runCliUpdate(method: InstallMethod): Promise<boolean> {
@@ -277,10 +350,13 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
     return;
   if (context.outputFormat === 'ndjson' || context.quietLogs === true) return;
 
-  const latest = await fetchLatestCliVersion();
+  const method = detectInstallMethod();
+  const latest =
+    method === 'brew'
+      ? await fetchLatestHomebrewFormulaVersion()
+      : await fetchLatestCliVersion();
   if (!latest || !isNewerVersion(latest, context.version)) return;
 
-  const method = detectInstallMethod();
   const updateCmd = formatUpdateCommand(method);
   const style = createCliStyle(context.colorEnabled);
   writeTextStderr(

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -7,6 +7,7 @@ import {
   detectInstallMethod,
   exitCodeForRelaunchClose,
   fetchLatestCliVersion,
+  fetchLatestHomebrewFormulaVersion,
   formatUpdateCommand,
   isNewerVersion,
 } from '@cli/runtime/updateChecker';
@@ -71,6 +72,19 @@ describe('detectInstallMethod', () => {
   it('falls back to npm for the unmarked global layout', () => {
     expect(
       detectInstallMethod('/usr/local/lib/node_modules/@texra-ai/cli/dist'),
+    ).toBe('npm');
+  });
+
+  it('does not treat Homebrew-managed Node npm globals as brew installs', () => {
+    expect(
+      detectInstallMethod(
+        '/opt/homebrew/lib/node_modules/@texra-ai/cli/dist/bin/texra.js',
+      ),
+    ).toBe('npm');
+    expect(
+      detectInstallMethod(
+        '/home/linuxbrew/.linuxbrew/lib/node_modules/@texra-ai/cli/dist/bin/texra.js',
+      ),
     ).toBe('npm');
   });
 });
@@ -196,5 +210,62 @@ describe('fetchLatestCliVersion', () => {
   it('returns undefined when the body lacks a version', async () => {
     const fetchImpl = (async () => jsonResponse({})) as typeof fetch;
     await expect(fetchLatestCliVersion({ fetchImpl })).resolves.toBeUndefined();
+  });
+});
+
+describe('fetchLatestHomebrewFormulaVersion', () => {
+  it('returns the stable formula version from brew info JSON', async () => {
+    await expect(
+      fetchLatestHomebrewFormulaVersion({
+        runCommand: async () =>
+          JSON.stringify({
+            formulae: [
+              {
+                name: 'texra',
+                versions: { stable: '0.39.0' },
+              },
+            ],
+          }),
+      }),
+    ).resolves.toBe('0.39.0');
+  });
+
+  it('returns undefined when brew info is unavailable or missing the formula', async () => {
+    await expect(
+      fetchLatestHomebrewFormulaVersion({
+        runCommand: async () => undefined,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      fetchLatestHomebrewFormulaVersion({
+        runCommand: async () => JSON.stringify({ formulae: [] }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('passes the formula and timeout through to the command runner', async () => {
+    const calls: Array<{
+      command: string;
+      args: readonly string[];
+      timeoutMs: number;
+    }> = [];
+    await fetchLatestHomebrewFormulaVersion({
+      formula: 'custom',
+      timeoutMs: 123,
+      runCommand: async (command, args, timeoutMs) => {
+        calls.push({ command, args, timeoutMs });
+        return JSON.stringify({
+          formulae: [{ name: 'custom', versions: { stable: '1.2.3' } }],
+        });
+      },
+    });
+
+    expect(calls).toEqual([
+      {
+        command: 'brew',
+        args: ['info', '--json=v2', 'custom'],
+        timeoutMs: 123,
+      },
+    ]);
   });
 });

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -243,18 +243,24 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('returns undefined when the Homebrew tap refresh fails', async () => {
+  it('still reads formula info when the Homebrew tap refresh fails', async () => {
     const calls: Array<{ command: string; args: readonly string[] }> = [];
     await expect(
       fetchLatestHomebrewFormulaVersion({
         runCommand: async (command, args) => {
           calls.push({ command, args });
-          return undefined;
+          if (args[0] === 'update') return undefined;
+          return JSON.stringify({
+            formulae: [{ name: 'texra', versions: { stable: '0.39.0' } }],
+          });
         },
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe('0.39.0');
 
-    expect(calls).toEqual([{ command: 'brew', args: ['update', '--quiet'] }]);
+    expect(calls).toEqual([
+      { command: 'brew', args: ['update', '--quiet'] },
+      { command: 'brew', args: ['info', '--json=v2', 'texra'] },
+    ]);
   });
 
   it('passes the formula and timeout through to the command runner', async () => {

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -47,6 +47,27 @@ describe('detectInstallMethod', () => {
     expect(detectInstallMethod('/Users/me/.bun/install/global/x')).toBe('bun');
   });
 
+  it('recognizes Homebrew Cellar layouts across platforms', () => {
+    // Apple Silicon.
+    expect(
+      detectInstallMethod(
+        '/opt/homebrew/Cellar/texra/0.38.7/libexec/dist/bin/texra.js',
+      ),
+    ).toBe('brew');
+    // Intel macOS.
+    expect(
+      detectInstallMethod(
+        '/usr/local/Cellar/texra/0.38.7/libexec/dist/bin/texra.js',
+      ),
+    ).toBe('brew');
+    // Linuxbrew.
+    expect(
+      detectInstallMethod(
+        '/home/linuxbrew/.linuxbrew/Cellar/texra/0.38.7/libexec/dist/bin/texra.js',
+      ),
+    ).toBe('brew');
+  });
+
   it('falls back to npm for the unmarked global layout', () => {
     expect(
       detectInstallMethod('/usr/local/lib/node_modules/@texra-ai/cli/dist'),
@@ -66,9 +87,18 @@ describe('buildUpdateCommand / formatUpdateCommand', () => {
       'yarn global add @texra-ai/cli@latest',
     );
     expect(formatUpdateCommand('bun')).toBe('bun add -g @texra-ai/cli@latest');
+    // Homebrew upgrades through brew, not the npm registry; refresh the tap
+    // first so the just-detected version is actually available locally.
+    expect(formatUpdateCommand('brew')).toBe(
+      'brew update && brew upgrade texra',
+    );
     expect(buildUpdateCommand('npm')).toEqual({
       command: 'npm',
       args: ['install', '-g', '@texra-ai/cli@latest'],
+    });
+    expect(buildUpdateCommand('brew')).toEqual({
+      command: 'brew',
+      args: ['update', '&&', 'brew', 'upgrade', 'texra'],
     });
   });
 });

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -243,6 +243,22 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('returns undefined when the Homebrew tap refresh fails', async () => {
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    await expect(
+      fetchLatestHomebrewFormulaVersion({
+        runCommand: async (command, args) => {
+          calls.push({ command, args });
+          return undefined;
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(calls).toEqual([
+      { command: 'brew', args: ['update', '--quiet'] },
+    ]);
+  });
+
   it('passes the formula and timeout through to the command runner', async () => {
     const calls: Array<{
       command: string;
@@ -261,6 +277,11 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
     });
 
     expect(calls).toEqual([
+      {
+        command: 'brew',
+        args: ['update', '--quiet'],
+        timeoutMs: 123,
+      },
       {
         command: 'brew',
         args: ['info', '--json=v2', 'custom'],

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -254,9 +254,7 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(calls).toEqual([
-      { command: 'brew', args: ['update', '--quiet'] },
-    ]);
+    expect(calls).toEqual([{ command: 'brew', args: ['update', '--quiet'] }]);
   });
 
   it('passes the formula and timeout through to the command runner', async () => {


### PR DESCRIPTION
The in-session update checker only recognized npm/pnpm/yarn/bun installs
and fell back to npm for everything else, so a Homebrew-installed CLI was
offered `npm install -g @texra-ai/cli@latest` — which would shadow or
clash with the brew-managed copy in the Cellar.

Add a `brew` InstallMethod, detect the Homebrew Cellar by path segment
(`/opt/homebrew`, `/usr/local/Cellar`, `/home/linuxbrew/.linuxbrew`),
and offer `brew update && brew upgrade texra` instead. The chained command
runs through the existing shell-backed runner and re-exec/relaunch flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to CLI startup update detection and optional self-update; no auth or data-path changes, with unit tests covering detection edge cases.
> 
> **Overview**
> The in-session CLI update checker now treats **Homebrew Cellar** installs as `brew` instead of defaulting to npm, so users are not offered `npm install -g @texra-ai/cli@latest` (which would clash with the brew-managed binary).
> 
> **Detection** keys off a `Cellar` path segment (Apple Silicon, Intel, Linuxbrew) and deliberately **does not** flag npm globals under `/opt/homebrew/lib/node_modules` when Node came from Homebrew.
> 
> For brew installs, **version discovery** runs `brew update --quiet` then `brew info --json=v2 texra` (with timeout and graceful fallback if refresh fails). The offered upgrade command is **`brew update && brew upgrade texra`**, executed via the existing shell-backed update and relaunch flow. npm/pnpm/yarn/bun behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d093fbfe11f1041f8f3c72b13098f6b9ab1a093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->