### PR TITLE
[codex] Render HTML markup in CLI transcript

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -96,8 +96,7 @@ const TABLE_FALLBACK_WIDTH = 80;
 // cli-table3 pads every cell with one space on each side, so a column's total
 // width is its content width + 2.
 const TABLE_CELL_PADDING = 2;
-const KNOWN_HTML_TAG_RE =
-  /<\/?(?:blockquote|strong|b|em|i|code|p|div|br)\b/i;
+const KNOWN_HTML_TAG_RE = /<\/?(?:blockquote|strong|b|em|i|code|p|div|br)\b/i;
 
 // Size each column to its widest cell (display width, ANSI-aware) so a compact
 // table stays compact instead of being stretched to fill the terminal. Only

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -96,6 +96,8 @@ const TABLE_FALLBACK_WIDTH = 80;
 // cli-table3 pads every cell with one space on each side, so a column's total
 // width is its content width + 2.
 const TABLE_CELL_PADDING = 2;
+const KNOWN_HTML_TAG_RE =
+  /<\/?(?:blockquote|strong|b|em|i|code|p|div|br)\b/i;
 
 // Size each column to its widest cell (display width, ANSI-aware) so a compact
 // table stays compact instead of being stretched to fill the terminal. Only
@@ -159,6 +161,38 @@ function renderAnsiTable(
   });
   for (const row of rows) table.push([...row]);
   return table.toString();
+}
+
+function quoteHtmlBlock(body: string): string {
+  const trimmed = body.trim();
+  if (trimmed === '') return '';
+  return trimmed
+    .split(/\r?\n/)
+    .map((line) => (line.trim() === '' ? '>' : `> ${line}`))
+    .join('\n');
+}
+
+function normalizeKnownHtmlForAnsiMarkdown(content: string): string {
+  if (!KNOWN_HTML_TAG_RE.test(content)) return content;
+
+  return content
+    .replaceAll(
+      /<blockquote\b[^>]*>([\s\S]*?)<\/blockquote>/gi,
+      (_match, body: string) => quoteHtmlBlock(body),
+    )
+    .replaceAll(/<br\s*\/?>/gi, '\n')
+    .replaceAll(/<\/(?:p|div)>/gi, '\n\n')
+    .replaceAll(/<(?:p|div)\b[^>]*>/gi, '')
+    .replaceAll(/<strong\b[^>]*>/gi, '**')
+    .replaceAll(/<\/strong>/gi, '**')
+    .replaceAll(/<b\b[^>]*>/gi, '**')
+    .replaceAll(/<\/b>/gi, '**')
+    .replaceAll(/<em\b[^>]*>/gi, '_')
+    .replaceAll(/<\/em>/gi, '_')
+    .replaceAll(/<i\b[^>]*>/gi, '_')
+    .replaceAll(/<\/i>/gi, '_')
+    .replaceAll(/<code\b[^>]*>/gi, '`')
+    .replaceAll(/<\/code>/gi, '`');
 }
 
 function restoreProtectedLatexInCell(cell: string, env: unknown): string {
@@ -458,7 +492,11 @@ export function renderAnsiMarkdown(
   options: RenderAnsiMarkdownOptions = {},
 ): string {
   const processor = processorFor(options.width, options.colorEnabled ?? true);
-  return wrapAnsiToWidth(processor(content), options.width, true).trimEnd();
+  return wrapAnsiToWidth(
+    processor(normalizeKnownHtmlForAnsiMarkdown(content)),
+    options.width,
+    true,
+  ).trimEnd();
 }
 
 /** Test seam: drop the cached processors so tests can re-init cleanly. */

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -51,6 +51,25 @@ describe('renderAnsiMarkdown', () => {
     expect(out).not.toContain('&gt;');
   });
 
+  it('renders common HTML formatting without leaking tags', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown(
+      [
+        '<blockquote><strong>Subagent <code>prover</code> finished execution abc:</strong>',
+        '',
+        'Done.</blockquote>',
+      ].join('\n'),
+      { colorEnabled: false, width: 80 },
+    );
+    const plain = stripAnsi(out);
+
+    expect(plain).toContain('│ Subagent `prover` finished execution abc:');
+    expect(plain).toContain('│ Done.');
+    expect(plain).not.toContain('<blockquote>');
+    expect(plain).not.toContain('<strong>');
+    expect(plain).not.toContain('<code>');
+  });
+
   it('passes typed code through cli-highlight without leaking sentinels', () => {
     _resetAnsiMarkdownForTests();
     const md = '```ts\nconst x: number = 1;\n```';


### PR DESCRIPTION
## Summary
- Normalize common HTML formatting tags before CLI ANSI markdown rendering
- Preserve plain angle-bracket text while rendering blockquote/strong/em/code tags as terminal-friendly Markdown
- Add a regression test for the subagent completion wrapper observed in a real TTY dogfood run

Fixes #6060

## Validation
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/AnsiMarkdown.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts
- node packages/cli/scripts/validate-tui.mjs subagent-followup-summary queued-subagent-followup-summary queued-subagent-followup-status-preview
- npm run typecheck
- npm run lint (passes with existing warnings)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in CLI markdown rendering with an early no-op when no known HTML tags are present; no auth, data, or API surface changes.
> 
> **Overview**
> **CLI transcripts** that include HTML from upstream (e.g. subagent completion wrappers) now render as terminal-friendly markdown instead of leaking raw tags.
> 
> `renderAnsiMarkdown` runs input through **`normalizeKnownHtmlForAnsiMarkdown`** first. A quick regex gate skips strings with no known tags so plain angle-bracket text like `Hello <world>` is unchanged. When tags are present, **blockquote** becomes `>`-quoted lines, **strong/b**, **em/i**, and **code** map to markdown emphasis and backticks, and **br** / **p** / **div** become line breaks.
> 
> A regression test covers the real **subagent blockquote + strong + code** shape and expects blockquote gutters (`│`) without leftover HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2d3345a31012f3621c3c7869b928627e5080c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->