### PR TITLE
[codex] Hide implicit default agent predicate

### DIFF
--- a/packages/cli/src/runtime/defaultAgents.ts
+++ b/packages/cli/src/runtime/defaultAgents.ts
@@ -4,7 +4,7 @@ export const BUILTIN_DEFAULT_CHAT_AGENT = 'assistant';
 
 const NON_IMPLICIT_DEFAULT_TOOL_USE_AGENTS = new Set(['simplifier']);
 
-export function isImplicitDefaultToolUseAgentAllowed(agent: string): boolean {
+function isImplicitDefaultToolUseAgentAllowed(agent: string): boolean {
   return !NON_IMPLICIT_DEFAULT_TOOL_USE_AGENTS.has(
     agentName(agent.trim()).toLowerCase(),
   );

--- a/src/test-kernel/cli/DefaultAgents.vitest.mts
+++ b/src/test-kernel/cli/DefaultAgents.vitest.mts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   BUILTIN_DEFAULT_CHAT_AGENT,
   implicitDefaultToolUseAgents,
-  isImplicitDefaultToolUseAgentAllowed,
   resolveImplicitToolUseAgentDefault,
 } from '@cli/runtime/defaultAgents';
 
@@ -12,19 +11,11 @@ describe('CLI implicit default agent policy', () => {
     expect(BUILTIN_DEFAULT_CHAT_AGENT).toBe('assistant');
   });
 
-  it('does not allow simplifier to become an implicit default', () => {
-    expect(isImplicitDefaultToolUseAgentAllowed('assistant')).toBe(true);
-    expect(isImplicitDefaultToolUseAgentAllowed(' simplifier ')).toBe(false);
-    expect(isImplicitDefaultToolUseAgentAllowed('SIMPLIFIER')).toBe(false);
-    expect(
-      isImplicitDefaultToolUseAgentAllowed('builtInToolUse:simplifier'),
-    ).toBe(false);
-  });
-
   it('filters implicit default candidates without mutating explicit options', () => {
     const candidates = [
       { name: 'simplifier', source: 'built-in' },
       { name: 'builtInToolUse:simplifier', source: 'built-in' },
+      { name: 'SIMPLIFIER', source: 'built-in' },
       { name: 'assistant', source: 'built-in' },
       { name: 'review', source: 'built-in' },
     ] as const;
@@ -38,6 +29,10 @@ describe('CLI implicit default agent policy', () => {
   it('normalizes only allowed implicit default values', () => {
     expect(resolveImplicitToolUseAgentDefault(' review ')).toBe('review');
     expect(resolveImplicitToolUseAgentDefault('simplifier')).toBeUndefined();
+    expect(resolveImplicitToolUseAgentDefault('SIMPLIFIER')).toBeUndefined();
+    expect(
+      resolveImplicitToolUseAgentDefault('builtInToolUse:simplifier'),
+    ).toBeUndefined();
     expect(resolveImplicitToolUseAgentDefault('   ')).toBeUndefined();
     expect(resolveImplicitToolUseAgentDefault(undefined)).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Small lean-code refactor following the CLI dogfood cleanup thread.

- stop exporting `isImplicitDefaultToolUseAgentAllowed`, which had no production caller outside `defaultAgents.ts`
- keep the policy private to the runtime default-agent module
- update tests to verify the public behavior through candidate filtering and normalization instead of reaching into the private predicate

## Why

The module only needs two public decisions: filter implicit default candidates and normalize a configured implicit default. Exporting the predicate made the module surface wider just for tests.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/DefaultAgents.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec prettier --write packages/cli/src/runtime/defaultAgents.ts src/test-kernel/cli/DefaultAgents.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API visibility and test refactor only; no change to runtime default-agent behavior.
> 
> **Overview**
> Narrows the public API of `defaultAgents.ts` by making **`isImplicitDefaultToolUseAgentAllowed`** a private helper instead of an export. Implicit-default policy (e.g. excluding **simplifier** and normalized variants) is unchanged; only **`implicitDefaultToolUseAgents`** and **`resolveImplicitToolUseAgentDefault`** remain the public surface.
> 
> Tests no longer import the predicate. They assert the same rules via filtering candidates and normalization, including **`SIMPLIFIER`** and **`builtInToolUse:simplifier`** cases moved from the removed direct predicate test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453127468594d1be62c934761750c77917654c71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->