### PR TITLE
refactor(progressView): validate context-state via ContextStateDataSchema

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -2,6 +2,7 @@ import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
+  ContextStateDataSchema,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_STATUS,
@@ -29,20 +30,8 @@ function isTaskGroupStatus(
 }
 
 function asContextStateData(data: unknown): ContextStateData | undefined {
-  if (typeof data !== 'object' || data === null) return undefined;
-  const value = data as Partial<ContextStateData>;
-  if (
-    typeof value.inputTokens === 'number' &&
-    typeof value.contextWindow === 'number' &&
-    typeof value.utilizationPercent === 'number'
-  ) {
-    return {
-      inputTokens: value.inputTokens,
-      contextWindow: value.contextWindow,
-      utilizationPercent: value.utilizationPercent,
-    };
-  }
-  return undefined;
+  const result = ContextStateDataSchema.safeParse(data);
+  return result.success ? result.data : undefined;
 }
 
 function toLogMessage(entry: StreamLogEntry): LogMessageData {


### PR DESCRIPTION
## What

\`asContextStateData\` (`progressView/frontend/slices/logSlice.ts`) cast \`unknown\` → \`Partial<ContextStateData>\` and then hand-rolled \`typeof === 'number'\` checks on \`inputTokens\` / \`contextWindow\` / \`utilizationPercent\` before rebuilding the object — duplicating validation that a Zod schema already expresses.

Replace the body with \`ContextStateDataSchema.safeParse(data)\`, the canonical schema in \`src/shared/schemas/contextManagement.ts\`. Net −11 lines, removes the cast.

## Why it's safe

- \`ContextStateDataSchema\` is already the source of truth for this exact shape at the IPC boundary (\`streamState.ts\`, \`progressView/outbound.ts\`), so the data reaching this single call site already conforms.
- \`safeParse\` returning \`undefined\` on failure preserves the existing contract (the call site at line ~134 only assigns when truthy).
- The schema is marginally stricter (nonnegative-int tokens, positive context window) — consistent with how the value is defined everywhere else; real context-state payloads satisfy it.

## Verification

- \`npx tsc --noEmit\` — no new errors.

🤖 Found via round 2 of a multi-agent data-structure complexity audit (adversarially verified).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation refactor in progress view UI state; behavior on success/failure is preserved and aligns with existing schema usage elsewhere.
> 
> **Overview**
> **`asContextStateData`** in the progress view log slice no longer casts `unknown` and checks three numeric fields by hand. It now uses **`ContextStateDataSchema.safeParse`**, matching the shared IPC/schema definition and returning `undefined` on failure like before.
> 
> Call sites that only set `streamState.contextState` when parsing succeeds are unchanged; validation is slightly stricter (e.g. nonnegative token counts, positive context window) in line with the rest of the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e800bf83ac46e8cbdcf135612bf2ed3aab01b443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->