### PR TITLE
[codex] Avoid duplicate subagent wait reports

### DIFF
--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -5,7 +5,14 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+import { ExecutionsTool } from '@tools/ExecutionsTool';
+
+import { createRecordingHost } from '../agent/progressTestUtils';
 
 const mocks = vi.hoisted(() => ({
   readConfig: vi.fn(),
@@ -33,8 +40,6 @@ vi.mock('@agent/storage', async () => {
     listExecutions: mocks.listExecutions,
   };
 });
-
-import { ExecutionsTool } from '@tools/ExecutionsTool';
 
 const config = {
   agent: 'chat',
@@ -104,7 +109,79 @@ describe('ExecutionsTool', () => {
     expect(result.error).toContain('Invalid input');
   });
 
-  it('does not duplicate auto-delivered subagent reports from wait summaries', async () => {
+  it('does not duplicate auto-delivered live subagent reports for the parent stream', async () => {
+    const explicit = createRecordingHost();
+    const session = new SessionHandle();
+    const executionId = 'abc123';
+    const parentStreamId = 'stream:parent-report-suppression' as StreamTabId;
+    const childStreamId = 'stream:child-report-suppression' as StreamTabId;
+    const otherStreamId = 'stream:other-report-reader' as StreamTabId;
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'review',
+      'toolUse',
+      explicit.host,
+    );
+
+    try {
+      session.executions.trackAgentExecution(handle, {
+        status: STREAM_STATUS.WAITING,
+      });
+      mocks.readMeta.mockResolvedValue({
+        timestamp: '2026-06-15T09:36:02.345Z',
+        category: 'toolUse',
+        parentExecutionId: 'parent123',
+      });
+      mocks.readReport.mockResolvedValue(
+        '<subagent-result>full report</subagent-result>',
+      );
+
+      const parentWaitResult = await withRunContext(
+        createRunContext({
+          runtimeHost: explicit.host,
+          streamId: parentStreamId,
+          session,
+        }),
+        () =>
+          new ExecutionsTool().call({
+            path: `/executions/${executionId}`,
+            action: 'wait',
+          }),
+      );
+      const crossTreeWaitResult = await withRunContext(
+        createRunContext({
+          runtimeHost: explicit.host,
+          streamId: otherStreamId,
+          session,
+        }),
+        () =>
+          new ExecutionsTool().call({
+            path: `/executions/${executionId}`,
+            action: 'wait',
+          }),
+      );
+
+      expect(parentWaitResult.output).toContain(
+        'Result: delivered automatically to this parent stream as a follow-up message.',
+      );
+      expect(parentWaitResult.output).toContain('/executions/abc123/report');
+      expect(parentWaitResult.output).not.toContain(
+        '<subagent-result>full report',
+      );
+      expect(crossTreeWaitResult.output).toContain(
+        '<subagent-result>full report</subagent-result>',
+      );
+      expect(crossTreeWaitResult.output).not.toContain(
+        'delivered automatically',
+      );
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('keeps completed wait summary reports inline when parent delivery cannot be confirmed', async () => {
     mocks.readMeta.mockResolvedValue({
       timestamp: '2026-06-15T09:36:02.345Z',
       category: 'toolUse',
@@ -124,10 +201,9 @@ describe('ExecutionsTool', () => {
     });
 
     expect(waitResult.output).toContain(
-      'Result: delivered automatically as a follow-up message.',
+      '<subagent-result>full report</subagent-result>',
     );
-    expect(waitResult.output).toContain('/executions/abc123/report');
-    expect(waitResult.output).not.toContain('<subagent-result>full report');
+    expect(waitResult.output).not.toContain('delivered automatically');
     expect(reportResult.output).toBe(
       '<subagent-result>full report</subagent-result>',
     );

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -9,6 +9,10 @@ import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 const mocks = vi.hoisted(() => ({
   readConfig: vi.fn(),
+  readMeta: vi.fn(),
+  readChildren: vi.fn(),
+  readTodos: vi.fn(),
+  readReport: vi.fn(),
   readWorkspaceFiles: vi.fn(),
   listExecutions: vi.fn(),
 }));
@@ -20,6 +24,10 @@ vi.mock('@agent/storage', async () => {
     ...actual,
     getExecutionStore: vi.fn(() => ({
       readConfig: mocks.readConfig,
+      readMeta: mocks.readMeta,
+      readChildren: mocks.readChildren,
+      readTodos: mocks.readTodos,
+      readReport: mocks.readReport,
       readWorkspaceFiles: mocks.readWorkspaceFiles,
     })),
     listExecutions: mocks.listExecutions,
@@ -54,6 +62,10 @@ describe('ExecutionsTool', () => {
     initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
     vi.clearAllMocks();
     mocks.listExecutions.mockResolvedValue([]);
+    mocks.readMeta.mockResolvedValue(null);
+    mocks.readChildren.mockResolvedValue([]);
+    mocks.readTodos.mockResolvedValue([]);
+    mocks.readReport.mockResolvedValue(null);
     mocks.readWorkspaceFiles.mockResolvedValue([]);
   });
 
@@ -90,6 +102,35 @@ describe('ExecutionsTool', () => {
 
     expect(result.isError).toBe(true);
     expect(result.error).toContain('Invalid input');
+  });
+
+  it('does not duplicate auto-delivered subagent reports from wait summaries', async () => {
+    mocks.readMeta.mockResolvedValue({
+      timestamp: '2026-06-15T09:36:02.345Z',
+      category: 'toolUse',
+      parentExecutionId: 'parent123',
+    });
+    mocks.readConfig.mockResolvedValue(config);
+    mocks.readReport.mockResolvedValue(
+      '<subagent-result>full report</subagent-result>',
+    );
+
+    const waitResult = await new ExecutionsTool().call({
+      path: '/executions/abc123',
+      action: 'wait',
+    });
+    const reportResult = await new ExecutionsTool().call({
+      path: '/executions/abc123/report',
+    });
+
+    expect(waitResult.output).toContain(
+      'Result: delivered automatically as a follow-up message.',
+    );
+    expect(waitResult.output).toContain('/executions/abc123/report');
+    expect(waitResult.output).not.toContain('<subagent-result>full report');
+    expect(reportResult.output).toBe(
+      '<subagent-result>full report</subagent-result>',
+    );
   });
 
   it('lists and reads persisted workspace files for tool-use executions', async () => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -30,7 +30,11 @@ import { currentSession } from '@agent/runtime/SessionHandle';
 
 // Local imports - utils
 import { toErrorMessage } from '@common/errors';
-import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
+import {
+  ExecutionIdSchema,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import {
   EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
   EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
@@ -184,23 +188,25 @@ const normalizeExecutionsToolInput = (input: unknown): unknown => {
   return { ...record, timeout: normalizeWaitTimeout(timeout) };
 };
 
-function isToolUseSubagentHandle(handle: unknown): boolean {
+function isCallerParentOfToolUseSubagent(
+  handle: unknown,
+  callerStreamId: StreamTabId | undefined,
+): boolean {
   return (
+    callerStreamId != null &&
     handle instanceof AgentExecutionHandle &&
     handle.category === 'toolUse' &&
-    handle.parentStreamId !== handle.childStreamId
+    handle.parentStreamId !== handle.childStreamId &&
+    handle.parentStreamId === callerStreamId
   );
 }
 
-function shouldSuppressAutoDeliveredSubagentReport(input: {
-  readonly options: ExecutionSummaryOptions;
-  readonly category: string | undefined;
-  readonly parentExecutionId: string | undefined;
-  readonly handle?: unknown;
-}): boolean {
-  if (!input.options.suppressAutoDeliveredSubagentReport) return false;
-  if (input.handle) return isToolUseSubagentHandle(input.handle);
-  return input.category === 'toolUse' && input.parentExecutionId != null;
+function shouldSuppressAutoDeliveredSubagentReport(
+  options: ExecutionSummaryOptions,
+  handle: unknown,
+): boolean {
+  if (!options.suppressAutoDeliveredSubagentReport) return false;
+  return isCallerParentOfToolUseSubagent(handle, tryUseRunContext()?.streamId);
 }
 
 export class ExecutionsTool extends defineTool({
@@ -485,12 +491,10 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         todos,
         report,
         {
-          suppressReport: shouldSuppressAutoDeliveredSubagentReport({
+          suppressReport: shouldSuppressAutoDeliveredSubagentReport(
             options,
-            category: handle.category,
-            parentExecutionId: meta?.parentExecutionId,
             handle,
-          }),
+          ),
         },
       );
 
@@ -549,11 +553,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       todos,
       report,
       {
-        suppressReport: shouldSuppressAutoDeliveredSubagentReport({
-          options,
-          category,
-          parentExecutionId: meta?.parentExecutionId,
-        }),
+        suppressReport: false,
       },
     );
 
@@ -582,7 +582,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     if (report && options.suppressReport) {
       lines.push(
         '',
-        `Result: delivered automatically as a follow-up message. Use /executions/${executionId}/report to read the persisted report explicitly.`,
+        `Result: delivered automatically to this parent stream as a follow-up message. Use /executions/${executionId}/report to read the persisted report explicitly.`,
       );
     } else if (report) {
       lines.push('', 'Result:', report);

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -154,6 +154,10 @@ const ExecutionsToolInputSchema = z.strictObject({
 
 export type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
 
+interface ExecutionSummaryOptions {
+  readonly suppressAutoDeliveredSubagentReport?: boolean;
+}
+
 const normalizeWaitTimeout = (timeout: number | null | undefined): number =>
   clamp(
     timeout ?? EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
@@ -179,6 +183,25 @@ const normalizeExecutionsToolInput = (input: unknown): unknown => {
 
   return { ...record, timeout: normalizeWaitTimeout(timeout) };
 };
+
+function isToolUseSubagentHandle(handle: unknown): boolean {
+  return (
+    handle instanceof AgentExecutionHandle &&
+    handle.category === 'toolUse' &&
+    handle.parentStreamId !== handle.childStreamId
+  );
+}
+
+function shouldSuppressAutoDeliveredSubagentReport(input: {
+  readonly options: ExecutionSummaryOptions;
+  readonly category: string | undefined;
+  readonly parentExecutionId: string | undefined;
+  readonly handle?: unknown;
+}): boolean {
+  if (!input.options.suppressAutoDeliveredSubagentReport) return false;
+  if (input.handle) return isToolUseSubagentHandle(input.handle);
+  return input.category === 'toolUse' && input.parentExecutionId != null;
+}
 
 export class ExecutionsTool extends defineTool({
   name: 'executions',
@@ -255,7 +278,9 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
           executionId,
           normalizeWaitTimeout(input.timeout),
         );
-      return this.showSummary(executionId);
+      return this.showSummary(executionId, {
+        suppressAutoDeliveredSubagentReport: input.action === 'wait',
+      });
     }
 
     switch (resource) {
@@ -419,7 +444,10 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     };
   }
 
-  private async showSummary(executionId: ExecutionId): Promise<ToolResult> {
+  private async showSummary(
+    executionId: ExecutionId,
+    options: ExecutionSummaryOptions = {},
+  ): Promise<ToolResult> {
     // Check in-memory handle first (free) — running executions have everything we need
     const handle = currentSession().executions.getHandle(executionId);
 
@@ -456,6 +484,14 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         children,
         todos,
         report,
+        {
+          suppressReport: shouldSuppressAutoDeliveredSubagentReport({
+            options,
+            category: handle.category,
+            parentExecutionId: meta?.parentExecutionId,
+            handle,
+          }),
+        },
       );
 
       return { output: lines.join('\n') };
@@ -512,6 +548,13 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       children,
       todos,
       report,
+      {
+        suppressReport: shouldSuppressAutoDeliveredSubagentReport({
+          options,
+          category,
+          parentExecutionId: meta?.parentExecutionId,
+        }),
+      },
     );
 
     return { output: lines.join('\n') };
@@ -528,6 +571,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     children: ChildRecord[],
     todos: TodoEntry[],
     report: string | null,
+    options: { readonly suppressReport?: boolean } = {},
   ): Promise<void> {
     await this.appendChildren(lines, children);
 
@@ -535,7 +579,12 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       lines.push('', ...formatTodoSection(todos));
     }
 
-    if (report) {
+    if (report && options.suppressReport) {
+      lines.push(
+        '',
+        `Result: delivered automatically as a follow-up message. Use /executions/${executionId}/report to read the persisted report explicitly.`,
+      );
+    } else if (report) {
       lines.push('', 'Result:', report);
     }
 


### PR DESCRIPTION
## Summary

Fixes #6042.

- suppresses the full persisted report from `executions` summaries when `action: "wait"` is used on a tool-use subagent
- keeps `/executions/{id}/report` as the explicit path for rereading the persisted report
- adds a regression test covering the wait-summary behavior and the report path

## Root Cause

Tool-use subagent results are delivered automatically as follow-up messages, but `executions action="wait"` also returned the full persisted report in the same parent turn. When the async follow-up arrived, the parent history contained the same `<subagent-result>` twice.

## Dogfood Evidence

In a real PTY run, `texra-local orchestrate` launched the Mathematician team, solved `/private/tmp/texra-dogfood-orchestrate-team-20260615/problem.md`, and approved one `review` subagent. The parent history `d7a4cc4a42eb` showed the same child report from `c3769c5cd63d` both as an `executions` tool result and as an async follow-up.

## Validation

- `corepack pnpm vitest run src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run texra-local:build`
- `npm run compile:fast`
- `npm run lint` (passes with existing warnings)
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted change to executions tool output formatting for wait summaries; no auth, persistence, or delivery pipeline changes beyond avoiding duplicate text in parent history.
> 
> **Overview**
> Fixes duplicate `<subagent-result>` content in parent conversation when a tool-use subagent finishes: auto follow-up delivery and `executions` `action: "wait"` both used to embed the full persisted report.
> 
> **`ExecutionsTool`** now passes `suppressAutoDeliveredSubagentReport` when returning a summary after `wait`. For a **live** execution where the caller stream is the parent of a tool-use subagent (`parentStreamId` matches run context), the summary omits the full report and instead notes that the result was delivered automatically, with a pointer to `/executions/{id}/report`. Plain `view`, completed runs (no in-memory handle), and waits from other streams still include the full report inline; `/executions/{id}/report` is unchanged.
> 
> Regression tests cover parent vs cross-tree wait output and the completed/no-handle fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf30a2994bcbc3e4d608337cb20d04579ee8d76c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->