### PR TITLE
[codex] Guide agents after command rejection

### DIFF
--- a/src/test-kernel/tools/WolframToolApproval.vitest.ts
+++ b/src/test-kernel/tools/WolframToolApproval.vitest.ts
@@ -101,4 +101,30 @@ describe('WolframTool approval', () => {
     });
     expect(execute).not.toHaveBeenCalled();
   });
+
+  it('tells the model not to retry after rejection without feedback', async () => {
+    const explicit = createRecordingHost();
+    const streamId = 'stream:wolfram-rejected-default' as StreamTabId;
+    const execute = vi.spyOn(wolframScriptUtils, 'executeWolframCode');
+
+    const result = withRunContext(
+      createRunContext({ runtimeHost: explicit.host, streamId }),
+      () => new WolframTool().call({ code: 'Factor[n^7 - n]' }),
+    );
+
+    const show = await waitForRecordedEvent(
+      explicit.events,
+      'showBashPermission',
+    );
+    await handleProgressViewBashApprovalAction({
+      requestId: show.payload.requestId,
+      action: 'reject',
+    });
+
+    await expect(result).resolves.toMatchObject({
+      isError: true,
+      userInstruction: expect.stringContaining('Do not retry'),
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
 });

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -29,6 +29,10 @@ export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
 
 export type BashApprovalAction = (typeof BASH_APPROVAL_ACTIONS)[number];
 
+const DEFAULT_BASH_REJECTION_INSTRUCTION =
+  'Do not retry this rejected command or another approval-gated shell command for the same check. ' +
+  'Continue without running it, use a non-shell method, or explain what approval would be needed.';
+
 export const bashApprovalController =
   createStreamApprovalController<BashApprovalResult>({
     rejectionResult: () => ({ accepted: false }),
@@ -164,6 +168,8 @@ export function buildBashApprovalRejectedResult(
   };
   if (feedback) {
     result.userInstruction = feedback;
+  } else {
+    result.userInstruction = DEFAULT_BASH_REJECTION_INSTRUCTION;
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- add a default model-facing instruction when a bash-style approval is rejected without explicit feedback
- cover Wolfram retries too, since Wolfram execution is approval-gated through `wolframscript`
- add a regression test for the Wolfram approval rejection path

Fixes #6047.

## Root cause
A plain rejection returned only `User rejected bash command: ...` as an error. The model received no explicit `userInstruction`, so in CLI dogfood the reviewer retried a near-identical shell-backed Wolfram command after rejection.

## Validation
- `corepack pnpm vitest run src/test-kernel/tools/WolframToolApproval.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/tools/WolframToolApproval.vitest.ts src/test-kernel/tools/BashTool.vitest.ts src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error payload shape on rejection paths; no execution or auth logic changes, with regression tests added.
> 
> **Overview**
> When a user rejects an approval-gated shell command **without** typing feedback, tool results now include a default **`userInstruction`** telling the model not to retry the same or similar approval-gated commands and to continue another way or explain what approval would be needed. Explicit rejection feedback still overrides this via **`userInstruction`** as before.
> 
> The behavior lives in **`buildBashApprovalRejectedResult`** in `bashApproval.ts`, so it applies to bash-style approval flows (including Wolfram’s **`wolframscript`** gate). A Wolfram approval test asserts the default instruction contains “Do not retry” when rejection has no feedback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc65ed60930d090f550adfce99ceac5f59b73187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->