### PR TITLE
[codex] Trust CLI stop capability in status bar

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -810,6 +810,13 @@ const SCENARIOS = [
     unexpect: ['approval: deny privileged actions'],
   },
   {
+    name: 'uninterruptible-running-status-bar',
+    env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
+    frame: 'tail',
+    expect: ['◆ running', '[Ctrl-C]exit'],
+    unexpect: ['[Ctrl-C]stop'],
+  },
+  {
     name: 'tools-form',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/tools', '\r'],

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -620,12 +620,10 @@ export function statusBarStreamTarget({
     canUseValue: (stream: StatusBarVisibleStream) =>
       isLiveStreamStatus(stream.status),
   });
-  const canStopVisibleRun =
-    isLiveStreamStatus(activeSlice?.status) || liveAncestor !== undefined;
   return {
     ctrlCAction: ctrlCActionForFocus({
       activeStreamId,
-      canStopActiveRun: canStopActiveRun || canStopVisibleRun,
+      canStopActiveRun,
       parentStream,
     }),
     displaySlice: activeSlice ?? liveAncestor?.value,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -791,7 +791,7 @@ describe('CLI StatusBar display model', () => {
     );
   });
 
-  it('projects the focused status target and visible stoppable run once', () => {
+  it('projects focused status while keeping stop capability host-owned', () => {
     const root = 'root';
     const child = 'child';
     const grandchild = 'grandchild';
@@ -821,6 +821,17 @@ describe('CLI StatusBar display model', () => {
         streams,
       }),
     ).toMatchObject({
+      ctrlCAction: 'exit',
+      displaySlice: rootSlice,
+    });
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: root,
+        canStopActiveRun: true,
+        parentStream: new Map([[child, root]]),
+        streams,
+      }),
+    ).toMatchObject({
       ctrlCAction: 'stop',
       displaySlice: rootSlice,
     });
@@ -832,6 +843,17 @@ describe('CLI StatusBar display model', () => {
         streams,
       }),
     ).toMatchObject({
+      ctrlCAction: 'exit',
+      displaySlice: childSlice,
+    });
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: child,
+        canStopActiveRun: true,
+        parentStream: new Map([[child, root]]),
+        streams,
+      }),
+    ).toMatchObject({
       ctrlCAction: 'stop root',
       displaySlice: childSlice,
     });
@@ -839,6 +861,20 @@ describe('CLI StatusBar display model', () => {
       statusBarStreamTarget({
         activeStreamId: grandchild,
         canStopActiveRun: false,
+        parentStream: new Map([
+          [child, root],
+          [grandchild, child],
+        ]),
+        streams,
+      }),
+    ).toMatchObject({
+      ctrlCAction: 'exit',
+      displaySlice: grandchildSlice,
+    });
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: grandchild,
+        canStopActiveRun: true,
         parentStream: new Map([
           [child, root],
           [grandchild, child],


### PR DESCRIPTION
## Summary
- trust the host-provided CLI stop capability when choosing the StatusBar Ctrl-C action label
- keep live stream status display separate from whether Ctrl-C can stop the run
- add TUI harness and kernel-test coverage for running-looking but uninterruptible streams

Closes #5988

## Validation
- corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm --filter @texra-ai/cli build
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-goal-next.7VaFl6/final-snapshots uninterruptible-running-status-bar approval-policy-status-bar task-picker subagent-picker empty-task-shortcut-hidden approval-form compact-approval-form slash-palette-overflow
- corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build uninterruptible-running-status-bar approval-policy-status-bar
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX change to status-bar shortcut labeling; behavior aligns with the host interrupt capability and is covered by tests.
> 
> **Overview**
> The StatusBar no longer treats a **live/running stream** (or a live ancestor) as proof that Ctrl-C can **stop** the run. **`statusBarStreamTarget`** now sets the Ctrl-C binding from the host-only **`canStopActiveRun`** flag only, while stream slices still drive the **running/idle** status text.
> 
> Unit tests were updated so **`ctrlCAction`** is **`exit`** when the host says stopping is unavailable, even if the focused stream is running. A TUI harness scenario **`uninterruptible-running-status-bar`** locks in **`◆ running`** with **`[Ctrl-C]exit`** and no **`[Ctrl-C]stop`** when the harness does not allow interrupt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1d185461a9f53d956f3baa15fbae66b14626dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->