### PR TITLE
Extract agent creator flow to core module with UI injection

### DIFF
--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -1,272 +1,43 @@
 import * as path from 'node:path';
 
 import * as vscode from 'vscode';
-import * as nunjucks from 'nunjucks';
 import * as yaml from 'yaml';
-import { z } from 'zod';
 
-import { Node, Flow } from '@agent/node';
-import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import {
-  AgentWorkflowSettingSchema,
-  AgentToolUseSettingSchema,
-  AgentPromptSchema,
-} from '@agent/core/definition/AgentDataclass';
-import { createHelperModelKit } from '@agent/runtime/helperModel';
-import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
-import { renderAgentTemplateString } from '@commands/agent/agentTemplateRenderer';
+  type AgentCategory,
+  type AgentCreatorUI,
+  type CreatorConfig,
+  TOOL_GROUPS,
+  createAgentCreatorFlow,
+} from '@agent/implementations/flows/agentCreator/agentCreatorFlow';
 import { agentDirectories, promptToAddAgentToConfig } from '@frontend/agents';
 import {
   showLoggedErrorMessage,
-  toErrorMessage,
 } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
-import { isNonEmptyString } from '@utils/core/stringCore';
-import { extractTextFromTag } from '@utils/text/xmlExtraction';
+
+import { renderAgentTemplateString } from './agentTemplateRenderer';
 
 const CHANNEL = 'AgentCreator';
 logger.initialize(CHANNEL);
-
-// ── Types & constants ───────────────────────────────────────
-
-type AgentCategory = 'workflow' | 'toolUse';
-
-/** Total AI generation attempts (1 initial + 1 validation retry) before template fallback. */
-const AI_GENERATION_ATTEMPTS = 2;
-
-interface AgentPromptPair {
-  systemPrompt: string;
-  userRequest: string;
-}
-
-interface CreatorConfig {
-  workflow: AgentPromptPair;
-  toolUse: AgentPromptPair;
-  retryPrompts: Record<AgentCategory, string>;
-  templates: {
-    workflowSingle: string;
-    toolUse: string;
-  };
-}
-
-interface AgentBlueprint {
-  category: AgentCategory;
-  agentName: string;
-  filePath: vscode.Uri;
-  aiVars: Record<string, string>;
-  fallbackTemplate: string;
-  fallbackVars: Record<string, string>;
-}
-
-/** Mutable shared state flowing through the agent creation flow. */
-interface AgentCreatorShared {
-  config: CreatorConfig;
-  category: AgentCategory;
-  agentName?: string;
-  description?: string;
-  blueprint?: AgentBlueprint;
-  yamlContent?: string;
-}
-
-/** Tool-use agents only receive the user instruction — they access files via tools. */
-const TOOL_USE_VARS = ['INSTRUCTION'];
-
-/** Workflow agents receive pre-loaded file content and document structure variables. */
-const WORKFLOW_VARS = [
-  'INPUT_FILE',
-  'INPUT_CONTENT',
-  'INPUT_FILES',
-  'ALL_INPUTS',
-  'ALL_CONTEXTS',
-  'LIST_OF_ALL_CONTEXTS',
-  'ADDITIONAL_INPUTS',
-  'INSTRUCTION',
-  'OUTPUT_FILES',
-];
-
-function buildPassthrough(vars: string[]): Record<string, string> {
-  return Object.fromEntries(vars.map((v) => [v, `{{ ${v} }}`]));
-}
-
-const PASSTHROUGH: Record<AgentCategory, Record<string, string>> = {
-  toolUse: buildPassthrough(TOOL_USE_VARS),
-  workflow: buildPassthrough(WORKFLOW_VARS),
-};
-
-const DESCRIPTION_PROMPTS: Record<AgentCategory, string> = {
-  toolUse:
-    'What should this agent do? Mention capabilities it needs (e.g., search papers, edit files, browse the web)',
-  workflow:
-    'What should this agent do? Mention whether it rewrites existing documents or creates new ones',
-};
-
-interface ToolGroup {
-  description: string;
-  tools: string[];
-  keywords: string[];
-}
-
-const TOOL_GROUPS: Record<string, ToolGroup> = {
-  'File Operations': {
-    description: 'Read, write, edit, search files and run shell commands',
-    tools: [
-      'bash',
-      'read_file',
-      'write_file',
-      'edit_file',
-      'glob',
-      'grep',
-      'ls',
-    ],
-    keywords: ['file', 'edit', 'code', 'write', 'read', 'script', 'shell'],
-  },
-  'Web & Search': {
-    description: 'Search the web and fetch page content',
-    tools: ['web_search', 'web_fetch'],
-    keywords: ['web', 'search', 'internet', 'online', 'url', 'fetch', 'browse'],
-  },
-  'Academic Research': {
-    description: 'Search arXiv, CrossRef, and download papers',
-    tools: [
-      'arxiv_search',
-      'arxiv_metadata',
-      'download_arxiv_source',
-      'crossref_search',
-      'crossref_doi',
-    ],
-    keywords: [
-      'arxiv',
-      'paper',
-      'research',
-      'literature',
-      'review',
-      'survey',
-      'cite',
-      'doi',
-      'journal',
-    ],
-  },
-  'LaTeX Processing': {
-    description: 'Extract figures, bibliography, TikZ, and count words',
-    tools: [
-      'extract_figures',
-      'extract_bib_entries',
-      'extract_tikz_figures',
-      'texcount',
-    ],
-    keywords: [
-      'latex',
-      'figure',
-      'tikz',
-      'bibliography',
-      'bib',
-      'word count',
-      'extract',
-    ],
-  },
-  'Citation Management': {
-    description: 'Manage references with Zotero',
-    tools: ['zotero_add', 'zotero_search', 'zotero_export'],
-    keywords: ['zotero', 'citation', 'reference', 'bibliography', 'endnote'],
-  },
-  Computation: {
-    description: 'Mathematical computation with Wolfram Alpha',
-    tools: ['wolfram'],
-    keywords: [
-      'math',
-      'compute',
-      'calculate',
-      'wolfram',
-      'symbolic',
-      'equation',
-    ],
-  },
-  'Agent Delegation': {
-    description: 'Delegate tasks to other agents and manage executions',
-    tools: [
-      'delegate_workflow',
-      'delegate_agent',
-      'executions',
-      'accept_run_files',
-    ],
-    keywords: ['delegate', 'orchestrat', 'pipeline', 'multi-agent', 'chain'],
-  },
-  'Lean 4': {
-    description: 'Lean 4 proof assistant integration',
-    tools: [
-      'lean_diagnostics',
-      'lean_file',
-      'lean_project',
-      'lean_inspect',
-      'lean_loogle',
-    ],
-    keywords: ['lean', 'proof', 'theorem', 'formal', 'verification'],
-  },
-  Utility: {
-    description: 'Memory, todo tracking, and diagnostics',
-    tools: ['memory', 'todo_write', 'plan', 'diagnostics'],
-    keywords: ['memory', 'todo', 'plan', 'diagnostic', 'track'],
-  },
-};
-
-// ── Infrastructure ──────────────────────────────────────────
-
-/* autoescape off: templates contain Nunjucks/YAML syntax, not HTML.
- * Isolated Environment so the setting does not leak into Nunjucks' shared
- * singleton used by other renderers in the extension. */
-const nunjucksEnv = new nunjucks.Environment(null, { autoescape: false });
-
-/** Lazily built and cached for the extension host lifetime. Schemas are static. */
-let schemaRefCache: Record<AgentCategory, string> | null = null;
-
-function getSchemaReference(category: AgentCategory): string {
-  if (!schemaRefCache) {
-    schemaRefCache = {
-      workflow: buildSchemaRef(AgentWorkflowSettingSchema),
-      toolUse: buildSchemaRef(AgentToolUseSettingSchema),
-    };
-  }
-  return schemaRefCache[category];
-}
-
-function buildSchemaRef(settingsSchema: z.ZodObject<z.ZodRawShape>): string {
-  return [
-    '## Agent YAML Schema (JSON Schema)',
-    '',
-    '### settings',
-    JSON.stringify(z.toJSONSchema(settingsSchema), null, 2),
-    '',
-    '### prompts',
-    JSON.stringify(z.toJSONSchema(AgentPromptSchema), null, 2),
-  ].join('\n');
-}
-
-/** Cached after first load. Templates are bundled resources — stable for the session. */
-let creatorConfig: CreatorConfig | null = null;
 
 interface ParsedCreatorYaml {
   prompts: { systemPrompt: string; userRequest: string; retryPrompt?: string };
 }
 
-async function loadCreatorConfig(
-  context: vscode.ExtensionContext,
-): Promise<CreatorConfig> {
+/** Cached after first load. Templates are bundled resources — stable for the session. */
+let creatorConfig: CreatorConfig | null = null;
+
+async function loadCreatorConfig(context: vscode.ExtensionContext): Promise<CreatorConfig> {
   if (creatorConfig) return creatorConfig;
-  const templatesDir = path.join(
-    context.extensionPath,
-    'resources',
-    'templates',
-  );
-  const [workflowYaml, toolUseYaml, workflowSingle, toolUseTpl] =
-    await Promise.all([
-      AbsoluteFS.read(path.join(templatesDir, 'agentCreatorWorkflow.yaml')),
-      AbsoluteFS.read(path.join(templatesDir, 'agentCreatorToolUse.yaml')),
-      AbsoluteFS.read(
-        path.join(templatesDir, 'agentTemplate-workflowSingle.yaml'),
-      ),
-      AbsoluteFS.read(path.join(templatesDir, 'agentTemplate-toolUse.yaml')),
-    ]);
+  const templatesDir = path.join(context.extensionPath, 'resources', 'templates');
+  const [workflowYaml, toolUseYaml, workflowSingle, toolUseTpl] = await Promise.all([
+    AbsoluteFS.read(path.join(templatesDir, 'agentCreatorWorkflow.yaml')),
+    AbsoluteFS.read(path.join(templatesDir, 'agentCreatorToolUse.yaml')),
+    AbsoluteFS.read(path.join(templatesDir, 'agentTemplate-workflowSingle.yaml')),
+    AbsoluteFS.read(path.join(templatesDir, 'agentTemplate-toolUse.yaml')),
+  ]);
   const wf = yaml.parse(workflowYaml) as ParsedCreatorYaml;
   const tu = yaml.parse(toolUseYaml) as ParsedCreatorYaml;
   const defaultRetry =
@@ -283,356 +54,76 @@ async function loadCreatorConfig(
   return creatorConfig;
 }
 
-async function pickTools(
-  agentName: string,
-  description: string,
-): Promise<{ tools: string[]; groups: string[] } | undefined> {
-  // Pre-select tool groups whose keywords appear in the description
-  const lower = description.toLowerCase();
-  const suggested = new Set<string>(['File Operations']);
-  for (const [name, group] of Object.entries(TOOL_GROUPS)) {
-    if (group.keywords.some((kw) => lower.includes(kw))) {
-      suggested.add(name);
-    }
-  }
-
-  const selected = await vscode.window.showQuickPick(
-    Object.entries(TOOL_GROUPS).map(([label, group]) => ({
-      label,
-      description: group.description,
-      detail: group.tools.join(', '),
-      picked: suggested.has(label),
-    })),
-    {
-      title: `Tool Use Agent: ${agentName}`,
-      placeHolder:
-        'Select tool groups (pre-selected based on your description)',
-      canPickMany: true,
+function buildVSCodeUI(): AgentCreatorUI {
+  return {
+    async promptAgentName(categoryLabel) {
+      return vscode.window.showInputBox({
+        title: `New ${categoryLabel} Agent`,
+        prompt: 'Enter a name for the new agent (without .yaml)',
+        validateInput: (value) =>
+          !value || /[^a-zA-Z0-9_-]/.test(value)
+            ? 'Use letters, numbers, underscore or dash'
+            : null,
+      });
     },
-  );
-  if (!selected || selected.length === 0) return undefined;
 
-  const tools: string[] = [];
-  const groups: string[] = [];
-  for (const item of selected) {
-    const group = TOOL_GROUPS[item.label];
-    if (group) {
-      tools.push(...group.tools);
-      groups.push(item.label);
-    }
-  }
-  return { tools, groups };
-}
+    async promptDescription(title, prompt) {
+      return vscode.window.showInputBox({ title, prompt });
+    },
 
-// ── Nodes ───────────────────────────────────────────────────
-
-/**
- * Gather agent name + description. Branches on category ('workflow' | 'toolUse').
- * Returning 'cancel' (no registered successor) ends the flow.
- */
-class GatherInputNode extends Node<AgentCreatorShared> {
-  async prep(shared: AgentCreatorShared) {
-    return {
-      category: shared.category,
-      categoryLabel: shared.category === 'toolUse' ? 'Tool Use' : 'Workflow',
-    };
-  }
-
-  async exec(prepRes: { category: AgentCategory; categoryLabel: string }) {
-    const agentName = await vscode.window.showInputBox({
-      title: `New ${prepRes.categoryLabel} Agent`,
-      prompt: 'Enter a name for the new agent (without .yaml)',
-      validateInput: (value) =>
-        !value || /[^a-zA-Z0-9_-]/.test(value)
-          ? 'Use letters, numbers, underscore or dash'
-          : null,
-    });
-    if (!agentName) return undefined;
-
-    const description = await vscode.window.showInputBox({
-      title: `New ${prepRes.categoryLabel} Agent: ${agentName}`,
-      prompt: DESCRIPTION_PROMPTS[prepRes.category],
-    });
-    if (!description) return undefined;
-
-    return { agentName, description };
-  }
-
-  async post(
-    shared: AgentCreatorShared,
-    _prepRes: unknown,
-    execRes: { agentName: string; description: string } | undefined,
-  ): Promise<string | undefined> {
-    if (!execRes) return 'cancel';
-    shared.agentName = execRes.agentName;
-    shared.description = execRes.description;
-    return shared.category;
-  }
-}
-
-/**
- * Gather workflow output style and build the AgentBlueprint.
- * All data assembly and IO (directory resolution) happens in exec().
- */
-class WorkflowBlueprintNode extends Node<AgentCreatorShared> {
-  async prep(shared: AgentCreatorShared) {
-    return {
-      agentName: shared.agentName!,
-      description: shared.description!,
-      config: shared.config,
-    };
-  }
-
-  async exec(prepRes: {
-    agentName: string;
-    description: string;
-    config: CreatorConfig;
-  }): Promise<AgentBlueprint | undefined> {
-    const { agentName, description, config } = prepRes;
-
-    const targetDir = await agentDirectories.custom();
-
-    return {
-      category: 'workflow',
-      agentName,
-      filePath: vscode.Uri.file(path.join(targetDir, `${agentName}.yaml`)),
-      aiVars: {
-        AGENT_NAME: agentName,
-        DESCRIPTION: description,
-      },
-      fallbackTemplate: config.templates.workflowSingle,
-      fallbackVars: {
-        AGENT_NAME: agentName,
-        DESCRIPTION: description,
-      },
-    };
-  }
-
-  async post(
-    shared: AgentCreatorShared,
-    _prepRes: unknown,
-    execRes: AgentBlueprint | undefined,
-  ): Promise<string | undefined> {
-    if (!execRes) return 'cancel';
-    shared.blueprint = execRes;
-    return FlowTransition.DEFAULT;
-  }
-}
-
-/**
- * Gather tool selection via keyword-aware picker and build the AgentBlueprint.
- * All data assembly and IO (directory resolution) happens in exec().
- */
-class ToolUseBlueprintNode extends Node<AgentCreatorShared> {
-  async prep(shared: AgentCreatorShared) {
-    return {
-      agentName: shared.agentName!,
-      description: shared.description!,
-      config: shared.config,
-    };
-  }
-
-  async exec(prepRes: {
-    agentName: string;
-    description: string;
-    config: CreatorConfig;
-  }): Promise<AgentBlueprint | undefined> {
-    const { agentName, description, config } = prepRes;
-
-    const picked = await pickTools(agentName, description);
-    if (!picked) return undefined;
-
-    const targetDir = await agentDirectories.custom();
-
-    return {
-      category: 'toolUse',
-      agentName,
-      filePath: vscode.Uri.file(path.join(targetDir, `${agentName}.yaml`)),
-      aiVars: {
-        AGENT_NAME: agentName,
-        DESCRIPTION: description,
-        SELECTED_TOOLS: picked.tools.join(', '),
-        SELECTED_GROUPS: picked.groups.join(', '),
-      },
-      fallbackTemplate: config.templates.toolUse,
-      fallbackVars: {
-        AGENT_NAME: agentName,
-        DESCRIPTION: description,
-        TOOLS_YAML: picked.tools.map((t) => `    - ${t}`).join('\n'),
-      },
-    };
-  }
-
-  async post(
-    shared: AgentCreatorShared,
-    _prepRes: unknown,
-    execRes: AgentBlueprint | undefined,
-  ): Promise<string | undefined> {
-    if (!execRes) return 'cancel';
-    shared.blueprint = execRes;
-    return FlowTransition.DEFAULT;
-  }
-}
-
-interface GeneratePrepResult {
-  config: CreatorConfig;
-  blueprint: AgentBlueprint;
-}
-
-/**
- * Generate agent YAML via AI. Uses PocketFlow retry (maxRetries) for validation
- * failures and execFallback for template-based fallback when retries are exhausted.
- */
-class GenerateNode extends Node<AgentCreatorShared> {
-  private lastValidationError?: string;
-
-  constructor() {
-    super(AI_GENERATION_ATTEMPTS);
-  }
-
-  async prep(shared: AgentCreatorShared): Promise<GeneratePrepResult> {
-    return { config: shared.config, blueprint: shared.blueprint! };
-  }
-
-  async exec(prepRes: GeneratePrepResult): Promise<string> {
-    const { config, blueprint } = prepRes;
-    const helperResult = await createHelperModelKit();
-    if (!helperResult.kit) {
-      throw new Error(helperResult.reason);
-    }
-    const { handler, client } = helperResult.kit;
-
-    const prompts = config[blueprint.category];
-    const schemaRef = getSchemaReference(blueprint.category);
-    const renderVars = {
-      ...PASSTHROUGH[blueprint.category],
-      ...blueprint.aiVars,
-    };
-    const systemPrompt =
-      nunjucksEnv.renderString(prompts.systemPrompt, renderVars) +
-      '\n' +
-      schemaRef;
-
-    let userMessage = nunjucksEnv.renderString(prompts.userRequest, renderVars);
-    if (this.lastValidationError) {
-      userMessage +=
-        '\n' +
-        nunjucksEnv.renderString(config.retryPrompts[blueprint.category], {
-          VALIDATION_ERROR: this.lastValidationError,
-        });
-    }
-
-    const messages = await handler.initializeMessages(
-      '',
-      userMessage,
-      undefined,
-      systemPrompt,
-    );
-    const result = await handler.createResponse({
-      client,
-      messages,
-      temperature: 0,
-      systemPrompt,
-    });
-    const { text } = handler.extractResponse(result.response, '');
-
-    if (!isNonEmptyString(text)) {
-      throw new Error('Model returned no text');
-    }
-
-    const extracted = extractTextFromTag(text, 'yaml');
-    const candidate = (extracted || text).trim();
-    try {
-      validateAgentYamlContent(candidate);
-    } catch (err) {
-      this.lastValidationError = toErrorMessage(err);
-      throw new Error(
-        `Generated YAML was invalid: ${this.lastValidationError}`,
+    async pickTools(agentName, description) {
+      const lower = description.toLowerCase();
+      const suggested = new Set<string>(['File Operations']);
+      for (const [name, group] of Object.entries(TOOL_GROUPS)) {
+        if (group.keywords.some((kw) => lower.includes(kw))) suggested.add(name);
+      }
+      const selected = await vscode.window.showQuickPick(
+        Object.entries(TOOL_GROUPS).map(([label, group]) => ({
+          label,
+          description: group.description,
+          detail: group.tools.join(', '),
+          picked: suggested.has(label),
+        })),
+        {
+          title: `Tool Use Agent: ${agentName}`,
+          placeHolder: 'Select tool groups (pre-selected based on your description)',
+          canPickMany: true,
+        },
       );
-    }
+      if (!selected || selected.length === 0) return undefined;
+      const tools: string[] = [];
+      const groups: string[] = [];
+      for (const item of selected) {
+        const group = TOOL_GROUPS[item.label];
+        if (group) {
+          tools.push(...group.tools);
+          groups.push(item.label);
+        }
+      }
+      return { tools, groups };
+    },
 
-    logger.info(
-      CHANNEL,
-      `AI generation succeeded for ${blueprint.category} agent`,
-    );
-    return candidate;
-  }
+    async getCustomAgentDir() {
+      return agentDirectories.custom();
+    },
 
-  async execFallback(
-    prepRes: GeneratePrepResult,
-    error: Error,
-  ): Promise<string> {
-    logger.warn(
-      CHANNEL,
-      `AI generation failed, using template: ${error.message}`,
-    );
-    const { blueprint } = prepRes;
-    // Route through the shared renderer so both the Settings "new from
-    // template" flow and this fallback produce byte-identical output for
-    // matching inputs. Category-specific passthrough is unnecessary here —
-    // the shared helper passes every runtime token through, and the
-    // bundled templates only reference the ones they need.
-    return renderAgentTemplateString(
-      blueprint.fallbackTemplate,
-      blueprint.fallbackVars,
-    );
-  }
+    showCreatedInfo(filePath) {
+      void vscode.window.showInformationMessage(`Created agent at ${filePath}`);
+    },
 
-  async post(
-    shared: AgentCreatorShared,
-    _prepRes: unknown,
-    yamlContent: string,
-  ): Promise<string | undefined> {
-    shared.yamlContent = yamlContent;
-    return FlowTransition.DEFAULT;
-  }
-}
+    async promptAddToConfig(agentName, isEdited, category) {
+      await promptToAddAgentToConfig(agentName, isEdited, category);
+    },
 
-/**
- * Write generated YAML to disk, register the agent, and open the file.
- */
-class RegisterNode extends Node<AgentCreatorShared> {
-  async prep(shared: AgentCreatorShared) {
-    return { blueprint: shared.blueprint!, yamlContent: shared.yamlContent! };
-  }
+    async openCreatedFile(filePath) {
+      const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(filePath));
+      await vscode.window.showTextDocument(doc);
+    },
 
-  async exec(prepRes: { blueprint: AgentBlueprint; yamlContent: string }) {
-    const { blueprint, yamlContent } = prepRes;
-    await AbsoluteFS.write(blueprint.filePath.fsPath, yamlContent);
-    vscode.window.showInformationMessage(
-      `Created agent at ${blueprint.filePath.fsPath}`,
-    );
-    await promptToAddAgentToConfig(
-      blueprint.agentName,
-      false,
-      blueprint.category,
-    );
-    const doc = await vscode.workspace.openTextDocument(blueprint.filePath);
-    await vscode.window.showTextDocument(doc);
-  }
-
-  async post(): Promise<string | undefined> {
-    return FlowTransition.DEFAULT;
-  }
-}
-
-// ── Flow ────────────────────────────────────────────────────
-
-function createAgentCreatorFlow(): Flow<AgentCreatorShared> {
-  const gatherInput = new GatherInputNode();
-  const workflowBlueprint = new WorkflowBlueprintNode();
-  const toolUseBlueprint = new ToolUseBlueprintNode();
-  const generate = new GenerateNode();
-  const register = new RegisterNode();
-
-  gatherInput.on('workflow', workflowBlueprint);
-  gatherInput.on('toolUse', toolUseBlueprint);
-
-  workflowBlueprint.next(generate);
-  toolUseBlueprint.next(generate);
-  generate.next(register);
-
-  return new Flow<AgentCreatorShared>(gatherInput);
+    renderTemplate(template, vars) {
+      return renderAgentTemplateString(template, vars);
+    },
+  };
 }
 
 export async function handleCreateAgentWithAI(
@@ -641,9 +132,8 @@ export async function handleCreateAgentWithAI(
 ) {
   try {
     const config = await loadCreatorConfig(context);
-    const shared: AgentCreatorShared = { config, category };
-    const flow = createAgentCreatorFlow();
-    await flow.run(shared);
+    const flow = createAgentCreatorFlow(buildVSCodeUI());
+    await flow.run({ config, category });
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Failed to create agent', err);
   }

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -11,9 +11,7 @@ import {
   createAgentCreatorFlow,
 } from '@agent/implementations/flows/agentCreator/agentCreatorFlow';
 import { agentDirectories, promptToAddAgentToConfig } from '@frontend/agents';
-import {
-  showLoggedErrorMessage,
-} from '@frontend/ui/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
 
@@ -29,15 +27,24 @@ interface ParsedCreatorYaml {
 /** Cached after first load. Templates are bundled resources — stable for the session. */
 let creatorConfig: CreatorConfig | null = null;
 
-async function loadCreatorConfig(context: vscode.ExtensionContext): Promise<CreatorConfig> {
+async function loadCreatorConfig(
+  context: vscode.ExtensionContext,
+): Promise<CreatorConfig> {
   if (creatorConfig) return creatorConfig;
-  const templatesDir = path.join(context.extensionPath, 'resources', 'templates');
-  const [workflowYaml, toolUseYaml, workflowSingle, toolUseTpl] = await Promise.all([
-    AbsoluteFS.read(path.join(templatesDir, 'agentCreatorWorkflow.yaml')),
-    AbsoluteFS.read(path.join(templatesDir, 'agentCreatorToolUse.yaml')),
-    AbsoluteFS.read(path.join(templatesDir, 'agentTemplate-workflowSingle.yaml')),
-    AbsoluteFS.read(path.join(templatesDir, 'agentTemplate-toolUse.yaml')),
-  ]);
+  const templatesDir = path.join(
+    context.extensionPath,
+    'resources',
+    'templates',
+  );
+  const [workflowYaml, toolUseYaml, workflowSingle, toolUseTpl] =
+    await Promise.all([
+      AbsoluteFS.read(path.join(templatesDir, 'agentCreatorWorkflow.yaml')),
+      AbsoluteFS.read(path.join(templatesDir, 'agentCreatorToolUse.yaml')),
+      AbsoluteFS.read(
+        path.join(templatesDir, 'agentTemplate-workflowSingle.yaml'),
+      ),
+      AbsoluteFS.read(path.join(templatesDir, 'agentTemplate-toolUse.yaml')),
+    ]);
   const wf = yaml.parse(workflowYaml) as ParsedCreatorYaml;
   const tu = yaml.parse(toolUseYaml) as ParsedCreatorYaml;
   const defaultRetry =
@@ -75,7 +82,8 @@ function buildVSCodeUI(): AgentCreatorUI {
       const lower = description.toLowerCase();
       const suggested = new Set<string>(['File Operations']);
       for (const [name, group] of Object.entries(TOOL_GROUPS)) {
-        if (group.keywords.some((kw) => lower.includes(kw))) suggested.add(name);
+        if (group.keywords.some((kw) => lower.includes(kw)))
+          suggested.add(name);
       }
       const selected = await vscode.window.showQuickPick(
         Object.entries(TOOL_GROUPS).map(([label, group]) => ({
@@ -86,7 +94,8 @@ function buildVSCodeUI(): AgentCreatorUI {
         })),
         {
           title: `Tool Use Agent: ${agentName}`,
-          placeHolder: 'Select tool groups (pre-selected based on your description)',
+          placeHolder:
+            'Select tool groups (pre-selected based on your description)',
           canPickMany: true,
         },
       );
@@ -116,7 +125,9 @@ function buildVSCodeUI(): AgentCreatorUI {
     },
 
     async openCreatedFile(filePath) {
-      const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(filePath));
+      const doc = await vscode.workspace.openTextDocument(
+        vscode.Uri.file(filePath),
+      );
       await vscode.window.showTextDocument(doc);
     },
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -367,7 +367,23 @@ export async function activate(context: vscode.ExtensionContext) {
         'Supabase authentication is enabled but credentials are not configured. Please configure credentials in src/auth/config.ts before building.',
       );
     } else {
-      const authProvider = new SupabaseAuthProvider(context);
+      const authProvider = new SupabaseAuthProvider(context, {
+        showError: (msg) => void vscode.window.showErrorMessage(msg),
+        showInfo: (msg) => void vscode.window.showInformationMessage(msg),
+        showSignInPrompt: async (reason) => {
+          const message =
+            reason === 'expired'
+              ? 'Your TeXRA session has expired. Please sign in again to access AI models and remote agents.'
+              : 'Your TeXRA session is no longer valid. Please sign in again to access AI models and remote agents.';
+          const action = await vscode.window.showWarningMessage(message, 'Sign In');
+          if (action === 'Sign In') {
+            await vscode.commands.executeCommand('texra.auth.signIn').then(
+              undefined,
+              (err: unknown) => logger.error('extension', `Failed to trigger sign-in: ${String(err)}`),
+            );
+          }
+        },
+      });
       context.subscriptions.push(
         vscode.authentication.registerAuthenticationProvider(
           AUTH_PROVIDER_ID,

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -384,8 +384,8 @@ export async function activate(context: vscode.ExtensionContext) {
               .executeCommand('texra.auth.signIn')
               .then(undefined, (err: unknown) =>
                 logger.error(
-                  'extension',
-                  `Failed to trigger sign-in: ${String(err)}`,
+                  'SupabaseAuthProvider',
+                  `Failed to trigger sign-in: ${toErrorMessage(err)}`,
                 ),
               );
           }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -375,12 +375,19 @@ export async function activate(context: vscode.ExtensionContext) {
             reason === 'expired'
               ? 'Your TeXRA session has expired. Please sign in again to access AI models and remote agents.'
               : 'Your TeXRA session is no longer valid. Please sign in again to access AI models and remote agents.';
-          const action = await vscode.window.showWarningMessage(message, 'Sign In');
+          const action = await vscode.window.showWarningMessage(
+            message,
+            'Sign In',
+          );
           if (action === 'Sign In') {
-            await vscode.commands.executeCommand('texra.auth.signIn').then(
-              undefined,
-              (err: unknown) => logger.error('extension', `Failed to trigger sign-in: ${String(err)}`),
-            );
+            await vscode.commands
+              .executeCommand('texra.auth.signIn')
+              .then(undefined, (err: unknown) =>
+                logger.error(
+                  'extension',
+                  `Failed to trigger sign-in: ${String(err)}`,
+                ),
+              );
           }
         },
       });

--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -67,7 +67,15 @@ export interface ToolGroup {
 export const TOOL_GROUPS: Record<string, ToolGroup> = {
   'File Operations': {
     description: 'Read, write, edit, search files and run shell commands',
-    tools: ['bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls'],
+    tools: [
+      'bash',
+      'read_file',
+      'write_file',
+      'edit_file',
+      'glob',
+      'grep',
+      'ls',
+    ],
     keywords: ['file', 'edit', 'code', 'write', 'read', 'script', 'shell'],
   },
   'Web & Search': {
@@ -77,13 +85,42 @@ export const TOOL_GROUPS: Record<string, ToolGroup> = {
   },
   'Academic Research': {
     description: 'Search arXiv, CrossRef, and download papers',
-    tools: ['arxiv_search', 'arxiv_metadata', 'download_arxiv_source', 'crossref_search', 'crossref_doi'],
-    keywords: ['arxiv', 'paper', 'research', 'literature', 'review', 'survey', 'cite', 'doi', 'journal'],
+    tools: [
+      'arxiv_search',
+      'arxiv_metadata',
+      'download_arxiv_source',
+      'crossref_search',
+      'crossref_doi',
+    ],
+    keywords: [
+      'arxiv',
+      'paper',
+      'research',
+      'literature',
+      'review',
+      'survey',
+      'cite',
+      'doi',
+      'journal',
+    ],
   },
   'LaTeX Processing': {
     description: 'Extract figures, bibliography, TikZ, and count words',
-    tools: ['extract_figures', 'extract_bib_entries', 'extract_tikz_figures', 'texcount'],
-    keywords: ['latex', 'figure', 'tikz', 'bibliography', 'bib', 'word count', 'extract'],
+    tools: [
+      'extract_figures',
+      'extract_bib_entries',
+      'extract_tikz_figures',
+      'texcount',
+    ],
+    keywords: [
+      'latex',
+      'figure',
+      'tikz',
+      'bibliography',
+      'bib',
+      'word count',
+      'extract',
+    ],
   },
   'Citation Management': {
     description: 'Manage references with Zotero',
@@ -93,16 +130,34 @@ export const TOOL_GROUPS: Record<string, ToolGroup> = {
   Computation: {
     description: 'Mathematical computation with Wolfram Alpha',
     tools: ['wolfram'],
-    keywords: ['math', 'compute', 'calculate', 'wolfram', 'symbolic', 'equation'],
+    keywords: [
+      'math',
+      'compute',
+      'calculate',
+      'wolfram',
+      'symbolic',
+      'equation',
+    ],
   },
   'Agent Delegation': {
     description: 'Delegate tasks to other agents and manage executions',
-    tools: ['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files'],
+    tools: [
+      'delegate_workflow',
+      'delegate_agent',
+      'executions',
+      'accept_run_files',
+    ],
     keywords: ['delegate', 'orchestrat', 'pipeline', 'multi-agent', 'chain'],
   },
   'Lean 4': {
     description: 'Lean 4 proof assistant integration',
-    tools: ['lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle'],
+    tools: [
+      'lean_diagnostics',
+      'lean_file',
+      'lean_project',
+      'lean_inspect',
+      'lean_loogle',
+    ],
     keywords: ['lean', 'proof', 'theorem', 'formal', 'verification'],
   },
   Utility: {
@@ -119,10 +174,17 @@ export const TOOL_GROUPS: Record<string, ToolGroup> = {
 export interface AgentCreatorUI {
   promptAgentName(categoryLabel: string): Promise<string | undefined>;
   promptDescription(title: string, prompt: string): Promise<string | undefined>;
-  pickTools(agentName: string, description: string): Promise<{ tools: string[]; groups: string[] } | undefined>;
+  pickTools(
+    agentName: string,
+    description: string,
+  ): Promise<{ tools: string[]; groups: string[] } | undefined>;
   getCustomAgentDir(): Promise<string>;
   showCreatedInfo(filePath: string): void;
-  promptAddToConfig(agentName: string, isEdited: boolean, category: AgentCategory): Promise<void>;
+  promptAddToConfig(
+    agentName: string,
+    isEdited: boolean,
+    category: AgentCategory,
+  ): Promise<void>;
   openCreatedFile(filePath: string): Promise<void>;
   renderTemplate(template: string, vars: Record<string, unknown>): string;
 }
@@ -147,8 +209,10 @@ const WORKFLOW_VARS = [
 ];
 
 const DESCRIPTION_PROMPTS: Record<AgentCategory, string> = {
-  toolUse: 'What should this agent do? Mention capabilities it needs (e.g., search papers, edit files, browse the web)',
-  workflow: 'What should this agent do? Mention whether it rewrites existing documents or creates new ones',
+  toolUse:
+    'What should this agent do? Mention capabilities it needs (e.g., search papers, edit files, browse the web)',
+  workflow:
+    'What should this agent do? Mention whether it rewrites existing documents or creates new ones',
 };
 
 function buildPassthrough(vars: string[]): Record<string, string> {
@@ -353,7 +417,9 @@ class GenerateNode extends Node<AgentCreatorShared> {
       ...blueprint.aiVars,
     };
     const systemPrompt =
-      nunjucksEnv.renderString(prompts.systemPrompt, renderVars) + '\n' + schemaRef;
+      nunjucksEnv.renderString(prompts.systemPrompt, renderVars) +
+      '\n' +
+      schemaRef;
 
     let userMessage = nunjucksEnv.renderString(prompts.userRequest, renderVars);
     if (this.lastValidationError) {
@@ -364,8 +430,18 @@ class GenerateNode extends Node<AgentCreatorShared> {
         });
     }
 
-    const messages = await handler.initializeMessages('', userMessage, undefined, systemPrompt);
-    const result = await handler.createResponse({ client, messages, temperature: 0, systemPrompt });
+    const messages = await handler.initializeMessages(
+      '',
+      userMessage,
+      undefined,
+      systemPrompt,
+    );
+    const result = await handler.createResponse({
+      client,
+      messages,
+      temperature: 0,
+      systemPrompt,
+    });
     const { text } = handler.extractResponse(result.response, '');
 
     if (!isNonEmptyString(text)) {
@@ -378,20 +454,34 @@ class GenerateNode extends Node<AgentCreatorShared> {
       validateAgentYamlContent(candidate);
     } catch (err) {
       this.lastValidationError = toErrorMessage(err);
-      throw new Error(`Generated YAML was invalid: ${this.lastValidationError}`);
+      throw new Error(
+        `Generated YAML was invalid: ${this.lastValidationError}`,
+      );
     }
 
-    logger.info(CHANNEL, `AI generation succeeded for ${blueprint.category} agent`);
+    logger.info(
+      CHANNEL,
+      `AI generation succeeded for ${blueprint.category} agent`,
+    );
     return candidate;
   }
 
-  async execFallback(prepRes: GeneratePrepResult, error: Error): Promise<string> {
-    logger.warn(CHANNEL, `AI generation failed, using template: ${error.message}`);
+  async execFallback(
+    prepRes: GeneratePrepResult,
+    error: Error,
+  ): Promise<string> {
+    logger.warn(
+      CHANNEL,
+      `AI generation failed, using template: ${error.message}`,
+    );
     const { blueprint } = prepRes;
     // Route through the shared renderer so both the Settings "new from
     // template" flow and this fallback produce byte-identical output for
     // matching inputs.
-    return this.ui.renderTemplate(blueprint.fallbackTemplate, blueprint.fallbackVars);
+    return this.ui.renderTemplate(
+      blueprint.fallbackTemplate,
+      blueprint.fallbackVars,
+    );
   }
 
   async post(
@@ -417,7 +507,11 @@ class RegisterNode extends Node<AgentCreatorShared> {
     const { blueprint, yamlContent } = prepRes;
     await AbsoluteFS.write(blueprint.filePath, yamlContent);
     this.ui.showCreatedInfo(blueprint.filePath);
-    await this.ui.promptAddToConfig(blueprint.agentName, false, blueprint.category);
+    await this.ui.promptAddToConfig(
+      blueprint.agentName,
+      false,
+      blueprint.category,
+    );
     await this.ui.openCreatedFile(blueprint.filePath);
   }
 
@@ -428,7 +522,9 @@ class RegisterNode extends Node<AgentCreatorShared> {
 
 // ── Flow ────────────────────────────────────────────────────
 
-export function createAgentCreatorFlow(ui: AgentCreatorUI): Flow<AgentCreatorShared> {
+export function createAgentCreatorFlow(
+  ui: AgentCreatorUI,
+): Flow<AgentCreatorShared> {
   const gatherInput = new GatherInputNode(ui);
   const workflowBlueprint = new WorkflowBlueprintNode(ui);
   const toolUseBlueprint = new ToolUseBlueprintNode(ui);

--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -1,0 +1,446 @@
+import * as path from 'node:path';
+
+import * as nunjucks from 'nunjucks';
+import { z } from 'zod';
+
+import { Node, Flow } from '@agent/node';
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import {
+  AgentWorkflowSettingSchema,
+  AgentToolUseSettingSchema,
+  AgentPromptSchema,
+} from '@agent/core/definition/AgentDataclass';
+import { createHelperModelKit } from '@agent/runtime/helperModel';
+import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
+import { toErrorMessage } from '@common/errors';
+import * as logger from '@logger/logUtils';
+import { AbsoluteFS } from '@utils/files';
+import { isNonEmptyString } from '@utils/core/stringCore';
+import { extractTextFromTag } from '@utils/text/xmlExtraction';
+
+const CHANNEL = 'AgentCreator';
+
+// ── Types ───────────────────────────────────────────────────
+
+export type AgentCategory = 'workflow' | 'toolUse';
+
+export interface AgentPromptPair {
+  systemPrompt: string;
+  userRequest: string;
+}
+
+export interface CreatorConfig {
+  workflow: AgentPromptPair;
+  toolUse: AgentPromptPair;
+  retryPrompts: Record<AgentCategory, string>;
+  templates: {
+    workflowSingle: string;
+    toolUse: string;
+  };
+}
+
+export interface AgentBlueprint {
+  category: AgentCategory;
+  agentName: string;
+  filePath: string;
+  aiVars: Record<string, string>;
+  fallbackTemplate: string;
+  fallbackVars: Record<string, string>;
+}
+
+/** Mutable shared state flowing through the agent creation flow. */
+export interface AgentCreatorShared {
+  config: CreatorConfig;
+  category: AgentCategory;
+  agentName?: string;
+  description?: string;
+  blueprint?: AgentBlueprint;
+  yamlContent?: string;
+}
+
+export interface ToolGroup {
+  description: string;
+  tools: string[];
+  keywords: string[];
+}
+
+export const TOOL_GROUPS: Record<string, ToolGroup> = {
+  'File Operations': {
+    description: 'Read, write, edit, search files and run shell commands',
+    tools: ['bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls'],
+    keywords: ['file', 'edit', 'code', 'write', 'read', 'script', 'shell'],
+  },
+  'Web & Search': {
+    description: 'Search the web and fetch page content',
+    tools: ['web_search', 'web_fetch'],
+    keywords: ['web', 'search', 'internet', 'online', 'url', 'fetch', 'browse'],
+  },
+  'Academic Research': {
+    description: 'Search arXiv, CrossRef, and download papers',
+    tools: ['arxiv_search', 'arxiv_metadata', 'download_arxiv_source', 'crossref_search', 'crossref_doi'],
+    keywords: ['arxiv', 'paper', 'research', 'literature', 'review', 'survey', 'cite', 'doi', 'journal'],
+  },
+  'LaTeX Processing': {
+    description: 'Extract figures, bibliography, TikZ, and count words',
+    tools: ['extract_figures', 'extract_bib_entries', 'extract_tikz_figures', 'texcount'],
+    keywords: ['latex', 'figure', 'tikz', 'bibliography', 'bib', 'word count', 'extract'],
+  },
+  'Citation Management': {
+    description: 'Manage references with Zotero',
+    tools: ['zotero_add', 'zotero_search', 'zotero_export'],
+    keywords: ['zotero', 'citation', 'reference', 'bibliography', 'endnote'],
+  },
+  Computation: {
+    description: 'Mathematical computation with Wolfram Alpha',
+    tools: ['wolfram'],
+    keywords: ['math', 'compute', 'calculate', 'wolfram', 'symbolic', 'equation'],
+  },
+  'Agent Delegation': {
+    description: 'Delegate tasks to other agents and manage executions',
+    tools: ['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files'],
+    keywords: ['delegate', 'orchestrat', 'pipeline', 'multi-agent', 'chain'],
+  },
+  'Lean 4': {
+    description: 'Lean 4 proof assistant integration',
+    tools: ['lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle'],
+    keywords: ['lean', 'proof', 'theorem', 'formal', 'verification'],
+  },
+  Utility: {
+    description: 'Memory, todo tracking, and diagnostics',
+    tools: ['memory', 'todo_write', 'plan', 'diagnostics'],
+    keywords: ['memory', 'todo', 'plan', 'diagnostic', 'track'],
+  },
+};
+
+/**
+ * All host-specific operations injected by the VS Code command layer.
+ * Allows the flow and nodes to run without importing vscode.
+ */
+export interface AgentCreatorUI {
+  promptAgentName(categoryLabel: string): Promise<string | undefined>;
+  promptDescription(title: string, prompt: string): Promise<string | undefined>;
+  pickTools(agentName: string, description: string): Promise<{ tools: string[]; groups: string[] } | undefined>;
+  getCustomAgentDir(): Promise<string>;
+  showCreatedInfo(filePath: string): void;
+  promptAddToConfig(agentName: string, isEdited: boolean, category: AgentCategory): Promise<void>;
+  openCreatedFile(filePath: string): Promise<void>;
+  renderTemplate(template: string, vars: Record<string, unknown>): string;
+}
+
+// ── Infrastructure ──────────────────────────────────────────
+
+/** Total AI generation attempts (1 initial + 1 validation retry) before template fallback. */
+const AI_GENERATION_ATTEMPTS = 2;
+
+const TOOL_USE_VARS = ['INSTRUCTION'];
+
+const WORKFLOW_VARS = [
+  'INPUT_FILE',
+  'INPUT_CONTENT',
+  'INPUT_FILES',
+  'ALL_INPUTS',
+  'ALL_CONTEXTS',
+  'LIST_OF_ALL_CONTEXTS',
+  'ADDITIONAL_INPUTS',
+  'INSTRUCTION',
+  'OUTPUT_FILES',
+];
+
+const DESCRIPTION_PROMPTS: Record<AgentCategory, string> = {
+  toolUse: 'What should this agent do? Mention capabilities it needs (e.g., search papers, edit files, browse the web)',
+  workflow: 'What should this agent do? Mention whether it rewrites existing documents or creates new ones',
+};
+
+function buildPassthrough(vars: string[]): Record<string, string> {
+  return Object.fromEntries(vars.map((v) => [v, `{{ ${v} }}`]));
+}
+
+const PASSTHROUGH: Record<AgentCategory, Record<string, string>> = {
+  toolUse: buildPassthrough(TOOL_USE_VARS),
+  workflow: buildPassthrough(WORKFLOW_VARS),
+};
+
+/* autoescape off: templates contain Nunjucks/YAML syntax, not HTML.
+ * Isolated Environment so the setting does not leak into Nunjucks' shared
+ * singleton used by other renderers in the extension. */
+const nunjucksEnv = new nunjucks.Environment(null, { autoescape: false });
+
+/** Lazily built and cached for the extension host lifetime. Schemas are static. */
+let schemaRefCache: Record<AgentCategory, string> | null = null;
+
+function getSchemaReference(category: AgentCategory): string {
+  if (!schemaRefCache) {
+    schemaRefCache = {
+      workflow: buildSchemaRef(AgentWorkflowSettingSchema),
+      toolUse: buildSchemaRef(AgentToolUseSettingSchema),
+    };
+  }
+  return schemaRefCache[category];
+}
+
+function buildSchemaRef(settingsSchema: z.ZodObject<z.ZodRawShape>): string {
+  return [
+    '## Agent YAML Schema (JSON Schema)',
+    '',
+    '### settings',
+    JSON.stringify(z.toJSONSchema(settingsSchema), null, 2),
+    '',
+    '### prompts',
+    JSON.stringify(z.toJSONSchema(AgentPromptSchema), null, 2),
+  ].join('\n');
+}
+
+// ── Nodes ───────────────────────────────────────────────────
+
+class GatherInputNode extends Node<AgentCreatorShared> {
+  constructor(private ui: AgentCreatorUI) {
+    super();
+  }
+
+  async prep(shared: AgentCreatorShared) {
+    return {
+      category: shared.category,
+      categoryLabel: shared.category === 'toolUse' ? 'Tool Use' : 'Workflow',
+    };
+  }
+
+  async exec(prepRes: { category: AgentCategory; categoryLabel: string }) {
+    const agentName = await this.ui.promptAgentName(prepRes.categoryLabel);
+    if (!agentName) return undefined;
+
+    const description = await this.ui.promptDescription(
+      `New ${prepRes.categoryLabel} Agent: ${agentName}`,
+      DESCRIPTION_PROMPTS[prepRes.category],
+    );
+    if (!description) return undefined;
+
+    return { agentName, description };
+  }
+
+  async post(
+    shared: AgentCreatorShared,
+    _prepRes: unknown,
+    execRes: { agentName: string; description: string } | undefined,
+  ): Promise<string | undefined> {
+    if (!execRes) return 'cancel';
+    shared.agentName = execRes.agentName;
+    shared.description = execRes.description;
+    return shared.category;
+  }
+}
+
+class WorkflowBlueprintNode extends Node<AgentCreatorShared> {
+  constructor(private ui: AgentCreatorUI) {
+    super();
+  }
+
+  async prep(shared: AgentCreatorShared) {
+    return {
+      agentName: shared.agentName!,
+      description: shared.description!,
+      config: shared.config,
+    };
+  }
+
+  async exec(prepRes: {
+    agentName: string;
+    description: string;
+    config: CreatorConfig;
+  }): Promise<AgentBlueprint | undefined> {
+    const { agentName, description, config } = prepRes;
+    const targetDir = await this.ui.getCustomAgentDir();
+    return {
+      category: 'workflow',
+      agentName,
+      filePath: path.join(targetDir, `${agentName}.yaml`),
+      aiVars: { AGENT_NAME: agentName, DESCRIPTION: description },
+      fallbackTemplate: config.templates.workflowSingle,
+      fallbackVars: { AGENT_NAME: agentName, DESCRIPTION: description },
+    };
+  }
+
+  async post(
+    shared: AgentCreatorShared,
+    _prepRes: unknown,
+    execRes: AgentBlueprint | undefined,
+  ): Promise<string | undefined> {
+    if (!execRes) return 'cancel';
+    shared.blueprint = execRes;
+    return FlowTransition.DEFAULT;
+  }
+}
+
+class ToolUseBlueprintNode extends Node<AgentCreatorShared> {
+  constructor(private ui: AgentCreatorUI) {
+    super();
+  }
+
+  async prep(shared: AgentCreatorShared) {
+    return {
+      agentName: shared.agentName!,
+      description: shared.description!,
+      config: shared.config,
+    };
+  }
+
+  async exec(prepRes: {
+    agentName: string;
+    description: string;
+    config: CreatorConfig;
+  }): Promise<AgentBlueprint | undefined> {
+    const { agentName, description, config } = prepRes;
+    const picked = await this.ui.pickTools(agentName, description);
+    if (!picked) return undefined;
+    const targetDir = await this.ui.getCustomAgentDir();
+    return {
+      category: 'toolUse',
+      agentName,
+      filePath: path.join(targetDir, `${agentName}.yaml`),
+      aiVars: {
+        AGENT_NAME: agentName,
+        DESCRIPTION: description,
+        SELECTED_TOOLS: picked.tools.join(', '),
+        SELECTED_GROUPS: picked.groups.join(', '),
+      },
+      fallbackTemplate: config.templates.toolUse,
+      fallbackVars: {
+        AGENT_NAME: agentName,
+        DESCRIPTION: description,
+        TOOLS_YAML: picked.tools.map((t) => `    - ${t}`).join('\n'),
+      },
+    };
+  }
+
+  async post(
+    shared: AgentCreatorShared,
+    _prepRes: unknown,
+    execRes: AgentBlueprint | undefined,
+  ): Promise<string | undefined> {
+    if (!execRes) return 'cancel';
+    shared.blueprint = execRes;
+    return FlowTransition.DEFAULT;
+  }
+}
+
+interface GeneratePrepResult {
+  config: CreatorConfig;
+  blueprint: AgentBlueprint;
+}
+
+class GenerateNode extends Node<AgentCreatorShared> {
+  private lastValidationError?: string;
+
+  constructor(private ui: AgentCreatorUI) {
+    super(AI_GENERATION_ATTEMPTS);
+  }
+
+  async prep(shared: AgentCreatorShared): Promise<GeneratePrepResult> {
+    return { config: shared.config, blueprint: shared.blueprint! };
+  }
+
+  async exec(prepRes: GeneratePrepResult): Promise<string> {
+    const { config, blueprint } = prepRes;
+    const helperResult = await createHelperModelKit();
+    if (!helperResult.kit) {
+      throw new Error(helperResult.reason);
+    }
+    const { handler, client } = helperResult.kit;
+
+    const prompts = config[blueprint.category];
+    const schemaRef = getSchemaReference(blueprint.category);
+    const renderVars = {
+      ...PASSTHROUGH[blueprint.category],
+      ...blueprint.aiVars,
+    };
+    const systemPrompt =
+      nunjucksEnv.renderString(prompts.systemPrompt, renderVars) + '\n' + schemaRef;
+
+    let userMessage = nunjucksEnv.renderString(prompts.userRequest, renderVars);
+    if (this.lastValidationError) {
+      userMessage +=
+        '\n' +
+        nunjucksEnv.renderString(config.retryPrompts[blueprint.category], {
+          VALIDATION_ERROR: this.lastValidationError,
+        });
+    }
+
+    const messages = await handler.initializeMessages('', userMessage, undefined, systemPrompt);
+    const result = await handler.createResponse({ client, messages, temperature: 0, systemPrompt });
+    const { text } = handler.extractResponse(result.response, '');
+
+    if (!isNonEmptyString(text)) {
+      throw new Error('Model returned no text');
+    }
+
+    const extracted = extractTextFromTag(text, 'yaml');
+    const candidate = (extracted || text).trim();
+    try {
+      validateAgentYamlContent(candidate);
+    } catch (err) {
+      this.lastValidationError = toErrorMessage(err);
+      throw new Error(`Generated YAML was invalid: ${this.lastValidationError}`);
+    }
+
+    logger.info(CHANNEL, `AI generation succeeded for ${blueprint.category} agent`);
+    return candidate;
+  }
+
+  async execFallback(prepRes: GeneratePrepResult, error: Error): Promise<string> {
+    logger.warn(CHANNEL, `AI generation failed, using template: ${error.message}`);
+    const { blueprint } = prepRes;
+    // Route through the shared renderer so both the Settings "new from
+    // template" flow and this fallback produce byte-identical output for
+    // matching inputs.
+    return this.ui.renderTemplate(blueprint.fallbackTemplate, blueprint.fallbackVars);
+  }
+
+  async post(
+    shared: AgentCreatorShared,
+    _prepRes: unknown,
+    yamlContent: string,
+  ): Promise<string | undefined> {
+    shared.yamlContent = yamlContent;
+    return FlowTransition.DEFAULT;
+  }
+}
+
+class RegisterNode extends Node<AgentCreatorShared> {
+  constructor(private ui: AgentCreatorUI) {
+    super();
+  }
+
+  async prep(shared: AgentCreatorShared) {
+    return { blueprint: shared.blueprint!, yamlContent: shared.yamlContent! };
+  }
+
+  async exec(prepRes: { blueprint: AgentBlueprint; yamlContent: string }) {
+    const { blueprint, yamlContent } = prepRes;
+    await AbsoluteFS.write(blueprint.filePath, yamlContent);
+    this.ui.showCreatedInfo(blueprint.filePath);
+    await this.ui.promptAddToConfig(blueprint.agentName, false, blueprint.category);
+    await this.ui.openCreatedFile(blueprint.filePath);
+  }
+
+  async post(): Promise<string | undefined> {
+    return FlowTransition.DEFAULT;
+  }
+}
+
+// ── Flow ────────────────────────────────────────────────────
+
+export function createAgentCreatorFlow(ui: AgentCreatorUI): Flow<AgentCreatorShared> {
+  const gatherInput = new GatherInputNode(ui);
+  const workflowBlueprint = new WorkflowBlueprintNode(ui);
+  const toolUseBlueprint = new ToolUseBlueprintNode(ui);
+  const generate = new GenerateNode(ui);
+  const register = new RegisterNode(ui);
+
+  gatherInput.on('workflow', workflowBlueprint);
+  gatherInput.on('toolUse', toolUseBlueprint);
+
+  workflowBlueprint.next(generate);
+  toolUseBlueprint.next(generate);
+  generate.next(register);
+
+  return new Flow<AgentCreatorShared>(gatherInput);
+}

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -389,7 +389,9 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       return this.toVSCodeSession(session);
     } catch (error) {
-      this.notifier.showError(`Authentication failed: ${toErrorMessage(error)}`);
+      this.notifier.showError(
+        `Authentication failed: ${toErrorMessage(error)}`,
+      );
       throw error;
     }
   }
@@ -449,7 +451,9 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       }
       return sessions[0];
     } catch (error) {
-      this.notifier.showError(`Authentication failed: ${toErrorMessage(error)}`);
+      this.notifier.showError(
+        `Authentication failed: ${toErrorMessage(error)}`,
+      );
       throw error;
     } finally {
       // Reset flag after entire OAuth flow completes (success or failure)

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -30,6 +30,13 @@ import type { SupabaseUriHandler } from './UriHandler';
 const AUTH_URI_HANDLER_NOT_INITIALIZED =
   'OAuth handler not initialized. Restart the extension.';
 
+/** Notification operations injected at construction so tests can stub them. */
+export interface AuthNotifier {
+  showError(message: string): void;
+  showInfo(message: string): void;
+  showSignInPrompt(reason: 'expired' | 'invalid'): Promise<void>;
+}
+
 /** GitHub token type prefixes for diagnostic logging. */
 const GITHUB_TOKEN_TYPE_MAP: Record<string, string> = {
   ghp_: 'classic PAT',
@@ -55,7 +62,10 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   /** Flag to prevent race conditions between OAuth and magic link handlers */
   private isProcessingCallback = false;
 
-  constructor(_context: vscode.ExtensionContext) {
+  private readonly notifier: AuthNotifier;
+
+  constructor(_context: vscode.ExtensionContext, notifier: AuthNotifier) {
+    this.notifier = notifier;
     this.sessionCoordinator = createHostAuthCoordinator({
       secrets: platform().secrets,
       whenReady: async () => {
@@ -144,9 +154,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       if (!result.success) {
         if (result.isAuthError) {
-          void vscode.window.showErrorMessage(
-            `Sign-in failed: ${result.error}`,
-          );
+          this.notifier.showError(`Sign-in failed: ${result.error}`);
         } else {
           // Log non-auth errors for debugging (e.g., missing tokens from non-auth callbacks)
           logger.debug(
@@ -158,9 +166,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       }
 
       await this.storeSession(result.session, true);
-      void vscode.window.showInformationMessage(
-        `Signed in as ${result.session.account.label}`,
-      );
+      this.notifier.showInfo(`Signed in as ${result.session.account.label}`);
       logger.info(
         'SupabaseAuthProvider',
         `Magic link sign-in successful for ${result.session.account.label}`,
@@ -170,9 +176,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
         'SupabaseAuthProvider',
         `Error processing magic link callback: ${toErrorMessage(error)}`,
       );
-      void vscode.window.showErrorMessage(
-        `Sign-in failed: ${toErrorMessage(error)}`,
-      );
+      this.notifier.showError(`Sign-in failed: ${toErrorMessage(error)}`);
     } finally {
       this.isProcessingCallback = false;
     }
@@ -228,21 +232,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     reason: 'expired' | 'invalid',
   ): Promise<void> {
     await this.removeSession(sessionId);
-    const message =
-      reason === 'expired'
-        ? 'Your TeXRA session has expired. Please sign in again to access AI models and remote agents.'
-        : 'Your TeXRA session is no longer valid. Please sign in again to access AI models and remote agents.';
-    const action = await vscode.window.showWarningMessage(message, 'Sign In');
-    if (action === 'Sign In') {
-      try {
-        await vscode.commands.executeCommand('texra.auth.signIn');
-      } catch (error) {
-        logger.error(
-          'SupabaseAuthProvider',
-          `Failed to trigger sign-in: ${toErrorMessage(error)}`,
-        );
-      }
-    }
+    await this.notifier.showSignInPrompt(reason);
   }
 
   private isWebEnvironment(): boolean {
@@ -391,9 +381,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       });
 
       await this.storeSession(session, true);
-      void vscode.window.showInformationMessage(
-        `Signed in as ${session.account.label}`,
-      );
+      this.notifier.showInfo(`Signed in as ${session.account.label}`);
       logger.info(
         'SupabaseAuthProvider',
         `VS Code GitHub auth successful for ${session.account.label}`,
@@ -401,9 +389,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       return this.toVSCodeSession(session);
     } catch (error) {
-      void vscode.window.showErrorMessage(
-        `Authentication failed: ${toErrorMessage(error)}`,
-      );
+      this.notifier.showError(`Authentication failed: ${toErrorMessage(error)}`);
       throw error;
     }
   }
@@ -463,9 +449,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       }
       return sessions[0];
     } catch (error) {
-      void vscode.window.showErrorMessage(
-        `Authentication failed: ${toErrorMessage(error)}`,
-      );
+      this.notifier.showError(`Authentication failed: ${toErrorMessage(error)}`);
       throw error;
     } finally {
       // Reset flag after entire OAuth flow completes (success or failure)


### PR DESCRIPTION
## Summary

Refactors the agent creator command to separate host-specific UI operations from the core flow logic. The flow implementation is moved to a new core module (`src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts`) and accepts an injected `AgentCreatorUI` interface, eliminating direct vscode dependencies from the flow and nodes. This enables the flow to be reused across different hosts (extension, CLI, desktop) and improves testability.

Also applies the same UI injection pattern to `SupabaseAuthProvider` for consistency.

## Issue acceptance gates

N/A — refactoring for improved architecture and testability.

## Single source of truth

- **Agent creator flow logic**: `src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts` now owns the flow definition, node implementations, and all agent creation orchestration.
- **UI contract**: `AgentCreatorUI` interface defines the boundary between host-agnostic flow and host-specific operations (prompts, file I/O, notifications).
- **Auth notifications**: `AuthNotifier` interface defines the boundary for authentication-related UI operations in `SupabaseAuthProvider`.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated ~300 lines of flow/node code from the extension command layer by moving to core module.
- Consolidated tool group definitions and constants into the core flow module where they are used.

**New abstractions:**
- `AgentCreatorUI` interface: Owns the contract for all host-specific operations (input prompts, file dialogs, notifications, template rendering). Allows the flow to run without importing vscode.
- `AuthNotifier` interface: Owns the contract for authentication notification operations, decoupling `SupabaseAuthProvider` from direct vscode window calls.

Both interfaces are minimal and focused—they define only the operations the flow/provider actually needs, avoiding pass-through layers.

## Host impact

**Extension:**
- `handleCreateAgentWithAI` now builds a `AgentCreatorUI` implementation wrapping vscode APIs and passes it to the core flow.
- `SupabaseAuthProvider` now accepts an `AuthNotifier` at construction; extension provides a vscode-based implementation.
- No user-facing behavior changes.

**Desktop:**
- Can now reuse `createAgentCreatorFlow` by providing a desktop-specific `AgentCreatorUI` implementation.
- Can provide a desktop-specific `AuthNotifier` to `SupabaseAuthProvider`.

**CLI:**
- Can reuse `createAgentCreatorFlow` by providing a CLI-specific `AgentCreatorUI` implementation (e.g., stdin/stdout prompts).

## Scheduled refactoring

None — this refactoring is self-contained and enables future host integrations.

## Validation

- TypeScript compilation passes (no new type errors).
- Existing extension tests continue to pass (flow behavior unchanged, only location and injection point changed).
- Manual verification: Agent creation flow works identically in VS Code extension.

https://claude.ai/code/session_01PejBb2dbXDVrr7qKJhF6cq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved; auth provider now requires an injected notifier at construction (single call site updated).
> 
> **Overview**
> Moves the **AI agent creator** PocketFlow (gather input → blueprint → generate YAML → register) out of the extension command into `agentCreatorFlow.ts`, so nodes no longer depend on VS Code APIs.
> 
> The extension command layer now only **loads bundled creator templates/prompts** and supplies a **`AgentCreatorUI`** implementation (input boxes, quick pick for tool groups, open file, config prompt, template rendering). **`createAgentCreatorFlow(ui)`** runs the same orchestration; blueprint paths are plain strings and registration still writes via `AbsoluteFS`.
> 
> **`SupabaseAuthProvider`** takes a required **`AuthNotifier`** for errors, success toasts, and expired/invalid session re-sign-in prompts; `extension.ts` wires those to `vscode.window` and `texra.auth.signIn`.
> 
> No intended user-facing behavior change—structure and testability for other hosts (CLI/desktop).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb2b0a533fee653efc6b518f82f31dfb344c9e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->