### PR TITLE
[codex] Clarify TUI snapshot reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run --config vitest.config.mjs",
     "test:watch": "vitest --config vitest.config.mjs",
     "test:kernel": "vitest run --config vitest.config.mjs",
+    "validate:tui": "corepack pnpm --filter @texra-ai/cli validate:tui",
     "workspace:typecheck": "corepack pnpm --recursive --if-present typecheck",
     "workspace:build": "corepack pnpm --recursive --if-present build",
     "desktop:build": "corepack pnpm --filter @texra/desktop build",

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2945,6 +2945,7 @@ const SNAPSHOT_THEME = {
   border: '#d8d0c3',
   headerBorder: '#e4ddd2',
   failedBorder: '#b55d54',
+  passedText: '#356f4f',
   link: '#1b5e8f',
   failureText: '#9b3d35',
 };
@@ -2984,22 +2985,40 @@ function writeSnapshot(index, name, frame) {
   writeFileSync(svgFile, snapshotSvgDocument(name, frame));
 }
 
+function snapshotStatus(result) {
+  if (result.skipped) return 'skipped';
+  return result.ok ? 'passed' : 'failed';
+}
+
 function snapshotHtmlDocument(results) {
   const generatedAt = new Date().toISOString();
+  const summary = results.reduce(
+    (counts, result) => {
+      counts[snapshotStatus(result)] += 1;
+      return counts;
+    },
+    { passed: 0, failed: 0, skipped: 0 },
+  );
+  const summaryText = [
+    `${summary.passed} passed`,
+    `${summary.failed} failed`,
+    `${summary.skipped} skipped`,
+  ].join(' · ');
   const entries = results
     .map((result, index) => {
       const textFile = snapshotFileName(index, result.name);
       const svgFile = snapshotFileName(index, result.name, 'svg');
       const frame = result.frame;
-      const statusClass = result.ok ? 'ok' : 'failed';
+      const status = snapshotStatus(result);
       const failures = result.failures.length
         ? `<ul>${result.failures
             .map((failure) => `<li>${escapeHtml(failure)}</li>`)
             .join('')}</ul>`
         : '';
-      return `<section class="scenario ${statusClass}">
+      return `<section class="scenario ${status}">
   <header>
     <h2>${escapeHtml(result.name)}</h2>
+    <span class="status ${status}">${escapeHtml(status)}</span>
     <nav>
       <a href="${escapeHtml(textFile)}">text frame</a>
       <a href="${escapeHtml(svgFile)}">svg frame</a>
@@ -3026,6 +3045,11 @@ function snapshotHtmlDocument(results) {
     main { max-width: 1280px; margin: 0 auto; padding: 24px; }
     h1 { font-size: 20px; margin: 0 0 6px; }
     .meta { color: ${SNAPSHOT_THEME.muted}; margin: 0 0 24px; }
+    .summary {
+      display: flex;
+      gap: 12px;
+      margin: 0 0 24px;
+    }
     .scenario {
       border: 1px solid ${SNAPSHOT_THEME.border};
       border-radius: 8px;
@@ -3034,15 +3058,30 @@ function snapshotHtmlDocument(results) {
       background: ${SNAPSHOT_THEME.cardBackground};
     }
     .scenario.failed { border-color: ${SNAPSHOT_THEME.failedBorder}; }
+    .scenario.skipped { border-color: ${SNAPSHOT_THEME.muted}; }
     header {
       align-items: center;
       border-bottom: 1px solid ${SNAPSHOT_THEME.headerBorder};
       display: flex;
-      justify-content: space-between;
+      gap: 12px;
       padding: 10px 14px;
     }
     h2 { font-size: 14px; margin: 0; }
-    nav { display: flex; gap: 14px; }
+    .status {
+      border: 1px solid ${SNAPSHOT_THEME.border};
+      border-radius: 999px;
+      color: ${SNAPSHOT_THEME.muted};
+      font-size: 12px;
+      padding: 2px 8px;
+      text-transform: uppercase;
+    }
+    .status.failed {
+      border-color: ${SNAPSHOT_THEME.failedBorder};
+      color: ${SNAPSHOT_THEME.failureText};
+    }
+    .status.passed { color: ${SNAPSHOT_THEME.passedText}; }
+    .status.skipped { color: ${SNAPSHOT_THEME.muted}; }
+    nav { display: flex; gap: 14px; margin-left: auto; }
     a { color: ${SNAPSHOT_THEME.link}; text-decoration: none; }
     ul { color: ${SNAPSHOT_THEME.failureText}; margin: 12px 14px 0; }
     pre {
@@ -3059,6 +3098,7 @@ function snapshotHtmlDocument(results) {
   <main>
     <h1>TeXRA TUI snapshots</h1>
     <p class="meta">Generated ${escapeHtml(generatedAt)} from ${results.length} scenario${results.length === 1 ? '' : 's'}.</p>
+    <p class="summary" aria-label="Snapshot summary">${escapeHtml(summaryText)}</p>
     ${entries}
   </main>
 </body>


### PR DESCRIPTION
## Summary\n\n- add a root `npm run validate:tui` entrypoint for the CLI TUI harness\n- show pass/fail/skip counts in generated snapshot reports\n- add visible per-scenario status labels so reports are easier to scan in browser or PR review\n\nCloses #6001.\n\n## Validation\n\n- `npm run validate:tui -- --list-selected plan-approval`\n- `corepack pnpm exec prettier --check package.json packages/cli/scripts/validate-tui.mjs`\n- `npm run validate:tui -- --snapshot-dir /private/tmp/texra-tui-report-check plan-approval ctrl-c-interrupt-active`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to dev validation scripts and snapshot report HTML/CSS; no runtime product behavior.
> 
> **Overview**
> Adds **`npm run validate:tui`** at the workspace root so the CLI TUI harness can be run without filtering to `@texra-ai/cli`.
> 
> The **`validate-tui.mjs`** snapshot **`index.html`** report now surfaces **pass / fail / skip** at a glance: a top-level summary line (`N passed · N failed · N skipped`), per-scenario **status pills**, and section styling for **skipped** runs (not only pass/fail). Status derivation uses a small **`snapshotStatus`** helper that treats `result.skipped` separately from assertion failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ffa51f48ceffb0a191b357a87e739bd6b66198a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->