### PR TITLE
[codex] Clarify rejected delegation feedback

### DIFF
--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -3,11 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { AgentProposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import {
   AgentExecutionHandle,
   executionRegistry,
 } from '@agent/runtime/executionRegistry';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { AgentFlowError } from '@agent/runtime/AgentFlowResult';
+import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
+import { RetryRequestCoordinatorImpl } from '@agent/runtime/RetryRequestCoordinator';
 import type { ToolUseBeforeWaitingCallback } from '@agent/implementations/flows/tooluse';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { StreamTabId } from '@shared/schemas';
@@ -365,6 +369,51 @@ describe('headless delegation', () => {
       expect.any(String),
       expect.not.objectContaining({ stopAfterCycle: true }),
     );
+  });
+
+  it('discourages equivalent delegation retries after a no-feedback rejection', async () => {
+    mocks.isProposalBypassed.mockReturnValue(false);
+    const host = runtimeHost();
+    const coordinators = {
+      plan: new PlanApprovalCoordinator(host),
+      proposal: new AgentProposalCoordinator(host),
+      retry: new RetryRequestCoordinatorImpl(host),
+    };
+    host.emit.mockImplementation((event, payload) => {
+      if (event !== 'showAgentProposal') return;
+      runCoordinatorBridge.resolveProposal(
+        (payload as { proposalId: string }).proposalId,
+        { action: 'reject' },
+      );
+    });
+
+    const result = await withRunContext(
+      createRunContext({
+        runtimeHost: host,
+        streamId: 'parent-stream',
+        executionId: 'parent-exec',
+        model: 'deepseekT',
+        coordinators,
+      }),
+      () =>
+        new DelegateAgentTool().call({
+          agent: 'review',
+          model: null,
+          instruction: 'Check the proof.',
+          memories: [],
+          working_directory: null,
+          execution_id: null,
+        }),
+    );
+
+    expect(result.summary).toBe("User rejected delegation to 'review'");
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain('No feedback provided.');
+    expect(result.output).toContain(
+      'Do not retry the same or equivalent delegation',
+    );
+    expect(result.output).toContain('continue directly with available context');
+    expect(mocks.executeAgent).not.toHaveBeenCalled();
   });
 
   it('canonicalizes legacy tool-use agent names before launch', async () => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -140,6 +140,11 @@ const TOOL_USE_SUBAGENT_HANDOFF_INSTRUCTION = [
   '- Include the substantive result requested: answer, findings, evidence/checks, and unresolved caveats.',
   '- Do not finish with only status/process notes such as "done", "complete", or "no files were edited"; if no files were edited, state that after the task result.',
 ].join('\n');
+const DEFAULT_DELEGATION_REJECTION_FEEDBACK = [
+  'No feedback provided.',
+  'Do not retry the same or equivalent delegation unless the user explicitly asks for it;',
+  'continue directly with available context, or ask the user a clarifying question.',
+].join(' ');
 
 function withToolUseSubagentHandoffInstruction(instruction: string): string {
   const trimmed = instruction.trimEnd();
@@ -760,7 +765,7 @@ function proposalResultToToolResult(
       const feedback = result.feedback?.trim();
       const feedbackLine = feedback
         ? `\nUser feedback: ${feedback}`
-        : '\nNo feedback provided. Consider asking the user for guidance.';
+        : `\n${DEFAULT_DELEGATION_REJECTION_FEEDBACK}`;
       return {
         summary: `User rejected delegation to '${agentName}'`,
         output: `Delegation to '${agentName}' was rejected.\nYour delegation was: ${echo}${feedbackLine}`,


### PR DESCRIPTION
## Summary

- Make the no-feedback rejection result for `delegate_agent`/proposal approvals explicitly tell the parent not to retry the same or equivalent delegation unless the user asks for it.
- Add a regression test that exercises a real rejected `delegate_agent` proposal through run coordinators.

## Why

Dogfood found that pressing plain `n` on subagent spawn approvals could lead to repeated equivalent spawn prompts (`prover` -> `research` -> `assistant`). The model-visible rejection result only said no feedback was provided, which was too weak to steer the parent away from retrying the same action.

Closes #6018

## Validation

- `pnpm exec vitest run src/test-kernel/tools/DelegationHeadless.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change to orchestrator-facing tool result copy and test coverage; no execution, auth, or data-path changes beyond steering parent behavior after rejection.
> 
> **Overview**
> When a user rejects a `delegate_agent` or `delegate_workflow` proposal **without** feedback, the tool error shown to the parent orchestrator now uses a shared **`DEFAULT_DELEGATION_REJECTION_FEEDBACK`** string instead of a vague “no feedback” hint.
> 
> The new copy tells the parent **not to retry the same or equivalent delegation** unless the user explicitly asks, and to **continue with existing context** or ask a clarifying question. Rejections that include user feedback are unchanged.
> 
> A headless Vitest exercises a real rejected `delegate_agent` proposal through run coordinators and asserts the stronger messaging and that **`executeAgent` is not called**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab792463045c2f511696c8dcf8a23402dcfa19e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->