### PR TITLE
[codex] Keep goal continuation queue logic in wait node

### DIFF
--- a/src/agent/goal/index.ts
+++ b/src/agent/goal/index.ts
@@ -1,6 +1,3 @@
-export {
-  maybeBuildGoalContinuation,
-  type GoalContinuationContext,
-} from './maybeBuildGoalContinuation';
+export { maybeBuildGoalContinuation } from './maybeBuildGoalContinuation';
 
 export { initializeGoalPrompts } from './promptLoader';

--- a/src/agent/goal/maybeBuildGoalContinuation.ts
+++ b/src/agent/goal/maybeBuildGoalContinuation.ts
@@ -4,44 +4,29 @@ import { GoalStore, isGoalEnabled } from '@tools/goal';
 
 import { buildContinuationFollowUp } from './buildContinuationFollowUp';
 
-export interface GoalContinuationContext {
-  streamId: StreamTabId;
-  /** True when the current wait-node is running inside an orchestrator-driven subagent. */
-  isSubagent: boolean;
-  /** Result of `session.hasQueuedFollowUp()` at the call site. */
-  hasQueuedFollowUp: boolean;
-}
-
 /**
- * Pre-wait Goal continuation check.
+ * Build the pre-wait Goal continuation for a stream.
  *
  * Returns a rendered continuation prompt when:
  *   - the feature flag is on,
- *   - the current node is NOT a subagent (parent orchestrator owns continuation
- *     — subagents only ever roll their usage up to the parent, never drive the
- *     loop),
- *   - no user followUp is already queued (caller-supplied snapshot),
  *   - the stream has a Goal with status `active`.
  *
- * Returns null in every other case so the caller falls back to the normal
- * blocking wait. Pure: no side effects. The autonomous loop runs until the
- * model finishes (`plan(command="complete")` → forget) or the user stops it;
- * there is no continuation counter or per-turn cap.
+ * Queue and subagent checks belong to the wait-node caller because it owns the
+ * blocking wait. This helper is pure: no side effects, no counter, no audit
+ * log. The autonomous loop runs until the model completes
+ * (`plan(command="complete")` → forget) or the user stops it.
  *
  * Called from `ToolUseWaitNode.exec()` BEFORE `session.waitForFollowUp` — the
  * wait blocks indefinitely on an empty queue, so the continuation cannot run
  * after it.
  */
 export async function maybeBuildGoalContinuation(
-  ctx: GoalContinuationContext,
+  streamId: StreamTabId,
 ): Promise<string | null> {
-  if (ctx.isSubagent) return null;
-  if (ctx.hasQueuedFollowUp) return null;
-
   // Read the store first — it is bootstrap-tolerant (returns null before
   // platform init), so the flag check below (which needs `platform()`) is only
   // reached when an active record actually exists on disk.
-  const goal = GoalStore.getForStream(ctx.streamId);
+  const goal = GoalStore.getForStream(streamId);
   if (!goal || goal.status !== 'active') return null;
 
   if (!isGoalEnabled()) return null;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -114,12 +114,8 @@ export class ToolUseWaitNode<C> extends Node<
     // failed/cancelled cycle so the user-recovery path still fires. The
     // post-build re-check of `hasQueuedFollowUp` lets user input that arrived
     // during the build win the race.
-    if (!prepRes.afterError) {
-      const followUp = await maybeBuildGoalContinuation({
-        streamId,
-        isSubagent: !!isSubagent,
-        hasQueuedFollowUp: session.hasQueuedFollowUp(),
-      });
+    if (!prepRes.afterError && !isSubagent && !session.hasQueuedFollowUp()) {
+      const followUp = await maybeBuildGoalContinuation(streamId);
       if (followUp && !session.hasQueuedFollowUp()) {
         return {
           kind: 'continue',

--- a/src/test-kernel/agent/GoalContinuation.vitest.ts
+++ b/src/test-kernel/agent/GoalContinuation.vitest.ts
@@ -99,11 +99,7 @@ describe('maybeBuildGoalContinuation', () => {
       STREAM_ID,
       'Complete the refactor until pnpm test passes',
     );
-    const out = await maybeBuildGoalContinuation({
-      streamId: STREAM_ID,
-      isSubagent: false,
-      hasQueuedFollowUp: false,
-    });
+    const out = await maybeBuildGoalContinuation(STREAM_ID);
     expect(out).toMatch(/<goal_context>/);
     expect(out).toContain('Complete the refactor until pnpm test passes');
     expect(out).toContain('Autonomous objective active');
@@ -113,68 +109,32 @@ describe('maybeBuildGoalContinuation', () => {
     expect(out).not.toContain('plan(command="pause")');
   });
 
-  it('returns null in subagent mode (parent owns continuation)', async () => {
-    await GoalStore.start(STREAM_ID, 'objective');
-    const out = await maybeBuildGoalContinuation({
-      streamId: STREAM_ID,
-      isSubagent: true,
-      hasQueuedFollowUp: false,
-    });
-    expect(out).toBeNull();
-  });
-
-  it('returns null when user already queued a follow-up', async () => {
-    await GoalStore.start(STREAM_ID, 'objective');
-    const out = await maybeBuildGoalContinuation({
-      streamId: STREAM_ID,
-      isSubagent: false,
-      hasQueuedFollowUp: true,
-    });
-    expect(out).toBeNull();
-  });
-
   it('returns null when the feature flag is off (with an active goal present)', async () => {
     await GoalStore.start(STREAM_ID, 'objective');
     // Flip just the flag — keep the same workspaceState so the active
     // goal is still on disk. Otherwise the test passes trivially.
     (platform.config as FakeConfigProvider).set(GOAL_FEATURE_FLAG_KEY, false);
-    const out = await maybeBuildGoalContinuation({
-      streamId: STREAM_ID,
-      isSubagent: false,
-      hasQueuedFollowUp: false,
-    });
+    const out = await maybeBuildGoalContinuation(STREAM_ID);
     expect(out).toBeNull();
     // Sanity: the record still exists; only the flag stopped the loop.
     expect(GoalStore.getForStream(STREAM_ID)?.status).toBe('active');
   });
 
   it('returns null when no goal exists for the stream', async () => {
-    const out = await maybeBuildGoalContinuation({
-      streamId: STREAM_ID,
-      isSubagent: false,
-      hasQueuedFollowUp: false,
-    });
+    const out = await maybeBuildGoalContinuation(STREAM_ID);
     expect(out).toBeNull();
   });
 
   it('returns null when the goal is paused', async () => {
     await GoalStore.start(STREAM_ID, 'objective');
     await GoalStore.setStatus(STREAM_ID, 'paused');
-    const out = await maybeBuildGoalContinuation({
-      streamId: STREAM_ID,
-      isSubagent: false,
-      hasQueuedFollowUp: false,
-    });
+    const out = await maybeBuildGoalContinuation(STREAM_ID);
     expect(out).toBeNull();
   });
 
   it('is a pure read — leaves the record untouched', async () => {
     const before = await GoalStore.start(STREAM_ID, 'objective');
-    await maybeBuildGoalContinuation({
-      streamId: STREAM_ID,
-      isSubagent: false,
-      hasQueuedFollowUp: false,
-    });
+    await maybeBuildGoalContinuation(STREAM_ID);
     const after = GoalStore.getForStream(STREAM_ID);
     // No counter, no audit log: the helper only reads. The loop runs until
     // the model completes or the user stops it.

--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -273,6 +273,168 @@ describe('ToolUseWaitNode', () => {
     }
   });
 
+  it('injects an active goal continuation before the blocking wait', async () => {
+    const streamId = 'wait-node-active-goal' as StreamTabId;
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(createFakePlatform({}));
+
+    await GoalStore.start(streamId, 'Finish the autonomous proof audit.');
+
+    const shared: ToolUseRunShared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const createUserFollowUpMessages = vi.fn(
+      async (messages: unknown[], userMessage: string) => [
+        ...messages,
+        { role: 'user', content: userMessage },
+      ],
+    );
+    const onFollowUpConsumed = vi.fn();
+    const waitForFollowUp = vi.fn();
+    const streamStatus = new StreamStatusRegistry();
+    const services = {
+      checkInterruption: () => false,
+      isSubagent: false,
+      logger: { error: vi.fn(), info: vi.fn() },
+      modelHandler: {
+        createUserFollowUpMessages,
+        extractAssistantText: () => undefined,
+      },
+      onFollowUpConsumed,
+      runtimeHost: { emit: vi.fn() },
+      session: {
+        hasQueuedFollowUp: () => false,
+        waitForFollowUp,
+      },
+      streamId,
+      streamStatus,
+    } as unknown as ToolUseServices;
+    const node = new ToolUseWaitNode().setServices(services);
+
+    try {
+      const prep = await node.prep(shared);
+      const exec = await node.exec(prep);
+
+      expect(exec.kind).toBe('continue');
+      if (exec.kind !== 'continue') return;
+      expect(exec.synthetic).toBe(true);
+      expect(exec.followUps).toEqual([
+        {
+          text: expect.stringContaining('Finish the autonomous proof audit.'),
+          origin: 'synthetic',
+        },
+      ]);
+      expect(waitForFollowUp).not.toHaveBeenCalled();
+      expect(streamStatus.get(streamId)).toBeUndefined();
+
+      const transition = await node.post(shared, prep, exec);
+
+      expect(transition).toBe(FlowTransition.CONTINUE);
+      expect(onFollowUpConsumed).not.toHaveBeenCalled();
+      expect(createUserFollowUpMessages).toHaveBeenCalledOnce();
+      expect(createUserFollowUpMessages).toHaveBeenCalledWith(
+        [],
+        expect.stringContaining('<goal_context>'),
+      );
+      expect(shared.messages).toEqual([
+        {
+          role: 'user',
+          content: expect.stringContaining(
+            'Finish the autonomous proof audit.',
+          ),
+        },
+      ]);
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
+    } finally {
+      await GoalStore.forget(streamId);
+    }
+  });
+
+  it('lets queued user follow-up win over an active goal continuation', async () => {
+    const streamId = 'wait-node-goal-user-queued' as StreamTabId;
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(createFakePlatform({}));
+
+    await GoalStore.start(streamId, 'Keep going autonomously.');
+
+    const waitForFollowUp = vi.fn(async () => ({
+      items: [{ text: 'user correction', origin: 'user' }],
+      synthetic: false,
+    }));
+    const services = {
+      checkInterruption: () => false,
+      logger: { error: vi.fn() },
+      modelHandler: { extractAssistantText: () => undefined },
+      runtimeHost: { emit: vi.fn() },
+      session: {
+        hasQueuedFollowUp: () => true,
+        waitForFollowUp,
+      },
+      streamId,
+      streamStatus: new StreamStatusRegistry(),
+    } as unknown as ToolUseServices;
+    const node = new ToolUseWaitNode().setServices(services);
+
+    try {
+      const exec = await node.exec({
+        afterError: false,
+        lastResponse: undefined,
+        previouslyDeliveredToOrchestrator: false,
+        touchedFiles: [],
+      });
+
+      expect(waitForFollowUp).toHaveBeenCalledOnce();
+      expect(exec).toEqual({
+        kind: 'continue',
+        followUps: [{ text: 'user correction', origin: 'user' }],
+        synthetic: false,
+      });
+    } finally {
+      await GoalStore.forget(streamId);
+    }
+  });
+
+  it('does not let a subagent drive the parent goal continuation loop', async () => {
+    const streamId = 'wait-node-goal-subagent' as StreamTabId;
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(createFakePlatform({}));
+
+    await GoalStore.start(streamId, 'Parent-owned objective.');
+
+    const waitForFollowUp = vi.fn(async () => null);
+    const services = {
+      checkInterruption: () => false,
+      isSubagent: true,
+      logger: { error: vi.fn() },
+      modelHandler: { extractAssistantText: () => undefined },
+      runtimeHost: { emit: vi.fn() },
+      session: {
+        hasQueuedFollowUp: () => false,
+        waitForFollowUp,
+      },
+      streamId,
+      streamStatus: new StreamStatusRegistry(),
+    } as unknown as ToolUseServices;
+    const node = new ToolUseWaitNode().setServices(services);
+
+    try {
+      const exec = await node.exec({
+        afterError: false,
+        lastResponse: undefined,
+        previouslyDeliveredToOrchestrator: false,
+        touchedFiles: [],
+      });
+
+      expect(waitForFollowUp).toHaveBeenCalledOnce();
+      expect(exec.kind).toBe('stop');
+      expect(GoalStore.getForStream(streamId)?.status).toBe('active');
+    } finally {
+      await GoalStore.forget(streamId);
+    }
+  });
+
   it('updates the injected stream status owner while waiting and resuming', async () => {
     const streamId = 'wait-node-owner' as StreamTabId;
     const streamStatus = new StreamStatusRegistry();


### PR DESCRIPTION
## Summary

- Simplify `maybeBuildGoalContinuation` so the Goal module only renders an active enabled goal for a stream.
- Keep wait-node-owned concerns, such as queued user follow-ups and subagent mode, in `ToolUseWaitNode`.
- Add wait-node coverage for active Goal synthetic continuation, queued user follow-up precedence, and subagent non-continuation.

## Why

A long CLI Goal-mode dogfood run showed the feature works under sustained use, but the implementation boundary still leaked wait-node queue/subagent state into the Goal helper. This keeps the module boundary leaner and tests the actual pre-wait workflow path that drives autonomous continuation.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/agent/GoalContinuation.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts src/test-kernel/cli/PlanApproval.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check src/agent/goal/maybeBuildGoalContinuation.ts src/agent/goal/index.ts src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts src/test-kernel/agent/GoalContinuation.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts`
- `corepack pnpm exec eslint src/agent/goal/maybeBuildGoalContinuation.ts src/agent/goal/index.ts src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts src/test-kernel/agent/GoalContinuation.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autonomous goal continuation wiring in ToolUseWaitNode, which affects when synthetic follow-ups run versus blocking wait; behavior is intended to be equivalent but boundary moved.
> 
> **Overview**
> **`maybeBuildGoalContinuation`** now only takes a `streamId` and decides whether to render a continuation for an **active, feature-flag-enabled** goal. It no longer accepts `GoalContinuationContext` or short-circuits on subagent mode or queued user follow-ups.
> 
> **`ToolUseWaitNode.exec()`** owns those wait-time guards: it calls the helper only when the cycle is not after error, the run is not a subagent, and the session has no queued follow-up, with a second `hasQueuedFollowUp` check after the async build so user input can win a race.
> 
> Unit tests for subagent and queued-follow-up behavior move from **`GoalContinuation.vitest.ts`** to **`ToolUseWaitNode.vitest.ts`**, including coverage for synthetic goal injection before `waitForFollowUp`, user queue precedence, and subagents not driving the parent goal loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f21b07d344205ecb7662844ade9a189ba436b046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->