### PR TITLE
fix: show public resume command in CLI hints

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -195,7 +195,7 @@ export interface RunChatInit {
   readonly teamName?: string;
   /** Multi-agent preset id when chat was launched from a team preset. */
   readonly cliMultiAgentPresetId?: string;
-  /** Pre-resolved startup resume from `texra --resume <id>`. */
+  /** Pre-resolved startup resume from `texra resume <id>`. */
   readonly initialResume?: {
     readonly id: ExecutionId;
     readonly resolution: CliToolUseResumeResolution;
@@ -423,7 +423,7 @@ export function chatTuiSigintAction(input: {
   // Resumable-idle (interruptible but not actively running): exit WITHOUT
   // interrupting so the suspended tool-use flow record survives for resume —
   // interrupting would clear it in runToolUseFlow's finally. preserve-exit
-  // calls process.exit, leaving the suspended flow on disk for `texra --resume`.
+  // calls process.exit, leaving the suspended flow on disk for `texra resume`.
   if (input.canInterruptActiveRun) return 'preserve-exit';
   return 'clean-exit';
 }
@@ -1812,7 +1812,7 @@ export async function runChat(
       case 'preserve-exit':
         // Resumable-idle: exit WITHOUT interrupting. This preserves the
         // suspended tool-use flow record (executions/<id>/flow-*.json) so
-        // `texra --resume` can continue it. Preserve the session's current
+        // `texra resume` can continue it. Preserve the session's current
         // terminal status too; an intentional idle exit after a successful turn
         // should not report SIGINT/130.
         //
@@ -1945,7 +1945,7 @@ export async function runChat(
         // The dangling runPromise keeps the event loop alive, so a normal return
         // would never let the process exit. Force-exit here, AFTER persistence
         // is flushed and the resume hint is printed, preserving the suspended
-        // flow record on disk for `texra --resume`. Run platform shutdown first
+        // flow record on disk for `texra resume`. Run platform shutdown first
         // so queued usage logs flush — bin/texra.ts's finally won't on exit().
         await runPlatformShutdown();
         process.exit(session.runExitCode);

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -36,7 +36,7 @@ export function formatResumeCommand(
   commandName: string | undefined,
   executionId: string,
 ): string {
-  return `${commandName || DEFAULT_RESUME_COMMAND_NAME} --resume ${executionId}`;
+  return `${commandName || DEFAULT_RESUME_COMMAND_NAME} resume ${executionId}`;
 }
 
 function formatInteger(value: number): string {

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -8,7 +8,7 @@ import { kittyFlags } from 'ink';
 // screen (?1049h is never sent), so it must NOT emit ?1049l here: terminals that
 // honor rmcup restore the primary screen grid to the snapshot from the last
 // smcup — which, with no smcup this session, is a stale grid that wipes whatever
-// was just printed at the bottom (notably the "texra --resume …" hint). tmux
+// was just printed at the bottom (notably the "texra resume …" hint). tmux
 // masks this by ignoring an unmatched rmcup; Ghostty/iTerm2/Terminal.app do not.
 const RESET_TERMINAL_MODES = '\x1b[?1000;1003;1006l\x1b[<u\x1b[?2004l\x1b[?25h';
 const CLEAR_ITERM_PROGRESS = '\x1b]9;4;0\x07';

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -25,7 +25,7 @@ import {
 import type { CliContext } from '../runtime/cliContext';
 
 /**
- * `texra --resume <id>` continues (resumes) a stored tool-use session by
+ * `texra resume <id>` continues (resumes) a stored tool-use session by
  * reopening the interactive chat TUI, which rehydrates the prior transcript and
  * continues the suspended flow.
  *

--- a/packages/cli/src/runtime/sessionResume.ts
+++ b/packages/cli/src/runtime/sessionResume.ts
@@ -1,4 +1,4 @@
-// Resolve what `texra --resume <id>` should continue.
+// Resolve what `texra resume <id>` should continue.
 //
 // Resume = continue (load the prior conversation), not re-run. The resumable
 // state lives in the per-execution flow record (executions/<id>/flow-*.json),

--- a/src/test-kernel/cli/ResumeCommand.vitest.mts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.mts
@@ -99,7 +99,7 @@ describe('runResumeExecution', () => {
     expect(mocks.resolveCliResumeSnapshot).not.toHaveBeenCalled();
     expect(mocks.runChat).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      expect.stringContaining(`texra --resume ${EXECUTION_ID}`),
+      expect.stringContaining(`texra resume ${EXECUTION_ID}`),
     );
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       expect.stringContaining('For scripting, use `texra run`.'),
@@ -117,7 +117,7 @@ describe('runResumeExecution', () => {
     ).resolves.toBe(2);
 
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      expect.stringContaining(`texra-local --resume ${EXECUTION_ID}`),
+      expect.stringContaining(`texra-local resume ${EXECUTION_ID}`),
     );
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       expect.stringContaining('For scripting, use `texra-local run`.'),

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -127,9 +127,9 @@ describe('collectResumeTargets', () => {
 
 describe('formatResumeHint', () => {
   it('formats resume commands with a local launcher when provided', () => {
-    expect(formatResumeCommand(undefined, 'root')).toBe('texra --resume root');
+    expect(formatResumeCommand(undefined, 'root')).toBe('texra resume root');
     expect(formatResumeCommand('texra-local', 'root')).toBe(
-      'texra-local --resume root',
+      'texra-local resume root',
     );
   });
 
@@ -142,8 +142,8 @@ describe('formatResumeHint', () => {
     ).toBe(
       [
         'Resume this session with:',
-        '  texra --resume root  (main)',
-        '  texra --resume rev  (reviewer)',
+        '  texra resume root  (main)',
+        '  texra resume rev  (reviewer)',
       ].join('\n'),
     );
   });
@@ -161,8 +161,8 @@ describe('formatResumeHint', () => {
     ).toBe(
       [
         'Resume this session with:',
-        '  texra-local --resume root  (main)',
-        '  texra-local --resume rev  (reviewer)',
+        '  texra-local resume root  (main)',
+        '  texra-local resume rev  (reviewer)',
       ].join('\n'),
     );
   });
@@ -180,7 +180,7 @@ describe('formatResumeHint', () => {
       [
         'Token usage: total=197,232,342 input=186,189,742 (+ 6,470,327,168 cached) output=11,042,600 (reasoning 3,489,148)',
         'Resume this session with:',
-        '  texra --resume root  (main)',
+        '  texra resume root  (main)',
       ].join('\n'),
     );
   });

--- a/src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts
+++ b/src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts
@@ -1,6 +1,6 @@
 // Focused test for the preserve-on-exit predicate that decides whether a
 // suspended tool-use session is left untouched (so its flow record survives
-// for `texra --resume`) or interrupted on shutdown. See the rationale on
+// for `texra resume`) or interrupted on shutdown. See the rationale on
 // chatTuiIsResumableIdleOnExit: interrupting clears the resumable state, so an
 // idle/WAITING session ("interruptible but not stoppable") must be preserved.
 

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -100,7 +100,7 @@ describe('CLI session status formatter', () => {
     });
 
     expect(status).toContain('session: abc123');
-    expect(status).toContain('resume later with: texra --resume abc123');
+    expect(status).toContain('resume later with: texra resume abc123');
   });
 
   it('uses the provided command name in the resume status line', () => {
@@ -115,7 +115,7 @@ describe('CLI session status formatter', () => {
       queuedFollowUpMessages: [],
     });
 
-    expect(status).toContain('resume later with: texra-local --resume abc123');
+    expect(status).toContain('resume later with: texra-local resume abc123');
   });
 
   it('omits session lines before the first run starts', () => {
@@ -129,7 +129,7 @@ describe('CLI session status formatter', () => {
     });
 
     expect(status).not.toContain('session:');
-    expect(status).not.toContain('--resume');
+    expect(status).not.toContain('resume later with:');
   });
 
   it('reports an empty follow-up queue explicitly', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1270,7 +1270,7 @@ describe('CLI StatusBar display model', () => {
       PERSONAL_API_MODE_LABEL,
     ]);
     expect(display.bindings).toBe(
-      'Resume this session with: texra --resume abc123',
+      'Resume this session with: texra resume abc123',
     );
   });
 
@@ -1295,7 +1295,7 @@ describe('CLI StatusBar display model', () => {
     });
 
     expect(display.bindings).toBe(
-      'Resume this session with: texra-local --resume abc123',
+      'Resume this session with: texra-local resume abc123',
     );
   });
 
@@ -1393,7 +1393,7 @@ describe('CLI StatusBar display model', () => {
       'Press Ctrl-C again to ex…',
     ]);
     expect(display.bindings).toBe(
-      'Resume this session with: texra --resume abc123',
+      'Resume this session with: texra resume abc123',
     );
   });
 


### PR DESCRIPTION
Fixes #5991.

## Summary
- Change the shared CLI resume hint formatter to display `texra resume <id>` instead of the hidden `--resume` shortcut.
- Update `/status`, pending-exit status bindings, exit-footer guidance, terminal-failure guidance, and tests through the shared formatter.
- Leave the existing top-level `--resume` shortcut parser intact for compatibility.

## Validation
- `npm run format`
- `corepack pnpm vitest run src/test-kernel/cli/ResumeHint.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ResumeCommand.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-goal-next.tr4kwW/tui-resume-hint-snapshots approval-policy-status-bar ctrl-c-exit ctrl-c-interrupt-active`
- Live patched TTY resume check: `/status` printed `resume later with: texra resume b91b7661f7d2`; exit footer printed `texra resume b91b7661f7d2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing string and comment updates only; resume behavior and the `--resume` compatibility shortcut are untouched.
> 
> **Overview**
> CLI copy and hints now tell users to run **`texra resume <id>`** (and **`texra-local resume <id>`** when applicable) instead of the hidden **`texra --resume <id>`** form.
> 
> The change is centralized in **`formatResumeCommand`** in `resumeHint.ts`, so exit footers, `/status`, armed-exit status bar bindings, headless resume errors, and related comments stay aligned. **Parsing for top-level `--resume` is unchanged** (`reorderFlags.ts` still maps it to the `resume` command).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2da402ff6fd01a132124615370228c2eccafce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->