### PR TITLE
refactor(schemas): single-source approval action sets in the schema layer

### DIFF
--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -20,21 +20,13 @@ import {
 } from '../inquiry';
 import {
   AgentProposalSchema,
+  BASH_APPROVAL_ACTIONS,
   PLAN_APPROVAL_ACTIONS,
+  TOOL_EDIT_APPROVAL_ACTIONS,
   USER_QUESTION_ACTIONS,
   UserQuestionAnswersSchema,
 } from '../prompts';
 import { AgentCategoryFilterSchema } from './data';
-
-const TOOL_EDIT_APPROVAL_ACTIONS = [
-  'approve',
-  'reject',
-  'openDiff',
-  'showLatexdiff',
-  'previewProposed',
-] as const;
-
-const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
 
 const TrimmedStringSchema = z
   .string()

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -188,6 +188,24 @@ export const PLAN_APPROVAL_ACTIONS = [
 ] as const;
 export type PlanApprovalAction = (typeof PLAN_APPROVAL_ACTIONS)[number];
 
+// Tool-edit and bash approval action sets live here (the schema layer) so the
+// IPC schema (progressView/inbound) and the runtime approval modules
+// (@tools/approval/*) share one definition. The schema layer has no @tools/
+// @agent imports, so the runtime modules import these without a cycle, and the
+// IPC schema never pulls runtime code into the renderer bundle.
+export const TOOL_EDIT_APPROVAL_ACTIONS = [
+  'approve',
+  'reject',
+  'openDiff',
+  'showLatexdiff',
+  'previewProposed',
+] as const;
+export type ToolEditApprovalAction =
+  (typeof TOOL_EDIT_APPROVAL_ACTIONS)[number];
+
+export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
+export type BashApprovalAction = (typeof BASH_APPROVAL_ACTIONS)[number];
+
 export const PlanApprovalPermissionSchema = z.strictObject({
   approvalId: z.string(),
   streamId: StreamTabIdSchema,

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -3,6 +3,10 @@ import { z } from 'zod';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
+import {
+  BASH_APPROVAL_ACTIONS,
+  type BashApprovalAction,
+} from '@shared/schemas/prompts';
 import { requireRuntimeHost } from '@tools/contextHelpers';
 import { type ToolResult } from '@tools/result';
 import { getConfig } from '@utils/config/configUtils';
@@ -25,9 +29,9 @@ export type BashApprovalResult = z.infer<typeof BashApprovalResultSchema>;
 
 export const BASH_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireBashApproval';
 
-export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
-
-export type BashApprovalAction = (typeof BASH_APPROVAL_ACTIONS)[number];
+// Defined in the schema layer (see @shared/schemas/prompts); re-exported here
+// so existing importers of `@tools/approval/bashApproval` keep working.
+export { BASH_APPROVAL_ACTIONS, type BashApprovalAction };
 
 const DEFAULT_BASH_REJECTION_INSTRUCTION =
   'Do not retry this rejected command or another approval-gated shell command for the same check. ' +

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -11,6 +11,10 @@ import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import {
+  TOOL_EDIT_APPROVAL_ACTIONS,
+  type ToolEditApprovalAction,
+} from '@shared/schemas/prompts';
+import {
   LineChangesSchema,
   type LineChanges,
   type ToolResult,
@@ -50,16 +54,9 @@ const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
 
 export const REVEAL_TIMEOUT_MS = 1500;
 
-export const TOOL_EDIT_APPROVAL_ACTIONS = [
-  'approve',
-  'reject',
-  'openDiff',
-  'showLatexdiff',
-  'previewProposed',
-] as const;
-
-export type ToolEditApprovalAction =
-  (typeof TOOL_EDIT_APPROVAL_ACTIONS)[number];
+// Defined in the schema layer (see @shared/schemas/prompts); re-exported here
+// so existing importers of `@tools/approval/toolEditApproval` keep working.
+export { TOOL_EDIT_APPROVAL_ACTIONS, type ToolEditApprovalAction };
 
 export const toolEditApprovalController =
   createStreamApprovalController<ToolEditApprovalResult>({


### PR DESCRIPTION
## What

`BASH_APPROVAL_ACTIONS` and `TOOL_EDIT_APPROVAL_ACTIONS` were declared **twice**, byte-identically:
- runtime modules `@tools/approval/bashApproval.ts` and `@tools/approval/toolEditApproval.ts`
- the IPC schema `src/shared/schemas/progressView/inbound.ts` (used in `z.enum(...)`)

…kept in sync by hand. Adding an action to one side and not the other makes the inbound schema reject an action the backend emits.

This hoists both `const` + derived `type` into `@shared/schemas/prompts.ts` — which already owns `PLAN_APPROVAL_ACTIONS` / `USER_QUESTION_ACTIONS` and has no `@tools`/`@agent` imports.

## Why the direction is correct (and a naive fix would be wrong)

The IPC schema **cannot** import from `@tools/approval/*` — those modules pull in `@agent/runtime` (RunContext), `diff-match-patch`, `WorkspaceFS`, and `inbound.ts` is re-exported into the desktop renderer bundle. So the canonical definition must live in the schema layer:
- `progressView/inbound.ts` imports the consts directly from `../prompts`.
- The runtime modules **re-export** them (`export { BASH_APPROVAL_ACTIONS, type BashApprovalAction }`), so every existing importer of `@tools/approval/bashApproval` / `toolEditApproval` (and the `@tools/approval` barrel, desktop, extension, CLI) is unchanged.
- Dependency direction is `@tools → @shared/schemas` only; no cycle, no runtime code in the renderer bundle.

No new layer — composition/shared-const per the repo's schema guidance.

## Verification

- `npx tsc --noEmit` — 0 errors.
- Approval suites pass (51): `DesktopToolEditApproval`, `BashApproval`, `ApprovalAdapter`, `ApprovalCleanupScope`, `ProgressViewCommandHandlers`.

🤖 Found via round 7 (schema-graph duplication); implemented with the reviewed correct (inverted) direction rather than the naive import-from-runtime fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with re-exports preserving public APIs; no behavior change beyond eliminating duplicate constant definitions.
> 
> **Overview**
> **`TOOL_EDIT_APPROVAL_ACTIONS`** and **`BASH_APPROVAL_ACTIONS`** (plus their TypeScript types) are now defined once in `@shared/schemas/prompts.ts`, alongside **`PLAN_APPROVAL_ACTIONS`** and **`USER_QUESTION_ACTIONS`**.
> 
> The progress view IPC inbound schema imports those consts for `z.enum(...)` instead of maintaining local copies. **`bashApproval.ts`** and **`toolEditApproval.ts`** import from the schema layer and **re-export** the same symbols so existing `@tools/approval/*` importers stay unchanged.
> 
> This removes hand-synced duplicates between renderer IPC validation and runtime approval handling, keeps dependency direction **`@tools` → `@shared/schemas`** (no pulling agent/runtime into the renderer bundle), and avoids inbound schema rejecting actions the backend already supports when only one side is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bdef662d100e6cc98b7559de46db9636c667b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->