### PR TITLE
refactor(runtime): drop dead/redundant data from the launch→flow projection

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -120,9 +120,8 @@ const STATUS_MESSAGES: Record<string, string> = {
  * This is the single owner of the launch-context → ambient-context mapping, so
  * new per-run flags (e.g. `stopAfterCycle`, `approvalPromptsUnavailable`,
  * `runtimeUnavailableTools`) live in one place and are never silently dropped.
- * The ambient context is intentionally a flat projection, so three fields are
+ * The ambient context is intentionally a flat projection, so two fields are
  * renamed from their nested `AgentCore` positions:
- *  - `AgentCore.logger`   → `RunContext.trace`
  *  - `AgentConfig.agent`  → `RunContext.agentName`
  *  - `AgentConfig.model`  → `RunContext.model`
  *
@@ -136,7 +135,6 @@ function agentContextToRunContext(
     runtimeHost: ctx.runtimeHost,
     streamId: ctx.streamId,
     executionId: ctx.executionId,
-    trace: ctx.logger,
     coordinators: ctx.coordinators,
     getModel: () => ctx.config.model,
     agentName: ctx.config.agent,

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -1,6 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import { noopTrace, type AgentTrace } from '@agent/trace';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
@@ -27,7 +26,6 @@ export interface RunCoordinators {
  * **Why the field names differ from AgentCore.** This is a *flat* ambient
  * projection, not a copy of the nested launch context, so the names describe
  * the run directly rather than mirror `AgentCore`'s shape:
- *   - `AgentCore.logger`   → `trace`     (the run's `AgentTrace` SDK channel)
  *   - `AgentConfig.agent`  → `agentName` (`AgentConfig` nests it; here it is flat)
  *   - `AgentConfig.model`  → `model`     (flat + live; see below)
  *
@@ -43,15 +41,6 @@ export interface RunContext {
   readonly runtimeHost: AgentRuntimeHost;
   readonly streamId?: StreamTabId;
   readonly executionId?: ExecutionId;
-  /**
-   * Discriminated-event SDK channel for this run. Defaults to `noopTrace`
-   * when the context is created without a trace (e.g. in tests).
-   *
-   * Most tools receive the trace via explicit parameter threading rather than
-   * reading it here; this field exists for test helpers and future SDK
-   * consumers that need the trace without access to the full AgentLaunchContext.
-   */
-  readonly trace: AgentTrace;
   readonly coordinators?: RunCoordinators;
   /** Current model short name for this run (e.g. "opus46T"). */
   readonly model?: string;
@@ -84,11 +73,6 @@ export interface CreateRunContextOptions {
   runtimeHost: AgentRuntimeHost;
   streamId?: StreamTabId;
   executionId?: ExecutionId;
-  /**
-   * Discriminated-event channel for the run. When omitted, the context uses
-   * `noopTrace`.
-   */
-  trace?: AgentTrace;
   coordinators?: RunCoordinators;
   /** Static model fallback for manually-created run contexts. */
   model?: string;
@@ -116,7 +100,6 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     runtimeHost: options.runtimeHost,
     streamId: options.streamId,
     executionId: options.executionId,
-    trace: options.trace ?? noopTrace,
     coordinators: options.coordinators,
     get model() {
       return getModel?.() ?? model;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -333,10 +333,7 @@ export async function executeAgent(
                 onRoundFinalized,
                 setting,
                 isSubagent,
-                approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-                runtimeUnavailableTools: options.runtimeUnavailableTools,
                 onBeforeWaiting: options.onBeforeWaiting,
-                stopAfterCycle: options.stopAfterCycle,
                 onProgress: (update) => {
                   if (update.kind === 'overview') {
                     toolUseTurns++;
@@ -487,8 +484,6 @@ export async function resumeToolUseFromSnapshot(
             // would drop subagent-specific instructions (e.g. the shared
             // /memories protocol) that the fresh run had included.
             isSubagent,
-            approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-            runtimeUnavailableTools: options.runtimeUnavailableTools,
             onFollowUpConsumed: () =>
               ctx.runtimeHost.emit('updateQueuedFollowUps', {
                 streamId: ctx.streamId,

--- a/src/test-kernel/agent/runtime/RunContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunContext.vitest.ts
@@ -22,7 +22,7 @@ describe('RunContext', () => {
     expect(Object.isFrozen(context)).toBe(true);
 
     expect(() => {
-      (context as { trace: unknown }).trace = {};
+      (context as { runtimeHost: unknown }).runtimeHost = {};
     }).toThrow(TypeError);
   });
 
@@ -32,13 +32,6 @@ describe('RunContext', () => {
         runtimeHost: undefined as unknown as AgentRuntimeHost,
       }),
     ).toThrow(/explicit runtimeHost/);
-  });
-
-  it('defaults to the no-op trace when none is provided', () => {
-    const context = createRunContext({ runtimeHost: createRuntimeHost() });
-
-    expect(context.trace).toBeDefined();
-    expect(() => context.trace.debug('hello')).not.toThrow();
   });
 
   it('exposes the runtime host owned by the active context', () => {


### PR DESCRIPTION
Two independent, behavior-preserving net-negative cleanups on the busiest call boundary in the runtime (`executeAgent` → `runToolUseFlow`). Found by the deep architectural audit (god-context / dead-carrier lenses).

## 1. Redundant flag re-passes (dual-write at the call boundary)

`executeAgent` assigns three per-run flags onto `ctx`:

```ts
ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
ctx.runtimeUnavailableTools   = options.runtimeUnavailableTools;
ctx.stopAfterCycle            = options.stopAfterCycle;
```

…then builds the flow input as `{ ...ctx, … }` **and** re-passes the same three from `options` — byte-identical, no intervening reassignment. The tell that this is accidental: `delegationDepth` is set the same way but is **not** re-passed, and flows correctly through the spread alone. Removed the redundant explicit fields at both the fresh and resume call sites; the spread carries them.

## 2. Dead `RunContext.trace` projection chain

`RunContext.trace` was set from `AgentLaunchContext` (`logger → trace`), defaulted to `noopTrace`, and **read in zero production sites** — every `tryUseRunContext()`/`useRunContext()` consumer reads `executionId`/`workingDirectory`/`streamId`/`coordinators`/`session`/`runtimeHost`/`model`/`delegationDepth`, never `.trace`. The only readers were two self-validating test assertions. The field's own JSDoc conceded it "exists for test helpers and future SDK consumers."

The public SDK trace surface — `AgentRunHandle.trace`, a distinct constructor-injected handle field — is **not** this projection and is untouched. Removed:
- `RunContext.trace` + `CreateRunContextOptions.trace` + the `noopTrace` default and now-unused `@agent/trace` import
- the `trace: ctx.logger` projection line + stale JSDoc (and the "three fields → two fields" count)
- the trace-default test; retargeted the freeze-immutability poke from `trace` to `runtimeHost`

Trace still reaches run-scoped code via explicit `AgentTrace` parameter threading / `createRunTrace()` — unchanged.

## Verification
- `tsc --noEmit` (root + test-kernel) clean for all touched files; prettier + eslint clean.
- `RunContext.vitest` passes (5/5).
- No production reader of `RunContext.trace`; no `createRunContext` caller passes `trace:`.

Net −31 LOC, no behavior change.

---
🤖 Round-3–10 deep audit (run against current origin/main).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving removal of redundant fields and an unused projection with no production readers; tool-use flags still flow through `ctx` spread.
> 
> **Overview**
> Cleans up the **`executeAgent` → `runToolUseFlow`** boundary so per-run flags (`approvalPromptsUnavailable`, `runtimeUnavailableTools`, `stopAfterCycle`) are carried only via the spread of `ctx` after they are assigned on the launch context—no second copy from `options` at fresh or resume call sites.
> 
> Removes the **dead ambient trace projection**: `RunContext.trace`, `CreateRunContextOptions.trace`, the `logger → trace` line in `agentContextToRunContext`, and the `@agent/trace` / `noopTrace` wiring in `RunContext`. Run-scoped tracing via explicit `AgentTrace` / `AgentRunHandle.trace` is unchanged.
> 
> Tests drop the noop-trace default assertion and poke freeze immutability on `runtimeHost` instead of `trace`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1aa6b6acfd540bdeeea8a10fc2bb97a270965ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->