### PR TITLE
perf(cli): dedupe stream descendants with a Set, not O(n^2) includes

### DIFF
--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -40,14 +40,16 @@ export function orderedDescendantsFromTree(init: {
   const out = orderedDescendantsFromSlice(init.parentSlice).filter((id) =>
     init.streams.has(id),
   );
+  const seen = new Set(out);
   for (const [child, recordedParent] of init.parentStream) {
     if (
       recordedParent !== init.parent ||
       !init.streams.has(child) ||
-      out.includes(child)
+      seen.has(child)
     ) {
       continue;
     }
+    seen.add(child);
     out.push(child);
   }
   return out;


### PR DESCRIPTION
## What

`orderedDescendantsFromTree` (`packages/cli/src/chat/tui/state/focusCycle.ts`) deduplicated children via `out.includes(child)` **inside** the loop over `parentStream` edges — O(n²) in descendant count. It runs on every `activeStreamTreeViews` recompute (tab-bar / child-picker render, and Ctrl-A/Ctrl-B focus cycling).

This seeds a `Set` from the filtered prefix and tests/inserts against it — O(n) total. Behavior is identical.

## Why it's safe

- Same dedup semantics: an id is appended iff not already present. `Set` membership ⇔ array membership here.
- Mirrors the pattern already used one function up (`orderedDescendantsFromSlice` returns `[...new Set(out)]`).
- No structural/type change; output ordering preserved.

## Impact

Removes quadratic work on a TUI render/navigation hot path. `n` is bounded by concurrent active+retained streams, so this matters most in multi-subagent workflows.

## Verification

- `npx tsc --noEmit` — no errors in the file.
- The focus-state suite (`TuiStateAndFocus.vitest.mts`) can't run in this sandbox due to a pre-existing missing `async-mutex` dependency in an unrelated import chain; CI runs it with deps installed. The change is a behavior-preserving dedup.

🤖 Found via round 9 (collection/index structures) of a multi-agent data-structure audit; the round's synthesis pass rejected 2 higher-severity "races" as false positives (single-threaded JS) and kept this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving performance tweak in TUI navigation; no API or semantics change beyond faster duplicate checks.
> 
> **Overview**
> **`orderedDescendantsFromTree`** in `focusCycle.ts` now tracks already-seen stream tab IDs with a **`Set`** seeded from the slice-derived prefix, instead of calling **`out.includes(child)`** on every `parentStream` edge.
> 
> Dedup semantics and output order are unchanged; total work drops from **O(n²)** to **O(n)** on a path used when recomputing **`activeStreamTreeViews`** (tab bar / child picker) and **Ctrl-A / Ctrl-B** focus cycling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8cd2e843cb55283ea7cddb5e14579ca6ed8d3ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->