### PR TITLE
Refactor arXiv processor and consolidate accent color rules

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -792,8 +792,8 @@ export abstract class ModelHandler<
   /**
    * Shared threshold check for input-token-based compaction, used by handlers
    * that track a single last-known input-token count. Compaction triggers only
-   * in tool-use mode, on a manual request, or when {@link inputTokens} exceeds
-   * the configured percentage of the context window.
+   * in tool-use mode, on a manual request, or when `inputTokens` exceeds the
+   * configured percentage of the context window.
    */
   protected shouldCompactByInputTokens(inputTokens: number): boolean {
     if (!this.isToolUseMode()) return false;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -490,9 +490,16 @@ export abstract class ModelHandler<
     return false;
   }
 
-  /** Request compaction on the next API call. Override in subclasses that support it. */
+  /**
+   * Flag to force compaction on the next API call, set by {@link requestCompaction}.
+   * Read by the per-provider compaction paths and cleared once compaction is
+   * attempted. Inert for handlers that don't run compaction.
+   */
+  protected compactionRequested = false;
+
+  /** Request compaction on the next API call. */
   requestCompaction(): void {
-    // No-op by default
+    this.compactionRequested = true;
   }
 
   /**
@@ -780,6 +787,25 @@ export abstract class ModelHandler<
       'texra.model.compactionThresholdPercent',
       DEFAULT_COMPACTION_THRESHOLD_PERCENT,
     );
+  }
+
+  /**
+   * Shared threshold check for input-token-based compaction, used by handlers
+   * that track a single last-known input-token count. Compaction triggers only
+   * in tool-use mode, on a manual request, or when {@link inputTokens} exceeds
+   * the configured percentage of the context window.
+   */
+  protected shouldCompactByInputTokens(inputTokens: number): boolean {
+    if (!this.isToolUseMode()) return false;
+    if (this.compactionRequested) return true;
+
+    const thresholdPercent = this.getCompactionThresholdPercent();
+    if (thresholdPercent <= 0) return false;
+
+    const threshold = Math.floor(
+      (thresholdPercent / 100) * this.config.contextWindow,
+    );
+    return inputTokens > threshold;
   }
 
   /**

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -192,9 +192,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
   Anthropic,
   BetaMessage
 > {
-  /** Flag to force compaction on the next API call, set by requestCompaction(). */
-  private compactionRequested = false;
-
   /** Tracks PDF page counts for files uploaded to the Anthropic Files API. */
   private uploadedPdfPageCounts = new Map<string, number>();
 
@@ -242,10 +239,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return (
       isCompactionEligibleModel(this.config.fullName) && this.isToolUseMode()
     );
-  }
-
-  override requestCompaction(): void {
-    this.compactionRequested = true;
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -126,9 +126,6 @@ export class ModelHandlerOpenAI<
   /** Tracks prompt_tokens from the last API response for compaction threshold checks. */
   private lastKnownInputTokens = 0;
 
-  /** Flag to force compaction on the next API call, set by requestCompaction(). */
-  private compactionRequested = false;
-
   protected useReasoningStreamAggregator: boolean = false;
 
   // ── Compaction interface overrides ────────────────────────────────────
@@ -136,10 +133,6 @@ export class ModelHandlerOpenAI<
   /** Client-side compaction is available for tool-use sessions. */
   override get supportsManualCompaction(): boolean {
     return this.isToolUseMode();
-  }
-
-  override requestCompaction(): void {
-    this.compactionRequested = true;
   }
 
   // ── Compaction internals ──────────────────────────────────────────────
@@ -152,19 +145,7 @@ export class ModelHandlerOpenAI<
    * - Last known input tokens exceed the configured threshold
    */
   private shouldCompact(): boolean {
-    if (!this.isToolUseMode()) return false;
-
-    if (this.compactionRequested) {
-      return true;
-    }
-
-    const thresholdPercent = this.getCompactionThresholdPercent();
-    if (thresholdPercent <= 0) return false;
-
-    const threshold = Math.floor(
-      (thresholdPercent / 100) * this.config.contextWindow,
-    );
-    return this.lastKnownInputTokens > threshold;
+    return this.shouldCompactByInputTokens(this.lastKnownInputTokens);
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -155,9 +155,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   OpenAI,
   Response
 > {
-  /** Flag to force compaction on the next API call, set by requestCompaction(). */
-  private compactionRequested = false;
-
   private isOpenRouterRoutingEnabled(): boolean {
     return this.config.openRouterOnly || getUseOpenRouter();
   }
@@ -205,10 +202,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   override get supportsManualCompaction(): boolean {
     return !this.isOpenRouterRoutingEnabled();
-  }
-
-  override requestCompaction(): void {
-    this.compactionRequested = true;
   }
 
   /**

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -88,7 +88,6 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
 > {
   // ── Client-side compaction state ──────────────────────────────────────
   private lastKnownInputTokens = 0;
-  private compactionRequested = false;
 
   override get supportsManualCompaction(): boolean {
     return this.isToolUseMode();
@@ -113,10 +112,6 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       this.capabilities.supportsReasoningEffort ||
       (this.isDeepSeek && this.capabilities.supportsReasoning)
     );
-  }
-
-  override requestCompaction(): void {
-    this.compactionRequested = true;
   }
 
   protected get usageProvider(): NormalizedUsage['provider'] {
@@ -291,16 +286,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   // ---------------------------------------------------------------------------
 
   private shouldCompact(): boolean {
-    if (!this.isToolUseMode()) return false;
-    if (this.compactionRequested) return true;
-
-    const thresholdPercent = this.getCompactionThresholdPercent();
-    if (thresholdPercent <= 0) return false;
-
-    const threshold = Math.floor(
-      (thresholdPercent / 100) * this.config.contextWindow,
-    );
-    return this.lastKnownInputTokens > threshold;
+    return this.shouldCompactByInputTokens(this.lastKnownInputTokens);
   }
 
   private async compactConversation(

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -269,8 +269,7 @@ class ArxivSourceProcessor {
 
     logger.info(this.channel, `Downloading arXiv source for ID: ${id}`);
 
-    const workspacePath = WorkspaceFS.getPath();
-    if (!workspacePath) {
+    if (!WorkspaceFS.getPath()) {
       throw new Error('No workspace folder is open');
     }
 
@@ -281,109 +280,19 @@ class ArxivSourceProcessor {
     const isRoot = paperDirRelative === '.';
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
-    // Check if source was already downloaded successfully.
-    // Skip for root destination — the workspace root likely already contains .tex files
-    // that would produce a false positive.
-    let needsDownload = true;
-    if (!isRoot && (await WorkspaceFS.exists(paperDirRelative))) {
-      const entries = await WorkspaceFS.readDir(paperDirRelative);
-      const hasTexFiles = entries.some(([name]) => hasExtension(name, '.tex'));
-      if (hasTexFiles) {
-        needsDownload = false;
-        logger.info(
-          this.channel,
-          `arXiv source already exists at: ${paperDirFull}`,
-        );
-      }
-    }
-
+    const needsDownload = !(await this.hasExistingSource(
+      paperDirRelative,
+      isRoot,
+      paperDirFull,
+    ));
     if (needsDownload) {
-      await WorkspaceFS.ensureDir(paperDirRelative);
-
-      // Use a unique staging directory name to avoid clobbering an existing 'download/' folder at root
-      const stagingDirName = `.arxiv-download-${id.replaceAll('/', '_')}`;
-      const downloadDirRelative = path.join(paperDirRelative, stagingDirName);
-      await WorkspaceFS.ensureDir(downloadDirRelative);
-
-      const downloadDirFull = path.join(paperDirFull, stagingDirName);
-      const downloadBasePath = path.join(downloadDirFull, 'source');
-
-      progressCallback?.(`Downloading arXiv source for ${id}...`, 20);
-
-      const downloadUrl = `https://arxiv.org/src/${id}`;
-      const downloadedPath = await this.downloadFile(
-        downloadUrl,
-        downloadBasePath,
+      await this.fetchAndPlaceSource(
+        id,
+        paperDirRelative,
+        paperDirFull,
+        isRoot,
+        progressCallback,
       );
-
-      // Detect PDF-only submissions (no LaTeX source available)
-      if (hasExtension(downloadedPath, '.pdf')) {
-        await AbsoluteFS.delete(downloadedPath);
-        await this.cleanUpBestEffort(downloadDirFull, 'download dir', {
-          recursive: true,
-        });
-        // Only clean up the paper directory when it was created for this download
-        if (!isRoot) {
-          await this.cleanUpBestEffort(paperDirFull, 'paper dir', {
-            recursive: true,
-          });
-        }
-        throw new Error(PDF_ONLY_SUBMISSION_ERROR);
-      }
-
-      const isArchive =
-        hasExtension(downloadedPath, '.tar') ||
-        downloadedPath.endsWith('.tar.gz') ||
-        hasExtension(downloadedPath, '.tgz');
-      const isGzipOnly = !isArchive && hasExtension(downloadedPath, '.gz');
-
-      if (isArchive) {
-        progressCallback?.('Extracting source files...', 60);
-
-        const extractResult = await this.extractTarFile(
-          downloadedPath,
-          paperDirFull,
-          { timeout: 30000 },
-        );
-
-        if (!extractResult.success) {
-          throw new Error(
-            `Failed to extract arXiv source: ${extractResult.error}`,
-          );
-        }
-
-        progressCallback?.('Cleaning up...', 80);
-
-        // Remove the downloaded archive file
-        await AbsoluteFS.delete(downloadedPath);
-      } else {
-        // For gzip-compressed single files, decompress first
-        let sourceFilePath = downloadedPath;
-        if (isGzipOnly) {
-          progressCallback?.('Decompressing source file...', 60);
-          const decompressedPath = downloadedPath.replace(/\.gz$/, '');
-          await pipeline(
-            AbsoluteFS.createReadStream(downloadedPath),
-            createGunzip(),
-            AbsoluteFS.createWriteStream(decompressedPath),
-          );
-          await AbsoluteFS.delete(downloadedPath);
-          sourceFilePath = decompressedPath;
-        }
-
-        // Rename to main.tex and move to paper root
-        const downloadedRel = WorkspaceFS.relativePath(sourceFilePath);
-        // Use forward slashes to match WorkspaceFS.relativePath() convention
-        const targetRel = [paperDirRelative, 'main.tex'].join('/');
-        if (downloadedRel !== targetRel) {
-          await WorkspaceFS.rename(downloadedRel, targetRel);
-        }
-      }
-
-      // Remove the temporary download directory (files are now in paper root)
-      await this.cleanUpBestEffort(downloadDirFull, 'temporary download dir', {
-        recursive: true,
-      });
     }
 
     // Skip auto-indent for root destination to avoid reformatting existing workspace files
@@ -403,6 +312,150 @@ class ArxivSourceProcessor {
     logger.info(this.channel, `arXiv source downloaded to: ${paperDirFull}`);
 
     return { path: paperDirFull, alreadyExisted: !needsDownload };
+  }
+
+  /**
+   * Whether a previously-downloaded source already exists at the paper directory.
+   * Skipped for the workspace root, where stray .tex files would be a false
+   * positive.
+   */
+  private async hasExistingSource(
+    paperDirRelative: string,
+    isRoot: boolean,
+    paperDirFull: string,
+  ): Promise<boolean> {
+    if (isRoot || !(await WorkspaceFS.exists(paperDirRelative))) {
+      return false;
+    }
+    const entries = await WorkspaceFS.readDir(paperDirRelative);
+    const hasTexFiles = entries.some(([name]) => hasExtension(name, '.tex'));
+    if (hasTexFiles) {
+      logger.info(
+        this.channel,
+        `arXiv source already exists at: ${paperDirFull}`,
+      );
+    }
+    return hasTexFiles;
+  }
+
+  /**
+   * Download the arXiv source tarball into a unique staging directory, reject
+   * PDF-only submissions, place the source files into the paper root, then
+   * remove the staging directory.
+   */
+  private async fetchAndPlaceSource(
+    id: string,
+    paperDirRelative: string,
+    paperDirFull: string,
+    isRoot: boolean,
+    progressCallback: DownloadSourceOptions['progressCallback'],
+  ): Promise<void> {
+    await WorkspaceFS.ensureDir(paperDirRelative);
+
+    // Use a unique staging directory name to avoid clobbering an existing 'download/' folder at root
+    const stagingDirName = `.arxiv-download-${id.replaceAll('/', '_')}`;
+    const downloadDirRelative = path.join(paperDirRelative, stagingDirName);
+    await WorkspaceFS.ensureDir(downloadDirRelative);
+
+    const downloadDirFull = path.join(paperDirFull, stagingDirName);
+    const downloadBasePath = path.join(downloadDirFull, 'source');
+
+    progressCallback?.(`Downloading arXiv source for ${id}...`, 20);
+
+    const downloadUrl = `https://arxiv.org/src/${id}`;
+    const downloadedPath = await this.downloadFile(
+      downloadUrl,
+      downloadBasePath,
+    );
+
+    // Detect PDF-only submissions (no LaTeX source available)
+    if (hasExtension(downloadedPath, '.pdf')) {
+      await AbsoluteFS.delete(downloadedPath);
+      await this.cleanUpBestEffort(downloadDirFull, 'download dir', {
+        recursive: true,
+      });
+      // Only clean up the paper directory when it was created for this download
+      if (!isRoot) {
+        await this.cleanUpBestEffort(paperDirFull, 'paper dir', {
+          recursive: true,
+        });
+      }
+      throw new Error(PDF_ONLY_SUBMISSION_ERROR);
+    }
+
+    await this.placeSourceFiles(
+      downloadedPath,
+      paperDirRelative,
+      paperDirFull,
+      progressCallback,
+    );
+
+    // Remove the temporary download directory (files are now in paper root)
+    await this.cleanUpBestEffort(downloadDirFull, 'temporary download dir', {
+      recursive: true,
+    });
+  }
+
+  /**
+   * Place the downloaded source into the paper directory: extract a tar/tgz
+   * archive in place, or decompress (gzip) and rename a single source file to
+   * main.tex. Removes the downloaded artifact on success.
+   */
+  private async placeSourceFiles(
+    downloadedPath: string,
+    paperDirRelative: string,
+    paperDirFull: string,
+    progressCallback: DownloadSourceOptions['progressCallback'],
+  ): Promise<void> {
+    const isArchive =
+      hasExtension(downloadedPath, '.tar') ||
+      downloadedPath.endsWith('.tar.gz') ||
+      hasExtension(downloadedPath, '.tgz');
+    const isGzipOnly = !isArchive && hasExtension(downloadedPath, '.gz');
+
+    if (isArchive) {
+      progressCallback?.('Extracting source files...', 60);
+
+      const extractResult = await this.extractTarFile(
+        downloadedPath,
+        paperDirFull,
+        { timeout: 30000 },
+      );
+
+      if (!extractResult.success) {
+        throw new Error(
+          `Failed to extract arXiv source: ${extractResult.error}`,
+        );
+      }
+
+      progressCallback?.('Cleaning up...', 80);
+
+      // Remove the downloaded archive file
+      await AbsoluteFS.delete(downloadedPath);
+      return;
+    }
+
+    // For gzip-compressed single files, decompress first
+    let sourceFilePath = downloadedPath;
+    if (isGzipOnly) {
+      progressCallback?.('Decompressing source file...', 60);
+      const decompressedPath = downloadedPath.replace(/\.gz$/, '');
+      await pipeline(
+        AbsoluteFS.createReadStream(downloadedPath),
+        createGunzip(),
+        AbsoluteFS.createWriteStream(decompressedPath),
+      );
+      await AbsoluteFS.delete(downloadedPath);
+      sourceFilePath = decompressedPath;
+    }
+
+    // Rename to main.tex and move to paper root
+    const downloadedRel = WorkspaceFS.relativePath(sourceFilePath);
+    // Use forward slashes to match WorkspaceFS.relativePath() convention
+    const targetRel = [paperDirRelative, 'main.tex'].join('/');
+    if (downloadedRel !== targetRel) {
+      await WorkspaceFS.rename(downloadedRel, targetRel);
+    }
   }
 }
 

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -6,27 +6,56 @@ import { css, unsafeCSS, type CSSResult } from 'lit';
  * and the shared layout rules apply automatically.
  */
 
-/** Container class names (plural, used as the outer wrapper). */
-const CONTAINER_NAMES = [
-  'approval-requests',
-  'bash-approval-requests',
-  'retry-requests',
-  'workflow-proposals',
-  'plan-approval-requests',
-  'external-inquiry-requests',
-  'user-question-requests',
+/**
+ * Single source of truth for request panel types. Each entry pairs the outer
+ * container class (plural), the item class (singular, used for cards and BEM
+ * children), and the accent color used for the item's left border and its
+ * matching header icon. Add a panel type here and the shared layout, accent,
+ * and icon rules all follow — no parallel arrays to keep in sync.
+ */
+const PANEL_TYPES = [
+  {
+    container: 'approval-requests',
+    item: 'approval-request',
+    accent: 'var(--wa-color-text-normal)',
+  },
+  {
+    container: 'bash-approval-requests',
+    item: 'bash-approval-request',
+    accent: 'var(--wa-color-terminal-ansi-yellow)',
+  },
+  {
+    container: 'retry-requests',
+    item: 'retry-request',
+    accent: 'var(--color-warning)',
+  },
+  {
+    container: 'workflow-proposals',
+    item: 'workflow-proposal',
+    accent: 'var(--wa-color-text-link)',
+  },
+  {
+    container: 'plan-approval-requests',
+    item: 'plan-approval-request',
+    accent: 'var(--wa-color-text-link)',
+  },
+  {
+    container: 'external-inquiry-requests',
+    item: 'external-inquiry-request',
+    accent: 'var(--wa-color-focus)',
+  },
+  {
+    container: 'user-question-requests',
+    item: 'user-question-request',
+    accent: 'var(--wa-color-focus)',
+  },
 ] as const;
 
+/** Container class names (plural, used as the outer wrapper). */
+const CONTAINER_NAMES = PANEL_TYPES.map((p) => p.container);
+
 /** Item class names (singular, used for individual cards and BEM children). */
-const ITEM_NAMES = [
-  'approval-request',
-  'bash-approval-request',
-  'retry-request',
-  'workflow-proposal',
-  'plan-approval-request',
-  'external-inquiry-request',
-  'user-question-request',
-] as const;
+const ITEM_NAMES = PANEL_TYPES.map((p) => p.item);
 
 /** Build a :is()-ready selector group from class names with an optional BEM suffix. */
 function selectorGroup(
@@ -51,32 +80,17 @@ const SCROLLABLE_DETAILS = selectorGroup(
   '__details',
 );
 
-/**
- * Accent color per panel type. Drives both the item's left border and the
- * header icon color (which always match). Keyed by item class name so adding a
- * panel type is a single entry the type checker enforces.
- */
-const ACCENT_COLORS: Record<(typeof ITEM_NAMES)[number], string> = {
-  'approval-request': 'var(--wa-color-text-normal)',
-  'bash-approval-request': 'var(--wa-color-terminal-ansi-yellow)',
-  'retry-request': 'var(--color-warning)',
-  'workflow-proposal': 'var(--wa-color-text-link)',
-  'plan-approval-request': 'var(--wa-color-text-link)',
-  'external-inquiry-request': 'var(--wa-color-focus)',
-  'user-question-request': 'var(--wa-color-focus)',
-};
-
 /** Per-type accent rules: item left-border plus matching header icon color. */
 const ACCENT_RULES = unsafeCSS(
-  ITEM_NAMES.map((item, i) => {
-    const color = ACCENT_COLORS[item];
-    return `.${item} {
-    border-left: var(--border-medium) solid ${color};
+  PANEL_TYPES.map(
+    ({ item, container, accent }) =>
+      `.${item} {
+    border-left: var(--border-medium) solid ${accent};
   }
-  .${CONTAINER_NAMES[i]}__header wa-icon {
-    color: ${color};
-  }`;
-  }).join('\n  '),
+  .${container}__header wa-icon {
+    color: ${accent};
+  }`,
+  ).join('\n  '),
 );
 
 const sp = {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -2,8 +2,8 @@ import { css, unsafeCSS, type CSSResult } from 'lit';
 
 /**
  * Shared selector groups for :is() consolidation.
- * To add a new request panel type, add its class names to these two arrays
- * and the shared layout rules apply automatically.
+ * To add a new request panel type, add an entry to the PANEL_TYPES table below
+ * and the shared layout, accent, and icon rules all follow automatically.
  */
 
 /**
@@ -269,7 +269,7 @@ export const requestPanelStyles: CSSResult = css`
     white-space: nowrap;
   }
 
-  /* Type-specific item accent + matching header icon color (see ACCENT_COLORS) */
+  /* Type-specific item accent + matching header icon color (see PANEL_TYPES / ACCENT_RULES) */
   ${ACCENT_RULES}
 
   /* ================================================================

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -51,6 +51,34 @@ const SCROLLABLE_DETAILS = selectorGroup(
   '__details',
 );
 
+/**
+ * Accent color per panel type. Drives both the item's left border and the
+ * header icon color (which always match). Keyed by item class name so adding a
+ * panel type is a single entry the type checker enforces.
+ */
+const ACCENT_COLORS: Record<(typeof ITEM_NAMES)[number], string> = {
+  'approval-request': 'var(--wa-color-text-normal)',
+  'bash-approval-request': 'var(--wa-color-terminal-ansi-yellow)',
+  'retry-request': 'var(--color-warning)',
+  'workflow-proposal': 'var(--wa-color-text-link)',
+  'plan-approval-request': 'var(--wa-color-text-link)',
+  'external-inquiry-request': 'var(--wa-color-focus)',
+  'user-question-request': 'var(--wa-color-focus)',
+};
+
+/** Per-type accent rules: item left-border plus matching header icon color. */
+const ACCENT_RULES = unsafeCSS(
+  ITEM_NAMES.map((item, i) => {
+    const color = ACCENT_COLORS[item];
+    return `.${item} {
+    border-left: var(--border-medium) solid ${color};
+  }
+  .${CONTAINER_NAMES[i]}__header wa-icon {
+    color: ${color};
+  }`;
+  }).join('\n  '),
+);
+
 const sp = {
   tiny: unsafeCSS('var(--wa-space-3xs)'),
   small: unsafeCSS('var(--wa-space-2xs)'),
@@ -227,36 +255,12 @@ export const requestPanelStyles: CSSResult = css`
     white-space: nowrap;
   }
 
-  /* Type-specific item accent */
-  .approval-request {
-    border-left: var(--border-medium) solid var(--wa-color-text-normal);
-  }
-  .bash-approval-request {
-    border-left: var(--border-medium) solid var(--wa-color-terminal-ansi-yellow);
-  }
-  .retry-request {
-    border-left: var(--border-medium) solid var(--color-warning);
-  }
-  .workflow-proposal {
-    border-left: var(--border-medium) solid var(--wa-color-text-link);
-  }
-  .plan-approval-request {
-    border-left: var(--border-medium) solid var(--wa-color-text-link);
-  }
-  .external-inquiry-request {
-    border-left: var(--border-medium) solid var(--wa-color-focus);
-  }
-  .user-question-request {
-    border-left: var(--border-medium) solid var(--wa-color-focus);
-  }
+  /* Type-specific item accent + matching header icon color (see ACCENT_COLORS) */
+  ${ACCENT_RULES}
 
   /* ================================================================
    * Approval requests (tool edits)
    * ================================================================ */
-
-  .approval-requests__header wa-icon {
-    color: var(--wa-color-text-normal);
-  }
 
   .approval-request__path {
     font-family: var(--wa-font-family-mono);
@@ -344,10 +348,6 @@ export const requestPanelStyles: CSSResult = css`
    * Bash approval requests
    * ================================================================ */
 
-  .bash-approval-requests__header wa-icon {
-    color: var(--wa-color-terminal-ansi-yellow);
-  }
-
   .bash-approval-request__command {
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size-sm);
@@ -377,10 +377,6 @@ export const requestPanelStyles: CSSResult = css`
   /* ================================================================
    * Retry requests
    * ================================================================ */
-
-  .retry-requests__header wa-icon {
-    color: var(--color-warning);
-  }
 
   .retry-request__operation {
     font-family: var(--wa-font-family-mono);
@@ -448,10 +444,6 @@ export const requestPanelStyles: CSSResult = css`
   /* ================================================================
    * Workflow proposals
    * ================================================================ */
-
-  .workflow-proposals__header wa-icon {
-    color: var(--wa-color-text-link);
-  }
 
   .workflow-proposal__header-row {
     display: flex;
@@ -582,10 +574,6 @@ export const requestPanelStyles: CSSResult = css`
    * Plan approval requests
    * ================================================================ */
 
-  .plan-approval-requests__header wa-icon {
-    color: var(--wa-color-text-link);
-  }
-
   .plan-approval-request__objective {
     margin: ${sp.small} 0;
     color: var(--wa-color-text-normal);
@@ -608,10 +596,6 @@ export const requestPanelStyles: CSSResult = css`
   /* ================================================================
    * External inquiry requests
    * ================================================================ */
-
-  .external-inquiry-requests__header wa-icon {
-    color: var(--wa-color-focus);
-  }
 
   /* Carousel navigation for multiple external inquiries */
   .external-inquiry-requests__nav {
@@ -928,10 +912,6 @@ export const requestPanelStyles: CSSResult = css`
   /* ================================================================
    * User question requests
    * ================================================================ */
-
-  .user-question-requests__header wa-icon {
-    color: var(--wa-color-focus);
-  }
 
   .user-question-request__context {
     font-size: var(--font-size-sm);


### PR DESCRIPTION
## Summary

This PR refactors the arXiv source processor to improve code organization and maintainability, and consolidates duplicated accent color styling rules in the request panel styles.

**ArXiv processor changes:**
- Extract source existence check into `hasExistingSource()` method
- Extract download and placement logic into `fetchAndPlaceSource()` method
- Extract file placement logic (archive extraction, decompression, renaming) into `placeSourceFiles()` method
- Simplify workspace path validation

**Request panel styles changes:**
- Introduce `ACCENT_COLORS` record mapping item types to their accent colors
- Generate accent rules programmatically via `ACCENT_RULES` to avoid duplication
- Remove 7 redundant per-type header icon color rules that are now generated from the single source of truth

**Model handler changes:**
- Move `compactionRequested` flag to base `ModelHandler` class
- Implement `requestCompaction()` in base class instead of overriding in each subclass
- Extract shared input-token-based compaction threshold logic into `shouldCompactByInputTokens()` helper
- Update OpenAI, OpenRouter, and Anthropic handlers to use the shared implementation

## Issue acceptance gates

N/A — refactoring for code quality and maintainability.

## Single source of truth

- **ArXiv processor:** `ArxivSourceProcessor` now owns the complete download workflow through three focused private methods
- **Request panel styles:** `ACCENT_COLORS` record is the single source of truth for all accent color mappings
- **Model handler compaction:** Base `ModelHandler` class owns the compaction request flag and shared threshold logic

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated 7 redundant header icon color rules in request panel styles by generating them from `ACCENT_COLORS`
- Eliminated duplicate `compactionRequested` flag and `requestCompaction()` implementations across 3 model handler subclasses
- Eliminated duplicate input-token threshold logic across 3 model handler subclasses

**New abstractions:**
- `hasExistingSource()` - Encapsulates the logic for detecting previously-downloaded sources
- `fetchAndPlaceSource()` - Owns the complete download-to-placement workflow
- `placeSourceFiles()` - Owns archive extraction, decompression, and file placement
- `shouldCompactByInputTokens()` - Shared threshold check for input-token-based compaction

## Host impact

Extension: No functional changes; internal refactoring only.

Desktop: No functional changes; internal refactoring only.

CLI: No functional changes; internal refactoring only.

## Scheduled refactoring

None.

## Validation

- TypeScript compilation passes (no type errors introduced)
- No new tests required; refactoring preserves existing behavior
- Existing test suite covers the refactored methods

https://claude.ai/code/session_01NzdqGtV9XUQGSJKUAD847D

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactors across agent compaction, LaTeX download, and UI styles with no intended behavior changes; main residual risk is subtle compaction or styling regressions if shared logic diverged from the old copies.
> 
> **Overview**
> **Model handlers:** Moves the manual compaction flag and `requestCompaction()` into base `ModelHandler`, and adds shared `shouldCompactByInputTokens()` for tool-use threshold checks. OpenAI, OpenRouter native, and Anthropic drop duplicate fields/overrides and route `shouldCompact()` through the base helper (Anthropic still uses server-side compaction via the inherited flag).
> 
> **arXiv processor:** Splits the download flow into `hasExistingSource()`, `fetchAndPlaceSource()`, and `placeSourceFiles()` without changing the outward behavior of `downloadSource`.
> 
> **Request panel styles:** Replaces parallel container/item name lists and hand-written per-type border/icon rules with a single `PANEL_TYPES` table (container, item, accent) that drives selectors and generated `ACCENT_RULES`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed55f3fd6d5080f8c57c673ec7392cfc6273b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->