### PR TITLE
fix: do not classify a stopped subagent as an error in the CLI

### DIFF
--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -4,6 +4,9 @@ export function childStatusColor(status: string | undefined): string {
   if (!status) return 'green';
   if (status === 'waiting' || status === 'idle') return 'yellow';
   if (isChildExecutionErrorStatus(status)) return 'red';
+  // A user stop is neither success nor error — show it neutral, matching the
+  // progress view / webview (gray), not green (which reads as completed).
+  if (status === 'stopped') return 'gray';
   return 'green';
 }
 

--- a/packages/cli/src/chat/tui/state/childExecutionStatus.ts
+++ b/packages/cli/src/chat/tui/state/childExecutionStatus.ts
@@ -1,4 +1,9 @@
-const ERROR_STATUSES = new Set(['error', 'failed', 'stopped']);
+// `stopped` is a user-initiated stop, not an error — the canonical run outcome
+// keeps `cancelled` a sibling of `failed`, never folded into it (see
+// RUN_OUTCOME in src/shared/schemas/stream.ts). Classifying it as an error made
+// a stopped subagent show a red dot in the CLI while the progress view / webview
+// show it neutral.
+const ERROR_STATUSES = new Set(['error', 'failed']);
 const IN_FLIGHT_STATUSES = new Set([
   'initializing',
   'resuming',

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -25,7 +25,9 @@ describe('CLI SubagentList display model', () => {
     expect(childStatusColor('error')).toBe('red');
     expect(childStatusColor('failed')).toBe('red');
     expect(childStatusColor('exit 2')).toBe('red');
-    expect(childStatusColor('stopped')).toBe('red');
+    // A user stop is not an error: neutral (gray), not red, matching the
+    // progress view / webview and the canonical RUN_OUTCOME (cancelled ≠ failed).
+    expect(childStatusColor('stopped')).toBe('gray');
   });
 
   it('uses a compact child row budget instead of clipping nested sections', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2890,6 +2890,8 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     expect(isChildExecutionErrorStatus('exit 1')).toBe(true);
     expect(isChildExecutionErrorStatus('exited with code 2')).toBe(true);
     expect(isChildExecutionErrorStatus('failed')).toBe(true);
+    // A user stop is not an error (RUN_OUTCOME keeps cancelled ≠ failed).
+    expect(isChildExecutionErrorStatus('stopped')).toBe(false);
   });
 
   it('does not keep a stale running status after a process leaves the active list', () => {


### PR DESCRIPTION
## Summary

`isChildExecutionErrorStatus` treated `'stopped'` as an error status, so a **user-stopped subagent showed a red status dot** in the CLI subagent list (`SubagentListDisplay.childStatusColor`) and was marked `isError` in the completed-process transcript — while the progress view and webview render a stop as **neutral**.

A user stop is not an error. The canonical run outcome (`RUN_OUTCOME` in `src/shared/schemas/stream.ts`) explicitly keeps `cancelled` a sibling of `failed`, *"never folded into it — a user stop is not an error."* The CLI's error set contradicted that.

## Fix
Drop `'stopped'` from `ERROR_STATUSES`. `'error'`, `'failed'`, and the `exited with code N` regex remain error states, so genuine failures are unaffected; a stop now reads neutral, matching the canonical model and the other surfaces.

## Verification
- Added a test asserting `isChildExecutionErrorStatus('stopped') === false`; the `classifies completed process error statuses` block passes (ran locally), with the existing `failed` / `error` / `exit 1` / `exited with code 2` assertions unchanged.
- Found by the cross-surface divergence sweep; verified against `RUN_OUTCOME` and both consumers (`SubagentListDisplay`, `completedProcessTranscript`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only status classification and display colors; no auth, data, or runtime behavior changes beyond how stopped children are labeled.
> 
> **Overview**
> **User-stopped subagents no longer show as errors in the CLI TUI**, aligning with the progress view, webview, and `RUN_OUTCOME` (cancelled ≠ failed).
> 
> `'stopped'` is removed from `ERROR_STATUSES` in `isChildExecutionErrorStatus`, so completed-process transcripts no longer set `isError` for a stop. `childStatusColor` maps `'stopped'` to **gray** instead of red (or green). Real failures (`error`, `failed`, non-zero exit codes) are unchanged.
> 
> Tests cover `isChildExecutionErrorStatus('stopped') === false` and gray status color for stopped subagents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bd00e12130ca842b96b6e1f60ad3cb2ab6fb325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->