### PR TITLE
[codex] simplify CLI launch agent resolution

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -18,8 +18,7 @@ import {
 } from '../runtime/runModel';
 import {
   TOOL_USE_AGENT_NAME_DESCRIPTION,
-  assertCliAgentLaunch,
-  resolveCliAgent,
+  resolveCliLaunchAgent,
 } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
@@ -69,11 +68,7 @@ export async function runToolUseAgent(
   const instruction = await resolveToolUseInstruction(init, context.cwd);
 
   await initLocalCliPlatform(context);
-  assertCliAgentLaunch(
-    init.agent,
-    await resolveCliAgent(init.agent, AgentCategory.ToolUse),
-    'agentsRun',
-  );
+  await resolveCliLaunchAgent(init.agent, 'agentsRun');
 
   const model = await resolveCliRunModel(context, init.model, 'chat');
   const runContext = buildHeadlessRunContext(context, model);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -16,7 +16,7 @@ import {
   buildHeadlessRunContext,
   resolveCliRunModel,
 } from '../runtime/runModel';
-import { assertCliAgentLaunch, resolveCliAgent } from '../runtime/agents';
+import { resolveCliLaunchAgent } from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
@@ -75,11 +75,7 @@ export async function runWorkflowAgent(
   await initLocalCliPlatform(context);
   // Pre-validate the resolved agent so usage errors land before stdin is read
   // or the runtime host starts.
-  const agent = assertCliAgentLaunch(
-    init.agent,
-    await resolveCliAgent(init.agent, AgentCategory.Workflow),
-    'run',
-  );
+  const agent = await resolveCliLaunchAgent(init.agent, 'run');
   if (init.output && hasMixedStdinWorkflowInputSpecs(init.inputFiles)) {
     throw new CliUsageError(
       'Use --output-dir for multi-input workflow runs; --output is only for a single final artifact.',

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -115,11 +115,30 @@ export function assertCliAgentLaunch(
  * CLI commands start with a local-only load so signed-out users avoid remote
  * auth/network work. Missing agents still get a remote-inclusive fallback, and
  * authenticated relay sessions reload bare names so the registry's normal
- * source priority can prefer remote definitions. The optional category only
- * selects the registry lookup priority; launch commands must validate the
- * returned entry explicitly with assertCliAgentLaunch().
+ * source priority can prefer remote definitions.
  */
 export async function resolveCliAgent(
+  name: string,
+): Promise<AgentEntry | undefined> {
+  return resolveCliAgentEntry(name);
+}
+
+/**
+ * Resolve and validate an agent for a CLI launch command.
+ */
+export async function resolveCliLaunchAgent(
+  name: string,
+  mode: CliAgentLaunchMode,
+): Promise<AgentEntry> {
+  const target = CLI_AGENT_LAUNCH_TARGETS[mode];
+  return assertCliAgentLaunch(
+    name,
+    await resolveCliAgentEntry(name, target.requiredCategory),
+    mode,
+  );
+}
+
+async function resolveCliAgentEntry(
   name: string,
   lookupCategory?: AgentCategory,
 ): Promise<AgentEntry | undefined> {

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -89,16 +89,14 @@ describe('CLI agent resolution', () => {
     expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
   });
 
-  it('uses lookup category for authenticated remote-priority reloads', async () => {
+  it('uses launch target category for authenticated remote-priority reloads', async () => {
     const local = agent('lean');
     const remote = agent('lean', 'remote');
     mocks.authProvider.isAuthenticated.mockResolvedValue(true);
     mocks.getAgent.mockReturnValueOnce(local).mockReturnValueOnce(remote);
-    const { resolveCliAgent } = await import('@cli/runtime/agents');
+    const { resolveCliLaunchAgent } = await import('@cli/runtime/agents');
 
-    await expect(resolveCliAgent('lean', AgentCategory.ToolUse)).resolves.toBe(
-      remote,
-    );
+    await expect(resolveCliLaunchAgent('lean', 'chat')).resolves.toBe(remote);
 
     expect(mocks.getAgent).toHaveBeenNthCalledWith(
       1,
@@ -129,14 +127,14 @@ describe('CLI agent resolution', () => {
     expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
   });
 
-  it('uses lookup category for local and remote-fallback lookups', async () => {
+  it('uses launch target category for local and remote-fallback lookups', async () => {
     const remote = agent('assistant', 'remote');
     mocks.getAgent.mockReturnValueOnce(undefined).mockReturnValueOnce(remote);
-    const { resolveCliAgent } = await import('@cli/runtime/agents');
+    const { resolveCliLaunchAgent } = await import('@cli/runtime/agents');
 
-    await expect(
-      resolveCliAgent('assistant', AgentCategory.ToolUse),
-    ).resolves.toBe(remote);
+    await expect(resolveCliLaunchAgent('assistant', 'agentsRun')).resolves.toBe(
+      remote,
+    );
 
     expect(mocks.getAgent).toHaveBeenNthCalledWith(
       1,
@@ -147,6 +145,15 @@ describe('CLI agent resolution', () => {
       2,
       'assistant',
       AgentCategory.ToolUse,
+    );
+  });
+
+  it('reports launch-specific missing-agent messages', async () => {
+    mocks.getAgent.mockReturnValue(undefined);
+    const { resolveCliLaunchAgent } = await import('@cli/runtime/agents');
+
+    await expect(resolveCliLaunchAgent('missing', 'agentsRun')).rejects.toThrow(
+      'Tool-use agent not found: missing. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
     );
   });
 

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => {
     withExpandedRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
     isAuthenticated: vi.fn(),
-    resolveCliAgent: vi.fn(),
+    resolveCliLaunchAgent: vi.fn(),
     resolveCliRunModel: vi.fn(),
     writeErrorStderr: vi.fn(),
     writeTextStderr: vi.fn(),
@@ -59,7 +59,7 @@ vi.mock('@cli/commands/_helpers/output', () => ({
 
 vi.mock('@cli/runtime/agents', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@cli/runtime/agents')>()),
-  resolveCliAgent: mocks.resolveCliAgent,
+  resolveCliLaunchAgent: mocks.resolveCliLaunchAgent,
 }));
 
 vi.mock('@cli/runtime/runExecution', () => ({
@@ -103,7 +103,7 @@ describe('CLI agents run command', () => {
         }) => Promise<unknown>,
       ) => run({ inputFiles: ['problem.md'], contextFiles: ['notes.md'] }),
     );
-    mocks.resolveCliAgent.mockResolvedValue({
+    mocks.resolveCliLaunchAgent.mockResolvedValue({
       name: 'chat',
       category: AgentCategory.ToolUse,
       source: 'builtInToolUse',
@@ -141,11 +141,11 @@ describe('CLI agents run command', () => {
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
     expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.resolveCliAgent.mock.invocationCallOrder[0],
+      mocks.resolveCliLaunchAgent.mock.invocationCallOrder[0],
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+    expect(mocks.resolveCliLaunchAgent).toHaveBeenCalledWith(
       'chat',
-      AgentCategory.ToolUse,
+      'agentsRun',
     );
     expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
       ['problem.md'],
@@ -191,12 +191,16 @@ describe('CLI agents run command', () => {
 
     expect(mocks.initLocalCliPlatform).not.toHaveBeenCalled();
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
-    expect(mocks.resolveCliAgent).not.toHaveBeenCalled();
+    expect(mocks.resolveCliLaunchAgent).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports missing agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockResolvedValueOnce(undefined);
+    mocks.resolveCliLaunchAgent.mockRejectedValueOnce(
+      new Error(
+        'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+      ),
+    );
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
 
     await expect(
@@ -214,22 +218,20 @@ describe('CLI agents run command', () => {
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+    expect(mocks.resolveCliLaunchAgent).toHaveBeenCalledWith(
       'missing-agent',
-      AgentCategory.ToolUse,
+      'agentsRun',
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports workflow agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockResolvedValueOnce({
-      name: 'polish',
-      category: AgentCategory.Workflow,
-      source: 'builtInWorkflow',
-      path: '/agents/polish.yaml',
-      tools: [],
-    });
+    mocks.resolveCliLaunchAgent.mockRejectedValueOnce(
+      new Error(
+        'Agent "polish" is a workflow agent; `texra agents run` only handles tool-use agents. Use `texra run polish` for workflow agents.',
+      ),
+    );
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
 
     await expect(
@@ -247,9 +249,9 @@ describe('CLI agents run command', () => {
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+    expect(mocks.resolveCliLaunchAgent).toHaveBeenCalledWith(
       'polish',
-      AgentCategory.ToolUse,
+      'agentsRun',
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => {
     withExpandedRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
     isAuthenticated: vi.fn(),
-    resolveCliAgent: vi.fn(),
+    resolveCliLaunchAgent: vi.fn(),
     resolveCliRunModel: vi.fn(),
   };
 });
@@ -60,7 +60,7 @@ vi.mock('@cli/commands/_helpers/output', () => ({
 
 vi.mock('@cli/runtime/agents', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@cli/runtime/agents')>()),
-  resolveCliAgent: mocks.resolveCliAgent,
+  resolveCliLaunchAgent: mocks.resolveCliLaunchAgent,
 }));
 
 vi.mock('@cli/runtime/runExecution', () => ({
@@ -98,7 +98,7 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
 describe('CLI workflow run command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveCliAgent.mockResolvedValue({
+    mocks.resolveCliLaunchAgent.mockResolvedValue({
       name: 'polish',
       category: AgentCategory.Workflow,
       source: 'builtInWorkflow',
@@ -149,13 +149,17 @@ describe('CLI workflow run command', () => {
     ).rejects.toThrow('Use either --output or --output-dir, not both.');
 
     expect(mocks.initLocalCliPlatform).not.toHaveBeenCalled();
-    expect(mocks.resolveCliAgent).not.toHaveBeenCalled();
+    expect(mocks.resolveCliLaunchAgent).not.toHaveBeenCalled();
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports missing workflow agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockResolvedValueOnce(undefined);
+    mocks.resolveCliLaunchAgent.mockRejectedValueOnce(
+      new Error(
+        'Agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+      ),
+    );
     const { runWorkflowAgent } = await import('@cli/commands/workflow');
 
     await expect(
@@ -171,24 +175,22 @@ describe('CLI workflow run command', () => {
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
     expect(mocks.initLocalCliPlatform.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.resolveCliAgent.mock.invocationCallOrder[0],
+      mocks.resolveCliLaunchAgent.mock.invocationCallOrder[0],
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
+    expect(mocks.resolveCliLaunchAgent).toHaveBeenCalledWith(
       'missing-agent',
-      AgentCategory.Workflow,
+      'run',
     );
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
   it('reports tool-use agents before resolving the model', async () => {
-    mocks.resolveCliAgent.mockResolvedValueOnce({
-      name: 'chat',
-      category: AgentCategory.ToolUse,
-      source: 'builtInToolUse',
-      path: '/agents/chat.yaml',
-      tools: [],
-    });
+    mocks.resolveCliLaunchAgent.mockRejectedValueOnce(
+      new Error(
+        'Agent "chat" is a toolUse agent; `texra run` only handles workflow agents.',
+      ),
+    );
     const { runWorkflowAgent } = await import('@cli/commands/workflow');
 
     await expect(
@@ -203,10 +205,7 @@ describe('CLI workflow run command', () => {
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: '/tmp/project' }),
     );
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
-      'chat',
-      AgentCategory.Workflow,
-    );
+    expect(mocks.resolveCliLaunchAgent).toHaveBeenCalledWith('chat', 'run');
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
@@ -227,10 +226,7 @@ describe('CLI workflow run command', () => {
     );
 
     expect(mocks.initLocalCliPlatform).toHaveBeenCalled();
-    expect(mocks.resolveCliAgent).toHaveBeenCalledWith(
-      'polish',
-      AgentCategory.Workflow,
-    );
+    expect(mocks.resolveCliLaunchAgent).toHaveBeenCalledWith('polish', 'run');
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
@@ -337,7 +333,7 @@ describe('CLI workflow run command', () => {
     ).rejects.toThrow(/--instruction-file: file not found: missing-prompt\.md/);
 
     expect(mocks.initLocalCliPlatform).not.toHaveBeenCalled();
-    expect(mocks.resolveCliAgent).not.toHaveBeenCalled();
+    expect(mocks.resolveCliLaunchAgent).not.toHaveBeenCalled();
     expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- keep `resolveCliAgent()` as a category-free catalog/details lookup
- add `resolveCliLaunchAgent(name, mode)` as the single launch boundary that owns category lookup and launch-mode validation
- update `texra run` and `texra agents run` to request a launch mode instead of passing category hints and asserting separately

## Why

The previous run-command call sites had to pass `AgentCategory.Workflow` or `AgentCategory.ToolUse` into the resolver and then separately remember to validate the same intent with a launch mode. This leaked launch ownership into callers and made the resolver API feel like an options-driven fallback point. The new boundary keeps generic lookup simple and puts launch-specific category rules in one place.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `npm run typecheck`
- `npm run lint` (exits 0; reports one pre-existing import-order warning in `src/agent/review/reviewDiff.ts`, outside this PR)
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/runtime/agents.ts packages/cli/src/commands/agentsRun.ts packages/cli/src/commands/workflow.ts src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`