### PR TITLE
[codex] Clarify plan-only lifecycle guidance

### DIFF
--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -351,22 +351,28 @@ describe('PlanTool — pause/complete (goal lifecycle)', () => {
     expect(GoalStore.getForStream(STREAM_ID)).toBeNull();
   });
 
-  it('complete is a no-op when no goal is running', async () => {
+  it('complete gives plan-only guidance when no goal is running', async () => {
     const result = await callTool({
       command: 'complete',
       reason: 'I think I am done.',
     });
     expect(result.isError).toBeFalsy();
-    expect(result.summary).toMatch(/no-op/i);
+    expect(result.summary).toBe(
+      'Plan-only work complete — summarize the result.',
+    );
+    expect(result.output).toContain(
+      'do not call plan(command="complete") again',
+    );
   });
 
-  it('pause is a no-op when no goal is running', async () => {
+  it('pause gives direct-response guidance when no goal is running', async () => {
     const result = await callTool({
       command: 'pause',
       reason: 'Need user input.',
     });
     expect(result.isError).toBeFalsy();
-    expect(result.summary).toMatch(/no-op/i);
+    expect(result.summary).toBe('No autonomous goal to pause.');
+    expect(result.output).toContain('ask the user directly');
   });
 
   it('rejects whitespace-only reason on pause', async () => {

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -9,8 +9,8 @@
  *
  * `command: 'pause'` and `command: 'complete'` drive the lifecycle of the
  * goal pursuing this plan: pause when user input is needed, complete when
- * the objective is verifiably done. Both are no-ops if no goal is in
- * flight on the current stream.
+ * the objective is verifiably done. When no autonomous goal is in flight,
+ * they return plain guidance for ordinary turn-by-turn chat.
  */
 
 // Third-party imports
@@ -102,7 +102,7 @@ Best practices:
 - Write the objective BEFORE starting implementation.
 - State a stopping condition that can be checked against external evidence (file contents, command output, test results).
 - Track execution steps with the todo tool; update the plan only when the objective or approach genuinely changes (every update requires re-approval).
-- pause/complete are no-ops if no goal is running on this stream.`,
+- pause/complete only affect autonomous goals; if no goal is running, they return guidance for ordinary chat.`,
   schema: PlanToolInputSchema,
 }) {
   protected async execute(input: PlanToolInput): Promise<ToolResult> {
@@ -180,11 +180,10 @@ Best practices:
     const goal = GoalStore.getForStream(streamId);
     if (!goal) {
       return {
-        summary: 'No goal running — pause is a no-op.',
+        summary: 'No autonomous goal to pause.',
         output:
-          'No autonomous goal is currently running on this stream. ' +
-          'If you need user input, return a message describing what you need; ' +
-          'no pause is necessary.',
+          'No autonomous goal is currently running on this stream, so there is nothing to pause. ' +
+          'If you need user input, ask the user directly in your next message; do not call plan(command="pause") again.',
       };
     }
     if (goal.status !== 'active') {
@@ -223,10 +222,10 @@ Best practices:
     const goal = GoalStore.getForStream(streamId);
     if (!goal) {
       return {
-        summary: 'No goal running — complete is a no-op.',
+        summary: 'Plan-only work complete — summarize the result.',
         output:
-          'No autonomous goal is currently running on this stream. ' +
-          'The plan is the only artifact; you may simply summarize the result for the user.',
+          'No autonomous goal is currently running on this stream, so there is nothing to mark complete. ' +
+          'The plan work is otherwise finished; return the final answer to the user and do not call plan(command="complete") again.',
       };
     }
     // Completing forgets the record — a goal is a live pursuit, not an


### PR DESCRIPTION
## Summary

Closes #6020.

This updates the plan tool's no-goal `pause`/`complete` responses so ordinary chat-mode runs do not surface an internal-looking `No goal running — complete is a no-op` transcript item after a user-approved plan.

Changes:
- keep the existing no-goal lifecycle semantics intact
- replace no-goal pause/complete summaries with ordinary chat guidance
- tell the model not to retry the same lifecycle command when no autonomous goal is running
- update focused plan-tool tests for the new guidance

## Dogfood Evidence

In a real `texra-local chat --approval-policy ask` run, a math task with plan approval, inline Python, and an accepted `review` subagent completed correctly, but the parent transcript showed:

```text
● plan (No goal running — complete is a no-op.)
```

This PR changes that visible result to plan-only completion guidance instead.

## Validation

- `npm run format`
- `pnpm exec vitest run src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and documentation-only behavior for the no-goal branch; goal store and active/paused goal paths are untouched.
> 
> **Overview**
> When **`plan(pause)`** or **`plan(complete)`** is called without an autonomous goal on the stream, responses no longer label the call a **no-op** in the transcript summary (e.g. `No goal running — complete is a no-op.`).
> 
> **`complete`** now returns **`Plan-only work complete — summarize the result.`** and tells the model to answer the user and not call **`plan(complete)`** again. **`pause`** returns **`No autonomous goal to pause.`** and directs the model to ask the user in chat instead of retrying **`plan(pause)`**. Autonomous-goal behavior when a goal exists is unchanged.
> 
> Tool docs and **`PlanToolWorkPlanState`** tests were updated to match the new copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495e9a966d1df4cc705aa632893a091bf7d29c76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->