### PR TITLE
[codex] Normalize HTML in CLI live transcript

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -22,9 +22,8 @@ import {
   type MarkdownItInstance,
   type MarkdownProcessor,
 } from '@shared/markdown';
-import { summarizeEmbeddedSubagentFollowups } from '@shared/subagentFollowup';
-
 import { wrapAnsiToWidth } from './ansiWrap';
+import { normalizeKnownHtmlForCliMarkdown } from './htmlMarkdownNormalize';
 
 import type { RenderRule } from 'markdown-it/lib/renderer.mjs';
 
@@ -97,7 +96,6 @@ const TABLE_FALLBACK_WIDTH = 80;
 // cli-table3 pads every cell with one space on each side, so a column's total
 // width is its content width + 2.
 const TABLE_CELL_PADDING = 2;
-const KNOWN_HTML_TAG_RE = /<\/?(?:blockquote|strong|b|em|i|code|p|div|br)\b/i;
 
 // Size each column to its widest cell (display width, ANSI-aware) so a compact
 // table stays compact instead of being stretched to fill the terminal. Only
@@ -161,39 +159,6 @@ function renderAnsiTable(
   });
   for (const row of rows) table.push([...row]);
   return table.toString();
-}
-
-function quoteHtmlBlock(body: string): string {
-  const trimmed = body.trim();
-  if (trimmed === '') return '';
-  return trimmed
-    .split(/\r?\n/)
-    .map((line) => (line.trim() === '' ? '>' : `> ${line}`))
-    .join('\n');
-}
-
-function normalizeKnownHtmlForAnsiMarkdown(content: string): string {
-  const summarized = summarizeEmbeddedSubagentFollowups(content);
-  if (!KNOWN_HTML_TAG_RE.test(summarized)) return summarized;
-
-  return summarized
-    .replaceAll(
-      /<blockquote\b[^>]*>([\s\S]*?)<\/blockquote>/gi,
-      (_match, body: string) => quoteHtmlBlock(body),
-    )
-    .replaceAll(/<br\s*\/?>/gi, '\n')
-    .replaceAll(/<\/(?:p|div)>/gi, '\n\n')
-    .replaceAll(/<(?:p|div)\b[^>]*>/gi, '')
-    .replaceAll(/<strong\b[^>]*>/gi, '**')
-    .replaceAll(/<\/strong>/gi, '**')
-    .replaceAll(/<b\b[^>]*>/gi, '**')
-    .replaceAll(/<\/b>/gi, '**')
-    .replaceAll(/<em\b[^>]*>/gi, '_')
-    .replaceAll(/<\/em>/gi, '_')
-    .replaceAll(/<i\b[^>]*>/gi, '_')
-    .replaceAll(/<\/i>/gi, '_')
-    .replaceAll(/<code\b[^>]*>/gi, '`')
-    .replaceAll(/<\/code>/gi, '`');
 }
 
 function restoreProtectedLatexInCell(cell: string, env: unknown): string {
@@ -494,7 +459,7 @@ export function renderAnsiMarkdown(
 ): string {
   const processor = processorFor(options.width, options.colorEnabled ?? true);
   return wrapAnsiToWidth(
-    processor(normalizeKnownHtmlForAnsiMarkdown(content)),
+    processor(normalizeKnownHtmlForCliMarkdown(content)),
     options.width,
     true,
   ).trimEnd();

--- a/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
+++ b/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
@@ -1,0 +1,49 @@
+import { summarizeEmbeddedSubagentFollowups } from '@shared/subagentFollowup';
+
+const KNOWN_HTML_TAG_RE =
+  /<\/?(?:blockquote|strong|b|em|i|code|p|div|br|h[1-6])\b/i;
+
+function quoteHtmlBlock(body: string): string {
+  const trimmed = body.trim();
+  if (trimmed === '') return '';
+  return trimmed
+    .split(/\r?\n/)
+    .map((line) => (line.trim() === '' ? '>' : `> ${line}`))
+    .join('\n');
+}
+
+function headingMarker(level: string): string {
+  const parsed = Number.parseInt(level, 10);
+  const depth = Number.isFinite(parsed) ? Math.min(6, Math.max(1, parsed)) : 3;
+  return '#'.repeat(depth);
+}
+
+export function normalizeKnownHtmlForCliMarkdown(content: string): string {
+  const summarized = summarizeEmbeddedSubagentFollowups(content);
+  if (!KNOWN_HTML_TAG_RE.test(summarized)) return summarized;
+
+  return summarized
+    .replaceAll(
+      /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
+      (_match, level: string, body: string) =>
+        `\n\n${headingMarker(level)} ${body.trim()}\n\n`,
+    )
+    .replaceAll(/<br\s*\/?>/gi, '\n')
+    .replaceAll(/<\/(?:p|div)>/gi, '\n\n')
+    .replaceAll(/<(?:p|div)\b[^>]*>/gi, '')
+    .replaceAll(/<strong\b[^>]*>/gi, '**')
+    .replaceAll(/<\/strong>/gi, '**')
+    .replaceAll(/<b\b[^>]*>/gi, '**')
+    .replaceAll(/<\/b>/gi, '**')
+    .replaceAll(/<em\b[^>]*>/gi, '_')
+    .replaceAll(/<\/em>/gi, '_')
+    .replaceAll(/<i\b[^>]*>/gi, '_')
+    .replaceAll(/<\/i>/gi, '_')
+    .replaceAll(/<code\b[^>]*>/gi, '`')
+    .replaceAll(/<\/code>/gi, '`')
+    .replaceAll(
+      /<blockquote\b[^>]*>([\s\S]*?)<\/blockquote>/gi,
+      (_match, body: string) => quoteHtmlBlock(body),
+    )
+    .trim();
+}

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -15,9 +15,9 @@ import { normalizeToolUseData } from '@shared/toolUse';
 
 import {
   hasIncompleteEmbeddedSubagentFollowup,
-  summarizeEmbeddedSubagentFollowups,
   summarizeFollowupMessage,
 } from '@shared/subagentFollowup';
+import { normalizeKnownHtmlForCliMarkdown } from '../render/htmlMarkdownNormalize';
 import {
   isRenderableTranscriptEntry,
   trimAssistantTranscriptLead,
@@ -161,7 +161,7 @@ function renderLogEntryText(
 ): string {
   switch (role) {
     case 'assistant':
-      return summarizeEmbeddedSubagentFollowups(
+      return normalizeKnownHtmlForCliMarkdown(
         trimAssistantTranscriptLead(text),
       );
     case 'error':

--- a/src/test-kernel/cli/AnsiMarkdown.vitest.mts
+++ b/src/test-kernel/cli/AnsiMarkdown.vitest.mts
@@ -70,6 +70,38 @@ describe('renderAnsiMarkdown', () => {
     expect(plain).not.toContain('<code>');
   });
 
+  it('renders HTML headings as markdown headings without leaking tags', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown(
+      '<h3>Verification Report</h3>The proof is <b>fully verified</b>.',
+      { colorEnabled: false, width: 80 },
+    );
+    const plain = stripAnsi(out);
+
+    expect(plain).toContain('Verification Report');
+    expect(plain).toContain('The proof is fully verified.');
+    expect(plain).not.toContain('<h3>');
+    expect(plain).not.toContain('</h3>');
+    expect(plain).not.toContain('<b>');
+    expect(plain).not.toContain('</b>');
+  });
+
+  it('keeps HTML headings inside HTML blockquotes quoted', () => {
+    _resetAnsiMarkdownForTests();
+    const out = renderAnsiMarkdown(
+      '<blockquote><h3>Quoted Report</h3><p>The proof is <b>fully verified</b>.</p></blockquote>',
+      { colorEnabled: false, width: 80 },
+    );
+    const plain = stripAnsi(out);
+
+    expect(plain).toContain('│ Quoted Report');
+    expect(plain).toContain('│ The proof is fully verified.');
+    expect(plain).not.toContain('\nQuoted Report');
+    expect(plain).not.toContain('<blockquote>');
+    expect(plain).not.toContain('<h3>');
+    expect(plain).not.toContain('<b>');
+  });
+
   it('summarizes embedded subagent result XML before HTML rendering', () => {
     _resetAnsiMarkdownForTests();
     const out = renderAnsiMarkdown(

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1781,6 +1781,31 @@ describe('CLI transcript state', () => {
     }
   });
 
+  it('normalizes common HTML before assistant text reaches the live transcript', () => {
+    const previousStore = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+
+    try {
+      const logger = createRunTrace(root).trace;
+      logger.info(
+        '<h3>Verification Report</h3>The proof is <b>fully verified</b>.',
+        { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
+      );
+
+      syncStreamLog(root);
+
+      const entries = cliState.streams.get().get(root)?.entries ?? [];
+      expect(entries.map((entry) => entry.text)).toEqual([
+        '### Verification Report\n\nThe proof is **fully verified**.',
+      ]);
+      expect(entries[0]?.text).not.toContain('<h3>');
+      expect(entries[0]?.text).not.toContain('<b>');
+    } finally {
+      setDefaultStreamLogStore(previousStore);
+    }
+  });
+
   it('bounds long subagent result responses in the visible transcript', () => {
     const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();


### PR DESCRIPTION
## Summary

- Move lightweight known-HTML cleanup into a shared CLI transcript helper.
- Apply that cleanup before assistant text enters TUI state, so live streaming rows do not expose raw `<h3>` / `<b>` tags.
- Keep the ANSI markdown renderer using the same helper for finalized transcript output.

Closes #6064.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/AnsiMarkdown.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with 34 existing warnings)
- `npm run compile:fast`
- `npm test`

## Dogfood Evidence

Live TTY run on `origin/main` `ee6a27a4f`:

```sh
TERM=xterm-256color texra-local chat --api-mode included --approval-policy ask
```

Parent session `9caaa1f8c3f4`, prover subagent `772f57535ef4`. The parent transcript displayed raw `<h3>Verification Report</h3>` and `<b>fully verified</b>` from the subagent report before this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only transcript/markdown path with no auth or persistence changes; behavior is covered by AnsiMarkdown and TuiStateAndFocus tests.
> 
> **Overview**
> Fixes live CLI streaming rows showing raw HTML (e.g. `<h3>`, `<b>`) from subagent reports by normalizing assistant text **before** it lands in TUI state, not only at ANSI render time.
> 
> **Shared helper:** Inline HTML cleanup moves from `ansiMarkdown.ts` into `normalizeKnownHtmlForCliMarkdown` in `htmlMarkdownNormalize.ts`. It still runs subagent follow-up summarization first, then maps common tags to markdown—including **new `h1`–`h6` → `#` headings**—with blockquotes processed after headings so quoted headings stay inside `>` lines.
> 
> **Pipeline:** `subscribeStreamLog` uses this helper for assistant `renderLogEntryText`; `renderAnsiMarkdown` calls the same function so live transcript text and finalized ANSI output stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4daacac30160da49e6049e7c8b8627b78039b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->