### PR TITLE
fix(settings): accessible name for icon-only agent badges

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -267,10 +267,14 @@ export class AgentSelectionPanel extends LitElement {
         <span class="agent-list-item-name">${agent.name}</span>
         <span class="agent-list-item-badges">
           ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span title="Remote agent">${waIcon('cloud')}</span>`
+            ? html`<span title="Remote agent"
+                >${waIcon('cloud', { label: 'Remote agent' })}</span
+              >`
             : nothing}
           ${agent.source === AGENT_SOURCE.CUSTOM
-            ? html`<span title="Custom agent">${waIcon('star')}</span>`
+            ? html`<span title="Custom agent"
+                >${waIcon('star', { label: 'Custom agent' })}</span
+              >`
             : nothing}
         </span>
       </div>


### PR DESCRIPTION
## Summary

Scope changed: the original Unicode→`waIcon()` refactor this PR carried (☁, ★, 🎯, ⚠️ → Web Awesome icons, plus the `star`/`bullseye` registry entries) **landed on `main` independently** while this PR was open. This PR has been rebased onto `main` and now contains only the one piece `main` is still missing — an accessibility fix.

## Change

`main`'s icon-only remote/custom agent badges render `aria-hidden` `wa-icon`s with no `label`, so their only accessible name is the wrapping `<span title>` — which assistive tech announces inconsistently on a non-interactive span. This passes a `label` to `waIcon()` so each icon carries its own accessible name (which also drops the auto `aria-hidden`), while keeping the `title` for the mouse hover tooltip.

The detail-view tags are unaffected: they already pair the icon with visible "Remote"/"Custom" text, so the decorative `aria-hidden` icon is correct there.

## Validation

- 1 file changed, +6/−2 — `AgentSelectionPanel.ts` only
- Prettier + ESLint clean; the `waIcon(..., { label })` construct is identical to one that previously type-checked on this branch
- No automated tests affected (UI rendering change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI accessibility tweak in settings agent list rendering with no logic or data changes.
> 
> **Overview**
> Adds **`label`** options to **`waIcon('cloud')`** and **`waIcon('star')`** on remote/custom badges in the agent list (`AgentSelectionPanel`), so the Web Awesome icons expose the same “Remote agent” / “Custom agent” text that was already on the surrounding **`title`** attributes.
> 
> No behavior or layout changes—only richer accessible naming for those list-row source indicators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9896fb37d8952a55d2e1f462ec26160d253d553d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->