### PR TITLE
fix: retry Monaco diff-editor load after a transient failure

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -171,7 +171,16 @@ export class TexraDiffView extends LitElement {
       changed.has('proposedText') ||
       changed.has('language')
     ) {
-      this.syncModels();
+      // If a prior editor load failed (or never completed), retry it when new
+      // diff content arrives instead of staying stuck on the error message for
+      // the rest of the session — the element is reused across re-opens. The
+      // `!this.loading` guard avoids a second concurrent load during the initial
+      // firstUpdated()+updated() cycle (firstUpdated sets loading synchronously).
+      if (!this.editor && !this.loading) {
+        void this.ensureEditor();
+      } else {
+        this.syncModels();
+      }
     }
     if (changed.has('hostTheme')) {
       this.applyTheme();


### PR DESCRIPTION
## Summary

`TexraDiffView` loads Monaco lazily via `ensureEditor()`, invoked **only from `firstUpdated()`** (fires once per element). If the dynamic `import('monaco-editor/...')` rejects — a recoverable failure (flaky chunk load, worker bootstrap throw) — the catch sets `errorMessage`, `this.editor` stays `undefined`, and `render()` returns the error div from then on. `updated()` only called `syncModels()`, which early-returns without an editor, and nothing ever re-attempted the load or cleared the error.

The element is **reused across re-opens** (the desktop diff overlay keeps a single `<texra-diff-view>`), so one transient failure left the diff view stuck on the error message for the rest of the session — even when opening completely different, valid diffs. Only reloading the window recovered it.

## Fix
Retry `ensureEditor()` from `updated()` when new diff content arrives and no editor exists:

```ts
if (!this.editor && !this.loading) {
  void this.ensureEditor();   // ensureEditor clears errorMessage + guards re-init
} else {
  this.syncModels();
}
```

`loadMonaco()` already clears its memo on failure, so this genuinely re-attempts the import. The `!this.loading` guard prevents a second concurrent load during the initial `firstUpdated()`+`updated()` cycle (`firstUpdated` sets `loading=true` synchronously before `updated()` runs).

## Verification
- Single-file change using existing methods/fields; behavior unchanged on the happy path (editor present → `syncModels`) and the initial load (loading guard → no double-load).
- Found by the error-handling sweep; CI `validate` confirms typecheck/build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path UI recovery logic in the diff view; happy path unchanged when an editor already exists.
> 
> **Overview**
> **`TexraDiffView`** no longer stays on a permanent error after a failed Monaco lazy load when the same element is reused (e.g. desktop diff overlay).
> 
> When **`originalText`**, **`proposedText`**, or **`language`** change, **`updated()`** now calls **`ensureEditor()`** if there is no editor and a load is not already in progress; otherwise it still runs **`syncModels()`**. That clears **`errorMessage`** and re-attempts the dynamic import ( **`loadMonaco()`** already resets its memo on failure). The **`!this.loading`** guard avoids a duplicate load on the initial **`firstUpdated()`** + **`updated()`** cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4bd45ab530c33539f465dab910eb423cec48239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->