### PR TITLE
Refactor schema parsing and normalize tool name handling

### DIFF
--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -162,7 +162,10 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
     return this.executionId;
   }
 
-  private async readParsed<T>(key: string, schema: z.ZodType<T>): Promise<T | null> {
+  private async readParsed<T>(
+    key: string,
+    schema: z.ZodType<T>,
+  ): Promise<T | null> {
     const raw = await this.read(key);
     if (!raw) return null;
     const result = schema.safeParse(raw);

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -162,20 +162,21 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
     return this.executionId;
   }
 
-  // -- Typed readers --------------------------------------------------------
-
-  async readMeta(): Promise<ExecutionMeta | null> {
-    const raw = await this.read(KEYS.META);
+  private async readParsed<T>(key: string, schema: z.ZodType<T>): Promise<T | null> {
+    const raw = await this.read(key);
     if (!raw) return null;
-    const result = ExecutionMetaSchema.safeParse(raw);
+    const result = schema.safeParse(raw);
     return result.success ? result.data : null;
   }
 
+  // -- Typed readers --------------------------------------------------------
+
+  async readMeta(): Promise<ExecutionMeta | null> {
+    return this.readParsed(KEYS.META, ExecutionMetaSchema);
+  }
+
   async readConfig(): Promise<AgentConfig | null> {
-    const raw = await this.read(KEYS.CONFIG);
-    if (!raw) return null;
-    const result = AgentConfigSchema.safeParse(raw);
-    return result.success ? result.data : null;
+    return this.readParsed(KEYS.CONFIG, AgentConfigSchema);
   }
 
   async readReport(): Promise<string | null> {
@@ -201,25 +202,19 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   /** Read children: per-child KV keys with schema validation. */
   async readChildren(): Promise<ChildRecord[]> {
     const childKeys = await this.listKeys('child-');
-
     if (childKeys.length === 0) return [];
-
     const entries = await Promise.all(
       childKeys.map(async (key) => {
         const id = key.replace('child-', '') as ExecutionId;
-        const raw = await this.read(key);
-        const result = ChildRecordDataSchema.safeParse(raw);
-        return result.success ? { id, ...result.data } : null;
+        const data = await this.readParsed(key, ChildRecordDataSchema);
+        return data ? { id, ...data } : null;
       }),
     );
     return entries.filter(filterNotNull);
   }
 
   async readResultMeta(): Promise<ResultMeta | null> {
-    const raw = await this.read(KEYS.RESULT_META);
-    if (!raw) return null;
-    const result = ResultMetaSchema.safeParse(raw);
-    return result.success ? result.data : null;
+    return this.readParsed(KEYS.RESULT_META, ResultMetaSchema);
   }
 
   // -- Typed writers --------------------------------------------------------

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -40,17 +40,22 @@ const ToolUseStatusSchema = z.enum([
   TOOL_USE_STATUS.COMPLETED,
 ]);
 
-export const ToolUseLogSchema = z.object({
-  toolName: z.string().optional(),
-  tool: z.string().optional(),
-  input: z.unknown().optional(),
-  output: z.unknown().optional(),
-  summary: z.string().optional(),
-  error: z.string().optional(),
-  isError: z.boolean().optional(),
-  userInstruction: z.string().optional(),
-  status: ToolUseStatusSchema.optional(),
-});
+export const ToolUseLogSchema = z
+  .object({
+    toolName: z.string().optional(),
+    tool: z.string().optional(), // legacy alias — normalized to toolName at parse time
+    input: z.unknown().optional(),
+    output: z.unknown().optional(),
+    summary: z.string().optional(),
+    error: z.string().optional(),
+    isError: z.boolean().optional(),
+    userInstruction: z.string().optional(),
+    status: ToolUseStatusSchema.optional(),
+  })
+  .transform(({ tool, toolName, ...rest }) => ({
+    ...rest,
+    toolName: toolName ?? tool,
+  }));
 export type ToolUseLog = z.infer<typeof ToolUseLogSchema>;
 
 const NormalizedToolUseSchema = z.object({

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -67,7 +67,7 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
   const outputContent = extractOutputContent(validated.output);
   const outputText = formatOutputText(outputContent);
 
-  const toolName = trimmedOrNull(validated.toolName ?? validated.tool) ?? '';
+  const toolName = trimmedOrNull(validated.toolName) ?? '';
   const isUserFeedback = userInstructionText.length > 0;
 
   // Preserve unknown fields stripped by the schema for fallback rendering.

--- a/src/test-kernel/shared/NormalizeToolUse.vitest.ts
+++ b/src/test-kernel/shared/NormalizeToolUse.vitest.ts
@@ -74,6 +74,26 @@ describe('normalizeToolUseData', () => {
     expect(normalized?.headerSummary).toBe('no such file');
   });
 
+  it('normalizes legacy `tool` alias to `toolName`', () => {
+    const normalized = normalizeToolUseData({
+      tool: 'Bash',
+      input: { command: 'ls' },
+      output: 'foo\nbar',
+      status: 'completed',
+    });
+    expect(normalized?.toolName).toBe('Bash');
+    expect(normalized?.outputText).toBe('foo\nbar');
+  });
+
+  it('prefers `toolName` over `tool` when both are present', () => {
+    const normalized = normalizeToolUseData({
+      toolName: 'Bash',
+      tool: 'LegacyName',
+      input: {},
+    });
+    expect(normalized?.toolName).toBe('Bash');
+  });
+
   it('treats userInstruction as a feedback marker', () => {
     const normalized = normalizeToolUseData({
       toolName: 'AskUserQuestion',


### PR DESCRIPTION
## Summary

This PR consolidates repeated schema parsing logic and improves tool name normalization by moving the `tool` → `toolName` alias resolution into the Zod schema layer.

**Changes:**
1. **ExecutionKVStore**: Extract common `readParsed<T>()` helper to eliminate duplication across `readMeta()`, `readConfig()`, `readChildren()`, and `readResultMeta()`.
2. **ToolUseLogSchema**: Add `.transform()` to normalize the legacy `tool` field to `toolName` at parse time, ensuring downstream code always sees a consistent shape.
3. **normalizeToolUseData()**: Simplify to rely on schema-level normalization; remove fallback to `validated.tool` since the schema now guarantees `toolName` is set.

## Issue acceptance gates

N/A — internal refactoring with no user-facing changes.

## Single source of truth

- **ToolUseLogSchema** now owns the normalization rule: `tool` (legacy) → `toolName` (canonical). All consumers receive the normalized form.
- **StorageFSKVStore.readParsed()** is the single point for schema validation across all typed readers.

## Duplication and abstraction budget

**Removed duplication:**
- 4 identical `read()` + `safeParse()` + null-check patterns consolidated into `readParsed<T>()`.
- Eliminated redundant `tool` fallback logic in `normalizeToolUseData()` by moving it to the schema.

**Abstraction invariant:**
- `readParsed<T>()` owns the contract: "read a key, parse it with a schema, return the typed result or null."
- `ToolUseLogSchema.transform()` owns the contract: "normalize legacy `tool` field to `toolName` at parse time."

## Host impact

Extension: No user-facing changes; internal refactoring.

Desktop: No user-facing changes; internal refactoring.

CLI: No user-facing changes; internal refactoring.

## Scheduled refactoring

None.

## Validation

- No new tests added; changes are refactoring-only with equivalent behavior.
- Existing schema and storage tests should pass without modification.
- Type inference via `z.infer<typeof ToolUseLogSchema>` ensures `toolName` is always present (never `tool`).

https://claude.ai/code/session_014nwfXgEo2mvNTLzfXoEd29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with equivalent behavior; legacy tool-name handling is covered by new tests and does not touch auth or persistence contracts beyond existing Zod validation.
> 
> **Overview**
> **ExecutionKVStore** adds a private `readParsed<T>()` helper so typed readers (`readMeta`, `readConfig`, `readChildren`, `readResultMeta`) no longer repeat read → `safeParse` → null-on-failure.
> 
> **ToolUseLogSchema** now uses a `.transform()` to map the legacy `tool` field onto canonical `toolName` (`toolName` wins when both are set). **`normalizeToolUseData()`** drops its `validated.tool` fallback and relies on that parsed shape.
> 
> Vitest coverage adds cases for legacy `tool` only and for `toolName` vs `tool` precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e29fbb9f4435541626f91aa493c398717060ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->