### PR TITLE
[DO NOT MERGE / WIP] Open-source prep: Apache-2.0 license, metadata, and governance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to TeXRA
+
+Thanks for your interest in improving TeXRA! This document explains how to set
+up the project, the conventions we follow, and how to get your changes merged.
+
+## Ways to contribute
+
+- **Report bugs** and request features in the
+  [issue tracker](https://github.com/texra-ai/texra-issues/issues).
+- **Improve documentation** — both the in-repo docs under `docs/` and the
+  guides published at [texra.ai/guide](https://texra.ai/guide/).
+- **Submit code** — bug fixes, new agents, new model providers, or new CLI/UI
+  features. For anything large, please open an issue first so we can agree on
+  the approach before you invest time.
+
+## Project layout
+
+TeXRA is a pnpm workspace. The most important directories:
+
+- Repo-root `src/` — host-agnostic core logic (agents, model handlers, LaTeX
+  processing, tools, shared schemas).
+- `packages/extension/` — the VS Code extension entry point, commands,
+  webviews, and packaged resources.
+- `packages/desktop/` — the Electron desktop shell.
+- `packages/cli/` — the `texra` terminal client.
+- `packages/core/` — the shared core package surface.
+
+See [CLAUDE.md](./CLAUDE.md) and [AGENTS.md](./AGENTS.md) for a deeper tour of
+the architecture and the coding conventions we expect (platform-coupling
+rules, Zod v4 patterns, PocketFlow flows, and more).
+
+## Development setup
+
+Requirements:
+
+- **Node.js >= 22.9.0**
+- **pnpm** via Corepack (the repo pins the exact version in `package.json`)
+- A **LaTeX distribution** and **Perl** are needed to exercise the LaTeX
+  features, but not to build or run the test suite.
+
+```bash
+# Install dependencies
+corepack pnpm install
+
+# Development build (esbuild + Vite)
+npm run compile:fast
+
+# Watch mode
+npm run watch:fast
+
+# Production build
+npm run package:fast
+```
+
+To try the extension, open the repo in VS Code and press <kbd>F5</kbd> to
+launch an Extension Development Host.
+
+To run your locally built CLI:
+
+```bash
+npm run texra-local:build   # bundle the CLI + resources
+npm run texra-local:link    # symlink `texra-local` into ~/.local/bin (one-time)
+```
+
+## Before you open a pull request
+
+Run these locally — CI runs the same checks:
+
+```bash
+npm run typecheck   # TypeScript type checking (builds do NOT type-check)
+npm run lint        # ESLint
+npm run format      # Prettier (writes changes)
+npm test            # Vitest suite
+```
+
+> **Note:** The `compile`/`watch`/`package` builds use esbuild, which only
+> strips types and does **not** type-check. Always run `npm run typecheck`
+> (or `npm run compile:safe`) before pushing.
+
+## Pull request guidelines
+
+- **Branch** off `main` and keep PRs focused on a single change.
+- **Describe** what changed and why; link the issue it addresses.
+- **Update `CHANGELOG.md`** for user-facing changes (under Features, Bug
+  Fixes, or Improvements). Don't document intermediate bugs fixed within the
+  same PR.
+- **Add or update tests** when you change behavior.
+- **Keep core platform-agnostic.** Code under `src/agent/`, `src/model/`,
+  `src/latex/`, `src/tools/`, `src/controllers/`, `src/shared/`, and the other
+  VS Code-free zones listed in [CLAUDE.md](./CLAUDE.md) must not import the
+  `vscode` module. Reach host services through `platform()` from `@platform`.
+- **Match the surrounding style.** Use the existing path aliases (`@agent/*`,
+  `@utils/*`, …) and follow the Zod-schema-first conventions documented in
+  AGENTS.md.
+
+## Commit messages
+
+Write clear, descriptive commit messages in the imperative mood
+(e.g. "Add Gemini streaming handler"). Group related changes into logical
+commits.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[Apache License 2.0](./LICENSE) that covers the project. You retain copyright
+to your contributions.

--- a/DO_NOT_MERGE.md
+++ b/DO_NOT_MERGE.md
@@ -1,0 +1,11 @@
+# ⛔ DO NOT MERGE
+
+This branch (`claude/codebase-open-source-prep-abpiu0`) prepares the TeXRA
+codebase for an open-source release (Apache-2.0 license, package metadata,
+and contributor/security governance docs).
+
+**It is intentionally not ready to merge and should not be merged anytime
+soon.** The open-sourcing decision and its timing are still under review.
+
+Remove this file as part of the final commit when the work is approved for
+merge.

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,201 @@
-LICENSE
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Sirui Lu and the TeXRA contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ The Setup Wizard checks for and helps install most of the above.
 
 Full docs at [texra.ai/guide](https://texra.ai/guide/).
 
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for how
+to set up the workspace, build, and run the test suite. To report a security
+issue, follow the process in [SECURITY.md](./SECURITY.md).
+
 ## Support
 
 Issues and feature requests: [GitHub](https://github.com/texra-ai/texra-issues/issues).
@@ -145,6 +151,8 @@ Contact: [contact@texra.ai](mailto:contact@texra.ai).
 
 ## License
 
-© TeXRA Team 2025–2026. All rights reserved.
+Licensed under the [Apache License 2.0](./LICENSE).
 
+Copyright © 2025–2026 Sirui Lu and the TeXRA contributors. Use of the hosted
+TeXRA service is additionally governed by the
 [Terms of Service](https://texra.ai/terms) · [Provider list](https://texra.ai/providers)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported versions
+
+TeXRA is under active development. Security fixes are applied to the latest
+released version of the extension, desktop app, and CLI. Please make sure you
+are on the most recent release before reporting an issue.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately through GitHub's
+[Security Advisories](https://github.com/texra-ai/texra-issues/security/advisories/new)
+("Report a vulnerability"). This keeps the report confidential until a fix is
+available.
+
+If you are unable to use GitHub Security Advisories, you may contact the
+maintainers at [contact@texra.ai](mailto:contact@texra.ai).
+
+Please include:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof-of-concept.
+- The affected component (extension, desktop, CLI, or shared core) and
+  version.
+- Any suggested mitigation, if you have one.
+
+## What to expect
+
+- We will acknowledge your report as soon as we can.
+- We will investigate, keep you informed of progress, and work on a fix.
+- Once a fix is released, we are happy to credit you for the discovery
+  (unless you prefer to remain anonymous).
+
+## Scope
+
+TeXRA executes AI-driven workflows that can read and write files, run shell
+commands, and call external model providers. When reporting, please consider:
+
+- Handling of API keys and credentials (the extension stores keys in VS Code's
+  encrypted SecretStorage; the CLI reads them from the environment).
+- Tool-use approval gating and any way to bypass per-stream approval.
+- Path traversal or unintended file access during workflows.
+- Injection or unsafe handling of model output that is executed or rendered.
+
+Thank you for helping keep TeXRA and its users safe.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,16 @@
   "name": "texra-workspace",
   "version": "0.38.9",
   "private": true,
+  "license": "Apache-2.0",
+  "description": "TeXRA — an AI theorist for academic writing, research, and document processing. VS Code extension, desktop app, and CLI.",
+  "homepage": "https://texra.ai",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/texra-ai/texra-issues.git"
+  },
+  "bugs": {
+    "url": "https://github.com/texra-ai/texra-issues/issues"
+  },
   "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,8 +2,8 @@
   "name": "@texra-ai/cli",
   "version": "0.38.9",
   "description": "TeXRA CLI — your AI theorist in the terminal.",
-  "license": "SEE LICENSE IN LICENSE.txt",
-  "author": "TeXRA.ai",
+  "license": "Apache-2.0",
+  "author": "Sirui Lu",
   "homepage": "https://texra.ai",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,8 @@
   "name": "@texra/core",
   "version": "0.38.9",
   "private": true,
+  "license": "Apache-2.0",
+  "author": "Sirui Lu",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -2,7 +2,8 @@
   "name": "@texra/desktop",
   "version": "0.38.9",
   "description": "TeXRA standalone desktop application",
-  "author": "TeXRA.ai <contact@texra.ai>",
+  "author": "Sirui Lu",
+  "license": "Apache-2.0",
   "homepage": "https://texra.ai",
   "repository": {
     "type": "git",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1653,8 +1653,8 @@
     "type": "git",
     "url": "https://github.com/texra-ai/texra-issues.git"
   },
-  "license": "SEE LICENSE IN LICENSE.txt",
-  "author": "TeXRA.ai",
+  "license": "Apache-2.0",
+  "author": "Sirui Lu",
   "icon": "resources/logo-512x512.png",
   "keywords": [
     "latex",


### PR DESCRIPTION
## ⛔ DO NOT MERGE — Work in progress

This PR prepares the TeXRA codebase for an eventual open-source release. **It should not be merged anytime soon** — the open-sourcing decision and its timing are still under review. A `DO_NOT_MERGE.md` marker is committed on the branch as a reminder; it should be removed in the final commit if/when this is approved.

## What's done so far

- **LICENSE** — filled in the full **Apache-2.0** text (the file was previously empty).
- **package.json metadata** (root + `cli`/`desktop`/`extension`/`core`) — `license` → `Apache-2.0` (replacing the broken `SEE LICENSE IN LICENSE.txt` pointer to a non-existent file); `author` → `Sirui Lu` (name only, dropped the embedded email); added `license`/`description`/`repository`/`bugs` to the workspace root.
- **README** — License section changed from "All rights reserved" to Apache-2.0; added a Contributing section.
- **CONTRIBUTING.md** — new contributor guide grounded in the real build/typecheck/lint/test commands.
- **SECURITY.md** — new vulnerability-reporting policy via GitHub Security Advisories.
- Code of Conduct intentionally **not** added (per maintainer preference).

## Still to do

- [ ] Audit & remove anything that shouldn't appear in a public codebase (secrets/credentials, personal/internal references, internal-only docs).
- [ ] Final review of `.github/` workflows for internal-only automation.
- [ ] Remove `DO_NOT_MERGE.md` when approved for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)