### PR TITLE
[codex] stabilize multi-agent run validator

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -812,6 +812,9 @@ function validateToolUseAgentRunCommand() {
 
 function validateMultiAgentRunCommand() {
   const cwd = mkdtempSync(path.join(tmpdir(), 'texra-cli-multi-agent-run-'));
+  // This preset has a local built-in delegating root; relay-only teams such as
+  // mathematician are unavailable in signed-out validation environments.
+  const validationPreset = 'software-engineer';
   try {
     const inputPath = path.join(cwd, 'math-problem.md');
     const validationFlagPath = path.join(
@@ -828,7 +831,7 @@ function validateMultiAgentRunCommand() {
       binaryPath,
       'multi-agent',
       'run',
-      'mathematician',
+      validationPreset,
       '--input',
       'math-problem.md',
       '--cwd',
@@ -846,7 +849,7 @@ function validateMultiAgentRunCommand() {
     assertSuccess(json, 'texra multi-agent run JSON');
     const jsonResult = JSON.parse(json.stdout);
     assert(
-      jsonResult.preset?.id === 'mathematician',
+      jsonResult.preset?.id === validationPreset,
       'multi-agent JSON output should identify the preset',
     );
     assert(
@@ -871,7 +874,7 @@ function validateMultiAgentRunCommand() {
         binaryPath,
         'multi-agent',
         'run',
-        'mathematician',
+        validationPreset,
         '--instruction',
         'Prove that every odd square is congruent to 1 modulo 8.',
         '--cwd',
@@ -887,7 +890,7 @@ function validateMultiAgentRunCommand() {
     assertSuccess(inlineInstruction, 'texra multi-agent instruction-only JSON');
     const inlineJsonResult = JSON.parse(inlineInstruction.stdout);
     assert(
-      inlineJsonResult.preset?.id === 'mathematician',
+      inlineJsonResult.preset?.id === validationPreset,
       'instruction-only multi-agent JSON output should identify the preset',
     );
     assert(
@@ -911,7 +914,7 @@ function validateMultiAgentRunCommand() {
       parseNdjson(ndjson.stdout, 'multi-agent run NDJSON').some(
         (record) =>
           record.kind === 'multi-agent-result' &&
-          record.preset?.id === 'mathematician' &&
+          record.preset?.id === validationPreset &&
           record.rootAgent === jsonResult.rootAgent,
       ),
       'multi-agent run NDJSON should include a preset result record with the selected root agent',


### PR DESCRIPTION
## Summary

- Switch the `validate:run` multi-agent success fixture from the relay-dependent `mathematician` preset to the local launchable `software-engineer` preset.
- Keep the same JSON, instruction-only JSON, and NDJSON assertions against the real multi-agent run path.
- Document why the validator should avoid relay-only teams in signed-out validation environments.

## Why

On current `main`, `corepack pnpm --filter @texra-ai/cli validate:run` failed because `mathematician` has no runnable team root in a signed-out local registry:

```text
Multi-agent preset "mathematician" cannot start as a team: no runnable team root.
```

The validator should prove the multi-agent runtime path works without depending on account-specific relay agent availability.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:run`
- `./node_modules/.bin/prettier --check packages/cli/scripts/validate-run.mjs`
- `git diff --check`
- `npm run lint` (0 errors; one existing import-order warning in `src/agent/review/reviewDiff.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to the CLI validation script; no production runtime or auth behavior is modified.
> 
> **Overview**
> Stabilizes **`validate:run`** by exercising **`texra multi-agent run`** with the **`software-engineer`** preset instead of **`mathematician`**, which cannot start as a team when signed out (no runnable relay root).
> 
> Assertions for JSON, instruction-only JSON, and NDJSON are unchanged aside from expecting the new preset id. A short comment documents why relay-only teams should not be used in signed-out validation environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51bc9f1121c00f7c65175dfc0ec95c5c7678a92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->