### PR TITLE
refactor: remove dead onboarding placeholder-rotation carrier

### DIFF
--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -92,7 +92,6 @@ import {
   DEFAULT_CHECKBOX_VALUES,
   FILE_UPDATE_COMMANDS,
   MULTI_FILE_COMMAND_TO_KEY,
-  PLACEHOLDER_ROTATION_MS,
   ONBOARDING_PLACEHOLDERS,
   FILE_SELECT_CONFIGS,
 } from './store';
@@ -245,7 +244,6 @@ export class MainApp extends MainAppBase {
     MainViewPersistedStateSchema,
   );
   private saveBlockCount = 0;
-  private placeholderTimer: number | null = null;
 
   private readonly messageHandlers: MainViewHandlerRegistry = {
     [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: (data) =>
@@ -353,7 +351,6 @@ export class MainApp extends MainAppBase {
   }
 
   override disconnectedCallback(): void {
-    this.stopPlaceholderRotation();
     if (this.instructionSaveTimer) {
       window.clearTimeout(this.instructionSaveTimer);
       this.instructionSaveTimer = null;
@@ -373,7 +370,7 @@ export class MainApp extends MainAppBase {
 
   protected override firstUpdated(): void {
     this.requestInitialData();
-    this.refreshInstructionPlaceholder(false);
+    this.refreshInstructionPlaceholder();
   }
 
   /**
@@ -1012,7 +1009,7 @@ export class MainApp extends MainAppBase {
     // `?open` template expression used to encode — but tracking it here
     // means subsequent user collapses survive re-renders.
     this.fileSelectionOpen.set(parsed === SESSION_TYPES.WORKFLOW);
-    this.refreshInstructionPlaceholder(false);
+    this.refreshInstructionPlaceholder();
     if (parsed === SESSION_TYPES.TOOL_USE) {
       this.outputFilesActive.set(false);
       this.updateMultiFiles('outputFiles', []);
@@ -1028,7 +1025,7 @@ export class MainApp extends MainAppBase {
     }
     this.swapModeInstruction(this.sessionType.get(), sessionType);
     this.sessionType.set(sessionType);
-    this.refreshInstructionPlaceholder(false);
+    this.refreshInstructionPlaceholder();
     this.saveState();
     postMessage(MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER);
   }
@@ -1087,7 +1084,7 @@ export class MainApp extends MainAppBase {
         this.workflowAgent.set(message.agentId);
       }
     }
-    this.refreshInstructionPlaceholder(false);
+    this.refreshInstructionPlaceholder();
     this.saveState();
   }
 
@@ -1105,13 +1102,6 @@ export class MainApp extends MainAppBase {
     }, 300);
   }
 
-  private stopPlaceholderRotation(): void {
-    if (this.placeholderTimer) {
-      window.clearInterval(this.placeholderTimer);
-      this.placeholderTimer = null;
-    }
-  }
-
   private get primaryInputFile(): string {
     return this.multiFiles.get().inputFiles[0] ?? '';
   }
@@ -1123,7 +1113,7 @@ export class MainApp extends MainAppBase {
     return opt?.isOrchestrator ?? false;
   }
 
-  private refreshInstructionPlaceholder(advance: boolean): void {
+  private refreshInstructionPlaceholder(): void {
     const placeholderKey: keyof typeof ONBOARDING_PLACEHOLDERS =
       this.isSelectedAgentOrchestrator()
         ? 'orchestrator'
@@ -1132,10 +1122,7 @@ export class MainApp extends MainAppBase {
     if (!placeholders.length) return;
     const current = this.instructionPlaceholder.get();
     const currentIndex = placeholders.indexOf(current);
-    if (advance) {
-      const nextIndex = (currentIndex + 1) % placeholders.length;
-      this.instructionPlaceholder.set(placeholders[nextIndex]);
-    } else if (!current || currentIndex === -1) {
+    if (!current || currentIndex === -1) {
       this.instructionPlaceholder.set(placeholders[0]);
     }
   }

--- a/packages/extension/src/webview/frontend/store.ts
+++ b/packages/extension/src/webview/frontend/store.ts
@@ -86,9 +86,6 @@ export const MULTI_FILE_COMMAND_TO_KEY: Record<string, keyof MultiFiles> = {
 // Placeholder Configuration
 // =========================================================================
 
-/** Placeholder rotation interval in milliseconds */
-export const PLACEHOLDER_ROTATION_MS = 12000;
-
 /** Onboarding placeholder texts by session type (+ orchestrator override) */
 export const ONBOARDING_PLACEHOLDERS = {
   workflow: [


### PR DESCRIPTION
## Summary

The instruction-input placeholder **rotation** in `MainApp` was fully dead-wired:
- `placeholderTimer` was only ever *cleared*, never assigned — there is **no `setInterval`** anywhere.
- `PLACEHOLDER_ROTATION_MS` was imported but unused.
- `refreshInstructionPlaceholder(advance)` was called from all 4 sites with `advance=false`, so the `if (advance)` branch that cycles placeholders was **unreachable**.

Net effect: the placeholder is only ever set once to the first hint for the current session type — the rotating-hint UX the machinery was built for never ran.

Per the decision to drop it (rather than wire it up), this removes the dead carrier — a behavior-preserving cleanup:
- delete `placeholderTimer`, `stopPlaceholderRotation()` + its `disconnectedCallback` call;
- delete the `PLACEHOLDER_ROTATION_MS` import and its `store.ts` constant;
- collapse `refreshInstructionPlaceholder()` to its sole reachable (set-first-hint) behavior, dropping the `advance` parameter.

## Verification
- No residual references to the removed symbols; the 4 call sites now call the arg-less method (unchanged behavior — first hint shown once).
- Extension typecheck clean. Net −16 LOC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving cleanup in webview UI only; no auth, IPC, or persistence changes.
> 
> **Overview**
> Removes **unfinished placeholder-rotation** plumbing from the main webview launcher. The instruction field still shows the first onboarding hint for workflow, tool-use, or orchestrator mode; nothing user-visible changes.
> 
> **`MainApp`** drops `placeholderTimer`, `stopPlaceholderRotation()` (and its `disconnectedCallback` cleanup), and the unused `advance` path in `refreshInstructionPlaceholder()`. Call sites now use the arg-less method, which only sets the first hint when the current placeholder is empty or not in the list for the active mode.
> 
> **`store.ts`** removes the unused `PLACEHOLDER_ROTATION_MS` constant. `ONBOARDING_PLACEHOLDERS` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5faaff0e3e0967e3d16b2a1e3eee7d72f2065b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->