### PR TITLE
fix(agent): keep correct workflow from rewriting math

### DIFF
--- a/packages/extension/resources/agents/correct.yaml
+++ b/packages/extension/resources/agents/correct.yaml
@@ -10,13 +10,13 @@ settings:
 
 prompts:
   systemPrompt: |
-    You are a meticulous LaTeX proofreader. Your task is to correct typos, grammar, and formatting issues in a research paper while preserving the authors' intent and content.
+    You are a meticulous LaTeX proofreader. Your task is to correct typos, grammar, and formatting issues in a research paper while preserving the authors' intent and content. Do not rewrite mathematical content.
 
     When correcting a professional *.tex \LaTeX document, you must:
     {{ LATEX_STYLE_RULES }}
 
   userPrefix: |
-    I am going to give you a \LaTeX document of a research paper. You are about to correct the typos and mistakes in the document. So please read the document carefully.
+    I am going to give you a \LaTeX document of a research paper. You are about to correct typos, grammar, and formatting in the document. So please read the document carefully.
 
     Here is the \LaTeX document with input files (which may include appendix, and LaTeX auxiliary files that define the math commands you should use):
 
@@ -34,11 +34,13 @@ prompts:
     {% endif %}
 
   userRequest: |
-    Please carefully read through the entire document, looking for any typos, grammatical errors, formatting inconsistencies, incorrect math, or factual inaccuracies.
+    Please carefully read through the entire document, looking for typos, grammatical errors, and formatting inconsistencies that can be corrected without changing the paper's claims.
 
-    As you review the document, make the following corrections and improvements:
-    - Ensure that all mathematical equations are correct and all statements are factually accurate.
-    - Use consistent mathematical symbols and notations throughout the document.
+    As you review the document, make only proofreading corrections:
+    - Preserve every mathematical claim, equation, theorem statement, and factual assertion.
+    - Do not change math tokens inside inline math, display math, theorem statements, or derivations except for LaTeX syntax/formatting fixes such as spacing, delimiters, braces, or indentation.
+    - Do not replace a false or unsupported mathematical statement with a different true statement. For example, if the input says `(x+1)^2 = x^2 + 1`, keep that equation unchanged.
+    - Mathematical verification belongs to review-oriented agents; this agent only proofreads.
 
     Output one updated \LaTeX document for each input file, using the matching input filename as the document name.
 

--- a/src/test-kernel/agent/CorrectAgentPrompt.vitest.mts
+++ b/src/test-kernel/agent/CorrectAgentPrompt.vitest.mts
@@ -1,0 +1,56 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+import * as yaml from 'yaml';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+interface CorrectAgentYaml {
+  description: string;
+  prompts: {
+    systemPrompt: string;
+    userRequest: string;
+  };
+}
+
+function readCorrectAgent(): CorrectAgentYaml {
+  const text = readFileSync(
+    resolve(REPO_ROOT, 'packages/extension/resources/agents/correct.yaml'),
+    'utf8',
+  );
+  return yaml.parse(text) as CorrectAgentYaml;
+}
+
+describe('correct agent prompt', () => {
+  it('keeps proofreading scoped to local corrections', () => {
+    const agent = readCorrectAgent();
+    const promptText = `${agent.description}\n${agent.prompts.systemPrompt}\n${agent.prompts.userRequest}`;
+
+    expect(promptText).toContain(
+      'without changing your writing style or content',
+    );
+    expect(promptText).toContain('Do not rewrite mathematical content');
+    expect(promptText).toContain(
+      'Preserve every mathematical claim, equation, theorem statement, and factual assertion.',
+    );
+    expect(promptText).toContain(
+      'Do not replace a false or unsupported mathematical statement with a different true statement.',
+    );
+    expect(promptText).toContain(
+      'if the input says `(x+1)^2 = x^2 + 1`, keep that equation unchanged',
+    );
+    expect(promptText).toContain(
+      'Mathematical verification belongs to review-oriented agents',
+    );
+    expect(promptText).not.toContain(
+      'Ensure that all mathematical equations are correct',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- narrow the built-in `correct` workflow prompt to proofreading ownership
- explicitly preserve mathematical claims/equations and route substantive verification to review-oriented agents
- add a prompt guard test so the old "ensure all equations are correct" instruction does not drift back

## Dogfood
Initial run on a small LaTeX identity changed the false equation:

```tex
(x+1)^2 = x^2 + 1
```

into a different true identity:

```tex
(x-1)(x+1) = x^2 - 1
```

After the prompt change, running with an isolated fresh TeXRA home that loaded the updated bundled resource preserved the equation and only fixed prose/formatting.

Commands exercised:

```sh
texra-local run correct --input /private/tmp/texra-workflow-dogfood/main.tex --output /private/tmp/texra-workflow-dogfood/corrected.tex --instruction "Fix grammar and LaTeX formatting only. Do not silently change mathematical claims unless they are typographical." --model gemini35f --api-mode included --approval-policy never --no-input --output-format text
HOME=/private/tmp/texra-dogfood-home texra-local run correct --input /private/tmp/texra-workflow-dogfood/main.tex --output /private/tmp/texra-workflow-dogfood/corrected-isolated-home.tex --instruction "Fix grammar and LaTeX formatting only. Do not silently change mathematical claims unless they are typographical." --model gemini35f --api-mode included --approval-policy never --no-input --output-format text
```

Note: the isolated home was used because local `texra-local` dogfood preserves same-version copied built-in agents in global storage. The throwaway home avoided mutating the user's real built-in agent cache while validating the updated bundled resource.

## Tests
- `corepack pnpm vitest run src/test-kernel/agent/CorrectAgentPrompt.vitest.mts src/test-kernel/agent/runtime/agentLoad.vitest.ts --reporter=dot`
- `npm run typecheck`

Fixes #6147

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to a bundled workflow agent plus a regression test; no runtime logic or security-sensitive paths.
> 
> **Overview**
> The built-in **`correct`** workflow is reframed as **proofreading only**: it must not rewrite math or verify claims. The system and user prompts now say to preserve mathematical claims, equations, and factual assertions; allow only LaTeX syntax/formatting tweaks inside math; and **not** substitute a different true equation when the input is wrong (with an explicit `(x+1)^2 = x^2 + 1` example). Instructions that asked the model to ensure equations are correct, fix incorrect math, or enforce notation consistency are **removed**; substantive math review is deferred to review-oriented agents.
> 
> A new Vitest guard reads `correct.yaml` and asserts the proofreading constraints stay present and the old "ensure all equations are correct" wording does not return.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18c3bd1d440d650e42ce978a21bc547c579271ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->