### PR TITLE
refactor(cli): use core formatCompactDuration for the run-line elapsed

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -10,6 +10,7 @@ import {
   type ExecutionStatus,
   type StreamStatus,
 } from '@shared/schemas';
+import { formatCompactDuration } from '@utils/core';
 
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
@@ -288,7 +289,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     ) {
       parts.push(`tools: ${this.state.toolCallCount}`);
     }
-    parts.push(formatElapsed(now - this.startedAt));
+    parts.push(formatCompactDuration(now - this.startedAt));
     return parts.join(' · ');
   }
 }
@@ -328,12 +329,4 @@ function formatActiveChildren(
   const suffix =
     namedChildren.length > 1 ? ` +${namedChildren.length - 1}` : '';
   return `${label}: ${first}${suffix}`;
-}
-
-function formatElapsed(ms: number): string {
-  const seconds = Math.max(0, Math.floor(ms / 1000));
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  if (minutes === 0) return `${remainingSeconds}s`;
-  return `${minutes}m ${remainingSeconds.toString().padStart(2, '0')}s`;
 }


### PR DESCRIPTION
`runProgressRenderer` hand-rolled a private `formatElapsed` (minutes/seconds split with zero-padded seconds), duplicating `@utils/core` `formatCompactDuration` — the canonical ms→human duration primitive the rest of the CLI already uses (`StatusBar`, `childControls`). The same run rendered its elapsed time through **two** formatters.

```ts
// before — private, in runProgressRenderer.ts
function formatElapsed(ms){ s=floor(ms/1000); m=floor(s/60); r=s%60;
  return m ? `${m}m ${pad(r)}s` : `${r}s`; }
parts.push(formatElapsed(now - this.startedAt));

// after
import { formatCompactDuration } from '@utils/core';
parts.push(formatCompactDuration(now - this.startedAt));
```

Folds the run status line onto the shared primitive (split-ownership of a deliberately-centralized helper).

**Output delta:** sub-minute is identical (`0s`/`1s`/`2s` — the only values `RunProgressRenderer.vitest` asserts). For ≥1min it drops the cosmetic zero-pad (`1m 5s` vs `1m 05s`); for ≥1h it uses `1h 15m` instead of `75m 00s` — both of which **match the rest of the CLI** rather than diverge from it.

## Verification
- CLI `tsc --noEmit`, prettier, eslint clean.
- `RunProgressRenderer.vitest` assertions are all sub-minute and unchanged under `formatCompactDuration` (CI runs the full suite; the local sandbox can't load it due to an unrelated missing-dep).

Net −6 LOC.

---
🤖 Round-3–10 deep audit (reimplemented-primitive lens).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic formatting consolidation in CLI progress output only; sub-minute behavior stays the same per existing tests.
> 
> **Overview**
> The run progress status line no longer uses a **private `formatElapsed` helper** in `runProgressRenderer.ts`. It now imports **`formatCompactDuration` from `@utils/core`**, the same duration formatter already used by the TUI status bar and child controls.
> 
> That removes duplicated minutes/seconds formatting logic (~8 lines) and **aligns long-run elapsed display** with the rest of the CLI (e.g. no zero-padded seconds after the minute; hour-scale durations use hours instead of very large minute counts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 165fc1942c53341af0ffe9b71f5c16c0bfc1fd1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->