### PR TITLE
[codex] Clarify multi-agent run help mode

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -51,6 +51,7 @@ import {
   missingToolUseAgentMessage,
 } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
+import { withUsageSections } from './_helpers/dispatch/usage';
 import { formatMultiAgentRunInstruction } from './_helpers/multiAgentInstruction';
 import { emitCliResult } from './_helpers/output';
 import {
@@ -437,60 +438,80 @@ const multiAgentInspectCommand = defineCliCommand({
   run: (context, ctx) => runMultiAgentInspect(context, ctx.args.preset),
 });
 
-const multiAgentRunCommand = defineCliCommand({
-  meta: { name: 'run', description: 'Run a multi-agent team preset' },
-  args: {
-    ...AGENT_RUN_GLOBAL_ARGS,
-    preset: {
-      type: 'positional',
-      required: true,
-      description: 'Preset id or name from `texra multi-agent list`',
+const multiAgentRunCommand = withUsageSections(
+  defineCliCommand({
+    meta: { name: 'run', description: 'Run a multi-agent team preset' },
+    args: {
+      ...AGENT_RUN_GLOBAL_ARGS,
+      preset: {
+        type: 'positional',
+        required: true,
+        description: 'Preset id or name from `texra multi-agent list`',
+      },
+      input: {
+        type: 'string',
+        alias: 'i',
+        valueHint: 'file',
+        description:
+          'Input file passed to the team orchestrator (repeatable; optional when --instruction or --instruction-file is provided; use `-` to read stdin)',
+      },
+      context: {
+        type: 'string',
+        alias: 'c',
+        valueHint: 'file',
+        description:
+          'Read-only context file passed to the team orchestrator (repeatable; use `-` to read stdin)',
+      },
+      agent: {
+        type: 'string',
+        description: MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION,
+      },
+      model: {
+        type: 'string',
+        alias: 'm',
+        description: MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION,
+      },
+      instruction: {
+        type: 'string',
+        description: 'Additional instruction for the team orchestrator',
+      },
+      'instruction-file': {
+        type: 'string',
+        valueHint: 'file',
+        description:
+          'File whose contents are passed before --instruction when both are set',
+      },
     },
-    input: {
-      type: 'string',
-      alias: 'i',
-      valueHint: 'file',
-      description:
-        'Input file passed to the team orchestrator (repeatable; optional when --instruction or --instruction-file is provided; use `-` to read stdin)',
+    run: (context, ctx) =>
+      runMultiAgentPreset(context, {
+        preset: ctx.args.preset,
+        inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
+        contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
+        agent: optString(ctx.args.agent),
+        model: optString(ctx.args.model),
+        instruction: optString(ctx.args.instruction) ?? '',
+        instructionFile: optionalStringFlagValue(
+          ctx.rawArgs,
+          'instruction-file',
+        ),
+      }),
+  }),
+  [
+    {
+      title: 'RUN MODE',
+      rows: [
+        [
+          'direct',
+          'executes the team in the terminal and exits after the final response',
+        ],
+        [
+          'rich TUI',
+          'use `texra orchestrate` to pick a team from the launcher and keep chat/subagent panes open',
+        ],
+      ],
     },
-    context: {
-      type: 'string',
-      alias: 'c',
-      valueHint: 'file',
-      description:
-        'Read-only context file passed to the team orchestrator (repeatable; use `-` to read stdin)',
-    },
-    agent: {
-      type: 'string',
-      description: MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION,
-    },
-    model: {
-      type: 'string',
-      alias: 'm',
-      description: MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION,
-    },
-    instruction: {
-      type: 'string',
-      description: 'Additional instruction for the team orchestrator',
-    },
-    'instruction-file': {
-      type: 'string',
-      valueHint: 'file',
-      description:
-        'File whose contents are passed before --instruction when both are set',
-    },
-  },
-  run: (context, ctx) =>
-    runMultiAgentPreset(context, {
-      preset: ctx.args.preset,
-      inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
-      contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
-      agent: optString(ctx.args.agent),
-      model: optString(ctx.args.model),
-      instruction: optString(ctx.args.instruction) ?? '',
-      instructionFile: optionalStringFlagValue(ctx.rawArgs, 'instruction-file'),
-    }),
-});
+  ],
+);
 
 export const multiAgentCommand = defineCommand({
   meta: {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1370,6 +1370,11 @@ describe('runCli usage output stream routing', () => {
       'Root agent for the team run (defaults to the preset orchestrator)',
     );
     expect(stdout).toContain('Model for the team root agent');
+    expect(stdout).toContain('RUN MODE');
+    expect(stdout).toContain(
+      'executes the team in the terminal and exits after the final response',
+    );
+    expect(stdout).toContain('use `texra orchestrate`');
     expect(stdout).not.toContain('root tool-use agent');
     expect(stderr).toBe('');
   });


### PR DESCRIPTION
## Summary

- add a `RUN MODE` section to `texra multi-agent run --help`
- clarify that `multi-agent run` is a direct terminal run that exits after the final response
- point users who want the rich launcher/chat/subagent panes to `texra orchestrate`

Fixes #5982.

## Dogfood evidence

From latest `origin/main`, I ran a real PTY session:

`TERM=xterm-256color node packages/cli/dist/bin/texra.js multi-agent run mathematician --cwd /private/tmp/texra-live-direct.qdKc9j --input main.tex --approval-policy ask --no-color --model deepseekT --instruction "Fix the mathematical proof and any LaTeX errors, compile main.tex, and stop after reporting the result."`

The direct runner showed readable edit and bash approval prompts, fixed the proof, compiled `main.tex`, and exited after the final response. That behavior is reasonable; the gap was that help text did not distinguish it from the rich TUI route.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/commands/multiAgent.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js --no-color help multi-agent run`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-latest-dogfood.1Ei4Rv/tui-snapshots queued-subagent-followup-status-preview queued-subagent-followup-summary subagents task-picker`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help-text and test-only changes; no change to run or orchestrate execution paths.
> 
> **Overview**
> Adds a **RUN MODE** section to `texra multi-agent run --help` (and `help multi-agent run`) via the existing `withUsageSections` helper, matching how `chat` and `orchestrate` document interactive behavior.
> 
> The section states that this command runs the team **directly in the terminal** and **exits after the final response**, and points users who want the launcher with persistent chat/subagent panes to **`texra orchestrate`**. CLI tests assert the new help lines appear on nested help paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ba13fc675204969997aed7c93e17da08655c8a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->