### PR TITLE
fix: avoid hidden CLI stdin filenames

### DIFF
--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -12,7 +12,9 @@ import type { Disposable } from '@platform/interfaces/disposable';
 import type { Stats } from 'node:fs';
 
 const STDIN_INPUT_TOKEN = '-';
-const STDIN_TEMP_PREFIX = '.texra-stdin-';
+// LaTeX derives auxiliary filenames from the input basename; leading-dot
+// job names can be rejected by TeX's file-open policy when it writes `.aux`.
+const STDIN_TEMP_PREFIX = 'texra-stdin-';
 
 function resolveAgainstCwd(candidate: string, cwd: string): string {
   return path.isAbsolute(candidate)

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -533,7 +533,7 @@ describe('CLI root argument routing', () => {
 
       expect(expanded).toHaveLength(1);
       expect(readCount).toBe(1);
-      expect(path.basename(expanded[0])).toMatch(/^\.texra-stdin-.+\.tex$/);
+      expect(path.basename(expanded[0])).toMatch(/^texra-stdin-.+\.tex$/);
       await expect(
         fs.readFile(path.resolve(root, expanded[0]), 'utf8'),
       ).resolves.toContain('\\begin{document}Hi');
@@ -563,7 +563,7 @@ describe('CLI root argument routing', () => {
         },
       );
 
-      expect(path.basename(expanded[0])).toMatch(/^\.texra-stdin-.+\.tex$/);
+      expect(path.basename(expanded[0])).toMatch(/^texra-stdin-.+\.tex$/);
       expect(expanded[1]).toBe('paper.tex');
     } finally {
       await fs.rm(root, { recursive: true, force: true });
@@ -657,7 +657,7 @@ describe('CLI root argument routing', () => {
 
       expect(inputFiles).toEqual(['main.tex']);
       expect(contextFiles).toHaveLength(1);
-      expect(path.basename(contextFiles[0])).toMatch(/^\.texra-stdin-.+\.tex$/);
+      expect(path.basename(contextFiles[0])).toMatch(/^texra-stdin-.+\.tex$/);
       await expect(
         fs.readFile(path.resolve(root, contextFiles[0]), 'utf8'),
       ).resolves.toBe('context body');


### PR DESCRIPTION
Closes #6117.

## Summary

- change workflow stdin materialization from `.texra-stdin-...tex` to `texra-stdin-...tex`
- keep the temporary-file lifecycle and cleanup behavior unchanged
- update CLI input expansion tests to assert the compile-safe basename

## Why

A workflow-mode dogfood run with `texra-local run correct --input -` exposed a compile-check failure unrelated to the document content. Because stdin was materialized as a hidden `.texra-stdin-...tex` file, pdfTeX derived a hidden `.aux` name and failed with:

```text
! I can't write on file `.texra-stdin-78939--r15-QUYJw_fL9ghThmIP.aux'.
```

Using a non-hidden temp basename lets TeX write the aux file normally. The fixed dogfood run materialized `texra-stdin-9148-WXRL1LUJSIejWejvOBYJK.tex`; its compile log opened `texra-stdin-9148-WXRL1LUJSIejWejvOBYJK.aux`, so the hidden-filename failure was gone. That run still had a separate document-content LaTeX error from the model output, but no longer failed at aux-file creation.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/WorkflowInputsLifecycle.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/workflowInputs.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run lint` (passes with existing warnings)
- dogfood before fix: execution `630e1c5355c0` failed at hidden `.aux` creation
- dogfood after fix: execution `f828b0ec6446` used non-hidden `texra-stdin-...tex` and no hidden `.aux` write failure occurred

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI naming fix with no auth, data, or lifecycle changes; risk is limited to stdin `--input`/`--context` workflow runs.
> 
> **Overview**
> **Fixes workflow runs that pipe stdin (`--input -`) failing before document compile** because pdfTeX could not write a hidden `.aux` derived from a hidden job basename.
> 
> Stdin materialization in `workflowInputs.ts` now uses the prefix `texra-stdin-` instead of `.texra-stdin-`, so auxiliary files like `texra-stdin-….aux` are writable under TeX’s file-open rules. **Temp file creation, shutdown cleanup, and stdin lifecycle are unchanged**; only the basename changes, with a short comment documenting the LaTeX constraint.
> 
> CLI tests in `CliRootArgs.vitest.mts` were updated to expect `^texra-stdin-.+\.tex$` for `--input` and `--context` stdin expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c76f5539b5934bc2a1680455d66c12c1b9c930e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->