### PR TITLE
fix: clean stdin temp files on cli shutdown

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -50,7 +50,8 @@ import {
 import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import { firstRunSetupAgentOverride } from '@cli/onboarding/setupContinuation';
 import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
-import { validateCliAgentLaunch } from '@cli/commands/_helpers/agentLookupText';
+import { assertCliAgentLaunch } from '@cli/commands/_helpers/agentLookupText';
+import { CliUsageError } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
@@ -496,12 +497,17 @@ function agentSupportsDelegation(agentName: string): boolean {
 export function chatToolUseAgentUsageError(
   agentName: string,
 ): string | undefined {
-  const launchTarget = validateCliAgentLaunch(
-    agentName,
-    getAgent(agentName, AgentCategory.ToolUse),
-    'chat',
-  );
-  return launchTarget.ok ? undefined : launchTarget.error;
+  try {
+    assertCliAgentLaunch(
+      agentName,
+      getAgent(agentName, AgentCategory.ToolUse),
+      'chat',
+    );
+    return undefined;
+  } catch (error) {
+    if (error instanceof CliUsageError) return error.message;
+    throw error;
+  }
 }
 
 function applyInitialCliAgentSelection(

--- a/packages/cli/src/commands/_helpers/agentLookupText.ts
+++ b/packages/cli/src/commands/_helpers/agentLookupText.ts
@@ -1,16 +1,14 @@
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
+import { CliUsageError } from '@cli/runtime/cliContext';
+
 const AGENT_LOOKUP_HINT =
   'Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.';
 const MULTI_AGENT_PRESET_LOOKUP_HINT =
   'Use `texra multi-agent list` for available team presets, then run `texra multi-agent inspect <preset>` to check a team before launch.';
 
 type CliAgentLaunchMode = 'chat' | 'run' | 'agentsRun';
-
-type CliAgentLaunchValidation =
-  | { readonly ok: true; readonly agent: AgentEntry }
-  | { readonly ok: false; readonly error: string };
 
 const CLI_AGENT_LAUNCH_TARGETS = {
   chat: {
@@ -57,15 +55,15 @@ export function cliAgentLaunchLookupCategory(
   return CLI_AGENT_LAUNCH_TARGETS[mode].requiredCategory;
 }
 
-export function validateCliAgentLaunch(
+export function assertCliAgentLaunch(
   name: string,
   agent: AgentEntry | undefined,
   mode: CliAgentLaunchMode,
-): CliAgentLaunchValidation {
+): AgentEntry {
   const target = CLI_AGENT_LAUNCH_TARGETS[mode];
-  if (!agent) return { ok: false, error: target.missing(name) };
+  if (!agent) throw new CliUsageError(target.missing(name));
   if (agent.category !== target.requiredCategory) {
-    return { ok: false, error: target.mismatch(name, agent.category) };
+    throw new CliUsageError(target.mismatch(name, agent.category));
   }
-  return { ok: true, agent };
+  return agent;
 }

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -23,8 +23,8 @@ import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import {
   TOOL_USE_AGENT_NAME_DESCRIPTION,
+  assertCliAgentLaunch,
   cliAgentLaunchLookupCategory,
-  validateCliAgentLaunch,
 } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
@@ -83,14 +83,7 @@ export async function runToolUseAgent(
     cliAgentLaunchLookupCategory(launchMode),
   );
 
-  const launchTarget = validateCliAgentLaunch(
-    init.agent,
-    agentEntry,
-    launchMode,
-  );
-  if (!launchTarget.ok) {
-    throw new CliUsageError(launchTarget.error);
-  }
+  assertCliAgentLaunch(init.agent, agentEntry, launchMode);
 
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -24,8 +24,8 @@ import { resolveCliAgent } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import {
+  assertCliAgentLaunch,
   cliAgentLaunchLookupCategory,
-  validateCliAgentLaunch,
 } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { emitCliResult } from './_helpers/output';
@@ -89,13 +89,7 @@ export async function runWorkflowAgent(
   );
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
-  const launchTarget = validateCliAgentLaunch(
-    init.agent,
-    agentEntry,
-    launchMode,
-  );
-  if (!launchTarget.ok) throw new CliUsageError(launchTarget.error);
-  const agent = launchTarget.agent;
+  const agent = assertCliAgentLaunch(init.agent, agentEntry, launchMode);
   if (init.output && hasMixedStdinWorkflowInputSpecs(init.inputFiles)) {
     throw new CliUsageError(
       'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -4,8 +4,11 @@ import * as path from 'node:path';
 import { glob, hasMagic } from 'glob';
 import { nanoid } from 'nanoid';
 
+import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
+import { tryPlatform } from '@platform/platform';
 import { CliUsageError } from '@cli/runtime/cliContext';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import type { Disposable } from '@platform/interfaces/disposable';
 import type { Stats } from 'node:fs';
 
 const STDIN_INPUT_TOKEN = '-';
@@ -94,17 +97,37 @@ export function createStdinWorkflowInputMaterializer(options: {
   readonly tempDir: string;
 }): StdinWorkflowInputMaterializer {
   let materialized: Promise<string> | undefined;
+  let materializedPath: string | undefined;
+  let shutdownCleanup: Disposable | undefined;
+  let cleanupStarted = false;
+  let cleanupPromise: Promise<void> | undefined;
   const inputFile = (() => {
-    materialized ??= materializeStdinWorkflowInput(options);
+    materialized ??= materializeStdinWorkflowInput(options).then(
+      (inputPath) => {
+        materializedPath = inputPath;
+        if (cleanupStarted) {
+          void fs.rm(inputPath, { force: true }).catch(() => undefined);
+        }
+        return inputPath;
+      },
+    );
     return materialized;
   }) as StdinWorkflowInputMaterializer;
   inputFile.cleanup = async () => {
-    if (!materialized) return;
-    const inputPath = await materialized.catch(() => undefined);
-    if (inputPath) {
-      await fs.rm(inputPath, { force: true });
-    }
+    cleanupStarted = true;
+    cleanupPromise ??= (async () => {
+      shutdownCleanup?.dispose();
+      shutdownCleanup = undefined;
+      if (materializedPath) {
+        await fs.rm(materializedPath, { force: true });
+      }
+    })();
+    await cleanupPromise;
   };
+  shutdownCleanup = tryPlatform()?.lifecycle.onShutdown(
+    SHUTDOWN_PHASE.BEFORE,
+    inputFile.cleanup,
+  );
   return inputFile;
 }
 

--- a/src/test-kernel/cli/WorkflowInputsLifecycle.vitest.mts
+++ b/src/test-kernel/cli/WorkflowInputsLifecycle.vitest.mts
@@ -1,0 +1,73 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { describe, expect, it } from 'vitest';
+
+import { createFakePlatform } from '@test/support/FakePlatform';
+import {
+  createStdinWorkflowInputMaterializer,
+  expandWorkflowInputSpecs,
+} from '@cli/runtime/workflowInputs';
+
+describe('CLI workflow input lifecycle', () => {
+  async function installFakePlatform(root: string) {
+    const fakePlatform = createFakePlatform({
+      globalStoragePath: path.join(root, 'global-storage'),
+      storagePath: path.join(root, 'workspace-storage'),
+      workspacePath: root,
+    });
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(fakePlatform);
+    return fakePlatform;
+  }
+
+  it('removes materialized stdin input on platform shutdown', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
+    const fakePlatform = await installFakePlatform(root);
+
+    try {
+      const stdinInputFile = createStdinWorkflowInputMaterializer({
+        tempDir: root,
+        readStdinText: async () => 'body from stdin',
+      });
+
+      const expanded = await expandWorkflowInputSpecs(['-'], root, '--input', {
+        stdinInputFile,
+      });
+
+      const inputPath = path.resolve(root, expanded[0]);
+      await expect(fs.readFile(inputPath, 'utf8')).resolves.toBe(
+        'body from stdin',
+      );
+
+      await fakePlatform.lifecycle.runShutdown();
+      await expect(fs.stat(inputPath)).rejects.toThrow();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not wait for unfinished stdin reads during platform shutdown', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
+    const fakePlatform = await installFakePlatform(root);
+
+    try {
+      const stdinInputFile = createStdinWorkflowInputMaterializer({
+        tempDir: root,
+        readStdinText: async () => new Promise<string>(() => undefined),
+      });
+
+      void stdinInputFile().catch(() => undefined);
+      const result = await Promise.race([
+        fakePlatform.lifecycle.runShutdown().then(() => 'shutdown'),
+        sleep(100).then(() => 'timeout'),
+      ]);
+
+      expect(result).toBe('shutdown');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- simplify CLI launch validation so command paths use a throwing assertion instead of `{ ok, error }` result plumbing
- register stdin workflow temp files with the CLI lifecycle so SIGINT shutdown removes materialized `.texra-stdin-*` files
- add a focused lifecycle test for stdin temp cleanup

## Dogfood notes
- `\goal` long-run coverage passed through focused tests and TUI harness scenarios
- a delegated `mathematician` run with `approval-policy yolo` ran for ~3.5 minutes, used the `review` subagent, and completed in an isolated scratch directory
- interrupting a live stdin workflow previously left `.texra-stdin-*`; after this change it exits 130 with no leftover temp file

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/WorkflowInputsLifecycle.vitest.mts src/test-kernel/cli/RunChatConfig.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/agent/GoalContinuation.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /private/tmp/texra-tui-third-post plan-approval-goal compact-plan-approval-goal plan-approval-approve-goal`
- `npm run check:cli-architecture`
- `git diff --check`
- `npm run lint`
- `npm run compile:fast`
- `npm test`
- live smoke: interrupted `texra-local run polish --input - ...` with SIGINT and verified no `.texra-stdin-*` files remained

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI lifecycle and error-handling refactor with new tests; no auth, persistence, or agent-runtime behavior changes beyond temp-file cleanup on exit.
> 
> **Overview**
> **Stdin workflow temp files** (`.texra-stdin-*`) now register with platform **BEFORE** shutdown so SIGINT and normal CLI teardown delete materialized stdin inputs; cleanup is idempotent and does not block shutdown on a hung stdin read.
> 
> **Agent launch validation** replaces `validateCliAgentLaunch`’s `{ ok, error }` pattern with **`assertCliAgentLaunch`**, which throws `CliUsageError` and returns the agent—used by `workflow`, `agents run`, and chat TUI (with try/catch where a string error is needed).
> 
> Adds **`WorkflowInputsLifecycle`** tests for shutdown cleanup and non-blocking shutdown when stdin never finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527c754e7075574853c2b31971df37411f2dcdcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->