### PR TITLE
[codex] Document CLI TUI snapshot capture

### DIFF
--- a/docs/dev/texra-cli-checkout.md
+++ b/docs/dev/texra-cli-checkout.md
@@ -90,6 +90,32 @@ For a deterministic local run check that does not require provider credentials:
 corepack pnpm --filter @texra-ai/cli validate:run
 ```
 
+For deterministic TUI checks, use the Ink frame validator. It drives the CLI
+through a PTY, so it verifies the same visible terminal frame a user sees in
+chat mode:
+
+```bash
+corepack pnpm --filter @texra-ai/cli validate:tui
+```
+
+To capture reviewable TUI screenshots, pass a snapshot directory and the
+scenario names you want to inspect. The command writes numbered `.txt` and
+`.svg` frames plus an `index.html` report:
+
+```bash
+corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-frames \
+  transcript edit-approval bash-approval-approve-session subagents
+```
+
+Open `/tmp/texra-tui-frames/index.html` in a browser to review the captured
+frames.
+
+List the available scenarios before narrowing a product-review pass:
+
+```bash
+corepack pnpm --filter @texra-ai/cli validate:tui -- --list
+```
+
 ## Remove the Linked Command
 
 For the side-by-side `texra-local` link:


### PR DESCRIPTION
## Summary
- document `validate:tui` in the checkout CLI validation flow
- add the snapshot-report command for reviewable `.txt`/`.svg` frames and `index.html`
- point developers to `--list` before narrowing product-review scenarios

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --list`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-docs-frames transcript edit-approval bash-approval-approve-session subagents`
- `corepack pnpm exec prettier --check docs/dev/texra-cli-checkout.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or build behavior changes.
> 
> **Overview**
> Extends the checkout **Validation** section in `docs/dev/texra-cli-checkout.md` with developer workflow for Ink TUI checks via `validate:tui` (PTY-driven, same frames as chat mode).
> 
> Documents how to capture reviewable output with `--snapshot-dir` (numbered `.txt`/`.svg` frames and `index.html`), how to open the HTML report, and how to use `--list` to discover scenarios before a focused product review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1878b19bf3d61b9385fcf69602e0f2a85696e8c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->