### PR TITLE
fix(cli): keep goal help local

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -42,7 +42,10 @@ import {
   type TranscriptViewportChange,
 } from '../src/chat/tui/state/transcriptViewportMode';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
-import { formatSlashCommandHelp } from '../src/chat/tui/commands/helpText';
+import {
+  formatSlashCommandHelp,
+  GOAL_MODE_HELP,
+} from '../src/chat/tui/commands/helpText';
 import {
   findSlashCommand,
   listSlashCommands,
@@ -1527,6 +1530,10 @@ function handleHarnessSlashCommand(line: string): boolean {
       return true;
     case 'status':
       appendHarnessStatus();
+      return true;
+    case 'goal':
+    case 'goals':
+      appendHarnessAssistantTranscript(GOAL_MODE_HELP);
       return true;
     case 'clear':
       resetHarnessForClear();

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -475,6 +475,32 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'slash-goal-help',
+    cols: 100,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/goal', '\r'],
+    frame: 'tail',
+    expect: [
+      'Goal mode starts from an approved plan',
+      'choose `r approve & run`',
+      'Goal mode auto-approves bash only',
+    ],
+    unexpect: ['Unknown command: /goal', 'running 1s'],
+  },
+  {
+    name: 'backslash-goal-help',
+    cols: 100,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['\\goal', '\r'],
+    frame: 'tail',
+    expect: [
+      'Goal mode starts from an approved plan',
+      'choose `r approve & run`',
+      'Goal mode auto-approves bash only',
+    ],
+    unexpect: ['Unknown command: /goal', 'running 1s'],
+  },
+  {
     name: 'slash-resume-empty',
     cols: 100,
     env: { HARNESS_ENTRIES: '4' },

--- a/packages/cli/src/chat/tui/commands/helpText.ts
+++ b/packages/cli/src/chat/tui/commands/helpText.ts
@@ -11,6 +11,15 @@ import { textInputEditingHelp } from '../input/textInputBindings';
 
 import type { SlashCommand, SlashCommandCategory } from './slashRegistry';
 
+export const GOAL_MODE_HELP = [
+  'Goal mode starts from an approved plan, not a standalone prompt.',
+  '',
+  'Ask the agent to create a plan, then choose `r approve & run` in the plan approval panel. ' +
+    'The active goal keeps the agent working across turns until it verifies completion, pauses, or you stop it.',
+  '',
+  'Use `/status` to inspect the active session. Goal mode auto-approves bash only; edits and other approvals still ask.',
+].join('\n');
+
 // Help sections in display order; `undefined` collects uncategorized
 // (plugin-style) registrations into a trailing "Other" section.
 const CATEGORY_SECTIONS: ReadonlyArray<{

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -326,6 +326,12 @@ export function registerBuiltinSlashCommands(options?: {
     category: 'session',
   });
   registerSlashCommand({
+    name: 'goal',
+    description: 'Explain autonomous goal mode',
+    aliases: ['goals'],
+    category: 'session',
+  });
+  registerSlashCommand({
     name: 'resume',
     description: 'Resume a previous session',
     category: 'session',

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -170,7 +170,7 @@ export function slashPickIntent(
 
 /**
  * Parse a `"/cmd remainder"` input into `{ name, remainder }`.
- * Also accepts `\clear` as a compatibility alias.
+ * Also accepts a small set of backslash compatibility aliases.
  * Returns `undefined` if `text` is not a slash command. Only command-shaped
  * tokens qualify: command names are plain identifiers (letters, digits, `_`,
  * `-`), so a leading token with any other character — `/Users/me/figure.pdf`,
@@ -185,6 +185,7 @@ export function parseSlashInput(
   if (!text.startsWith('/')) {
     const trimmed = text.trim();
     if (trimmed === '\\clear') return { name: 'clear', remainder: '' };
+    if (trimmed === '\\goal') return { name: 'goal', remainder: '' };
     return undefined;
   }
   const body = text.slice(1);

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -125,7 +125,7 @@ import {
   openCliSlashCommandForm,
   openRegisteredCliSlashForm,
 } from './commands/slashForms';
-import { formatSlashCommandHelp } from './commands/helpText';
+import { formatSlashCommandHelp, GOAL_MODE_HELP } from './commands/helpText';
 import {
   findSlashCommand,
   listSlashCommands,
@@ -947,6 +947,10 @@ async function handleTuiSlashCommand(
       );
       return true;
     }
+    case 'goal':
+    case 'goals':
+      appendLocalAssistantTranscript(GOAL_MODE_HELP);
+      return true;
     case 'resume': {
       if (!rest) {
         openCliSlashCommandForm('resume', rest);

--- a/src/test-kernel/cli/SlashHelpText.vitest.mts
+++ b/src/test-kernel/cli/SlashHelpText.vitest.mts
@@ -34,6 +34,9 @@ describe('formatSlashCommandHelp', () => {
     // Each command renders as its own markdown list item — single newlines
     // collapse in the transcript's markdown renderer, list items do not.
     expect(help).toContain('- `/clear` — Start a fresh chat session');
+    expect(help).toContain(
+      '- `/goal` (`/goals`) — Explain autonomous goal mode',
+    );
     expect(help).toContain('- `/exit` (`/quit`) — Exit the CLI session');
     expect(help).toContain('- `/model` (`/models`) — List available models');
   });

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -85,6 +85,7 @@ describe('slashRegistry', () => {
         'approval',
         'yolo',
         'status',
+        'goal',
         'resume',
         'memory',
         'skills',
@@ -671,6 +672,10 @@ describe('parseSlashInput', () => {
   it('accepts the historical clear spelling without treating TeX as commands', () => {
     expect(parseSlashInput('\\clear')).toEqual({
       name: 'clear',
+      remainder: '',
+    });
+    expect(parseSlashInput('\\goal')).toEqual({
+      name: 'goal',
       remainder: '',
     });
     expect(parseSlashInput('\\alpha + \\beta')).toBeUndefined();


### PR DESCRIPTION
## Summary

Fixes #6139.

Live CLI dogfood showed that goal mode was hard to discover from chat:

- `/help` did not list a goal-mode entry point.
- `/goal` returned an unknown-command message.
- `\goal` was treated as a normal user message and started a real agent turn with tool calls before being stopped.

This keeps the existing goal ownership intact: PlanTool still owns start/pause/complete and goal mode still starts from plan approval. The new `/goal` command only explains that path, and `\goal` maps to the same local help path like the existing `\clear` compatibility alias. Ordinary LaTeX input such as `\alpha + \beta` still reaches the agent.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/SlashHelpText.vitest.mts --reporter=dot`
- `corepack pnpm vitest run src/test-kernel/agent/GoalContinuation.vitest.ts src/test-kernel/agent/toolUse/ToolUseWaitNode.vitest.ts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts src/test-kernel/cli/PlanApproval.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/SlashHelpText.vitest.mts --reporter=dot`
- `npm run validate:tui -- slash-help slash-goal-help backslash-goal-help --snapshot-dir /private/tmp/texra-goal-command-snapshots`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- live PTY check with rebuilt `texra-local chat --api-mode included`: `/goal` shows local help; `/status` remains `not started` after goal help, confirming no model run was started.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI slash-command and help routing only; does not alter plan approval, goal execution, or agent tooling.
> 
> **Overview**
> Adds a **session** slash command **`/goal`** (alias **`/goals`**) so users can discover autonomous goal mode without starting an agent turn. **`/help`** now lists it under Session; submitting **`/goal`** or **`/goals`** appends shared **`GOAL_MODE_HELP`** text locally (plan approval via **`r approve & run`**, bash-only auto-approve, **`/status`**), matching **`/status`**-style local transcript output rather than unknown-command or model runs.
> 
> **`\goal`** is parsed as a backslash compatibility alias (like **`\clear`**) so mistyped input shows the same help instead of being sent as user message. Live chat TUI, TUI harness, unit tests, and **`validate-tui`** scenarios **`slash-goal-help`** / **`backslash-goal-help`** cover the behavior. Goal lifecycle remains unchanged—this is documentation-only routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d16587c2d94b77d1a2d7b69ff4aba5faa1d1354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->