### PR TITLE
[codex] Reduce review agent over-verification

### DIFF
--- a/packages/extension/resources/tool_use_agents/review.yaml
+++ b/packages/extension/resources/tool_use_agents/review.yaml
@@ -36,11 +36,11 @@ prompts:
     (1) For every key derivation, reproduce it step-by-step. Check that each step follows logically from the previous one. When a step is nontrivial, write out the intermediate algebra explicitly.
     (2) Verify limiting cases and special cases of results. Does the general formula reduce correctly when a parameter vanishes or diverges?
     (3) Check dimensional consistency of equations.
-    (4) Verify numerical values, coefficients, and prefactors by independent computation.
+    (4) Verify numerical values, coefficients, and prefactors by independent computation when they are substantive or not easily checked by inspection.
     (5) For inequalities or bounds, test with concrete examples to confirm they hold.
     (6) For differential equations, verify that stated solutions satisfy the original equation.
-    (7) Use the wolfram tool to verify symbolic algebra, evaluate integrals, check identities, and perform numerical spot-checks. Sessions do NOT persist between wolfram tool calls — each execution starts fresh. For multi-step verifications needing persistence, write to a .wl file and run via bash.
-    (8) If wolfram is unavailable, fall back to bash with short Python/SymPy scripts for the same computational checks.
+    (7) Prefer direct mathematical review when a claim can be checked by hand. Use the wolfram tool only when computation adds real evidence for nontrivial symbolic algebra, integrals, identities, or numerical spot-checks; do not request external computation for elementary facts such as nonnegativity of squares or $x^2 = 0$ over the reals. Sessions do NOT persist between wolfram tool calls — each execution starts fresh. For multi-step verifications needing persistence, write to a .wl file and run via bash.
+    (8) If computational verification is warranted and wolfram is unavailable, fall back to bash with short Python/SymPy scripts for the same checks.
 
     Notation Consistency:
     (1) Use grep to find all occurrences of key symbols and variables across the manuscript.

--- a/src/test-kernel/agent/ReviewAgentPrompt.vitest.mts
+++ b/src/test-kernel/agent/ReviewAgentPrompt.vitest.mts
@@ -48,4 +48,18 @@ describe('review agent prompt', () => {
     expect(agent.settings.tools).toContain('write_file');
     expect(agent.settings.tools).toContain('edit_file');
   });
+
+  it('prefers direct review over computation for elementary facts', () => {
+    const agent = readReviewAgent();
+    const systemPrompt = agent.prompts.systemPrompt;
+
+    expect(systemPrompt).toContain(
+      'Prefer direct mathematical review when a claim can be checked by hand',
+    );
+    expect(systemPrompt).toContain(
+      'do not request external computation for elementary facts',
+    );
+    expect(agent.settings.tools).toContain('wolfram');
+    expect(agent.settings.tools).toContain('bash');
+  });
 });


### PR DESCRIPTION
## Summary

- tighten the built-in `review` agent prompt so direct mathematical review is preferred for hand-checkable elementary facts
- keep Wolfram and Python/SymPy available for nontrivial symbolic, numeric, or computational checks
- add a focused prompt test to prevent the guidance from regressing

Closes #6035

## Dogfood evidence

In a real TTY run via `texra-local orchestrate`, the Mathematician team delegated a quick review of a generated proof for the elementary real-valued claim `x^2 + y^2 = 0 => x = 0 and y = 0`. The `review` subagent read `team_proof.tex` and `problem.txt`, then requested Wolfram for `Reduce[x^2 + y^2 == 0, {x, y}, Reals]`. After that was rejected as unnecessary, it requested a Python/SymPy fallback for the same fact.

The TUI parts around this worked: launcher team selection, model picker, edit approval panel, subagent spawn approval, and stream tabs were readable. The friction here is agent behavior: a quick proof review should not create repeated computation approvals for facts that are easier to verify directly.

## Validation

- `corepack pnpm exec prettier --check packages/extension/resources/tool_use_agents/review.yaml src/test-kernel/agent/ReviewAgentPrompt.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/agent/ReviewAgentPrompt.vitest.mts`
- `git diff --check`
- `npm run texra-local:build && npm run texra-local:link`
- verified copied bundle contains the revised review prompt at `packages/cli/dist/resources/tool_use_agents/review.yaml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and test-only change; no auth, data, or execution-path logic modified beyond agent instructions.
> 
> **Overview**
> **Tightens the built-in `review` agent’s mathematical verification instructions** so it does less unnecessary Wolfram/Python work on trivial claims.
> 
> Numeric prefactor checks are limited to values that are **substantive or not easily verified by inspection**. Wolfram is framed as **optional evidence for nontrivial** symbolic or numeric work, with explicit guidance to **prefer hand review** and **avoid external computation for elementary facts** (e.g. squares over the reals). The Python/SymPy fallback via `bash` is tied to cases where **computational verification is actually warranted**.
> 
> A **new Vitest** in `ReviewAgentPrompt.vitest.mts` locks in those prompt phrases and confirms `wolfram` and `bash` stay on the tool list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a305f0538dc041d1dcd14c67d3574a4c54ed3e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->