### PR TITLE
fix(security): redact the set_api_key key from the persisted transcript

### DIFF
--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -8,6 +8,7 @@ import {
   StreamLogStore,
 } from '@transcript';
 import {
+  emitToolUseCard,
   endToolUseCard,
   startToolUseCard,
   type AgentTrace,
@@ -225,6 +226,30 @@ describe('AgentTrace stream output', () => {
 });
 
 describe('tool-use card groupId resolution', () => {
+  it('redacts set_api_key input from fast-tool transcript persistence', () => {
+    withStore((store, logger) => {
+      const rawInput = { provider: 'openai', key: 'sk-secret-value' };
+      const ref = emitToolUseCard(logger, {
+        toolName: 'set_api_key',
+        input: rawInput,
+        summary: 'Stored OpenAI API key',
+        output: 'Stored API key for provider "openai".',
+        status: 'completed',
+      });
+
+      const entries = store.get('stream')?.getRange(0) ?? [];
+      const toolEntry = entries.find((e) => e.id === ref.logId);
+
+      expect(toolEntry?.data).toMatchObject({
+        toolName: 'set_api_key',
+        input: { provider: 'openai', key: '[redacted]' },
+        status: 'completed',
+      });
+      expect(JSON.stringify(toolEntry?.data)).not.toContain('sk-secret-value');
+      expect(rawInput.key).toBe('sk-secret-value');
+    });
+  });
+
   it('reuses the captured groupId when endToolUseCard is called with no explicit stage', async () => {
     const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -62,6 +62,26 @@ function debugModeEnabled(): boolean {
   return getConfig<boolean>('texra.logger.debugMode', false);
 }
 
+/**
+ * Redact secrets from a tool's recorded input before it is persisted. The
+ * set_api_key tool masks its own user-facing result, but tool.start/tool.end can
+ * carry the raw input — which would write the cleartext provider key to the
+ * on-disk transcript (and reload it via history/restorable state). Keep this in
+ * sync with SetApiKeyTool.name; new secret-bearing tool inputs must extend this
+ * guard.
+ */
+function redactToolInputForLog(toolName: string, input: unknown): unknown {
+  if (
+    toolName === 'set_api_key' &&
+    input !== null &&
+    typeof input === 'object' &&
+    'key' in input
+  ) {
+    return { ...(input as Record<string, unknown>), key: '[redacted]' };
+  }
+  return input;
+}
+
 interface StreamSinkState {
   buffer: string;
   pending: string[];
@@ -197,7 +217,7 @@ export function attachTranscriptRecorder(
           messageType: MESSAGE_TYPES.TOOL_USE,
           data: {
             toolName: event.toolName,
-            input: event.input,
+            input: redactToolInputForLog(event.toolName, event.input),
             status: 'in_progress',
           } satisfies ToolUseLog,
           verbose: debugModeEnabled(),
@@ -206,13 +226,20 @@ export function attachTranscriptRecorder(
 
       case 'tool.end': {
         const result = (event.result ?? {}) as Partial<ToolUseLog>;
+        const redactedResult =
+          typeof result.toolName === 'string'
+            ? {
+                ...result,
+                input: redactToolInputForLog(result.toolName, result.input),
+              }
+            : result;
         // Omit groupId on update — undefined would clobber the canonical
         // value stamped at tool.start (deferred tools never copy the
         // resolved id back into their ref).
         store.update(streamId, event.logId, {
           messageType: MESSAGE_TYPES.TOOL_USE,
           data: {
-            ...result,
+            ...redactedResult,
             status: event.status,
           } as ToolUseLog,
         });


### PR DESCRIPTION
## The issue (cleartext secret persisted to disk)

`set_api_key` carefully **masks its own user-facing result** — but `tool.start` records the raw tool **input** verbatim:

```ts
// TexraTranscriptRecorder, tool.start handler
input: event.input,   // ← { provider, key: '<the raw key the user pasted>' }
```

So the documented setup flow (user pastes their provider key in chat → agent calls `set_api_key`) writes the **cleartext API key to the on-disk stream log**, and it's reloaded via history / restorable state. The result-masking is defeated by the input-recording.

## The fix

Redact at the persistence boundary — the recorder strips the secret before appending:

```ts
function redactToolInputForLog(toolName: string, input: unknown): unknown {
  if (toolName === 'set_api_key' && /* has key */) {
    return { ...input, key: '[redacted]' };
  }
  return input;
}
// ...
input: redactToolInputForLog(event.toolName, event.input),
```

Scoped to `set_api_key`'s `key` field — other tools and fields are untouched (no over-redaction). The transcript still shows the tool was called with which provider, just not the secret.

## Verification
- `tsc --noEmit` (root + `tsconfig.test-kernel.json`), prettier, eslint clean.

A recorder-level redaction test is a recommended follow-up — there's no existing `TexraTranscriptRecorder` test harness, and the helper is module-private.

---
🤖 Security/integrity audit (secret-exposure lens). Re-verified against live code: `tool.start` records `event.input` unmasked, and `set_api_key`'s `key` is the only secret-carrying input among the registered tools.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, persistence-only redaction for one tool field; reduces secret exposure with minimal behavior change elsewhere.
> 
> **Overview**
> **Stops cleartext API keys from being written to on-disk stream logs** when `set_api_key` runs. Tool-use cards already masked user-facing output, but `tool.start` / `tool.end` still persisted the raw `input`, so history and restorable state could reload the secret.
> 
> `TexraTranscriptRecorder` now runs tool inputs through **`redactToolInputForLog`** before append/update: for `set_api_key`, the `key` field is stored as `[redacted]` while `provider` and other fields stay visible. The same redaction applies on **`tool.end`** when the result carries `toolName` and `input`.
> 
> A **`RunTraceStream`** test uses `emitToolUseCard` to assert the persisted tool-use entry never contains the raw key and does not mutate the in-memory input object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6913a902c9701f2973c89d58d96fc2d33a3072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->