### PR TITLE
[codex] End extracted workflow outputs with newline

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -221,7 +221,7 @@ export class XmlOutputManager {
       const texLocation = isExternal
         ? createExternalLocation(texFile)
         : this.fileService.createLocation(texFile);
-      const cleanedContent = this.removeTrailingEndDocument(
+      const cleanedContent = this.cleanExtractedDocumentContent(
         doc.content.trim(),
         texFile,
       );
@@ -268,17 +268,22 @@ export class XmlOutputManager {
     }
   }
 
-  private removeTrailingEndDocument(content: string, fileName: string): string {
+  private cleanExtractedDocumentContent(
+    content: string,
+    fileName: string,
+  ): string {
     const trimmed = content.trimEnd();
 
-    if (
+    const cleaned =
       trimmed.includes('\\begin{document}') ||
       !trimmed.endsWith('\\end{document}')
-    ) {
-      return trimmed;
+        ? trimmed
+        : trimmed.replace(/\\end{document}\s*$/, '').trimEnd();
+
+    if (cleaned !== trimmed) {
+      this.logger.debug(`Removed trailing \\end{document} from ${fileName}`);
     }
 
-    this.logger.debug(`Removed trailing \\end{document} from ${fileName}`);
-    return trimmed.replace(/\\end{document}\s*$/, '');
+    return cleaned === '' ? '' : `${cleaned}\n`;
   }
 }

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentTrace } from '@agent/trace';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { XmlOutputManager } from '@agent/output/XmlOutputManager';
+import {
+  AbsoluteFS,
+  TaskRunFileService,
+  createExternalLocation,
+} from '@utils/files';
+
+async function initFakePlatform(files: Record<string, string> = {}) {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(createFakePlatform({ files, workspacePath: '/workspace' }));
+}
+
+function createXmlManager(): XmlOutputManager {
+  return new XmlOutputManager(
+    {
+      agentCategory: AgentCategory.Workflow,
+      documentTag: 'document',
+      endTag: '</documents>',
+      temperature: 0,
+      requiredFiles: {},
+      requiredFilesInternal: {},
+      defaultOutputFiles: [],
+      filePatternsContain: [],
+      tools: [],
+      isRewrite: true,
+      rounds: 1,
+      prefills: [],
+    },
+    {
+      inputFiles: ['paper.tex'],
+    } as AgentConfig,
+    { debug: vi.fn() } as unknown as AgentTrace,
+    new TaskRunFileService(),
+  );
+}
+
+describe('XmlOutputManager', () => {
+  beforeEach(async () => {
+    await initFakePlatform({ '/tmp/run/output.xml': '<documents />' });
+  });
+
+  it('writes extracted full-document outputs with one final newline', async () => {
+    const manager = createXmlManager();
+
+    await manager.processMultipleLatexDocuments(
+      [
+        {
+          name: 'paper.tex',
+          content:
+            '\n\\documentclass{article}\n\\begin{document}\nHi.\n\\end{document}\n\n',
+        },
+      ],
+      createExternalLocation('/tmp/run/output.xml'),
+      0,
+    );
+
+    await expect(AbsoluteFS.read('/tmp/run/paper.tex')).resolves.toBe(
+      '\\documentclass{article}\n\\begin{document}\nHi.\n\\end{document}\n',
+    );
+  });
+
+  it('keeps legacy trailing end-document removal and adds one final newline', async () => {
+    const manager = createXmlManager();
+
+    await manager.processMultipleLatexDocuments(
+      [
+        {
+          name: 'fragment.tex',
+          content: '\nBody only.\n\\end{document}\n\n',
+        },
+      ],
+      createExternalLocation('/tmp/run/output.xml'),
+      0,
+    );
+
+    await expect(AbsoluteFS.read('/tmp/run/fragment.tex')).resolves.toBe(
+      'Body only.\n',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Real CLI workflow dogfooding showed extracted TeX workflow outputs could be written without a final newline. That made consecutive `.tex` outputs render awkwardly in terminal inspection and left Git reporting `No newline at end of file`.

This keeps the existing legacy cleanup behavior for fragment-style outputs that end with a stray `\end{document}`, but normalizes every non-empty extracted document to exactly one trailing newline.

## Validation

- `corepack pnpm exec prettier --check src/agent/output/XmlOutputManager.ts src/test-kernel/agent/output/XmlOutputManager.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/agent/output/XmlOutputManager.vitest.ts src/test-kernel/agent/output/OutputProgressEvents.vitest.ts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/OutputGuards.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

## Dogfood evidence

- `texra-local` workflow-output dogfood exposed the missing final newline in extracted `.tex` files.
- Separate `\goal` mode dogfood run continued for 2h 15m 29s after its first heartbeat and recorded final verification in `/private/tmp/texra-goal-longrun/goal-longrun-log.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to workflow XML-to-TeX write formatting with tests; no auth, security, or data-path impact.
> 
> **Overview**
> Extracted workflow `.tex` files are now normalized so **non-empty** content always ends with exactly one newline, fixing terminal display and Git’s “no newline at end of file” warnings.
> 
> `removeTrailingEndDocument` was renamed to `cleanExtractedDocumentContent` and extended: it still strips a stray trailing `\end{document}` on fragment-style outputs (no `\begin{document}`), but full documents are left intact aside from the newline. Debug logging for that strip only runs when removal actually happens.
> 
> New `XmlOutputManager` vitest coverage asserts both full-document and fragment extraction paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48acf2c8f5a11c9b13926492aee2ffa6032eab79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->