### PR TITLE
[codex] Clarify plan approve-and-run notice

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1393,7 +1393,7 @@ const SCENARIOS = [
     ],
     unexpect: [
       'r approve & run',
-      'Bash + file edits auto-approved',
+      'Press r: auto-approve bash + file edits',
       '[/model]models',
     ],
     maxBlankLinesBetween: [
@@ -1412,7 +1412,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
-      'Bash + file edits auto-approved',
+      'Press r: auto-approve bash + file edits',
       'r approve & run',
       'y approve',
       'n reject',
@@ -1443,7 +1443,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
-      'Bash + file edits auto-approved',
+      'Press r: auto-approve bash + file edits',
       'observations. Do not edit any files',
       'r approve & run',
       'y approve',
@@ -1482,7 +1482,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
-      'Bash + file edits auto-approved',
+      'Press r: auto-approve bash + file edits',
       '4. Delegate a brief independent verification to the `review` subagent to',
       "check the derivation's correctness.",
       'r approve & run',
@@ -1505,7 +1505,7 @@ const SCENARIOS = [
       'e feedback',
       'Esc cancel',
     ],
-    unexpect: ['Bash + file edits auto-approved', '[/model]models'],
+    unexpect: ['auto-approve bash + file edits', '[/model]models'],
   },
   {
     name: 'compact-plan-approval-goal',
@@ -1521,7 +1521,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
-      'Bash + file edits auto-approved',
+      'Press r: auto-approve bash + file edits',
       'r approve & run',
       'y approve',
       'n reject',

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -23,7 +23,7 @@ export const COMPACT_PLAN_APPROVAL_MAX_ROWS = 7;
 const MIN_PLAN_APPROVAL_CONTENT_WIDTH = 20;
 const PLAN_APPROVAL_TITLE = 'Approve plan?';
 export const PLAN_APPROVAL_GOAL_NOTICE =
-  'Bash + file edits auto-approved until pause/complete.';
+  'Press r: auto-approve bash + file edits for this goal.';
 const PLAN_APPROVAL_GOAL_NOTICE_ROWS = 2;
 const PLAN_APPROVAL_NON_COMPACT_FIXED_ROWS = 7;
 const PLAN_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;

--- a/src/test-kernel/cli/PlanApproval.vitest.mts
+++ b/src/test-kernel/cli/PlanApproval.vitest.mts
@@ -127,7 +127,8 @@ describe('CLI plan approval layout', () => {
   });
 
   it('keeps the autonomous warning concise enough for the approval card', () => {
-    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('Bash + file edits');
+    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('Press r');
+    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('bash + file edits');
     expect(PLAN_APPROVAL_GOAL_NOTICE.length).toBeLessThanOrEqual(56);
   });
 
@@ -135,7 +136,7 @@ describe('CLI plan approval layout', () => {
     const notice = planApprovalGoalNoticeLine(40);
 
     expect(textDisplayWidth(notice)).toBe(40);
-    expect(notice).toContain('Bash + file edits');
+    expect(notice).toContain('Press r');
     expect(notice).toContain('…');
   });
 


### PR DESCRIPTION
## Summary

Clarifies the CLI plan approval notice for the `r approve & run` shortcut.

The previous copy said `Bash + file edits auto-approved until pause/complete.` During dogfood this was easy to read as applying to the normal `y approve` path, even though the code only sends `approve_and_goal` for the extra `r` action. The new copy anchors the scope to `Press r` and says the auto-approval applies to this goal, so ordinary approval and approve-and-run have clearer meanings.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/PlanApproval.vitest.mts src/test-kernel/cli/ConfirmCardState.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs plan-approval plan-approval-goal plan-approval-wrap-boundary plan-approval-stale-tail compact-plan-approval compact-plan-approval-goal`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and test expectations only; no changes to approval decision handling or permissions.
> 
> **Overview**
> Updates the CLI plan approval card notice from **Bash + file edits auto-approved until pause/complete.** to **Press r: auto-approve bash + file edits for this goal.** so users see that bash/file auto-approval applies only to the **`r` approve & run** path (`approve_and_goal`), not ordinary **`y` approve**.
> 
> `PlanApproval.vitest.mts` and `validate-tui.mjs` plan-approval scenarios now assert the new strings (including compact layouts where the notice is hidden).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36a6dd69bc1c89a20015fa581216d2a07ac5cd42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->