### PR TITLE
[codex] Tolerate bash command descriptions

### DIFF
--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -251,6 +251,27 @@ describe('BashTool', () => {
     assert.equal(receivedSignal.aborted, false);
   });
 
+  it('accepts optional command descriptions without passing them to the shell', async () => {
+    vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
+      success: true,
+      stdout: 'checked\n',
+      stderr: '',
+      timedOut: false,
+      exitCode: 0,
+    });
+
+    const result = await new BashTool().call({
+      command: 'test -f proof.tex',
+      description: 'Check that the proof file exists.',
+    });
+
+    assert.equal(result.output, 'checked\n');
+    assert.equal(
+      vi.mocked(execUtils.executeCommand).mock.calls[0]?.[0],
+      'test -f proof.tex',
+    );
+  });
+
   it('finalizes deferred progress card when foreground bash is aborted', async () => {
     let activeController: AbortController | null = null;
     let receivedSignal: AbortSignal | undefined;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -66,6 +66,12 @@ function backgroundBashTerminalStatus(success: boolean) {
 
 const BashInputSchema = z.strictObject({
   command: z.string(),
+  description: z
+    .string()
+    .nullish()
+    .describe(
+      'Optional human-readable purpose for the command. Ignored by execution.',
+    ),
   timeout: z
     .int()
     .min(1000)


### PR DESCRIPTION
## Summary

- Allow the `bash` tool input to include an optional human-readable `description` field
- Ignore that field during execution so only the actual command reaches the shell
- Add a regression test for model calls that include a harmless command description

Fixes #6040.

## Dogfood evidence

In a real `texra-local chat` TTY run, the assistant attempted a lightweight proof-file check. The first bash call failed before execution with `Invalid input: ✖ Unrecognized key: "description"`; the model then retried a near-identical command without that field and succeeded.

Session resumes: main `0f3b38d0a81a`, review `c60734766dcf`.

## Validation

- `corepack pnpm exec prettier --check src/tools/bash.ts src/test-kernel/tools/BashTool.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/tools/BashTool.vitest.ts src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts`
- `git diff --check`
- `npm run lint` (0 errors; existing import-order warnings)
- `npm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only tolerance for an ignored field with a regression test; no change to command execution or approval behavior.
> 
> **Overview**
> Fixes validation failures when models include a harmless **`description`** alongside **`command`** on bash tool calls (previously rejected by `z.strictObject` as an unrecognized key).
> 
> **`BashInputSchema`** gains an optional, nullish **`description`** documented as human-readable purpose only; **`execute`** paths are unchanged and still pass **`input.command`** to **`executeCommand`**.
> 
> A **`BashTool`** unit test asserts a call with both fields succeeds and the shell receives only the command string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f759d8e88d51ad538e6a4b543e004dc723cc4c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->