### PR TITLE
[codex] Preview long CLI subagent results

### DIFF
--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -18,6 +18,8 @@ const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
 const EMBEDDED_SUBAGENT_BLOCK_RE =
   /<subagent-(?:progress|result|error)\b[^>]*\/>|<subagent-(progress|result|error)\b[^>]*>[\s\S]*?<\/subagent-\1>/g;
 const EMPTY_FOLLOW_UP_SUMMARY = '(empty follow-up)';
+const RESULT_RESPONSE_PREVIEW_LINES = 12;
+const RESULT_RESPONSE_PREVIEW_CHARS = 1400;
 
 function followupText(text: unknown): string | undefined {
   return typeof text === 'string' ? text : undefined;
@@ -129,6 +131,26 @@ function progressDetail(xml: string): string {
   }
 }
 
+function resultResponsePreview(response: string): string {
+  const decoded = decodeXmlEntities(response).trim();
+  if (decoded === '') return '';
+
+  const lines = decoded.split('\n');
+  const lineLimited = lines.length > RESULT_RESPONSE_PREVIEW_LINES;
+  let preview = lines.slice(0, RESULT_RESPONSE_PREVIEW_LINES).join('\n');
+  const charLimited = preview.length > RESULT_RESPONSE_PREVIEW_CHARS;
+  if (charLimited) {
+    preview = preview.slice(0, RESULT_RESPONSE_PREVIEW_CHARS).trimEnd();
+  }
+
+  if (!lineLimited && !charLimited) return decoded;
+
+  const hidden = lineLimited
+    ? `${lines.length - RESULT_RESPONSE_PREVIEW_LINES} more line${lines.length - RESULT_RESPONSE_PREVIEW_LINES === 1 ? '' : 's'}`
+    : 'more text';
+  return `${preview}\n… ${hidden}; open the subagent transcript for the full response`;
+}
+
 /**
  * Collapse a subagent follow-up XML block into a one-line (or, for results,
  * status + response) human-readable summary. Returns `text` unchanged when it
@@ -153,7 +175,8 @@ export function summarizeSubagentFollowup(text: unknown): string {
     const wall = innerTag(trimmed, 'wall-time');
     const response = innerTag(trimmed, 'response');
     const head = `✓ ${agent} ${status}${wall ? ` · ${wall}` : ''}`;
-    return response ? `${head}\n${decodeXmlEntities(response)}` : head;
+    const preview = response ? resultResponsePreview(response) : '';
+    return preview ? `${head}\n${preview}` : head;
   }
 
   // <subagent-error>
@@ -170,7 +193,7 @@ export function summarizeFollowupMessage(text: unknown): string {
 
 export function summarizeEmbeddedSubagentFollowups(text: string): string {
   if (!text.includes('<subagent-')) return text;
-  return text.replace(EMBEDDED_SUBAGENT_BLOCK_RE, (block) =>
+  return text.replaceAll(EMBEDDED_SUBAGENT_BLOCK_RE, (block) =>
     summarizeSubagentFollowup(block),
   );
 }

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -133,6 +133,30 @@ describe('summarizeSubagentFollowup', () => {
     );
   });
 
+  it('previews long result responses without flooding the transcript', () => {
+    const response = Array.from(
+      { length: 20 },
+      (_, index) => `result line ${index + 1}`,
+    ).join('\n');
+    const xml = [
+      '<subagent-result id="abc" agent="prover" category="toolUse" status="completed">',
+      '<wall-time>2m</wall-time>',
+      '<response>',
+      response,
+      '</response>',
+      '</subagent-result>',
+    ].join('\n');
+
+    const summary = summarizeSubagentFollowup(xml);
+
+    expect(summary).toContain('✓ prover completed · 2m');
+    expect(summary).toContain('result line 12');
+    expect(summary).not.toContain('result line 13');
+    expect(summary).toContain(
+      '… 8 more lines; open the subagent transcript for the full response',
+    );
+  });
+
   it('summarizes wrapped result follow-up messages for queued displays', () => {
     const xml = [
       '<orchestrator-followup>',

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1764,6 +1764,45 @@ describe('CLI transcript state', () => {
     }
   });
 
+  it('bounds long subagent result responses in the visible transcript', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      const response = Array.from(
+        { length: 20 },
+        (_, index) => `proof line ${index + 1}`,
+      ).join('\n');
+      logger.info(
+        [
+          '<subagent-result id="abc" agent="prover" category="toolUse" status="completed">',
+          '<wall-time>2m</wall-time>',
+          '<response>',
+          response,
+          '</response>',
+          '</subagent-result>',
+        ].join('\n'),
+        { messageType: MESSAGE_TYPES.USER_MESSAGE },
+      );
+
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.text).toContain('✓ prover completed · 2m');
+      expect(entries[0]?.text).toContain('proof line 12');
+      expect(entries[0]?.text).not.toContain('proof line 13');
+      expect(entries[0]?.text).toContain(
+        '… 8 more lines; open the subagent transcript for the full response',
+      );
+      expect(entries[0]?.text).not.toContain('<subagent-result');
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
   it('mirrors error log entries into the transcript', () => {
     const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();


### PR DESCRIPTION
## Summary

Fixes #6016.

- Add a bounded preview for long `<subagent-result><response>` bodies in shared follow-up display formatting.
- Keep short result responses unchanged.
- Preserve the full subagent result for model input; this only changes visible transcript summaries.
- Add focused CLI state coverage so parent-visible transcripts do not expand long child responses.

## Dogfood Evidence

A real TTY `texra-local chat --agent assistant --model gemini35f --api-mode included --approval-policy ask` run at 110x32 delegated a finite-combinatorics proof to `prover`. After the child completed, the parent stream showed the full multi-page prover proof inline and became idle instead of leaving a compact parent view. Main resume: `908d0fc081d9`; prover resume: `09502b68de20`.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts --config vitest.config.mjs`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings outside this change)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in shared follow-up formatting; model-facing follow-up XML is untouched and coverage is added for transcript projection.
> 
> **Overview**
> Long **`<subagent-result>`** response bodies no longer expand the full child output in CLI (and other host-neutral) follow-up summaries. **`summarizeSubagentFollowup`** now routes result **`<response>`** text through **`resultResponsePreview`**, capped at **12 lines** and **1400 characters**, with a trailing hint to open the subagent transcript when content is truncated; short responses stay unchanged.
> 
> **`summarizeEmbeddedSubagentFollowups`** switches to **`replaceAll`** for embedded blocks (behavior unchanged aside from inheriting the new preview). Tests cover the formatter and **`syncStreamLog`** so parent-visible transcripts stay compact without altering full XML for model input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c393c4dc828ef122308a1c9a7c596552bc450fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->