### PR TITLE
[codex] route model list chevrons through waIcon

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -3,7 +3,6 @@
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -314,14 +313,11 @@ export class ModelSelectionList extends LitElement {
             class="provider-group-toggle"
             @click=${() => this.toggleProvider(group.provider)}
           >
-            <wa-icon
-              library="texra"
-              name="chevron-right"
-              class=${classMap({
-                'provider-group-chevron': true,
-                expanded: isExpanded,
-              })}
-            ></wa-icon>
+            ${waIcon('chevron-right', {
+              className: isExpanded
+                ? 'provider-group-chevron expanded'
+                : 'provider-group-chevron',
+            })}
             <span class="provider-group-name">${group.displayName}</span>
             <span class="provider-group-count">
               ${enabledCount}/${totalCount} enabled
@@ -353,14 +349,11 @@ export class ModelSelectionList extends LitElement {
         size="small"
         @click=${() => this.toggleDeprecated(group.provider)}
       >
-        <wa-icon
-          library="texra"
-          name="chevron-right"
-          class=${classMap({
-            'provider-group-chevron': true,
-            expanded: isOpen,
-          })}
-        ></wa-icon>
+        ${waIcon('chevron-right', {
+          className: isOpen
+            ? 'provider-group-chevron expanded'
+            : 'provider-group-chevron',
+        })}
         ${group.deprecated.length} deprecated
       </wa-button>
       ${isOpen


### PR DESCRIPTION
## Summary

- convert the two remaining static raw `wa-icon` chevrons in `ModelSelectionList` to the shared `waIcon()` helper
- preserve the existing `provider-group-chevron` / `expanded` classes
- remove the now-unused `classMap` import

This completes the remaining static settings-view icon migration tracked by #6215. The only raw settings-view `wa-icon` left is the dynamic preset icon in `MultiAgentTab`, which belongs to #6214.

Closes #6215.

## Validation

- `corepack pnpm exec prettier --check packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts`
- `npm run typecheck`
- `corepack pnpm vitest run src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational refactor with no behavior or data-path changes; chevron classes and click handlers are unchanged.
> 
> **Overview**
> Finishes the static settings-view icon migration for **Model Selection** by replacing the last two raw `wa-icon` chevrons with the shared `waIcon()` helper.
> 
> Provider expand/collapse and the deprecated-models toggle still use `provider-group-chevron` / `expanded` for rotation styling; only the rendering path changes. The unused `classMap` import is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a433f35b205ebc1cba06d0eff7af5943580eb5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->