### PR TITLE
[codex] Remove unused CLI agent validation local

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -114,7 +114,6 @@ export async function runToolUseAgent(
     writeTextStderr(launchTarget.error);
     return CliExitCode.Usage;
   }
-  const agent = launchTarget.agent;
 
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);


### PR DESCRIPTION
## Summary

- remove the now-unused local variable left after CLI agent launch validation was centralized

## Why

A bot review on #6104 correctly noticed that `runToolUseAgent` validates the launch target but does not need to retain `launchTarget.agent` afterward. This follow-up removes that dead local.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/_helpers/agentLookupText.ts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json`
- `corepack pnpm exec eslint packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/_helpers/agentLookupText.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line removal of an unused variable with no change to validation or execution flow.
> 
> **Overview**
> Removes the dead `const agent = launchTarget.agent` assignment in `runToolUseAgent` after `validateCliAgentLaunch` succeeds.
> 
> Launch validation still runs the same way; the run path already uses `init.agent` when building config, so keeping the validated agent object locally added no behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9cd95c26cc5783d5945cccb874765379d1c0101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->