### PR TITLE
[codex] Close approval picker before applying policy

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -169,6 +169,7 @@ export function registerBuiltinSlashCommands(options?: {
             action: () => options?.onApprovalPolicySelect?.(value),
             value,
             onDone: props.onDone,
+            completion: 'beforeAction',
           })
         }
         onCancel={() => props.onDone(undefined)}

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -266,7 +266,6 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       if (idx != null && idx < props.items.length) {
         const choice = props.items[idx];
         if (choice && !choice.disabled) {
-          setHighlight(idx);
           props.onSelect(choice.value);
         }
       }

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -20,6 +20,7 @@ import {
 } from '@cli/chat/tui/commands/slashForms';
 import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
+import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
@@ -447,6 +448,34 @@ describe('slashRegistry', () => {
     await settleFormSelection();
 
     expect(apiNode.isClosed()).toBe(true);
+  });
+
+  it('closes the approval policy picker before applying the new policy', async () => {
+    let closed = false;
+    let sawClosedBeforePolicySelect = false;
+    registerBuiltinSlashCommands({
+      onApprovalPolicySelect: () => {
+        sawClosedBeforePolicySelect = closed;
+      },
+    });
+    const approval = listSlashCommands().find((cmd) => cmd.name === 'approval');
+
+    if (!approval) throw new Error('Expected /approval to be registered');
+
+    expect(openRegisteredCliSlashForm(approval, '')).toBe(true);
+
+    const approvalNode = renderFormAdapter<{
+      onSelect?: (value: CliApprovalPolicy) => void;
+    }>(
+      cliState.activeForm.get()?.render(() => {
+        closed = true;
+      }, 20),
+    );
+    approvalNode.props?.onSelect?.('yolo');
+    await settleFormSelection();
+
+    expect(closed).toBe(true);
+    expect(sawClosedBeforePolicySelect).toBe(true);
   });
 
   it('closes the resume picker before running the resume action', async () => {


### PR DESCRIPTION
## Summary

- Close the `/approval` picker before applying the selected policy, matching the instant-selection behavior used by other synchronous slash forms.
- Stop direct select hotkeys from repainting a new highlighted row right before the picker closes.
- Add a slash-registry regression test for the close-before-apply behavior.

## Why

While dogfooding `texra-local chat` in a real PTY, selecting `/approval` → `3` briefly showed the old `Ask` checkmark inside the picker while the status bar already changed to `yolo`. Closing the picker before applying the policy avoids that contradictory transitional frame.

## Validation

- Live PTY: `TERM=xterm-256color texra-local chat --cwd <tmp> --approval-policy ask --api-mode included`, `/approval`, `3`
- `corepack pnpm exec vitest run src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/SelectHotkeys.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts src/test-kernel/cli/ApprovalPolicyForm.vitest.mts src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- approval-form compact-approval-form model-form-buffered-hotkey api-form-buffered-hotkey`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/ui/Select.tsx packages/cli/src/chat/tui/commands/registerBuiltins.tsx src/test-kernel/cli/SlashRegistry.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/ui/Select.tsx packages/cli/src/chat/tui/commands/registerBuiltins.tsx src/test-kernel/cli/SlashRegistry.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint`
- `npm run texra-local:build`
- `npm test`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only timing and highlight behavior for slash forms; no auth, data, or API changes.
> 
> **Overview**
> Fixes a brief UI mismatch when picking an approval policy with number hotkeys: the status bar could already show the new policy while the `/approval` list still displayed the old **✓** on the previous row.
> 
> The `/approval` form now uses **`completion: 'beforeAction'`** in `runFormSelection`, so the picker closes before `onApprovalPolicySelect` runs—aligned with memory, resume, and skills pickers.
> 
> In **`Select`**, direct hotkey selection no longer updates highlight before `onSelect`, avoiding a flash of the wrong focused row as the form dismisses.
> 
> A slash-registry test asserts the approval form is closed before the policy handler runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a715171ddd633f5e88e021a479da744d2724fbc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->