### PR TITLE
fix: surface error/ready status on the focused CLI stream tab

### DIFF
--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -2,6 +2,10 @@ import { Box, Text } from 'ink';
 
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
+import {
+  isInFlightStatus,
+  isTerminalStatus,
+} from '@common/constants/streamStatus';
 
 import { textDisplayWidth, truncateToWidth } from '../render/terminalText';
 import { cliState, type StreamSlice } from '../state/cliState';
@@ -15,6 +19,12 @@ export interface StreamTabDisplayItem {
   readonly running: boolean;
   readonly shortcutIndex?: number;
   readonly status?: string;
+  /**
+   * Whether the run has ENDED (stopped/error/ready) — terminal but not
+   * in-flight. WAITING is terminal-but-in-flight and is intentionally excluded
+   * so an active waiting tab stays unsuffixed.
+   */
+  readonly ended?: boolean;
 }
 
 const MAX_LABEL_WIDTH = 18;
@@ -27,10 +37,11 @@ export function streamTabSegmentText(item: StreamTabDisplayItem): string {
       : `${item.shortcutIndex}:${item.label}`;
   const label = item.active ? `[${labeled}]` : labeled;
   const running = item.running ? '*' : '';
+  // Inactive tabs surface any non-running status; the active tab additionally
+  // surfaces an ended state (stopped/error/ready) so an active stream that
+  // errors or finishes isn't visually indistinguishable from one still running.
   const status =
-    item.status &&
-    item.status !== 'running' &&
-    (!item.active || item.status === 'stopped')
+    item.status && item.status !== 'running' && (!item.active || item.ended)
       ? `(${item.status})`
       : '';
   return `${label}${running}${status}`;
@@ -187,6 +198,8 @@ export function streamTabsDisplayItems(init: {
       running: slice?.status === STREAM_STATUS.RUNNING,
       shortcutIndex: view.shortcutIndex,
       status,
+      ended:
+        isTerminalStatus(slice?.status) && !isInFlightStatus(slice?.status),
     };
   });
   return collapseMiddle(items, init.width);

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -362,6 +362,41 @@ describe('CLI stream tabs strip', () => {
     ]);
   });
 
+  it('labels a focused error or ready stream like a focused stopped one', () => {
+    const root = streamId('root');
+    const child1 = streamId('child-1');
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [
+        root,
+        slice('root', {
+          status: STREAM_STATUS.READY,
+          childStreams: [
+            child({
+              executionId: 'r1',
+              childStreamId: child1,
+              agentName: 'strategy',
+            }),
+          ],
+        }),
+      ],
+      [child1, slice('child-1', { status: STREAM_STATUS.ERROR })],
+    ]);
+
+    const items = streamTabsDisplayItems({
+      activeStreamId: child1,
+      streams,
+      parentStream: new Map([[child1, root]]),
+      width: 80,
+    });
+
+    // The focused (active) error tab surfaces its status, matching stopped;
+    // previously only 'stopped' was special-cased and error/ready showed bare.
+    expect(items.map(streamTabSegmentText)).toEqual([
+      'main(ready)',
+      '[1:strategy](error)',
+    ]);
+  });
+
   it('labels nested child stream roots with their friendly stream name', () => {
     const root = streamId('root');
     const child1 = streamId('child-1');


### PR DESCRIPTION
## Summary

`streamTabSegmentText` showed a status suffix on the **active** tab only when the status was the literal `'stopped'`:

```ts
(!item.active || item.status === 'stopped')
```

So a focused stream that reached **ERROR** or **READY** rendered with no suffix — visually indistinguishable from a still-running tab — even though inactive tabs render every status. Only `STOPPED` was special-cased (it was added in isolation by an earlier fix).

## Fix
Replace the single hard-coded label check with a canonical **`ended`** flag derived from the stream traits — `isTerminalStatus(s) && !isInFlightStatus(s)`:

- covers **stopped / error / ready** (terminal, run ended), fixing the bug;
- intentionally **excludes WAITING** (terminal *but* in-flight), so an active waiting tab stays unsuffixed exactly as before.

Computed once at item construction from the raw `StreamStatus` (not the display label, which maps WAITING→`idle` and would break raw equality), avoiding the incomplete-enumeration anti-pattern.

## Verification
- Added a test for a focused error/ready stream (`main(ready)` / `[1:strategy](error)`).
- Full `StreamTabsStrip.vitest.mts` suite passes (18/18) — the existing active-WAITING tabs still render no suffix, confirming no regression.
- Found by the conditional-logic sweep; verified against `STREAM_STATUS_TRAITS`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI tab label logic only; no auth, data, or runtime behavior changes.
> 
> **Overview**
> **Focused CLI stream tabs** now show a status suffix for **error** and **ready** (not only **stopped**), so a finished or failed run does not look like it is still running.
> 
> `streamTabSegmentText` no longer special-cases the display label `'stopped'` on the active tab. It uses a new **`ended`** flag on tab items, set from raw `StreamStatus` via `isTerminalStatus` and `!isInFlightStatus` (covers stopped/error/ready; **WAITING** stays unsuffixed when focused).
> 
> A vitest case asserts focused **ready** / **error** labels match the existing stopped behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8926d0dd8d10d83a0c84012a8fcaa95864f76d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->