### PR TITLE
[codex] Include cwd in CLI resume hints

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -472,6 +472,7 @@ function stoppedFocusedChildFollowUpMessage(streamId: StreamTabId): string {
 interface SlashCommandContext {
   readonly session: TuiSession;
   readonly commandName?: string;
+  readonly cwd: string;
   readonly initialAgent: string;
   readonly initialModel: string;
   readonly interruptActive: () => void;
@@ -908,6 +909,8 @@ async function handleTuiSlashCommand(
           // a "not started" status.
           sessionId: slice ? context.session.executionId : undefined,
           commandName: context.commandName,
+          cwd: context.cwd,
+          processCwd: process.cwd(),
           queuedFollowUpMessages:
             activeStreamId === undefined
               ? []
@@ -1080,6 +1083,7 @@ export async function runChat(
   const slashCommandContext = (): SlashCommandContext => ({
     session,
     commandName: context.commandName,
+    cwd: context.cwd,
     initialAgent: agent,
     initialModel: model,
     interruptActive,
@@ -1749,6 +1753,7 @@ export async function runChat(
       }),
       collectResumeUsage(streams),
       context.commandName,
+      { cwd: context.cwd, processCwd: process.cwd() },
     );
     if (hint) writeTextStdout(`\n${hint}`);
   };

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -20,6 +20,8 @@ export interface CliSessionStatusInput {
    *  mid-session instead of only in the exit hint. */
   readonly sessionId?: string;
   readonly commandName?: string;
+  readonly cwd?: string;
+  readonly processCwd?: string;
 }
 
 export function formatCliStatusLabel(status: string | undefined): string {
@@ -73,6 +75,7 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
           `resume later with: ${formatResumeCommand(
             input.commandName,
             input.sessionId,
+            { cwd: input.cwd, processCwd: input.processCwd },
           )}`,
         ]
       : []),

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -11,6 +11,7 @@ import {
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
+import { quotePosixShellArg } from '@utils/system/shellQuote';
 
 import type { StreamSlice } from './cliState';
 
@@ -30,13 +31,26 @@ export type ResumeUsageStats = TokenUsageStats & {
   readonly reasoningTokens?: number;
 };
 
+export interface ResumeCommandOptions {
+  /** Effective workspace for the session being resumed. */
+  readonly cwd?: string;
+  /** Ambient shell cwd where the printed command will be copy-pasted. */
+  readonly processCwd?: string;
+}
+
 const DEFAULT_RESUME_COMMAND_NAME = 'texra';
 
 export function formatResumeCommand(
   commandName: string | undefined,
   executionId: string,
+  options: ResumeCommandOptions = {},
 ): string {
-  return `${commandName || DEFAULT_RESUME_COMMAND_NAME} resume ${executionId}`;
+  const cwd = options.cwd?.trim();
+  const cwdArg =
+    cwd && cwd !== options.processCwd?.trim()
+      ? ` --cwd ${quotePosixShellArg(cwd)}`
+      : '';
+  return `${commandName || DEFAULT_RESUME_COMMAND_NAME} resume ${executionId}${cwdArg}`;
 }
 
 function formatInteger(value: number): string {
@@ -136,6 +150,7 @@ export function formatResumeHint(
   targets: readonly ResumeTarget[],
   usage?: ResumeUsageStats,
   commandName?: string,
+  commandOptions?: ResumeCommandOptions,
 ): string | undefined {
   if (targets.length === 0) return undefined;
   const lines = [formatResumeUsage(usage), 'Resume this session with:'].filter(
@@ -143,7 +158,11 @@ export function formatResumeHint(
   );
   for (const target of targets) {
     lines.push(
-      `  ${formatResumeCommand(commandName, target.executionId)}  (${target.label})`,
+      `  ${formatResumeCommand(
+        commandName,
+        target.executionId,
+        commandOptions,
+      )}  (${target.label})`,
     );
   }
   return lines.join('\n');

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -133,6 +133,24 @@ describe('formatResumeHint', () => {
     );
   });
 
+  it('adds a quoted cwd when the session workspace differs from the shell cwd', () => {
+    expect(
+      formatResumeCommand('texra-local', 'root', {
+        cwd: "/tmp/texra user's paper",
+        processCwd: '/tmp/launcher',
+      }),
+    ).toBe("texra-local resume root --cwd '/tmp/texra user'\\''s paper'");
+  });
+
+  it('omits cwd when the resume command is already printed from that workspace', () => {
+    expect(
+      formatResumeCommand('texra-local', 'root', {
+        cwd: '/tmp/paper',
+        processCwd: '/tmp/paper',
+      }),
+    ).toBe('texra-local resume root');
+  });
+
   it('renders one resume line per target', () => {
     expect(
       formatResumeHint([
@@ -163,6 +181,26 @@ describe('formatResumeHint', () => {
         'Resume this session with:',
         '  texra-local resume root  (main)',
         '  texra-local resume rev  (reviewer)',
+      ].join('\n'),
+    );
+  });
+
+  it('includes cwd on every resume target when needed', () => {
+    expect(
+      formatResumeHint(
+        [
+          { executionId: 'root', label: 'main', isRoot: true },
+          { executionId: 'rev', label: 'reviewer', isRoot: false },
+        ],
+        undefined,
+        'texra-local',
+        { cwd: '/tmp/paper', processCwd: '/tmp/launcher' },
+      ),
+    ).toBe(
+      [
+        'Resume this session with:',
+        "  texra-local resume root --cwd '/tmp/paper'  (main)",
+        "  texra-local resume rev --cwd '/tmp/paper'  (reviewer)",
       ].join('\n'),
     );
   });

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -118,6 +118,25 @@ describe('CLI session status formatter', () => {
     expect(status).toContain('resume later with: texra-local resume abc123');
   });
 
+  it('includes cwd in the resume status line when the session uses another workspace', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'personal',
+      approval: 'ask',
+      status: 'running',
+      sessionId: 'abc123',
+      commandName: 'texra-local',
+      cwd: '/tmp/paper',
+      processCwd: '/tmp/launcher',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).toContain(
+      "resume later with: texra-local resume abc123 --cwd '/tmp/paper'",
+    );
+  });
+
   it('omits session lines before the first run starts', () => {
     const status = formatCliSessionStatus({
       agent: 'chat',


### PR DESCRIPTION
## Summary

Fixes a CLI dogfood issue where chat sessions started with `--cwd` printed a resume command that could fail when copied from the original shell working directory.

The resume command formatter now appends a shell-quoted `--cwd <workspace>` when the session workspace differs from the ambient process cwd. The same formatting is used for the final exit footer and `/status` resume line.

Closes #6073.

## Dogfood Evidence

Started chat from `/private/tmp/texra-cli-dogfood-20260615-latest` with:

```sh
TERM=xterm-256color texra-local chat --cwd /tmp/texra-chat-dogfood-20260615 --api-mode included --approval-policy ask
```

The session completed a real edit/compile flow, then printed `texra-local resume 47b3db6952eb`. From the shell cwd, `texra-local history show 47b3db6952eb --output-format=json` failed with `Execution not found: 47b3db6952eb`; with the chat workspace supplied via `--cwd`, the same id resolved.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/chat/tui/state/resumeHint.ts packages/cli/src/chat/tui/sessionStatus.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/ResumeHint.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/ResumeHint.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI hint formatting with existing shell quoting; no changes to resume execution or auth paths.
> 
> **Overview**
> Fixes copy-paste resume commands for chats started with **`--cwd`**: when the session workspace is not the ambient shell directory, printed **`resume`** lines now include a shell-quoted **`--cwd <path>`** (via **`quotePosixShellArg`**). If the user is already in that workspace, **`--cwd`** is omitted so the command stays short.
> 
> The same formatting is wired through **`/status`** (“resume later with: …”), the exit scrollback footer (**`formatResumeHint`**), and slash-command context that carries **`context.cwd`** plus **`process.cwd()`** for comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d284d50f6864f5e7df695eae1bebdb1c5a0d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->