### PR TITLE
[codex] Contain tool edit approval actions

### DIFF
--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -148,6 +148,11 @@ export const requestPanelStyles: CSSResult = css`
     max-width: 100%;
   }
 
+  :is(${ACTIONS}) > * {
+    min-width: 0;
+    max-width: 100%;
+  }
+
   /* The primary action buttons (which carry data-action) fill the row
      equally; the diff dropdown's own buttons keep their bespoke sizing. */
   :is(${ACTIONS}) wa-button[data-action] {
@@ -168,13 +173,10 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .approval-request__actions wa-button[data-action] {
-    display: inline-flex;
-    flex: 0 0 auto;
+    flex: 0 1 7rem;
     width: auto;
-    inline-size: max-content;
     min-width: min(5.5rem, 100%);
     max-width: min(7rem, 100%);
-    max-inline-size: min(7rem, 100%);
   }
 
   :is(${ACTIONS}) wa-button[data-action]::part(base) {
@@ -184,10 +186,18 @@ export const requestPanelStyles: CSSResult = css`
 
   .approval-request__actions wa-button[data-action]::part(base) {
     justify-content: center;
-    width: auto;
-    inline-size: auto;
+    width: 100%;
+    inline-size: 100%;
     min-width: 0;
     max-width: 100%;
+  }
+
+  .approval-request__actions wa-button[data-action]::part(label),
+  .approval-request__actions .diff-dropdown .diff-main-button::part(label) {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* Shared action button colors */
@@ -284,9 +294,9 @@ export const requestPanelStyles: CSSResult = css`
     position: relative;
     display: inline-flex;
     align-items: center;
-    flex: 0 1 8.25rem;
+    flex: 1 1 7rem;
     min-width: 0;
-    max-width: 100%;
+    max-width: min(8.25rem, 100%);
     max-inline-size: 100%;
   }
 

--- a/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
+++ b/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
@@ -27,28 +27,47 @@ describe('request panel styles', () => {
     const actionStart = source.indexOf(
       '.approval-request__actions wa-button[data-action] {',
     );
+    const boundedChildrenStart = source.indexOf(':is(${ACTIONS}) > * {');
+    const primaryActionsCommentStart = source.indexOf(
+      '/* The primary action buttons',
+    );
     const baseStart = source.indexOf(
       '.approval-request__actions wa-button[data-action]::part(base)',
     );
+    const labelStart = source.indexOf(
+      '.approval-request__actions wa-button[data-action]::part(label)',
+    );
+    const colorsStart = source.indexOf('/* Shared action button colors */');
     const actionRule = source.slice(actionStart, baseStart);
     const baseRule = source.slice(baseStart, source.indexOf('}', baseStart));
+    const boundedChildrenRule = source.slice(
+      boundedChildrenStart,
+      primaryActionsCommentStart,
+    );
+    const labelRule = source.slice(labelStart, colorsStart);
 
     expect(hostStart).toBeGreaterThanOrEqual(0);
     expect(containersStart).toBeGreaterThan(hostStart);
     expect(hostRule).toContain('min-width: 0');
     expect(hostRule).toContain('max-width: 100%');
+    expect(boundedChildrenStart).toBeGreaterThanOrEqual(0);
+    expect(primaryActionsCommentStart).toBeGreaterThan(boundedChildrenStart);
+    expect(boundedChildrenRule).toContain('min-width: 0');
+    expect(boundedChildrenRule).toContain('max-width: 100%');
     expect(actionStart).toBeGreaterThanOrEqual(0);
     expect(baseStart).toBeGreaterThan(actionStart);
-    expect(actionRule).toContain('display: inline-flex');
-    expect(actionRule).toContain('flex: 0 0 auto');
-    expect(actionRule).toContain('inline-size: max-content');
+    expect(actionRule).toContain('flex: 0 1 7rem');
     expect(actionRule).toContain('min-width: min(5.5rem, 100%)');
     expect(actionRule).toContain('max-width: min(7rem, 100%)');
-    expect(actionRule).toContain('max-inline-size: min(7rem, 100%)');
     expect(baseRule).toContain('justify-content: center');
-    expect(baseRule).toContain('width: auto');
-    expect(baseRule).toContain('inline-size: auto');
+    expect(baseRule).toContain('width: 100%');
+    expect(baseRule).toContain('inline-size: 100%');
     expect(baseRule).toContain('max-width: 100%');
+    expect(labelStart).toBeGreaterThan(baseStart);
+    expect(colorsStart).toBeGreaterThan(labelStart);
+    expect(labelRule).toContain('overflow: hidden');
+    expect(labelRule).toContain('text-overflow: ellipsis');
+    expect(labelRule).toContain('white-space: nowrap');
   });
 
   it('lets the tool edit diff dropdown shrink inside narrow panels', () => {
@@ -67,9 +86,9 @@ describe('request panel styles', () => {
 
     expect(dropdownStart).toBeGreaterThanOrEqual(0);
     expect(dropdownButtonStart).toBeGreaterThan(dropdownStart);
-    expect(dropdownRule).toContain('flex: 0 1 8.25rem');
+    expect(dropdownRule).toContain('flex: 1 1 7rem');
     expect(dropdownRule).toContain('min-width: 0');
-    expect(dropdownRule).toContain('max-width: 100%');
+    expect(dropdownRule).toContain('max-width: min(8.25rem, 100%)');
     expect(dropdownRule).toContain('max-inline-size: 100%');
     expect(dropdownButtonRule).toContain('flex: 1 1 auto');
     expect(dropdownButtonRule).toContain('width: auto');


### PR DESCRIPTION
## Summary
- Keep tool-edit approval action controls within the approval card by allowing the row children to shrink and wrap.
- Let Open diff / Approve / Reject labels ellipsize inside their buttons instead of forcing the card wider.

Fixes #6094.

## Validation
- `corepack pnpm exec prettier --check src/shared/styles/requestPanelStyles.ts`
- `corepack pnpm exec eslint src/shared/styles/requestPanelStyles.ts`
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json`
- `corepack pnpm --filter texra vite:webviews`
- Chrome layout probe against the built progress-view bundle at 260px, 320px, and 420px: no card/action scroll overflow and no controls crossing the card boundary

## Notes
- The screenshot-backed issue was in the approval/mock surface; this changes the shared request-panel CSS so the real Progress approval panel and design mock use the same containment behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout changes for approval action rows; no auth, data, or runtime logic touched.
> 
> **Overview**
> **Keeps tool-edit approval cards from overflowing** in narrow progress-view widths by tightening how the shared action row lays out in `requestPanelStyles`.
> 
> Action rows now cap every direct child with `min-width: 0` / `max-width: 100%`, and **approval** Open diff / Approve / Reject controls use shrinkable flex (`flex: 0 1 7rem`) with full-width button bases plus **ellipsis** on labels (including the diff dropdown main button). The diff dropdown switches to `flex: 1 1 7rem` with `max-width: min(8.25rem, 100%)` so it can share the row without forcing the card wider.
> 
> Vitest source assertions in `RequestPanelStyles.vitest.mts` are updated to lock in the new rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4daa079bb1c2fa3008876016366ee6bb608c600f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->