### PR TITLE
[codex] Inline workflow output resolution

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -65,42 +65,6 @@ interface WorkflowRunInit {
   readonly instructionFile?: string;
 }
 
-/**
- * Resolve the workflow output, mapping a failure to an exit code: an
- * interrupted run yields `Interrupted`, otherwise the run is marked errored and
- * `AgentError` is returned. Returns the display result on success; callers
- * branch on `typeof result === 'number'`.
- */
-async function resolveWorkflowDisplayResultOrExit(
-  executionId: ReturnType<typeof generateExecutionId>,
-  output: Parameters<typeof resolveWorkflowOutput>[0],
-  outputDir: Parameters<typeof resolveWorkflowOutput>[1],
-  result: Parameters<typeof resolveWorkflowOutput>[2],
-  runContext: Parameters<typeof resolveWorkflowOutput>[3],
-  options: Parameters<typeof resolveWorkflowOutput>[4],
-): Promise<CliRunResult | CliExitCode> {
-  const { terminalStatus } = options;
-  try {
-    return (
-      await resolveWorkflowOutput(
-        output,
-        outputDir,
-        result,
-        runContext,
-        options,
-      )
-    ).displayResult;
-  } catch (error) {
-    if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-      writeErrorStderr(error);
-      return CliExitCode.Interrupted;
-    }
-    await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-    writeErrorStderr(error);
-    return CliExitCode.AgentError;
-  }
-}
-
 export async function runWorkflowAgent(
   context: CliContext,
   init: WorkflowRunInit,
@@ -185,20 +149,32 @@ export async function runWorkflowAgent(
         markErrorOnThrow: true,
       },
     );
-    const displayResult = await resolveWorkflowDisplayResultOrExit(
-      executionId,
-      init.output,
-      init.outputDir,
-      result,
-      runContext,
-      {
-        expectedOutputFiles: init.outputDir
-          ? expectedOutputFilesForOutputDir(agent, inputFiles)
-          : undefined,
-        terminalStatus,
-      },
-    );
-    if (typeof displayResult === 'number') return displayResult;
+    let displayResult: CliRunResult;
+    try {
+      displayResult = (
+        await resolveWorkflowOutput(
+          init.output,
+          init.outputDir,
+          result,
+          runContext,
+          {
+            expectedOutputFiles: init.outputDir
+              ? expectedOutputFilesForOutputDir(agent, inputFiles)
+              : undefined,
+            terminalStatus,
+          },
+        )
+      ).displayResult;
+    } catch (error) {
+      if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+        writeErrorStderr(error);
+        return CliExitCode.Interrupted;
+      }
+
+      await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+      writeErrorStderr(error);
+      return CliExitCode.AgentError;
+    }
 
     emitCliResult(runContext, {
       json: displayResult,


### PR DESCRIPTION
## Summary
- remove the single-use workflow output resolution wrapper
- handle workflow output errors directly where the result is resolved
- keep interrupted vs agent-error exit mapping unchanged

## Validation
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/WorkflowRunCommand.vitest.mts
- corepack pnpm exec prettier --check packages/cli/src/commands/workflow.ts
- corepack pnpm exec eslint packages/cli/src/commands/workflow.ts
- corepack pnpm exec tsc --noEmit --pretty false -p tsconfig.json
- corepack pnpm --filter @texra-ai/cli typecheck
- npm run check:cli-architecture
- npm run texra-local:build
- goal TUI harness: plan-approval-goal, compact-plan-approval-goal, plan-approval-approve-goal
- rebuilt CLI stdin workflow smoke with texra run polish --input -
- npm run lint
- npm run compile:fast
- npm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with identical control flow and exit codes; no new APIs or workflow semantics.
> 
> **Overview**
> Removes the single-use `resolveWorkflowDisplayResultOrExit` helper from the workflow CLI command and **inlines** the same logic in `runWorkflowAgent` immediately after `executeCliRequest`.
> 
> The inlined `try/catch` still calls `resolveWorkflowOutput` with the same `expectedOutputFiles` and `terminalStatus` options. **Interrupted** runs still log to stderr and return `CliExitCode.Interrupted`; other failures still mark the execution `ERROR`, log, and return `CliExitCode.AgentError`. Success path and `emitCliResult` behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c35270e1e9b93cee53c52cb77e391ecceeb070f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->