### PR TITLE
refactor(a11y): route webview MainApp/InstructionPanel icons through waIcon()

### DIFF
--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1699,14 +1699,8 @@ export class MainApp extends MainAppBase {
           without-scroll-controls
           @wa-tab-show=${this.onViewTabShow}
         >
-          <wa-tab panel="launcher">
-            ${waIcon('pencil')}
-            Launcher
-          </wa-tab>
-          <wa-tab panel="progress">
-            ${waIcon('robot')}
-            Progress
-          </wa-tab>
+          <wa-tab panel="launcher"> ${waIcon('pencil')} Launcher </wa-tab>
+          <wa-tab panel="progress"> ${waIcon('robot')} Progress </wa-tab>
           <wa-tab-panel name="launcher"></wa-tab-panel>
           <wa-tab-panel name="progress"></wa-tab-panel>
         </wa-tab-group>
@@ -1864,8 +1858,7 @@ export class MainApp extends MainAppBase {
             }}
           >
             <span slot="summary" class="file-selection-summary">
-              ${waIcon('folder-tree')}
-              Files
+              ${waIcon('folder-tree')} Files
             </span>
             <div class="file-selection-group">
               ${repeat(

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -54,7 +54,7 @@ import {
 // Constants-only module: safe for the webview bundle (no platform imports).
 import {
   registerTeXRAWebAwesomeIcons,
-  TEXRA_ICON_LIBRARY,
+  waIcon,
 } from '@shared/wa/webAwesomeIcons';
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 import { agentName } from '@shared/schemas/agent';
@@ -1700,19 +1700,11 @@ export class MainApp extends MainAppBase {
           @wa-tab-show=${this.onViewTabShow}
         >
           <wa-tab panel="launcher">
-            <wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name="pencil"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('pencil')}
             Launcher
           </wa-tab>
           <wa-tab panel="progress">
-            <wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name="robot"
-              variant="solid"
-            ></wa-icon>
+            ${waIcon('robot')}
             Progress
           </wa-tab>
           <wa-tab-panel name="launcher"></wa-tab-panel>
@@ -1726,11 +1718,7 @@ export class MainApp extends MainAppBase {
           size="small"
           @click=${this.onOpenDashboard}
         >
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="gear"
-            variant="solid"
-          ></wa-icon>
+          ${waIcon('gear')}
         </wa-button>
         <wa-tooltip for="openDashboardButton"> Open dashboard </wa-tooltip>
         <wa-button
@@ -1741,11 +1729,7 @@ export class MainApp extends MainAppBase {
           size="small"
           @click=${this.onPopOutProgress}
         >
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="picture-in-picture"
-            variant="solid"
-          ></wa-icon>
+          ${waIcon('picture-in-picture')}
         </wa-button>
         <wa-tooltip for="popOutProgressButton">
           Open progress sessions in editor
@@ -1880,11 +1864,7 @@ export class MainApp extends MainAppBase {
             }}
           >
             <span slot="summary" class="file-selection-summary">
-              <wa-icon
-                library=${TEXRA_ICON_LIBRARY}
-                name="folder-tree"
-                variant="solid"
-              ></wa-icon>
+              ${waIcon('folder-tree')}
               Files
             </span>
             <div class="file-selection-group">

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -16,10 +16,10 @@ import { keyed } from 'lit/directives/keyed.js';
 import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
 
 // Local imports - shared styles
-import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { designTokens } from '@shared/styles';
 import { commonViewStyles } from '@shared/styles/commonViewStyles';
 import { selectStyles } from '@shared/styles/selectStyles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared utils
 import {

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -16,6 +16,7 @@ import { keyed } from 'lit/directives/keyed.js';
 import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
 
 // Local imports - shared styles
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { designTokens } from '@shared/styles';
 import { commonViewStyles } from '@shared/styles/commonViewStyles';
 import { selectStyles } from '@shared/styles/selectStyles';
@@ -476,7 +477,7 @@ export class InstructionPanel extends LitElement {
             variant="brand"
             @click=${this.handleExecute}
           >
-            <wa-icon slot="start" library="texra" name="play"></wa-icon>
+            ${waIcon('play', { slot: 'start' })}
             <span class="execute-button__label">Run</span>
           </wa-button>
           <wa-tooltip for="executeButton">


### PR DESCRIPTION
## Summary

Extends the `waIcon()` a11y migration (#6211, #6220, #6232) to the **main webview surface**, which still rendered icons as raw `<wa-icon>` tags — bypassing the helper that sets `aria-hidden` on decorative icons.

Converts the **6 production sites**:
- **MainApp** — launcher/progress tab icons (`pencil`/`robot`), the dashboard (`gear`) and pop-out (`picture-in-picture`) header buttons, and the file-selection summary (`folder-tree`).
- **InstructionPanel** — the Run button (`play`, `slot="start"`).

### Fixes the double-speak the audit flagged
The dashboard and pop-out buttons already carry their own `aria-label`, so their inner icons were announced redundantly. Routing through `waIcon()` makes the icons `aria-hidden`, leaving each button's `aria-label` as the sole accessible name.

Also drops the now-unused `TEXRA_ICON_LIBRARY` import from MainApp (replaced by `waIcon`). Dev-only mocks (`MocksGallery`, `ContextUtilizationMock`) are intentionally left as-is.

## Verification
- Changed files typecheck clean; `waIcon()` validates the names at compile time. Net −19 LOC.
- Decorative-only behavior change (icons gain `aria-hidden`); visual output unchanged (waIcon defaults match the prior `library`/`variant="solid"`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Decorative-only accessibility markup change with no logic, API, or visual behavior changes beyond `aria-hidden` on icons.
> 
> **Overview**
> Continues the webview **a11y icon migration** by replacing inline `<wa-icon>` markup in **MainApp** and **InstructionPanel** with the shared **`waIcon()`** helper, which marks decorative icons **`aria-hidden`** while keeping the same TeXRA library and solid variant defaults.
> 
> **MainApp** updates the launcher/progress tab icons, dashboard and pop-out header buttons, and the Files summary icon; the unused **`TEXRA_ICON_LIBRARY`** import is removed in favor of **`waIcon`**.
> 
> **InstructionPanel** routes the Run button’s play icon through **`waIcon('play', { slot: 'start' })`**.
> 
> For controls that already expose an **`aria-label`** (e.g. dashboard, pop-out), icons no longer duplicate what screen readers announce. Visual rendering is unchanged; dev mocks are left on raw icons per the PR scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d579470f263c4434a0f2bcb20eae362bea9c8481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->