### PR TITLE
[codex] Centralize CLI agent launch validation

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -50,7 +50,7 @@ import {
 import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import { firstRunSetupAgentOverride } from '@cli/onboarding/setupContinuation';
 import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
-import { missingToolUseAgentMessage } from '@cli/commands/_helpers/agentLookupText';
+import { validateCliAgentLaunch } from '@cli/commands/_helpers/agentLookupText';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
@@ -496,14 +496,12 @@ function agentSupportsDelegation(agentName: string): boolean {
 export function chatToolUseAgentUsageError(
   agentName: string,
 ): string | undefined {
-  const agent = getAgent(agentName, AgentCategory.ToolUse);
-  if (!agent) {
-    return missingToolUseAgentMessage(agentName);
-  }
-  if (agent.category !== AgentCategory.ToolUse) {
-    return `Agent "${agentName}" is a ${agent.category} agent; \`texra chat\` only handles tool-use agents. Use \`texra run ${agentName}\` for workflow agents, or \`texra multi-agent run <preset>\` for teams.`;
-  }
-  return undefined;
+  const launchTarget = validateCliAgentLaunch(
+    agentName,
+    getAgent(agentName, AgentCategory.ToolUse),
+    'chat',
+  );
+  return launchTarget.ok ? undefined : launchTarget.error;
 }
 
 function applyInitialCliAgentSelection(

--- a/packages/cli/src/commands/_helpers/agentLookupText.ts
+++ b/packages/cli/src/commands/_helpers/agentLookupText.ts
@@ -1,7 +1,37 @@
+import type { AgentEntry } from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+
 const AGENT_LOOKUP_HINT =
   'Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.';
 const MULTI_AGENT_PRESET_LOOKUP_HINT =
   'Use `texra multi-agent list` for available team presets, then run `texra multi-agent inspect <preset>` to check a team before launch.';
+
+type CliAgentLaunchMode = 'chat' | 'run' | 'agentsRun';
+
+type CliAgentLaunchValidation =
+  | { readonly ok: true; readonly agent: AgentEntry }
+  | { readonly ok: false; readonly error: string };
+
+const CLI_AGENT_LAUNCH_TARGETS = {
+  chat: {
+    category: AgentCategory.ToolUse,
+    missing: missingToolUseAgentMessage,
+    mismatch: (name: string, actual: AgentEntry['category']) =>
+      `Agent "${name}" is a ${actual} agent; \`texra chat\` only handles tool-use agents. Use \`texra run ${name}\` for workflow agents, or \`texra multi-agent run <preset>\` for teams.`,
+  },
+  run: {
+    category: AgentCategory.Workflow,
+    missing: missingAgentMessage,
+    mismatch: (name: string, actual: AgentEntry['category']) =>
+      `Agent "${name}" is a ${actual} agent; \`texra run\` only handles workflow agents. Start it interactively with \`texra chat --agent ${name}\`, or run a headless team with \`texra multi-agent run\`.`,
+  },
+  agentsRun: {
+    category: AgentCategory.ToolUse,
+    missing: missingToolUseAgentMessage,
+    mismatch: (name: string, actual: AgentEntry['category']) =>
+      `Agent "${name}" is a ${actual} agent; \`texra agents run\` only handles tool-use agents. Use \`texra run ${name}\` for workflow agents.`,
+  },
+} as const;
 
 export const AGENT_NAME_DESCRIPTION =
   'Agent name from `texra agents list` or a known launchable agent name';
@@ -19,4 +49,23 @@ export function missingToolUseAgentMessage(name: string): string {
 
 export function missingMultiAgentPresetMessage(name: string): string {
   return `Multi-agent preset not found: ${name}. ${MULTI_AGENT_PRESET_LOOKUP_HINT}`;
+}
+
+export function cliAgentLaunchCategory(
+  mode: CliAgentLaunchMode,
+): AgentCategory {
+  return CLI_AGENT_LAUNCH_TARGETS[mode].category;
+}
+
+export function validateCliAgentLaunch(
+  name: string,
+  agent: AgentEntry | undefined,
+  mode: CliAgentLaunchMode,
+): CliAgentLaunchValidation {
+  const target = CLI_AGENT_LAUNCH_TARGETS[mode];
+  if (!agent) return { ok: false, error: target.missing(name) };
+  if (agent.category !== target.category) {
+    return { ok: false, error: target.mismatch(name, agent.category) };
+  }
+  return { ok: true, agent };
 }

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -23,7 +23,8 @@ import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import {
   TOOL_USE_AGENT_NAME_DESCRIPTION,
-  missingToolUseAgentMessage,
+  cliAgentLaunchCategory,
+  validateCliAgentLaunch,
 } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
@@ -98,18 +99,21 @@ export async function runToolUseAgent(
   if (typeof instruction === 'number') return instruction;
 
   await initLocalCliPlatform(context);
-  const agent = await resolveCliAgent(init.agent, AgentCategory.ToolUse);
+  const agentEntry = await resolveCliAgent(
+    init.agent,
+    cliAgentLaunchCategory('agentsRun'),
+  );
 
-  if (!agent) {
-    writeTextStderr(missingToolUseAgentMessage(init.agent));
+  const launchTarget = validateCliAgentLaunch(
+    init.agent,
+    agentEntry,
+    'agentsRun',
+  );
+  if (!launchTarget.ok) {
+    writeTextStderr(launchTarget.error);
     return CliExitCode.Usage;
   }
-  if (agent.category !== AgentCategory.ToolUse) {
-    writeTextStderr(
-      `Agent "${init.agent}" is a ${agent.category} agent; \`texra agents run\` only handles tool-use agents. Use \`texra run ${init.agent}\` for workflow agents.`,
-    );
-    return CliExitCode.Usage;
-  }
+  const agent = launchTarget.agent;
 
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -99,15 +99,16 @@ export async function runToolUseAgent(
   if (typeof instruction === 'number') return instruction;
 
   await initLocalCliPlatform(context);
+  const launchMode = 'agentsRun';
   const agentEntry = await resolveCliAgent(
     init.agent,
-    cliAgentLaunchCategory('agentsRun'),
+    cliAgentLaunchCategory(launchMode),
   );
 
   const launchTarget = validateCliAgentLaunch(
     init.agent,
     agentEntry,
-    'agentsRun',
+    launchMode,
   );
   if (!launchTarget.ok) {
     writeTextStderr(launchTarget.error);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -118,13 +118,18 @@ export async function runWorkflowAgent(
   const instruction = await resolveFileBackedInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
+  const launchMode = 'run';
   const agentEntry = await resolveCliAgent(
     init.agent,
-    cliAgentLaunchCategory('run'),
+    cliAgentLaunchCategory(launchMode),
   );
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
-  const launchTarget = validateCliAgentLaunch(init.agent, agentEntry, 'run');
+  const launchTarget = validateCliAgentLaunch(
+    init.agent,
+    agentEntry,
+    launchMode,
+  );
   if (!launchTarget.ok) throw new CliUsageError(launchTarget.error);
   const agent = launchTarget.agent;
   if (init.output && hasMixedStdinWorkflowInputSpecs(init.inputFiles)) {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -23,7 +23,10 @@ import {
 import { resolveCliAgent } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
-import { missingAgentMessage } from './_helpers/agentLookupText';
+import {
+  cliAgentLaunchCategory,
+  validateCliAgentLaunch,
+} from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { emitCliResult } from './_helpers/output';
 import {
@@ -115,17 +118,15 @@ export async function runWorkflowAgent(
   const instruction = await resolveFileBackedInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
-  const agent = await resolveCliAgent(init.agent, AgentCategory.Workflow);
+  const agentEntry = await resolveCliAgent(
+    init.agent,
+    cliAgentLaunchCategory('run'),
+  );
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
-  if (!agent) {
-    throw new CliUsageError(missingAgentMessage(init.agent));
-  }
-  if (agent.category !== AgentCategory.Workflow) {
-    throw new CliUsageError(
-      `Agent "${init.agent}" is a ${agent.category} agent; \`texra run\` only handles workflow agents. Start it interactively with \`texra chat --agent ${init.agent}\`, or run a headless team with \`texra multi-agent run\`.`,
-    );
-  }
+  const launchTarget = validateCliAgentLaunch(init.agent, agentEntry, 'run');
+  if (!launchTarget.ok) throw new CliUsageError(launchTarget.error);
+  const agent = launchTarget.agent;
   if (init.output && hasMixedStdinWorkflowInputSpecs(init.inputFiles)) {
     throw new CliUsageError(
       'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',


### PR DESCRIPTION
## Summary

- centralize CLI agent launch category validation and user-facing mismatch text
- keep registry lookup priority explicit through `cliAgentLaunchCategory(...)`
- reuse the same launch validation for `texra chat`, `texra run`, and `texra agents run`

## Why

The CLI resolver category argument is lookup priority, not category enforcement. This change makes launch-category ownership explicit in one helper instead of repeating missing/wrong-category checks in each command.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/commands/_helpers/agentLookupText.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/chat/tui/runChatTui.tsx`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/RunChatConfig.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json`
- `corepack pnpm exec eslint packages/cli/src/commands/_helpers/agentLookupText.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/RunChatConfig.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts`
- `npm run check:cli-architecture`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of usage-error paths only; intended behavior and user-facing messages stay the same, with existing CLI tests covering resolution and run commands.
> 
> **Overview**
> Adds shared **`validateCliAgentLaunch`** and **`cliAgentLaunchCategory`** in `agentLookupText.ts`, keyed by launch mode (`chat`, `run`, `agentsRun`). Each mode defines the expected agent category, missing-agent copy, and wrong-category guidance in one table.
> 
> **`texra chat`**, **`texra run`**, and **`texra agents run`** now resolve agents with the mode-specific lookup category, then run the same validation instead of duplicating inline missing/category checks. `chatToolUseAgentUsageError` delegates to the shared helper as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf583da4ab69c33063d828883294f3e039838c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->