### PR TITLE
[codex] Preserve delegated evidence in summaries

### DIFF
--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -233,6 +233,14 @@ describe('headless delegation', () => {
     );
   });
 
+  it('tells orchestrators to preserve delegated result evidence when summarizing', () => {
+    const description = new DelegateAgentTool().definition.description;
+
+    expect(description).toContain('preserve its stated evidence');
+    expect(description).toContain('tool names');
+    expect(description).toContain('do not substitute or invent methods');
+  });
+
   it('formats returned child error results as subagent errors', async () => {
     const recordSubagentCost = vi.fn();
     mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -1086,6 +1086,8 @@ export class DelegateAgentTool extends defineTool({
 
 **Resume** (with execution_id): Sends follow-up instructions to a WAITING or still-running subagent. If the subagent is busy, the instruction is queued for its next turn. The subagent keeps its full history. Result arrives asynchronously like the original delegation.
 
+When a subagent result is delivered, preserve its stated evidence, tool names, and caveats accurately; do not substitute or invent methods while summarizing it for the user.
+
 Available agents:
 ${formatAgentList(getVisibleAgents('toolUse'))}
 


### PR DESCRIPTION
## Summary

- Add parent-facing `delegate_agent` guidance to preserve a subagent's stated evidence, tool names, and caveats when summarizing returned results.
- Cover that delegation contract with a focused headless delegation test.

## Root cause

A long-running multi-agent dogfood run delegated an independent check to the `research` agent. The child reported Wolfram evidence, but the parent summarized it as Python plus symbolic calculations. The child handoff contract already required substantive evidence, but the parent-facing tool description did not explicitly tell orchestrators to preserve the returned method/tool details.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/tools/DelegationHeadless.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `npm run typecheck`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to `delegate_agent` description plus a test; no delegation runtime, auth, or data-path changes.
> 
> **Overview**
> **Parent orchestrators** now get explicit `delegate_agent` guidance: when a subagent result is delivered, they must **preserve stated evidence, tool names, and caveats** and must **not substitute or invent methods** while summarizing for the user.
> 
> This closes a gap where child handoffs already required substantive evidence, but the parent-facing tool text did not say to keep the returned method/tool details faithful (e.g. Wolfram vs Python).
> 
> A **headless delegation test** asserts the tool description includes that contract (`preserve its stated evidence`, `tool names`, `do not substitute or invent methods`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d173f5bfc8be572597b15fd864b8412e3643c29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->