### PR TITLE
[codex] Centralize CLI child execution labels

### DIFF
--- a/docs/proposals/tui-extension-sharing.md
+++ b/docs/proposals/tui-extension-sharing.md
@@ -78,7 +78,7 @@ three divergent accept→approve / reject+feedback copies collapse to one.
   next to `LIVE_ELAPSED_STREAM_STATUSES` in the shared stream schema. Add
   `TERMINAL_STREAM_STATUSES` + `isTerminalStreamStatus()` there and delegate.
 - **Child-stream selectors** (small): move `mergeChildStreams` +
-  `visibleSubagentRows` (`childStreamMerge.ts`) and `childElapsed` /
+  `visibleSubagentRows` (`childExecutions.ts`) and `childElapsed` /
   `hasLiveChildElapsed` (`childControls.ts`) into
   `src/shared/selectors/` (they depend only on `ActiveChildInfo`), leaving thin
   re-exports so CLI call sites/tests are untouched; the webview adopts them in a

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -14,7 +14,10 @@ import {
   liveChildExecutionElapsedKey,
   processTailLines,
 } from '../state/childControls';
-import { visibleSubagentRows } from '../state/childStreamMerge';
+import {
+  childExecutionLabel,
+  visibleSubagentRows,
+} from '../state/childExecutions';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { CHILD_STATUS_MARKER, childStatusColor } from './SubagentListDisplay';
 import type { ProcessOutputTail, StreamSlice } from '../state/cliState';
@@ -49,7 +52,7 @@ export function compactChildRowText({
 }): string {
   const tailSummary = processTailLines(tail).at(-1);
   const elapsed = childElapsed(child, nowMs);
-  const label = child.agentName || child.toolName || child.executionId;
+  const label = childExecutionLabel(child);
   const statusLabel = childStatusLabel(child.status);
   return [
     `${label}${statusLabel ? ` ${statusLabel}` : ''}`,
@@ -71,7 +74,7 @@ function Row({
   // pulling the last `TAIL_LINES` non-blank lines is bounded work.
   const tailLines = compact ? [] : processTailLines(tail).slice(-TAIL_LINES);
   const elapsed = childElapsed(child, nowMs);
-  const label = child.agentName || child.toolName || child.executionId;
+  const label = childExecutionLabel(child);
   const statusLabel = childStatusLabel(child.status);
   return (
     <Box

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -12,7 +12,11 @@ import { formatDuration } from '@utils/core';
 
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
-import { visibleSubagentRows } from './childStreamMerge';
+import {
+  childExecutionKey,
+  childExecutionLabel,
+  visibleSubagentRows,
+} from './childExecutions';
 import {
   activeStreamTreeEntries,
   nearestActiveStreamAncestor,
@@ -106,20 +110,6 @@ export function childElapsed(
   return formatDuration(Math.max(0, nowMs - startedAt));
 }
 
-function childLabel(child: {
-  readonly agentName?: string;
-  readonly toolName?: string;
-  readonly executionId: string;
-}): string {
-  return child.agentName || child.toolName || child.executionId;
-}
-
-function childKey(
-  child: Pick<ActiveChildInfo, 'childStreamId' | 'executionId'>,
-): string {
-  return child.childStreamId ?? child.executionId;
-}
-
 function streamDescription(
   child: Pick<ActiveChildInfo, 'childStreamId'>,
   streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'description'>>,
@@ -162,7 +152,7 @@ function buildSubagentItem(
   nowMs?: number,
   killable = true,
 ): ChildControlItem {
-  const label = childLabel(child);
+  const label = childExecutionLabel(child);
   const command = streamDescription(child, streamsById) ?? label;
   const elapsed = childElapsed(child, nowMs);
   const statusLabel = childStatusDescription(child.status);
@@ -187,7 +177,7 @@ function buildProcessItem(
 ): ChildControlItem {
   const tailLines = processTailLines(tail);
   const lastLine = tailLines.at(-1);
-  const label = childLabel(child);
+  const label = childExecutionLabel(child);
   const elapsed = childElapsed(child, nowMs);
   const statusLabel = childStatusDescription(child.status);
   return {
@@ -239,13 +229,13 @@ export function buildChildControlItems(
   > = new Map(),
   nowMs?: number,
 ): readonly ChildControlItem[] {
-  const activeKeys = new Set(slice.activeSubagents.map(childKey));
+  const activeKeys = new Set(slice.activeSubagents.map(childExecutionKey));
   const subagentItems = visibleSubagentRows(slice).map((child) =>
     buildSubagentItem(
       child,
       streamsById,
       nowMs,
-      activeKeys.has(childKey(child)),
+      activeKeys.has(childExecutionKey(child)),
     ),
   );
   if (mode === 'subagents') {

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -1,8 +1,16 @@
 // Local imports - shared schemas
 import type { ActiveChildInfo } from '@shared/schemas';
 
-function childKey(child: ActiveChildInfo): string {
+export function childExecutionKey(
+  child: Pick<ActiveChildInfo, 'childStreamId' | 'executionId'>,
+): string {
   return child.childStreamId ?? child.executionId;
+}
+
+export function childExecutionLabel(
+  child: Pick<ActiveChildInfo, 'agentName' | 'toolName' | 'executionId'>,
+): string {
+  return child.agentName || child.toolName || child.executionId;
 }
 
 export function mergeChildStreams(
@@ -11,7 +19,7 @@ export function mergeChildStreams(
 ): readonly ActiveChildInfo[] {
   const byStream = new Map<string, ActiveChildInfo>();
   for (const child of [...current, ...next]) {
-    byStream.set(childKey(child), child);
+    byStream.set(childExecutionKey(child), child);
   }
   return [...byStream.values()];
 }
@@ -22,9 +30,11 @@ export function visibleSubagentRows(slice: {
   readonly activeSubagents: readonly ActiveChildInfo[];
   readonly childStreams: readonly ActiveChildInfo[];
 }): readonly ActiveChildInfo[] {
-  const activeKeys = new Set(slice.activeSubagents.map(childKey));
+  const activeKeys = new Set(slice.activeSubagents.map(childExecutionKey));
   return [
     ...slice.activeSubagents,
-    ...slice.childStreams.filter((child) => !activeKeys.has(childKey(child))),
+    ...slice.childStreams.filter(
+      (child) => !activeKeys.has(childExecutionKey(child)),
+    ),
   ];
 }

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -5,6 +5,7 @@ import {
   completedChildExecutionStatus,
   isChildExecutionErrorStatus,
 } from './childExecutionStatus';
+import { childExecutionLabel } from './childExecutions';
 import type {
   CompletedProcessTranscript,
   ConversationEntry,
@@ -32,7 +33,7 @@ export function buildCompletedProcessTranscript(
   const status = completedChildExecutionStatus(info.status);
   return {
     executionId: info.executionId,
-    title: info.agentName || info.toolName || info.executionId,
+    title: childExecutionLabel(info),
     status,
     elapsed: info.elapsed,
     isError: isChildExecutionErrorStatus(status),

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -12,7 +12,7 @@
 
 import { type StreamTabId } from '@shared/schemas';
 
-import { visibleSubagentRows } from './childStreamMerge';
+import { visibleSubagentRows } from './childExecutions';
 import { cliState, type StreamSlice } from './cliState';
 
 function orderedDescendantsFromSlice(

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -12,6 +12,7 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 
+import { childExecutionLabel } from './childExecutions';
 import type { StreamSlice } from './cliState';
 
 export interface ResumeTarget {
@@ -122,7 +123,7 @@ export function collectResumeTargets({
       seen.add(child.executionId);
       targets.push({
         executionId: child.executionId,
-        label: child.agentName || child.toolName || child.executionId,
+        label: childExecutionLabel(child),
         isRoot: false,
       });
     }

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -7,7 +7,11 @@
 import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 
 // Local imports - CLI state
-import { visibleSubagentRows } from './childStreamMerge';
+import {
+  childExecutionKey,
+  childExecutionLabel,
+  visibleSubagentRows,
+} from './childExecutions';
 import { orderedDescendantsFromTree } from './focusCycle';
 import type { StreamSlice } from './cliState';
 
@@ -92,14 +96,6 @@ export function nearestActiveStreamAncestor<T>(init: {
   return undefined;
 }
 
-function childReferenceKey(child: ActiveChildInfo): string {
-  return child.childStreamId ?? child.executionId;
-}
-
-function childReferenceLabel(child: ActiveChildInfo): string {
-  return child.agentName || child.toolName || child.executionId;
-}
-
 const emptyChildReferenceSlice = {
   activeSubagents: [],
   childStreams: [],
@@ -114,8 +110,8 @@ function childStreamReferenceLabel(
   const child = [
     ...visibleSubagentRows(parent ?? emptyChildReferenceSlice),
     ...(parent?.activeProcesses ?? []),
-  ].find((entry) => childReferenceKey(entry) === streamId);
-  return child ? childReferenceLabel(child) : streamId;
+  ].find((entry) => childExecutionKey(entry) === streamId);
+  return child ? childExecutionLabel(child) : streamId;
 }
 
 export function streamDisplayLabel(init: {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -19,7 +19,7 @@ import {
   setParentStream,
   type ProcessOutputTail,
 } from './cliState';
-import { mergeChildStreams } from './childStreamMerge';
+import { mergeChildStreams } from './childExecutions';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
 import { sumResumeUsageStats } from './resumeHint';
 import { appendLocalAssistantTranscript } from './transcript';

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -36,7 +36,7 @@ import {
   resolveChildControlDisplayTargets,
   resolveChildControlStreamTarget,
 } from '@cli/chat/tui/state/childControls';
-import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
+import { visibleSubagentRows } from '@cli/chat/tui/state/childExecutions';
 import { NO_BYPASS } from '@cli/chat/tui/state/cliState';
 import { streamDisplayLabel } from '@cli/chat/tui/state/streamViews';
 import type {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -43,7 +43,7 @@ import {
 } from '@cli/chat/tui/state/focusCycle';
 import { hasChildControlItems } from '@cli/chat/tui/state/childControls';
 import { focusedChildInputDisabledMessage } from '@cli/chat/tui/state/focusedChildFollowUp';
-import { visibleSubagentRows } from '@cli/chat/tui/state/childStreamMerge';
+import { visibleSubagentRows } from '@cli/chat/tui/state/childExecutions';
 import {
   finalizeSettledPrefix,
   syncStreamLog,


### PR DESCRIPTION
## Summary

- Rename `childStreamMerge` to `childExecutions` so the module owns child execution identity, labels, merging, and visible-row projection.
- Replace duplicate `childStreamId ?? executionId` and `agentName || toolName || executionId` fallback logic across CLI TUI subagent rows, picker items, stream labels, resume hints, and completed process transcript entries.
- Update the proposal note that referenced the old filename.
- Keep the behavior unchanged while giving subagent/task UI one source of truth for child execution references.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SubagentScopedViewer.vitest.mts src/test-kernel/cli/ResumeHint.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/childExecutions.ts packages/cli/src/chat/tui/state/childControls.ts packages/cli/src/chat/tui/state/streamViews.ts packages/cli/src/chat/tui/panes/SubagentList.tsx packages/cli/src/chat/tui/state/resumeHint.ts packages/cli/src/chat/tui/state/completedProcessTranscript.ts packages/cli/src/chat/tui/state/focusCycle.ts packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec prettier --check docs/proposals/tui-extension-sharing.md`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/state/childExecutions.ts packages/cli/src/chat/tui/state/childControls.ts packages/cli/src/chat/tui/state/streamViews.ts packages/cli/src/chat/tui/panes/SubagentList.tsx packages/cli/src/chat/tui/state/resumeHint.ts packages/cli/src/chat/tui/state/completedProcessTranscript.ts packages/cli/src/chat/tui/state/focusCycle.ts packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of display/key helpers with no runtime or API changes; existing vitest coverage for child controls and TUI state still applies.
> 
> **Overview**
> Renames **`childStreamMerge`** to **`childExecutions`** and exports **`childExecutionKey`** and **`childExecutionLabel`** so child identity (`childStreamId ?? executionId`) and display names (`agentName || toolName || executionId`) live in one place.
> 
> Call sites across the CLI TUI—subagent list, child controls/pickers, stream tab labels, focus cycle, resume hints, completed process transcripts, and runtime host merge—import those helpers instead of duplicating the same fallbacks. **`childControls`** and **`streamViews`** drop their local `childLabel` / `childKey` (and stream reference) helpers in favor of the shared module. The TUI sharing proposal doc now points at **`childExecutions.ts`** for the future move to **`src/shared/selectors/`**.
> 
> Behavior is unchanged; this is consolidation ahead of sharing selectors with the webview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d26870011dd04adb13bbc723dcaf70628d9102d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->