### PR TITLE
Refactor RoundFileMapping to consolidate file relationships

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -161,7 +161,10 @@ export class LatexDiffManager {
     const artifacts: CompiledPdfArtifact[] = [];
 
     if (this.agentSetting.isRewrite) {
-      const basePairs = [...mapping.baseToOutput.entries()];
+      const basePairs: [string, FileLocation][] = [];
+      for (const [outputPath, entry] of mapping) {
+        if (entry.base) basePairs.push([outputPath, entry.base]);
+      }
       this.logPairMatches(basePairs, 'base files to output files');
 
       for (const [outputPath, baseLocation] of basePairs) {
@@ -196,14 +199,17 @@ export class LatexDiffManager {
     );
 
     if (generateBetweenRoundDiffs && currRound > 0) {
-      const prevPairs = [...mapping.prevToOutput.entries()];
+      const prevPairs: [string, FileLocation][] = [];
+      for (const [outputPath, entry] of mapping) {
+        if (entry.prev) prevPairs.push([outputPath, entry.prev]);
+      }
       this.logPairMatches(
         prevPairs,
         'previous round files to current round files',
       );
 
       for (const [outputPath, prevLocation] of prevPairs) {
-        const originalLocation = mapping.originByOutput.get(outputPath) ?? null;
+        const originalLocation = mapping.get(outputPath)?.origin ?? null;
         const result = await this.runSingleDiff({
           outputPath,
           baseLocation: prevLocation,

--- a/src/agent/output/diffComputation.ts
+++ b/src/agent/output/diffComputation.ts
@@ -123,8 +123,9 @@ export async function computeOutputDiffStats(
       const location = output.location;
       const locationPath = getComparablePath(location);
 
-      const baseLocation = mapping.baseToOutput.get(locationPath) ?? null;
-      const originalLocation = mapping.originByOutput.get(locationPath) ?? null;
+      const entry = mapping.get(locationPath);
+      const baseLocation = entry?.base ?? null;
+      const originalLocation = entry?.origin ?? null;
 
       // Use original as diff base when there's no direct base mapping
       // and the original is a different file (not self-referencing)

--- a/src/agent/output/lineageMapping.ts
+++ b/src/agent/output/lineageMapping.ts
@@ -96,12 +96,17 @@ export function traceFileLineage(
   const baseEntries = buildBaseEntries(baseFiles);
   const currentLocations = currentOutputs.map((entry) => entry.location);
 
+  // 'contains' matches base filenames that appear as substrings of output names
+  // (e.g. "paper" matches "paper_r1"), which handles round-suffixed rewrite outputs.
   const baseToOutput = invertMapping(
     createFileMapping(baseFiles, currentLocations, 'contains'),
     baseFiles,
   );
 
   const prevLocations = prevOutputs.map((entry) => entry.location);
+  // 'basename' with roundAware=true strips round suffixes before comparing, so
+  // "paper_r1" and "paper_r2" are treated as the same file across rounds.
+  // Returns an empty map when there are no previous-round outputs to pair with.
   const prevToOutput =
     prevLocations.length === 0
       ? new Map<string, FileLocation>()

--- a/src/agent/output/lineageMapping.ts
+++ b/src/agent/output/lineageMapping.ts
@@ -11,7 +11,7 @@ import type { FileLocation } from '@shared/schemas';
 import { createFileMapping, getComparablePath } from '@utils/files';
 
 import type { OutputState } from './outputState';
-import type { RoundFileMapping } from './types';
+import type { RoundFileEntry, RoundFileMapping } from './types';
 
 interface BaseEntry {
   readonly loc: FileLocation;
@@ -96,15 +96,11 @@ export function traceFileLineage(
   const baseEntries = buildBaseEntries(baseFiles);
   const currentLocations = currentOutputs.map((entry) => entry.location);
 
-  // Map output paths to base files using 'contains' strategy.
   const baseToOutput = invertMapping(
     createFileMapping(baseFiles, currentLocations, 'contains'),
     baseFiles,
   );
 
-  // Map output paths to previous round files using 'basename' strategy with
-  // round number stripping. Returns an empty map when there are no previous
-  // outputs to map from.
   const prevLocations = prevOutputs.map((entry) => entry.location);
   const prevToOutput =
     prevLocations.length === 0
@@ -114,13 +110,15 @@ export function traceFileLineage(
           prevLocations,
         );
 
-  const originByOutput = new Map<string, FileLocation | undefined>();
+  const mapping = new Map<string, RoundFileEntry>();
   for (const entry of currentOutputs) {
-    originByOutput.set(
-      getComparablePath(entry.location),
-      findMatchingBaseFile(baseEntries, entry.source),
-    );
+    const key = getComparablePath(entry.location);
+    mapping.set(key, {
+      base: baseToOutput.get(key),
+      prev: prevToOutput.get(key),
+      origin: findMatchingBaseFile(baseEntries, entry.source),
+    });
   }
 
-  return { baseToOutput, prevToOutput, originByOutput };
+  return mapping;
 }

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -1,11 +1,14 @@
 import type { FileLocation } from '@shared/schemas';
 
-/** Internal mapping for file relationships (used by OutputHandler). All maps indexed by OUTPUT path. */
-export interface RoundFileMapping {
-  /** Output path → base FileLocation (for round-based diffs) */
-  baseToOutput: Map<string, FileLocation>;
-  /** Output path → previous round FileLocation (for inter-round diffs) */
-  prevToOutput: Map<string, FileLocation>;
-  /** Output path → original base FileLocation (for tracking lineage) */
-  originByOutput: Map<string, FileLocation | undefined>;
+/** File relationship facts for a single output path. All fields optional — absence means no match. */
+export interface RoundFileEntry {
+  /** Base FileLocation for round-based diffs (rewrite agents). */
+  base?: FileLocation;
+  /** Previous-round FileLocation for between-round diffs. */
+  prev?: FileLocation;
+  /** Original base FileLocation for lineage tracking. */
+  origin?: FileLocation;
 }
+
+/** Maps output paths to their file relationship facts. Used by LatexDiffManager and diffComputation. */
+export type RoundFileMapping = Map<string, RoundFileEntry>;


### PR DESCRIPTION
## Summary

Consolidates the three separate maps in `RoundFileMapping` into a single `Map<string, RoundFileEntry>` structure. This reduces redundancy and improves type safety by grouping all file relationship facts for a given output path into a single entry object.

The change affects:
- `lineageMapping.ts`: Builds a single consolidated map instead of three separate ones
- `types.ts`: Replaces the three-map interface with a `RoundFileEntry` type and a `RoundFileMapping` type alias
- `LatexDiffManager.ts` and `diffComputation.ts`: Updated to access file relationships through the new structure

## Issue acceptance gates

N/A — This is a refactoring with no functional changes.

## Single source of truth

The `RoundFileEntry` type now owns the schema for file relationship facts associated with a single output path. All three consumers (`LatexDiffManager`, `diffComputation`, and callers of `traceFileLineage`) access these facts through the same structure.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated three separate `Map` declarations and their corresponding iteration/lookup patterns
- Consolidated the invariant that all three maps share the same key set (output paths) into a single map with structured values

**Abstraction added:**
- `RoundFileEntry` encapsulates the three optional file location fields (`base`, `prev`, `origin`), making the relationship between them explicit and reducing the cognitive load of tracking three parallel maps

## Host impact

Extension: No user-facing changes; internal refactoring only.

Desktop: No user-facing changes; internal refactoring only.

CLI: No user-facing changes; internal refactoring only.

## Scheduled refactoring

None.

## Validation

- TypeScript compilation passes (no type errors introduced)
- Existing call sites in `LatexDiffManager.ts` and `diffComputation.ts` updated to use the new structure
- Logic remains identical; only data structure and access patterns changed

https://claude.ai/code/session_01QJsKYvXBCgvDpZH5kEYnJU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal data-shape refactor with equivalent mapping logic; no user-facing or security-sensitive behavior changes.
> 
> **Overview**
> **`RoundFileMapping`** is no longer an object with three parallel maps (`baseToOutput`, `prevToOutput`, `originByOutput`). It is now **`Map<string, RoundFileEntry>`**, where each entry groups optional **`base`**, **`prev`**, and **`origin`** `FileLocation`s for one output path.
> 
> **`traceFileLineage`** still builds the same base/prev/origin relationships via `createFileMapping` and `invertMapping`, but assembles them into one map keyed by comparable output paths instead of three maps that had to stay in sync.
> 
> **`LatexDiffManager`** and **`computeOutputDiffStats`** read relationships via `mapping.get(path)` / iteration over `mapping` entries (filtering on `entry.base` / `entry.prev`) instead of separate map lookups.
> 
> Comments in **`lineageMapping`** clarify the `contains` and round-aware `basename` matching strategies; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db79ac4da18cb1a2ac666b06221ce0e95097b3f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->