### PR TITLE
refactor(a11y): finish settingsView waIcon sweep — status + dynamic-name icons (part 4)

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -314,8 +314,7 @@ export class HistoryItemElement extends LitElement {
     const metaParts: Array<string | TemplateResult> = [
       timestamp,
       html`<wa-tag variant=${categoryVariant} size="small">
-        ${decorator.icon ? waIcon(decorator.icon) : nothing}
-        ${decorator.label}
+        ${decorator.icon ? waIcon(decorator.icon) : nothing} ${decorator.label}
       </wa-tag>`,
       `Agent: ${config.agent ?? 'Unknown'}`,
       `Model: ${config.model ?? 'Unknown'}`,

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -314,9 +314,7 @@ export class HistoryItemElement extends LitElement {
     const metaParts: Array<string | TemplateResult> = [
       timestamp,
       html`<wa-tag variant=${categoryVariant} size="small">
-        ${decorator.icon
-          ? html`<wa-icon library="texra" name=${decorator.icon}></wa-icon>`
-          : nothing}
+        ${decorator.icon ? waIcon(decorator.icon) : nothing}
         ${decorator.label}
       </wa-tag>`,
       `Agent: ${config.agent ?? 'Unknown'}`,

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -288,8 +288,7 @@ export class ToolCard extends LitElement {
         appearance="accent"
         size="small"
       >
-        ${waIcon(config.icon)}
-        ${label}
+        ${waIcon(config.icon)} ${label}
       </wa-tag>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -11,7 +11,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
-import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
@@ -240,7 +240,7 @@ export class ToolCard extends LitElement {
   private static readonly STATUS_CONFIG: Record<
     ToolDashboardItem['status'],
     {
-      icon: string;
+      icon: TeXRAIconName;
       variant: 'brand' | 'neutral' | 'success' | 'warning' | 'danger';
     }
   > = {
@@ -270,7 +270,7 @@ export class ToolCard extends LitElement {
         aria-label=${label}
         title=${label}
       >
-        <wa-icon library="texra" name=${config.icon}></wa-icon>
+        ${waIcon(config.icon)}
       </span>
     `;
   }
@@ -288,7 +288,7 @@ export class ToolCard extends LitElement {
         appearance="accent"
         size="small"
       >
-        <wa-icon library="texra" name=${config.icon}></wa-icon>
+        ${waIcon(config.icon)}
         ${label}
       </wa-tag>
     `;

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -245,11 +245,9 @@ export class LaTeXTab extends LitElement {
     return html`
       <div class="dependency-card">
         <div class="dependency-row">
-          <wa-icon
-            library="texra"
-            name=${installed ? 'check' : 'warning'}
-            class="dependency-icon ${installed ? 'installed' : 'missing'}"
-          ></wa-icon>
+          ${waIcon(installed ? 'check' : 'warning', {
+            className: `dependency-icon ${installed ? 'installed' : 'missing'}`,
+          })}
           <div class="dependency-info">
             <div class="dependency-name">${dep.name}</div>
             <div class="dependency-description">
@@ -395,11 +393,9 @@ export class LaTeXTab extends LitElement {
     const isSet = this.settings[info.key];
     return html`
       <div class="setting-card">
-        <wa-icon
-          library="texra"
-          name=${isSet ? 'check' : 'warning'}
-          class="setting-status-icon ${isSet ? 'is-set' : 'not-set'}"
-        ></wa-icon>
+        ${waIcon(isSet ? 'check' : 'warning', {
+          className: `setting-status-icon ${isSet ? 'is-set' : 'not-set'}`,
+        })}
         <div class="setting-info">
           <div class="setting-name">${info.name}</div>
           <div class="setting-config-key">${info.configKey}</div>
@@ -489,13 +485,11 @@ export class LaTeXTab extends LitElement {
         ${waIcon('comment-discussion')} Inline Criticism
       </div>
       <div class="setting-card">
-        <wa-icon
-          library="texra"
-          name=${this.inlineCriticismEnabled ? 'check' : 'circle-slash'}
-          class="setting-status-icon ${this.inlineCriticismEnabled
-            ? 'is-set'
-            : 'not-set'}"
-        ></wa-icon>
+        ${waIcon(this.inlineCriticismEnabled ? 'check' : 'circle-slash', {
+          className: `setting-status-icon ${
+            this.inlineCriticismEnabled ? 'is-set' : 'not-set'
+          }`,
+        })}
         <div class="setting-info">
           <div class="setting-name">Surface \\criticize annotations</div>
           <div class="setting-description">
@@ -641,11 +635,9 @@ export class LaTeXTab extends LitElement {
     const isCustom = opts.currentValue !== undefined;
     return html`
       <div class="setting-card">
-        <wa-icon
-          library="texra"
-          name=${effective ? 'check' : 'circle-slash'}
-          class="setting-status-icon ${effective ? 'is-set' : 'not-set'}"
-        ></wa-icon>
+        ${waIcon(effective ? 'check' : 'circle-slash', {
+          className: `setting-status-icon ${effective ? 'is-set' : 'not-set'}`,
+        })}
         <div class="setting-info">
           <div class="setting-name">${opts.label}</div>
           <div class="setting-description">${opts.description}</div>
@@ -671,12 +663,10 @@ export class LaTeXTab extends LitElement {
    * Red is reserved for booleans that are Off, where it carries meaning.
    */
   private renderSettingStatusIcon(isCustom: boolean): TemplateResult {
-    return html`<wa-icon
-      library="texra"
-      name=${isCustom ? 'edit' : 'gear'}
-      class="setting-status-icon ${isCustom ? 'is-set' : 'is-default'}"
-      title=${isCustom ? 'Customized' : 'Using default'}
-    ></wa-icon>`;
+    return waIcon(isCustom ? 'edit' : 'gear', {
+      className: `setting-status-icon ${isCustom ? 'is-set' : 'is-default'}`,
+      title: isCustom ? 'Customized' : 'Using default',
+    });
   }
 
   /** Reset-to-default button shown when a config value has been customized. */

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -395,8 +395,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          ${waIcon(meta.icon)}
-          ${meta.label}
+          ${waIcon(meta.icon)} ${meta.label}
           <span class="category-count">(${items.length})</span>
         </div>
         ${repeat(

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -8,7 +8,7 @@ import { repeat } from 'lit/directives/repeat.js';
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
 import { renderLoadingState } from '@shared/wa/loadingState';
-import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
@@ -29,7 +29,7 @@ import '../components/tools/ToolCard';
 /** Per-category display metadata. */
 interface CategoryMeta {
   readonly label: string;
-  readonly icon: string;
+  readonly icon: TeXRAIconName;
 }
 
 /**
@@ -395,7 +395,7 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          <wa-icon library="texra" name=${meta.icon}></wa-icon>
+          ${waIcon(meta.icon)}
           ${meta.label}
           <span class="category-count">(${items.length})</span>
         </div>


### PR DESCRIPTION
## Summary

Completes the settingsView `waIcon()` migration (#6211, #6220, #6232) by converting the sites that needed either the new `title` option or **icon-name source typing**:

- **LaTeXTab** — 5 status icons (dependency / setting-status). Their names are ternaries of literals (already `TeXRAIconName`-typed) and classes are template strings, so they're expressible via `waIcon(name, { className, title })` now that #6232 added `title`.
- **ToolsTab** — type `CategoryMeta.icon` as `TeXRAIconName`; convert the category header (`name=${meta.icon}`).
- **ToolCard** — type `STATUS_CONFIG.icon` as `TeXRAIconName`; convert the two status icons (`name=${config.icon}`).
- **HistoryItemElement** — convert the category-decorator icon (`decorator.icon` is const-narrowed to `'symbol-method' | 'tools'`, already a `TeXRAIconName`).

### Why typing the sources matters
Making the `icon` fields `TeXRAIconName` means **`tsc` validates every stored value against the icon registry at compile time** — turning silent missing-icon bugs into build errors. All values checked out (no registry additions needed). This is the careful, verified approach the round-8 audit asked for, rather than a blind cast.

## Intentionally left raw (3 sites)
- **MultiAgentTab `preset.icon`** — the source stores `codicon-`-prefixed strings; converting would need an unsafe cast for no real gain.
- **ModelSelectionList** ×2 — provider/deprecated rotation chevrons bind `class=${classMap(...)}`, which `waIcon`'s static `className` can't express.

settingsView is otherwise fully migrated to `waIcon()`.

## Verification
- Extension package typechecks clean (the `TeXRAIconName` source typings are validated by `tsc`). Net −12 LOC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor in settings UI with no auth, data, or API changes; behavior should match prior icon rendering.
> 
> **Overview**
> Finishes the settings view **waIcon()** sweep by replacing remaining raw `wa-icon` tags with the shared helper, including status icons that need **`className`** and **`title`**.
> 
> **LaTeXTab** dependency and setting status icons now use `waIcon(name, { className, title })` instead of inline `wa-icon` markup. **ToolCard** and **ToolsTab** type stored icon names as **`TeXRAIconName`** and render category/status icons through `waIcon`. **HistoryItemElement** uses `waIcon` for the agent-category decorator in history meta tags.
> 
> No new user-facing behavior—centralized icon rendering and compile-time checks on icon registry keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e527c91f82e8b91f08a9a4e88904c2bca89ea711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->