### PR TITLE
Extend SyncStreamContentPayload from LogContentExtras

### DIFF
--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -52,15 +52,15 @@ export interface LogContentExtras {
   contextState?: ContextStateData;
 }
 
-/** Payload for batched stream content hydration (tab switch). */
-export interface SyncStreamContentPayload {
+/**
+ * Payload for batched stream content hydration (tab switch).
+ *
+ * Extends {@link LogContentExtras} so the workflow files / usage / context
+ * fields shared with incremental log updates have a single definition.
+ */
+export interface SyncStreamContentPayload extends LogContentExtras {
   stream: StreamTabId | '';
   action?: 'render' | 'clear';
-  workflowFiles?: Record<string, OutputFileInfo[]>;
-  workflowMissingOutputs?: Record<string, string[]>;
-  workflowCompileFailures?: Record<string, CompileFailure[]>;
-  runUsage?: Record<string, TokenUsageStats>;
-  contextState?: ContextStateData;
   todos: TodoItem[];
   plan: Plan | null;
   queuedFollowUps: string[];


### PR DESCRIPTION
## Summary

Refactor `SyncStreamContentPayload` to extend `LogContentExtras` instead of duplicating shared fields. This eliminates redundant field definitions (`workflowFiles`, `workflowMissingOutputs`, `workflowCompileFailures`, `runUsage`, `contextState`) that were already defined in `LogContentExtras`.

## Issue acceptance gates

N/A

## Single source of truth

`LogContentExtras` now serves as the single source of truth for workflow metadata fields (`workflowFiles`, `workflowMissingOutputs`, `workflowCompileFailures`, `runUsage`, `contextState`) shared across both incremental log updates and batched stream content hydration.

## Duplication and abstraction budget

Removed 5 duplicate field definitions from `SyncStreamContentPayload` by using interface extension. This ensures that any future changes to the shared metadata structure only need to be made in one place.

## Host impact

Extension: No behavioral change; internal type refinement only.

Desktop: No behavioral change; internal type refinement only.

CLI: No impact.

## Scheduled refactoring

None

## Validation

No testing needed. This is a pure type-level refactoring with no runtime behavior changes. The interface contract remains identical from a serialization perspective.

https://claude.ai/code/session_01RDgwi1ZceoKK5yRPSuTefB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor in `WebviewUpdater.ts` with identical serialized fields; no behavior or security impact.
> 
> **Overview**
> **`SyncStreamContentPayload`** now **extends `LogContentExtras`** instead of re-declaring the same optional workflow/metadata fields (`workflowFiles`, `workflowMissingOutputs`, `workflowCompileFailures`, `runUsage`, `contextState`).
> 
> JSDoc on the sync payload notes that shared fields are defined once for both incremental log extras and tab-switch hydration. **No runtime or IPC shape change**—pure TypeScript consolidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e62f744d11d1eb0c09afa16d94c6f16e71097c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->