### PR TITLE
Replace emoji log levels and unicode icons with text tags and web-awesome icons

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -39,11 +39,11 @@ export interface LogUtilsOptions {
   data?: unknown;
 }
 
-const EMOJI_BY_LEVEL: Record<LogLevel, string> = {
-  [LOG_LEVELS.ERROR]: '🔴',
-  [LOG_LEVELS.WARN]: '🟡',
-  [LOG_LEVELS.INFO]: '🟢',
-  [LOG_LEVELS.DEBUG]: '🔍',
+const LEVEL_TAG: Record<LogLevel, string> = {
+  [LOG_LEVELS.ERROR]: 'ERROR',
+  [LOG_LEVELS.WARN]: 'WARN ',
+  [LOG_LEVELS.INFO]: 'INFO ',
+  [LOG_LEVELS.DEBUG]: 'DEBUG',
 };
 
 interface OutputSink {
@@ -107,7 +107,7 @@ function writeLine(
   const sink = ensureChannel(channel, isAgent);
   const prefix = isAgent ? '' : `[${channel}] `;
   sink.appendLine(
-    `${EMOJI_BY_LEVEL[level]} [${getTimestamp()}] ${prefix}${message}`,
+    `${LEVEL_TAG[level]} [${getTimestamp()}] ${prefix}${message}`,
   );
 
   if (data === null || data === undefined) return;

--- a/src/shared/utils/icons.ts
+++ b/src/shared/utils/icons.ts
@@ -64,7 +64,6 @@ export function getModelProviderDecorator(provider: string): ProviderDecorator {
 
 export interface AgentDecorator {
   icon: string;
-  unicode: string;
   label: string;
   hint?: string;
 }
@@ -73,20 +72,18 @@ export const AGENT_DECORATORS = {
   properties: {
     remote: {
       icon: 'cloud',
-      unicode: '☁',
       label: 'Remote',
       hint: 'Remote agent: Prompts loaded from cloud',
     },
     custom: {
       icon: 'account',
-      unicode: '★',
       label: 'Custom',
       hint: 'Custom agent: User-defined in your agents directory',
     },
   },
   agentCategories: {
-    workflow: { icon: 'symbol-method', unicode: '▷', label: 'Workflow' },
-    toolUse: { icon: 'tools', unicode: '🔧', label: 'Tool Use' },
+    workflow: { icon: 'symbol-method', label: 'Workflow' },
+    toolUse: { icon: 'tools', label: 'Tool Use' },
   },
 } as const;
 

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -57,7 +57,9 @@ function renderAgentOption(opt: AgentOptionData): TemplateResult {
         ? html`<span class="agent-icon">${waIcon('bullseye')} </span>`
         : nothing}${opt.label}
       ${opt.isRemote
-        ? html`<span class="agent-icon"> ${waIcon(AGENT_DECORATORS.properties.remote.icon)}</span>`
+        ? html`<span class="agent-icon">
+            ${waIcon(AGENT_DECORATORS.properties.remote.icon)}</span
+          >`
         : nothing}
     </wa-option>
   `;

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -40,7 +40,6 @@ function buildAgentTooltip(opt: AgentOptionData): string {
 }
 
 function renderAgentOption(opt: AgentOptionData): TemplateResult {
-  const { properties } = AGENT_DECORATORS;
   const tooltip = buildAgentTooltip(opt);
 
   const isOrch = opt.isOrchestrator;
@@ -58,7 +57,7 @@ function renderAgentOption(opt: AgentOptionData): TemplateResult {
         ? html`<span class="agent-icon">${waIcon('bullseye')} </span>`
         : nothing}${opt.label}
       ${opt.isRemote
-        ? html`<span class="agent-icon"> ${waIcon('cloud')}</span>`
+        ? html`<span class="agent-icon"> ${waIcon(AGENT_DECORATORS.properties.remote.icon)}</span>`
         : nothing}
     </wa-option>
   `;

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -9,6 +9,7 @@ import { repeat } from 'lit/directives/repeat.js';
 
 import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
 import { agentName } from '@shared/schemas/agent';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { AGENT_DECORATORS, getModelProviderDecorator } from './icons';
 
 /**
@@ -54,10 +55,10 @@ function renderAgentOption(opt: AgentOptionData): TemplateResult {
       data-description=${opt.description || nothing}
     >
       ${isOrch
-        ? html`<span class="agent-icon">🎯 </span>`
+        ? html`<span class="agent-icon">${waIcon('bullseye')} </span>`
         : nothing}${opt.label}
       ${opt.isRemote
-        ? html`<span class="agent-icon"> ${properties.remote.unicode}</span>`
+        ? html`<span class="agent-icon"> ${waIcon('cloud')}</span>`
         : nothing}
     </wa-option>
   `;


### PR DESCRIPTION
## Summary

This PR replaces emoji-based log level indicators with text tags and removes hardcoded unicode characters in favor of the web-awesome icon system. The changes improve consistency, accessibility, and maintainability by centralizing icon usage through the `waIcon()` utility.

### Changes:
1. **Logger**: Renamed `EMOJI_BY_LEVEL` to `LEVEL_TAG` and replaced emoji indicators (🔴, 🟡, 🟢, 🔍) with text tags (ERROR, WARN, INFO, DEBUG)
2. **Icons**: Removed `unicode` field from `AgentDecorator` interface and all hardcoded unicode values (☁, ★, ▷, 🔧)
3. **Select Templates**: Replaced hardcoded emoji (🎯) and unicode characters with `waIcon()` calls (`bullseye`, `cloud`)

## Issue acceptance gates

N/A — This is a refactoring to improve code organization and consistency.

## Single source of truth

Icon rendering is now centralized through the `waIcon()` utility from `@shared/wa/webAwesomeIcons`, eliminating scattered unicode and emoji literals throughout the codebase.

## Duplication and abstraction budget

Removed hardcoded unicode/emoji strings that were duplicated across multiple files. The `waIcon()` abstraction ensures all icon references go through a single, maintainable source.

## Host impact

Extension: Log output format changes from emoji to text tags; agent option rendering uses web-awesome icons instead of unicode.

Desktop: No direct impact.

CLI: Log output format changes from emoji to text tags.

## Scheduled refactoring

None.

## Validation

- Existing tests pass (no test changes required for this refactoring)
- Log output format is now more consistent and accessible
- Icon rendering is centralized and maintainable

https://claude.ai/code/session_01QiuRKFM5uWDJk3vtPW9LfP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic logging and dropdown rendering only; model provider unicode in `icons.ts` is unchanged.
> 
> **Overview**
> **Logging** output prefixes each line with fixed text tags (`ERROR`, `WARN`, `INFO`, `DEBUG`) instead of emoji level indicators, via renaming `EMOJI_BY_LEVEL` to `LEVEL_TAG` in `logUtils.ts`.
> 
> **Agent UI metadata** in `icons.ts` removes the `unicode` field from `AgentDecorator` and drops hardcoded unicode from remote/custom and category decorators (icons remain on the `icon` string for Web Awesome).
> 
> **Agent select options** in `selectTemplates.ts` render orchestrator and remote markers with `waIcon('bullseye')` and `waIcon(AGENT_DECORATORS.properties.remote.icon)` instead of inline 🎯 and ☁ characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7679cb9e294c1deb0687559d80161cc2b30942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->