### PR TITLE
refactor: centralize CLI launch agent resolution

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -20,7 +20,6 @@ import {
 } from '../runtime/runModel';
 import {
   TOOL_USE_AGENT_NAME_DESCRIPTION,
-  assertCliAgentLaunch,
   resolveCliAgent,
 } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
@@ -71,9 +70,7 @@ export async function runToolUseAgent(
   const instruction = await resolveToolUseInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
-  const agentEntry = await resolveCliAgent(init.agent, AgentCategory.ToolUse);
-
-  assertCliAgentLaunch(init.agent, agentEntry, 'agentsRun');
+  await resolveCliAgent(init.agent, 'agentsRun');
 
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -18,7 +18,7 @@ import {
   buildHeadlessRunContext,
   resolveCliRunModel,
 } from '../runtime/runModel';
-import { assertCliAgentLaunch, resolveCliAgent } from '../runtime/agents';
+import { resolveCliAgent } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
@@ -75,10 +75,9 @@ export async function runWorkflowAgent(
   const instruction = await resolveFileBackedInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
-  const agentEntry = await resolveCliAgent(init.agent, AgentCategory.Workflow);
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
-  const agent = assertCliAgentLaunch(init.agent, agentEntry, 'run');
+  const agent = await resolveCliAgent(init.agent, 'run');
   if (init.output && hasMixedStdinWorkflowInputSpecs(init.inputFiles)) {
     throw new CliUsageError(
       'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -115,29 +115,41 @@ export function assertCliAgentLaunch(
  * CLI commands start with a local-only load so signed-out users avoid remote
  * auth/network work. Missing agents still get a remote-inclusive fallback, and
  * authenticated relay sessions reload bare names so the registry's normal
- * source priority can prefer remote definitions. Category-specific commands
- * pass their lookup category through to keep name priority owned by the
- * registry; category enforcement stays with the command-specific launch
- * validation.
+ * source priority can prefer remote definitions. Launching commands pass their
+ * mode so lookup priority and category enforcement share the same target.
  */
+export function resolveCliAgent(name: string): Promise<AgentEntry | undefined>;
+export function resolveCliAgent(
+  name: string,
+  launchMode: CliAgentLaunchMode,
+): Promise<AgentEntry>;
 export async function resolveCliAgent(
   name: string,
-  lookupCategory?: AgentCategory,
+  launchMode?: CliAgentLaunchMode,
 ): Promise<AgentEntry | undefined> {
+  const lookupCategory = launchMode
+    ? CLI_AGENT_LAUNCH_TARGETS[launchMode].requiredCategory
+    : undefined;
   await loadAgents({ includeRemote: false });
   const agent = getAgent(name, lookupCategory);
 
   if (!agent) {
     await loadAgents();
-    return getAgent(name, lookupCategory);
+    const remoteAgent = getAgent(name, lookupCategory);
+    return launchMode
+      ? assertCliAgentLaunch(name, remoteAgent, launchMode)
+      : remoteAgent;
   }
 
   if (name.includes(':') || !(await getCliAuthProvider().isAuthenticated())) {
-    return agent;
+    return launchMode ? assertCliAgentLaunch(name, agent, launchMode) : agent;
   }
 
   await loadAgents();
-  return getAgent(name, lookupCategory);
+  const remotePriorityAgent = getAgent(name, lookupCategory);
+  return launchMode
+    ? assertCliAgentLaunch(name, remotePriorityAgent, launchMode)
+    : remotePriorityAgent;
 }
 
 export async function loadCliAgentList(

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -27,12 +27,13 @@ vi.mock('@cli/runtime/supabaseAuth', () => ({
 function agent(
   name: string,
   source: AgentEntry['source'] = 'builtInToolUse',
+  category: AgentEntry['category'] = AgentCategory.ToolUse,
 ): AgentEntry {
   return {
     name,
     source,
     path: `/agents/${name}.yaml`,
-    category: AgentCategory.ToolUse,
+    category,
   };
 }
 
@@ -88,16 +89,14 @@ describe('CLI agent resolution', () => {
     expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
   });
 
-  it('passes lookup category through authenticated remote-priority reloads', async () => {
+  it('uses launch mode category for authenticated remote-priority reloads', async () => {
     const local = agent('lean');
     const remote = agent('lean', 'remote');
     mocks.authProvider.isAuthenticated.mockResolvedValue(true);
     mocks.getAgent.mockReturnValueOnce(local).mockReturnValueOnce(remote);
     const { resolveCliAgent } = await import('@cli/runtime/agents');
 
-    await expect(resolveCliAgent('lean', AgentCategory.ToolUse)).resolves.toBe(
-      remote,
-    );
+    await expect(resolveCliAgent('lean', 'chat')).resolves.toBe(remote);
 
     expect(mocks.getAgent).toHaveBeenNthCalledWith(
       1,
@@ -128,14 +127,12 @@ describe('CLI agent resolution', () => {
     expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
   });
 
-  it('passes lookup category through local and remote-fallback lookups', async () => {
+  it('uses launch mode category for local and remote-fallback lookups', async () => {
     const remote = agent('assistant', 'remote');
     mocks.getAgent.mockReturnValueOnce(undefined).mockReturnValueOnce(remote);
     const { resolveCliAgent } = await import('@cli/runtime/agents');
 
-    await expect(
-      resolveCliAgent('assistant', AgentCategory.ToolUse),
-    ).resolves.toBe(remote);
+    await expect(resolveCliAgent('assistant', 'chat')).resolves.toBe(remote);
 
     expect(mocks.getAgent).toHaveBeenNthCalledWith(
       1,
@@ -146,6 +143,20 @@ describe('CLI agent resolution', () => {
       2,
       'assistant',
       AgentCategory.ToolUse,
+    );
+  });
+
+  it('validates launch mode category before returning an agent', async () => {
+    const workflow = agent(
+      'correct',
+      'builtInWorkflow',
+      AgentCategory.Workflow,
+    );
+    mocks.getAgent.mockReturnValue(workflow);
+    const { resolveCliAgent } = await import('@cli/runtime/agents');
+
+    await expect(resolveCliAgent('correct', 'chat')).rejects.toThrow(
+      'Agent "correct" is a workflow agent; `texra chat` only handles tool-use agents.',
     );
   });
 });

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -143,10 +143,7 @@ describe('CLI agents run command', () => {
     expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.resolveCliAgent.mock.invocationCallOrder[0],
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
-      'chat',
-      AgentCategory.ToolUse,
-    );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('chat', 'agentsRun');
     expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
       ['problem.md'],
       ['notes.md'],
@@ -196,7 +193,11 @@ describe('CLI agents run command', () => {
   });
 
   it('reports missing agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockResolvedValueOnce(undefined);
+    mocks.resolveCliAgent.mockRejectedValueOnce(
+      new Error(
+        'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+      ),
+    );
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
 
     await expect(
@@ -216,20 +217,18 @@ describe('CLI agents run command', () => {
     );
     expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
       'missing-agent',
-      AgentCategory.ToolUse,
+      'agentsRun',
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports workflow agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockResolvedValueOnce({
-      name: 'polish',
-      category: AgentCategory.Workflow,
-      source: 'builtInWorkflow',
-      path: '/agents/polish.yaml',
-      tools: [],
-    });
+    mocks.resolveCliAgent.mockRejectedValueOnce(
+      new Error(
+        'Agent "polish" is a workflow agent; `texra agents run` only handles tool-use agents. Use `texra run polish` for workflow agents.',
+      ),
+    );
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
 
     await expect(
@@ -247,10 +246,7 @@ describe('CLI agents run command', () => {
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
-      'polish',
-      AgentCategory.ToolUse,
-    );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('polish', 'agentsRun');
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -155,7 +155,11 @@ describe('CLI workflow run command', () => {
   });
 
   it('reports missing workflow agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockResolvedValueOnce(undefined);
+    mocks.resolveCliAgent.mockRejectedValueOnce(
+      new Error(
+        'Agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+      ),
+    );
     const { runWorkflowAgent } = await import('@cli/commands/workflow');
 
     await expect(
@@ -173,22 +177,17 @@ describe('CLI workflow run command', () => {
     expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.resolveCliAgent.mock.invocationCallOrder[0],
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
-      'missing-agent',
-      AgentCategory.Workflow,
-    );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('missing-agent', 'run');
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports tool-use agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockResolvedValueOnce({
-      name: 'chat',
-      category: AgentCategory.ToolUse,
-      source: 'builtInToolUse',
-      path: '/agents/chat.yaml',
-      tools: [],
-    });
+    mocks.resolveCliAgent.mockRejectedValueOnce(
+      new Error(
+        'Agent "chat" is a toolUse agent; `texra run` only handles workflow agents. Start it interactively with `texra chat --agent chat`, or run a headless team with `texra multi-agent run`.',
+      ),
+    );
     const { runWorkflowAgent } = await import('@cli/commands/workflow');
 
     await expect(
@@ -203,10 +202,7 @@ describe('CLI workflow run command', () => {
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
-      'chat',
-      AgentCategory.Workflow,
-    );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('chat', 'run');
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
@@ -227,10 +223,7 @@ describe('CLI workflow run command', () => {
     );
 
     expect(mocks.initLocalCliPlatform).toHaveBeenCalled();
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
-      'polish',
-      AgentCategory.Workflow,
-    );
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('polish', 'run');
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- make `resolveCliAgent(name, launchMode)` own the lookup category for launch paths
- remove duplicated `AgentCategory.*` plumbing from `texra run` and `texra agents run`
- keep launch-mode mismatch and missing-agent usage errors before model/stdin/runtime setup

## Why

The CLI launch mode already determines whether a command expects a workflow or tool-use agent. Passing both a category and a launch mode leaked that ownership to callers and made the resolver API easier to misuse.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts --reporter=dot`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/agents.ts packages/cli/src/commands/workflow.ts packages/cli/src/commands/agentsRun.ts src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts`
- `git diff --check`
- `npm run texra-local:build && npm run texra-local:link && texra-local doctor --output-format json`
- `texra-local run assistant --cwd /private/tmp/texra-workflow-dogfood-case --input main.tex --instruction 'No model call should happen; this should fail category validation.' --approval-policy never --no-input --output-format text`
- `texra-local agents run correct --cwd /private/tmp/texra-workflow-dogfood-case --instruction 'No model call should happen; this should fail category validation.' --approval-policy never --no-input --output-format text`
- `npm run lint` (0 errors, existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of CLI agent resolution and error timing only; behavior is preserved and covered by existing command and resolution tests.
> 
> **Overview**
> **`resolveCliAgent`** now takes an optional **`CliAgentLaunchMode`** (`'chat'`, `'run'`, `'agentsRun'`) instead of a raw **`AgentCategory`**. When a launch mode is set, the resolver derives the registry lookup category from **`CLI_AGENT_LAUNCH_TARGETS`** and runs **`assertCliAgentLaunch`** before returning, so missing-agent and category-mismatch errors still surface from one place.
> 
> **`texra agents run`** and **`texra run`** no longer pass **`AgentCategory.*`** or call **`assertCliAgentLaunch`** themselves; they invoke **`resolveCliAgent(name, 'agentsRun')`** and **`resolveCliAgent(name, 'run')`** respectively. Non-launch paths (e.g. **`texra agents show`**) keep the single-argument **`resolveCliAgent(name)`** overload that returns **`AgentEntry | undefined`** without category enforcement.
> 
> Tests were updated to expect launch-mode arguments and to treat validation failures as rejections from **`resolveCliAgent`** rather than separate assertion steps after a successful lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41e7e38bcf76d795ea9eeab7a2a666bce998680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->