### PR TITLE
[codex] Let agents run usage errors propagate

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -13,7 +13,7 @@ import {
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
-import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
+import { writeTextStderr } from '../runtime/logSinks';
 import {
   buildHeadlessRunContext,
   resolveCliRunModel,
@@ -68,35 +68,13 @@ async function resolveToolUseInstruction(
   return instruction;
 }
 
-/**
- * Run a thunk, mapping a `CliUsageError` to the `Usage` exit code (after writing
- * it to stderr) and re-throwing anything else. Returns the thunk's value on
- * success; callers branch on `typeof result === 'number'` for the exit code.
- */
-async function withUsageExit<T>(
-  thunk: () => Promise<T>,
-): Promise<T | CliExitCode> {
-  try {
-    return await thunk();
-  } catch (error: unknown) {
-    if (!(error instanceof CliUsageError)) {
-      throw error;
-    }
-    writeErrorStderr(error);
-    return CliExitCode.Usage;
-  }
-}
-
 export async function runToolUseAgent(
   context: CliContext,
   init: ToolUseAgentRunInit,
 ): Promise<number> {
   let inputFiles: string[];
   let contextFiles: string[];
-  const instruction = await withUsageExit(() =>
-    resolveToolUseInstruction(init, context.cwd),
-  );
-  if (typeof instruction === 'number') return instruction;
+  const instruction = await resolveToolUseInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
   const launchMode = 'agentsRun';
@@ -111,8 +89,7 @@ export async function runToolUseAgent(
     launchMode,
   );
   if (!launchTarget.ok) {
-    writeTextStderr(launchTarget.error);
-    return CliExitCode.Usage;
+    throw new CliUsageError(launchTarget.error);
   }
 
   const model = await resolveCliRunModel(context, init.model, 'chat');
@@ -123,14 +100,16 @@ export async function runToolUseAgent(
     tempDir: runContext.cwd,
   });
   try {
-    const expanded = await withUsageExit(() =>
-      expandRunInputs(init.inputFiles, init.contextFiles, runContext.cwd, {
+    const expanded = await expandRunInputs(
+      init.inputFiles,
+      init.contextFiles,
+      runContext.cwd,
+      {
         allowEmptyInput: true,
         requireWorkspaceFiles: true,
         stdinInputFile,
-      }),
+      },
     );
-    if (typeof expanded === 'number') return expanded;
     inputFiles = expanded.inputFiles;
     contextFiles = expanded.contextFiles;
 

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -162,39 +162,38 @@ describe('CLI agents run command', () => {
   it('reports missing instruction before resolving the model', async () => {
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
 
-    const exitCode = await runToolUseAgent(cliContext(), {
-      agent: 'chat',
-      inputFiles: [],
-      contextFiles: [],
-      model: 'gpt54',
-      instruction: '',
-    });
+    await expect(
+      runToolUseAgent(cliContext(), {
+        agent: 'chat',
+        inputFiles: [],
+        contextFiles: [],
+        model: 'gpt54',
+        instruction: '',
+      }),
+    ).rejects.toThrow('Provide --instruction or --instruction-file.');
 
-    expect(exitCode).toBe(2);
     expect(mocks.initLocalCliPlatform).not.toHaveBeenCalled();
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.resolveCliAgent).not.toHaveBeenCalled();
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
-    expect(mocks.writeErrorStderr).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Provide --instruction or --instruction-file.',
-      }),
-    );
   });
 
   it('reports missing agents before resolving the model', async () => {
     mocks.resolveCliAgent.mockResolvedValueOnce(undefined);
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
 
-    const exitCode = await runToolUseAgent(cliContext(), {
-      agent: 'missing-agent',
-      inputFiles: [],
-      contextFiles: [],
-      model: 'gpt54',
-      instruction: 'Check this.',
-    });
+    await expect(
+      runToolUseAgent(cliContext(), {
+        agent: 'missing-agent',
+        inputFiles: [],
+        contextFiles: [],
+        model: 'gpt54',
+        instruction: 'Check this.',
+      }),
+    ).rejects.toThrow(
+      'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+    );
 
-    expect(exitCode).toBe(2);
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
@@ -204,9 +203,6 @@ describe('CLI agents run command', () => {
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
-    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
-    );
   });
 
   it('reports workflow agents before resolving the model', async () => {
@@ -219,15 +215,18 @@ describe('CLI agents run command', () => {
     });
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
 
-    const exitCode = await runToolUseAgent(cliContext(), {
-      agent: 'polish',
-      inputFiles: [],
-      contextFiles: [],
-      model: 'gpt54',
-      instruction: 'Check this.',
-    });
+    await expect(
+      runToolUseAgent(cliContext(), {
+        agent: 'polish',
+        inputFiles: [],
+        contextFiles: [],
+        model: 'gpt54',
+        instruction: 'Check this.',
+      }),
+    ).rejects.toThrow(
+      'Agent "polish" is a workflow agent; `texra agents run` only handles tool-use agents. Use `texra run polish` for workflow agents.',
+    );
 
-    expect(exitCode).toBe(2);
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
@@ -237,8 +236,5 @@ describe('CLI agents run command', () => {
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.expandRunInputs).not.toHaveBeenCalled();
-    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'Agent "polish" is a workflow agent; `texra agents run` only handles tool-use agents. Use `texra run polish` for workflow agents.',
-    );
   });
 });


### PR DESCRIPTION
## Summary
- remove the local `withUsageExit` wrapper from `texra agents run`
- let `CliUsageError` propagate to the root CLI handler like `texra run` and `multi-agent run`
- update focused tests so direct helper calls assert the shared throw-on-usage contract

## Dogfood
- `validate-tui --snapshot-dir` passed launcher, approval, goal, subagent, task, and todo scenarios; reports written under `/private/tmp/texra-tui-snapshots-next` and `/private/tmp/texra-tui-narrow-snapshots-next`
- `texra run polish --input README.md ...` completed a real workflow run and recorded history
- `texra agents run assistant --instruction "Solve this concisely: does sqrt(6)/3 equal sqrt(2)/sqrt(3)?"` completed and returned the correct algebra

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/commands/agentsRun.ts src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/commands/agentsRun.ts src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run texra-local:build`
- `node packages/cli/dist/bin/texra.js agents run assistant --no-color --no-input`
- `npm run check:cli-architecture`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral alignment for CLI usage errors only; success paths unchanged and tests cover the throw contract.
> 
> **Overview**
> **`texra agents run`** no longer catches usage failures inside `runToolUseAgent`. The local **`withUsageExit`** helper and **`writeErrorStderr`** usage for those paths are removed; missing instruction, invalid agent launch, and **`expandRunInputs`** failures now **throw `CliUsageError`** so the shared root CLI handler can map them to the usage exit code, matching **`texra run`** and multi-agent run.
> 
> Invalid launch targets that previously wrote stderr and returned **`CliExitCode.Usage`** now **`throw new CliUsageError(launchTarget.error)`** instead.
> 
> Tests that call **`runToolUseAgent`** directly were updated to **`expect(...).rejects.toThrow(...)`** and no longer assert stderr writes or exit code **2** for those cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25dbe47c46c2852154a8e7f04213f4c5f42b5882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->