### PR TITLE
refactor(cli): reuse core isRelayMonthlyLimitMessage for relay-limit detection

### DIFF
--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -1,3 +1,4 @@
+import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { ApprovalDecision as SharedApprovalDecision } from '@shared/schemas';
 
@@ -35,14 +36,6 @@ export function hasCliApprovalDenied(context: CliContext): boolean {
   return deniedApprovalContexts.has(context);
 }
 
-function isCliMonthlySpendingLimitMessage(
-  message: string | undefined,
-): boolean {
-  return (
-    message?.toLowerCase().includes('monthly spending limit reached') ?? false
-  );
-}
-
 export function isCliApiSwitchableRetry(
   payload: ProgressEventPayloads['showRetryRequest'],
 ): boolean {
@@ -50,12 +43,12 @@ export function isCliApiSwitchableRetry(
   return (
     details?.isCredentialExhausted === true &&
     (details.isRelayError === true ||
-      isCliMonthlySpendingLimitMessage(payload.errorMessage))
+      isRelayMonthlyLimitMessage(payload.errorMessage))
   );
 }
 
 export function appendCliApiSwitchHint(text: string): string {
-  if (!isCliMonthlySpendingLimitMessage(text)) return text;
+  if (!isRelayMonthlyLimitMessage(text)) return text;
   if (text.includes('/api personal')) return text;
   return [text, CLI_PERSONAL_API_RETRY_HINT].join('\n');
 }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -35,3 +35,5 @@ export {
   getSdkErrorMessage,
   buildErrorLogData,
 } from './sdkError/providerErrorFormat';
+
+export { isRelayMonthlyLimitMessage } from './sdkError/relayDetection';


### PR DESCRIPTION
`approvalPolicy` hand-rolled `isCliMonthlySpendingLimitMessage`, **byte-identical** to core `isRelayMonthlyLimitMessage` — the `'monthly spending limit reached'` substring lived in exactly these two places:

```ts
// CLI (deleted)                         // core (the owner)
message?.toLowerCase()                   message?.toLowerCase()
  .includes('monthly spending limit reached')
```

`normalizeProviderError` already owns this classification (it folds the predicate into `ProviderError.isRelayError`: `isRelay = isRelayError(body) || isRelayMonthlyLimitMessage(msg)`), so the CLI was the lone host re-spelling the literal — a violation of single-owner-of-provider-error-classification.

## Change
- Re-export `isRelayMonthlyLimitMessage` from `@common/errors/sdkErrorUtils` (the established SDK-util barrel).
- Call it at both CLI sites — the `isCliApiSwitchableRetry` message fallback and `appendCliApiSwitchHint` — and delete the CLI copy.

I deliberately **kept** the existing `details.isRelayError === true || …message…` disjunct rather than collapsing to the flag alone: that stronger simplification depends on `payload.errorMessage` and the body `extractedMessage` always agreeing, which isn't guaranteed across sources. Calling the canonical function keeps behavior **identical** while still consolidating the literal into one module.

## Verification
- root + CLI `tsc --noEmit`, prettier, eslint clean.
- `ApprovalAdapter.vitest` (21/21) passes — retry classification unchanged.

Net −5 LOC.

---
🤖 Round-3–10 deep audit (reimplemented-primitive / single-owner lens).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deduplication with identical substring matching; no change to approval or retry control flow beyond the import path.
> 
> **Overview**
> Removes the CLI-only **`isCliMonthlySpendingLimitMessage`** helper in `approvalPolicy.ts` and routes both relay-limit checks (`isCliApiSwitchableRetry` and `appendCliApiSwitchHint`) through **`isRelayMonthlyLimitMessage`** from `@common/errors/sdkErrorUtils`.
> 
> The shared predicate is **re-exported** from the existing SDK error barrel (`relayDetection.ts`), so the `'monthly spending limit reached'` string lives in one place alongside `normalizeProviderError`’s relay classification. Retry/hint behavior stays the same, including the `isRelayError || message` fallback on switchable retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd7ee5449b85e4071dffd3dfe0056862d830185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->