### PR TITLE
[codex] Clarify CLI agent lookup priority

### DIFF
--- a/packages/cli/src/commands/_helpers/agentLookupText.ts
+++ b/packages/cli/src/commands/_helpers/agentLookupText.ts
@@ -14,19 +14,19 @@ type CliAgentLaunchValidation =
 
 const CLI_AGENT_LAUNCH_TARGETS = {
   chat: {
-    category: AgentCategory.ToolUse,
+    requiredCategory: AgentCategory.ToolUse,
     missing: missingToolUseAgentMessage,
     mismatch: (name: string, actual: AgentEntry['category']) =>
       `Agent "${name}" is a ${actual} agent; \`texra chat\` only handles tool-use agents. Use \`texra run ${name}\` for workflow agents, or \`texra multi-agent run <preset>\` for teams.`,
   },
   run: {
-    category: AgentCategory.Workflow,
+    requiredCategory: AgentCategory.Workflow,
     missing: missingAgentMessage,
     mismatch: (name: string, actual: AgentEntry['category']) =>
       `Agent "${name}" is a ${actual} agent; \`texra run\` only handles workflow agents. Start it interactively with \`texra chat --agent ${name}\`, or run a headless team with \`texra multi-agent run\`.`,
   },
   agentsRun: {
-    category: AgentCategory.ToolUse,
+    requiredCategory: AgentCategory.ToolUse,
     missing: missingToolUseAgentMessage,
     mismatch: (name: string, actual: AgentEntry['category']) =>
       `Agent "${name}" is a ${actual} agent; \`texra agents run\` only handles tool-use agents. Use \`texra run ${name}\` for workflow agents.`,
@@ -51,10 +51,10 @@ export function missingMultiAgentPresetMessage(name: string): string {
   return `Multi-agent preset not found: ${name}. ${MULTI_AGENT_PRESET_LOOKUP_HINT}`;
 }
 
-export function cliAgentLaunchCategory(
+export function cliAgentLaunchLookupCategory(
   mode: CliAgentLaunchMode,
 ): AgentCategory {
-  return CLI_AGENT_LAUNCH_TARGETS[mode].category;
+  return CLI_AGENT_LAUNCH_TARGETS[mode].requiredCategory;
 }
 
 export function validateCliAgentLaunch(
@@ -64,7 +64,7 @@ export function validateCliAgentLaunch(
 ): CliAgentLaunchValidation {
   const target = CLI_AGENT_LAUNCH_TARGETS[mode];
   if (!agent) return { ok: false, error: target.missing(name) };
-  if (agent.category !== target.category) {
+  if (agent.category !== target.requiredCategory) {
     return { ok: false, error: target.mismatch(name, agent.category) };
   }
   return { ok: true, agent };

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -23,7 +23,7 @@ import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import {
   TOOL_USE_AGENT_NAME_DESCRIPTION,
-  cliAgentLaunchCategory,
+  cliAgentLaunchLookupCategory,
   validateCliAgentLaunch,
 } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
@@ -102,7 +102,7 @@ export async function runToolUseAgent(
   const launchMode = 'agentsRun';
   const agentEntry = await resolveCliAgent(
     init.agent,
-    cliAgentLaunchCategory(launchMode),
+    cliAgentLaunchLookupCategory(launchMode),
   );
 
   const launchTarget = validateCliAgentLaunch(

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -24,7 +24,7 @@ import { resolveCliAgent } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import {
-  cliAgentLaunchCategory,
+  cliAgentLaunchLookupCategory,
   validateCliAgentLaunch,
 } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
@@ -121,7 +121,7 @@ export async function runWorkflowAgent(
   const launchMode = 'run';
   const agentEntry = await resolveCliAgent(
     init.agent,
-    cliAgentLaunchCategory(launchMode),
+    cliAgentLaunchLookupCategory(launchMode),
   );
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -56,18 +56,20 @@ export function parseCliAgentCategoryFilter(
  * auth/network work. Missing agents still get a remote-inclusive fallback, and
  * authenticated relay sessions reload bare names so the registry's normal
  * source priority can prefer remote definitions. Category-specific commands
- * pass their category through to keep lookup priority owned by the registry.
+ * pass their lookup category through to keep name priority owned by the
+ * registry; category enforcement stays with the command-specific launch
+ * validation.
  */
 export async function resolveCliAgent(
   name: string,
-  category?: AgentCategory,
+  lookupCategory?: AgentCategory,
 ): Promise<AgentEntry | undefined> {
   await loadAgents({ includeRemote: false });
-  const agent = getAgent(name, category);
+  const agent = getAgent(name, lookupCategory);
 
   if (!agent) {
     await loadAgents();
-    return getAgent(name, category);
+    return getAgent(name, lookupCategory);
   }
 
   if (name.includes(':') || !(await getCliAuthProvider().isAuthenticated())) {
@@ -75,7 +77,7 @@ export async function resolveCliAgent(
   }
 
   await loadAgents();
-  return getAgent(name, category);
+  return getAgent(name, lookupCategory);
 }
 
 export async function loadCliAgentList(

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -232,22 +232,23 @@ const LEGACY_AGENT_ALIASES: Record<string, string> = {
  * Canonical agent resolver: look up an agent by identifier.
  *
  * Supports "source:name" format or just "name". Plain names use the default
- * source priority unless the lookup is for a tool-use session, where built-in
- * tool-use agents outrank built-in workflow agents.
+ * source priority unless `lookupCategory` requests a category-specific
+ * priority. This is not a category filter: callers that require a category
+ * must check the returned entry.
  *
  * All other lookups in this module (`resolveAgent`, `resolveAgentKey`,
  * `isRemoteAgent`, `updateAgent*`) delegate here.
  */
 export function getAgent(
   identifier: string,
-  category?: AgentCategoryType,
+  lookupCategory?: AgentCategoryType,
 ): AgentEntry | undefined {
   // Direct lookup for source:name format (already resolved)
   if (cache.has(identifier)) return cache.get(identifier);
 
   // Find first match using session-appropriate priority
   const priority =
-    category === AgentCategory.ToolUse
+    lookupCategory === AgentCategory.ToolUse
       ? TOOL_USE_LOOKUP_PRIORITY
       : LOOKUP_PRIORITY;
   for (const source of priority) {
@@ -262,7 +263,7 @@ export function getAgent(
   const alias = LEGACY_AGENT_ALIASES[name];
   if (alias) {
     const prefix = identifier.slice(0, identifier.length - name.length);
-    return getAgent(`${prefix}${alias}`, category);
+    return getAgent(`${prefix}${alias}`, lookupCategory);
   }
   return undefined;
 }
@@ -358,10 +359,10 @@ export async function refresh(options: LoadAgentsOptions = {}): Promise<void> {
  */
 export function resolveAgentKey(
   agentIdentifier: string,
-  category?: AgentCategoryType,
+  lookupCategory?: AgentCategoryType,
 ): string {
   if (!agentIdentifier) return agentIdentifier;
-  const entry = getAgent(agentIdentifier, category);
+  const entry = getAgent(agentIdentifier, lookupCategory);
   if (!entry) return agentIdentifier;
   return createKey(entry.source, entry.name);
 }

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -11,6 +11,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform } from '@platform/platform';
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { setAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import {
   getAgent,
@@ -70,6 +71,12 @@ describe('agent registry legacy aliases', () => {
     expect(getAgent('builtInToolUse:chat')?.name).toBe('assistant');
     expect(getAgent('builtInToolUse:assistant')?.name).toBe('assistant');
     expect(getAgent('custom:no-such-agent')).toBeUndefined();
+  });
+
+  it('treats lookup category as priority, not a filter', () => {
+    const workflow = getAgent('builtInWorkflow:polish', AgentCategory.ToolUse);
+    expect(workflow?.name).toBe('polish');
+    expect(workflow?.category).toBe(AgentCategory.Workflow);
   });
 
   it('migrates persisted legacy keys at load time', () => {

--- a/src/test-kernel/agent/ExecutionWriterCategory.vitest.mts
+++ b/src/test-kernel/agent/ExecutionWriterCategory.vitest.mts
@@ -9,8 +9,8 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 const state = { ready: true };
 vi.mock('@agent/index/agentRegistry', () => ({
   isAgentRegistryReady: vi.fn(() => state.ready),
-  getAgent: vi.fn((name: string, category?: AgentCategory) =>
-    name === 'research' && category === AgentCategory.ToolUse
+  getAgent: vi.fn((name: string, lookupCategory?: AgentCategory) =>
+    name === 'research' && lookupCategory === AgentCategory.ToolUse
       ? { name, category: AgentCategory.ToolUse }
       : undefined,
   ),

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -88,7 +88,7 @@ describe('CLI agent resolution', () => {
     expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
   });
 
-  it('passes command category through authenticated remote-priority reloads', async () => {
+  it('passes lookup category through authenticated remote-priority reloads', async () => {
     const local = agent('lean');
     const remote = agent('lean', 'remote');
     mocks.authProvider.isAuthenticated.mockResolvedValue(true);
@@ -128,7 +128,7 @@ describe('CLI agent resolution', () => {
     expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
   });
 
-  it('passes command category through local and remote-fallback lookups', async () => {
+  it('passes lookup category through local and remote-fallback lookups', async () => {
     const remote = agent('assistant', 'remote');
     mocks.getAgent.mockReturnValueOnce(undefined).mockReturnValueOnce(remote);
     const { resolveCliAgent } = await import('@cli/runtime/agents');


### PR DESCRIPTION
## Summary
- rename CLI agent lookup inputs from generic `category` to `lookupCategory`
- make the launch target table say it owns lookup priority, while command validation owns category enforcement
- add a registry test proving lookup category is a priority hint, not a filter

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/AgentRegistryAlias.vitest.mts src/test-kernel/agent/ExecutionWriterCategory.vitest.mts src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/RunChatConfig.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/commands/_helpers/agentLookupText.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts packages/cli/src/runtime/agents.ts src/agent/index/agentRegistry.ts src/test-kernel/agent/AgentRegistryAlias.vitest.mts src/test-kernel/agent/ExecutionWriterCategory.vitest.mts src/test-kernel/cli/AgentResolution.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json`
- `corepack pnpm exec eslint packages/cli/src/commands/_helpers/agentLookupText.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts packages/cli/src/runtime/agents.ts src/agent/index/agentRegistry.ts src/test-kernel/agent/AgentRegistryAlias.vitest.mts src/test-kernel/agent/ExecutionWriterCategory.vitest.mts src/test-kernel/cli/AgentResolution.vitest.mts`
- `npm run check:cli-architecture`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly renames and comments plus a clarifying test; launch validation behavior is unchanged.
> 
> **Overview**
> Renames and documents the split between **registry lookup priority** and **command launch category checks**, so `category` is not read as “only return agents of this type.”
> 
> `getAgent` / `resolveCliAgent` / `resolveAgentKey` now take **`lookupCategory`** (tool-use sessions still use tool-use source priority; it does **not** filter results). CLI launch helpers rename **`cliAgentLaunchCategory`** → **`cliAgentLaunchLookupCategory`**, and the per-command launch table uses **`requiredCategory`** for **`validateCliAgentLaunch`** mismatch errors. Comments in the registry and CLI runtime spell out that callers must enforce category after resolve.
> 
> A registry test asserts that requesting **`AgentCategory.ToolUse`** lookup priority can still resolve a workflow agent (e.g. `builtInWorkflow:polish`) with its real category unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7164d8f570c15e10ec09d400a4725d3fe48ff04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->