### PR TITLE
[codex] show planned workflow rounds in CLI progress

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -1,5 +1,9 @@
 import path from 'node:path';
 
+// Local imports - agent metadata
+import { getAgent } from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+
 // Local imports - progress events
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
@@ -19,6 +23,7 @@ type ProgressEvent = keyof ProgressEventPayloads;
 
 interface RenderState {
   round?: number;
+  plannedRounds?: number;
   toolCallCount?: number;
   agent?: string;
   inputLabel?: string;
@@ -184,6 +189,10 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     const config = payload.taskState.agentConfig;
     this.state.agent = config.agent;
     this.state.inputLabel = formatInputLabel(config.inputFiles);
+    this.state.plannedRounds =
+      config.agentCategory === AgentCategory.Workflow
+        ? getAgent(config.agent, AgentCategory.Workflow)?.rounds
+        : undefined;
     this.state.phase ??= 'running';
     return true;
   }
@@ -270,7 +279,11 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
   private formatLine(now: number): string {
     const parts: string[] = [];
-    if (this.state.round != null) parts.push(`[r${this.state.round}]`);
+    if (this.state.round != null) {
+      parts.push(
+        formatRoundProgress(this.state.round, this.state.plannedRounds),
+      );
+    }
 
     const subject = [this.state.agent, this.state.inputLabel]
       .filter(Boolean)
@@ -278,6 +291,9 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     const phase = this.state.phase;
     parts.push(subject || phase || 'running');
     if (subject && phase && phase !== 'running') parts.push(phase);
+    if (this.state.round == null && isMultiRound(this.state.plannedRounds)) {
+      parts.push(formatPlannedRounds(this.state.plannedRounds));
+    }
 
     if (this.state.activeSubagents) parts.push(this.state.activeSubagents);
     if (this.state.activeProcesses) parts.push(this.state.activeProcesses);
@@ -328,6 +344,24 @@ function formatActiveChildren(
   const suffix =
     namedChildren.length > 1 ? ` +${namedChildren.length - 1}` : '';
   return `${label}: ${first}${suffix}`;
+}
+
+function formatRoundProgress(
+  round: number,
+  plannedRounds: number | undefined,
+): string {
+  if (isMultiRound(plannedRounds) && round <= plannedRounds) {
+    return `[r${round}/${plannedRounds}]`;
+  }
+  return `[r${round}]`;
+}
+
+function formatPlannedRounds(rounds: number): string {
+  return `${rounds} rounds`;
+}
+
+function isMultiRound(rounds: number | undefined): rounds is number {
+  return rounds != null && rounds > 1;
 }
 
 function formatElapsed(ms: number): string {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { pickGlobalArgs } from '@cli/runtime/globalArgs';
@@ -9,6 +9,14 @@ import {
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { EXECUTION_STATUS, STREAM_STATUS } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  getAgent: vi.fn(),
+}));
+
+vi.mock('@agent/index', () => ({
+  getAgent: mocks.getAgent,
+}));
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
   return {
@@ -69,6 +77,41 @@ function workflowTaskState(
   };
 }
 
+function toolUseTaskState(
+  overrides: {
+    streamId?: string;
+    agent?: string;
+    inputFiles?: string[];
+  } = {},
+) {
+  return {
+    streamId: overrides.streamId ?? 'stream-1',
+    taskState: {
+      agentConfig: {
+        agent: overrides.agent ?? 'polish',
+        agentCategory: AgentCategory.ToolUse,
+        model: 'deepseekT',
+        inputFiles: overrides.inputFiles ?? [],
+        contextFiles: [],
+        mediaFiles: [],
+        outputFiles: [],
+        editedFile: null,
+        editedFiles: [],
+        toolConfig: {
+          autoExtractFigure: false,
+          autoExtractTikzFigure: false,
+          attachTeXCount: false,
+          attachDiagnostics: false,
+          autoCompileInputPdf: false,
+        },
+        memories: [],
+        instruction: '',
+        workingDirectory: '/tmp/project',
+      },
+    },
+  };
+}
+
 async function captureStreamWrites(
   stream: NodeJS.WriteStream,
   action: () => Promise<void>,
@@ -106,6 +149,10 @@ function decodeStreamChunk(
 }
 
 describe('CLI run progress renderer', () => {
+  beforeEach(() => {
+    mocks.getAgent.mockReset();
+  });
+
   it('renders a single ANSI status line and clears it on close', () => {
     let now = 0;
     let output = '';
@@ -192,6 +239,65 @@ describe('CLI run progress renderer', () => {
     );
 
     expect(output).toBe('polish number-theory.tex +1 · 0s\n');
+  });
+
+  it('shows planned workflow rounds before the first model turn', () => {
+    mocks.getAgent.mockReturnValue({
+      rounds: 2,
+    });
+    let output = '';
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: (text) => {
+          output += text;
+        },
+        minIntervalMs: 0,
+        nowMs: () => 0,
+      },
+    );
+
+    renderer?.handle('setTaskState', workflowTaskState());
+    renderer?.handle('updateConversationProgress', {
+      streamId: 'stream-1',
+      progress: { conversationTurns: 1, toolCallCount: 0 },
+    });
+
+    expect(mocks.getAgent).toHaveBeenCalledWith(
+      'polish',
+      AgentCategory.Workflow,
+    );
+    expect(output).toBe(
+      'polish paper.tex · 2 rounds · 0s\n' + '[r1/2] · polish paper.tex · 0s\n',
+    );
+  });
+
+  it('does not add workflow round hints to tool-use progress', () => {
+    mocks.getAgent.mockReturnValue({
+      rounds: 2,
+    });
+    let output = '';
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: (text) => {
+          output += text;
+        },
+        nowMs: () => 0,
+      },
+    );
+
+    renderer?.handle(
+      'setTaskState',
+      toolUseTaskState({
+        inputFiles: [],
+      }),
+    );
+
+    expect(mocks.getAgent).not.toHaveBeenCalled();
+    expect(output).toBe('polish · 0s\n');
   });
 
   it('prints phase changes on separate lines when ANSI is disabled', () => {


### PR DESCRIPTION
## Summary
- show configured workflow round counts in the CLI run progress line before the first model turn
- render live workflow progress as `[rN/M]` when the planned total is known
- keep tool-use progress unchanged and covered by focused renderer tests

Closes #6255

## Validation
- corepack pnpm vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts
- corepack pnpm exec tsc --noEmit --pretty false
- npm run lint (passes with existing warning in src/agent/review/reviewDiff.ts)
- corepack pnpm --filter @texra-ai/cli validate:run
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CLI progress formatting with scoped workflow lookup and focused unit tests; no auth, data, or execution-path changes.
> 
> **Overview**
> The CLI **run progress** line now surfaces **workflow round counts** from agent metadata, so multi-round workflows are easier to read at a glance.
> 
> On **`setTaskState`**, workflow runs resolve **`plannedRounds`** via `getAgent(..., AgentCategory.Workflow)`; tool-use runs leave that unset and behave as before. Before the first model turn, multi-round workflows append a **`N rounds`** hint; once turns are known, the prefix becomes **`[rN/M]`** when `M > 1` and the current round is within plan, otherwise **`[rN]`**.
> 
> Renderer tests mock **`getAgent`** and assert the pre-turn hint, **`[r1/2]`** transition, and that tool-use progress does not call **`getAgent`** or show round hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9abcf2987a5d811bbee5a479f7b9d4760916204f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->