### PR TITLE
[codex] Simplify multi-agent approval warning

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -20,7 +20,6 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform, initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 import {
-  agentHasDelegationTools,
   cliMultiAgentPlanHasGaps,
   cliMultiAgentPresetCanLaunchTeam,
   cliMultiAgentPresetNdjsonRecords,
@@ -191,27 +190,6 @@ export function writeMissingPresetAgents(
   }
 }
 
-function writeApprovalUnavailableDelegationWarning(
-  context: CliContext,
-  plan: CliMultiAgentPresetRunPlan,
-): void {
-  if (
-    !plan.rootAgent ||
-    !agentHasDelegationTools(plan.rootAgent) ||
-    !approvalPromptsUnavailable(context)
-  ) {
-    return;
-  }
-
-  const reason =
-    context.approvalPolicy === 'never'
-      ? 'approval policy "never" denies approval-gated delegation tools'
-      : 'headless approval policy "ask" cannot show delegation prompts';
-  writeTextStderr(
-    `WARN preset ${plan.preset.id} may run without subagent delegation because ${reason}. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
-  );
-}
-
 function writeMultiAgentRunResult(
   context: CliContext,
   plan: CliMultiAgentPresetRunPlan,
@@ -355,7 +333,15 @@ export async function runMultiAgentPreset(
         stdinInputFile,
       },
     );
-    writeApprovalUnavailableDelegationWarning(runContext, plan);
+    if (approvalPromptsUnavailable(runContext)) {
+      const reason =
+        runContext.approvalPolicy === 'never'
+          ? 'approval policy "never" denies approval-gated delegation tools'
+          : 'headless approval policy "ask" cannot show delegation prompts';
+      writeTextStderr(
+        `WARN preset ${plan.preset.id} may run without subagent delegation because ${reason}. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
+      );
+    }
 
     const config: AgentConfigPayload = {
       agent: rootAgent.name,

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -552,7 +552,7 @@ function formatAvailableTeamAgentCount(count: number): string {
     : `${count} available team agents`;
 }
 
-export function agentHasDelegationTools(agent: AgentEntry): boolean {
+function agentHasDelegationTools(agent: AgentEntry): boolean {
   return hasDelegationTool(agent.tools);
 }
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -55,19 +55,7 @@ vi.mock('@cli/runtime/supabaseAuth', () => ({
 }));
 
 vi.mock('@cli/runtime/multiAgentPresets', () => {
-  const delegationTools = new Set([
-    'delegate_workflow',
-    'delegate_agent',
-    'resume_agent',
-    'propose_workflow',
-    'propose_agent',
-  ]);
-
   return {
-    agentHasDelegationTools: vi.fn(
-      (agent: { tools?: readonly string[] }) =>
-        agent.tools?.some((tool) => delegationTools.has(tool)) ?? false,
-    ),
     cliMultiAgentPlanHasGaps: mocks.cliMultiAgentPlanHasGaps,
     cliMultiAgentPresetCanLaunchTeam: mocks.cliMultiAgentPresetCanLaunchTeam,
     cliMultiAgentPresetNdjsonRecords: vi.fn(() => []),


### PR DESCRIPTION
## Summary
- Removes the single-use multi-agent approval warning helper from the command layer.
- Keeps root/delegation launchability owned by the multi-agent preset planner.
- Makes `agentHasDelegationTools` private and removes the stale test mock export.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check packages/cli/src/commands/multiAgent.ts packages/cli/src/runtime/multiAgentPresets.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/commands/multiAgent.ts packages/cli/src/runtime/multiAgentPresets.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `npm run validate:tui -- orchestrate-launcher compact-orchestrate-launcher team-status-empty-subagents-hidden`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI refactor with similar user-visible warnings on successful team launches; delegation eligibility remains enforced by `cliMultiAgentPresetCanLaunchTeam` before the run proceeds.
> 
> **Overview**
> Inlines the headless multi-agent **subagent delegation** stderr warning into `runMultiAgentPreset` and drops the dedicated `writeApprovalUnavailableDelegationWarning` helper. The message still depends on `approvalPromptsUnavailable` (`never` vs headless `ask`); the command no longer imports or checks `agentHasDelegationTools` because team launchability (delegating root, members) stays in the preset planner.
> 
> `agentHasDelegationTools` is now module-private in `multiAgentPresets.ts`, and the run-command test mock no longer stubs that export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff5f09aa6fc4689056f91d9fff28f5a525f990fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->