### PR TITLE
fix: clarify CLI edit bypass badge

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -654,7 +654,7 @@ const BYPASS_BADGES: ReadonlyArray<{
 }> = [
   { field: 'superYolo', text: 'YOLO', badgeColor: 'red' },
   { field: 'bash', text: 'AUTO-BASH', badgeColor: 'yellow' },
-  { field: 'toolEdit', text: 'AUTO-APPROVE', badgeColor: 'yellow' },
+  { field: 'toolEdit', text: 'AUTO-EDIT', badgeColor: 'yellow' },
 ];
 
 export function buildStatusBarDisplay(

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1280,7 +1280,7 @@ describe('CLI StatusBar display model', () => {
     ]);
   });
 
-  it('preserves distinct YOLO and auto-approval badges', () => {
+  it('preserves distinct YOLO, bash, and edit bypass badges', () => {
     const display = buildStatusBarDisplay({
       status: STREAM_STATUS.RUNNING,
       pendingExitHint: false,
@@ -1305,7 +1305,7 @@ describe('CLI StatusBar display model', () => {
       PERSONAL_API_MODE_LABEL,
       'YOLO',
       'AUTO-BASH',
-      'AUTO-APPROVE',
+      'AUTO-EDIT',
     ]);
     expect(display.left.at(-3)).toMatchObject({
       badge: true,
@@ -1341,7 +1341,7 @@ describe('CLI StatusBar display model', () => {
       width: 61,
     });
 
-    expect(display.right).toBe('Keep the pr…');
+    expect(display.right).toBe('Keep the proof…');
     expect(display.bindings).toContain('[Ctrl-C]exit');
   });
 


### PR DESCRIPTION
## Summary
- rename the status bar file-edit bypass badge from `AUTO-APPROVE` to `AUTO-EDIT`
- update the status bar display tests for the clearer label and resulting preview width

## Why
During real TTY dogfood on `origin/main` (`41673114c`), the Mathematician team run showed `AUTO-BASH` and `AUTO-APPROVE` while a delegated `research` subagent still correctly prompted `Spawn research?`. The underlying behavior is right: the badge comes from the tool-edit bypass flag, not global approval policy or delegation approval. The label was too broad.

Closes #5999.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/panes/StatusBar.tsx src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/panes/StatusBar.tsx src/test-kernel/cli/StatusBar.vitest.mts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label and test expectation changes in the CLI status bar; no bypass or approval logic is modified.
> 
> **Overview**
> Renames the CLI status bar badge for the **tool-edit bypass** from **`AUTO-APPROVE`** to **`AUTO-EDIT`**, so it matches **`AUTO-BASH`** and **`YOLO`** and does not read like global approval is off when delegation or other prompts still appear.
> 
> Tests are updated for the new label and for the right-side queued follow-up preview truncation after the slightly wider left status row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 039c436170c9dd1d2bf8b503a5d5fb258085c2e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->