### PR TITLE
[codex] Gate Wolfram executions on approval

### DIFF
--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -44,7 +44,7 @@ const SLOW_TOOLS = new Set([
 ]);
 
 /** Tools that defer in-progress logging until after approval. */
-const DEFERRED_LOG_TOOLS = new Set(['bash', 'codex']);
+const DEFERRED_LOG_TOOLS = new Set(['bash', 'codex', 'wolfram']);
 
 /** Tools that support streaming partial output to the UI. */
 const STREAMABLE_TOOLS = new Set(['bash']);

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.mts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.mts
@@ -42,7 +42,7 @@ describe('response cycle tool visibility', () => {
       }) as any,
     );
 
-    expect(toolNames(tools)).toEqual(['grep', 'wolfram']);
+    expect(toolNames(tools)).toEqual(['grep']);
   });
 
   it('keeps workflow tools when approval prompts are available', () => {

--- a/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
@@ -71,7 +71,7 @@ describe('tool-use tool resolution', () => {
       delegationBlocked: false,
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual(['grep', 'wolfram']);
+    expect(tools.map((tool) => tool.name)).toEqual(['grep']);
     expect(delegationTrimmed).toBe(false);
   });
 

--- a/src/test-kernel/tools/WolframToolApproval.vitest.ts
+++ b/src/test-kernel/tools/WolframToolApproval.vitest.ts
@@ -1,0 +1,104 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - agent
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - tools
+import { cleanupAllApprovals } from '@tools/approval';
+import { handleProgressViewBashApprovalAction } from '@tools/approval/bashApproval';
+import {
+  WolframTool,
+  wolframApprovalCommand,
+} from '@tools/wolfram/WolframTool';
+import * as wolframScriptUtils from '@tools/wolfram/wolframScriptUtils';
+
+// Local imports - test helpers
+import { createRecordingHost } from '../agent/progressTestUtils';
+
+async function waitForRecordedEvent<TEvent extends string>(
+  events: Array<{ event: TEvent; payload: unknown }>,
+  eventName: TEvent,
+): Promise<{ event: TEvent; payload: any }> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const event = events.find((entry) => entry.event === eventName);
+    if (event) return event;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error(`Timed out waiting for ${eventName}`);
+}
+
+describe('WolframTool approval', () => {
+  afterEach(() => {
+    cleanupAllApprovals();
+    vi.restoreAllMocks();
+  });
+
+  it('requests bash-style approval before executing wolframscript', async () => {
+    const explicit = createRecordingHost();
+    const streamId = 'stream:wolfram-approval' as StreamTabId;
+    const execute = vi
+      .spyOn(wolframScriptUtils, 'executeWolframCode')
+      .mockResolvedValue({
+        success: true,
+        output: '2',
+        error: '',
+        timedOut: false,
+        exitCode: 0,
+      });
+
+    const result = withRunContext(
+      createRunContext({ runtimeHost: explicit.host, streamId }),
+      () => new WolframTool().call({ code: '1+1' }),
+    );
+
+    const show = await waitForRecordedEvent(
+      explicit.events,
+      'showBashPermission',
+    );
+    expect(show.payload).toMatchObject({
+      command: wolframApprovalCommand('1+1'),
+      allowBypass: true,
+      streamId,
+    });
+
+    await handleProgressViewBashApprovalAction({
+      requestId: show.payload.requestId,
+      action: 'approve',
+    });
+
+    await expect(result).resolves.toMatchObject({
+      output: '2',
+      summary: 'Executed: 1+1',
+    });
+    expect(execute).toHaveBeenCalledWith('1+1', { timeout: 30000 });
+  });
+
+  it('does not execute wolframscript when approval is rejected', async () => {
+    const explicit = createRecordingHost();
+    const streamId = 'stream:wolfram-rejected' as StreamTabId;
+    const execute = vi.spyOn(wolframScriptUtils, 'executeWolframCode');
+
+    const result = withRunContext(
+      createRunContext({ runtimeHost: explicit.host, streamId }),
+      () => new WolframTool().call({ code: '2+2' }),
+    );
+
+    const show = await waitForRecordedEvent(
+      explicit.events,
+      'showBashPermission',
+    );
+    await handleProgressViewBashApprovalAction({
+      requestId: show.payload.requestId,
+      action: 'reject',
+      feedback: 'Use the requested node check instead.',
+    });
+
+    await expect(result).resolves.toMatchObject({
+      isError: true,
+      userInstruction: 'Use the requested node check instead.',
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/approvalGatedTools.ts
+++ b/src/tools/approvalGatedTools.ts
@@ -23,6 +23,7 @@ const APPROVAL_GATED_TOOL_NAME_LIST = [
   'str_replace_editor',
   'unset_api_key',
   'update_config',
+  'wolfram',
   'write_file',
 ] as const satisfies readonly RegisteredToolName[];
 

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -1,9 +1,16 @@
 // Third-party imports
 import { z } from 'zod';
 
+// Local imports - agent
+import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
+
 // Local imports - tools
 import { ToolResult, ToolError } from '@tools/result';
 import { defineTool } from '@tools/core/define';
+import {
+  buildBashApprovalRejectedResult,
+  requestBashApproval,
+} from '@tools/approval/bashApproval';
 
 // Local imports - utils
 import {
@@ -29,6 +36,10 @@ export function wolframRunSummary(code: string): string {
   return preview ? `Executed: ${preview}` : 'Executed';
 }
 
+export function wolframApprovalCommand(code: string): string {
+  return `wolframscript -code ${JSON.stringify(code)}`;
+}
+
 const WolframInputSchema = z.strictObject({
   code: z.string(),
   timeout: z
@@ -45,10 +56,18 @@ export type WolframInput = z.infer<typeof WolframInputSchema>;
 
 export class WolframTool extends defineTool({
   name: 'wolfram',
-  description: `Execute Wolfram Language code. Use this tool for quick calculations, symbolic math, and one-off evaluations. Sessions do NOT persist between calls - each execution starts fresh with no memory of previous variables or definitions. For complex scripts requiring session persistence, iterative development, or saving intermediate results, write to a .wl file and run via bash instead. IMPORTANT: Never hardcode expected values in Print statements - always compute and display actual results dynamically. Write tests using VerificationTest or assertions to verify properties, printing computed values rather than predetermined strings.`,
+  description: `Execute approval-gated Wolfram Language code. Use this tool for quick calculations, symbolic math, and one-off evaluations only when Wolfram/external computation is allowed by the user. Do not use it when the user requested a specific verification method or prohibited external computation. Sessions do NOT persist between calls - each execution starts fresh with no memory of previous variables or definitions. For complex scripts requiring session persistence, iterative development, or saving intermediate results, write to a .wl file and run via bash instead. IMPORTANT: Never hardcode expected values in Print statements - always compute and display actual results dynamically. Write tests using VerificationTest or assertions to verify properties, printing computed values rather than predetermined strings.`,
   schema: WolframInputSchema,
 }) {
   protected async execute(input: WolframInput): Promise<ToolResult> {
+    const command = wolframApprovalCommand(input.code);
+    const approval = await requestBashApproval({ command });
+    if (!approval.accepted) {
+      return buildBashApprovalRejectedResult(command, approval.userMessage);
+    }
+
+    getCurrentToolContexts()?.callContext?.onExecutionReady?.();
+
     const effectiveTimeout = input.timeout ?? WOLFRAM_CODE_TIMEOUT_MS;
     const result = await executeWolframCode(input.code, {
       timeout: effectiveTimeout,


### PR DESCRIPTION
## Summary

- Treat `wolfram` as an approval-gated tool when approval prompts are unavailable.
- Reuse the existing bash approval flow before launching `wolframscript -code ...`.
- Defer Wolfram tool logging until after approval, matching bash/codex behavior.
- Add regression coverage for tool resolution and Wolfram approval accept/reject paths.

## Why

CLI dogfood on current `origin/main` with `--approval-policy ask` showed the assistant running `wolfram` repeatedly without any approval prompt while the task asked for a specific approval-gated `node -e` verification flow. The root cause was that `wolfram` launched a local external process but was neither in the approval-gated tool set nor requesting an approval at execution time.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts src/test-kernel/tools/WolframToolApproval.vitest.ts src/test-kernel/tools/WolframRunSummary.vitest.ts src/test-kernel/tools/wolframScriptUtils.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts src/test-kernel/cli/ApprovalQueue.vitest.mts src/test-kernel/cli/ApprovalEvents.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing repo warnings)
- `npm run compile:fast`
- `npm run texra-local:build`
- Live TTY smoke test: `texra chat --approval-policy ask` prompted before `wolfram` execution as `Run bash command? $ wolframscript -code "1+1"`, then completed with result `2` after approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes external-process execution gating and tool visibility for approval-unavailable modes; behavior is aligned with bash but affects agent workflows that relied on silent Wolfram runs.
> 
> **Overview**
> **Wolfram** is now treated like other approval-gated tools: it is hidden from the model when approval prompts cannot be shown, and each run must pass user approval before `wolframscript` starts.
> 
> Execution reuses the existing **bash approval** path with a synthetic command (`wolframscript -code …`). Rejections return the same user-feedback error shape as bash; approvals call `onExecutionReady` so in-progress tool UI logging is deferred until after approval, consistent with bash/codex.
> 
> Tests expect `wolfram` to be filtered when prompts are unavailable, and new coverage exercises approve/reject flows for Wolfram.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1283476687674e9982ccfa5debc2891f263fb685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->