### PR TITLE
[codex] Continue after blank tool-result turns

### DIFF
--- a/src/agent/core/flows/ToolUseRoundFlow.ts
+++ b/src/agent/core/flows/ToolUseRoundFlow.ts
@@ -39,8 +39,8 @@ export {
  *
  * Flow structure:
  *   Prep → Call → Process → Dispatch
- *     ↑                        |
- *     └────── CONTINUE ────────┘
+ *     ↑           |            |
+ *     └───────────┴ CONTINUE ──┘
  *
  * Queued user messages (typed during tool execution) are injected in PrepNode
  * BEFORE calling the model, so the model's thinking/response considers the
@@ -74,6 +74,7 @@ export function createToolUseRoundFlow<C>(): Flow<
   prepNode.next(callNode);
   callNode.next(processNode);
   processNode.next(dispatchNode);
+  processNode.on(FlowTransition.CONTINUE, prepNode);
   dispatchNode.on(FlowTransition.CONTINUE, prepNode);
 
   return new Flow<ToolUseRoundShared, CycleParams, ToolUseRoundServices<C>>(

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -3,7 +3,9 @@ import { BaseNode } from '@agent/node';
 import { logWebFetch, logWebSearch } from '@agent/trace';
 import { recordCycleMetrics } from '@agent/core/execution/AgentState';
 import { extractModelResponse } from '@agent/core/flows/CommonCycleTypes';
+import { appendFollowUpAsUserMessage } from '@agent/toolUse/followUpMessages';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
@@ -17,6 +19,35 @@ import { formatContent } from '@utils/text/xmlUtils';
 import { FlowTransition } from '../FlowTransitions';
 import type { CycleParams, ToolUseRoundServices } from '../CycleServices';
 import type { ToolUseRoundShared } from './roundShared';
+
+const BLANK_TOOL_RESULT_CONTINUATION =
+  'The previous assistant turn after a tool result was blank. Continue now with the final answer or next required action.';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function hasToolResultContent(value: unknown): boolean {
+  if (!Array.isArray(value)) return false;
+  return value.some((item) => {
+    if (!isRecord(item)) return false;
+    return item.type === 'tool_result' || isRecord(item.functionResponse);
+  });
+}
+
+function isToolResultMessage(message: ProviderMessage | undefined): boolean {
+  if (!isRecord(message)) return false;
+  const record: Record<string, unknown> = message;
+
+  if (record['type'] === 'function_call_output') return true;
+  if (record['role'] === 'tool') return true;
+
+  return (
+    record['role'] === 'user' &&
+    (hasToolResultContent(record['content']) ||
+      hasToolResultContent(record['parts']))
+  );
+}
 
 /** Result of exec() containing extracted data needed for post() side effects. */
 type ToolUseProcessExecResult =
@@ -157,6 +188,30 @@ export class ToolUseProcessNode<C> extends BaseNode<
     shared.stopReason = execRes.stopReason;
 
     if (execRes.endTurn) {
+      const lastMessageIndex = shared.messages.length - 1;
+      const blankAfterToolResult =
+        !execRes.text?.trim() && isToolResultMessage(shared.messages.at(-1));
+      if (
+        blankAfterToolResult &&
+        shared.blankToolResultContinuationMessageIndex !== lastMessageIndex
+      ) {
+        shared.blankToolResultContinuationMessageIndex = lastMessageIndex;
+        shared.messages = await appendFollowUpAsUserMessage(
+          shared.messages,
+          {
+            text: BLANK_TOOL_RESULT_CONTINUATION,
+            origin: 'synthetic',
+          },
+          this.services,
+        );
+        workspace.resetServerToolContent();
+        workspace.resetReasoning();
+        shared.roundIndex += 1;
+        shared.roundResponseTimeMs = 0;
+        shared.roundNormalizedUsage = undefined;
+        return FlowTransition.CONTINUE;
+      }
+
       shared.toolCalls = undefined;
       shared.shouldStop = true;
       shared.endTurn = true;

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -51,6 +51,8 @@ export const ToolUseRoundFieldsSchema = BaseCycleFieldsSchema.extend({
    * Reset after finalization when continuing to next round.
    */
   roundNormalizedUsage: NormalizedUsageSchema.optional(),
+  /** Last tool-result message index that received a blank-turn continuation. */
+  blankToolResultContinuationMessageIndex: z.int().nonnegative().optional(),
 });
 
 /** Tool-use round fields derived from schema */
@@ -71,4 +73,6 @@ export interface ToolUseRoundShared extends ToolUseRoundFields {
   toolCalls?: SdkToolCall[];
   /** Normalized usage with proper typing */
   roundNormalizedUsage?: NormalizedUsage;
+  /** Last tool-result message index that received a blank-turn continuation. */
+  blankToolResultContinuationMessageIndex?: number;
 }

--- a/src/test-kernel/agent/toolUse/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseRoundFollowUpMedia.vitest.ts
@@ -92,4 +92,192 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       { absolutePath: '/tmp/figure.png' },
     ]);
   });
+
+  function toolResultMessage(callId: string): ProviderMessage {
+    return {
+      type: 'function_call_output',
+      call_id: callId,
+      output: 'tool completed',
+    } as ProviderMessage;
+  }
+
+  function createShared(messages: ProviderMessage[]): ToolUseRoundShared {
+    return {
+      messages,
+      shouldStop: false,
+      endTurn: false,
+      response: undefined,
+      responseTimeMs: undefined,
+      stopReason: undefined,
+      lastError: undefined,
+      toolCalls: undefined,
+      text: undefined,
+      roundIndex: 0,
+      roundResponseTimeMs: 0,
+      roundNormalizedUsage: undefined,
+    };
+  }
+
+  function createBlankTurnServices(
+    responses: Array<{ id: string; text?: string; toolCall?: boolean }>,
+  ): {
+    createResponse: ReturnType<typeof vi.fn>;
+    createUserFollowUpMessages: ReturnType<typeof vi.fn>;
+    services: ToolUseRoundServices;
+  } {
+    const createUserFollowUpMessages = vi.fn(
+      async (messages: ProviderMessage[], userMessage: string) =>
+        [
+          ...messages,
+          { type: 'message', role: 'user', content: userMessage },
+        ] as ProviderMessage[],
+    );
+    const createResponse = vi.fn(async () => ({
+      response: responses.shift() ?? { id: 'unexpected-blank', text: '' },
+    }));
+    const createToolUseFollowUpMessages = vi.fn(
+      async (_client, call: { callId: string; name: string }) =>
+        [
+          {
+            type: 'function_call',
+            call_id: call.callId,
+            name: call.name,
+            arguments: '{}',
+          },
+          toolResultMessage(call.callId),
+        ] as ProviderMessage[],
+    );
+
+    const services = {
+      checkInterruption: () => false,
+      client: {},
+      config: { agent: 'test-agent', model: 'test-model' },
+      executionId: 'test-exec',
+      fileService: {
+        createLocation: (filePath: string) => ({ absolutePath: filePath }),
+      },
+      logger: createRunTrace('ToolUseRoundBlankToolResult').trace,
+      modelHandler: {
+        addMediaToUserMessage: vi.fn(async () => {}),
+        capabilities: { supportsVision: true },
+        createAssistantMessageFromResponse: vi.fn(
+          (_response: unknown, text: string) =>
+            ({ type: 'message', role: 'assistant', content: text }) as never,
+        ),
+        createResponse,
+        createToolUseFollowUpMessages,
+        createUserFollowUpMessages,
+        extractAssistantContent: () => [],
+        extractResponse: (response: { text?: string; toolCall?: boolean }) => ({
+          text: response.text ?? '',
+          usage: null,
+          stopReason: response.toolCall ? 'tool_calls' : 'stop',
+        }),
+        extractServerToolData: () => ({
+          contentBlocks: [],
+          webFetchResults: [],
+          webSearchResults: [],
+        }),
+        extractToolUse: (response: { toolCall?: boolean }) =>
+          response.toolCall
+            ? [
+                {
+                  callId: 'again-1',
+                  input: {},
+                  name: 'again',
+                  provider: 'test',
+                  raw: {},
+                },
+              ]
+            : [],
+        getStreamingConfig: () => false,
+        isEndTurnStop: (stopReason: string) => stopReason === 'stop',
+        processThinkingBlock: () => null,
+        setOutputStreaming: vi.fn(),
+      },
+      prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
+      run: AgentRunStateSnapshotSchema.parse({}),
+      runtimeHost: noopAgentRuntimeHost,
+      session: {
+        hasQueuedFollowUp: () => false,
+      },
+      setAbortController: () => {},
+      setting: { temperature: 0, tools: [{ name: 'again' }] },
+      streamId: 'test-stream',
+      streamStatus: new StreamStatusRegistry(),
+      toolRegistry: new MapToolRegistry({
+        again: {
+          call: vi.fn(async () => ({ output: 'again result' })),
+          definition: { name: 'again' },
+        } as never,
+      }),
+      userVarChannels: { input: {}, transient: {} },
+      workspace: AgentWorkspaceState.create(),
+    } as unknown as ToolUseRoundServices;
+
+    return { createResponse, createUserFollowUpMessages, services };
+  }
+
+  it('continues when the model returns blank text after a tool result', async () => {
+    const { createResponse, createUserFollowUpMessages, services } =
+      createBlankTurnServices([
+        { id: 'blank', text: '' },
+        { id: 'final', text: 'Final answer: 3842.' },
+      ]);
+    const shared = createShared([toolResultMessage('executions-1')]);
+
+    await createToolUseRoundFlow().setServices(services).run(shared);
+
+    expect(createResponse).toHaveBeenCalledTimes(2);
+    expect(createUserFollowUpMessages).toHaveBeenCalledWith(
+      [expect.objectContaining({ type: 'function_call_output' })],
+      expect.stringContaining('previous assistant turn after a tool result'),
+    );
+    expect(shared.messages.at(-1)).toEqual({
+      type: 'message',
+      role: 'assistant',
+      content: 'Final answer: 3842.',
+    });
+    expect(shared.endTurn).toBe(true);
+  });
+
+  it('does not retry repeatedly for the same blank tool result', async () => {
+    const { createResponse, createUserFollowUpMessages, services } =
+      createBlankTurnServices([
+        { id: 'blank', text: '' },
+        { id: 'still-blank', text: '' },
+      ]);
+    const shared = createShared([toolResultMessage('executions-1')]);
+
+    await createToolUseRoundFlow().setServices(services).run(shared);
+
+    expect(createResponse).toHaveBeenCalledTimes(2);
+    expect(createUserFollowUpMessages).toHaveBeenCalledTimes(1);
+    expect(shared.messages.at(-1)).toEqual(
+      expect.objectContaining({ role: 'user' }),
+    );
+    expect(shared.endTurn).toBe(true);
+  });
+
+  it('retries again for a later blank turn after a different tool result', async () => {
+    const { createResponse, createUserFollowUpMessages, services } =
+      createBlankTurnServices([
+        { id: 'first-blank', text: '' },
+        { id: 'tool-call', text: 'checking again', toolCall: true },
+        { id: 'second-blank', text: '' },
+        { id: 'final', text: 'Final answer after second retry.' },
+      ]);
+    const shared = createShared([toolResultMessage('executions-1')]);
+
+    await createToolUseRoundFlow().setServices(services).run(shared);
+
+    expect(createResponse).toHaveBeenCalledTimes(4);
+    expect(createUserFollowUpMessages).toHaveBeenCalledTimes(2);
+    expect(shared.messages.at(-1)).toEqual({
+      type: 'message',
+      role: 'assistant',
+      content: 'Final answer after second retry.',
+    });
+    expect(shared.endTurn).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Add a one-shot continuation when a model returns a blank end-turn immediately after a tool result.
- Detect provider tool-result message shapes across OpenAI Responses, OpenAI/OpenRouter tool messages, Anthropic tool_result blocks, and Gemini functionResponse parts.
- Add a regression test covering the blank-after-tool-result path.

## Dogfood evidence
In a live TTY chat run on current `origin/main` (`13d583e08`), the assistant solved a combinatorics task, ran one approved `node -e` check, and spawned one constrained subagent verifier. The subagent completed and `executions` returned the result, but the parent went idle with the final-answer todo still pending and no final assistant answer. Resume handles from the run: main `20cd7a100452`, review `4f6a3d1e83e2`.

## Validation
- `pnpm exec vitest run src/test-kernel/agent/toolUse/ToolUseRoundFollowUpMedia.vitest.ts`
- `pnpm exec vitest run src/test-kernel/agent/toolUse/ToolUseRoundFollowUpMedia.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/tools/BashTool.vitest.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order/naming warnings only)

## Notes
This is deliberately scoped to blank model turns that immediately follow a tool result, and it retries only once to avoid masking repeated provider failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tool-use round termination and message history; scoped to blank end-turns after tool results with a one-shot guard, but still affects when sessions stop and what gets sent to the model.
> 
> **Overview**
> Fixes cases where the agent stops after tool results return but the model produces a **blank end-turn** (no final answer), by treating that as recoverable instead of completing the round.
> 
> **`ToolUseProcessNode`** now detects when the last message is a tool result (OpenAI Responses `function_call_output`, `role: tool`, Anthropic `tool_result`, Gemini `functionResponse`) and the model response has no trimmed text. It appends a **synthetic user** continuation via `appendFollowUpAsUserMessage`, resets workspace server-tool/reasoning state, bumps round counters, and returns **`FlowTransition.CONTINUE`**. **`blankToolResultContinuationMessageIndex`** ensures **at most one retry per tool-result message**; a second blank still ends the turn.
> 
> **`createToolUseRoundFlow`** adds **`processNode.on(CONTINUE, prepNode)`** so that continuation skips dispatch and goes straight back to prep/call. Shared state/schema gains the optional index field for serialization.
> 
> **Tests** in `ToolUseRoundFollowUpMedia.vitest.ts` cover successful retry, no double-retry on the same result, and retry again after a later tool result in a multi-round flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 615f78702b76c19b7950deff29adbbd6a052eb08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->