### PR TITLE
[codex] Show multi-input workflow progress

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -21,7 +21,7 @@ interface RenderState {
   round?: number;
   toolCallCount?: number;
   agent?: string;
-  inputFile?: string;
+  inputLabel?: string;
   phase?: string;
   activeProcesses?: string;
   activeSubagents?: string;
@@ -184,7 +184,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
     const config = payload.taskState.agentConfig;
     this.state.agent = config.agent;
-    this.state.inputFile = safeBasename(config.inputFiles.at(0));
+    this.state.inputLabel = formatInputLabel(config.inputFiles);
     this.state.phase ??= 'running';
     return true;
   }
@@ -279,7 +279,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     const parts: string[] = [];
     if (this.state.round != null) parts.push(`[r${this.state.round}]`);
 
-    const subject = [this.state.agent, this.state.inputFile]
+    const subject = [this.state.agent, this.state.inputLabel]
       .filter(Boolean)
       .join(' ');
     const phase = this.state.phase;
@@ -314,8 +314,12 @@ function formatRunProgressStatus(
   return status;
 }
 
-function safeBasename(file: string | undefined): string | undefined {
-  return file ? path.basename(file) : undefined;
+function formatInputLabel(files: readonly string[]): string | undefined {
+  const first = files.at(0);
+  if (!first) return undefined;
+
+  const firstName = path.basename(first);
+  return files.length === 1 ? firstName : `${firstName} +${files.length - 1}`;
 }
 
 function formatActiveChildren(

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -132,6 +132,29 @@ describe('CLI run progress renderer', () => {
     expect(output.endsWith('\r\x1b[2K')).toBe(true);
   });
 
+  it('summarizes multi-input workflow progress without hiding extra files', () => {
+    let output = '';
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: (text) => {
+          output += text;
+        },
+        nowMs: () => 0,
+      },
+    );
+
+    renderer?.handle(
+      'setTaskState',
+      workflowTaskState({
+        inputFiles: ['number-theory.tex', 'algebra.tex'],
+      }),
+    );
+
+    expect(output).toBe('polish number-theory.tex +1 · 0s\n');
+  });
+
   it('prints phase changes on separate lines when ANSI is disabled', () => {
     let output = '';
     const renderer = createRunProgressRenderer(


### PR DESCRIPTION
## Summary

- Display multi-input workflow runs as `first-file.tex +N` in the CLI progress line.
- Preserve the existing single-input progress text.
- Add a focused renderer regression test for the multi-input label.

## Why

During workflow dogfood, `texra-local run polish --input number-theory.tex --input algebra.tex --output-dir polished ...` processed and copied both files correctly, but the live progress line showed only `polish number-theory.tex`. That makes a multi-input run look like a single-file run while it is still in progress.

This keeps the label compact but makes the extra inputs visible: `polish number-theory.tex +1`.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/runProgressRenderer.ts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm --filter @texra-ai/cli --if-present build`
- `npm run lint` (0 errors, existing warnings only)
- Dogfood before fix: multi-input polish run copied both outputs and compiled them, but progress showed `polish number-theory.tex`.
- Dogfood after rebuild: same command showed `polish number-theory.tex +1`, completed, copied both outputs, and both generated `.tex` files compiled with `latexmk -pdf -interaction=nonstopmode`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only stderr progress text in the CLI renderer; no execution or I/O behavior changes.
> 
> **Overview**
> The CLI run progress line now reflects **multiple input files** instead of showing only the first basename.
> 
> `RenderState` uses `inputLabel` built by `formatInputLabel`: one file stays `paper.tex`; two or more become `number-theory.tex +1` (first basename plus a `+N` suffix for additional inputs). Single-input behavior is unchanged.
> 
> A renderer test asserts the multi-input label on `setTaskState`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89bbaa7681a1623b9bfe27db515727274efe38a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->