### PR TITLE
fix(github): pass the bind-time session to subscription follow-ups

### DIFF
--- a/src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
@@ -1,8 +1,18 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+const sendFollowUpMock = vi.hoisted(() =>
+  vi.fn(async () => ({ status: 'sent' as const })),
+);
+
+vi.mock('@agent/toolUse/ToolUseFollowUp', () => ({
+  sendFollowUp: sendFollowUpMock,
+}));
+
 // Local imports - agent runtime
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 
 // Local imports - shared schemas
 import type { StreamTabId } from '@shared/schemas';
@@ -63,6 +73,7 @@ class TestPollingSource extends PollingSourceBase<
 class RegistryTestSource {
   private readonly keys = new Set<string>();
   private readonly keyListeners = new Set<(keys: readonly string[]) => void>();
+  private readonly onEventByKey = new Map<string, (text: string) => void>();
 
   has(key: string): boolean {
     return this.keys.has(key);
@@ -84,16 +95,21 @@ class RegistryTestSource {
     onEvent: (text: string) => void,
     runtimeHost: AgentRuntimeHost,
   ): { dispose(): void } {
-    void onEvent;
     void runtimeHost;
     this.keys.add(input);
+    this.onEventByKey.set(input, onEvent);
     this.emitKeysChanged();
     return {
       dispose: () => {
         this.keys.delete(input);
+        this.onEventByKey.delete(input);
         this.emitKeysChanged();
       },
     };
+  }
+
+  emit(input: string, text: string): void {
+    this.onEventByKey.get(input)?.(text);
   }
 
   private emitKeysChanged(): void {
@@ -198,5 +214,38 @@ describe('GitHub subscription progress events', () => {
     expect(host.events).toEqual([
       { event: 'repoSubscriptionBindingsChanged', payload: undefined },
     ]);
+  });
+
+  it('passes the bind-time session to detached subscription follow-ups', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const host = createRecordingHost();
+    const source = new RegistryTestSource();
+    const session = { tag: 'window-session' } as unknown as SessionHandle;
+    const registry = new StreamSubscriptionRegistry<string, string>({
+      name: 'test subscriptions',
+      source,
+      keyOf: (input) => input,
+      bindingsChangedEvent: 'repoSubscriptionBindingsChanged',
+    });
+    sendFollowUpMock.mockClear();
+
+    withRunContext(
+      createRunContext({
+        runtimeHost: host.host,
+        streamId,
+        session,
+      }),
+      () => registry.bind(streamId, 'owner/repo', host.host),
+    );
+
+    source.emit('owner/repo', 'new github event');
+
+    expect(sendFollowUpMock).toHaveBeenCalledWith(
+      streamId,
+      'new github event',
+      undefined,
+      undefined,
+      session,
+    );
   });
 });

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -15,6 +15,10 @@ import type { AgentTrace } from '@agent/trace';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  currentSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -61,6 +65,15 @@ interface BoundSubscription {
   disposable: Disposable;
   onEvent: (text: string) => void;
   runtimeHost: AgentRuntimeHost;
+  /**
+   * Session captured at bind() time (inside the run's AsyncLocalStorage).
+   * onEvent fires later from a detached polling timer where the ALS is empty, so
+   * it must pass this session to sendFollowUp explicitly — otherwise sendFollowUp
+   * falls back to defaultSession() and the follow-up is misrouted/dropped on a
+   * non-default session (e.g. a desktop per-window session). Mirrors
+   * ExecutionSubscriptionBinder.
+   */
+  session: SessionHandle;
 }
 
 export class StreamSubscriptionRegistry<K extends string, Input> {
@@ -85,6 +98,10 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   ): boolean {
     this.ensureHooks();
     const key = this.opts.keyOf(input);
+    // Capture the session HERE: bind() runs inside the run's AsyncLocalStorage
+    // (the github tool's execute()), but onEvent fires later from a detached
+    // polling timer where the ALS is empty.
+    const session = currentSession();
     let bound = this.perStream.get(streamId);
     if (!bound) {
       bound = new Map();
@@ -93,6 +110,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     const existing = bound.get(key);
     if (existing) {
       existing.runtimeHost = runtimeHost;
+      existing.session = session;
       this.opts.source.updateSubscription?.(
         input,
         existing.onEvent,
@@ -107,9 +125,16 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       disposable: { dispose: () => {} },
       onEvent: () => {},
       runtimeHost,
+      session,
     };
     subscription.onEvent = (text: string) => {
-      void sendFollowUp(streamId, text).then((result) => {
+      void sendFollowUp(
+        streamId,
+        text,
+        undefined,
+        undefined,
+        subscription.session,
+      ).then((result) => {
         if (result.status === 'sent' || result.status === 'queued') {
           subscription.runtimeHost.emit('updateQueuedFollowUps', { streamId });
         }


### PR DESCRIPTION
## The defect

`StreamSubscriptionRegistry.onEvent` called `sendFollowUp(streamId, text)` with **no session**. But `onEvent` fires from the polling source's `setInterval` timer — **detached** from the run's `AsyncLocalStorage` — so `sendFollowUp` falls back to `currentSession()` → `defaultSession()`.

`getToolUseFollowUpTarget` is a **per-`SessionHandle`** lookup, so on a non-default session (e.g. a desktop **per-window** `SessionHandle`) the wrong registry is queried, the target resolves to `no_session`, and the live GitHub subscription follow-up is **silently dropped** (only a `warn`).

`sendFollowUp`'s own docstring requires detached host-path callers to pass their session, and the two siblings already comply — `ExecutionSubscriptionBinder.send` threads `this.session`, and the desktop IPC path threads its window session. `StreamSubscriptionRegistry` was the **lone violator** of that contract.

## The fix

Mirror `ExecutionSubscriptionBinder`: capture `currentSession()` in `bind()` (which runs inside the github tool's `execute()` — ALS still active), store it on `BoundSubscription`, refresh it on the re-bind path, and pass it as the `session` arg of `sendFollowUp` from the detached `onEvent`.

```ts
const session = currentSession();           // bind(): ALS active
// ...
subscription.onEvent = (text) =>
  void sendFollowUp(streamId, text, undefined, undefined, subscription.session)...
```

`+1` field, no new abstraction. In the extension (single default session) behavior is unchanged; on desktop multi-window it stops dropping events.

## Verification
- `tsc --noEmit` (root **and** `tsconfig.test-kernel.json`), prettier, eslint clean.
- `GitHubSubscriptionProgressEvents.vitest` + `ExecutionSubscriptionBinderSession.vitest` pass (6/6).

---
🤖 Deep audit round 11 (concurrency: run-scoped session resolved from a detached timer). Re-verified against live code, including the documented `sendFollowUp` contract and its two compliant callers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent follow-up routing for live GitHub subscriptions; behavior is unchanged on the default session but fixes misrouting on multi-window desktop.
> 
> **Overview**
> Fixes **silent loss of GitHub subscription follow-ups** on non-default sessions (e.g. desktop per-window handles). Polling `onEvent` runs outside run `AsyncLocalStorage`, so `sendFollowUp(streamId, text)` was resolving the wrong session and dropping events.
> 
> **`StreamSubscriptionRegistry`** now captures `currentSession()` in `bind()` (and refreshes it on re-bind), stores it on `BoundSubscription`, and passes that session into `sendFollowUp` from the detached callback—matching **`ExecutionSubscriptionBinder`**.
> 
> Tests mock `sendFollowUp` and assert the bind-time session is forwarded when the test source emits an event after `withRunContext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f0440511c16d40dbc33710c082a76e195b00bd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->