### PR TITLE
fix: use canonical WA color tokens in relay quota meter

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
@@ -56,15 +56,15 @@ export class RelayQuotaMeter extends LitElement {
         padding: var(--wa-space-m) var(--wa-space-l);
         border: var(--border-thin) solid var(--wa-color-neutral-border-quiet);
         border-radius: var(--border-radius);
-        background: var(--wa-color-neutral-background-quiet);
+        background: var(--wa-color-neutral-fill-quiet);
       }
       .quota-meter[data-state='exhausted'] {
         border-color: var(--wa-color-danger-border-quiet);
-        background: var(--wa-color-danger-background-quiet);
+        background: var(--wa-color-danger-fill-quiet);
       }
       .quota-meter[data-state='warning'] {
         border-color: var(--wa-color-warning-border-quiet);
-        background: var(--wa-color-warning-background-quiet);
+        background: var(--wa-color-warning-fill-quiet);
       }
       .quota-row {
         display: flex;
@@ -80,7 +80,7 @@ export class RelayQuotaMeter extends LitElement {
       .quota-amount {
         font-variant-numeric: tabular-nums;
         font-size: var(--wa-font-size-s);
-        color: var(--wa-color-neutral-text-quiet);
+        color: var(--wa-color-neutral-on-quiet);
       }
       /* Native wa-progress-bar, compacted to a 6px track; colour the indicator
          per quota state via its --indicator-color custom property. */
@@ -98,7 +98,7 @@ export class RelayQuotaMeter extends LitElement {
       .quota-note {
         margin-top: var(--wa-space-xs);
         font-size: var(--wa-font-size-xs);
-        color: var(--wa-color-neutral-text-quiet);
+        color: var(--wa-color-neutral-on-quiet);
       }
     `,
   ];


### PR DESCRIPTION
## Summary

`RelayQuotaMeter` (Settings → Models, relay quota/spend meter) referenced **four Web Awesome color tokens that don't exist** in either host bridge (`packages/extension/src/common/styles/common.css`, `packages/desktop/src/renderer/themeTokens.css`) or Web Awesome itself — and with **no `var(..., fallback)`**:

| Phantom token | Sites | Should be |
|---|---|---|
| `--wa-color-neutral-background-quiet` | `.quota-meter` bg | `--wa-color-neutral-fill-quiet` |
| `--wa-color-danger-background-quiet` | exhausted state | `--wa-color-danger-fill-quiet` |
| `--wa-color-warning-background-quiet` | warning state | `--wa-color-warning-fill-quiet` |
| `--wa-color-neutral-text-quiet` | amount + note text (×2) | `--wa-color-neutral-on-quiet` |

Because the tokens resolve to nothing, the neutral/warning/exhausted **background bands render transparent** (inheriting the surrounding surface) and the spend-amount + note text **fall back to inherited color** instead of the intended muted tone. The band color is the meter's primary state signal, so the warning vs. exhausted distinction — the whole point of the meter — is visually lost. This is baked into shipped builds.

## Fix

WA's semantic color scale is `<variant>-fill-<weight>` (background) and `<variant>-on-<weight>` (foreground sitting on that fill). The **sibling lines in the same stylesheet already use the canonical names** (`-border-quiet` at :57/62/66, `-fill-loud` at :90/93/96) — only these five picked invented names. Rename them to the canonical tokens, all of which are verified present in **both** host bridges:

```diff
-        background: var(--wa-color-neutral-background-quiet);
+        background: var(--wa-color-neutral-fill-quiet);
...
-        color: var(--wa-color-neutral-text-quiet);   /* ×2 */
+        color: var(--wa-color-neutral-on-quiet);
```

`-on-quiet` is the correct foreground token for text on the meter's `-fill-quiet` background.

## Why

Found during a deep design-token audit. A tree-wide check (every referenced `--wa-color-*` minus the union of both bridges and WA's own defs) found these were the **only** undefined `--wa-color-*` tokens in production code — narrow and concentrated, not a broad drift epidemic.

## Scope / verification
- Pure rename, **net 0 LOC** (5 sites). Behavior change is corrective: bands gain their intended color.
- All 4 canonical tokens confirmed defined in `common.css` **and** `themeTokens.css`, so the fix resolves on extension + desktop.
- No phantom `*-background-quiet` / `*-text-quiet` tokens remain in the file.
- CSS-string-only change (inside a `css\`\`` template) — no TypeScript surface; CI `validate` build confirms.

## Noted but not included
A dev-only mock (`webview/frontend/mocks/ContextUtilizationMock.ts:71`) uses `--wa-color-danger-text-loud`, the same phantom-token class. Left out of this PR: it's not user-facing, and the right replacement there is a semantic judgment (loud danger *text* vs. an `-on-loud` foreground) better made separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only token renames in one component stylesheet; restores intended visuals with no logic or data-path changes.
> 
> **Overview**
> **`RelayQuotaMeter`** (Settings → Models relay spend meter) used **five Web Awesome CSS variables that are not defined** (`*-background-quiet`, `*-text-quiet`), so state backgrounds were transparent and muted text did not render as intended.
> 
> The diff **renames only those variables** to the canonical WA pairs already used elsewhere in the same block: **`--wa-color-*-fill-quiet`** for neutral/warning/danger meter backgrounds and **`--wa-color-neutral-on-quiet`** for the amount and note text. No TypeScript or layout changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f687d501440c0b01ff12eee073fb77c83fc232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->