### PR TITLE
fix: use bridged danger token in context mock

### DIFF
--- a/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
@@ -68,7 +68,7 @@ export class ContextUtilizationMock extends LitElement {
       }
 
       .ctx-chip--danger {
-        color: var(--wa-color-danger-text-loud);
+        color: var(--wa-color-danger-on-quiet);
       }
 
       .ctx-chip--danger .ctx-chip__fill {

--- a/src/test-kernel/webview/MocksGalleryStyles.vitest.mts
+++ b/src/test-kernel/webview/MocksGalleryStyles.vitest.mts
@@ -16,6 +16,23 @@ function readSource(relativePath: string): string {
 }
 
 describe('mock gallery styles', () => {
+  it('uses host-bridged danger tokens in context utilization mock', () => {
+    const source = readSource(
+      'packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts',
+    );
+    const extensionBridge = readSource(
+      'packages/extension/src/common/styles/common.css',
+    );
+    const desktopBridge = readSource(
+      'packages/desktop/src/renderer/themeTokens.css',
+    );
+
+    expect(source).not.toContain('--wa-color-danger-text-loud');
+    expect(source).toContain('--wa-color-danger-on-quiet');
+    expect(extensionBridge).toContain('--wa-color-danger-on-quiet');
+    expect(desktopBridge).toContain('--wa-color-danger-on-quiet');
+  });
+
   it('keeps mock previews inside the launcher panel', () => {
     const source = readSource(
       'packages/extension/src/webview/frontend/mocks/MocksGallery.ts',


### PR DESCRIPTION
## Summary
- replace the phantom `--wa-color-danger-text-loud` reference in `ContextUtilizationMock` with `--wa-color-danger-on-quiet`
- add a regression check that the mock uses the bridged token and that both extension and desktop token bridges define it

Closes #6173

## Validation
- `corepack pnpm vitest run src/test-kernel/webview/MocksGalleryStyles.vitest.mts`
- `corepack pnpm exec prettier --check packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts src/test-kernel/webview/MocksGalleryStyles.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warning in `src/agent/review/reviewDiff.ts`)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic token fix in a dev mock preview plus a static source assertion; no runtime logic or security-sensitive paths.
> 
> **Overview**
> Fixes **high context utilization** styling in `ContextUtilizationMock` by swapping the undefined `--wa-color-danger-text-loud` token for `--wa-color-danger-on-quiet`, which is defined on the extension and desktop theme bridges.
> 
> Adds a **MocksGalleryStyles** regression test that asserts the mock no longer references the phantom token and that both `common.css` and `themeTokens.css` expose `--wa-color-danger-on-quiet`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05ba3a1cf3bd781bdec3d95fbcd8ff0e43033577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->