### PR TITLE
[codex] Harden Goal long-run continuation coverage

### DIFF
--- a/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts
@@ -352,7 +352,7 @@ describe('ToolUseWaitNode', () => {
     }
   });
 
-  it('keeps injecting active goal continuations across repeated cycles', async () => {
+  it('keeps injecting active goal continuations across a long run', async () => {
     const streamId = 'wait-node-long-goal' as StreamTabId;
     const { initPlatform } = await import('@platform/platform');
     initPlatform(createFakePlatform({}));
@@ -393,7 +393,11 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      for (const cycle of [0, 1, 2]) {
+      const continuationCycles = 25;
+      for (const cycle of Array.from(
+        { length: continuationCycles },
+        (_, index) => index,
+      )) {
         const prep = await node.prep(shared);
         const exec = await node.exec(prep);
 
@@ -410,8 +414,10 @@ describe('ToolUseWaitNode', () => {
       }
 
       expect(waitForFollowUp).not.toHaveBeenCalled();
-      expect(createUserFollowUpMessages).toHaveBeenCalledTimes(3);
-      expect(shared.messages).toHaveLength(3);
+      expect(createUserFollowUpMessages).toHaveBeenCalledTimes(
+        continuationCycles,
+      );
+      expect(shared.messages).toHaveLength(continuationCycles);
 
       await GoalStore.setStatus(streamId, 'paused');
 


### PR DESCRIPTION
## Summary

- Strengthens the existing Goal continuation test from a short repeated-cycle check to a 25-cycle long-run check.
- Keeps the same behavior contract: active Goal continuations stay synthetic and bypass user wait, then pausing the Goal stops the loop.

## Why

The Goal mode should keep working through long hard-problem runs, not just one or two continuation cycles. This is test-only coverage and does not add new CLI surface or resolver logic.

## Validation

- `corepack pnpm exec prettier --check src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts`
- `corepack pnpm exec eslint src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/agent/GoalContinuation.vitest.ts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts src/test-kernel/cli/PlanApproval.vitest.mts src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (passes with existing warnings)
- `npm run validate:tui -- --no-build --skip-if-missing-deps plan-approval-goal plan-approval-approve-goal compact-plan-approval-goal`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only vitest expectations and loop count; no application code paths are modified.
> 
> **Overview**
> **Test-only change** in `ToolUseWaitNode.vitest.ts`: the long-run Goal continuation case is renamed and scaled from **3** `prep`/`exec`/`post` loops to **25**, with expectations updated to match (`createUserFollowUpMessages` call count and `shared.messages` length).
> 
> The scenario is unchanged: while the Goal stays **active**, `ToolUseWaitNode` keeps emitting synthetic goal continuations without calling `waitForFollowUp`; after `GoalStore.setStatus(..., 'paused')`, the next cycle blocks on `waitForFollowUp` and stops. No production or CLI changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bda8f67bcaf7c4d7d690ccebf3d598586383035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->