### PR TITLE
fix: CLI context-window gauge counts input tokens only

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -130,16 +130,21 @@ function formatUsage(
   model: string,
 ): StatusBarSegment | undefined {
   if (!usage) return undefined;
-  const total = usage.inputTokens + usage.outputTokens;
-  if (total <= 0) return undefined;
+  // Context-window occupancy is input tokens only — the prompt that fills the
+  // window. Output tokens are the generated response, not part of the context,
+  // so they must not inflate the gauge. This matches every other surface
+  // (ModelHandler utilizationPercent, trace, transcript recorder, the extension
+  // UsagePanel), which all compute inputTokens / contextWindow.
+  const used = usage.inputTokens;
+  if (used <= 0) return undefined;
 
   const base = { compactPriority: STATUS_BAR_COMPACT_PRIORITY.usage };
   const contextWindow = MODEL_CONFIGS[model]?.contextWindow;
   if (!contextWindow || contextWindow <= 0) {
-    return { ...base, text: formatCompactNumber(total), color: 'dim' };
+    return { ...base, text: formatCompactNumber(used), color: 'dim' };
   }
 
-  const ratio = total / contextWindow;
+  const ratio = used / contextWindow;
   const percent = Math.max(1, Math.round(ratio * 100));
   let color: StatusBarColor;
   if (ratio >= 0.9) color = 'red';
@@ -147,7 +152,7 @@ function formatUsage(
   else color = 'dim';
   return {
     ...base,
-    text: `${formatCompactNumber(total)}/${formatCompactNumber(
+    text: `${formatCompactNumber(used)}/${formatCompactNumber(
       contextWindow,
     )} (${percent}%)`,
     // Keep context visibility on narrow terminals: degrade to the bare

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -498,7 +498,7 @@ describe('CLI StatusBar display model', () => {
       'running',
       'relay',
       'r2',
-      '105k/1M (10%)',
+      '80k/1M (8%)',
       'queued 2',
       '2 sub',
       '1 proc',
@@ -1457,15 +1457,15 @@ describe('CLI StatusBar display model', () => {
       buildStatusBarDisplay({ ...input, width: 80 }).left.map(
         statusBarSegmentText,
       ),
-    ).toContain('105k/1M (10%)');
+    ).toContain('80k/1M (8%)');
 
     // Narrow: the segment degrades to the bare percentage instead of
     // disappearing, keeping context pressure visible.
     const narrow = buildStatusBarDisplay({ ...input, width: 24 }).left.map(
       statusBarSegmentText,
     );
-    expect(narrow).not.toContain('105k/1M (10%)');
-    expect(narrow).toContain('10%');
+    expect(narrow).not.toContain('80k/1M (8%)');
+    expect(narrow).toContain('8%');
   });
 
   it('keeps the exit confirmation visible in very narrow footers', () => {


### PR DESCRIPTION
## Summary

The CLI status-bar usage segment computed context-window occupancy as `inputTokens + outputTokens`:

```ts
const total = usage.inputTokens + usage.outputTokens;
const ratio = total / contextWindow;  // drives % and the yellow/red warning color
```

Output tokens are the model's generated response — **not** part of the prompt that occupies the context window. Including them overstated occupancy and flipped the gauge into yellow (≥60%) / red (≥90%) prematurely once a sizable answer had streamed.

Every other surface defines context occupancy as **input-only**, so the CLI also disagreed with the progress view for the identical run:
- `ModelHandler` `utilizationPercent = (inputTokens / contextWindow) * 100`
- `agent/trace/helpers` and `TexraTranscriptRecorder` — same
- extension `UsagePanel` — displays `inputTokens / contextWindow`

(`cliState` even documents the field as *"current context occupancy … must not be accumulated"*.)

## Fix
Use `inputTokens` for the gauge — the occupancy %, the warning color, and the no-context-window bare fallback (which represents the same "current context size" concept). Output throughput, if ever wanted, belongs in a separate readout, not the context indicator.

Example: input 80k / output 25k against a 1M window now reads **`80k/1M (8%)`** instead of `105k/1M (10%)`.

## Verification
- Updated the two `StatusBar` test cases to the input-only expectation; **all 45 `StatusBar.vitest.mts` tests pass** (ran locally).
- Found by a multi-agent correctness sweep; adversarially verified against the four agreeing surfaces.
- CI `validate` confirms typecheck/build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single display calculation in the CLI TUI with no auth, data, or API behavior changes.
> 
> **Overview**
> The CLI status bar **context-window usage segment** no longer treats **output tokens** as part of occupancy. `formatUsage` now drives the fraction, percentage, warning colors (yellow ≥60%, red ≥90%), and the no–context-window fallback from **`inputTokens` only**, aligning with `ModelHandler`, trace, transcript, and the extension usage panel.
> 
> With a large streamed reply, the bar no longer overstates pressure—for example **80k/1M (8%)** instead of counting input+output as **105k/1M (10%)**. **StatusBar** vitest expectations were updated for wide and narrow (compact **%**) layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a209d0be34bbb66f52f3434602c1b1c30fe54d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->