### PR TITLE
[codex] Validate packaged CLI skills

### DIFF
--- a/packages/cli/scripts/validate-pack.mjs
+++ b/packages/cli/scripts/validate-pack.mjs
@@ -48,8 +48,7 @@ function assertNoForbiddenTarballEntries(entries) {
       relative.startsWith('dist/resources/walkthroughs/') ||
       relative.startsWith('dist/resources/examples/') ||
       relative.startsWith('dist/resources/logo-') ||
-      // Bundled skills and reference agents are not part of the public CLI.
-      relative.startsWith('dist/resources/skills/') ||
+      // Reference agents are not part of the public CLI.
       relative.startsWith('dist/resources/reference-agents/') ||
       relative === 'dist/resources/templates/chatExport.tex'
     );
@@ -60,6 +59,23 @@ function assertNoForbiddenTarballEntries(entries) {
     `npm package contains entries excluded from the public CLI artifact:\n${forbidden.join(
       '\n',
     )}`,
+  );
+}
+
+function assertBundledSkillsIncluded(entries) {
+  const hasBundledSkillManifest = entries.some((entry) => {
+    const relative = entry.startsWith(packageDir)
+      ? entry.slice(packageDir.length)
+      : entry;
+    return (
+      relative.startsWith('dist/resources/skills/') &&
+      relative.endsWith('/SKILL.md')
+    );
+  });
+
+  assert(
+    hasBundledSkillManifest,
+    'npm package should include bundled CLI skill manifests.',
   );
 }
 
@@ -107,6 +123,7 @@ try {
     .filter(Boolean)
     .sort();
   assertNoForbiddenTarballEntries(entries);
+  assertBundledSkillsIncluded(entries);
 
   const installRoot = path.join(tmp, 'install');
   run('npm', ['install', '--prefix', installRoot, tarballPath]);


### PR DESCRIPTION
## Summary

- Update the CLI npm package validator to allow packaged `dist/resources/skills/**` resources.
- Add a positive tarball check that bundled skill manifests are present in the package.

## Why

CLI dogfooding found that `corepack pnpm --filter @texra-ai/cli validate:pack -- --no-build` failed after a normal build because the validator still treated bundled skills as forbidden package contents. That rule became stale after `fix: bundle CLI skills` made packaged skills part of the runtime resource contract.

## Validation

- `npm run texra-local:build && npm run texra-local:link && texra-local doctor --output-format json`
- Real PTY chat smoke: `TERM=xterm-256color texra-local chat --agent chat --model deepseekproT`, exercised `/help`, `/status`, `/model`, `/agent`, then exited with Ctrl-C.
- Real PTY launcher smoke: `TERM=xterm-256color texra-local`, opened Help from the launcher.
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-dogfood-frames orchestrate-launcher compact-orchestrate-launcher model-form agent-form approval-form plan-approval-goal plan-approval-approve-goal bash-approval edit-approval subagent-picker task-picker task-subworkflow-detail ctrl-c-exit`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `corepack pnpm --filter @texra-ai/cli validate:pack -- --no-build`
- `corepack pnpm --filter @texra-ai/cli build && corepack pnpm --filter @texra-ai/cli validate:pack -- --no-build`
- `corepack pnpm vitest run src/test-kernel/cli/CliSkills.vitest.mts src/test-kernel/skills/LoadSkills.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/scripts/validate-pack.mjs`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the CLI pack validation script; no runtime auth, data, or install behavior is modified.
> 
> **Overview**
> **Pack validation** now matches the CLI’s bundled-skills contract instead of treating them as forbidden tarball content.
> 
> `validate-pack.mjs` no longer flags `dist/resources/skills/**` as excluded from the public npm artifact, and adds **`assertBundledSkillsIncluded`**, which fails the pack check unless the tarball contains at least one `dist/resources/skills/**/SKILL.md` manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a0341d3926d35225a0c0ba2facaeb175803bd01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->