### PR TITLE
refactor: drop dead public exports (internal-only types/schemas)

### DIFF
--- a/src/agent/output/outputOperations.ts
+++ b/src/agent/output/outputOperations.ts
@@ -5,7 +5,7 @@ import { MESSAGE_TYPES, type MessageType } from '@shared/schemas';
 /** Trace levels that the output managers use for recoverable failures. */
 type OutputLogLevel = 'error' | 'warn' | 'debug';
 
-export interface TryOperationOptions<T> {
+interface TryOperationOptions<T> {
   /** Trace used for the internal failure line. */
   logger: AgentTrace;
   /** Trace level for the failure line (mirrors each call site's prior level). */

--- a/src/model/openRouterRouting.ts
+++ b/src/model/openRouterRouting.ts
@@ -1,4 +1,4 @@
-export interface OpenRouterRoutingConfig {
+interface OpenRouterRoutingConfig {
   requiresResponsesAPI?: boolean;
   openRouterOnly: boolean;
 }

--- a/src/skills/SkillSchema.ts
+++ b/src/skills/SkillSchema.ts
@@ -24,7 +24,7 @@ export const SkillNameSchema = z
     'Skill name must not contain repeated hyphens',
   );
 
-export const SkillDescriptionSchema = z
+const SkillDescriptionSchema = z
   .string()
   .transform((description) => collapseWhitespace(description))
   .refine(

--- a/src/skills/skillSources.ts
+++ b/src/skills/skillSources.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 
 import type { SkillSource } from './loadSkills';
 
-export interface SkillSourceContext {
+interface SkillSourceContext {
   readonly cwd: string;
   readonly resourcesPath: string;
 }

--- a/src/telemetry/UsageLogTypes.ts
+++ b/src/telemetry/UsageLogTypes.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
 
-export const UsageLogMetadataSchema = z.object({
+const UsageLogMetadataSchema = z.object({
   model: z.string(),
   provider: UsageProviderSchema,
   agentName: z.string().optional(),
@@ -12,9 +12,9 @@ export const UsageLogMetadataSchema = z.object({
   streamId: z.string().optional(),
 });
 
-export type UsageLogMetadata = z.infer<typeof UsageLogMetadataSchema>;
+type UsageLogMetadata = z.infer<typeof UsageLogMetadataSchema>;
 
-export const UsageLogStatsSchema = z.object({
+const UsageLogStatsSchema = z.object({
   inputTokens: z.int().nonnegative(),
   outputTokens: z.int().nonnegative(),
   cost: z.number().nonnegative(),
@@ -25,7 +25,7 @@ export const UsageLogStatsSchema = z.object({
   reasoningTokens: z.int().nonnegative().optional(),
 });
 
-export type UsageLogStats = z.infer<typeof UsageLogStatsSchema>;
+type UsageLogStats = z.infer<typeof UsageLogStatsSchema>;
 
 export const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
   UsageLogStatsSchema.shape,

--- a/src/telemetry/UsageLogTypes.ts
+++ b/src/telemetry/UsageLogTypes.ts
@@ -12,8 +12,6 @@ const UsageLogMetadataSchema = z.object({
   streamId: z.string().optional(),
 });
 
-type UsageLogMetadata = z.infer<typeof UsageLogMetadataSchema>;
-
 const UsageLogStatsSchema = z.object({
   inputTokens: z.int().nonnegative(),
   outputTokens: z.int().nonnegative(),
@@ -24,8 +22,6 @@ const UsageLogStatsSchema = z.object({
   cacheCreationInputTokens: z.int().nonnegative().optional(),
   reasoningTokens: z.int().nonnegative().optional(),
 });
-
-type UsageLogStats = z.infer<typeof UsageLogStatsSchema>;
 
 export const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
   UsageLogStatsSchema.shape,


### PR DESCRIPTION
Six symbols carry an `export` modifier but have **zero importers outside their declaring file** (verified by repo-wide grep across `src` + `packages`, named-import and `export *`-leak checked). Each is legitimately used *internally* — only the public surface is dead. Dropping `export` removes the false API without any behavior change.

| Symbol | File | Internal use |
|---|---|---|
| `OpenRouterRoutingConfig` | `model/openRouterRouting.ts` | param type of `shouldRouteModelThroughOpenRouter` |
| `SkillSourceContext` | `skills/skillSources.ts` | param type of `defaultSkillSources` |
| `SkillDescriptionSchema` | `skills/SkillSchema.ts` | composed into `SkillFrontmatterSchema`/`SkillSchema` |
| `UsageLogMetadataSchema` + type | `telemetry/UsageLogTypes.ts` | `.extend()` into `UsageLogEntrySchema` |
| `UsageLogStatsSchema` + type | `telemetry/UsageLogTypes.ts` | `.shape` into `UsageLogEntrySchema` |
| `TryOperationOptions<T>` | `agent/output/outputOperations.ts` | param type of `tryOperation` |

## Notes
- **No barrel edits.** `SkillSourceContext` / `SkillDescriptionSchema` only leaked through `skills/index.ts`'s `export *` — dropping the source `export` stops the leak; no consumer imported them by name.
- The genuinely-consumed exports are untouched: `UsageLogEntry`/`UsageLogBatch`/`UsageLogResponse`, `Skill`/`SkillFrontmatter` (`z.infer` types), `ToolResultPayload`, `shouldRouteModelThroughOpenRouter`.
- `SkillFrontmatterSchema` was deliberately **kept** exported (it is consumed in validation composition) — correctly excluded.

## Verification
- `npx tsc --noEmit` — 0 errors.

🤖 Found via round 12 (broadened dead-export sweep) of a multi-agent audit; each symbol re-grepped by hand (0 external files) before the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only visibility cleanup with no logic changes; verified no external imports of the removed exports.
> 
> **Overview**
> **Narrows the public module surface** by removing `export` from six symbols that had no importers outside their declaring files. Each remains in use locally (function params, schema composition, etc.).
> 
> Affected areas: `TryOperationOptions` in agent output helpers; `OpenRouterRoutingConfig` in OpenRouter routing; `SkillDescriptionSchema` and `SkillSourceContext` in skills; `UsageLogMetadataSchema`, `UsageLogStatsSchema`, and their inferred types in telemetry (only `UsageLogEntry` and related batch/response types stay exported).
> 
> No runtime or type behavior change for existing consumers; intended exports such as `shouldRouteModelThroughOpenRouter`, `Skill`/`SkillFrontmatter`, and `UsageLogEntry` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2aff82f043af54818c9a03664a9cc874059913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->