### PR TITLE
[codex] Make agent lookup context explicit

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -486,7 +486,7 @@ interface SlashCommandContext {
 
 function agentSupportsDelegation(agentName: string): boolean {
   return (
-    getAgent(agentName, true)?.tools?.some((toolName) =>
+    getAgent(agentName, AgentCategory.ToolUse)?.tools?.some((toolName) =>
       DELEGATION_TOOLS.has(toolName),
     ) ?? false
   );
@@ -495,7 +495,7 @@ function agentSupportsDelegation(agentName: string): boolean {
 export function chatToolUseAgentUsageError(
   agentName: string,
 ): string | undefined {
-  const agent = getAgent(agentName, true);
+  const agent = getAgent(agentName, AgentCategory.ToolUse);
   if (!agent) {
     return missingToolUseAgentMessage(agentName);
   }

--- a/packages/extension/src/MainViewProvider.ts
+++ b/packages/extension/src/MainViewProvider.ts
@@ -14,6 +14,7 @@ import {
   createKey,
   getAgent,
 } from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local imports - common
@@ -203,7 +204,7 @@ export class MainViewProvider
       this.pendingSetupAgentSelection = false;
       // Resolve the qualified registry key so the dropdown matches by value;
       // the plain name still resolves by label if the registry isn't loaded.
-      const entry = getAgent('setup', true);
+      const entry = getAgent('setup', AgentCategory.ToolUse);
       view.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_SELECTED_AGENT,
         agentId: entry ? createKey(entry.source, entry.name) : 'setup',

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -10,6 +10,7 @@ import { ProgressAgentProposalController } from '@controllers/progressView/Progr
 import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { getAgent } from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
   validateExecutionRequest,
@@ -554,7 +555,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
   private createFollowUpController(): ProgressFollowUpController {
     return new ProgressFollowUpController({
-      getAgentCategory: (agent) => getAgent(agent, true)?.category,
+      getAgentCategory: (agent) =>
+        getAgent(agent, AgentCategory.ToolUse)?.category,
       workspace: {
         locatePath: (candidate) => WorkspaceFS.locatePath(candidate),
         exists: (relativePath) => WorkspaceFS.exists(relativePath),

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -4,7 +4,10 @@ import { platform } from '@platform/platform';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import * as logger from '@logger/logUtils';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import type { AgentSource } from '@shared/schemas/agent';
+import type {
+  AgentCategory as AgentCategoryType,
+  AgentSource,
+} from '@shared/schemas/agent';
 import { agentKey as createKey, agentName } from '@shared/schemas/agent';
 import { getAgentDirectories } from './agentDirectoriesRegistry';
 import {
@@ -228,23 +231,25 @@ const LEGACY_AGENT_ALIASES: Record<string, string> = {
 /**
  * Canonical agent resolver: look up an agent by identifier.
  *
- * Supports "source:name" format or just "name". Plain names are matched
- * against {@link LOOKUP_PRIORITY} (or {@link TOOL_USE_LOOKUP_PRIORITY} when
- * `preferToolUse` is true), returning the first hit. This handles name
- * collisions where, e.g., a workflow agent shadows a tool-use agent.
+ * Supports "source:name" format or just "name". Plain names use the default
+ * source priority unless the lookup is for a tool-use session, where built-in
+ * tool-use agents outrank built-in workflow agents.
  *
  * All other lookups in this module (`resolveAgent`, `resolveAgentKey`,
  * `isRemoteAgent`, `updateAgent*`) delegate here.
  */
 export function getAgent(
   identifier: string,
-  preferToolUse = false,
+  category?: AgentCategoryType,
 ): AgentEntry | undefined {
   // Direct lookup for source:name format (already resolved)
   if (cache.has(identifier)) return cache.get(identifier);
 
   // Find first match using session-appropriate priority
-  const priority = preferToolUse ? TOOL_USE_LOOKUP_PRIORITY : LOOKUP_PRIORITY;
+  const priority =
+    category === AgentCategory.ToolUse
+      ? TOOL_USE_LOOKUP_PRIORITY
+      : LOOKUP_PRIORITY;
   for (const source of priority) {
     const entry = cache.get(`${source}:${identifier}`);
     if (entry) return entry;
@@ -257,7 +262,7 @@ export function getAgent(
   const alias = LEGACY_AGENT_ALIASES[name];
   if (alias) {
     const prefix = identifier.slice(0, identifier.length - name.length);
-    return getAgent(`${prefix}${alias}`, preferToolUse);
+    return getAgent(`${prefix}${alias}`, category);
   }
   return undefined;
 }
@@ -353,10 +358,10 @@ export async function refresh(options: LoadAgentsOptions = {}): Promise<void> {
  */
 export function resolveAgentKey(
   agentIdentifier: string,
-  preferToolUse = false,
+  category?: AgentCategoryType,
 ): string {
   if (!agentIdentifier) return agentIdentifier;
-  const entry = getAgent(agentIdentifier, preferToolUse);
+  const entry = getAgent(agentIdentifier, category);
   if (!entry) return agentIdentifier;
   return createKey(entry.source, entry.name);
 }
@@ -413,7 +418,7 @@ export function getVisibleAgent(
   );
   if (exact) return exact;
 
-  const entry = getAgent(identifier, category === AgentCategory.ToolUse);
+  const entry = getAgent(identifier, category);
   if (!entry) return undefined;
   return entries.find((visible) => visible.name === entry.name);
 }
@@ -458,9 +463,7 @@ function filterVisible(
     configured.flatMap((value) => {
       const name = agentName(value);
       if (entries.some((entry) => entry.name === name)) return [name];
-      return [
-        getAgent(value, category === AgentCategory.ToolUse)?.name ?? name,
-      ];
+      return [getAgent(value, category)?.name ?? name];
     }),
   );
   return entries.filter((entry) => enabledNames.has(entry.name));

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -10,6 +10,7 @@
 import { getAgent } from '@agent/index';
 import { writeSessionDescription } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createHelperModelKit } from '@agent/runtime/helperModel';
 import { getSdkErrorMessage } from '@common/errors';
@@ -84,7 +85,7 @@ export async function generateSessionDescription(
     const instruction = getSessionDescriptionInstruction(config);
     if (!instruction) return;
 
-    const agentEntry = getAgent(config.agent, true);
+    const agentEntry = getAgent(config.agent, AgentCategory.ToolUse);
     const agentDescription = agentEntry?.description;
 
     const helperResult = await createHelperModelKit();

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -38,7 +38,12 @@ export function normalizeWriterCategory(
 ): AgentConfig {
   if (config.agentCategory !== AgentCategory.ToolUse) return config;
   if (!isAgentRegistryReady()) return config;
-  if (getAgent(agentName)?.category === AgentCategory.ToolUse) return config;
+  if (
+    getAgent(agentName, AgentCategory.ToolUse)?.category ===
+    AgentCategory.ToolUse
+  ) {
+    return config;
+  }
   return { ...config, agentCategory: AgentCategory.Workflow };
 }
 

--- a/src/controllers/mainView/MainViewStateRestoreController.ts
+++ b/src/controllers/mainView/MainViewStateRestoreController.ts
@@ -1,5 +1,6 @@
 // Local imports - agent registry
 import { resolveAgentKey } from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 // Local imports - task state
 import {
@@ -23,11 +24,13 @@ export function buildMainViewState(
   const isWorkflow = isWorkflowTaskState(taskState);
   const toolConfig = agentConfig.toolConfig ?? {};
 
+  const agentCategory = isToolUse
+    ? AgentCategory.ToolUse
+    : AgentCategory.Workflow;
+
   // Resolve agent name to full key (e.g., "criticize" -> "builtIn:criticize").
   // This ensures the frontend receives the exact key used in dropdown options.
-  // Pass isToolUse to prefer builtInToolUse source for tool-use sessions,
-  // preventing workflow agents from shadowing tool-use agents with same name.
-  const resolvedAgent = resolveAgentKey(agentConfig.agent, isToolUse);
+  const resolvedAgent = resolveAgentKey(agentConfig.agent, agentCategory);
 
   // Build partial state from agentConfig and toolConfig, then parse with schema
   // to apply prefault defaults for any missing fields.

--- a/src/test-kernel/agent/ExecutionWriterCategory.vitest.mts
+++ b/src/test-kernel/agent/ExecutionWriterCategory.vitest.mts
@@ -9,8 +9,10 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 const state = { ready: true };
 vi.mock('@agent/index/agentRegistry', () => ({
   isAgentRegistryReady: vi.fn(() => state.ready),
-  getAgent: vi.fn((name: string) =>
-    name === 'research' ? { name, category: AgentCategory.ToolUse } : undefined,
+  getAgent: vi.fn((name: string, category?: AgentCategory) =>
+    name === 'research' && category === AgentCategory.ToolUse
+      ? { name, category: AgentCategory.ToolUse }
+      : undefined,
   ),
 }));
 

--- a/src/test-kernel/cli/RunChatConfig.vitest.mts
+++ b/src/test-kernel/cli/RunChatConfig.vitest.mts
@@ -163,7 +163,10 @@ describe('CLI chat run config', () => {
     mockedGetAgent.mockReturnValueOnce(registryAgent(AgentCategory.ToolUse));
 
     expect(chatToolUseAgentUsageError('assistant')).toBeUndefined();
-    expect(mockedGetAgent).toHaveBeenCalledWith('assistant', true);
+    expect(mockedGetAgent).toHaveBeenCalledWith(
+      'assistant',
+      AgentCategory.ToolUse,
+    );
   });
 
   it('rejects missing root chat agents before a prompt is submitted', () => {


### PR DESCRIPTION
## Summary

- Replace the agent registry's boolean tool-use lookup switch with an explicit `AgentCategory` context.
- Thread that category through main-view restore, setup selection, follow-up/session-description lookups, and visible-agent filtering.
- Tighten `normalizeWriterCategory` so a real tool-use agent is resolved with tool-use priority before demoting synthetic process rows.

## Why

The previous `getAgent(name, true)` surface hid the reason for the alternate lookup order at call sites. Passing the session category makes the ownership clearer without adding another resolver layer.

## Validation

- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec vitest run src/test-kernel/agent/ExecutionWriterCategory.vitest.mts src/test-kernel/agent/AgentRegistryAlias.vitest.mts src/test-kernel/agent/GoalContinuation.vitest.ts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- plan-approval-goal compact-plan-approval-goal plan-approval-approve-goal`
- `npm run lint` (passes with existing warnings only)

## Dogfood

- Started `TERM=xterm-256color texra-local chat --approval-policy=ask --agent assistant --model gpt55` in a real PTY.
- Approved a hard Collatz-analysis plan with `r approve & run`.
- Observed `goal_7101a40aa37c started`, `AUTO-BASH`, read-only tool activity, stable todo/status rendering, and clean interrupt/resume output: `texra-local resume 0bc4099da52d`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with no new resolver layer; behavior is unchanged except clearer lookup intent at call sites, with existing tests covering writer category and CLI chat agent checks.
> 
> **Overview**
> **Agent registry lookups now take an explicit session category** instead of `getAgent(name, true)`. `getAgent` and `resolveAgentKey` accept optional `AgentCategory`; only `AgentCategory.ToolUse` selects `TOOL_USE_LOOKUP_PRIORITY`, otherwise default `LOOKUP_PRIORITY` applies.
> 
> Call sites that run in tool-use sessions (CLI chat validation/delegation, extension setup agent and follow-up category, session descriptions, main-view restore, visible-agent filtering) pass `AgentCategory.ToolUse` or derive workflow vs tool-use from task state. **`normalizeWriterCategory`** resolves synthetic process names with tool-use priority before demoting non–tool-use agents to workflow.
> 
> Tests updated to expect the category argument on mocked `getAgent` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e849564872f745c507478ce94c10c971bfafaa2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->