### PR TITLE
[codex] Mark blank tool-result retry after append

### DIFF
--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -195,7 +195,6 @@ export class ToolUseProcessNode<C> extends BaseNode<
         blankAfterToolResult &&
         shared.blankToolResultContinuationMessageIndex !== lastMessageIndex
       ) {
-        shared.blankToolResultContinuationMessageIndex = lastMessageIndex;
         shared.messages = await appendFollowUpAsUserMessage(
           shared.messages,
           {
@@ -204,6 +203,7 @@ export class ToolUseProcessNode<C> extends BaseNode<
           },
           this.services,
         );
+        shared.blankToolResultContinuationMessageIndex = lastMessageIndex;
         workspace.resetServerToolContent();
         workspace.resetReasoning();
         shared.roundIndex += 1;

--- a/src/test-kernel/agent/toolUse/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseRoundFollowUpMedia.vitest.ts
@@ -259,6 +259,26 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
     expect(shared.endTurn).toBe(true);
   });
 
+  it('does not mark a blank tool-result continuation until append succeeds', async () => {
+    const { createUserFollowUpMessages, services } = createBlankTurnServices([
+      { id: 'blank', text: '' },
+    ]);
+    const originalToolResult = toolResultMessage('executions-1');
+    const shared = createShared([originalToolResult]);
+
+    createUserFollowUpMessages.mockRejectedValueOnce(
+      new Error('follow-up append failed'),
+    );
+
+    await expect(
+      createToolUseRoundFlow().setServices(services).run(shared),
+    ).rejects.toThrow('follow-up append failed');
+
+    expect(createUserFollowUpMessages).toHaveBeenCalledTimes(1);
+    expect(shared.blankToolResultContinuationMessageIndex).toBeUndefined();
+    expect(shared.messages).toEqual([originalToolResult]);
+  });
+
   it('retries again for a later blank turn after a different tool result', async () => {
     const { createResponse, createUserFollowUpMessages, services } =
       createBlankTurnServices([


### PR DESCRIPTION
## Summary

Fixes #6026.

Moves `blankToolResultContinuationMessageIndex` assignment until after the synthetic blank tool-result continuation message is successfully appended. If provider-specific follow-up message creation fails, shared state no longer records a retry marker for a message that was never added.

Adds a regression test that makes `createUserFollowUpMessages` throw and verifies both the marker and message list remain unchanged.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/toolUse/ToolUseRoundFollowUpMedia.vitest.ts`
- `npm run typecheck`
- `npm run format`
- `npm run lint` (passes with existing warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ordering fix in agent round state with a targeted test; no auth or data-path changes.
> 
> **Overview**
> When the model ends a turn with blank text after a tool result, the tool-use round flow injects a synthetic user continuation and tracks which tool-result message was retried via `blankToolResultContinuationMessageIndex`.
> 
> **This PR moves that index assignment to run only after `appendFollowUpAsUserMessage` completes successfully.** Previously the marker was set before the async append; if provider follow-up creation threw, shared state could record a retry for a continuation that never landed, blocking further retries incorrectly.
> 
> A regression test asserts that when `createUserFollowUpMessages` rejects, the flow throws, `blankToolResultContinuationMessageIndex` stays unset, and `messages` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cff45d175513b589412548d07c8da1f495ed15c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->