### PR TITLE
fix: align queued follow-up TUI harness stop state

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -184,6 +184,7 @@ const SCENARIOS = [
     cols: 120,
     env: {
       HARNESS_ENTRIES: '2',
+      HARNESS_CAN_INTERRUPT: '1',
       HARNESS_QUEUED_FOLLOWUPS:
         'First queued follow-up||Second queued follow-up',
     },
@@ -240,6 +241,7 @@ const SCENARIOS = [
     cols: 60,
     env: {
       HARNESS_ENTRIES: '2',
+      HARNESS_CAN_INTERRUPT: '1',
       HARNESS_QUEUED_FOLLOWUPS:
         'First queued follow-up||Second queued follow-up',
     },


### PR DESCRIPTION
## Summary

- mark the queued follow-up TUI validator scenarios as interruptible when they expect `[Ctrl-C]stop`
- keep the status bar stop decision host-owned; this fixes the fixture mismatch instead of broadening UI logic

Fixes #5995.

## Validation

- `node scripts/validate-tui.mjs --no-build --snapshot-dir /private/tmp/texra-goal-cli.qAU3r1-focused-snapshots queued-followups compact-queued-followups`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `node scripts/validate-tui.mjs --no-build`
- `corepack pnpm exec prettier --check packages/cli/scripts/validate-tui.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness configuration only in `validate-tui.mjs`; no runtime CLI or status-bar behavior changes.
> 
> **Overview**
> Sets **`HARNESS_CAN_INTERRUPT: '1'`** on the **`queued-followups`** and **`compact-queued-followups`** scenarios in `validate-tui.mjs` so the harness matches the status bar’s host-owned rule: when a response can be interrupted, Ctrl-C is labeled **`[Ctrl-C]stop`** instead of exit.
> 
> This fixes a **fixture mismatch** for #5995 without changing production TUI logic—only the validator env for scenarios that already assert **`[Ctrl-C]stop`** alongside queued follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a4c3d74025f62f0c5db03ee2198474b0d79d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->