### PR TITLE
fix: keep diff dropdown width capped

### DIFF
--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -315,7 +315,6 @@ export const requestPanelStyles: CSSResult = css`
     flex: 1 1 7rem;
     min-width: 0;
     max-width: min(8.25rem, 100%);
-    max-inline-size: 100%;
   }
 
   .approval-request__actions .diff-dropdown .diff-main-button {

--- a/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
+++ b/src/test-kernel/progressView/RequestPanelStyles.vitest.mts
@@ -70,7 +70,7 @@ describe('request panel styles', () => {
     expect(labelRule).toContain('white-space: nowrap');
   });
 
-  it('lets the tool edit diff dropdown shrink inside narrow panels', () => {
+  it('keeps the tool edit diff dropdown capped inside approval panels', () => {
     const source = readRequestPanelStyles();
     const dropdownStart = source.indexOf(
       '.approval-request__actions .diff-dropdown {',
@@ -89,7 +89,7 @@ describe('request panel styles', () => {
     expect(dropdownRule).toContain('flex: 1 1 7rem');
     expect(dropdownRule).toContain('min-width: 0');
     expect(dropdownRule).toContain('max-width: min(8.25rem, 100%)');
-    expect(dropdownRule).toContain('max-inline-size: 100%');
+    expect(dropdownRule).not.toContain('max-inline-size: 100%');
     expect(dropdownButtonRule).toContain('flex: 1 1 auto');
     expect(dropdownButtonRule).toContain('width: auto');
     expect(dropdownButtonRule).toContain('min-width: 0');


### PR DESCRIPTION
## Summary
- remove the `max-inline-size: 100%` declaration that overrides the diff dropdown `max-width` cap
- update the request-panel style regression test to assert the cap remains effective

Closes #6096

## Validation
- `corepack pnpm vitest run src/test-kernel/progressView/RequestPanelStyles.vitest.mts`
- `corepack pnpm exec prettier --check src/shared/styles/requestPanelStyles.ts src/test-kernel/progressView/RequestPanelStyles.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warning in `src/agent/review/reviewDiff.ts`)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only tweak to approval-panel diff dropdown sizing with a matching regression test; no auth, data, or API impact.
> 
> **Overview**
> Fixes layout in **tool edit approval** panels where the diff dropdown could grow past its intended cap in narrow widths.
> 
> The PR **drops** `max-inline-size: 100%` from `.approval-request__actions .diff-dropdown`. That logical-property rule was effectively overriding the existing `max-width: min(8.25rem, 100%)` cap, so the control could stretch instead of staying compact.
> 
> The **request-panel style regression test** is renamed and updated to assert the dropdown rule still has the flex/max-width cap and **does not** include `max-inline-size: 100%`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7fb41034a23da78689a123679dadeb772b82ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->