### PR TITLE
fix: hide embedded subagent progress XML

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -13,7 +13,10 @@ import {
 } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
 
-import { summarizeFollowupMessage } from '@shared/subagentFollowup';
+import {
+  summarizeEmbeddedSubagentFollowups,
+  summarizeFollowupMessage,
+} from '@shared/subagentFollowup';
 import {
   isRenderableTranscriptEntry,
   trimAssistantTranscriptLead,
@@ -155,7 +158,9 @@ function renderLogEntryText(
 ): string {
   switch (role) {
     case 'assistant':
-      return trimAssistantTranscriptLead(text);
+      return summarizeEmbeddedSubagentFollowups(
+        trimAssistantTranscriptLead(text),
+      );
     case 'error':
       return appendCliApiSwitchHint(text);
     case 'user':

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -15,6 +15,8 @@
 import escapeRegExp from 'escape-string-regexp';
 
 const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
+const EMBEDDED_SUBAGENT_BLOCK_RE =
+  /<subagent-(?:progress|result|error)\b[^>]*\/>|<subagent-(progress|result|error)\b[^>]*>[\s\S]*?<\/subagent-\1>/g;
 const EMPTY_FOLLOW_UP_SUMMARY = '(empty follow-up)';
 
 function followupText(text: unknown): string | undefined {
@@ -38,6 +40,12 @@ function attr(xml: string, name: string): string | undefined {
 
 function innerTag(xml: string, tag: string): string | undefined {
   return new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(xml)?.[1]?.trim();
+}
+
+function elementBody(xml: string, tag: string): string | undefined {
+  return new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`)
+    .exec(xml)?.[1]
+    ?.trim();
 }
 
 // `<message>` bodies are escapeText()'d by the producer; decode for display.
@@ -73,8 +81,49 @@ function progressDetail(xml: string): string {
       return attr(xml, 'status') === 'cleared'
         ? 'plan cleared'
         : `plan · ${attr(xml, 'steps') ?? '0'} steps`;
-    case 'todos':
-      return `todos · ${attr(xml, 'completed') ?? '0'} done, ${attr(xml, 'active') ?? '0'} active, ${attr(xml, 'pending') ?? '0'} pending`;
+    case 'todos': {
+      const completed = attr(xml, 'completed');
+      const active = attr(xml, 'active');
+      const pending = attr(xml, 'pending');
+      if (completed || active || pending) {
+        return `todos · ${completed ?? '0'} done, ${active ?? '0'} active, ${pending ?? '0'} pending`;
+      }
+      const body = elementBody(xml, 'subagent-progress');
+      if (!body) return 'todos updated';
+      try {
+        const todos = JSON.parse(decodeXmlEntities(body));
+        if (!Array.isArray(todos)) return 'todos updated';
+        let done = 0;
+        let inProgress = 0;
+        let todo = 0;
+        for (const item of todos) {
+          const status =
+            typeof item === 'object' && item !== null && 'status' in item
+              ? item.status
+              : undefined;
+          if (status === 'completed') done += 1;
+          else if (status === 'in_progress') inProgress += 1;
+          else todo += 1;
+        }
+        return `todos · ${done} done, ${inProgress} active, ${todo} pending`;
+      } catch {
+        return 'todos updated';
+      }
+    }
+    case 'conversations': {
+      const turns = attr(xml, 'turns');
+      const chars = attr(xml, 'characters');
+      const parts: string[] = [];
+      if (turns) parts.push(`${turns} turns`);
+      if (chars) parts.push(`${chars} chars`);
+      return parts.length > 0
+        ? `conversation · ${parts.join(' · ')}`
+        : 'conversation update';
+    }
+    case 'activity': {
+      const body = elementBody(xml, 'subagent-progress');
+      return body ? decodeXmlEntities(body).split('\n')[0]! : 'activity';
+    }
     default:
       return 'working';
   }
@@ -117,4 +166,11 @@ export function summarizeSubagentFollowup(text: unknown): string {
 
 export function summarizeFollowupMessage(text: unknown): string {
   return summarizeSubagentFollowup(stripOrchestratorFollowup(text));
+}
+
+export function summarizeEmbeddedSubagentFollowups(text: string): string {
+  if (!text.includes('<subagent-')) return text;
+  return text.replace(EMBEDDED_SUBAGENT_BLOCK_RE, (block) =>
+    summarizeSubagentFollowup(block),
+  );
 }

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   stripOrchestratorFollowup,
+  summarizeEmbeddedSubagentFollowups,
   summarizeFollowupMessage,
   summarizeSubagentFollowup,
 } from '@shared/subagentFollowup';
@@ -67,6 +68,44 @@ describe('summarizeSubagentFollowup', () => {
         '<subagent-progress id="abc" agent="numerics" type="round" current="2" total="5">\n<file path="a.tex" />\n</subagent-progress>',
       ),
     ).toBe('⟳ numerics · round 2/5');
+  });
+
+  it('summarizes todo progress blocks that carry JSON bodies', () => {
+    const xml = [
+      '<subagent-progress id="abc" agent="review" type="todos">',
+      '[',
+      '{"content":"done","status":"completed"},',
+      '{"content":"active","status":"in_progress"},',
+      '{"content":"todo","status":"pending"}',
+      ']',
+      '</subagent-progress>',
+    ].join('');
+    expect(summarizeSubagentFollowup(xml)).toBe(
+      '⟳ review · todos · 1 done, 1 active, 1 pending',
+    );
+  });
+
+  it('summarizes embedded subagent blocks inside assistant text', () => {
+    const text = [
+      'before',
+      '<subagent-progress id="abc" agent="review" type="started" />',
+      '<subagent-progress id="abc" agent="review" type="conversations" turns="4" characters="4471">',
+      'Last message',
+      '</subagent-progress>',
+      '<subagent-progress id="abc" agent="review" type="round" current="2" total="3">',
+      '<file path="a.tex" />',
+      '</subagent-progress>',
+      'after',
+    ].join('\n');
+    expect(summarizeEmbeddedSubagentFollowups(text)).toBe(
+      [
+        'before',
+        '⟳ review · started',
+        '⟳ review · conversation · 4 turns · 4471 chars',
+        '⟳ review · round 2/3',
+        'after',
+      ].join('\n'),
+    );
   });
 
   it('summarizes a completed result with wall time and response', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1730,6 +1730,40 @@ describe('CLI transcript state', () => {
     }
   });
 
+  it('summarizes embedded subagent progress blocks in assistant transcript text', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info(
+        [
+          'Waiting for the child.',
+          '<subagent-progress id="abc" agent="prover" type="todos">',
+          '[{"content":"check","status":"completed"},{"content":"prove","status":"in_progress"}]',
+          '</subagent-progress>',
+          '<subagent-progress id="abc" agent="prover" type="activity">Subagent prover is proving completeness.</subagent-progress>',
+        ].join('\n'),
+        { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
+      );
+
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        [
+          'Waiting for the child.',
+          '⟳ prover · todos · 1 done, 1 active, 0 pending',
+          '⟳ prover · Subagent prover is proving completeness.',
+        ].join('\n'),
+      ]);
+      expect(entries[0]?.text).not.toContain('<subagent-progress');
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
   it('mirrors error log entries into the transcript', () => {
     const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();


### PR DESCRIPTION
## Summary

- collapse embedded `<subagent-progress>` blocks in assistant transcript text before CLI rendering
- make todo, conversation, and activity progress summaries useful when progress blocks come from `executions wait`
- keep model/tool payloads untouched; this is display-only normalization

Fixes #6013.

## Dogfood evidence

After #6014, a real `texra-local chat` run still showed raw `<subagent-progress>` blocks in the parent assistant transcript after a `prover` subagent completed. Completion results were summarized, but progress blocks embedded in assistant text were not.

## Testing

- `corepack pnpm vitest run src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts --config vitest.config.mjs`
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only transcript normalization in shared formatting and CLI rendering; no changes to protocol, persistence, or tool payloads.
> 
> **Overview**
> Fixes raw `<subagent-progress>` (and related) XML showing in the **parent assistant transcript** after subagent waits—especially when progress is embedded in model response text, not only in queued user follow-ups.
> 
> **Shared `@shared/subagentFollowup`:** Adds `summarizeEmbeddedSubagentFollowups`, which finds self-closing or paired subagent blocks in a string and replaces each with the same one-line summaries used elsewhere. Progress formatting is extended for **`executions wait`–style blocks**: todo progress can count statuses from a JSON body when count attributes are missing; **conversations** and **activity** types get readable lines from attributes or element body.
> 
> **CLI:** Assistant transcript text from the stream log now runs through that helper after `trimAssistantTranscriptLead` in `subscribeStreamLog`—**display-only**; stored log/model payloads are unchanged.
> 
> Tests cover the new summarizer and an end-to-end TUI sync case with embedded progress in a `MODEL_RESPONSE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2aeb3b98fc32d98431e00948419966108aa343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->