### PR TITLE
fix(cli): keep workflow progress line alive

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -73,8 +73,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private rootStreamId: string | undefined;
   private rootStreamTerminal = false;
   private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
-  private activeProcessCount = 0;
-  private activeSubagentCount = 0;
 
   constructor(init: RunProgressRendererInit) {
     this.write = init.write ?? writeRawStderr;
@@ -93,6 +91,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         if (
           this.applyTaskState(payload as ProgressEventPayloads['setTaskState'])
         ) {
+          this.updateHeartbeat();
           this.render(true);
         }
         return true;
@@ -103,6 +102,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
             payload as ProgressEventPayloads['updateConversationProgress'],
           )
         ) {
+          this.updateHeartbeat();
           this.render();
         }
         return true;
@@ -135,8 +135,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
           if (this.rootStreamTerminal) {
             this.state.activeProcesses = undefined;
             this.state.activeSubagents = undefined;
-            this.activeProcessCount = 0;
-            this.activeSubagentCount = 0;
           }
           this.updateHeartbeat();
           this.render(true);
@@ -153,6 +151,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
           this.state.phase = (
             payload as ProgressEventPayloads['updateStreamDescription']
           ).description;
+          this.updateHeartbeat();
           this.render(true);
         }
         return true;
@@ -205,7 +204,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   ): void {
     if (!this.claimRootStream(payload.parentStreamId)) return;
 
-    this.activeProcessCount = payload.processes.length;
     this.state.activeProcesses = formatActiveChildren(
       'tool',
       payload.processes.map(
@@ -219,7 +217,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   ): void {
     if (!this.claimRootStream(payload.parentStreamId)) return;
 
-    this.activeSubagentCount = payload.children.length;
     this.state.activeSubagents = formatActiveChildren(
       'subagent',
       payload.children.map((child) => child.agentName),
@@ -253,7 +250,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 
   private updateHeartbeat(): void {
-    if (this.rootStreamTerminal || !this.hasActiveChildren()) {
+    if (this.rootStreamTerminal || !this.rootStreamId) {
       this.stopHeartbeat();
       return;
     }
@@ -269,10 +266,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     if (!this.heartbeatTimer) return;
     this.clearInterval(this.heartbeatTimer);
     this.heartbeatTimer = undefined;
-  }
-
-  private hasActiveChildren(): boolean {
-    return this.activeSubagentCount > 0 || this.activeProcessCount > 0;
   }
 
   private formatLine(now: number): string {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -132,6 +132,45 @@ describe('CLI run progress renderer', () => {
     expect(output.endsWith('\r\x1b[2K')).toBe(true);
   });
 
+  it('ticks the ANSI status line while a root workflow is quiet', () => {
+    let now = 0;
+    let output = '';
+    let heartbeat: (() => void) | undefined;
+    let clearCount = 0;
+    const renderer = createRunProgressRenderer(context(), {
+      colorEnabled: true,
+      write: (text) => {
+        output += text;
+      },
+      nowMs: () => now,
+      setInterval: ((callback: () => void) => {
+        heartbeat = callback;
+        return { unref() {} } as unknown as ReturnType<typeof setInterval>;
+      }) as unknown as typeof setInterval,
+      clearInterval: (() => {
+        clearCount += 1;
+      }) as typeof clearInterval,
+    });
+
+    renderer?.handle('setTaskState', workflowTaskState());
+
+    expect(heartbeat).toBeDefined();
+    now = 1000;
+    heartbeat?.();
+    now = 2300;
+    heartbeat?.();
+
+    expect(output).toContain('\r\x1b[2Kpolish paper.tex · 1s');
+    expect(output).toContain('\r\x1b[2Kpolish paper.tex · 2s');
+
+    renderer?.handle('updateStreamStatus', {
+      streamId: 'stream-1',
+      status: STREAM_STATUS.STOPPED,
+      previousStatus: STREAM_STATUS.RUNNING,
+    });
+    expect(clearCount).toBe(1);
+  });
+
   it('summarizes multi-input workflow progress without hiding extra files', () => {
     let output = '';
     const renderer = createRunProgressRenderer(


### PR DESCRIPTION
## Summary

Closes #6151.

Dogfood found that a headless `texra run correct` workflow could sit silent for several minutes during a quiet root workflow model call, even though the run was still alive and eventually completed successfully.

This keeps the existing headless run progress heartbeat active for any known, non-terminal root run in ANSI mode, not only while active child tools or subagents are present. It also removes the now-unneeded active-child counters from the renderer.

## Dogfood evidence

- Built the CLI bundle from current `origin/main`.
- `doctor --output-format json --no-color` passed.
- `agents list` and `multi-agent list/inspect mathematician` worked.
- Ran `correct` on a finite-integral-domain LaTeX proof; output preserved the math and fixed grammar, but the progress line was silent during a 5m56s wait.

## Test plan

- `corepack pnpm vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts --reporter=dot`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/runProgressRenderer.ts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only progress rendering and test changes; no auth, data, or execution logic affected.
> 
> **Overview**
> Fixes headless runs where the ANSI progress line went **silent for minutes** during a quiet root workflow model call even though the run was still active.
> 
> **`RunProgressRenderer`** now keeps the periodic heartbeat whenever a **non-terminal root stream** is known (after `setTaskState` / root claim), not only while active child tools or subagents are reported. Heartbeat setup is also triggered on more progress events (`setTaskState`, conversation progress, stream description). The old **`activeProcessCount` / `activeSubagentCount`** tracking and **`hasActiveChildren()`** gate are removed.
> 
> Adds a test that the status line **ticks elapsed time** on heartbeat while a root workflow is quiet, and **stops** the interval when the stream reaches a terminal status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fe027eeb5813c0c53b410218dfafb9efab77e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->