### PR TITLE
[codex] fix: hide provider thinking in history previews

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -30,6 +30,7 @@ import { readCliToolUseResumeDataForListing } from './toolUseResumeData';
 const HISTORY_FILE_SCAN_DEPTH = 2;
 const CONVERSATION_PREVIEW_MESSAGE_LIMIT = 3;
 const CONVERSATION_PREVIEW_CONTENT_LIMIT = 4000;
+const HIDDEN_PROVIDER_REASONING_MARKER = '[provider reasoning hidden]';
 const WORKSPACE_FILE_TOOL_NAMES = new Set(['write_file', 'edit_file']);
 
 const KV_FILES = new Set([
@@ -472,6 +473,7 @@ function formatConversationMessage(
   raw: Record<string, unknown>,
   options: ConversationMessageFormatOptions,
 ): string {
+  const role = typeof raw.role === 'string' ? raw.role : '';
   const parts = [
     formatConversationMessageContent(raw.content, options),
     formatConversationMessageContent(raw.parts, options),
@@ -479,7 +481,15 @@ function formatConversationMessage(
       ? formatTopLevelToolCalls(raw.tool_calls)
       : []),
   ].filter((part) => part.trim().length > 0);
-  return parts.join('\n').trim();
+  if (parts.length > 0) return parts.join('\n').trim();
+  if (
+    isAssistantMessageRole(role) &&
+    (hasProviderReasoningBlock(raw.content) ||
+      hasProviderReasoningBlock(raw.parts))
+  ) {
+    return HIDDEN_PROVIDER_REASONING_MARKER;
+  }
+  return '';
 }
 
 function isAssistantMessageRole(role: string): boolean {
@@ -556,6 +566,9 @@ function formatConversationContentBlock(
   }
 
   switch (block.type) {
+    case 'thinking':
+    case 'redacted_thinking':
+      return '';
     case 'tool_use':
       if (options.includeToolUseMarkers !== true) return '';
       return `[tool_use: ${String(block.name ?? 'unknown')}]`;
@@ -564,6 +577,18 @@ function formatConversationContentBlock(
     default:
       return formatJsonish(block);
   }
+}
+
+function hasProviderReasoningBlock(content: unknown): boolean {
+  if (Array.isArray(content)) return content.some(isProviderReasoningBlock);
+  return isProviderReasoningBlock(content);
+}
+
+function isProviderReasoningBlock(block: unknown): boolean {
+  return (
+    isObject(block) &&
+    (block.type === 'thinking' || block.type === 'redacted_thinking')
+  );
 }
 
 function formatGoogleFunctionResponse(

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -289,6 +289,101 @@ describe('CLI history runtime', () => {
     );
   });
 
+  it('omits provider thinking blocks from history previews', async () => {
+    mocks.readConversation.mockResolvedValue([
+      { role: 'user', content: 'Polish the lemma.' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'thinking',
+            thinking: 'hidden chain of thought',
+            signature: 'secret-signature',
+          },
+          { type: 'text', text: 'Final polished lemma.' },
+        ],
+      },
+    ]);
+
+    const details = await readCliHistoryDetails('a1' as ExecutionId, {
+      includeFullConversation: true,
+    });
+    const text = formatCliHistoryDetailsText(details!);
+
+    expect(details?.conversationPreview?.messages).toEqual([
+      {
+        index: 2,
+        role: 'assistant',
+        content: 'Final polished lemma.',
+        truncated: false,
+      },
+    ]);
+    expect(details?.conversation?.messages).toEqual([
+      {
+        index: 1,
+        role: 'user',
+        content: 'Polish the lemma.',
+        truncated: false,
+      },
+      {
+        index: 2,
+        role: 'assistant',
+        content: 'Final polished lemma.',
+        truncated: false,
+      },
+    ]);
+    expect(text).toContain('[assistant #2]\nFinal polished lemma.');
+    expect(text).not.toContain('hidden chain of thought');
+    expect(text).not.toContain('secret-signature');
+  });
+
+  it('keeps a placeholder for thinking-only assistant turns', async () => {
+    mocks.readConversation.mockResolvedValue([
+      { role: 'assistant', content: 'Earlier visible answer.' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'redacted_thinking',
+            thinking: 'hidden newer reasoning',
+            signature: 'new-secret-signature',
+          },
+        ],
+      },
+    ]);
+
+    const details = await readCliHistoryDetails('a1' as ExecutionId, {
+      includeFullConversation: true,
+    });
+    const text = formatCliHistoryDetailsText(details!);
+
+    expect(details?.conversationPreview?.messages).toEqual([
+      {
+        index: 2,
+        role: 'assistant',
+        content: '[provider reasoning hidden]',
+        truncated: false,
+      },
+    ]);
+    expect(details?.conversation?.messages).toEqual([
+      {
+        index: 1,
+        role: 'assistant',
+        content: 'Earlier visible answer.',
+        truncated: false,
+      },
+      {
+        index: 2,
+        role: 'assistant',
+        content: '[provider reasoning hidden]',
+        truncated: false,
+      },
+    ]);
+    expect(text).toContain('[assistant #2]\n[provider reasoning hidden]');
+    expect(text).not.toContain('hidden newer reasoning');
+    expect(text).not.toContain('new-secret-signature');
+  });
+
   it('can show the full stored conversation for post-run inspection', async () => {
     const longToolOutput = `${'tool-output-line\n'.repeat(320)}done`;
     mocks.readConversation.mockResolvedValue([


### PR DESCRIPTION
## Summary

- Hide provider `thinking` and `redacted_thinking` content blocks when formatting CLI history conversations.
- Keep visible assistant `text` blocks as the history preview and full transcript content.
- Preserve thinking-only assistant/model turns with a `[provider reasoning hidden]` placeholder so previews do not fall back to stale older replies.
- Add regression coverage for provider thinking text and signatures staying out of `texra history show` output.

## Why

A real `texra-local run polish ...` dogfood execution stored Anthropic-style thinking blocks before the final assistant text. `texra-local history show` fell back to JSON formatting for those blocks, so the preview displayed a large raw thinking/signature payload and hid the useful assistant response behind truncation.

History output is a user-facing inspection tool, so it should show the assistant answer and tool markers/results, not provider-internal reasoning payloads or signatures. When a provider stores a reasoning-only assistant turn, history should still show that the latest turn exists without exposing the hidden payload.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/History.vitest.mts`
- `CI=true npm run texra-local:build && CI=true npm run texra-local:link`
- `texra-local history show a298b4e269af --cwd /tmp/texra-workflow-polish-HGF67P --output-format text`
- `npm run typecheck`
- `npm run lint` (passes with one existing import-order warning in `src/agent/review/reviewDiff.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in CLI history formatting with no auth, persistence, or execution-path impact; covered by targeted Vitest cases.
> 
> **Overview**
> **CLI history formatting** no longer surfaces provider-internal `thinking` / `redacted_thinking` blocks in previews or full transcripts from `texra history show`.
> 
> Those block types are stripped during content formatting (instead of falling back to raw JSON), so visible assistant `text` remains what users see. Assistant turns that contain **only** reasoning blocks now show **`[provider reasoning hidden]`** so the turn is not dropped silently.
> 
> Regression tests cover mixed thinking+text messages and thinking-only assistant turns (including signatures staying out of formatted output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25bfcbf983b40bbb6bec020890eae14c7ca52948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->