### PR TITLE
[codex] derive stream hints schema

### DIFF
--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -18,11 +18,10 @@ import { createChannelTrace } from '@logger';
 import {
   AgentCategoryFilterSchema,
   ContextStateDataSchema,
-  ExecutionIdSchema,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
-  StreamTabIdSchema,
+  StreamTabInfoSchema,
   type ActiveChildInfo,
   type AgentCategoryFilter,
   type ConversationProgress,
@@ -42,16 +41,16 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { clamp } from '@utils/core';
 
 /** Ephemeral stream metadata hints, displayed before TaskState is fully populated. */
-export const StreamHintsSchema = z.object({
-  agent: z.string().optional(),
-  agentCategory: z.enum(AgentCategory).optional(),
-  inputFile: z.string().optional(),
-  isRemote: z.boolean().optional(),
-  creationTimestamp: z.number().optional(),
-  executionId: ExecutionIdSchema.optional(),
-  parentStreamId: StreamTabIdSchema.optional(),
-  description: z.string().optional(),
-});
+export const StreamHintsSchema = StreamTabInfoSchema.pick({
+  agent: true,
+  agentCategory: true,
+  inputFile: true,
+  isRemote: true,
+  creationTimestamp: true,
+  executionId: true,
+  parentStreamId: true,
+  description: true,
+}).partial();
 
 export type StreamHints = z.infer<typeof StreamHintsSchema>;
 


### PR DESCRIPTION
## Summary

Derives `StreamHintsSchema` from `StreamTabInfoSchema.pick(...).partial()` instead of hand-redeclaring the same eight optional hint fields. This removes one duplicated schema surface from #6229 while keeping the rest of that tracking issue open for the more semantic parser/persistence cases.

Part of #6229.

## Validation

- `corepack pnpm vitest run src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts`
- `corepack pnpm exec prettier --check src/shared/progressView/backend/state/ProgressViewState.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warning in `src/agent/review/reviewDiff.ts`)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-shape refactor with no runtime logic changes; risk is limited to subtle validation differences if `StreamTabInfoSchema` field definitions ever diverge from the former hand-written hints.
> 
> **Overview**
> **`StreamHintsSchema`** in `ProgressViewState.ts` no longer re-declares the same eight optional hint fields (`agent`, `agentCategory`, `inputFile`, `isRemote`, `creationTimestamp`, `executionId`, `parentStreamId`, `description`). It is built as **`StreamTabInfoSchema.pick({ ... }).partial()`**, so hint validation stays aligned with stream tab metadata and duplicate schema definitions are removed (part of #6229).
> 
> Imports are adjusted accordingly: **`StreamTabInfoSchema`** is pulled from `@shared/schemas`, and **`ExecutionIdSchema`** / **`StreamTabIdSchema`** are dropped from this file because they were only needed for the old inline schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d54f9451802b6e6fd6cc32452dda4beecdc1f018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->