### PR TITLE
fix(security): reject path traversal in the executions files reader

### DIFF
--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -109,6 +109,15 @@ describe('ExecutionsTool', () => {
     expect(result.error).toContain('Invalid input');
   });
 
+  it("rejects '..' path traversal in /executions/{id}/files/{path}", async () => {
+    const result = await new ExecutionsTool().call({
+      path: '/executions/abc123def456/files/../../../../../../etc/passwd',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain("must not contain '..'");
+  });
+
   it('does not duplicate auto-delivered live subagent reports for the parent stream', async () => {
     const explicit = createRecordingHost();
     const session = new SessionHandle();

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -854,6 +854,12 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     viewRange?: [number, number],
   ): Promise<ToolResult> {
     const displayPath = `/executions/${executionId}/files/${filePath}`;
+    // Contain the read to the run's storage dir: resolveStoragePath joins
+    // filePath under executions/{id}, so a `..` segment would escape the storage
+    // root and read arbitrary host files. Mirrors AcceptRunFilesTool's guard.
+    if (getPathSegments(filePath).includes('..')) {
+      throw new ToolError(`path must not contain '..': ${filePath}`);
+    }
     const fullPath = await resolveStoragePath(executionId, filePath);
     if (!fullPath) {
       throw new ToolError(`File not found: ${displayPath}`);


### PR DESCRIPTION
## The vulnerability (high severity — arbitrary host-file read, approval-gate bypass)

The `/executions/{id}/files/{path}` reader routes straight to `readFile(executionId, rest.join('/'))` and passes the path into `resolveStoragePath`, which `path.join`s it under `executions/{id}`. A `..` segment collapses out and **escapes the storage root**:

```
/executions/<validHexId>/files/../../../../../../etc/passwd
```

The execution id is enumerable via the `/executions` listing, and the tool has **no approval gate**, so a steered agent (poisoned input doc, crafted model output, remote-agent response) can read arbitrary readable host files — `/etc/passwd`, `~/.ssh/id_rsa`, `~/.texra` tokens — straight into the conversation. Local single-user → secret/data exfiltration.

The asymmetry confirms it's an oversight: the sibling `readWorkspaceFile` is protected by a recorded-paths allowlist, and `AcceptRunFilesTool` already rejects `..` (`getPathSegments(...).includes('..')`). Only this `/files/` reader was unguarded.

## The fix

Add the same guard at the top of `readFile` (mirroring `AcceptRunFilesTool`; `getPathSegments` is already imported):

```ts
if (getPathSegments(filePath).includes('..')) {
  throw new ToolError(`path must not contain '..': ${filePath}`);
}
```

Legitimate subdirectory reads (e.g. `r0/output.tex`) are unaffected — recorded run files are always subdir-relative.

## Verification
- `tsc --noEmit` (root + `tsconfig.test-kernel.json`), prettier, eslint clean.
- `ExecutionsToolWorkspaceFiles.vitest` **9/9**, including a new test asserting `/files/../../../etc/passwd` is rejected.
- Checked the other `/executions` sinks: `readProcessOutput`/`listFiles` take no user path, and `workspace-files` is allowlisted — the `/files/` reader was the lone sink.

---
🤖 Security/integrity audit (path-traversal lens). Re-verified against live code; mirrors the existing `AcceptRunFilesTool` guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted security fix aligned with an existing guard elsewhere; behavior change is limited to rejecting malicious paths.
> 
> **Overview**
> Closes a **path traversal** hole on `/executions/{id}/files/{path}`: user-supplied segments were joined under the run storage directory without rejecting `..`, so paths like `../../../../../../etc/passwd` could read arbitrary host files via the ungated executions tool.
> 
> **`ExecutionsTool.readFile`** now rejects any `filePath` whose segments include `..` (same `getPathSegments` check as **`AcceptRunFilesTool`**), before `resolveStoragePath` runs. Normal subpaths under the run dir are unchanged.
> 
> A **vitest** case asserts traversal requests fail with `must not contain '..'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c5f1c492e65f7ffd3af4c682852386d3d50cc66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->