### PR TITLE
[codex] Pass CLI agent category into resolver

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -98,7 +98,7 @@ export async function runToolUseAgent(
   if (typeof instruction === 'number') return instruction;
 
   await initLocalCliPlatform(context);
-  const agent = await resolveCliAgent(init.agent);
+  const agent = await resolveCliAgent(init.agent, AgentCategory.ToolUse);
 
   if (!agent) {
     writeTextStderr(missingToolUseAgentMessage(init.agent));

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -115,7 +115,7 @@ export async function runWorkflowAgent(
   const instruction = await resolveFileBackedInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
-  const agent = await resolveCliAgent(init.agent);
+  const agent = await resolveCliAgent(init.agent, AgentCategory.Workflow);
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
   if (!agent) {

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -55,17 +55,19 @@ export function parseCliAgentCategoryFilter(
  * CLI commands start with a local-only load so signed-out users avoid remote
  * auth/network work. Missing agents still get a remote-inclusive fallback, and
  * authenticated relay sessions reload bare names so the registry's normal
- * source priority can prefer remote definitions.
+ * source priority can prefer remote definitions. Category-specific commands
+ * pass their category through to keep lookup priority owned by the registry.
  */
 export async function resolveCliAgent(
   name: string,
+  category?: AgentCategory,
 ): Promise<AgentEntry | undefined> {
   await loadAgents({ includeRemote: false });
-  const agent = getAgent(name);
+  const agent = getAgent(name, category);
 
   if (!agent) {
     await loadAgents();
-    return getAgent(name);
+    return getAgent(name, category);
   }
 
   if (name.includes(':') || !(await getCliAuthProvider().isAuthenticated())) {
@@ -73,7 +75,7 @@ export async function resolveCliAgent(
   }
 
   await loadAgents();
-  return getAgent(name);
+  return getAgent(name, category);
 }
 
 export async function loadCliAgentList(

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -88,6 +88,33 @@ describe('CLI agent resolution', () => {
     expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
   });
 
+  it('passes command category through authenticated remote-priority reloads', async () => {
+    const local = agent('lean');
+    const remote = agent('lean', 'remote');
+    mocks.authProvider.isAuthenticated.mockResolvedValue(true);
+    mocks.getAgent.mockReturnValueOnce(local).mockReturnValueOnce(remote);
+    const { resolveCliAgent } = await import('@cli/runtime/agents');
+
+    await expect(resolveCliAgent('lean', AgentCategory.ToolUse)).resolves.toBe(
+      remote,
+    );
+
+    expect(mocks.getAgent).toHaveBeenNthCalledWith(
+      1,
+      'lean',
+      AgentCategory.ToolUse,
+    );
+    expect(mocks.getAgent).toHaveBeenNthCalledWith(
+      2,
+      'lean',
+      AgentCategory.ToolUse,
+    );
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(1, {
+      includeRemote: false,
+    });
+    expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
+  });
+
   it('does not apply remote priority to source-qualified agent names', async () => {
     const local = agent('local:lean');
     mocks.authProvider.isAuthenticated.mockResolvedValue(true);
@@ -99,5 +126,26 @@ describe('CLI agent resolution', () => {
     expect(mocks.loadAgents).toHaveBeenCalledOnce();
     expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
     expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it('passes command category through local and remote-fallback lookups', async () => {
+    const remote = agent('assistant', 'remote');
+    mocks.getAgent.mockReturnValueOnce(undefined).mockReturnValueOnce(remote);
+    const { resolveCliAgent } = await import('@cli/runtime/agents');
+
+    await expect(
+      resolveCliAgent('assistant', AgentCategory.ToolUse),
+    ).resolves.toBe(remote);
+
+    expect(mocks.getAgent).toHaveBeenNthCalledWith(
+      1,
+      'assistant',
+      AgentCategory.ToolUse,
+    );
+    expect(mocks.getAgent).toHaveBeenNthCalledWith(
+      2,
+      'assistant',
+      AgentCategory.ToolUse,
+    );
   });
 });

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -127,6 +127,10 @@ describe('CLI agents run command', () => {
     expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.resolveCliAgent.mock.invocationCallOrder[0],
     );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'chat',
+      AgentCategory.ToolUse,
+    );
     expect(mocks.expandRunInputs).toHaveBeenCalledWith(
       ['problem.md'],
       ['notes.md'],
@@ -194,6 +198,10 @@ describe('CLI agents run command', () => {
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'missing-agent',
+      AgentCategory.ToolUse,
+    );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
@@ -222,6 +230,10 @@ describe('CLI agents run command', () => {
     expect(exitCode).toBe(2);
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
+    );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'polish',
+      AgentCategory.ToolUse,
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -153,6 +153,10 @@ describe('CLI workflow run command', () => {
     expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.resolveCliAgent.mock.invocationCallOrder[0],
     );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'missing-agent',
+      AgentCategory.Workflow,
+    );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
   });
@@ -179,6 +183,10 @@ describe('CLI workflow run command', () => {
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'chat',
+      AgentCategory.Workflow,
+    );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
   });
@@ -199,7 +207,10 @@ describe('CLI workflow run command', () => {
     );
 
     expect(mocks.initLocalCliPlatform).toHaveBeenCalled();
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('polish');
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'polish',
+      AgentCategory.Workflow,
+    );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- pass workflow/tool-use command intent into the existing CLI agent resolver
- keep source-priority policy inside the registry instead of adding resolver option objects
- cover resolver fallback and command call sites in focused CLI tests

## Why
`texra run` and `texra agents run` are category-specific command surfaces, but the shared CLI resolver was doing category-blind registry lookups. The registry already owns category-aware lookup priority, so the leaner fix is to forward the command category rather than introduce a separate `preferToolUse`-style policy.

## Validation
- `corepack pnpm exec prettier --check packages/cli/src/runtime/agents.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/runtime/agents.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI resolver wiring change with added unit tests; no auth or data-path changes beyond more precise agent selection.
> 
> **Overview**
> **`resolveCliAgent`** now accepts an optional **`AgentCategory`** and forwards it to every **`getAgent`** call (local load, remote fallback, and authenticated remote-priority reload), so category-specific commands use the registry’s category-aware lookup instead of name-only resolution.
> 
> **`texra agents run`** passes **`AgentCategory.ToolUse`**; **`texra run`** passes **`AgentCategory.Workflow`**. Existing post-resolve category checks are unchanged. Tests assert the category is threaded through resolver paths and command call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2472818111c7bf7f71ae69b870802fec59087389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->