### PR TITLE
[codex] Use OpenAI addOutputText helper

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1,5 +1,8 @@
 // Third-party imports
 import OpenAI from 'openai';
+// Exported by openai@6.x via the package's ./lib/* subpath; keep typecheck
+// coverage around SDK upgrades because this is not a top-level public helper.
+import { addOutputText } from 'openai/lib/ResponsesParser';
 
 // Local imports - agent
 import {
@@ -85,7 +88,6 @@ import {
   extractTextContentPart,
   isAssistantTextMessage,
   isMessageItem,
-  isOutputMessage,
 } from './openAIResponseContent';
 import {
   buildInlineAttachmentParts,
@@ -1734,26 +1736,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
     }
     let newResponse = responseObject.output_text?.trim() ?? '';
-
-    if (!newResponse && responseObject.output) {
-      const fallbackSegments: string[] = [];
-
-      for (const item of responseObject.output) {
-        if (!isOutputMessage(item)) {
-          continue;
-        }
-
-        for (const part of item.content) {
-          if (part.type === 'output_text') {
-            fallbackSegments.push(part.text);
-          }
-        }
-      }
-
-      const fallbackText = fallbackSegments.join('').trim();
-      if (fallbackText) {
-        newResponse = fallbackText;
-      }
+    if (!newResponse && Array.isArray(responseObject.output)) {
+      // Mutates responseObject.output_text from output message parts.
+      addOutputText(responseObject);
+      newResponse = responseObject.output_text?.trim() ?? '';
     }
 
     const stopReason =

--- a/src/agent/modelHandlers/openai/openAIResponseContent.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseContent.ts
@@ -8,7 +8,6 @@ import type {
   ResponseInputContent,
   ResponseInputFile,
   ResponseInputItem,
-  ResponseOutputItem,
   ResponseOutputMessage,
 } from 'openai/resources/responses/responses';
 
@@ -55,13 +54,6 @@ export function extractTextContentPart(part: unknown): string | undefined {
     typeof candidate.text === 'string'
     ? candidate.text
     : undefined;
-}
-
-/** Type guard for ResponseOutputMessage items from the SDK. */
-export function isOutputMessage(
-  item: ResponseOutputItem,
-): item is ResponseOutputMessage {
-  return item.type === 'message';
 }
 
 /** Type guard for input_file content parts. */

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -243,6 +243,109 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
   });
 });
 
+describe('ModelHandlerOpenAIResponse.extractResponse', () => {
+  it('fills missing output_text from output message parts', () => {
+    const handler = createHandler();
+    const result = handler.extractResponse(
+      {
+        id: 'resp-output-fallback',
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [
+              { type: 'output_text', text: 'alpha ' },
+              { type: 'output_text', text: 'beta' },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 1,
+          output_tokens: 2,
+          total_tokens: 3,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      } as any,
+      '',
+    );
+
+    assert.equal(result.text, 'alpha beta');
+  });
+
+  it('preserves top-level output_text when output has no message text', () => {
+    const handler = createHandler();
+    const result = handler.extractResponse(
+      {
+        id: 'resp-top-level-text',
+        status: 'completed',
+        output_text: 'relay text',
+        output: [{ type: 'reasoning', id: 'rs_1', summary: [] }],
+        usage: {
+          input_tokens: 1,
+          output_tokens: 2,
+          total_tokens: 3,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      } as any,
+      '',
+    );
+
+    assert.equal(result.text, 'relay text');
+  });
+
+  it('uses top-level output_text when output is absent', () => {
+    const handler = createHandler();
+    const result = handler.extractResponse(
+      {
+        id: 'resp-output-missing',
+        status: 'completed',
+        output_text: 'relay text',
+        usage: {
+          input_tokens: 1,
+          output_tokens: 2,
+          total_tokens: 3,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      } as any,
+      '',
+    );
+
+    assert.equal(result.text, 'relay text');
+  });
+
+  it('fills blank output_text from output message parts', () => {
+    const handler = createHandler();
+    const result = handler.extractResponse(
+      {
+        id: 'resp-blank-output-text',
+        status: 'completed',
+        output_text: '   ',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'fallback text' }],
+          },
+        ],
+        usage: {
+          input_tokens: 1,
+          output_tokens: 2,
+          total_tokens: 3,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      } as any,
+      '',
+    );
+
+    assert.equal(result.text, 'fallback text');
+  });
+});
+
 describe('ModelHandlerOpenAIResponse.extractAssistantText', () => {
   it('extracts assistant text from response output text parts', () => {
     const handler = createHandler();


### PR DESCRIPTION
## What changed

- Replaced the manual OpenAI Responses `output_text` reconstruction in `ModelHandlerOpenAIResponse.extractResponse()` with the SDK-native `addOutputText()` helper.
- Removed the now-unneeded local message-output walk from that handler path.
- Added a focused regression test for responses that omit top-level `output_text` but still contain assistant `output_text` parts in `output`.

## Why

The handler was duplicating normalization logic that the pinned OpenAI SDK already exposes. Using the SDK helper narrows local maintenance surface while preserving the fallback behavior we need.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts`
- `corepack pnpm exec eslint src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts`
- `corepack pnpm exec prettier --check src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to response text parsing with explicit tests; relies on a non-public SDK subpath that the PR notes should be watched on upgrades.
> 
> **Overview**
> **OpenAI Responses text extraction** now delegates missing or blank `output_text` recovery to the pinned SDK helper `addOutputText()` from `openai/lib/ResponsesParser` instead of walking `output` message items locally.
> 
> The custom `isOutputMessage` guard and its import are removed from `openAIResponseContent.ts`. Behavior when top-level `output_text` is present or when `output` has no assistant message text should stay the same.
> 
> New **`extractResponse` tests** cover fallback from `output_text` parts, preserving relay `output_text`, and treating whitespace-only `output_text` as empty so fallback still runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc408f667238e99b177aeaaeaebdb19173e377db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->