### PR TITLE
refactor: reuse shared truncateSummary in tool formatters

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -16,6 +16,7 @@ import type { LogMessageData } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { isObject } from '@utils/core';
+import { truncateSummary } from '@utils/text/stringUtils';
 
 // Local imports - Lit template utilities
 import {
@@ -51,7 +52,6 @@ import {
   getToolTimeoutMs,
   joinWithSeparator,
   truncateHeaderSummary,
-  truncatePrompt,
   EXECUTIONS_DEFAULT_ACTION,
 } from './toolFormatters/helpers';
 import { dispatchToolSections } from './toolFormatters/toolSections';
@@ -108,13 +108,13 @@ export function formatToolUseTemplate(
       isObject(input) &&
       typeof input.prompt === 'string'
     ) {
-      headerSummary = truncatePrompt(input.prompt, 60);
+      headerSummary = truncateSummary(input.prompt, 60);
     } else if (
       toolName === 'bash' &&
       isObject(input) &&
       typeof input.command === 'string'
     ) {
-      headerSummary = truncatePrompt(input.command, 60);
+      headerSummary = truncateSummary(input.command, 60);
     }
   }
   headerSummary = truncateHeaderSummary(headerSummary, 120);

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -91,11 +91,6 @@ export function getToolTimeoutMs(
   return typeof input.timeout === 'number' ? input.timeout : defaultTimeout;
 }
 
-/** Truncate a prompt string for display in collapsed headers. */
-export function truncatePrompt(text: string, maxLength: number): string {
-  return truncateWithEllipsis(collapseWhitespace(text), maxLength);
-}
-
 /** Truncate tool header text without pulling streamed stdout/stderr into it. */
 export function truncateHeaderSummary(text: string, maxLength: number): string {
   const oneLine = collapseWhitespace(text);


### PR DESCRIPTION
## Summary

`truncatePrompt(text, maxLength)` in the progress view's tool formatters was a byte-for-byte duplicate of the shared `truncateSummary()` in `@utils/text/stringUtils`:

```ts
// helpers.ts (deleted)
export function truncatePrompt(text, maxLength) {
  return truncateWithEllipsis(collapseWhitespace(text), maxLength);
}
// stringUtils.ts (canonical)
export function truncateSummary(text, maxLength) {
  return truncateWithEllipsis(collapseWhitespace(text), maxLength);
}
```

The CLI (`sessionStatus.ts`) and `src/tools` already consume the shared `truncateSummary`; the progress view was the only place re-deriving it locally. This deletes `truncatePrompt` and calls `truncateSummary` at its two call sites (codex prompt, bash command headers).

`truncateHeaderSummary` in the same file is **kept** — it's a distinct variant that strips `<stdout>`/`<stderr>` markers before truncating.

## Why

Found during a UI-standardization audit (round 2, dup-formatters lens). Behaviorally identical (same body), so this is a pure dead-code dedup. Net −5 LOC.

## Verification
- `corepack pnpm --filter texra typecheck` — passes.
- `grep truncatePrompt` across `src/` + `packages/` — zero residual references after the change.
- Bodies are identical, so output is unchanged for every call site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical truncation logic; display-only progress view formatting.
> 
> **Overview**
> Removes the local **`truncatePrompt`** helper from progress-view tool formatters and uses the shared **`truncateSummary`** from `@utils/text/stringUtils` for collapsed **codex** prompt and **bash** command header text (60-char limit). Behavior is unchanged because the deleted helper matched the shared implementation.
> 
> **`truncateHeaderSummary`** in `helpers.ts` is unchanged; it still strips `<stdout>`/`<stderr>` markers before truncating longer headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda5115174707ab710036635db4fa1117e1a5427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->