### PR TITLE
refactor: centralize CLI execution setup

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -1,9 +1,5 @@
-import { writeTerminalStatus } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
-import { validateExecutionRequest } from '@agent/core/execution/executionRequests';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { EXECUTION_STATUS } from '@shared/schemas';
-import { generateExecutionId } from '@utils/core/executionId';
 
 import {
   CliUsageError,
@@ -11,7 +7,6 @@ import {
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
-import { writeTextStderr } from '../runtime/logSinks';
 import {
   buildHeadlessRunContext,
   resolveCliRunModel,
@@ -31,7 +26,7 @@ import {
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
 import { emitCliResult } from './_helpers/output';
-import { executeCliRequest } from '../runtime/runExecution';
+import { executeCliConfig } from '../runtime/runExecution';
 import {
   createCliRunResult,
   terminalStatusExitCode,
@@ -98,29 +93,17 @@ export async function runToolUseAgent(
         agentCategory: AgentCategory.ToolUse,
       };
 
-      const executionId = generateExecutionId();
-      const validation = validateExecutionRequest({ config, executionId });
-      if (!validation.valid) {
-        writeTextStderr(validation.message);
-        return CliExitCode.Usage;
-      }
-      const { result, terminalStatus } = await executeCliRequest(
-        validation.request,
-        runContext,
-        {
-          enforceCategory: true,
-          registerExecution: true,
-          markErrorOnThrow: true,
-          stopAfterCycle: true,
-        },
-      );
-      if (result.category !== AgentCategory.ToolUse) {
-        await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-        writeTextStderr(
-          `Agent "${init.agent}" resolved to a non tool-use run.`,
-        );
-        return CliExitCode.AgentError;
-      }
+      const execution = await executeCliConfig(config, runContext, {
+        enforceCategory: true,
+        registerExecution: true,
+        markErrorOnThrow: true,
+        stopAfterCycle: true,
+        expectedCategory: AgentCategory.ToolUse,
+        categoryMismatchMessage: `Agent "${init.agent}" resolved to a non tool-use run.`,
+      });
+      if (!execution.ok) return execution.exitCode;
+
+      const { result, terminalStatus } = execution;
 
       const displayResult: CliToolUseRunResult = createCliRunResult(
         result,

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -1,13 +1,9 @@
 import { defineCommand } from 'citty';
 
 import { getAgentsByCategory, loadAgents } from '@agent/index';
-import { writeTerminalStatus } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
-import { validateExecutionRequest } from '@agent/core/execution/executionRequests';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
-import { EXECUTION_STATUS } from '@shared/schemas';
-import { generateExecutionId } from '@utils/core/executionId';
 import { approvalPromptsUnavailable } from '../runtime/approvalPolicyAvailability';
 import {
   missingMultiAgentPresetMessage,
@@ -59,7 +55,7 @@ import {
   optString,
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
-import { executeCliRequest } from '../runtime/runExecution';
+import { executeCliConfig } from '../runtime/runExecution';
 import {
   createCliRunResult,
   terminalStatusExitCode,
@@ -350,30 +346,18 @@ export async function runMultiAgentPreset(
         cliMultiAgentPresetId: plan.preset.id,
       };
 
-      const executionId = generateExecutionId();
-      const validation = validateExecutionRequest({ config, executionId });
-      if (!validation.valid) {
-        writeTextStderr(validation.message);
-        return CliExitCode.Usage;
-      }
-      const { result, terminalStatus } = await executeCliRequest(
-        validation.request,
-        runContext,
-        {
-          enforceCategory: true,
-          registerExecution: true,
-          markErrorOnThrow: true,
-          stopAfterCycle: true,
-          wrap: (run) => withCliMultiAgentPresetVisibility(plan, run),
-        },
-      );
-      if (result.category !== AgentCategory.ToolUse) {
-        await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-        writeTextStderr(
-          `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,
-        );
-        return CliExitCode.AgentError;
-      }
+      const execution = await executeCliConfig(config, runContext, {
+        enforceCategory: true,
+        registerExecution: true,
+        markErrorOnThrow: true,
+        stopAfterCycle: true,
+        wrap: (run) => withCliMultiAgentPresetVisibility(plan, run),
+        expectedCategory: AgentCategory.ToolUse,
+        categoryMismatchMessage: `Multi-agent preset "${init.preset}" resolved to a non tool-use execution.`,
+      });
+      if (!execution.ok) return execution.exitCode;
+
+      const { result, terminalStatus } = execution;
       const displayResult: CliToolUseRunResult = createCliRunResult(
         result,
         terminalStatus,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,9 +1,7 @@
 import { writeTerminalStatus } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
-import { validateExecutionRequest } from '@agent/core/execution/executionRequests';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { EXECUTION_STATUS } from '@shared/schemas';
-import { generateExecutionId } from '@utils/core/executionId';
 
 import {
   CliUsageError,
@@ -11,7 +9,7 @@ import {
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
-import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
+import { writeErrorStderr } from '../runtime/logSinks';
 import {
   buildHeadlessRunContext,
   resolveCliRunModel,
@@ -28,7 +26,7 @@ import {
   optString,
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
-import { executeCliRequest } from '../runtime/runExecution';
+import { executeCliConfig } from '../runtime/runExecution';
 import {
   terminalStatusExitCode,
   type CliRunResult,
@@ -109,21 +107,14 @@ export async function runWorkflowAgent(
         agentCategory: AgentCategory.Workflow,
       };
 
-      const executionId = generateExecutionId();
-      const validation = validateExecutionRequest({ config, executionId });
-      if (!validation.valid) {
-        writeTextStderr(validation.message);
-        return CliExitCode.Usage;
-      }
-      const { result, terminalStatus } = await executeCliRequest(
-        validation.request,
-        runContext,
-        {
-          enforceCategory: true,
-          registerExecution: true,
-          markErrorOnThrow: true,
-        },
-      );
+      const execution = await executeCliConfig(config, runContext, {
+        enforceCategory: true,
+        registerExecution: true,
+        markErrorOnThrow: true,
+      });
+      if (!execution.ok) return execution.exitCode;
+
+      const { executionId, result, terminalStatus } = execution;
       let displayResult: CliRunResult;
       try {
         displayResult = (

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,15 +1,23 @@
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { tryPlatform } from '@platform/platform';
 import { writeTerminalStatus } from '@agent/storage';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import {
+  validateExecutionRequest,
+  type ValidatedExecutionRequest,
+} from '@agent/core/execution/executionRequests';
 import { runAgent } from '@agent/runtime/runAgent';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
-import type { ValidatedExecutionRequest } from '@agent/core/execution/executionRequests';
+import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+import { generateExecutionId } from '@utils/core/executionId';
 
 import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
 import { installCliApprovalHandlers } from './approvalAdapter';
 import { createCliRuntimeHost } from './runtimeHost';
+import { CliExitCode } from './exitCodes';
+import { writeTextStderr } from './logSinks';
 import {
   readCliTerminalStatus,
   type ExecuteAgentResult,
@@ -37,6 +45,76 @@ export interface CliExecuteOptions {
   readonly wrap?: (
     run: () => Promise<ExecuteAgentResult>,
   ) => Promise<ExecuteAgentResult>;
+}
+
+type ExecuteAgentResultForCategory<C extends AgentCategory | undefined> =
+  C extends AgentCategory
+    ? Extract<ExecuteAgentResult, { category: C }>
+    : ExecuteAgentResult;
+
+export interface CliConfigExecuteOptions<
+  C extends AgentCategory | undefined = undefined,
+> extends CliExecuteOptions {
+  /** Defensive post-run guard for command paths that must stay in one category. */
+  readonly expectedCategory?: C;
+  readonly categoryMismatchMessage?: string;
+}
+
+export type CliConfigExecuteResult<C extends AgentCategory | undefined> =
+  | {
+      readonly ok: true;
+      readonly executionId: string;
+      readonly result: ExecuteAgentResultForCategory<C>;
+      readonly terminalStatus: ExecutionStatus;
+    }
+  | {
+      readonly ok: false;
+      readonly exitCode: CliExitCode;
+    };
+
+/**
+ * Build and validate a headless CLI execution request, then run it. Command
+ * handlers own command-specific config construction; this module owns the
+ * common request lifecycle so workflow, tool-use, and multi-agent runs cannot
+ * drift on validation, execution ids, or category-mismatch status writes.
+ */
+export async function executeCliConfig<
+  C extends AgentCategory | undefined = undefined,
+>(
+  config: AgentConfigPayload,
+  runContext: CliContext,
+  options: CliConfigExecuteOptions<C> = {},
+): Promise<CliConfigExecuteResult<C>> {
+  const { expectedCategory, categoryMismatchMessage, ...executeOptions } =
+    options;
+  const executionId = generateExecutionId();
+  const validation = validateExecutionRequest({ config, executionId });
+  if (!validation.valid) {
+    writeTextStderr(validation.message);
+    return { ok: false, exitCode: CliExitCode.Usage };
+  }
+
+  const { result, terminalStatus } = await executeCliRequest(
+    validation.request,
+    runContext,
+    executeOptions,
+  );
+
+  if (expectedCategory !== undefined && result.category !== expectedCategory) {
+    await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+    writeTextStderr(
+      categoryMismatchMessage ??
+        `Agent resolved to a non ${expectedCategory} run.`,
+    );
+    return { ok: false, exitCode: CliExitCode.AgentError };
+  }
+
+  return {
+    ok: true,
+    executionId,
+    result: result as ExecuteAgentResultForCategory<C>,
+    terminalStatus,
+  };
 }
 
 /**

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -6,7 +6,7 @@ import { RUN_OUTCOME } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => {
   return {
-    executeCliRequest: vi.fn(),
+    executeCliConfig: vi.fn(),
     withExpandedRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
     isAuthenticated: vi.fn(),
@@ -63,7 +63,7 @@ vi.mock('@cli/runtime/agents', async (importOriginal) => ({
 }));
 
 vi.mock('@cli/runtime/runExecution', () => ({
-  executeCliRequest: mocks.executeCliRequest,
+  executeCliConfig: mocks.executeCliConfig,
 }));
 
 vi.mock('@cli/runtime/workflowInputs', () => ({
@@ -114,7 +114,9 @@ describe('CLI agents run command', () => {
       async (_context: CliContext, model: string | undefined) =>
         model ?? 'gpt54',
     );
-    mocks.executeCliRequest.mockResolvedValue({
+    mocks.executeCliConfig.mockResolvedValue({
+      ok: true,
+      executionId: 'exec-1',
       result: {
         category: AgentCategory.ToolUse,
         executionId: 'exec-1',
@@ -158,22 +160,16 @@ describe('CLI agents run command', () => {
       },
       expect.any(Function),
     );
-    const request = mocks.executeCliRequest.mock.calls[0]?.[0];
-    expect(request?.config.inputFiles).toEqual(['problem.md']);
-    expect(request?.config.contextFiles).toEqual(['notes.md']);
-    expect(request?.config.displayInstruction).toBe(
-      'Assess the proof concisely.',
-    );
-    expect(request?.config.instruction).toContain('Primary user input files:');
-    expect(request?.config.instruction).toContain('- "problem.md"');
-    expect(request?.config.instruction).toContain('Read-only context files:');
-    expect(request?.config.instruction).toContain('- "notes.md"');
-    expect(request?.config.instruction).toContain(
-      'Additional user instruction:',
-    );
-    expect(request?.config.instruction).toContain(
-      'Assess the proof concisely.',
-    );
+    const config = mocks.executeCliConfig.mock.calls[0]?.[0];
+    expect(config?.inputFiles).toEqual(['problem.md']);
+    expect(config?.contextFiles).toEqual(['notes.md']);
+    expect(config?.displayInstruction).toBe('Assess the proof concisely.');
+    expect(config?.instruction).toContain('Primary user input files:');
+    expect(config?.instruction).toContain('- "problem.md"');
+    expect(config?.instruction).toContain('Read-only context files:');
+    expect(config?.instruction).toContain('- "notes.md"');
+    expect(config?.instruction).toContain('Additional user instruction:');
+    expect(config?.instruction).toContain('Assess the proof concisely.');
   });
 
   it('reports missing instruction before resolving the model', async () => {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -9,7 +9,7 @@ import { RUN_OUTCOME } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => {
   return {
-    executeCliRequest: vi.fn(),
+    executeCliConfig: vi.fn(),
     withExpandedRunInputs: vi.fn(),
     cliMultiAgentPlanHasGaps: vi.fn(),
     cliMultiAgentPresetCanLaunchTeam: vi.fn(),
@@ -102,7 +102,7 @@ vi.mock('@cli/runtime/runModel', () => ({
 }));
 
 vi.mock('@cli/runtime/runExecution', () => ({
-  executeCliRequest: mocks.executeCliRequest,
+  executeCliConfig: mocks.executeCliConfig,
 }));
 
 vi.mock('@cli/runtime/workflowInputs', () => ({
@@ -203,7 +203,9 @@ describe('CLI multi-agent run command', () => {
       toolUseAgentKeys: ['builtInToolUse:orchestrator'],
     });
     mocks.isAuthenticated.mockResolvedValue(false);
-    mocks.executeCliRequest.mockResolvedValue({
+    mocks.executeCliConfig.mockResolvedValue({
+      ok: true,
+      executionId: 'exec-1',
       result: {
         category: 'toolUse',
         executionId: 'exec-1',
@@ -226,8 +228,8 @@ describe('CLI multi-agent run command', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(mocks.executeCliRequest).toHaveBeenCalledTimes(1);
-    expect(mocks.executeCliRequest.mock.calls[0]?.[2]).toMatchObject({
+    expect(mocks.executeCliConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.executeCliConfig.mock.calls[0]?.[2]).toMatchObject({
       enforceCategory: true,
       registerExecution: true,
       markErrorOnThrow: true,
@@ -244,13 +246,13 @@ describe('CLI multi-agent run command', () => {
       },
       expect.any(Function),
     );
-    const request = mocks.executeCliRequest.mock.calls[0]?.[0];
-    expect(request?.config.instruction).toContain('Primary user input files:');
-    expect(request?.config.instruction).toContain('- "problem.tex"');
-    expect(request?.config.instruction).toContain(
+    const config = mocks.executeCliConfig.mock.calls[0]?.[0];
+    expect(config?.instruction).toContain('Primary user input files:');
+    expect(config?.instruction).toContain('- "problem.tex"');
+    expect(config?.instruction).toContain(
       'This CLI run exits after your final response.',
     );
-    expect(request?.config.instruction).toContain(
+    expect(config?.instruction).toContain(
       'Do not end by asking the user whether to perform more work',
     );
   });
@@ -423,10 +425,10 @@ describe('CLI multi-agent run command', () => {
       },
       expect.any(Function),
     );
-    const request = mocks.executeCliRequest.mock.calls[0]?.[0];
-    expect(request?.config.inputFiles).toEqual([]);
-    expect(request?.config.instruction).toContain('User instruction:');
-    expect(request?.config.instruction).toContain(
+    const config = mocks.executeCliConfig.mock.calls[0]?.[0];
+    expect(config?.inputFiles).toEqual([]);
+    expect(config?.instruction).toContain('User instruction:');
+    expect(config?.instruction).toContain(
       'Prove that every odd square is congruent to 1 modulo 8.',
     );
   });
@@ -465,10 +467,10 @@ describe('CLI multi-agent run command', () => {
         },
         expect.any(Function),
       );
-      const request = mocks.executeCliRequest.mock.calls[0]?.[0];
-      expect(request?.config.inputFiles).toEqual([]);
-      expect(request?.config.instruction).toContain('User instruction:');
-      expect(request?.config.instruction).toContain(
+      const config = mocks.executeCliConfig.mock.calls[0]?.[0];
+      expect(config?.inputFiles).toEqual([]);
+      expect(config?.instruction).toContain('User instruction:');
+      expect(config?.instruction).toContain(
         'Read the prompt from disk.\n\nThen summarize the plan.',
       );
     } finally {
@@ -542,7 +544,7 @@ describe('CLI multi-agent run command', () => {
     });
 
     expect(exitCode).toBe(2);
-    expect(mocks.executeCliRequest).not.toHaveBeenCalled();
+    expect(mocks.executeCliConfig).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(message);
     expect(
       mocks.formatCliMultiAgentTeamLaunchBlockMessage,
@@ -629,7 +631,7 @@ describe('CLI multi-agent run command', () => {
     });
 
     expect(exitCode).toBe(2);
-    expect(mocks.executeCliRequest).not.toHaveBeenCalled();
+    expect(mocks.executeCliConfig).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(message);
     expect(
       mocks.formatCliMultiAgentTeamLaunchBlockMessage,

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   prepareInteractivePrompt: vi.fn(),
   readCliTerminalStatus: vi.fn(),
   runAgent: vi.fn(),
+  writeTextStderr: vi.fn(),
   writeTerminalStatus: vi.fn(),
 }));
 
@@ -32,6 +33,10 @@ vi.mock('@cli/runtime/approvalAdapter', () => ({
 
 vi.mock('@cli/runtime/terminalStatus', () => ({
   readCliTerminalStatus: mocks.readCliTerminalStatus,
+}));
+
+vi.mock('@cli/runtime/logSinks', () => ({
+  writeTextStderr: mocks.writeTextStderr,
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
@@ -260,5 +265,77 @@ describe('executeCliRequest', () => {
     await platform.lifecycle.runShutdown();
 
     expect(mocks.writeTerminalStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('executeCliConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.close.mockResolvedValue(undefined);
+    mocks.installCliApprovalHandlers.mockReturnValue(vi.fn());
+    mocks.createCliRuntimeHost.mockReturnValue({
+      emit: vi.fn(),
+      prepareInteractivePrompt: mocks.prepareInteractivePrompt,
+      close: mocks.close,
+    });
+    mocks.readCliTerminalStatus.mockResolvedValue('completed');
+    mocks.runAgent.mockResolvedValue({
+      category: 'toolUse',
+      executionId: 'exec-1',
+      status: 'completed',
+      streamId: 'stream-1',
+    });
+  });
+
+  it('reports invalid configs without starting the runtime host', async () => {
+    const { executeCliConfig } = await import('@cli/runtime/runExecution');
+    const invalidConfig = { agentCategory: 'invalid' } as unknown as Parameters<
+      typeof executeCliConfig
+    >[0];
+
+    const result = await executeCliConfig(invalidConfig, cliContext());
+
+    expect(result).toMatchObject({ ok: false });
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(expect.any(String));
+    expect(mocks.createCliRuntimeHost).not.toHaveBeenCalled();
+    expect(mocks.runAgent).not.toHaveBeenCalled();
+  });
+
+  it('marks executions errored when the resolved category is unexpected', async () => {
+    const { AgentCategory } =
+      await import('@agent/core/definition/AgentDataclass');
+    const { executeCliConfig } = await import('@cli/runtime/runExecution');
+    mocks.runAgent.mockResolvedValueOnce({
+      category: AgentCategory.Workflow,
+      executionId: 'exec-1',
+      outcome: 'completed',
+      outputs: [],
+      compileFailures: [],
+    });
+
+    const result = await executeCliConfig(
+      {
+        agent: 'chat',
+        model: 'gpt54',
+        inputFiles: [],
+        contextFiles: [],
+        instruction: 'Check this.',
+        workingDirectory: '/tmp/project',
+        agentCategory: AgentCategory.ToolUse,
+      },
+      cliContext(),
+      {
+        expectedCategory: AgentCategory.ToolUse,
+        categoryMismatchMessage: 'wrong category',
+      },
+    );
+
+    expect(result).toMatchObject({ ok: false });
+    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
+      expect.any(String),
+      EXECUTION_STATUS.ERROR,
+    );
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith('wrong category');
+    expect(mocks.close).toHaveBeenCalledOnce();
   });
 });

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -10,7 +10,7 @@ import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => {
   return {
-    executeCliRequest: vi.fn(),
+    executeCliConfig: vi.fn(),
     withExpandedRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
     isAuthenticated: vi.fn(),
@@ -64,7 +64,7 @@ vi.mock('@cli/runtime/agents', async (importOriginal) => ({
 }));
 
 vi.mock('@cli/runtime/runExecution', () => ({
-  executeCliRequest: mocks.executeCliRequest,
+  executeCliConfig: mocks.executeCliConfig,
 }));
 
 vi.mock('@cli/runtime/workflowInputs', () => ({
@@ -121,7 +121,9 @@ describe('CLI workflow run command', () => {
         }) => Promise<unknown>,
       ) => run({ inputFiles: ['paper.tex'], contextFiles: [] }),
     );
-    mocks.executeCliRequest.mockResolvedValue({
+    mocks.executeCliConfig.mockResolvedValue({
+      ok: true,
+      executionId: 'exec-1',
       result: {
         category: AgentCategory.Workflow,
         executionId: 'exec-1',
@@ -257,8 +259,8 @@ describe('CLI workflow run command', () => {
         { readStdinText: expect.any(Function) },
         expect.any(Function),
       );
-      const request = mocks.executeCliRequest.mock.calls[0]?.[0];
-      expect(request?.config.instruction).toBe(
+      const config = mocks.executeCliConfig.mock.calls[0]?.[0];
+      expect(config?.instruction).toBe(
         'Read this prompt from disk.\n\nThen keep the final response concise.',
       );
     } finally {
@@ -272,7 +274,9 @@ describe('CLI workflow run command', () => {
       const generated = path.join(root, 'run', 'r1', 'paper.tex');
       await fs.mkdir(path.dirname(generated), { recursive: true });
       await fs.writeFile(generated, 'polished');
-      mocks.executeCliRequest.mockResolvedValueOnce({
+      mocks.executeCliConfig.mockResolvedValueOnce({
+        ok: true,
+        executionId: 'exec-output',
         result: {
           category: AgentCategory.Workflow,
           executionId: 'exec-output',
@@ -305,8 +309,8 @@ describe('CLI workflow run command', () => {
       });
 
       expect(exitCode).toBe(0);
-      const request = mocks.executeCliRequest.mock.calls[0]?.[0];
-      expect(request?.config).toMatchObject({
+      const config = mocks.executeCliConfig.mock.calls[0]?.[0];
+      expect(config).toMatchObject({
         inputFiles: ['paper.tex'],
         outputFiles: [],
         cliOutputFile: 'polished.tex',


### PR DESCRIPTION
## Summary
- add a shared CLI config execution helper for validation, execution id allocation, request execution, and category mismatch status handling
- remove duplicated validation/execution boilerplate from workflow, agents run, and multi-agent run commands
- update CLI command tests and runtime tests around the shared lifecycle

## Verification
- corepack pnpm vitest run src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
- npm run typecheck
- npm run lint (passes with existing import/order warning in src/agent/review/reviewDiff.ts)
- npm run compile:fast
- CI=true npm run texra-local:build
- CI=true npm run texra-local:link
- texra-local run polish --cwd /tmp/texra-workflow-refactor-uoXJzE --input main.tex --output out/main.tex --instruction "Rewrite this into a concise rigorous LaTeX proof, preserving the statement and keeping it under 120 words." --model gemini35f --output-format json

## Design note
This intentionally removes repeated command-level lifecycle code instead of adding another resolver layer. The command handlers still own their config construction; the runtime owns the common validation/run/status path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only consolidation of existing behavior with tests updated; no new user-facing paths beyond the same validation and category guards now living in one module.
> 
> **Overview**
> Introduces **`executeCliConfig`** in `runExecution.ts` as the shared path from `AgentConfigPayload` through validation, execution-id allocation, `executeCliRequest`, and optional **category-mismatch** handling (terminal status ERROR + stderr + exit code).
> 
> **Workflow**, **`agents run`**, and **`multi-agent run`** no longer duplicate that boilerplate; they build config locally and call `executeCliConfig` with run-specific options (`stopAfterCycle`, `wrap`, `expectedCategory`, etc.), then branch on `execution.ok`.
> 
> Tests are retargeted to mock **`executeCliConfig`** and assert on the config argument; **`RunExecution.vitest.mts`** adds coverage for invalid config (no runtime host) and unexpected category after a run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0922145ea2b5ae10e08eb341173bf42187fc3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->