### PR TITLE
refactor(cli): validate launch config via shared validateExecutionRequest

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -1,8 +1,6 @@
 import { writeTerminalStatus } from '@agent/storage';
-import {
-  AgentConfigSchema,
-  type AgentConfigPayload,
-} from '@agent/core/definition/AgentConfig';
+import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import { validateExecutionRequest } from '@agent/core/execution/executionRequests';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
@@ -106,9 +104,13 @@ export async function runToolUseAgent(
       };
 
       const executionId = generateExecutionId();
-      const registeredConfig = AgentConfigSchema.parse(config);
+      const validation = validateExecutionRequest({ config, executionId });
+      if (!validation.valid) {
+        writeTextStderr(validation.message);
+        return CliExitCode.Usage;
+      }
       const { result, terminalStatus } = await executeCliRequest(
-        { config: registeredConfig, executionId },
+        validation.request,
         runContext,
         {
           enforceCategory: true,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -2,10 +2,8 @@ import { defineCommand } from 'citty';
 
 import { getAgentsByCategory, loadAgents } from '@agent/index';
 import { writeTerminalStatus } from '@agent/storage';
-import {
-  AgentConfigSchema,
-  type AgentConfigPayload,
-} from '@agent/core/definition/AgentConfig';
+import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import { validateExecutionRequest } from '@agent/core/execution/executionRequests';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { EXECUTION_STATUS } from '@shared/schemas';
@@ -353,9 +351,13 @@ export async function runMultiAgentPreset(
       };
 
       const executionId = generateExecutionId();
-      const registeredConfig = AgentConfigSchema.parse(config);
+      const validation = validateExecutionRequest({ config, executionId });
+      if (!validation.valid) {
+        writeTextStderr(validation.message);
+        return CliExitCode.Usage;
+      }
       const { result, terminalStatus } = await executeCliRequest(
-        { config: registeredConfig, executionId },
+        validation.request,
         runContext,
         {
           enforceCategory: true,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,8 +1,6 @@
 import { writeTerminalStatus } from '@agent/storage';
-import {
-  AgentConfigSchema,
-  type AgentConfigPayload,
-} from '@agent/core/definition/AgentConfig';
+import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import { validateExecutionRequest } from '@agent/core/execution/executionRequests';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
@@ -13,7 +11,7 @@ import {
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
-import { writeErrorStderr } from '../runtime/logSinks';
+import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 import {
   buildHeadlessRunContext,
   resolveCliRunModel,
@@ -116,9 +114,13 @@ export async function runWorkflowAgent(
       };
 
       const executionId = generateExecutionId();
-      const registeredConfig = AgentConfigSchema.parse(config);
+      const validation = validateExecutionRequest({ config, executionId });
+      if (!validation.valid) {
+        writeTextStderr(validation.message);
+        return CliExitCode.Usage;
+      }
       const { result, terminalStatus } = await executeCliRequest(
-        { config: registeredConfig, executionId },
+        validation.request,
         runContext,
         {
           enforceCategory: true,


### PR DESCRIPTION
## What

The three headless CLI runners — `agents run`, `workflow run`, `multi-agent run` — each called `AgentConfigSchema.parse(config)` directly at the launch boundary:

```ts
const registeredConfig = AgentConfigSchema.parse(config);   // throws ZodError
await executeCliRequest({ config: registeredConfig, executionId }, …);
```

Every UI host (`ProgressViewMessageHandler`, `MainViewExecutionController`, desktop `desktopProgressFileActions`) deliberately funnels the same boundary through the shared **`validateExecutionRequest()`**, which `safeParse`s and returns a path-qualified `{ valid, message }`. The CLI was the lone host re-implementing it a second, divergent (throwing) way.

```ts
const validation = validateExecutionRequest({ config, executionId });
if (!validation.valid) {
  writeTextStderr(validation.message);
  return CliExitCode.Usage;
}
await executeCliRequest(validation.request, …);
```

## Why it matters (not just dedup — a correctness/UX bug)

The raw `parse` throws a `ZodError` **outside** the `CliUsageError → CliExitCode.Usage(2)` catch, so a *user-fixable* bad config surfaced as an internal crash:

```
TeXRA CLI failed: … <stack> …        ← AgentError exit, "please file a bug" line
```

instead of the clean, human-readable boundary error the guide (clig.dev, "rewrite errors for humans") calls for:

```
Invalid configuration (model): …      ← Usage(2)
```

## Notes

- `executeCliRequest` already takes the validator's `ValidatedExecutionRequest`, so on the happy path the parsed config flows through **unchanged** (`validateExecutionRequest` returns `AgentConfigSchema.safeParse(...).data` — same value the old `.parse` produced).
- Drops the now-unused `AgentConfigSchema` import from the CLI command layer → one owner of launch-boundary validation across all hosts.
- The interactive chat TUI parse (`runChatTui.tsx`) is intentionally **left as-is**: it returns the parsed config for downstream use and its rejection lands on a promise, not the headless crash path.

## Verification

- `tsc --noEmit -p packages/cli/tsconfig.json` — **0 errors** in the three files.
- `src/test-kernel/agent/core/ConfigSchemas.vitest.ts` passes; prettier + eslint clean.
- No test pinned the old throwing behavior. (Local `AgentsRunCommand` run is blocked by an unrelated missing-dep artifact in this sandbox; CI `validate` runs it with full deps.)

---
🤖 Found by Round 2 of the abstraction-layer audit (schema-placement lens). `fixKind: dedup`; the win is one-owner + correct CLI error UX.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized launch-boundary refactor with clearer usage errors; happy-path execution payload is unchanged.
> 
> **Overview**
> Headless **`agents run`**, **`workflow run`**, and **`multi-agent run`** no longer call **`AgentConfigSchema.parse`** at launch. They use the shared **`validateExecutionRequest`** helper (same path as web/desktop hosts), pass **`validation.request`** into **`executeCliRequest`**, and on failure print the validator message to stderr and return **`CliExitCode.Usage`** instead of letting a **`ZodError`** bubble up as a CLI crash.
> 
> **`AgentConfigSchema`** imports are dropped from these command modules; successful validation still yields the same parsed config as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130e20a3f0e57537580ebe1633389debd3d2446d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->