### PR TITLE
[codex] expose workflow round counts

### DIFF
--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -208,6 +208,10 @@ export function formatCliAgentDetails(entry: AgentEntry): string {
     lines.push('');
     lines.push(...metadataLines);
   }
+  if (entry.rounds) {
+    if (metadataLines.length === 0) lines.push('');
+    lines.push(`rounds: ${entry.rounds}`);
+  }
   return lines.join('\n');
 }
 

--- a/src/agent/core/definition/agentDefinitionInheritance.ts
+++ b/src/agent/core/definition/agentDefinitionInheritance.ts
@@ -1,0 +1,17 @@
+// Third-party imports
+import deepmerge from 'deepmerge';
+
+function replaceArrays(
+  _destinationArray: unknown[],
+  sourceArray: unknown[],
+): unknown[] {
+  return sourceArray;
+}
+
+/** Merge inherited agent config blocks with child arrays replacing parent arrays. */
+export function mergeInheritedAgentObject<T extends object>(
+  parent: T,
+  child: object,
+): T {
+  return deepmerge(parent, child, { arrayMerge: replaceArrays }) as T;
+}

--- a/src/agent/index/agentEntry.ts
+++ b/src/agent/index/agentEntry.ts
@@ -17,6 +17,7 @@ export interface AgentEntry {
   description?: string;
   tools?: string[]; // tool names for tool-use agents
   defaultOutputFiles?: string[];
+  rounds?: number; // workflow round count
   visibility?: string[]; // remote only: group names that can access the agent
   internal?: boolean; // internal agents are hidden from dropdowns but launchable by commands
 }

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -12,6 +12,7 @@ import { agentKey as createKey, agentName } from '@shared/schemas/agent';
 import { getAgentDirectories } from './agentDirectoriesRegistry';
 import {
   DEFAULT_WORKFLOW_AGENT,
+  LEGACY_AGENT_ALIASES,
   LOOKUP_PRIORITY,
   PREFERRED_TOOL_USE_AGENTS,
   TOOL_USE_LOOKUP_PRIORITY,
@@ -169,6 +170,7 @@ async function doLoad(options: LoadAgentsOptions = {}): Promise<void> {
   for (const entry of allEntries) {
     if (toolUseOverrides.has(entry.name)) {
       entry.category = AgentCategory.ToolUse;
+      entry.rounds = undefined;
     }
     const key = `${entry.source}:${entry.name}`;
     cache.set(key, entry);
@@ -217,16 +219,6 @@ function migrateLegacyAgentNameKeys(): void {
     logger.info(CHANNEL, `Migrated legacy agent names in ${stateKey}`);
   }
 }
-
-/**
- * Legacy agent-name aliases — keep prior configs, histories, and delegation
- * calls working when a built-in agent is renamed. Each entry maps
- * `<old name> → <canonical name>`. Applied only when the original identifier
- * resolves to nothing, so a user-defined agent with the old name still wins.
- */
-const LEGACY_AGENT_ALIASES: Record<string, string> = {
-  chat: 'assistant',
-};
 
 /**
  * Canonical agent resolver: look up an agent by identifier.

--- a/src/agent/index/agentRegistryConstants.ts
+++ b/src/agent/index/agentRegistryConstants.ts
@@ -18,6 +18,14 @@ export const TOOL_USE_LOOKUP_PRIORITY: AgentSource[] = [
   'builtInWorkflow',
 ];
 
+/**
+ * Legacy agent-name aliases — keep prior configs, histories, delegation calls,
+ * and inherited references working when a built-in agent is renamed.
+ */
+export const LEGACY_AGENT_ALIASES: Record<string, string> = {
+  chat: 'assistant',
+};
+
 /** Default workflow agent when no workflow preference exists. */
 export const DEFAULT_WORKFLOW_AGENT = 'correct';
 

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -7,15 +7,26 @@ import * as yaml from 'yaml';
 import {
   AgentCategory,
   AgentDefinitionSchema,
+  AgentWorkflowSettingSchema,
+  type AgentDefinition,
 } from '@agent/core/definition/AgentDataclass';
+import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitionInheritance';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { AgentSource } from '@shared/schemas/agent';
 import { AbsoluteFS } from '@utils/files';
 import { filterNotNull } from '@utils/core';
+import { LEGACY_AGENT_ALIASES } from './agentRegistryConstants';
 import type { AgentEntry } from './agentEntry';
 
 const CHANNEL = 'agentRegistry';
+const INVALID_WORKFLOW_ROUNDS = Number.NaN;
+
+interface ParsedAgentYaml {
+  readonly name: string;
+  readonly path: string;
+  readonly definition: AgentDefinition;
+}
 
 /**
  * Extract tool names from raw YAML tool configs.
@@ -43,34 +54,113 @@ export async function scanDirectory(
       absolute: true,
       nodir: true,
     });
-    const entries = await Promise.all(
-      files.map((f) => {
-        const name = path.basename(f, '.yaml');
-        return scanYaml(name, f, source);
-      }),
+    const parsed = (
+      await Promise.all(files.map((file) => readYamlDefinition(file)))
+    ).filter(filterNotNull);
+    const definitions = new Map(
+      parsed.map((entry) => [entry.name, entry] as const),
     );
+    const entries = parsed
+      .map((entry) => scanYaml(entry, source, definitions))
+      .filter(filterNotNull);
 
-    const result = entries.filter(filterNotNull);
-    logger.debug(CHANNEL, `Scanned ${result.length} agents from ${source}`);
-    return result;
+    logger.debug(CHANNEL, `Scanned ${entries.length} agents from ${source}`);
+    return entries;
   } catch (err) {
     logger.error(CHANNEL, `Failed to scan ${dir}: ${toErrorMessage(err)}`);
     return [];
   }
 }
 
-async function scanYaml(
-  name: string,
+async function readYamlDefinition(
   yamlPath: string,
-  source: AgentSource,
-): Promise<AgentEntry | null> {
+): Promise<ParsedAgentYaml | null> {
   try {
     const content = await AbsoluteFS.read(yamlPath);
     const parsed = yaml.parse(content);
-    const validated = AgentDefinitionSchema.parse(parsed);
+    const definition = AgentDefinitionSchema.parse(parsed);
+    return {
+      name: path.basename(yamlPath, '.yaml'),
+      path: yamlPath,
+      definition,
+    };
+  } catch (err) {
+    logger.warn(CHANNEL, `Failed to scan ${yamlPath}: ${toErrorMessage(err)}`);
+    return null;
+  }
+}
+
+type InheritedBlockName = 'prompts' | 'settings';
+
+interface InheritedDefinitionBlock {
+  readonly value: Record<string, unknown>;
+  readonly complete: boolean;
+}
+
+function parentDefinition(
+  parentName: string,
+  definitions: Map<string, ParsedAgentYaml>,
+): ParsedAgentYaml | undefined {
+  return (
+    definitions.get(parentName) ??
+    definitions.get(LEGACY_AGENT_ALIASES[parentName] ?? '')
+  );
+}
+
+function inheritedDefinitionBlock(
+  entry: ParsedAgentYaml,
+  definitions: Map<string, ParsedAgentYaml>,
+  block: InheritedBlockName,
+  seen: ReadonlySet<string> = new Set([entry.name]),
+): InheritedDefinitionBlock {
+  const ownBlock = entry.definition[block];
+  const parentName = entry.definition.inherits;
+  if (!parentName) return { value: ownBlock, complete: true };
+
+  const parent = parentDefinition(parentName, definitions);
+  if (!parent || seen.has(parent.name)) {
+    return { value: ownBlock, complete: false };
+  }
+
+  const inherited = inheritedDefinitionBlock(
+    parent,
+    definitions,
+    block,
+    new Set([...seen, parent.name]),
+  );
+  return {
+    value: mergeInheritedAgentObject(inherited.value, ownBlock),
+    complete: inherited.complete,
+  };
+}
+
+function userRequestTemplateCount(rawPrompts: Record<string, unknown>): number {
+  const userRequest = rawPrompts.userRequest;
+  if (Array.isArray(userRequest)) return userRequest.length;
+  return typeof userRequest === 'string' && userRequest ? 1 : 0;
+}
+
+function scanYaml(
+  entry: ParsedAgentYaml,
+  source: AgentSource,
+  definitions: Map<string, ParsedAgentYaml>,
+): AgentEntry | null {
+  try {
+    const validated = entry.definition;
 
     // Extract lightweight metadata
-    const rawSettings = (validated.settings ?? {}) as Record<string, unknown>;
+    const settingsBlock = inheritedDefinitionBlock(
+      entry,
+      definitions,
+      'settings',
+    );
+    const promptsBlock = inheritedDefinitionBlock(
+      entry,
+      definitions,
+      'prompts',
+    );
+    const rawSettings = settingsBlock.value;
+    const rawPrompts = promptsBlock.value;
     const defaultOutputFiles = rawSettings.defaultOutputFiles as
       | string[]
       | undefined;
@@ -85,22 +175,39 @@ async function scanYaml(
         : AgentCategory.Workflow;
 
     const internal = rawSettings.internal === true || undefined;
+    let rounds: number | undefined;
+    if (
+      category === AgentCategory.Workflow &&
+      settingsBlock.complete &&
+      promptsBlock.complete
+    ) {
+      const parsedRounds = AgentWorkflowSettingSchema.shape.rounds
+        .catch(INVALID_WORKFLOW_ROUNDS)
+        .parse(rawSettings.rounds);
+      if (!Number.isNaN(parsedRounds)) {
+        rounds = Math.max(parsedRounds, userRequestTemplateCount(rawPrompts));
+      }
+    }
 
     return {
-      name,
+      name: entry.name,
       displayName: validated.displayName,
       source,
-      path: yamlPath,
+      path: entry.path,
       category,
       description: validated.description,
       tools: tools?.length ? tools : undefined,
       defaultOutputFiles: defaultOutputFiles?.length
         ? defaultOutputFiles
         : undefined,
+      rounds,
       internal,
     };
   } catch (err) {
-    logger.warn(CHANNEL, `Failed to scan ${yamlPath}: ${toErrorMessage(err)}`);
+    logger.warn(
+      CHANNEL,
+      `Failed to scan ${entry.path}: ${toErrorMessage(err)}`,
+    );
     return null;
   }
 }

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 
-import deepmerge from 'deepmerge';
 import * as yaml from 'yaml';
 
 import {
@@ -16,6 +15,7 @@ import {
   type AgentSetting,
   type AgentPrompt,
 } from '@agent/core/definition/AgentDataclass';
+import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitionInheritance';
 import { RemoteAgentLoader } from '@agent/remote/RemoteAgentLoader';
 import * as logger from '@logger/logUtils';
 import { resolveToolDefinitions } from '@tools/registry';
@@ -112,12 +112,8 @@ export async function loadAgentSettingAndPrompts(
       await loadAgentSettingAndPrompts(parentResolution);
 
     // Parent provides defaults, child overrides
-    settings = deepmerge(parentSettings, config.settings, {
-      arrayMerge: (_d, s) => s,
-    });
-    prompts = deepmerge(parentPrompts, config.prompts, {
-      arrayMerge: (_d, s) => s,
-    });
+    settings = mergeInheritedAgentObject(parentSettings, config.settings);
+    prompts = mergeInheritedAgentObject(parentPrompts, config.prompts);
   }
 
   settings = ensureAgentCategoryForSource(settings, entry.source);

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -67,6 +67,12 @@ describe('agent registry legacy aliases', () => {
     expect(getAgent('assistant')?.name).toBe('assistant');
   });
 
+  it('exposes workflow round counts from local agent YAML', () => {
+    expect(getAgent('polish')?.rounds).toBe(2);
+    expect(getAgent('correct')?.rounds).toBe(1);
+    expect(getAgent('assistant')?.rounds).toBeUndefined();
+  });
+
   it('resolves source-qualified legacy keys', () => {
     expect(getAgent('builtInToolUse:chat')?.name).toBe('assistant');
     expect(getAgent('builtInToolUse:assistant')?.name).toBe('assistant');
@@ -97,6 +103,18 @@ describe('agent registry legacy aliases', () => {
     const visible = getVisibleAgents('toolUse').map((a) => a.name);
     expect(visible).toContain('assistant');
     expect(getVisibleAgent('toolUse', 'chat')?.name).toBe('assistant');
+  });
+
+  it('drops workflow round metadata when category is overridden to tool-use', async () => {
+    await platform().workspaceState.update(
+      WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      ['polish'],
+    );
+    await refresh({ includeRemote: false });
+
+    const entry = getAgent('polish');
+    expect(entry?.category).toBe(AgentCategory.ToolUse);
+    expect(entry?.rounds).toBeUndefined();
   });
 
   it('preserves bare custom chat while migrating qualified built-in chat keys', async () => {

--- a/src/test-kernel/agent/AgentYamlScanner.vitest.mts
+++ b/src/test-kernel/agent/AgentYamlScanner.vitest.mts
@@ -1,0 +1,103 @@
+// Standard library imports
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+// Third-party imports
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// Local imports - test setup
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { scanDirectory } from '@agent/index/agentYamlScanner';
+
+describe('agent YAML scanner', () => {
+  beforeAll(async () => {
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
+  });
+
+  it('derives workflow round counts from inherited settings and prompts', async () => {
+    const agentDir = await mkdtemp(resolve(tmpdir(), 'texra-agent-scan-'));
+    await writeFile(
+      resolve(agentDir, 'base.yaml'),
+      [
+        'name: base',
+        'settings:',
+        '  agentCategory: workflow',
+        '  rounds: 4',
+        'prompts:',
+        '  userRequest: base',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(agentDir, 'child.yaml'),
+      [
+        'name: child',
+        'inherits: base',
+        'prompts:',
+        '  userRequest: child',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(agentDir, 'assistant.yaml'),
+      [
+        'name: assistant',
+        'settings:',
+        '  agentCategory: workflow',
+        '  rounds: 5',
+        'prompts:',
+        '  userRequest: assistant',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(agentDir, 'alias-child.yaml'),
+      [
+        'name: alias-child',
+        'inherits: chat',
+        'prompts:',
+        '  userRequest: alias child',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(agentDir, 'prompt-base.yaml'),
+      [
+        'name: prompt-base',
+        'settings:',
+        '  agentCategory: workflow',
+        '  rounds: 1',
+        'prompts:',
+        '  userRequest:',
+        '    - first',
+        '    - second',
+        '    - third',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(agentDir, 'prompt-child.yaml'),
+      ['name: prompt-child', 'inherits: prompt-base', ''].join('\n'),
+    );
+    await writeFile(
+      resolve(agentDir, 'missing-parent.yaml'),
+      ['name: missing-parent', 'inherits: no-such-parent', ''].join('\n'),
+    );
+
+    const entries = await scanDirectory(agentDir, 'custom');
+
+    expect(entries.find((entry) => entry.name === 'child')?.rounds).toBe(4);
+    expect(entries.find((entry) => entry.name === 'alias-child')?.rounds).toBe(
+      5,
+    );
+    expect(entries.find((entry) => entry.name === 'prompt-child')?.rounds).toBe(
+      3,
+    );
+    expect(
+      entries.find((entry) => entry.name === 'missing-parent')?.rounds,
+    ).toBeUndefined();
+  });
+});

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -181,6 +181,7 @@ describe('CLI agents command', () => {
       path: '/tmp/resources/agents/correct.yaml',
       category: AgentCategory.Workflow,
       description: 'Fixes typos.',
+      rounds: 1,
     };
     const toolUseAgent = {
       name: 'chat',
@@ -239,6 +240,28 @@ describe('CLI agents command', () => {
       json: localAgent,
       ndjson: { kind: 'agent', agent: localAgent },
       text: expect.stringContaining('source: builtInToolUse'),
+    });
+  });
+
+  it('renders workflow round counts in agent details', async () => {
+    const workflowAgent = {
+      name: 'polish',
+      source: 'builtInWorkflow',
+      path: '/tmp/resources/agents/polish.yaml',
+      category: AgentCategory.Workflow,
+      description: 'Polishes prose.',
+      rounds: 2,
+    };
+    mocks.resolveCliAgent.mockResolvedValue(workflowAgent);
+    const { showAgent } = await import('@cli/commands/agents');
+
+    const exitCode = await showAgent(cliContext(), 'polish');
+
+    expect(exitCode).toBe(0);
+    expect(mocks.emitCliResult).toHaveBeenCalledWith(expect.anything(), {
+      json: workflowAgent,
+      ndjson: { kind: 'agent', agent: workflowAgent },
+      text: expect.stringContaining('rounds: 2'),
     });
   });
 


### PR DESCRIPTION
## Summary

- expose local workflow agent `settings.rounds` on `AgentEntry`
- show `rounds` in `texra agents show` text output and JSON/list records
- preserve the workflow default of 2 rounds when the YAML omits `settings.rounds`

Refs #6255. This addresses the metadata visibility part of the workflow cost-risk issue; it does not close the broader UX question around upfront cost hints.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/AgentRegistryAlias.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing `src/agent/review/reviewDiff.ts` import-order warning)
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `node packages/cli/dist/bin/texra.js agents show polish --output-format json` shows `"rounds": 2`
- `node packages/cli/dist/bin/texra.js agents list --category workflow --all --output-format json` includes `"rounds": 2` for `polish`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and scan-path changes only; runtime agent loading behavior is aligned via shared merge helper with added test coverage.
> 
> **Overview**
> Adds optional **`rounds`** on **`AgentEntry`** so workflow agents advertise how many execution rounds they imply (from inherited **`settings.rounds`**, defaulting via schema when omitted, and at least the number of **`userRequest`** prompt templates).
> 
> **YAML scanning** now parses an entire directory first, merges inherited **`settings`** / **`prompts`** (including **`inherits: chat`** via **`LEGACY_AGENT_ALIASES`**), and only sets **`rounds`** when the inheritance chain is complete; broken parents omit **`rounds`**. **`mergeInheritedAgentObject`** centralizes parent/child deep-merge (child arrays win) for both scanning and **`agentLoad`**.
> 
> The registry **clears `rounds`** when a workflow agent is forced to tool-use via workspace overrides. **`formatCliAgentDetails`** prints **`rounds: N`** in text output alongside existing JSON/list payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aecc49446372c1f733c61d4ade7793eaa2279dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->