### PR TITLE
Add safeParseJson helper for validated JSON parsing

### DIFF
--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -1,5 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 import yaml from 'yaml';
+import { z } from 'zod';
 
 import {
   type AgentSetting,
@@ -15,6 +16,7 @@ import {
 import { SUPABASE_CONFIG } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { ensureError, toErrorMessage } from '@common/errors/errorMessage';
+import { parseJsonWith } from '@common/parsing/safeParseJson';
 import * as logger from '@logger/logUtils';
 import { resolveToolDefinitions } from '@tools/registry';
 
@@ -43,12 +45,13 @@ interface RemoteAgentListRow {
   agent_category?: string | null;
 }
 
-interface RemoteAgentListQueryError {
-  code?: string;
-  message?: string;
-  details?: string;
-  hint?: string;
-}
+const RemoteAgentListQueryErrorSchema = z.object({
+  code: z.string().optional(),
+  message: z.string().optional(),
+  details: z.string().optional(),
+  hint: z.string().optional(),
+});
+type RemoteAgentListQueryError = z.infer<typeof RemoteAgentListQueryErrorSchema>;
 
 /**
  * True only for the pre-migration database shape where `remote_agents.tools`
@@ -265,11 +268,8 @@ function parseRemoteAgentListErrorBody(
   rawBody: string,
 ): RemoteAgentListQueryError {
   if (!rawBody) return {};
-  try {
-    return JSON.parse(rawBody) as RemoteAgentListQueryError;
-  } catch {
-    return { message: rawBody };
-  }
+  const result = parseJsonWith(rawBody, RemoteAgentListQueryErrorSchema);
+  return result.ok ? result.value : { message: rawBody };
 }
 
 /** Fetch and parse agent config from edge function. */

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -51,7 +51,9 @@ const RemoteAgentListQueryErrorSchema = z.object({
   details: z.string().optional(),
   hint: z.string().optional(),
 });
-type RemoteAgentListQueryError = z.infer<typeof RemoteAgentListQueryErrorSchema>;
+type RemoteAgentListQueryError = z.infer<
+  typeof RemoteAgentListQueryErrorSchema
+>;
 
 /**
  * True only for the pre-migration database shape where `remote_agents.tools`

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -46,10 +46,10 @@ interface RemoteAgentListRow {
 }
 
 const RemoteAgentListQueryErrorSchema = z.object({
-  code: z.string().optional(),
-  message: z.string().optional(),
-  details: z.string().optional(),
-  hint: z.string().optional(),
+  code: z.string().nullish(),
+  message: z.string().nullish(),
+  details: z.string().nullish(),
+  hint: z.string().nullish(),
 });
 type RemoteAgentListQueryError = z.infer<
   typeof RemoteAgentListQueryErrorSchema

--- a/src/common/parsing/safeParseJson.ts
+++ b/src/common/parsing/safeParseJson.ts
@@ -1,0 +1,50 @@
+// Third-party imports
+import { type ZodType } from 'zod';
+
+// Local imports
+import { ensureError } from '@common/errors/errorMessage';
+
+/**
+ * Outcome of a non-throwing JSON parse. Mirrors the shape of Zod's
+ * `safeParse` so call sites can branch on `ok` without try/catch.
+ */
+export type JsonParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: Error };
+
+/**
+ * Parse JSON text without throwing.
+ *
+ * Returns `{ ok: true, value }` with the parsed value typed as `unknown`
+ * (the honest type for untrusted text), or `{ ok: false, error }` with the
+ * `SyntaxError` raised by `JSON.parse`. Use this instead of a bare
+ * `JSON.parse(...)` wrapped in try/catch.
+ */
+export function safeParseJson(text: string): JsonParseResult<unknown> {
+  try {
+    return { ok: true, value: JSON.parse(text) as unknown };
+  } catch (error) {
+    return { ok: false, error: ensureError(error) };
+  }
+}
+
+/**
+ * Parse JSON text and validate the result against a Zod schema, without
+ * throwing. A parse failure or a schema mismatch both yield
+ * `{ ok: false, error }`; on success `value` is the validated, typed result.
+ *
+ * Prefer this over `JSON.parse(text) as T` whenever the text comes from an
+ * untrusted source (disk, network, IPC): the cast lies if the bytes don't
+ * match `T`, whereas this surfaces the mismatch as an error.
+ */
+export function parseJsonWith<T>(
+  text: string,
+  schema: ZodType<T>,
+): JsonParseResult<T> {
+  const parsed = safeParseJson(text);
+  if (!parsed.ok) return parsed;
+
+  const result = schema.safeParse(parsed.value);
+  if (result.success) return { ok: true, value: result.data };
+  return { ok: false, error: result.error };
+}

--- a/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
@@ -9,7 +9,9 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 function installRemoteAgentListClient(
   ...results: Array<{
     data: unknown[] | null;
-    error: { code?: string; message?: string } | null;
+    error: Partial<
+      Record<'code' | 'message' | 'details' | 'hint', string | null>
+    > | null;
   }>
 ): string[] {
   const selectedColumns: string[] = [];
@@ -100,6 +102,41 @@ describe('remote agent schema compatibility', () => {
 
     expect(agents).toHaveLength(1);
     expect(agents[0]?.name).toBe('legacy-agent');
+    expect(selectedColumns).toEqual([
+      'id, name, description, visibility, tools, agent_category',
+      'id, name, description, visibility, agent_category',
+    ]);
+  });
+
+  it('keeps the missing-tools fallback when PostgREST sends null details', async () => {
+    const selectedColumns = installRemoteAgentListClient(
+      {
+        data: null,
+        error: {
+          code: 'PGRST204',
+          message: 'tools',
+          details: null,
+          hint: null,
+        },
+      },
+      {
+        data: [
+          {
+            id: 'agent-1',
+            name: 'nullable-error-agent',
+            description: 'Legacy row',
+            visibility: ['public'],
+            agent_category: null,
+          },
+        ],
+        error: null,
+      },
+    );
+
+    const agents = await RemoteAgentLoader.listRemoteAgents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0]?.name).toBe('nullable-error-agent');
     expect(selectedColumns).toEqual([
       'id, name, description, visibility, tools, agent_category',
       'id, name, description, visibility, agent_category',

--- a/src/test-kernel/common/SafeParseJson.vitest.ts
+++ b/src/test-kernel/common/SafeParseJson.vitest.ts
@@ -1,0 +1,46 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+// Local imports
+import { parseJsonWith, safeParseJson } from '@common/parsing/safeParseJson';
+
+describe('safeParseJson', () => {
+  it('returns the parsed value for valid JSON', () => {
+    const result = safeParseJson('{"a":1,"b":["x"]}');
+    expect(result).toEqual({ ok: true, value: { a: 1, b: ['x'] } });
+  });
+
+  it('returns an error instead of throwing for malformed JSON', () => {
+    const result = safeParseJson('{not json');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(Error);
+    }
+  });
+});
+
+describe('parseJsonWith', () => {
+  const schema = z.object({
+    code: z.string().optional(),
+    message: z.string().optional(),
+  });
+
+  it('parses and validates against the schema', () => {
+    const result = parseJsonWith('{"code":"E1","extra":true}', schema);
+    expect(result).toEqual({ ok: true, value: { code: 'E1' } });
+  });
+
+  it('fails when the parsed value does not match the schema', () => {
+    const result = parseJsonWith('"just a string"', schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(z.ZodError);
+    }
+  });
+
+  it('fails on malformed JSON without throwing', () => {
+    const result = parseJsonWith('{nope', schema);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/test-kernel/utils/files/RelativeFSJson.vitest.ts
+++ b/src/test-kernel/utils/files/RelativeFSJson.vitest.ts
@@ -6,6 +6,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import { z } from 'zod';
 
 // Local imports - test support
 import { createFakePlatform } from '@test/support/FakePlatform';
@@ -62,5 +63,34 @@ describe('RelativeFS JSON helpers', () => {
     const result = await TestRelativeFS.readJson<typeof payload>('sample.json');
 
     assert.deepStrictEqual(result, payload);
+  });
+
+  it('validates readJson results with a schema', async () => {
+    await TestRelativeFS.writeJson('typed.json', {
+      name: 'alpha',
+      extra: true,
+    });
+
+    const result = await TestRelativeFS.readJson(
+      'typed.json',
+      z.object({ name: z.string() }),
+    );
+
+    assert.deepStrictEqual(result, { name: 'alpha' });
+  });
+
+  it('preserves malformed JSON errors as the readJson cause', async () => {
+    await TestRelativeFS.write('broken.json', '{not json');
+
+    await assert.rejects(
+      () =>
+        TestRelativeFS.readJson('broken.json', z.object({ name: z.string() })),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /Failed to parse JSON from broken\.json:/);
+        assert.ok(error.cause instanceof SyntaxError);
+        return true;
+      },
+    );
   });
 });

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -46,6 +46,7 @@ export abstract class RelativeFS extends BaseFS {
     if (!result.ok) {
       throw new Error(
         `Failed to parse JSON from ${target}: ${result.error.message}`,
+        { cause: result.error },
       );
     }
     return result.value as T;

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -42,9 +42,7 @@ export abstract class RelativeFS extends BaseFS {
     schema?: ZodType<T>,
   ): Promise<T> {
     const raw = await this.read(target);
-    const result = schema
-      ? parseJsonWith(raw, schema)
-      : safeParseJson(raw);
+    const result = schema ? parseJsonWith(raw, schema) : safeParseJson(raw);
     if (!result.ok) {
       throw new Error(
         `Failed to parse JSON from ${target}: ${result.error.message}`,

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -1,10 +1,14 @@
 // Standard library imports
 import * as path from 'node:path';
 
-// Platform imports
-import { isFile } from './fsEntryType';
+// Third-party imports
+import { type ZodType } from 'zod';
+
+// Local imports
+import { parseJsonWith, safeParseJson } from '@common/parsing/safeParseJson';
 
 // Local imports - filesystem
+import { isFile } from './fsEntryType';
 import { BaseFS } from './baseFS';
 
 export abstract class RelativeFS extends BaseFS {
@@ -25,9 +29,28 @@ export abstract class RelativeFS extends BaseFS {
     await this.write(target, json);
   }
 
-  public static async readJson<T>(target: string): Promise<T> {
+  /**
+   * Read and parse a JSON file.
+   *
+   * Pass a Zod `schema` to validate the parsed value — the returned `T` is
+   * then guaranteed to match it. Without a schema the result is parsed but
+   * cast unchecked, so prefer the schema overload for untrusted files.
+   * Either way a malformed file throws a descriptive error naming the target.
+   */
+  public static async readJson<T>(
+    target: string,
+    schema?: ZodType<T>,
+  ): Promise<T> {
     const raw = await this.read(target);
-    return JSON.parse(raw) as T;
+    const result = schema
+      ? parseJsonWith(raw, schema)
+      : safeParseJson(raw);
+    if (!result.ok) {
+      throw new Error(
+        `Failed to parse JSON from ${target}: ${result.error.message}`,
+      );
+    }
+    return result.value as T;
   }
 
   public static async cleanupOldFiles(


### PR DESCRIPTION
Introduce src/common/parsing/safeParseJson.ts with two non-throwing entry points:
- safeParseJson(text): parse only, value typed as unknown
- parseJsonWith(text, schema): parse + Zod-validate

Migrate the two blind-cast sites that trusted untrusted bytes:
- RelativeFS.readJson now accepts an optional Zod schema for validated reads and throws a descriptive error (naming the file) on malformed JSON instead of a bare SyntaxError. Back-compatible: existing callers without a schema keep the same return type.
- RemoteAgentLoader validates the list error body against a schema (interface converted to a z.infer-derived type) instead of casting, so a non-object body falls back cleanly rather than lying about its type.

https://claude.ai/code/session_01E177U3DqhAyGivNYhgh5mU

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing hardening with backward-compatible `readJson` and clearer remote list error handling; no auth or data-model changes.
> 
> **Overview**
> Adds **`safeParseJson`** and **`parseJsonWith`** in `@common/parsing/safeParseJson` so untrusted JSON is parsed without try/catch and can be validated with Zod via an `{ ok, value | error }` result shape.
> 
> **`RelativeFS.readJson`** now routes through those helpers: callers can pass an optional Zod schema for validated reads, and malformed JSON throws an error that names the file and chains the underlying parse failure. Existing callers without a schema keep the same API.
> 
> **`RemoteAgentLoader`** replaces a blind `JSON.parse` cast on PostgREST list error bodies with **`RemoteAgentListQueryErrorSchema`** and `parseJsonWith`, so non-object bodies fall back to `{ message: rawBody }` instead of lying about the shape. A test covers the legacy missing-`tools` column fallback when `details`/`hint` are null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea0f239b682052e87083ad0342ce55814c268ccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->