### PR TITLE
refactor: extract roundMapSchema helper for round-keyed stream data

### DIFF
--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -179,8 +179,14 @@ function recordToRoundMap<T>(record: Record<string, T[]>): Map<number, T[]> {
  * the schema itself does not fall back to insertion order.
  *
  * The single cast here replaces the per-schema casts that the
- * `.transform(recordToRoundMap)` → `.catch(new Map())` pipeline would
- * otherwise require at each call site.
+ * `.transform(recordToRoundMap)` → `.catch(…)` pipeline would otherwise
+ * require at each call site.
+ *
+ * The fallback uses a `() => new Map()` factory rather than a literal
+ * `new Map()`: Zod stores a literal catch value once and returns that same
+ * instance on every failure, and consumers (e.g. `StreamSnapshotStore`) hold
+ * the parsed map by reference and mutate it via `.set()`, so a shared instance
+ * would leak rounds across streams whose sidecar JSON is malformed.
  */
 function roundMapSchema<T>(
   itemList: z.ZodType<T[]>,
@@ -188,7 +194,7 @@ function roundMapSchema<T>(
   return z
     .record(z.string(), itemList)
     .transform(recordToRoundMap)
-    .catch(new Map()) as z.ZodType<Map<number, T[]>>;
+    .catch(() => new Map()) as z.ZodType<Map<number, T[]>>;
 }
 
 function warnDroppedItem(
@@ -203,7 +209,8 @@ function warnDroppedItem(
 }
 
 // ============================================================================
-// Output files: { round: OutputFileInfo[] }
+// Output files: { round: OutputFileInfo[] } (caller pre-flattens legacy input,
+// threading the activeRunId hint in via flattenLegacyRuns).
 // ============================================================================
 
 const OutputFileListSchema = z
@@ -218,13 +225,6 @@ const OutputFileListSchema = z
   )
   .catch([]);
 
-/**
- * Parses a flat round-keyed record to `Map<number, OutputFileInfo[]>`.
- * Legacy nested records (`{ runId: { round: items[] } }`) must be
- * pre-flattened by the caller (see `flattenLegacyRuns`) so the
- * activeRunId hint can be threaded in — the schema itself does not fall
- * back to insertion order.
- */
 export const OutputFilesDataSchema = roundMapSchema(OutputFileListSchema);
 
 // ============================================================================

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -18,12 +18,7 @@
 
 import { z } from 'zod';
 
-import {
-  CompileFailureSchema,
-  OutputFileInfoSchema,
-  type CompileFailure,
-  type OutputFileInfo,
-} from './output';
+import { CompileFailureSchema, OutputFileInfoSchema } from './output';
 import {
   TokenUsageStatsSchema,
   emptyUsageStats,
@@ -175,6 +170,27 @@ function recordToRoundMap<T>(record: Record<string, T[]>): Map<number, T[]> {
   return map;
 }
 
+/**
+ * Builds a schema that parses a flat round-keyed record
+ * (`{ "1": items[], … }`) into `Map<number, items[]>`: keys are coerced to
+ * integers, empty/malformed rounds are dropped, and a malformed top-level
+ * value falls back to an empty map. Callers pre-flatten legacy nested records
+ * (`{ runId: { round: items[] } }`, see `flattenLegacyRuns`) before parsing —
+ * the schema itself does not fall back to insertion order.
+ *
+ * The single cast here replaces the per-schema casts that the
+ * `.transform(recordToRoundMap)` → `.catch(new Map())` pipeline would
+ * otherwise require at each call site.
+ */
+function roundMapSchema<T>(
+  itemList: z.ZodType<T[]>,
+): z.ZodType<Map<number, T[]>> {
+  return z
+    .record(z.string(), itemList)
+    .transform(recordToRoundMap)
+    .catch(new Map()) as z.ZodType<Map<number, T[]>>;
+}
+
 function warnDroppedItem(
   kind: string,
   error: { issues: readonly { path: PropertyKey[]; message: string }[] },
@@ -209,28 +225,23 @@ const OutputFileListSchema = z
  * activeRunId hint can be threaded in — the schema itself does not fall
  * back to insertion order.
  */
-export const OutputFilesDataSchema = z
-  .record(z.string(), OutputFileListSchema)
-  .transform(recordToRoundMap)
-  .catch(new Map()) as z.ZodType<Map<number, OutputFileInfo[]>>;
+export const OutputFilesDataSchema = roundMapSchema(OutputFileListSchema);
 
 // ============================================================================
 // Missing outputs: { round: string[] } (caller pre-flattens legacy input).
 // ============================================================================
 
-export const MissingOutputsDataSchema = z
-  .record(z.string(), z.array(z.string()).catch([]))
-  .transform(recordToRoundMap)
-  .catch(new Map()) as z.ZodType<Map<number, string[]>>;
+export const MissingOutputsDataSchema = roundMapSchema(
+  z.array(z.string()).catch([]),
+);
 
 // ============================================================================
 // Compile failures: { round: CompileFailure[] } (caller pre-flattens legacy input).
 // ============================================================================
 
-export const CompileFailuresDataSchema = z
-  .record(z.string(), z.array(CompileFailureSchema).catch([]))
-  .transform(recordToRoundMap)
-  .catch(new Map()) as z.ZodType<Map<number, CompileFailure[]>>;
+export const CompileFailuresDataSchema = roundMapSchema(
+  z.array(CompileFailureSchema).catch([]),
+);
 
 // ============================================================================
 // Usage stats — per-run map kept (tool-use can resume → multiple runs).

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -305,4 +305,9 @@ export const UsageDataSchema = z
     }
     return map;
   })
-  .catch(new Map()) as z.ZodType<Map<string, TokenUsageStats>>;
+  // `() => new Map()` (not a literal) for the same reason as `roundMapSchema`:
+  // a fresh fallback per failed parse. The current consumer copies this map
+  // (StreamSnapshotStore.applyStreamData) so a shared instance is safe today,
+  // but the factory keeps the file consistent and guards a future by-reference
+  // reader from leaking usage across streams with malformed sidecar JSON.
+  .catch(() => new Map()) as z.ZodType<Map<string, TokenUsageStats>>;

--- a/src/test-kernel/schemas/StreamDataRoundMaps.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataRoundMaps.vitest.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CompileFailuresDataSchema,
+  MissingOutputsDataSchema,
+  OutputFilesDataSchema,
+} from '@shared/schemas';
+
+describe('round-keyed stream data parsing', () => {
+  it('coerces string round keys and drops empty rounds', () => {
+    const missing = MissingOutputsDataSchema.parse({
+      '1': ['a.tex', 'b.tex'],
+      '2': [],
+    });
+
+    expect(missing).toBeInstanceOf(Map);
+    expect(missing.get(1)).toEqual(['a.tex', 'b.tex']);
+    // Round 2 is empty and must be dropped, not stored as an empty array.
+    expect(missing.has(2)).toBe(false);
+  });
+
+  it('falls back to an empty map on malformed top-level input', () => {
+    const result = OutputFilesDataSchema.parse('not-a-record');
+
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns a fresh map per failed parse so consumers cannot leak across streams', () => {
+    // Both parses fail and hit the `.catch(() => new Map())` fallback. Each
+    // must yield a distinct instance, because consumers (StreamSnapshotStore)
+    // hold the parsed map by reference and mutate it via `.set()`.
+    const first = CompileFailuresDataSchema.parse(42);
+    const second = CompileFailuresDataSchema.parse(42);
+
+    expect(first).not.toBe(second);
+
+    first.set(1, []);
+    expect(second.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

A data-structure review flagged duplicated transformation code in the per-stream sidecar schemas. The three round-keyed schemas in `src/shared/schemas/streamData.ts` — `OutputFilesDataSchema`, `MissingOutputsDataSchema`, and `CompileFailuresDataSchema` — each repeated the same construction verbatim:

```ts
z.record(z.string(), <itemList>)
  .transform(recordToRoundMap)
  .catch(new Map()) as z.ZodType<Map<number, T[]>>
```

That's three copies of the same pipeline plus three copies of the same `as z.ZodType<…>` cast (needed because Zod widens the `.catch(new Map())` output type).

This PR extracts a generic `roundMapSchema<T>(itemList)` helper so each schema becomes a single declarative call and the cast lives in exactly one place.

## What changed

- Added `roundMapSchema<T>` next to `recordToRoundMap` with a doc comment explaining the key coercion, drop-empty-rounds, and malformed-fallback semantics.
- Rewrote the three schemas as one-line calls to the helper.
- Dropped the now-unused `OutputFileInfo` / `CompileFailure` type-only imports (they were only referenced by the removed casts).

Behavior is unchanged: identical key coercion (`RoundKeySchema`), identical drop-empty-rounds rule, identical malformed-input fallback to an empty `Map`.

## Verification

- `npm run typecheck` — passes
- `npx eslint src/shared/schemas/streamData.ts` — clean
- `npx vitest run src/test-kernel/transcript/ src/test-kernel/schemas/` — 38 tests pass (covers `StreamSnapshotStore` and `StreamDataUsage`, which exercise these schemas through the disk-read path)

## Scope note

The broader review surfaced larger structural items (the four parallel `Map<StreamTabId, Map<…>>` accumulators in `StreamSnapshotStore`, and the 11-optional-field `SyncStreamContentMessageSchema`). Those are higher-risk refactors that touch the webview contract and were intentionally left out of this focused, behavior-preserving PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011w4bNQ3Gagyyznz8nAD5hd

---
_Generated by [Claude Code](https://claude.ai/code/session_011w4bNQ3Gagyyznz8nAD5hd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized schema refactor with a defensive parsing fix and new unit tests; no API or webview contract changes beyond safer empty-map fallbacks on malformed disk data.
> 
> **Overview**
> **Refactors** the three round-keyed sidecar parsers (`OutputFilesDataSchema`, `MissingOutputsDataSchema`, `CompileFailuresDataSchema`) in `streamData.ts` through a shared **`roundMapSchema`** helper so the `record` → `recordToRoundMap` → typed `Map` pipeline and its cast live in one place instead of three copies.
> 
> **Changes** malformed-parse fallbacks from `.catch(new Map())` to **`.catch(() => new Map())`** on those schemas and on **`UsageDataSchema`**, so Zod does not reuse one empty `Map` instance when sidecar JSON fails validation—important because **`StreamSnapshotStore`** keeps parsed maps by reference and mutates them.
> 
> Adds **`StreamDataRoundMaps.vitest.ts`** to lock in string round-key coercion, dropping empty rounds, empty-map fallback, and distinct fallback map instances per failed parse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c0eb8a9a46db48d2a6a6af38843c323913f4daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->