### PR TITLE
refactor(schemas): reuse canonical SwitchViewMessageSchema in view inbound unions

### DIFF
--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
 import { COMMON_COMMANDS } from '@shared/ipc';
-import { MainViewPersistedStateSchema } from './mainView';
+// Import from the leaf state module, not the ./mainView barrel: the barrel
+// re-exports ./inbound, which imports this file — going through the barrel
+// would close a load-time cycle (see PR #6185 review).
+import { MainViewPersistedStateSchema } from './mainView/state';
 
 /** Theme values - single source of truth for all theme schemas */
 export const ThemeSchema = z.enum(['dark', 'light', 'high-contrast']);

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { COMMON_COMMANDS } from '@shared/ipc';
 // Import from the leaf state module, not the ./mainView barrel: the barrel
 // re-exports ./inbound, which imports this file — going through the barrel
-// would close a load-time cycle (see PR #6185 review).
+// would close a load-time cycle.
 import { MainViewPersistedStateSchema } from './mainView/state';
 
 /** Theme values - single source of truth for all theme schemas */

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -14,6 +14,7 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 
+import { SwitchViewMessageSchema } from '../commonViewMessages';
 import {
   commandOnly,
   withFilesArray,
@@ -29,11 +30,7 @@ const CommonMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.WEBVIEW_READY),
   commandOnly(MAIN_VIEW_COMMANDS.GET_THEME),
   commandOnly(MAIN_VIEW_COMMANDS.GET_DEBUG_MODE),
-  z.object({
-    command: z.literal(MAIN_VIEW_COMMANDS.SWITCH_VIEW),
-    view: z.enum(['main', 'progress', 'dashboard']),
-    openInEditor: z.boolean().nullish(),
-  }),
+  SwitchViewMessageSchema,
   z.object({
     command: z.literal(MAIN_VIEW_COMMANDS.THEME_SET),
     theme: z.enum(['dark', 'light']),

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -11,6 +11,7 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 
+import { SwitchViewMessageSchema } from '../commonViewMessages';
 import { StreamTabIdSchema } from '../identifiers';
 import {
   ExternalInquirySessionLinksSchema,
@@ -42,12 +43,6 @@ const TrimmedStringSchema = z
 
 const WebviewReadyMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.WEBVIEW_READY),
-});
-
-const SwitchViewMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.SWITCH_VIEW),
-  view: z.enum(['main', 'progress', 'dashboard']),
-  openInEditor: z.boolean().nullish(),
 });
 
 const InboundDeleteAllMessageSchema = z.object({


### PR DESCRIPTION
## What

`mainView/inbound.ts` and `progressView/inbound.ts` each inlined an identical `SWITCH_VIEW` message schema — `{ view: z.enum(['main','progress','dashboard']), openInEditor: z.boolean().nullish() }` — instead of composing the canonical `SwitchViewMessageSchema` already exported from `commonViewMessages.ts`. This replaces both inline copies with the canonical schema.

## Why it's safe

- The three command literals are the **same string**: `MAIN_VIEW_COMMANDS.SWITCH_VIEW` and `PROGRESS_VIEW_COMMANDS.SWITCH_VIEW` both spread `COMMON_COMMANDS` with no `SWITCH_VIEW` override, so all resolve to `COMMON_COMMANDS.SWITCH_VIEW` (`'switchView'`). The discriminated-union discriminant is unchanged.
- The inline schemas were not exported, so no external consumer depends on them being distinct.
- Follows the existing compose pattern — `settingsView/inbound.ts` already imports a shared message schema from `commonViewMessages`.
- **No new layer**; pure dedup endorsed by the repo's schema-composition guidance.

## Impact

Removes hand-synced duplication: adding a view target (e.g. `'debug'`) previously required three lockstep edits to the same enum. Maintainability only — view switching is unaffected (all three literals agree today).

## Scope note

Deliberately did **not** touch `WebviewReadyMessageSchema` — progressView's copy has no `view` field while the canonical one does; that's an intentional variant, not a duplicate.

## Verification

- `npx tsc --noEmit` — no new errors (the only 2 errors are a pre-existing missing `async-mutex` module, unrelated).

🤖 Found via round 7 (schema-graph duplication) of a multi-agent data-structure audit; adversarially verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema deduplication and import-path fix only; no runtime logic or IPC command strings change.
> 
> **Overview**
> **Deduplicates `SWITCH_VIEW` validation** by wiring `mainView/inbound.ts` and `progressView/inbound.ts` to the shared `SwitchViewMessageSchema` from `commonViewMessages.ts`, removing two identical inline Zod objects (`view` enum + optional `openInEditor`).
> 
> **Breaks a load-time import cycle** in `commonViewMessages.ts` by importing `MainViewPersistedStateSchema` from `./mainView/state` instead of the `./mainView` barrel (which re-exports inbound and would pull this file back in).
> 
> View-switching behavior and the `'switchView'` command literal are unchanged; future view targets only need updating in one place (`SwitchViewTargetSchema`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf248d8822d1ca26610fafab900dcb377d687448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->