### PR TITLE
[codex] docs(cli): advertise goal mode in chat help

### DIFF
--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -66,6 +66,7 @@ export const chatCommand = withUsageSections(
       rows: [
         ['/help', 'show slash commands inside chat'],
         ['/status', 'show session state'],
+        ['/goal', 'explain autonomous goal mode and approved-plan startup'],
         ['/login, /logout', 'sign in or out of included access'],
         ['Ctrl-T', 'open the transcript viewer'],
         ['Tab', 'cycle visible streams when subagents are active'],

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1272,6 +1272,10 @@ describe('runCli usage output stream routing', () => {
     expect(stdout).toContain('INTERACTIVE CONTROLS');
     expect(stdout).toContain('/help');
     expect(stdout).toContain('/status');
+    expect(stdout).toContain('/goal');
+    expect(stdout).toContain(
+      'explain autonomous goal mode and approved-plan startup',
+    );
     expect(stdout).toContain('/login, /logout');
     expect(stdout).toContain('Ctrl-T');
     expect(stdout).toContain('Tab');
@@ -1379,6 +1383,7 @@ describe('runCli usage output stream routing', () => {
     expect(stdout).toContain('Interactive tool-use chat session');
     expect(stdout).toContain('USAGE texra chat');
     expect(stdout).toContain('INTERACTIVE CONTROLS');
+    expect(stdout).toContain('/goal');
     expect(stdout).toContain('Esc s');
     expect(stdout).toContain('open subagents when available');
     expect(stdout).toContain('Esc 1..9');


### PR DESCRIPTION
## Summary

- Add `/goal` to the `texra chat --help` interactive controls section.
- Cover both `texra chat --help` and `texra help chat` so command-specific help stays aligned with the TUI.

## Why

During goal-mode dogfood, the in-TUI `/goal` command and plan approval goal flow worked through the PTY snapshot harness, but the command-line discovery path omitted `/goal` from `texra chat --help`. A user checking the chat command before launching the TUI could miss that autonomous goal mode exists and starts from an approved plan.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/SlashHelpText.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `CI=true npm run texra-local:build && CI=true npm run texra-local:link`
- `texra-local chat --help`
- `texra-local help chat`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-goal-tui-EmiXX3 slash-goal-help backslash-goal-help plan-approval-goal plan-approval-approve-goal compact-plan-approval-goal`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-goal-tui-after-help-GPI17k slash-goal-help backslash-goal-help plan-approval-goal plan-approval-approve-goal compact-plan-approval-goal`
- `npm run typecheck`
- `npm run lint` (passes with one existing import-order warning in `src/agent/review/reviewDiff.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes to help output; no runtime or auth behavior.
> 
> **Overview**
> **Chat help now lists `/goal`** in the **INTERACTIVE CONTROLS** section so `texra chat --help` and `texra help chat` match what the TUI already supports.
> 
> The new line documents that `/goal` explains **autonomous goal mode** and **approved-plan startup**. Tests in `CliRootArgs.vitest.mts` assert the control and its description appear on both help paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0567f6802cc5a8b3a93ae8d6f1b3456344b2ce74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->