### PR TITLE
refactor(a11y): route settingsView icons through waIcon() (part 1)

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
@@ -16,6 +16,7 @@ import { repeat } from 'lit/directives/repeat.js';
 // Local imports - shared
 import type { HistoryItem as HistoryItemData } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { historyStyles } from '@shared/styles/historyStyles';
 
 // Side-effect imports - register WA icon component
@@ -247,7 +248,7 @@ export class HistoryList extends LitElement {
   override render(): TemplateResult {
     if (!this.items.length) {
       return html`<div class="empty-state">
-        <wa-icon library="texra" name="history"></wa-icon>
+        ${waIcon('history')}
         <p>No history items found.</p>
         <p class="text-secondary">
           History is recorded when you run agent commands. Past results will
@@ -268,7 +269,7 @@ export class HistoryList extends LitElement {
     // container with no count or message — show explicit no-results feedback.
     if (this.searchTerm && displayItems.length === 0) {
       return html`<div class="empty-state">
-        <wa-icon library="texra" name="history"></wa-icon>
+        ${waIcon('history')}
         <p>No history items match your search.</p>
       </div>`;
     }

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -12,6 +12,7 @@ import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -79,7 +80,7 @@ export class MemoryList extends LitElement {
   override render(): TemplateResult {
     if (!this.items.length) {
       return html`<div class="empty-state">
-        <wa-icon library="texra" name="database"></wa-icon>
+        ${waIcon('database')}
         <p>No saved memories yet.</p>
         <p class="text-secondary">
           Memories are created automatically when the assistant learns something

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -7,6 +7,7 @@ import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports - shared styles
 import { badgeStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import {
   renderSetStatusIcon,
@@ -221,7 +222,7 @@ export class ProviderKeyList extends LitElement {
               title="${isExpanded ? 'Collapse settings' : 'Expand settings'}"
               @click=${() => this.toggleExpanded(entry.provider)}
             >
-              <wa-icon library="texra" name="chevron-right"></wa-icon>
+              ${waIcon('chevron-right')}
             </wa-button>
             <span class="provider-name">${entry.displayName}</span>
           </div>

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -8,6 +8,7 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared events
 import { createEvent } from '@shared/utils/events';
@@ -180,7 +181,7 @@ export class ProviderKeyModal extends LitElement {
             type="submit"
             form="provider-key-form"
           >
-            <wa-icon library="texra" name="key" slot="start"></wa-icon>
+            ${waIcon('key', { slot: 'start' })}
             Save Key
           </wa-button>
         </div>

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -181,8 +181,7 @@ export class ProviderKeyModal extends LitElement {
             type="submit"
             form="provider-key-form"
           >
-            ${waIcon('key', { slot: 'start' })}
-            Save Key
+            ${waIcon('key', { slot: 'start' })} Save Key
           </wa-button>
         </div>
       </wa-dialog>

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -12,6 +12,7 @@ import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { renderLoadingState } from '@shared/wa/loadingState';
 
 // Local imports - shared schemas
@@ -313,7 +314,7 @@ export class AIAgentsTab extends LitElement {
             title="Re-check integration availability"
             @click=${this.handleRecheck}
           >
-            <wa-icon slot="start" library="texra" name="refresh"></wa-icon>
+            ${waIcon('refresh', { slot: 'start' })}
             Re-check
           </wa-button>
         </div>

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -314,8 +314,7 @@ export class AIAgentsTab extends LitElement {
             title="Re-check integration availability"
             @click=${this.handleRecheck}
           >
-            ${waIcon('refresh', { slot: 'start' })}
-            Re-check
+            ${waIcon('refresh', { slot: 'start' })} Re-check
           </wa-button>
         </div>
 

--- a/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
@@ -130,8 +130,7 @@ export class GoalTab extends LitElement {
               size="small"
               @click=${this.handleRefresh}
             >
-              ${waIcon('rotate-right', { slot: 'start' })}
-              Refresh
+              ${waIcon('rotate-right', { slot: 'start' })} Refresh
             </wa-button>
           </div>
         </div>
@@ -169,9 +168,7 @@ export class GoalTab extends LitElement {
             ${renderDotMeta(metaParts)}
           </div>
         </div>
-        ${inFlight
-          ? waIcon('chevron-right')
-          : nothing}
+        ${inFlight ? waIcon('chevron-right') : nothing}
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
@@ -12,6 +12,7 @@ import {
 } from '@shared/schemas';
 import type { Goal, GoalStatus } from '@shared/schemas';
 import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { MetaPart } from '@shared/wa/metaStrip';
 import { capitalize } from '@utils/text/stringUtils';
 
@@ -112,11 +113,7 @@ export class GoalTab extends LitElement {
   private renderReminder(): TemplateResult {
     return html`
       <div class="settings-reminder">
-        <wa-icon
-          library="texra"
-          name="info"
-          class="settings-reminder-icon"
-        ></wa-icon>
+        ${waIcon('info', { className: 'settings-reminder-icon' })}
         <div class="settings-reminder-body">
           <div class="settings-reminder-title">Goal</div>
           <div class="settings-reminder-description">
@@ -133,11 +130,7 @@ export class GoalTab extends LitElement {
               size="small"
               @click=${this.handleRefresh}
             >
-              <wa-icon
-                slot="start"
-                library="texra"
-                name="rotate-right"
-              ></wa-icon>
+              ${waIcon('rotate-right', { slot: 'start' })}
               Refresh
             </wa-button>
           </div>
@@ -177,7 +170,7 @@ export class GoalTab extends LitElement {
           </div>
         </div>
         ${inFlight
-          ? html`<wa-icon library="texra" name="chevron-right"></wa-icon>`
+          ? waIcon('chevron-right')
           : nothing}
       </div>
     `;
@@ -189,7 +182,7 @@ export class GoalTab extends LitElement {
         ${this.renderReminder()}
         ${this.items.length === 0
           ? html`<div class="empty-state">
-              <wa-icon library="texra" name="compass"></wa-icon>
+              ${waIcon('compass')}
               <p>No Goals yet.</p>
             </div>`
           : html`

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -310,7 +310,7 @@ export class MultiAgentTab extends LitElement {
                 variant="brand"
                 size="small"
               >
-                <wa-icon library="texra" name="check"></wa-icon> Active
+                ${waIcon('check')} Active
               </wa-tag>`
             : nothing}
         </div>
@@ -351,7 +351,7 @@ export class MultiAgentTab extends LitElement {
               @click=${(e: Event) => this.handleDeletePreset(e, preset)}
               title="Delete team"
             >
-              <wa-icon library="texra" name="trash"></wa-icon>
+              ${waIcon('trash')}
             </button>`
           : nothing}
       </div>
@@ -362,11 +362,7 @@ export class MultiAgentTab extends LitElement {
     return html`
       <div class="multi-agent-container tab-content-container">
         <div class="settings-reminder">
-          <wa-icon
-            library="texra"
-            name="organization"
-            class="settings-reminder-icon"
-          ></wa-icon>
+          ${waIcon('organization', { className: 'settings-reminder-icon' })}
           <div class="settings-reminder-body">
             <div class="settings-reminder-title">Multi-agent workflow</div>
             <div class="settings-reminder-description">


### PR DESCRIPTION
## Summary

The settingsView rendered icons as raw `<wa-icon library="texra" name="…">` tags, **bypassing the shared `waIcon()` helper** — the single owner of the icon standard, which also sets `aria-hidden` on decorative icons so screen readers don't announce them as unlabeled glyphs. settingsView used `waIcon()` **zero** times.

This first installment migrates the straightforward sites in **7 files** (13 icons), preserving `slot`/`class` via `waIcon()` options:

- **GoalTab** — info (`className`), rotate-right (`slot`), chevron-right, compass
- **MultiAgentTab** — check, trash, organization (`className`)
- **ProviderKeyModal** (key, `slot`), **ProviderKeyList** (chevron-right), **MemoryList** (database), **AIAgentsTab** (refresh, `slot`), **HistoryList** (history ×2)

Line-neutral-to-negative; decorative icons now carry `aria-hidden` through the helper.

## Scope (deferred to follow-ups)
- **Dynamic-name sites** (`name=${preset.icon…}`, `name=${meta.icon}`, `name=${config.icon}`, `name=${decorator.icon}`) — these need the source typed as `TeXRAIconName` first (the "untyped icon pipeline" item); converting blind would type-error or require casts.
- **Larger multi-icon surfaces**: SettingsApp (16), LaTeXTab (17), ToolsTab, AgentsTab, GitTab, MemoryTab, ToolCard, HistoryItemElement, Pagination, ApiAccessSection, ModelsTab, ModelSelectionList — mechanical but higher-volume, batched for review.

## Verification
- Extension package typechecks clean — `waIcon()`'s `TeXRAIconName` parameter validates every migrated name at compile time (a bonus safety net this migration adds).
- Additive a11y improvement; no behavior change beyond decorative icons gaining `aria-hidden`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational refactor with additive a11y attributes; no logic or data-path changes in the touched files.
> 
> **Overview**
> **Part 1** of a settingsView icon cleanup: seven Lit components/tabs stop inlining `<wa-icon library="texra" …>` and render icons through the shared **`waIcon()`** helper instead.
> 
> Decorative glyphs (empty states, reminder headers, expand chevrons, refresh/re-check buttons, save-key affordance, etc.) now go through the same path as the rest of the app, including **`aria-hidden`** on decorative icons and compile-time **`TeXRAIconName`** checks. Existing **`slot`** and **`className`** behavior is preserved via `waIcon()` options where needed.
> 
> Dynamic icon names (preset/meta/config decorators) and larger surfaces are **unchanged** in this PR and called out for follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a85920eb3cc6512e30301156279b12e8d2f7ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->