### PR TITLE
[codex] docs(cli): point agent help at full catalog

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -14,7 +14,10 @@ import {
   buildHeadlessRunContext,
   resolveCliRunModel,
 } from '../runtime/runModel';
-import { resolveCliLaunchAgent } from '../runtime/agents';
+import {
+  resolveCliLaunchAgent,
+  WORKFLOW_AGENT_NAME_DESCRIPTION,
+} from '../runtime/agents';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
@@ -163,7 +166,7 @@ export const runWorkflowCommand = defineCliCommand({
     agent: {
       type: 'positional',
       required: true,
-      description: 'Workflow agent name',
+      description: WORKFLOW_AGENT_NAME_DESCRIPTION,
     },
     input: {
       type: 'string',

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -23,7 +23,7 @@ export interface CliAgentListResult {
 export type CliAgentLaunchMode = 'chat' | 'run' | 'agentsRun';
 
 const AGENT_LOOKUP_HINT =
-  'Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.';
+  'Use `texra agents list` for visible starter agents, `texra agents list --all` for the full catalog, or pass a known launchable agent name from a team preset.';
 const MULTI_AGENT_PRESET_LOOKUP_HINT =
   'Use `texra multi-agent list` for available team presets, then run `texra multi-agent inspect <preset>` to check a team before launch.';
 
@@ -49,10 +49,13 @@ const CLI_AGENT_LAUNCH_TARGETS = {
 } as const;
 
 export const AGENT_NAME_DESCRIPTION =
-  'Agent name from `texra agents list` or a known launchable agent name';
+  'Agent name from `texra agents list` or `texra agents list --all`';
+
+export const WORKFLOW_AGENT_NAME_DESCRIPTION =
+  'Workflow agent name from `texra agents list --category workflow --all`';
 
 export const TOOL_USE_AGENT_NAME_DESCRIPTION =
-  'Tool-use agent name from `texra agents list` or a known launchable agent name';
+  'Tool-use agent name from `texra agents list --category toolUse --all`';
 
 const AGENT_CATEGORY_FILTER_ALIASES = [
   [AgentCategory.Workflow, AgentCategory.Workflow],

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -153,7 +153,7 @@ describe('CLI agent resolution', () => {
     const { resolveCliLaunchAgent } = await import('@cli/runtime/agents');
 
     await expect(resolveCliLaunchAgent('missing', 'agentsRun')).rejects.toThrow(
-      'Tool-use agent not found: missing. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+      'Tool-use agent not found: missing. Use `texra agents list` for visible starter agents, `texra agents list --all` for the full catalog, or pass a known launchable agent name from a team preset.',
     );
   });
 

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -300,7 +300,7 @@ describe('CLI agents command', () => {
 
     expect(exitCode).toBe(2);
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'Agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+      'Agent not found: missing-agent. Use `texra agents list` for visible starter agents, `texra agents list --all` for the full catalog, or pass a known launchable agent name from a team preset.',
     );
     expect(mocks.emitCliResult).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -194,7 +194,7 @@ describe('CLI agents run command', () => {
   it('reports missing agents before resolving the model', async () => {
     mocks.resolveCliLaunchAgent.mockRejectedValueOnce(
       new Error(
-        'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+        'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, `texra agents list --all` for the full catalog, or pass a known launchable agent name from a team preset.',
       ),
     );
     const { runToolUseAgent } = await import('@cli/commands/agentsRun');
@@ -208,7 +208,7 @@ describe('CLI agents run command', () => {
         instruction: 'Check this.',
       }),
     ).rejects.toThrow(
-      'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+      'Tool-use agent not found: missing-agent. Use `texra agents list` for visible starter agents, `texra agents list --all` for the full catalog, or pass a known launchable agent name from a team preset.',
     );
 
     expect(mocks.initLocalCliPlatform).toHaveBeenCalledWith(

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1191,6 +1191,24 @@ describe('runCli usage output stream routing', () => {
     expect(stderr).toBe('');
   });
 
+  it('points run-command agent arguments at the full agent catalog', async () => {
+    let result = await runCli(['run', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain(
+      'Workflow agent name from `texra agents list --category workflow --all`',
+    );
+    expect(stderr).toBe('');
+
+    stdout = '';
+    stderr = '';
+    result = await runCli(['agents', 'run', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain(
+      'Tool-use agent name from `texra agents list --category toolUse --all`',
+    );
+    expect(stderr).toBe('');
+  });
+
   it('rejects unknown flags before running command bodies', async () => {
     const result = await runCli(['doctor', '--bogus', '--no-input']);
     expect(result.exitCode).toBe(2);

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -159,7 +159,7 @@ describe('CLI workflow run command', () => {
   it('reports missing workflow agents before resolving the model', async () => {
     mocks.resolveCliLaunchAgent.mockRejectedValueOnce(
       new Error(
-        'Agent not found: missing-agent. Use `texra agents list` for visible starter agents, or pass a known launchable agent name from a team preset.',
+        'Agent not found: missing-agent. Use `texra agents list` for visible starter agents, `texra agents list --all` for the full catalog, or pass a known launchable agent name from a team preset.',
       ),
     );
     const { runWorkflowAgent } = await import('@cli/commands/workflow');


### PR DESCRIPTION
## Summary

- Point missing-agent errors at `texra agents list --all` in addition to the visible starter list.
- Make `texra run --help` point workflow-agent users at `texra agents list --category workflow --all`.
- Make `texra agents run --help` point tool-use users at `texra agents list --category toolUse --all`.

## Why

Workflow dogfood on a real math proof used the built-in `correct` workflow. `correct` is runnable and useful, but it is hidden from the default `texra agents list --category workflow` output. The command does print a hidden-agent notice when listing agents, but the `texra run <agent>` missing-agent hint only mentioned the visible starter list, so users looking for hidden runnable workflows could be sent to a list that still does not show the full catalog.

This keeps the existing visible-starter behavior while making the full-catalog path explicit at the launch boundary.

## Dogfood evidence

- `texra-local agents list --category workflow` showed only `polish` plus a hidden-agent notice.
- `texra-local agents list --category workflow --all --output-format json` showed runnable hidden workflows including `correct`.
- `texra-local run correct --cwd /tmp/texra-workflow-correct-LF0uQV --input irrational.tex --output out/irrational.tex --model gpt54 --api-mode personal --instruction 'Fix grammar, spelling, and LaTeX formatting only. Preserve every mathematical claim and do not strengthen or rewrite the proof.' --output-format json` completed successfully and produced a corrected proof.
- Captured JSON-mode stdout separately and verified it parses as JSON; progress stayed on stderr.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/AgentResolution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `CI=true npm run texra-local:build && CI=true npm run texra-local:link`
- `texra-local run --help`
- `texra-local agents run --help`
- `texra-local run bogus --cwd /tmp/texra-workflow-correct-LF0uQV --input irrational.tex --model gpt54 --api-mode personal --output-format text`
- `npm run typecheck`
- `npm run lint` (passes with one existing import-order warning in `src/agent/review/reviewDiff.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes to CLI descriptions and error hints; no agent resolution or launch behavior changes.
> 
> **Overview**
> CLI **help and missing-agent hints** now steer users toward the full agent catalog, not only the default visible starter list.
> 
> Shared lookup text (`AGENT_LOOKUP_HINT` and related messages) adds **`texra agents list --all`**. **`texra run`** documents workflow agents via **`texra agents list --category workflow --all`** (`WORKFLOW_AGENT_NAME_DESCRIPTION`). **`texra agents run`** documents tool-use agents via **`texra agents list --category toolUse --all`**.
> 
> Tests were updated for the new copy, including **`run --help`** and **`agents run --help`** asserting those strings appear on stdout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6c84a64883fc30e10b119a31ee9a37386a68f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->