### PR TITLE
fix(cli): clean up the TUI approval pipeline per-run, not at session teardown

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1312,7 +1312,6 @@ export async function runChat(
       wrapped,
     );
     const unbindApprovals = installTuiApprovals(wrapped, sessionContext);
-    disposers.push(unbindApprovals);
     const executionId = generateExecutionId();
     let waitingTurn = 0;
     let executionRegistered = false;
@@ -1391,6 +1390,10 @@ export async function runChat(
       })
       .finally(() => {
         detachResultToast();
+        // Per-run: restore host.emit + clear the global tool-edit handler now,
+        // not at session teardown — otherwise a stale handler bound to this dead
+        // run's host survives between turns and disposers[] grows each turn.
+        unbindApprovals();
         if (session.runtimeHost === wrapped) session.runtimeHost = undefined;
         markChatTuiRunCompleted(session);
         void runtimeHost.close();
@@ -1479,7 +1482,6 @@ export async function runChat(
       wrapped,
     );
     const unbindApprovals = installTuiApprovals(wrapped, sessionContext);
-    disposers.push(unbindApprovals);
     const approvalsUnavailable = approvalPromptsUnavailable(sessionContext);
 
     session.runPromise = setCliHelperModel(currentModel)
@@ -1508,6 +1510,10 @@ export async function runChat(
       })
       .finally(() => {
         detachResultToast();
+        // Per-run: restore host.emit + clear the global tool-edit handler now,
+        // not at session teardown — otherwise a stale handler bound to this dead
+        // run's host survives between turns and disposers[] grows each turn.
+        unbindApprovals();
         if (session.runtimeHost === wrapped) session.runtimeHost = undefined;
         markChatTuiRunCompleted(session);
         void runtimeHost.close();


### PR DESCRIPTION
## The defect

`installTuiApprovals` wraps `host.emit` and installs a **process-global** tool-edit approval handler (`setToolEditApprovalHandler`), returning an `unbind` that restores `emit` + clears the handler. Both run call sites pushed that `unbind` into the **session-lifetime** `disposers[]` array:

```ts
const unbindApprovals = installTuiApprovals(wrapped, sessionContext);
disposers.push(unbindApprovals);   // ← only drained at session teardown (line ~1968)
```

…instead of the per-run `.finally()` where `detachResultToast()` (its exact lifecycle sibling) already runs. Consequences across turns:

- The **previous run's** tool-edit handler stays installed — bound to a now-dead `runtimeHost`/context — until the whole session ends.
- `disposers[]` **grows by one every turn** (a small but unbounded leak).

## The fix

Move `unbindApprovals()` into each run's `.finally()`, right after `detachResultToast()`, and drop the `disposers.push` at both call sites:

```ts
.finally(() => {
  detachResultToast();
  unbindApprovals();   // per-run: restore emit + clear the global handler now
  ...
});
```

The approval pipeline is now strictly per-run, matching the established `detachResultToast` lifecycle. No stale handler survives between turns; `disposers[]` stops growing. (Aligns with the TUI's per-run vs session-lifetime ownership discipline.)

## Verification
- CLI `tsc --noEmit` + `tsconfig.test-kernel.json`, prettier, eslint clean.
- `ApprovalQueue.vitest` (4/4), `RunChatRegistration.vitest` (4/4), `CliPersistenceFlush.vitest` (2/2) pass.

---
🤖 Deep audit round 12 (lifecycle: per-run disposer parked in session-lifetime storage). Re-verified against live code; the 6 sibling session-lifetime `disposers.push` calls are correctly once-per-session — only these two per-run pushes were misplaced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lifecycle-only change in the chat TUI; aligns approval cleanup with existing per-run toast teardown and does not alter approval policy behavior.
> 
> **Overview**
> **Moves TUI approval teardown to match each agent run’s lifecycle** instead of deferring it until the whole chat session ends.
> 
> `installTuiApprovals` returns an `unbind` that restores the wrapped `host.emit` and clears the process-global tool-edit handler. That cleanup now runs in each run’s `.finally()` (next to `detachResultToast()`) for both fresh runs (`startAgentRun`) and resumed runs (`resumeAgentRun`). The `disposers.push(unbindApprovals)` calls are removed.
> 
> This stops stale approval handlers from staying bound to a finished run’s host between turns and prevents `disposers[]` from growing on every turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd55a0ad1d3a4008a667f98828f7bd268d88d483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->