### PR TITLE
fix(runtime): don't recreate output state for unregistered processes

### DIFF
--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -152,6 +152,15 @@ export class ProcessOutputPoller {
       (source) => {
         const { outputPaths } = source.handle;
         if (!outputPaths) return Promise.resolve();
+        // The snapshot above is taken before pMap drains it; a process can be
+        // unregistered while its read is still queued. Re-check membership at
+        // dequeue time so we don't recreate decoder state for a dead process
+        // (that orphan would leak in outputStates until dispose, since no
+        // future unregister fires for it). The flush() path is unaffected —
+        // it calls readIncremental directly with a caller-owned handle.
+        if (!this.processOutputs.has(source.handle.executionId)) {
+          return Promise.resolve();
+        }
         return this.readIncremental(
           source.handle.executionId,
           source.handle.parentStreamId,

--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -152,21 +152,19 @@ export class ProcessOutputPoller {
       (source) => {
         const { outputPaths } = source.handle;
         if (!outputPaths) return Promise.resolve();
-        // The snapshot above is taken before pMap drains it; a process can be
-        // unregistered while its read is still queued. Re-check membership at
-        // dequeue time so we don't recreate decoder state for a dead process
-        // (that orphan would leak in outputStates until dispose, since no
-        // future unregister fires for it). The flush() path is unaffected —
-        // it calls readIncremental directly with a caller-owned handle.
-        if (!this.processOutputs.has(source.handle.executionId)) {
-          return Promise.resolve();
-        }
+        // Poll reads are gated on the process still being registered
+        // (requireRegistered=true): the snapshot above is taken before pMap
+        // drains it, and a process can be unregistered while its read is
+        // queued. Recreating decoder state for a dead process would orphan an
+        // outputStates entry that no future unregister clears. The flush() path
+        // owns its handle and reads with the default requireRegistered=false.
         return this.readIncremental(
           source.handle.executionId,
           source.handle.parentStreamId,
           outputPaths.stdout,
           outputPaths.stderr,
           source.runtimeHost,
+          true,
         );
       },
       { concurrency: OUTPUT_POLL_CONCURRENCY },
@@ -179,10 +177,20 @@ export class ProcessOutputPoller {
     stdoutPath: string,
     stderrPath: string,
     runtimeHost: AgentRuntimeHost,
+    requireRegistered = false,
   ): Promise<void> {
     const inflight = this.readingInProgress.get(executionId);
     if (inflight) {
       await inflight;
+    }
+
+    // Re-check registration AFTER awaiting any in-flight read: that read may be
+    // the terminal flush() whose .finally(unregister) deletes this process's
+    // state, and recreating it below (getOrCreateState) would orphan a decoder
+    // entry no future unregister clears. flush() itself passes
+    // requireRegistered=false so it still runs after unregister.
+    if (requireRegistered && !this.processOutputs.has(executionId)) {
+      return;
     }
 
     const work = (async () => {


### PR DESCRIPTION
## What

`pollProcessOutputs` snapshots `[...this.processOutputs.values()]` and feeds it to `pMap` (concurrency 8). A process can be `unregister`ed while one of its reads is still queued in `pMap`. When that queued read runs, `readIncremental` → `getOrCreateState(executionId)` **recreates** an `outputStates` entry for the now-dead process — and since `unregister` already fired, nothing will ever clear it. The orphaned decoder state leaks until `dispose()`.

This re-checks `processOutputs.has(executionId)` at dequeue time inside the poll callback and skips dead processes.

## Why it's safe / scoped correctly

- The guard is on the **poll path only**. The `flush(handle, host)` path calls `readIncremental` directly with a caller-owned handle (used before/without registration, e.g. final-output flush and the unit tests), so it must *not* be gated on registry membership — an earlier attempt to guard inside `readIncremental` broke `flush` and is avoided here.
- Final output is already flushed before `unregister` runs (`untrackHandle` does `flush().finally(unregister)`), so skipping a post-unregister poll read drops no data.

## Impact

Fixes decoder-state accumulation in long sessions with many short-lived background processes (bash scripts, parallel codex runs). Not a functional failure — resident-set growth cleared only at `dispose()`.

## Verification

- `npx tsc --noEmit` — clean.
- `ProcessOutputPoller.vitest.ts` (4) and `ExecutionRegistry.vitest.ts` (18) — all pass. (Confirmed the flush-path tests still pass, which the rejected `readIncremental`-level guard would have broken.)

🤖 Found via round 9 (collection/index) of a multi-agent data-structure audit; verdict downgraded to needs-discussion, implemented here with the poll-path-only fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to poll-path output reads; flush and unregister ordering is unchanged, so no expected functional regression beyond avoiding leaked decoder state.
> 
> **Overview**
> Fixes a **memory leak** in `ProcessOutputPoller` when concurrent poll reads race with process teardown.
> 
> Background output polling snapshots registered processes and reads them via `pMap` (concurrency 8). A process can be **unregistered** while its poll read is still queued; when that read runs, `readIncremental` → `getOrCreateState` would **recreate** `outputStates` for an execution that `unregister` already cleared, leaving decoder state that nothing removes until `dispose()`.
> 
> Poll-path reads now pass **`requireRegistered=true`** and bail out if `processOutputs` no longer contains the `executionId`, including **after** waiting on an in-flight read (e.g. terminal `flush()` + `unregister`). **`flush()`** still calls `readIncremental` with the default `requireRegistered=false`, so final output is not gated on registry membership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7289f64de0629918f8c2b2366c5616ad9f3dbbb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->