### PR TITLE
[codex] Bundle CLI skills in built package

### DIFF
--- a/packages/cli/scripts/copy-resources.mjs
+++ b/packages/cli/scripts/copy-resources.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const packageDir = path.resolve(scriptDir, '..');
 const source = path.resolve(packageDir, '../extension/resources');
+const repoRoot = path.resolve(packageDir, '../..');
 const target = path.resolve(packageDir, 'dist/resources');
 const runtimeResourceEntries = [
   'agents',
@@ -20,10 +21,13 @@ const runtimeResourceEntries = [
 ];
 
 await rm(target, { recursive: true, force: true });
-await Promise.all(
-  runtimeResourceEntries.map((entry) =>
+await Promise.all([
+  ...runtimeResourceEntries.map((entry) =>
     cp(path.join(source, entry), path.join(target, entry), {
       recursive: true,
     }),
   ),
-);
+  cp(path.join(repoRoot, 'skills'), path.join(target, 'skills'), {
+    recursive: true,
+  }),
+]);

--- a/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
@@ -87,7 +87,7 @@ export function skillsSelectWindow(args: {
   return computeSelectWindowSize({
     availableRows: args.availableRows,
     itemCount: args.itemCount,
-    chromeRows: args.hasIssues ? 6 : 5,
+    chromeRows: args.hasIssues ? 7 : 6,
   });
 }
 

--- a/src/skills/skillSources.ts
+++ b/src/skills/skillSources.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -21,15 +22,23 @@ export const INTEROP_SKILL_DIRS = [
 ] as const;
 
 function bundledSkillSources(resourcesPath: string): SkillSource[] {
+  const packagedSource = {
+    scope: 'bundled',
+    path: path.join(resourcesPath, 'skills'),
+    label: 'bundled',
+  } satisfies SkillSource;
+  if (existsSync(packagedSource.path)) return [packagedSource];
+
   return [
-    {
-      scope: 'bundled',
-      path: path.join(resourcesPath, 'skills'),
-      label: 'bundled',
-    },
+    packagedSource,
     {
       scope: 'bundled',
       path: path.resolve(resourcesPath, '../../..', 'skills'),
+      label: 'bundled source',
+    },
+    {
+      scope: 'bundled',
+      path: path.resolve(resourcesPath, '../../../..', 'skills'),
       label: 'bundled source',
     },
   ];

--- a/src/test-kernel/cli/CliSkills.vitest.mts
+++ b/src/test-kernel/cli/CliSkills.vitest.mts
@@ -49,8 +49,17 @@ afterEach(async () => {
 describe('CLI skills runtime', () => {
   it('resolves default, interop, and custom skill sources in precedence order', () => {
     const cwd = '/tmp/project';
-    const resourcesPath = '/tmp/resources';
-    const bundledSourcePath = path.resolve(resourcesPath, '../../..', 'skills');
+    const resourcesPath = '/tmp/repo/packages/cli/dist/resources';
+    const extensionBundledSourcePath = path.resolve(
+      resourcesPath,
+      '../../..',
+      'skills',
+    );
+    const cliDistBundledSourcePath = path.resolve(
+      resourcesPath,
+      '../../../..',
+      'skills',
+    );
     const sources = defaultSkillSources(
       {
         cwd,
@@ -74,8 +83,9 @@ describe('CLI skills runtime', () => {
       path.join(os.homedir(), '.claude', 'skills'),
       path.join(os.homedir(), '.codex', 'skills'),
       path.join(os.homedir(), '.gemini', 'skills'),
-      '/tmp/resources/skills',
-      bundledSourcePath,
+      '/tmp/repo/packages/cli/dist/resources/skills',
+      extensionBundledSourcePath,
+      cliDistBundledSourcePath,
     ]);
     expect(sources.map((source) => source.scope)).toEqual([
       'custom',
@@ -89,6 +99,7 @@ describe('CLI skills runtime', () => {
       'interop',
       'interop',
       'interop',
+      'bundled',
       'bundled',
       'bundled',
     ]);
@@ -105,6 +116,7 @@ describe('CLI skills runtime', () => {
       '.codex user',
       '.gemini user',
       'bundled',
+      'bundled source',
       'bundled source',
     ]);
     expect(

--- a/src/test-kernel/cli/SkillsListForm.vitest.mts
+++ b/src/test-kernel/cli/SkillsListForm.vitest.mts
@@ -101,13 +101,13 @@ describe('SkillsListForm helpers', () => {
         itemCount: 10,
         hasIssues: false,
       }),
-    ).toEqual({ maxVisibleItems: 3, showOverflow: true });
+    ).toEqual({ maxVisibleItems: 2, showOverflow: true });
     expect(
       skillsSelectWindow({
         availableRows: 10,
         itemCount: 10,
         hasIssues: true,
       }),
-    ).toEqual({ maxVisibleItems: 2, showOverflow: true });
+    ).toEqual({ maxVisibleItems: 1, showOverflow: true });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #6044.

- copy repo-root `skills/` into the CLI package resources as `dist/resources/skills`
- make bundled skill discovery prefer packaged skills when present, with source-tree fallbacks for development layouts
- reserve enough rows in the `/skills` TUI form so overflow is explicit instead of clipping a skill row

## Root Cause

The CLI runtime looked for bundled skills at `resources/skills`, but `packages/cli/scripts/copy-resources.mjs` never copied the repo-root `skills/` directory into the built CLI resources. In source checkouts, the fallback from `packages/cli/dist/resources` also walked up to `packages/skills` instead of repo-root `skills`.

## Validation

- `corepack pnpm prettier --check packages/cli/scripts/copy-resources.mjs packages/cli/src/chat/tui/forms/SkillsListForm.tsx src/skills/skillSources.ts src/test-kernel/cli/CliSkills.vitest.mts src/test-kernel/cli/SkillsListForm.vitest.mts`
- `git diff --check`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/CliSkills.vitest.mts src/test-kernel/skills/RuntimeSkills.vitest.mts src/test-kernel/cli/SkillsListForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli run build`
- `texra-local skills list --cwd /private/tmp/texra-live-chat-scout-20260615b`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-scout-20260615-skills-final skills-form`

## Dogfood Evidence

Before the fix, a real TTY `texra-local chat` session in an empty workspace showed `No discoverable skills found` for `/skills`. After the fix, the foreground `/skills` form lists the bundled skills and shows an explicit overflow marker (`... 4 more`) in the harness frame.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time resource copy and skill path resolution/TUI layout only; no auth or data-handling changes.
> 
> **Overview**
> Fixes bundled skills not appearing in installed/built CLI runs by **copying repo-root `skills/` into `dist/resources/skills`** during the CLI resource copy step.
> 
> **Skill discovery** now prefers the packaged `resources/skills` directory when it exists on disk; otherwise it keeps **dev-layout fallbacks** (including an extra relative path from `packages/cli/dist/resources` up to repo-root `skills`).
> 
> The **`/skills` TUI** reserves one more row of chrome (`chromeRows` 6/7 instead of 5/6) so long skill lists show an explicit overflow indicator instead of clipping a row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4de150670a7807380f1c6363344cb1a7f17f7d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->