### PR TITLE
[codex] keep multi-agent completeness checks internal

### DIFF
--- a/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
+++ b/packages/cli/src/commands/_helpers/multiAgentInstruction.ts
@@ -10,7 +10,7 @@ interface MultiAgentInstructionPreset {
 }
 
 const COMPLETENESS_GUIDANCE =
-  'Before claiming a result is complete, check the full domain stated by the user, including sign choices, zero and boundary cases, and symmetry branches.';
+  'Before claiming a result is complete, internally check the full domain stated by the user, including sign choices, zero and boundary cases, and symmetry branches. Use this as a correctness checklist; do not add a separate checklist or case analysis to the final answer unless the user asks for it, and keep the final answer within the user-requested scope and length.';
 
 export function formatMultiAgentRunInstruction(
   preset: MultiAgentInstructionPreset,

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -105,7 +105,7 @@ describe('formatUnavailableApprovalInstruction', () => {
 });
 
 describe('formatMultiAgentRunInstruction', () => {
-  it('reminds the orchestrator to check domain edge cases before claiming completeness', () => {
+  it('keeps domain edge-case checks subordinate to the requested answer shape', () => {
     for (const mode of ['headless', 'interactive'] as const) {
       for (const approvalPolicy of ['never', 'ask', 'yolo'] as const) {
         const instruction = formatMultiAgentRunInstruction(preset, {
@@ -117,11 +117,15 @@ describe('formatMultiAgentRunInstruction', () => {
         });
 
         expect(instruction).toContain(
-          'check the full domain stated by the user',
+          'internally check the full domain stated by the user',
         );
         expect(instruction).toContain('sign choices');
         expect(instruction).toContain('zero and boundary cases');
         expect(instruction).toContain('symmetry branches');
+        expect(instruction).toContain('do not add a separate checklist');
+        expect(instruction).toContain(
+          'keep the final answer within the user-requested scope and length',
+        );
       }
     }
   });


### PR DESCRIPTION
## Summary

- keep the multi-agent domain/completeness checklist as an internal correctness check
- tell orchestrators not to add separate checklist/case-analysis sections unless requested
- preserve the user-requested answer scope and length in final responses

## Dogfood evidence

I ran the `mathematician` preset on a small proof task:

```sh
texra-local multi-agent run mathematician \
  --cwd /tmp/texra-multiagent-dogfood-20260618 \
  --model gemini35f \
  --approval-policy yolo \
  --no-input \
  --output-format json \
  --instruction "Check this concise proof task. Claim: for any real numbers a,b, (a+b)^2 <= 2a^2+2b^2. Provide a rigorous proof in 5 lines or fewer. You may delegate to at most one specialist subagent if useful, but do not run shell commands, do not edit files, and do not browse the web."
```

Before this change, the final response included the requested 4-line proof but then appended a separate “Domain, Boundary, and Symmetry Verification” checklist. That happened because the CLI wrapper prompt required full-domain checks without saying that those checks should stay internal or defer to the user-requested output shape.

After this change, the same run returned a 4-line proof and did not expose the internal checklist:

```text
**Proof:**
1. For any real numbers $a, b \in \mathbb{R}$, we have the trivial inequality $(a - b)^2 \ge 0$.
2. Expanding this yields $a^2 - 2ab + b^2 \ge 0$, which is equivalent to $2ab \le a^2 + b^2$.
3. Adding $a^2 + b^2$ to both sides results in $a^2 + 2ab + b^2 \le 2a^2 + 2b^2$.
4. Factoring the left-hand side gives $(a + b)^2 \le 2a^2 + 2b^2$, with equality if and only if $a=b$. Q.E.D.
```

## Validation

- `texra-local multi-agent run mathematician --cwd /tmp/texra-multiagent-dogfood-scope-20260618 --model gemini35f --approval-policy yolo --no-input --output-format json --instruction "Check this concise proof task. Claim: for any real numbers a,b, (a+b)^2 <= 2a^2+2b^2. Provide a rigorous proof in 5 lines or fewer. You may delegate to at most one specialist subagent if useful, but do not run shell commands, do not edit files, and do not browse the web."`
- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentInstruction.vitest.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run typecheck`
- `npm run lint` (exits 0; reports one pre-existing import-order warning in `src/agent/review/reviewDiff.ts`, outside this PR)
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/commands/_helpers/multiAgentInstruction.ts src/test-kernel/cli/MultiAgentInstruction.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to `COMPLETENESS_GUIDANCE` with matching unit tests; no auth, data, or runtime logic changes.
> 
> **Overview**
> Multi-agent CLI orchestrator prompts still require **internal** domain/completeness verification (signs, boundaries, symmetry), but now tell the model **not** to surface that work as extra checklist or case-analysis sections unless the user asked for them, and to **stay within the requested answer scope and length**.
> 
> Tests in `MultiAgentInstruction.vitest.ts` were updated to assert the new wording (`internally check`, `do not add a separate checklist`, scope/length constraints).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a99ef37691366302fffeb022905881b954e10e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->