### PR TITLE
fix: show stop for live delegated CLI streams

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -367,10 +367,14 @@ export function chatTuiCanStopActiveRun(
 export function chatTuiCanStopVisibleRun(
   session: InterruptibleTuiSessionState,
   status: StreamStatus | undefined,
+  streamTreeHasLiveRun = false,
 ): boolean {
   return (
     chatTuiCanStopActiveRun(session, status) ||
-    Boolean(session.streamId && LIVE_ELAPSED_STREAM_STATUSES.has(status ?? ''))
+    Boolean(
+      session.streamId &&
+      (LIVE_ELAPSED_STREAM_STATUSES.has(status ?? '') || streamTreeHasLiveRun),
+    )
   );
 }
 
@@ -1199,8 +1203,18 @@ export async function runChat(
   };
   const canInterruptActiveRun = (): boolean =>
     chatTuiCanInterruptActiveRun(session);
+  const streamTreeHasLiveRun = (): boolean => {
+    for (const stream of cliState.streams.get().values()) {
+      if (LIVE_ELAPSED_STREAM_STATUSES.has(stream.status ?? '')) return true;
+    }
+    return false;
+  };
   const canStopActiveRun = (): boolean =>
-    chatTuiCanStopVisibleRun(session, rootStreamStatus());
+    chatTuiCanStopVisibleRun(
+      session,
+      rootStreamStatus(),
+      streamTreeHasLiveRun(),
+    );
   const canStopPendingRunWithoutStream = (): boolean =>
     Boolean(session.runPromise && !session.runCompleted && !session.streamId);
   const shouldDetachSubagentsOnStop = (): boolean =>

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1325,6 +1325,28 @@ describe('CLI TUI row allocation', () => {
         STREAM_STATUS.WAITING,
       ),
     ).toBe(false);
+    expect(
+      chatTuiCanStopVisibleRun(
+        {
+          runCompleted: false,
+          runPromise: Promise.resolve(),
+          streamId: root,
+        },
+        STREAM_STATUS.WAITING,
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      chatTuiCanStopVisibleRun(
+        {
+          runCompleted: false,
+          runPromise: Promise.resolve(),
+          streamId: root,
+        },
+        STREAM_STATUS.WAITING,
+        false,
+      ),
+    ).toBe(false);
   });
 
   it('resolves the TUI Ctrl-C action from armed, stoppable, and interruptible state', () => {


### PR DESCRIPTION
## Summary

- treat a live child stream in the active CLI stream tree as stoppable for Ctrl-C routing
- keep parked/root `WAITING` sessions non-stoppable when no stream is live, preserving resumable-idle exits
- add regression coverage for root `WAITING` with and without a live delegated child

Fixes #5997.

## Live dogfood evidence

In a real PTY run from current `origin/main` (`41673114c`):

1. `TERM=xterm-256color texra-local`
2. choose `Team Mathematician`
3. choose `Gemini 3.5 Flash`
4. ask for a proof of infinitely many primes `1 mod 4` and request a delegated checker
5. approve `Spawn research?`

The child stream ran tools (`ls`, `todo_write`, `wolfram`) and `Esc` stopped it, but the footer kept rendering `[Ctrl-C]exit` while the status was running. This patch aligns the Ctrl-C label/SIGINT predicate with the same live stream tree that makes the run actually stoppable.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Ctrl-C/stop predicates and footer labeling; resumable-idle behavior is unchanged when no delegated stream is live.
> 
> **Overview**
> Fixes the chat TUI showing **`[Ctrl-C]exit`** while a **delegated child stream** is still running tools, even though **Esc** could stop the run.
> 
> **`chatTuiCanStopVisibleRun`** takes an optional **`streamTreeHasLiveRun`** flag. When the **root** stream is **`WAITING`** (parked / resumable-idle) but **any** entry in **`cliState.streams`** has a **live elapsed** status, the session is treated as **stoppable** for Ctrl-C routing and the status bar—matching the stream tree that makes interrupt actually work.
> 
> **`runChatTui`** wires **`streamTreeHasLiveRun()`** (scan all tracked streams) into **`canStopActiveRun`**, which feeds **`chatTuiSigintAction`** and graceful exit logic. **Root `WAITING` with no live child** stays **non-stoppable**, preserving **resumable-idle** exits.
> 
> Regression tests cover root **`WAITING`** with the third parameter **true** vs **false**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8578ef1cf6b23197f62be128450449d4e2d3836a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->