### PR TITLE
refactor: adopt splitContentLines and hasExtension instead of inline equivalents

### DIFF
--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -14,7 +14,10 @@ import * as path from 'node:path';
 // Local imports
 import { platform } from '@platform/platform';
 import { executeCommand } from '@utils/system/execUtils';
-import { splitOutputLines } from '@utils/text/stringUtils';
+import {
+  splitContentLines,
+  splitOutputLines,
+} from '@utils/text/stringUtils';
 
 import { normalizeReviewFilePath } from './reviewIssues';
 
@@ -266,9 +269,7 @@ export function buildUntrackedFileDiff(
   const text = new TextDecoder().decode(
     content.subarray(0, MAX_UNTRACKED_FILE_BYTES),
   );
-  const lines = text.split('\n');
-  // Drop the empty trailing element from a final newline.
-  if (lines.at(-1) === '') lines.pop();
+  const lines = splitContentLines(text);
   if (lines.length === 0) {
     return `${header}(empty file)\n`;
   }

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -14,10 +14,7 @@ import * as path from 'node:path';
 // Local imports
 import { platform } from '@platform/platform';
 import { executeCommand } from '@utils/system/execUtils';
-import {
-  splitContentLines,
-  splitOutputLines,
-} from '@utils/text/stringUtils';
+import { splitContentLines, splitOutputLines } from '@utils/text/stringUtils';
 
 import { normalizeReviewFilePath } from './reviewIssues';
 

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -332,10 +332,10 @@ class ArxivSourceProcessor {
       }
 
       const isArchive =
-        downloadedPath.endsWith('.tar') ||
+        hasExtension(downloadedPath, '.tar') ||
         downloadedPath.endsWith('.tar.gz') ||
-        downloadedPath.endsWith('.tgz');
-      const isGzipOnly = !isArchive && downloadedPath.endsWith('.gz');
+        hasExtension(downloadedPath, '.tgz');
+      const isGzipOnly = !isArchive && hasExtension(downloadedPath, '.gz');
 
       if (isArchive) {
         progressCallback?.('Extracting source files...', 60);

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -12,6 +12,7 @@ import * as tar from 'tar';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
+import { hasExtension } from '@utils/core/pathCore';
 import { normaliseArxivIdentifier } from './arxivIdentifier';
 import { indentLatexFilesInDirectory } from './formatter/indentDirectory';
 
@@ -286,7 +287,7 @@ class ArxivSourceProcessor {
     let needsDownload = true;
     if (!isRoot && (await WorkspaceFS.exists(paperDirRelative))) {
       const entries = await WorkspaceFS.readDir(paperDirRelative);
-      const hasTexFiles = entries.some(([name]) => name.endsWith('.tex'));
+      const hasTexFiles = entries.some(([name]) => hasExtension(name, '.tex'));
       if (hasTexFiles) {
         needsDownload = false;
         logger.info(
@@ -316,7 +317,7 @@ class ArxivSourceProcessor {
       );
 
       // Detect PDF-only submissions (no LaTeX source available)
-      if (downloadedPath.endsWith('.pdf')) {
+      if (hasExtension(downloadedPath, '.pdf')) {
         await AbsoluteFS.delete(downloadedPath);
         await this.cleanUpBestEffort(downloadDirFull, 'download dir', {
           recursive: true,


### PR DESCRIPTION
## Summary

- **`reviewDiff.ts`**: Replace a 3-line manual `split('\n')` + trailing-empty-pop pattern with the existing `splitContentLines()` utility from `@utils/text/stringUtils`. The manual pattern is semantically identical to the utility and the comment even describes what `splitContentLines` already documents.
- **`arxivProcessor.ts`**: Replace two `endsWith('.tex')` / `endsWith('.pdf')` calls with `hasExtension()` from `@utils/core/pathCore`. The utility performs a case-insensitive comparison, which is the correct behaviour for filesystem paths, and keeps extension checks consistent across the codebase.

Both utilities were already present and used elsewhere; these changes close adoption gaps identified by a codebase-wide consolidation audit.

## What was NOT changed

The audit flagged several other candidates that do not meet the bar for consolidation:
- **`LinesBuilder`/`XmlBuilder` abstraction** — each XML-building site is distinct enough that a wrapper would add indirection without reducing code.
- **`trimOrFallback` utility** — the `?.trim() || fallback` pattern has too many different fallback values (15+ distinct literals) to benefit from a shared helper.
- **`uniqueBy` generic** — `deduplicateByName` and `uniqueSources` both have non-trivial merge semantics (priority ranking and required-flag promotion respectively) that a simple first-wins `uniqueBy` cannot capture.
- **`splitOutputLines` adoption** — remaining `.split('\n')` sites preserve blank lines intentionally (line-range slicing, diff processing, text editing) and should not use the blank-filtering variant.

## Test plan

- [x] `npm run compile:fast` — builds cleanly
- [x] `npm test` — 3248 passed, 3 skipped; 1 pre-existing flaky process-group test unrelated to these changes

https://claude.ai/code/session_017UXLPQVYc1PgkgQtr1knj6

---
_Generated by [Claude Code](https://claude.ai/code/session_017UXLPQVYc1PgkgQtr1knj6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small mechanical refactors with equivalent or slightly stricter (case-insensitive) extension behavior; no auth, data, or workflow logic changes.
> 
> **Overview**
> **Agent review** untracked pseudo-diffs now split decoded file text with `splitContentLines()` instead of a local `split('\n')` plus trailing-empty-line pop, matching how other review diff code normalizes lines.
> 
> **arXiv source download** replaces several `endsWith('.ext')` checks with `hasExtension()` for `.tex`, `.pdf`, `.tar`, `.tgz`, and `.gz`, so extension detection is case-insensitive and aligned with shared path helpers. Compound `.tar.gz` detection still uses `endsWith('.tar.gz')`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50fb64e44305ea8c46d63ed3c244953f397abf7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->