### PR TITLE
refactor: use async reflection output existence checks

### DIFF
--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -22,7 +22,9 @@ export interface ReflectionServices<
   readonly latexMediaManager: LatexMediaManager;
   readonly promptBuilder: PromptBuilder;
   readonly fileService: TaskRunFileService;
-  readonly getOutputFileLocation: (round: number) => AgentFileLocation;
+  readonly getOutputFileLocation: (
+    round: number,
+  ) => AgentFileLocation | Promise<AgentFileLocation>;
   readonly baseFiles: WorkspaceFileLocation[];
   readonly onRoundFinalized: RoundFinalizedCallback;
 }

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -54,7 +54,9 @@ export class ResponseCycleNode<C = unknown> extends Node<
 
     return {
       shared,
-      outputLocation: this.services.getOutputFileLocation(shared.currentRound),
+      outputLocation: await this.services.getOutputFileLocation(
+        shared.currentRound,
+      ),
       round,
       run,
       workspace,

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -57,7 +57,9 @@ export interface RunReflectionFlowInput<
   setting: AgentWorkflowSetting;
   storageKey: StorageKey;
   parentStage: StageHandle;
-  getOutputFileLocation?: (round: number) => AgentFileLocation;
+  getOutputFileLocation?: (
+    round: number,
+  ) => AgentFileLocation | Promise<AgentFileLocation>;
   onRoundCompleted?: (
     roundIndex: number,
     totalRounds: number,
@@ -137,7 +139,7 @@ export async function runReflectionFlow<C = unknown>(
 
   const getOutputFileLocation =
     input.getOutputFileLocation ??
-    ((round: number): AgentFileLocation => {
+    (async (round: number): Promise<AgentFileLocation> => {
       // The default `r{round}/output.xml` filename is only collision-safe
       // when resolved through a run-storage-bound fileService. Enforce the
       // invariant so a misconfigured TaskRunFileService can't silently
@@ -154,11 +156,11 @@ export async function runReflectionFlow<C = unknown>(
       // older build that used `.tex` for non-scratchpad agents, keep using that
       // file on resume so initializeOutputAndPrefill sees the existing content
       // instead of starting a fresh round at output.xml.
-      if (!AbsoluteFS.existsSync(canonical.absolutePath)) {
+      if (!(await AbsoluteFS.exists(canonical.absolutePath))) {
         const legacy = fileService.createLocation(
           getOutputFileName(WORKFLOW_DOCUMENT_OUTPUT_EXT, round),
         ) as AgentFileLocation;
-        if (AbsoluteFS.existsSync(legacy.absolutePath)) {
+        if (await AbsoluteFS.exists(legacy.absolutePath)) {
           return legacy;
         }
       }

--- a/src/test-kernel/agent/ReflectionOutputLocation.vitest.ts
+++ b/src/test-kernel/agent/ReflectionOutputLocation.vitest.ts
@@ -1,0 +1,62 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - reflection flow
+import { ResponseCycleNode } from '@agent/implementations/flows/reflection/nodes/ResponseCycleNode';
+import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
+import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
+
+// Local imports - agent state
+import {
+  AgentRunStateSnapshotSchema,
+  ConversationRoundStateSnapshotSchema,
+} from '@agent/core/execution/AgentState';
+import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
+
+// Local imports - shared schemas
+import type { AgentFileLocation } from '@shared/schemas';
+
+function reflectionShared(): ReflectionFlowShared {
+  return {
+    currentRound: 1,
+    totalRounds: 2,
+    workspaceSnapshot: AgentWorkspaceState.emptySnapshot(),
+    context: {
+      messages: [],
+      prefill: '',
+      stateRoundSnapshot: ConversationRoundStateSnapshotSchema.parse({
+        roundIndex: 1,
+      }),
+    },
+    outputLocation: null,
+    conversation: [],
+    runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+    roundStateSnapshots: [],
+    roundOutputs: [],
+    continueRounds: true,
+    endTurn: false,
+  };
+}
+
+describe('reflection output location resolution', () => {
+  it('awaits async output location resolvers before initializing a round', async () => {
+    const outputLocation: AgentFileLocation = {
+      kind: 'workspace',
+      absolutePath: '/tmp/output.xml',
+      relativePath: 'output.xml',
+    };
+    let resolvedRound: number | undefined;
+    const node = new ResponseCycleNode().setServices({
+      getOutputFileLocation: async (round: number) => {
+        resolvedRound = round;
+        await Promise.resolve();
+        return outputLocation;
+      },
+    } as unknown as ReflectionServices);
+
+    const prep = await node.prep(reflectionShared());
+
+    expect(resolvedRound).toBe(1);
+    expect(prep.outputLocation).toBe(outputLocation);
+  });
+});


### PR DESCRIPTION
## Summary
- allow reflection output-location resolution to await async filesystem checks
- replace the default legacy-output lookup with `AbsoluteFS.exists()` instead of `existsSync()`
- add a focused regression test that `ResponseCycleNode.prep()` awaits async output-location resolvers

Closes #6202

## Validation
- `corepack pnpm vitest run src/test-kernel/agent/ReflectionOutputLocation.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warning in `src/agent/review/reviewDiff.ts`)
- `corepack pnpm exec prettier --check src/agent/implementations/flows/reflection/ReflectionServices.ts src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts src/agent/implementations/flows/reflection/runReflectionFlow.ts src/test-kernel/agent/ReflectionOutputLocation.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small typing and await wiring in the reflection flow; behavior change is limited to how output paths are resolved on disk checks, with a regression test.
> 
> **Overview**
> Reflection **output path resolution** now supports sync or async `getOutputFileLocation` hooks: types on `ReflectionServices` and `RunReflectionFlowInput` allow `Promise<AgentFileLocation>`, and `ResponseCycleNode.prep()` **awaits** the resolver before each round.
> 
> The default resolver in `runReflectionFlow` is **async** and uses **`AbsoluteFS.exists()`** instead of `existsSync()` when choosing between canonical `output.xml` and legacy `.tex` paths for resume compatibility.
> 
> Adds **`ReflectionOutputLocation.vitest.ts`** to assert `prep()` waits on async resolvers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d7311ceab301b3759da1126422c9a429d3b57e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->