### PR TITLE
fix: explain cwd-scoped history misses

### DIFF
--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -7,6 +7,7 @@ import {
   cliHistoryNdjsonRecords,
   deleteCliHistory,
   formatCliHistoryDetailsText,
+  formatCliHistoryNotFoundText,
   formatCliHistoryText,
   listCliHistoryEntries,
   parseCliHistoryId,
@@ -64,7 +65,7 @@ async function runHistoryShow(
     includeFullConversation: options.full === true,
   });
   if (!details) {
-    writeTextStderr(`Execution not found: ${id}`);
+    writeTextStderr(formatCliHistoryNotFoundText(id, context.cwd));
     return CliExitCode.Usage;
   }
 
@@ -117,7 +118,7 @@ async function runHistoryDelete(
     !result.found &&
     context.outputFormat === 'text'
   ) {
-    writeTextStderr(`Execution not found: ${result.id}`);
+    writeTextStderr(formatCliHistoryNotFoundText(result.id, context.cwd));
     return CliExitCode.Usage;
   }
 

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -276,6 +276,19 @@ export function formatCliHistoryText(
     .join('\n');
 }
 
+export function formatCliHistoryNotFoundText(
+  id: ExecutionId,
+  cwd?: string,
+): string {
+  const workspace = cwd?.trim();
+  return [
+    workspace
+      ? `Execution not found in workspace ${workspace}: ${id}`
+      : `Execution not found: ${id}`,
+    'History is scoped by --cwd; use the workspace from the original run or run `texra history list --cwd <workspace>`.',
+  ].join('\n');
+}
+
 export function cliHistoryNdjsonRecords(
   entries: readonly CliHistoryEntry[],
   ts = new Date().toISOString(),

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -60,6 +60,7 @@ import {
   cliHistoryNdjsonRecords,
   deleteCliHistory,
   formatCliHistoryDetailsText,
+  formatCliHistoryNotFoundText,
   formatCliHistoryText,
   listCliHistoryEntries,
   parseCliHistoryId,
@@ -141,6 +142,27 @@ describe('CLI history runtime', () => {
     expect(parseHistoryListLimit('abc')).toBeUndefined();
     expect(parseHistoryListLimit('')).toBeUndefined();
     expect(parseHistoryListLimit(undefined)).toBeUndefined();
+  });
+
+  it('explains missing history ids as workspace-scoped', () => {
+    expect(formatCliHistoryNotFoundText('a9ce2eb983bc' as ExecutionId)).toBe(
+      [
+        'Execution not found: a9ce2eb983bc',
+        'History is scoped by --cwd; use the workspace from the original run or run `texra history list --cwd <workspace>`.',
+      ].join('\n'),
+    );
+
+    expect(
+      formatCliHistoryNotFoundText(
+        'a9ce2eb983bc' as ExecutionId,
+        '/tmp/texra-workflow-correct-yM0MOz',
+      ),
+    ).toBe(
+      [
+        'Execution not found in workspace /tmp/texra-workflow-correct-yM0MOz: a9ce2eb983bc',
+        'History is scoped by --cwd; use the workspace from the original run or run `texra history list --cwd <workspace>`.',
+      ].join('\n'),
+    );
   });
 
   it('returns null for ids without persisted metadata, config, or flow state', async () => {


### PR DESCRIPTION
## Summary
- add one shared history not-found formatter that includes the active workspace and a `--cwd` recovery hint
- use it from `history show` and text-mode `history delete`
- cover the message with the existing CLI history test suite

## Dogfood evidence
While testing `texra-local run correct` on a temporary math manuscript workspace, the workflow completed and returned execution id `a9ce2eb983bc`. Running `texra-local history show a9ce2eb983bc` from the repo checkout failed with only `Execution not found`, even though `texra-local history show a9ce2eb983bc --cwd /tmp/texra-workflow-correct-yM0MOz` worked. The new message keeps history workspace-scoped but tells the user how to recover.

## Verification
- `texra-local run correct --cwd /tmp/texra-workflow-correct-yM0MOz --input main.tex --output out/main.tex --model gemini35f --output-format json`
- `corepack pnpm vitest run src/test-kernel/cli/History.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing import/order warning in `src/agent/review/reviewDiff.ts`)
- `npm run compile:fast`
- `CI=true npm run texra-local:build && CI=true npm run texra-local:link`
- `texra-local history show a9ce2eb983bc --output-format text`
- `texra-local history show a9ce2eb983bc --cwd /tmp/texra-workflow-correct-yM0MOz --output-format json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI error text only; no changes to history lookup, storage, or structured output contracts.
> 
> **Overview**
> When `history show` or text-mode `history delete` cannot find an execution, stderr now uses a shared **`formatCliHistoryNotFoundText`** helper instead of a one-line `Execution not found` message.
> 
> The new text optionally names the **active workspace** (`context.cwd`) and adds a second line that history is scoped by **`--cwd`**, with a hint to reuse the original run workspace or run `texra history list --cwd <workspace>`. JSON/NDJSON delete behavior is unchanged; only the human-readable not-found path is updated.
> 
> Tests in **`History.vitest.mts`** assert both variants (with and without workspace path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff781c980fd93ffd5ee665c32a77929ea2408336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->