### PR TITLE
[codex] Show Gemini conversations in CLI history

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -398,8 +398,8 @@ function createConversationPreview(
   });
   if (!transcript) return null;
 
-  const lastAssistant = transcript.messages.findLast(
-    (message) => message.role === 'assistant',
+  const lastAssistant = transcript.messages.findLast((message) =>
+    isAssistantMessageRole(message.role),
   );
   const selected = lastAssistant
     ? [lastAssistant]
@@ -460,11 +460,16 @@ function formatConversationMessage(
 ): string {
   const parts = [
     formatConversationMessageContent(raw.content, options),
+    formatConversationMessageContent(raw.parts, options),
     ...(options.includeToolUseMarkers === true
       ? formatTopLevelToolCalls(raw.tool_calls)
       : []),
   ].filter((part) => part.trim().length > 0);
   return parts.join('\n').trim();
+}
+
+function isAssistantMessageRole(role: string): boolean {
+  return role === 'assistant' || role === 'model';
 }
 
 function formatConversationPreview(
@@ -523,6 +528,19 @@ function formatConversationContentBlock(
   if (!isObject(block)) return formatJsonish(block);
   if (typeof block.text === 'string') return block.text;
 
+  if (isObject(block.functionCall)) {
+    if (options.includeToolUseMarkers !== true) return '';
+    const name =
+      typeof block.functionCall.name === 'string'
+        ? block.functionCall.name
+        : 'unknown';
+    return `[tool_use: ${name}]`;
+  }
+
+  if (isObject(block.functionResponse)) {
+    return `[tool_result: ${formatGoogleFunctionResponse(block.functionResponse, options)}]`;
+  }
+
   switch (block.type) {
     case 'tool_use':
       if (options.includeToolUseMarkers !== true) return '';
@@ -532,6 +550,22 @@ function formatConversationContentBlock(
     default:
       return formatJsonish(block);
   }
+}
+
+function formatGoogleFunctionResponse(
+  functionResponse: Record<string, unknown>,
+  options: ConversationMessageFormatOptions,
+): string {
+  const response = isObject(functionResponse.response)
+    ? functionResponse.response
+    : undefined;
+  if (response && Object.hasOwn(response, 'result')) {
+    return formatConversationMessageContent(response.result, options);
+  }
+  if (response !== undefined) {
+    return formatConversationMessageContent(response, options);
+  }
+  return formatJsonish(functionResponse);
 }
 
 function formatTopLevelToolCalls(toolCalls: unknown): string[] {

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -346,6 +346,92 @@ describe('CLI history runtime', () => {
     expect(text).toContain('[assistant #6]\nFinal proof analysis.');
   });
 
+  it('can show Gemini parts-based conversations', async () => {
+    mocks.readConversation.mockResolvedValue([
+      {
+        role: 'user',
+        parts: [{ text: 'Solve the finite Pell check.' }],
+      },
+      {
+        role: 'model',
+        parts: [
+          { text: 'I will inspect the workspace first.' },
+          {
+            functionCall: {
+              name: 'ls',
+              args: { path: '.' },
+              id: 'tool-1',
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'tool-1',
+              name: 'ls',
+              response: { result: 'file problem.tex' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'model',
+        parts: [{ text: 'Final answer: (9, 4) and (-9, 4).' }],
+      },
+    ]);
+
+    const details = await readCliHistoryDetails('a1' as ExecutionId, {
+      includeFullConversation: true,
+    });
+    const text = formatCliHistoryDetailsText(details!);
+
+    expect(details?.conversationPreview?.messages).toEqual([
+      {
+        index: 4,
+        role: 'model',
+        content: 'Final answer: (9, 4) and (-9, 4).',
+        truncated: false,
+      },
+    ]);
+    expect(details?.conversation).toEqual({
+      messageCount: 4,
+      messages: [
+        {
+          index: 1,
+          role: 'user',
+          content: 'Solve the finite Pell check.',
+          truncated: false,
+        },
+        {
+          index: 2,
+          role: 'model',
+          content: 'I will inspect the workspace first.\n[tool_use: ls]',
+          truncated: false,
+        },
+        {
+          index: 3,
+          role: 'user',
+          content: '[tool_result: file problem.tex]',
+          truncated: false,
+        },
+        {
+          index: 4,
+          role: 'model',
+          content: 'Final answer: (9, 4) and (-9, 4).',
+          truncated: false,
+        },
+      ],
+    });
+    expect(text).toContain('[model #2]');
+    expect(text).toContain('I will inspect the workspace first.');
+    expect(text).toContain('[tool_use: ls]');
+    expect(text).toContain('[user #3]\n[tool_result: file problem.tex]');
+    expect(text).toContain('[model #4]\nFinal answer: (9, 4) and (-9, 4).');
+  });
+
   it('uses the stored report instead of duplicating conversation preview text', async () => {
     mocks.readReport.mockResolvedValue('Structured report.');
     mocks.readConversation.mockResolvedValue([


### PR DESCRIPTION
Fixes #6098

## Summary

- Teaches CLI history rendering to read Gemini-style stored `parts` alongside OpenAI-style `content`.
- Renders Gemini `functionCall` entries as full-transcript tool-use markers and `functionResponse` entries as tool results.
- Treats Gemini `model` messages as assistant-like when selecting the final history preview.
- Adds regression coverage for full and preview history rendering of Gemini conversations.

## Root Cause

`texra history show --full` built previews/transcripts only from `message.content` and top-level OpenAI `tool_calls`. Gemini-backed runs persist conversation messages under `parts`, with tool calls and tool responses nested as `functionCall` / `functionResponse`. As a result, completed Gemini multi-agent sessions could have a populated `conversation.json` while `history show --full --output-format json` returned `conversation: null`.

## Dogfood Evidence

A real run of:

```sh
texra-local multi-agent run mathematician --instruction 'Solve this finite math problem using the team where useful. Find all integer pairs (x,y) with 0 < y < 20 and x^2 - 5y^2 = 1. Ask one suitable subagent to independently verify the enumeration, then give a brief final answer.' --model gemini35f --api-mode included --approval-policy yolo --no-input --quiet --output-format json
```

created parent execution `8cb9c1383770` and child execution `c516d10ca470`. Before this fix, the parent had an 18-message `conversation.json` but history JSON reported `conversation: null`. With the patched CLI bundle, the same stored execution reports `conversation.messageCount: 18`, previews the final `model` response, and the text view shows the full transcript including `[tool_use: delegate_agent]` and the subagent result.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/runtime/history.ts src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/runtime/history.ts src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json`
- `npm test`
- `npm run lint` (passes with existing warnings)
- `corepack pnpm --filter @texra-ai/cli run bundle`
- Patched CLI bundle smoke-tested against stored execution `8cb9c1383770` from `/tmp/texra-multiagent-math-yolo`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CLI conversation display/formatting in `history.ts` with tests; no auth, persistence, or execution runtime behavior is modified.
> 
> **Overview**
> **CLI history** now builds conversation previews and full transcripts from Gemini-style **`parts`** in addition to OpenAI-style **`content`**, so stored Gemini runs no longer surface as `conversation: null` when `conversation.json` is populated.
> 
> Message formatting maps **`functionCall`** blocks to `[tool_use: …]` markers (in full transcript mode) and **`functionResponse`** blocks to `[tool_result: …]`, with response bodies taken from nested `response.result` when present. Preview selection treats **`model`** like **`assistant`** when picking the final message to show.
> 
> Regression coverage adds a Vitest case for a parts-based Gemini thread (preview, JSON conversation shape, and text output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c911840fbabab7e0de0ebf5c6522ac1cc7a6be05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->