### PR TITLE
[codex] Suppress duplicate subagent result echoes

### DIFF
--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -137,6 +137,10 @@ export function splitTranscriptEntries(
       pending.push(entry);
       continue;
     }
+    if (entry.pendingSubagentResultEcho) {
+      pending.push(entry);
+      continue;
+    }
     if (entry.role === 'process') {
       finalized.push(entry);
       continue;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -31,6 +31,8 @@ export interface ConversationEntry {
   readonly text: string;
   /** True while rendered assistant text is hiding an incomplete protocol block. */
   readonly pendingEmbeddedSubagentFollowup?: boolean;
+  /** True while an assistant subagent echo is waiting for canonical delivery. */
+  readonly pendingSubagentResultEcho?: boolean;
   /** True once the stream transitions to `WAITING`/`COMPLETED`. */
   readonly finalized: boolean;
   /** Populated only when `role === 'tool'`. */

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -15,6 +15,7 @@ import { normalizeToolUseData } from '@shared/toolUse';
 
 import {
   hasIncompleteEmbeddedSubagentFollowup,
+  readSubagentFollowupIdentity,
   summarizeEmbeddedSubagentFollowups,
   summarizeFollowupMessage,
 } from '@shared/subagentFollowup';
@@ -133,6 +134,7 @@ function entriesEqual(
     prev.text !== next.text ||
     prev.pendingEmbeddedSubagentFollowup !==
       next.pendingEmbeddedSubagentFollowup ||
+    prev.pendingSubagentResultEcho !== next.pendingSubagentResultEcho ||
     prev.finalized !== next.finalized
   ) {
     return false;
@@ -145,6 +147,16 @@ function entriesEqual(
     return prev.process === next.process;
   }
   return true;
+}
+
+function withSubagentEchoPending(
+  entry: ConversationEntry,
+  echo: SubagentResultRef | undefined,
+): ConversationEntry {
+  if (echo) return { ...entry, pendingSubagentResultEcho: true };
+  if (!entry.pendingSubagentResultEcho) return entry;
+  const { pendingSubagentResultEcho: _pending, ...rest } = entry;
+  return rest;
 }
 
 function logEntryRole(
@@ -258,7 +270,9 @@ function isSettledEntry(
       return entry.toolUse?.status === TOOL_USE_STATUS.COMPLETED;
     case 'assistant':
       return (
-        !entry.pendingEmbeddedSubagentFollowup && index < entries.length - 1
+        !entry.pendingEmbeddedSubagentFollowup &&
+        !entry.pendingSubagentResultEcho &&
+        index < entries.length - 1
       );
   }
 }
@@ -269,8 +283,10 @@ function isSettledEntry(
 // viewport would clip the round's earlier content). Only a contiguous
 // prefix is promoted: `<Static>` is append-only, so an entry must not
 // finalize while any earlier entry is still pending, or insertion order
-// would reverse. When the stream reaches a final status every remaining
-// entry settles, including the trailing live block.
+// would reverse. Pending subagent echoes stay retractable because a canonical
+// <subagent-result> can still arrive after parent exit; after stream finality,
+// later entries may still settle so an unresolved echo does not strand the
+// whole tail in the live pane.
 export function finalizeSettledPrefix(
   entries: readonly ConversationEntry[],
   streamFinal: boolean,
@@ -280,7 +296,11 @@ export function finalizeSettledPrefix(
   for (let index = 0; index < entries.length; index += 1) {
     const entry = entries[index];
     if (!entry || entry.finalized) continue;
-    if (!streamFinal && (sealed || !isSettledEntry(entry, index, entries))) {
+    if (entry.pendingSubagentResultEcho) {
+      if (!streamFinal) sealed = true;
+      continue;
+    }
+    if (sealed || (!streamFinal && !isSettledEntry(entry, index, entries))) {
       sealed = true;
       continue;
     }
@@ -309,7 +329,41 @@ type TranscriptCandidate = {
   readonly rendered: ConversationEntry;
   readonly sortSeq: number;
   readonly tieBreak: number;
+  readonly subagentEcho?: SubagentResultRef;
+  readonly subagentResult?: SubagentResultRef;
 };
+
+type SubagentResultRef = {
+  readonly id: string;
+};
+
+// Models sometimes echo a delegated result in the parent stream just before
+// the canonical <subagent-result> follow-up lands. Treat only whole entries
+// whose first visible line is the echo header as suppressible; mixed entries
+// with assistant prose before the header remain visible. There is no delimiter
+// for prose after the header, so the rest of the entry is the echoed block.
+const ASSISTANT_SUBAGENT_ECHO_RE =
+  /^\s*(?:👤\s*)?Subagent\s+[`'"]?[^`'"\n(]+?[`'"]?\s*\(([0-9a-f][-0-9a-f]*)\)\s+says:\s*\n[\s\S]*\S\s*$/i;
+
+function subagentResultRefFromLogEntry(
+  entry: StreamLogEntry,
+): SubagentResultRef | undefined {
+  if (entry.messageType !== MESSAGE_TYPES.USER_MESSAGE) return undefined;
+  const identity = readSubagentFollowupIdentity(entry.text);
+  if (identity?.kind !== 'result' || !identity.id) return undefined;
+  return { id: identity.id };
+}
+
+function subagentEchoRefFromLogEntry(
+  entry: StreamLogEntry,
+): SubagentResultRef | undefined {
+  if (entry.messageType !== MESSAGE_TYPES.MODEL_RESPONSE) return undefined;
+  const text = trimAssistantTranscriptLead(entry.text ?? '');
+  const match = ASSISTANT_SUBAGENT_ECHO_RE.exec(text);
+  const id = match?.[1];
+  if (!id) return undefined;
+  return { id };
+}
 
 function compareTranscriptCandidates(
   left: TranscriptCandidate,
@@ -333,6 +387,34 @@ function sortTranscriptCandidatesIfNeeded(
     }
   }
   return candidates;
+}
+
+function dropAssistantSubagentResultEchoes(
+  candidates: TranscriptCandidate[],
+): TranscriptCandidate[] {
+  let resultSeenAfter: Set<string> | undefined;
+  let filtered: TranscriptCandidate[] | undefined;
+
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    const candidate = candidates[index];
+    if (!candidate) continue;
+
+    const echo = candidate.subagentEcho;
+    if (echo && resultSeenAfter?.has(echo.id)) {
+      filtered ??= candidates.slice(index + 1);
+      continue;
+    }
+
+    if (filtered) filtered.unshift(candidate);
+
+    const result = candidate.subagentResult;
+    if (result) {
+      resultSeenAfter ??= new Set();
+      resultSeenAfter.add(result.id);
+    }
+  }
+
+  return filtered ?? candidates;
 }
 
 export function subscribeStreamLog(): () => void {
@@ -386,9 +468,16 @@ export function syncStreamLog(streamId: StreamTabId): void {
     const streamFinal = isFinalTranscriptStatus(slice.status);
     const logCandidates: TranscriptCandidate[] = [];
     for (const entry of responses) {
-      const rendered = renderLogEntry(entry, existing.get(entry.id));
-      if (!rendered) continue;
-      logCandidates.push({ rendered, sortSeq: entry.seqNo, tieBreak: 0 });
+      const baseRendered = renderLogEntry(entry, existing.get(entry.id));
+      if (!baseRendered) continue;
+      const subagentEcho = subagentEchoRefFromLogEntry(entry);
+      logCandidates.push({
+        rendered: withSubagentEchoPending(baseRendered, subagentEcho),
+        sortSeq: entry.seqNo,
+        tieBreak: 0,
+        subagentEcho,
+        subagentResult: subagentResultRefFromLogEntry(entry),
+      });
     }
     // The synthetic loop's duplicate check scans `logCandidates`, so synthetics
     // push into a copy; without synthetics the log list is used as-is.
@@ -413,9 +502,9 @@ export function syncStreamLog(streamId: StreamTabId): void {
       });
     }
 
-    const ordered = sortTranscriptCandidatesIfNeeded(candidates).map(
-      (candidate) => candidate.rendered,
-    );
+    const ordered = dropAssistantSubagentResultEchoes(
+      sortTranscriptCandidatesIfNeeded(candidates),
+    ).map((candidate) => candidate.rendered);
     // Promote the settled prefix only after sorting: "is there a later
     // entry" and Static append order are both defined on the final stream
     // order, not the per-entry render order.

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -193,6 +193,7 @@ export function finalizeAssistantTranscriptEntries(
     let changed = false;
     const entries = slice.entries.map((entry) => {
       if (entry.finalized) return entry;
+      if (entry.pendingSubagentResultEcho) return entry;
       if (entry.role !== 'assistant' && entry.role !== 'tool') return entry;
       changed = true;
       return { ...entry, finalized: true };

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -193,6 +193,29 @@ export function summarizeFollowupMessage(text: unknown): string {
   return summarizeSubagentFollowup(stripOrchestratorFollowup(text));
 }
 
+export type SubagentFollowupKind = 'progress' | 'result' | 'error';
+
+export interface SubagentFollowupIdentity {
+  readonly kind: SubagentFollowupKind;
+  readonly id: string | undefined;
+}
+
+export function readSubagentFollowupIdentity(
+  text: unknown,
+): SubagentFollowupIdentity | undefined {
+  const normalized = followupText(text);
+  if (normalized === undefined) return undefined;
+
+  const stripped = stripOrchestratorFollowup(normalized).trim();
+  const match = /^<subagent-(progress|result|error)\b/.exec(stripped);
+  if (!match) return undefined;
+
+  return {
+    kind: match[1] as SubagentFollowupKind,
+    id: attr(stripped, 'id'),
+  };
+}
+
 type IncompleteEmbeddedSubagentFollowup = {
   readonly index: number;
   readonly block: string;

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -149,6 +149,18 @@ describe('CLI conversation transcript splitting', () => {
     expect(waitingBeforeFinalize.pending).toEqual([]);
   });
 
+  it('keeps pending subagent echoes visible after waiting status', () => {
+    const echo = {
+      ...entry('a1', 'assistant', 'Subagent says...', false),
+      pendingSubagentResultEcho: true,
+    };
+
+    const split = splitTranscriptEntries([echo], STREAM_STATUS.WAITING);
+
+    expect(split.finalized).toEqual([]);
+    expect(split.pending).toEqual([echo]);
+  });
+
   it('freezes assistant entries before they enter static scrollback', () => {
     resetCliState();
     patchStream(STREAM_ID, (slice) => ({
@@ -169,6 +181,25 @@ describe('CLI conversation transcript splitting', () => {
     );
     expect(split.finalized.map((item) => item.id)).toEqual(['u1', 'a1']);
     expect(split.pending).toEqual([]);
+  });
+
+  it('keeps pending subagent echoes out of stream-level finalization', () => {
+    resetCliState();
+    patchStream(STREAM_ID, (slice) => ({
+      ...slice,
+      entries: [
+        {
+          ...entry('a1', 'assistant', 'Subagent says...', false),
+          pendingSubagentResultEcho: true,
+        },
+        entry('a2', 'assistant', 'Ordinary final text.', false),
+      ],
+    }));
+
+    finalizeAssistantTranscriptEntries(STREAM_ID);
+
+    const entries = cliState.streams.get().get(STREAM_ID)?.entries ?? [];
+    expect(entries.map((item) => item.finalized)).toEqual([false, true]);
   });
 
   it('freezes assistant entries when a stream returns to ready', () => {

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   hasIncompleteEmbeddedSubagentFollowup,
+  readSubagentFollowupIdentity,
   stripOrchestratorFollowup,
   summarizeEmbeddedSubagentFollowups,
   summarizeFollowupMessage,
@@ -27,6 +28,15 @@ describe('summarizeSubagentFollowup', () => {
     expect(stripOrchestratorFollowup('ordinary user text')).toBe(
       'ordinary user text',
     );
+  });
+
+  it('reads subagent follow-up identity through orchestrator wrappers', () => {
+    expect(
+      readSubagentFollowupIdentity(
+        '<orchestrator-followup><subagent-result id="abc" agent="prover" category="toolUse" status="completed">Done.</subagent-result></orchestrator-followup>',
+      ),
+    ).toEqual({ kind: 'result', id: 'abc' });
+    expect(readSubagentFollowupIdentity('ordinary user text')).toBeUndefined();
   });
 
   it('summarizes malformed non-string follow-up payloads without throwing', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1684,6 +1684,37 @@ describe('finalizeSettledPrefix', () => {
     expect(finalizedIds(out)).toEqual([]);
   });
 
+  it('keeps assistant subagent result echoes pending while stream runs', () => {
+    const out = finalizeSettledPrefix(
+      [
+        {
+          ...assistant('a1'),
+          pendingSubagentResultEcho: true,
+        },
+        tool('t1', 'completed'),
+        assistant('a2'),
+      ],
+      false,
+    );
+
+    expect(finalizedIds(out)).toEqual([]);
+  });
+
+  it('keeps only assistant subagent result echoes pending after stream finality', () => {
+    const out = finalizeSettledPrefix(
+      [
+        {
+          ...assistant('a1'),
+          pendingSubagentResultEcho: true,
+        },
+        assistant('a2'),
+      ],
+      true,
+    );
+
+    expect(finalizedIds(out)).toEqual(['a2']);
+  });
+
   it('does not promote past a still-running tool (preserves Static order)', () => {
     const out = finalizeSettledPrefix(
       [assistant('a1'), tool('t1', 'in_progress'), tool('t2', 'completed')],
@@ -1815,6 +1846,137 @@ describe('CLI transcript state', () => {
         '… 8 more lines; open the subagent transcript for the full response',
       );
       expect(entries[0]?.text).not.toContain('<subagent-result');
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('suppresses assistant subagent result echoes when structured delivery follows', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info(
+        [
+          "👤 Subagent `prover' (550e8400-e29b-41d4-a716-446655440000) says:",
+          '',
+          'Here is the proof.',
+        ].join('\n'),
+        { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
+      );
+      logger.info(
+        [
+          '<subagent-result id="550e8400-e29b-41d4-a716-446655440000" agent="prover" category="toolUse" status="completed">',
+          '<response>',
+          'Here is the proof.',
+          '</response>',
+          '</subagent-result>',
+        ].join('\n'),
+        { messageType: MESSAGE_TYPES.USER_MESSAGE },
+      );
+
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        '✓ prover completed\nHere is the proof.',
+      ]);
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('does not finalize a live subagent echo before delayed structured delivery', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info(
+        ["👤 Subagent `prover' (abc123) says:", '', 'Here is the proof.'].join(
+          '\n',
+        ),
+        { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
+      );
+      logger.info('Waiting for canonical delivery.', {
+        messageType: MESSAGE_TYPES.USER_MESSAGE,
+      });
+
+      syncStreamLog(root);
+
+      let entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries[0]).toMatchObject({
+        pendingSubagentResultEcho: true,
+        finalized: false,
+      });
+
+      logger.info(
+        [
+          '<subagent-result id="abc123" agent="prover" category="toolUse" status="completed">',
+          '<response>',
+          'Here is the proof.',
+          '</response>',
+          '</subagent-result>',
+        ].join('\n'),
+        { messageType: MESSAGE_TYPES.USER_MESSAGE },
+      );
+
+      syncStreamLog(root);
+
+      entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        'Waiting for canonical delivery.',
+        '✓ prover completed\nHere is the proof.',
+      ]);
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
+  it('keeps assistant narration that only contains a later subagent echo', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info(
+        [
+          'I checked the result before summarizing it.',
+          '',
+          "👤 Subagent `prover' (abc123) says:",
+          '',
+          'Here is the proof.',
+        ].join('\n'),
+        { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
+      );
+      logger.info(
+        [
+          '<subagent-result id="abc123" agent="prover" category="toolUse" status="completed">',
+          '<response>',
+          'Here is the proof.',
+          '</response>',
+          '</subagent-result>',
+        ].join('\n'),
+        { messageType: MESSAGE_TYPES.USER_MESSAGE },
+      );
+
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        [
+          'I checked the result before summarizing it.',
+          '',
+          "👤 Subagent `prover' (abc123) says:",
+          '',
+          'Here is the proof.',
+        ].join('\n'),
+        '✓ prover completed\nHere is the proof.',
+      ]);
     } finally {
       setDefaultStreamLogStore(previousStore);
     }


### PR DESCRIPTION
## Summary
- add a shared parser for subagent follow-up identity metadata
- suppress assistant-generated `Subagent ... says` echoes in the CLI transcript when a structured `<subagent-result>` for the same execution follows
- cover the parser and the dogfooded duplicate transcript shape with CLI regression tests

## Root Cause
During a `texra-local` TUI dogfood run, the parent transcript showed the subagent proof twice: first as a model-generated `Subagent ... says` block, then again as the canonical structured `<subagent-result>` follow-up. The persisted parent conversation had both entries, so the TUI transcript mirror needs to treat the structured delivery as canonical and hide the preceding echo for the same child execution id.

## Validation
- `pnpm exec vitest run src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `pnpm exec eslint src/shared/subagentFollowup.ts packages/cli/src/chat/tui/state/subscribeStreamLog.ts src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings only)
- `pnpm exec prettier --check src/shared/subagentFollowup.ts packages/cli/src/chat/tui/state/subscribeStreamLog.ts src/test-kernel/cli/SubagentFollowup.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CLI transcript mirroring and display logic; no auth, persistence, or orchestration behavior is altered beyond hiding duplicate UI rows when ids match.
> 
> **Overview**
> Fixes duplicate subagent output in the CLI transcript when the parent model prints a **Subagent … says** block and the same execution is later delivered as structured **`<subagent-result>`** follow-up.
> 
> Adds **`readSubagentFollowupIdentity`** in shared subagent follow-up parsing so the CLI can match echo and canonical rows by execution id (including orchestrator-wrapped messages). During stream-log sync, whole assistant entries whose visible text starts with the echo header are tagged **`pendingSubagentResultEcho`**; after ordering, **`dropAssistantSubagentResultEchoes`** removes echoes that have a later structured result with the same id. Mixed entries with prose before the echo header are left visible.
> 
> Finalization and live/static splitting were updated so unresolved echoes stay pending (and retractable) until canonical delivery or stream finality, without blocking promotion of later settled entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaaba93fc52c3f06691f5ab6048671266c2149b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->