### PR TITLE
[codex] Clarify plan approve-and-run notice

### DIFF
--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -22,7 +22,8 @@ export interface PlanApprovalProps {
 export const COMPACT_PLAN_APPROVAL_MAX_ROWS = 7;
 const MIN_PLAN_APPROVAL_CONTENT_WIDTH = 20;
 const PLAN_APPROVAL_TITLE = 'Approve plan?';
-export const PLAN_APPROVAL_GOAL_NOTICE = 'Bash auto-approved; edits still ask.';
+export const PLAN_APPROVAL_GOAL_NOTICE =
+  'Approve&run: bash auto; edits still ask.';
 const PLAN_APPROVAL_GOAL_NOTICE_ROWS = 2;
 const PLAN_APPROVAL_NON_COMPACT_FIXED_ROWS = 7;
 const PLAN_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;

--- a/src/test-kernel/cli/PlanApproval.vitest.mts
+++ b/src/test-kernel/cli/PlanApproval.vitest.mts
@@ -127,6 +127,7 @@ describe('CLI plan approval layout', () => {
   });
 
   it('keeps the autonomous warning concise enough for the approval card', () => {
+    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('Approve&run');
     expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('edits still ask');
     expect(PLAN_APPROVAL_GOAL_NOTICE.length).toBeLessThanOrEqual(56);
   });
@@ -135,6 +136,7 @@ describe('CLI plan approval layout', () => {
     const notice = planApprovalGoalNoticeLine(40);
 
     expect(textDisplayWidth(notice)).toBe(40);
+    expect(notice).toContain('Approve&run');
     expect(notice).toContain('edits still ask');
     expect(notice).not.toContain('…');
   });


### PR DESCRIPTION
## Summary
- Clarify the CLI plan approval notice so bash auto-approval is scoped to the `approve&run` path.
- Keep the notice within the existing one-row narrow-card constraint.
- Update the focused plan approval layout tests.

Fixes #6075.

## Dogfood evidence
During `texra-local orchestrate --cwd /tmp/texra-math-dogfood-20260615b --api-mode included --approval-policy ask`, the plan card showed `Bash auto-approved; edits still ask.` before I chose plain `y approve`. Later bash still correctly prompted for `pdflatex`, so the runtime behavior was right but the copy was misleading.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/PlanApproval.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and test assertions only; no approval or runtime behavior changes.
> 
> **Overview**
> Updates the CLI plan approval **goal notice** so it no longer reads as if bash is auto-approved for every approval choice.
> 
> The string changes from `Bash auto-approved; edits still ask.` to **`Approve&run: bash auto; edits still ask.`**, tying bash auto-approval to the **approve & run** path while keeping the “edits still ask” behavior. Layout tests now assert the new **`Approve&run`** wording and still enforce the existing length and single-row narrow-card constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a342273623237a6ba1b0d6e876f0fb5304526c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->