### PR TITLE
[codex] type agent team preset icons

### DIFF
--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -6,7 +6,7 @@ import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { agentKey } from '@shared/schemas/agent';
 import {
   AGENT_MODE_PRESETS,
-  AgentModePresetSchema,
+  parseAgentModePresets,
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
 import { implicitDefaultToolUseAgents } from './defaultAgents';
@@ -87,7 +87,7 @@ export function formatCliMultiAgentInspectCommand(preset: string): string {
 }
 
 export function parseCliCustomAgentPresets(raw: unknown): AgentModePreset[] {
-  return AgentModePresetSchema.array().catch([]).parse(raw);
+  return parseAgentModePresets(raw);
 }
 
 export function readCliMultiAgentPresets(): CliMultiAgentPreset[] {

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -298,11 +298,7 @@ export class MultiAgentTab extends LitElement {
         title="Apply ${preset.name} team"
       >
         <div class="preset-card-header">
-          <wa-icon
-            library="texra"
-            name=${preset.icon.replace('codicon-', '')}
-            class="preset-card-icon"
-          ></wa-icon>
+          ${waIcon(preset.icon, { className: 'preset-card-icon' })}
           <span class="preset-card-name">${preset.name}</span>
           ${isActive
             ? html`<wa-tag

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -2,7 +2,7 @@
 import type { AgentModePreset } from '@shared/schemas/agentPresets';
 import {
   AGENT_MODE_PRESETS_BY_ID,
-  AgentModePresetSchema,
+  parseAgentModePresets,
 } from '@shared/schemas/agentPresets';
 import {
   agentKey,
@@ -127,9 +127,7 @@ export class SettingsAgentCatalogController {
   }
 
   getCustomPresets(): AgentModePreset[] {
-    return AgentModePresetSchema.array()
-      .catch([])
-      .parse(this.deps.state.getCustomPresetsRaw());
+    return parseAgentModePresets(this.deps.state.getCustomPresetsRaw());
   }
 
   getCustomPreset(presetId: string): AgentModePreset | null {
@@ -159,7 +157,7 @@ export class SettingsAgentCatalogController {
       id: `custom-${this.deps.now?.() ?? Date.now()}`,
       name: trimmedName,
       description: `Custom team: ${[...toolUseAgents, ...workflowAgents].join(', ')}`,
-      icon: 'codicon-bookmark',
+      icon: 'bookmark',
       workflowAgents,
       toolUseAgents,
     };

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -9,17 +9,60 @@
 
 import { z } from 'zod';
 
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
+
+const AGENT_MODE_PRESET_ICON_NAMES = [
+  'bookmark',
+  'rocket',
+  'symbol-structure',
+  'symbol-operator',
+  'symbol-number',
+  'symbol-method',
+  'tools',
+] as const satisfies readonly TeXRAIconName[];
+
+type AgentModePresetIconName = (typeof AGENT_MODE_PRESET_ICON_NAMES)[number];
+
+const AGENT_MODE_PRESET_ICON_NAME_SET = new Set<string>(
+  AGENT_MODE_PRESET_ICON_NAMES,
+);
+
+const AgentModePresetIconSchema = z.string().transform((rawIcon, ctx) => {
+  const icon = rawIcon.trim();
+  const normalized = icon.startsWith('codicon-') ? icon.slice(8) : icon;
+  if (AGENT_MODE_PRESET_ICON_NAME_SET.has(normalized)) {
+    return normalized as AgentModePresetIconName;
+  }
+
+  ctx.addIssue({
+    code: 'custom',
+    message: `Unknown agent team icon: ${normalized}`,
+  });
+  return z.NEVER;
+});
+
 /** Schema for a single agent team. */
 export const AgentModePresetSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
-  icon: z.string(),
+  icon: AgentModePresetIconSchema,
   workflowAgents: z.array(z.string()),
   toolUseAgents: z.array(z.string()),
 });
 
 export type AgentModePreset = z.infer<typeof AgentModePresetSchema>;
+
+export function parseAgentModePresets(raw: unknown): AgentModePreset[] {
+  return z
+    .array(z.unknown())
+    .catch([])
+    .parse(raw)
+    .flatMap((preset) => {
+      const result = AgentModePresetSchema.safeParse(preset);
+      return result.success ? [result.data] : [];
+    });
+}
 
 /**
  * Generic default team applied when the user skips the setup agent's
@@ -36,7 +79,7 @@ export const STARTER_AGENT_MODE_PRESET: AgentModePreset = {
   id: 'starter',
   name: 'Starter',
   description: 'Balanced default roster for a first project.',
-  icon: 'codicon-rocket',
+  icon: 'rocket',
   workflowAgents: ['correct', 'polish'],
   toolUseAgents: [
     'assistant',
@@ -60,7 +103,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     name: 'Lean Project',
     description:
       'For Lean 4 projects -- theorem search, tactic simplification, and blueprints.',
-    icon: 'codicon-symbol-structure',
+    icon: 'symbol-structure',
     workflowAgents: [],
     toolUseAgents: [
       'lean',
@@ -77,7 +120,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     name: 'Physicist',
     description:
       'For physics papers -- analytical derivations, numerical experiments, literature search, slides, and critical review.',
-    icon: 'codicon-symbol-operator',
+    icon: 'symbol-operator',
     workflowAgents: ['criticize', 'generic', 'devise', 'apply'],
     toolUseAgents: [
       'orchestrator',
@@ -96,7 +139,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     name: 'Mathematician',
     description:
       'For math research -- attacking open problems, proofs, Lean 4 formalization, and LaTeX correction.',
-    icon: 'codicon-symbol-number',
+    icon: 'symbol-number',
     workflowAgents: ['correct', 'polish', 'generic', 'devise', 'apply'],
     toolUseAgents: [
       'prover',
@@ -115,7 +158,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     name: 'Computer Scientist',
     description:
       'For CS papers -- algorithm design, code-driven experiments and ablations, tests for reproducibility, literature search, and critical review.',
-    icon: 'codicon-symbol-method',
+    icon: 'symbol-method',
     workflowAgents: ['criticize', 'generic', 'devise', 'apply', 'polish'],
     toolUseAgents: [
       'orchestrator',
@@ -136,7 +179,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     name: 'Software Engineer',
     description:
       "For a project's code -- the engineer lead delegates implementation, review, debugging, and testing across a team of specialists.",
-    icon: 'codicon-tools',
+    icon: 'tools',
     workflowAgents: [],
     toolUseAgents: [
       'engineer',

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -502,7 +502,36 @@ describe('CLI multi-agent presets', () => {
       },
     ];
 
-    expect(parseCliCustomAgentPresets(valid)).toEqual(valid);
+    expect(parseCliCustomAgentPresets(valid)).toEqual([
+      {
+        ...valid[0],
+        icon: 'bookmark',
+      },
+    ]);
+    expect(parseCliCustomAgentPresets([{ id: 'broken' }, ...valid])).toEqual([
+      {
+        ...valid[0],
+        icon: 'bookmark',
+      },
+    ]);
+    expect(
+      parseCliCustomAgentPresets([
+        ...valid,
+        {
+          id: 'custom-broken-icon',
+          name: 'Broken Icon',
+          description: 'Structurally valid but uses an unknown icon.',
+          icon: 'not-a-valid-icon',
+          workflowAgents: [],
+          toolUseAgents: [],
+        },
+      ]),
+    ).toEqual([
+      {
+        ...valid[0],
+        icon: 'bookmark',
+      },
+    ]);
     expect(parseCliCustomAgentPresets([{ id: 'broken' }])).toEqual([]);
   });
 
@@ -694,7 +723,7 @@ describe('CLI multi-agent presets', () => {
         id: 'custom-review',
         name: 'Custom review',
         description: 'User-authored review team.',
-        icon: 'codicon-symbol-method',
+        icon: 'symbol-method',
         source: 'custom',
         workflowAgents: [],
         toolUseAgents: ['review'],
@@ -717,7 +746,7 @@ describe('CLI multi-agent presets', () => {
         id: 'custom-review',
         name: 'Custom review',
         description: 'User-authored review team.',
-        icon: 'codicon-symbol-method',
+        icon: 'symbol-method',
         source: 'custom',
         workflowAgents: [],
         toolUseAgents: ['review', 'engineer'],
@@ -741,7 +770,7 @@ describe('CLI multi-agent presets', () => {
         id: 'custom-review',
         name: 'Custom review',
         description: 'User-authored review team.',
-        icon: 'codicon-symbol-method',
+        icon: 'symbol-method',
         source: 'custom',
         workflowAgents: [],
         toolUseAgents: ['review'],
@@ -762,7 +791,7 @@ describe('CLI multi-agent presets', () => {
         id: 'custom-cleanup',
         name: 'Custom cleanup',
         description: 'User-authored cleanup team.',
-        icon: 'codicon-symbol-method',
+        icon: 'symbol-method',
         source: 'custom',
         workflowAgents: [],
         toolUseAgents: ['simplifier'],

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -304,7 +304,7 @@ describe('CLI multi-agent run command', () => {
         id: 'mathematician',
         name: 'Mathematician',
         description: 'For math papers.',
-        icon: 'codicon-symbol-operator',
+        icon: 'symbol-operator',
         workflowAgents: [],
         toolUseAgents: ['orchestrator'],
         source: 'built-in',

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -81,7 +81,7 @@ function preset(overrides: Partial<CliMultiAgentPreset>): CliMultiAgentPreset {
     id: 'physicist',
     name: 'Physicist',
     description: 'Physics team',
-    icon: 'codicon-symbol-operator',
+    icon: 'symbol-operator',
     workflowAgents: ['criticize'],
     toolUseAgents: ['orchestrator', 'review'],
     source: 'built-in',

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -141,7 +141,7 @@ describe('SettingsAgentCatalogController', () => {
   });
 
   it('applies custom presets by resolving names to canonical source keys', async () => {
-    const preset: AgentModePreset = {
+    const persistedPreset = {
       id: 'custom-team',
       name: 'Custom Team',
       description: 'test',
@@ -150,12 +150,15 @@ describe('SettingsAgentCatalogController', () => {
       toolUseAgents: ['review', 'missing'],
     };
     const { controller, enabled } = createController({
-      customPresets: [preset],
+      customPresets: [persistedPreset],
     });
 
     assert.deepEqual(await controller.applyPreset('custom-team'), {
       ok: true,
-      preset,
+      preset: {
+        ...persistedPreset,
+        icon: 'bookmark',
+      },
     });
     assert.deepEqual(enabled.workflow, ['remote:writer']);
     // Unresolved names are kept bare so the agent joins the roster the
@@ -181,6 +184,33 @@ describe('SettingsAgentCatalogController', () => {
     assert.deepEqual(controller.getCustomPresets(), []);
   });
 
+  it('drops only invalid custom presets', () => {
+    const { controller } = createController({
+      customPresets: [
+        { id: 'broken' },
+        {
+          id: 'custom-team',
+          name: 'Custom Team',
+          description: 'test',
+          icon: 'codicon-bookmark',
+          workflowAgents: [],
+          toolUseAgents: ['review'],
+        },
+      ],
+    });
+
+    assert.deepEqual(controller.getCustomPresets(), [
+      {
+        id: 'custom-team',
+        name: 'Custom Team',
+        description: 'test',
+        icon: 'bookmark',
+        workflowAgents: [],
+        toolUseAgents: ['review'],
+      },
+    ]);
+  });
+
   it('saves the currently visible agents as a custom preset', async () => {
     const state = createController({
       now: 456,
@@ -194,7 +224,7 @@ describe('SettingsAgentCatalogController', () => {
       id: 'custom-456',
       name: 'My Team',
       description: 'Custom team: review, correct',
-      icon: 'codicon-bookmark',
+      icon: 'bookmark',
       workflowAgents: ['correct'],
       toolUseAgents: ['review'],
     });
@@ -206,7 +236,7 @@ describe('SettingsAgentCatalogController', () => {
       id: 'custom-team',
       name: 'Custom Team',
       description: 'test',
-      icon: 'codicon-bookmark',
+      icon: 'bookmark',
       workflowAgents: [],
       toolUseAgents: [],
     };


### PR DESCRIPTION
## Summary

- type agent team preset icons as a validated `TeXRAIconName` subset at the schema boundary
- normalize legacy `codicon-*` persisted custom team icons to unprefixed names
- render multi-agent team-card icons through `waIcon(preset.icon)` instead of raw `<wa-icon>` markup

Closes #6214.

## Validation

- `corepack pnpm vitest run src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- `npm run typecheck`
- `corepack pnpm exec prettier --check src/shared/schemas/agentPresets.ts src/controllers/settingsView/SettingsAgentCatalogController.ts packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`
- `rg -n "<wa-icon" packages/extension/src/settingsView/frontend -g '*.ts'` returns no matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and UI-only changes to icon strings and parsing; invalid custom presets are filtered out, which is intentional backward-compatible behavior.
> 
> **Overview**
> **Agent team preset icons** are now a validated subset of `TeXRAIconName` on `AgentModePresetSchema`, with legacy persisted `codicon-*` values normalized to unprefixed names at parse time. Unknown icons cause that preset to be dropped rather than failing the whole custom preset list.
> 
> **`parseAgentModePresets`** centralizes loading custom teams for CLI (`parseCliCustomAgentPresets`) and settings (`SettingsAgentCatalogController.getCustomPresets`). Built-in preset definitions and newly saved custom teams use unprefixed icons (e.g. `bookmark`, `rocket`).
> 
> **Settings UI:** multi-agent team cards render preset icons through **`waIcon(preset.icon)`** instead of manual `<wa-icon>` markup that stripped a `codicon-` prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3010601c0b1d3f572545f130d43e0fa7514a9b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->