### PR TITLE
refactor(a11y): add waIcon() title option; convert ModelSelectionList tooltip icons

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -8,6 +8,7 @@ import { classMap } from 'lit/directives/class-map.js';
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import {
   renderSetStatusIcon,
   statusCheckIconStyles,
@@ -202,13 +203,10 @@ export class ModelSelectionList extends LitElement {
         )}
       </wa-select>
       ${includedAccessCap
-        ? html`<wa-icon
-            library="texra"
-            name="warning"
-            class="model-row-icon model-row-icon--warning"
-            title=${title}
-            aria-hidden="true"
-          ></wa-icon>`
+        ? waIcon('warning', {
+            className: 'model-row-icon model-row-icon--warning',
+            title,
+          })
         : nothing}
     `;
   }
@@ -226,14 +224,7 @@ export class ModelSelectionList extends LitElement {
       ? 'model-row-icon'
       : 'model-row-icon model-row-icon--warning';
 
-    return html`
-      <wa-icon
-        library="texra"
-        name=${iconName}
-        class=${className}
-        title=${title}
-      ></wa-icon>
-    `;
+    return waIcon(iconName, { className, title });
   }
 
   private renderModelRow(model: ModelSelectionItem): TemplateResult {
@@ -259,12 +250,10 @@ export class ModelSelectionList extends LitElement {
           <span class="model-shortname">(${model.name})</span>
           ${this.renderAvailabilityIcon(model)}
           ${isExpensiveModel(model.provider, model.name)
-            ? html`<wa-icon
-                library="texra"
-                name="warning"
-                class="model-row-icon model-row-icon--warning"
-                title=${EXPENSIVE_MODEL_HINT}
-              ></wa-icon>`
+            ? waIcon('warning', {
+                className: 'model-row-icon model-row-icon--warning',
+                title: EXPENSIVE_MODEL_HINT,
+              })
             : nothing}
         </wa-checkbox>
         ${this.renderReasoningDropdown(model)}

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -386,6 +386,9 @@ interface WaIconOptions {
   readonly className?: string;
   readonly variant?: 'solid' | 'regular';
   readonly label?: string;
+  // Native `title` tooltip. Purely visual — a decorative icon with a hover
+  // tooltip stays `aria-hidden` (only `label` exposes it to assistive tech).
+  readonly title?: string;
 }
 
 // Lit template for <wa-icon>. Decorative icons stay hidden from assistive
@@ -401,6 +404,7 @@ export function waIcon(
     slot=${ifDefined(options.slot)}
     class=${ifDefined(options.className)}
     label=${ifDefined(options.label)}
+    title=${ifDefined(options.title)}
     aria-hidden=${ifDefined(options.label == null ? 'true' : undefined)}
   ></wa-icon>`;
 }


### PR DESCRIPTION
## Summary

Continues the waIcon sweep (#6211, #6220). The `waIcon()` helper had no way to express a native hover **tooltip**, so icons pairing a decorative glyph with a `title` had to stay as raw `<wa-icon>` tags.

- Add an optional **`title`** to `WaIconOptions`, rendered via `ifDefined`. A `title` alone keeps the icon `aria-hidden` — only `label` exposes an icon to assistive tech — so a decorative-icon-with-tooltip stays correctly hidden while keeping its visual tooltip.
- Convert **ModelSelectionList**'s three tooltip icons to `waIcon()`:
  - availability icon (`renderAvailabilityIcon` — `name` is the typed ternary `'key' | 'warning'`),
  - included-access reasoning-cap warning,
  - expensive-model warning.

The two provider/deprecated toggle **chevrons stay raw** — they bind a dynamic `class=${classMap(...)}` for rotation state, which `waIcon`'s static `className` can't express (and isn't worth adding classMap support for).

## Scope note
LaTeXTab's status icons (also unblocked by this `title` option, since their names are ternaries-of-literals) are deferred to a follow-up to avoid stacking on the still-open #6220, which already edits LaTeXTab.

## Verification
- Changed files (`webAwesomeIcons.ts`, `ModelSelectionList.ts`) typecheck clean; `title` is an additive optional option (no impact on existing callers). CI `validate` confirms.
- Net −7 LOC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive API change and UI refactor in settings model list; no auth, data, or backend impact.
> 
> **Overview**
> Extends the shared **`waIcon()`** helper with an optional **`title`** for native hover tooltips, wired through `ifDefined` on the underlying `<wa-icon>`. **Tooltip-only** icons stay **`aria-hidden`**; only **`label`** changes assistive exposure, so decorative warning/key glyphs keep correct a11y while showing tooltips.
> 
> **Model Selection** in settings now uses **`waIcon()`** for the three tooltip icons (availability key/warning, included-access reasoning cap, expensive-model warning) instead of inline `<wa-icon library="texra">` tags. Provider expand/collapse **chevrons remain raw** because they need **`classMap`** for rotation classes, which `waIcon`'s static `className` does not cover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc461b366676ed75d6d47ad0bacbdc67d6e8ed6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->