### PR TITLE
fix: make clickable file/ref links keyboard-activatable in progress view

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -300,6 +300,7 @@ export class FileList extends LitElement {
           id=${ELEMENT_IDS.GENERATED_FILES}
           class="files-container"
           @click=${this.handleFileClick}
+          @keydown=${this.handleFileKey}
         >
           ${repeat(
             this.sortedRounds,
@@ -452,6 +453,8 @@ export class FileList extends LitElement {
             title=${tooltipPath}
             data-command=${PROGRESS_VIEW_COMMANDS.OPEN_FILE}
             data-file=${filePath}
+            role="button"
+            tabindex="0"
           >
             <span class="file-dir">${dir}</span>
             <span class="file-basename">${basename}</span>
@@ -480,6 +483,24 @@ export class FileList extends LitElement {
    * All data is stored directly on command elements for unified delegation.
    */
   private handleFileClick(event: MouseEvent): void {
+    this.dispatchFileActionFrom(event);
+  }
+
+  // Keyboard activation parity for the clickable file rows (Enter/Space), so
+  // the generated-files list is reachable without a mouse — mirrors the click
+  // delegation, including the composed-path lookup for the nested span.
+  private handleFileKey(event: KeyboardEvent): void {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const actionEl = getComposedPathElement<HTMLElement>(
+      event,
+      '[data-command]',
+    );
+    if (!(actionEl instanceof HTMLElement)) return;
+    event.preventDefault();
+    this.dispatchFileActionFrom(event);
+  }
+
+  private dispatchFileActionFrom(event: Event): void {
     const actionEl = getComposedPathElement<HTMLElement>(
       event,
       '[data-command]',

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -488,16 +488,16 @@ export class FileList extends LitElement {
 
   // Keyboard activation parity for the clickable file rows (Enter/Space), so
   // the generated-files list is reachable without a mouse — mirrors the click
-  // delegation, including the composed-path lookup for the nested span.
+  // delegation for file-path spans without intercepting native wa-button keys.
   private handleFileKey(event: KeyboardEvent): void {
     if (event.key !== 'Enter' && event.key !== ' ') return;
     const actionEl = getComposedPathElement<HTMLElement>(
       event,
-      '[data-command]',
+      '.file-path[data-command]',
     );
     if (!(actionEl instanceof HTMLElement)) return;
     event.preventDefault();
-    this.dispatchFileActionFrom(event);
+    this.dispatchFileAction(actionEl);
   }
 
   private dispatchFileActionFrom(event: Event): void {
@@ -506,7 +506,10 @@ export class FileList extends LitElement {
       '[data-command]',
     );
     if (!(actionEl instanceof HTMLElement)) return;
+    this.dispatchFileAction(actionEl);
+  }
 
+  private dispatchFileAction(actionEl: HTMLElement): void {
     const { command, file, base, prev } = actionEl.dataset;
     if (!command || !file) return;
 

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -91,7 +91,15 @@ export class LatexdiffResults extends LitElement {
     return html`<span
       class="file-link"
       data-file=${filePath}
+      role="button"
+      tabindex="0"
       @click=${() => this.handleFileClick(filePath)}
+      @keydown=${(e: KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          this.handleFileClick(filePath);
+        }
+      }}
       >${label}</span
     >`;
   }

--- a/packages/extension/src/progressView/frontend/components/PermissionCard.ts
+++ b/packages/extension/src/progressView/frontend/components/PermissionCard.ts
@@ -314,7 +314,11 @@ export class PermissionCard extends LitElement {
     if (files.length === 0) return nothing;
 
     return html`
-      <div class="file-list" @click=${this.handleFileClick}>
+      <div
+        class="file-list"
+        @click=${this.handleFileClick}
+        @keydown=${this.handleFileKey}
+      >
         <span class="file-list-label">${label}:</span>
         ${repeat(
           files,
@@ -324,6 +328,8 @@ export class PermissionCard extends LitElement {
                 class="${clickable ? 'file-link' : 'file-label'}"
                 title=${file}
                 data-file=${ifDefined(clickable ? file : undefined)}
+                role=${ifDefined(clickable ? 'button' : undefined)}
+                tabindex=${ifDefined(clickable ? '0' : undefined)}
                 >${getBasename(file)}</span
               >`,
         )}
@@ -332,7 +338,21 @@ export class PermissionCard extends LitElement {
   }
 
   private handleFileClick(event: MouseEvent): void {
-    const file = (event.target as HTMLElement).dataset.file;
+    this.openFileFromTarget(event.target);
+  }
+
+  // Keyboard activation parity for the clickable file spans (Enter/Space),
+  // matching the GoalTab row pattern so keyboard / screen-reader users can
+  // open a proposed file, not just mouse users.
+  private handleFileKey(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.openFileFromTarget(event.target);
+    }
+  }
+
+  private openFileFromTarget(target: EventTarget | null): void {
+    const file = (target as HTMLElement | null)?.dataset.file;
     if (file) {
       postMessage(PROGRESS_VIEW_COMMANDS.OPEN_FILE, { file });
     }

--- a/src/test-kernel/progressView/FileList.vitest.mts
+++ b/src/test-kernel/progressView/FileList.vitest.mts
@@ -1,0 +1,171 @@
+// Third-party imports
+import { JSDOM } from 'jsdom';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+// Local imports - progress view component types
+import type { FileList } from '@progressView/frontend/components/FileList';
+import type { ProgressFileActionDetail } from '@progressView/frontend/events';
+
+// Local imports - shared schemas
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type { OutputFileInfo } from '@shared/schemas';
+
+// Local imports - test utilities
+import { installAttachInternalsFallback } from '../settings/litComponentTestUtils';
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+  customElements: globalThis.customElements,
+  HTMLElement: globalThis.HTMLElement,
+  Element: globalThis.Element,
+  Document: globalThis.Document,
+  ShadowRoot: globalThis.ShadowRoot,
+  CSSStyleSheet: globalThis.CSSStyleSheet,
+  MutationObserver: globalThis.MutationObserver,
+  Event: globalThis.Event,
+  CustomEvent: globalThis.CustomEvent,
+  KeyboardEvent: globalThis.KeyboardEvent,
+  ResizeObserver: globalThis.ResizeObserver,
+  localStorage: globalThis.localStorage,
+  Node: (globalThis as { Node?: unknown }).Node,
+};
+
+class NoopResizeObserver implements ResizeObserver {
+  disconnect(): void {}
+  observe(): void {}
+  unobserve(): void {}
+}
+
+function installDom(): void {
+  const dom = new JSDOM('<!doctype html><body></body>', {
+    url: 'http://localhost',
+  });
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  globalThis.customElements = dom.window.customElements;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.Element = dom.window.Element;
+  globalThis.Document = dom.window.Document;
+  globalThis.ShadowRoot = dom.window.ShadowRoot;
+  globalThis.CSSStyleSheet = dom.window.CSSStyleSheet;
+  globalThis.MutationObserver = dom.window.MutationObserver;
+  globalThis.Event = dom.window.Event;
+  globalThis.CustomEvent = dom.window.CustomEvent;
+  globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+  globalThis.ResizeObserver = NoopResizeObserver;
+  globalThis.localStorage = dom.window.localStorage;
+  (globalThis as { Node: unknown }).Node = dom.window.Node;
+  installAttachInternalsFallback(
+    dom.window as unknown as Parameters<
+      typeof installAttachInternalsFallback
+    >[0],
+  );
+}
+
+function restoreDom(): void {
+  globalThis.document = originalGlobals.document;
+  globalThis.window = originalGlobals.window;
+  globalThis.customElements = originalGlobals.customElements;
+  globalThis.HTMLElement = originalGlobals.HTMLElement;
+  globalThis.Element = originalGlobals.Element;
+  globalThis.Document = originalGlobals.Document;
+  globalThis.ShadowRoot = originalGlobals.ShadowRoot;
+  globalThis.CSSStyleSheet = originalGlobals.CSSStyleSheet;
+  globalThis.MutationObserver = originalGlobals.MutationObserver;
+  globalThis.Event = originalGlobals.Event;
+  globalThis.CustomEvent = originalGlobals.CustomEvent;
+  globalThis.KeyboardEvent = originalGlobals.KeyboardEvent;
+  globalThis.ResizeObserver = originalGlobals.ResizeObserver;
+  globalThis.localStorage = originalGlobals.localStorage;
+  if (originalGlobals.Node === undefined) {
+    delete (globalThis as { Node?: unknown }).Node;
+  } else {
+    (globalThis as { Node: unknown }).Node = originalGlobals.Node;
+  }
+}
+
+function outputFile(): OutputFileInfo {
+  return {
+    source: 'paper_revised.tex',
+    location: {
+      kind: 'workspace',
+      absolutePath: '/workspace/paper_revised.tex',
+      relativePath: 'paper_revised.tex',
+    },
+    round: 1,
+    lineage: {
+      original: {
+        kind: 'workspace',
+        absolutePath: '/workspace/paper.tex',
+        relativePath: 'paper.tex',
+      },
+      diffBase: null,
+      diffFile: null,
+    },
+    diff: { added: 2, removed: 1 },
+  };
+}
+
+async function mountFileList(): Promise<FileList> {
+  const element = document.createElement('file-list') as FileList;
+  element.filesByRound = { '1': [outputFile()] };
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+function dispatchSpace(target: Element): void {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    }),
+  );
+}
+
+beforeAll(async () => {
+  installDom();
+  await import('@progressView/frontend/components/FileList');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+afterAll(() => {
+  restoreDom();
+});
+
+describe('file-list keyboard activation', () => {
+  it('opens file paths on Space without hijacking native action buttons', async () => {
+    const element = await mountFileList();
+    const actions: ProgressFileActionDetail[] = [];
+    element.addEventListener('file-action', (event) => {
+      actions.push((event as CustomEvent<ProgressFileActionDetail>).detail);
+    });
+
+    const filePath = element.shadowRoot?.querySelector('.file-path');
+    expect(filePath).toBeInstanceOf(HTMLElement);
+    dispatchSpace(filePath!);
+
+    expect(actions).toEqual([
+      {
+        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
+        file: '/workspace/paper_revised.tex',
+        base: undefined,
+        prev: undefined,
+      },
+    ]);
+
+    const nativeButton = element.shadowRoot?.querySelector(
+      'wa-button[data-command]',
+    );
+    expect(nativeButton).toBeInstanceOf(HTMLElement);
+    dispatchSpace(nativeButton!);
+
+    expect(actions).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Clickable file/ref links in the progress view were **mouse-only**: rendered as `<span>` with a click handler but no `role`/`tabindex`/keydown, so they weren't in the tab order and Enter/Space did nothing. Keyboard-only and screen-reader users couldn't open a proposed file (agent-proposal approval — a primary, frequent flow), a generated file, or a latexdiff result. Tellingly, the shared `.file-link:focus-visible` style was **dead** because the spans could never receive focus — focusability was intended but never wired.

## Fix

Make each clickable span a real activatable control — `role="button"` + `tabindex="0"` + an Enter/Space `keydown` that runs the **same action as click** (with `preventDefault`) — following the existing `GoalTab.handleRowKey` pattern:

- **PermissionCard** (agent-proposal approval): `@keydown` parity on the `.file-list` container; shared `openFileFromTarget`.
- **LatexdiffResults**: `role`/`tabindex` + keydown on the file link.
- **FileList** (generated files): `role`/`tabindex` on the row span; `@keydown` on the container mirroring the existing composed-path click delegation (`getComposedPathElement`, which already accepts any `Event`).

## Scope / verification
- **Additive** — mouse behavior is unchanged; this only adds keyboard/SR reachability and restores the intended focus-visible styling.
- Changed files typecheck clean; CI `validate` confirms the full build.
- Found by the focus/keyboard sweep, verified against the `GoalTab` precedent.

### Not included
The `LogList` transcript-link case (`file-link` / `latex-ref` / `proposal-restore-link` produced via HTML-string formatter builders across ~9 render sites, plus the `MouseEvent`-gated delegation owner) is a larger, separate change — left as a follow-up rather than bundled here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive accessibility wiring in progress-view UI; mouse behavior unchanged and a targeted vitest guards FileList keyboard delegation.
> 
> **Overview**
> Makes **mouse-only** file links in the progress view keyboard- and screen-reader reachable by treating clickable spans as controls (`role="button"`, `tabindex="0"`) and firing the **same open-file behavior** on **Enter/Space** (with `preventDefault`), so existing `.file-link:focus-visible` styling can apply.
> 
> **PermissionCard** adds container `@keydown` and **`openFileFromTarget`** for proposal file lists. **LatexdiffResults** wires keydown on each file link. **FileList** refactors click handling into **`dispatchFileActionFrom` / `dispatchFileAction`** and limits keyboard activation to **`.file-path`** targets so **Space** on native **`wa-button`** action buttons is not intercepted.
> 
> Adds **`FileList.vitest.mts`** to assert Space on a file path dispatches **`OPEN_FILE`** and does not double-fire when Space hits a **`wa-button`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0bcf829c10e75e1dca05bf4582be458a3622dbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->