### PR TITLE
[codex] Show CLI approval feedback in tool rows

### DIFF
--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -285,6 +285,19 @@ function outputDisplayLines(
   return out;
 }
 
+function userFeedbackDisplayLines(
+  toolUse: NormalizedToolUse,
+): readonly string[] {
+  const feedback = collapseWhitespace(toolUse.userInstructionText);
+  if (!feedback) return [];
+  return [
+    `${OUTPUT_CORNER} User feedback: ${truncateWithEllipsis(
+      feedback,
+      MAX_ERROR_PREVIEW,
+    )}`,
+  ];
+}
+
 function universalToolUseDisplayLines(
   toolUse: NormalizedToolUse,
   options: {
@@ -318,6 +331,7 @@ function universalToolUseDisplayLines(
           )}`,
         ]
       : []),
+    ...userFeedbackDisplayLines(toolUse),
     ...(showNoOutput ? [`${OUTPUT_CORNER} (no output)`] : []),
   ];
 }
@@ -343,6 +357,7 @@ function bashToolUseDisplayLines(
           )}`,
         ]
       : []),
+    ...userFeedbackDisplayLines(toolUse),
     ...(toolUse.status === TOOL_USE_STATUS.COMPLETED &&
     !toolUse.isError &&
     outputLines.length === 0
@@ -475,10 +490,12 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     visibleOutput.length === 0 &&
     !patchGroups &&
     !toolUse.isError;
+  const userFeedback = collapseWhitespace(toolUse.userInstructionText);
   const hasDetails =
     visibleOutput.length > 0 ||
     (patchGroups?.length ?? 0) > 0 ||
     toolUse.isError ||
+    userFeedback.length > 0 ||
     showNoOutput;
 
   return (
@@ -505,6 +522,14 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
             collapseWhitespace(errorText),
             MAX_ERROR_PREVIEW,
           )}
+        </CornerLine>
+      ) : null}
+      {userFeedback ? (
+        <CornerLine>
+          {`User feedback: ${truncateWithEllipsis(
+            userFeedback,
+            MAX_ERROR_PREVIEW,
+          )}`}
         </CornerLine>
       ) : null}
       {showNoOutput ? <CornerLine>(no output)</CornerLine> : null}

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -117,6 +117,30 @@ describe('CLI tool renderer registry', () => {
     `);
   });
 
+  it('surfaces user feedback on collapsed approval rejections', () => {
+    const message = 'User rejected bash command: wolframscript -code "check"';
+    const entry = toolUse(
+      'wolfram',
+      { code: 'check' },
+      {
+        errorText: message,
+        isError: true,
+        isUserFeedback: true,
+        outputText: message,
+        userInstructionText:
+          'Skip external computation; prove it directly from the identity.',
+      },
+    );
+
+    expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
+      [
+        "● wolfram (check)",
+        "⎿ User rejected bash command: wolframscript -code "check"",
+        "⎿ User feedback: Skip external computation; prove it directly from the identity.",
+      ]
+    `);
+  });
+
   it('keeps long duplicate error output in the full transcript view', () => {
     const message = `User rejected bash command: ${'diagnostic detail '.repeat(30)}`;
     const entry = toolUse(


### PR DESCRIPTION
## Summary
- show approval rejection feedback as its own compact detail line in CLI tool rows
- keep duplicate rejection output collapsed while preserving the user note
- add a focused renderer regression test from CLI dogfood

## Validation
- pnpm exec vitest run src/test-kernel/cli/ToolRenderers.vitest.mts
- pnpm exec prettier --check packages/cli/src/chat/tui/panes/toolRenderers.tsx src/test-kernel/cli/ToolRenderers.vitest.mts
- pnpm exec eslint packages/cli/src/chat/tui/panes/toolRenderers.tsx src/test-kernel/cli/ToolRenderers.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build bash-approval
- corepack pnpm --filter @texra-ai/cli typecheck
- git diff --check

## Dogfood Evidence
Live Mathematician TUI run rejected a wolframscript approval with feedback. The child conversation received the note, but the parent/tool row only showed the compact rejection text, hiding the actionable feedback from the visible transcript.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI display-only change in tool row rendering with no auth or data-path impact; covered by a focused renderer test.
> 
> **Overview**
> CLI tool rows now show **`userInstructionText`** as a separate **`User feedback:`** detail line (truncated like errors), so notes from approval rejections stay visible in the transcript when rejection output is collapsed to a single error line.
> 
> The change applies to both **plain-text** tool display lines (`universalToolUseDisplayLines`, `bashToolUseDisplayLines`) and the **live Ink** `ToolRow` UI, including `hasDetails` spacing when feedback is present. A regression test covers collapsed approval rejections that still surface the user note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df024fd34249f74a69c4b2b0b2b19154d5da21a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->