### PR TITLE
[codex] use shared team preset parser

### DIFF
--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -86,10 +86,6 @@ export function formatCliMultiAgentInspectCommand(preset: string): string {
   return `texra multi-agent inspect ${preset}`;
 }
 
-export function parseCliCustomAgentPresets(raw: unknown): AgentModePreset[] {
-  return parseAgentModePresets(raw);
-}
-
 export function readCliMultiAgentPresets(): CliMultiAgentPreset[] {
   const customRaw = platform().workspaceState.get<unknown>(
     WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
@@ -105,7 +101,7 @@ export function cliMultiAgentPresets(
       ...preset,
       source: 'built-in' as const,
     })),
-    ...parseCliCustomAgentPresets(customRaw).map((preset) => ({
+    ...parseAgentModePresets(customRaw).map((preset) => ({
       ...preset,
       source: 'custom' as const,
     })),

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -19,7 +19,6 @@ import {
   formatCliMultiAgentPresetRunWarnings,
   planCliMultiAgentPresets,
   planCliMultiAgentPresetRun,
-  parseCliCustomAgentPresets,
 } from '@cli/runtime/multiAgentPresets';
 
 function agent(
@@ -490,7 +489,7 @@ describe('CLI multi-agent presets', () => {
     ]);
   });
 
-  it('parses valid custom team presets and ignores invalid state', () => {
+  it('loads valid custom team presets and ignores invalid state', () => {
     const valid = [
       {
         id: 'custom-paper',
@@ -501,21 +500,25 @@ describe('CLI multi-agent presets', () => {
         toolUseAgents: ['review'],
       },
     ];
+    const customPresets = (raw: unknown) =>
+      cliMultiAgentPresets(raw).filter((preset) => preset.source === 'custom');
 
-    expect(parseCliCustomAgentPresets(valid)).toEqual([
+    expect(customPresets(valid)).toEqual([
       {
         ...valid[0],
         icon: 'bookmark',
+        source: 'custom',
       },
     ]);
-    expect(parseCliCustomAgentPresets([{ id: 'broken' }, ...valid])).toEqual([
+    expect(customPresets([{ id: 'broken' }, ...valid])).toEqual([
       {
         ...valid[0],
         icon: 'bookmark',
+        source: 'custom',
       },
     ]);
     expect(
-      parseCliCustomAgentPresets([
+      customPresets([
         ...valid,
         {
           id: 'custom-broken-icon',
@@ -530,9 +533,10 @@ describe('CLI multi-agent presets', () => {
       {
         ...valid[0],
         icon: 'bookmark',
+        source: 'custom',
       },
     ]);
-    expect(parseCliCustomAgentPresets([{ id: 'broken' }])).toEqual([]);
+    expect(customPresets([{ id: 'broken' }])).toEqual([]);
   });
 
   it('finds presets by id, name, or slugified name', () => {


### PR DESCRIPTION
## Summary

- Remove the CLI-only `parseCliCustomAgentPresets` forwarding function.
- Route custom multi-agent presets directly through the shared `parseAgentModePresets` schema parser.
- Update the CLI preset test to cover the public preset loader instead of the removed wrapper.

## Why

Custom team preset parsing now has a single owner in `src/shared/schemas/agentPresets.ts`. The CLI should consume that boundary directly rather than keeping a shallow wrapper with no behavior.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `npm run typecheck`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/multiAgentPresets.ts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `git diff --check`
- `npm run lint`
- `npm run compile:fast`

## Dogfood notes

Before this cleanup I also refreshed the local CLI and ran the PTY TUI validator on `main`:

- `npm run texra-local:build`
- `npm run texra-local:link`
- `texra-local doctor --output-format json`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-main-1781852678`

The TUI validator passed all 137 scenarios, including slash goal help, plan approval goal mode, compact approval layouts, slash palette overflow, subagent pickers, task pickers, and interrupt handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with no behavior change beyond consolidating on the existing shared parser; tests cover the same validation paths.
> 
> **Overview**
> Removes the CLI-only **`parseCliCustomAgentPresets`** helper and has **`cliMultiAgentPresets`** call shared **`parseAgentModePresets`** directly for workspace custom presets.
> 
> Tests now assert custom preset loading through **`cliMultiAgentPresets`** (filtering **`source: 'custom'`**) instead of the removed export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b4ffae9dd7fcabcbac6cc175a4cd6b651b1cae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->