### PR TITLE
refactor(trace): drop dead utilizationPercent from trace ContextStateData

### DIFF
--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -35,7 +35,6 @@ export interface TokenUsageStats {
 export interface ContextStateData {
   readonly inputTokens: number;
   readonly contextWindow: number;
-  readonly utilizationPercent: number;
 }
 
 /**

--- a/src/agent/trace/helpers.ts
+++ b/src/agent/trace/helpers.ts
@@ -194,8 +194,6 @@ export function logContextStateSnapshot(
     {
       inputTokens,
       contextWindow,
-      utilizationPercent:
-        contextWindow > 0 ? (inputTokens / contextWindow) * 100 : 0,
     },
     { stageId },
   );


### PR DESCRIPTION
## What

The trace-layer `ContextStateData` interface (`src/agent/trace/events.ts`) declared a required `utilizationPercent` field, but it was dead:

- `TraceEmitter.contextState()` emits only `inputTokens`/`contextWindow` - the resulting `ContextStateEvent` has no `utilizationPercent` field at all.
- The value computed in `logContextStateSnapshot()` (`helpers.ts`) was therefore dropped on emit and **recomputed** downstream in `TexraTranscriptRecorder` from the event's tokens.

So the field was computed, discarded, then recomputed. This removes it from the trace interface and its producer.

## Why it's safe

- The single producer is `logContextStateSnapshot()`; its single caller (`CommonCycleTypes.ts`) passes only tokens.
- The single consumer (`TraceEmitter.contextState()`) never read it.
- `TexraTranscriptRecorder` already derives the percentage itself - unchanged.

## Not touched

The **distinct** Zod-derived `ContextStateData` in `src/shared/schemas/contextManagement.ts` keeps `utilizationPercent` - that one is genuinely live (rendered in `UsagePanel`). Different type, left alone.

## Verification

- `npx tsc --noEmit` - no new errors in the changed files or their consumers.

Found via a multi-agent data-structure complexity audit, adversarially verified.