### PR TITLE
[codex] Keep workflow output target separate

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,5 +1,3 @@
-import * as path from 'node:path';
-
 import { writeTerminalStatus } from '@agent/storage';
 import {
   AgentConfigSchema,
@@ -103,16 +101,12 @@ export async function runWorkflowAgent(
         );
       }
 
-      const modelOutputFile =
-        init.output && path.isAbsolute(init.output)
-          ? path.basename(init.output)
-          : init.output;
       const config: AgentConfigPayload = {
         agent: init.agent,
         model,
         inputFiles,
         contextFiles,
-        outputFiles: modelOutputFile ? [modelOutputFile] : [],
+        outputFiles: [],
         cliOutputFile: init.output,
         instruction,
         workingDirectory: runContext.cwd,

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -255,6 +255,59 @@ describe('CLI workflow run command', () => {
     }
   });
 
+  it('keeps the single-output copy target separate from workflow output names', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-workflow-'));
+    try {
+      const generated = path.join(root, 'run', 'r1', 'paper.tex');
+      await fs.mkdir(path.dirname(generated), { recursive: true });
+      await fs.writeFile(generated, 'polished');
+      mocks.executeCliRequest.mockResolvedValueOnce({
+        result: {
+          category: AgentCategory.Workflow,
+          executionId: 'exec-output',
+          streamId: 'stream-output',
+          outcome: RUN_OUTCOME.COMPLETED,
+          outputs: [
+            {
+              round: 1,
+              relativePath: 'r1/paper.tex',
+              absolutePath: generated,
+              location: 'runStorage',
+              originalPath: path.join(root, 'paper.tex'),
+              added: null,
+              removed: null,
+            },
+          ],
+          compileFailures: [],
+        },
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      });
+
+      const { runWorkflowAgent } = await import('@cli/commands/workflow');
+
+      const exitCode = await runWorkflowAgent(cliContext({ cwd: root }), {
+        agent: 'polish',
+        inputFiles: ['paper.tex'],
+        contextFiles: [],
+        output: 'polished.tex',
+        instruction: '',
+      });
+
+      expect(exitCode).toBe(0);
+      const request = mocks.executeCliRequest.mock.calls[0]?.[0];
+      expect(request?.config).toMatchObject({
+        inputFiles: ['paper.tex'],
+        outputFiles: [],
+        cliOutputFile: 'polished.tex',
+      });
+      await expect(
+        fs.readFile(path.join(root, 'polished.tex'), 'utf8'),
+      ).resolves.toBe('polished');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('reports missing instruction files before starting platform or input work', async () => {
     const { runWorkflowAgent } = await import('@cli/commands/workflow');
 


### PR DESCRIPTION
## Summary

- Stop passing the CLI `--output` copy target through `config.outputFiles`.
- Keep workflow document names implicit from the input/default output contract while preserving the final copy target in `cliOutputFile`.
- Add a CLI command regression test that verifies `--output polished.tex` still copies the generated workflow output while leaving `outputFiles` empty.

## Root Cause

`texra run --output polished.tex` used `outputFiles: ["polished.tex"]` even though `outputFiles` is consumed by workflow prompting, diff, and lineage code as generated document names. During dogfood, a polish run emitted `main.tex` but reported output lineage against the requested copy target instead of the original input document.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts --testNamePattern "workflow output|Workflow|output target|resume output|single-output|output-dir|CLI workflow"`
- `corepack pnpm exec prettier --check packages/cli/src/commands/workflow.ts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm --filter @texra-ai/cli --if-present build`
- `npm run lint` (0 errors, existing warnings only)
- Dogfood: rebuilt `texra-local run polish --input main.tex --output polished.tex --model gemini35f --api-mode included --output-format json --no-input`; result stored `outputFiles: []`, `cliOutputFile: "polished.tex"`, output lineage pointed at `original/main.tex`, copied `polished.tex`, and `latexmk -pdf -interaction=nonstopmode polished.tex` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI config wiring fix with a targeted regression test; copy behavior is preserved via `cliOutputFile` and existing `resolveWorkflowOutput` logic.
> 
> **Overview**
> **`texra run --output`** no longer feeds the copy destination into **`config.outputFiles`**. Workflow runs now always register **`outputFiles: []`** and keep the CLI copy path only on **`cliOutputFile`**, so prompting, diff, and lineage treat generated document names separately from where the final artifact is copied.
> 
> The **`node:path`** import and basename/absolute-path shaping for **`outputFiles`** were removed. A regression test asserts **`--output polished.tex`** still copies the generated workflow file while **`outputFiles`** stays empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a57a4c3a5e607ef6386545539da8950bd6650e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->