### PR TITLE
[codex] Centralize CLI run input lifecycle

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -43,10 +43,7 @@ import {
   type CliToolUseRunResult,
 } from '../runtime/terminalStatus';
 import { formatToolUseAgentRunInstruction } from './_helpers/toolUseRunInstruction';
-import {
-  createStdinWorkflowInputMaterializer,
-  expandRunInputs,
-} from '../runtime/workflowInputs';
+import { withExpandedRunInputs } from '../runtime/workflowInputs';
 
 export interface ToolUseAgentRunInit {
   readonly agent: string;
@@ -72,8 +69,6 @@ export async function runToolUseAgent(
   context: CliContext,
   init: ToolUseAgentRunInit,
 ): Promise<number> {
-  let inputFiles: string[];
-  let contextFiles: string[];
   const instruction = await resolveToolUseInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
@@ -88,74 +83,67 @@ export async function runToolUseAgent(
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);
 
-  const stdinInputFile = createStdinWorkflowInputMaterializer({
-    readStdinText: readCliStdinText,
-    tempDir: runContext.cwd,
-  });
-  try {
-    const expanded = await expandRunInputs(
-      init.inputFiles,
-      init.contextFiles,
-      runContext.cwd,
-      {
-        allowEmptyInput: true,
-        requireWorkspaceFiles: true,
-        stdinInputFile,
-      },
-    );
-    inputFiles = expanded.inputFiles;
-    contextFiles = expanded.contextFiles;
-
-    const config: AgentConfigPayload = {
-      agent: init.agent,
-      model,
-      inputFiles,
-      contextFiles,
-      instruction: formatToolUseAgentRunInstruction({
+  return withExpandedRunInputs(
+    init.inputFiles,
+    init.contextFiles,
+    runContext.cwd,
+    {
+      allowEmptyInput: true,
+      requireWorkspaceFiles: true,
+      readStdinText: readCliStdinText,
+    },
+    async ({ inputFiles, contextFiles }) => {
+      const config: AgentConfigPayload = {
+        agent: init.agent,
+        model,
         inputFiles,
         contextFiles,
-        instruction,
-      }),
-      displayInstruction: instruction,
-      workingDirectory: runContext.cwd,
-      agentCategory: AgentCategory.ToolUse,
-    };
-
-    const executionId = generateExecutionId();
-    const registeredConfig = AgentConfigSchema.parse(config);
-    const { result, terminalStatus } = await executeCliRequest(
-      { config: registeredConfig, executionId },
-      runContext,
-      {
-        enforceCategory: true,
-        registerExecution: true,
-        markErrorOnThrow: true,
-        stopAfterCycle: true,
-      },
-    );
-    if (result.category !== AgentCategory.ToolUse) {
-      await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-      writeTextStderr(`Agent "${init.agent}" resolved to a non tool-use run.`);
-      return CliExitCode.AgentError;
-    }
-
-    const displayResult: CliToolUseRunResult = createCliRunResult(
-      result,
-      terminalStatus,
-      {
+        instruction: formatToolUseAgentRunInstruction({
+          inputFiles,
+          contextFiles,
+          instruction,
+        }),
+        displayInstruction: instruction,
         workingDirectory: runContext.cwd,
-      },
-    );
-    emitCliResult(runContext, {
-      json: displayResult,
-      ndjson: { kind: 'agent-result', result: displayResult },
-      text: toolUseResultText(displayResult),
-    });
+        agentCategory: AgentCategory.ToolUse,
+      };
 
-    return terminalStatusExitCode(terminalStatus, runContext);
-  } finally {
-    await stdinInputFile.cleanup();
-  }
+      const executionId = generateExecutionId();
+      const registeredConfig = AgentConfigSchema.parse(config);
+      const { result, terminalStatus } = await executeCliRequest(
+        { config: registeredConfig, executionId },
+        runContext,
+        {
+          enforceCategory: true,
+          registerExecution: true,
+          markErrorOnThrow: true,
+          stopAfterCycle: true,
+        },
+      );
+      if (result.category !== AgentCategory.ToolUse) {
+        await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+        writeTextStderr(
+          `Agent "${init.agent}" resolved to a non tool-use run.`,
+        );
+        return CliExitCode.AgentError;
+      }
+
+      const displayResult: CliToolUseRunResult = createCliRunResult(
+        result,
+        terminalStatus,
+        {
+          workingDirectory: runContext.cwd,
+        },
+      );
+      emitCliResult(runContext, {
+        json: displayResult,
+        ndjson: { kind: 'agent-result', result: displayResult },
+        text: toolUseResultText(displayResult),
+      });
+
+      return terminalStatusExitCode(terminalStatus, runContext);
+    },
+  );
 }
 
 export const agentsRunCommand = defineCliCommand({

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -68,10 +68,7 @@ import {
   toolUseResultText,
   type CliToolUseRunResult,
 } from '../runtime/terminalStatus';
-import {
-  createStdinWorkflowInputMaterializer,
-  expandRunInputs,
-} from '../runtime/workflowInputs';
+import { withExpandedRunInputs } from '../runtime/workflowInputs';
 
 interface MultiAgentRunInit {
   readonly preset: string;
@@ -318,81 +315,75 @@ export async function runMultiAgentPreset(
   // model after agent validation so usage errors stay focused on bad agents.
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);
-  const stdinInputFile = createStdinWorkflowInputMaterializer({
-    readStdinText: readCliStdinText,
-    tempDir: runContext.cwd,
-  });
-  try {
-    const { inputFiles, contextFiles } = await expandRunInputs(
-      init.inputFiles,
-      init.contextFiles,
-      runContext.cwd,
-      {
-        allowEmptyInput: hasInstruction,
-        requireWorkspaceFiles: true,
-        stdinInputFile,
-      },
-    );
-    if (approvalPromptsUnavailable(runContext)) {
-      const reason =
-        runContext.approvalPolicy === 'never'
-          ? 'approval policy "never" denies approval-gated delegation tools'
-          : 'headless approval policy "ask" cannot show delegation prompts';
-      writeTextStderr(
-        `WARN preset ${plan.preset.id} may run without subagent delegation because ${reason}. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
-      );
-    }
+  return withExpandedRunInputs(
+    init.inputFiles,
+    init.contextFiles,
+    runContext.cwd,
+    {
+      allowEmptyInput: hasInstruction,
+      requireWorkspaceFiles: true,
+      readStdinText: readCliStdinText,
+    },
+    async ({ inputFiles, contextFiles }) => {
+      if (approvalPromptsUnavailable(runContext)) {
+        const reason =
+          runContext.approvalPolicy === 'never'
+            ? 'approval policy "never" denies approval-gated delegation tools'
+            : 'headless approval policy "ask" cannot show delegation prompts';
+        writeTextStderr(
+          `WARN preset ${plan.preset.id} may run without subagent delegation because ${reason}. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
+        );
+      }
 
-    const config: AgentConfigPayload = {
-      agent: rootAgent.name,
-      model,
-      inputFiles,
-      contextFiles,
-      instruction: formatMultiAgentRunInstruction(plan.preset, {
+      const config: AgentConfigPayload = {
+        agent: rootAgent.name,
+        model,
         inputFiles,
         contextFiles,
-        instruction,
-        approvalContext: runContext,
+        instruction: formatMultiAgentRunInstruction(plan.preset, {
+          inputFiles,
+          contextFiles,
+          instruction,
+          approvalContext: runContext,
+          workingDirectory: runContext.cwd,
+        }),
         workingDirectory: runContext.cwd,
-      }),
-      workingDirectory: runContext.cwd,
-      agentCategory: AgentCategory.ToolUse,
-      cliMultiAgentPresetId: plan.preset.id,
-    };
+        agentCategory: AgentCategory.ToolUse,
+        cliMultiAgentPresetId: plan.preset.id,
+      };
 
-    const executionId = generateExecutionId();
-    const registeredConfig = AgentConfigSchema.parse(config);
-    const { result, terminalStatus } = await executeCliRequest(
-      { config: registeredConfig, executionId },
-      runContext,
-      {
-        enforceCategory: true,
-        registerExecution: true,
-        markErrorOnThrow: true,
-        stopAfterCycle: true,
-        wrap: (run) => withCliMultiAgentPresetVisibility(plan, run),
-      },
-    );
-    if (result.category !== AgentCategory.ToolUse) {
-      await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-      writeTextStderr(
-        `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,
+      const executionId = generateExecutionId();
+      const registeredConfig = AgentConfigSchema.parse(config);
+      const { result, terminalStatus } = await executeCliRequest(
+        { config: registeredConfig, executionId },
+        runContext,
+        {
+          enforceCategory: true,
+          registerExecution: true,
+          markErrorOnThrow: true,
+          stopAfterCycle: true,
+          wrap: (run) => withCliMultiAgentPresetVisibility(plan, run),
+        },
       );
-      return CliExitCode.AgentError;
-    }
-    const displayResult: CliToolUseRunResult = createCliRunResult(
-      result,
-      terminalStatus,
-      {
-        workingDirectory: runContext.cwd,
-      },
-    );
-    writeMultiAgentRunResult(runContext, plan, displayResult);
+      if (result.category !== AgentCategory.ToolUse) {
+        await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+        writeTextStderr(
+          `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,
+        );
+        return CliExitCode.AgentError;
+      }
+      const displayResult: CliToolUseRunResult = createCliRunResult(
+        result,
+        terminalStatus,
+        {
+          workingDirectory: runContext.cwd,
+        },
+      );
+      writeMultiAgentRunResult(runContext, plan, displayResult);
 
-    return terminalStatusExitCode(terminalStatus, runContext);
-  } finally {
-    await stdinInputFile.cleanup();
-  }
+      return terminalStatusExitCode(terminalStatus, runContext);
+    },
+  );
 }
 
 const multiAgentListCommand = defineCliCommand({

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -42,9 +42,8 @@ import {
   type CliRunResult,
 } from '../runtime/terminalStatus';
 import {
-  createStdinWorkflowInputMaterializer,
-  expandRunInputs,
   hasMixedStdinWorkflowInputSpecs,
+  withExpandedRunInputs,
 } from '../runtime/workflowInputs';
 import {
   assertOutputDirAvailable,
@@ -99,90 +98,84 @@ export async function runWorkflowAgent(
   const model = await resolveCliRunModel(context, init.model, 'run');
   const runContext = buildHeadlessRunContext(context, model);
 
-  const stdinInputFile = createStdinWorkflowInputMaterializer({
-    readStdinText: readCliStdinText,
-    tempDir: runContext.cwd,
-  });
-  try {
-    const { inputFiles, contextFiles } = await expandRunInputs(
-      init.inputFiles,
-      init.contextFiles,
-      runContext.cwd,
-      { stdinInputFile },
-    );
-    if (init.output && inputFiles.length > 1) {
-      throw new CliUsageError(
-        'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
-      );
-    }
-
-    const modelOutputFile =
-      init.output && path.isAbsolute(init.output)
-        ? path.basename(init.output)
-        : init.output;
-    const config: AgentConfigPayload = {
-      agent: init.agent,
-      model,
-      inputFiles,
-      contextFiles,
-      outputFiles: modelOutputFile ? [modelOutputFile] : [],
-      cliOutputFile: init.output,
-      instruction,
-      workingDirectory: runContext.cwd,
-      agentCategory: AgentCategory.Workflow,
-    };
-
-    const executionId = generateExecutionId();
-    const registeredConfig = AgentConfigSchema.parse(config);
-    const { result, terminalStatus } = await executeCliRequest(
-      { config: registeredConfig, executionId },
-      runContext,
-      {
-        enforceCategory: true,
-        registerExecution: true,
-        markErrorOnThrow: true,
-      },
-    );
-    let displayResult: CliRunResult;
-    try {
-      displayResult = (
-        await resolveWorkflowOutput(
-          init.output,
-          init.outputDir,
-          result,
-          runContext,
-          {
-            expectedOutputFiles: init.outputDir
-              ? expectedOutputFilesForOutputDir(agent, inputFiles)
-              : undefined,
-            terminalStatus,
-          },
-        )
-      ).displayResult;
-    } catch (error) {
-      if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-        writeErrorStderr(error);
-        return CliExitCode.Interrupted;
+  return withExpandedRunInputs(
+    init.inputFiles,
+    init.contextFiles,
+    runContext.cwd,
+    { readStdinText: readCliStdinText },
+    async ({ inputFiles, contextFiles }) => {
+      if (init.output && inputFiles.length > 1) {
+        throw new CliUsageError(
+          'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',
+        );
       }
 
-      await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-      writeErrorStderr(error);
-      return CliExitCode.AgentError;
-    }
+      const modelOutputFile =
+        init.output && path.isAbsolute(init.output)
+          ? path.basename(init.output)
+          : init.output;
+      const config: AgentConfigPayload = {
+        agent: init.agent,
+        model,
+        inputFiles,
+        contextFiles,
+        outputFiles: modelOutputFile ? [modelOutputFile] : [],
+        cliOutputFile: init.output,
+        instruction,
+        workingDirectory: runContext.cwd,
+        agentCategory: AgentCategory.Workflow,
+      };
 
-    emitCliResult(runContext, {
-      json: displayResult,
-      ndjson: { kind: 'result', result: displayResult },
-      text:
-        displayResult.category === AgentCategory.Workflow
-          ? formatWorkflowTextResult(displayResult)
-          : terminalStatus,
-    });
+      const executionId = generateExecutionId();
+      const registeredConfig = AgentConfigSchema.parse(config);
+      const { result, terminalStatus } = await executeCliRequest(
+        { config: registeredConfig, executionId },
+        runContext,
+        {
+          enforceCategory: true,
+          registerExecution: true,
+          markErrorOnThrow: true,
+        },
+      );
+      let displayResult: CliRunResult;
+      try {
+        displayResult = (
+          await resolveWorkflowOutput(
+            init.output,
+            init.outputDir,
+            result,
+            runContext,
+            {
+              expectedOutputFiles: init.outputDir
+                ? expectedOutputFilesForOutputDir(agent, inputFiles)
+                : undefined,
+              terminalStatus,
+            },
+          )
+        ).displayResult;
+      } catch (error) {
+        if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+          writeErrorStderr(error);
+          return CliExitCode.Interrupted;
+        }
 
-    return terminalStatusExitCode(terminalStatus, runContext);
-  } finally {
-    await stdinInputFile.cleanup();
-  }
+        await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+        writeErrorStderr(error);
+        return CliExitCode.AgentError;
+      }
+
+      emitCliResult(runContext, {
+        json: displayResult,
+        ndjson: { kind: 'result', result: displayResult },
+        text:
+          displayResult.category === AgentCategory.Workflow
+            ? formatWorkflowTextResult(displayResult)
+            : terminalStatus,
+      });
+
+      return terminalStatusExitCode(terminalStatus, runContext);
+    },
+  );
 }
 
 export const runWorkflowCommand = defineCliCommand({

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -360,3 +360,41 @@ export async function expandRunInputs(
   );
   return { inputFiles, contextFiles };
 }
+
+export interface ExpandedRunInputs {
+  readonly inputFiles: string[];
+  readonly contextFiles: string[];
+}
+
+/**
+ * Own the stdin-temp-file lifecycle for headless runs that accept --input /
+ * --context. Callers get already-expanded paths; this module creates and
+ * removes the temporary stdin file whether expansion, execution, or output
+ * handling fails.
+ */
+export async function withExpandedRunInputs<T>(
+  inputSpecs: readonly string[],
+  contextSpecs: readonly string[],
+  cwd: string,
+  options: {
+    readonly readStdinText: () => Promise<string>;
+    readonly allowEmptyInput?: boolean;
+    readonly requireWorkspaceFiles?: boolean;
+  },
+  run: (inputs: ExpandedRunInputs) => Promise<T>,
+): Promise<T> {
+  const stdinInputFile = createStdinWorkflowInputMaterializer({
+    readStdinText: options.readStdinText,
+    tempDir: cwd,
+  });
+  try {
+    const inputs = await expandRunInputs(inputSpecs, contextSpecs, cwd, {
+      allowEmptyInput: options.allowEmptyInput,
+      requireWorkspaceFiles: options.requireWorkspaceFiles,
+      stdinInputFile,
+    });
+    return await run(inputs);
+  } finally {
+    await stdinInputFile.cleanup();
+  }
+}

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -5,14 +5,12 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import { RUN_OUTCOME } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => {
-  const stdinInputFile = Object.assign(vi.fn(), { cleanup: vi.fn() });
   return {
     executeCliRequest: vi.fn(),
-    expandRunInputs: vi.fn(),
+    withExpandedRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
     resolveCliAgent: vi.fn(),
     resolveCliRunModel: vi.fn(),
-    stdinInputFile,
     writeErrorStderr: vi.fn(),
     writeTextStderr: vi.fn(),
   };
@@ -58,8 +56,7 @@ vi.mock('@cli/runtime/runExecution', () => ({
 }));
 
 vi.mock('@cli/runtime/workflowInputs', () => ({
-  createStdinWorkflowInputMaterializer: vi.fn(() => mocks.stdinInputFile),
-  expandRunInputs: mocks.expandRunInputs,
+  withExpandedRunInputs: mocks.withExpandedRunInputs,
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
@@ -83,10 +80,18 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
 describe('CLI agents run command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.expandRunInputs.mockResolvedValue({
-      inputFiles: ['problem.md'],
-      contextFiles: ['notes.md'],
-    });
+    mocks.withExpandedRunInputs.mockImplementation(
+      async (
+        _inputSpecs: readonly string[],
+        _contextSpecs: readonly string[],
+        _cwd: string,
+        _options: unknown,
+        run: (inputs: {
+          readonly inputFiles: string[];
+          readonly contextFiles: string[];
+        }) => Promise<unknown>,
+      ) => run({ inputFiles: ['problem.md'], contextFiles: ['notes.md'] }),
+    );
     mocks.resolveCliAgent.mockResolvedValue({
       name: 'chat',
       category: AgentCategory.ToolUse,
@@ -131,15 +136,16 @@ describe('CLI agents run command', () => {
       'chat',
       AgentCategory.ToolUse,
     );
-    expect(mocks.expandRunInputs).toHaveBeenCalledWith(
+    expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
       ['problem.md'],
       ['notes.md'],
       '/tmp/project',
       {
         allowEmptyInput: true,
         requireWorkspaceFiles: true,
-        stdinInputFile: mocks.stdinInputFile,
+        readStdinText: expect.any(Function),
       },
+      expect.any(Function),
     );
     const request = mocks.executeCliRequest.mock.calls[0]?.[0];
     expect(request?.config.inputFiles).toEqual(['problem.md']);
@@ -175,7 +181,7 @@ describe('CLI agents run command', () => {
     expect(mocks.initLocalCliPlatform).not.toHaveBeenCalled();
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.resolveCliAgent).not.toHaveBeenCalled();
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports missing agents before resolving the model', async () => {
@@ -202,7 +208,7 @@ describe('CLI agents run command', () => {
       AgentCategory.ToolUse,
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports workflow agents before resolving the model', async () => {
@@ -235,6 +241,6 @@ describe('CLI agents run command', () => {
       AgentCategory.ToolUse,
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -8,10 +8,9 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import { RUN_OUTCOME } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => {
-  const stdinInputFile = Object.assign(vi.fn(), { cleanup: vi.fn() });
   return {
     executeCliRequest: vi.fn(),
-    expandRunInputs: vi.fn(),
+    withExpandedRunInputs: vi.fn(),
     cliMultiAgentPlanHasGaps: vi.fn(),
     cliMultiAgentPresetCanLaunchTeam: vi.fn(),
     formatCliMultiAgentPresetRunWarnings: vi.fn(),
@@ -22,7 +21,6 @@ const mocks = vi.hoisted(() => {
     loadAgents: vi.fn(),
     planCliMultiAgentPresets: vi.fn(),
     planCliMultiAgentPresetRun: vi.fn(),
-    stdinInputFile,
     writeTextStderr: vi.fn(),
     writeTextStdout: vi.fn(),
   };
@@ -104,8 +102,7 @@ vi.mock('@cli/runtime/runExecution', () => ({
 }));
 
 vi.mock('@cli/runtime/workflowInputs', () => ({
-  createStdinWorkflowInputMaterializer: vi.fn(() => mocks.stdinInputFile),
-  expandRunInputs: mocks.expandRunInputs,
+  withExpandedRunInputs: mocks.withExpandedRunInputs,
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
@@ -126,6 +123,24 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
   };
 }
 
+function mockExpandedRunInputs(inputs: {
+  readonly inputFiles: string[];
+  readonly contextFiles: string[];
+}): void {
+  mocks.withExpandedRunInputs.mockImplementation(
+    async (
+      _inputSpecs: readonly string[],
+      _contextSpecs: readonly string[],
+      _cwd: string,
+      _options: unknown,
+      run: (expanded: {
+        readonly inputFiles: string[];
+        readonly contextFiles: string[];
+      }) => Promise<unknown>,
+    ) => run(inputs),
+  );
+}
+
 describe('CLI multi-agent run command', () => {
   const approvalUnavailableWarning =
     'WARN preset mathematician may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
@@ -134,7 +149,7 @@ describe('CLI multi-agent run command', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.expandRunInputs.mockResolvedValue({
+    mockExpandedRunInputs({
       inputFiles: ['problem.tex'],
       contextFiles: [],
     });
@@ -214,15 +229,16 @@ describe('CLI multi-agent run command', () => {
       markErrorOnThrow: true,
       stopAfterCycle: true,
     });
-    expect(mocks.expandRunInputs).toHaveBeenCalledWith(
+    expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
       ['problem.tex'],
       [],
       '/tmp/project',
       {
         allowEmptyInput: true,
         requireWorkspaceFiles: true,
-        stdinInputFile: mocks.stdinInputFile,
+        readStdinText: expect.any(Function),
       },
+      expect.any(Function),
     );
     const request = mocks.executeCliRequest.mock.calls[0]?.[0];
     expect(request?.config.instruction).toContain('Primary user input files:');
@@ -233,7 +249,6 @@ describe('CLI multi-agent run command', () => {
     expect(request?.config.instruction).toContain(
       'Do not end by asking the user whether to perform more work',
     );
-    expect(mocks.stdinInputFile.cleanup).toHaveBeenCalledTimes(1);
   });
 
   it('marks run-plan resolution when authenticated gaps triggered a remote load', async () => {
@@ -378,7 +393,7 @@ describe('CLI multi-agent run command', () => {
   });
 
   it('allows instruction-only team runs without input files', async () => {
-    mocks.expandRunInputs.mockResolvedValue({
+    mockExpandedRunInputs({
       inputFiles: [],
       contextFiles: [],
     });
@@ -393,22 +408,27 @@ describe('CLI multi-agent run command', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(mocks.expandRunInputs).toHaveBeenCalledWith([], [], '/tmp/project', {
-      allowEmptyInput: true,
-      requireWorkspaceFiles: true,
-      stdinInputFile: mocks.stdinInputFile,
-    });
+    expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
+      [],
+      [],
+      '/tmp/project',
+      {
+        allowEmptyInput: true,
+        requireWorkspaceFiles: true,
+        readStdinText: expect.any(Function),
+      },
+      expect.any(Function),
+    );
     const request = mocks.executeCliRequest.mock.calls[0]?.[0];
     expect(request?.config.inputFiles).toEqual([]);
     expect(request?.config.instruction).toContain('User instruction:');
     expect(request?.config.instruction).toContain(
       'Prove that every odd square is congruent to 1 modulo 8.',
     );
-    expect(mocks.stdinInputFile.cleanup).toHaveBeenCalledTimes(1);
   });
 
   it('allows instruction-file-only team runs without input files', async () => {
-    mocks.expandRunInputs.mockResolvedValue({
+    mockExpandedRunInputs({
       inputFiles: [],
       contextFiles: [],
     });
@@ -430,11 +450,17 @@ describe('CLI multi-agent run command', () => {
       });
 
       expect(exitCode).toBe(0);
-      expect(mocks.expandRunInputs).toHaveBeenCalledWith([], [], root, {
-        allowEmptyInput: true,
-        requireWorkspaceFiles: true,
-        stdinInputFile: mocks.stdinInputFile,
-      });
+      expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
+        [],
+        [],
+        root,
+        {
+          allowEmptyInput: true,
+          requireWorkspaceFiles: true,
+          readStdinText: expect.any(Function),
+        },
+        expect.any(Function),
+      );
       const request = mocks.executeCliRequest.mock.calls[0]?.[0];
       expect(request?.config.inputFiles).toEqual([]);
       expect(request?.config.instruction).toContain('User instruction:');
@@ -461,7 +487,7 @@ describe('CLI multi-agent run command', () => {
     ).rejects.toThrow(
       /--instruction-file: file not found: missing-prompt\.txt/,
     );
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('still requires an input file or instruction text', async () => {
@@ -478,7 +504,7 @@ describe('CLI multi-agent run command', () => {
     ).rejects.toThrow(
       /Provide --input, --instruction, or --instruction-file for the team task\. Example: texra multi-agent run physicist --instruction "Check this derivation"/,
     );
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('refuses built-in presets without a runnable root agent', async () => {

--- a/src/test-kernel/cli/WorkflowInputsLifecycle.vitest.mts
+++ b/src/test-kernel/cli/WorkflowInputsLifecycle.vitest.mts
@@ -9,6 +9,7 @@ import { createFakePlatform } from '@test/support/FakePlatform';
 import {
   createStdinWorkflowInputMaterializer,
   expandWorkflowInputSpecs,
+  withExpandedRunInputs,
 } from '@cli/runtime/workflowInputs';
 
 describe('CLI workflow input lifecycle', () => {
@@ -66,6 +67,36 @@ describe('CLI workflow input lifecycle', () => {
       ]);
 
       expect(result).toBe('shutdown');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('removes materialized stdin input when the headless run callback fails', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
+    await installFakePlatform(root);
+    let materializedPath = '';
+
+    try {
+      await expect(
+        withExpandedRunInputs(
+          ['-'],
+          [],
+          root,
+          { readStdinText: async () => 'body from stdin' },
+          async ({ inputFiles }) => {
+            const inputPath = inputFiles.at(0);
+            if (!inputPath) throw new Error('missing materialized input');
+            materializedPath = path.resolve(root, inputPath);
+            await expect(fs.readFile(materializedPath, 'utf8')).resolves.toBe(
+              'body from stdin',
+            );
+            throw new Error('run failed');
+          },
+        ),
+      ).rejects.toThrow('run failed');
+
+      await expect(fs.stat(materializedPath)).rejects.toThrow();
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -9,14 +9,12 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => {
-  const stdinInputFile = Object.assign(vi.fn(), { cleanup: vi.fn() });
   return {
     executeCliRequest: vi.fn(),
-    expandRunInputs: vi.fn(),
+    withExpandedRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
     resolveCliAgent: vi.fn(),
     resolveCliRunModel: vi.fn(),
-    stdinInputFile,
   };
 });
 
@@ -55,8 +53,7 @@ vi.mock('@cli/runtime/runExecution', () => ({
 }));
 
 vi.mock('@cli/runtime/workflowInputs', () => ({
-  createStdinWorkflowInputMaterializer: vi.fn(() => mocks.stdinInputFile),
-  expandRunInputs: mocks.expandRunInputs,
+  withExpandedRunInputs: mocks.withExpandedRunInputs,
   hasMixedStdinWorkflowInputSpecs: vi.fn((inputFiles: readonly string[]) => {
     const specs = new Set(
       inputFiles.map((spec) => spec.trim()).filter(Boolean),
@@ -97,10 +94,18 @@ describe('CLI workflow run command', () => {
       async (_context: CliContext, model: string | undefined) =>
         model ?? 'deepseekT',
     );
-    mocks.expandRunInputs.mockResolvedValue({
-      inputFiles: ['paper.tex'],
-      contextFiles: [],
-    });
+    mocks.withExpandedRunInputs.mockImplementation(
+      async (
+        _inputSpecs: readonly string[],
+        _contextSpecs: readonly string[],
+        _cwd: string,
+        _options: unknown,
+        run: (inputs: {
+          readonly inputFiles: string[];
+          readonly contextFiles: string[];
+        }) => Promise<unknown>,
+      ) => run({ inputFiles: ['paper.tex'], contextFiles: [] }),
+    );
     mocks.executeCliRequest.mockResolvedValue({
       result: {
         category: AgentCategory.Workflow,
@@ -131,7 +136,7 @@ describe('CLI workflow run command', () => {
     expect(mocks.initLocalCliPlatform).not.toHaveBeenCalled();
     expect(mocks.resolveCliAgent).not.toHaveBeenCalled();
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports missing workflow agents before resolving the model', async () => {
@@ -158,7 +163,7 @@ describe('CLI workflow run command', () => {
       AgentCategory.Workflow,
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports tool-use agents before resolving the model', async () => {
@@ -188,7 +193,7 @@ describe('CLI workflow run command', () => {
       AgentCategory.Workflow,
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports single-output mixed stdin usage before resolving the model', async () => {
@@ -212,7 +217,7 @@ describe('CLI workflow run command', () => {
       AgentCategory.Workflow,
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('passes instruction file contents before inline workflow instructions', async () => {
@@ -234,17 +239,17 @@ describe('CLI workflow run command', () => {
       });
 
       expect(exitCode).toBe(0);
-      expect(mocks.expandRunInputs).toHaveBeenCalledWith(
+      expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
         ['paper.tex'],
         [],
         root,
-        { stdinInputFile: mocks.stdinInputFile },
+        { readStdinText: expect.any(Function) },
+        expect.any(Function),
       );
       const request = mocks.executeCliRequest.mock.calls[0]?.[0];
       expect(request?.config.instruction).toBe(
         'Read this prompt from disk.\n\nThen keep the final response concise.',
       );
-      expect(mocks.stdinInputFile.cleanup).toHaveBeenCalledTimes(1);
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
@@ -266,6 +271,6 @@ describe('CLI workflow run command', () => {
     expect(mocks.initLocalCliPlatform).not.toHaveBeenCalled();
     expect(mocks.resolveCliAgent).not.toHaveBeenCalled();
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
-    expect(mocks.expandRunInputs).not.toHaveBeenCalled();
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- move stdin temp-file lifetime ownership into `workflowInputs` for headless workflow, tool-use agent, and multi-agent runs
- replace duplicated command-level materializer `try/finally` blocks with one scoped `withExpandedRunInputs` helper
- add regression coverage that the materialized stdin file is removed even when the run callback fails

## Why
The workflow commands were each responsible for creating, passing, and cleaning up the stdin materializer. That repeated lifecycle logic made it easy for future command changes to leak temp input files or clean them at the wrong time. This keeps the command files focused on launch behavior and gives `workflowInputs` the single source of truth for input expansion lifecycle.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/WorkflowInputsLifecycle.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing warnings outside this change)
- `corepack pnpm exec prettier --check packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/multiAgent.ts packages/cli/src/commands/workflow.ts packages/cli/src/runtime/workflowInputs.ts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/WorkflowInputsLifecycle.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with behavior preserved; risk is limited to stdin temp-file cleanup timing, now covered by an explicit failure-path test.
> 
> **Overview**
> Headless **workflow**, **tool-use agent**, and **multi-agent** runs no longer each create a stdin materializer, call `expandRunInputs`, and `cleanup` in their own `try/finally` blocks. They now go through **`withExpandedRunInputs`** in `workflowInputs`, which expands `--input` / `--context`, runs the command callback with resolved paths, and always tears down the stdin temp file.
> 
> Callers pass **`readStdinText`** instead of wiring `stdinInputFile` themselves. Command tests mock the new helper; **`WorkflowInputsLifecycle`** adds a regression that the materialized stdin file is removed when the run callback throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 050bf8bf3eec16ef185dc31398376d7e9e58dd43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->