### PR TITLE
[codex] Ignore late CLI progress after host close

### DIFF
--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -23,6 +23,7 @@ export type CliRuntimeHost = AgentRuntimeHost & {
 export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
   let sink: LogSink | undefined;
   let logger: Logger | undefined;
+  let closed = false;
   const runProgress = createRunProgressRenderer(context);
   function ensureLogger(): Logger {
     if (logger) return logger;
@@ -38,6 +39,8 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
   return {
     prepareInteractivePrompt,
     emit(event, payload) {
+      if (closed) return;
+
       if (
         handleCliApprovalEvent(event, payload, context, {
           beforePrompt: prepareInteractivePrompt,
@@ -80,6 +83,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       ensureLogger().debug(`Progress event: ${String(event)}`);
     },
     async close() {
+      closed = true;
       runProgress?.clear();
       await sink?.flush?.();
       await sink?.close?.();

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -670,6 +670,37 @@ describe('CLI run progress renderer', () => {
     ]);
   });
 
+  it('does not write late ndjson progress after the runtime host closes', async () => {
+    const output = await captureStreamWrites(process.stdout, async () => {
+      const host = createCliRuntimeHost(
+        context({ outputFormat: 'ndjson', renderRunProgress: false }),
+      );
+      host.emit('updateStreamStatus', {
+        streamId: 'stream-1',
+        status: STREAM_STATUS.RUNNING,
+        previousStatus: STREAM_STATUS.READY,
+      });
+      await host.close();
+      host.emit('updateStreamDescription', {
+        streamId: 'stream-1',
+        description: 'late helper label',
+      });
+    });
+
+    expect(output).not.toBe('');
+    const records = output
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        kind: 'progress',
+        event: 'updateStreamStatus',
+      }),
+    ]);
+  });
+
   it('maps the global quiet flag into CLI context args', () => {
     expect(
       pickGlobalArgs({


### PR DESCRIPTION
Closes #6070.

## Summary

- Treat the CLI runtime host `close()` call as a real lifecycle boundary.
- Ignore progress emits after close so late fire-and-forget helper events do not write post-result NDJSON.
- Add a regression test for late NDJSON progress after host close.

## Evidence

Dogfood repro with separated streams:

```sh
texra-local multi-agent run mathematician \
  --approval-policy ask \
  --no-input \
  --instruction "Say OK only. Do not call tools." \
  --output-format=ndjson \
  >/tmp/texra-ndjson-stdout.txt \
  2>/tmp/texra-ndjson-stderr.txt
```

The human preset/warning text went to stderr and stdout parsed as NDJSON, but a delayed `progress.updateStreamDescription` record arrived after `multi-agent-result`. That makes simple line-oriented consumers see a progress record rather than the terminal run result at the end of stdout.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/runtime/runtimeHost.ts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle guard in CLI output routing with a focused regression test; no auth, data, or core agent logic changes.
> 
> **Overview**
> **`createCliRuntimeHost`** now treats **`close()`** as a hard lifecycle boundary: a **`closed`** flag is set when the host shuts down, and **`emit`** returns immediately without writing logs, NDJSON progress, or approval handling after that point.
> 
> This stops delayed fire-and-forget progress events (e.g. **`updateStreamDescription`**) from appending **`kind: 'progress'`** lines to stdout after the final run result in **`--output-format=ndjson`**, so line-oriented consumers can treat the last meaningful record as the terminal outcome.
> 
> A regression test asserts that only pre-close progress is written to stdout when a late emit happens after **`await host.close()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257d14820ccc6af8ba80cdd2261d6b4e066b9e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->