### PR TITLE
[codex] Update child TUI scrollback harness

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1752,7 +1752,7 @@ const SCENARIOS = [
     ],
   },
   {
-    name: 'subagent-focused-own-scrollback-history',
+    name: 'subagent-focused-bounded-live-tail',
     cols: 120,
     rows: 14,
     env: {
@@ -1764,14 +1764,41 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     keys: ['\t'],
     expect: [
-      'strategy detail line 01',
+      'strategy detail line 15',
       'strategy detail line 18',
       '[1:strategy]*',
     ],
     unexpect: [
+      'strategy detail line 01',
       'entry-1 chat history line',
       'entry-4 chat history line',
       '[PgUp',
+      '[main]*',
+      'signal read during notification phase',
+      'ERROR',
+    ],
+  },
+  {
+    name: 'subagent-focused-transcript-viewer-full-history',
+    cols: 120,
+    rows: 14,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_LONG_CHILD_OUTPUT: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: '[Tab]streams',
+    keys: ['\t', DC4, 'g'],
+    expect: [
+      'strategy\n› Please handle the harness-child-strategy sub-workflow.',
+      'strategy detail line 01',
+      'PgUp/PgDn page',
+      'Esc close',
+    ],
+    unexpect: [
+      'entry-1 chat history line',
+      'entry-4 chat history line',
       '[main]*',
       'signal read during notification phase',
       'ERROR',


### PR DESCRIPTION
Closes #6031

## Summary
- replace the stale focused-child overflow scenario with a bounded live-tail assertion
- add a focused-child Ctrl-T transcript viewer scenario that proves the first child output line is still reachable

## Why
PR #6030 intentionally moved focused child live output onto the same bounded row-budgeted path as root streams. The old harness scenario still expected the removed overflow behavior by requiring `strategy detail line 01` in the focused child live frame.

## Validation
- corepack pnpm exec prettier --check packages/cli/scripts/validate-tui.mjs
- git diff --check
- npm run typecheck
- npm run lint (0 errors, existing warnings)
- corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build
- targeted snapshot run wrote /private/tmp/texra-tui-snapshots-post6030-broader/index.html

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to `validate-tui.mjs` scenarios; no production TUI or runtime behavior is modified in this diff.
> 
> **Overview**
> Updates **focused subagent** TUI validation in `validate-tui.mjs` to match PR #6030’s **bounded row-budgeted** live output for child streams.
> 
> The former `subagent-focused-own-scrollback-history` scenario is renamed **`subagent-focused-bounded-live-tail`**: it now expects the **tail** of long child output (`strategy detail line 15`–`18`) and **fails** if the first line (`strategy detail line 01`) appears in the live frame.
> 
> A new **`subagent-focused-transcript-viewer-full-history`** scenario drives Tab → **Ctrl-T** → `g` and asserts the transcript viewer still shows the **full** child history (including line 01) with paging/close chrome, without leaking main-chat scrollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a9462c8e0f0e82daa1d8fd215d614fec3bc0bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->