### PR TITLE
Replace custom ANSI and HTTP status helpers with packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,6 +77,7 @@
     "react": "^19.2.7",
     "semver": "^7.8.4",
     "string-width": "^8.0.0",
+    "strip-ansi": "^7.2.0",
     "typescript": "^6.0.3",
     "wrap-ansi": "^10.0.0"
   }

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -1,8 +1,6 @@
-import {
-  ANSI_ESCAPE_START,
-  ansiEscapeEnd,
-  stripAnsiSequences,
-} from '@cli/runtime/ansiEscapes';
+import stripAnsi from 'strip-ansi';
+
+import { ANSI_ESCAPE_START, ansiEscapeEnd } from '@cli/runtime/ansiEscapes';
 import {
   LIVE_ELAPSED_STREAM_STATUSES,
   type StreamStatus,
@@ -25,7 +23,7 @@ function isInvisibleTranscriptChar(char: string | undefined): boolean {
 
 export function terminalVisibleTranscriptText(text: string): string {
   let out = '';
-  for (const char of stripAnsiSequences(text)) {
+  for (const char of stripAnsi(text)) {
     if (!isInvisibleTranscriptChar(char)) out += char;
   }
   return out;

--- a/packages/cli/src/chat/tui/render/ansiWrap.ts
+++ b/packages/cli/src/chat/tui/render/ansiWrap.ts
@@ -1,10 +1,7 @@
+import stripAnsi from 'strip-ansi';
 import wrapAnsi from 'wrap-ansi';
 
-import {
-  ANSI_ESCAPE_START,
-  ansiEscapeEnd,
-  stripAnsiSequences,
-} from '@cli/runtime/ansiEscapes';
+import { ANSI_ESCAPE_START, ansiEscapeEnd } from '@cli/runtime/ansiEscapes';
 
 const MIN_WRAP_WIDTH = 1;
 
@@ -39,7 +36,7 @@ function markdownContinuationPrefix(line: string):
       width: number;
     }
   | undefined {
-  const plain = stripAnsiSequences(line);
+  const plain = stripAnsi(line);
   const list = plain.match(/^((?:│ )*)( {2}(?:•|\d+[.)]) )/);
   if (list) {
     const quote = list[1] ?? '';

--- a/packages/cli/src/chat/tui/render/ansiWrap.ts
+++ b/packages/cli/src/chat/tui/render/ansiWrap.ts
@@ -1,9 +1,17 @@
 import stripAnsi from 'strip-ansi';
 import wrapAnsi from 'wrap-ansi';
 
-import { ANSI_ESCAPE_START, ansiEscapeEnd } from '@cli/runtime/ansiEscapes';
+import {
+  ANSI_C1_CSI_START,
+  ANSI_ESCAPE_START,
+  ansiEscapeEnd,
+} from '@cli/runtime/ansiEscapes';
 
 const MIN_WRAP_WIDTH = 1;
+
+function isAnsiControlStart(char: string | undefined): boolean {
+  return char === ANSI_ESCAPE_START || char === ANSI_C1_CSI_START;
+}
 
 function splitRawAtVisiblePrefix(
   line: string,
@@ -12,14 +20,14 @@ function splitRawAtVisiblePrefix(
   let visible = 0;
   let index = 0;
   while (index < line.length && visible < visiblePrefixLength) {
-    if (line[index] === ANSI_ESCAPE_START) {
+    if (isAnsiControlStart(line[index])) {
       index = ansiEscapeEnd(line, index);
     } else {
       visible += 1;
       index += 1;
     }
   }
-  while (line[index] === ANSI_ESCAPE_START) {
+  while (isAnsiControlStart(line[index])) {
     index = ansiEscapeEnd(line, index);
   }
   return {

--- a/packages/cli/src/commands/_helpers/dispatch/usage.ts
+++ b/packages/cli/src/commands/_helpers/dispatch/usage.ts
@@ -1,8 +1,8 @@
 import { renderUsage } from 'citty';
+import stripAnsi from 'strip-ansi';
 
 import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
 import { readCliAmbientState } from '@cli/runtime/cliContext';
-import { stripAnsiSequences } from '@cli/runtime/ansiEscapes';
 
 import { resolveCommandMeta, type AnyCommand } from './commandTree';
 import { knownGlobalFlagTokenCount } from './argTokens';
@@ -104,7 +104,7 @@ async function renderUsageWithSections(
     ? `${usage}\n${sections.map(formatUsageSection).join('\n\n')}`
     : usage;
   return usageColorEnabled(stream) === false
-    ? stripAnsiSequences(usageWithSections)
+    ? stripAnsi(usageWithSections)
     : usageWithSections;
 }
 

--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -1,4 +1,5 @@
 export const ANSI_ESCAPE_START = String.fromCharCode(27);
+export const ANSI_C1_CSI_START = String.fromCharCode(0x9b);
 
 const ANSI_BEL = String.fromCharCode(7);
 const ANSI_C1_STRING_TERMINATOR = String.fromCharCode(0x9c);
@@ -15,18 +16,23 @@ function isAnsiIntermediateByte(char: string | undefined): boolean {
   return char === '(' || char === ')' || char === '#';
 }
 
+function csiEscapeEnd(text: string, start: number): number {
+  for (let end = start; end < text.length; end += 1) {
+    const code = text.charCodeAt(end);
+    if (code >= CSI_FINAL_BYTE_MIN && code <= CSI_FINAL_BYTE_MAX) {
+      return end + 1;
+    }
+  }
+  return text.length;
+}
+
 export function ansiEscapeEnd(text: string, index: number): number {
+  if (text[index] === ANSI_C1_CSI_START) return csiEscapeEnd(text, index + 1);
   if (text[index] !== ANSI_ESCAPE_START) return index;
 
   const next = text[index + 1];
   if (next === '[') {
-    for (let end = index + 2; end < text.length; end += 1) {
-      const code = text.charCodeAt(end);
-      if (code >= CSI_FINAL_BYTE_MIN && code <= CSI_FINAL_BYTE_MAX) {
-        return end + 1;
-      }
-    }
-    return text.length;
+    return csiEscapeEnd(text, index + 2);
   }
 
   if (next === ']') {

--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -9,17 +9,9 @@ const CSI_FINAL_BYTE_MAX = 0x7e; // '~'
 /** An OSC sequence (`ESC ]`) ends with BEL or the two-char ST (`ESC \`). */
 const OSC_STRING_TERMINATOR = `${ANSI_ESCAPE_START}\\`;
 
+/** ISO-2022 intermediate bytes for charset/line-size designators (`ESC ( 0`, `ESC # 3`, etc.). */
 function isAnsiIntermediateByte(char: string | undefined): boolean {
-  return (
-    char === '[' ||
-    char === ']' ||
-    char === '\\' ||
-    char === '(' ||
-    char === ')' ||
-    char === '#' ||
-    char === ';' ||
-    char === '?'
-  );
+  return char === '(' || char === ')' || char === '#';
 }
 
 export function ansiEscapeEnd(text: string, index: number): number {

--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -9,6 +9,19 @@ const CSI_FINAL_BYTE_MAX = 0x7e; // '~'
 /** An OSC sequence (`ESC ]`) ends with BEL or the two-char ST (`ESC \`). */
 const OSC_STRING_TERMINATOR = `${ANSI_ESCAPE_START}\\`;
 
+function isAnsiIntermediateByte(char: string | undefined): boolean {
+  return (
+    char === '[' ||
+    char === ']' ||
+    char === '\\' ||
+    char === '(' ||
+    char === ')' ||
+    char === '#' ||
+    char === ';' ||
+    char === '?'
+  );
+}
+
 export function ansiEscapeEnd(text: string, index: number): number {
   if (text[index] !== ANSI_ESCAPE_START) return index;
 
@@ -29,6 +42,12 @@ export function ansiEscapeEnd(text: string, index: number): number {
     if (belEnd === -1 && stEnd === -1) return text.length;
     if (belEnd !== -1 && (stEnd === -1 || belEnd < stEnd)) return belEnd + 1;
     return stEnd + OSC_STRING_TERMINATOR.length;
+  }
+
+  if (isAnsiIntermediateByte(next)) {
+    let end = index + 1;
+    while (end < text.length && isAnsiIntermediateByte(text[end])) end += 1;
+    return Math.min(end + 1, text.length);
   }
 
   return Math.min(index + 2, text.length);

--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -1,5 +1,3 @@
-import stripAnsi from 'strip-ansi';
-
 export const ANSI_ESCAPE_START = String.fromCharCode(27);
 
 const ANSI_BEL = String.fromCharCode(7);
@@ -34,8 +32,4 @@ export function ansiEscapeEnd(text: string, index: number): number {
   }
 
   return Math.min(index + 2, text.length);
-}
-
-export function stripAnsiSequences(text: string): string {
-  return stripAnsi(text);
 }

--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -1,6 +1,7 @@
 export const ANSI_ESCAPE_START = String.fromCharCode(27);
 
 const ANSI_BEL = String.fromCharCode(7);
+const ANSI_C1_STRING_TERMINATOR = String.fromCharCode(0x9c);
 
 /** A CSI sequence (`ESC [`) ends at its final byte, in the range `@`–`~`. */
 const CSI_FINAL_BYTE_MIN = 0x40; // '@'
@@ -31,9 +32,13 @@ export function ansiEscapeEnd(text: string, index: number): number {
   if (next === ']') {
     const belEnd = text.indexOf(ANSI_BEL, index + 2);
     const stEnd = text.indexOf(OSC_STRING_TERMINATOR, index + 2);
-    if (belEnd === -1 && stEnd === -1) return text.length;
-    if (belEnd !== -1 && (stEnd === -1 || belEnd < stEnd)) return belEnd + 1;
-    return stEnd + OSC_STRING_TERMINATOR.length;
+    const c1End = text.indexOf(ANSI_C1_STRING_TERMINATOR, index + 2);
+    const ends = [
+      belEnd === -1 ? undefined : belEnd + 1,
+      stEnd === -1 ? undefined : stEnd + OSC_STRING_TERMINATOR.length,
+      c1End === -1 ? undefined : c1End + 1,
+    ].filter((end): end is number => end !== undefined);
+    return ends.length === 0 ? text.length : Math.min(...ends);
   }
 
   if (isAnsiIntermediateByte(next)) {

--- a/packages/cli/src/runtime/ansiEscapes.ts
+++ b/packages/cli/src/runtime/ansiEscapes.ts
@@ -1,3 +1,5 @@
+import stripAnsi from 'strip-ansi';
+
 export const ANSI_ESCAPE_START = String.fromCharCode(27);
 
 const ANSI_BEL = String.fromCharCode(7);
@@ -35,14 +37,5 @@ export function ansiEscapeEnd(text: string, index: number): number {
 }
 
 export function stripAnsiSequences(text: string): string {
-  let stripped = '';
-  for (let index = 0; index < text.length; ) {
-    if (text[index] === ANSI_ESCAPE_START) {
-      index = ansiEscapeEnd(text, index);
-      continue;
-    }
-    stripped += text[index];
-    index += 1;
-  }
-  return stripped;
+  return stripAnsi(text);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,6 +438,9 @@ importers:
       string-width:
         specifier: ^8.0.0
         version: 8.2.1
+      strip-ansi:
+        specifier: ^7.2.0
+        version: 7.2.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -1,5 +1,7 @@
 /** Retry state management: Node retry config, error tracking, and retryable node base class. */
 
+import { StatusCodes } from 'http-status-codes';
+
 import { Node, type NonIterableObject } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -13,7 +15,6 @@ import {
   toErrorMessage,
 } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
-import { StatusCodes } from 'http-status-codes';
 import { STREAM_STATUS, type RetryErrorInfo } from '@shared/schemas';
 import { getConfig } from '@utils/config/configUtils';
 

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -13,6 +13,7 @@ import {
   toErrorMessage,
 } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
+import { StatusCodes } from 'http-status-codes';
 import { STREAM_STATUS, type RetryErrorInfo } from '@shared/schemas';
 import { getConfig } from '@utils/config/configUtils';
 
@@ -141,7 +142,7 @@ export abstract class RetryableInvocationNode<
       return result;
     } catch (retryErr) {
       const retryFormatted = normalizeProviderError(retryErr);
-      if (retryFormatted.isRelayError && retryFormatted.statusCode === 401) {
+      if (retryFormatted.isRelayError && retryFormatted.statusCode === StatusCodes.UNAUTHORIZED) {
         services.logger.debug(
           'Still 401 after token refresh, skipping auto-retries',
         );
@@ -183,7 +184,7 @@ export abstract class RetryableInvocationNode<
       const formatted = normalizeProviderError(err);
       if (
         formatted.isRelayError &&
-        formatted.statusCode === 401 &&
+        formatted.statusCode === StatusCodes.UNAUTHORIZED &&
         !this._hasAttemptedTokenRefresh
       ) {
         return this.attemptRelay401Recovery(err, operation);
@@ -205,7 +206,7 @@ export abstract class RetryableInvocationNode<
     if (formatted.isCredentialExhausted) return false;
     if (!formatted.userRetryable) return false;
     const code = formatted.statusCode;
-    return code !== 401 && code !== 403;
+    return code !== StatusCodes.UNAUTHORIZED && code !== StatusCodes.FORBIDDEN;
   }
 
   protected isBackgroundModeActive(): boolean {

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -142,7 +142,10 @@ export abstract class RetryableInvocationNode<
       return result;
     } catch (retryErr) {
       const retryFormatted = normalizeProviderError(retryErr);
-      if (retryFormatted.isRelayError && retryFormatted.statusCode === StatusCodes.UNAUTHORIZED) {
+      if (
+        retryFormatted.isRelayError &&
+        retryFormatted.statusCode === StatusCodes.UNAUTHORIZED
+      ) {
         services.logger.debug(
           'Still 401 after token refresh, skipping auto-retries',
         );

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -13,7 +13,6 @@
 // CLI can consume it.
 
 import escapeRegExp from 'escape-string-regexp';
-import he from 'he';
 
 const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
 const EMBEDDED_SUBAGENT_BLOCK_RE =
@@ -54,9 +53,15 @@ function elementBody(xml: string, tag: string): string | undefined {
 }
 
 // `<message>` bodies are escapeText()'d by the producer; decode for display.
+// `&amp;` last so an escaped `&lt;` never double-decodes.
 export function decodeXmlEntities(text: string): string {
   if (!text.includes('&')) return text;
-  return he.decode(text);
+  return text
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&');
 }
 
 function progressDetail(xml: string): string {

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -13,6 +13,7 @@
 // CLI can consume it.
 
 import escapeRegExp from 'escape-string-regexp';
+import he from 'he';
 
 const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
 const EMBEDDED_SUBAGENT_BLOCK_RE =
@@ -53,15 +54,9 @@ function elementBody(xml: string, tag: string): string | undefined {
 }
 
 // `<message>` bodies are escapeText()'d by the producer; decode for display.
-// `&amp;` last so an escaped `&lt;` never double-decodes.
 export function decodeXmlEntities(text: string): string {
   if (!text.includes('&')) return text;
-  return text
-    .replaceAll('&quot;', '"')
-    .replaceAll('&apos;', "'")
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
-    .replaceAll('&amp;', '&');
+  return he.decode(text);
 }
 
 function progressDetail(xml: string): string {

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -187,6 +187,7 @@ describe('renderAnsiMarkdown', () => {
     const plain = stripAnsi(out);
     const lines = plain.split('\n');
 
+    expect(lines.length).toBeGreaterThan(1);
     expect(lines[0]).toBe('│   • abcd');
     expect(lines.slice(1).every((line) => line.startsWith('│     '))).toBe(
       true,

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -198,6 +198,24 @@ describe('renderAnsiMarkdown', () => {
     }
   });
 
+  it('wraps quoted list prefixes after C1-ST OSC hyperlinks', () => {
+    const esc = String.fromCharCode(27);
+    const c1StringTerminator = String.fromCharCode(0x9c);
+    const link = `${esc}]8;;https://example.test${c1StringTerminator}`;
+    const out = wrapAnsiToWidth(`${link}│   • abcdef ghijkl mnopqr`, 10, true);
+    const plain = stripAnsi(out);
+    const lines = plain.split('\n');
+
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0]).toBe('│   • abcd');
+    expect(lines.slice(1).every((line) => line.startsWith('│     '))).toBe(
+      true,
+    );
+    for (const wrappedLine of lines) {
+      expect(displayWidthForTest(wrappedLine)).toBeLessThanOrEqual(10);
+    }
+  });
+
   it('styles heading text across inline code boundaries', () => {
     _resetAnsiMarkdownForTests();
     const out = renderAnsiMarkdown('## Use `git` correctly');

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -216,6 +216,28 @@ describe('renderAnsiMarkdown', () => {
     }
   });
 
+  it('wraps quoted list prefixes after C1 CSI styles', () => {
+    const c1Csi = String.fromCharCode(0x9b);
+    const out = wrapAnsiToWidth(
+      `${c1Csi}31m│ ${c1Csi}39m  • abcdef ghijkl mnopqr`,
+      10,
+      true,
+    );
+    const plain = stripAnsi(out);
+    const lines = plain.split('\n');
+
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0]).toBe('│   • abcd');
+    expect(lines.slice(1).every((line) => line.startsWith('│     '))).toBe(
+      true,
+    );
+    expect(plain).not.toContain('31m');
+    expect(plain).not.toContain('39m');
+    for (const wrappedLine of lines) {
+      expect(displayWidthForTest(wrappedLine)).toBeLessThanOrEqual(10);
+    }
+  });
+
   it('styles heading text across inline code boundaries', () => {
     _resetAnsiMarkdownForTests();
     const out = renderAnsiMarkdown('## Use `git` correctly');

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -180,6 +180,24 @@ describe('renderAnsiMarkdown', () => {
     }
   });
 
+  it('keeps quoted list prefixes aligned across ANSI charset escapes', () => {
+    const esc = String.fromCharCode(27);
+    const line = `${esc}(0│ ${esc}(B  • abcdef ghijkl mnopqr`;
+    const out = wrapAnsiToWidth(line, 10, true);
+    const plain = stripAnsi(out);
+    const lines = plain.split('\n');
+
+    expect(lines[0]).toBe('│   • abcd');
+    expect(lines.slice(1).every((line) => line.startsWith('│     '))).toBe(
+      true,
+    );
+    expect(plain).not.toContain('0│');
+    expect(plain).not.toContain('B  •');
+    for (const wrappedLine of lines) {
+      expect(displayWidthForTest(wrappedLine)).toBeLessThanOrEqual(10);
+    }
+  });
+
   it('styles heading text across inline code boundaries', () => {
     _resetAnsiMarkdownForTests();
     const out = renderAnsiMarkdown('## Use `git` correctly');

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  decodeXmlEntities,
   hasIncompleteEmbeddedSubagentFollowup,
   stripOrchestratorFollowup,
   summarizeEmbeddedSubagentFollowups,
@@ -171,6 +172,12 @@ describe('summarizeSubagentFollowup', () => {
     expect(summarizeSubagentFollowup(xml)).toBe(
       '✓ research completed\nKeep </response> literal & inspect <file>',
     );
+  });
+
+  it('decodes only XML entities in a single pass', () => {
+    expect(decodeXmlEntities('&quot;&apos;&lt;&gt;&amp;')).toBe('"\'<>&');
+    expect(decodeXmlEntities('&amp;lt;')).toBe('&lt;');
+    expect(decodeXmlEntities('&copy; &#39;')).toBe('&copy; &#39;');
   });
 
   it('previews long result responses without flooding the transcript', () => {

--- a/src/tools/github/githubClient.ts
+++ b/src/tools/github/githubClient.ts
@@ -112,7 +112,10 @@ export async function ghGet<T>(
       // the cached/unchanged response so callers can distinguish from 4xx.
       if (status === StatusCodes.NOT_MODIFIED) return { status: 304 };
 
-      if (status === StatusCodes.UNAUTHORIZED || status === StatusCodes.FORBIDDEN) {
+      if (
+        status === StatusCodes.UNAUTHORIZED ||
+        status === StatusCodes.FORBIDDEN
+      ) {
         // Primary rate limit: x-ratelimit-remaining hits 0 with an
         // epoch-seconds reset timestamp. Only applies when credentials were
         // otherwise valid.
@@ -126,7 +129,10 @@ export async function ghGet<T>(
         // "non-zero remaining". Without this branch we'd misclassify as an
         // auth error and stop the subscription permanently.
         const retryAfter = responseHeaders?.['retry-after'];
-        if (status === StatusCodes.FORBIDDEN && typeof retryAfter === 'string') {
+        if (
+          status === StatusCodes.FORBIDDEN &&
+          typeof retryAfter === 'string'
+        ) {
           const secs = Number(retryAfter);
           if (Number.isFinite(secs) && secs > 0) {
             throw new GitHubRateLimitError(
@@ -140,7 +146,11 @@ export async function ghGet<T>(
       }
       // Permanent HTTP failures — retrying won't help; surface immediately so
       // callers can halt rather than burning a slot for 24 h.
-      if (status === StatusCodes.NOT_FOUND || status === StatusCodes.GONE || status === StatusCodes.UNPROCESSABLE_ENTITY) {
+      if (
+        status === StatusCodes.NOT_FOUND ||
+        status === StatusCodes.GONE ||
+        status === StatusCodes.UNPROCESSABLE_ENTITY
+      ) {
         throw new GitHubPermanentError(
           status,
           `GitHub returned ${status}: ${extractApiMessage(responseData, err.message)}`,

--- a/src/tools/github/githubClient.ts
+++ b/src/tools/github/githubClient.ts
@@ -9,6 +9,7 @@
 
 import { request as octokitRequest } from '@octokit/request';
 import { RequestError } from '@octokit/request-error';
+import { StatusCodes } from 'http-status-codes';
 
 import { getGitHubToken } from './githubAuth';
 
@@ -109,9 +110,9 @@ export async function ghGet<T>(
 
       // 304 Not Modified comes through as an error in octokit. Surface it as
       // the cached/unchanged response so callers can distinguish from 4xx.
-      if (status === 304) return { status: 304 };
+      if (status === StatusCodes.NOT_MODIFIED) return { status: 304 };
 
-      if (status === 401 || status === 403) {
+      if (status === StatusCodes.UNAUTHORIZED || status === StatusCodes.FORBIDDEN) {
         // Primary rate limit: x-ratelimit-remaining hits 0 with an
         // epoch-seconds reset timestamp. Only applies when credentials were
         // otherwise valid.
@@ -125,7 +126,7 @@ export async function ghGet<T>(
         // "non-zero remaining". Without this branch we'd misclassify as an
         // auth error and stop the subscription permanently.
         const retryAfter = responseHeaders?.['retry-after'];
-        if (status === 403 && typeof retryAfter === 'string') {
+        if (status === StatusCodes.FORBIDDEN && typeof retryAfter === 'string') {
           const secs = Number(retryAfter);
           if (Number.isFinite(secs) && secs > 0) {
             throw new GitHubRateLimitError(
@@ -139,7 +140,7 @@ export async function ghGet<T>(
       }
       // Permanent HTTP failures — retrying won't help; surface immediately so
       // callers can halt rather than burning a slot for 24 h.
-      if (status === 404 || status === 410 || status === 422) {
+      if (status === StatusCodes.NOT_FOUND || status === StatusCodes.GONE || status === StatusCodes.UNPROCESSABLE_ENTITY) {
         throw new GitHubPermanentError(
           status,
           `GitHub returned ${status}: ${extractApiMessage(responseData, err.message)}`,

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -19,6 +19,7 @@
 // Third-party imports
 import axios, { AxiosError } from 'axios';
 import { type Work } from '@jamesgopsill/crossref-client';
+import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
 // Local imports - core
@@ -147,7 +148,7 @@ async function callZoteroConnector(
         headers: { 'Content-Type': 'application/json' },
       },
     );
-    if (response.status === 200 || response.status === 201) {
+    if (response.status === StatusCodes.OK || response.status === StatusCodes.CREATED) {
       return { status: 'success' };
     }
     return {

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -148,7 +148,10 @@ async function callZoteroConnector(
         headers: { 'Content-Type': 'application/json' },
       },
     );
-    if (response.status === StatusCodes.OK || response.status === StatusCodes.CREATED) {
+    if (
+      response.status === StatusCodes.OK ||
+      response.status === StatusCodes.CREATED
+    ) {
       return { status: 'success' };
     }
     return {

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -9,6 +9,7 @@
 
 // Third-party imports
 import axios from 'axios';
+import { StatusCodes } from 'http-status-codes';
 
 // Local imports - core
 import { toErrorMessage } from '@common/errors';
@@ -219,7 +220,7 @@ export async function callBetterBibTeX<T = unknown>(
             `Ask the user to start Zotero or verify the port (setting: texra.bib.zoteroPort).`,
         );
       }
-      if (error.response?.status === 404) {
+      if (error.response?.status === StatusCodes.NOT_FOUND) {
         throw new ToolError(
           'Better BibTeX plugin is not installed in Zotero. ' +
             'Ask the user to install it from https://retorque.re/zotero-better-bibtex/',


### PR DESCRIPTION
## Summary

This PR replaces two custom/common patterns with maintained packages while preserving XML follow-up decoding semantics:

1. ANSI escape sequence stripping now uses `strip-ansi` at CLI call sites.
2. HTTP status code literals now use named constants from `http-status-codes`.
3. XML entity decoding stays intentionally XML-only; the follow-up helper keeps the prior single-pass behavior and now has regression tests for nested/non-XML entities.

## Single source of truth

- ANSI escape stripping: delegated to `strip-ansi` where stripping is needed.
- ANSI boundary detection: `ansiEscapeEnd` remains in `ansiEscapes.ts` for prefix/split logic.
- HTTP status codes: centralized via `StatusCodes` constants.
- Subagent XML body decoding: `decodeXmlEntities` remains the XML-only decoder in `@shared/subagentFollowup`.

## Host impact

Extension: no intended behavior change.

Desktop: no intended behavior change.

CLI: ANSI stripping uses `strip-ansi`; subagent follow-up summaries preserve previous XML-only decoding behavior.

## Review follow-up

Cursor Bugbot flagged broader `he.decode` behavior. The latest commit restores XML-only decoding and adds tests for `&amp;lt;`, XML entities, and non-XML entities such as `&copy;` / `&#39;`.

## Validation

- `pnpm exec vitest run src/test-kernel/cli/SubagentFollowup.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings outside this patch)
- CI on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dependency swaps and named constants with targeted ANSI parsing fixes and tests; behavior is intended to stay the same aside from improved TUI wrap edge cases.
> 
> **Overview**
> Replaces the CLI’s custom **`stripAnsiSequences`** helper with the **`strip-ansi`** package for transcript visibility, usage rendering, and markdown wrap prefix detection, while keeping **`ansiEscapeEnd`** for ANSI-aware splitting.
> 
> **`ansiEscapes.ts`** drops the local stripper and extends boundary parsing for **C1 CSI** (`0x9b`), **C1 string terminators** on OSC sequences, and **ISO-2022 charset designators** (`ESC ( 0`, etc.); **`ansiWrap.ts`** treats those as control starts so quoted-list wrapping stays aligned. New **`AnsiMarkdown`** tests cover those escape shapes.
> 
> HTTP comparisons switch from numeric literals to **`StatusCodes`** from **`http-status-codes`** in agent retry logic (**401/403** auto-retry rules), the GitHub client (304/401/403/404/410/422), and Zotero connector/BBT success and 404 handling.
> 
> Adds regression tests for **`decodeXmlEntities`** (single-pass XML-only decoding: nested `&amp;lt;`, no HTML entities like `&copy;`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d41f37321ebb5f3cb960dd0deb38fd5f1d56514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->