### PR TITLE
[codex] Simplify CLI agent launch lookup

### DIFF
--- a/packages/cli/src/commands/_helpers/agentLookupText.ts
+++ b/packages/cli/src/commands/_helpers/agentLookupText.ts
@@ -49,12 +49,6 @@ export function missingMultiAgentPresetMessage(name: string): string {
   return `Multi-agent preset not found: ${name}. ${MULTI_AGENT_PRESET_LOOKUP_HINT}`;
 }
 
-export function cliAgentLaunchLookupCategory(
-  mode: CliAgentLaunchMode,
-): AgentCategory {
-  return CLI_AGENT_LAUNCH_TARGETS[mode].requiredCategory;
-}
-
 export function assertCliAgentLaunch(
   name: string,
   agent: AgentEntry | undefined,

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -24,7 +24,6 @@ import { initLocalCliPlatform } from '../runtime/initPlatform';
 import {
   TOOL_USE_AGENT_NAME_DESCRIPTION,
   assertCliAgentLaunch,
-  cliAgentLaunchLookupCategory,
 } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
@@ -72,13 +71,9 @@ export async function runToolUseAgent(
   const instruction = await resolveToolUseInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
-  const launchMode = 'agentsRun';
-  const agentEntry = await resolveCliAgent(
-    init.agent,
-    cliAgentLaunchLookupCategory(launchMode),
-  );
+  const agentEntry = await resolveCliAgent(init.agent, AgentCategory.ToolUse);
 
-  assertCliAgentLaunch(init.agent, agentEntry, launchMode);
+  assertCliAgentLaunch(init.agent, agentEntry, 'agentsRun');
 
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -23,10 +23,7 @@ import {
 import { resolveCliAgent } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
-import {
-  assertCliAgentLaunch,
-  cliAgentLaunchLookupCategory,
-} from './_helpers/agentLookupText';
+import { assertCliAgentLaunch } from './_helpers/agentLookupText';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { emitCliResult } from './_helpers/output';
 import {
@@ -81,14 +78,10 @@ export async function runWorkflowAgent(
   const instruction = await resolveFileBackedInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
-  const launchMode = 'run';
-  const agentEntry = await resolveCliAgent(
-    init.agent,
-    cliAgentLaunchLookupCategory(launchMode),
-  );
+  const agentEntry = await resolveCliAgent(init.agent, AgentCategory.Workflow);
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
-  const agent = assertCliAgentLaunch(init.agent, agentEntry, launchMode);
+  const agent = assertCliAgentLaunch(init.agent, agentEntry, 'run');
   if (init.output && hasMixedStdinWorkflowInputSpecs(init.inputFiles)) {
     throw new CliUsageError(
       'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',


### PR DESCRIPTION
## Summary

- remove the `cliAgentLaunchLookupCategory` pass-through helper
- pass the command-owned launch category directly to `resolveCliAgent`
- keep existing launch validation and user-facing error messages unchanged

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentResolution.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing warnings)
- `corepack pnpm exec prettier --check packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/_helpers/agentLookupText.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with no behavior change to validation or user-facing error messages; agent resolution paths stay the same.
> 
> **Overview**
> Removes the **`cliAgentLaunchLookupCategory`** helper from `agentLookupText.ts` and stops routing launch mode through it to discover the required **`AgentCategory`**.
> 
> **`agentsRun`** and **`workflow`** now pass the category each command owns directly to **`resolveCliAgent`** (`AgentCategory.ToolUse` vs `AgentCategory.Workflow`), while **`assertCliAgentLaunch`** still receives the same launch mode string literals (`'agentsRun'` / `'run'`) for category mismatch and missing-agent errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf745c90250ad075103ce5f34fc4e74136720f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->