### PR TITLE
[codex] Cover CLI approval feedback viewport

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1000,6 +1000,7 @@ const SCENARIOS = [
     name: 'edit-approval',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
     bootExpect: '[Ctrl-C]',
+    frame: 'tail',
     expect: [
       'Apply edit to draft.tex?',
       'y approve',
@@ -1008,6 +1009,23 @@ const SCENARIOS = [
       'Use foreground panel shortcuts',
     ],
     unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
+  },
+  {
+    name: 'edit-approval-feedback',
+    rows: 24,
+    cols: 80,
+    env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
+    bootExpect: '[Ctrl-C]',
+    keys: ['e', 'needs direct proof'],
+    frame: 'tail',
+    expect: [
+      'Apply edit to draft.tex?',
+      '> needs direct proof',
+      'Enter send note',
+      'Esc back',
+      '1 approval',
+    ],
+    unexpect: ['[/model]models'],
   },
   {
     name: 'narrow-edit-approval',


### PR DESCRIPTION
## Summary
- switch the idle edit-approval TUI snapshot to the viewport tail so the report reflects the visible screen
- add an 80x24 edit-approval feedback scenario that types a rejection note and checks the note plus submit/back hints are visible

Closes #6066

## Validation
- node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-approval-feedback-snapshots edit-approval edit-approval-feedback narrow-edit-approval
- git diff --check

## Dogfood evidence
The targeted 80x24 PTY probe for edit approval feedback shows the viewport includes:
- > needs direct proof
- Enter send note / Esc back

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to TUI validation scenarios in validate-tui.mjs; no production CLI or approval logic is modified.
> 
> **Overview**
> Extends the CLI **deterministic TUI PTY validator** so edit-approval checks match what users actually see on screen.
> 
> The idle **`edit-approval`** scenario now asserts against the **viewport tail** (`frame: 'tail'`) instead of the full scrollback buffer, aligning snapshots with the visible terminal area.
> 
> A new **`edit-approval-feedback`** scenario (80×24) drives the harness into edit approval, presses **`e`**, types a rejection note (`needs direct proof`), and expects the tail to show the draft prompt, the typed note (`> needs direct proof`), and the **Enter send note** / **Esc back** hints plus the approval count—without the normal chat model shortcut leaking through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b7b82eff5273c477988b5002b3f4645681a040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->