### PR TITLE
refactor: drop redundant config.model write in model-switch callback

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -356,8 +356,11 @@ export async function executeAgent(
                   });
                   options.onFollowUpConsumed?.();
                 },
-                onModelChanged: (modelHandler, model) => {
-                  ctx.config.model = model;
+                onModelChanged: (modelHandler) => {
+                  // The tool-use flow already wrote services.config.model
+                  // (=== ctx.config.model, same object), so the live model is
+                  // updated before this fires; only the usage side-effect is
+                  // left to do here.
                   ctx.usageMonitor.setModelInfo({
                     capabilities: modelHandler.capabilities,
                     config: modelHandler.config,


### PR DESCRIPTION
## What

Removes a duplicate writer of `config.model`. When the tool-use flow switches models, **two places** wrote the same field to the same value on the same object:

```ts
// runToolUseFlow switchModel() — owner #1
services.config.model = model;
input.onModelChanged?.(nextHandler, model);

// executeAgent onModelChanged callback — owner #2 (redundant)
onModelChanged: (modelHandler, model) => {
  ctx.config.model = model;            // ← same object, same value, already set
  ctx.usageMonitor.setModelInfo({ capabilities: modelHandler.capabilities, config: modelHandler.config });
}
```

After:

```ts
onModelChanged: (modelHandler) => {
  ctx.usageMonitor.setModelInfo({ capabilities: modelHandler.capabilities, config: modelHandler.config });
}
```

## Why it's safe (single-owner)

- `services` is built as `{ ...input }` and the flow input as `{ ...ctx }`, with `config` never overridden — so **`services.config === ctx.config`** (same reference).
- `switchModel` sets `services.config.model = model` **before** invoking `onModelChanged`, so `ctx.config.model` is already updated when the callback fires.
- `RunContext.model` reads `ctx.config.model` **live** via `getModel: () => ctx.config.model` (`AgentLaunchContext.ts`) — the docstring explicitly notes "mid-session model switches are visible."
- The **resume call site** in `executeAgent` passes **no `onModelChanged`** and relies solely on the flow's write — proving the flow's write alone is sufficient.
- `setModelInfo` uses `modelHandler.capabilities`/`config`, not the `model` string, so the now-unused `model` param is dropped.

This is the documented single-owner / resolve-once cleanup: the flow owns `config.model`; the host callback does the usage side-effect only.

## Verification

- `src/test-kernel/agent/toolUse/ModelSwitchState.vitest.ts` — **3/3 pass**.
- `tsc --noEmit` (root + test-kernel), prettier, eslint clean.
- No test referenced the host callback's write.

---
🤖 Found by Round 2 of the abstraction-layer audit (dual-ownership-state lens). `fixKind: delete`, net −2 LOC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving cleanup with no change to who persists the model string; usage tracking still runs on switch.
> 
> **Overview**
> Removes duplicate ownership of **`config.model`** during mid-session model switches in tool-use runs.
> 
> The **`onModelChanged`** hook in **`executeAgent`** no longer assigns **`ctx.config.model`** or takes the **`model`** argument. **`runToolUseFlow`**’s **`switchModel`** already sets **`services.config.model`** on the shared config object before the callback runs, so the host only updates **`usageMonitor.setModelInfo`** from the new handler’s capabilities/config.
> 
> **`resumeToolUseFromSnapshot`** still omits **`onModelChanged`**, unchanged—resume continues to rely on the flow as the sole writer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8544925cef2c81e1a55d038d1d2f3df3d9d41f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->