### PR TITLE
[codex] share work plan schemas and sanitize review git env

### DIFF
--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -15,11 +15,11 @@ import * as path from 'node:path';
 import simpleGit, { type SimpleGit } from 'simple-git';
 
 // Local imports
+import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { platform } from '@platform/platform';
-import { splitContentLines, splitOutputLines } from '@utils/text/stringUtils';
 import { extendEnvPath } from '@utils/system/platformPaths';
+import { splitContentLines, splitOutputLines } from '@utils/text/stringUtils';
 
 import { normalizeReviewFilePath } from './reviewIssues';
 
@@ -33,6 +33,35 @@ const MAX_UNTRACKED_FILE_LINES = 400;
 const MAX_UNTRACKED_FILE_BYTES = 200 * 1024;
 /** Overall cap on the diff text sent to the model (~40k tokens). */
 const MAX_REVIEW_DIFF_CHARS = 160_000;
+
+const SIMPLE_GIT_UNSAFE_ENV_KEYS = new Set([
+  'editor',
+  'git_askpass',
+  'git_config_global',
+  'git_config_system',
+  'git_config_count',
+  'git_config',
+  'git_editor',
+  'git_exec_path',
+  'git_external_diff',
+  'git_pager',
+  'git_proxy_command',
+  'git_sequence_editor',
+  'git_template_dir',
+  'pager',
+  'prefix',
+  'ssh_askpass',
+]);
+
+function makeMachineGitEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (SIMPLE_GIT_UNSAFE_ENV_KEYS.has(key.toLowerCase())) continue;
+    env[key] = value;
+  }
+  env.PATH = extendEnvPath(env.PATH);
+  return env;
+}
 
 export interface CollectReviewDiffOptions {
   /** Any path inside the repository; the diff always covers the whole repo. */
@@ -78,10 +107,9 @@ function makeGit(cwd: string): SimpleGit {
   // with a minimal PATH that omits Homebrew / /usr/local/bin, so `git` may be
   // unresolvable. executeCommand previously ran git with extendEnvPath();
   // preserve that here so simple-git can still locate the binary.
-  return simpleGit(cwd, { timeout: { block: GIT_TIMEOUT_MS } }).env({
-    ...process.env,
-    PATH: extendEnvPath(),
-  });
+  return simpleGit(cwd, { timeout: { block: GIT_TIMEOUT_MS } }).env(
+    makeMachineGitEnv(),
+  );
 }
 
 /** Run a git command, returning stdout on success and null on error. */

--- a/src/shared/schemas/streamSnapshot.ts
+++ b/src/shared/schemas/streamSnapshot.ts
@@ -26,14 +26,13 @@ import { z } from 'zod';
 
 import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
 import { OutputFileInfoSchema, CompileFailureSchema } from './output';
-import { PlanSchema } from './plan';
 import { StreamStatusSchema } from './stream';
 import {
   ActiveChildInfoSchema,
   ConversationProgressSchema,
 } from './streamState';
-import { TodoItemSchema } from './todo';
 import { TokenUsageStatsSchema } from './usage';
+import { WorkPlanSnapshotShape } from './workPlan';
 
 /**
  * Bump when the persisted shape changes. A reader enforces this as a
@@ -76,9 +75,9 @@ export const PersistedWorkPlanSchema = z.object({
   schemaVersion: z
     .literal(STREAM_SNAPSHOT_SCHEMA_VERSION)
     .catch(STREAM_SNAPSHOT_SCHEMA_VERSION),
-  todos: z.array(TodoItemSchema).catch([]),
-  plan: PlanSchema.nullable().catch(null),
-  planSummary: z.string().nullable().catch(null),
+  todos: WorkPlanSnapshotShape.todos.catch([]),
+  plan: WorkPlanSnapshotShape.plan.catch(null),
+  planSummary: WorkPlanSnapshotShape.planSummary.catch(null),
 });
 
 // ============================================================================
@@ -92,9 +91,9 @@ export const StreamSnapshotSchema = z.object({
   streamId: StreamTabIdSchema,
 
   // -- Durable display state (persisted in field-scoped files) --------------
-  todos: z.array(TodoItemSchema).prefault([]),
-  plan: PlanSchema.nullable().prefault(null),
-  planSummary: z.string().nullable().prefault(null),
+  todos: WorkPlanSnapshotShape.todos.prefault([]),
+  plan: WorkPlanSnapshotShape.plan.prefault(null),
+  planSummary: WorkPlanSnapshotShape.planSummary.prefault(null),
   outputFilesByRound: OutputFilesByRoundSchema,
   missingOutputsByRound: MissingOutputsByRoundSchema,
   compileFailuresByRound: CompileFailuresByRoundSchema,

--- a/src/shared/schemas/workPlan.ts
+++ b/src/shared/schemas/workPlan.ts
@@ -38,13 +38,20 @@ function normalizeWorkPlanSnapshot(input: unknown): unknown {
   };
 }
 
+/** Raw work-plan field types; callers apply their own fallback policy. */
+export const WorkPlanSnapshotShape = {
+  todos: z.array(TodoItemSchema),
+  plan: PlanSchema.nullable(),
+  planSummary: z.string().nullable(),
+} satisfies z.ZodRawShape;
+
 /** Current serializable shape for workspace plan and todo progress state. */
 export const WorkPlanSnapshotSchema = z.preprocess(
   normalizeWorkPlanSnapshot,
   z.strictObject({
-    todos: z.array(TodoItemSchema).prefault([]),
-    plan: PlanSchema.nullable().prefault(null),
-    planSummary: z.string().nullable().prefault(null),
+    todos: WorkPlanSnapshotShape.todos.prefault([]),
+    plan: WorkPlanSnapshotShape.plan.prefault(null),
+    planSummary: WorkPlanSnapshotShape.planSummary.prefault(null),
   }),
 );
 

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -122,6 +122,29 @@ describe('collectReviewDiff (real git repository)', () => {
     expect(await realpath(result.value.repoRoot)).toBe(await realpath(repo));
   });
 
+  it('ignores inherited interactive git environment variables', async () => {
+    const previousPager = process.env.PAGER;
+    const previousEditor = process.env.EDITOR;
+    process.env.PAGER = 'less';
+    process.env.EDITOR = 'vim';
+    try {
+      await git('checkout', '-b', 'feature');
+      await writeFile(path.join(repo, 'paper.tex'), 'changed line\n');
+
+      const result = await collectReviewDiff({
+        cwd: repo,
+        includeUntracked: false,
+        includeSubmodules: true,
+      });
+      expect(result.ok).toBe(true);
+    } finally {
+      if (previousPager === undefined) delete process.env.PAGER;
+      else process.env.PAGER = previousPager;
+      if (previousEditor === undefined) delete process.env.EDITOR;
+      else process.env.EDITOR = previousEditor;
+    }
+  });
+
   it('caps oversized untracked files at a bounded prefix with a truncation marker', async () => {
     await git('checkout', '-b', 'feature');
     // Larger than MAX_UNTRACKED_FILE_BYTES (200 KB); only a prefix may load.


### PR DESCRIPTION
## Summary

- Export the raw work-plan snapshot field shape from `workPlan.ts` and reuse it in stream snapshot schemas.
- Keep fallback policy local to each boundary: runtime snapshot parsing still uses `.prefault()`, persisted work-plan parsing still uses `.catch()`.
- Sanitize interactive git environment variables before review-diff `simple-git` calls so machine-readable git commands are not rejected when `PAGER`, `EDITOR`, or related env vars are present.
- Add a focused regression test for inherited interactive git env variables.

Part of #6229; this does not close it because other duplicated schema fields remain.

## Validation

- `corepack pnpm vitest run src/test-kernel/schemas/WorkPlan.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/agent/review/AgentReviewDiff.vitest.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `corepack pnpm exec prettier --check src/agent/review/reviewDiff.ts src/test-kernel/agent/review/AgentReviewDiff.vitest.ts src/shared/schemas/workPlan.ts src/shared/schemas/streamSnapshot.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized schema deduplication and review-diff git env handling; no auth, persistence format version bump, or broad behavioral changes beyond fixing interactive-env failures during diff collection.
> 
> **Overview**
> Centralizes **todos / plan / planSummary** Zod field definitions in `WorkPlanSnapshotShape` and wires `streamSnapshot` schemas to reuse them, while keeping boundary-specific fallbacks (`.prefault()` on runtime snapshots, `.catch()` on persisted `workPlan.json`).
> 
> For agent review diff collection, **`simple-git` no longer inherits interactive git env** (`PAGER`, `EDITOR`, askpass-related vars, etc.): `makeMachineGitEnv()` strips those keys and still extends `PATH` so machine-readable `git` commands succeed in GUI-launched hosts. A regression test covers inherited `PAGER`/`EDITOR`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80c383dd45c8e53f181f900114733de426b26518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->