### PR TITLE
[codex] Hide streaming subagent protocol blocks

### DIFF
--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -29,6 +29,8 @@ export interface ConversationEntry {
   readonly role: 'assistant' | 'error' | 'process' | 'tool' | 'user';
   /** Concatenated text for `MODEL_RESPONSE` entries. Empty for tool rows. */
   readonly text: string;
+  /** True while rendered assistant text is hiding an incomplete protocol block. */
+  readonly pendingEmbeddedSubagentFollowup?: boolean;
   /** True once the stream transitions to `WAITING`/`COMPLETED`. */
   readonly finalized: boolean;
   /** Populated only when `role === 'tool'`. */

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -14,6 +14,7 @@ import {
 import { normalizeToolUseData } from '@shared/toolUse';
 
 import {
+  hasIncompleteEmbeddedSubagentFollowup,
   summarizeEmbeddedSubagentFollowups,
   summarizeFollowupMessage,
 } from '@shared/subagentFollowup';
@@ -130,6 +131,8 @@ function entriesEqual(
   if (
     prev.role !== next.role ||
     prev.text !== next.text ||
+    prev.pendingEmbeddedSubagentFollowup !==
+      next.pendingEmbeddedSubagentFollowup ||
     prev.finalized !== next.finalized
   ) {
     return false;
@@ -213,6 +216,8 @@ function renderLogEntry(
 
   const text = entry.text ?? '';
   const role = logEntryRole(entry.messageType);
+  const assistantTranscript =
+    role === 'assistant' ? trimAssistantTranscriptLead(text) : undefined;
   const renderedText = renderLogEntryText(role, text);
   // Assistant text is promoted by `finalizeSettledPrefix` once the model
   // moves on to a later entry; inherit the prior flag here so a re-sync
@@ -223,6 +228,10 @@ function renderLogEntry(
     id: entry.id,
     role,
     text: renderedText,
+    ...(assistantTranscript !== undefined &&
+    hasIncompleteEmbeddedSubagentFollowup(assistantTranscript)
+      ? { pendingEmbeddedSubagentFollowup: true }
+      : {}),
     finalized,
   };
   if (!isRenderableTranscriptEntry(next)) return null;
@@ -248,7 +257,9 @@ function isSettledEntry(
     case 'tool':
       return entry.toolUse?.status === TOOL_USE_STATUS.COMPLETED;
     case 'assistant':
-      return index < entries.length - 1;
+      return (
+        !entry.pendingEmbeddedSubagentFollowup && index < entries.length - 1
+      );
   }
 }
 

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -17,6 +17,8 @@ import escapeRegExp from 'escape-string-regexp';
 const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
 const EMBEDDED_SUBAGENT_BLOCK_RE =
   /<subagent-(?:progress|result|error)\b[^>]*\/>|<subagent-(progress|result|error)\b[^>]*>[\s\S]*?<\/subagent-\1>/g;
+const EMBEDDED_SUBAGENT_OPEN_RE =
+  /<subagent-(progress|result|error)\b[^>]*(?:\/>|>)/g;
 const EMPTY_FOLLOW_UP_SUMMARY = '(empty follow-up)';
 const RESULT_RESPONSE_PREVIEW_LINES = 12;
 const RESULT_RESPONSE_PREVIEW_CHARS = 1400;
@@ -191,9 +193,45 @@ export function summarizeFollowupMessage(text: unknown): string {
   return summarizeSubagentFollowup(stripOrchestratorFollowup(text));
 }
 
+type IncompleteEmbeddedSubagentFollowup = {
+  readonly index: number;
+  readonly block: string;
+};
+
+function findIncompleteEmbeddedSubagentFollowup(
+  text: string,
+): IncompleteEmbeddedSubagentFollowup | undefined {
+  for (const match of text.matchAll(EMBEDDED_SUBAGENT_OPEN_RE)) {
+    const index = match.index;
+    const tag = match[1];
+    const opening = match[0];
+    if (index === undefined || tag === undefined || opening.endsWith('/>')) {
+      continue;
+    }
+
+    const closing = new RegExp(`</subagent-${tag}>`, 'g');
+    closing.lastIndex = index + opening.length;
+    if (!closing.exec(text)) {
+      return { index, block: text.slice(index) };
+    }
+  }
+  return undefined;
+}
+
+export function hasIncompleteEmbeddedSubagentFollowup(text: string): boolean {
+  return (
+    text.includes('<subagent-') &&
+    findIncompleteEmbeddedSubagentFollowup(text) !== undefined
+  );
+}
+
 export function summarizeEmbeddedSubagentFollowups(text: string): string {
   if (!text.includes('<subagent-')) return text;
-  return text.replaceAll(EMBEDDED_SUBAGENT_BLOCK_RE, (block) =>
-    summarizeSubagentFollowup(block),
+  const completeSummarized = text.replaceAll(
+    EMBEDDED_SUBAGENT_BLOCK_RE,
+    (block) => summarizeSubagentFollowup(block),
   );
+  const incomplete = findIncompleteEmbeddedSubagentFollowup(completeSummarized);
+  if (!incomplete) return completeSummarized;
+  return `${completeSummarized.slice(0, incomplete.index)}${summarizeSubagentFollowup(incomplete.block)}`;
 }

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  hasIncompleteEmbeddedSubagentFollowup,
   stripOrchestratorFollowup,
   summarizeEmbeddedSubagentFollowups,
   summarizeFollowupMessage,
@@ -106,6 +107,45 @@ describe('summarizeSubagentFollowup', () => {
         'after',
       ].join('\n'),
     );
+  });
+
+  it('summarizes incomplete embedded subagent blocks while streaming', () => {
+    const text = [
+      'before',
+      '<subagent-result id="abc" agent="prover" category="toolUse" status="completed">',
+      'The response is still streaming.',
+    ].join('\n');
+
+    expect(summarizeEmbeddedSubagentFollowups(text)).toBe(
+      ['before', '✓ prover completed'].join('\n'),
+    );
+  });
+
+  it('detects incomplete embedded subagent blocks', () => {
+    expect(
+      hasIncompleteEmbeddedSubagentFollowup(
+        [
+          'before',
+          '<subagent-result id="abc" agent="prover" category="toolUse" status="completed">',
+          'The response is still streaming.',
+        ].join('\n'),
+      ),
+    ).toBe(true);
+    expect(
+      hasIncompleteEmbeddedSubagentFollowup(
+        [
+          'before',
+          '<subagent-result id="abc" agent="prover" category="toolUse" status="completed">',
+          '<response>Done.</response>',
+          '</subagent-result>',
+        ].join('\n'),
+      ),
+    ).toBe(false);
+    expect(
+      hasIncompleteEmbeddedSubagentFollowup(
+        '<subagent-progress id="abc" agent="review" type="started" />',
+      ),
+    ).toBe(false);
   });
 
   it('summarizes a completed result with wall time and response', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1646,8 +1646,16 @@ describe('finalizeSettledPrefix', () => {
         status,
       },
     }) as const;
-  const assistant = (id: string) =>
-    ({ id, role: 'assistant', text: id, finalized: false }) as const;
+  const assistant = (id: string, pendingEmbeddedSubagentFollowup = false) =>
+    ({
+      id,
+      role: 'assistant',
+      text: id,
+      ...(pendingEmbeddedSubagentFollowup
+        ? { pendingEmbeddedSubagentFollowup }
+        : {}),
+      finalized: false,
+    }) as const;
   const finalizedIds = (
     entries: readonly { id: string; finalized: boolean }[],
   ) => entries.filter((entry) => entry.finalized).map((entry) => entry.id);
@@ -1664,6 +1672,15 @@ describe('finalizeSettledPrefix', () => {
 
   it('keeps the in-flight tail pending while the stream runs', () => {
     const out = finalizeSettledPrefix([assistant('a1')], false);
+    expect(finalizedIds(out)).toEqual([]);
+  });
+
+  it('keeps assistant entries with incomplete subagent blocks pending', () => {
+    const out = finalizeSettledPrefix(
+      [assistant('a1', true), tool('t1', 'completed'), assistant('a2')],
+      false,
+    );
+
     expect(finalizedIds(out)).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

- Collapse dangling embedded `<subagent-progress|result|error>` blocks while assistant text is still streaming, so the CLI never renders raw protocol XML in the parent transcript.
- Track when an assistant row is hiding an incomplete subagent follow-up block and keep it out of append-only static scrollback until the complete block arrives.
- Add parser and TUI settlement regression coverage for incomplete subagent follow-up blocks.

## Root Cause

During dogfood, the parent stream briefly rendered raw `<subagent-result>` / `<subagent-progress>` XML after a child subagent completed. Complete embedded blocks were already summarized, but a streaming chunk can contain an opening subagent protocol tag before its closing tag. The TUI then rendered the partial block and could finalize it into static scrollback as soon as a later entry appeared.

## Validation

- `pnpm exec prettier --write src/shared/subagentFollowup.ts packages/cli/src/chat/tui/state/cliState.ts packages/cli/src/chat/tui/state/subscribeStreamLog.ts src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `pnpm exec vitest run src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI transcript and shared display parsing changes with no auth or data-path impact; behavior is covered by new unit tests.
> 
> **Overview**
> Fixes a case where the CLI parent transcript could briefly show raw `<subagent-*>` XML while a child block was still streaming, and could promote that partial row into append-only static scrollback once a later entry appeared.
> 
> **Shared parsing** (`subagentFollowup.ts`) now detects **incomplete** embedded subagent tags (opening tag without a matching close) and summarizes them like complete blocks instead of leaving protocol XML visible. `summarizeEmbeddedSubagentFollowups` applies that after normalizing fully closed blocks.
> 
> **CLI TUI** marks assistant rows with `pendingEmbeddedSubagentFollowup` when the raw assistant text still has an incomplete block, and treats those rows as **not settled** so `finalizeSettledPrefix` keeps them in the live pane until the block finishes. Equality checks include the new flag so sync ticks pick up the change.
> 
> Regression tests cover incomplete-block detection/summarization and settlement behavior when the flag is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b753f898f87cd40b55f6af02502f16be3e54c0bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->