### PR TITLE
[codex] remove delay dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "axios": "^1.18.0",
     "bibtex": "^0.9.0",
     "deepmerge": "^4.3.1",
-    "delay": "^7.0.0",
     "diff-match-patch": "^1.0.5",
     "dotenv": "^17.4.2",
     "escape-string-regexp": "^5.0.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1699,7 +1699,6 @@
     "axios": "^1.18.0",
     "bibtex": "^0.9.0",
     "deepmerge": "^4.3.1",
-    "delay": "^7.0.0",
     "diff-match-patch": "^1.0.5",
     "dotenv": "^17.4.2",
     "execa": "^9.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
-      delay:
-        specifier: ^7.0.0
-        version: 7.0.0
       diff-match-patch:
         specifier: ^1.0.5
         version: 1.0.5
@@ -568,9 +565,6 @@ importers:
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
-      delay:
-        specifier: ^7.0.0
-        version: 7.0.0
       diff-match-patch:
         specifier: ^1.0.5
         version: 1.0.5
@@ -3473,10 +3467,6 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  delay@7.0.0:
-    resolution: {integrity: sha512-C3vaGs818qzZjCvVJ98GQUMVyWeg7dr5w2Nwwb2t5K8G98jOyyVO2ti2bKYk5yoYElqH3F2yA53ykuEnwD6MCg==}
-    engines: {node: '>=20'}
-
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -5241,10 +5231,6 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  random-int@3.1.0:
-    resolution: {integrity: sha512-h8CRz8cpvzj0hC/iH/1Gapgcl2TQ6xtnCpyOI5WvWfXf/yrDx2DOU+tD9rX23j36IF11xg1KqB9W11Z18JPMdw==}
-    engines: {node: '>=12'}
-
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -5892,10 +5878,6 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
-
-  unlimited-timeout@0.1.0:
-    resolution: {integrity: sha512-D4g+mxFeQGQHzCfnvij+R35ukJ0658Zzudw7j16p4tBBbNasKkKM4SocYxqhwT5xA7a9JYWDzKkEFyMlRi5sng==}
-    engines: {node: '>=20'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -9093,11 +9075,6 @@ snapshots:
       object-keys: 1.1.1
     optional: true
 
-  delay@7.0.0:
-    dependencies:
-      random-int: 3.1.0
-      unlimited-timeout: 0.1.0
-
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -10983,8 +10960,6 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  random-int@3.1.0: {}
-
   range-parser@1.2.1: {}
 
   raw-body@3.0.2:
@@ -11678,8 +11653,6 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
-
-  unlimited-timeout@0.1.0: {}
 
   unpipe@1.0.0: {}
 

--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -1,12 +1,12 @@
 import { StringDecoder } from 'node:string_decoder';
 
-import delay from 'delay';
 import pMap from 'p-map';
 
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { StreamTabId } from '@shared/schemas';
+import { delay } from '@utils/core/async';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ProcessExecutionHandle } from './ExecutionHandle';

--- a/src/test-kernel/utils/Async.vitest.ts
+++ b/src/test-kernel/utils/Async.vitest.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { delay } from '@utils/core/async';
+
+describe('async utilities', () => {
+  it('resolves after the requested delay', async () => {
+    await expect(delay(0)).resolves.toBeUndefined();
+  });
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    const reason = new Error('stop');
+    controller.abort(reason);
+
+    await expect(delay(100, { signal: controller.signal })).rejects.toBe(
+      reason,
+    );
+  });
+
+  it('rejects an in-flight delay when the signal aborts', async () => {
+    const controller = new AbortController();
+    const promise = delay(100, { signal: controller.signal });
+
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/src/utils/core/async.ts
+++ b/src/utils/core/async.ts
@@ -5,5 +5,39 @@
 // Re-export debounce from perfect-debounce for consistent usage across codebase
 export { debounce } from 'perfect-debounce';
 
-// Re-export delay for AbortSignal-aware sleeping: delay(ms, { signal })
-export { default as delay } from 'delay';
+interface DelayOptions {
+  readonly signal?: AbortSignal;
+}
+
+function createAbortReason(): unknown {
+  if (typeof DOMException === 'function') {
+    return new DOMException('The operation was aborted', 'AbortError');
+  }
+  const error = new Error('The operation was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+/**
+ * AbortSignal-aware sleep shared by extension, CLI, and webview code.
+ */
+export function delay(ms: number, options: DelayOptions = {}): Promise<void> {
+  const { signal } = options;
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason ?? createAbortReason());
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', abort);
+      resolve();
+    }, ms);
+
+    const abort = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason ?? createAbortReason());
+    };
+
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+}


### PR DESCRIPTION
## Summary
- replace the external `delay` dependency with the existing shared `@utils/core/async` helper
- keep the helper browser-safe because `@utils/core` is imported by webview-facing code
- route the one direct package import through the shared helper and remove `delay` from root/extension manifests and lockfile

## Context
This came from a real `texra-local multi-agent run software-engineer` dogfood run. The agent suggested using Node timers, but local inspection showed the shared helper must remain browser-safe, so the implementation keeps a small AbortSignal-aware wrapper around `setTimeout` instead of adding a Node-only import to the shared barrel.

## Validation
- `corepack pnpm vitest run src/test-kernel/utils/Async.vitest.ts src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts src/test-kernel/cli/StaticBandResize.vitest.mts`
- `corepack pnpm exec prettier --check package.json packages/extension/package.json pnpm-lock.yaml src/utils/core/async.ts src/agent/runtime/ProcessOutputPoller.ts src/test-kernel/utils/Async.vitest.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `git diff --check`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dependency swap with equivalent API and targeted tests; no auth, data, or architectural changes.
> 
> **Overview**
> Drops the **`delay`** npm dependency from the workspace and extension manifests (and lockfile) and implements **`delay(ms, { signal })`** directly in `@utils/core/async` so extension, CLI, and webview code share one **AbortSignal-aware** sleep built on `setTimeout` (with a browser-safe `AbortError` path).
> 
> **`ProcessOutputPoller`** is updated to import `delay` from `@utils/core/async` instead of the removed package. New **`Async.vitest.ts`** covers resolve, pre-aborted signals, and mid-flight abort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7d72127441188d360114b7c313dd4a658950b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->