### PR TITLE
[codex] Summarize queued subagent follow-ups in CLI status

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -217,6 +217,24 @@ const SCENARIOS = [
     unexpect: ['<orchestrator-followup>', '<subagent-result'],
   },
   {
+    name: 'queued-subagent-followup-status-preview',
+    cols: 140,
+    env: {
+      HARNESS_ENTRIES: '2',
+      HARNESS_QUEUED_FOLLOWUPS:
+        '<orchestrator-followup><subagent-progress id="child-q" agent="review" category="toolUse" type="todos" completed="6" active="0" pending="0"/></orchestrator-followup>',
+    },
+    bootExpect: 'queued 1',
+    frame: 'tail',
+    expect: [
+      'Queued follow-ups (1)',
+      '1. ⟳ review · todos · 6 done, 0 active, 0 pending',
+      'queued 1',
+      '⟳ review · todos · 6 done, 0 active, 0 pending',
+    ],
+    unexpect: ['<orchestrator-followup>', '<subagent-progress'],
+  },
+  {
     name: 'compact-queued-followups',
     rows: 8,
     cols: 60,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -13,6 +13,7 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
+import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { filterNotNullish } from '@utils/core';
 
 import { truncateSummaryToWidth } from '../render/terminalText';
@@ -199,7 +200,10 @@ function numberedQueuedFollowUpPreview(
 ): string {
   const prefix = `${index + 1}. `;
   const bodyColumns = Math.max(0, maxColumns - stringWidth(prefix));
-  return `${prefix}${truncateSummaryToWidth(message, bodyColumns)}`;
+  return `${prefix}${truncateSummaryToWidth(
+    summarizeFollowupMessage(message),
+    bodyColumns,
+  )}`;
 }
 
 function queuedFollowUpsListSummary(
@@ -239,7 +243,10 @@ export function queuedFollowUpsSummary(
   if (messages.length > 1) {
     return queuedFollowUpsListSummary(messages, previewLength);
   }
-  return truncateSummaryToWidth(messages[0] ?? '', previewLength);
+  return truncateSummaryToWidth(
+    summarizeFollowupMessage(messages[0] ?? ''),
+    previewLength,
+  );
 }
 
 function queuedFollowUpsCountSegment(

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -13,6 +13,10 @@ import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import { STREAM_STATUS } from '@shared/schemas';
 
 const PERSONAL_API_MODE_LABEL = shortCliApiMode('personal');
+const COMPLETED_REVIEW_FOLLOWUP =
+  '<orchestrator-followup><subagent-result id="child-q" agent="review" category="toolUse" status="completed"><response>All good &lt;ok&gt;</response></subagent-result></orchestrator-followup>';
+const PROGRESS_REVIEW_FOLLOWUP =
+  '<orchestrator-followup><subagent-progress id="child-q" agent="review" category="toolUse" type="todos" completed="6" active="0" pending="0"/></orchestrator-followup>';
 
 describe('CLI StatusBar display model', () => {
   it('previews queued follow-up messages without duplicating the count', () => {
@@ -26,6 +30,29 @@ describe('CLI StatusBar display model', () => {
         'Also mention the finite monoid argument.',
       ]),
     ).toBe('1. Keep the proof und… · 2. Also mention the f…');
+  });
+
+  it('summarizes queued subagent follow-up XML in the status preview', () => {
+    expect(queuedFollowUpsSummary([COMPLETED_REVIEW_FOLLOWUP], 80)).toBe(
+      '✓ review completed All good <ok>',
+    );
+
+    const progressSummary = queuedFollowUpsSummary(
+      [PROGRESS_REVIEW_FOLLOWUP],
+      80,
+    );
+    expect(progressSummary).toBe(
+      '⟳ review · todos · 6 done, 0 active, 0 pending',
+    );
+    expect(progressSummary).not.toContain('<subagent-progress');
+
+    const listSummary = queuedFollowUpsSummary([
+      PROGRESS_REVIEW_FOLLOWUP,
+      'Check the edge case.',
+    ]);
+    expect(listSummary).toContain('1. ⟳ review');
+    expect(listSummary).not.toContain('<orchestrator-followup>');
+    expect(listSummary).not.toContain('<subagent-progress');
   });
 
   it('marks hidden queued follow-up previews', () => {


### PR DESCRIPTION
## Summary
- reuse the shared subagent follow-up summarizer for CLI status-bar queued previews
- prevent raw `<orchestrator-followup>` / `<subagent-progress>` XML from appearing in the visible status line
- add unit and TUI harness coverage for queued subagent follow-up previews

## Dogfood Evidence
- While running `texra-local orchestrate` with Team Mathematician, the status line briefly showed a raw `<subagent-progress ...>` queued follow-up after a delegated review completed. The queued panel already had the right summarizer; the status preview did not.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- queued-subagent-followup-status-preview queued-subagent-followup-summary`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/panes/StatusBar.tsx src/test-kernel/cli/StatusBar.vitest.mts packages/cli/scripts/validate-tui.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow display-layer change reusing existing shared summarization; tests and harness cover the new behavior with no auth or data-handling impact.
> 
> **Overview**
> **Queued follow-up previews in the CLI status bar now use the shared `summarizeFollowupMessage` helper**, so subagent orchestrator XML shows as human-readable lines (e.g. completed review text or in-progress todo counts) instead of raw `<orchestrator-followup>` / `<subagent-progress>` tags.
> 
> Single-item and numbered multi-item previews both run through the summarizer before width truncation. **Unit tests** cover completed and progress XML plus mixed lists, and a **TUI harness scenario** (`queued-subagent-followup-status-preview`) asserts the visible status line and queued panel stay free of raw markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c55dd291aacdc23c1d0c398000f58f616383b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->