### PR TITLE
[codex] Clarify approve and run bash notice

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1411,7 +1411,7 @@ const SCENARIOS = [
     ],
     unexpect: [
       'r approve & run',
-      'Run auto-approves bash; edits still ask',
+      'Approve & run only auto-approves bash',
       '[/model]models',
     ],
     maxBlankLinesBetween: [
@@ -1430,7 +1430,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
-      'Run auto-approves bash; edits still ask',
+      'Approve & run only auto-approves bash',
       'r approve & run',
       'y approve',
       'n reject',
@@ -1461,7 +1461,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
-      'Run auto-approves bash; edits still ask',
+      'Approve & run only auto-approves bash',
       'observations. Do not edit any files',
       'r approve & run',
       'y approve',
@@ -1500,7 +1500,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     expect: [
       'Approve plan?',
-      'Run auto-approves bash; edits still ask',
+      'Approve & run only auto-approves bash',
       '4. Delegate a brief independent verification to the `review` subagent to',
       "check the derivation's correctness.",
       'r approve & run',
@@ -1523,7 +1523,11 @@ const SCENARIOS = [
       'e feedback',
       'Esc cancel',
     ],
-    unexpect: ['Run auto-approves bash; edits still ask', '[/model]models'],
+    unexpect: [
+      'Approve & run only auto-approves bash',
+      'Run auto-approves bash; edits still ask',
+      '[/model]models',
+    ],
   },
   {
     name: 'compact-plan-approval-goal',
@@ -1539,7 +1543,7 @@ const SCENARIOS = [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
       'Split the finite and symbolic cases',
-      'Run auto-approves bash; edits still ask',
+      'Approve & run only auto-approves bash',
       'r approve & run',
       'y approve',
       'n reject',

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -23,7 +23,7 @@ export const COMPACT_PLAN_APPROVAL_MAX_ROWS = 7;
 const MIN_PLAN_APPROVAL_CONTENT_WIDTH = 20;
 const PLAN_APPROVAL_TITLE = 'Approve plan?';
 export const PLAN_APPROVAL_GOAL_NOTICE =
-  'Run auto-approves bash; edits still ask.';
+  'Approve & run only auto-approves bash.';
 const PLAN_APPROVAL_GOAL_NOTICE_ROWS = 2;
 const PLAN_APPROVAL_NON_COMPACT_FIXED_ROWS = 7;
 const PLAN_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;

--- a/src/test-kernel/cli/PlanApproval.vitest.mts
+++ b/src/test-kernel/cli/PlanApproval.vitest.mts
@@ -127,17 +127,17 @@ describe('CLI plan approval layout', () => {
   });
 
   it('keeps the autonomous warning concise enough for the approval card', () => {
-    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('Run auto-approves bash');
-    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('edits still ask');
-    expect(PLAN_APPROVAL_GOAL_NOTICE.length).toBeLessThanOrEqual(56);
+    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('Approve & run only');
+    expect(PLAN_APPROVAL_GOAL_NOTICE).toContain('auto-approves bash');
+    expect(PLAN_APPROVAL_GOAL_NOTICE.length).toBeLessThanOrEqual(40);
   });
 
   it('keeps the autonomous warning to one display row on narrow cards', () => {
     const notice = planApprovalGoalNoticeLine(40);
 
     expect(textDisplayWidth(notice)).toBe(40);
-    expect(notice).toContain('Run auto-approves bash');
-    expect(notice).toContain('edits still ask');
+    expect(notice).toContain('Approve & run only');
+    expect(notice).toContain('auto-approves bash');
     expect(notice).not.toContain('…');
   });
 


### PR DESCRIPTION
## Summary

- Clarify the CLI plan approval Goal notice so plain `y approve` no longer appears to enable bash auto-approval.
- Keep the notice within the existing one-line 40-column approval-card budget.
- Update TUI snapshot expectations for the scoped wording.

Closes #6075.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/PlanApproval.vitest.mts src/test-kernel/cli/TuiValidatorArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-plan-approval-copy-frames plan-approval plan-approval-goal plan-approval-wrap-boundary compact-plan-approval-goal plan-approval-approve-goal plan-approval-ctrl-r-ignored`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/modals/PlanApproval.tsx src/test-kernel/cli/PlanApproval.vitest.mts packages/cli/scripts/validate-tui.mjs`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (0 errors, existing warnings only)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in the plan approval modal plus test/validator updates; no approval logic or security behavior changed.
> 
> **Overview**
> Updates the **Goal** plan-approval notice from *"Run auto-approves bash; edits still ask"* to **"Approve & run only auto-approves bash."** so plain **`y approve`** is not read as enabling bash auto-approval.
> 
> The shorter string stays within the existing **40-column**, one-line approval-card budget. TUI harness scenarios and `PlanApproval` unit tests were aligned with the new wording and length limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eacc368ec22227d65fd1b3504e08862159bf4fe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->