### PR TITLE
[codex] Hide completed goal todos during live turns

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -207,6 +207,7 @@ const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_NESTED_CHILDREN = process.env.HARNESS_NESTED_CHILDREN === '1';
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
 const SHOW_IDLE_TODOS = process.env.HARNESS_TODOS_IDLE === '1';
+const SHOW_COMPLETED_TODOS_ONLY = process.env.HARNESS_TODOS_COMPLETED === '1';
 const FAILED_CHILD_AGENT = process.env.HARNESS_FAILED_CHILD?.trim();
 const TEAM_NAME = process.env.HARNESS_TEAM_NAME?.trim() || undefined;
 let canInterrupt = process.env.HARNESS_CAN_INTERRUPT === '1';
@@ -1093,12 +1094,16 @@ if (SHOW_TODOS) {
       {
         content: 'Ask leanSolver to verify the finite case',
         activeForm: 'Waiting for leanSolver',
-        status: TODO_STATUS.IN_PROGRESS,
+        status: SHOW_COMPLETED_TODOS_ONLY
+          ? TODO_STATUS.COMPLETED
+          : TODO_STATUS.IN_PROGRESS,
       },
       {
         content: 'Merge subagent conclusions into final answer',
         activeForm: 'Merging subagent conclusions',
-        status: TODO_STATUS.PENDING,
+        status: SHOW_COMPLETED_TODOS_ONLY
+          ? TODO_STATUS.COMPLETED
+          : TODO_STATUS.PENDING,
       },
     ],
     plan: {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2611,6 +2611,20 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'completed-todos-hidden-while-running',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_TODOS: '1',
+      HARNESS_TODOS_COMPLETED: '1',
+    },
+    frame: 'tail',
+    expect: ['◆ running'],
+    unexpect: [
+      'Split theorem into algebraic and analytic checks',
+      'Coordinate a small math proof through nested CLI work.',
+    ],
+  },
+  {
     name: 'idle-todos-hidden',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -16,7 +16,12 @@ import {
   isActiveStatus,
   isLiveElapsedStatus,
 } from '@common/constants/streamStatus';
-import { type StreamStatus, type StreamTabId } from '@shared/schemas';
+import {
+  TODO_STATUS,
+  type StreamStatus,
+  type StreamTabId,
+  type TodoItem,
+} from '@shared/schemas';
 
 import { assertNever } from './assertNever';
 import { SLASH_PALETTE_ROWS } from './commands/SlashPalette';
@@ -305,16 +310,23 @@ export function shouldShowTipRow({
 export function shouldShowTodosPlanPanel({
   foregroundOpen,
   hasPlan,
-  hasTodos,
   status,
+  todos,
 }: {
   readonly foregroundOpen: boolean;
   readonly hasPlan: boolean;
-  readonly hasTodos: boolean;
   readonly status: StreamStatus | undefined;
+  readonly todos: readonly TodoItem[];
 }): boolean {
   if (foregroundOpen) return false;
+  const hasTodos = todos.length > 0;
   if (!hasTodos && !hasPlan) return false;
+  if (
+    hasTodos &&
+    todos.every((todo) => todo.status === TODO_STATUS.COMPLETED)
+  ) {
+    return false;
+  }
   return isLiveElapsedStatus(status);
 }
 
@@ -673,8 +685,8 @@ export function App(props: AppProps): React.JSX.Element {
   const hasTodosPlanPanel = shouldShowTodosPlanPanel({
     foregroundOpen,
     hasPlan: activeSlice?.plan != null,
-    hasTodos: (activeSlice?.todos.length ?? 0) > 0,
     status: activeSlice?.status,
+    todos: activeSlice?.todos ?? [],
   });
   const transcriptWidth = Math.max(MIN_TRANSCRIPT_WIDTH, columns);
   const foregroundKind = foregroundSurfaceKind({

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -94,8 +94,10 @@ import {
   DEFAULT_TOOL_CONFIG,
   MESSAGE_TYPES,
   STREAM_STATUS,
+  TODO_STATUS,
   type StorageKey,
   type StreamTabId,
+  type TodoItem,
 } from '@shared/schemas';
 import { stripOrchestratorFollowup } from '@shared/subagentFollowup';
 
@@ -668,52 +670,71 @@ describe('CLI TUI row allocation', () => {
   });
 
   it('shows todo and plan chrome only while a stream is active', () => {
+    const openTodo = {
+      content: 'Check the live proof',
+      activeForm: 'Checking the live proof',
+      status: TODO_STATUS.IN_PROGRESS,
+    } satisfies TodoItem;
     expect(
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: false,
-        hasTodos: true,
         status: STREAM_STATUS.RUNNING,
+        todos: [openTodo],
       }),
     ).toBe(true);
     expect(
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: true,
-        hasTodos: false,
         status: STREAM_STATUS.RESUMING,
+        todos: [],
       }),
     ).toBe(true);
     expect(
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: false,
-        hasTodos: true,
         status: STREAM_STATUS.WAITING,
+        todos: [openTodo],
       }),
     ).toBe(false);
     expect(
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: false,
-        hasTodos: true,
         status: STREAM_STATUS.STOPPED,
+        todos: [openTodo],
       }),
     ).toBe(false);
     expect(
       shouldShowTodosPlanPanel({
         foregroundOpen: true,
         hasPlan: false,
-        hasTodos: true,
         status: STREAM_STATUS.RUNNING,
+        todos: [openTodo],
       }),
     ).toBe(false);
     expect(
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: false,
-        hasTodos: false,
         status: STREAM_STATUS.RUNNING,
+        todos: [],
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowTodosPlanPanel({
+        foregroundOpen: false,
+        hasPlan: true,
+        status: STREAM_STATUS.RUNNING,
+        todos: [
+          {
+            content: 'Finish the old goal',
+            activeForm: 'Finishing the old goal',
+            status: TODO_STATUS.COMPLETED,
+          },
+        ],
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Make the TUI todos/plan panel inspect actual todo statuses instead of a lossy "has todos" boolean.
- Hide completed-only todo state during live/resumed turns so finished goal progress does not reappear while a later ordinary follow-up is running.
- Add focused unit coverage and a real TUI harness scenario for completed-only todos while running.

## Root Cause
A resumed session can restore completed goal todos and a plan on the active stream. When a later non-goal follow-up starts, the stream becomes live again before new todos arrive, and the previous boolean visibility check was enough to redraw stale completed goal progress.

## Goal-mode Dogfood
- Ran a real `texra-local chat` goal-mode proof workflow for an infinite primes problem; it ran for roughly 94 seconds, used plan/todo/tool progress, completed, and `/status` returned idle with no active goal.
- Resumed the completed session and sent a normal follow-up; it answered without starting a new plan/goal, which exposed the completed-todos visual artifact fixed here.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-completed-todos completed-todos-hidden-while-running`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-hide-completed` (134/134 scenarios)
- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings outside touched files)
- `npm run compile:fast`
- `npm test` (457 files, 3247 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI visibility logic only; behavior is gated on todo status and existing live-stream checks, with focused unit and harness tests.
> 
> **Overview**
> **Hides stale goal progress in the TUI** when a resumed session goes live again on an ordinary follow-up but the stream still carries **completed** todos/plan from an earlier goal.
> 
> `shouldShowTodosPlanPanel` now takes the **todo list** and treats **all-completed** todos as invisible during **running/resuming** live turns, instead of showing the panel whenever any todos existed. Call sites pass `activeSlice.todos` through.
> 
> Adds **unit tests** for the completed-only case and a **TUI harness** scenario (`HARNESS_TODOS_COMPLETED`) plus **validate-tui** coverage that the todos/plan chrome stays off while `◆ running`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e2bd77fdeec3b07a65f94a386a04c19437b4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->