### PR TITLE
fix: correct formatTokens M-suffix threshold (100k no longer renders as 0.2M)

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
@@ -37,9 +37,9 @@ export function formatTimestamp(date: Date): {
   };
 }
 
-/** Format token counts for display. Values >= 100k display as "M", > 4096 as "k", otherwise raw. */
+/** Format token counts for display. Values >= 1M display as "M", > 4096 as "k", otherwise raw. */
 export function formatTokens(tokens: number): string {
-  if (tokens >= 100_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
   if (tokens > 4096) return `${Math.round(tokens / 1000)}k`;
   return `${tokens}`;
 }


### PR DESCRIPTION
## Summary

`formatTokens` (progress-view token display) triggers the `M` suffix at `tokens >= 100_000` but divides by `1_000_000`:

```ts
if (tokens >= 100_000) return `${(tokens / 1_000_000).toFixed(1)}M`;  // bug: 100k = 0.1M
```

So every value in `[100_000, 1_000_000)` renders as a fractional megatoken:

| tokens | rendered (before) | rendered (after) |
|--------|-------------------|------------------|
| 100,000 | `0.1M` | `100k` |
| 128,000 | `0.1M` | `128k` |
| 200,000 | `0.2M` | `200k` |
| 1,000,000 | `1.0M` | `1.0M` |

These are exactly the common model context-window magnitudes (128k, 200k), so the bug fires on essentially every panel render.

## Symptom
In the progress view, the `UsagePanel` context gauge shows `0.2M / 0.2M` for a 200k window, input/output/cache figures show `0.1M`, and the context-management reduction line shows `0.2M → 0.1M` — all nonsensically tiny, and inconsistent with the CLI.

## Fix
Raise the `M` threshold to `1_000_000` (one-line constant + doc comment). The existing `> 4096` k-band then formats the 100k–1M range as `200k`, matching the CLI's `formatCompactNumber` (`StatusBar.tsx`), which already uses the correct 1M boundary.

## Why / verification
- Found by a multi-agent correctness sweep (round 7); confirmed by two independent lenses and adversarially re-verified against the call sites (`UsagePanel.ts`, `contextManagementFormatters.ts`).
- Correct behavior is unambiguous and has in-repo precedent (CLI `formatCompactNumber` 1M boundary).
- Display-only change, no functional side effects; CI `validate` build + typecheck confirm.

This is the concrete wrong-output half of the known `formatTokens`-vs-`formatCompactNumber` drift; full formatter unification remains a separate follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatter constant change with no logic beyond the threshold; affects progress view labels only.
> 
> **Overview**
> **Fixes misleading token labels in the progress view** by aligning `formatTokens` with how megatokens should read: the `M` suffix now applies only at **≥ 1M** tokens instead of **≥ 100k**, while still dividing by `1_000_000`.
> 
> Previously, 100k–999k values were shown as fractional megatokens (e.g. 200k → `0.2M`), which broke context gauges and usage lines for common window sizes (128k, 200k). Those values now use the existing `k` band (`200k`, etc.), consistent with the CLI’s `formatCompactNumber`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 776642f50b9af54b8acbb3178e186ed547bd15da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->