### PR TITLE
refactor: replace inline error-extraction and path patterns with shared utilities

### DIFF
--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -14,6 +14,7 @@
 import { Box, Text } from 'ink';
 import { Component, type ReactNode } from 'react';
 
+import { toErrorMessage } from '@common/errors';
 import * as logUtils from '@logger/logUtils';
 
 interface EntryErrorBoundaryProps {
@@ -31,7 +32,7 @@ interface EntryErrorBoundaryState {
 export function formatRenderError(error: unknown): string {
   let message = '';
   try {
-    message = error instanceof Error ? error.message : String(error);
+    message = toErrorMessage(error);
   } catch {
     return '';
   }

--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
 import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
+import { isNonEmptyString } from '@utils/core';
 
 export type { ApiProvider };
 
@@ -98,7 +99,7 @@ export class SecretManager {
    */
   public static async hasUsableApiKey(provider: ApiProvider): Promise<boolean> {
     const key = await this.lookupApiKey(provider);
-    return typeof key === 'string' && key.trim().length > 0;
+    return isNonEmptyString(key);
   }
 
   public static async getApiProviderQuickPickItems(): Promise<

--- a/packages/extension/src/progressView/frontend/formatters/baseLogFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/baseLogFormatter.ts
@@ -1,6 +1,7 @@
 /**
  * Base log formatter utilities for open state management and error handling.
  */
+import { toErrorMessage } from '@common/errors';
 
 export type FormatOptions = {
   preservedOpen?: boolean;
@@ -21,7 +22,7 @@ export function safeFormat<T>(
     const value = formatter();
     return { ok: true, value };
   } catch (e) {
-    const errorMsg = e instanceof Error ? e.message : String(e);
+    const errorMsg = toErrorMessage(e);
     console.error(`Error parsing ${errorContext}:`, e);
     return { ok: false, error: errorMsg };
   }

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -2,8 +2,6 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { toErrorMessage } from '@common/errors';
-
 import {
   findSlashCommand,
   listSlashCommands,
@@ -23,6 +21,7 @@ import {
 import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import { toErrorMessage } from '@common/errors';
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -2,6 +2,8 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { toErrorMessage } from '@common/errors';
+
 import {
   findSlashCommand,
   listSlashCommands,
@@ -361,7 +363,7 @@ describe('slashRegistry', () => {
         throw new Error('model failed');
       },
       onError: (error) => {
-        errors.push(error instanceof Error ? error.message : String(error));
+        errors.push(toErrorMessage(error));
       },
     });
     const model = listSlashCommands().find((cmd) => cmd.name === 'model');
@@ -397,7 +399,7 @@ describe('slashRegistry', () => {
         throw new Error('api mode failed');
       },
       onError: (error) => {
-        errors.push(error instanceof Error ? error.message : String(error));
+        errors.push(toErrorMessage(error));
       },
     });
     const api = listSlashCommands().find((cmd) => cmd.name === 'api');

--- a/src/tools/executions/runDirectoryFiles.ts
+++ b/src/tools/executions/runDirectoryFiles.ts
@@ -81,7 +81,5 @@ export async function listRunDirectoryFiles(
   runDir: string,
 ): Promise<RunDirectoryEntry[]> {
   const entries = await walkDirectory(runDir, '', 2);
-  return entries.filter(
-    (entry) => !isKVFile(path.basename(entry.path)),
-  );
+  return entries.filter((entry) => !isKVFile(path.basename(entry.path)));
 }

--- a/src/tools/executions/runDirectoryFiles.ts
+++ b/src/tools/executions/runDirectoryFiles.ts
@@ -82,6 +82,6 @@ export async function listRunDirectoryFiles(
 ): Promise<RunDirectoryEntry[]> {
   const entries = await walkDirectory(runDir, '', 2);
   return entries.filter(
-    (entry) => !isKVFile(entry.path.split('/').pop() ?? ''),
+    (entry) => !isKVFile(path.basename(entry.path)),
   );
 }


### PR DESCRIPTION
## Summary

Consolidates repeated inline patterns that already have canonical shared utilities, flagged by an automated codebase audit.

- **`toErrorMessage()` from `@common/errors`** — replaces `instanceof Error ? err.message : String(err)` in three places:
  - `packages/extension/src/progressView/frontend/formatters/baseLogFormatter.ts`
  - `packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx` (`formatRenderError`)
  - `src/test-kernel/cli/SlashRegistry.vitest.mts` (two `onError` callbacks)

- **`isNonEmptyString()` from `@utils/core`** — replaces `typeof key === 'string' && key.trim().length > 0` in `SecretManager.hasUsableApiKey` (`packages/extension/src/frontend/secretManager.ts`)

- **`path.basename()` from the already-imported `node:path`** — replaces `entry.path.split('/').pop() ?? ''` in `src/tools/executions/runDirectoryFiles.ts`; native `path.basename` correctly handles Windows separators (`\`) that the split-on-`/` approach missed

## Test plan

- [x] 3353 tests pass (1 pre-existing flaky process-abort timing test unrelated to these changes)
- [x] No new type errors introduced (two pre-existing `TS2688` errors for `node`/`vscode` type definitions exist in the dev environment baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTooJn2rjnZpNW88zJSGww

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTooJn2rjnZpNW88zJSGww)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactors with a small win for Windows path handling in run directory listing; no new auth or data paths.
> 
> **Overview**
> Replaces duplicated inline patterns with existing shared helpers across the CLI, extension, tests, and run-directory tooling.
> 
> **Error text** — `toErrorMessage` from `@common/errors` now backs `formatRenderError` in the TUI entry error boundary, `safeFormat` in progress-view log formatters, and slash-command `onError` assertions in `SlashRegistry` tests (instead of `instanceof Error ? … : String(…)`).
> 
> **API keys** — `SecretManager.hasUsableApiKey` uses `isNonEmptyString` from `@utils/core` for the same “non-blank credential” check.
> 
> **Run listing** — `listRunDirectoryFiles` uses `path.basename(entry.path)` when filtering KV metadata files, so basename handling is correct on Windows paths as well as POSIX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78bf09ca766d9e576a4f8ae437dda92a1232dfd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->