### PR TITLE
[codex] Separate embedded subagent summaries

### DIFF
--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -225,11 +225,29 @@ export function hasIncompleteEmbeddedSubagentFollowup(text: string): boolean {
   );
 }
 
+function embeddedBoundary(text: string, index: number): string {
+  const char = text[index];
+  return char !== undefined && !/\s/.test(char) ? '\n' : '';
+}
+
+function summarizeEmbeddedSubagentBlock(
+  block: string,
+  offset: number,
+  source: string,
+): string {
+  return [
+    embeddedBoundary(source, offset - 1),
+    summarizeSubagentFollowup(block),
+    embeddedBoundary(source, offset + block.length),
+  ].join('');
+}
+
 export function summarizeEmbeddedSubagentFollowups(text: string): string {
   if (!text.includes('<subagent-')) return text;
   const completeSummarized = text.replaceAll(
     EMBEDDED_SUBAGENT_BLOCK_RE,
-    (block) => summarizeSubagentFollowup(block),
+    (block, _tag, offset, source) =>
+      summarizeEmbeddedSubagentBlock(block, offset, source),
   );
   const incomplete = findIncompleteEmbeddedSubagentFollowup(completeSummarized);
   if (!incomplete) return completeSummarized;

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -109,6 +109,18 @@ describe('summarizeSubagentFollowup', () => {
     );
   });
 
+  it('separates embedded subagent summaries from adjacent assistant text', () => {
+    expect(
+      summarizeEmbeddedSubagentFollowups(
+        [
+          'Before',
+          '<subagent-result id="abc" agent="review" category="toolUse" status="completed"></subagent-result>',
+          'Next sentence.',
+        ].join(''),
+      ),
+    ).toBe(['Before', '✓ review completed', 'Next sentence.'].join('\n'));
+  });
+
   it('summarizes incomplete embedded subagent blocks while streaming', () => {
     const text = [
       'before',


### PR DESCRIPTION
## Summary
- Add newline boundaries when embedded subagent follow-up XML is summarized next to adjacent assistant text.
- Keep existing whitespace-preserving behavior when the model already emitted separators.
- Add a focused regression test for the glued `completed` + next sentence case.

## Dogfood evidence
In a live TTY chat run on current `origin/main`, a subagent completed and the parent immediately continued with its own assistant text. The main transcript rendered `✓ review completed🔍 Based...`, with the subagent summary glued to the parent sentence. This happened after a successful run solving a combinatorics problem with one bash approval and one constrained verification subagent.

## Validation
- `pnpm exec vitest run src/test-kernel/cli/SubagentFollowup.vitest.mts`
- `pnpm exec vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `pnpm exec tsc --noEmit --pretty false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-only change in shared follow-up summarization with a targeted unit test; no auth, data, or orchestration behavior changes.
> 
> **Overview**
> Fixes CLI transcript rendering when a subagent XML block is **summarized inline** next to parent assistant prose with no separator (e.g. `✓ review completed🔍 Based...`).
> 
> **`summarizeEmbeddedSubagentFollowups`** now wraps each replaced block via **`summarizeEmbeddedSubagentBlock`**, which inserts a newline before and/or after the one-line summary only when the surrounding source characters are **non-whitespace**—existing spacing (newlines/spaces) is left unchanged.
> 
> Adds a regression test for the glued `Before` + `<subagent-result>` + `Next sentence.` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536b9abf437be1c0747ca472c966fdf935ab153c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->