### PR TITLE
[codex] Validate chat root agents before launch

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -50,6 +50,7 @@ import {
 import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import { firstRunSetupAgentOverride } from '@cli/onboarding/setupContinuation';
 import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
+import { missingToolUseAgentMessage } from '@cli/commands/_helpers/agentLookupText';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
@@ -491,6 +492,19 @@ function agentSupportsDelegation(agentName: string): boolean {
   );
 }
 
+export function chatToolUseAgentUsageError(
+  agentName: string,
+): string | undefined {
+  const agent = getAgent(agentName, true);
+  if (!agent) {
+    return missingToolUseAgentMessage(agentName);
+  }
+  if (agent.category !== AgentCategory.ToolUse) {
+    return `Agent "${agentName}" is a ${agent.category} agent; \`texra chat\` only handles tool-use agents. Use \`texra run ${agentName}\` for workflow agents, or \`texra multi-agent run <preset>\` for teams.`;
+  }
+  return undefined;
+}
+
 function applyInitialCliAgentSelection(
   agentName: string,
   context: SlashCommandContext,
@@ -503,6 +517,11 @@ function applyInitialCliAgentSelection(
   }
 
   const nextAgent = agentName.trim();
+  const usageError = chatToolUseAgentUsageError(nextAgent);
+  if (usageError) {
+    appendLocalAssistantTranscript(usageError);
+    return;
+  }
   cliState.sessionMeta.set({
     ...cliState.sessionMeta.get(),
     agent: nextAgent,
@@ -1033,6 +1052,12 @@ export async function runChat(
     envAgent: context.envAgent,
     envModel: context.envModel,
   });
+  await loadAgents();
+  const agentUsageError = chatToolUseAgentUsageError(defaults.agent);
+  if (agentUsageError) {
+    writeTextStderr(agentUsageError);
+    return { exitCode: CliExitCode.Usage };
+  }
   // One API mode for the whole session: an explicit --api-mode/env override
   // wins, otherwise the persisted account default. Model resolution, the
   // no-models hints, and the header/status all read this same value so they can
@@ -1090,7 +1115,6 @@ export async function runChat(
     resetSession: resetSessionForClear,
     resumeExecution: resumeAgentRun,
   });
-  await loadAgents();
   cliState.sessionMeta.set({
     agent,
     model,

--- a/src/test-kernel/cli/RunChatConfig.vitest.mts
+++ b/src/test-kernel/cli/RunChatConfig.vitest.mts
@@ -1,11 +1,37 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getAgent, type AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   buildInitialChatAgentConfig,
+  chatToolUseAgentUsageError,
   restorePendingSkillActivations,
   takePendingSkillActivations,
 } from '@cli/chat/tui/runChatTui';
+
+vi.mock('@agent/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent/index')>();
+  return {
+    ...actual,
+    getAgent: vi.fn(),
+  };
+});
+
+const mockedGetAgent = vi.mocked(getAgent);
+
+function registryAgent(category: AgentCategory): AgentEntry {
+  return {
+    name: category === AgentCategory.ToolUse ? 'assistant' : 'polish',
+    source:
+      category === AgentCategory.ToolUse ? 'builtInToolUse' : 'builtInWorkflow',
+    path: '/tmp/agent.yaml',
+    category,
+  };
+}
+
+beforeEach(() => {
+  mockedGetAgent.mockReset();
+});
 
 describe('CLI chat run config', () => {
   it('tags preset-launched team chats with the multi-agent preset id', () => {
@@ -130,6 +156,29 @@ describe('CLI chat run config', () => {
     expect(prepared.displayInstruction).toBe('compare A < B & C');
     expect(prepared.instruction).toContain(
       '<user_request>\ncompare A &lt; B &amp; C\n</user_request>',
+    );
+  });
+
+  it('accepts valid tool-use root chat agents', () => {
+    mockedGetAgent.mockReturnValueOnce(registryAgent(AgentCategory.ToolUse));
+
+    expect(chatToolUseAgentUsageError('assistant')).toBeUndefined();
+    expect(mockedGetAgent).toHaveBeenCalledWith('assistant', true);
+  });
+
+  it('rejects missing root chat agents before a prompt is submitted', () => {
+    mockedGetAgent.mockReturnValueOnce(undefined);
+
+    expect(chatToolUseAgentUsageError('mathematician')).toContain(
+      'Tool-use agent not found: mathematician.',
+    );
+  });
+
+  it('rejects workflow agents as root chat agents', () => {
+    mockedGetAgent.mockReturnValueOnce(registryAgent(AgentCategory.Workflow));
+
+    expect(chatToolUseAgentUsageError('polish')).toContain(
+      '`texra chat` only handles tool-use agents',
     );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #6077.

- validates the resolved root chat agent before the Ink chat TUI mounts
- rejects unknown agents and workflow-only agents with usage errors instead of failing after the first prompt
- applies the same validation to direct `/agent <name>` changes before the first message

## Dogfood Evidence

On latest main (`ba20da5de`), this opened chat with `agent: mathematician`, then failed only after prompt submission with `Could not find agent: mathematician`:

```sh
TERM=xterm-256color texra-local chat \
  --cwd /tmp/texra-chat-dogfood-20260615c \
  --api-mode included \
  --approval-policy ask \
  --agent mathematician \
  --model gemini35f
```

After this change and rebuilding the CLI bundle, the same command exits before mounting the TUI:

```text
Tool-use agent not found: mathematician. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.
```

A workflow agent now also exits before chat:

```text
Agent "polish" is a workflow agent; `texra chat` only handles tool-use agents. Use `texra run polish` for workflow agents, or `texra multi-agent run <preset>` for teams.
```

A valid tool-use agent still opens chat normally:

```sh
TERM=xterm-256color texra-local chat --agent assistant --model gemini35f
```

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/RunChatConfig.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/RunChatConfig.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli run bundle`
- `corepack pnpm --filter @texra-ai/cli run check:architecture`
- `corepack pnpm vitest run src/test-kernel/cli/RunChatConfig.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX guardrails around agent selection with no auth, data, or execution-path changes beyond earlier failure.
> 
> **Overview**
> **`texra chat`** now checks the resolved root agent **before** the Ink TUI mounts, instead of failing only after the first prompt.
> 
> A new **`chatToolUseAgentUsageError`** helper rejects unknown agents (reusing **`missingToolUseAgentMessage`**) and **workflow** agents with guidance to use **`texra run`** or **`texra multi-agent run`**. Startup calls **`loadAgents()`** first, prints the error to stderr, and exits with a usage code. The same check runs when changing the root agent via **`/agent`** before the first message.
> 
> Unit tests cover valid tool-use agents, missing names, and workflow agents via a mocked registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec68a28c599672b7236e548cc056688f0eb26765. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->