### PR TITLE
fix(auth): lock auth-bridge deep-link target to the TeXRA publisher

### DIFF
--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -57,8 +57,12 @@ const ALLOWED_EXT_SCHEMES = [
   'pearai',
 ] as const;
 
-/** Extension id format: publisher.name with the usual id characters. */
-const EXTENSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+/**
+ * Allowed deep-link target extension id. Locked to the TeXRA publisher so the
+ * bridge can only ever hand a code back to a TeXRA extension, never an arbitrary
+ * scheme://publisher.name that an attacker could place in redirect_to.
+ */
+const EXTENSION_ID_PATTERN = /^texra-ai\.[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 
 // =============================================================================
 // Validation


### PR DESCRIPTION
The auth-bridge accepted any syntactically valid extension id, so a crafted redirect_to could make the page hand the OAuth code to scheme://arbitrary.publisher/auth-callback. PKCE already makes that code unusable without the verifier the editor never shared, but lock the id to the TeXRA publisher as defense-in-depth against open-redirect.

This reconciles the committed source with prod: PR #6245 merged from a head that predated this fix, so EXTENSION_ID_PATTERN on main was still permissive while the deployed function already enforces the texra-ai lock.

Edge function redeployed from this branch. Follow-up to #6245 (whose merge predated this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change that narrows allowed redirect targets; reduces open-redirect surface without altering auth token handling.
> 
> **Overview**
> **Tightens auth-bridge extension id validation** so deep links can only target `texra-ai.*` extension ids, not any syntactically valid `publisher.name` from a crafted `redirect_to`.
> 
> `EXTENSION_ID_PATTERN` changes from a generic extension-id regex to one that requires the `texra-ai.` publisher prefix. Server-side `isValidExtensionId` and the client-side mirror (`ID_RE`) both use this pattern, so OAuth codes can only be handed off to TeXRA extensions—defense-in-depth on top of PKCE, which already blocks misuse of the code without the verifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b44a2b43ef6d1336082fcfd7f9ffed044d84d33a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->