### PR TITLE
fix(security): bind desktop OAuth callbacks to a per-attempt nonce

### DIFF
--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto';
+
 import { z } from 'zod';
 
 import { platform } from '@platform/platform';
@@ -30,6 +32,7 @@ const DESKTOP_PENDING_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
 
 const DesktopPendingOAuthStateSchema = z.object({
   createdAt: z.number(),
+  nonce: z.string(),
 });
 type DesktopPendingOAuthState = z.infer<typeof DesktopPendingOAuthStateSchema>;
 
@@ -41,7 +44,13 @@ export interface DesktopSupabaseAuth {
 
 export interface DesktopAuthCallbackState {
   hasPendingSignIn(): boolean;
-  beginAuthAttempt(): Promise<void>;
+  beginAuthAttempt(nonce: string): Promise<void>;
+  /**
+   * True only when a sign-in is pending AND its stored nonce equals `nonce`.
+   * Binds an inbound callback to the attempt THIS client started, so a verified
+   * but foreign-account token deeplink can't complete a sign-in (login-CSRF).
+   */
+  matchesPendingNonce(nonce: string | undefined): boolean;
   clearAwaitingCallback(): Promise<void>;
 }
 
@@ -107,9 +116,14 @@ export function createDesktopAuthCallbackState(
       }
       return true;
     },
-    async beginAuthAttempt() {
-      pendingState = { createdAt: Date.now() };
+    async beginAuthAttempt(nonce: string) {
+      pendingState = { createdAt: Date.now(), nonce };
       await persistPendingState(pendingState);
+    },
+    matchesPendingNonce: (nonce: string | undefined) => {
+      if (!nonce || !pendingState) return false;
+      if (isPendingOAuthStateExpired(pendingState)) return false;
+      return pendingState.nonce === nonce;
     },
     async clearAwaitingCallback() {
       pendingState = null;
@@ -177,6 +191,14 @@ export function createDesktopSupabaseAuth(
       );
       return;
     }
+    const callbackNonce =
+      new URLSearchParams(callback.query).get('app_nonce') ?? undefined;
+    if (!callbackState.matchesPendingNonce(callbackNonce)) {
+      options.log?.warn?.(
+        'Desktop auth callback rejected: nonce mismatch (possible login-CSRF or stale callback)',
+      );
+      return;
+    }
     void callbackState.clearAwaitingCallback().catch((error: unknown) => {
       options.log?.debug?.(
         `Desktop auth callback state clear failed: ${toErrorMessage(error)}`,
@@ -194,7 +216,13 @@ export function createDesktopSupabaseAuth(
   return {
     async signIn(provider = DEFAULT_OAUTH_PROVIDER) {
       try {
-        const redirectTo = getAuthCallbackUri(TEXRA_PROTOCOL);
+        // Bind this attempt to a one-time nonce carried on the callback URL.
+        // Supabase preserves redirect_to query params through to the callback
+        // (the same mechanism the Codespaces ?state= routing token relies on),
+        // so the nonce returns in the texra:// callback query — letting us reject
+        // a foreign token deeplink delivered while a sign-in is merely pending.
+        const nonce = randomBytes(16).toString('hex');
+        const redirectTo = `${getAuthCallbackUri(TEXRA_PROTOCOL)}?app_nonce=${nonce}`;
         const { data, error } = await oauthClient.auth.signInWithOAuth({
           provider,
           options: { redirectTo },
@@ -205,7 +233,7 @@ export function createDesktopSupabaseAuth(
           );
         }
 
-        await callbackState.beginAuthAttempt();
+        await callbackState.beginAuthAttempt(nonce);
         await options.openExternalUrl(data.url);
         await options.showInfoMessage?.(
           'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -222,7 +222,9 @@ export function createDesktopSupabaseAuth(
         // so the nonce returns in the texra:// callback query — letting us reject
         // a foreign token deeplink delivered while a sign-in is merely pending.
         const nonce = randomBytes(16).toString('hex');
-        const redirectTo = `${getAuthCallbackUri(TEXRA_PROTOCOL)}?app_nonce=${nonce}`;
+        const callbackUri = getAuthCallbackUri(TEXRA_PROTOCOL);
+        const sep = callbackUri.includes('?') ? '&' : '?';
+        const redirectTo = `${callbackUri}${sep}app_nonce=${nonce}`;
         const { data, error } = await oauthClient.auth.signInWithOAuth({
           provider,
           options: { redirectTo },

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -122,7 +122,11 @@ export function createDesktopAuthCallbackState(
     },
     matchesPendingNonce: (nonce: string | undefined) => {
       if (!nonce || !pendingState) return false;
-      if (isPendingOAuthStateExpired(pendingState)) return false;
+      if (isPendingOAuthStateExpired(pendingState)) {
+        pendingState = null;
+        void persistPendingState(null).catch(() => {});
+        return false;
+      }
       return pendingState.nonce === nonce;
     },
     async clearAwaitingCallback() {
@@ -225,6 +229,7 @@ export function createDesktopSupabaseAuth(
         const callbackUri = getAuthCallbackUri(TEXRA_PROTOCOL);
         const sep = callbackUri.includes('?') ? '&' : '?';
         const redirectTo = `${callbackUri}${sep}app_nonce=${nonce}`;
+        await callbackState.beginAuthAttempt(nonce);
         const { data, error } = await oauthClient.auth.signInWithOAuth({
           provider,
           options: { redirectTo },
@@ -235,7 +240,6 @@ export function createDesktopSupabaseAuth(
           );
         }
 
-        await callbackState.beginAuthAttempt(nonce);
         await options.openExternalUrl(data.url);
         await options.showInfoMessage?.(
           'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -90,12 +90,21 @@ function createOAuthClient() {
 function authCallbackUrl(input: {
   accessToken: string;
   refreshToken: string;
+  nonce?: string;
 }): string {
   const fragment = new URLSearchParams({
     access_token: input.accessToken,
     refresh_token: input.refreshToken,
   });
-  return `texra://texra-ai.texra/auth-callback#${fragment}`;
+  const query = input.nonce ? `?app_nonce=${input.nonce}` : '';
+  return `texra://texra-ai.texra/auth-callback${query}#${fragment}`;
+}
+
+/** Extract the app_nonce that signIn placed on its OAuth redirect_to. */
+function nonceFor(oauthClient: ReturnType<typeof createOAuthClient>): string {
+  const call = oauthClient.auth.signInWithOAuth.mock.calls.at(-1)?.[0];
+  const redirectTo = call?.options?.redirectTo ?? '';
+  return new URL(redirectTo).searchParams.get('app_nonce') ?? '';
 }
 
 function createDeferred<T>() {
@@ -152,7 +161,9 @@ describe('desktop Supabase auth', () => {
     expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalledWith({
       provider: 'github',
       options: {
-        redirectTo: 'texra://texra-ai.texra/auth-callback',
+        redirectTo: expect.stringMatching(
+          /^texra:\/\/texra-ai\.texra\/auth-callback\?app_nonce=[0-9a-f]{32}$/,
+        ),
       },
     });
     expect(openExternalUrl).toHaveBeenCalledWith(
@@ -180,6 +191,7 @@ describe('desktop Supabase auth', () => {
       authCallbackUrl({
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
+        nonce: nonceFor(oauthClient),
       }),
     );
 
@@ -193,12 +205,76 @@ describe('desktop Supabase auth', () => {
     });
     expect(coordinator.createSessionFromCallback).toHaveBeenCalledWith({
       path: '/auth-callback',
-      query: '',
+      query: expect.stringMatching(/^app_nonce=[0-9a-f]{32}$/),
       fragment: 'access_token=access-token&refresh_token=refresh-token',
     });
     expect(onSessionChanged).toHaveBeenCalled();
 
     expect(await SupabaseClient.isAuthenticated()).toBe(false);
+    auth.dispose();
+  });
+
+  it('rejects a foreign callback whose nonce does not match the pending sign-in (login-CSRF)', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const oauthClient = createOAuthClient();
+    const log = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient,
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      log,
+    });
+
+    await auth.signIn();
+    // Attacker-delivered deeplink carrying valid tokens for another account but
+    // NOT the nonce this client minted in its redirect_to.
+    router.routeUrl(
+      authCallbackUrl({
+        accessToken: 'attacker-access',
+        refreshToken: 'attacker-refresh',
+        nonce: 'deadbeefdeadbeefdeadbeefdeadbeef',
+      }),
+    );
+    await Promise.resolve();
+
+    expect(coordinator.createSessionFromCallback).not.toHaveBeenCalled();
+    expect(coordinator.storeSession).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      'Desktop auth callback rejected: nonce mismatch (possible login-CSRF or stale callback)',
+    );
+    auth.dispose();
+  });
+
+  it('rejects a callback with no nonce while a sign-in is pending', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+    });
+
+    await auth.signIn();
+    router.routeUrl(
+      authCallbackUrl({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      }),
+    );
+    await Promise.resolve();
+
+    expect(coordinator.createSessionFromCallback).not.toHaveBeenCalled();
+    expect(coordinator.storeSession).not.toHaveBeenCalled();
     auth.dispose();
   });
 
@@ -256,6 +332,7 @@ describe('desktop Supabase auth', () => {
       authCallbackUrl({
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
+        nonce: nonceFor(oauthClient),
       }),
     );
 
@@ -353,6 +430,7 @@ describe('desktop Supabase auth', () => {
       authCallbackUrl({
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
+        nonce: nonceFor(oauthClient),
       }),
     );
 
@@ -387,7 +465,11 @@ describe('desktop Supabase auth', () => {
 
     await auth.signIn();
     router.routeUrl(
-      authCallbackUrl({ accessToken: 'first', refreshToken: 'first' }),
+      authCallbackUrl({
+        accessToken: 'first',
+        refreshToken: 'first',
+        nonce: nonceFor(oauthClient),
+      }),
     );
     router.routeUrl(
       authCallbackUrl({ accessToken: 'second', refreshToken: 'second' }),
@@ -436,6 +518,7 @@ describe('desktop Supabase auth', () => {
       authCallbackUrl({
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
+        nonce: nonceFor(oauthClient),
       }),
     );
     await vi.waitFor(() => {
@@ -481,6 +564,7 @@ describe('desktop Supabase auth', () => {
       authCallbackUrl({
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
+        nonce: nonceFor(oauthClient),
       }),
     );
 

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -5,10 +5,14 @@ import * as agentRegistry from '@agent/index/agentRegistry';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { SupabaseSession } from '@auth/SupabaseSession';
 import { setServerSideKeyService } from '@auth/serverKeys';
-import { createDesktopProtocolCallbackRouter } from '@desktop/main/desktopProtocolCallbacks';
+import {
+  createDesktopProtocolCallbackRouter,
+  parseDesktopProtocolCallback,
+} from '@desktop/main/desktopProtocolCallbacks';
 import {
   createDesktopAuthCallbackState,
   createDesktopSupabaseAuth,
+  type DesktopAuthCallbackState,
   type DesktopOAuthClient,
 } from '@desktop/main/desktopSupabaseAuth';
 import { buildProfileMessage } from '@shared/settingsView/handlers/profileHandlers';
@@ -104,7 +108,8 @@ function authCallbackUrl(input: {
 function nonceFor(oauthClient: ReturnType<typeof createOAuthClient>): string {
   const call = oauthClient.auth.signInWithOAuth.mock.calls.at(-1)?.[0];
   const redirectTo = call?.options?.redirectTo ?? '';
-  return new URL(redirectTo).searchParams.get('app_nonce') ?? '';
+  const callback = parseDesktopProtocolCallback(redirectTo);
+  return new URLSearchParams(callback?.query).get('app_nonce') ?? '';
 }
 
 function createDeferred<T>() {
@@ -169,6 +174,49 @@ describe('desktop Supabase auth', () => {
     expect(openExternalUrl).toHaveBeenCalledWith(
       'https://auth.example.test/start',
     );
+    auth.dispose();
+  });
+
+  it('persists the nonce before sending it to Supabase', async () => {
+    const events: string[] = [];
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const callbackState: DesktopAuthCallbackState = {
+      hasPendingSignIn: vi.fn(() => false),
+      beginAuthAttempt: vi.fn(async () => {
+        events.push('begin');
+      }),
+      matchesPendingNonce: vi.fn(() => false),
+      clearAwaitingCallback: vi.fn(async () => {
+        events.push('clear');
+      }),
+    };
+    const oauthClient: DesktopOAuthClient = {
+      auth: {
+        signInWithOAuth: vi.fn(async () => {
+          events.push('oauth');
+          return {
+            data: { url: 'https://auth.example.test/start' },
+            error: null,
+          };
+        }),
+      },
+    };
+    const openExternalUrl = vi.fn(async () => {
+      events.push('open');
+    });
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient,
+      callbackState,
+      secrets: createSecrets(),
+      openExternalUrl,
+    });
+
+    await auth.signIn();
+
+    expect(events).toEqual(['begin', 'oauth', 'open']);
     auth.dispose();
   });
 
@@ -398,6 +446,26 @@ describe('desktop Supabase auth', () => {
       expect(expiredCallbackState.hasPendingSignIn()).toBe(false);
       expect(coordinator.createSessionFromCallback).not.toHaveBeenCalled();
       recreatedAuth.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears expired pending state when matching a nonce directly', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-06T00:00:00Z'));
+      const stateStore = createStateStore();
+      const callbackState = createDesktopAuthCallbackState(stateStore);
+
+      await callbackState.beginAuthAttempt('attempt-nonce');
+      vi.setSystemTime(Date.now() + 11 * 60 * 1000);
+
+      expect(callbackState.matchesPendingNonce('attempt-nonce')).toBe(false);
+      expect(callbackState.hasPendingSignIn()).toBe(false);
+      expect(
+        createDesktopAuthCallbackState(stateStore).hasPendingSignIn(),
+      ).toBe(false);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
> ⚠️ **Draft pending a live desktop sign-in smoke-test.** The nonce logic, `texra://` URL parsing, and the test suite are all verified, but I could not run the live Supabase OAuth flow to confirm the redirect-URL allowlist accepts a `?app_nonce=` query param on the `texra://` callback. The existing Codespaces `?state=` routing token (documented in `src/auth/config.ts`) relies on the *same* redirect-param-preservation mechanism, so this is very likely fine — please confirm with one real sign-in, then un-draft.

## The vulnerability (login-CSRF / session fixation)

The desktop `texra://` OAuth callback was accepted on `hasPendingSignIn()` **alone**. `DesktopPendingOAuthState` carried only `{ createdAt }` — **no client secret** tying the inbound callback to the sign-in attempt *this machine* started.

The flow is **implicit** (tokens in the URL fragment) and GoTrue owns the OAuth `state` (a custom `queryParams.state` would overwrite it → `bad_oauth_state`), so there was no CSRF binding. An attacker who completes a real OAuth flow for **their own** account gets a valid token deeplink; delivered to a victim who is mid-sign-in (10-min TTL), the desktop app accepts it and **signs the victim into the attacker's account**.

## The fix

Bind each attempt to a one-time nonce that rides the callback URL:

1. `signIn` mints `randomBytes(16).toString('hex')` and sets `redirectTo = …/auth-callback?app_nonce=<nonce>`.
2. The nonce is persisted in the pending state (`DesktopPendingOAuthState.nonce`).
3. The callback handler extracts `app_nonce` from `callback.query` and **rejects** anything that doesn't match the pending nonce *before* a session is created.

Supabase preserves `redirect_to` query params through to the callback — the exact mechanism the **Codespaces `?state=` routing token** already relies on (`config.ts`) — so the nonce returns in the `texra://` callback query. A foreign deeplink (wrong nonce, or none) is dropped with a `warn`.

## Verification
- `tsc --noEmit` (desktop + `tsconfig.test-kernel.json`), prettier, eslint clean.
- `DesktopSupabaseAuth.vitest` **14/14**, including two new tests: a mismatched-nonce foreign callback and a no-nonce callback are both rejected (no `createSessionFromCallback`, no `storeSession`).
- Verified `new URL('texra://…?app_nonce=x').searchParams` and `URLSearchParams(callback.query)` parse the nonce correctly for the custom scheme.

Old persisted `{ createdAt }`-only state fails the stricter schema → treated as no-pending (a sign-in spanning the upgrade is dropped, not mis-trusted).

---
🤖 Security/integrity audit (auth-callback-trust lens). Re-verified against live code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication callback acceptance in the desktop app; incorrect nonce handling or Supabase not preserving `redirect_to` query params could break sign-in, but the fix is narrowly scoped and well-tested.
> 
> **Overview**
> Closes a **login-CSRF** gap where any valid `texra://` token deeplink could complete sign-in while the desktop app merely had a pending OAuth attempt, potentially signing the user into an attacker’s account.
> 
> Each `signIn` now generates a 32-hex `app_nonce`, appends it to the OAuth `redirectTo` callback URL, and stores it in persisted pending state. Incoming protocol callbacks must carry a matching `app_nonce` in the query string before session creation; mismatches or missing nonces are rejected with a warning. Pending state schema now requires `nonce`; legacy `{ createdAt }` blobs fail validation and are treated as no pending attempt.
> 
> Tests were updated to expect nonce-bearing redirects and add coverage for foreign callbacks, missing nonces, persist-before-OAuth ordering, and expired nonce matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a791c529f86db8d0658eadcc2092fd41145e115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->