### PR TITLE
fix: show exit after stopped CLI runs

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2575,7 +2575,9 @@ const SCENARIOS = [
       'Harness interrupt requested.',
       '[main](stopped)',
       '◆ stopped keys',
+      '[Ctrl-C]exit',
     ],
+    unexpect: ['[Ctrl-C]stop'],
   },
 ];
 

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -485,6 +485,7 @@ export interface AppProps {
   readonly onKillExecution: (executionId: string) => void;
   readonly canInterruptActiveRun: () => boolean;
   readonly canStopActiveRun?: () => boolean;
+  readonly canStopPendingRunWithoutStream?: () => boolean;
   readonly colorEnabled?: boolean;
   readonly commandName?: string;
   readonly onInterruptActive: () => void;
@@ -521,6 +522,8 @@ export function App(props: AppProps): React.JSX.Element {
   const [tipHour] = useState(() => new Date().getHours());
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
+  const canStopPendingRunWithoutStream =
+    props.canStopPendingRunWithoutStream ?? (() => false);
   const agentSelectionAvailable = rootRunStartAvailable;
   const activeApprovalVisible = approvalVisibleForActiveStream({
     activeStreamId,
@@ -998,6 +1001,7 @@ export function App(props: AppProps): React.JSX.Element {
         <StatusBar
           agentSelectionAvailable={agentSelectionAvailable}
           canStopActiveRun={canStopActiveRun}
+          canStopPendingRunWithoutStream={canStopPendingRunWithoutStream}
           commandName={props.commandName}
           foregroundEscapeAction={foregroundEscapeAction({
             activeFormEscapeAction: activeForm?.escapeAction,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -556,6 +556,17 @@ function isLiveStreamStatus(status: string | undefined): boolean {
   return status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status);
 }
 
+function hasPendingOrLiveStream(
+  streams: ReadonlyMap<StreamTabId, StatusBarVisibleStream>,
+): boolean {
+  for (const stream of streams.values()) {
+    if (stream.status === undefined || isLiveStreamStatus(stream.status)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function rootActiveSegment(
   input: StatusBarDisplayInput,
 ): StatusBarSegment | undefined {
@@ -604,11 +615,13 @@ export interface StatusBarStreamTarget {
 export function statusBarStreamTarget({
   activeStreamId,
   canStopActiveRun,
+  canStopPendingRunWithoutStream = false,
   parentStream,
   streams,
 }: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly canStopActiveRun: boolean;
+  readonly canStopPendingRunWithoutStream?: boolean;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): StatusBarStreamTarget {
@@ -620,10 +633,13 @@ export function statusBarStreamTarget({
     canUseValue: (stream: StatusBarVisibleStream) =>
       isLiveStreamStatus(stream.status),
   });
+  const canStopVisibleRun =
+    canStopActiveRun &&
+    (canStopPendingRunWithoutStream || hasPendingOrLiveStream(streams));
   return {
     ctrlCAction: ctrlCActionForFocus({
       activeStreamId,
-      canStopActiveRun,
+      canStopActiveRun: canStopVisibleRun,
       parentStream,
     }),
     displaySlice: activeSlice ?? liveAncestor?.value,
@@ -780,6 +796,7 @@ export function buildStatusBarDisplay(
 export interface StatusBarProps {
   readonly agentSelectionAvailable?: boolean;
   readonly canStopActiveRun?: () => boolean;
+  readonly canStopPendingRunWithoutStream?: () => boolean;
   readonly commandName?: string;
   readonly foregroundEscapeAction?: string;
   readonly queuedFollowUpPreview?: boolean;
@@ -802,6 +819,8 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const target = statusBarStreamTarget({
     activeStreamId,
     canStopActiveRun: props.canStopActiveRun?.() === true,
+    canStopPendingRunWithoutStream:
+      props.canStopPendingRunWithoutStream?.() === true,
     parentStream,
     streams,
   });

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1201,6 +1201,8 @@ export async function runChat(
     chatTuiCanInterruptActiveRun(session);
   const canStopActiveRun = (): boolean =>
     chatTuiCanStopVisibleRun(session, rootStreamStatus());
+  const canStopPendingRunWithoutStream = (): boolean =>
+    Boolean(session.runPromise && !session.runCompleted && !session.streamId);
   const shouldDetachSubagentsOnStop = (): boolean =>
     tryPlatform()?.workspaceState.get<boolean>(
       WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
@@ -1668,6 +1670,7 @@ export async function runChat(
       onSubmit={handleSubmit}
       canInterruptActiveRun={canInterruptActiveRun}
       canStopActiveRun={canStopActiveRun}
+      canStopPendingRunWithoutStream={canStopPendingRunWithoutStream}
       colorEnabled={stdoutColorEnabled}
       commandName={context.commandName}
       onInterruptActive={interruptActive}

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -885,6 +885,106 @@ describe('CLI StatusBar display model', () => {
       ctrlCAction: 'stop root',
       displaySlice: grandchildSlice,
     });
+
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: undefined,
+        canStopActiveRun: true,
+        canStopPendingRunWithoutStream: false,
+        parentStream: new Map([[child, root]]),
+        streams: new Map(),
+      }),
+    ).toMatchObject({
+      ctrlCAction: 'exit',
+      displaySlice: undefined,
+    });
+
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: undefined,
+        canStopActiveRun: true,
+        canStopPendingRunWithoutStream: true,
+        parentStream: new Map([[child, root]]),
+        streams: new Map(),
+      }),
+    ).toMatchObject({
+      ctrlCAction: 'stop',
+      displaySlice: undefined,
+    });
+
+    const pendingRootSlice = {
+      streamId: root,
+      status: undefined,
+    } as StreamSlice;
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: root,
+        canStopActiveRun: true,
+        parentStream: new Map([[child, root]]),
+        streams: new Map<StreamSlice['streamId'], StreamSlice>([
+          [root, pendingRootSlice],
+        ]),
+      }),
+    ).toMatchObject({
+      ctrlCAction: 'stop',
+      displaySlice: pendingRootSlice,
+    });
+
+    const waitingRootSlice = {
+      streamId: root,
+      status: STREAM_STATUS.WAITING,
+    } as StreamSlice;
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: root,
+        canStopActiveRun: true,
+        canStopPendingRunWithoutStream: true,
+        parentStream: new Map([[child, root]]),
+        streams: new Map<StreamSlice['streamId'], StreamSlice>([
+          [root, waitingRootSlice],
+        ]),
+      }),
+    ).toMatchObject({
+      ctrlCAction: 'stop',
+      displaySlice: waitingRootSlice,
+    });
+
+    const stoppedRootSlice = {
+      streamId: root,
+      status: STREAM_STATUS.STOPPED,
+    } as StreamSlice;
+    const stoppedChildSlice = {
+      streamId: child,
+      status: STREAM_STATUS.STOPPED,
+    } as StreamSlice;
+    const stoppedStreams = new Map<StreamSlice['streamId'], StreamSlice>([
+      [root, stoppedRootSlice],
+      [child, stoppedChildSlice],
+    ]);
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: root,
+        // A stale host callback must not leave the footer advertising stop
+        // after the visible stream tree has already become terminal.
+        canStopActiveRun: true,
+        parentStream: new Map([[child, root]]),
+        streams: stoppedStreams,
+      }),
+    ).toMatchObject({
+      ctrlCAction: 'exit',
+      displaySlice: stoppedRootSlice,
+    });
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: child,
+        canStopActiveRun: true,
+        parentStream: new Map([[child, root]]),
+        streams: stoppedStreams,
+      }),
+    ).toMatchObject({
+      ctrlCAction: 'exit',
+      displaySlice: stoppedChildSlice,
+    });
     expect(
       statusBarStreamTarget({
         activeStreamId: root,


### PR DESCRIPTION
Fixes #5993.

## Summary
- require a visible pending/live stream, or a host-reported pending run before stream binding, before the CLI footer advertises Ctrl-C stop
- keep the existing stop-root behavior when a parent stream is still live
- extend the Ctrl-C TUI fixture so stopped runs must show exit and must not show stop
- add unit coverage for stale empty state, pre-stream startup, undefined-status startup, old WAITING slices during next-turn startup, and all-stopped terminal streams

## Validation
- npm run format
- git diff --check
- corepack pnpm vitest run src/test-kernel/cli/StatusBar.vitest.mts
- corepack pnpm --filter @texra-ai/cli build
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-goal-approval.ocnEAJ/tui-ctrlc-check-snapshots ctrl-c-interrupt-active focused-stopped-subagent-submit stopped-subagent-picker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI footer hint logic and tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes misleading **Ctrl-C** hints after runs finish: the status bar no longer advertises **stop** when every visible stream is terminal, even if the host still reports a stoppable run.
> 
> **Status bar logic** now derives stop vs exit from the stream map, not only `canStopActiveRun`. A new `hasPendingOrLiveStream` helper requires at least one stream with pending (`status` undefined) or live status before showing stop; otherwise the footer shows **exit**. `canStopPendingRunWithoutStream` keeps stop available for the brief window when a run exists but `streamId` is not set yet.
> 
> **Wiring:** `App` / `runChatTui` pass the new callback; `statusBarStreamTarget` gates `ctrlCAction` with `canStopVisibleRun`.
> 
> **Tests:** `StatusBar.vitest.mts` covers empty maps, pending roots, waiting streams, and stale host callbacks on stopped trees. The `ctrl-c-interrupt-active` TUI scenario expects **exit** and forbids **stop** after interrupt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58ed59ba3a88f2b8873586aa6c003755b0dcf458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->