### PR TITLE
fix: show "No matching commands" instead of a blank command palette

### DIFF
--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -76,6 +76,7 @@ export function createDesktopCommandPalette({
       item: 'desktop-command-palette-item',
       label: 'desktop-command-palette-label',
       meta: 'desktop-command-palette-meta',
+      empty: 'desktop-command-palette-empty',
     },
   });
 }

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -470,6 +470,13 @@ wa-input.desktop-command-palette-input::part(base) {
   padding: var(--wa-space-2xs);
 }
 
+.desktop-command-palette-empty {
+  padding: var(--wa-space-s) var(--wa-space-m);
+  color: var(--wa-color-text-quiet);
+  font-size: var(--wa-font-size-s);
+  text-align: center;
+}
+
 .desktop-command-palette-item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/src/shared/wa/commandPalette.ts
+++ b/src/shared/wa/commandPalette.ts
@@ -10,7 +10,7 @@
 
 import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
-import { html, render } from 'lit';
+import { html, nothing, render } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
@@ -61,6 +61,7 @@ export interface CommandPaletteClassNames {
   readonly item?: string;
   readonly label?: string;
   readonly meta?: string;
+  readonly empty?: string;
 }
 
 export interface CommandPaletteController {
@@ -226,6 +227,7 @@ export function createCommandPalette({
   const itemClass = classes?.item;
   const labelClass = classes?.label;
   const metaClass = classes?.meta;
+  const emptyClass = classes?.empty;
 
   const renderTemplate = (): void => {
     render(
@@ -242,6 +244,11 @@ export function createCommandPalette({
           @keydown=${handleFilterKeydown}
         ></wa-input>
         <div class=${listClass ?? ''} role="listbox">
+          ${visibleEntries.length === 0
+            ? html`<div class=${emptyClass ?? ''} role="status">
+                No matching commands
+              </div>`
+            : nothing}
           ${repeat(
             visibleEntries,
             (entry) => entry.id,


### PR DESCRIPTION
## Summary

When a command-palette filter excluded every entry, `renderTemplate` emitted zero `<button role="option">` rows and **no fallback**, leaving just the search box over an empty box — indistinguishable from a broken/loading palette. `activeIndex` is `-1`, so Enter was also a silent no-op.

## Fix
Render a non-interactive status row (`No matching commands`, `role="status"`) inside the listbox when `visibleEntries.length === 0`:
- Added an optional `empty` class to `CommandPaletteClassNames` (shared module).
- Wired `empty: 'desktop-command-palette-empty'` in the desktop palette and added a muted, centered `.desktop-command-palette-empty` CSS rule.

A plain status row (not `role="option"`) keeps the listbox semantics correct, and the visible message makes the now-expected dead Enter unambiguous (there's nothing to run).

## Verification
- Empty branch only renders when there are no matches; non-empty behavior is unchanged.
- Type-safe (optional field + `nothing`); CI `validate` confirms typecheck/build across the shared + desktop packages.
- Found by the empty/loading/error-state sweep; markup choice (status row + host CSS class) per the a11y review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI and optional styling hook in shared palette code; no auth, data, or command-dispatch behavior changes when results exist.
> 
> **Overview**
> When filtering leaves **no commands**, the shared command palette now shows a **"No matching commands"** status row inside the listbox instead of a blank list, so the palette no longer looks broken and Enter with no selection stays clearly intentional.
> 
> The shared `commandPalette` module adds an optional **`empty` CSS class** on `CommandPaletteClassNames` and renders that row with **`role="status"`** (not `role="option"`) when `visibleEntries` is empty. The desktop host passes **`desktop-command-palette-empty`** and styles it as muted, centered text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe02e778daf2705b714246591f2096ffdaa4f231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->