### PR TITLE
fix: summarize subagent follow-ups in CLI logs

### DIFF
--- a/src/agent/core/flows/toolUseRound/ToolUsePrepNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUsePrepNode.ts
@@ -5,7 +5,10 @@ import {
   resetCycleState,
   saveCycleDebug,
 } from '@agent/core/flows/CommonCycleTypes';
-import { appendFollowUpAsUserMessage } from '@agent/toolUse/followUpMessages';
+import {
+  appendFollowUpAsUserMessage,
+  followUpDisplayText,
+} from '@agent/toolUse/followUpMessages';
 import type { FollowUpQueueBatchItem } from '@agent/toolUse/FollowUpQueue';
 
 // Local file imports
@@ -68,10 +71,7 @@ export class ToolUsePrepNode<C> extends BaseNode<
     if (prepRes.queuedFollowUps?.length) {
       if (!prepRes.synthetic) {
         for (const followUp of prepRes.queuedFollowUps) {
-          logUserMessage(
-            this.services.logger,
-            followUp.displayText ?? followUp.text,
-          );
+          logUserMessage(this.services.logger, followUpDisplayText(followUp));
         }
       }
       for (const followUp of prepRes.queuedFollowUps) {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -2,7 +2,10 @@ import { maybeBuildGoalContinuation } from '@agent/goal';
 import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { appendFollowUpAsUserMessage } from '@agent/toolUse/followUpMessages';
+import {
+  appendFollowUpAsUserMessage,
+  followUpDisplayText,
+} from '@agent/toolUse/followUpMessages';
 import { STREAM_STATUS } from '@shared/schemas';
 import { GoalStore, setGoalSessionAutoApprovals } from '@tools/goal';
 
@@ -189,7 +192,7 @@ export class ToolUseWaitNode<C> extends Node<
       shared.deliveredToOrchestrator = undefined;
       onFollowUpConsumed?.();
       for (const followUp of execRes.followUps) {
-        logUserMessage(logger, followUp.displayText ?? followUp.text);
+        logUserMessage(logger, followUpDisplayText(followUp));
       }
     }
 

--- a/src/agent/toolUse/followUpMessages.ts
+++ b/src/agent/toolUse/followUpMessages.ts
@@ -9,6 +9,7 @@ import {
   formatMediaNeedsVisionWarning,
   shouldWarnMediaNeedsVision,
 } from '@agent/runtime/mediaVisionWarning';
+import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import type { TaskRunFileService } from '@utils/files';
 import type { FollowUpQueueBatchItem } from './FollowUpQueue';
 
@@ -19,6 +20,13 @@ interface FollowUpMessageServices<C> {
   >;
   readonly fileService: Pick<TaskRunFileService, 'createLocation'>;
   readonly logger: Pick<AgentTrace, 'warn'>;
+}
+
+export function followUpDisplayText(followUp: FollowUpQueueBatchItem): string {
+  if (followUp.displayText !== undefined) return followUp.displayText;
+  return followUp.origin === 'subagent_result'
+    ? summarizeFollowupMessage(followUp.text)
+    : followUp.text;
 }
 
 export async function appendFollowUpAsUserMessage<C>(

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -12,7 +12,11 @@ import {
   StreamStatusService,
 } from '@agent/runtime/StreamStatusService';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  MESSAGE_TYPES,
+  STREAM_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
 import { GoalStore } from '@tools/goal';
 
 describe('ToolUseWaitNode', () => {
@@ -388,5 +392,11 @@ describe('ToolUseWaitNode', () => {
       { role: 'user', content: '<subagent-result>done</subagent-result>' },
       { role: 'user', content: 'please revise the theorem' },
     ]);
+    expect(info).toHaveBeenCalledWith('✓ subagent completed', {
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+    });
+    expect(info).toHaveBeenCalledWith('please revise the theorem', {
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- add a shared display helper for queued follow-ups
- summarize subagent protocol follow-ups before writing visible user log entries
- keep raw subagent XML in the provider conversation so the orchestrator model still receives the full payload

Closes #6013.

## Testing

- `corepack pnpm vitest run src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts --config vitest.config.mjs`
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only logging change; conversation payload for the model is unchanged.
> 
> **Overview**
> Queued follow-ups now use a shared **`followUpDisplayText`** helper wherever visible user log lines are written (`ToolUsePrepNode`, `ToolUseWaitNode`), instead of `displayText ?? text`.
> 
> For **`subagent_result`** items without an explicit `displayText`, logs show the same short summary as elsewhere (e.g. `✓ subagent completed`) via **`summarizeFollowupMessage`**, while **`appendFollowUpAsUserMessage`** still appends the raw **`followUp.text`** so the orchestrator model keeps the full subagent XML.
> 
> Tests assert the summarized subagent line and the plain user follow-up are logged separately with **`USER_MESSAGE`** typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a1768766422204249e4903d43bb61a302f641e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->