### PR TITLE
[codex] Keep plan goal edits gated

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1393,7 +1393,7 @@ const SCENARIOS = [
     ],
     unexpect: [
       'r approve & run',
-      'Press r: auto-approve bash + file edits',
+      'Bash auto-approved; edits still ask',
       '[/model]models',
     ],
     maxBlankLinesBetween: [
@@ -1412,7 +1412,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
-      'Press r: auto-approve bash + file edits',
+      'Bash auto-approved; edits still ask',
       'r approve & run',
       'y approve',
       'n reject',
@@ -1443,7 +1443,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
-      'Press r: auto-approve bash + file edits',
+      'Bash auto-approved; edits still ask',
       'observations. Do not edit any files',
       'r approve & run',
       'y approve',
@@ -1482,7 +1482,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
-      'Press r: auto-approve bash + file edits',
+      'Bash auto-approved; edits still ask',
       '4. Delegate a brief independent verification to the `review` subagent to',
       "check the derivation's correctness.",
       'r approve & run',
@@ -1505,7 +1505,7 @@ const SCENARIOS = [
       'e feedback',
       'Esc cancel',
     ],
-    unexpect: ['auto-approve bash + file edits', '[/model]models'],
+    unexpect: ['Bash auto-approved; edits still ask', '[/model]models'],
   },
   {
     name: 'compact-plan-approval-goal',
@@ -1521,7 +1521,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
-      'Press r: auto-approve bash + file edits',
+      'Bash auto-approved; edits still ask',
       'r approve & run',
       'y approve',
       'n reject',

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -22,8 +22,7 @@ export interface PlanApprovalProps {
 export const COMPACT_PLAN_APPROVAL_MAX_ROWS = 7;
 const MIN_PLAN_APPROVAL_CONTENT_WIDTH = 20;
 const PLAN_APPROVAL_TITLE = 'Approve plan?';
-export const PLAN_APPROVAL_GOAL_NOTICE =
-  'Press r: auto-approve bash + file edits for this goal.';
+export const PLAN_APPROVAL_GOAL_NOTICE = 'Bash auto-approved; edits still ask.';
 const PLAN_APPROVAL_GOAL_NOTICE_ROWS = 2;
 const PLAN_APPROVAL_NON_COMPACT_FIXED_ROWS = 7;
 const PLAN_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -7,7 +7,7 @@ import {
   followUpDisplayText,
 } from '@agent/toolUse/followUpMessages';
 import { STREAM_STATUS } from '@shared/schemas';
-import { GoalStore, setGoalSessionAutoApprovals } from '@tools/goal';
+import { GoalStore, setGoalSessionBashAutoApproval } from '@tools/goal';
 
 import { findLastAssistantText, extractTouchedFiles } from './types';
 import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
@@ -91,7 +91,7 @@ export class ToolUseWaitNode<C> extends Node<
       const goal = GoalStore.getForStream(streamId);
       if (goal?.status === 'active') {
         await GoalStore.setStatus(streamId, 'paused');
-        await setGoalSessionAutoApprovals(streamId, false, runtimeHost);
+        await setGoalSessionBashAutoApproval(streamId, false, runtimeHost);
         runtimeHost.emit('goalPaused', { streamId });
       }
     }

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -17,6 +17,7 @@ import {
   STREAM_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
+import { cleanupApprovalsForStream } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
 
 describe('ToolUseWaitNode', () => {
@@ -262,12 +263,13 @@ describe('ToolUseWaitNode', () => {
         'updateBashApprovalBypassState',
         { streamId, bypassActive: false },
       );
-      expect(runtimeHost.emit).toHaveBeenCalledWith(
+      expect(runtimeHost.emit).not.toHaveBeenCalledWith(
         'updateToolEditApprovalBypassState',
         { streamId, bypassActive: false },
       );
     } finally {
       await GoalStore.forget(streamId);
+      cleanupApprovalsForStream(streamId);
     }
   });
 

--- a/src/test-kernel/cli/PlanApproval.vitest.mts
+++ b/src/test-kernel/cli/PlanApproval.vitest.mts
@@ -127,8 +127,7 @@ describe('CLI plan approval layout', () => {
   });
 
   it('keeps the autonomous warning concise enough for the approval card', () => {
-    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('Press r');
-    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('bash + file edits');
+    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('edits still ask');
     expect(PLAN_APPROVAL_GOAL_NOTICE.length).toBeLessThanOrEqual(56);
   });
 
@@ -136,8 +135,8 @@ describe('CLI plan approval layout', () => {
     const notice = planApprovalGoalNoticeLine(40);
 
     expect(textDisplayWidth(notice)).toBe(40);
-    expect(notice).toContain('Press r');
-    expect(notice).toContain('…');
+    expect(notice).toContain('edits still ask');
+    expect(notice).not.toContain('…');
   });
 
   it('wraps body lines before Ink renders the bordered card', () => {

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -14,6 +14,11 @@ import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator'
 import { type RunCoordinators } from '@agent/runtime/RunContext';
 import { withToolEnvironment } from '@agent/toolUse/ToolFileInteractionContext';
 import { planSummaryLine, type Plan, type StreamTabId } from '@shared/schemas';
+import {
+  cleanupApprovalsForStream,
+  isApprovalBypassedForStream,
+  isBashApprovalBypassedForStream,
+} from '@tools/approval';
 import { GOAL_FEATURE_FLAG_KEY, GoalStore } from '@tools/goal';
 import { PlanTool } from '@tools/plan/PlanTool';
 import { createRecordingHost } from '../agent/progressTestUtils';
@@ -164,8 +169,11 @@ describe('PlanTool — update (plan approval)', () => {
       expect(goal!.status).toBe('active');
       // The approved plan document seeds the goal verbatim.
       expect(goal!.objective).toBe(plan.objective);
+      expect(isBashApprovalBypassedForStream(streamId)).toBe(true);
+      expect(isApprovalBypassedForStream(streamId)).toBe(false);
     } finally {
       await GoalStore.forget(streamId);
+      cleanupApprovalsForStream(streamId);
     }
   });
 
@@ -215,8 +223,11 @@ describe('PlanTool — update (plan approval)', () => {
       expect(goal!.status).toBe('active');
       expect(goal!.objective).toBe(followUpPlan.objective);
       expect(goal!.objective).not.toContain('Old objective');
+      expect(isBashApprovalBypassedForStream(streamId)).toBe(true);
+      expect(isApprovalBypassedForStream(streamId)).toBe(false);
     } finally {
       await GoalStore.forget(streamId);
+      cleanupApprovalsForStream(streamId);
     }
   });
 

--- a/src/tools/goal/goalAutoApproval.ts
+++ b/src/tools/goal/goalAutoApproval.ts
@@ -2,14 +2,14 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas/identifiers';
 
 /**
- * Engage or clear the per-stream bash + tool-edit approval bypass for an
- * autonomous goal.
+ * Engage or clear the per-stream bash approval bypass for an autonomous goal.
  *
  * "Approve & Run Autonomously" is the user's explicit consent to unattended
- * execution; without the bypass, the first bash/edit approval prompt silently
- * parks the loop, which reads as the goal "stopping early". Engaged when a
- * goal starts or is retargeted, cleared whenever it pauses or ends so manual
- * follow-up turns prompt normally again.
+ * command execution; without the bypass, the first verification/build command
+ * silently parks the loop, which reads as the goal "stopping early". File edits
+ * keep their normal diff approval prompt because an approved plan is not an
+ * edit approval. Engaged when a goal starts or is retargeted, cleared whenever
+ * it pauses or ends so manual follow-up turns prompt normally again.
  *
  * Subagents inherit the parent stream's bypass through the existing
  * delegation wiring (`inheritBashBypassOnChildStream`), so no child-stream
@@ -20,18 +20,12 @@ import type { StreamTabId } from '@shared/schemas/identifiers';
  * modules at module scope drags their filesystem/logger imports into every
  * consumer — breaking partial logger mocks in CLI tests.
  */
-export async function setGoalSessionAutoApprovals(
+export async function setGoalSessionBashAutoApproval(
   streamId: StreamTabId,
   enabled: boolean,
   runtimeHost: AgentRuntimeHost,
 ): Promise<void> {
-  const [
-    { setBashApprovalSessionBypass },
-    { setToolEditApprovalSessionBypass },
-  ] = await Promise.all([
-    import('@tools/approval/bashApproval'),
-    import('@tools/approval/toolEditApproval'),
-  ]);
+  const { setBashApprovalSessionBypass } =
+    await import('@tools/approval/bashApproval');
   setBashApprovalSessionBypass(streamId, enabled, runtimeHost);
-  setToolEditApprovalSessionBypass(streamId, enabled, runtimeHost);
 }

--- a/src/tools/goal/index.ts
+++ b/src/tools/goal/index.ts
@@ -11,4 +11,4 @@ export {
 } from './goalMeta';
 
 export { GoalStore } from './goalStore';
-export { setGoalSessionAutoApprovals } from './goalAutoApproval';
+export { setGoalSessionBashAutoApproval } from './goalAutoApproval';

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -32,7 +32,7 @@ import {
   isGoalEnabled,
   isGoalInFlight,
   goalElapsedMs,
-  setGoalSessionAutoApprovals,
+  setGoalSessionBashAutoApproval,
   type Goal,
 } from '@tools/goal';
 import { ToolError, type ToolResult } from '@tools/result';
@@ -193,7 +193,7 @@ Best practices:
       };
     }
     const updated = (await GoalStore.setStatus(streamId, 'paused')) ?? goal;
-    await this.setAutoApprovals(streamId, false);
+    await this.setBashAutoApproval(streamId, false);
     return {
       summary: 'Goal paused.',
       output: `Goal paused: ${reason}\n\n${formatGoalView(updated)}`,
@@ -201,17 +201,17 @@ Best practices:
   }
 
   /**
-   * Engage/clear the goal's bash + edit auto-approval bypass when the run
-   * context can reach the host. Best-effort: without a runtime host (e.g.
+   * Engage/clear the goal's bash auto-approval bypass when the run context can
+   * reach the host. Best-effort: without a runtime host (e.g.
    * tests or headless edge paths) approvals simply keep prompting.
    */
-  private async setAutoApprovals(
+  private async setBashAutoApproval(
     streamId: string,
     enabled: boolean,
   ): Promise<void> {
     const runtimeHost = getCurrentToolContexts()?.runContext?.runtimeHost;
     if (runtimeHost) {
-      await setGoalSessionAutoApprovals(streamId, enabled, runtimeHost);
+      await setGoalSessionBashAutoApproval(streamId, enabled, runtimeHost);
     }
   }
 
@@ -232,7 +232,7 @@ Best practices:
     // archived one. The autonomous loop stops because no `active` record
     // remains for the next wait-node continuation check.
     await GoalStore.forget(streamId);
-    await this.setAutoApprovals(streamId, false);
+    await this.setBashAutoApproval(streamId, false);
     return {
       summary: 'Goal complete.',
       output:
@@ -340,7 +340,7 @@ Best practices:
           retargeted.status === 'paused'
             ? ((await GoalStore.setStatus(streamId, 'active')) ?? retargeted)
             : retargeted;
-        await this.setAutoApprovals(streamId, true);
+        await this.setBashAutoApproval(streamId, true);
         return {
           summary: `Plan approved — goal ${active.goalId} retargeted`,
           output:
@@ -376,7 +376,7 @@ Best practices:
 
     try {
       const goal = await GoalStore.start(streamId, objective);
-      await this.setAutoApprovals(streamId, true);
+      await this.setBashAutoApproval(streamId, true);
       return {
         summary: `Plan approved — goal ${goal.goalId} started`,
         output:


### PR DESCRIPTION
## Summary
- Narrow plan approve-and-run auto-approval to bash commands only
- Keep file edits on the normal diff approval path during autonomous goals
- Update plan approval copy, TUI harness expectations, and goal-pause tests for the narrower scope

## Root Cause
The goal auto-approval helper set both bash and tool-edit bypasses for an approved autonomous plan. In live CLI dogfood this made a no-edit plan show `AUTO-EDIT` after `r approve & run`, even though the approved plan explicitly required no file changes.

Fixes #6011.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/cli/PlanApproval.vitest.mts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts`
- `node packages/cli/scripts/validate-tui.mjs plan-approval plan-approval-goal plan-approval-wrap-boundary plan-approval-stale-tail compact-plan-approval compact-plan-approval-goal plan-approval-approve-goal plan-approval-ctrl-r-ignored bash-approval-session-status`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when privileged bash vs. file-edit actions prompt during autonomous goals; behavior is narrower (more prompts for edits) and covered by targeted tests.
> 
> **Overview**
> **Approve & run** no longer auto-approves file edits—only **bash** commands get a session bypass during an autonomous goal. Plan approval, goal start/retarget/pause/complete, and error-driven goal pause all go through the renamed bash-only helper (`setGoalSessionBashAutoApproval`).
> 
> The plan approval card copy now says **"Bash auto-approved; edits still ask."** TUI harness scenarios and kernel tests were updated to match, including assertions that `approve_and_goal` enables bash bypass but not tool-edit bypass, and that pausing a goal after a failed cycle clears bash bypass without emitting tool-edit bypass events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020e550a16109eff321f0dfd39084acadbe76d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->