### PR TITLE
fix(storage): write durable run/flow KV state atomically

### DIFF
--- a/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
+++ b/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
@@ -3,14 +3,18 @@
  *
  * Wraps vscode.workspace.fs operations, converting string paths to vscode.Uri.
  */
+import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as vscode from 'vscode';
 
 import { isFileNotFoundError } from '@common/errors';
+import * as logger from '@logger/logUtils';
 import type {
   FileSystemProvider,
   FileStat,
 } from '@platform/interfaces/filesystem';
+
+const CHANNEL = 'VscodeFileSystem';
 
 export class VscodeFileSystem implements FileSystemProvider {
   /**
@@ -56,6 +60,28 @@ export class VscodeFileSystem implements FileSystemProvider {
 
   async writeFile(target: string, content: Uint8Array): Promise<void> {
     await vscode.workspace.fs.writeFile(vscode.Uri.file(target), content);
+  }
+
+  async writeFileAtomic(target: string, content: Uint8Array): Promise<void> {
+    // vscode.workspace.fs has no atomic write; stage to a unique sibling temp
+    // and rename over the target so an unclean exit can't leave a torn file.
+    const tmp = `${target}.${randomBytes(6).toString('hex')}.tmp`;
+    const tmpUri = vscode.Uri.file(tmp);
+    try {
+      await vscode.workspace.fs.writeFile(tmpUri, content);
+      await vscode.workspace.fs.rename(tmpUri, vscode.Uri.file(target), {
+        overwrite: true,
+      });
+    } catch (err) {
+      try {
+        await vscode.workspace.fs.delete(tmpUri);
+      } catch (cleanupError) {
+        logger.debug(CHANNEL, `Failed to clean up temp file: ${tmp}`, {
+          data: cleanupError,
+        });
+      }
+      throw err;
+    }
   }
 
   async appendFile(target: string, content: Uint8Array): Promise<void> {

--- a/src/common/storage/KVStore.ts
+++ b/src/common/storage/KVStore.ts
@@ -65,7 +65,9 @@ function createStorageStore(dir: string): KeyvStoreAdapter {
         dirEnsured = true;
       }
       // Keyv has already run the serializer, so StorageFS receives raw JSON.
-      await StorageFS.write(keyToPath(dir, key), value as string);
+      // Atomic: a torn flow_{id}.json on an unclean exit makes the run fail to
+      // parse on resume and silently restart from scratch (losing applied edits).
+      await StorageFS.writeAtomic(keyToPath(dir, key), value as string);
     },
 
     async delete(key: string): Promise<boolean> {

--- a/src/platform/defaults/nodeFilesystem.ts
+++ b/src/platform/defaults/nodeFilesystem.ts
@@ -4,6 +4,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import writeFileAtomicLib from 'write-file-atomic';
+
 import { isFileNotFoundError } from '@common/errors';
 
 import {
@@ -115,6 +117,12 @@ export const nodeFilesystem: FileSystemProvider = {
 
   async writeFile(target: string, content: Uint8Array): Promise<void> {
     await fs.promises.writeFile(target, content);
+  },
+
+  async writeFileAtomic(target: string, content: Uint8Array): Promise<void> {
+    // write-file-atomic stages to a sibling temp, fsyncs, and renames over the
+    // target — resolving the realpath first, so a symlinked path is preserved.
+    await writeFileAtomicLib(target, Buffer.from(content));
   },
 
   async appendFile(target: string, content: Uint8Array): Promise<void> {

--- a/src/platform/interfaces/filesystem.ts
+++ b/src/platform/interfaces/filesystem.ts
@@ -37,6 +37,13 @@ export interface FileSystemProvider {
     length: number,
   ): Promise<Uint8Array>;
   writeFile(path: string, content: Uint8Array): Promise<void>;
+  /**
+   * Crash-safe write: stage to a temp file and atomically rename over the
+   * target so a torn/partial file is never observable after an unclean exit.
+   * Used for durable run/flow state; plain `writeFile` remains for workspace
+   * files (where atomic rename would replace a user's symlink).
+   */
+  writeFileAtomic(path: string, content: Uint8Array): Promise<void>;
   appendFile(path: string, content: Uint8Array): Promise<void>;
   delete(path: string, options?: { recursive?: boolean }): Promise<void>;
   createDirectory(path: string): Promise<void>;

--- a/src/test-kernel/cli/CliPersistenceFlush.vitest.mts
+++ b/src/test-kernel/cli/CliPersistenceFlush.vitest.mts
@@ -36,13 +36,18 @@ function emptyStorage(): { writes: Map<string, unknown> } {
   vi.spyOn(StorageFS, 'readJson').mockRejectedValue(notFound());
   vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
   vi.spyOn(StorageFS, 'stat').mockRejectedValue(notFound());
-  vi.spyOn(StorageFS, 'write').mockImplementation(async (target, content) => {
+  const recordWrite = async (
+    target: string,
+    content: string | Uint8Array,
+  ): Promise<void> => {
     const text =
       typeof content === 'string'
         ? content
         : Buffer.from(content).toString('utf8');
     writes.set(target, JSON.parse(text));
-  });
+  };
+  vi.spyOn(StorageFS, 'write').mockImplementation(recordWrite);
+  vi.spyOn(StorageFS, 'writeAtomic').mockImplementation(recordWrite);
   vi.spyOn(StorageFS, 'delete').mockResolvedValue(undefined);
   return { writes };
 }

--- a/src/test-kernel/platform/NodeFilesystemAtomicWrite.vitest.ts
+++ b/src/test-kernel/platform/NodeFilesystemAtomicWrite.vitest.ts
@@ -1,0 +1,29 @@
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+
+describe('nodeFilesystem.writeFileAtomic', () => {
+  it('writes content, overwrites in place, and leaves no temp residue', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'texra-atomic-'));
+    try {
+      const target = path.join(dir, 'flow.json');
+
+      await nodeFilesystem.writeFileAtomic(target, Buffer.from('{"step":1}'));
+      expect(await readFile(target, 'utf8')).toBe('{"step":1}');
+
+      // Overwrite — the crash-sensitive path (re-serialized flow state).
+      await nodeFilesystem.writeFileAtomic(target, Buffer.from('{"step":2}'));
+      expect(await readFile(target, 'utf8')).toBe('{"step":2}');
+
+      // The temp file must have been renamed away, not abandoned.
+      const entries = await readdir(dir);
+      expect(entries).toEqual(['flow.json']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -316,6 +316,12 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     this.writeFileSync(target, content, { overwrite: true });
   }
 
+  async writeFileAtomic(target: string, content: Uint8Array): Promise<void> {
+    // In-memory: the temp+rename of a real atomic write has no observable
+    // intermediate state here, so a direct write is equivalent.
+    this.writeFileSync(target, content, { overwrite: true });
+  }
+
   async appendFile(target: string, content: Uint8Array): Promise<void> {
     const existing = this.records.get(normalizePath(target));
     if (existing && existing.type !== FileType.File) {

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -162,7 +162,10 @@ function mockStorage({
     }
     throw new Error(`Unexpected stat target: ${target}`);
   });
-  vi.spyOn(StorageFS, 'write').mockImplementation(async (target, content) => {
+  const recordWrite = async (
+    target: string,
+    content: string | Uint8Array,
+  ): Promise<void> => {
     if (
       pauseLogWriteKey != null &&
       !pausedLogWriteUsed &&
@@ -180,7 +183,9 @@ function mockStorage({
         ? content
         : Buffer.from(content).toString('utf8');
     writes.set(target, JSON.parse(text));
-  });
+  };
+  vi.spyOn(StorageFS, 'write').mockImplementation(recordWrite);
+  vi.spyOn(StorageFS, 'writeAtomic').mockImplementation(recordWrite);
   vi.spyOn(StorageFS, 'delete').mockImplementation(async (target) => {
     deletes.push(target);
     writes.delete(target);

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -80,6 +80,23 @@ export abstract class BaseFS {
     await platform().fs.writeFile(this.preparePath(target), toBuffer(content));
   }
 
+  /**
+   * Crash-safe variant of {@link write} — stages to a temp file and atomically
+   * renames over the target. Use for durable storage state (run/flow KV files)
+   * so an unclean exit can't leave a truncated file that fails to parse on
+   * resume. Not for workspace files (atomic rename would replace user symlinks).
+   */
+  public static async writeAtomic(
+    this: typeof BaseFS,
+    target: string,
+    content: string | Uint8Array,
+  ): Promise<void> {
+    await platform().fs.writeFileAtomic(
+      this.preparePath(target),
+      toBuffer(content),
+    );
+  }
+
   public static async appendFile(
     this: typeof BaseFS,
     target: string,


### PR DESCRIPTION
## The integrity bug (silent run loss on unclean exit)

Every durable run write funnels through `KVStore.set → StorageFS.write → BaseFS.write → platform().fs.writeFile`, and **both** backends are bare truncate-then-write — `nodeFilesystem` is `fs.promises.writeFile`, `vscodeFileSystem` is `vscode.workspace.fs.writeFile`. Neither stages to a temp + rename.

The most crash-sensitive consumer, `PersistedFlow`, re-serializes the **entire** flow shared state (full conversation history) into `flow_{runId}.json` after **every node step**. A mid-write crash — Ctrl-C/SIGKILL, VS Code reload, OOM, power loss — leaves the file truncated. On resume `KVStore` does an unguarded `JSON.parse`, it throws, and the interrupted run is **silently discarded and restarted from scratch** — already-applied file edits are *not* rolled back.

The asymmetry confirms the gap: the sibling `JsonStore` already writes via `write-file-atomic`; only the `KVStore`/`StorageFS` path didn't.

## The fix

Add `writeFileAtomic` to the FS port and route durable storage writes through it:

- **node**: `write-file-atomic` (already a dep) — stages to a sibling temp, **fsyncs**, and renames over the target, resolving realpath first so a **symlinked path is preserved**.
- **vscode**: stage to a unique sibling temp + `rename(overwrite)` (workspace.fs has no fsync, but the rename still prevents a torn file).
- `BaseFS.writeAtomic` wraps it; `KVStore.set` now calls `StorageFS.writeAtomic`.

**Scoped to storage only.** Workspace file writes keep plain `writeFile` — an atomic temp+rename would replace a user's symlinked file with a regular file. Storage files (`~/.texra/...`) are never user symlinks, so atomicity is pure upside there.

## Verification
- `tsc --noEmit` across **root + test-kernel + extension + cli + desktop** (every `FileSystemProvider` implementer compiles), prettier, eslint clean.
- New `NodeFilesystemAtomicWrite.vitest` (write / overwrite-in-place / no temp residue) passes against real `write-file-atomic`.
- `RelativeFSJson.vitest` (the storage FS family) still passes.

---
🤖 Security/integrity audit (persistence-atomicity lens). Re-verified against live code; mirrors the existing `JsonStore` + `write-file-atomic` precedent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence integrity for all KV-backed run/flow state across platforms; scoped away from workspace writes but resume behavior depends on the new atomic path.
> 
> **Overview**
> Adds **`writeFileAtomic`** to the filesystem port and routes **durable KV persistence** through it so unclean exits cannot leave torn JSON that fails to parse on resume (e.g. `flow_{runId}.json`).
> 
> **Node** uses `write-file-atomic` (temp + fsync + rename); **VS Code** stages to a unique sibling `.tmp` and renames with overwrite, with temp cleanup on failure. **`BaseFS.writeAtomic`** and **`KVStore.set`** now call **`StorageFS.writeAtomic`** instead of plain **`write`**. Workspace writes stay on non-atomic **`writeFile`** to avoid replacing user symlinks.
> 
> Tests add **`NodeFilesystemAtomicWrite`**, stub **`writeAtomic`** in storage mocks, and implement **`writeFileAtomic`** on the fake filesystem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b66eb01f123aee9924d2d3fa064dd2612f4ee10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->