### PR TITLE
[codex] Mark interrupted CLI shutdown runs

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,3 +1,5 @@
+import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
+import { tryPlatform } from '@platform/platform';
 import { writeTerminalStatus } from '@agent/storage';
 import { runAgent } from '@agent/runtime/runAgent';
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -60,6 +62,19 @@ export async function executeCliRequest(
   const uninstallApprovalHandlers = installCliApprovalHandlers(runContext, {
     beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),
   });
+  const ownedExecutionId = options.registerExecution
+    ? request.executionId
+    : undefined;
+  let shutdownInterrupted = false;
+  const disposeShutdownStatus = ownedExecutionId
+    ? tryPlatform()?.lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, async () => {
+        shutdownInterrupted = true;
+        await writeTerminalStatus(
+          ownedExecutionId,
+          EXECUTION_STATUS.INTERRUPTED,
+        );
+      })
+    : undefined;
   const invoke = (): Promise<ExecuteAgentResult> =>
     runAgent(request, {
       runtimeHost,
@@ -82,6 +97,12 @@ export async function executeCliRequest(
     }
     throw error;
   } finally {
+    disposeShutdownStatus?.dispose();
+    // If the run settles while shutdown is in progress, keep the
+    // signal-owned interrupted status as the final write.
+    if (shutdownInterrupted && ownedExecutionId) {
+      await writeTerminalStatus(ownedExecutionId, EXECUTION_STATUS.INTERRUPTED);
+    }
     detachResultToast();
     uninstallApprovalHandlers();
     await runtimeHost.close();

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createFakePlatform } from '@test/support/FakePlatform';
 import type { CliContext } from '@cli/runtime/cliContext';
+import { EXECUTION_STATUS } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),
@@ -196,5 +198,67 @@ describe('executeCliRequest', () => {
     expect(uninstall.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.close.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
+  });
+
+  it('marks owned executions interrupted during platform shutdown', async () => {
+    const { initPlatform } = await import('@platform/platform');
+    const platform = createFakePlatform();
+    initPlatform(platform);
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+    let resolveRun:
+      | ((result: Awaited<ReturnType<typeof mocks.runAgent>>) => void)
+      | undefined;
+    mocks.runAgent.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRun = resolve;
+      }),
+    );
+
+    const run = executeCliRequest(request, cliContext(), {
+      registerExecution: true,
+    });
+    await Promise.resolve();
+    await platform.lifecycle.runShutdown();
+
+    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
+      'exec-1',
+      EXECUTION_STATUS.INTERRUPTED,
+    );
+
+    resolveRun?.({
+      category: 'toolUse',
+      executionId: 'exec-1',
+      status: 'completed',
+      streamId: 'stream-1',
+    });
+    await run;
+    expect(mocks.writeTerminalStatus).toHaveBeenCalledTimes(2);
+    expect(mocks.writeTerminalStatus).toHaveBeenLastCalledWith(
+      'exec-1',
+      EXECUTION_STATUS.INTERRUPTED,
+    );
+  });
+
+  it('removes the shutdown status hook after owned executions finish', async () => {
+    const { initPlatform } = await import('@platform/platform');
+    const platform = createFakePlatform();
+    initPlatform(platform);
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+
+    await executeCliRequest(request, cliContext(), {
+      registerExecution: true,
+    });
+    mocks.writeTerminalStatus.mockClear();
+    await platform.lifecycle.runShutdown();
+
+    expect(mocks.writeTerminalStatus).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Mark owned headless CLI executions as `interrupted` when the CLI platform shuts down on SIGINT/SIGTERM.
- Dispose that shutdown status hook once the run finishes normally so completed/error runs are not overwritten.
- Add focused runner tests for pending shutdown and normal completion cleanup.

## Root Cause

Long-running headless CLI runs could be interrupted before the agent lifecycle wrote a terminal status. The execution had config/meta on disk, but no `terminalStatus`, so `texra-local history list` displayed `unknown` after Ctrl-C.

## Impact

Interrupted long workflow/agent/multi-agent CLI runs now leave an explicit interrupted history record instead of looking like statusless crashes. Resume-owned executions still avoid status writes because the existing `registerExecution` ownership flag gates the hook.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/InitPlatformSignalHandlers.vitest.mts src/test-kernel/cli/HistoryStatus.vitest.ts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/agent/GoalContinuation.vitest.ts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts src/test-kernel/tools/GoalForget.vitest.ts src/test-kernel/tools/GoalLegacyMigration.vitest.ts`
- `node packages/cli/scripts/validate-tui.mjs plan-approval-goal plan-approval-approve-goal`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run check:cli-architecture`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `npm test`

Live dogfood: rebuilt/relinked `texra-local`, started a long `texra-local run polish --input - ...`, sent Ctrl-C during the model-wait phase, and confirmed the newest `texra-local history list --output-format json --no-color` entry had `status: "interrupted"`; the stdin temp file was also cleaned up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to headless `executeCliRequest` when `registerExecution` is true; only affects terminal status persistence on shutdown, not agent logic or auth.
> 
> **Overview**
> Headless CLI runs that **own** their execution (`registerExecution: true`) now register a platform **before-shutdown** hook that writes **`interrupted`** terminal status when SIGINT/SIGTERM triggers shutdown, so history no longer shows **unknown** for Ctrl-C’d long runs.
> 
> The hook is **disposed** when the run finishes; if shutdown already fired, **`finally`** writes **`interrupted` again** so a late **completed** status from the agent does not overwrite the signal-driven outcome. **Resume** and other non-owned paths stay unchanged because the hook only attaches when `registerExecution` is set.
> 
> Tests cover shutdown while a run is pending (status stays **interrupted** after completion) and that shutdown after a normal finish does not touch status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 394df0aab4a9dd1e2ca2c1f426959d74330c592f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->