### PR TITLE
fix(tools): scope TextEditorTool undo history by run, not just path

### DIFF
--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 
 // Local imports - tool definitions
+import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { toErrorMessage } from '@common/errors';
 import { isTexFile } from '@common/files/fileTypeUtils';
 import * as logger from '@logger/logUtils';
@@ -565,7 +566,8 @@ export class TextEditorTool extends defineTool({
     displayPath: string,
   ): Promise<ToolResult> {
     try {
-      const history = this.fileHistory.get(filePath);
+      const key = this.historyKey(filePath);
+      const history = this.fileHistory.get(key);
       if (!history || history.length === 0) {
         throw new ToolError(`No edit history found for ${displayPath}.`);
       }
@@ -601,7 +603,7 @@ export class TextEditorTool extends defineTool({
       recordToolFileRead(filePath);
 
       if (history.length === 0) {
-        this.fileHistory.delete(filePath);
+        this.fileHistory.delete(key);
       }
 
       const userDiffNote = formatUnifiedApprovalUserDiff(
@@ -645,12 +647,26 @@ export class TextEditorTool extends defineTool({
     return userDiffNote ? `${baseMsg}\n\n${userDiffNote}` : baseMsg;
   }
 
+  /**
+   * Scope undo history to the run that produced the edit. `fileHistory` is a
+   * process singleton (one TextEditorTool in the default registry), so keying by
+   * path alone bleeds edits across concurrent runs — a non-awaited subagent and
+   * its parent editing the same absolute path share the stack, so undo_edit could
+   * pop, or silently write to disk under YOLO, a foreign run's snapshot. Keying
+   * by the active run's executionId isolates them; with no run context
+   * (tests/manual) it collapses to the prior path-only behavior.
+   */
+  private historyKey(filePath: string): string {
+    return `${tryUseRunContext()?.executionId ?? ''}\u0000${filePath}`;
+  }
+
   private addToHistory(filePath: string, content: string): void {
-    const history = this.fileHistory.get(filePath);
+    const key = this.historyKey(filePath);
+    const history = this.fileHistory.get(key);
     if (history) {
       history.push(content);
     } else {
-      this.fileHistory.set(filePath, [content]);
+      this.fileHistory.set(key, [content]);
     }
   }
 


### PR DESCRIPTION
## The bug

`TextEditorTool.fileHistory` is a **process singleton** — one `new TextEditorTool()` in the default registry (`registry.ts`), and both `executeAgent` call sites pass `undefined` for the tool registry, so every run resolves the same instance. Its undo stack is a `Map<string, string[]>` keyed **only by absolute filePath**.

Subagents run via a **non-awaited** `executeAgent` (`DelegationTools.ts`), so a parent and a default-cwd subagent overlap on the event loop and a same-named edit resolves the **same absolute path → same map key**. Then `undo_edit` reads `history.at(-1)` — a *foreign* run's snapshot — and writes it to disk via `writeApprovedContent`; under YOLO (common on child streams) the approval auto-accepts, so the **wrong on-disk revert is silent**. The interleaved read-modify-write can also pop the wrong entry.

## The fix

Key the history by the active run's `executionId` (`tryUseRunContext()`) plus the path, with a `` separator (can appear in neither the hex id nor a path). Concurrent runs no longer share a stack. With no run context (tests/manual) the key collapses to path-only — **prior behavior preserved**. The sibling read-before-edit tracker is **already per-run**, so this removes an inconsistency rather than adding a concept (no new abstraction — just a rekey of the existing map).

## Verification
- `tsc --noEmit` (root **and** `tsconfig.test-kernel.json`), prettier, eslint clean.

A two-run undo-isolation regression test is a recommended follow-up (`ToolEditApprovalGate.vitest` is the closest harness).

---
🤖 Deep audit round 11 (concurrency: per-run state on a process singleton). Re-verified end-to-end against live code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes file-edit undo semantics on a shared singleton tool; wrong keying could break undo in edge cases, but scope is limited to in-memory history lookup.
> 
> **Overview**
> **Fixes cross-run bleed on `undo_edit`** when overlapping agent runs edit the same file through the shared process `TextEditorTool` instance.
> 
> Undo snapshots in `fileHistory` are now keyed by **`executionId` + path** (via `tryUseRunContext()` and a `historyKey` helper) instead of path alone, so concurrent parent/subagent runs no longer share one stack and `undo_edit` cannot revert to another run’s snapshot (including silent wrong writes under YOLO). **Tests and manual use without run context** keep path-only keys, matching previous behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ab520234aeb863099bed3d946cc31361a16103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->