### PR TITLE
Refactor round-keyed message schemas and remove legacy tool field

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -78,7 +78,15 @@ function wrapWithErrorHandling(
 function getToolUseRenderLabel(message: LogMessageData): string {
   const data = message.data;
   if (!isObject(data)) return 'tool use';
-  const toolName = typeof data.toolName === 'string' ? data.toolName : '';
+  // Reads the raw (unparsed) payload, so fall back to the legacy `tool` field
+  // — older persisted streams stored the name there — to keep error labels
+  // actionable. The main render path normalizes this via ToolUseLogSchema.
+  const toolName =
+    typeof data.toolName === 'string'
+      ? data.toolName
+      : typeof data.tool === 'string'
+        ? data.tool
+        : '';
   return toolName.trim() ? `tool use (${toolName.trim()})` : 'tool use';
 }
 

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -78,12 +78,7 @@ function wrapWithErrorHandling(
 function getToolUseRenderLabel(message: LogMessageData): string {
   const data = message.data;
   if (!isObject(data)) return 'tool use';
-  const toolName =
-    typeof data.toolName === 'string'
-      ? data.toolName
-      : typeof data.tool === 'string'
-        ? data.tool
-        : '';
+  const toolName = typeof data.toolName === 'string' ? data.toolName : '';
   return toolName.trim() ? `tool use (${toolName.trim()})` : 'tool use';
 }
 

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -42,7 +42,6 @@ const ToolUseStatusSchema = z.enum([
 
 export const ToolUseLogSchema = z.object({
   toolName: z.string().optional(),
-  tool: z.string().optional(),
   input: z.unknown().optional(),
   output: z.unknown().optional(),
   summary: z.string().optional(),

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -40,16 +40,26 @@ const ToolUseStatusSchema = z.enum([
   TOOL_USE_STATUS.COMPLETED,
 ]);
 
-export const ToolUseLogSchema = z.object({
-  toolName: z.string().optional(),
-  input: z.unknown().optional(),
-  output: z.unknown().optional(),
-  summary: z.string().optional(),
-  error: z.string().optional(),
-  isError: z.boolean().optional(),
-  userInstruction: z.string().optional(),
-  status: ToolUseStatusSchema.optional(),
-});
+export const ToolUseLogSchema = z
+  .object({
+    toolName: z.string().optional(),
+    input: z.unknown().optional(),
+    output: z.unknown().optional(),
+    summary: z.string().optional(),
+    error: z.string().optional(),
+    isError: z.boolean().optional(),
+    userInstruction: z.string().optional(),
+    status: ToolUseStatusSchema.optional(),
+    // Legacy persisted payloads stored the tool name under `tool` instead of
+    // `toolName`. Accept it on input and fold it into `toolName` here so
+    // resumed/replayed streams keep tool-specific headers, icons, and file
+    // links; downstream code (both hosts) reads the canonical `toolName` only.
+    tool: z.string().optional(),
+  })
+  .transform(({ tool, ...rest }) => ({
+    ...rest,
+    toolName: rest.toolName ?? tool,
+  }));
 export type ToolUseLog = z.infer<typeof ToolUseLogSchema>;
 
 const NormalizedToolUseSchema = z.object({

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -95,26 +95,36 @@ export const LogDeltaMessageSchema = z.object({
   updates: z.array(StreamLogEntrySchema).prefault([]),
 });
 
-export const UpdateFilesMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_FILES),
-  stream: StreamTabIdSchema,
-  rounds: z.record(z.string(), z.array(OutputFileInfoSchema)).optional(),
-  reset: z.boolean().optional(),
-});
+// Round-keyed update messages share one shape: a stream id, an optional
+// `rounds` record of per-round arrays, and an optional `reset` flag. The
+// generic `command`/element params keep each `command` literal distinct so the
+// outbound discriminated union still narrows.
+function RoundUpdateMessageSchema<C extends string, T extends z.ZodType>(
+  command: C,
+  elementSchema: T,
+) {
+  return z.object({
+    command: z.literal(command),
+    stream: StreamTabIdSchema,
+    rounds: z.record(z.string(), z.array(elementSchema)).optional(),
+    reset: z.boolean().optional(),
+  });
+}
 
-export const UpdateMissingOutputsMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_MISSING_OUTPUTS),
-  stream: StreamTabIdSchema,
-  rounds: z.record(z.string(), z.array(z.string())).optional(),
-  reset: z.boolean().optional(),
-});
+export const UpdateFilesMessageSchema = RoundUpdateMessageSchema(
+  PROGRESS_VIEW_COMMANDS.UPDATE_FILES,
+  OutputFileInfoSchema,
+);
 
-export const UpdateCompileFailuresMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_COMPILE_FAILURES),
-  stream: StreamTabIdSchema,
-  rounds: z.record(z.string(), z.array(CompileFailureSchema)).optional(),
-  reset: z.boolean().optional(),
-});
+export const UpdateMissingOutputsMessageSchema = RoundUpdateMessageSchema(
+  PROGRESS_VIEW_COMMANDS.UPDATE_MISSING_OUTPUTS,
+  z.string(),
+);
+
+export const UpdateCompileFailuresMessageSchema = RoundUpdateMessageSchema(
+  PROGRESS_VIEW_COMMANDS.UPDATE_COMPILE_FAILURES,
+  CompileFailureSchema,
+);
 
 export const UpdateTodosMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_TODOS),

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -67,7 +67,7 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
   const outputContent = extractOutputContent(validated.output);
   const outputText = formatOutputText(outputContent);
 
-  const toolName = trimmedOrNull(validated.toolName ?? validated.tool) ?? '';
+  const toolName = trimmedOrNull(validated.toolName) ?? '';
   const isUserFeedback = userInstructionText.length > 0;
 
   // Preserve unknown fields stripped by the schema for fallback rendering.

--- a/src/test-kernel/shared/NormalizeToolUse.vitest.ts
+++ b/src/test-kernel/shared/NormalizeToolUse.vitest.ts
@@ -74,6 +74,27 @@ describe('normalizeToolUseData', () => {
     expect(normalized?.headerSummary).toBe('no such file');
   });
 
+  // Backward compat: streams persisted by older versions stored the tool name
+  // under the legacy `tool` key. `ToolUseLogSchema` folds it into `toolName` so
+  // resumed/replayed cards keep tool-specific headers, icons, and file links.
+  it('reads the legacy `tool` field when `toolName` is absent', () => {
+    const normalized = normalizeToolUseData({
+      tool: 'Bash',
+      input: { command: 'ls' },
+      status: 'completed',
+    });
+    expect(normalized?.toolName).toBe('Bash');
+  });
+
+  it('prefers `toolName` over the legacy `tool` field', () => {
+    const normalized = normalizeToolUseData({
+      toolName: 'Edit',
+      tool: 'Bash',
+      status: 'completed',
+    });
+    expect(normalized?.toolName).toBe('Edit');
+  });
+
   it('treats userInstruction as a feedback marker', () => {
     const normalized = normalizeToolUseData({
       toolName: 'AskUserQuestion',


### PR DESCRIPTION
## Summary

This PR consolidates three similar message schemas (`UpdateFilesMessage`, `UpdateMissingOutputsMessage`, `UpdateCompileFailuresMessage`) into a single reusable factory function, eliminating duplication. It also standardizes tool-use log normalization on the `toolName` field while preserving backward compatibility with the legacy `tool` field at the schema boundary.

## Issue acceptance gates

N/A

## Single source of truth

- **`RoundUpdateMessageSchema` factory function** in `src/shared/schemas/progressView/outbound.ts` now owns the shape of all round-keyed update messages (stream id, optional rounds record, optional reset flag).
- **`ToolUseLogSchema`** in `src/shared/schemas/progressView/data.ts` is the single source of truth for tool use log structure. It accepts the legacy `tool` field on input and folds it into the canonical `toolName` via a `.transform()`, so downstream code reads only `toolName`.

## Duplication and abstraction budget

**Removed duplication:**
- Three nearly-identical message schemas (`UpdateFilesMessageSchema`, `UpdateMissingOutputsMessageSchema`, `UpdateCompileFailuresMessageSchema`) were replaced with calls to a generic `RoundUpdateMessageSchema` factory.
- The factory captures the invariant: all three messages share the same structure (command literal, stream id, optional rounds record keyed by string with per-round arrays, optional reset flag), differing only in the element type within each round&#39;s array.

**Normalization (legacy handled at the entry point):**
- Legacy `tool` handling is centralized in `ToolUseLogSchema` via a `.transform()` that folds `tool` into `toolName`. As a result, `normalizeToolUseData` reads only `validated.toolName` — no scattered consumer fallback — while older persisted streams that stored only `tool` still resolve the correct tool name (and thus tool-specific headers, icons, and file links) on resume/replay.
- `getToolUseRenderLabel` reads the raw, unparsed `message.data` for formatter error labels, so it intentionally **retains** a documented `tool` fallback for replaying old streams. (Only a clarifying comment was added here; the fallback itself is kept.)

## Host impact

**Extension:** No functional change; schemas are internal to message validation.

**Desktop:** No functional change; schemas are internal to message validation.

**CLI:** No functional change; schemas are internal to message validation.

## Scheduled refactoring

None

## Validation

- Existing Zod schema tests pass (schemas remain functionally equivalent).
- Type inference from the factory function maintains discriminated union narrowing for the outbound message union.
- Backward compatibility for the legacy `tool` field is covered by new Vitest cases (legacy-only and `toolName`-precedence); `normalizeToolUseData` resolves the tool name via the schema transform, so consumers reference only `toolName`.

https://claude.ai/code/session_016gcjHhkNhApEhffStYHAwb


---


&gt; [!NOTE]
&gt; **Low Risk**
&gt; Schema refactors and backward-compat normalization for progress-view IPC and persisted tool-use logs; no auth or data-mutation paths.
&gt; 
&gt; **Overview**
&gt; Introduces **`RoundUpdateMessageSchema`** so `UpdateFiles`, `UpdateMissingOutputs`, and `UpdateCompileFailures` outbound messages share one Zod shape (stream, optional per-round arrays, optional `reset`) while keeping distinct `command` literals for the discriminated union.
&gt; 
&gt; **`ToolUseLogSchema`** now accepts legacy persisted **`tool`** and **transforms** it into canonical **`toolName`** on parse; **`normalizeToolUseData`** only reads `toolName` after validation. Vitest covers legacy-only and `toolName`-wins cases.
&gt; 
&gt; The extension **`getToolUseRenderLabel`** still falls back to raw **`tool`** on unparsed log payloads so formatter error labels stay actionable when replaying old streams.
&gt; 
&gt; &lt;sup&gt;Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b7cd171ad90068bdeb6a0462d10ff80cdb3c7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).&lt;/sup&gt;
