### PR TITLE
refactor(a11y): route settingsView icons through waIcon() (part 2)

### DIFF
--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -785,8 +785,7 @@ export class SettingsApp extends SettingsAppBase {
               title="Sign out"
               @click=${this.handleSignOut}
             >
-              ${waIcon('xmark', { slot: 'start' })}
-              Sign out
+              ${waIcon('xmark', { slot: 'start' })} Sign out
             </wa-button>
           </div>
         </div>
@@ -808,8 +807,7 @@ export class SettingsApp extends SettingsAppBase {
             title="Set provider API key"
             @click=${this.handleSetDefaultProviderKey}
           >
-            ${waIcon('key', { slot: 'start' })}
-            Set API key
+            ${waIcon('key', { slot: 'start' })} Set API key
           </wa-button>
           <wa-button
             class="settings-header-auth-button"
@@ -819,8 +817,7 @@ export class SettingsApp extends SettingsAppBase {
             title="Sign in"
             @click=${this.handleSignIn}
           >
-            ${waIcon('user', { slot: 'start' })}
-            Sign in
+            ${waIcon('user', { slot: 'start' })} Sign in
           </wa-button>
         </div>
       </div>

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -30,7 +30,7 @@ import {
 import type { SpendingStatus } from '@shared/schemas/spendingStatus';
 import {
   registerTeXRAWebAwesomeIcons,
-  TEXRA_ICON_LIBRARY,
+  waIcon,
 } from '@shared/wa/webAwesomeIcons';
 import {
   type AgentSelectionItem,
@@ -761,11 +761,7 @@ export class SettingsApp extends SettingsAppBase {
             title="Open VS Code Settings"
             @click=${this.handleOpenVscodeSettings}
           >
-            <wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name="gear"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('gear')}
           </wa-button>
         `;
 
@@ -773,12 +769,7 @@ export class SettingsApp extends SettingsAppBase {
       return html`
         <div class="settings-header">
           <div class="settings-header-user">
-            <wa-icon
-              class="settings-header-user-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="circle-user"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('circle-user', { className: 'settings-header-user-icon' })}
             <div class="settings-header-info">
               <span class="settings-header-email">${this.userEmail.get()}</span>
               <span class="settings-header-tier">${this.tier.get()} Plan</span>
@@ -794,12 +785,7 @@ export class SettingsApp extends SettingsAppBase {
               title="Sign out"
               @click=${this.handleSignOut}
             >
-              <wa-icon
-                slot="start"
-                library=${TEXRA_ICON_LIBRARY}
-                name="xmark"
-                variant="solid"
-              ></wa-icon>
+              ${waIcon('xmark', { slot: 'start' })}
               Sign out
             </wa-button>
           </div>
@@ -822,12 +808,7 @@ export class SettingsApp extends SettingsAppBase {
             title="Set provider API key"
             @click=${this.handleSetDefaultProviderKey}
           >
-            <wa-icon
-              slot="start"
-              library=${TEXRA_ICON_LIBRARY}
-              name="key"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('key', { slot: 'start' })}
             Set API key
           </wa-button>
           <wa-button
@@ -838,12 +819,7 @@ export class SettingsApp extends SettingsAppBase {
             title="Sign in"
             @click=${this.handleSignIn}
           >
-            <wa-icon
-              slot="start"
-              library=${TEXRA_ICON_LIBRARY}
-              name="user"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('user', { slot: 'start' })}
             Sign in
           </wa-button>
         </div>
@@ -875,12 +851,7 @@ export class SettingsApp extends SettingsAppBase {
       <div class="tab-content-container">
         <div class="settings-unavailable">
           <div class="settings-unavailable-title">
-            <wa-icon
-              class="settings-unavailable-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="ban"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('ban', { className: 'settings-unavailable-icon' })}
             ${title}
           </div>
           <div>${description}</div>
@@ -903,93 +874,43 @@ export class SettingsApp extends SettingsAppBase {
           @wa-tab-show=${this.handleTabShow}
         >
           <wa-tab panel="memory"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="database"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('database', { className: 'settings-tab-icon' })}
             Memory</wa-tab
           >
           <wa-tab panel="history"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="clock-rotate-left"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('clock-rotate-left', { className: 'settings-tab-icon' })}
             History</wa-tab
           >
           <wa-tab panel="models"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="server"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('server', { className: 'settings-tab-icon' })}
             Models</wa-tab
           >
           <wa-tab panel="agents"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="robot"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('robot', { className: 'settings-tab-icon' })}
             Agents</wa-tab
           >
           <wa-tab panel="multi-agent"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="users"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('users', { className: 'settings-tab-icon' })}
             Multi-Agent</wa-tab
           >
           <wa-tab panel="tools"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="screwdriver-wrench"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('screwdriver-wrench', { className: 'settings-tab-icon' })}
             Tools</wa-tab
           >
           <wa-tab panel="ai-agents"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="robot"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('robot', { className: 'settings-tab-icon' })}
             Integrations</wa-tab
           >
           <wa-tab panel="git"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="code-branch"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('code-branch', { className: 'settings-tab-icon' })}
             Git</wa-tab
           >
           <wa-tab panel="latex"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="file-code"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('file-code', { className: 'settings-tab-icon' })}
             LaTeX</wa-tab
           >
           <wa-tab panel="goal"
-            ><wa-icon
-              class="settings-tab-icon"
-              library=${TEXRA_ICON_LIBRARY}
-              name="compass"
-              variant="solid"
-            ></wa-icon>
+            >${waIcon('compass', { className: 'settings-tab-icon' })}
             Goal</wa-tab
           >
 

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -15,6 +15,7 @@ import { getAgentCategoryDecorator } from '@shared/utils/icons';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -292,7 +293,7 @@ export class HistoryItemElement extends LitElement {
           Object.entries(config.toolConfig) as Array<[string, ConfigValue]>
         ).filter(([, value]) => this.hasValue(value));
         const toolSection = this.renderConfigSection(
-          html`<wa-icon library="texra" name="tools"></wa-icon> Config`,
+          html`${waIcon('tools')} Config`,
           toolEntries,
         );
         if (toolSection) extraDetails.push(toolSection);

--- a/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
@@ -5,6 +5,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -70,12 +71,7 @@ export class ApiAccessSection extends LitElement {
         ${this.mode === 'included'
           ? html`
               <div class="api-access-support">
-                <wa-icon
-                  library="texra"
-                  name="heart"
-                  class="api-access-support-icon"
-                  aria-hidden="true"
-                ></wa-icon>
+                ${waIcon('heart', { className: 'api-access-support-icon' })}
                 <span class="api-access-support-copy">
                   ${PROMO_NOTICE_LONG.supportLead}<a
                     href=${PROMO_NOTICE_LONG.supportSponsorsUrl}

--- a/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
@@ -10,7 +10,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles and utilities
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { createEvent } from '@shared/utils/events';
 import { clamp } from '@utils/core';
 
@@ -141,11 +141,7 @@ export class Pagination extends LitElement {
             ?disabled=${atFirst}
             @click=${this.goFirst}
           >
-            <wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name="backward-step"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('backward-step')}
           </wa-button>
           <wa-button
             appearance="outlined"
@@ -156,11 +152,7 @@ export class Pagination extends LitElement {
             ?disabled=${atFirst}
             @click=${this.goPrev}
           >
-            <wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name="chevron-left"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('chevron-left')}
           </wa-button>
           <span class="pagination-status">
             ${this.page + 1}/${this.totalPages}
@@ -174,11 +166,7 @@ export class Pagination extends LitElement {
             ?disabled=${atLast}
             @click=${this.goNext}
           >
-            <wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name="chevron-right"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('chevron-right')}
           </wa-button>
           <wa-button
             appearance="outlined"
@@ -189,11 +177,7 @@ export class Pagination extends LitElement {
             ?disabled=${atLast}
             @click=${this.goLast}
           >
-            <wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name="forward-step"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('forward-step')}
           </wa-button>
         </div>
       </div>

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -11,7 +11,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
@@ -334,12 +334,7 @@ export class ToolCard extends LitElement {
                   @click=${this.handleRunInstallCommand}
                   title=${this.item.installCommand}
                 >
-                  <wa-icon
-                    slot="start"
-                    library=${TEXRA_ICON_LIBRARY}
-                    name="terminal"
-                    variant="solid"
-                  ></wa-icon>
+                  ${waIcon('terminal', { slot: 'start', variant: 'solid' })}
                   Install in Terminal
                 </wa-button>
               `
@@ -353,12 +348,10 @@ export class ToolCard extends LitElement {
                   @click=${this.handleRunAuthCommand}
                   title=${this.item.authCommand}
                 >
-                  <wa-icon
-                    slot="start"
-                    library=${TEXRA_ICON_LIBRARY}
-                    name="right-to-bracket"
-                    variant="solid"
-                  ></wa-icon>
+                  ${waIcon('right-to-bracket', {
+                    slot: 'start',
+                    variant: 'solid',
+                  })}
                   Sign in
                 </wa-button>
               `
@@ -371,12 +364,10 @@ export class ToolCard extends LitElement {
                   size="small"
                   @click=${this.handleInstallExtension}
                 >
-                  <wa-icon
-                    slot="start"
-                    library=${TEXRA_ICON_LIBRARY}
-                    name="cloud-arrow-down"
-                    variant="solid"
-                  ></wa-icon>
+                  ${waIcon('cloud-arrow-down', {
+                    slot: 'start',
+                    variant: 'solid',
+                  })}
                   Install Extension
                 </wa-button>
               `
@@ -389,12 +380,10 @@ export class ToolCard extends LitElement {
                   size="small"
                   @click=${this.handleInstallUrl}
                 >
-                  <wa-icon
-                    slot="start"
-                    library=${TEXRA_ICON_LIBRARY}
-                    name="arrow-up-right-from-square"
-                    variant="solid"
-                  ></wa-icon>
+                  ${waIcon('arrow-up-right-from-square', {
+                    slot: 'start',
+                    variant: 'solid',
+                  })}
                   Open Install Page
                 </wa-button>
               `
@@ -428,7 +417,7 @@ export class ToolCard extends LitElement {
     if (!this.item.authNote) return nothing;
     return html`
       <span class="tool-auth-note">
-        <wa-icon library="texra" name="key"></wa-icon>
+        ${waIcon('key')}
         ${this.item.authNote}
       </span>
     `;

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -334,8 +334,7 @@ export class ToolCard extends LitElement {
                   @click=${this.handleRunInstallCommand}
                   title=${this.item.installCommand}
                 >
-                  ${waIcon('terminal', { slot: 'start', variant: 'solid' })}
-                  Install in Terminal
+                  ${waIcon('terminal', { slot: 'start' })} Install in Terminal
                 </wa-button>
               `
             : nothing}
@@ -348,11 +347,7 @@ export class ToolCard extends LitElement {
                   @click=${this.handleRunAuthCommand}
                   title=${this.item.authCommand}
                 >
-                  ${waIcon('right-to-bracket', {
-                    slot: 'start',
-                    variant: 'solid',
-                  })}
-                  Sign in
+                  ${waIcon('right-to-bracket', { slot: 'start' })} Sign in
                 </wa-button>
               `
             : nothing}
@@ -364,11 +359,8 @@ export class ToolCard extends LitElement {
                   size="small"
                   @click=${this.handleInstallExtension}
                 >
-                  ${waIcon('cloud-arrow-down', {
-                    slot: 'start',
-                    variant: 'solid',
-                  })}
-                  Install Extension
+                  ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
+                  Extension
                 </wa-button>
               `
             : nothing}
@@ -380,10 +372,7 @@ export class ToolCard extends LitElement {
                   size="small"
                   @click=${this.handleInstallUrl}
                 >
-                  ${waIcon('arrow-up-right-from-square', {
-                    slot: 'start',
-                    variant: 'solid',
-                  })}
+                  ${waIcon('arrow-up-right-from-square', { slot: 'start' })}
                   Open Install Page
                 </wa-button>
               `

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -417,8 +417,7 @@ export class ToolCard extends LitElement {
     if (!this.item.authNote) return nothing;
     return html`
       <span class="tool-auth-note">
-        ${waIcon('key')}
-        ${this.item.authNote}
+        ${waIcon('key')} ${this.item.authNote}
       </span>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -240,15 +240,13 @@ export class AgentsTab extends LitElement {
             @wa-tab-show=${this.handleSubTabShow}
           >
             <wa-tab panel="workflow">
-              ${waIcon('symbol-method')}
-              Workflow
+              ${waIcon('symbol-method')} Workflow
               <span class="agents-sub-tab-count"
                 >(${this.workflowAgents.length})</span
               >
             </wa-tab>
             <wa-tab panel="toolUse">
-              ${waIcon('tools')}
-              Tool Use
+              ${waIcon('tools')} Tool Use
               <span class="agents-sub-tab-count"
                 >(${this.toolUseAgents.length})</span
               >
@@ -262,8 +260,7 @@ export class AgentsTab extends LitElement {
               title="Save current agent configuration as a team"
               @click=${this.handleSaveTeam}
             >
-              ${waIcon('save', { slot: 'start' })}
-              Save Team
+              ${waIcon('save', { slot: 'start' })} Save Team
             </wa-button>
             ${this.desktopHost
               ? nothing
@@ -275,8 +272,7 @@ export class AgentsTab extends LitElement {
                     title="Create a new agent from a blank YAML template"
                     @click=${this.handleCreateFromTemplate}
                   >
-                    ${waIcon('new-file', { slot: 'start' })}
-                    From Template
+                    ${waIcon('new-file', { slot: 'start' })} From Template
                   </wa-button>
                   <wa-button
                     class="agents-create-btn"
@@ -286,8 +282,7 @@ export class AgentsTab extends LitElement {
                     title="Create a new agent with AI"
                     @click=${this.handleCreateAgent}
                   >
-                    ${waIcon('add', { slot: 'start' })}
-                    New Agent
+                    ${waIcon('add', { slot: 'start' })} New Agent
                   </wa-button>
                 `}
           </div>

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -24,6 +24,7 @@ import {
 import type { AgentCategory } from '@shared/schemas/agent';
 import type { AgentSelectionItem } from '@shared/schemas/settingsViewMessages';
 import type { WaTabShowEvent } from '@shared/wa/tabs';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { AgentSelectionEvents } from '../components/profile/events';
 
 // Local imports - settings view components (side-effect: register)
@@ -239,14 +240,14 @@ export class AgentsTab extends LitElement {
             @wa-tab-show=${this.handleSubTabShow}
           >
             <wa-tab panel="workflow">
-              <wa-icon library="texra" name="symbol-method"></wa-icon>
+              ${waIcon('symbol-method')}
               Workflow
               <span class="agents-sub-tab-count"
                 >(${this.workflowAgents.length})</span
               >
             </wa-tab>
             <wa-tab panel="toolUse">
-              <wa-icon library="texra" name="tools"></wa-icon>
+              ${waIcon('tools')}
               Tool Use
               <span class="agents-sub-tab-count"
                 >(${this.toolUseAgents.length})</span
@@ -261,7 +262,7 @@ export class AgentsTab extends LitElement {
               title="Save current agent configuration as a team"
               @click=${this.handleSaveTeam}
             >
-              <wa-icon slot="start" library="texra" name="save"></wa-icon>
+              ${waIcon('save', { slot: 'start' })}
               Save Team
             </wa-button>
             ${this.desktopHost
@@ -274,11 +275,7 @@ export class AgentsTab extends LitElement {
                     title="Create a new agent from a blank YAML template"
                     @click=${this.handleCreateFromTemplate}
                   >
-                    <wa-icon
-                      slot="start"
-                      library="texra"
-                      name="new-file"
-                    ></wa-icon>
+                    ${waIcon('new-file', { slot: 'start' })}
                     From Template
                   </wa-button>
                   <wa-button
@@ -289,7 +286,7 @@ export class AgentsTab extends LitElement {
                     title="Create a new agent with AI"
                     @click=${this.handleCreateAgent}
                   >
-                    <wa-icon slot="start" library="texra" name="add"></wa-icon>
+                    ${waIcon('add', { slot: 'start' })}
                     New Agent
                   </wa-button>
                 `}
@@ -298,7 +295,7 @@ export class AgentsTab extends LitElement {
 
         <!-- Row 2: Custom directory info bar -->
         <div class="agents-dir-bar">
-          <wa-icon library="texra" name="folder"></wa-icon>
+          ${waIcon('folder')}
           <span class="agents-dir-label">Custom agents:</span>
           <span class="agents-dir-path" title=${this.customAgentDir}
             >${this.customAgentDir}</span
@@ -317,7 +314,7 @@ export class AgentsTab extends LitElement {
               @click=${this.handleOpenFolder}
               title="Open folder in file explorer"
             >
-              <wa-icon library="texra" name="folder-opened"></wa-icon>
+              ${waIcon('folder-opened')}
             </button>
             <wa-button
               appearance="outlined"

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -276,8 +276,7 @@ export class GitTab extends LitElement {
                           size="small"
                           @click=${this.handleRemoveGitHubToken}
                         >
-                          ${waIcon('trash', { slot: 'start' })}
-                          Remove
+                          ${waIcon('trash', { slot: 'start' })} Remove
                         </wa-button>`
                       : nothing}
                     <wa-button
@@ -286,8 +285,7 @@ export class GitTab extends LitElement {
                       size="small"
                       @click=${this.handleOpenGitHubTokenUrl}
                     >
-                      ${waIcon('github', { slot: 'start' })}
-                      Create on GitHub…
+                      ${waIcon('github', { slot: 'start' })} Create on GitHub…
                     </wa-button>
                   </span>
                 </div>
@@ -388,8 +386,7 @@ export class GitTab extends LitElement {
                           @click=${() =>
                             this.handleUnsubscribePR(subscription.key)}
                         >
-                          ${waIcon('debug-stop', { slot: 'start' })}
-                          Stop
+                          ${waIcon('debug-stop', { slot: 'start' })} Stop
                         </wa-button>
                       </li>
                     `,

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -10,6 +10,7 @@ import {
   renderSetStatusIcon,
   statusCheckIconStyles,
 } from '@shared/wa/statusIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Web Awesome icon bundle (side-effect import)
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -264,11 +265,7 @@ export class GitTab extends LitElement {
                       size="small"
                       @click=${this.handleSetGitHubToken}
                     >
-                      <wa-icon
-                        slot="start"
-                        library="texra"
-                        name="key"
-                      ></wa-icon>
+                      ${waIcon('key', { slot: 'start' })}
                       ${tokenIsSet ? 'Replace token' : 'Set token'}
                     </wa-button>
                     ${this.githubTokenStatus === 'secret'
@@ -279,11 +276,7 @@ export class GitTab extends LitElement {
                           size="small"
                           @click=${this.handleRemoveGitHubToken}
                         >
-                          <wa-icon
-                            slot="start"
-                            library="texra"
-                            name="trash"
-                          ></wa-icon>
+                          ${waIcon('trash', { slot: 'start' })}
                           Remove
                         </wa-button>`
                       : nothing}
@@ -293,11 +286,7 @@ export class GitTab extends LitElement {
                       size="small"
                       @click=${this.handleOpenGitHubTokenUrl}
                     >
-                      <wa-icon
-                        slot="start"
-                        library="texra"
-                        name="github"
-                      ></wa-icon>
+                      ${waIcon('github', { slot: 'start' })}
                       Create on GitHub…
                     </wa-button>
                   </span>
@@ -376,11 +365,9 @@ export class GitTab extends LitElement {
                                               owner.streamId,
                                             )}
                                         >
-                                          <wa-icon
-                                            slot="start"
-                                            library="texra"
-                                            name="comment-discussion"
-                                          ></wa-icon>
+                                          ${waIcon('comment-discussion', {
+                                            slot: 'start',
+                                          })}
                                           Jump to agent
                                         </wa-button>
                                       </div>
@@ -401,11 +388,7 @@ export class GitTab extends LitElement {
                           @click=${() =>
                             this.handleUnsubscribePR(subscription.key)}
                         >
-                          <wa-icon
-                            slot="start"
-                            library="texra"
-                            name="debug-stop"
-                          ></wa-icon>
+                          ${waIcon('debug-stop', { slot: 'start' })}
                           Stop
                         </wa-button>
                       </li>

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -14,6 +14,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
 import { renderLoadingState } from '@shared/wa/loadingState';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Web Awesome button + icon bundles (side-effect imports)
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -275,11 +276,7 @@ export class LaTeXTab extends LitElement {
                         }),
                       )}
                   >
-                    <wa-icon
-                      slot="start"
-                      library="texra"
-                      name="cloud-download"
-                    ></wa-icon>
+                    ${waIcon('cloud-download', { slot: 'start' })}
                     ${dep.actionLabel ?? 'Install'}
                   </wa-button>
                 `
@@ -301,11 +298,7 @@ export class LaTeXTab extends LitElement {
                   title="Run: ${installCmd.command}"
                   @click=${() => this.handleRunInTerminal(installCmd.command)}
                 >
-                  <wa-icon
-                    slot="start"
-                    library="texra"
-                    name="terminal"
-                  ></wa-icon>
+                  ${waIcon('terminal', { slot: 'start' })}
                   Run in Terminal
                 </wa-button>
               </div>
@@ -365,7 +358,7 @@ export class LaTeXTab extends LitElement {
   ): TemplateResult {
     return html`
       <wa-callout class="prerequisite-hint" variant="brand">
-        <wa-icon library="texra" name="info" slot="icon"></wa-icon>
+        ${waIcon('info', { slot: 'icon' })}
         <div class="hint-title">${title}</div>
         <div class="hint-description">${description}</div>
         <div class="hint-actions">
@@ -380,7 +373,7 @@ export class LaTeXTab extends LitElement {
               : `Run ${pmName} installer in VS Code terminal`}
             @click=${() => this.handleRunInTerminal(installCommand)}
           >
-            <wa-icon slot="start" library="texra" name="terminal"></wa-icon>
+            ${waIcon('terminal', { slot: 'start' })}
             Run in Terminal
           </wa-button>
         </div>
@@ -395,7 +388,7 @@ export class LaTeXTab extends LitElement {
 
     return html`
       <div class="section-header">
-        <wa-icon library="texra" name="package"></wa-icon>
+        ${waIcon('package')}
         Dependencies
       </div>
       ${this.renderPrerequisiteHint()}
@@ -427,7 +420,7 @@ export class LaTeXTab extends LitElement {
                 title="Reset this setting to default"
                 @click=${() => this.handleApply(info.key, true)}
               >
-                <wa-icon slot="start" library="texra" name="discard"></wa-icon>
+                ${waIcon('discard', { slot: 'start' })}
                 Reset
               </wa-button>
             `
@@ -439,7 +432,7 @@ export class LaTeXTab extends LitElement {
                 title="Apply this setting"
                 @click=${() => this.handleApply(info.key)}
               >
-                <wa-icon slot="start" library="texra" name="check"></wa-icon>
+                ${waIcon('check', { slot: 'start' })}
                 Apply
               </wa-button>
             `}
@@ -468,11 +461,7 @@ export class LaTeXTab extends LitElement {
                   title="Apply all recommended settings"
                   @click=${() => this.handleApply()}
                 >
-                  <wa-icon
-                    slot="start"
-                    library="texra"
-                    name="check-all"
-                  ></wa-icon>
+                  ${waIcon('check-all', { slot: 'start' })}
                   Apply All
                 </wa-button>
               </div>
@@ -483,7 +472,7 @@ export class LaTeXTab extends LitElement {
           ? nothing
           : html`
               <div class="section-header" style="margin-top:var(--wa-space-s)">
-                <wa-icon library="texra" name="settings-gear"></wa-icon>
+                ${waIcon('settings-gear')}
                 Recommended Settings
               </div>
 
@@ -506,7 +495,7 @@ export class LaTeXTab extends LitElement {
   private renderInlineCriticismSetting(): TemplateResult {
     return html`
       <div class="section-header" style="margin-top:var(--wa-space-s)">
-        <wa-icon library="texra" name="comment-discussion"></wa-icon>
+        ${waIcon('comment-discussion')}
         Inline Criticism
       </div>
       <div class="setting-card">
@@ -552,7 +541,7 @@ export class LaTeXTab extends LitElement {
     const cv = this.configValues;
     return html`
       <div class="section-header" style="margin-top:var(--wa-space-s)">
-        <wa-icon library="texra" name="zap"></wa-icon>
+        ${waIcon('zap')}
         Compile &amp; Diff
       </div>
       <div class="latex-description">
@@ -714,7 +703,7 @@ export class LaTeXTab extends LitElement {
       title="Reset to default (${defaultDisplay})"
       @click=${() => this.dispatchSetConfigValue(field, undefined)}
     >
-      <wa-icon library="texra" name="discard"></wa-icon>
+      ${waIcon('discard')}
     </wa-button>`;
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -298,8 +298,7 @@ export class LaTeXTab extends LitElement {
                   title="Run: ${installCmd.command}"
                   @click=${() => this.handleRunInTerminal(installCmd.command)}
                 >
-                  ${waIcon('terminal', { slot: 'start' })}
-                  Run in Terminal
+                  ${waIcon('terminal', { slot: 'start' })} Run in Terminal
                 </wa-button>
               </div>
             `
@@ -373,8 +372,7 @@ export class LaTeXTab extends LitElement {
               : `Run ${pmName} installer in VS Code terminal`}
             @click=${() => this.handleRunInTerminal(installCommand)}
           >
-            ${waIcon('terminal', { slot: 'start' })}
-            Run in Terminal
+            ${waIcon('terminal', { slot: 'start' })} Run in Terminal
           </wa-button>
         </div>
       </wa-callout>
@@ -387,10 +385,7 @@ export class LaTeXTab extends LitElement {
       : DEPENDENCIES;
 
     return html`
-      <div class="section-header">
-        ${waIcon('package')}
-        Dependencies
-      </div>
+      <div class="section-header">${waIcon('package')} Dependencies</div>
       ${this.renderPrerequisiteHint()}
       ${dependencies.map((dep) => this.renderDependencyCard(dep))}
     `;
@@ -420,8 +415,7 @@ export class LaTeXTab extends LitElement {
                 title="Reset this setting to default"
                 @click=${() => this.handleApply(info.key, true)}
               >
-                ${waIcon('discard', { slot: 'start' })}
-                Reset
+                ${waIcon('discard', { slot: 'start' })} Reset
               </wa-button>
             `
           : html`
@@ -432,8 +426,7 @@ export class LaTeXTab extends LitElement {
                 title="Apply this setting"
                 @click=${() => this.handleApply(info.key)}
               >
-                ${waIcon('check', { slot: 'start' })}
-                Apply
+                ${waIcon('check', { slot: 'start' })} Apply
               </wa-button>
             `}
       </div>
@@ -461,8 +454,7 @@ export class LaTeXTab extends LitElement {
                   title="Apply all recommended settings"
                   @click=${() => this.handleApply()}
                 >
-                  ${waIcon('check-all', { slot: 'start' })}
-                  Apply All
+                  ${waIcon('check-all', { slot: 'start' })} Apply All
                 </wa-button>
               </div>
             `
@@ -472,8 +464,7 @@ export class LaTeXTab extends LitElement {
           ? nothing
           : html`
               <div class="section-header" style="margin-top:var(--wa-space-s)">
-                ${waIcon('settings-gear')}
-                Recommended Settings
+                ${waIcon('settings-gear')} Recommended Settings
               </div>
 
               <div class="latex-description">
@@ -495,8 +486,7 @@ export class LaTeXTab extends LitElement {
   private renderInlineCriticismSetting(): TemplateResult {
     return html`
       <div class="section-header" style="margin-top:var(--wa-space-s)">
-        ${waIcon('comment-discussion')}
-        Inline Criticism
+        ${waIcon('comment-discussion')} Inline Criticism
       </div>
       <div class="setting-card">
         <wa-icon
@@ -541,8 +531,7 @@ export class LaTeXTab extends LitElement {
     const cv = this.configValues;
     return html`
       <div class="section-header" style="margin-top:var(--wa-space-s)">
-        ${waIcon('zap')}
-        Compile &amp; Diff
+        ${waIcon('zap')} Compile &amp; Diff
       </div>
       <div class="latex-description">
         TeXRA-specific compile and diff behavior, persisted per workspace. These

--- a/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
@@ -5,6 +5,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
 import type { MemoryViewItem } from '@shared/schemas';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { MemoryViewEvents } from '../components/memory/events';
 
@@ -51,11 +52,7 @@ export class MemoryTab extends LitElement {
   private renderMemoryReminder(): TemplateResult {
     return html`
       <div class="settings-reminder memory-reminder">
-        <wa-icon
-          library="texra"
-          name="info"
-          class="settings-reminder-icon"
-        ></wa-icon>
+        ${waIcon('info', { className: 'settings-reminder-icon' })}
         <div class="settings-reminder-body">
           <div class="settings-reminder-title">Memory notes</div>
           <div class="settings-reminder-description">
@@ -70,11 +67,7 @@ export class MemoryTab extends LitElement {
               size="small"
               @click=${this.handleRefresh}
             >
-              <wa-icon
-                slot="start"
-                library="texra"
-                name="rotate-right"
-              ></wa-icon>
+              ${waIcon('rotate-right', { slot: 'start' })}
               Refresh
             </wa-button>
             <wa-button
@@ -84,11 +77,7 @@ export class MemoryTab extends LitElement {
               title="Open memory folder in file explorer"
               @click=${this.handleOpenFolder}
             >
-              <wa-icon
-                slot="start"
-                library="texra"
-                name="folder-open"
-              ></wa-icon>
+              ${waIcon('folder-open', { slot: 'start' })}
               Open Folder
             </wa-button>
           </div>

--- a/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MemoryTab.ts
@@ -67,8 +67,7 @@ export class MemoryTab extends LitElement {
               size="small"
               @click=${this.handleRefresh}
             >
-              ${waIcon('rotate-right', { slot: 'start' })}
-              Refresh
+              ${waIcon('rotate-right', { slot: 'start' })} Refresh
             </wa-button>
             <wa-button
               appearance="outlined"
@@ -77,8 +76,7 @@ export class MemoryTab extends LitElement {
               title="Open memory folder in file explorer"
               @click=${this.handleOpenFolder}
             >
-              ${waIcon('folder-open', { slot: 'start' })}
-              Open Folder
+              ${waIcon('folder-open', { slot: 'start' })} Open Folder
             </wa-button>
           </div>
         </div>

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -100,8 +100,7 @@ export class ModelsTab extends LitElement {
               size="small"
               @click=${this.handleScrollToApiConfig}
             >
-              ${waIcon('key', { slot: 'start' })}
-              Jump to API Configuration
+              ${waIcon('key', { slot: 'start' })} Jump to API Configuration
             </wa-button>
           </div>
         </div>

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -5,6 +5,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Web Awesome icon bundle (side-effect import)
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -87,11 +88,7 @@ export class ModelsTab extends LitElement {
 
     return html`
       <div class="settings-reminder">
-        <wa-icon
-          library="texra"
-          name="info"
-          class="settings-reminder-icon"
-        ></wa-icon>
+        ${waIcon('info', { className: 'settings-reminder-icon' })}
         <div class="settings-reminder-body">
           <div class="settings-reminder-title">API key settings</div>
           <div class="settings-reminder-description">${description}</div>
@@ -103,7 +100,7 @@ export class ModelsTab extends LitElement {
               size="small"
               @click=${this.handleScrollToApiConfig}
             >
-              <wa-icon slot="start" library="texra" name="key"></wa-icon>
+              ${waIcon('key', { slot: 'start' })}
               Jump to API Configuration
             </wa-button>
           </div>

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -244,8 +244,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          ${waIcon('shield')}
-          Approval &amp; Safety
+          ${waIcon('shield')} Approval &amp; Safety
         </div>
 
         <div class="setting-block">
@@ -265,8 +264,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          ${waIcon('desktop-download')}
-          Desktop Diagnostics
+          ${waIcon('desktop-download')} Desktop Diagnostics
         </div>
         <div class="desktop-settings">
           <p class="desktop-settings-title">Native crash reporting</p>
@@ -374,14 +372,12 @@ export class ToolsTab extends LitElement {
           </svg>
           <div class="tools-health-labels">
             <span class="tools-summary-stat tools-stat-available">
-              ${waIcon('check')}
-              ${available} available
+              ${waIcon('check')} ${available} available
             </span>
             ${missing > 0
               ? html`
                   <span class="tools-summary-stat tools-stat-missing">
-                    ${waIcon('warning')}
-                    ${missing} need setup
+                    ${waIcon('warning')} ${missing} need setup
                   </span>
                 `
               : nothing}
@@ -436,8 +432,7 @@ export class ToolsTab extends LitElement {
               title="Re-check tool availability"
               @click=${this.handleRecheck}
             >
-              ${waIcon('refresh', { slot: 'start' })}
-              Re-check
+              ${waIcon('refresh', { slot: 'start' })} Re-check
             </wa-button>
           </div>
         </div>

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -8,6 +8,7 @@ import { repeat } from 'lit/directives/repeat.js';
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
 import { renderLoadingState } from '@shared/wa/loadingState';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
@@ -243,7 +244,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          <wa-icon library="texra" name="shield"></wa-icon>
+          ${waIcon('shield')}
           Approval &amp; Safety
         </div>
 
@@ -264,7 +265,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          <wa-icon library="texra" name="desktop-download"></wa-icon>
+          ${waIcon('desktop-download')}
           Desktop Diagnostics
         </div>
         <div class="desktop-settings">
@@ -296,7 +297,7 @@ export class ToolsTab extends LitElement {
               size="small"
               @click=${this.handleSetDesktopCrashReportingDsn}
             >
-              <wa-icon slot="start" library="texra" name="key"></wa-icon>
+              ${waIcon('key', { slot: 'start' })}
               ${this.desktopCrashReportingConfigured
                 ? 'Replace DSN'
                 : 'Set DSN'}
@@ -373,13 +374,13 @@ export class ToolsTab extends LitElement {
           </svg>
           <div class="tools-health-labels">
             <span class="tools-summary-stat tools-stat-available">
-              <wa-icon library="texra" name="check"></wa-icon>
+              ${waIcon('check')}
               ${available} available
             </span>
             ${missing > 0
               ? html`
                   <span class="tools-summary-stat tools-stat-missing">
-                    <wa-icon library="texra" name="warning"></wa-icon>
+                    ${waIcon('warning')}
                     ${missing} need setup
                   </span>
                 `
@@ -435,7 +436,7 @@ export class ToolsTab extends LitElement {
               title="Re-check tool availability"
               @click=${this.handleRecheck}
             >
-              <wa-icon slot="start" library="texra" name="refresh"></wa-icon>
+              ${waIcon('refresh', { slot: 'start' })}
               Re-check
             </wa-button>
           </div>


### PR DESCRIPTION
## Summary

Continues #6211 — migrates the remaining straightforward raw `<wa-icon library="texra">` tags across **11 settingsView files** to the shared `waIcon()` helper (single owner of the icon standard; auto-applies `aria-hidden` to decorative icons so screen readers don't announce them as unlabeled glyphs).

**62 sites converted:** SettingsApp 16, LaTeXTab 12, AgentsTab 7, ToolsTab 6, ToolCard 5, GitTab 5, Pagination 4, MemoryTab 3, ModelsTab 2, ApiAccessSection 1, HistoryItemElement 1 — `slot`/`class` preserved via `waIcon()` options. **Net −153 LOC** as multi-line tags collapse to one call.

Done as a parallel per-file migration (one agent per file, shared worktree, no overlap), then verified centrally.

## Deferred (left as raw `<wa-icon>`, by design)
~15 sites that can't be faithfully expressed via the current `waIcon()` options:
- **Dynamic name** (`name=${meta.icon}` / `config.icon` / `decorator.icon` / ternaries) — need the icon source typed as `TeXRAIconName` first.
- **Dynamic `title` tooltip** (ModelSelectionList expensive/availability icons) — `waIcon()` has no `title` option; mapping `title`→`label` would change tooltip→aria semantics.
- **`classMap` rotating chevrons** (ModelSelectionList provider/deprecated toggles).

These are a clean follow-up once `waIcon()` grows a `title` option and the icon-name sources are typed.

## Verification
- Extension package **typechecks clean** — `waIcon()`'s `TeXRAIconName` parameter validates every migrated name at compile time.
- Additive a11y improvement; no behavior change beyond decorative icons gaining `aria-hidden`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor in the settings webview with no auth, data, or business-logic changes; main risk is minor markup/a11y regressions on edge cases left on raw icons.
> 
> **Overview**
> Continues the settings webview icon standardization by replacing **~62** inline `<wa-icon library="texra">` usages with the shared **`waIcon()`** helper across **11** settingsView modules (`SettingsApp`, tab components, and shared pieces like pagination and tool cards).
> 
> Imports switch from **`TEXRA_ICON_LIBRARY`** to **`waIcon`**; existing **`slot`** and **`class`** behavior is preserved via helper options (`slot`, `className`). Markup shrinks (multi-line icon tags become single calls), and decorative icons pick up **`aria-hidden`** through the helper without changing visible UI behavior.
> 
> **Intentionally unchanged:** dynamic icon names, tooltip-only icons, and similar cases still use raw `<wa-icon>` until `waIcon()` gains options like `title` and stricter icon-name typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d15c18f8b8c409f670db2606abe946c87a7645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->