### PR TITLE
Replace emoji icons with WebAwesome icon components

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -33,8 +33,6 @@ import {
   type FormatResult,
 } from './litTemplates';
 
-// Local imports - shared utilities
-
 type TemplateFormatterFn = (
   message: LogMessageData,
   options?: { defaultOpen?: boolean },

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -57,6 +57,7 @@ export function formatProgressStatusTemplate(
   const detailText = stringifyWithLanguage(data).text;
   const levelIcon = waIcon(ICON_BY_LEVEL[level], {
     className: `log-level-icon log-level-icon--${level}`,
+    label: level === 'error' || level === 'warn' ? level : undefined,
   });
 
   // prettier-ignore
@@ -164,6 +165,7 @@ export function formatDefaultLogMessageTemplate(
   const { id, text, level, timestamp, groupId, verbose } = logMessage;
   const levelIcon = waIcon(ICON_BY_LEVEL[level], {
     className: `log-level-icon log-level-icon--${level}`,
+    label: level === 'error' || level === 'warn' ? level : undefined,
   });
   const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
     new Date(timestamp),


### PR DESCRIPTION
## Summary

Replace hardcoded emoji icons with WebAwesome icon library components throughout the extension. This change improves consistency, maintainability, and accessibility by using a centralized icon system instead of scattered emoji strings.

## Changes

- **Constants**: Renamed `EMOJI_BY_LEVEL` to `ICON_BY_LEVEL` and changed values from emoji strings to `TeXRAIconName` references (`'error'`, `'warning'`, `'info'`, `'circle-dot'`)
- **Log formatters**: Updated `formatProgressStatusTemplate()` and `formatDefaultLogMessageTemplate()` to use `waIcon()` helper instead of emoji strings
- **Error rendering**: Replaced warning emoji (⚠️) with `waIcon('warning')` in error fallback template
- **Multi-agent tab**: Replaced orchestrator emoji (🎯) with `<wa-icon name="compass">` component
- **Imports**: Added `waIcon` import from `@shared/wa/webAwesomeIcons` to support the new icon rendering

## Issue acceptance gates

N/A (refactoring/improvement)

## Single source of truth

Icon selection is now centralized in `ICON_BY_LEVEL` constant, with all log level icons resolved through the WebAwesome icon library.

## Duplication and abstraction budget

Removed scattered emoji literals and consolidated icon rendering through the `waIcon()` helper function, reducing duplication and improving maintainability.

## Host impact

**Extension**: Icon rendering now uses WebAwesome components instead of emoji, improving visual consistency and accessibility.

**Desktop**: No changes.

**CLI**: No changes.

## Scheduled refactoring

None

## Validation

- TypeScript compilation passes (type-safe icon names via `TeXRAIconName`)
- Changes are localized to UI rendering layers with no logic changes
- Icon mappings are straightforward string-to-string replacements

https://claude.ai/code/session_012GUq695PPBHvspb8gFcGVy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only accessibility tweak in log rendering with no logic or data-path changes.
> 
> **Overview**
> This diff tightens **log-level icon rendering** in the progress view formatters by passing an optional **`label`** into `waIcon()` for **error** and **warn** levels in `formatProgressStatusTemplate` and `formatDefaultLogMessageTemplate`, so those icons expose meaningful text to assistive tech. Info-level icons stay unlabeled. A no-op comment cleanup in the formatters barrel file is also included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02bd11c8be46d68fa2941d776daeaae4bfa2101b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->