### PR TITLE
[codex] Use compact elapsed time in CLI status

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -979,7 +979,7 @@ if (SHOW_CHILDREN) {
       agentName: 'leanSolver',
       childStreamId: 'harness-child-lean-stream',
       status: STREAM_STATUS.WAITING,
-      elapsed: '2m 03s',
+      elapsed: '2m 3s',
     },
     {
       executionId: 'harness-child-review',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2293,7 +2293,7 @@ const SCENARIOS = [
     bootExpect: 'TeXRA',
     keys: [ESC + 's'], // Esc/Alt-s
     frame: 'tail',
-    expect: ['◆ running 75s keys 3 sub'],
+    expect: ['◆ running 1m 15s keys 3 sub'],
     unexpect: ['◆running', 'keys3', '3 sub 1 proc'],
   },
   {

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -18,7 +18,7 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
-import { filterNotNullish } from '@utils/core';
+import { filterNotNullish, formatCompactDuration } from '@utils/core';
 
 import { truncateSummaryToWidth } from '../render/terminalText';
 import { formatCliStatusLabel } from '../sessionStatus';
@@ -678,7 +678,7 @@ export function buildStatusBarDisplay(
       input.elapsedMs !== undefined
     ) {
       left.push({
-        text: `${Math.floor(Math.max(0, input.elapsedMs) / 1000)}s`,
+        text: formatCompactDuration(input.elapsedMs),
         color: 'dim',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.elapsed,
       });

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -9,7 +9,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
-import { formatDuration } from '@utils/core';
+import { formatCompactDuration } from '@utils/core';
 
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
@@ -108,7 +108,7 @@ export function childElapsed(
   if (startedAt === undefined || !hasLiveChildElapsed(child)) {
     return child.elapsed;
   }
-  return formatDuration(Math.max(0, nowMs - startedAt));
+  return formatCompactDuration(nowMs - startedAt);
 }
 
 function streamDescription(

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -319,6 +319,12 @@ describe('CLI child execution controls', () => {
       },
     ]);
     expect(childElapsed(state.activeProcesses[0], 62_000)).toBe('1s');
+    expect(
+      childElapsed(
+        { startedAt: 0, status: STREAM_STATUS.RUNNING, elapsed: '1s' },
+        7_501_234,
+      ),
+    ).toBe('2h 5m');
   });
 
   it('uses CLI-facing labels in picker descriptions', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -596,7 +596,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
-      '75s',
+      '1m 15s',
       PERSONAL_API_MODE_LABEL,
       '3 sub',
     ]);
@@ -630,7 +630,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
-      '75s',
+      '1m 15s',
       PERSONAL_API_MODE_LABEL,
     ]);
   });
@@ -689,7 +689,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
-      '75s',
+      '1m 15s',
       PERSONAL_API_MODE_LABEL,
     ]);
     expect(display.right).toBeUndefined();
@@ -1225,7 +1225,7 @@ describe('CLI StatusBar display model', () => {
     expect(running.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
-      '110s',
+      '1m 50s',
       PERSONAL_API_MODE_LABEL,
     ]);
 
@@ -1247,7 +1247,7 @@ describe('CLI StatusBar display model', () => {
     expect(thinking.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
-      '110s',
+      '1m 50s',
       'thinking...',
       PERSONAL_API_MODE_LABEL,
     ]);

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -9,6 +9,7 @@ export {
   isNonEmptyString,
   isString,
   extractErrorMessage,
+  formatCompactDuration,
   formatDuration,
   serializeError,
   type SerializedError,


### PR DESCRIPTION
## Summary

- Reuse the shared compact duration formatter for the CLI status footer elapsed time.
- Reuse the same formatter for live child execution elapsed text so subagent/task panels stay consistent in long runs.
- Keep TUI harness fixtures and snapshot expectations aligned with the compact duration format.
- Update status-bar and child-control unit expectations from raw/uncapped duration strings to compact minute/hour strings.

## Why

Goal-mode and subagent dogfooding showed the footer could display `75s` while the surrounding panels displayed `1m 15s`, which made long-running sessions scan inconsistently. Review also caught that the panel and footer paths could diverge again after an hour because one path capped duration units and the other did not.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/utils/StringCore.vitest.ts src/test-kernel/agent/GoalContinuation.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-status-duration-frames-3 subagent-picker task-picker tiny-status-separators`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-goal-mode-frames-2 plan-approval-goal compact-plan-approval-goal plan-approval-approve-goal`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/panes/StatusBar.tsx packages/cli/src/chat/tui/state/childControls.ts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/utils/core/index.ts packages/cli/scripts/tui-harness.tsx packages/cli/scripts/validate-tui.mjs`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing warnings)
- `corepack pnpm --filter @texra-ai/cli --if-present build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting in the CLI TUI with no auth, data, or API behavior changes.
> 
> **Overview**
> The CLI **status footer** and **subagent/task picker** live elapsed strings now use the shared **`formatCompactDuration`** helper instead of raw seconds or the longer `formatDuration` format, so durations like **75s** display as **`1m 15s`** to match surrounding panels.
> 
> **`formatCompactDuration`** is re-exported from **`@utils/core`** for CLI imports. TUI harness fixtures, **`validate-tui`** snapshot expectations, and **StatusBar** / **ChildControls** unit tests are updated for the new strings (including hour-scale cases such as **`2h 5m`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 163f26345523b859245316f019a25e10724a2a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->