### PR TITLE
refactor(webview): route duplicated color fallbacks through semantic tokens

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -24,9 +24,9 @@ const COMPACTION_THRESHOLD = 75;
 
 /** Solid fill color based on context utilization. */
 function fillColor(percent: number): string {
-  if (percent <= 65) return 'var(--wa-color-success-on-quiet, #73c991)';
-  if (percent <= 80) return 'var(--wa-color-warning-on-quiet, #cca700)';
-  return 'var(--wa-color-testing-failed, #f48771)';
+  if (percent <= 65) return 'var(--color-success)';
+  if (percent <= 80) return 'var(--color-warning)';
+  return 'var(--color-status-error)';
 }
 
 @customElement('usage-panel')

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -59,26 +59,25 @@ export const toolUseStyles = css`
   }
 
   .banner-details--relay-error {
-    border-left: var(--border-medium) solid
-      var(--wa-color-warning-on-quiet, #ff8c00);
+    border-left: var(--border-medium) solid var(--color-warning);
     border-radius: 0 var(--border-radius-small) var(--border-radius-small) 0;
   }
 
   .banner-details--relay-error > .details-summary .label {
-    color: var(--wa-color-warning-on-quiet, #ff8c00);
+    color: var(--color-warning);
   }
 
   .tool-use-user-feedback > .details-summary :is(.tool-use-title, wa-icon) {
-    color: var(--wa-color-text-link, #3794ff);
+    color: var(--color-text-link);
   }
 
   .tool-use-in-progress > .details-summary :is(.tool-use-title, wa-icon),
   .tool-use-in-progress > .details-summary wa-spinner {
-    color: var(--wa-color-chart-yellow, #cca700);
+    color: var(--color-pending);
   }
 
   .tool-use-in-progress > .details-summary tool-timer {
-    color: var(--wa-color-chart-yellow, #cca700);
+    color: var(--color-pending);
   }
 
   :is(.tool-user-feedback, .tool-error-content, .tool-output-full) {
@@ -94,7 +93,7 @@ export const toolUseStyles = css`
 
   .tool-user-feedback {
     background-color: var(--wa-color-brand-fill-quiet, rgba(55, 148, 255, 0.1));
-    border-left-color: var(--wa-color-text-link, #3794ff);
+    border-left-color: var(--color-text-link);
   }
 
   .tool-error-content {
@@ -147,15 +146,15 @@ export const toolUseStyles = css`
 
   /* Diff styles */
   .diff-add {
-    color: var(--wa-color-git-added, #3fb950);
+    color: var(--color-diff-added);
   }
 
   .diff-remove {
-    color: var(--wa-color-git-deleted, #f85149);
+    color: var(--color-diff-removed);
   }
 
   .diff-hunk {
-    color: var(--wa-color-git-modified, #d29922);
+    color: var(--color-diff-modified);
   }
 
   .edit-diff-container {
@@ -180,12 +179,12 @@ export const toolUseStyles = css`
 
   .diff-inline-del {
     background-color: var(--wa-color-diff-removed, rgba(255, 0, 0, 0.2));
-    color: var(--wa-color-git-deleted, #f85149);
+    color: var(--color-diff-removed);
     text-decoration: line-through;
   }
 
   .diff-inline-add {
     background-color: var(--wa-color-diff-inserted, rgba(0, 255, 0, 0.2));
-    color: var(--wa-color-git-added, #3fb950);
+    color: var(--color-diff-added);
   }
 `;

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -78,7 +78,7 @@ export class ToolCard extends LitElement {
         width: 18px;
         height: 18px;
         flex: 0 0 18px;
-        color: var(--wa-color-testing-passed, #73c991);
+        color: var(--color-status-ok);
       }
 
       .tool-status-icon wa-icon {
@@ -135,12 +135,8 @@ export class ToolCard extends LitElement {
         border-radius: var(--border-radius);
         white-space: nowrap;
         font-weight: var(--font-weight-medium);
-        color: var(--wa-color-chart-blue, #3794ff);
-        background: color-mix(
-          in srgb,
-          var(--wa-color-chart-blue, #3794ff) 12%,
-          transparent
-        );
+        color: var(--color-info);
+        background: color-mix(in srgb, var(--color-info) 12%, transparent);
       }
 
       .tool-toggle {

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
@@ -64,12 +64,12 @@ export const latexTabStyles: CSSResult = css`
 
   .dependency-icon.installed,
   .setting-status-icon.is-set {
-    color: var(--wa-color-testing-passed, #73c991);
+    color: var(--color-status-ok);
   }
 
   .dependency-icon.missing,
   .setting-status-icon.not-set {
-    color: var(--wa-color-testing-failed, #f48771);
+    color: var(--color-status-error);
   }
 
   /* Using-default state for non-boolean settings (number/enum). Not a

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -122,14 +122,14 @@ export class ToolsTab extends LitElement {
 
       .tools-health-ring__available {
         fill: none;
-        stroke: var(--wa-color-testing-passed, #73c991);
+        stroke: var(--color-status-ok);
         stroke-width: 4;
         stroke-linecap: round;
       }
 
       .tools-health-ring__missing {
         fill: none;
-        stroke: var(--wa-color-testing-failed, #f48771);
+        stroke: var(--color-status-error);
         stroke-width: 4;
         stroke-linecap: round;
       }
@@ -151,11 +151,11 @@ export class ToolsTab extends LitElement {
       }
 
       .tools-stat-available {
-        color: var(--wa-color-testing-passed, #73c991);
+        color: var(--color-status-ok);
       }
 
       .tools-stat-missing {
-        color: var(--wa-color-testing-failed, #f48771);
+        color: var(--color-status-error);
       }
 
       .category-section {

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -4,7 +4,7 @@ export const designTokens: CSSResult = css`
   :host {
     /* Text colors */
     --color-text-secondary: var(--wa-color-text-quiet);
-    --color-text-link: var(--wa-color-text-link);
+    --color-text-link: var(--wa-color-text-link, #3794ff);
     --color-text-link-active: var(--wa-color-text-link-active);
 
     /* Background colors */
@@ -20,6 +20,20 @@ export const designTokens: CSSResult = css`
     --color-info: var(--wa-color-chart-blue, #3794ff);
     --color-added: var(--wa-color-chart-green, #4caf50);
     --color-removed: var(--wa-color-chart-red, #f44336);
+
+    /* Status indicators (dependency installed/missing, tool available/missing).
+       Distinct from --color-success/--color-error: these use the editor
+       "testing" palette so green/salmon status icons match the host theme. */
+    --color-status-ok: var(--wa-color-testing-passed, #73c991);
+    --color-status-error: var(--wa-color-testing-failed, #f48771);
+
+    /* In-progress / pending accent (running-tool spinner, timers). */
+    --color-pending: var(--wa-color-chart-yellow, #cca700);
+
+    /* Diff foreground colors (added/removed/modified lines in tool diffs). */
+    --color-diff-added: var(--wa-color-git-added, #3fb950);
+    --color-diff-removed: var(--wa-color-git-deleted, #f85149);
+    --color-diff-modified: var(--wa-color-git-modified, #d29922);
 
     /* Component aliases */
     --background-color: var(--color-bg-secondary);

--- a/src/shared/styles/markdownStyles.ts
+++ b/src/shared/styles/markdownStyles.ts
@@ -45,7 +45,7 @@ export const markdownStyles = css`
   }
 
   .markdown-content :is(h1, h2, h3, h4) {
-    color: var(--wa-color-text-link, #3794ff);
+    color: var(--color-text-link);
     font-size: var(--font-size-lg);
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-heading);


### PR DESCRIPTION
## Summary

A UI-consistency audit of the webview style modules found several places that **bypass the semantic `--color-*` token layer** defined in `designTokens` (`src/shared/styles/litStyles.ts`), re-referencing raw `--wa-color-*` variables with their own hardcoded hex fallbacks. This duplicated color values across files and let them drift:

- `toolUseStyles.ts` used `#ff8c00` as the warning fallback, but the canonical `--color-warning` token uses `#cca700`.
- `UsagePanel.ts` used `#73c991` (the *testing-passed* color) as the fallback for `--wa-color-success-on-quiet`, where `--color-success` uses `#2ea043`.
- The `--wa-color-testing-passed` / `-failed` pair was duplicated with hex fallbacks across **8 sites** (LaTeXTab, ToolsTab ×4, ToolCard, UsagePanel).

## Changes

Add the missing semantic tokens **once** in `designTokens`, plus a fallback for `--color-text-link`:

- `--color-status-ok` / `--color-status-error` — dependency/tool status (editor "testing" palette, distinct from `--color-success`/`--color-error`)
- `--color-pending` — in-progress spinner/timer accent
- `--color-diff-added` / `--color-diff-removed` / `--color-diff-modified` — tool diff line colors

Then route the bypassing call sites through them:

| File | What changed |
|------|--------------|
| `toolUseStyles.ts` | relay-error warning, user-feedback/in-progress accents, diff add/remove/hunk |
| `LaTeXTab.styles.ts` | dependency / setting status icons |
| `ToolsTab.ts` | health-ring strokes + summary stats |
| `ToolCard.ts` | tool status icon; auth note `--wa-color-chart-blue` → existing `--color-info` |
| `UsagePanel.ts` | utilization band routed through canonical success/warning + status-error |

## Behavior

No rendered-color change when the `--wa-color-*` variables are present (the normal runtime case in both the VS Code webview and the desktop host) — this only de-duplicates the fallbacks and makes the semantic token layer authoritative, so future token edits land in one place.

## Verification

- `npm run typecheck` — clean
- `npx eslint` + `npx prettier` on all touched files — clean
- `npm test` — 3354 passed; the single failure (`execUtils.vitest.ts` process-group abort timing) is pre-existing and unrelated to these CSS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX4ESxnnzDYF8LHhLbHYsH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RX4ESxnnzDYF8LHhLbHYsH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only token indirection with no logic or API changes; low risk aside from edge cases where theme variables are missing and fallbacks now follow the centralized map.
> 
> **Overview**
> **Centralizes semantic color tokens** in `designTokens` (`litStyles.ts`): status indicators (`--color-status-ok` / `--color-status-error`), pending accents (`--color-pending`), diff line colors (`--color-diff-*`), and a hex fallback on `--color-text-link`.
> 
> **Replaces inline `--wa-color-*` + hardcoded hex** across webview style modules with those tokens—tool-use banners/spinners/diffs, LaTeX/settings tool health UI, usage gauge bands, markdown headings, and tool-card auth styling (`--color-info`).
> 
> **Intent:** one authoritative fallback layer so warning/success/testing colors don’t drift between files; when host `--wa-color-*` vars are present, rendered colors should stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc29189c3d63c04228457709d4d7af3c1424be20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->