### PR TITLE
[codex] Show active goals in CLI status

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -112,6 +112,7 @@ import {
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { escapeText } from '@shared/utils/xmlEscape';
+import { GoalStore } from '@tools/goal';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 import { generateExecutionId } from '@utils/core/executionId';
 
@@ -923,6 +924,9 @@ async function handleTuiSlashCommand(
           approval: formatApprovalPolicy(context.getApprovalPolicy()),
           approvalBypasses: slice?.bypass,
           status: slice?.status ?? 'not started',
+          goal: activeStreamId
+            ? GoalStore.getForStream(activeStreamId)
+            : undefined,
           // Only surface the resume id once a stream exists — never next to
           // a "not started" status.
           sessionId: slice ? context.session.executionId : undefined,

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -6,6 +6,12 @@ import { formatResumeCommand } from './state/resumeHint';
 import type { BypassState } from './state/cliState';
 
 const QUEUED_FOLLOW_UP_STATUS_LENGTH = 160;
+const GOAL_OBJECTIVE_STATUS_LENGTH = 160;
+
+export interface CliSessionGoalStatus {
+  readonly status: string;
+  readonly objective: string;
+}
 
 export interface CliSessionStatusInput {
   readonly agent: string;
@@ -15,6 +21,7 @@ export interface CliSessionStatusInput {
   readonly approval: string;
   readonly approvalBypasses?: Partial<BypassState>;
   readonly status: string;
+  readonly goal?: CliSessionGoalStatus | null;
   readonly queuedFollowUpMessages: readonly string[];
   /** Root execution id, when a run has started. Surfaces the resume command
    *  mid-session instead of only in the exit hint. */
@@ -67,6 +74,15 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
       ? [`auto-approvals: ${bypassLabels.join(', ')}`]
       : []),
     `status: ${formatCliStatusLabel(input.status)}`,
+    ...(input.goal
+      ? [
+          `goal: ${input.goal.status}`,
+          `goal objective: ${truncateSummary(
+            input.goal.objective,
+            GOAL_OBJECTIVE_STATUS_LENGTH,
+          )}`,
+        ]
+      : []),
     ...(input.sessionId
       ? [
           `session: ${input.sessionId}`,

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -162,6 +162,29 @@ describe('CLI session status formatter', () => {
     expect(status).not.toContain('all privileged actions');
   });
 
+  it('surfaces an active goal in status details', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'included relay',
+      approval: 'ask before privileged actions',
+      status: 'stopped',
+      goal: {
+        status: 'active',
+        objective:
+          'Solve the autonomous goal problem and produce a verifier before stopping.',
+      },
+      sessionId: 'goal123',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).toContain('status: stopped');
+    expect(status).toContain('goal: active');
+    expect(status).toContain(
+      'goal objective: Solve the autonomous goal problem and produce a verifier before stopping.',
+    );
+  });
+
   it('includes team identity when a chat was launched from a preset', () => {
     expect(
       formatCliSessionStatus({


### PR DESCRIPTION
## Summary
- show active Goal state in `/status` for the current CLI stream
- include a one-line truncated goal objective so resumed/stopped sessions reveal the in-flight goal
- cover the formatter with a focused CLI status test

## Why
A long `texra-local chat` goal-mode dogfood run on a hard math fixture stayed alive for about six minutes and persisted an active goal record. After stopping and resuming, `/status` reported only `status: stopped` and `queued follow-ups: 0`, even though the workspace state still contained `goals:byStream:assistant@deepseekproT#59b1f441df71` with `status: active`. This made the active goal invisible after resume.

This PR does not change goal lifecycle or continuation behavior. It only surfaces the existing goal record where users already inspect session state.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/SessionStatus.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/sessionStatus.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/SessionStatus.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/sessionStatus.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/SessionStatus.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with 33 existing warnings)
- rebuilt/relinked `texra-local`, resumed `59b1f441df71`, and verified `/status` now prints `goal: active` and `goal objective: ...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only display wiring in the TUI status formatter; goal persistence and behavior are unchanged.
> 
> **Overview**
> **`/status` now surfaces in-flight goal state** for the active CLI stream by reading the existing `GoalStore` record (no lifecycle or continuation changes).
> 
> When a goal is present, the status block adds **`goal:`** (status) and **`goal objective:`** (one line, truncated like queued follow-ups) so stopped or resumed sessions still show the active objective instead of only stream status and follow-up counts.
> 
> `formatCliSessionStatus` gains an optional `goal` field and a focused formatter test covers the new lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea130da5a1f2b9941b281b850b0741d63c141cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->