### PR TITLE
fix: truncate by code points so truncateWithEllipsis never splits a surrogate pair

### DIFF
--- a/src/test-kernel/utils/text/StringUtils.vitest.ts
+++ b/src/test-kernel/utils/text/StringUtils.vitest.ts
@@ -6,6 +6,8 @@ import {
   pluralize,
   splitContentLines,
   splitOutputLines,
+  tailWithEllipsis,
+  truncateWithEllipsis,
 } from '@utils/text/stringUtils';
 
 describe('splitContentLines', () => {
@@ -57,5 +59,15 @@ describe('pluralize', () => {
 
   it('honors explicit plural overrides', () => {
     expect(pluralize(2, 'person', 'people')).toBe('people');
+  });
+});
+
+describe('Unicode-safe ellipsis helpers', () => {
+  it('does not split a surrogate pair at the trailing truncation boundary', () => {
+    expect(truncateWithEllipsis('abc🍕def', 5)).toBe('abc🍕…');
+  });
+
+  it('does not split a surrogate pair at the leading truncation boundary', () => {
+    expect(tailWithEllipsis('abc🍕def', 5)).toBe('…🍕def');
   });
 });

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -122,10 +122,13 @@ export function truncateSummary(text: string, maxLength: number): string {
  * Keep the last `maxLen` characters; prepend an ellipsis when truncated.
  * Complement to `truncateWithEllipsis` for cases where the relevant content
  * is at the end (e.g. terminal installer output where success/error appears last).
+ * Like `truncateWithEllipsis`, this counts Unicode code points so the leading
+ * cut never leaves a dangling low surrogate.
  */
 export function tailWithEllipsis(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  return `…${text.slice(-(maxLen - 1))}`;
+  const codePoints = [...text];
+  if (codePoints.length <= maxLen) return text;
+  return `…${codePoints.slice(-(maxLen - 1)).join('')}`;
 }
 
 /**

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -85,15 +85,18 @@ export function countLines(text: string): number {
  * Returns the original string unchanged if it fits within the limit.
  *
  * The ellipsis is a single Unicode character (U+2026), so the truncated
- * result is exactly `maxLen` characters long.
+ * result is exactly `maxLen` code points long. Truncation operates on code
+ * points (not UTF-16 units) so an astral character (emoji, CJK extension, …)
+ * straddling the cut boundary is never split into a corrupted lone surrogate.
  *
  * @example
  * truncateWithEllipsis('short', 60)           // 'short'
  * truncateWithEllipsis('a very long text', 10) // 'a very lo…'
  */
 export function truncateWithEllipsis(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  return `${text.slice(0, maxLen - 1)}…`;
+  const codePoints = [...text];
+  if (codePoints.length <= maxLen) return text;
+  return `${codePoints.slice(0, maxLen - 1).join('')}…`;
 }
 
 /**


### PR DESCRIPTION
## Summary

`truncateWithEllipsis` truncated with `text.slice(0, maxLen - 1)`, which operates on **UTF-16 code units**. When the cut index landed inside a surrogate pair (any astral character — emoji, CJK extension, math alphanumerics), it left a dangling **lone high surrogate** immediately before the `…`, rendering as a broken replacement glyph (�).

It feeds CLI tool-error previews (`MAX_ERROR_PREVIEW`) and other one-line summaries, so a preview whose text has an emoji near the boundary showed a corrupted character.

## Fix
Slice by **code points** (`[...text]`) instead of code units — matching the code-point-safe iteration the CLI's own `clipToWidth` (`render/terminalText.ts`) already uses.

```ts
const codePoints = [...text];
if (codePoints.length <= maxLen) return text;
return `${codePoints.slice(0, maxLen - 1).join('')}…`;
```

## Verification
- **ASCII output is byte-identical** to the old behavior (verified across the existing examples + boundary cases); astral characters at the cut are now kept whole instead of split.
- `maxLen` now counts code points rather than UTF-16 units — the intended "characters" semantics (the doc comment is updated accordingly).
- Found by the parsing/escaping sweep; CI `validate` + the `WolframRunSummary` test (which exercises this util) confirm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-string utility change with no auth, persistence, or API surface impact; only `maxLen` semantics differ for strings containing astral characters.
> 
> **Overview**
> **`truncateWithEllipsis` and `tailWithEllipsis`** no longer cut on UTF-16 indices via `slice`; they spread the string into code points, enforce `maxLen` on that count, and join before adding `…`. That stops astral characters (emoji, etc.) at the boundary from becoming lone surrogates and broken `` glyphs in one-line previews (tool errors, session labels, summaries via `truncateSummary`).
> 
> Docs now state that **`maxLen` is code points**, not UTF-16 units. ASCII truncation behavior stays the same.
> 
> Vitest adds a **Unicode-safe ellipsis** block with surrogate-pair cases for both helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c399f7297f04d2a54f170009d35e5257ed688a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->