### PR TITLE
[codex] Carry constraints into subagent handoffs

### DIFF
--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -197,6 +197,40 @@ describe('headless delegation', () => {
       expect.any(String),
       expect.anything(),
     );
+    expect(mocks.executeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instruction: expect.stringContaining(
+          'Follow any tool, network, file, approval',
+        ),
+      }),
+      expect.any(String),
+      expect.anything(),
+    );
+    expect(mocks.executeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instruction: expect.stringContaining(
+          'report the conflict instead of guessing permission',
+        ),
+      }),
+      expect.any(String),
+      expect.anything(),
+    );
+  });
+
+  it('tells orchestrators that delegated instructions must carry parent constraints', () => {
+    const parameters = new DelegateAgentTool().definition.parameters as {
+      properties?: Record<string, { description?: string }>;
+    };
+    const instructionDescription =
+      parameters.properties?.instruction?.description ?? '';
+
+    expect(instructionDescription).toContain(
+      'copy every relevant parent constraint',
+    );
+    expect(instructionDescription).toContain('tool/network/file/approval');
+    expect(instructionDescription).toContain(
+      'does not automatically inherit the parent conversation',
+    );
   });
 
   it('formats returned child error results as subagent errors', async () => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -136,6 +136,9 @@ const WORKTREE_DISABLED_MESSAGE =
   "git worktree support is disabled in this workspace. Omit working_directory, or enable 'Allow agents to work in git worktrees' on the Multi-Agent settings tab.";
 const TOOL_USE_SUBAGENT_HANDOFF_INSTRUCTION = [
   'Delegated task handoff:',
+  '- Treat the delegated instruction as your full task contract.',
+  '- Follow any tool, network, file, approval, output-format, or scope constraints it includes.',
+  '- If a requested action conflicts with those constraints or needs missing context, report the conflict instead of guessing permission.',
   '- Your final response is delivered verbatim to the parent orchestrator.',
   '- Include the substantive result requested: answer, findings, evidence/checks, and unresolved caveats.',
   '- Do not finish with only status/process notes such as "done", "complete", or "no files were edited"; if no files were edited, state that after the task result.',
@@ -1059,7 +1062,7 @@ const DelegateAgentInputSchema = z.strictObject({
   instruction: z
     .string()
     .describe(
-      'Plain prose instruction for the agent. For new delegations, include file paths naturally. For resumes, reference previous work freely — the subagent retains its full history.',
+      'Plain prose instruction for the agent. For new delegations, include file paths naturally and copy every relevant parent constraint into this field: tool/network/file/approval limits, output format, and scope. The subagent does not automatically inherit the parent conversation or hidden constraints. For resumes, reference previous work freely — the subagent retains its full history.',
     ),
   memories: memoriesField,
   working_directory: workingDirectoryField,


### PR DESCRIPTION
## Summary
- Make `delegate_agent` schema text explicit that subagents do not automatically inherit parent constraints.
- Add a child handoff footer requiring delegated agents to follow tool, network, file, approval, output-format, and scope constraints when present.
- Cover both the parent-facing schema and child-facing launch prompt in tests.

## Dogfood evidence
A live TTY chat run asked the parent to use exactly one approval-gated shell command, avoid network/files, and spawn one verification subagent. The subagent approval prompt omitted those constraints, and the child then used additional tools. This PR tightens the delegation boundary so the parent model is told to copy constraints into the child instruction and the child is told to treat them as binding.

## Review follow-up
- Addressed TeXRA review feedback by removing the forward-looking `budget` category from the constraint list.

## Validation
- `pnpm exec vitest run src/test-kernel/tools/DelegationHeadless.vitest.mts`
- `pnpm exec tsc --noEmit --pretty false`
- `npm run texra-local:build`
- Confirmed the rebuilt CLI bundle contains the updated delegation constraint wording.