### PR TITLE
refactor(cli): separate agent lookup and launch validation

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -20,6 +20,7 @@ import {
 } from '../runtime/runModel';
 import {
   TOOL_USE_AGENT_NAME_DESCRIPTION,
+  assertCliAgentLaunch,
   resolveCliAgent,
 } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
@@ -70,7 +71,11 @@ export async function runToolUseAgent(
   const instruction = await resolveToolUseInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
-  await resolveCliAgent(init.agent, 'agentsRun');
+  assertCliAgentLaunch(
+    init.agent,
+    await resolveCliAgent(init.agent, AgentCategory.ToolUse),
+    'agentsRun',
+  );
 
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -18,7 +18,7 @@ import {
   buildHeadlessRunContext,
   resolveCliRunModel,
 } from '../runtime/runModel';
-import { resolveCliAgent } from '../runtime/agents';
+import { assertCliAgentLaunch, resolveCliAgent } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
@@ -77,7 +77,11 @@ export async function runWorkflowAgent(
   await initLocalCliPlatform(context);
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
-  const agent = await resolveCliAgent(init.agent, 'run');
+  const agent = assertCliAgentLaunch(
+    init.agent,
+    await resolveCliAgent(init.agent, AgentCategory.Workflow),
+    'run',
+  );
   if (init.output && hasMixedStdinWorkflowInputSpecs(init.inputFiles)) {
     throw new CliUsageError(
       'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -110,46 +110,33 @@ export function assertCliAgentLaunch(
 }
 
 /**
- * Resolve a CLI launch target from the agent registry.
+ * Resolve a CLI-visible agent from the registry.
  *
  * CLI commands start with a local-only load so signed-out users avoid remote
  * auth/network work. Missing agents still get a remote-inclusive fallback, and
  * authenticated relay sessions reload bare names so the registry's normal
- * source priority can prefer remote definitions. Launching commands pass their
- * mode so lookup priority and category enforcement share the same target.
+ * source priority can prefer remote definitions. The optional category only
+ * selects the registry lookup priority; launch commands must validate the
+ * returned entry explicitly with assertCliAgentLaunch().
  */
-export function resolveCliAgent(name: string): Promise<AgentEntry | undefined>;
-export function resolveCliAgent(
-  name: string,
-  launchMode: CliAgentLaunchMode,
-): Promise<AgentEntry>;
 export async function resolveCliAgent(
   name: string,
-  launchMode?: CliAgentLaunchMode,
+  lookupCategory?: AgentCategory,
 ): Promise<AgentEntry | undefined> {
-  const lookupCategory = launchMode
-    ? CLI_AGENT_LAUNCH_TARGETS[launchMode].requiredCategory
-    : undefined;
   await loadAgents({ includeRemote: false });
   const agent = getAgent(name, lookupCategory);
 
   if (!agent) {
     await loadAgents();
-    const remoteAgent = getAgent(name, lookupCategory);
-    return launchMode
-      ? assertCliAgentLaunch(name, remoteAgent, launchMode)
-      : remoteAgent;
+    return getAgent(name, lookupCategory);
   }
 
   if (name.includes(':') || !(await getCliAuthProvider().isAuthenticated())) {
-    return launchMode ? assertCliAgentLaunch(name, agent, launchMode) : agent;
+    return agent;
   }
 
   await loadAgents();
-  const remotePriorityAgent = getAgent(name, lookupCategory);
-  return launchMode
-    ? assertCliAgentLaunch(name, remotePriorityAgent, launchMode)
-    : remotePriorityAgent;
+  return getAgent(name, lookupCategory);
 }
 
 export async function loadCliAgentList(

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -89,14 +89,16 @@ describe('CLI agent resolution', () => {
     expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
   });
 
-  it('uses launch mode category for authenticated remote-priority reloads', async () => {
+  it('uses lookup category for authenticated remote-priority reloads', async () => {
     const local = agent('lean');
     const remote = agent('lean', 'remote');
     mocks.authProvider.isAuthenticated.mockResolvedValue(true);
     mocks.getAgent.mockReturnValueOnce(local).mockReturnValueOnce(remote);
     const { resolveCliAgent } = await import('@cli/runtime/agents');
 
-    await expect(resolveCliAgent('lean', 'chat')).resolves.toBe(remote);
+    await expect(resolveCliAgent('lean', AgentCategory.ToolUse)).resolves.toBe(
+      remote,
+    );
 
     expect(mocks.getAgent).toHaveBeenNthCalledWith(
       1,
@@ -127,12 +129,14 @@ describe('CLI agent resolution', () => {
     expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
   });
 
-  it('uses launch mode category for local and remote-fallback lookups', async () => {
+  it('uses lookup category for local and remote-fallback lookups', async () => {
     const remote = agent('assistant', 'remote');
     mocks.getAgent.mockReturnValueOnce(undefined).mockReturnValueOnce(remote);
     const { resolveCliAgent } = await import('@cli/runtime/agents');
 
-    await expect(resolveCliAgent('assistant', 'chat')).resolves.toBe(remote);
+    await expect(
+      resolveCliAgent('assistant', AgentCategory.ToolUse),
+    ).resolves.toBe(remote);
 
     expect(mocks.getAgent).toHaveBeenNthCalledWith(
       1,
@@ -146,16 +150,15 @@ describe('CLI agent resolution', () => {
     );
   });
 
-  it('validates launch mode category before returning an agent', async () => {
+  it('validates launch mode category at the launch boundary', async () => {
     const workflow = agent(
       'correct',
       'builtInWorkflow',
       AgentCategory.Workflow,
     );
-    mocks.getAgent.mockReturnValue(workflow);
-    const { resolveCliAgent } = await import('@cli/runtime/agents');
+    const { assertCliAgentLaunch } = await import('@cli/runtime/agents');
 
-    await expect(resolveCliAgent('correct', 'chat')).rejects.toThrow(
+    expect(() => assertCliAgentLaunch('correct', workflow, 'chat')).toThrow(
       'Agent "correct" is a workflow agent; `texra chat` only handles tool-use agents.',
     );
   });

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -143,7 +143,10 @@ describe('CLI agents run command', () => {
     expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.resolveCliAgent.mock.invocationCallOrder[0],
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('chat', 'agentsRun');
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'chat',
+      AgentCategory.ToolUse,
+    );
     expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
       ['problem.md'],
       ['notes.md'],
@@ -193,11 +196,7 @@ describe('CLI agents run command', () => {
   });
 
   it('reports missing agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockRejectedValueOnce(
-      new Error(
-        'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
-      ),
-    );
+    mocks.resolveCliAgent.mockResolvedValueOnce(undefined);
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
 
     await expect(
@@ -217,18 +216,20 @@ describe('CLI agents run command', () => {
     );
     expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
       'missing-agent',
-      'agentsRun',
+      AgentCategory.ToolUse,
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports workflow agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockRejectedValueOnce(
-      new Error(
-        'Agent "polish" is a workflow agent; `texra agents run` only handles tool-use agents. Use `texra run polish` for workflow agents.',
-      ),
-    );
+    mocks.resolveCliAgent.mockResolvedValueOnce({
+      name: 'polish',
+      category: AgentCategory.Workflow,
+      source: 'builtInWorkflow',
+      path: '/agents/polish.yaml',
+      tools: [],
+    });
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
 
     await expect(
@@ -246,7 +247,10 @@ describe('CLI agents run command', () => {
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('polish', 'agentsRun');
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'polish',
+      AgentCategory.ToolUse,
+    );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -155,11 +155,7 @@ describe('CLI workflow run command', () => {
   });
 
   it('reports missing workflow agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockRejectedValueOnce(
-      new Error(
-        'Agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
-      ),
-    );
+    mocks.resolveCliAgent.mockResolvedValueOnce(undefined);
     const { runWorkflowAgent } = await import('@cli/commands/workflow');
 
     await expect(
@@ -177,17 +173,22 @@ describe('CLI workflow run command', () => {
     expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.resolveCliAgent.mock.invocationCallOrder[0],
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('missing-agent', 'run');
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'missing-agent',
+      AgentCategory.Workflow,
+    );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports tool-use agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockRejectedValueOnce(
-      new Error(
-        'Agent "chat" is a toolUse agent; `texra run` only handles workflow agents. Start it interactively with `texra chat --agent chat`, or run a headless team with `texra multi-agent run`.',
-      ),
-    );
+    mocks.resolveCliAgent.mockResolvedValueOnce({
+      name: 'chat',
+      category: AgentCategory.ToolUse,
+      source: 'builtInToolUse',
+      path: '/agents/chat.yaml',
+      tools: [],
+    });
     const { runWorkflowAgent } = await import('@cli/commands/workflow');
 
     await expect(
@@ -202,7 +203,10 @@ describe('CLI workflow run command', () => {
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('chat', 'run');
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'chat',
+      AgentCategory.Workflow,
+    );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
@@ -223,7 +227,10 @@ describe('CLI workflow run command', () => {
     );
 
     expect(mocks.initLocalCliPlatform).toHaveBeenCalled();
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith('polish', 'run');
+    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+      'polish',
+      AgentCategory.Workflow,
+    );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary\n- make resolveCliAgent a pure CLI-visible registry lookup helper with optional lookup category\n- move launch category validation to texra run / texra agents run command boundaries via assertCliAgentLaunch\n- update resolver and command tests so missing/mismatched agents exercise the real assertion path\n\n## Dogfood\n- texra-local run chat --input README.md --no-input --approval-policy never --output-format text\n- texra-local agents run polish --instruction "Check this proof." --no-input --approval-policy never --output-format text\n\n## Tests\n- corepack pnpm vitest run src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts --reporter=dot\n- npm run typecheck\n- npm run lint\n\nFixes #6141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of CLI agent resolution with unchanged user-facing error messages and fast-fail ordering preserved; risk is low unless other callers assumed `resolveCliAgent` threw on category mismatch.
> 
> **Overview**
> **`resolveCliAgent`** is now a registry-only helper: it takes an optional **`AgentCategory`** for lookup priority and always returns **`AgentEntry | undefined`**, without enforcing which CLI command may launch the agent.
> 
> **Launch rules** move to **`assertCliAgentLaunch`** at command boundaries. **`texra agents run`** and **`texra run`** resolve with the expected category (`ToolUse` / `Workflow`), then assert the matching launch mode (`agentsRun` / `run`) so missing agents and wrong-category agents still fail before model resolution.
> 
> Tests were updated so resolver specs cover lookup behavior and command specs mock **`resolveCliAgent`** return values and exercise the real assertion path for usage errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a18dfae31154b8069875c2d4001b270429788dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->