### PR TITLE
refactor(usage): drop dead inherited cache fields from NormalizedUsage

### DIFF
--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -26,8 +26,21 @@ export const UsageProviderSchema = z.enum([
 
 export type UsageProvider = z.infer<typeof UsageProviderSchema>;
 
-/** Normalized usage statistics from any model provider. */
-export const NormalizedUsageSchema = TokenUsageStatsSchema.extend({
+/**
+ * Normalized usage statistics from any model provider.
+ *
+ * Reuses only the required base fields via `.pick()` — the optional cache
+ * fields on `TokenUsageStatsSchema` (`cacheReadInputTokens` /
+ * `cacheCreationInputTokens`) are never populated for a NormalizedUsage; the
+ * live cache metrics below (`cachedInputTokens` / `cacheCreationTokens`) are
+ * the authoritative names. Extending the full base instead would inherit
+ * those dead fields and duplicate `cacheMissInputTokens`.
+ */
+export const NormalizedUsageSchema = TokenUsageStatsSchema.pick({
+  inputTokens: true,
+  outputTokens: true,
+  cost: true,
+}).extend({
   /** Response time in milliseconds */
   responseTimeMs: z.number().nonnegative(),
   /** Provider that generated this usage data */


### PR DESCRIPTION
## What

\`NormalizedUsageSchema\` extended the full \`TokenUsageStatsSchema\`, which gave a normalized-usage value **two naming schemes for the same data**:

- It inherited the base's optional \`cacheReadInputTokens\` / \`cacheCreationInputTokens\`, which **no builder ever populates** and **no consumer ever reads** — the live metrics use the distinct names \`cachedInputTokens\` / \`cacheCreationTokens\`.
- It redeclared \`cacheMissInputTokens\` identically to the base (a no-op override).

This reuses only the legitimately-shared **required** fields via \`.pick({ inputTokens, outputTokens, cost })\`, dropping the dead inherited cache fields. The live cache fields are unchanged.

## Why it's safe

- **No consumer changes.** \`RunUsageAccumulator\`, \`UsageMonitor\`, and the sole builder \`UsageNormalizer.normalizeUsage\` already read/write the \`cached*\` / \`cacheCreationTokens\` names. The removed names appear nowhere as reads off a \`NormalizedUsage\`.
- **Persisted state is fine.** \`NormalizedUsageSchema\` is embedded in \`AgentState\` and accumulator snapshots, but the removed fields were *never written*, so old payloads never contained them (no parse breakage; the schema is strict).
- Follows the repo's composition guidance (\`.pick()\`), keeping \`TokenUsageStatsSchema\` as the source of truth for the shared trio.

> Chose \`.pick()\` over renaming the live fields to the base names (the other obvious fix) precisely *because* the schema is persisted — a rename would orphan existing \`cachedInputTokens\` data in stored state. This change touches no stored field names.

## Verification

- \`npx tsc --noEmit\` — no new errors in \`NormalizedUsage\` or its consumers.
- \`ModelHandlerAnthropic\` + \`ModelHandlerDeepSeek\` usage suites: **51 passed** (exercise \`normalizeUsage\` + schema parse).

🤖 Found via a multi-agent data-structure complexity audit (adversarially verified).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type/schema-only change with no runtime or consumer edits; persisted field names for normalized usage are unchanged.
> 
> **Overview**
> **`NormalizedUsageSchema`** no longer extends the full **`TokenUsageStatsSchema`**. It now **`.pick()`s** only **`inputTokens`**, **`outputTokens`**, and **`cost`**, then **`.extend()`s** the existing normalized fields (**`cachedInputTokens`**, **`cacheCreationTokens`**, etc.).
> 
> This drops inherited optional base cache keys (**`cacheReadInputTokens`** / **`cacheCreationInputTokens`**) that were never written on normalized usage and duplicated naming with the live **`cached*`** fields. A block comment documents why **`.pick()`** is used instead of a full extend or a rename (persisted state keeps **`cachedInputTokens`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54b94769a3cbf3112596b1f002282740e25a0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->