### PR TITLE
[codex] Cover resume slash form in TUI harness

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -473,6 +473,21 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'slash-resume-empty',
+    cols: 100,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/resume', '\r'],
+    frame: 'tail',
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: [
+      '/resume',
+      'No resumable sessions found.',
+      'Esc close',
+      'Use foreground panel shortcuts',
+    ],
+    unexpect: ['/resume is registered but has no harness action.'],
+  },
+  {
     name: 'slash-clear',
     cols: 100,
     env: {


### PR DESCRIPTION
## Summary

- add a `slash-resume-empty` validator scenario that opens `/resume` through the PTY harness
- assert the visible empty state, close affordance, and that the registered slash command does not fall through to the generic no-action message

Closes #5986.

## Validation

- real PTY harness check: typed `/resume` into `node packages/cli/dist/bin/tui-harness.js`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-next-scout.DVF8hU/tui-snapshots slash-resume-empty`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build slash-resume-empty slash-help slash-palette`
- `node packages/cli/scripts/validate-tui.mjs --no-build --list | rg '^slash-resume-empty$'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to `validate-tui.mjs`; no production runtime behavior is modified.
> 
> **Overview**
> Adds a **`slash-resume-empty`** scenario to the CLI TUI PTY validator so `/resume` is exercised end-to-end in the harness.
> 
> The scenario types `/resume` and Enter, waits for async form settle, and checks the **empty-state** UI (`No resumable sessions found.`, `Esc close`, foreground panel shortcuts). It also **fails** if the harness falls through to **`/resume is registered but has no harness action.`**, matching the pattern used for `/clear` and other slash forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d4984598ad11450fc668ffde5a3dac6f6b65fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->