### PR TITLE
fix(schemas): make SyncStreamContent todos/plan/queuedFollowUps required

### DIFF
--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -278,9 +278,9 @@ export const SyncStreamContentMessageSchema = z.object({
   // correctly accumulates. Frontend derives sessionUsage as the sum.
   runUsage: z.record(z.string(), TokenUsageStatsSchema).optional(),
   contextState: ContextStateDataSchema.optional(),
-  todos: z.array(TodoItemSchema).optional(),
-  plan: PlanSchema.nullable().optional(),
-  queuedFollowUps: z.array(z.string()).optional(),
+  todos: z.array(TodoItemSchema),
+  plan: PlanSchema.nullable(),
+  queuedFollowUps: z.array(z.string()),
   agentCategory: z.string().optional(),
   // Tab-switch state (R2: replaces separate syncActiveStreamState messages)
   conversationProgress: ConversationProgressSchema.optional(),


### PR DESCRIPTION
## What

`SyncStreamContentMessageSchema` marked `todos`, `plan`, and `queuedFollowUps` as `.optional()`, but the `SyncStreamContentPayload` **interface** (`WebviewUpdater.ts`) declares all three as **required**. The optionality was a serialization artifact, not a real contract — it forced frontend consumers to null-check fields that are always present.

This drops `.optional()` on those three so the schema matches the interface.

## Why it's safe

- Sole producer is `WebviewUpdater.sendSyncStreamContent(payload: SyncStreamContentPayload)`, called from exactly two sites in `ProgressEventHandler`:
  - clear-path explicitly passes `todos: []`, `plan: null`, `queuedFollowUps: []`
  - render-path is TS-enforced to pass all three (the payload type requires them)
- The values are arrays / `null` (never `undefined`), so they survive structured-clone / JSON serialization — the receipt-side `safeParse` (desktop renderer) still passes.
- The other genuinely-conditional fields on this message (`action`, `workflowFiles`, `badges`, …) are left optional.

## Impact

Aligns the schema with the interface and lets the type system enforce presence at send time; removes the need for defensive null-checks on these fields downstream. No new layer.

## Verification

- `npx tsc --noEmit` — no new errors (only the pre-existing missing `async-mutex` module).

🤖 Found via round 8 (boundary serialization) of a multi-agent data-structure audit; adversarially verified, and the sole producer + both call sites checked by hand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only alignment with an existing send contract; no behavior change if payloads already include these fields.
> 
> **Overview**
> **`SyncStreamContentMessageSchema`** now treats **`todos`**, **`plan`**, and **`queuedFollowUps`** as required instead of optional, matching the **`SyncStreamContentPayload`** contract used when sending **`SYNC_STREAM_CONTENT`**.
> 
> The producer already always supplies these (e.g. clear uses `[]` / `null` / `[]`); only the Zod shape was looser than the TypeScript interface. Other optional fields on the same message are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41de87d8cee13d590b4a69cf17622fab2f519a59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->