### PR TITLE
[codex] Centralize live stream status checks

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -12,12 +12,11 @@ import {
 } from 'react';
 
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
-import { isActiveStatus } from '@common/constants/streamStatus';
 import {
-  LIVE_ELAPSED_STREAM_STATUSES,
-  type StreamStatus,
-  type StreamTabId,
-} from '@shared/schemas';
+  isActiveStatus,
+  isLiveElapsedStatus,
+} from '@common/constants/streamStatus';
+import { type StreamStatus, type StreamTabId } from '@shared/schemas';
 
 import { assertNever } from './assertNever';
 import { SLASH_PALETTE_ROWS } from './commands/SlashPalette';
@@ -316,7 +315,7 @@ export function shouldShowTodosPlanPanel({
 }): boolean {
   if (foregroundOpen) return false;
   if (!hasTodos && !hasPlan) return false;
-  return status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status);
+  return isLiveElapsedStatus(status);
 }
 
 export function appFocusShortcutsActive({

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -9,8 +9,8 @@ import {
   metaChordLabel,
 } from '@cli/runtime/shortcutLabels';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import { isLiveElapsedStatus } from '@common/constants/streamStatus';
 import {
-  LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
   type ConversationProgress,
   type StreamStatus,
@@ -550,17 +550,11 @@ export function ctrlCActionForFocus({
     : 'stop';
 }
 
-/** In-flight run statuses — stoppable, and live enough to represent a
- *  focused child's ancestor in the bar. */
-function isLiveStreamStatus(status: string | undefined): boolean {
-  return status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status);
-}
-
 function hasPendingOrLiveStream(
   streams: ReadonlyMap<StreamTabId, StatusBarVisibleStream>,
 ): boolean {
   for (const stream of streams.values()) {
-    if (stream.status === undefined || isLiveStreamStatus(stream.status)) {
+    if (stream.status === undefined || isLiveElapsedStatus(stream.status)) {
       return true;
     }
   }
@@ -570,7 +564,7 @@ function hasPendingOrLiveStream(
 function rootActiveSegment(
   input: StatusBarDisplayInput,
 ): StatusBarSegment | undefined {
-  return input.ctrlCAction === 'stop root' && !isLiveStreamStatus(input.status)
+  return input.ctrlCAction === 'stop root' && !isLiveElapsedStatus(input.status)
     ? {
         text: 'root active',
         color: 'yellow',
@@ -631,7 +625,7 @@ export function statusBarStreamTarget({
     parentStream,
     values: streams,
     canUseValue: (stream: StatusBarVisibleStream) =>
-      isLiveStreamStatus(stream.status),
+      isLiveElapsedStatus(stream.status),
   });
   const canStopVisibleRun =
     canStopActiveRun &&

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -1,10 +1,8 @@
 import stripAnsi from 'strip-ansi';
 
 import { ANSI_ESCAPE_START, ansiEscapeEnd } from '@cli/runtime/ansiEscapes';
-import {
-  LIVE_ELAPSED_STREAM_STATUSES,
-  type StreamStatus,
-} from '@shared/schemas';
+import { isLiveElapsedStatus } from '@common/constants/streamStatus';
+import { type StreamStatus } from '@shared/schemas';
 
 import type { ConversationEntry } from '../state/cliState';
 
@@ -94,8 +92,7 @@ export function userPromptAwaitsLiveContinuation(
     entry?.role !== 'user' ||
     isInquiryContinuationText(entry.text) ||
     !isRenderableTranscriptEntry(entry) ||
-    status === undefined ||
-    !LIVE_ELAPSED_STREAM_STATUSES.has(status)
+    !isLiveElapsedStatus(status)
   ) {
     return false;
   }
@@ -117,8 +114,7 @@ export function splitTranscriptEntries(
    *  fixed. */
   readonly pending: ConversationEntry[];
 } {
-  const showLiveAssistant =
-    status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status);
+  const showLiveAssistant = isLiveElapsedStatus(status);
   const finalized: ConversationEntry[] = [];
   const pending: ConversationEntry[] = [];
   for (const [index, entry] of entries.entries()) {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -98,12 +98,12 @@ import {
   formatCliMemoryList,
   formatCliMemoryPreview,
 } from '@cli/runtime/memory';
+import { isLiveElapsedStatus } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { bus } from '@eventBus/ProgressEventBus';
 import { sumUsageStats } from '@shared/schemas';
 import {
   EXECUTION_STATUS,
-  LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
   type StreamStatus,
   type ExecutionId,
@@ -362,7 +362,7 @@ export function chatTuiCanStopActiveRun(
 ): boolean {
   if (!session.runPromise || session.runCompleted) return false;
   if (!session.streamId) return true;
-  return status === undefined || LIVE_ELAPSED_STREAM_STATUSES.has(status);
+  return status === undefined || isLiveElapsedStatus(status);
 }
 
 export function chatTuiCanStopVisibleRun(
@@ -371,7 +371,7 @@ export function chatTuiCanStopVisibleRun(
 ): boolean {
   return (
     chatTuiCanStopActiveRun(session, status) ||
-    Boolean(session.streamId && LIVE_ELAPSED_STREAM_STATUSES.has(status ?? ''))
+    Boolean(session.streamId && isLiveElapsedStatus(status))
   );
 }
 
@@ -1250,8 +1250,7 @@ export async function runChat(
 
     if (
       (isRunPending && activeStatus !== STREAM_STATUS.WAITING) ||
-      (activeStatus !== undefined &&
-        LIVE_ELAPSED_STREAM_STATUSES.has(activeStatus))
+      isLiveElapsedStatus(activeStatus)
     ) {
       appendLocalAssistantTranscript(
         'Wait for the active response to finish, or press Ctrl-C before /clear.',

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -1,8 +1,9 @@
 // Pure state helpers for App-level child execution shortcuts and pickers.
 
+import { isLiveElapsedStatus } from '@common/constants/streamStatus';
+
 // Local imports - shared schemas
 import {
-  LIVE_ELAPSED_STREAM_STATUSES,
   STREAM_STATUS,
   type ActiveChildInfo,
   type StreamTabId,
@@ -95,7 +96,7 @@ function hasLiveChildElapsed(
 ): boolean {
   return (
     child.startedAt !== undefined &&
-    LIVE_ELAPSED_STREAM_STATUSES.has(child.status ?? STREAM_STATUS.RUNNING)
+    isLiveElapsedStatus(child.status ?? STREAM_STATUS.RUNNING)
   );
 }
 

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -114,3 +114,12 @@ export function isInFlightStatus(status: StreamStatus | undefined): boolean {
 export function isTerminalStatus(status: StreamStatus | undefined): boolean {
   return status !== undefined && STREAM_STATUS_TRAITS[status].terminal;
 }
+
+/** Check if elapsed-time displays should keep advancing for this status. */
+export function isLiveElapsedStatus(status: string | undefined): boolean {
+  return (
+    status !== undefined &&
+    Object.hasOwn(STREAM_STATUS_TRAITS, status) &&
+    STREAM_STATUS_TRAITS[status as StreamStatus].liveElapsed
+  );
+}

--- a/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
+++ b/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
@@ -6,6 +6,7 @@ import {
   deriveRunOutcome,
   isActiveStatus,
   isInFlightStatus,
+  isLiveElapsedStatus,
   isTerminalStatus,
   projectRunOutcome,
   RUN_OUTCOME_PROJECTION,
@@ -104,11 +105,17 @@ describe('stream status trait table', () => {
     expect(isActiveStatus(STREAM_STATUS.INITIALIZING)).toBe(false);
     expect(isTerminalStatus(STREAM_STATUS.INITIALIZING)).toBe(false);
     expect(isInFlightStatus(STREAM_STATUS.INITIALIZING)).toBe(true);
+    expect(isLiveElapsedStatus(STREAM_STATUS.INITIALIZING)).toBe(true);
   });
 
   it('treats undefined as no status for every predicate', () => {
     expect(isActiveStatus(undefined)).toBe(false);
     expect(isInFlightStatus(undefined)).toBe(false);
+    expect(isLiveElapsedStatus(undefined)).toBe(false);
     expect(isTerminalStatus(undefined)).toBe(false);
+  });
+
+  it('treats unknown child execution statuses as not live elapsed', () => {
+    expect(isLiveElapsedStatus('completed')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Add `isLiveElapsedStatus` beside the shared stream status predicates so elapsed/live UI checks read the stream trait table through one owner.
- Replace direct `LIVE_ELAPSED_STREAM_STATUSES.has(...)` reads in the CLI TUI with the predicate while preserving each caller's existing undefined-status behavior.
- Keep compatibility with broader child execution status strings by treating unknown statuses such as `completed` as not live elapsed.

## Validation

- `texra-local doctor --output-format json`
- `npm run validate:tui`
- `corepack pnpm exec vitest run src/test-kernel/common/RunOutcomeAlgebra.vitest.ts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/RunChatConfig.vitest.mts`
- `corepack pnpm exec prettier --check src/common/constants/streamStatus.ts packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/StatusBar.tsx packages/cli/src/chat/tui/panes/transcriptEntries.ts packages/cli/src/chat/tui/state/childControls.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/common/RunOutcomeAlgebra.vitest.ts`
- `corepack pnpm exec eslint src/common/constants/streamStatus.ts packages/cli/src/chat/tui/App.tsx packages/cli/src/chat/tui/panes/StatusBar.tsx packages/cli/src/chat/tui/panes/transcriptEntries.ts packages/cli/src/chat/tui/state/childControls.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/common/RunOutcomeAlgebra.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of TUI display and interrupt guards with explicit handling for unknown status strings; no auth or persistence changes, but behavior at status boundaries is worth a quick regression pass on stop/Ctrl-C and /clear.
> 
> **Overview**
> Adds **`isLiveElapsedStatus`** next to the other stream-status predicates in `@common/constants/streamStatus`, so “live elapsed” UI behavior reads the **`liveElapsed`** trait from `STREAM_STATUS_TRAITS` in one place instead of scattering **`LIVE_ELAPSED_STREAM_STATUSES.has(...)`** across the CLI TUI.
> 
> **App**, **StatusBar**, **transcriptEntries**, **childControls**, and **runChatTui** now import that helper for todos/plan visibility, status-bar “live” stream detection, live transcript splitting, child elapsed timers, and stop/**/clear** guards. **StatusBar** drops its local `isLiveStreamStatus` wrapper in favor of the shared predicate.
> 
> The helper accepts **`string | undefined`** and returns false for unknown values (e.g. child execution **`completed`**), so broader status strings don’t accidentally count as live-elapsed. Tests in **RunOutcomeAlgebra.vitest** cover the new predicate and that edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c0353422a3fa739948581a45846025d9ff0fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->