### PR TITLE
[codex] derive token usage parsing schema

### DIFF
--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -24,7 +24,11 @@ import {
   type CompileFailure,
   type OutputFileInfo,
 } from './output';
-import { TokenUsageStatsSchema, type TokenUsageStats } from './usage';
+import {
+  TokenUsageStatsSchema,
+  emptyUsageStats,
+  type TokenUsageStats,
+} from './usage';
 
 // ============================================================================
 // Shared: round key coercion
@@ -238,44 +242,31 @@ const FiniteNumber = z.coerce
   .number()
   .transform((n) => (Number.isFinite(n) ? n : 0));
 
+type TokenUsageStatKey = keyof typeof TokenUsageStatsSchema.shape;
+
+const TokenUsageStatsParsingShape = {} as Record<
+  TokenUsageStatKey,
+  z.ZodType<number>
+>;
+for (const [key, schema] of Object.entries(TokenUsageStatsSchema.shape) as [
+  TokenUsageStatKey,
+  z.ZodType,
+][]) {
+  TokenUsageStatsParsingShape[key] = schema.isOptional()
+    ? FiniteNumber.optional().prefault(0)
+    : FiniteNumber;
+}
+
 /** Parsing schema with safe number coercion. */
-const TokenUsageStatsParsingBaseSchema = z.object({
-  inputTokens: FiniteNumber,
-  outputTokens: FiniteNumber,
-  cost: FiniteNumber,
-  cacheReadInputTokens: FiniteNumber.optional().prefault(0),
-  cacheMissInputTokens: FiniteNumber.optional().prefault(0),
-  cacheCreationInputTokens: FiniteNumber.optional().prefault(0),
-});
+const TokenUsageStatsParsingBaseSchema = z.object(TokenUsageStatsParsingShape);
 
 export const TokenUsageStatsParsingSchema =
-  TokenUsageStatsParsingBaseSchema.catch({
-    inputTokens: 0,
-    outputTokens: 0,
-    cost: 0,
-    cacheReadInputTokens: 0,
-    cacheMissInputTokens: 0,
-    cacheCreationInputTokens: 0,
-  });
+  TokenUsageStatsParsingBaseSchema.catch(emptyUsageStats());
 
 // Compile-time assertion: parsing schema output must be assignable to canonical type.
-type _AssertSchemaCompatible =
-  z.infer<typeof TokenUsageStatsParsingSchema> extends TokenUsageStats
-    ? true
-    : never;
-void (true as _AssertSchemaCompatible);
-
-// Runtime assertion: ensure all canonical keys are handled
-const canonicalKeys = TokenUsageStatsSchema.keyof().options;
-const parsingKeys = new Set(
-  Object.keys(TokenUsageStatsParsingBaseSchema.shape),
-);
-const missingKeys = canonicalKeys.filter((k) => !parsingKeys.has(k));
-if (missingKeys.length > 0) {
-  throw new Error(
-    `TokenUsageStatsParsingSchema missing keys from canonical schema: ${missingKeys.join(', ')}`,
-  );
-}
+void (null as unknown as z.infer<
+  typeof TokenUsageStatsParsingSchema
+> satisfies TokenUsageStats);
 
 /** Checks if usage stats are all zeros (effectively empty) */
 export function isEmptyUsage(usage: TokenUsageStats): boolean {

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -14,7 +14,7 @@ export const TokenUsageStatsSchema = z.strictObject({
 export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 
 /** Returns zero-initialized usage stats. */
-export function emptyUsageStats(): TokenUsageStats {
+export function emptyUsageStats(): Required<TokenUsageStats> {
   return {
     inputTokens: 0,
     outputTokens: 0,

--- a/src/test-kernel/schemas/StreamDataUsage.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataUsage.vitest.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { UsageDataSchema } from '@shared/schemas';
+
+describe('stream data usage parsing', () => {
+  it('coerces persisted usage fields and defaults missing cache counters', () => {
+    const usage = UsageDataSchema.parse({
+      run: {
+        inputTokens: '10',
+        outputTokens: '2',
+        cost: '0.25',
+      },
+    });
+
+    expect(usage.get('run')).toEqual({
+      inputTokens: 10,
+      outputTokens: 2,
+      cost: 0.25,
+      cacheReadInputTokens: 0,
+      cacheMissInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    });
+  });
+
+  it('drops usage entries that parse to empty defaults', () => {
+    const usage = UsageDataSchema.parse({
+      run: {
+        inputTokens: 'not-a-number',
+        outputTokens: Number.POSITIVE_INFINITY,
+        cost: Number.NaN,
+      },
+    });
+
+    expect(usage.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Derive `TokenUsageStatsParsingBaseSchema` from `TokenUsageStatsSchema.shape` instead of re-declaring the six usage fields by hand.
- Keep the persisted-data parser's behavior: usage fields are still coerced to finite numbers, optional cache counters still default to zero, and empty parsed usage entries are still dropped.
- Reuse `emptyUsageStats()` for the parser fallback and tighten that helper's return type to the complete zero-filled usage object it already returns.
- Add focused tests for usage field coercion, cache-counter defaults, and empty-entry filtering.

This addresses the remaining explicit checklist item in #6229.

## Validation

- `corepack pnpm vitest run src/test-kernel/schemas/StreamDataUsage.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run compile:fast`
- `corepack pnpm exec prettier --check src/shared/schemas/usage.ts src/shared/schemas/streamData.ts src/test-kernel/schemas/StreamDataUsage.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema refactor with preserved parse behavior and new unit tests; no auth, security, or critical runtime paths beyond persisted usage JSON.
> 
> **Overview**
> **Token usage parsing** in stream sidecar JSON is now built from `TokenUsageStatsSchema.shape` instead of a duplicate six-field object, so new canonical fields automatically get the same finite-number coercion and optional-cache defaults.
> 
> The parser’s `.catch()` fallback reuses **`emptyUsageStats()`**, whose return type is **`Required<TokenUsageStats>`** to match the fully zero-filled object. Schema compatibility is enforced with a compile-time `satisfies TokenUsageStats` check; the old runtime “missing keys” guard is removed because shape derivation keeps keys in sync.
> 
> Adds **`StreamDataUsage.vitest.ts`** covering string coercion, default cache counters, and dropping runs that parse to all-zero usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0cad66fe7db692b54e6911c210a94ec81a94f13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->