### PR TITLE
refactor: centralize child control mode copy

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -12,6 +12,7 @@ import type { StreamTabId } from '@shared/schemas';
 import { clamp, clampIndex } from '@utils/core';
 
 import {
+  CHILD_CONTROL_MODE_COPY,
   buildChildControlItems,
   childPickerKeyAction,
   liveChildExecutionElapsedKey,
@@ -54,13 +55,11 @@ const PICKER_HORIZONTAL_CHROME_COLUMNS = 4;
 const MIN_COLUMNS_FOR_KILL_HINT = 44;
 
 export function pickerTitle(mode: ChildControlMode): string {
-  return mode === 'subagents' ? 'Subagents' : 'Tasks and sub-workflows';
+  return CHILD_CONTROL_MODE_COPY[mode].title;
 }
 
 export function emptyPickerText(mode: ChildControlMode): string {
-  return mode === 'subagents'
-    ? 'No active subagents.'
-    : 'No active tasks or sub-workflows.';
+  return CHILD_CONTROL_MODE_COPY[mode].emptyText;
 }
 
 export function isUltraCompactPickerRows(

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -32,6 +32,26 @@ import type {
 
 export type ChildControlMode = 'subagents' | 'tasks';
 
+export const CHILD_CONTROL_MODE_COPY = {
+  subagents: {
+    emptyText: 'No active subagents.',
+    missingItemsText: 'has no subagents',
+    title: 'Subagents',
+  },
+  tasks: {
+    emptyText: 'No active tasks or sub-workflows.',
+    missingItemsText: 'has no tasks or sub-workflows',
+    title: 'Tasks and sub-workflows',
+  },
+} as const satisfies Record<
+  ChildControlMode,
+  {
+    readonly emptyText: string;
+    readonly missingItemsText: string;
+    readonly title: string;
+  }
+>;
+
 export interface ChildControlItem {
   readonly executionId: string;
   readonly childStreamId?: StreamTabId;
@@ -322,9 +342,7 @@ function childControlFallbackDetail(
   targetStreamLabel: string | undefined,
 ): string | undefined {
   if (!fallbackFromStreamLabel || !targetStreamLabel) return undefined;
-  return mode === 'subagents'
-    ? `${fallbackFromStreamLabel} has no subagents`
-    : `${fallbackFromStreamLabel} has no tasks or sub-workflows`;
+  return `${fallbackFromStreamLabel} ${CHILD_CONTROL_MODE_COPY[mode].missingItemsText}`;
 }
 
 function resolveChildControlDisplayTarget({


### PR DESCRIPTION
## Summary

- add one mode-copy table for child-control `subagents` and `tasks` text
- have the task/subagent picker use that table for titles and empty states
- reuse the same table for fallback scope text such as `review has no tasks or sub-workflows`

## Why

The task/sub-workflow TUI surfaces already share state ownership through `childControls.ts`, but their mode-specific copy was split between the state resolver and the picker. This keeps the two child-control modes as a single source of truth without changing rendering behavior.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SubagentScopedViewer.vitest.mts --reporter=dot`
- `node packages/cli/scripts/validate-tui.mjs --snapshot-dir /private/tmp/texra-workflow-task-snapshots-after-copy-refactor task-picker task-subworkflow-detail compact-task-picker-process-overflow narrow-task-picker tiny-task-subworkflow-detail`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/childControls.ts packages/cli/src/chat/tui/modals/ChildControlPicker.tsx src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SubagentScopedViewer.vitest.mts`
- `git diff --check`
- `npm run lint` (0 errors, existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only refactor with identical text; no logic, auth, or data-path changes.
> 
> **Overview**
> Introduces **`CHILD_CONTROL_MODE_COPY`** in `childControls.ts` as the single source for `subagents` vs `tasks` user-facing strings: picker **title**, **empty** message, and **missing-items** fragment used in scope fallback text.
> 
> **`ChildControlPicker`** now reads `pickerTitle` and `emptyPickerText` from that table instead of inline `mode === 'subagents'` branches. **`childControlFallbackDetail`** builds messages like `review has no tasks or sub-workflows` via `missingItemsText` from the same table.
> 
> No intended UI or behavior change—only consolidation of duplicated copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3ce54e74828d25770a2c466801f4a097071f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->