### PR TITLE
fix(github): read the GitHub token via platform secrets (works in CLI/desktop)

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -37,8 +37,8 @@ import {
 } from '@auth/config';
 import { getAuthStatus } from '@auth/authCommands';
 import { AUTH_PROVIDER_ID } from '@auth/constants';
-import { tryResumeFromSnapshot } from '@commands/agent/resumeFromSnapshot';
 import { hasAnyUsableSetupCredential } from '@commands/setup';
+import { tryResumeFromSnapshot } from '@commands/agent/resumeFromSnapshot';
 import { createSampleProjectWithoutWorkspace } from '@commands/system/sampleProjectCommands';
 import { toErrorMessage } from '@common/errors';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
@@ -86,7 +86,6 @@ import { setOpenPdfOpener } from '@tools/OpenPdfTool';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import { setSetupPlatform } from '@tools/setup';
 import {
-  setGitHubTokenProvider,
   prPollingSource,
   repoPollingSource,
   issuePollingSource,
@@ -523,15 +522,6 @@ export async function activate(context: vscode.ExtensionContext) {
       runCommand: (args) => runTerminalCommand(args),
     },
   });
-  // GitHub token lives in SecretStorage (managed via the Git settings tab).
-  // The tool layer only supports a synchronous token lookup, so we cache here
-  // and refresh on secret changes.
-  let cachedGitHubToken: string | undefined;
-  const refreshGitHubToken = async () => {
-    cachedGitHubToken = await SecretManager.getGitHubToken();
-  };
-  setGitHubTokenProvider(() => cachedGitHubToken);
-  void refreshGitHubToken();
   // VS Code's event emitters don't await async listeners, so we funnel
   // fire-and-forget async work through this helper to log rejections
   // instead of letting them become unhandled promise rejections.
@@ -545,13 +535,11 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     context.secrets.onDidChange((e) => {
       if (e.key !== SecretManager.GITHUB_TOKEN_KEY) return;
-      // Refresh the cached token first so availability checks see the
-      // new value, then re-probe so any subscribed UI (Tools tab) and
-      // the runtime cache pick up the change automatically.
-      void (async () => {
-        await refreshGitHubToken();
-        await refreshToolAvailability(extensionAgentRuntimeHost);
-      })().catch(logRefreshFailure('secret change'));
+      // Re-probe so any subscribed UI (Tools tab) reflects the new token
+      // presence; getGitHubToken() now reads SecretStorage live (no cache).
+      void refreshToolAvailability(extensionAgentRuntimeHost).catch(
+        logRefreshFailure('secret change'),
+      );
     }),
     // Lean/LaTeX extension installed or removed → re-probe so the Tools tab
     // reflects the new state without the user clicking Re-check.

--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
+import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
 
 export type { ApiProvider };
 
@@ -39,16 +40,10 @@ export class SecretManager {
 
   public static readonly API_PROVIDERS = API_PROVIDERS;
 
-  public static readonly GITHUB_TOKEN_KEY = 'github.token';
+  public static readonly GITHUB_TOKEN_KEY = GITHUB_TOKEN_STORAGE_KEY;
 
   public static getApiKeySecretName(provider: ApiProvider): string {
     return `apiKey.${provider}`;
-  }
-
-  /** Read the GitHub personal access token from secret storage, env fallback. */
-  public static async getGitHubToken(): Promise<string | undefined> {
-    const stored = await this.get(this.GITHUB_TOKEN_KEY);
-    return stored ?? process.env.GITHUB_TOKEN ?? undefined;
   }
 
   public static async gitHubTokenExists(): Promise<'secret' | 'env' | 'none'> {

--- a/src/test-kernel/tools/GitHubAuth.vitest.ts
+++ b/src/test-kernel/tools/GitHubAuth.vitest.ts
@@ -1,0 +1,46 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalGitHubToken = process.env.GITHUB_TOKEN;
+
+afterEach(() => {
+  if (originalGitHubToken === undefined) {
+    delete process.env.GITHUB_TOKEN;
+  } else {
+    process.env.GITHUB_TOKEN = originalGitHubToken;
+  }
+  vi.resetModules();
+});
+
+describe('getGitHubToken', () => {
+  it('uses the GITHUB_TOKEN fallback before platform initialization', async () => {
+    vi.resetModules();
+    process.env.GITHUB_TOKEN = 'gh-env-token';
+
+    const { getGitHubToken } = await import('@tools/github/githubAuth');
+
+    await expect(getGitHubToken()).resolves.toBe('gh-env-token');
+  });
+
+  it('prefers the platform secret when the platform is initialized', async () => {
+    vi.resetModules();
+    process.env.GITHUB_TOKEN = 'gh-env-token';
+
+    const [{ initPlatform }, { createFakePlatform }, githubAuth] =
+      await Promise.all([
+        import('@platform/platform'),
+        import('@test/support/FakePlatform'),
+        import('@tools/github/githubAuth'),
+      ]);
+
+    initPlatform(
+      createFakePlatform({
+        secrets: {
+          [githubAuth.GITHUB_TOKEN_STORAGE_KEY]: 'gh-secret-token',
+        },
+      }),
+    );
+
+    await expect(githubAuth.getGitHubToken()).resolves.toBe('gh-secret-token');
+  });
+});

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -148,7 +148,7 @@ async function getGitHubPRPrerequisites(): Promise<{
   tokenPresent: boolean;
   inGitRepo: boolean;
 }> {
-  const tokenPresent = getGitHubToken() !== undefined;
+  const tokenPresent = (await getGitHubToken()) !== undefined;
   const inGitRepo = await isGitRepository();
   return { tokenPresent, inGitRepo };
 }

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -1,22 +1,20 @@
 /**
- * Injectable GitHub token provider.
+ * GitHub personal access token lookup.
  *
- * This module is VS Code-free. The extension host registers an implementation
- * during activation (see `setGitHubTokenProvider`) that reads from VS Code's
- * SecretStorage (or `GITHUB_TOKEN` env fallback). Tools and the polling
- * service read the token lazily via `getGitHubToken()` so they never depend on
- * VS Code APIs directly.
+ * Host-neutral: reads from the platform secrets port (each host wires its own
+ * secret store) with a `GITHUB_TOKEN` environment-variable fallback. The token
+ * is persisted under `github.token` (set via the Git settings tab), while the
+ * conventional env var is `GITHUB_TOKEN` — a different name — hence the explicit
+ * second fallback. Because every host wires `platform().secrets`, GitHub tools
+ * now work in the CLI and desktop too, not just the extension.
  */
+import { platform } from '@platform/platform';
 
-export type GitHubTokenProvider = () => string | undefined;
+/** SecretStorage key under which the GitHub PAT is persisted. */
+export const GITHUB_TOKEN_STORAGE_KEY = 'github.token';
 
-let provider: GitHubTokenProvider = () => undefined;
-
-export function setGitHubTokenProvider(p: GitHubTokenProvider): void {
-  provider = p;
-}
-
-export function getGitHubToken(): string | undefined {
-  const token = provider();
+export async function getGitHubToken(): Promise<string | undefined> {
+  const stored = await platform().secrets.get(GITHUB_TOKEN_STORAGE_KEY);
+  const token = stored ?? process.env.GITHUB_TOKEN;
   return token && token.length > 0 ? token : undefined;
 }

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -8,13 +8,13 @@
  * second fallback. Because every host wires `platform().secrets`, GitHub tools
  * now work in the CLI and desktop too, not just the extension.
  */
-import { platform } from '@platform/platform';
+import { tryPlatform } from '@platform/platform';
 
 /** SecretStorage key under which the GitHub PAT is persisted. */
 export const GITHUB_TOKEN_STORAGE_KEY = 'github.token';
 
 export async function getGitHubToken(): Promise<string | undefined> {
-  const stored = await platform().secrets.get(GITHUB_TOKEN_STORAGE_KEY);
+  const stored = await tryPlatform()?.secrets.get(GITHUB_TOKEN_STORAGE_KEY);
   const token = stored ?? process.env.GITHUB_TOKEN;
   return token && token.length > 0 ? token : undefined;
 }

--- a/src/tools/github/githubClient.ts
+++ b/src/tools/github/githubClient.ts
@@ -7,10 +7,10 @@
  * back on subsequent requests; a 304 means "no change since that ETag".
  */
 
-import { isNonEmptyString } from '@utils/core';
 import { request as octokitRequest } from '@octokit/request';
 import { RequestError } from '@octokit/request-error';
 import { StatusCodes } from 'http-status-codes';
+import { isNonEmptyString } from '@utils/core';
 
 import { getGitHubToken } from './githubAuth';
 
@@ -83,7 +83,7 @@ export async function ghGet<T>(
   path: string,
   etag?: string,
 ): Promise<ConditionalResponse<T>> {
-  const token = getGitHubToken();
+  const token = await getGitHubToken();
   const headers: Record<string, string> = {
     'X-GitHub-Api-Version': API_VERSION,
     'user-agent': 'TeXRA-Extension',

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -122,8 +122,8 @@ function parsePath(raw: string): ParsedPath {
   );
 }
 
-function requireToken(): void {
-  if (!getGitHubToken()) {
+async function requireToken(): Promise<void> {
+  if (!(await getGitHubToken())) {
     throw new ToolError(
       'No GitHub token configured. Open TeXRA settings → Git tab → "Set token" (or export GITHUB_TOKEN). Needs `repo` scope for private repos, `public_repo` for public.',
     );
@@ -176,7 +176,7 @@ function prSubscriptionActivitySentence(
 async function execSubscribe(
   input: GitHubSubscriptionInput,
 ): Promise<ToolResult> {
-  requireToken();
+  await requireToken();
   const { streamId, runtimeHost } = requireSubscriptionContext();
   const target = requirePath(input);
   const minAnnotationLevel = getMinAnnotationLevel(input);
@@ -459,7 +459,7 @@ async function getFindCurrentFallbackInfo(
 async function execFindCurrent(
   input: GitHubSubscriptionInput,
 ): Promise<ToolResult> {
-  requireToken();
+  await requireToken();
   const cwd =
     parseWorkingDirectory(input.working_directory) ??
     tryUseRunContext()?.workingDirectory;

--- a/src/tools/github/index.ts
+++ b/src/tools/github/index.ts
@@ -1,5 +1,4 @@
 export { GitHubSubscriptionTool } from './githubSubscriptionTool';
-export { setGitHubTokenProvider } from './githubAuth';
 export { prPollingSource } from './PRPollingSource';
 export { repoPollingSource } from './RepoPollingSource';
 export { issuePollingSource } from './IssuePollingSource';


### PR DESCRIPTION
## The dead-in-two-hosts bug

`getGitHubToken()` read from a module-scope singleton in `githubAuth.ts`:

```ts
let provider: GitHubTokenProvider = () => undefined;
export function getGitHubToken() { return provider()?... }
```

…and **only the extension ever filled it** (`extension.ts` cached `SecretManager.getGitHubToken()` and pushed it in via `setGitHubTokenProvider`). The **CLI and desktop never call the setter**, so `getGitHubToken()` returned `undefined` there and every GitHub tool/probe was silently dead in two of three hosts — a parallel owner of a fact `platform().secrets` already owns and all three hosts already wire.

## Fix — read through the secrets port

```ts
export async function getGitHubToken(): Promise<string | undefined> {
  const stored = await platform().secrets.get('github.token');
  const token = stored ?? process.env.GITHUB_TOKEN;
  return token && token.length > 0 ? token : undefined;
}
```

- The storage key `github.token` differs from the conventional `GITHUB_TOKEN` env var, so the env fallback is **explicit** (the per-host secret providers only probe `process.env[key]`, never `GITHUB_TOKEN`) — this is the subtlety the original `SecretManager.getGitHubToken` handled, now preserved host-neutrally.
- The three readers — `ghGet`, `getGitHubPRPrerequisites`, `requireToken` — already run in async contexts; `requireToken` becomes `async` and its two callers `await` it.
- Deleted: the `githubAuth` singleton + `setGitHubTokenProvider`, the `@tools/github` barrel re-export, the extension caching dance, and the now-dead `SecretManager.getGitHubToken` (its logic lives once now). The SecretStorage key is owned once by `githubAuth` (`GITHUB_TOKEN_STORAGE_KEY`) and referenced by `SecretManager`.
- The `secrets.onDidChange` listener still re-probes tool availability; `getGitHubToken()` now reads SecretStorage live (no cache to refresh).

## Behavior
- **Extension: preserved** — reads `context.secrets['github.token']` + `GITHUB_TOKEN` env, same as before.
- **CLI / desktop: fixed** — GitHub tools now resolve the token from their wired secret store + `GITHUB_TOKEN` env (previously always dead).

## Verification
- `tsc --noEmit` (root + extension) clean — no remaining `setGitHubTokenProvider`/`getGitHubToken` sync callers.
- prettier + eslint clean; `GitHubSubscriptionProgressEvents.vitest` passes (5/5).

> Note: the deep-audit finding proposed the **wrong** storage key (`GITHUB_TOKEN` instead of `github.token`) and mis-stated all readers as already-async; this PR uses the verified key + explicit env fallback and makes `requireToken` async.

---
🤖 Round-3–10 deep audit (parallel-singleton / incomplete-port lens), corrected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitHub credentials are resolved across extension, CLI, and desktop; behavior should match the extension path but any host with incomplete `platform().secrets` wiring could still fail silently.
> 
> **Overview**
> **GitHub PAT resolution is host-neutral** — `getGitHubToken()` is now async and reads `github.token` from `platform().secrets` (via `tryPlatform()`), with an explicit `GITHUB_TOKEN` env fallback. The extension-only injectable provider (`setGitHubTokenProvider`), in-memory token cache, and `SecretManager.getGitHubToken()` are removed.
> 
> **Call sites follow the async API** — `ghGet`, GitHub tool availability probes, and `requireToken` in the subscription tool `await` the lookup. The VS Code extension still re-probes tool availability when the GitHub secret changes; it no longer refreshes a cached token first.
> 
> **Single storage key** — `GITHUB_TOKEN_STORAGE_KEY` lives in `githubAuth` and is reused by `SecretManager.GITHUB_TOKEN_KEY`. Vitest covers env-only (pre-platform) and secret-over-env when the platform is initialized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e61ed33a43e4cc509d7c6b17dcb290309bd7bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->