### PR TITLE
[codex] Disclose plan auto-approval scope

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1377,7 +1377,11 @@ const SCENARIOS = [
       'y approve',
       'n reject',
     ],
-    unexpect: ['r approve & run', '[/model]models'],
+    unexpect: [
+      'r approve & run',
+      'Bash + file edits auto-approved',
+      '[/model]models',
+    ],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: 'Approve plan?', max: 3 },
     ],
@@ -1394,6 +1398,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
+      'Bash + file edits auto-approved',
       'r approve & run',
       'y approve',
       'n reject',
@@ -1424,6 +1429,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
+      'Bash + file edits auto-approved',
       'observations. Do not edit any files',
       'r approve & run',
       'y approve',
@@ -1462,6 +1468,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
+      'Bash + file edits auto-approved',
       '4. Delegate a brief independent verification to the `review` subagent to',
       "check the derivation's correctness.",
       'r approve & run',
@@ -1484,7 +1491,7 @@ const SCENARIOS = [
       'e feedback',
       'Esc cancel',
     ],
-    unexpect: ['[/model]models'],
+    unexpect: ['Bash + file edits auto-approved', '[/model]models'],
   },
   {
     name: 'compact-plan-approval-goal',
@@ -1500,6 +1507,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
+      'Bash + file edits auto-approved',
       'r approve & run',
       'y approve',
       'n reject',

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -6,6 +6,7 @@ import { Box, Text, useWindowSize, type BoxProps } from 'ink';
 import { useInput } from 'ink';
 
 import {
+  confirmCardCompactHintLayout,
   confirmCardFeedbackHints,
   confirmCardKeyAction,
   confirmCardKeyHintsForWidth,
@@ -114,35 +115,29 @@ export function ConfirmCard({
     key: action.key,
     action: action.label,
   }));
+  const compactHintLayout = feedbackMode
+    ? undefined
+    : confirmCardCompactHintLayout({
+        title,
+        approveLabel,
+        rejectLabel,
+        alwaysAllowLabel: alwaysAllow?.label,
+        extraActions: mappedExtraActions,
+        columns,
+      });
   const hints = feedbackMode
     ? confirmCardFeedbackHints()
-    : confirmCardKeyHintsForWidth({
-        approveLabel,
-        rejectLabel,
-        alwaysAllowLabel: alwaysAllow?.label,
-        extraActions: mappedExtraActions,
-        maxColumns: Math.max(
-          0,
-          columns -
-            (compact
-              ? title.length + KEY_HINT_SEPARATOR.length
-              : CONFIRM_CARD_HORIZONTAL_DECORATION),
-        ),
-      });
-  const stackedCompactHints = feedbackMode
-    ? hints
-    : confirmCardKeyHintsForWidth({
-        approveLabel,
-        rejectLabel,
-        alwaysAllowLabel: alwaysAllow?.label,
-        extraActions: mappedExtraActions,
-        maxColumns: columns,
-      });
-  const stackCompactHints =
-    compact &&
-    !feedbackMode &&
-    hints.some((hint) => hint.key === 'Esc') &&
-    stackedCompactHints.length > hints.length;
+    : compact
+      ? (compactHintLayout?.inlineHints ?? [])
+      : confirmCardKeyHintsForWidth({
+          approveLabel,
+          rejectLabel,
+          alwaysAllowLabel: alwaysAllow?.label,
+          extraActions: mappedExtraActions,
+          maxColumns: Math.max(0, columns - CONFIRM_CARD_HORIZONTAL_DECORATION),
+        });
+  const stackedCompactHints = compactHintLayout?.stackedHints ?? hints;
+  const stackCompactHints = compact && (compactHintLayout?.stack ?? false);
 
   if (compact) {
     return (

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -30,6 +30,17 @@ export interface ConfirmCardHintWidthOptions extends ConfirmCardHintOptions {
   readonly maxColumns?: number;
 }
 
+export interface ConfirmCardCompactHintLayoutOptions extends ConfirmCardHintOptions {
+  readonly title: string;
+  readonly columns: number;
+}
+
+export interface ConfirmCardCompactHintLayout {
+  readonly inlineHints: readonly ConfirmCardHintAction[];
+  readonly stackedHints: readonly ConfirmCardHintAction[];
+  readonly stack: boolean;
+}
+
 export function confirmCardKeyAction(
   input: string,
   key: ConfirmCardKey,
@@ -141,4 +152,41 @@ export function confirmCardKeyHintsForWidth(
   if (hintsFit(coreHints, options.maxColumns)) return coreHints;
 
   return [{ key: 'Esc', action: 'cancel' }];
+}
+
+export function confirmCardCompactHintLayout({
+  title,
+  columns,
+  approveLabel,
+  rejectLabel,
+  alwaysAllowLabel,
+  extraActions,
+}: ConfirmCardCompactHintLayoutOptions): ConfirmCardCompactHintLayout {
+  const inlineHints = confirmCardKeyHintsForWidth({
+    approveLabel,
+    rejectLabel,
+    alwaysAllowLabel,
+    extraActions,
+    maxColumns: Math.max(0, columns - title.length - KEY_HINT_SEPARATOR.length),
+  });
+  const stackedHints = confirmCardKeyHintsForWidth({
+    approveLabel,
+    rejectLabel,
+    alwaysAllowLabel,
+    extraActions,
+    maxColumns: columns,
+  });
+  return {
+    inlineHints,
+    stackedHints,
+    stack:
+      inlineHints.some((hint) => hint.key === 'Esc') &&
+      stackedHints.length > inlineHints.length,
+  };
+}
+
+export function confirmCardCompactChromeRows(
+  options: ConfirmCardCompactHintLayoutOptions,
+): number {
+  return confirmCardCompactHintLayout(options).stack ? 2 : 1;
 }

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -1,11 +1,16 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Box, Text, useWindowSize } from 'ink';
 
 import type { PlanApprovalPermission } from '@shared/schemas';
 
 import { ConfirmCard, CONFIRM_CARD_HORIZONTAL_DECORATION } from './ConfirmCard';
+import { confirmCardCompactChromeRows } from './ConfirmCardState';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
-import { fillRows } from '../render/terminalText';
+import {
+  fillRows,
+  textDisplayWidth,
+  truncateToWidth,
+} from '../render/terminalText';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface PlanApprovalProps {
@@ -16,25 +21,142 @@ export interface PlanApprovalProps {
 
 export const COMPACT_PLAN_APPROVAL_MAX_ROWS = 7;
 const MIN_PLAN_APPROVAL_CONTENT_WIDTH = 20;
+const PLAN_APPROVAL_TITLE = 'Approve plan?';
+export const PLAN_APPROVAL_GOAL_NOTICE =
+  'Bash + file edits auto-approved until pause/complete.';
+const PLAN_APPROVAL_GOAL_NOTICE_ROWS = 2;
+const PLAN_APPROVAL_NON_COMPACT_FIXED_ROWS = 7;
+const PLAN_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;
+const PLAN_APPROVAL_FEEDBACK_PREFIX_COLUMNS = 2;
+const PLAN_APPROVAL_FEEDBACK_PLACEHOLDER = 'Feedback to send with rejection';
+const PLAN_APPROVAL_GOAL_ACTION = {
+  key: 'r',
+  action: 'approve & run',
+} as const;
 
 export function isCompactPlanApprovalRows(
   availableRows: number | undefined,
+  goalEnabled = false,
 ): boolean {
+  const compactMaxRows =
+    COMPACT_PLAN_APPROVAL_MAX_ROWS +
+    (goalEnabled ? PLAN_APPROVAL_GOAL_NOTICE_ROWS : 0);
   return (
     availableRows !== undefined &&
     availableRows > 0 &&
-    availableRows <= COMPACT_PLAN_APPROVAL_MAX_ROWS
+    availableRows <= compactMaxRows
   );
+}
+
+export function planApprovalBodyRowsBudget({
+  availableRows,
+  goalEnabled,
+  feedbackRows = 0,
+}: {
+  readonly availableRows: number | undefined;
+  readonly goalEnabled: boolean;
+  readonly feedbackRows?: number;
+}): number | undefined {
+  if (availableRows === undefined) return undefined;
+  const noticeRows = goalEnabled ? PLAN_APPROVAL_GOAL_NOTICE_ROWS : 0;
+  return Math.max(
+    1,
+    availableRows -
+      PLAN_APPROVAL_NON_COMPACT_FIXED_ROWS -
+      noticeRows -
+      feedbackRows,
+  );
+}
+
+export function planApprovalGoalNoticeLine(width: number): string {
+  const lineWidth = Math.max(1, width);
+  return fillRows(
+    truncateToWidth(PLAN_APPROVAL_GOAL_NOTICE, lineWidth),
+    lineWidth,
+  );
+}
+
+export function planApprovalCompactBodyRowsBudget({
+  availableRows,
+  columns,
+  goalEnabled,
+}: {
+  readonly availableRows: number | undefined;
+  readonly columns: number;
+  readonly goalEnabled: boolean;
+}): number | undefined {
+  if (availableRows === undefined) return undefined;
+  const chromeRows = confirmCardCompactChromeRows({
+    title: PLAN_APPROVAL_TITLE,
+    columns,
+    extraActions: goalEnabled ? [PLAN_APPROVAL_GOAL_ACTION] : [],
+  });
+  return Math.max(0, availableRows - chromeRows);
+}
+
+export function planApprovalFeedbackRows({
+  columns,
+  placeholder = PLAN_APPROVAL_FEEDBACK_PLACEHOLDER,
+  value,
+}: {
+  readonly columns: number;
+  readonly placeholder?: string;
+  readonly value: string;
+}): number {
+  const text = value.length > 0 ? value : placeholder;
+  const width = Math.max(
+    1,
+    columns -
+      CONFIRM_CARD_HORIZONTAL_DECORATION -
+      PLAN_APPROVAL_FEEDBACK_PREFIX_COLUMNS,
+  );
+  return (
+    PLAN_APPROVAL_FEEDBACK_MARGIN_ROWS +
+    Math.max(1, wrapAnsiToWidth(text, width).split('\n').length)
+  );
+}
+
+export function isPlanApprovalGoalActionVisible({
+  compact,
+  goalEnabled,
+  visibleBodyRows,
+}: {
+  readonly compact: boolean;
+  readonly goalEnabled: boolean;
+  readonly visibleBodyRows: number;
+}): boolean {
+  return goalEnabled && (!compact || visibleBodyRows > 0);
+}
+
+function renderPlanLineWithSuffix({
+  line,
+  suffix,
+  width,
+}: {
+  readonly line: string;
+  readonly suffix: string;
+  readonly width: number;
+}): string {
+  const lineWidth = Math.max(1, width);
+  const visibleSuffix = truncateToWidth(suffix, lineWidth);
+  const prefixWidth = Math.max(0, lineWidth - textDisplayWidth(visibleSuffix));
+  const prefix =
+    prefixWidth === 0 ? '' : truncateToWidth(line.trimEnd(), prefixWidth);
+  return fillRows(`${prefix}${visibleSuffix}`, lineWidth);
 }
 
 export function renderCompactPlanLine(
   line: string,
   isLastVisibleLine: boolean,
   hiddenLineCount: number,
+  width?: number,
 ): string {
   if (!isLastVisibleLine || hiddenLineCount === 0) return line || ' ';
-  if (!line.trim()) return `… ${hiddenLineCount} more lines`;
-  return `${line} · … ${hiddenLineCount} more`;
+  const suffix = line.trim()
+    ? ` · … ${hiddenLineCount} more`
+    : `… ${hiddenLineCount} more lines`;
+  if (width === undefined) return line.trim() ? `${line}${suffix}` : suffix;
+  return renderPlanLineWithSuffix({ line, suffix, width });
 }
 
 export function planApprovalDisplayLines({
@@ -60,21 +182,45 @@ export function planApprovalDisplayLines({
 
 export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
   const { columns } = useWindowSize();
-  const compact = isCompactPlanApprovalRows(props.availableRows);
+  const [feedbackMode, setFeedbackMode] = useState(false);
+  const [feedbackValue, setFeedbackValue] = useState('');
+  const goalEnabled = props.payload.goalEnabled;
+  const compact = isCompactPlanApprovalRows(props.availableRows, goalEnabled);
   const contentWidth = compact
     ? columns
     : columns - CONFIRM_CARD_HORIZONTAL_DECORATION;
+  const initialCompactBodyRows = compact
+    ? planApprovalCompactBodyRowsBudget({
+        availableRows: props.availableRows,
+        columns,
+        goalEnabled,
+      })
+    : undefined;
+  const goalActionVisible = isPlanApprovalGoalActionVisible({
+    compact,
+    goalEnabled,
+    visibleBodyRows: initialCompactBodyRows ?? 0,
+  });
+  const goalNoticeVisible = goalActionVisible && !feedbackMode;
+  const bodyObjective =
+    compact && goalNoticeVisible
+      ? `${PLAN_APPROVAL_GOAL_NOTICE}\n\n${props.payload.plan.objective}`
+      : props.payload.plan.objective;
   const bodyLines = useMemo(
     () =>
       planApprovalDisplayLines({
-        objective: props.payload.plan.objective,
+        objective: bodyObjective,
         width: contentWidth,
         padLines: !compact,
       }),
-    [compact, contentWidth, props.payload.plan.objective],
+    [bodyObjective, compact, contentWidth],
   );
   const compactBodyRows = compact
-    ? Math.max(0, (props.availableRows ?? 1) - 1)
+    ? planApprovalCompactBodyRowsBudget({
+        availableRows: props.availableRows,
+        columns,
+        goalEnabled: goalActionVisible,
+      })
     : undefined;
   const visibleCompactBodyLines =
     compactBodyRows === undefined ? [] : bodyLines.slice(0, compactBodyRows);
@@ -82,19 +228,36 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
     compactBodyRows === undefined
       ? 0
       : Math.max(0, bodyLines.length - compactBodyRows);
+  const nonCompactBodyRows = compact
+    ? undefined
+    : planApprovalBodyRowsBudget({
+        availableRows: props.availableRows,
+        goalEnabled: goalNoticeVisible,
+        feedbackRows: feedbackMode
+          ? planApprovalFeedbackRows({ columns, value: feedbackValue })
+          : 0,
+      });
+  const visibleNonCompactBodyLines =
+    nonCompactBodyRows === undefined
+      ? bodyLines
+      : bodyLines.slice(0, nonCompactBodyRows);
+  const hiddenNonCompactBodyLines =
+    nonCompactBodyRows === undefined
+      ? 0
+      : Math.max(0, bodyLines.length - nonCompactBodyRows);
 
   return (
     <ConfirmCard
       borderStyle="double"
       color="blue"
       compact={compact}
-      title="Approve plan?"
+      title={PLAN_APPROVAL_TITLE}
       extraActions={
-        props.payload.goalEnabled
+        goalActionVisible
           ? [
               {
-                key: 'r',
-                label: 'approve & run',
+                key: PLAN_APPROVAL_GOAL_ACTION.key,
+                label: PLAN_APPROVAL_GOAL_ACTION.action,
                 decision: {
                   accepted: true,
                   planAction: 'approve_and_goal',
@@ -103,7 +266,9 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
             ]
           : []
       }
-      feedbackPlaceholder="Feedback to send with rejection"
+      feedbackPlaceholder={PLAN_APPROVAL_FEEDBACK_PLACEHOLDER}
+      onFeedbackModeChange={setFeedbackMode}
+      onFeedbackValueChange={setFeedbackValue}
       onDecide={props.onDecide}
     >
       {compact ? (
@@ -114,15 +279,29 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
                 line,
                 index === visibleCompactBodyLines.length - 1,
                 hiddenCompactBodyLines,
+                contentWidth,
               )}
             </Text>
           ))}
         </Box>
       ) : (
         <Box flexDirection="column" marginY={1}>
-          {bodyLines.map((line, index) => (
-            <Text key={index}>{line || ' '}</Text>
+          {visibleNonCompactBodyLines.map((line, index) => (
+            <Text key={index} wrap="truncate-end">
+              {renderCompactPlanLine(
+                line,
+                index === visibleNonCompactBodyLines.length - 1,
+                hiddenNonCompactBodyLines,
+                contentWidth,
+              )}
+            </Text>
           ))}
+          {goalNoticeVisible ? (
+            <>
+              <Text> </Text>
+              <Text>{planApprovalGoalNoticeLine(contentWidth)}</Text>
+            </>
+          ) : null}
         </Box>
       )}
     </ConfirmCard>

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  confirmCardCompactChromeRows,
   confirmCardFeedbackHints,
   confirmCardKeyAction,
   confirmCardKeyHints,
@@ -109,5 +110,15 @@ describe('CLI confirm-card key handling', () => {
         maxColumns: 10,
       }),
     ).toEqual([{ key: 'Esc', action: 'cancel' }]);
+  });
+
+  it('reports stacked compact chrome rows for long extra actions', () => {
+    const options = {
+      title: 'Approve plan?',
+      extraActions: [{ key: 'r', action: 'approve & run' }],
+    };
+
+    expect(confirmCardCompactChromeRows({ ...options, columns: 60 })).toBe(2);
+    expect(confirmCardCompactChromeRows({ ...options, columns: 100 })).toBe(1);
   });
 });

--- a/src/test-kernel/cli/PlanApproval.vitest.mts
+++ b/src/test-kernel/cli/PlanApproval.vitest.mts
@@ -2,16 +2,106 @@ import { describe, expect, it } from 'vitest';
 
 import {
   COMPACT_PLAN_APPROVAL_MAX_ROWS,
+  PLAN_APPROVAL_GOAL_NOTICE,
   isCompactPlanApprovalRows,
+  isPlanApprovalGoalActionVisible,
+  planApprovalBodyRowsBudget,
+  planApprovalCompactBodyRowsBudget,
   planApprovalDisplayLines,
+  planApprovalFeedbackRows,
+  planApprovalGoalNoticeLine,
   renderCompactPlanLine,
 } from '@cli/chat/tui/modals/PlanApproval';
+import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
 
 describe('CLI plan approval layout', () => {
   it('switches to compact rendering before the bordered card clips plan text', () => {
     expect(COMPACT_PLAN_APPROVAL_MAX_ROWS).toBe(7);
     expect(isCompactPlanApprovalRows(7)).toBe(true);
     expect(isCompactPlanApprovalRows(8)).toBe(false);
+    expect(isCompactPlanApprovalRows(9, true)).toBe(true);
+    expect(isCompactPlanApprovalRows(10, true)).toBe(false);
+  });
+
+  it('reserves non-compact rows for the autonomous warning and controls', () => {
+    expect(
+      planApprovalBodyRowsBudget({ availableRows: 10, goalEnabled: true }),
+    ).toBe(1);
+    expect(
+      planApprovalBodyRowsBudget({ availableRows: 10, goalEnabled: false }),
+    ).toBe(3);
+    expect(
+      planApprovalBodyRowsBudget({
+        availableRows: undefined,
+        goalEnabled: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      planApprovalBodyRowsBudget({
+        availableRows: 10,
+        goalEnabled: false,
+        feedbackRows: 2,
+      }),
+    ).toBe(1);
+  });
+
+  it('reserves compact rows when goal approval hints stack below the title', () => {
+    expect(
+      planApprovalCompactBodyRowsBudget({
+        availableRows: 9,
+        columns: 60,
+        goalEnabled: true,
+      }),
+    ).toBe(7);
+    expect(
+      planApprovalCompactBodyRowsBudget({
+        availableRows: 9,
+        columns: 100,
+        goalEnabled: true,
+      }),
+    ).toBe(8);
+    expect(
+      planApprovalCompactBodyRowsBudget({
+        availableRows: 2,
+        columns: 60,
+        goalEnabled: true,
+      }),
+    ).toBe(0);
+    expect(
+      planApprovalCompactBodyRowsBudget({
+        availableRows: 2,
+        columns: 60,
+        goalEnabled: false,
+      }),
+    ).toBe(1);
+  });
+
+  it('hides approve-and-run when compact mode cannot show its scope notice', () => {
+    expect(
+      isPlanApprovalGoalActionVisible({
+        compact: true,
+        goalEnabled: true,
+        visibleBodyRows: 0,
+      }),
+    ).toBe(false);
+    expect(
+      isPlanApprovalGoalActionVisible({
+        compact: true,
+        goalEnabled: true,
+        visibleBodyRows: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('budgets feedback input rows by visible input width', () => {
+    expect(planApprovalFeedbackRows({ columns: 80, value: '' })).toBe(2);
+    expect(
+      planApprovalFeedbackRows({
+        columns: 44,
+        value:
+          'This rejection note is intentionally long enough to wrap on a narrow card.',
+      }),
+    ).toBeGreaterThan(2);
   });
 
   it('uses a clear overflow label when compact clipping lands on a blank line', () => {
@@ -22,6 +112,31 @@ describe('CLI plan approval layout', () => {
     expect(renderCompactPlanLine('Verify typecheck', true, 2)).toBe(
       'Verify typecheck · … 2 more',
     );
+  });
+
+  it('shows the non-compact hidden-row marker before final padding', () => {
+    const line = renderCompactPlanLine(
+      'Verify typecheck before committing'.padEnd(40),
+      true,
+      12,
+      40,
+    );
+
+    expect(textDisplayWidth(line)).toBe(40);
+    expect(line).toContain('12 more');
+  });
+
+  it('keeps the autonomous warning concise enough for the approval card', () => {
+    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('Bash + file edits');
+    expect(PLAN_APPROVAL_GOAL_NOTICE.length).toBeLessThanOrEqual(56);
+  });
+
+  it('keeps the autonomous warning to one display row on narrow cards', () => {
+    const notice = planApprovalGoalNoticeLine(40);
+
+    expect(textDisplayWidth(notice)).toBe(40);
+    expect(notice).toContain('Bash + file edits');
+    expect(notice).toContain('…');
   });
 
   it('wraps body lines before Ink renders the bordered card', () => {


### PR DESCRIPTION
## Summary

- disclose the hidden auto-approval scope on plan approvals that offer `r approve & run`
- keep the warning visible near the action row for tall plans and at the top for compact approvals
- cover the disclosure in focused plan approval unit and TUI harness scenarios

## Why

During CLI dogfood, `r approve & run` looked like plain plan approval plus continuation, but it immediately enabled `AUTO-BASH` and `AUTO-EDIT`. The modal now tells users that autonomous run auto-approves bash and file edits until pause/complete before they press `r`.

Closes #6008.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/PlanApproval.vitest.mts --config vitest.config.mjs`
- `node packages/cli/scripts/validate-tui.mjs plan-approval plan-approval-goal plan-approval-wrap-boundary plan-approval-stale-tail compact-plan-approval compact-plan-approval-goal plan-approval-approve-goal plan-approval-ctrl-r-ignored`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes privileged-action disclosure and approval UI layout; behavior of approve & run is unchanged but consent messaging is safety-relevant.
> 
> **Overview**
> Plan approvals that offer **`r approve & run`** now show that choice auto-approves **bash and file edits** until pause or complete, so users see the scope before confirming.
> 
> The **`PlanApproval`** modal adds a short goal notice, row budgets for compact vs bordered layouts (including feedback mode), and hides approve-and-run in compact mode when there is no room to show that warning. **`ConfirmCard`** compact key hints are centralized via **`confirmCardCompactHintLayout`** / **`confirmCardCompactChromeRows`**. TUI harness scenarios and unit tests cover the new copy and layout rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9983c77164cb1fd9c9ad26af113e3f55dd89d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->