### PR TITLE
[codex] Cover repeated bash approvals

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -113,6 +113,8 @@ const HARNESS_YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
 const SHOW_EDIT_APPROVAL = process.env.HARNESS_EDIT_APPROVAL === '1';
 const SHOW_BASH_APPROVAL = process.env.HARNESS_BASH_APPROVAL === '1';
+const SHOW_REPEATED_BASH_APPROVAL =
+  process.env.HARNESS_REPEATED_BASH_APPROVAL === '1';
 const SHOW_RETRY_APPROVAL = process.env.HARNESS_RETRY_APPROVAL === '1';
 const SHOW_EXTERNAL_INQUIRY = process.env.HARNESS_EXTERNAL_INQUIRY === '1';
 const SHOW_USER_QUESTION = process.env.HARNESS_USER_QUESTION === '1';
@@ -735,9 +737,10 @@ function makeEditApprovalRequest() {
   };
 }
 
-function makeBashApprovalPayload() {
+function makeBashApprovalPayload(index = 1) {
   return {
-    requestId: 'harness-bash-approval',
+    requestId:
+      index === 1 ? 'harness-bash-approval' : `harness-bash-approval-${index}`,
     command: BASH_APPROVAL_COMMAND,
     cwd: HARNESS_CWD,
     allowBypass: true,
@@ -1126,14 +1129,32 @@ if (SHOW_EDIT_APPROVAL) {
 }
 
 if (SHOW_BASH_APPROVAL) {
-  const showApproval = () =>
-    void enqueueApproval(
+  const showApproval = (index = 1) =>
+    enqueueApproval(
       {
         kind: 'bash',
-        payload: makeBashApprovalPayload(),
+        payload: makeBashApprovalPayload(index),
       },
       { onPresent: () => notify({ kind: 'approvalNeeded' }) },
-    ).then(applyHarnessApprovalDecision);
+    );
+  const showRepeatedApprovals = () =>
+    void showApproval(1)
+      .then((decision) => {
+        applyHarnessApprovalDecision(decision);
+        if (!decision.accepted) return decision;
+        return showApproval(2).then((secondDecision) => {
+          applyHarnessApprovalDecision(secondDecision);
+          appendHarnessAssistantTranscript(
+            secondDecision.accepted
+              ? 'SECOND-BASH-APPROVED'
+              : 'SECOND-BASH-REJECTED',
+          );
+          return secondDecision;
+        });
+      })
+      .catch(() => undefined);
+  const showSingleApproval = () =>
+    void showApproval(1).then(applyHarnessApprovalDecision);
 
   if (SHOW_BASH_APPROVAL_AFTER_CHILD_FOCUS) {
     let pollCount = 0;
@@ -1145,11 +1166,13 @@ if (SHOW_BASH_APPROVAL) {
         return;
       }
       clearInterval(timer);
-      showApproval();
+      if (SHOW_REPEATED_BASH_APPROVAL) showRepeatedApprovals();
+      else showSingleApproval();
     }, 25);
     timer.unref?.();
   } else {
-    showApproval();
+    if (SHOW_REPEATED_BASH_APPROVAL) showRepeatedApprovals();
+    else showSingleApproval();
   }
 }
 

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1188,6 +1188,20 @@ const SCENARIOS = [
     unexpect: ['AUTO-APPROVE', 'Run bash command?', '1 approval'],
   },
   {
+    name: 'bash-approval-approve-twice',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_BASH_APPROVAL: '1',
+      HARNESS_REPEATED_BASH_APPROVAL: '1',
+    },
+    bootExpect: '[Ctrl-C]',
+    keys: ['y', { input: 'y', delayMs: 1000 }],
+    settleMs: 6000,
+    frame: 'tail',
+    expect: ['SECOND-BASH-APPROVED', '[/status]details', '[/model]models'],
+    unexpect: ['Run bash command?', '1 approval'],
+  },
+  {
     name: 'bash-approval-session-status',
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
     bootExpect: '[Ctrl-C]',


### PR DESCRIPTION
Closes #6033.

## Summary

- add a TUI harness mode that queues a second bash approval after the first bash approval resolves
- add `bash-approval-approve-twice` to verify two separate `y` decisions clear consecutive bash approval prompts
- keep existing single-approval and approve-session behavior unchanged

## Why

Live CLI dogfood with a small LaTeX proof exercised a common pattern: create a file, run `pdflatex`, then run a follow-up compile. The TUI suite covered a single bash approval and approve-session bypass, but not two normal bash approvals in one session.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-snapshots-repeated-bash bash-approval-approve-twice bash-approval-approve-session bash-approval`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build`
- `corepack pnpm exec prettier --check packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs`
- `git diff --check`
- `npm run lint` (0 errors, existing warnings only)
- `npm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the CLI TUI harness and validator scripts; production approval behavior is untouched.
> 
> **Overview**
> Adds **TUI test coverage** for approving **two separate bash prompts** in one session (e.g. create file → `pdflatex` → second compile), which the suite did not exercise before.
> 
> The harness gains `HARNESS_REPEATED_BASH_APPROVAL`: it queues a **second** bash approval after the first resolves (distinct `requestId`s via `makeBashApprovalPayload(index)`), applies each decision, and writes `SECOND-BASH-APPROVED` / `SECOND-BASH-REJECTED` to the transcript. Single-approval and approve-session paths are unchanged and selected when the new flag is off.
> 
> `validate-tui.mjs` adds **`bash-approval-approve-twice`**, driving two `y` keystrokes with delay and asserting the second prompt clears and the harness marker appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84bd27b35dcbc08f5aee25ab0b3a54cece909820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->