### PR TITLE
test(cli): refresh slash palette overflow expectation

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1018,7 +1018,7 @@ const SCENARIOS = [
       'Switch approval policy',
       '/status',
       'Show session details',
-      '… 5 more',
+      '… 6 more',
       'Esc close',
     ],
   },


### PR DESCRIPTION
## Summary

Closes #6154.

The full PTY-backed TUI harness found one stale assertion in `slash-palette-overflow`: the slash command registry now leaves 6 commands after the highlighted window, not 5. The captured frame is visually coherent, so this updates the harness expectation to match current UI state.

## Dogfood evidence

- Ran the full TUI screenshot harness on current `origin/main`.
- Initial result: 136/137 scenarios passed; only `slash-palette-overflow` failed.
- Captured frame showed `/approval`, `/status`, `/goal`, and `… 6 more`, matching the current command list.
- After the expectation update, the targeted scenario and the full 137-scenario harness passed.

## Test plan

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /private/tmp/texra-tui-frames-slash slash-palette-overflow`
- `corepack pnpm exec prettier --check packages/cli/scripts/validate-tui.mjs`
- `git diff --check`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /private/tmp/texra-tui-frames-current-fixed`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only expectation tweak with no production behavior changes.
> 
> **Overview**
> Updates the PTY TUI harness scenario **`slash-palette-overflow`** so the expected trailing overflow label is **`… 6 more`** instead of **`… 5 more`**, matching the slash command list after the registry grew by one entry.
> 
> No CLI or TUI runtime code changes—only the golden frame assertion in `validate-tui.mjs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06adc4f93ecc86f62aef8a519006d491cf1b6c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->