### PR TITLE
[codex] Fix CLI list form row budgets

### DIFF
--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -48,8 +48,8 @@ export function modelSelectWindow(args: {
   readonly availableRows: number | undefined;
   readonly itemCount: number;
 }): SelectWindowSize {
-  // Border, title, description, and key hints are the irreducible chrome.
-  return computeSelectWindowSize({ ...args, chromeRows: 5 });
+  // Border, title, description, footer spacer, and key hints are the chrome.
+  return computeSelectWindowSize({ ...args, chromeRows: 6 });
 }
 
 export function modelListDescription({
@@ -205,7 +205,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
           />
         </Box>
       )}
-      <Box>
+      <Box marginTop={1}>
         {props.selectable && items.length > 0 ? (
           <KeyHints
             hints={[

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -52,11 +52,11 @@ export function formatToolDescriptionForTui(tool: CliToolStatusRecord): string {
   ].join(' · ');
 }
 
-function toolsSelectWindow(args: {
+export function toolsSelectWindow(args: {
   readonly availableRows: number | undefined;
   readonly itemCount: number;
 }): SelectWindowSize {
-  return computeSelectWindowSize({ ...args, chromeRows: 5 });
+  return computeSelectWindowSize({ ...args, chromeRows: 6 });
 }
 
 export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {

--- a/src/test-kernel/cli/CliTools.vitest.mts
+++ b/src/test-kernel/cli/CliTools.vitest.mts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatToolDescriptionForTui } from '@cli/chat/tui/forms/ToolsListForm';
+import {
+  formatToolDescriptionForTui,
+  toolsSelectWindow,
+} from '@cli/chat/tui/forms/ToolsListForm';
 import {
   cliToolIds,
   findCliToolDef,
@@ -129,5 +132,22 @@ describe('CLI tools runtime', () => {
         }),
       ),
     ).toBe('coming soon · detected · not yet usable');
+  });
+});
+
+describe('CLI ToolsListForm row budget', () => {
+  it('reserves the full bordered form chrome before showing overflow', () => {
+    expect(toolsSelectWindow({ availableRows: 7, itemCount: 8 })).toEqual({
+      maxVisibleItems: 1,
+      showOverflow: false,
+    });
+    expect(toolsSelectWindow({ availableRows: 8, itemCount: 8 })).toEqual({
+      maxVisibleItems: 2,
+      showOverflow: false,
+    });
+    expect(toolsSelectWindow({ availableRows: 12, itemCount: 8 })).toEqual({
+      maxVisibleItems: 4,
+      showOverflow: true,
+    });
   });
 });

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -348,6 +348,10 @@ describe('CLI ModelListForm row budget', () => {
       showOverflow: false,
     });
     expect(modelSelectWindow({ availableRows: 7, itemCount: 8 })).toEqual({
+      maxVisibleItems: 1,
+      showOverflow: false,
+    });
+    expect(modelSelectWindow({ availableRows: 8, itemCount: 8 })).toEqual({
       maxVisibleItems: 2,
       showOverflow: false,
     });
@@ -355,7 +359,7 @@ describe('CLI ModelListForm row budget', () => {
 
   it('spends overflow rows only when the budget can fit them', () => {
     expect(modelSelectWindow({ availableRows: 12, itemCount: 8 })).toEqual({
-      maxVisibleItems: 5,
+      maxVisibleItems: 4,
       showOverflow: true,
     });
   });


### PR DESCRIPTION
## Summary
- reserve 6 chrome rows in `/model` and `/tools` list forms to match the bordered form layout
- add the missing `/model` footer spacer so its row budget matches the rendered chrome
- add row-budget coverage for the tools form and update model form expectations

## Root cause
`SkillsListForm` was corrected to reserve the full bordered form chrome, but the similar model and tools forms still reserved 5 rows. `/tools` already rendered the spacer row; `/model` needed the same footer spacing so the 6-row budget reflects the actual UI.

Closes #6046

## Validation
- `pnpm exec vitest run src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/CliTools.vitest.mts`
- `npm run typecheck`
- `npm run validate:tui -- --snapshot-dir /private/tmp/texra-tui-form-snapshots-20260615b model-form tools-form compact-model-form compact-tools-form`
- `npm run lint` (passes with existing import-order warnings outside this patch)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI layout and test-only exports; no auth, data, or runtime API behavior changes.
> 
> **Overview**
> Fixes **layout clipping on short terminals** for the `/model` and `/tools` slash forms by reserving **one more chrome row** when sizing the select list (6 instead of 5), matching the full bordered layout (including a **footer spacer** before key hints).
> 
> `ModelListForm` adds **`marginTop={1}`** above the key-hint row so the reserved budget matches what is rendered. `toolsSelectWindow` is **exported** so the same row-budget rules can be tested.
> 
> Vitest expectations for `modelSelectWindow` are updated, and new coverage asserts `toolsSelectWindow` behavior at 7, 8, and 12 available rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82fab9ba3cf373b5b03c466856f15a72fc238e56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->