### PR TITLE
[codex] test text editor undo isolation

### DIFF
--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -2,8 +2,6 @@
 import * as assert from 'node:assert';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 
-// Third-party imports
-
 // Local imports - tests
 import { createFakePlatform } from '@test/support/FakePlatform';
 
@@ -13,6 +11,7 @@ import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 
 // Local imports - tools
 import type { StreamTabId } from '@shared/schemas';
+import { TextEditorTool } from '@tools/TextEditorTool';
 import { WriteFileTool } from '@tools/WriteTool';
 import {
   cleanupAllApprovals,
@@ -26,9 +25,29 @@ import { WorkspaceFS } from '@utils/files';
 // Test stream ID for per-stream YOLO mode tests
 const TEST_STREAM_ID = 'TestAgent@model: test.tex' as StreamTabId;
 
-async function installPlatform(config: Record<string, unknown> = {}) {
+async function installPlatform(
+  config: Record<string, unknown> = {},
+  files: Record<string, string | Uint8Array> = {},
+) {
   const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspacePath: '/workspace', config }));
+  initPlatform(
+    createFakePlatform({ workspacePath: '/workspace', config, files }),
+  );
+}
+
+async function callTextEditorInRun(
+  tool: TextEditorTool,
+  executionId: string,
+  input: unknown,
+) {
+  return withRunContext(
+    createRunContext({
+      runtimeHost: noopAgentRuntimeHost,
+      streamId: `stream:${executionId}` as StreamTabId,
+      executionId,
+    }),
+    () => tool.call(input),
+  );
 }
 
 describe('Tool edit approval gating', () => {
@@ -171,6 +190,50 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(handlerCalled, false);
     assert.strictEqual(writtenContent, 'auto');
     assert.strictEqual(result.output, 'written');
+  });
+
+  it('keeps text editor undo history isolated between execution ids', async () => {
+    await installPlatform(
+      {},
+      {
+        '/workspace/shared.tex': 'alpha\n',
+      },
+    );
+    const tool = new TextEditorTool();
+
+    setToolEditApprovalHandler(async () => ({ accepted: true }));
+
+    const parentEdit = await callTextEditorInRun(tool, 'aaaaaa', {
+      command: 'str_replace',
+      path: 'shared.tex',
+      old_str: 'alpha',
+      new_str: 'parent',
+    });
+    assert.notStrictEqual(parentEdit.isError, true);
+    assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'parent\n');
+
+    const childEdit = await callTextEditorInRun(tool, 'bbbbbb', {
+      command: 'str_replace',
+      path: 'shared.tex',
+      old_str: 'parent',
+      new_str: 'child',
+    });
+    assert.notStrictEqual(childEdit.isError, true);
+    assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'child\n');
+
+    const parentUndo = await callTextEditorInRun(tool, 'aaaaaa', {
+      command: 'undo_edit',
+      path: 'shared.tex',
+    });
+    assert.notStrictEqual(parentUndo.isError, true);
+    assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'alpha\n');
+
+    const childUndo = await callTextEditorInRun(tool, 'bbbbbb', {
+      command: 'undo_edit',
+      path: 'shared.tex',
+    });
+    assert.notStrictEqual(childUndo.isError, true);
+    assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'parent\n');
   });
 
   it('toggleToolEditApprovalSessionBypass toggles state and returns new value', () => {


### PR DESCRIPTION
## Summary

Adds a regression test for `TextEditorTool` undo history isolation across concurrent execution IDs. The test uses one tool instance, two active run contexts, and the in-memory fake workspace so a parent run and child run editing the same file cannot consume each other's undo snapshot.

Closes #6228.

## Validation

- `corepack pnpm vitest run src/test-kernel/tools/ToolEditApprovalGate.vitest.ts`
- `corepack pnpm exec prettier --check src/test-kernel/tools/ToolEditApprovalGate.vitest.ts`
- `npm run lint` (passes with existing import-order warning in `src/agent/review/reviewDiff.ts`)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths modified.
> 
> **Overview**
> Adds a **regression test** in `ToolEditApprovalGate.vitest.ts` for **`TextEditorTool` undo history isolation** when parent and child runs share one tool instance and edit the same path.
> 
> Test helpers are extended so the fake platform can seed workspace files and **`TextEditorTool` calls run under distinct `withRunContext` `executionId`s** (with edit approval auto-accepted). The scenario edits `shared.tex` from two execution IDs, then **`undo_edit` in each run only reverts that run’s snapshot** (parent undo → `alpha`, child undo → `parent`), guarding against cross-run undo bleed on a process-wide tool singleton.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fcb295ceaeb512b0dab1dd8b4168193a179bebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->