### PR TITLE
fix: prevent markdown chat export from breaking on triple-backtick content

### DIFF
--- a/packages/extension/src/commands/history/chatExport/markdownSpec.ts
+++ b/packages/extension/src/commands/history/chatExport/markdownSpec.ts
@@ -9,6 +9,22 @@ import {
 } from './formatSpec';
 import type { DocumentMeta } from './schemas';
 
+/**
+ * Wrap raw body text in a fenced code block whose delimiter is longer than the
+ * longest backtick run inside the body. Tool output and fetched pages routinely
+ * contain ``` lines; a fixed three-backtick fence would let them break out and
+ * corrupt the document. CommonMark closes a fence only on a backtick run at
+ * least as long as the opening one, so an over-long fence is breakout-proof.
+ */
+function fencedBlock(body: string, info = ''): string {
+  const longestRun = Math.max(
+    0,
+    ...[...body.matchAll(/`+/g)].map((m) => m[0].length),
+  );
+  const fence = '`'.repeat(Math.max(3, longestRun + 1));
+  return `${fence}${info}\n${body}\n${fence}`;
+}
+
 function markdownHeader(meta: DocumentMeta): string {
   const fields = HEADER_FIELDS.filter((f) => meta[f.key])
     .map((f) => `**${f.label}:** ${meta[f.key]}  `)
@@ -58,9 +74,9 @@ const MD_NODES: NodeRenderers = {
   'assistant-text': ({ text }) => `### Assistant\n\n${text}\n`,
 
   'tool-call': ({ name, input }) =>
-    `#### Tool: \`${name}\`\n\n\`\`\`json\n${input}\n\`\`\`\n`,
+    `#### Tool: \`${name}\`\n\n${fencedBlock(input, 'json')}\n`,
 
-  'tool-result': ({ text }) => `#### Tool Result\n\n\`\`\`\n${text}\n\`\`\`\n`,
+  'tool-result': ({ text }) => `#### Tool Result\n\n${fencedBlock(text)}\n`,
 
   'web-search': ({ query }) => `#### Web Search\n\n**Query:** ${query}\n`,
 
@@ -73,7 +89,7 @@ const MD_NODES: NodeRenderers = {
       '',
       url ? `**URL:** ${url}` : undefined,
       title ? `**Title:** ${title}` : undefined,
-      content ? `\n\`\`\`\n${content}\n\`\`\`` : undefined,
+      content ? `\n${fencedBlock(content)}` : undefined,
       '',
     ]
       .filter(filterNotNullish)


### PR DESCRIPTION
## Summary

The Markdown chat-export spec wrapped tool-call input, tool-result text, and web-fetch content in a **fixed three-backtick fence**:

```ts
'tool-result': ({ text }) => `#### Tool Result\n\n\`\`\`\n${text}\n\`\`\`\n`,
```

Tool results are raw provider output (bash dumps, file reads, fetched pages, agent transcripts) that routinely contain a ` ``` ` line. Per CommonMark, a fenced block closes at the first line with a backtick run **at least as long** as the opening fence — so an embedded ` ``` ` closes the fence early, and everything after it renders as prose (headings/links/bold interpreted), with the document's later fences going unbalanced. The exported `.md` is corrupted for ordinary input.

## Fix

Add a `fencedBlock(body, info)` helper that sizes the fence one backtick longer than the longest backtick run in the body, and use it for all three fenced renderers (tool-call, tool-result, web-fetch):

```ts
const fence = '`'.repeat(Math.max(3, longestBacktickRun(body) + 1));
```

An opening fence of length N is only closed by a run of ≥N backticks, so the raw body can't break out. Output is **byte-identical** for fence-free bodies.

## Why / verification
- Found by a multi-agent correctness sweep (round 9), adversarially verified against the export spec and the raw bodies fed in by `normalizeMessages`.
- Decisive in-repo precedent: the sibling LaTeX renderer (`escapeUtils.ts` `latexListing`) already sanitizes the same breakout hazard (`\end{lstlisting}`) for the same raw tool output; the Markdown path simply lacked the guard. This is the standard GitHub/pandoc nested-fence idiom.
- Verified: fence-free body → unchanged output; body containing ` ``` ` → escalates to a 4-backtick fence (breakout-proof). CI `validate` build + typecheck confirm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to markdown export rendering only; no runtime, auth, or persistence impact.
> 
> **Overview**
> Markdown chat export no longer uses a fixed three-backtick fence around tool JSON, tool results, and web-fetch bodies. A new **`fencedBlock`** helper picks a fence length one backtick longer than the longest backtick run in the content (minimum three), so embedded ` ``` ` lines in raw tool or page output cannot close the fence early and corrupt the rest of the `.md`.
> 
> **Tool-call**, **tool-result**, and **web-fetch** renderers now call **`fencedBlock`** instead of hard-coded fences; output stays the same when the body has no backticks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d818f2be7e6253027cc74ae1c570f1a1eab8ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->