### PR TITLE
refactor: consolidate isNonEmptyString usage and simplify uniqueSources

### DIFF
--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -59,7 +59,9 @@ function deriveEndTag(input: unknown): unknown {
   if (typeof input !== 'object' || input === null) return input;
   const obj = input as Record<string, unknown>;
   if (obj.endTag !== undefined) return obj;
-  const docTag = isNonEmptyString(obj.documentTag) ? obj.documentTag : 'documents';
+  const docTag = isNonEmptyString(obj.documentTag)
+    ? obj.documentTag
+    : 'documents';
   return { ...obj, endTag: `</${docTag}>` };
 }
 

--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -9,6 +9,7 @@ export { AgentCategory };
 export const AgentSettingBaseSchema = z.strictObject({
   documentTag: z
     .string()
+    .trim()
     .min(1, 'documentTag cannot be empty')
     .prefault('documents'),
   endTag: z.string().prefault('</documents>'),
@@ -60,7 +61,7 @@ function deriveEndTag(input: unknown): unknown {
   const obj = input as Record<string, unknown>;
   if (obj.endTag !== undefined) return obj;
   const docTag = isNonEmptyString(obj.documentTag)
-    ? obj.documentTag
+    ? obj.documentTag.trim()
     : 'documents';
   return { ...obj, endTag: `</${docTag}>` };
 }

--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { isNonEmptyString } from '@utils/core';
 import { ToolDefinitionSchema } from '@model';
 import { AgentCategory } from '@shared/schemas/agent';
 
@@ -58,10 +59,7 @@ function deriveEndTag(input: unknown): unknown {
   if (typeof input !== 'object' || input === null) return input;
   const obj = input as Record<string, unknown>;
   if (obj.endTag !== undefined) return obj;
-  const docTag =
-    typeof obj.documentTag === 'string' && obj.documentTag.length > 0
-      ? obj.documentTag
-      : 'documents';
+  const docTag = isNonEmptyString(obj.documentTag) ? obj.documentTag : 'documents';
   return { ...obj, endTag: `</${docTag}>` };
 }
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -46,6 +46,7 @@ import replacementEngine from '@replacement/engine';
 import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@tools/result';
 // Local imports - utils
+import { isNonEmptyString } from '@utils/core';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
 import {
@@ -200,10 +201,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     for (const entry of entries) {
       const fileName = entry.file_name ?? 'unnamed-file';
       const mimeType = entry.media_type ?? DEFAULT_ATTACHMENT_MIME_TYPE;
-      const inlinePayload =
-        typeof entry.data === 'string' && entry.data.length > 0
-          ? entry.data
-          : null;
+      const inlinePayload = isNonEmptyString(entry.data) ? entry.data : null;
 
       if (inlinePayload) {
         const payloadBytes = Buffer.byteLength(inlinePayload, 'base64');

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -261,10 +261,9 @@ export async function buildInlineAttachmentParts(
         });
       } else {
         // PDF, office documents, and other file types accepted by input_file
-        const filename =
-          isNonEmptyString(attachment.path)
-            ? path.basename(attachment.path)
-            : 'attachment';
+        const filename = isNonEmptyString(attachment.path)
+          ? path.basename(attachment.path)
+          : 'attachment';
         parts.push({
           type: 'input_file',
           file_data: `data:${mimeType};base64,${base64}`,

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -262,7 +262,7 @@ export async function buildInlineAttachmentParts(
       } else {
         // PDF, office documents, and other file types accepted by input_file
         const filename =
-          typeof attachment.path === 'string' && attachment.path.length > 0
+          isNonEmptyString(attachment.path)
             ? path.basename(attachment.path)
             : 'attachment';
         parts.push({

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -118,7 +118,7 @@ export function extractToolAttachments(
 
   // Build sanitized result, stripping binary data, undefined values, and redundant error fields
   const sanitizedResult: ToolResultPayload = {};
-  const hasError = typeof parsed.error === 'string' && parsed.error.length > 0;
+  const hasError = isNonEmptyString(parsed.error);
 
   for (const [key, value] of Object.entries(parsed)) {
     if (value === undefined) continue;

--- a/src/controllers/onboarding/onboardingFunnel.ts
+++ b/src/controllers/onboarding/onboardingFunnel.ts
@@ -14,6 +14,7 @@
  * sources and reads the flags below from its `platform().globalState`.
  */
 
+import { isNonEmptyString } from '@utils/core';
 import { API_PROVIDERS, lookupApiKey } from '@model/apiProviders';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
@@ -114,7 +115,7 @@ export async function setFirstRunDone(
 /** User-level default team id, written by the setup agent's `apply_team`. */
 export function getDefaultTeamId(state: StateStore): string | undefined {
   const value = state.get<string>(GlobalStateKey.ONBOARDING_DEFAULT_TEAM_ID);
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
+  return isNonEmptyString(value) ? value : undefined;
 }
 
 export async function setDefaultTeamId(
@@ -173,7 +174,7 @@ export async function hasAnyProviderApiKey(
   for (const provider of API_PROVIDERS) {
     // Sequential by design: stop at the first key found.
     const key = await lookupApiKey(secrets, provider);
-    if (typeof key === 'string' && key.trim().length > 0) return true;
+    if (isNonEmptyString(key)) return true;
   }
   return false;
 }

--- a/src/skills/skillSources.ts
+++ b/src/skills/skillSources.ts
@@ -50,21 +50,19 @@ function resolveSkillSourcePath(base: string, candidate: string): string {
 }
 
 function uniqueSources(sources: readonly SkillSource[]): SkillSource[] {
-  const unique: SkillSource[] = [];
-  const seen = new Map<string, number>();
+  const seen = new Map<string, SkillSource>();
   for (const source of sources) {
     const key = path.resolve(source.path);
-    const existingIndex = seen.get(key);
-    if (existingIndex !== undefined) {
+    const existing = seen.get(key);
+    if (existing) {
       if (source.required === true) {
-        unique[existingIndex] = { ...unique[existingIndex], required: true };
+        seen.set(key, { ...existing, required: true });
       }
-      continue;
+    } else {
+      seen.set(key, { ...source, path: key });
     }
-    seen.set(key, unique.length);
-    unique.push({ ...source, path: key });
   }
-  return unique;
+  return [...seen.values()];
 }
 
 export function defaultSkillSources(

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -16,6 +16,25 @@ describe('AgentSettingSchema', () => {
     expect(setting.agentCategory).toBe(AgentCategory.Workflow);
     expect(Object.hasOwn(setting, 'outputExt')).toBe(false);
   });
+
+  it('trims documentTag before deriving endTag', () => {
+    const setting = AgentSettingSchema.parse({
+      agentCategory: AgentCategory.Workflow,
+      documentTag: '  latex_document  ',
+    });
+
+    expect(setting.documentTag).toBe('latex_document');
+    expect(setting.endTag).toBe('</latex_document>');
+  });
+
+  it('rejects blank documentTag values', () => {
+    expect(() =>
+      AgentSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+        documentTag: '   ',
+      }),
+    ).toThrow('documentTag cannot be empty');
+  });
 });
 
 describe('AgentDefinitionSchema', () => {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -46,6 +46,7 @@ import {
   requestBashApproval,
   buildBashApprovalRejectedResult,
 } from '@tools/approval/bashApproval';
+import { isNonEmptyString } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -281,7 +282,7 @@ export async function runStreamedTurn(params: {
       usage = raw.usage ?? null;
       totalCostUsd = raw.total_cost_usd;
       if (raw.subtype === 'success') {
-        if (typeof raw.result === 'string' && raw.result.length > 0) {
+        if (isNonEmptyString(raw.result)) {
           responseParts.push(raw.result);
         }
       } else {
@@ -314,7 +315,7 @@ function handleAssistantBlocks(
   for (const block of blocks) {
     switch (block.type) {
       case 'text':
-        if (typeof block.text === 'string' && block.text.length > 0) {
+        if (isNonEmptyString(block.text)) {
           logger.info(block.text, {
             messageType: MESSAGE_TYPES.MODEL_RESPONSE,
           });
@@ -322,7 +323,7 @@ function handleAssistantBlocks(
         }
         break;
       case 'thinking':
-        if (typeof block.thinking === 'string' && block.thinking.length > 0) {
+        if (isNonEmptyString(block.thinking)) {
           logger.info(block.thinking, { messageType: MESSAGE_TYPES.THINKING });
         }
         break;

--- a/src/tools/github/githubClient.ts
+++ b/src/tools/github/githubClient.ts
@@ -7,6 +7,7 @@
  * back on subsequent requests; a 304 means "no change since that ETag".
  */
 
+import { isNonEmptyString } from '@utils/core';
 import { request as octokitRequest } from '@octokit/request';
 import { RequestError } from '@octokit/request-error';
 
@@ -53,11 +54,10 @@ export class GitHubPermanentError extends Error {
  * to a JSON-stringified form if we ever need to format it ourselves.
  */
 function extractApiMessage(data: unknown, fallback: string): string {
-  if (typeof data === 'string' && data.trim()) return data;
+  if (isNonEmptyString(data)) return data;
   if (data && typeof data === 'object') {
     const rec = data as { message?: unknown };
-    if (typeof rec.message === 'string' && rec.message.trim())
-      return rec.message;
+    if (isNonEmptyString(rec.message)) return rec.message;
     // `data` is a plain GitHub error object (already JSON-parsed), so
     // stringifying it can't realistically throw — no guard needed.
     return JSON.stringify(data);


### PR DESCRIPTION
## Summary

- **Replace 8 inline `typeof x === 'string' && x.length > 0` / `x.trim()` checks** with the existing `isNonEmptyString()` utility across 7 files, adding the import where missing. Whitespace-only strings are now consistently treated as empty, which is the correct behavior in all affected cases (paths, model text, error messages, XML tag names, API keys).
- **Simplify `uniqueSources()` in `skillSources.ts`** — replace the dual `Map<key,index>` + separate array tracking with a single `Map<key, SkillSource>`, which is functionally equivalent and more readable.

## Files changed

| File | Change |
|---|---|
| `src/skills/skillSources.ts` | `uniqueSources()`: single Map instead of parallel Map+array |
| `src/agent/core/definition/AgentDataclass.ts` | `isNonEmptyString(obj.documentTag)` (add import) |
| `src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts` | `isNonEmptyString(entry.data)` (add import) |
| `src/agent/modelHandlers/openai/openAIResponseFileUploads.ts` | `isNonEmptyString(attachment.path)` (import already present) |
| `src/agent/modelHandlers/utils/toolAttachmentUtils.ts` | `isNonEmptyString(parsed.error)` (import already present) |
| `src/controllers/onboarding/onboardingFunnel.ts` | 2 checks replaced (add import) |
| `src/tools/claudeAgent.ts` | 3 checks replaced (`raw.result`, `block.text`, `block.thinking`) (add import) |
| `src/tools/github/githubClient.ts` | 2 checks in `extractApiMessage` replaced (add import) |

## Test plan

- [x] `npm run typecheck` — passes clean (0 errors)
- [x] `npm test` — 455/456 test files pass; the 1 failure is a pre-existing OS-level process-group kill test unrelated to these changes

https://claude.ai/code/session_016DmTMAT8XtAvMBh78hhjdm

---
_Generated by [Claude Code](https://claude.ai/code/session_016DmTMAT8XtAvMBh78hhjdm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral tightening on whitespace-only strings is intentional and localized; deduplication logic is equivalent. No auth or payment paths beyond consistent API-key trimming checks.
> 
> **Overview**
> Standardizes **non-empty string** handling by swapping scattered `typeof … && length` / manual `trim()` checks for the shared **`isNonEmptyString()`** helper across agent settings, model handlers (Google/OpenAI attachments), tool result sanitization, onboarding credential/team-id reads, Claude Code stream parsing, and GitHub error message extraction. Whitespace-only values are now treated as empty consistently (paths, API keys, inline media, errors, model text).
> 
> **Agent settings** gain **`.trim()` on `documentTag`** in the Zod schema, **`deriveEndTag`** uses `isNonEmptyString` + trim, and new tests cover trimmed tags, derived `endTag`, and rejection of blank `documentTag`.
> 
> **Skill loading** refactors **`uniqueSources()`** to a single `Map<path, SkillSource>` (still merging `required: true` on duplicates) instead of parallel map + array indexing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ba316d18695577691e4a584f692d574486beb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->