### PR TITLE
[codex] Summarize subagent XML in CLI transcript

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -22,6 +22,7 @@ import {
   type MarkdownItInstance,
   type MarkdownProcessor,
 } from '@shared/markdown';
+import { summarizeEmbeddedSubagentFollowups } from '@shared/subagentFollowup';
 
 import { wrapAnsiToWidth } from './ansiWrap';
 
@@ -172,9 +173,10 @@ function quoteHtmlBlock(body: string): string {
 }
 
 function normalizeKnownHtmlForAnsiMarkdown(content: string): string {
-  if (!KNOWN_HTML_TAG_RE.test(content)) return content;
+  const summarized = summarizeEmbeddedSubagentFollowups(content);
+  if (!KNOWN_HTML_TAG_RE.test(summarized)) return summarized;
 
-  return content
+  return summarized
     .replaceAll(
       /<blockquote\b[^>]*>([\s\S]*?)<\/blockquote>/gi,
       (_match, body: string) => quoteHtmlBlock(body),

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -70,6 +70,28 @@ describe('renderAnsiMarkdown', () => {
     expect(plain).not.toContain('<code>');
   });
 
+  it('summarizes embedded subagent result XML before HTML rendering', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown(
+      [
+        '<blockquote>',
+        '<subagent-result id="abc" agent="review" category="toolUse" status="completed">',
+        '<wall-time>2m</wall-time>',
+        '<response>All good &lt;ok&gt;</response>',
+        '</subagent-result>',
+        '</blockquote>',
+      ].join('\n'),
+      { colorEnabled: false, width: 80 },
+    );
+    const plain = stripAnsi(out);
+
+    expect(plain).toContain('│ ✓ review completed · 2m');
+    expect(plain).toContain('│ All good <ok>');
+    expect(plain).not.toContain('<subagent-result');
+    expect(plain).not.toContain('<response>');
+    expect(plain).not.toContain('<blockquote>');
+  });
+
   it('passes typed code through cli-highlight without leaking sentinels', () => {
     _resetAnsiMarkdownForTests();
     const md = '```ts\nconst x: number = 1;\n```';


### PR DESCRIPTION
## Summary

Fixes #6062.

This patches the CLI ANSI markdown path so embedded subagent follow-up XML is collapsed with the existing shared `summarizeEmbeddedSubagentFollowups` parser before common HTML normalization runs. That keeps queued-followup/status parsing and transcript rendering on the same source of truth.

## Root Cause

The prior live transcript fix normalized common HTML tags such as `<blockquote>`, but the parent stream can also receive raw custom `<subagent-result>` blocks embedded inside those wrappers. The general markdown renderer did not run the shared subagent follow-up summarizer, so users could still see implementation XML in normal CLI output.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/AnsiMarkdown.vitest.mts src/test-kernel/cli/SubagentFollowup.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs --no-build queued-subagent-followup-summary queued-subagent-followup-status-preview`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `corepack pnpm exec prettier --write packages/cli/src/chat/tui/render/ansiMarkdown.ts src/test-kernel/cli/AnsiMarkdown.vitest.mts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow display-layer change in CLI markdown preprocessing with a shared helper already used elsewhere; no auth or data-path changes.
> 
> **Overview**
> **CLI live transcript output** no longer shows raw `<subagent-result>` XML when those blocks are embedded inside HTML wrappers (e.g. `<blockquote>`).
> 
> `normalizeKnownHtmlForAnsiMarkdown` in `ansiMarkdown.ts` now runs shared `summarizeEmbeddedSubagentFollowups` **before** the existing HTML-to-markdown normalization, matching the transcript path in `subscribeStreamLog`. Users see human-readable status lines (e.g. `✓ review completed · 2m`) and decoded response text instead of implementation tags.
> 
> A vitest case in `AnsiMarkdown.vitest.mts` locks in that behavior for blockquote-wrapped subagent XML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8811fff069e4ff29ce1f8fa6bbd4c9076d564ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->