### PR TITLE
Replace native details elements with wa-details in BackgroundTasksPanel

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -165,10 +165,10 @@ export class BackgroundTasksPanel extends LitElement {
         line-height: 1;
       }
 
-      /* Nested sections are native <wa-details class="collapsible-quiet">;
-         the section label lives in the summary slot and keeps the uppercase
-         small-caps look. wa-details supplies the disclosure chevron, so no
-         hand-rolled toggle icon. */
+      /* Nested sections use Web Awesome <wa-details class="collapsible-quiet">
+         in place of a hand-rolled <details>; the section label lives in the
+         summary slot and keeps the uppercase small-caps look. wa-details
+         supplies the disclosure chevron, so no hand-rolled toggle icon. */
       wa-details.collapsible-quiet::part(header) {
         padding-inline: 0;
       }
@@ -199,7 +199,7 @@ export class BackgroundTasksPanel extends LitElement {
         font-style: italic;
       }
 
-      /* Collapsible output per task — also native wa-details. */
+      /* Collapsible output per task — also a <wa-details>. */
       wa-details.task-output {
         margin-left: calc(var(--wa-space-2xs) + var(--font-size-sm));
       }

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -1,9 +1,12 @@
 /**
  * Collapsible panel for displaying background tasks (processes and subagents).
  *
- * Uses `<wa-details>` for consistent styling with other panels (Todos,
- * Files, etc.). Each active subagent is clickable to navigate to its stream tab.
- * Processes don't have their own tab so they are not clickable.
+ * Uses `<wa-details>` for the outer panel and for each nested section
+ * (Processes, Subagents, Inquiries) and per-task output, for consistent
+ * styling with other panels (Todos, Files, etc.) — the nested sections use the
+ * `.collapsible-quiet` variant. Each active subagent is clickable to navigate
+ * to its stream tab. Processes don't have their own tab so they are not
+ * clickable.
  */
 
 // Third-party imports
@@ -162,23 +165,23 @@ export class BackgroundTasksPanel extends LitElement {
         line-height: 1;
       }
 
+      /* Nested sections are native <wa-details class="collapsible-quiet">;
+         the section label lives in the summary slot and keeps the uppercase
+         small-caps look. wa-details supplies the disclosure chevron, so no
+         hand-rolled toggle icon. */
+      wa-details.collapsible-quiet::part(header) {
+        padding-inline: 0;
+      }
+
       .section-label {
         display: flex;
         align-items: center;
         gap: var(--wa-space-2xs);
-        padding: var(--wa-space-2xs) 0 var(--wa-space-3xs);
         font-size: var(--font-size-xs);
         font-weight: var(--font-weight-semibold);
         color: var(--color-text-secondary);
         text-transform: uppercase;
         letter-spacing: var(--letter-spacing-caps);
-        cursor: pointer;
-        list-style: none;
-        user-select: none;
-      }
-
-      .section-label::-webkit-details-marker {
-        display: none;
       }
 
       .section-label:hover {
@@ -196,18 +199,14 @@ export class BackgroundTasksPanel extends LitElement {
         font-style: italic;
       }
 
-      /* Collapsible output per task */
-      details.task-output {
+      /* Collapsible output per task — also native wa-details. */
+      wa-details.task-output {
         margin-left: calc(var(--wa-space-2xs) + var(--font-size-sm));
       }
 
-      details.task-output > summary {
-        padding: var(--wa-space-3xs) 0;
+      wa-details.task-output::part(header) {
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
-        cursor: pointer;
-        list-style: none;
-        user-select: none;
       }
 
       .output-container {
@@ -299,14 +298,8 @@ export class BackgroundTasksPanel extends LitElement {
     ).length;
 
     return html`
-      <details open>
-        <summary class="section-label">
-          <wa-icon
-            library="texra"
-            name="chevron-right"
-            class="toggle-icon"
-            aria-hidden="true"
-          ></wa-icon>
+      <wa-details class="collapsible-quiet" open>
+        <div slot="summary" class="section-label">
           <wa-icon library="texra" name="comments" aria-hidden="true"></wa-icon>
           <span
             >Inquiries${openCount
@@ -317,7 +310,7 @@ export class BackgroundTasksPanel extends LitElement {
               ? html` &middot; ${droppedCount} dropped`
               : nothing}</span
           >
-        </summary>
+        </div>
         <div class="section-content">
           ${repeat(
             this.inquiries,
@@ -325,7 +318,7 @@ export class BackgroundTasksPanel extends LitElement {
             (thread) => this.renderInquiryItem(thread),
           )}
         </div>
-      </details>
+      </wa-details>
     `;
   }
 
@@ -375,14 +368,8 @@ export class BackgroundTasksPanel extends LitElement {
     const label = kind === 'process' ? 'Processes' : 'Subagents';
 
     return html`
-      <details>
-        <summary class="section-label">
-          <wa-icon
-            library="texra"
-            name="chevron-right"
-            class="toggle-icon"
-            aria-hidden="true"
-          ></wa-icon>
+      <wa-details class="collapsible-quiet">
+        <div slot="summary" class="section-label">
           <wa-icon library="texra" name=${icon} aria-hidden="true"></wa-icon>
           <span
             >${label}${hasActive
@@ -391,7 +378,7 @@ export class BackgroundTasksPanel extends LitElement {
               ? html` &middot; ${finishedCount} done`
               : nothing}</span
           >
-        </summary>
+        </div>
         <div class="section-content">
           ${hasActive
             ? repeat(
@@ -406,7 +393,7 @@ export class BackgroundTasksPanel extends LitElement {
               </div>`
             : nothing}
         </div>
-      </details>
+      </wa-details>
     `;
   }
 
@@ -483,20 +470,12 @@ export class BackgroundTasksPanel extends LitElement {
 
   private renderOutputStream(label: string, text: string): TemplateResult {
     return html`
-      <details class="task-output" open>
-        <summary>
-          <wa-icon
-            library="texra"
-            name="chevron-right"
-            class="toggle-icon"
-            aria-hidden="true"
-          ></wa-icon>
-          ${label}
-        </summary>
+      <wa-details class="collapsible-quiet task-output" open>
+        <span slot="summary">${label}</span>
         <div class="output-container">
           <terminal-output .text=${text}></terminal-output>
         </div>
-      </details>
+      </wa-details>
     `;
   }
 


### PR DESCRIPTION
## Summary

Refactors the BackgroundTasksPanel to use the `<wa-details>` web component consistently throughout, replacing native HTML `<details>` elements for nested sections (Processes, Subagents, Inquiries) and per-task output. This provides uniform styling and behavior across all collapsible panels in the UI.

The changes include:
- Replace native `<details>` with `<wa-details class="collapsible-quiet">` for section headers
- Replace native `<summary>` with `<div slot="summary">` to work with wa-details API
- Remove hand-rolled toggle icons (chevron-right) — wa-details provides the disclosure chevron
- Remove custom CSS for native details styling (cursor, list-style, user-select, webkit-details-marker)
- Update CSS to use wa-details `::part(header)` for styling instead of summary selectors
- Simplify section label styling by removing padding and interaction styles now handled by wa-details

## Issue acceptance gates

N/A — This is a refactoring to improve consistency and maintainability.

## Single source of truth

The `<wa-details>` web component now owns the collapsible behavior and styling for all nested sections and task output in BackgroundTasksPanel, replacing the previous mix of native details elements and custom styling.

## Duplication and abstraction budget

Removed custom CSS for native `<details>` element styling (cursor, list-style, user-select, webkit-details-marker) that is now provided by wa-details. Eliminated hand-rolled toggle icons in favor of wa-details' built-in disclosure chevron, reducing template complexity.

## Host impact

Extension: BackgroundTasksPanel now uses consistent wa-details styling for all collapsible sections, improving visual and behavioral consistency with other panels (Todos, Files, etc.).

Desktop: N/A

CLI: N/A

## Scheduled refactoring

None

## Validation

No testing needed — this is a straightforward component refactoring that maintains existing functionality while improving consistency. The changes are purely structural (replacing element types and styling) with no behavioral changes to the panel's logic or data handling.

https://claude.ai/code/session_01EhvzawJ4u9u3cxyfh1ntRJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only markup/CSS swap in one Lit component; task listing, navigation, and auto open/close behavior are unchanged.
> 
> **Overview**
> **BackgroundTasksPanel** nested collapsibles (Processes, Subagents, Inquiries, and per-task stdout/stderr) now use **`<wa-details class="collapsible-quiet">`** instead of native **`<details>` / `<summary>`**, matching the outer panel and other progress-view panels.
> 
> Section headers move into **`slot="summary"`** (with the existing `.section-label` styling kept for Processes/Subagents/Inquiries). Hand-rolled **chevron-right** toggle icons and CSS aimed at native disclosure (marker hiding, summary cursor/list-style) are removed; styling shifts to **`wa-details::part(header)`** for nested and task-output blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e709cabd318f4fb806a14f8da39e5c87a23ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->