### PR TITLE
[codex] skip AI session labels for workflow runs

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -287,7 +287,7 @@ export async function executeAgent(
 
     // Fire-and-forget: generate AI session description from the user's instruction.
     // Triggered at the start so cancelled/errored sessions still get descriptions.
-    // Applies to all agents including subagents so their progress tabs show
+    // Applies to tool-use agents, including subagents, so their progress tabs show
     // meaningful descriptions in multi-agent pipelines.
     generateSessionDescription(
       ctx.executionId,

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -82,6 +82,8 @@ export async function generateSessionDescription(
   runtimeHost: AgentRuntimeHost,
 ): Promise<void> {
   try {
+    if (config.agentCategory !== AgentCategory.ToolUse) return;
+
     const instruction = getSessionDescriptionInstruction(config);
     if (!instruction) return;
 

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -1,11 +1,48 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   cleanSessionDescription,
+  generateSessionDescription,
   getSessionDescriptionInstruction,
 } from '@agent/runtime/sessionDescription';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  createHelperModelKit: vi.fn(),
+  emit: vi.fn(),
+  getAgent: vi.fn(),
+  writeSessionDescription: vi.fn(),
+}));
+
+vi.mock('@agent/index', () => ({
+  getAgent: mocks.getAgent,
+}));
+
+vi.mock('@agent/runtime/helperModel', () => ({
+  createHelperModelKit: mocks.createHelperModelKit,
+}));
+
+vi.mock('@agent/storage', () => ({
+  writeSessionDescription: mocks.writeSessionDescription,
+}));
+
+function configFor(category: AgentCategory) {
+  return AgentConfigSchema.parse({
+    agent: category === AgentCategory.ToolUse ? 'chat' : 'correct',
+    model: 'gemini35f',
+    instruction: 'Fix grammar.',
+    agentCategory: category,
+  });
+}
 
 describe('session description helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('normalizes model-generated descriptions for compact UI labels', () => {
     expect(cleanSessionDescription('"Fixing TikZ arrows."')).toBe(
       'Fixing TikZ arrows',
@@ -32,5 +69,46 @@ describe('session description helpers', () => {
         instruction: 'Summarize the paper.',
       }),
     ).toBe('Summarize the paper.');
+  });
+
+  it('does not generate helper-model descriptions for workflow runs', async () => {
+    await generateSessionDescription(
+      'exec-workflow' as ExecutionId,
+      'stream-workflow' as StreamTabId,
+      configFor(AgentCategory.Workflow),
+      { emit: mocks.emit } as unknown as AgentRuntimeHost,
+    );
+
+    expect(mocks.createHelperModelKit).not.toHaveBeenCalled();
+    expect(mocks.writeSessionDescription).not.toHaveBeenCalled();
+    expect(mocks.emit).not.toHaveBeenCalled();
+  });
+
+  it('keeps generating compact descriptions for tool-use runs', async () => {
+    const handler = {
+      createResponse: vi.fn().mockResolvedValue({ response: {} }),
+      extractResponse: vi.fn().mockReturnValue({ text: 'Fixing proof typos' }),
+      initializeMessages: vi.fn().mockResolvedValue([]),
+    };
+    mocks.getAgent.mockReturnValue({ description: 'General chat assistant' });
+    mocks.createHelperModelKit.mockResolvedValue({
+      kit: { client: {}, handler },
+    });
+
+    await generateSessionDescription(
+      'exec-tool' as ExecutionId,
+      'stream-tool' as StreamTabId,
+      configFor(AgentCategory.ToolUse),
+      { emit: mocks.emit } as unknown as AgentRuntimeHost,
+    );
+
+    expect(mocks.writeSessionDescription).toHaveBeenCalledWith(
+      'exec-tool',
+      'Fixing proof typos',
+    );
+    expect(mocks.emit).toHaveBeenCalledWith('updateStreamDescription', {
+      streamId: 'stream-tool',
+      description: 'Fixing proof typos',
+    });
   });
 });


### PR DESCRIPTION
## Summary

- make `generateSessionDescription` return immediately for non-tool-use runs
- update the `executeAgent` comment so the documented ownership matches the code
- add regression tests that workflow configs do not call the helper model while tool-use configs still generate compact labels

## Dogfood evidence

While testing `texra-local run correct` on a small variance-lemma LaTeX document, the workflow completed and produced a corrected file, but the run metadata persisted a helper-generated description: `Ready. Please provide the text you would like me to correct`. That description also appeared in the live progress line even though the workflow had a real input file and returned structured `<documents>` output.

Root cause: session-label generation is documented as tool-use session labeling, but `executeAgent` invoked it for every agent category. The generator then looked up the agent only as `AgentCategory.ToolUse`; for workflow agents like `correct`, it had no proper agent context and could persist a bad helper-model label.

After this change, a rebuilt `texra-local run correct` on the same style of math input completed with clean metadata:

```json
{
  "timestamp": "2026-06-18T18:15:06.936Z",
  "category": "workflow",
  "terminalStatus": "completed"
}
```

No stale `description` is persisted for workflow history rows.

## Validation

- `texra-local run correct --cwd /tmp/texra-workflow-dogfood-sessiondesc-20260618 --input variance_note.tex --output corrected.tex --model gemini35f --instruction "Fix grammar and LaTeX formatting only; preserve the mathematical statements and proof structure." --no-input --approval-policy never --output-format json`
- `corepack pnpm vitest run src/test-kernel/agent/runtime/SessionDescription.vitest.ts src/test-kernel/agent/runtime/CleanSessionDescription.vitest.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run typecheck`
- `npm run lint` (exits 0; reports one pre-existing import-order warning in `src/agent/review/reviewDiff.ts`, outside this PR)
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src/agent/runtime/sessionDescription.ts src/agent/runtime/executeAgent.ts src/test-kernel/agent/runtime/SessionDescription.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Early-return guard on an existing fire-and-forget path; no auth, data, or workflow execution logic changes beyond skipping label generation for workflows.
> 
> **Overview**
> **Workflow runs no longer get helper-model session descriptions.** `generateSessionDescription` returns immediately when `config.agentCategory` is not `AgentCategory.ToolUse`, so workflow agents (e.g. `correct`) no longer trigger a one-shot label that could persist misleading text like generic “ready” prompts in run metadata and the progress UI.
> 
> The `executeAgent` comment is updated to state that labeling applies to **tool-use agents** (including subagents), matching the generator’s intended scope.
> 
> Regression tests assert workflow configs never call `createHelperModelKit` / persistence / emit, while tool-use configs still write and emit compact descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d61a3c09aec203e8805236bee569cfb82294452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->