### PR TITLE
fix: stop unavailable models from being enabled via a dimmed-but-live checkbox

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -189,6 +189,7 @@ export class ModelSelectionList extends LitElement {
         class="reasoning-level-select"
         .value=${currentValue}
         title=${title}
+        ?disabled=${model.disabled}
         @change=${(e: Event) => this.handleReasoningLevelChange(model.name, e)}
       >
         <wa-option value=""> ${defaultLabel} </wa-option>
@@ -243,6 +244,7 @@ export class ModelSelectionList extends LitElement {
       <div class="model-row${unavailableClass}">
         <wa-checkbox
           ?checked=${model.enabled}
+          ?disabled=${!available && !model.enabled}
           @change=${(e: Event) => {
             const checked = (e.target as WaCheckbox).checked;
             this.dispatchEvent(


### PR DESCRIPTION
## Summary

In **Settings → Models**, a model that is unavailable (missing API key / not in the relay allowlist) renders with `.model-row--unavailable`, which only **dims** it (`opacity`) — it sets no `pointer-events` guard and the `<wa-checkbox>` had **no `?disabled` binding**. So the dimmed checkbox stayed fully clickable: toggling it fired `setModelEnabled` and added an **unusable model to the persisted enabled set**, with no feedback. The adjacent reasoning-level `<wa-select>` was likewise live.

## Fix

Gate the controls to match their disabled appearance — **asymmetrically**, so the fix doesn't strand a model that was enabled *before* its key was removed:

- **Checkbox**: `?disabled=${!available && !model.enabled}` — blocks *enabling* an unusable model, while still allowing an already-enabled-but-now-unavailable model to be **unchecked** (removed).
- **Reasoning select**: `?disabled=${model.disabled}` for unavailable models.

`wa-*` `disabled` is native, so both mouse and keyboard now respect the gate.

## Verification
- Logic table: available → interactive; unavailable + unchecked → disabled (can't enable); unavailable + checked → still uncheckable (can remove).
- Minimal type-safe Lit binding change; CI `validate` confirms typecheck/build.
- Found by the control-enable-state sweep; the asymmetry addresses the edge case the reviewer flagged (don't strand `enabled && disabled` models).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Lit template bindings in settings UI only; no auth, persistence logic, or backend changes.
> 
> **Overview**
> **Settings → Models** previously dimmed unavailable rows with CSS only, so users could still toggle checkboxes and reasoning selects and persist unusable models in the enabled set.
> 
> This wires native **`?disabled`** on the model row checkbox and reasoning **`wa-select`** so interaction matches availability. The checkbox uses **`?disabled=${!available && !model.enabled}`** so you cannot *enable* an unavailable model, but you can still *uncheck* one that was enabled before its key was removed. Unavailable models always disable the reasoning dropdown via **`model.disabled`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dc22a0aa3c5adf58b85a3fa4dd3055fa114c724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->