### PR TITLE
[codex] Clarify goal approval notice

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1411,7 +1411,7 @@ const SCENARIOS = [
     ],
     unexpect: [
       'r approve & run',
-      'Bash auto-approved; edits still ask',
+      'Run auto-approves bash; edits still ask',
       '[/model]models',
     ],
     maxBlankLinesBetween: [
@@ -1430,7 +1430,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
-      'Bash auto-approved; edits still ask',
+      'Run auto-approves bash; edits still ask',
       'r approve & run',
       'y approve',
       'n reject',
@@ -1461,7 +1461,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
-      'Bash auto-approved; edits still ask',
+      'Run auto-approves bash; edits still ask',
       'observations. Do not edit any files',
       'r approve & run',
       'y approve',
@@ -1500,7 +1500,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
-      'Bash auto-approved; edits still ask',
+      'Run auto-approves bash; edits still ask',
       '4. Delegate a brief independent verification to the `review` subagent to',
       "check the derivation's correctness.",
       'r approve & run',
@@ -1523,7 +1523,7 @@ const SCENARIOS = [
       'e feedback',
       'Esc cancel',
     ],
-    unexpect: ['Bash auto-approved; edits still ask', '[/model]models'],
+    unexpect: ['Run auto-approves bash; edits still ask', '[/model]models'],
   },
   {
     name: 'compact-plan-approval-goal',
@@ -1539,7 +1539,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
-      'Bash auto-approved; edits still ask',
+      'Run auto-approves bash; edits still ask',
       'r approve & run',
       'y approve',
       'n reject',

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -22,7 +22,8 @@ export interface PlanApprovalProps {
 export const COMPACT_PLAN_APPROVAL_MAX_ROWS = 7;
 const MIN_PLAN_APPROVAL_CONTENT_WIDTH = 20;
 const PLAN_APPROVAL_TITLE = 'Approve plan?';
-export const PLAN_APPROVAL_GOAL_NOTICE = 'Bash auto-approved; edits still ask.';
+export const PLAN_APPROVAL_GOAL_NOTICE =
+  'Run auto-approves bash; edits still ask.';
 const PLAN_APPROVAL_GOAL_NOTICE_ROWS = 2;
 const PLAN_APPROVAL_NON_COMPACT_FIXED_ROWS = 7;
 const PLAN_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;

--- a/src/test-kernel/cli/PlanApproval.vitest.mts
+++ b/src/test-kernel/cli/PlanApproval.vitest.mts
@@ -127,6 +127,7 @@ describe('CLI plan approval layout', () => {
   });
 
   it('keeps the autonomous warning concise enough for the approval card', () => {
+    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('Run auto-approves bash');
     expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('edits still ask');
     expect(PLAN_APPROVAL_GOAL_NOTICE.length).toBeLessThanOrEqual(56);
   });
@@ -135,6 +136,7 @@ describe('CLI plan approval layout', () => {
     const notice = planApprovalGoalNoticeLine(40);
 
     expect(textDisplayWidth(notice)).toBe(40);
+    expect(notice).toContain('Run auto-approves bash');
     expect(notice).toContain('edits still ask');
     expect(notice).not.toContain('…');
   });


### PR DESCRIPTION
## Summary

- Reword the plan approval goal notice from a current-state claim to an action-specific explanation: `Run auto-approves bash; edits still ask.`
- Update the TUI validator expectations and the compact-width assertions for the new copy.

## Root cause

During a real TTY goal-mode dogfood run, the approval modal displayed `Bash auto-approved; edits still ask.` before I selected `r approve & run`. That read as if bash auto-approval was already active while the approval was still pending. The new wording makes the behavior conditional on the run action.

## Validation

- Real TTY dogfood: `texra-local chat --cwd /tmp/texra-goal-mode-dogfood --api-mode included --model gemini35f --approval-policy ask`
  - Prompted the model to propose a plan for proving infinitely many primes congruent to 1 mod 4.
  - Selected `r approve & run`.
  - Observed goal `goal_ee9ee1b6de6a` start, continue autonomously through todo/Wolfram work, call `plan` complete, and return to idle.
- `corepack pnpm exec vitest run src/test-kernel/cli/PlanApproval.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-goal-notice plan-approval-goal compact-plan-approval-goal`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `npm run typecheck`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in the plan approval modal plus test expectation updates; no approval or execution logic changed.
> 
> **Overview**
> Updates the plan approval **goal-mode** notice so it describes what **Run** does instead of sounding like bash is already auto-approved while the modal is still open.
> 
> The string changes from `Bash auto-approved; edits still ask.` to **`Run auto-approves bash; edits still ask.`** in `PLAN_APPROVAL_GOAL_NOTICE` (`PlanApproval.tsx`). TUI harness scenarios in `validate-tui.mjs` and unit tests in `PlanApproval.vitest.mts` now assert the new wording (including narrow-card layout checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb0ceb8c7f5140d7a64c85bcebb913c0ae6f8ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->