### PR TITLE
[codex] Cover bash approval feedback in TUI harness

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1100,6 +1100,23 @@ const SCENARIOS = [
     unexpect: [' · …', 'a session'],
   },
   {
+    name: 'bash-approval-feedback',
+    rows: 24,
+    cols: 80,
+    env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
+    bootExpect: '[Ctrl-C]',
+    keys: ['e', 'use portable python3 instead'],
+    frame: 'tail',
+    expect: [
+      'Run bash command?',
+      '> use portable python3 instead',
+      'Enter send note',
+      'Esc back',
+      '1 approval',
+    ],
+    unexpect: ['[/model]models'],
+  },
+  {
     name: 'long-bash-approval',
     rows: 24,
     env: {


### PR DESCRIPTION
## Summary
- add a `bash-approval-feedback` validate-tui scenario
- assert the bash approval feedback note, Enter/Esc hints, and approval count remain visible
- close #6068

## Validation
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-bash-approval-feedback-frames bash-approval-feedback`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-approval-feedback-frames bash-approval bash-approval-feedback edit-approval-feedback narrow-bash-approval`
- `corepack pnpm exec prettier --check packages/cli/scripts/validate-tui.mjs && git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to `validate-tui.mjs`; no runtime CLI or TUI behavior is modified.
> 
> **Overview**
> Adds a **`bash-approval-feedback`** entry to the CLI `validate-tui` harness so regressions in the bash approval **feedback note** flow are caught in CI.
> 
> The scenario boots with `HARNESS_BASH_APPROVAL`, presses **`e`** and types a note, then asserts the modal still shows **Run bash command?**, the drafted note (`> use portable python3 instead`), **Enter send note** / **Esc back** hints, and **1 approval**, while the normal chat status bar (`[/model]models`) stays hidden behind the foreground panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335ca0027c70e3327dea3b15ee925dc0f8e9524d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->