### PR TITLE
[codex] Reuse OpenAI Responses export helpers

### DIFF
--- a/packages/extension/src/commands/history/chatExport/normalizeMessages.ts
+++ b/packages/extension/src/commands/history/chatExport/normalizeMessages.ts
@@ -11,6 +11,11 @@ import {
   isToolMessage,
 } from 'openai/lib/chatCompletionUtils';
 import { assertToolCallsAreChatCompletionFunctionToolCalls } from 'openai/lib/parser';
+import {
+  extractTextContentPart,
+  isFunctionCallOutputItem,
+} from '@agent/modelHandlers/openai/openAIResponseContent';
+import { isResponseFunctionToolCallItem } from '@agent/modelHandlers/openai/responseStreamEvents';
 import type { Part } from '@google/genai';
 import type {
   ChatCompletionMessageParam,
@@ -200,15 +205,21 @@ export function normalizeMessages(messages: unknown[]): ExportNode[] {
   let lastAssistantHadToolUse = false;
 
   for (const raw of messages) {
-    const item = raw as Record<string, unknown>;
+    const item = asObject(raw);
+    if (!item) {
+      continue;
+    }
 
     // OpenAI Response API: top-level function_call items (not wrapped in a message)
-    if (isResponseFunctionCallItem(item)) {
+    const responseToolCall = item as unknown as
+      | ResponseFunctionToolCallItem
+      | undefined;
+    if (isResponseFunctionToolCallItem(responseToolCall)) {
       const args =
-        typeof item.arguments === 'string'
-          ? item.arguments
-          : JSON.stringify(item.arguments ?? {}, null, 2);
-      const name = item.name ?? 'unknown';
+        typeof responseToolCall.arguments === 'string'
+          ? responseToolCall.arguments
+          : JSON.stringify(responseToolCall.arguments ?? {}, null, 2);
+      const name = responseToolCall.name ?? 'unknown';
       nodes.push({ kind: 'tool-call', name, input: args });
       lastAssistantHadToolUse = true;
       continue;
@@ -216,19 +227,17 @@ export function normalizeMessages(messages: unknown[]): ExportNode[] {
 
     // OpenAI Response API: top-level function_call_output items.
     // output can be a string OR an array of input_text/input_file/input_image parts.
-    if (isResponseFunctionCallOutputItem(item)) {
-      const output = item.output;
+    const responseInputItem = item as unknown as ResponseInputItem | undefined;
+    if (isFunctionCallOutputItem(responseInputItem)) {
+      const output = responseInputItem.output;
       if (Array.isArray(output)) {
-        const textParts: string[] = [];
-        for (const part of output) {
-          if (part.type === 'input_text' && typeof part.text === 'string') {
-            textParts.push(part.text);
-          } else if (part.type === 'input_image') {
-            textParts.push('[image attachment]');
-          } else if (part.type === 'input_file') {
-            textParts.push('[file attachment]');
-          }
-        }
+        const textParts = output.flatMap((part) => {
+          const text = extractTextContentPart(part);
+          if (text !== undefined) return [text];
+          if (part.type === 'input_image') return ['[image attachment]'];
+          if (part.type === 'input_file') return ['[file attachment]'];
+          return [];
+        });
         if (textParts.length) {
           nodes.push({ kind: 'tool-result', text: textParts.join('\n') });
         }
@@ -288,7 +297,7 @@ export function normalizeMessages(messages: unknown[]): ExportNode[] {
     }
 
     // OpenAI Chat Completions tool role
-    const openaiMsg = toChatCompletionMessageParam(item);
+    const openaiMsg = item as unknown as ChatCompletionMessageParam;
     if (role === 'tool' || isToolMessage(openaiMsg)) {
       const text =
         typeof openaiMsg.content === 'string'
@@ -302,38 +311,16 @@ export function normalizeMessages(messages: unknown[]): ExportNode[] {
   return nodes;
 }
 
-function isResponseFunctionCallItem(
-  item: unknown,
-): item is ResponseFunctionToolCallItem {
-  return (
-    typeof item === 'object' &&
-    item !== null &&
-    'type' in item &&
-    item.type === 'function_call'
-  );
-}
-
-function isResponseFunctionCallOutputItem(
-  item: unknown,
-): item is ResponseInputItem.FunctionCallOutput {
-  return (
-    typeof item === 'object' &&
-    item !== null &&
-    'type' in item &&
-    item.type === 'function_call_output'
-  );
-}
-
-function toChatCompletionMessageParam(
-  item: unknown,
-): ChatCompletionMessageParam {
-  return item as ChatCompletionMessageParam;
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
 function getAssistantToolCalls(
   item: unknown,
 ): ChatCompletionMessageFunctionToolCall[] {
-  const message = toChatCompletionMessageParam(item);
+  const message = item as ChatCompletionMessageParam;
   if (!isAssistantMessage(message) || !Array.isArray(message.tool_calls)) {
     return [];
   }

--- a/src/agent/modelHandlers/openai/openAIResponseContent.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseContent.ts
@@ -46,6 +46,13 @@ export function isAssistantTextMessage(
   );
 }
 
+/** Type guard for function_call_output input items. */
+export function isFunctionCallOutputItem(
+  item?: ResponseInputItem,
+): item is ResponseInputItem.FunctionCallOutput {
+  return item?.type === 'function_call_output';
+}
+
 /** Extract the text from an input_text/output_text content part, if it is one. */
 export function extractTextContentPart(part: unknown): string | undefined {
   if (!part || typeof part !== 'object') return undefined;

--- a/src/test-kernel/commands/history/chatExportFormatter.vitest.ts
+++ b/src/test-kernel/commands/history/chatExportFormatter.vitest.ts
@@ -54,4 +54,34 @@ describe('formatChatAsMarkdown', () => {
     assert.doesNotMatch(markdown, /custom_tool/);
     assert.doesNotMatch(markdown, /call_malformed/);
   });
+
+  it('renders OpenAI Responses function call outputs with mixed parts', () => {
+    const markdown = formatChatAsMarkdown({
+      timestamp: '2026-01-01T00:00:00.000Z',
+      config: {},
+      messages: [
+        {
+          type: 'function_call',
+          name: 'fetch_notes',
+          arguments: '{"topic":"sdk"}',
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_1',
+          output: [
+            { type: 'input_text', text: 'first line' },
+            { type: 'input_text', text: '' },
+            { type: 'input_image', image_url: 'https://example.com/image.png' },
+            { type: 'input_file', file_id: 'file_123' },
+          ],
+        },
+      ],
+    });
+
+    assert.match(markdown, /#### Tool: `fetch_notes`/);
+    assert.match(
+      markdown,
+      /```\nfirst line\n\n\[image attachment]\n\[file attachment]\n```/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Reuse shared OpenAI Responses helpers in chat export normalization instead of duplicating local `function_call` and `function_call_output` discrimination.
- Add a shared `isFunctionCallOutputItem()` helper alongside the existing OpenAI Responses content helpers.
- Cover mixed `function_call_output` export rendering with a focused formatter test, including preservation of empty text parts and attachment placeholders.

## Why

The export formatter had its own OpenAI Responses item-shape logic even though the runtime already centralizes that logic. This keeps export behavior the same while reducing drift between export and runtime response handling.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/commands/history/chatExportFormatter.vitest.ts`
- `corepack pnpm exec eslint packages/extension/src/commands/history/chatExport/normalizeMessages.ts src/agent/modelHandlers/openai/openAIResponseContent.ts src/test-kernel/commands/history/chatExportFormatter.vitest.ts`
- `corepack pnpm exec prettier --check packages/extension/src/commands/history/chatExport/normalizeMessages.ts src/agent/modelHandlers/openai/openAIResponseContent.ts src/test-kernel/commands/history/chatExportFormatter.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of chat export normalization with no auth or data-path changes; behavior is pinned by a new formatter test.
> 
> **Overview**
> Chat export normalization now uses the same **OpenAI Responses** type guards and text extraction as the runtime (`isResponseFunctionToolCallItem`, `isFunctionCallOutputItem`, `extractTextContentPart`) instead of local duplicates in `normalizeMessages.ts`.
> 
> A new shared **`isFunctionCallOutputItem()`** lives in `openAIResponseContent.ts` next to the existing content helpers. Mixed `function_call_output` arrays are flattened with `extractTextContentPart` plus attachment placeholders for images/files. Non-object message entries are skipped via **`asObject()`**.
> 
> A formatter test asserts markdown export for Responses **`function_call`** / **`function_call_output`** with mixed text, empty text, image, and file parts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10aed9c232c61880ebbda47fb9bee7e368297ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->