### PR TITLE
[codex] Avoid slow lake version probe in tools list

### DIFF
--- a/src/test-kernel/tools/externalToolDefs.vitest.ts
+++ b/src/test-kernel/tools/externalToolDefs.vitest.ts
@@ -1,12 +1,17 @@
 // Third-party imports
 import * as assert from 'node:assert';
-import { describe, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Node.js built-in imports
 
 // Local imports - platform/test support/tools
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { findExternalToolDef } from '@tools/externalToolDefs';
+import { BinaryResolver } from '@utils/system/binaryResolver';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('external tool definitions', () => {
   it('keeps Zotero visible as a user-toggleable tool group', () => {
@@ -65,6 +70,51 @@ describe('external tool definitions', () => {
         await texraCli.statusLabel?.(probeResult),
         'Detected; integration coming soon',
       );
+    } finally {
+      initPlatform(previousPlatform ?? createFakePlatform());
+    }
+  });
+
+  it('detects Lean direct mode from the lake binary without running lake', async () => {
+    const lean = findExternalToolDef('lean4');
+    assert.ok(lean, 'Lean tool definition should exist');
+    const findPath = vi
+      .spyOn(BinaryResolver, 'findPath')
+      .mockReturnValue('/usr/local/bin/lake');
+    // Dynamic import: the no-platform-init-outside-composition-root lint rule
+    // reserves static initPlatform imports for composition roots.
+    const { initPlatform, tryPlatform } = await import('@platform/platform');
+    const previousPlatform = tryPlatform();
+    initPlatform(
+      createFakePlatform(
+        {},
+        {
+          toolAvailability: {
+            isVscodeExtensionInstalled: () => false,
+            isTexraCliEntrypoint: () => false,
+          },
+        },
+      ),
+    );
+
+    try {
+      const probeResult = await lean.probe?.();
+
+      expect(findPath).toHaveBeenCalledWith('lake');
+      expect(probeResult).toEqual({
+        extensionAvailable: false,
+        lakeAvailable: true,
+      });
+      await expect(lean.check(probeResult)).resolves.toBe(true);
+
+      findPath.mockReturnValue(null);
+      const missingProbeResult = await lean.probe?.();
+
+      expect(missingProbeResult).toEqual({
+        extensionAvailable: false,
+        lakeAvailable: false,
+      });
+      await expect(lean.check(missingProbeResult)).resolves.toBe(false);
     } finally {
       initPlatform(previousPlatform ?? createFakePlatform());
     }

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -39,6 +39,7 @@ import { formatResultCount } from '@utils/text/stringUtils';
 import { isGitRepository } from '@utils/system/isGitRepository';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import { isWSL } from '@utils/system/wslDetect';
+import { BinaryResolver } from '@utils/system/binaryResolver';
 
 const ZOTERO_PROBE_TIMEOUT_MS = 2000;
 const TEXRA_CLI_CHECK = {
@@ -305,7 +306,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       '  3. The extension will auto-install elan and Lean toolchain\n\n' +
       'Setup (CLI / desktop):\n' +
       '  1. Install elan: `curl https://elan.lean-lang.org/elan-init.sh -sSf | sh`\n' +
-      '  2. Make sure `lake --version` works in a fresh shell\n' +
+      '  2. Make sure `lake` is on PATH in a fresh shell\n' +
       '  3. Open a folder containing a lakefile.lean / lakefile.toml',
     installUrl:
       'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
@@ -318,10 +319,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
         platform().toolAvailability.isVscodeExtensionInstalled(
           LEAN4_EXTENSION_ID,
         );
-      const lakeAvailable = await checkToolInstalled(
-        { command: 'lake --version', errorMessage: 'lake not on PATH' },
-        false,
-      );
+      const lakeAvailable = BinaryResolver.findPath('lake') !== null;
       return { extensionAvailable, lakeAvailable };
     },
     check: async (probeResult) => {


### PR DESCRIPTION
## Summary
- replace the Lean tools-list probe's `lake --version` call with a PATH lookup through `BinaryResolver`
- cover the direct-mode Lean probe so it verifies `lake` discovery without spawning `lake`

## Dogfood evidence
- In a real TTY, `/tools` showed `Checking tool integrations...` for roughly 8 seconds before rendering the tool list.
- `texra-local tools list --output-format json --no-color` took about `5.355s` before the fix.
- The root cause was the Lean probe running `lake --version`; in this environment that command took about `36.123s`, while the generic tool check times out at 5 seconds.
- After the fix and CLI bundle rebuild, `texra-local tools list --output-format json --no-color` took about `0.575s`.
- In a fresh TTY after rebuilding, `/tools` rendered the list within roughly 1.5 seconds.

## Notes
- This keeps the availability question narrow: direct Lean mode only needs to know whether `lake` is discoverable.
- Actual Lean tool execution still surfaces project or toolchain failures at call time.

## Validation
- `corepack pnpm exec prettier --check src/tools/externalToolDefs.ts src/test-kernel/tools/externalToolDefs.vitest.ts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/tools/externalToolDefs.vitest.ts src/test-kernel/tools/lean/LeanExternalToolStatus.vitest.ts src/test-kernel/cli/CliTools.vitest.mts`
- `corepack pnpm exec eslint src/tools/externalToolDefs.ts src/test-kernel/tools/externalToolDefs.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli run bundle`
- `texra-local tools list --output-format json --no-color`
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json`
- `npm run lint` (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow availability check for the tools dashboard/CLI only; actual Lean execution is unchanged, with a small tradeoff that a broken `lake` on PATH may show as available until a tool is used.
> 
> **Overview**
> **Speeds up the tools list** by changing how Lean 4 direct mode is detected during integration probing.
> 
> The Lean `probe` no longer runs `lake --version` via `checkToolInstalled` (which could block for many seconds or hit a 5s timeout). It now treats direct mode as available when `BinaryResolver.findPath('lake')` finds an executable on PATH. The Lean install copy is aligned to say `lake` should be on PATH rather than referencing `lake --version`.
> 
> A Vitest case mocks `BinaryResolver.findPath` and asserts the Lean probe reports `lakeAvailable` true/false without spawning `lake`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d62893f13391d39dc257bec569cb2231c5ce7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->