### PR TITLE
refactor(settings): one canonical buildProfileMessage owner for both hosts

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -15,7 +15,6 @@ import {
 } from '@agent/index/agentRegistry';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { getAllActiveExecutionIds } from '@agent/runtime/SessionHandle';
-import { MAX_TIER, ULTRA_TIER } from '@auth/sharedConfig';
 import {
   API_PROVIDERS,
   apiKeySecretName,
@@ -56,6 +55,7 @@ import {
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
 import { buildHistoryMessage } from '@shared/settingsView/handlers/historyHandlers';
+import { buildProfileMessage } from '@shared/settingsView/handlers/profileHandlers';
 import {
   buildModelSelectionMessage,
   createModelSelectionController,
@@ -80,7 +80,6 @@ import {
   detectPackageManager,
 } from '@utils/system/toolUtils';
 import {
-  getGlobalStreaming,
   getProviderDisplayName,
   getProviderEndpoint,
   getProviderKeyUrl,
@@ -96,10 +95,6 @@ import {
   setDesktopCrashReportingDsn,
   setDesktopCrashReportingEnabled,
 } from './desktopCrashReporting.js';
-import {
-  unauthenticatedProfileData,
-  type DesktopAuthProfileData,
-} from './desktopSupabaseAuth.js';
 import { refreshDesktopModelListStateIfNeeded } from './desktopModelListRefresh.js';
 import {
   buildDefaultToolDashboardItems,
@@ -152,7 +147,6 @@ export interface DesktopSettingsIpcOptions {
   confirmAction?: (message: string, confirmLabel?: string) => Promise<boolean>;
   signIn?: () => Promise<void>;
   signOut?: () => Promise<void>;
-  getAuthProfileData?: () => Promise<DesktopAuthProfileData>;
   setApiAccessMode?: (mode: 'included' | 'personal') => Promise<void>;
   initializeCrashReporting?: () => Promise<void>;
   secrets?: PlatformSecrets;
@@ -346,15 +340,10 @@ export function createDesktopSettingsIpc(
   }
 
   async function postProfileData(): Promise<void> {
-    const authProfile =
-      (await options.getAuthProfileData?.()) ?? unauthenticatedProfileData();
-    options.postToRenderer({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
-      ...authProfile,
-      tierConstants: { ultra: ULTRA_TIER, max: MAX_TIER },
-      providerKeyStatuses: await getProviderKeyStatuses(),
-      globalStreamingDefault: getGlobalStreaming(),
+    const message = await buildProfileMessage({
+      getProviderKeyStatuses: () => getProviderKeyStatuses(),
     });
+    options.postToRenderer(message);
   }
 
   async function postMemoryData(): Promise<void> {

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -1,11 +1,6 @@
 import { z } from 'zod';
 
 import { platform } from '@platform/platform';
-import {
-  getAgentsBySource,
-  loadAgents,
-  toRemoteAgentProfileData,
-} from '@agent/index';
 import { DEFAULT_OAUTH_PROVIDER, getAuthCallbackUri } from '@auth/config';
 import { createHostAuthCoordinator } from '@auth/SupabaseAuthCoordinator';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -19,10 +14,9 @@ import {
   initializeServerSideKeyAccess,
 } from '@auth/serverKeys';
 import type { AuthServiceLogger } from '@auth/serviceLogger';
-import { FREE_TIER, type OAuthProvider } from '@auth/sharedConfig';
+import { type OAuthProvider } from '@auth/sharedConfig';
 import type { AuthCallbackUriParts } from '@auth/core/authCallback';
 import { toErrorMessage } from '@common/errors/errorMessage';
-import type { RemoteAgent } from '@shared/schemas/profileViewMessages';
 import { TEXRA_PROTOCOL } from '../desktopProtocol.js';
 import type { StateStore } from '@platform/interfaces/state';
 import type { PlatformSecrets } from '@platform/secrets';
@@ -39,20 +33,9 @@ const DesktopPendingOAuthStateSchema = z.object({
 });
 type DesktopPendingOAuthState = z.infer<typeof DesktopPendingOAuthStateSchema>;
 
-export interface DesktopAuthProfileData {
-  authenticated: boolean;
-  user: { email: string; id: string } | null;
-  tier: string;
-  permissions: string[];
-  remoteAgents: RemoteAgent[];
-  apiAccessMode: 'included' | 'personal';
-  accessExpiresAt?: string | null;
-}
-
 export interface DesktopSupabaseAuth {
   signIn(provider?: OAuthProvider): Promise<void>;
   signOut(): Promise<void>;
-  getProfileData(): Promise<DesktopAuthProfileData>;
   dispose(): void;
 }
 
@@ -244,10 +227,6 @@ export function createDesktopSupabaseAuth(
       await options.onSessionChanged?.();
     },
 
-    async getProfileData() {
-      return loadDesktopAuthProfileData();
-    },
-
     dispose() {
       subscription.dispose();
     },
@@ -317,69 +296,6 @@ async function processProtocolCallback(
     `Signed in as ${result.session.account.label}`,
   );
   await options.onSessionChanged?.();
-}
-
-async function loadDesktopAuthProfileData(): Promise<DesktopAuthProfileData> {
-  const authenticated = await SupabaseClient.isAuthenticated();
-  if (!authenticated) return unauthenticatedProfileData();
-
-  const user = await SupabaseClient.getUser();
-  let authContext: { tier: string; permissions: string[] } = {
-    tier: FREE_TIER,
-    permissions: [],
-  };
-  try {
-    authContext = await SupabaseClient.getUserAuthContext();
-  } catch {
-    // Keep the UI signed in even if profile metadata is temporarily unavailable.
-  }
-
-  let apiAccessMode: 'included' | 'personal' = 'personal';
-  let accessExpiresAt: string | null = null;
-  try {
-    const serverSideKeyService = getServerSideKeyService();
-    apiAccessMode = serverSideKeyService.getUseIncludedModelAccess()
-      ? 'included'
-      : 'personal';
-    await serverSideKeyService.canUseServerSideKeys();
-    accessExpiresAt =
-      serverSideKeyService.getAccessExpirationDate()?.toISOString() ?? null;
-  } catch {
-    // Server-side key access is optional; personal provider keys still work.
-  }
-
-  let remoteAgents: RemoteAgent[] = [];
-  try {
-    await loadAgents();
-    remoteAgents = getAgentsBySource('remote').map(toRemoteAgentProfileData);
-  } catch {
-    // Keep auth/profile UI usable even if agent registry refresh fails.
-  }
-
-  return {
-    authenticated: true,
-    user: {
-      email: user?.email ?? 'N/A',
-      id: user?.id ?? '',
-    },
-    tier: authContext.tier,
-    permissions: authContext.permissions,
-    remoteAgents,
-    apiAccessMode,
-    accessExpiresAt,
-  };
-}
-
-export function unauthenticatedProfileData(): DesktopAuthProfileData {
-  return {
-    authenticated: false,
-    user: null,
-    tier: FREE_TIER,
-    permissions: [],
-    remoteAgents: [],
-    apiAccessMode: 'personal',
-    accessExpiresAt: null,
-  };
 }
 
 function createSessionLog(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -16,6 +16,7 @@ import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { getServerSideKeyService } from '@auth/serverKeys';
+import { SupabaseClient } from '@auth/SupabaseClient';
 import type { TerminalRunResult } from '@hosts/terminalHost';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
@@ -348,9 +349,9 @@ function createWindow(options: {
     },
   });
   const refreshDesktopAuthSurfaces = async () => {
-    const profile = await desktopAuth.getProfileData();
+    const authenticated = await SupabaseClient.isAuthenticated();
     ipcRef.current?.postToRenderer({
-      command: profile.authenticated
+      command: authenticated
         ? MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER
         : MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER,
     });
@@ -541,7 +542,6 @@ function createWindow(options: {
     },
     signIn: () => desktopAuth.signIn(),
     signOut: () => desktopAuth.signOut(),
-    getAuthProfileData: () => desktopAuth.getProfileData(),
     setApiAccessMode: async (mode) => {
       await getServerSideKeyService().setUseIncludedModelAccess(
         mode === 'included',
@@ -658,7 +658,7 @@ function createWindow(options: {
     shellActions,
     modelListRefresh,
     getAuthStatus: async () => ({
-      authenticated: (await desktopAuth.getProfileData()).authenticated,
+      authenticated: await SupabaseClient.isAuthenticated(),
     }),
     onAsyncError: reportAsyncError,
   });

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -13,16 +13,8 @@ import * as vscode from 'vscode';
 // Shared schemas and dispatchers
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { platform } from '@platform/platform';
-import {
-  getAgentsBySource,
-  loadAgents,
-  toRemoteAgentProfileData,
-} from '@agent/index';
-import { SupabaseClient } from '@auth/SupabaseClient';
-import { FREE_TIER, ULTRA_TIER, MAX_TIER } from '@auth/config';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
-import { getTierService } from '@auth/tier';
 import { BaseViewMessageHandler } from '@common/webview';
 import {
   GlobalStateKey,
@@ -53,6 +45,7 @@ import {
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { StreamTabId } from '@shared/schemas';
+import { buildProfileMessage } from '@shared/settingsView/handlers/profileHandlers';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import {
   dispatchSettingsViewInbound,
@@ -81,7 +74,6 @@ import {
   PROVIDER_VSCODE_SETTINGS,
 } from '@shared/constants/providers';
 import type {
-  RemoteAgent,
   ProviderKeyStatus,
   ProviderVscodeSetting,
   NumberVscodeSetting,
@@ -100,7 +92,6 @@ import { hasExtension } from '@utils/core/pathCore';
 import { readGitAuthorSettingsFromState } from '@utils/system/gitAuthorSettings';
 import { setToolUseMemoryEnabled } from '@utils/config/constants';
 import {
-  getGlobalStreaming,
   setGlobalStreaming,
   getProviderStreaming,
   setProviderStreaming,
@@ -630,12 +621,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // Helpers
   // ============================================================
 
-  private async primeIncludedAccessIfEnabled(): Promise<void> {
-    const serverSideKeyService = getServerSideKeyService();
-    if (!serverSideKeyService.getUseIncludedModelAccess()) return;
-    await serverSideKeyService.canUseServerSideKeys();
-  }
-
   // ============================================================
   // Public methods for external access
   // ============================================================
@@ -718,70 +703,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendProfileData(webview: vscode.Webview): Promise<void> {
-    const isAuthenticated = await SupabaseClient.isAuthenticated();
-    const providerKeyStatuses = await getProviderKeyStatuses();
-
-    const globalStreamingDefault = getGlobalStreaming();
-
-    if (!isAuthenticated) {
-      await webview.postMessage({
-        command: SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
-        authenticated: false,
-        user: null,
-        tier: 'free',
-        permissions: [],
-        remoteAgents: [],
-        apiAccessMode: 'personal',
-        tierConstants: {
-          ultra: ULTRA_TIER,
-          max: MAX_TIER,
-        },
-        providerKeyStatuses,
-        globalStreamingDefault,
-      });
-      return;
-    }
-
-    await this.primeIncludedAccessIfEnabled();
-    const serverSideKeyService = getServerSideKeyService();
-
-    const user = await SupabaseClient.getUser();
-    const authContext = await SupabaseClient.getUserAuthContext();
-
-    await loadAgents();
-    const remoteAgents: RemoteAgent[] = getAgentsBySource('remote').map(
-      toRemoteAgentProfileData,
-    );
-
-    const apiAccessMode = serverSideKeyService.getUseIncludedModelAccess()
-      ? 'included'
-      : 'personal';
-
-    const accessExpiresAt = serverSideKeyService.getAccessExpirationDate();
-    const spendingStatus = getTierService().getSpendingStatus();
-    const quotaAutoSwitched = serverSideKeyService.wasQuotaAutoSwitched();
-
-    await webview.postMessage({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
-      authenticated: true,
-      user: {
-        email: user?.email ?? 'N/A',
-        id: user?.id ?? '',
-      },
-      tier: authContext.tier,
-      permissions: authContext.permissions,
-      remoteAgents,
-      apiAccessMode,
-      tierConstants: {
-        ultra: ULTRA_TIER,
-        max: MAX_TIER,
-      },
-      accessExpiresAt: accessExpiresAt?.toISOString() ?? null,
-      spendingStatus,
-      quotaAutoSwitched,
-      providerKeyStatuses,
-      globalStreamingDefault,
+    const message = await buildProfileMessage({
+      getProviderKeyStatuses: () => getProviderKeyStatuses(),
     });
+    await webview.postMessage(message);
   }
 
   public async sendModelSelectionData(webview: vscode.Webview): Promise<void> {

--- a/src/shared/settingsView/handlers/profileHandlers.ts
+++ b/src/shared/settingsView/handlers/profileHandlers.ts
@@ -84,11 +84,19 @@ export async function buildProfileMessage(
   let quotaAutoSwitched = false;
   try {
     const serverSideKeyService = getServerSideKeyService();
+    // Prime included-access ONLY when it is actually enabled. canUseServerSideKeys()
+    // refreshes (and can clear) the tier cache including the spending snapshot, so
+    // priming in personal mode would blank the relay quota UI on every refresh.
+    // (This mirrors the extension's prior primeIncludedAccessIfEnabled gating.)
+    if (serverSideKeyService.getUseIncludedModelAccess()) {
+      await serverSideKeyService.canUseServerSideKeys();
+    }
+    // Read AFTER priming, so a quota-exhaustion auto-switch (included -> personal,
+    // flipped inside canUseServerSideKeys) is reflected in apiAccessMode /
+    // quotaAutoSwitched rather than reporting the pre-switch mode.
     apiAccessMode = serverSideKeyService.getUseIncludedModelAccess()
       ? 'included'
       : 'personal';
-    // Prime the server-side key cache so the reads below see fresh values.
-    await serverSideKeyService.canUseServerSideKeys();
     accessExpiresAt =
       serverSideKeyService.getAccessExpirationDate()?.toISOString() ?? null;
     quotaAutoSwitched = serverSideKeyService.wasQuotaAutoSwitched();

--- a/src/shared/settingsView/handlers/profileHandlers.ts
+++ b/src/shared/settingsView/handlers/profileHandlers.ts
@@ -1,0 +1,123 @@
+/**
+ * Profile message construction shared between the VS Code extension and the
+ * Electron desktop.
+ *
+ * Builds the `UPDATE_PROFILE` wire message from shared auth / tier / agent
+ * services so the two hosts can't drift — previously each host hand-assembled
+ * the message and desktop silently dropped `spendingStatus` + `quotaAutoSwitched`
+ * (killing the RelayQuotaMeter / quota-auto-switch banner on desktop). The one
+ * host-specific input — provider key statuses, which carry VS Code settings on
+ * the extension and none on desktop — is injected as a callback.
+ *
+ * Profile-metadata reads degrade gracefully: a transient failure keeps the user
+ * signed in with fallback values rather than failing the whole refresh (the
+ * resilience the desktop assembly already had).
+ */
+import {
+  getAgentsBySource,
+  loadAgents,
+  toRemoteAgentProfileData,
+} from '@agent/index';
+import { SupabaseClient } from '@auth/SupabaseClient';
+import { FREE_TIER, ULTRA_TIER, MAX_TIER } from '@auth/config';
+import { getServerSideKeyService } from '@auth/serverKeys';
+import { getTierService } from '@auth/tier';
+import { PROFILE_VIEW_COMMANDS } from '@shared/ipc';
+import type {
+  ApiAccessMode,
+  ProviderKeyStatus,
+  RemoteAgent,
+  UpdateProfileMessage,
+} from '@shared/schemas/profileViewMessages';
+import { getGlobalStreaming } from '@utils/config/providerConfig';
+
+export interface BuildProfileMessageDeps {
+  /**
+   * Build the provider key statuses. Host-specific: the extension fills
+   * `vscodeSettings` from VS Code config; desktop returns them empty.
+   */
+  getProviderKeyStatuses: () => Promise<ProviderKeyStatus[]>;
+}
+
+/** Assemble the canonical `UPDATE_PROFILE` message for either host. */
+export async function buildProfileMessage(
+  deps: BuildProfileMessageDeps,
+): Promise<UpdateProfileMessage> {
+  const authenticated = await SupabaseClient.isAuthenticated();
+  const providerKeyStatuses = await deps.getProviderKeyStatuses();
+  const globalStreamingDefault = getGlobalStreaming();
+  const tierConstants = { ultra: ULTRA_TIER, max: MAX_TIER };
+
+  if (!authenticated) {
+    return {
+      command: PROFILE_VIEW_COMMANDS.UPDATE_PROFILE,
+      authenticated: false,
+      user: null,
+      tier: FREE_TIER,
+      permissions: [],
+      remoteAgents: [],
+      apiAccessMode: 'personal',
+      tierConstants,
+      accessExpiresAt: null,
+      spendingStatus: null,
+      quotaAutoSwitched: false,
+      providerKeyStatuses,
+      globalStreamingDefault,
+    };
+  }
+
+  const user = await SupabaseClient.getUser();
+
+  let tier = FREE_TIER;
+  let permissions: string[] = [];
+  try {
+    const authContext = await SupabaseClient.getUserAuthContext();
+    tier = authContext.tier;
+    permissions = authContext.permissions;
+  } catch {
+    // Keep the UI signed in even if profile metadata is temporarily unavailable.
+  }
+
+  let apiAccessMode: ApiAccessMode = 'personal';
+  let accessExpiresAt: string | null = null;
+  let spendingStatus: UpdateProfileMessage['spendingStatus'] = null;
+  let quotaAutoSwitched = false;
+  try {
+    const serverSideKeyService = getServerSideKeyService();
+    apiAccessMode = serverSideKeyService.getUseIncludedModelAccess()
+      ? 'included'
+      : 'personal';
+    // Prime the server-side key cache so the reads below see fresh values.
+    await serverSideKeyService.canUseServerSideKeys();
+    accessExpiresAt =
+      serverSideKeyService.getAccessExpirationDate()?.toISOString() ?? null;
+    quotaAutoSwitched = serverSideKeyService.wasQuotaAutoSwitched();
+    spendingStatus = getTierService().getSpendingStatus();
+  } catch {
+    // Server-side key / tier access is optional; personal provider keys work.
+  }
+
+  let remoteAgents: RemoteAgent[] = [];
+  try {
+    await loadAgents();
+    remoteAgents = getAgentsBySource('remote').map(toRemoteAgentProfileData);
+  } catch {
+    // Keep auth/profile UI usable even if the agent registry refresh fails.
+  }
+
+  return {
+    command: PROFILE_VIEW_COMMANDS.UPDATE_PROFILE,
+    authenticated: true,
+    user: { email: user?.email ?? 'N/A', id: user?.id ?? '' },
+    tier,
+    permissions,
+    remoteAgents,
+    apiAccessMode,
+    tierConstants,
+    accessExpiresAt,
+    spendingStatus,
+    quotaAutoSwitched,
+    providerKeyStatuses,
+    globalStreamingDefault,
+  };
+}

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -10,8 +10,8 @@ import {
   createDesktopAuthCallbackState,
   createDesktopSupabaseAuth,
   type DesktopOAuthClient,
-  type DesktopAuthProfileData,
 } from '@desktop/main/desktopSupabaseAuth';
+import { buildProfileMessage } from '@shared/settingsView/handlers/profileHandlers';
 import type { StateStore } from '@platform/interfaces/state';
 
 function createCoordinator() {
@@ -198,8 +198,7 @@ describe('desktop Supabase auth', () => {
     });
     expect(onSessionChanged).toHaveBeenCalled();
 
-    const profile = (await auth.getProfileData()) as DesktopAuthProfileData;
-    expect(profile.authenticated).toBe(false);
+    expect(await SupabaseClient.isAuthenticated()).toBe(false);
     auth.dispose();
   });
 
@@ -542,11 +541,13 @@ describe('desktop Supabase auth', () => {
       openExternalUrl: vi.fn(async () => {}),
     });
 
-    const profile = await auth.getProfileData();
+    const message = await buildProfileMessage({
+      getProviderKeyStatuses: async () => [],
+    });
 
     expect(ensureFreshToken).toHaveBeenCalled();
     expect(loadAgents).toHaveBeenCalled();
-    expect(profile).toMatchObject({
+    expect(message).toMatchObject({
       authenticated: true,
       user: { email: 'user@example.com', id: 'user-1' },
       tier: 'free',
@@ -581,9 +582,11 @@ describe('desktop Supabase auth', () => {
       openExternalUrl: vi.fn(async () => {}),
     });
 
-    const profile = await auth.getProfileData();
+    const message = await buildProfileMessage({
+      getProviderKeyStatuses: async () => [],
+    });
 
-    expect(profile).toMatchObject({
+    expect(message).toMatchObject({
       authenticated: true,
       user: { email: 'user@example.com', id: 'user-1' },
       remoteAgents: [],


### PR DESCRIPTION
## The drift bug

`UPDATE_PROFILE` was hand-assembled **separately** in the extension (`SettingsViewMessageHandler.sendProfileData`) and the desktop (`loadDesktopAuthProfileData` + `postProfileData`), and the canonical `UpdateProfileMessage` type was **referenced nowhere** — so the compiler checked neither producer against the schema. They drifted: desktop silently omitted `spendingStatus` and `quotaAutoSwitched`, so the shared frontend's **RelayQuotaMeter / quota-auto-switch banner render dead on desktop**.

## The fix — one host-neutral owner

New `src/shared/settingsView/handlers/profileHandlers.buildProfileMessage()` (mirroring the existing `buildHistoryMessage`): a single projection over the shared auth / tier / server-side-key / agent services that returns the **typed** `UpdateProfileMessage`. The only host-specific input — provider key statuses (VS Code settings on the extension, none on desktop) — is injected as a callback.

```ts
// both hosts, now identical:
const message = await buildProfileMessage({ getProviderKeyStatuses });
postMessage(message);  // webview.postMessage / options.postToRenderer
```

Because the builder's return type is `UpdateProfileMessage`, the compiler now **enforces all 13 fields on both hosts** — desktop gets `spendingStatus` + `quotaAutoSwitched` for free, and future fields can't drift.

## Behavior

- The builder keeps the **desktop's graceful try/catch resilience** (a transient metadata failure keeps the user signed in with fallback values rather than failing the whole refresh). The extension *gains* that resilience — a deliberate, safe improvement on the three metadata reads.
- It primes the server-side-key cache via `canUseServerSideKeys()`, as both hosts already did (the extension's `primeIncludedAccessIfEnabled` is folded in).

## Deletions (net −170 LOC)

- Extension: the `sendProfileData` inline assembly + `primeIncludedAccessIfEnabled` + 6 now-unused imports.
- Desktop: `loadDesktopAuthProfileData`, `unauthenticatedProfileData`, `DesktopAuthProfileData`, `DesktopSupabaseAuth.getProfileData`, the `getAuthProfileData` IPC option.
- The two `index.ts` `getProfileData` consumers (login banner + `getAuthStatus`) only read `.authenticated`, so they move to `SupabaseClient.isAuthenticated()` directly — which unblocked deleting the whole indirection.

## Verification
- `tsc --noEmit` on **all three** tsconfigs (root + extension + desktop) clean; prettier + eslint clean.
- `DesktopSettingsIpc.vitest` (33/33), `DesktopSettingsSurface.vitest` (2/2), `HistoryHandlers.vitest` (1/1) pass.

---
🤖 Round-3–10 deep audit (contract-leakage / untyped-wire-drift lens), scoped up to the full canonical-owner refactor per maintainer request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth profile refresh, included-access priming, and tier/spending snapshots; behavior is intentionally aligned but changes failure modes and when relay quota data is refreshed.
> 
> **Overview**
> Introduces shared **`buildProfileMessage()`** so the VS Code extension and Electron desktop both emit the same typed **`UpdateProfileMessage`**, with only **`getProviderKeyStatuses`** injected per host.
> 
> **Desktop** now includes **`spendingStatus`** and **`quotaAutoSwitched`** (previously omitted, breaking RelayQuotaMeter / quota-auto-switch UI). **Extension** gains the same graceful try/catch fallbacks on tier, server-side keys, and remote agents.
> 
> Removes desktop **`getProfileData`** / **`DesktopAuthProfileData`** and the **`getAuthProfileData`** settings IPC hook; login banner and **`getAuthStatus`** use **`SupabaseClient.isAuthenticated()`** directly. Tests assert profile shape via **`buildProfileMessage`** instead of **`auth.getProfileData()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d3fa02a074e666b6ea83ab361fb45a3c1c6adf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->