### PR TITLE
refactor: extract byName comparator and deduplicate toPosixPath logic

### DIFF
--- a/src/agent/index/agentOptionsBuilder.ts
+++ b/src/agent/index/agentOptionsBuilder.ts
@@ -4,6 +4,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentOptionData } from '@shared/schemas';
 import { agentKey as createKey } from '@shared/schemas/agent';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
+import { byName } from '@utils/core';
 import type { AgentEntry } from './agentEntry';
 
 export interface AgentOptionsDataPayload {
@@ -41,6 +42,6 @@ export function sortAgentEntries(
     if (aIdx != null && bIdx != null) return aIdx - bIdx;
     if (aIdx != null) return -1;
     if (bIdx != null) return 1;
-    return a.name.localeCompare(b.name);
+    return byName(a, b);
   });
 }

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -4,6 +4,7 @@ import {
   AGENT_MODE_PRESETS_BY_ID,
   AgentModePresetSchema,
 } from '@shared/schemas/agentPresets';
+import { byName } from '@utils/core';
 import {
   agentKey,
   type AgentCategory,
@@ -188,7 +189,7 @@ export class SettingsAgentCatalogController {
     return this.deps.state
       .getAgents(category)
       .map((entry) => this.toSelectionItem(entry, enabledKeys))
-      .sort((a, b) => a.name.localeCompare(b.name));
+      .sort(byName);
   }
 
   private toSelectionItem(

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -22,6 +22,7 @@ import {
   type ModelSelectionItem,
   type ReasoningLevel,
 } from '@shared/schemas/settingsViewMessages';
+import { byName } from '@utils/core';
 
 export interface SettingsModelSelectionState {
   getEnabledModels(): string[] | undefined;
@@ -171,7 +172,7 @@ export class SettingsModelSelectionController {
       items.push(item);
     }
 
-    return items.sort((a, b) => a.name.localeCompare(b.name));
+    return items.sort(byName);
   }
 
   private getEffectiveHelperModel(visibleModels: readonly string[]): string {

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -8,6 +8,7 @@ import {
   isNotADirectoryError,
   toErrorMessage,
 } from '@common/errors';
+import { byName } from '@utils/core';
 
 // Local imports - skill parsing
 import { type SkillLoadIssue, issue, loadSkillDirectory } from './skillLoader';
@@ -81,7 +82,7 @@ export async function discoverSkills(
     return { skills, errors };
   }
 
-  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+  for (const entry of entries.sort(byName)) {
     if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
 
     const skillDir = path.join(root, entry.name);

--- a/src/utils/core/comparators.ts
+++ b/src/utils/core/comparators.ts
@@ -1,0 +1,8 @@
+/**
+ * Reusable sort comparator functions for use with Array.sort / Array.toSorted.
+ */
+
+/** Alphabetically compare two objects by their `name` property. */
+export function byName<T extends { name: string }>(a: T, b: T): number {
+  return a.name.localeCompare(b.name);
+}

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -22,5 +22,6 @@ export {
   ensureArray,
 } from './typeGuards';
 export { debounce, delay } from './async';
+export { byName } from './comparators';
 export { clamp, clampIndex, clampOptional, roundTo } from './math';
 export { tryParseUrl } from './urlCore';

--- a/src/utils/core/pathCore.ts
+++ b/src/utils/core/pathCore.ts
@@ -7,21 +7,20 @@ import * as path from 'node:path';
 
 import slash from 'slash';
 
-/** Convert a path to POSIX style (forward slashes, collapsed separators). */
-export function toPosixPath(relativePath: string): string {
-  if (!relativePath || relativePath === '.') {
-    return '.';
-  }
-  return slash(relativePath.trim()).split('/').filter(Boolean).join('/');
-}
-
 /** Get path segments as an array. */
 export function getPathSegments(input: string): string[] {
   if (!input || input === '.') {
     return [];
   }
-  // slash+trim then split directly — avoids the redundant join/split inside toPosixPath.
   return slash(input.trim()).split('/').filter(Boolean);
+}
+
+/** Convert a path to POSIX style (forward slashes, collapsed separators). */
+export function toPosixPath(relativePath: string): string {
+  if (!relativePath || relativePath === '.') {
+    return '.';
+  }
+  return getPathSegments(relativePath).join('/');
 }
 
 /** Normalize a path for LaTeX \input commands (strips leading ./). */


### PR DESCRIPTION
## Summary

- **Extract `byName` sort comparator** — the inline `(a, b) => a.name.localeCompare(b.name)` pattern appeared verbatim in four files. A shared `byName<T extends {name: string}>(a, b)` function in `@utils/core` replaces all four copies.
- **Deduplicate `toPosixPath` logic** — `toPosixPath` and `getPathSegments` in `pathCore.ts` shared identical `slash(x.trim()).split('/').filter(Boolean)` logic. `toPosixPath` is now expressed as `getPathSegments(x).join('/')`, making the relationship explicit and eliminating the duplicate chain.

### Files changed

| File | Change |
|---|---|
| `src/utils/core/comparators.ts` | New — exports `byName` comparator |
| `src/utils/core/index.ts` | Re-exports `byName` from barrel |
| `src/utils/core/pathCore.ts` | `toPosixPath` delegates to `getPathSegments`; reordered so primitive comes first |
| `src/agent/index/agentOptionsBuilder.ts` | Uses `byName` |
| `src/controllers/settingsView/SettingsAgentCatalogController.ts` | Uses `byName` |
| `src/controllers/settingsView/SettingsModelSelectionController.ts` | Uses `byName` |
| `src/skills/loadSkills.ts` | Uses `byName` |

## Test plan

- [x] `npm run compile:fast` — clean build (0 errors)
- [x] `npm test` — 457/458 test files pass; the 1 failure (`execUtils` process-abort timing) is pre-existing and unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01381QFXw8cBi3v2Zrvtgkv2

---
_Generated by [Claude Code](https://claude.ai/code/session_01381QFXw8cBi3v2Zrvtgkv2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with equivalent sort and path normalization behavior; no auth, data, or API surface changes.
> 
> **Overview**
> Introduces a shared **`byName`** sort comparator in `@utils/core` and replaces four copy-pasted `(a, b) => a.name.localeCompare(b.name)` usages in agent options, settings agent/model lists, and skill discovery.
> 
> In **`pathCore`**, **`toPosixPath`** now builds POSIX paths via **`getPathSegments(...).join('/')`** instead of repeating the same `slash` / trim / split / filter logic, with **`getPathSegments`** defined first as the primitive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a951c7577c62bbb7bc5f24ede1bf6ed537109e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->