### PR TITLE
[codex] unify compact token formatting

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -18,7 +18,11 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
-import { filterNotNullish, formatCompactDuration } from '@utils/core';
+import {
+  filterNotNullish,
+  formatCompactDuration,
+  formatCompactTokenCount,
+} from '@utils/core';
 
 import { truncateSummaryToWidth } from '../render/terminalText';
 import { formatCliStatusLabel } from '../sessionStatus';
@@ -112,19 +116,6 @@ export interface StatusBarDisplay {
   readonly bindings: string;
 }
 
-function compactScale(scaled: number, suffix: string): string {
-  const rounded = Number.isInteger(scaled)
-    ? `${scaled}`
-    : scaled.toFixed(1).replace(/\.0$/, '');
-  return `${rounded}${suffix}`;
-}
-
-function formatCompactNumber(value: number): string {
-  if (value < 1000) return `${value}`;
-  if (value < 1_000_000) return compactScale(value / 1000, 'k');
-  return compactScale(value / 1_000_000, 'M');
-}
-
 function formatUsage(
   usage: TokenUsageStats | undefined,
   model: string,
@@ -141,7 +132,7 @@ function formatUsage(
   const base = { compactPriority: STATUS_BAR_COMPACT_PRIORITY.usage };
   const contextWindow = MODEL_CONFIGS[model]?.contextWindow;
   if (!contextWindow || contextWindow <= 0) {
-    return { ...base, text: formatCompactNumber(used), color: 'dim' };
+    return { ...base, text: formatCompactTokenCount(used), color: 'dim' };
   }
 
   const ratio = used / contextWindow;
@@ -152,7 +143,7 @@ function formatUsage(
   else color = 'dim';
   return {
     ...base,
-    text: `${formatCompactNumber(used)}/${formatCompactNumber(
+    text: `${formatCompactTokenCount(used)}/${formatCompactTokenCount(
       contextWindow,
     )} (${percent}%)`,
     // Keep context visibility on narrow terminals: degrade to the bare

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -10,10 +10,9 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
 import type { TokenUsageStats } from '@shared/schemas';
-import { clamp } from '@utils/core';
+import { clamp, formatCompactTokenCount } from '@utils/core';
 
 // Local imports - progress view
-import { formatTokens } from '../formatters/timestampUtils';
 import { ELEMENT_IDS } from '../constants';
 import type { ContextStateData } from '../store';
 
@@ -182,7 +181,7 @@ export class UsagePanel extends LitElement {
           title="Input tokens"
           aria-hidden="true"
         ></wa-icon
-        >${formatTokens(inputTokens)}
+        >${formatCompactTokenCount(inputTokens)}
         ${when(
           cacheRead > 0,
           () =>
@@ -193,7 +192,7 @@ export class UsagePanel extends LitElement {
                 title="Cache read tokens (discounted)"
                 aria-hidden="true"
               ></wa-icon>
-              ${formatTokens(cacheRead)}`,
+              ${formatCompactTokenCount(cacheRead)}`,
         )}
         ${when(
           cacheMiss > 0,
@@ -205,7 +204,7 @@ export class UsagePanel extends LitElement {
                 title="Cache miss tokens (full price)"
                 aria-hidden="true"
               ></wa-icon>
-              ${formatTokens(cacheMiss)}`,
+              ${formatCompactTokenCount(cacheMiss)}`,
         )}
         ${when(
           cacheWrite > 0,
@@ -217,7 +216,7 @@ export class UsagePanel extends LitElement {
                 title="Cache creation tokens (1.25x cost)"
                 aria-hidden="true"
               ></wa-icon>
-              ${formatTokens(cacheWrite)}`,
+              ${formatCompactTokenCount(cacheWrite)}`,
         )}
         ·
         <wa-icon
@@ -226,7 +225,7 @@ export class UsagePanel extends LitElement {
           title="Output tokens"
           aria-hidden="true"
         ></wa-icon
-        >${formatTokens(outputTokens)} · $${cost.toFixed(3)}
+        >${formatCompactTokenCount(outputTokens)} · $${cost.toFixed(3)}
       </span>
     `;
   }
@@ -255,7 +254,8 @@ export class UsagePanel extends LitElement {
           ></span>
         </span>
         <span class="context-state__value">
-          ${formatTokens(inputTokens)} / ${formatTokens(contextWindow)}
+          ${formatCompactTokenCount(inputTokens)} /
+          ${formatCompactTokenCount(contextWindow)}
         </span>
       </span>
     `;
@@ -264,6 +264,6 @@ export class UsagePanel extends LitElement {
   private buildUsageLabel(): string {
     if (!this.usage) return '';
     const { inputTokens, outputTokens, cost } = this.usage;
-    return `Total usage: ${formatTokens(inputTokens)} input tokens, ${formatTokens(outputTokens)} output tokens, $${cost.toFixed(3)}`;
+    return `Total usage: ${formatCompactTokenCount(inputTokens)} input tokens, ${formatCompactTokenCount(outputTokens)} output tokens, $${cost.toFixed(3)}`;
   }
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -14,12 +14,10 @@ import {
   type ContextManagementData,
   type LogMessageData,
 } from '@shared/schemas';
+import { formatCompactTokenCount } from '@utils/core';
 
 // Local imports - Lit template utilities
 import { html, type FormatResult } from '../litTemplates';
-
-// Local imports - formatter helpers
-import { formatTokens } from '../timestampUtils';
 
 // Local imports - component types
 
@@ -94,7 +92,7 @@ function buildContextManagementItems(data: ContextManagementData): {
     items.push({
       icon: 'arrow-down',
       label: 'Max tokens reduced',
-      value: `${formatTokens(data.originalMaxTokens)} → ${formatTokens(data.reducedMaxTokens)}`,
+      value: `${formatCompactTokenCount(data.originalMaxTokens)} → ${formatCompactTokenCount(data.reducedMaxTokens)}`,
     });
   }
 
@@ -105,7 +103,7 @@ function buildContextManagementItems(data: ContextManagementData): {
       items.push({
         icon: 'dash',
         label: 'Tokens freed',
-        value: formatTokens(tokensFreed),
+        value: formatCompactTokenCount(tokensFreed),
       });
     }
   }
@@ -124,7 +122,7 @@ function buildContextManagementItems(data: ContextManagementData): {
   items.push({
     icon: 'window',
     label: 'Context window',
-    value: formatTokens(data.contextWindow),
+    value: formatCompactTokenCount(data.contextWindow),
   });
 
   if (data.details) {

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -20,13 +20,13 @@ import {
   type LogMessageData,
 } from '@shared/schemas';
 import { getBasename } from '@shared/utils/path';
+import { formatCompactTokenCount } from '@utils/core';
 
 // Local imports - shared schemas
 import { html, ifDefined, type FormatResult } from '../litTemplates';
 
 // Local imports - formatter helpers
 import { buildFileListRender, buildDetailsSummary } from '../htmlBuilders';
-import { formatTokens } from '../timestampUtils';
 
 /** Format file list entry as TemplateResult. */
 export function formatFileListTemplate(
@@ -130,14 +130,24 @@ type StatFieldConfig = readonly [
 
 // Statistics field configuration
 const STAT_FIELDS: readonly StatFieldConfig[] = [
-  ['inputTokens', 'arrow-up', 'Input tokens', formatTokens],
-  ['outputTokens', 'arrow-down', 'Output tokens', formatTokens],
-  ['cacheReadInputTokens', 'history', 'Cache hits', formatTokens],
-  ['cacheMissInputTokens', 'cloud-upload', 'Cache misses', formatTokens],
-  ['cacheCreationInputTokens', 'save', 'Cache writes', formatTokens],
+  ['inputTokens', 'arrow-up', 'Input tokens', formatCompactTokenCount],
+  ['outputTokens', 'arrow-down', 'Output tokens', formatCompactTokenCount],
+  ['cacheReadInputTokens', 'history', 'Cache hits', formatCompactTokenCount],
+  [
+    'cacheMissInputTokens',
+    'cloud-upload',
+    'Cache misses',
+    formatCompactTokenCount,
+  ],
+  ['cacheCreationInputTokens', 'save', 'Cache writes', formatCompactTokenCount],
   ['percentageCached', 'graph-line', 'Cached %', (v) => `${v.toFixed(2)}%`],
-  ['reasoningTokens', 'comment-discussion', 'Reasoning tokens', formatTokens],
-  ['toolUseTokens', 'tools', 'Tool tokens', formatTokens],
+  [
+    'reasoningTokens',
+    'comment-discussion',
+    'Reasoning tokens',
+    formatCompactTokenCount,
+  ],
+  ['toolUseTokens', 'tools', 'Tool tokens', formatCompactTokenCount],
   ['elapsedTime', 'clock', 'Elapsed time', (v) => `${v}s`],
   ['cost', 'rocket', 'Cost', (v) => `$${v.toFixed(3)}`],
 ];

--- a/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
@@ -2,7 +2,7 @@
  * Timestamp formatting utilities for progress view formatters.
  */
 
-// Local imports - formatter helpers
+// Local imports - formatter constants
 import { DATETIME_FORMAT_OPTIONS, TIME_FORMAT_OPTIONS } from './constants';
 
 // Shared formatters (lazily initialized for browser environments)
@@ -35,11 +35,4 @@ export function formatTimestamp(date: Date): {
     timeDisplay: getTimeFormatter().format(date),
     tooltipTimestamp: getDateTimeFormatter().format(date),
   };
-}
-
-/** Format token counts for display. Values >= 1M display as "M", > 4096 as "k", otherwise raw. */
-export function formatTokens(tokens: number): string {
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
-  if (tokens > 4096) return `${Math.round(tokens / 1000)}k`;
-  return `${tokens}`;
 }

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -498,7 +498,7 @@ describe('CLI StatusBar display model', () => {
       'running',
       'relay',
       'r2',
-      '80k/1M (8%)',
+      '80k/1.0M (8%)',
       'queued 2',
       '2 sub',
       '1 proc',
@@ -1457,14 +1457,14 @@ describe('CLI StatusBar display model', () => {
       buildStatusBarDisplay({ ...input, width: 80 }).left.map(
         statusBarSegmentText,
       ),
-    ).toContain('80k/1M (8%)');
+    ).toContain('80k/1.0M (8%)');
 
     // Narrow: the segment degrades to the bare percentage instead of
     // disappearing, keeping context pressure visible.
     const narrow = buildStatusBarDisplay({ ...input, width: 24 }).left.map(
       statusBarSegmentText,
     );
-    expect(narrow).not.toContain('80k/1M (8%)');
+    expect(narrow).not.toContain('80k/1.0M (8%)');
     expect(narrow).toContain('8%');
   });
 

--- a/src/test-kernel/utils/StringCore.vitest.ts
+++ b/src/test-kernel/utils/StringCore.vitest.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatCompactDuration } from '@utils/core/stringCore';
+import {
+  formatCompactDuration,
+  formatCompactTokenCount,
+} from '@utils/core/stringCore';
 
 describe('formatCompactDuration', () => {
   it.each([
@@ -16,5 +19,21 @@ describe('formatCompactDuration', () => {
     [90_000_000, '1d 1h'],
   ])('renders %i ms as %s', (ms, label) => {
     expect(formatCompactDuration(ms)).toBe(label);
+  });
+});
+
+describe('formatCompactTokenCount', () => {
+  it.each([
+    [0, '0'],
+    [999, '999'],
+    [4096, '4096'],
+    [4097, '4k'],
+    [999_499, '999k'],
+    [999_500, '1.0M'],
+    [999_999, '1.0M'],
+    [1_000_000, '1.0M'],
+    [1_250_000, '1.3M'],
+  ])('renders %i tokens as %s', (tokens, label) => {
+    expect(formatCompactTokenCount(tokens)).toBe(label);
   });
 });

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -10,6 +10,7 @@ export {
   isString,
   extractErrorMessage,
   formatCompactDuration,
+  formatCompactTokenCount,
   formatDuration,
   serializeError,
   type SerializedError,

--- a/src/utils/core/stringCore.ts
+++ b/src/utils/core/stringCore.ts
@@ -91,3 +91,16 @@ export function formatCompactDuration(durationMs: number): string {
     unitCount: 2,
   });
 }
+
+/**
+ * Format token counts for compact usage displays.
+ *
+ * Token displays intentionally stay raw until they exceed 4096, the common
+ * small-context threshold where an abbreviated number starts buying space. Once
+ * k-format rounding would print `1000k`, switch to `M` instead.
+ */
+export function formatCompactTokenCount(tokens: number): string {
+  if (tokens >= 999_500) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens > 4096) return `${Math.round(tokens / 1000)}k`;
+  return `${tokens}`;
+}


### PR DESCRIPTION
## Summary

- add a shared compact token-count formatter in @utils/core
- use it directly from the CLI status bar and progress-view token consumers
- cover the 4096 threshold and k/M rounding boundary in shared formatter tests

This intentionally makes the CLI status bar use the same display policy as the progress view: raw counts through 4096, rounded k-values above that, and M-values once k-rounding would otherwise print 1000k.

Closes #6204

## Validation

- corepack pnpm vitest run src/test-kernel/utils/StringCore.vitest.ts src/test-kernel/cli/StatusBar.vitest.mts
- corepack pnpm exec tsc --noEmit --pretty false
- npm run lint (passes with the existing reviewDiff.ts import-order warning)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only refactor with no auth, billing, or data-path changes; risk is limited to slightly different abbreviated token strings in the UI.
> 
> **Overview**
> Introduces **`formatCompactTokenCount`** in `@utils/core` and uses it everywhere token counts are shown compactly, so the CLI status bar and VS Code progress view follow the same rules.
> 
> **Display policy:** raw counts through **4096**, rounded **`k`** above that, and one-decimal **`M`** from **999.5k** upward (e.g. context window **`1.0M`** instead of **`1M`**). The CLI drops its local **`formatCompactNumber`** helpers; the extension drops **`formatTokens`** from **`timestampUtils`** in favor of the shared helper in **`UsagePanel`**, statistics/context-management formatters, and related UI.
> 
> Tests in **`StringCore.vitest`** cover the thresholds; **`StatusBar.vitest`** expectations are updated for the new million formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc4436f77b338020fa71c1f5f49aff96f4b1180c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->