### PR TITLE
feat(extension): surface Agent Review in the Source Control panel with per-run options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 
 - **Homebrew installs get the right upgrade command** — the CLI's in-session update prompt now recognizes a Homebrew install (the `texra-ai/tap` formula) and offers `brew update && brew upgrade texra` instead of misdetecting it as an npm global and suggesting `npm install -g`, which would have clashed with the brew-managed copy.
 
+### Extension (VS Code)
+
+#### Features
+
+- **Agent Review in the Source Control panel** — the agent review that scans your changes for issues now appears as a **Find Issues** section right in VS Code's Source Control (git) view, alongside the existing entry in the TeXRA sidebar. A new **Find Issues with Options…** action opens quick prompts to set optional free-text instructions, the review approach (Quick / Thorough) for this run, and the branch to diff against — so you can target a one-off review without changing your saved settings. Findings still stream into the panel and the Problems view with the same Fix-with-Agent and Dismiss actions.
+
 ## [0.38.7] - 2026-06-11
 
 ### Shared (all surfaces)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 #### Features
 
-- **Agent Review in the Source Control panel** — the agent review that scans your changes for issues now appears as a **Find Issues** section right in VS Code's Source Control (git) view, alongside the existing entry in the TeXRA sidebar. A new **Find Issues with Options…** action opens quick prompts to set optional free-text instructions, the review approach (Quick / Thorough) for this run, and the branch to diff against — so you can target a one-off review without changing your saved settings. Findings still stream into the panel and the Problems view with the same Fix-with-Agent and Dismiss actions.
+- **Agent Review in the Source Control panel** — the agent review that scans your changes for issues now lives as a **Find Issues** section right in VS Code's Source Control (git) view, next to Changes and Commits (it moved out of the TeXRA sidebar). A new **Find Issues with Options…** action opens quick prompts to set optional free-text instructions, the review approach (Quick / Thorough) for this run, and the branch to diff against — so you can target a one-off review without changing your saved settings. Findings still stream into the panel and the Problems view with the same Fix-with-Agent and Dismiss actions.
 
 ## [0.38.7] - 2026-06-11
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1041,9 +1041,17 @@
       },
       {
         "command": "texra.agentReview.run",
-        "title": "Run Agent Review",
+        "title": "Find Issues (Agent Review)",
+        "shortTitle": "Find Issues",
         "category": "TeXRA",
-        "icon": "$(refresh)"
+        "icon": "$(search)"
+      },
+      {
+        "command": "texra.agentReview.runWithOptions",
+        "title": "Find Issues with Options (Agent Review)",
+        "shortTitle": "Options…",
+        "category": "TeXRA",
+        "icon": "$(ellipsis)"
       },
       {
         "command": "texra.agentReview.fixAllIssues",
@@ -1218,12 +1226,27 @@
           "contextualTitle": "Agent Review",
           "visibility": "collapsed"
         }
+      ],
+      "scm": [
+        {
+          "type": "tree",
+          "id": "texra.scmAgentReviewView",
+          "name": "Agent Review",
+          "contextualTitle": "Agent Review",
+          "visibility": "collapsed",
+          "when": "texra.activated"
+        }
       ]
     },
     "viewsWelcome": [
       {
         "view": "texra.agentReviewView",
-        "contents": "Review your working-tree changes against the main branch with an AI agent. Issues also appear in the Problems panel with quick fixes.\n[Run Agent Review](command:texra.agentReview.run)",
+        "contents": "Review your working-tree changes against the main branch with an AI agent. Issues also appear in the Problems panel with quick fixes.\n[Find Issues](command:texra.agentReview.run)\n[Find Issues with Options…](command:texra.agentReview.runWithOptions)",
+        "when": "texra.activated && !texra.agentReview.running"
+      },
+      {
+        "view": "texra.scmAgentReviewView",
+        "contents": "Review changes against the main branch for issues.\n[Find Issues](command:texra.agentReview.run)\n[Find Issues with Options…](command:texra.agentReview.runWithOptions)",
         "when": "texra.activated && !texra.agentReview.running"
       }
     ],
@@ -1293,28 +1316,34 @@
         },
         {
           "command": "texra.agentReview.run",
-          "when": "texra.activated && view == texra.agentReviewView",
+          "when": "texra.activated && view =~ /^texra\\.(agentReview|scmAgentReview)View$/",
           "group": "navigation@1"
         },
         {
-          "command": "texra.agentReview.fixAllIssues",
-          "when": "texra.activated && view == texra.agentReviewView && texra.agentReview.hasIssues",
+          "command": "texra.agentReview.runWithOptions",
+          "when": "texra.activated && view =~ /^texra\\.(agentReview|scmAgentReview)View$/",
           "group": "navigation@2"
         },
         {
+          "command": "texra.agentReview.fixAllIssues",
+          "when": "texra.activated && view =~ /^texra\\.(agentReview|scmAgentReview)View$/ && texra.agentReview.hasIssues",
+          "group": "navigation@3"
+        },
+        {
           "command": "texra.agentReview.clear",
-          "when": "texra.activated && view == texra.agentReviewView && texra.agentReview.hasIssues"
+          "when": "texra.activated && view =~ /^texra\\.(agentReview|scmAgentReview)View$/ && texra.agentReview.hasIssues",
+          "group": "navigation@4"
         }
       ],
       "view/item/context": [
         {
           "command": "texra.agentReview.fixIssue",
-          "when": "view == texra.agentReviewView && viewItem == texraReviewIssue",
+          "when": "view =~ /^texra\\.(agentReview|scmAgentReview)View$/ && viewItem == texraReviewIssue",
           "group": "inline@1"
         },
         {
           "command": "texra.agentReview.dismissIssue",
-          "when": "view == texra.agentReviewView && viewItem == texraReviewIssue",
+          "when": "view =~ /^texra\\.(agentReview|scmAgentReview)View$/ && viewItem == texraReviewIssue",
           "group": "inline@2"
         }
       ],
@@ -1345,6 +1374,10 @@
       "commandPalette": [
         {
           "command": "texra.agentReview.run",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.agentReview.runWithOptions",
           "when": "texra.activated"
         },
         {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1218,13 +1218,6 @@
           "id": "texra.mainView",
           "name": "TeXRA",
           "contextualTitle": "TeXRA"
-        },
-        {
-          "type": "tree",
-          "id": "texra.agentReviewView",
-          "name": "Agent Review",
-          "contextualTitle": "Agent Review",
-          "visibility": "collapsed"
         }
       ],
       "scm": [
@@ -1239,11 +1232,6 @@
       ]
     },
     "viewsWelcome": [
-      {
-        "view": "texra.agentReviewView",
-        "contents": "Review your working-tree changes against the main branch with an AI agent. Issues also appear in the Problems panel with quick fixes.\n[Find Issues](command:texra.agentReview.run)\n[Find Issues with Options…](command:texra.agentReview.runWithOptions)",
-        "when": "texra.activated && !texra.agentReview.running"
-      },
       {
         "view": "texra.scmAgentReviewView",
         "contents": "Review changes against the main branch for issues.\n[Find Issues](command:texra.agentReview.run)\n[Find Issues with Options…](command:texra.agentReview.runWithOptions)",
@@ -1316,34 +1304,34 @@
         },
         {
           "command": "texra.agentReview.run",
-          "when": "texra.activated && view =~ /^texra\\.(agentReview|scmAgentReview)View$/",
+          "when": "texra.activated && view == texra.scmAgentReviewView",
           "group": "navigation@1"
         },
         {
           "command": "texra.agentReview.runWithOptions",
-          "when": "texra.activated && view =~ /^texra\\.(agentReview|scmAgentReview)View$/",
+          "when": "texra.activated && view == texra.scmAgentReviewView",
           "group": "navigation@2"
         },
         {
           "command": "texra.agentReview.fixAllIssues",
-          "when": "texra.activated && view =~ /^texra\\.(agentReview|scmAgentReview)View$/ && texra.agentReview.hasIssues",
+          "when": "texra.activated && view == texra.scmAgentReviewView && texra.agentReview.hasIssues",
           "group": "navigation@3"
         },
         {
           "command": "texra.agentReview.clear",
-          "when": "texra.activated && view =~ /^texra\\.(agentReview|scmAgentReview)View$/ && texra.agentReview.hasIssues",
+          "when": "texra.activated && view == texra.scmAgentReviewView && texra.agentReview.hasIssues",
           "group": "navigation@4"
         }
       ],
       "view/item/context": [
         {
           "command": "texra.agentReview.fixIssue",
-          "when": "view =~ /^texra\\.(agentReview|scmAgentReview)View$/ && viewItem == texraReviewIssue",
+          "when": "view == texra.scmAgentReviewView && viewItem == texraReviewIssue",
           "group": "inline@1"
         },
         {
           "command": "texra.agentReview.dismissIssue",
-          "when": "view =~ /^texra\\.(agentReview|scmAgentReview)View$/ && viewItem == texraReviewIssue",
+          "when": "view == texra.scmAgentReviewView && viewItem == texraReviewIssue",
           "group": "inline@2"
         }
       ],

--- a/packages/extension/src/commands/review/agentReviewCommands.ts
+++ b/packages/extension/src/commands/review/agentReviewCommands.ts
@@ -33,9 +33,6 @@ import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'AgentReview';
 
-/** Mirror of the sidebar review tree contributed into the Source Control panel. */
-const SCM_AGENT_REVIEW_VIEW_ID = 'texra.scmAgentReviewView';
-
 const agentReviewCommands = {
   run: 'texra.agentReview.run',
   runWithOptions: 'texra.agentReview.runWithOptions',
@@ -98,37 +95,28 @@ export function registerAgentReviewCommands(
     AgentReviewService.addIssueReport(report),
   );
 
-  // One provider backs both surfaces: the TeXRA sidebar tree and a mirror in
-  // VS Code's Source Control panel (GitKraken/Cursor-style). Tree item ids are
-  // per-view, so sharing the provider is safe.
+  // The Agent Review tree lives in VS Code's Source Control (git) panel,
+  // GitKraken/Cursor-style.
   const treeProvider = new AgentReviewTreeProvider();
-  const treeViews = [
-    vscode.window.createTreeView(AGENT_REVIEW_VIEW_ID, {
-      treeDataProvider: treeProvider,
-    }),
-    vscode.window.createTreeView(SCM_AGENT_REVIEW_VIEW_ID, {
-      treeDataProvider: treeProvider,
-    }),
-  ];
+  const treeView = vscode.window.createTreeView(AGENT_REVIEW_VIEW_ID, {
+    treeDataProvider: treeProvider,
+  });
   const syncView = () => {
     const state = AgentReviewService.getState();
     const count = state.issues.length;
-    const badge =
+    treeView.message = state.summary;
+    treeView.badge =
       count > 0
         ? {
             value: count,
             tooltip: `${count} agent review issue${count === 1 ? '' : 's'}`,
           }
         : undefined;
-    for (const view of treeViews) {
-      view.message = state.summary;
-      view.badge = badge;
-    }
   };
   syncView();
   context.subscriptions.push(
     treeProvider,
-    ...treeViews,
+    treeView,
     AgentReviewService.onDidChange(syncView),
     vscode.languages.registerCodeActionsProvider(
       { scheme: 'file' },

--- a/packages/extension/src/commands/review/agentReviewCommands.ts
+++ b/packages/extension/src/commands/review/agentReviewCommands.ts
@@ -26,13 +26,19 @@ import {
   openReviewIssue,
   type AgentReviewNode,
 } from '@frontend/review/AgentReviewTreeProvider';
+import { promptReviewOptions } from '@frontend/review/promptReviewOptions';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { setReportReviewIssueSink } from '@tools/ReportReviewIssueTool';
+import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'AgentReview';
 
+/** Mirror of the sidebar review tree contributed into the Source Control panel. */
+const SCM_AGENT_REVIEW_VIEW_ID = 'texra.scmAgentReviewView';
+
 const agentReviewCommands = {
   run: 'texra.agentReview.run',
+  runWithOptions: 'texra.agentReview.runWithOptions',
   fixAll: 'texra.agentReview.fixAllIssues',
   fixIssue: 'texra.agentReview.fixIssue',
   dismissIssue: 'texra.agentReview.dismissIssue',
@@ -68,6 +74,20 @@ async function handleOpenIssue(node: AgentReviewNode): Promise<void> {
   }
 }
 
+/** "Find Issues" split-button options: gather per-run choices, then run. */
+async function handleRunWithOptions(): Promise<void> {
+  const cwd = WorkspaceFS.getPath();
+  if (!cwd) {
+    void vscode.window.showErrorMessage(
+      'Agent review needs an open workspace folder.',
+    );
+    return;
+  }
+  const options = await promptReviewOptions(cwd);
+  if (!options) return; // Cancelled at one of the QuickPick steps.
+  await AgentReviewService.runReview('manual', options);
+}
+
 export function registerAgentReviewCommands(
   context: vscode.ExtensionContext,
 ): void {
@@ -78,26 +98,37 @@ export function registerAgentReviewCommands(
     AgentReviewService.addIssueReport(report),
   );
 
+  // One provider backs both surfaces: the TeXRA sidebar tree and a mirror in
+  // VS Code's Source Control panel (GitKraken/Cursor-style). Tree item ids are
+  // per-view, so sharing the provider is safe.
   const treeProvider = new AgentReviewTreeProvider();
-  const treeView = vscode.window.createTreeView(AGENT_REVIEW_VIEW_ID, {
-    treeDataProvider: treeProvider,
-  });
+  const treeViews = [
+    vscode.window.createTreeView(AGENT_REVIEW_VIEW_ID, {
+      treeDataProvider: treeProvider,
+    }),
+    vscode.window.createTreeView(SCM_AGENT_REVIEW_VIEW_ID, {
+      treeDataProvider: treeProvider,
+    }),
+  ];
   const syncView = () => {
     const state = AgentReviewService.getState();
     const count = state.issues.length;
-    treeView.message = state.summary;
-    treeView.badge =
+    const badge =
       count > 0
         ? {
             value: count,
             tooltip: `${count} agent review issue${count === 1 ? '' : 's'}`,
           }
         : undefined;
+    for (const view of treeViews) {
+      view.message = state.summary;
+      view.badge = badge;
+    }
   };
   syncView();
   context.subscriptions.push(
     treeProvider,
-    treeView,
+    ...treeViews,
     AgentReviewService.onDidChange(syncView),
     vscode.languages.registerCodeActionsProvider(
       { scheme: 'file' },
@@ -112,6 +143,10 @@ export function registerAgentReviewCommands(
     {
       id: agentReviewCommands.run,
       handler: () => void AgentReviewService.runReview('manual'),
+    },
+    {
+      id: agentReviewCommands.runWithOptions,
+      handler: () => void handleRunWithOptions(),
     },
     {
       id: agentReviewCommands.fixAll,

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -54,7 +54,8 @@ const FIX_AGENT = 'coder';
  */
 const MAX_ISSUES_PER_REVIEW = 25;
 
-export const AGENT_REVIEW_VIEW_ID = 'texra.agentReviewView';
+/** The Agent Review tree lives in VS Code's Source Control (git) panel. */
+export const AGENT_REVIEW_VIEW_ID = 'texra.scmAgentReviewView';
 
 type AgentReviewTrigger = 'manual' | 'commit';
 

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -24,6 +24,7 @@ import {
   buildFixInstruction,
   buildReviewInstruction,
   createReviewIssue,
+  type ReviewApproach,
   type ReviewIssue,
   type ReviewIssueReport,
   type ReviewSeverity,
@@ -60,6 +61,12 @@ type AgentReviewTrigger = 'manual' | 'commit';
 interface AgentReviewRunOptions {
   baseRef?: string;
   baseDescription?: string;
+  /** Per-run base branch (merge-base) from the "Diff Against…" picker. */
+  baseBranch?: string;
+  /** Per-run approach override; falls back to the configured default. */
+  approach?: ReviewApproach;
+  /** Optional free-text focus from the "Find Issues" options. */
+  userInstructions?: string;
 }
 
 interface AgentReviewStateSnapshot {
@@ -226,6 +233,7 @@ class AgentReviewServiceImpl {
       ),
       baseRef: options.baseRef,
       baseDescription: options.baseDescription,
+      baseBranch: options.baseBranch,
     });
     if (generation !== this.reviewGeneration) return;
 
@@ -282,17 +290,20 @@ class AgentReviewServiceImpl {
         changedFiles,
         diff,
         truncated,
-        approach: getValidatedConfig(
-          'agentReview.approach',
-          z.enum(AGENT_REVIEW_APPROACHES),
-          'quick',
-        ),
+        approach:
+          options.approach ??
+          getValidatedConfig(
+            'agentReview.approach',
+            z.enum(AGENT_REVIEW_APPROACHES),
+            'quick',
+          ),
+        userInstructions: options.userInstructions,
       });
       const model = getConfig<string>('agentReview.model', '').trim();
       const config = AgentConfigSchema.parse({
         agent: REVIEW_AGENT,
         instruction,
-        displayInstruction: `Agent review: diff with ${baseDescription} (${changedFiles.length} file${changedFiles.length === 1 ? '' : 's'})`,
+        displayInstruction: `Agent review: diff with ${baseDescription} (${changedFiles.length} file${changedFiles.length === 1 ? '' : 's'})${options.userInstructions ? ' · custom focus' : ''}`,
         // The instruction's paths are repo-relative; anchor the session's
         // tool calls (read_file, grep, bash) to the repository root, which
         // may sit above the opened workspace folder.

--- a/packages/extension/src/frontend/review/promptReviewOptions.ts
+++ b/packages/extension/src/frontend/review/promptReviewOptions.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-run options prompt for the "Find Issues" agent review.
+ *
+ * Mirrors the GitKraken/Cursor "Find Issues" popover with native VS Code
+ * QuickPicks: an optional free-text focus, the review approach, and the
+ * branch to diff against. Returns the gathered options, or `undefined` when
+ * the user cancels at any step (Escape).
+ */
+
+// Third-party imports
+import * as vscode from 'vscode';
+import { z } from 'zod';
+
+// Local imports
+import { listBaseBranchCandidates } from '@agent/review/reviewDiff';
+import type { ReviewApproach } from '@agent/review/reviewIssues';
+import { AGENT_REVIEW_APPROACHES } from '@shared/schemas/coreSettings';
+import { getValidatedConfig } from '@utils/config/configUtils';
+
+export interface ReviewOptions {
+  /** Free-text focus for the reviewer; omitted when left blank. */
+  userInstructions?: string;
+  /** Per-run approach override. */
+  approach: ReviewApproach;
+  /** Branch to diff against; omitted to auto-detect the main branch. */
+  baseBranch?: string;
+}
+
+interface ApproachItem extends vscode.QuickPickItem {
+  value: ReviewApproach;
+}
+
+interface BranchItem extends vscode.QuickPickItem {
+  /** Ref to diff against; `undefined` for the auto-detect default. */
+  ref: string | undefined;
+}
+
+/**
+ * Drive the three-step QuickPick flow. Each step honors Escape: returning
+ * `undefined` from any prompt cancels the whole run, so a half-configured
+ * review never starts.
+ */
+export async function promptReviewOptions(
+  cwd: string,
+): Promise<ReviewOptions | undefined> {
+  const userInstructions = await vscode.window.showInputBox({
+    title: 'Agent Review — Optional Instructions',
+    prompt: 'Focus the review (optional). Leave blank for a general review.',
+    placeHolder: 'e.g. Focus on error handling and concurrency',
+    ignoreFocusOut: true,
+  });
+  // Escape returns undefined; an empty submission returns "".
+  if (userInstructions === undefined) return undefined;
+
+  const currentApproach = getValidatedConfig(
+    'agentReview.approach',
+    z.enum(AGENT_REVIEW_APPROACHES),
+    'quick',
+  );
+  const quickItem: ApproachItem = {
+    label: 'Quick',
+    detail: 'Verify only the strongest suspicions with tools — fast and cheap.',
+    value: 'quick',
+  };
+  const thoroughItem: ApproachItem = {
+    label: 'Thorough',
+    detail:
+      'Read every changed file, check callers, and pull diagnostics — deeper, higher cost.',
+    value: 'thorough',
+  };
+  // List the configured default first so Enter keeps the current behavior.
+  const approachItems =
+    currentApproach === 'thorough'
+      ? [thoroughItem, quickItem]
+      : [quickItem, thoroughItem];
+  const approachPick = await vscode.window.showQuickPick(approachItems, {
+    title: 'Agent Review — Approach',
+    placeHolder: 'Choose review depth',
+    ignoreFocusOut: true,
+  });
+  if (!approachPick) return undefined;
+
+  const candidates = await listBaseBranchCandidates(cwd);
+  const branchItems: BranchItem[] = [
+    {
+      label: '$(git-branch) Auto-detect main branch',
+      detail: "Diff against the repository's main branch (recommended).",
+      ref: undefined,
+    },
+    ...candidates.map(
+      (candidate): BranchItem => ({
+        label: `$(git-branch) ${candidate.ref}`,
+        description: candidate.current ? 'current branch' : undefined,
+        ref: candidate.ref,
+      }),
+    ),
+  ];
+  const branchPick = await vscode.window.showQuickPick(branchItems, {
+    title: 'Agent Review — Diff Against',
+    placeHolder: 'Choose the branch to compare against',
+    ignoreFocusOut: true,
+  });
+  if (!branchPick) return undefined;
+
+  return {
+    userInstructions: userInstructions.trim() || undefined,
+    approach: approachPick.value,
+    baseBranch: branchPick.ref,
+  };
+}

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -359,8 +359,16 @@
         {
           "category": "TeXRA",
           "command": "texra.agentReview.run",
-          "icon": "$(refresh)",
-          "title": "Run Agent Review"
+          "icon": "$(search)",
+          "shortTitle": "Find Issues",
+          "title": "Find Issues (Agent Review)"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.agentReview.runWithOptions",
+          "icon": "$(ellipsis)",
+          "shortTitle": "Options…",
+          "title": "Find Issues with Options (Agent Review)"
         },
         {
           "category": "TeXRA",
@@ -1106,6 +1114,10 @@
             "when": "texra.activated"
           },
           {
+            "command": "texra.agentReview.runWithOptions",
+            "when": "texra.activated"
+          },
+          {
             "command": "texra.agentReview.fixAllIssues",
             "when": "texra.activated && texra.agentReview.hasIssues"
           },
@@ -1406,12 +1418,12 @@
           {
             "command": "texra.agentReview.fixIssue",
             "group": "inline@1",
-            "when": "view == texra.agentReviewView && viewItem == texraReviewIssue"
+            "when": "view == texra.scmAgentReviewView && viewItem == texraReviewIssue"
           },
           {
             "command": "texra.agentReview.dismissIssue",
             "group": "inline@2",
-            "when": "view == texra.agentReviewView && viewItem == texraReviewIssue"
+            "when": "view == texra.scmAgentReviewView && viewItem == texraReviewIssue"
           }
         ],
         "view/title": [
@@ -1448,33 +1460,42 @@
           {
             "command": "texra.agentReview.run",
             "group": "navigation@1",
-            "when": "texra.activated && view == texra.agentReviewView"
+            "when": "texra.activated && view == texra.scmAgentReviewView"
+          },
+          {
+            "command": "texra.agentReview.runWithOptions",
+            "group": "navigation@2",
+            "when": "texra.activated && view == texra.scmAgentReviewView"
           },
           {
             "command": "texra.agentReview.fixAllIssues",
-            "group": "navigation@2",
-            "when": "texra.activated && view == texra.agentReviewView && texra.agentReview.hasIssues"
+            "group": "navigation@3",
+            "when": "texra.activated && view == texra.scmAgentReviewView && texra.agentReview.hasIssues"
           },
           {
             "command": "texra.agentReview.clear",
-            "when": "texra.activated && view == texra.agentReviewView && texra.agentReview.hasIssues"
+            "group": "navigation@4",
+            "when": "texra.activated && view == texra.scmAgentReviewView && texra.agentReview.hasIssues"
           }
         ]
       },
       "views": {
+        "scm": [
+          {
+            "contextualTitle": "Agent Review",
+            "id": "texra.scmAgentReviewView",
+            "name": "Agent Review",
+            "type": "tree",
+            "visibility": "collapsed",
+            "when": "texra.activated"
+          }
+        ],
         "texra": [
           {
             "contextualTitle": "TeXRA",
             "id": "texra.mainView",
             "name": "TeXRA",
             "type": "webview"
-          },
-          {
-            "contextualTitle": "Agent Review",
-            "id": "texra.agentReviewView",
-            "name": "Agent Review",
-            "type": "tree",
-            "visibility": "collapsed"
           }
         ]
       },
@@ -1489,8 +1510,8 @@
       },
       "viewsWelcome": [
         {
-          "contents": "Review your working-tree changes against the main branch with an AI agent. Issues also appear in the Problems panel with quick fixes.\n[Run Agent Review](command:texra.agentReview.run)",
-          "view": "texra.agentReviewView",
+          "contents": "Review changes against the main branch for issues.\n[Find Issues](command:texra.agentReview.run)\n[Find Issues with Options…](command:texra.agentReview.runWithOptions)",
+          "view": "texra.scmAgentReviewView",
           "when": "texra.activated && !texra.agentReview.running"
         }
       ],

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -158,8 +158,8 @@ async function detectBaseBranch(cwd: string): Promise<BaseBranch | null> {
 /**
  * Resolve a user-chosen base branch (from the "Diff Against…" picker). The ref
  * is verified so a stale pick degrades to a clear failure rather than a
- * confusing empty diff. The short name drops a leading `origin/` so the
- * "branch already checked out" comparison still matches.
+ * confusing empty diff. The short name drops a leading `origin/` for
+ * user-facing labels in on-branch fallback descriptions.
  */
 async function resolveBaseBranch(
   cwd: string,
@@ -375,7 +375,10 @@ export async function collectReviewDiff(
     const head = (
       await git(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD'])
     )?.trim();
-    if (head === base.shortName) {
+    const checkedOutBase = options.baseBranch
+      ? head === base.ref
+      : head === base.shortName;
+    if (checkedOutBase) {
       ({ baseRef, baseDescription } = await resolveOnBaseBranch(
         repoRoot,
         base.shortName,

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -42,6 +42,12 @@ export interface CollectReviewDiffOptions {
   baseRef?: string;
   /** User-facing label for {@link baseRef}. */
   baseDescription?: string;
+  /**
+   * Explicit base *branch* to diff against, with merge-base semantics (like
+   * the auto-detected main branch). Set by the "Diff Against…" picker;
+   * ignored when {@link baseRef} is provided.
+   */
+  baseBranch?: string;
 }
 
 export interface ReviewDiff {
@@ -147,6 +153,63 @@ async function detectBaseBranch(cwd: string): Promise<BaseBranch | null> {
     }
   }
   return null;
+}
+
+/**
+ * Resolve a user-chosen base branch (from the "Diff Against…" picker). The ref
+ * is verified so a stale pick degrades to a clear failure rather than a
+ * confusing empty diff. The short name drops a leading `origin/` so the
+ * "branch already checked out" comparison still matches.
+ */
+async function resolveBaseBranch(
+  cwd: string,
+  branch: string,
+): Promise<BaseBranch | null> {
+  const verified = await git(cwd, ['rev-parse', '--verify', '--quiet', branch]);
+  if (verified === null) return null;
+  return { ref: branch, shortName: branch.replace(/^origin\//, '') };
+}
+
+/** A branch offered by the "Diff Against…" picker. */
+export interface BaseBranchCandidate {
+  /** Ref usable as a diff base: a local branch name or `origin/<name>`. */
+  ref: string;
+  /** True when this is the currently checked-out branch. */
+  current: boolean;
+}
+
+/**
+ * List local and origin branches for the "Diff Against…" picker, flagging the
+ * current branch. Best-effort: returns an empty list when the repository
+ * cannot be resolved, leaving the picker with just its auto-detect default.
+ */
+export async function listBaseBranchCandidates(
+  cwd: string,
+): Promise<BaseBranchCandidate[]> {
+  const repoRoot = (await git(cwd, ['rev-parse', '--show-toplevel']))?.trim();
+  if (!repoRoot) return [];
+  const [headOut, localsOut, remotesOut] = await Promise.all([
+    git(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD']),
+    git(repoRoot, ['for-each-ref', '--format=%(refname:short)', 'refs/heads']),
+    git(repoRoot, [
+      'for-each-ref',
+      '--format=%(refname:short)',
+      'refs/remotes/origin',
+    ]),
+  ]);
+  const current = headOut?.trim();
+  const seen = new Set<string>();
+  const candidates: BaseBranchCandidate[] = [];
+  for (const ref of [
+    ...splitOutputLines(localsOut ?? ''),
+    ...splitOutputLines(remotesOut ?? ''),
+  ]) {
+    // `origin/HEAD` is a symbolic alias, not a real branch to diff against.
+    if (!ref || ref === 'origin/HEAD' || seen.has(ref)) continue;
+    seen.add(ref);
+    candidates.push({ ref, current: ref === current });
+  }
+  return candidates;
 }
 
 /**
@@ -297,11 +360,15 @@ export async function collectReviewDiff(
     baseRef = options.baseRef;
     baseDescription = options.baseDescription ?? options.baseRef;
   } else {
-    const base = await detectBaseBranch(repoRoot);
+    const base = options.baseBranch
+      ? await resolveBaseBranch(repoRoot, options.baseBranch)
+      : await detectBaseBranch(repoRoot);
     if (!base) {
       return {
         ok: false,
-        reason: `Could not find the repository's main branch (looked for origin/HEAD plus local and origin remote-tracking ${BASE_BRANCH_CANDIDATES.join('/')}).`,
+        reason: options.baseBranch
+          ? `Could not resolve the base branch "${options.baseBranch}"; it may have been deleted.`
+          : `Could not find the repository's main branch (looked for origin/HEAD plus local and origin remote-tracking ${BASE_BRANCH_CANDIDATES.join('/')}).`,
       };
     }
 
@@ -322,7 +389,9 @@ export async function collectReviewDiff(
         };
       }
       baseRef = mergeBase.trim();
-      baseDescription = `main branch (${base.ref})`;
+      baseDescription = options.baseBranch
+        ? `branch ${base.ref}`
+        : `main branch (${base.ref})`;
     }
   }
 

--- a/src/agent/review/reviewIssues.ts
+++ b/src/agent/review/reviewIssues.ts
@@ -83,6 +83,8 @@ export interface ReviewInstructionInput {
   diff: string;
   truncated: boolean;
   approach: ReviewApproach;
+  /** Optional free-text focus supplied per run via the "Find Issues" options. */
+  userInstructions?: string;
 }
 
 const QUICK_GUIDANCE =
@@ -97,13 +99,21 @@ const THOROUGH_GUIDANCE =
  * untracked files appear as synthesized `new file (untracked)` entries.
  */
 export function buildReviewInstruction(input: ReviewInstructionInput): string {
-  return [
+  const sections = [
     `Review the working tree's diff with the ${input.baseDescription}.`,
     input.approach === 'thorough' ? THOROUGH_GUIDANCE : QUICK_GUIDANCE,
+  ];
+  if (input.userInstructions) {
+    sections.push(
+      `The user gave extra instructions for this review — prioritize them, but still report any other critical issues you find:\n<reviewer-instructions>\n${input.userInstructions}\n</reviewer-instructions>`,
+    );
+  }
+  sections.push(
     `Report each confirmed finding with the report_review_issue tool, using the repository-relative path exactly as it appears in the diff.${input.truncated ? ' The diff was truncated to fit; read the listed files for the full picture.' : ''}`,
     `<changed-files>\n${input.changedFiles.join('\n')}\n</changed-files>`,
     `<diff>\n${input.diff}\n</diff>`,
-  ].join('\n\n');
+  );
+  return sections.join('\n\n');
 }
 
 /**

--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -370,9 +370,17 @@ export const commandCatalog = [
   },
   {
     id: 'texra.agentReview.run',
-    title: 'Run Agent Review',
+    title: 'Find Issues (Agent Review)',
+    shortTitle: 'Find Issues',
     category: 'TeXRA',
-    icon: '$(refresh)',
+    icon: '$(search)',
+  },
+  {
+    id: 'texra.agentReview.runWithOptions',
+    title: 'Find Issues with Options (Agent Review)',
+    shortTitle: 'Options…',
+    category: 'TeXRA',
+    icon: '$(ellipsis)',
   },
   {
     id: 'texra.agentReview.fixAllIssues',

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -252,6 +252,28 @@ describe('collectReviewDiff (real git repository)', () => {
     expect(result.value.changedFiles).toEqual(['paper.tex']);
   });
 
+  it('diffs against an explicitly chosen remote ref even on the matching local branch', async () => {
+    await git('update-ref', 'refs/remotes/origin/main', 'refs/heads/main');
+    await writeFile(path.join(repo, 'notes.txt'), 'first unpushed commit\n');
+    await git('add', '.');
+    await git('commit', '-m', 'first unpushed');
+    await writeFile(path.join(repo, 'paper.tex'), 'second unpushed commit\n');
+    await git('commit', '-am', 'second unpushed');
+
+    const result = await collectReviewDiff({
+      cwd: repo,
+      includeUntracked: false,
+      includeSubmodules: true,
+      baseBranch: 'origin/main',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.baseDescription).toBe('branch origin/main');
+    expect(result.value.diff).toContain('+first unpushed commit');
+    expect(result.value.diff).toContain('+second unpushed commit');
+    expect(result.value.changedFiles).toEqual(['notes.txt', 'paper.tex']);
+  });
+
   it('fails clearly when the chosen base branch does not exist', async () => {
     await git('checkout', '-b', 'feature');
     const result = await collectReviewDiff({

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -328,12 +328,7 @@ describe('collectReviewDiff (real git repository)', () => {
     const candidates = await listBaseBranchCandidates(repo);
     const byRef = new Map(candidates.map((c) => [c.ref, c]));
     expect([...byRef.keys()]).toEqual(
-      expect.arrayContaining([
-        'main',
-        'develop',
-        'feature',
-        'origin/release',
-      ]),
+      expect.arrayContaining(['main', 'develop', 'feature', 'origin/release']),
     );
     // origin/HEAD is a symbolic alias, not a diffable branch.
     expect(byRef.has('origin/HEAD')).toBe(false);

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -13,6 +13,7 @@ import {
   buildUntrackedFileDiff,
   collectReviewDiff,
   isPathInChangeSet,
+  listBaseBranchCandidates,
 } from '@agent/review/reviewDiff';
 import { executeCommand } from '@utils/system/execUtils';
 
@@ -224,6 +225,46 @@ describe('collectReviewDiff (real git repository)', () => {
     expect(result.value.diff).toContain('-original line');
   });
 
+  it('diffs against a chosen base branch (merge-base) from the picker', async () => {
+    // A second long-lived branch the user can pick as the diff base.
+    await git('checkout', '-b', 'develop');
+    await writeFile(path.join(repo, 'dev-only.txt'), 'develop work\n');
+    await git('add', '.');
+    await git('commit', '-m', 'develop work');
+
+    await git('checkout', 'main');
+    await git('checkout', '-b', 'feature');
+    await writeFile(path.join(repo, 'paper.tex'), 'feature line\n');
+
+    const result = await collectReviewDiff({
+      cwd: repo,
+      includeUntracked: false,
+      includeSubmodules: true,
+      baseBranch: 'develop',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Merge-base with develop is the initial commit, so develop's own work
+    // is not part of the review — only the feature change is.
+    expect(result.value.baseDescription).toBe('branch develop');
+    expect(result.value.diff).toContain('+feature line');
+    expect(result.value.diff).not.toContain('develop work');
+    expect(result.value.changedFiles).toEqual(['paper.tex']);
+  });
+
+  it('fails clearly when the chosen base branch does not exist', async () => {
+    await git('checkout', '-b', 'feature');
+    const result = await collectReviewDiff({
+      cwd: repo,
+      includeUntracked: false,
+      includeSubmodules: true,
+      baseBranch: 'no-such-branch',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toContain('no-such-branch');
+  });
+
   it('uses an explicit base ref for commit-triggered reviews', async () => {
     await writeFile(path.join(repo, 'notes.txt'), 'notes before\n');
     await git('add', '.');
@@ -273,6 +314,37 @@ describe('collectReviewDiff (real git repository)', () => {
         ok: false,
         reason: 'The workspace is not a git repository.',
       });
+    } finally {
+      await rm(plain, { recursive: true, force: true });
+    }
+  });
+
+  it('lists local and origin branches for the picker, flagging the current one', async () => {
+    await git('branch', 'develop');
+    await git('update-ref', 'refs/remotes/origin/release', 'refs/heads/main');
+    await git('update-ref', 'refs/remotes/origin/HEAD', 'refs/heads/main');
+    await git('checkout', '-b', 'feature');
+
+    const candidates = await listBaseBranchCandidates(repo);
+    const byRef = new Map(candidates.map((c) => [c.ref, c]));
+    expect([...byRef.keys()]).toEqual(
+      expect.arrayContaining([
+        'main',
+        'develop',
+        'feature',
+        'origin/release',
+      ]),
+    );
+    // origin/HEAD is a symbolic alias, not a diffable branch.
+    expect(byRef.has('origin/HEAD')).toBe(false);
+    expect(byRef.get('feature')?.current).toBe(true);
+    expect(byRef.get('main')?.current).toBe(false);
+  });
+
+  it('returns no branch candidates outside a git repository', async () => {
+    const plain = await mkdtemp(path.join(tmpdir(), 'texra-plain-'));
+    try {
+      expect(await listBaseBranchCandidates(plain)).toEqual([]);
     } finally {
       await rm(plain, { recursive: true, force: true });
     }

--- a/src/test-kernel/agent/review/AgentReviewIssues.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewIssues.vitest.ts
@@ -94,6 +94,28 @@ describe('buildReviewInstruction', () => {
     expect(quick).toContain('QUICK');
     expect(quick).not.toContain('truncated');
   });
+
+  it('weaves in per-run user instructions when provided', () => {
+    const focused = buildReviewInstruction({
+      baseDescription: 'main',
+      changedFiles: ['a.tex'],
+      diff: 'x',
+      truncated: false,
+      approach: 'quick',
+      userInstructions: 'Focus on error handling',
+    });
+    expect(focused).toContain('<reviewer-instructions>');
+    expect(focused).toContain('Focus on error handling');
+
+    const plain = buildReviewInstruction({
+      baseDescription: 'main',
+      changedFiles: ['a.tex'],
+      diff: 'x',
+      truncated: false,
+      approach: 'quick',
+    });
+    expect(plain).not.toContain('reviewer-instructions');
+  });
 });
 
 describe('buildFixInstruction', () => {


### PR DESCRIPTION
Mirror the existing change-review feature into VS Code's native Source
Control (git) view (GitKraken/Cursor-style) and add a "Find Issues with
Options…" flow for one-off, per-run control.

- Register a second Agent Review tree in the `scm` view container, sharing
  the existing provider/service, so it shows up in the git panel while the
  TeXRA-sidebar view stays. Both surfaces get "Find Issues" welcome buttons
  and a shared toolbar (run / options / fix all / clear) via regex `when`.
- Add `texra.agentReview.runWithOptions`: native QuickPick prompts for
  optional instructions, approach (Quick/Thorough) override, and the branch
  to diff against; thread these through the service to the review run.
- Engine: collectReviewDiff gains a `baseBranch` override (merge-base
  semantics) plus a `listBaseBranchCandidates` helper; buildReviewInstruction
  weaves in per-run user instructions.
- Keep the shared command catalog in sync with package.json.
- Cover the new diff-base override, branch listing, and instruction weaving
  with tests.

https://claude.ai/code/session_01N13tTeHfPHBDTgbj4i9gVf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Extension UI and review-run options only; git diff logic is extended with tests and does not touch auth or data persistence beyond existing review flows.
> 
> **Overview**
> **Agent Review** moves from the TeXRA sidebar into VS Code’s **Source Control** view as a collapsed **Agent Review** tree (`texra.scmAgentReviewView`), with toolbar and welcome copy rebranded to **Find Issues** (search icon) instead of “Run Agent Review.”
> 
> A new **`texra.agentReview.runWithOptions`** command drives a three-step QuickPick: optional review focus text, Quick vs Thorough for that run only, and **Diff Against** (auto-detect main or a chosen local/`origin` branch). Those overrides flow through `AgentReviewService` into diff collection and the reviewer prompt; saved settings stay the default for one-click **Find Issues**.
> 
> Under the hood, `collectReviewDiff` gains a **`baseBranch`** merge-base override (with clearer errors for missing refs), **`listBaseBranchCandidates`** feeds the branch picker, and **`buildReviewInstruction`** can include per-run **user instructions**. Command catalog, package invariants snapshot, and tests cover the new diff base and instruction weaving.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5144e74982d34690db45c29b8b35074458c65ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->