### PR TITLE
fix(security): end rg option parsing in the grep tool (stop --pre flag injection)

### DIFF
--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -120,7 +120,19 @@ export class GrepTool extends defineTool({
       ignoreFile,
     ]);
 
-    const command = ['rg', ...args, ...ignoreArgs, input.pattern, path.fsPath];
+    // `--` ends rg option parsing so the LLM-controlled pattern can't be read as
+    // a flag — e.g. `--pre=<cmd>` would run <cmd> as a preprocessor on every
+    // searched file (code execution via this non-approval-gated tool). Our own
+    // flags in args/ignoreArgs precede it and are unaffected; a leading-dash
+    // literal pattern (e.g. "-foo") now searches correctly instead of erroring.
+    const command = [
+      'rg',
+      ...args,
+      ...ignoreArgs,
+      '--',
+      input.pattern,
+      path.fsPath,
+    ];
 
     const result = await executeCommand(command, {
       cwd: root,


### PR DESCRIPTION
## The vulnerability (high severity — approval-gate bypass → code execution)

`grep` builds its ripgrep command with **no end-of-options separator**:

```ts
const command = ['rg', ...args, ...ignoreArgs, input.pattern, path.fsPath];
```

`input.pattern` is **LLM-controlled** (`z.string().min(1)` — no leading-dash check). ripgrep treats a leading-`-` positional as a flag, so a pattern of `--pre=/abs/path/script.sh` makes rg run that script as a **preprocessor on every searched file** — i.e. arbitrary local code execution. `executeCommand` passes an **execa arg-array** (no shell), so this is argument injection *into rg itself*, not shell injection.

Critically, `GrepTool` has **no approval flow** (unlike `bash`/`codex`/Wolfram, which call `requestBashApproval`). So a steered agent — poisoned input doc, crafted model output, or a remote-agent response — reaches code execution **without** the approval prompt the user relies on, and can stage the script first with the (also non-gated) write tool.

## The fix

Insert a literal `--` before the pattern:

```ts
const command = ['rg', ...args, ...ignoreArgs, '--', input.pattern, path.fsPath];
```

After `--`, rg treats `input.pattern` and `path.fsPath` as positionals (pattern + path) and **will not interpret a leading dash as a flag**. Our own flags (`args`, `ignoreArgs`) precede the `--` and are unaffected.

No legitimate search behavior changes — and as a bonus, a *literal* leading-dash pattern (e.g. searching for `-foo`) now works instead of erroring.

## Verification
- `tsc --noEmit` (root + `tsconfig.test-kernel.json`), prettier, eslint clean.
- `grep.vitest` (4/4) passes — `buildArguments` is unchanged.
- Confirmed `executeCommand` uses an execa arg-array (no shell) and `GrepTool.execute` has no approval gate, so the `--` guard is the complete fix.

---
🤖 Security/integrity audit (argument-injection lens). Re-verified end-to-end against live code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line hardening in grep command construction; reduces security risk with no intended behavior change for normal searches.
> 
> **Overview**
> Closes an **approval-bypass code-execution path** in the non-gated `grep` tool by inserting ripgrep’s `--` end-of-options marker **before** the LLM-controlled `input.pattern`.
> 
> Without it, a pattern starting with `-` (e.g. `--pre=<script>`) could be parsed as an `rg` flag and run arbitrary commands as a per-file preprocessor. Trusted flags in `args` / `ignoreArgs` stay before `--`; only the pattern and search path are forced to be positionals afterward.
> 
> **Bonus:** literal searches for strings that start with `-` (e.g. `-foo`) work instead of failing as invalid flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 370e958724965515c87c0bb82b5e41136427d2f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->