### PR TITLE
[codex] Cover long-running goal continuation

### DIFF
--- a/src/test-kernel/agent/GoalContinuation.vitest.ts
+++ b/src/test-kernel/agent/GoalContinuation.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
@@ -107,6 +107,33 @@ describe('maybeBuildGoalContinuation', () => {
     // it steers toward persistence instead.
     expect(out).not.toContain('plan(command="complete")');
     expect(out).not.toContain('plan(command="pause")');
+  });
+
+  it('continues rendering after more than two hours elapsed', async () => {
+    const startedAt = new Date('2026-06-17T00:00:00.000Z');
+    const afterTwoHours = new Date(
+      startedAt.getTime() + 2 * 60 * 60 * 1000 + 5 * 60 * 1000 + 1234,
+    );
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(startedAt);
+      await GoalStore.start(
+        STREAM_ID,
+        'Keep solving the hard problem until verification is complete.',
+      );
+
+      vi.setSystemTime(afterTwoHours);
+      const out = await maybeBuildGoalContinuation(STREAM_ID);
+
+      expect(out).toContain('<goal_context>');
+      expect(out).toContain(
+        'Keep solving the hard problem until verification is complete.',
+      );
+      expect(out).toContain('Time elapsed: 2h 5m');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns null when the feature flag is off (with an active goal present)', async () => {


### PR DESCRIPTION
## Summary
- add a regression test that advances an active Goal past two hours of elapsed wall-clock time
- assert the continuation still renders the goal context, objective, and compact elapsed duration

## Why
Goal mode is intended to keep autonomous continuation active for long-running hard problems. The existing tests covered repeated cycles, but not the elapsed-time formatting and continuation behavior after the two-hour mark.

## Validation
- corepack pnpm vitest run src/test-kernel/agent/GoalContinuation.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts --testNamePattern "Goal|goal"
- corepack pnpm --filter @texra-ai/cli validate:tui -- plan-approval-approve-goal
- corepack pnpm exec prettier --check src/test-kernel/agent/GoalContinuation.vitest.ts
- corepack pnpm exec tsc --noEmit --pretty false
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modifications.
> 
> **Overview**
> Adds a **regression test** in `GoalContinuation.vitest.ts` for long-running autonomous goals: it uses Vitest fake timers to start a goal, advance wall clock past **2+ hours**, and asserts `maybeBuildGoalContinuation` still returns `<goal_context>`, the objective text, and compact elapsed time (`Time elapsed: 2h 5m`).
> 
> No production code changes—only test coverage for elapsed-time formatting and continuation behavior after the two-hour mark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f4a031a9784c7eea3d8ab0e55601383eaa7f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->