### PR TITLE
fix: make progress-view transcript links keyboard-activatable

### DIFF
--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -97,11 +97,13 @@ export class LogList extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
     this.addEventListener('click', this.handleClickEvent);
+    this.addEventListener('keydown', this.handleKeyEvent);
     this.addEventListener('file-click', this.handleFileClickEvent);
   }
 
   override disconnectedCallback(): void {
     this.removeEventListener('click', this.handleClickEvent);
+    this.removeEventListener('keydown', this.handleKeyEvent);
     this.removeEventListener('file-click', this.handleFileClickEvent);
     super.disconnectedCallback();
   }
@@ -250,40 +252,7 @@ export class LogList extends LitElement {
   /** Handle click events for file links, copy buttons, etc. */
   private async handleClickEvent(event: Event): Promise<void> {
     if (!(event instanceof MouseEvent)) return;
-    const fileLink = this.findTargetInPath<HTMLElement>(event, '.file-link');
-    if (fileLink?.dataset.file) {
-      postMessage(PROGRESS_VIEW_COMMANDS.OPEN_FILE, {
-        file: fileLink.dataset.file,
-        ...(fileLink.dataset.fileLine && {
-          line: Number(fileLink.dataset.fileLine),
-        }),
-      });
-      return;
-    }
-
-    const latexRef = this.findTargetInPath<HTMLElement>(event, '.latex-ref');
-    if (latexRef?.dataset.label) {
-      postMessage(PROGRESS_VIEW_COMMANDS.OPEN_LABEL, {
-        label: latexRef.dataset.label,
-      });
-      return;
-    }
-
-    // Handle proposal restore links (may be inside <summary>, so prevent toggle)
-    const proposalLink = this.findTargetInPath<HTMLElement>(
-      event,
-      '.proposal-restore-link',
-    );
-    if (proposalLink?.dataset.proposalId) {
-      event.preventDefault();
-      const proposal = getProposalInput(proposalLink.dataset.proposalId);
-      if (proposal) {
-        postMessage(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG, {
-          proposal,
-        });
-      }
-      return;
-    }
+    if (this.activateLinkFromEvent(event)) return;
 
     // Handle copy buttons - content is stored in the copy registry
     const copyButton = this.findTargetInPath<HTMLElement>(
@@ -306,6 +275,68 @@ export class LogList extends LitElement {
         successClass: isCodeBlock ? 'copied' : undefined,
       });
     }
+  }
+
+  /**
+   * Keyboard activation (Enter/Space) for the focusable transcript link spans
+   * (file-link / latex-ref / proposal-restore-link). Copy buttons are native
+   * <wa-button>s and already keyboard-activatable via the click handler, so
+   * they are intentionally excluded here to avoid double-firing.
+   */
+  private handleKeyEvent(event: Event): void {
+    if (!(event instanceof KeyboardEvent)) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const target = event.target;
+    if (
+      !(target instanceof Element) ||
+      !target.closest('.file-link, .latex-ref, .proposal-restore-link')
+    ) {
+      return;
+    }
+    event.preventDefault();
+    this.activateLinkFromEvent(event);
+  }
+
+  /**
+   * Dispatch a file-link / latex-ref / proposal-restore-link activation from a
+   * click or keydown event. Returns true when one was handled.
+   */
+  private activateLinkFromEvent(event: Event): boolean {
+    const fileLink = this.findTargetInPath<HTMLElement>(event, '.file-link');
+    if (fileLink?.dataset.file) {
+      postMessage(PROGRESS_VIEW_COMMANDS.OPEN_FILE, {
+        file: fileLink.dataset.file,
+        ...(fileLink.dataset.fileLine && {
+          line: Number(fileLink.dataset.fileLine),
+        }),
+      });
+      return true;
+    }
+
+    const latexRef = this.findTargetInPath<HTMLElement>(event, '.latex-ref');
+    if (latexRef?.dataset.label) {
+      postMessage(PROGRESS_VIEW_COMMANDS.OPEN_LABEL, {
+        label: latexRef.dataset.label,
+      });
+      return true;
+    }
+
+    // Handle proposal restore links (may be inside <summary>, so prevent toggle)
+    const proposalLink = this.findTargetInPath<HTMLElement>(
+      event,
+      '.proposal-restore-link',
+    );
+    if (proposalLink?.dataset.proposalId) {
+      event.preventDefault();
+      const proposal = getProposalInput(proposalLink.dataset.proposalId);
+      if (proposal) {
+        postMessage(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG, {
+          proposal,
+        });
+      }
+      return true;
+    }
+    return false;
   }
 
   private findTargetInPath<T extends Element>(

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -286,10 +286,12 @@ export class LogList extends LitElement {
   private handleKeyEvent(event: Event): void {
     if (!(event instanceof KeyboardEvent)) return;
     if (event.key !== 'Enter' && event.key !== ' ') return;
-    const target = event.target;
+    if (event.defaultPrevented) return;
     if (
-      !(target instanceof Element) ||
-      !target.closest('.file-link, .latex-ref, .proposal-restore-link')
+      !this.findTargetInPath<Element>(
+        event,
+        '.file-link, .latex-ref, .proposal-restore-link',
+      )
     ) {
       return;
     }

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -184,7 +184,7 @@ export function buildFileListRender(files: FileListEntry[]): {
     const sourceText = file.sourceDisplay ?? source;
 
     // prettier-ignore
-    return html`<li class="detail-item" title=${filePath}><wa-icon library="texra" name=${iconName} aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${filePath}>${fileName}</span>${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${showSource ? html` <span class="file-source">(${sourceText})</span>` : ''}</li>`;
+    return html`<li class="detail-item" title=${filePath}><wa-icon library="texra" name=${iconName} aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${filePath} role="button" tabindex="0">${fileName}</span>${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${showSource ? html` <span class="file-source">(${sourceText})</span>` : ''}</li>`;
   })}`;
 
   const loadedFiles = files.filter((file) => file.ok).length;
@@ -290,7 +290,7 @@ export function buildFileLinkWithLines(
   const displayText = fileName + lineInfo;
 
   // prettier-ignore
-  return html`<span class="file-link clickable-link" data-file=${filePath} data-file-line=${ifDefined(startLine)}><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> ${displayText}</span>`;
+  return html`<span class="file-link clickable-link" data-file=${filePath} data-file-line=${ifDefined(startLine)} role="button" tabindex="0"><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> ${displayText}</span>`;
 }
 
 // ============================================================================

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -143,7 +143,11 @@ function renderCodexFileChangeItem(
   return html`
     <li class="detail-item">
       <wa-icon library="texra" name="file" aria-hidden="true"></wa-icon>
-      <span class="file-link clickable-link" data-file=${change.path}
+      <span
+        class="file-link clickable-link"
+        data-file=${change.path}
+        role="button"
+        tabindex="0"
         >${change.path}</span
       >
       <span class="file-source">(${change.kind})</span>

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -61,7 +61,7 @@ export function formatFileListTemplate(
 function renderXmlLink(xmlFile: string, documentTag: string | null) {
   const xmlFileName = getBasename(xmlFile);
   // prettier-ignore
-  return html`<div class="xml-link-container"><wa-icon library="texra" name="file-code" aria-hidden="true"></wa-icon> <span>Open XML to check tag consistency:</span> <span class="file-link clickable-link" data-file=${xmlFile}>${xmlFileName}</span>${documentTag ? html` <span class="document-tag">(Expected &lt;${documentTag}&gt; block)</span>` : ''}</div>`;
+  return html`<div class="xml-link-container"><wa-icon library="texra" name="file-code" aria-hidden="true"></wa-icon> <span>Open XML to check tag consistency:</span> <span class="file-link clickable-link" data-file=${xmlFile} role="button" tabindex="0">${xmlFileName}</span>${documentTag ? html` <span class="document-tag">(Expected &lt;${documentTag}&gt; block)</span>` : ''}</div>`;
 }
 
 /** Format missing outputs entry as TemplateResult. */
@@ -88,7 +88,7 @@ export function formatMissingOutputsTemplate(
   const listItems = missing.map((f) => {
     const filePath = String(f);
     const basename = getBasename(filePath);
-    return html`<li class="detail-item" title=${filePath}><wa-icon library="texra" name="warning" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${filePath}>${basename}</span></li>`;
+    return html`<li class="detail-item" title=${filePath}><wa-icon library="texra" name="warning" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${filePath} role="button" tabindex="0">${basename}</span></li>`;
   });
   // prettier-ignore
   return html`<details class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -197,7 +197,7 @@ export function formatToolUseTemplate(
       : null;
 
   // prettier-ignore
-  const extraContent = html`${timerTemplate ?? nothing}${proposalId ? html`<span class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration"><wa-icon library="texra" name="reply" aria-hidden="true"></wa-icon> Setup</span>` : nothing}`;
+  const extraContent = html`${timerTemplate ?? nothing}${proposalId ? html`<span class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration" role="button" tabindex="0"><wa-icon library="texra" name="reply" aria-hidden="true"></wa-icon> Setup</span>` : nothing}`;
 
   // prettier-ignore
   return html`<details class=${classMap({

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -271,7 +271,7 @@ function buildAcceptRunFilesSections(
         ? html` <span class="file-stats"><span class="added">+${edit.lineChanges.added}</span><span class="removed" style="margin-left:var(--wa-space-2xs)">-${edit.lineChanges.removed}</span></span>`
         : nothing;
       // prettier-ignore
-      return html`<li class="detail-item"><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${dest}>${dest}</span>${isMapped ? html` <span class="file-source">(from ${source})</span>` : nothing}${diffStats}</li>`;
+      return html`<li class="detail-item"><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${dest} role="button" tabindex="0">${dest}</span>${isMapped ? html` <span class="file-source">(from ${source})</span>` : nothing}${diffStats}</li>`;
     })}`;
     // prettier-ignore
     sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
@@ -323,7 +323,7 @@ function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
   const fileGroups = getProposalFileGroups(delegateInput);
   if (fileGroups.length > 0) {
     // prettier-ignore
-    const fileItems = html`${fileGroups.flatMap((g) => g.files.map((f) => html`<li class="detail-item"><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> <span class="${g.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(g.clickable ? f : undefined)}>${f}</span> <span class="file-source">(${g.label})</span></li>`))}`;
+    const fileItems = html`${fileGroups.flatMap((g) => g.files.map((f) => html`<li class="detail-item"><wa-icon library="texra" name="file" aria-hidden="true"></wa-icon> <span class="${g.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(g.clickable ? f : undefined)} role=${ifDefined(g.clickable ? 'button' : undefined)} tabindex=${ifDefined(g.clickable ? '0' : undefined)}>${f}</span> <span class="file-source">(${g.label})</span></li>`))}`;
     // prettier-ignore
     sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
   }

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -80,7 +80,7 @@ const REF_PLACEHOLDER = /@@LATEX-REF-(\d+)@@/g;
 function defaultFormatLatexReference(refType: string, label: string): string {
   const safeAttrLabel = escapeAttr(label);
   const safeTextLabel = escapeText(label);
-  return `<span class="latex-ref clickable-link" data-label="${safeAttrLabel}">\\${refType}{${safeTextLabel}}</span>`;
+  return `<span class="latex-ref clickable-link" data-label="${safeAttrLabel}" role="button" tabindex="0">\\${refType}{${safeTextLabel}}</span>`;
 }
 
 function protectLatexReferences(content: string): {

--- a/src/shared/styles/markdownStyles.ts
+++ b/src/shared/styles/markdownStyles.ts
@@ -115,6 +115,12 @@ export const markdownStyles = css`
     color: var(--wa-color-symbol-keyword);
   }
 
+  .markdown-content .latex-ref:focus-visible {
+    outline: var(--border-thin) solid var(--wa-color-focus);
+    outline-offset: 1px;
+    border-radius: var(--border-radius-small);
+  }
+
   .markdown-content a {
     color: var(--color-text-link);
     text-decoration: none;

--- a/src/test-kernel/progressView/LogListKeyboard.vitest.mts
+++ b/src/test-kernel/progressView/LogListKeyboard.vitest.mts
@@ -1,0 +1,71 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - progress view component types
+import type { LogList } from '@progressView/frontend/components/LogList';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+useLitComponentTestDom(
+  () => import('@progressView/frontend/components/LogList'),
+);
+
+interface LogListTestHooks {
+  handleKeyEvent(event: Event): void;
+  activateLinkFromEvent(event: Event): boolean;
+}
+
+describe('log-list keyboard activation', () => {
+  it('uses the composed path for transcript links across shadow roots', () => {
+    const element = document.createElement('log-list') as LogList;
+    const link = document.createElement('span');
+    link.className = 'file-link clickable-link';
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'composedPath', {
+      configurable: true,
+      value: () => [link, element, document.body, document, window],
+    });
+
+    const hooks = element as unknown as LogListTestHooks;
+    const activateLinkFromEvent = vi.fn(() => true);
+    hooks.activateLinkFromEvent = activateLinkFromEvent;
+
+    hooks.handleKeyEvent(event);
+
+    expect(activateLinkFromEvent).toHaveBeenCalledWith(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does not re-activate links when a child handler consumed the key', () => {
+    const element = document.createElement('log-list') as LogList;
+    const link = document.createElement('span');
+    link.className = 'file-link clickable-link';
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'composedPath', {
+      configurable: true,
+      value: () => [link, element, document.body, document, window],
+    });
+    event.preventDefault();
+
+    const hooks = element as unknown as LogListTestHooks;
+    const activateLinkFromEvent = vi.fn(() => true);
+    hooks.activateLinkFromEvent = activateLinkFromEvent;
+
+    hooks.handleKeyEvent(event);
+
+    expect(activateLinkFromEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/progressView/MarkdownRendererSecurity.vitest.mts
+++ b/src/test-kernel/progressView/MarkdownRendererSecurity.vitest.mts
@@ -25,6 +25,8 @@ describe('processMarkdownContent security', () => {
     expect(ref).not.toBeNull();
     expect(ref?.getAttribute('onclick')).toBeNull();
     expect(ref?.getAttribute('data-label')).toBe(label);
+    expect(ref?.getAttribute('role')).toBe('button');
+    expect(ref?.getAttribute('tabindex')).toBe('0');
     expect(ref?.textContent).toBe(`\\ref{${label}}`);
     expect(dom.window.document.querySelector('img')).toBeNull();
   });


### PR DESCRIPTION
## Summary

The clickable links rendered into the progress-view transcript (`LogList`) — **file links**, **LaTeX refs**, and the **proposal-restore (“Setup”) link** — were mouse-only. They are `<span>`s with no `role`/`tabindex`/keydown, reached through `LogList`'s **click delegation** (`handleClickEvent`, gated on `MouseEvent`). Keyboard-only and screen-reader users couldn't open a referenced file, jump to a LaTeX label, or restore a proposal config — and the shared `.file-link:focus-visible` style was dead because the spans were never focusable.

This is the same class fixed in #6186 (PermissionCard / FileList / LatexdiffResults); this PR covers the remaining transcript surface.

## Fix
- **`LogList`**: extract the file-link / latex-ref / proposal-restore-link dispatch into `activateLinkFromEvent()`, reused by the existing click handler **and** a new `keydown` handler (Enter/Space → `preventDefault` → same dispatch) bound in `connectedCallback`. Copy buttons stay **click-only** — they're native `<wa-button>`s, already keyboard-activatable, so excluding them avoids double-firing.
- Add `role="button"` + `tabindex="0"` to the clickable `.file-link` spans across the formatter builders (`htmlBuilders`, `codexToolTemplates`, `dataFormatters`, `toolSections`) and the `.proposal-restore-link` span, so they enter the tab order and the existing focus-visible style applies.

## Verification
- **Additive** — mouse behavior unchanged (`activateLinkFromEvent` is the same logic the click path already ran); only keyboard reachability is added.
- Extension package typechecks clean.
- Found by the focus/keyboard sweep; completes the keyboard-access class.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive a11y change: mouse behavior is unchanged and activation logic is refactored, not rewritten; copy and IPC paths are unchanged aside from keyboard entry.
> 
> **Overview**
> Makes **mouse-only transcript controls** in the progress view reachable by keyboard and assistive tech, completing the same accessibility class as #6186 for the log transcript surface.
> 
> **`LogList`** pulls file-link, LaTeX ref, and proposal-restore handling into **`activateLinkFromEvent`**, used from the existing click path and a new **`keydown`** listener (Enter/Space, `composedPath` across shadow roots). Copy actions stay on the click handler only so native **`wa-button`** copy controls are not double-fired.
> 
> Renderable **`.file-link`**, **`.proposal-restore-link`**, and markdown **`.latex-ref`** spans now get **`role="button"`** and **`tabindex="0"`** across formatters and **`createMarkdownProcessor`**, so existing **`:focus-visible`** styles in log/markdown CSS actually apply.
> 
> Tests cover keyboard activation via composed path and assert LaTeX ref markup still escapes labels while exposing the new ARIA/tab attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 362af78f7c66e190994d51c9a7d3c8a9bcac37fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->