### PR TITLE
fix: preserve approval policy in CLI resume hints

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -762,6 +762,7 @@ export function buildStatusBarDisplay(
         ? `Resume this session with: ${formatResumeCommand(
             input.commandName,
             input.pendingExitResumeId,
+            { approvalPolicy: input.approvalPolicy },
           )}`
         : input.shortcutsActive === false
           ? foregroundBindingsText(

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -938,6 +938,7 @@ async function handleTuiSlashCommand(
           commandName: context.commandName,
           cwd: context.cwd,
           processCwd: process.cwd(),
+          approvalPolicy: context.getApprovalPolicy(),
           queuedFollowUpMessages:
             activeStreamId === undefined
               ? []
@@ -1784,7 +1785,11 @@ export async function runChat(
       }),
       collectResumeUsage(streams),
       context.commandName,
-      { cwd: context.cwd, processCwd: process.cwd() },
+      {
+        cwd: context.cwd,
+        processCwd: process.cwd(),
+        approvalPolicy: activeApprovalPolicy,
+      },
     );
     if (hint) writeTextStdout(`\n${hint}`);
   };

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -1,3 +1,4 @@
+import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { truncateSummary } from '@utils/text/stringUtils';
@@ -29,6 +30,7 @@ export interface CliSessionStatusInput {
   readonly commandName?: string;
   readonly cwd?: string;
   readonly processCwd?: string;
+  readonly approvalPolicy?: CliApprovalPolicy;
 }
 
 export function formatCliStatusLabel(status: string | undefined): string {
@@ -91,7 +93,11 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
           `resume later with: ${formatResumeCommand(
             input.commandName,
             input.sessionId,
-            { cwd: input.cwd, processCwd: input.processCwd },
+            {
+              cwd: input.cwd,
+              processCwd: input.processCwd,
+              approvalPolicy: input.approvalPolicy,
+            },
           )}`,
         ]
       : []),

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -5,6 +5,7 @@
 // (only tool-use agents do). Reads only the in-memory stream tree, which still
 // holds finished subagents for the session, so no exit-time disk I/O is needed.
 
+import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import {
   AgentCategory,
   sumUsageStats,
@@ -37,6 +38,7 @@ export interface ResumeCommandOptions {
   readonly cwd?: string;
   /** Ambient shell cwd where the printed command will be copy-pasted. */
   readonly processCwd?: string;
+  readonly approvalPolicy?: CliApprovalPolicy;
 }
 
 const DEFAULT_RESUME_COMMAND_NAME = 'texra';
@@ -51,7 +53,11 @@ export function formatResumeCommand(
     cwd && cwd !== options.processCwd?.trim()
       ? ` --cwd ${quotePosixShellArg(cwd)}`
       : '';
-  return `${commandName || DEFAULT_RESUME_COMMAND_NAME} resume ${executionId}${cwdArg}`;
+  const policyFlag =
+    options.approvalPolicy && options.approvalPolicy !== 'ask'
+      ? ` --approval-policy ${options.approvalPolicy}`
+      : '';
+  return `${commandName || DEFAULT_RESUME_COMMAND_NAME} resume ${executionId}${cwdArg}${policyFlag}`;
 }
 
 function formatInteger(value: number): string {

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -51,6 +51,7 @@ export async function runResumeExecution(
         headlessMessage: `Resuming continues an interactive chat session — run \`${formatResumeCommand(
           commandName,
           id,
+          { approvalPolicy: context.approvalPolicy },
         )}\` in a terminal. For scripting, use \`${runCommand}\`.`,
         dumbTerminalCommand: 'resume',
         dumbTerminalOptions: {

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -151,6 +151,30 @@ describe('formatResumeHint', () => {
     ).toBe('texra-local resume root');
   });
 
+  it('preserves non-default approval policies in resume commands', () => {
+    expect(
+      formatResumeCommand('texra-local', 'root', { approvalPolicy: 'ask' }),
+    ).toBe('texra-local resume root');
+    expect(
+      formatResumeCommand('texra-local', 'root', { approvalPolicy: 'never' }),
+    ).toBe('texra-local resume root --approval-policy never');
+    expect(
+      formatResumeCommand(undefined, 'root', { approvalPolicy: 'yolo' }),
+    ).toBe('texra resume root --approval-policy yolo');
+  });
+
+  it('includes both cwd and approval policy when both are needed', () => {
+    expect(
+      formatResumeCommand('texra-local', 'root', {
+        cwd: '/tmp/paper',
+        processCwd: '/tmp/launcher',
+        approvalPolicy: 'never',
+      }),
+    ).toBe(
+      "texra-local resume root --cwd '/tmp/paper' --approval-policy never",
+    );
+  });
+
   it('renders one resume line per target', () => {
     expect(
       formatResumeHint([
@@ -175,12 +199,13 @@ describe('formatResumeHint', () => {
         ],
         undefined,
         'texra-local',
+        { approvalPolicy: 'never' },
       ),
     ).toBe(
       [
         'Resume this session with:',
-        '  texra-local resume root  (main)',
-        '  texra-local resume rev  (reviewer)',
+        '  texra-local resume root --approval-policy never  (main)',
+        '  texra-local resume rev --approval-policy never  (reviewer)',
       ].join('\n'),
     );
   });

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -137,6 +137,44 @@ describe('CLI session status formatter', () => {
     );
   });
 
+  it('includes the active non-default approval policy in the resume status line', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'personal',
+      approval: 'deny privileged actions',
+      approvalPolicy: 'never',
+      status: 'waiting',
+      sessionId: 'abc123',
+      commandName: 'texra-local',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).toContain(
+      'resume later with: texra-local resume abc123 --approval-policy never',
+    );
+  });
+
+  it('includes cwd and approval policy when both affect the resume status line', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'harness-model',
+      api: 'personal',
+      approval: 'deny privileged actions',
+      approvalPolicy: 'never',
+      status: 'waiting',
+      sessionId: 'abc123',
+      commandName: 'texra-local',
+      cwd: '/tmp/paper',
+      processCwd: '/tmp/launcher',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).toContain(
+      "resume later with: texra-local resume abc123 --cwd '/tmp/paper' --approval-policy never",
+    );
+  });
+
   it('omits session lines before the first run starts', () => {
     const status = formatCliSessionStatus({
       agent: 'chat',


### PR DESCRIPTION
## Summary
- include non-default CLI approval policies in `texra resume` commands shown by `/status`, pending-exit footer, non-interactive resume guidance, and exit scrollback
- keep the change scoped to existing resume/status formatting surfaces; no new storage or agent-config fields
- add focused formatter coverage for `never`/`yolo` resume command output

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ResumeHint.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run texra-local:build`
- `npm run texra-local:link`
- real TTY: `TERM=xterm-256color texra-local resume ce11077f62e7 --approval-policy never --no-color`; `/status` printed `resume later with: texra-local resume ce11077f62e7 --approval-policy never`, and exit scrollback printed the same resume command
- `npm run lint` (passes with existing warnings outside this change)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible string formatting for resume hints only; default `ask` behavior is unchanged and there is no change to approval enforcement or stored session data.
> 
> **Overview**
> **Non-default CLI approval policies** (`never`, `yolo`) are now reflected in every generated `texra resume …` command, so copy-pasted resumes match how the session was run.
> 
> `formatResumeCommand` appends `--approval-policy <policy>` when the policy is not the default `ask` (same pattern as optional `--cwd`). Call sites pass the active policy into **`/status`**, the **pending-exit status bar** binding, **exit scrollback** (`formatResumeHint`), and **headless resume** error text in `resume.ts`.
> 
> No new persistence or agent config—only resume/status formatting surfaces changed. Tests cover the formatter and session status lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e239b30838fe2c1e27be592ba6b8af424f2c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->