### PR TITLE
fix(fs): add appendFile to the platform FS port so output appends use one authority

### DIFF
--- a/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
+++ b/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
@@ -6,6 +6,7 @@
 import * as fs from 'node:fs';
 import * as vscode from 'vscode';
 
+import { isFileNotFoundError } from '@common/errors';
 import type {
   FileSystemProvider,
   FileStat,
@@ -47,6 +48,24 @@ export class VscodeFileSystem implements FileSystemProvider {
 
   async writeFile(target: string, content: Uint8Array): Promise<void> {
     await vscode.workspace.fs.writeFile(vscode.Uri.file(target), content);
+  }
+
+  async appendFile(target: string, content: Uint8Array): Promise<void> {
+    // vscode.workspace.fs has no native append, so read-modify-write through
+    // the same virtual FS keeps appends on the one authority writeFile uses
+    // (a remote/web workspace is not the local node disk).
+    const uri = vscode.Uri.file(target);
+    let existing: Uint8Array;
+    try {
+      existing = await vscode.workspace.fs.readFile(uri);
+    } catch (error) {
+      if (!isFileNotFoundError(error)) throw error;
+      existing = new Uint8Array(0);
+    }
+    const merged = new Uint8Array(existing.length + content.length);
+    merged.set(existing, 0);
+    merged.set(content, existing.length);
+    await vscode.workspace.fs.writeFile(uri, merged);
   }
 
   async delete(

--- a/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
+++ b/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
@@ -13,6 +13,14 @@ import type {
 } from '@platform/interfaces/filesystem';
 
 export class VscodeFileSystem implements FileSystemProvider {
+  /**
+   * Per-path append chains. vscode.workspace.fs has no atomic append, so
+   * appendFile() does read-modify-write; serializing per path stops concurrent
+   * appends to the same file from racing (each reading the same bytes, the last
+   * write clobbering the others).
+   */
+  private readonly appendChains = new Map<string, Promise<void>>();
+
   async stat(target: string): Promise<FileStat> {
     const stat = await vscode.workspace.fs.stat(vscode.Uri.file(target));
     return {
@@ -51,9 +59,28 @@ export class VscodeFileSystem implements FileSystemProvider {
   }
 
   async appendFile(target: string, content: Uint8Array): Promise<void> {
+    const prior = this.appendChains.get(target) ?? Promise.resolve();
+    const next = prior
+      .catch(() => {})
+      .then(() => this.appendFileUnsafe(target, content));
+    this.appendChains.set(target, next);
+    try {
+      await next;
+    } finally {
+      if (this.appendChains.get(target) === next) {
+        this.appendChains.delete(target);
+      }
+    }
+  }
+
+  private async appendFileUnsafe(
+    target: string,
+    content: Uint8Array,
+  ): Promise<void> {
     // vscode.workspace.fs has no native append, so read-modify-write through
     // the same virtual FS keeps appends on the one authority writeFile uses
-    // (a remote/web workspace is not the local node disk).
+    // (a remote/web workspace is not the local node disk). appendFile()
+    // serializes these per path so the read-modify-write can't race.
     const uri = vscode.Uri.file(target);
     let existing: Uint8Array;
     try {

--- a/src/platform/defaults/nodeFilesystem.ts
+++ b/src/platform/defaults/nodeFilesystem.ts
@@ -117,6 +117,10 @@ export const nodeFilesystem: FileSystemProvider = {
     await fs.promises.writeFile(target, content);
   },
 
+  async appendFile(target: string, content: Uint8Array): Promise<void> {
+    await fs.promises.appendFile(target, content);
+  },
+
   async delete(
     target: string,
     options?: { recursive?: boolean },

--- a/src/platform/interfaces/filesystem.ts
+++ b/src/platform/interfaces/filesystem.ts
@@ -37,6 +37,7 @@ export interface FileSystemProvider {
     length: number,
   ): Promise<Uint8Array>;
   writeFile(path: string, content: Uint8Array): Promise<void>;
+  appendFile(path: string, content: Uint8Array): Promise<void>;
   delete(path: string, options?: { recursive?: boolean }): Promise<void>;
   createDirectory(path: string): Promise<void>;
   readDirectory(path: string): Promise<[string, number][]>;

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -316,6 +316,18 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     this.writeFileSync(target, content, { overwrite: true });
   }
 
+  async appendFile(target: string, content: Uint8Array): Promise<void> {
+    const existing = this.records.get(normalizePath(target));
+    if (existing && existing.type !== FileType.File) {
+      throw fakeFsError('EISDIR', `Path is a directory: ${target}`);
+    }
+    const base = existing?.content ?? new Uint8Array(0);
+    const merged = new Uint8Array(base.length + content.length);
+    merged.set(base, 0);
+    merged.set(content, base.length);
+    this.writeFileSync(target, merged, { overwrite: true });
+  }
+
   async delete(
     target: string,
     options?: { recursive?: boolean },

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -85,7 +85,7 @@ export abstract class BaseFS {
     target: string,
     content: string | Uint8Array,
   ): Promise<void> {
-    await fs.promises.appendFile(this.preparePath(target), toBuffer(content));
+    await platform().fs.appendFile(this.preparePath(target), toBuffer(content));
   }
 
   public static async delete(


### PR DESCRIPTION
## The split

`BaseFS` (the platform-routed FS facade) routes `write`/`read`/`stat`/`delete` through `platform().fs` — `vscode.workspace.fs` in the extension, a **virtual, remote/SSH/web-aware** filesystem. But `appendFile` called `fs.promises.appendFile` directly — the **local node disk**:

```ts
BaseFS.write       -> platform().fs.writeFile        // virtual FS
BaseFS.appendFile  -> fs.promises.appendFile          // LOCAL disk (bypass)
```

The `FileSystemProvider` port had no append surface, so the bypass was **forced by an incomplete port**, not a host-allowed exception.

**Live symptom:** `ResponseCycleFlow` writes an output file's first chunk via the port and appends every later chunk via the bypass — *one file, one flow, two different filesystems* in a remote/web workspace.

## The fix — complete the port

- Add `appendFile(path, content): Promise<void>` to `FileSystemProvider`.
- Implement in all three providers:
  - `nodeFilesystem` → `fs.promises.appendFile`
  - `VscodeFileSystem` → read-modify-write through `vscode.workspace.fs` (`FileNotFound` → empty, so append-creates like node)
  - `FakePlatform` (test fake) → in-memory concat
- Repoint `BaseFS.appendFile` → `platform().fs.appendFile`.

Every append caller (`flexibleFS` → `ResponseCycleFlow`, CLI `inputHistory`) now appends through the same authority it writes through.

## Behavior

- **Node / CLI / desktop: byte-identical** — still `fs.promises.appendFile` via the node provider.
- **Extension:** appends now hit the virtual FS that `writeFile` already used. In a local workspace that *is* the local disk (equivalent); in a remote/web workspace it fixes the split.

## Scope

`appendFile` only. The finding also flagged two `runReflectionFlow` `existsSync` resume-compat checks — but those sit in a **synchronous** path resolver (`(round) => AgentFileLocation`), so converting them to the async port-backed `exists()` needs a signature change and is intentionally **not** in this PR.

## Verification
- `tsc --noEmit` (root + test-kernel + extension) clean — no `FileSystemProvider` implementer left without `appendFile`.
- prettier + eslint clean.
- `InputHistory` (3/3), `ResponseCycleTools` (5/5), `ProcessOutputPoller` (4/4), `ToolEditApprovalGate` (5/5) pass.

---
🤖 Round-3–10 deep audit (leaky-port / incomplete-abstraction lens) — the highest-value finding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how appended output is persisted in the VS Code extension (including remote/web workspaces); the VS Code path relies on read-modify-write rather than true append, with per-path serialization to limit races.
> 
> **Overview**
> **Adds `appendFile` to the platform `FileSystemProvider` and routes `BaseFS.appendFile` through `platform().fs` instead of `fs.promises.appendFile`.** That closes a leak where writes used the host FS (e.g. `vscode.workspace.fs` in remote/web workspaces) while appends always hit the local Node disk—so flows like streaming output could mix authorities on one file.
> 
> **Node** still uses `fs.promises.appendFile`; **tests** use in-memory concat on the fake provider. **VS Code** emulates append with read-modify-write on `vscode.workspace.fs`, treats missing files as empty (append-create), and **serializes concurrent appends per path** so parallel RMW cannot clobber each other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4d49d6a28afa2983af8bbb00a174a4b2cf7013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->