### PR TITLE
fix: don't blank a reopened PDF when a close is still animating

### DIFF
--- a/packages/desktop/src/renderer/pdfOverlay.ts
+++ b/packages/desktop/src/renderer/pdfOverlay.ts
@@ -41,6 +41,9 @@ export function createPdfOverlay(appRoot: HTMLElement): PdfOverlayController {
   let frameEl: HTMLIFrameElement | null = null;
   let titleEl: HTMLElement | null = null;
   let subtitleEl: HTMLElement | null = null;
+  // Intent across the async hide animation: distinguishes a genuine close from
+  // a reopen that lands while the previous close is still animating.
+  let wantOpen = false;
 
   function ensure(): WaDialog {
     if (dialog) return dialog;
@@ -91,8 +94,21 @@ export function createPdfOverlay(appRoot: HTMLElement): PdfOverlayController {
     });
     d.append(close);
 
-    // Clear the iframe src on hide so the PDF isn't resident across closes.
+    // `wa-hide` fires for every close (close button, Escape, close()); open()
+    // sets wantOpen back to true. wa-after-hide runs after the hide animation
+    // — by which point a reopen during the animation has set a new src and
+    // wantOpen=true. In that case re-assert the open state (the dialog already
+    // flipped open=false internally as the close completed) so the new PDF
+    // shows instead of getting wiped. Otherwise clear the src so the PDF isn't
+    // resident across closes.
+    d.addEventListener('wa-hide', () => {
+      wantOpen = false;
+    });
     d.addEventListener('wa-after-hide', () => {
+      if (wantOpen) {
+        d.open = true;
+        return;
+      }
       if (frameEl) frameEl.removeAttribute('src');
     });
 
@@ -115,6 +131,7 @@ export function createPdfOverlay(appRoot: HTMLElement): PdfOverlayController {
     if (titleEl) titleEl.textContent = payload.title;
     if (subtitleEl) subtitleEl.textContent = payload.pdfPath;
     if (frameEl) frameEl.src = pdfPathToFileUrl(payload.pdfPath);
+    wantOpen = true;
     d.open = true;
   }
 


### PR DESCRIPTION
## Summary

The desktop PDF overlay cleared the iframe `src` on `wa-after-hide`, which fires **asynchronously after** the dialog's hide animation. If a new `showPdf` arrived during that window (clicking a second output PDF, or close-then-show), `open()` set the new `src` and reopened the dialog — but the **trailing `wa-after-hide` from the prior close then wiped the freshly-set `src`**, leaving a blank frame in an open dialog (recoverable only by closing and reopening).

## Fix
Track open intent across the async hide:
- `wa-hide` (fires for **every** close — close button, Escape, `close()`) sets `wantOpen = false`.
- `open()` sets `wantOpen = true`.
- In `wa-after-hide`: if `wantOpen` is true, a reopen landed mid-animation → re-assert `d.open = true` (the dialog already flipped `open=false` internally as the close completed) and **keep** the new `src`. Otherwise clear the `src` as before.

This mirrors the suppress-flag pattern other `wa-after-hide` handlers in the repo already use, and additionally handles the re-show (the masking the verifier flagged) by re-asserting open after the hide fully completes.

## Verification / safety
- **Normal close path is unchanged**: `wantOpen` ends false → `src` cleared exactly as before → no regression and the PDF is still not resident across closes.
- Reopen-during-hide now keeps its `src` and re-shows instead of going blank; worst case is no worse than today (reopen again).
- Type-trivial (a boolean flag + one event listener); CI `validate` confirms the desktop build/typecheck.

Narrow timing bug (reopen within the ~hundreds-of-ms hide animation); a desktop smoke-test of rapid close→show is worth a reviewer glance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file UI timing fix with no auth, data, or API changes; normal close still clears the iframe as before.
> 
> **Overview**
> Fixes a race where reopening the desktop PDF preview during the dialog’s hide animation left an **open dialog with a blank iframe**.
> 
> Previously, `wa-after-hide` always cleared the iframe `src` after the close animation. If `open()` ran in that window, the new `src` was set and the dialog reopened, but the **stale** `wa-after-hide` from the prior close still ran and wiped `src`.
> 
> The overlay now tracks **`wantOpen`**: `wa-hide` clears it on any close; `open()` sets it true. On `wa-after-hide`, if `wantOpen` is still true (reopen during animation), it **re-asserts** `d.open = true` and skips clearing `src`; otherwise behavior is unchanged and `src` is removed so PDFs aren’t kept loaded after a real close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34235d7f8934dbac3d06517e5f48cc89a40ed0f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->