### PR TITLE
[codex] Drop Google tool-call control glyphs

### DIFF
--- a/src/agent/modelHandlers/google/googleMessageHelpers.ts
+++ b/src/agent/modelHandlers/google/googleMessageHelpers.ts
@@ -13,19 +13,14 @@ const GOOGLE_TOOL_CALL_CONTROL_TEXT = new Set([
   '\u25ba',
 ]);
 
-/** Extract concatenated text from parts, excluding thought parts. */
+/** Extract concatenated text from parts, excluding thought/control parts. */
 export function extractNonThinkingText(parts: Part[], trim = false): string {
-  const hasFunctionCall = parts.some((part) => part.functionCall);
   const text = parts
     .filter(
       (part): part is Part & { text: string } =>
         isTextPart(part) && !part.thought,
     )
-    .filter(
-      (part) =>
-        !hasFunctionCall ||
-        !GOOGLE_TOOL_CALL_CONTROL_TEXT.has(part.text.trim()),
-    )
+    .filter((part) => !GOOGLE_TOOL_CALL_CONTROL_TEXT.has(part.text.trim()))
     .map((part) => part.text)
     .join('');
   return trim ? text.trim() : text;

--- a/src/agent/modelHandlers/google/googleMessageHelpers.ts
+++ b/src/agent/modelHandlers/google/googleMessageHelpers.ts
@@ -23,7 +23,8 @@ export function extractNonThinkingText(parts: Part[], trim = false): string {
     )
     .filter(
       (part) =>
-        !hasFunctionCall || !GOOGLE_TOOL_CALL_CONTROL_TEXT.has(part.text.trim()),
+        !hasFunctionCall ||
+        !GOOGLE_TOOL_CALL_CONTROL_TEXT.has(part.text.trim()),
     )
     .map((part) => part.text)
     .join('');

--- a/src/agent/modelHandlers/google/googleMessageHelpers.ts
+++ b/src/agent/modelHandlers/google/googleMessageHelpers.ts
@@ -6,12 +6,24 @@ export function isTextPart(part: Part): part is Part & { text: string } {
   return typeof part.text === 'string';
 }
 
+const GOOGLE_TOOL_CALL_CONTROL_TEXT = new Set([
+  '\u25c0',
+  '\u25c4',
+  '\u25b6',
+  '\u25ba',
+]);
+
 /** Extract concatenated text from parts, excluding thought parts. */
 export function extractNonThinkingText(parts: Part[], trim = false): string {
+  const hasFunctionCall = parts.some((part) => part.functionCall);
   const text = parts
     .filter(
       (part): part is Part & { text: string } =>
         isTextPart(part) && !part.thought,
+    )
+    .filter(
+      (part) =>
+        !hasFunctionCall || !GOOGLE_TOOL_CALL_CONTROL_TEXT.has(part.text.trim()),
     )
     .map((part) => part.text)
     .join('');

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -593,8 +593,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
         const responseParts =
           baseResponse.candidates?.[0]?.content?.parts ?? [];
-        const finalOutputText =
-          aggregatedText || extractNonThinkingText(responseParts);
+        const finalOutputText = extractNonThinkingText(responseParts);
         output.finalize(finalOutputText);
 
         // Ensure text field excludes thinking content

--- a/src/test-kernel/agent/modelHandlers/GoogleGenAIStreamingText.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleGenAIStreamingText.vitest.ts
@@ -210,4 +210,78 @@ describe('ModelHandlerGoogleGenAI streaming text extraction', () => {
       path: '/executions/example',
     });
   });
+
+  it('drops Google tool-call control glyphs split before streamed function calls', async () => {
+    const streamRecords: StreamRecord[] = [];
+    const handler = createStreamingHandler(streamRecords);
+
+    const glyphChunk = new GenerateContentResponse();
+    glyphChunk.candidates = [
+      {
+        content: {
+          role: 'model',
+          parts: [createPartFromText('\u25c4')],
+        },
+      } as any,
+    ];
+
+    const toolChunk = new GenerateContentResponse();
+    toolChunk.candidates = [
+      {
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'google-call-1',
+                name: 'executions',
+                args: { action: 'wait', path: '/executions/example' },
+              },
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      } as any,
+    ];
+
+    const fakeClient = {
+      chats: {
+        create: () => ({
+          sendMessageStream: async () =>
+            (async function* () {
+              yield glyphChunk;
+              yield toolChunk;
+            })(),
+          sendMessage: async () => {
+            throw new Error(
+              'sendMessage should not be called when streaming is enabled',
+            );
+          },
+        }),
+      },
+      models: {},
+    } as any;
+
+    const messages: Content[] = [
+      { role: 'user', parts: [createPartFromText('wait for subagent')] },
+    ];
+
+    const response = await handler.createResponse({
+      client: fakeClient,
+      messages,
+      temperature: 0,
+    });
+
+    expect(handler.extractResponse(response.response, '').text).toBe('');
+    expect(streamRecords[1]?.appends).toEqual([]);
+    expect(streamRecords[1]?.finalized).toBe('');
+
+    const [toolInfo] = handler.extractToolUse(response.response);
+    expect(toolInfo?.callId).toBe('google-call-1');
+    expect(toolInfo?.name).toBe('executions');
+    expect(toolInfo?.input).toEqual({
+      action: 'wait',
+      path: '/executions/example',
+    });
+  });
 });

--- a/src/test-kernel/agent/modelHandlers/GoogleGenAIStreamingText.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleGenAIStreamingText.vitest.ts
@@ -146,4 +146,68 @@ describe('ModelHandlerGoogleGenAI streaming text extraction', () => {
     expect(toolInfo?.name).toBe('list_files');
     expect(toolInfo?.input).toEqual({ path: '.' });
   });
+
+  it('drops Google tool-call control glyphs from visible streamed text', async () => {
+    const streamRecords: StreamRecord[] = [];
+    const handler = createStreamingHandler(streamRecords);
+
+    const chunk = new GenerateContentResponse();
+    chunk.candidates = [
+      {
+        content: {
+          role: 'model',
+          parts: [
+            createPartFromText('\u25c4'),
+            {
+              functionCall: {
+                id: 'google-call-1',
+                name: 'executions',
+                args: { action: 'wait', path: '/executions/example' },
+              },
+            },
+          ],
+        },
+        finishReason: FinishReason.STOP,
+      } as any,
+    ];
+
+    const fakeClient = {
+      chats: {
+        create: () => ({
+          sendMessageStream: async () =>
+            (async function* () {
+              yield chunk;
+            })(),
+          sendMessage: async () => {
+            throw new Error(
+              'sendMessage should not be called when streaming is enabled',
+            );
+          },
+        }),
+      },
+      models: {},
+    } as any;
+
+    const messages: Content[] = [
+      { role: 'user', parts: [createPartFromText('wait for subagent')] },
+    ];
+
+    const response = await handler.createResponse({
+      client: fakeClient,
+      messages,
+      temperature: 0,
+    });
+
+    expect(handler.extractResponse(response.response, '').text).toBe('');
+    expect(streamRecords[1]?.appends).toEqual([]);
+    expect(streamRecords[1]?.finalized).toBe('');
+
+    const [toolInfo] = handler.extractToolUse(response.response);
+    expect(toolInfo?.callId).toBe('google-call-1');
+    expect(toolInfo?.name).toBe('executions');
+    expect(toolInfo?.input).toEqual({
+      action: 'wait',
+      path: '/executions/example',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Drops provider-generated pointer-glyph control fragments from Google visible text extraction when the same response also contains a function call.
- Keeps normal assistant prose before tool calls visible.
- Adds a streaming Google regression test covering the stray `◄` artifact observed during a live orchestrator/subagent wait.

## Root Cause

During a real Mathematician team TTY run, Gemini returned a model turn containing both `text: "◄"` and an `executions.wait` function call after subagent progress. The CLI persisted that text as a normal assistant response, so the parent transcript showed a standalone `◄` line. This belongs at the provider-output boundary rather than in the TUI renderer.

## Validation

- `pnpm exec vitest run src/test-kernel/agent/modelHandlers/GoogleGenAIStreamingText.vitest.ts`
- `pnpm exec vitest run src/test-kernel/cli/PlanApproval.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `node packages/cli/scripts/validate-tui.mjs plan-approval-goal plan-approval-approve-goal compact-plan-approval-goal`
- `pnpm exec eslint src/agent/modelHandlers/google/googleMessageHelpers.ts src/test-kernel/agent/modelHandlers/GoogleGenAIStreamingText.vitest.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Google provider text sanitization and streaming finalize behavior with targeted tests; no auth, data, or broad API surface changes.
> 
> **Overview**
> Fixes stray **◄** (and similar pointer glyphs) showing up as assistant lines when Gemini returns tool calls alongside provider control text.
> 
> **`extractNonThinkingText`** now filters a small set of Unicode arrow glyphs (`◀`, `◄`, `▶`, `►`) in addition to thought parts, so they never become user-visible prose.
> 
> Google streaming **finalization** always derives visible output from the aggregated response parts via **`extractNonThinkingText`**, instead of falling back to the per-chunk **`aggregatedText`** buffer—keeping streamed and extracted text aligned when glyphs are stripped mid-stream.
> 
> Adds streaming regression tests for glyph-only turns (same chunk as a function call, and glyph split across chunks before the call); tool calls are still parsed unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b32880de0a32376159e1e45ff062d41bba3200f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->