### PR TITLE
[codex] inline agents run instruction check

### DIFF
--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -45,22 +45,14 @@ export interface ToolUseAgentRunInit {
   readonly instructionFile?: string;
 }
 
-async function resolveToolUseInstruction(
-  init: Pick<ToolUseAgentRunInit, 'instruction' | 'instructionFile'>,
-  cwd: string,
-): Promise<string> {
-  const instruction = await resolveFileBackedInstruction(init, cwd);
-  if (!instruction) {
-    throw new CliUsageError('Provide --instruction or --instruction-file.');
-  }
-  return instruction;
-}
-
 export async function runToolUseAgent(
   context: CliContext,
   init: ToolUseAgentRunInit,
 ): Promise<number> {
-  const instruction = await resolveToolUseInstruction(init, context.cwd);
+  const instruction = await resolveFileBackedInstruction(init, context.cwd);
+  if (!instruction) {
+    throw new CliUsageError('Provide --instruction or --instruction-file.');
+  }
 
   await initLocalCliPlatform(context);
   await resolveCliLaunchAgent(init.agent, 'agentsRun');


### PR DESCRIPTION
## Summary

- inline the `agents run` required-instruction check at the command boundary
- remove the single-use `resolveToolUseInstruction` pass-through helper
- keep `resolveFileBackedInstruction` as the shared source for instruction-file merging

## Why

This trims a shallow helper that only forwarded one call and one usage error. The command now owns its own required-input rule directly, while the shared instruction resolver still owns file-backed instruction assembly.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts`
- `./node_modules/.bin/prettier --check packages/cli/src/commands/agentsRun.ts`
- `git diff --check`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with the existing `src/agent/review/reviewDiff.ts` import-order warning)

## Dogfood context

Before this cleanup, I ran a real multi-input `texra-local run correct` workflow on two small LaTeX math snippets with `--output-dir`; it completed and copied both corrected outputs. I also checked fast failure paths for multi-input `--output`, missing `--input`, and launching a tool-use agent through `texra run`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with identical validation and error messaging; no change to run execution or instruction assembly.
> 
> **Overview**
> Removes the single-use `resolveToolUseInstruction` helper and moves its logic into `runToolUseAgent` at the start of the command.
> 
> `runToolUseAgent` now calls `resolveFileBackedInstruction` directly and throws the same `CliUsageError` when neither `--instruction` nor `--instruction-file` yields content. File-backed instruction merging stays in the shared helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce70f0c55c67c996c9f5f9e08c28a6672e8b0ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->