### PR TITLE
Replace emoji icons with Font Awesome icons in log entries

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -11,11 +11,20 @@ import {
 // Local imports - shared schemas
 import type { LogLevel } from '@shared/schemas';
 
-export const EMOJI_BY_LEVEL: Record<LogLevel, string> = {
-  error: '🔴',
-  warn: '🟡',
-  info: '🟢',
-  debug: '🔍',
+// Local imports - shared utilities
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
+
+/**
+ * Font Awesome icon name per log level, rendered via {@link waIcon}. Replaces
+ * the former emoji map so log levels use the same icon set as the rest of the
+ * UI; per-level color is applied through the `log-level-icon--{level}` classes
+ * in logEntryStyles.
+ */
+export const ICON_BY_LEVEL: Record<LogLevel, TeXRAIconName> = {
+  error: 'error',
+  warn: 'warning',
+  info: 'info',
+  debug: 'search',
 };
 
 // DateTimeFormat options for consistent timestamp formatting

--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -15,7 +15,7 @@ import type { LogLevel } from '@shared/schemas';
 import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 /**
- * Font Awesome icon name per log level, rendered via {@link waIcon}. Replaces
+ * Font Awesome icon name per log level, rendered via `waIcon`. Replaces
  * the former emoji map so log levels use the same icon set as the rest of the
  * UI; per-level color is applied through the `log-level-icon--{level}` classes
  * in logEntryStyles.

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -32,7 +32,8 @@ import {
   type FormatResult,
 } from './litTemplates';
 
-// Local imports - shared schemas
+// Local imports - shared utilities
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 type TemplateFormatterFn = (
   message: LogMessageData,
@@ -57,7 +58,7 @@ const NULLABLE_TYPES: Set<MessageType> = new Set([
 /** Create an error fallback template when formatting fails. */
 function formatRenderError(label: string, errorMsg: string): TemplateResult {
   // prettier-ignore
-  return html`<div class="log-line log-line--render-error"><span class="render-error-icon">⚠️</span><span class="render-error-text">Failed to render ${label}: ${errorMsg}</span></div>`;
+  return html`<div class="log-line log-line--render-error"><span class="render-error-icon">${waIcon('warning')}</span><span class="render-error-text">Failed to render ${label}: ${errorMsg}</span></div>`;
 }
 
 /** Wrap a formatter function with error handling for graceful degradation. */

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -32,7 +32,7 @@ import {
 // Local imports - formatter helpers
 import { stringifyWithLanguage } from '../parseUtils';
 import { formatTimestamp } from '../timestampUtils';
-import { EMOJI_BY_LEVEL } from '../constants';
+import { ICON_BY_LEVEL } from '../constants';
 import { registerCopyContent } from '../copyContentStore';
 
 /** Format user message entry as TemplateResult. */
@@ -55,14 +55,16 @@ export function formatProgressStatusTemplate(
 
   const summaryText = (text ?? '').trim() || 'Status update';
   const detailText = stringifyWithLanguage(data).text;
-  const emoji = EMOJI_BY_LEVEL[level] ?? '•';
+  const levelIcon = waIcon(ICON_BY_LEVEL[level], {
+    className: `log-level-icon log-level-icon--${level}`,
+  });
 
   // prettier-ignore
   return html`<div
       data-log-id=${ifDefined(id)}
       data-group-id=${ifDefined(groupId)}
       data-timestamp=${ifDefined(fullTimestamp)}
-    ><div class="log-line"><span class="timestamp" title=${tooltipTimestamp}>${emoji} [${timeDisplay}]</span> <span class=${`message-${level}`}>${summaryText}</span></div>${when(
+    ><div class="log-line"><span class="timestamp" title=${tooltipTimestamp}>${levelIcon} [${timeDisplay}]</span> <span class=${`message-${level}`}>${summaryText}</span></div>${when(
         detailText,
         () => html`<pre class=${`log-line message-${level}`}>${detailText}</pre>`,
       )}</div>`;
@@ -160,12 +162,16 @@ export function formatDefaultLogMessageTemplate(
   logMessage: LogMessageData,
 ): FormatResult {
   const { id, text, level, timestamp, groupId, verbose } = logMessage;
-  const emoji = EMOJI_BY_LEVEL[level] ?? '•';
+  const levelIcon = waIcon(ICON_BY_LEVEL[level], {
+    className: `log-level-icon log-level-icon--${level}`,
+  });
   const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
     new Date(timestamp),
   );
 
-  const timestampContent = verbose ? `${emoji} [${timeDisplay}]` : emoji;
+  const timestampContent = verbose
+    ? html`${levelIcon} [${timeDisplay}]`
+    : levelIcon;
 
   // prettier-ignore
   return html`<div

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -215,6 +215,30 @@ export const logEntryStyles = css`
     color: var(--color-text-secondary);
   }
 
+  /* Per-level log icons (replaces the former emoji map). Font Awesome glyphs
+     render in currentColor, so each level sets its own color to preserve the
+     at-a-glance severity coding the colored emoji used to carry. */
+  .log-level-icon {
+    font-size: var(--font-size-sm);
+    vertical-align: -0.1em;
+  }
+
+  .log-level-icon--error {
+    color: var(--color-error);
+  }
+
+  .log-level-icon--warn {
+    color: var(--color-warning);
+  }
+
+  .log-level-icon--info {
+    color: var(--color-success);
+  }
+
+  .log-level-icon--debug {
+    color: var(--color-text-secondary);
+  }
+
   /* Log level badges */
   :is(.level-debug, .level-info, .level-warn, .level-error) {
     font-weight: var(--font-weight-bold);

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -2,6 +2,7 @@
 
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import {
   LitElement,
   html,
@@ -15,6 +16,7 @@ import { classMap } from 'lit/directives/class-map.js';
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared schemas and events
 import {
@@ -265,10 +267,10 @@ export class AgentSelectionPanel extends LitElement {
         <span class="agent-list-item-name">${agent.name}</span>
         <span class="agent-list-item-badges">
           ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span title="Remote agent">☁</span>`
+            ? html`<span title="Remote agent">${waIcon('cloud')}</span>`
             : nothing}
           ${agent.source === AGENT_SOURCE.CUSTOM
-            ? html`<span title="Custom agent">★</span>`
+            ? html`<span title="Custom agent">${waIcon('star')}</span>`
             : nothing}
         </span>
       </div>
@@ -352,12 +354,12 @@ export class AgentSelectionPanel extends LitElement {
             : nothing}
           ${isCustom
             ? html`<wa-tag variant="neutral" size="small" title="Custom agent"
-                >★ Custom</wa-tag
+                >${waIcon('star')} Custom</wa-tag
               >`
             : nothing}
           ${agent.source === AGENT_SOURCE.REMOTE
             ? html`<wa-tag variant="neutral" size="small" title="Remote agent"
-                >☁ Remote</wa-tag
+                >${waIcon('cloud')} Remote</wa-tag
               >`
             : nothing}
         </div>

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -15,6 +15,7 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - shared utils
 import { createEvent } from '@shared/utils/events';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared schemas
 import {
@@ -325,7 +326,7 @@ export class MultiAgentTab extends LitElement {
                     title="${name} is the orchestrator for this team"
                   >
                     <span class="preset-orchestrator-icon" aria-hidden="true"
-                      >🎯</span
+                      >${waIcon('bullseye')}</span
                     >
                     ${name}
                   </wa-tag>

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -13,6 +13,7 @@ import { faBookmark } from '@fortawesome/free-solid-svg-icons/faBookmark';
 import { faBox } from '@fortawesome/free-solid-svg-icons/faBox';
 import { faBoxArchive } from '@fortawesome/free-solid-svg-icons/faBoxArchive';
 import { faBuilding } from '@fortawesome/free-solid-svg-icons/faBuilding';
+import { faBullseye } from '@fortawesome/free-solid-svg-icons/faBullseye';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
 import { faChartLine } from '@fortawesome/free-solid-svg-icons/faChartLine';
 import { faChartPie } from '@fortawesome/free-solid-svg-icons/faChartPie';
@@ -97,6 +98,7 @@ import { faScrewdriverWrench } from '@fortawesome/free-solid-svg-icons/faScrewdr
 import { faServer } from '@fortawesome/free-solid-svg-icons/faServer';
 import { faShield } from '@fortawesome/free-solid-svg-icons/faShield';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons/faSpinner';
+import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
 import { faTerminal } from '@fortawesome/free-solid-svg-icons/faTerminal';
 import { faThumbtack } from '@fortawesome/free-solid-svg-icons/faThumbtack';
 import { faThumbtackSlash } from '@fortawesome/free-solid-svg-icons/faThumbtackSlash';
@@ -153,6 +155,7 @@ const icons = {
   box: faBox,
   'box-archive': faBoxArchive,
   building: faBuilding,
+  bullseye: faBullseye,
   'caret-down': faCaretDown,
   'chart-line': faChartLine,
   'chart-pie': faChartPie,
@@ -237,6 +240,7 @@ const icons = {
   server: faServer,
   shield: faShield,
   spinner: faSpinner,
+  star: faStar,
   terminal: faTerminal,
   thumbtack: faThumbtack,
   'thumbtack-slash': faThumbtackSlash,


### PR DESCRIPTION
## Summary

Replaces emoji icons with Font Awesome icons throughout the log entry system and agent selection UI. This unifies the icon set across the application and enables consistent styling through CSS classes rather than relying on emoji color properties.

Changes include:
- Converting log level indicators (error, warn, info, debug) from colored emoji to Font Awesome icons with per-level CSS color classes
- Replacing emoji badges in agent selection (cloud, star, bullseye) with Font Awesome equivalents
- Updating the error fallback icon in log formatters
- Adding new Font Awesome icon imports (`star`, `bullseye`) to the icon registry

## Issue acceptance gates

N/A — This is a UI consistency improvement with no associated issue.

## Single source of truth

The icon registry in `src/shared/wa/webAwesomeIcons.ts` now owns the canonical mapping of icon names to Font Awesome glyphs. Log level icons are defined in `ICON_BY_LEVEL` constant in `packages/extension/src/progressView/frontend/formatters/constants.ts`, replacing the former `EMOJI_BY_LEVEL` map.

## Duplication and abstraction budget

Removed emoji duplication by consolidating to a single icon system. The `waIcon()` utility function now handles all icon rendering, eliminating ad-hoc emoji literals scattered throughout templates. Per-level color styling is centralized in `logEntryStyles.ts` via the `log-level-icon--{level}` CSS classes, replacing inline emoji color properties.

## Host impact

**Extension:** Log entries and agent selection UI now render Font Awesome icons instead of emoji. Visual appearance is preserved through CSS color classes that maintain the severity coding (red for error, yellow for warning, green for info, gray for debug).

**Desktop:** No changes.

**CLI:** No changes.

## Scheduled refactoring

None.

## Validation

- Existing CSS and template structure remains intact; only icon source changes
- Icon registry additions are straightforward Font Awesome imports
- No new dependencies introduced; uses existing `@fortawesome/free-solid-svg-icons` package
- Changes are isolated to UI rendering layer with no impact on data flow or business logic

https://claude.ai/code/session_01BLeB1EXjwDSrVZiz3wuMkM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in Lit templates and CSS; no data flow or API impact.
> 
> **Overview**
> Unifies progress log and settings UI on the shared **`waIcon`** / TeXRA icon registry instead of inline emoji.
> 
> **Progress logs:** `EMOJI_BY_LEVEL` becomes **`ICON_BY_LEVEL`** (`TeXRAIconName` per `LogLevel`). Default and progress-status formatters render level icons through `waIcon` with **`log-level-icon--{level}`** classes; **`logEntryStyles`** adds per-level colors so severity still reads like the old colored emoji. Render-error fallbacks use **`waIcon('warning')`** instead of ⚠️.
> 
> **Settings:** Agent list/detail badges (remote cloud, custom star) and multi-agent orchestrator pills swap ☁/★/🎯 for **`cloud`**, **`star`**, and **`bullseye`**; **`webAwesomeIcons`** registers **`faStar`** and **`faBullseye`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75090f910bd0c87d3326d1ef1444a19a6e8b31ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->