### PR TITLE
[codex] Bound live child transcript panes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,11 +300,10 @@ mouse-scroll for finalized history, so don't reinvent them.
   in-flight content belongs in the redrawn `<Box>` below `<Static>`: the
   streaming tail, spinners, side panels, input bar, and the active approval
   modal. In child focus, the same live region renders only the focused child's
-  pending entries and may overflow into native scrollback while the child is
-  still running; finalized child history belongs to that child's Static
-  scrollback owner. Cap root panels (`BOTTOM_PANEL_MAX_ROWS`) so chrome never
-  pushes the input off-screen. Don't park finalized content in the live region
-  "for now."
+  pending entries through the bounded row-budgeted path; full child history
+  belongs to that child's Static scrollback owner and Ctrl-T transcript viewer.
+  Cap root panels (`BOTTOM_PANEL_MAX_ROWS`) so chrome never pushes the input
+  off-screen. Don't park finalized content in the live region "for now."
 - **Stateless renderers.** Tool / diff / markdown components are props-in → JSX-out (the "Render-Time Workarounds" rule, applied to the TUI). No `Date.now()`, synthetic ids, or dedup at render time. Any view-level toggle (collapse/expand, focus) belongs in shared signal state (`state/cliState.ts`), not per-component local state.
 - **Defer non-terminal content to the host.** The TUI does not render PDFs, LaTeX figures, or inline images (iTerm2 / Kitty / Sixel). Hand previews to the webview/desktop or the OS opener. The terminal is for chat, text, and diffs; rebuilding a document viewer in cells is out of scope.
 - **Capability-gate terminal features.** Negotiate support via the DA1-sentinel discovery (`state/terminalCapabilities.ts`) before emitting Kitty-keyboard, OSC color, bracketed-paste, or notification sequences. No "assume a modern terminal" feature use.

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -961,7 +961,6 @@ export function App(props: AppProps): React.JSX.Element {
         <Box flexDirection="column" overflowY="hidden">
           {!transcriptViewerOpen && conversationRows > 0 ? (
             <ConversationPane
-              allowNativeScrollbackOverflow={scopedTranscript}
               colorEnabled={props.colorEnabled}
               width={transcriptWidth}
               maxRows={conversationRows}

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -47,7 +47,6 @@ function ThinkingRow(): React.JSX.Element {
 export interface ConversationPaneProps {
   readonly width?: number;
   readonly maxRows?: number;
-  readonly allowNativeScrollbackOverflow?: boolean;
   readonly colorEnabled?: boolean;
 }
 
@@ -123,20 +122,6 @@ export function ConversationPane(
   const entries = slice?.entries ?? [];
   const displayEntries = splitTranscriptEntries(entries, slice?.status).pending;
   const showThinking = thinkingIndicatorVisible(slice);
-  if (props.allowNativeScrollbackOverflow) {
-    return (
-      <Box flexDirection="column">
-        {displayEntries.map((entry) =>
-          renderConversationPaneEntry({
-            colorEnabled: props.colorEnabled,
-            entry,
-            width: props.width,
-          }),
-        )}
-        {showThinking ? <ThinkingRow /> : null}
-      </Box>
-    );
-  }
 
   const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;
   // The thinking liveness row is budgeted like any other live content: it


### PR DESCRIPTION
Closes #6029

## Summary
- keep the live conversation pane on the bounded viewport for child streams
- remove the special unbounded child live-pane prop

## Why
During TTY dogfood, a delegated review child with a long prompt repainted the full prompt while the child was in hidden reasoning. Full transcript access is still available via Ctrl-T/static finalized scrollback, but the active live pane should not overflow while waiting.

## Validation
- npm run format
- npm run typecheck
- npm run lint (0 errors, existing warnings)
- npm run texra-local:build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ink TUI layout-only change; finalized history and Ctrl-T transcript access are unchanged.
> 
> **Overview**
> **Focused child streams no longer use an unbounded live conversation pane.** `ConversationPane` always applies the existing `maxRows` viewport selection and explicit height, including when viewing a scoped child stream.
> 
> **Removed** the `allowNativeScrollbackOverflow` prop from `App` → `ConversationPane` and deleted the alternate render path that painted all pending entries without row limits (which could flood native scrollback during long in-flight child prompts, e.g. hidden reasoning).
> 
> **Docs:** `CLAUDE.md` now states that child-focus live regions show only pending entries through the bounded path; full child history stays on that stream’s `<Static>` scrollback and **Ctrl-T** transcript viewer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc6bbc4739014b22109b9adf73123109cbc4f41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->