### PR TITLE
refactor: lift proposal reconstruction out of progress-view renderer

### DIFF
--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -4,10 +4,7 @@ import * as vscode from 'vscode';
 // Local imports
 import { loadAgents } from '@agent/index';
 import { registerExecution } from '@agent/storage';
-import {
-  AgentConfigSchema,
-  DEFAULT_AGENT_MODEL,
-} from '@agent/core/definition/AgentConfig';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { AUTH_COMMANDS } from '@auth/constants';
@@ -18,6 +15,7 @@ import { GlobalStateKey, globalSM } from '@common/state';
 import { SecretManager } from '@frontend/secretManager';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import * as logger from '@logger/logUtils';
+import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { agentName } from '@shared/schemas/agent';
 import { generateExecutionId } from '@utils/core/executionId';

--- a/packages/extension/src/progressView/frontend/formatters/proposalInputStore.ts
+++ b/packages/extension/src/progressView/frontend/formatters/proposalInputStore.ts
@@ -4,97 +4,18 @@
  * Stores typed proposal payloads by ID so they can be retrieved when the user
  * clicks the "Setup" link on a completed proposal log entry.
  *
- * Uses content-based hashing (like copyContentStore) so re-rendering the
- * same message produces the same ID — no memory leak on stream switches.
+ * Parsing the raw tool input into a typed proposal is domain logic and lives in
+ * the schema layer (`parseDelegationToolInput`); this module is a thin registry
+ * over it. Uses content-based hashing (like copyContentStore) so re-rendering
+ * the same message produces the same ID — no memory leak on stream switches.
  */
 
-import { z } from 'zod';
-
-import {
-  AgentCategory,
-  ToolConfigSchema,
-  ToolUseAgentProposalSchema,
-  WorkflowAgentProposalSchema,
-  migrateLegacyContextFileFields,
-  type AgentProposal,
-} from '@shared/schemas';
-import { isObject } from '@utils/core';
+import { parseDelegationToolInput, type AgentProposal } from '@shared/schemas';
 
 import { hashString } from './hashUtils';
 
-/**
- * Lenient proposal schemas derived from the canonical shared schemas.
- * Add `.prefault()` defaults for fields the LLM may omit in tool input.
- */
-const LenientToolUseProposalSchema = ToolUseAgentProposalSchema.extend({
-  model: z.string().prefault('gemini35f'),
-});
-
-const LenientWorkflowProposalSchema = WorkflowAgentProposalSchema.extend({
-  model: z.string().prefault('gemini35f'),
-  inputFiles: z.array(z.string()).prefault([]),
-  contextFiles: z.array(z.string()).prefault([]),
-  mediaFiles: z.array(z.string()).prefault([]),
-  outputFiles: z.array(z.string()).prefault([]),
-  toolConfig: ToolConfigSchema,
-});
-
 const MAX_STORE_SIZE = 500;
 const proposalInputStore = new Map<string, AgentProposal>();
-
-function parseProposalInput(
-  input: unknown,
-  toolName: string,
-): AgentProposal | null {
-  const spread = isObject(input) ? input : {};
-
-  if (toolName === 'delegate_agent' || toolName === 'propose_agent') {
-    const result = LenientToolUseProposalSchema.safeParse({
-      agentCategory: AgentCategory.ToolUse,
-      ...spread,
-    });
-    return result.success ? result.data : null;
-  }
-
-  if (toolName === 'delegate_workflow' || toolName === 'propose_workflow') {
-    const migrated = migrateLegacyContextFileFields(spread) as Record<
-      string,
-      unknown
-    >;
-    // Map extraction shorthand flags into toolConfig.
-    // Note: at runtime, DelegationTools.execute also inherits flags from the
-    // parent agent's toolConfig when omitted. That inheritance can't be
-    // replicated here (no access to parent context), so the store reflects
-    // only what the LLM explicitly requested.
-    const extractFigures =
-      migrated.extractFigures != null
-        ? Boolean(migrated.extractFigures)
-        : undefined;
-    const extractTikz =
-      migrated.extractTikz != null ? Boolean(migrated.extractTikz) : undefined;
-    const existingToolConfig = isObject(migrated.toolConfig)
-      ? migrated.toolConfig
-      : {};
-    const toolConfig = {
-      ...existingToolConfig,
-      ...(extractFigures !== undefined && {
-        autoExtractFigure: extractFigures,
-      }),
-      ...(extractTikz !== undefined && {
-        autoExtractTikzFigure: extractTikz,
-      }),
-    };
-
-    const result = LenientWorkflowProposalSchema.safeParse({
-      agentCategory: AgentCategory.Workflow,
-      ...migrated,
-      toolConfig,
-    });
-    return result.success ? result.data : null;
-  }
-
-  return null;
-}
 
 /**
  * Register proposal input and return a stable ID for lookup.
@@ -103,7 +24,7 @@ export function registerProposalInput(
   input: unknown,
   toolName: string,
 ): string | null {
-  const proposal = parseProposalInput(input, toolName);
+  const proposal = parseDelegationToolInput(input, toolName);
   if (!proposal) return null;
 
   const serialized = JSON.stringify(proposal);

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import {
   NullableFileFieldsSchema,
   migrateLegacyContextFileFields,
@@ -8,7 +9,9 @@ import { ToolConfigSchema } from '@shared/schemas/toolConfig';
 import { AgentCategory } from './AgentDataclass';
 
 const DEFAULT_AGENT_NAME = 'correct';
-export const DEFAULT_AGENT_MODEL = 'gemini35f';
+// Re-exported from the shared constants source so existing `@agent` importers
+// keep their import path while the literal lives in one place.
+export { DEFAULT_AGENT_MODEL };
 const DEFAULT_AGENT_INSTRUCTION = '';
 
 /** Pure object schema without refinements for use with .partial(). */

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -9,9 +9,6 @@ import { ToolConfigSchema } from '@shared/schemas/toolConfig';
 import { AgentCategory } from './AgentDataclass';
 
 const DEFAULT_AGENT_NAME = 'correct';
-// Re-exported from the shared constants source so existing `@agent` importers
-// keep their import path while the literal lives in one place.
-export { DEFAULT_AGENT_MODEL };
 const DEFAULT_AGENT_INSTRUCTION = '';
 
 /** Pure object schema without refinements for use with .partial(). */

--- a/src/shared/constants/delegationTools.ts
+++ b/src/shared/constants/delegationTools.ts
@@ -1,3 +1,5 @@
+import { AgentCategory } from '../schemas/agent';
+
 /**
  * Tools that delegate work to sub-agents.
  *
@@ -13,6 +15,20 @@ export const DELEGATION_TOOLS: ReadonlySet<string> = new Set([
   'propose_workflow',
   'propose_agent',
 ]);
+
+/**
+ * Maps each proposal-bearing delegation tool to the agent category it launches.
+ * `resume_agent` is intentionally absent — it carries no proposal payload to
+ * reconstruct. Single source of truth for routing raw delegation tool input to
+ * the matching proposal schema.
+ */
+export const DELEGATION_TOOL_CATEGORY: Readonly<Record<string, AgentCategory>> =
+  {
+    delegate_workflow: AgentCategory.Workflow,
+    propose_workflow: AgentCategory.Workflow,
+    delegate_agent: AgentCategory.ToolUse,
+    propose_agent: AgentCategory.ToolUse,
+  };
 
 /** True when any of the given tool names is a delegation tool. */
 export function hasDelegationTool(

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -138,6 +138,14 @@ export const PROVIDER_URLS: Record<string, string> = {
 export const DEFAULT_HELPER_MODEL = 'deepseek';
 
 /**
+ * Default model used when a new agent run / proposal omits one. Single source of
+ * truth shared by the agent config schema (`@agent/core/definition/AgentConfig`),
+ * the main-view persisted state, and the progress-view proposal reconstruction —
+ * so a change here propagates to all three instead of drifting per call site.
+ */
+export const DEFAULT_AGENT_MODEL = 'gemini35f';
+
+/**
  * Zod schema for a VS Code boolean setting surfaced per provider (without runtime value).
  * This is the single source of truth — ProviderVscodeSettingSchema in
  * profileViewMessages.ts extends this with a `value` field for runtime state.

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -37,6 +37,7 @@ export * from './streamData';
 export * from './subagentProgress';
 export * from './inquiry';
 export * from './prompts';
+export * from './proposalInput';
 export * from './diffResult';
 
 // Layer 4: MainView schemas (consolidated)

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -5,6 +5,7 @@
  */
 import { z } from 'zod';
 
+import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import {
   UIFileFieldsSchema,
   migrateLegacyContextFileFields,
@@ -120,7 +121,7 @@ const MainViewPersistedStateBaseSchema = UIFileFieldsSchema.merge(
   sessionType: SessionTypeSchema.prefault('toolUse'),
   workflowAgent: z.string().prefault('correct'),
   toolUseAgent: z.string().prefault('orchestrator'),
-  model: z.string().prefault('gemini35f'),
+  model: z.string().prefault(DEFAULT_AGENT_MODEL),
   commit: z.string().prefault('HEAD'),
   instruction: z.string().prefault(''),
   workflowInstruction: z.string().prefault(''),

--- a/src/shared/schemas/proposalInput.ts
+++ b/src/shared/schemas/proposalInput.ts
@@ -1,0 +1,109 @@
+/**
+ * Reconstruct a canonical {@link AgentProposal} from the raw delegation/proposal
+ * tool input captured in a progress-view log entry.
+ *
+ * The progress view's "Setup" link replays a past delegation into the main view.
+ * To do that it must rebuild the typed proposal from the raw tool-call input that
+ * was logged. This parser owns that reconstruction.
+ *
+ * It lives in the schema layer (not the renderer) because it encodes domain
+ * knowledge rather than presentation: which delegation tools map to which agent
+ * category, the `extractFigures` / `extractTikz` shorthand → `toolConfig`
+ * mapping, and the legacy file-field migration. The renderer-side
+ * `proposalInputStore` is a thin registry over this parser.
+ *
+ * The schemas here are deliberately lenient: the LLM may omit fields the
+ * canonical proposal schema requires, so display-only defaults
+ * ({@link DEFAULT_AGENT_MODEL}, empty file lists) are layered on top of the
+ * shared proposal schemas.
+ *
+ * Note: at runtime `DelegationTools.execute` also inherits extraction flags from
+ * the parent agent's `toolConfig` when omitted. That parent context is not
+ * available here, so the reconstruction reflects only what the tool input
+ * explicitly carried.
+ */
+import { z } from 'zod';
+
+import { isObject } from '@utils/core';
+
+import { DEFAULT_AGENT_MODEL } from '../constants/providers';
+import { DELEGATION_TOOL_CATEGORY } from '../constants/delegationTools';
+import { AgentCategory } from './agent';
+import { migrateLegacyContextFileFields } from './fileFields';
+import {
+  ToolUseAgentProposalSchema,
+  WorkflowAgentProposalSchema,
+  type AgentProposal,
+} from './prompts';
+import { ToolConfigSchema } from './toolConfig';
+
+/**
+ * Lenient proposal schemas derived from the canonical shared schemas.
+ * Add display-only defaults for fields the LLM may omit in tool input.
+ */
+const LenientToolUseProposalSchema = ToolUseAgentProposalSchema.extend({
+  model: z.string().prefault(DEFAULT_AGENT_MODEL),
+});
+
+const LenientWorkflowProposalSchema = WorkflowAgentProposalSchema.extend({
+  model: z.string().prefault(DEFAULT_AGENT_MODEL),
+  inputFiles: z.array(z.string()).prefault([]),
+  contextFiles: z.array(z.string()).prefault([]),
+  mediaFiles: z.array(z.string()).prefault([]),
+  outputFiles: z.array(z.string()).prefault([]),
+  toolConfig: ToolConfigSchema,
+});
+
+/**
+ * Fold the `extractFigures` / `extractTikz` delegation shorthand into the
+ * canonical `toolConfig.autoExtract*` flags. Mirrors the runtime mapping in
+ * `DelegationTools.execute`, but only sets a flag the input explicitly carried
+ * (absent stays undefined so the lenient schema's prefault applies).
+ */
+function extractionShorthandToolConfig(
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const existing = isObject(source.toolConfig) ? source.toolConfig : {};
+  const overrides: Record<string, unknown> = { ...existing };
+  if (source.extractFigures != null) {
+    overrides.autoExtractFigure = Boolean(source.extractFigures);
+  }
+  if (source.extractTikz != null) {
+    overrides.autoExtractTikzFigure = Boolean(source.extractTikz);
+  }
+  return overrides;
+}
+
+/**
+ * Parse raw delegation/proposal tool input into a canonical {@link AgentProposal},
+ * or `null` when the tool is not proposal-bearing or the input fails validation.
+ */
+export function parseDelegationToolInput(
+  input: unknown,
+  toolName: string,
+): AgentProposal | null {
+  const category = DELEGATION_TOOL_CATEGORY[toolName];
+  if (!category) return null;
+
+  const spread = isObject(input) ? input : {};
+
+  if (category === AgentCategory.ToolUse) {
+    const result = LenientToolUseProposalSchema.safeParse({
+      agentCategory: AgentCategory.ToolUse,
+      ...spread,
+    });
+    return result.success ? result.data : null;
+  }
+
+  // Workflow: migrate legacy file fields, then map extraction shorthand flags.
+  const migrated = migrateLegacyContextFileFields(spread) as Record<
+    string,
+    unknown
+  >;
+  const result = LenientWorkflowProposalSchema.safeParse({
+    agentCategory: AgentCategory.Workflow,
+    ...migrated,
+    toolConfig: extractionShorthandToolConfig(migrated),
+  });
+  return result.success ? result.data : null;
+}

--- a/src/shared/schemas/proposalInput.ts
+++ b/src/shared/schemas/proposalInput.ts
@@ -35,7 +35,6 @@ import {
   WorkflowAgentProposalSchema,
   type AgentProposal,
 } from './prompts';
-import { ToolConfigSchema } from './toolConfig';
 
 /**
  * Lenient proposal schemas derived from the canonical shared schemas.
@@ -51,7 +50,8 @@ const LenientWorkflowProposalSchema = WorkflowAgentProposalSchema.extend({
   contextFiles: z.array(z.string()).prefault([]),
   mediaFiles: z.array(z.string()).prefault([]),
   outputFiles: z.array(z.string()).prefault([]),
-  toolConfig: ToolConfigSchema,
+  // toolConfig is inherited from WorkflowAgentProposalSchema (via
+  // WorkflowSpecificFieldsSchema) and already object-prefaulted — no override.
 });
 
 /**
@@ -82,7 +82,11 @@ export function parseDelegationToolInput(
   input: unknown,
   toolName: string,
 ): AgentProposal | null {
-  const category = DELEGATION_TOOL_CATEGORY[toolName];
+  // Own-property guard: toolName derives from untrusted logged input, so a
+  // value like 'constructor' must not resolve to an inherited Object member.
+  const category = Object.hasOwn(DELEGATION_TOOL_CATEGORY, toolName)
+    ? DELEGATION_TOOL_CATEGORY[toolName]
+    : undefined;
   if (!category) return null;
 
   const spread = isObject(input) ? input : {};

--- a/src/test-kernel/shared/ParseDelegationToolInput.vitest.ts
+++ b/src/test-kernel/shared/ParseDelegationToolInput.vitest.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgentCategory } from '@shared/schemas/agent';
+import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
+import { parseDelegationToolInput } from '@shared/schemas/proposalInput';
+
+describe('parseDelegationToolInput', () => {
+  it('returns null for non proposal-bearing tools (incl. resume_agent)', () => {
+    expect(parseDelegationToolInput({ agent: 'a' }, 'bash')).toBeNull();
+    expect(parseDelegationToolInput({ agent: 'a' }, 'resume_agent')).toBeNull();
+  });
+
+  it('routes delegate_agent / propose_agent to a tool-use proposal', () => {
+    for (const tool of ['delegate_agent', 'propose_agent']) {
+      const proposal = parseDelegationToolInput(
+        { agent: 'orchestrator', instruction: 'do it' },
+        tool,
+      );
+      expect(proposal?.agentCategory).toBe(AgentCategory.ToolUse);
+      expect(proposal?.agent).toBe('orchestrator');
+    }
+  });
+
+  it('routes delegate_workflow / propose_workflow to a workflow proposal', () => {
+    for (const tool of ['delegate_workflow', 'propose_workflow']) {
+      const proposal = parseDelegationToolInput(
+        { agent: 'correct', instruction: 'fix', inputFiles: ['paper.tex'] },
+        tool,
+      );
+      expect(proposal?.agentCategory).toBe(AgentCategory.Workflow);
+      if (proposal?.agentCategory === AgentCategory.Workflow) {
+        expect(proposal.inputFiles).toEqual(['paper.tex']);
+      }
+    }
+  });
+
+  it('defaults the model to DEFAULT_AGENT_MODEL when omitted', () => {
+    const proposal = parseDelegationToolInput(
+      { agent: 'correct', instruction: 'fix' },
+      'delegate_workflow',
+    );
+    expect(proposal?.model).toBe(DEFAULT_AGENT_MODEL);
+  });
+
+  it('maps extractFigures / extractTikz shorthand into toolConfig', () => {
+    const proposal = parseDelegationToolInput(
+      {
+        agent: 'correct',
+        instruction: 'fix',
+        extractFigures: true,
+        extractTikz: false,
+      },
+      'delegate_workflow',
+    );
+    expect(proposal?.agentCategory).toBe(AgentCategory.Workflow);
+    if (proposal?.agentCategory === AgentCategory.Workflow) {
+      expect(proposal.toolConfig.autoExtractFigure).toBe(true);
+      expect(proposal.toolConfig.autoExtractTikzFigure).toBe(false);
+    }
+  });
+
+  it('leaves toolConfig flags at their defaults when shorthand is absent', () => {
+    const proposal = parseDelegationToolInput(
+      { agent: 'correct', instruction: 'fix' },
+      'delegate_workflow',
+    );
+    if (proposal?.agentCategory === AgentCategory.Workflow) {
+      expect(proposal.toolConfig.autoExtractFigure).toBe(false);
+      expect(proposal.toolConfig.autoExtractTikzFigure).toBe(false);
+    }
+  });
+
+  it('migrates legacy single-slot file fields into the canonical lists', () => {
+    const proposal = parseDelegationToolInput(
+      { agent: 'correct', instruction: 'fix', inputFile: 'legacy.tex' },
+      'delegate_workflow',
+    );
+    if (proposal?.agentCategory === AgentCategory.Workflow) {
+      expect(proposal.inputFiles).toEqual(['legacy.tex']);
+    }
+  });
+
+  it('returns null when required fields are missing', () => {
+    // instruction is required by the canonical proposal schema.
+    expect(
+      parseDelegationToolInput({ agent: 'correct' }, 'delegate_agent'),
+    ).toBeNull();
+  });
+
+  it('tolerates non-object input', () => {
+    expect(parseDelegationToolInput(null, 'delegate_agent')).toBeNull();
+    expect(parseDelegationToolInput('nope', 'delegate_workflow')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

A code-review pass for abstraction-layer violations found one genuine blocker: the progress-view `proposalInputStore` (a renderer module) owned domain logic that belongs in the schema layer. This PR relocates that logic and removes the duplication it created.

`proposalInputStore.ts` was responsible for:
- **Lenient proposal schemas** with a hardcoded `'gemini35f'` default — a duplicate of `DEFAULT_AGENT_MODEL`, with no type-level link keeping them in sync.
- **Tool-name routing** (`delegate_agent` / `propose_agent` → tool-use; `delegate_workflow` / `propose_workflow` → workflow) — domain knowledge expressed as inline string comparisons in a formatter.
- **The `extractFigures` / `extractTikz` shorthand → `toolConfig` mapping** — duplicated from the runtime source of truth in `DelegationTools.execute`.
- **A legacy file-field migration call** (`migrateLegacyContextFileFields`) in the render path.

Any change to delegation schemas, the default model, or extraction flags previously required editing this renderer separately from the domain layer, with nothing enforcing parity.

## Changes

- **New `@shared/schemas/proposalInput.ts`** — `parseDelegationToolInput(input, toolName)` is now the single domain home for rebuilding a typed `AgentProposal` from raw delegation tool input. Behavior (lenient defaults, shorthand mapping, legacy migration, null handling) is preserved exactly. The `DELEGATION_TOOL_CATEGORY` lookup is guarded with `Object.hasOwn` so an untrusted logged `toolName` (e.g. `'constructor'`) can't resolve to an inherited member.
- **`proposalInputStore.ts` is now a thin registry** — content-hash IDs, eviction, and lookup only; no parsing.
- **`DELEGATION_TOOL_CATEGORY`** added to `@shared/constants/delegationTools.ts` so tool-name → agent-category routing has one source of truth.
- **`DEFAULT_AGENT_MODEL` centralized** in `@shared/constants/providers.ts` (alongside `DEFAULT_HELPER_MODEL`). `AgentConfig`, the main-view state schema, the proposal reconstruction, and the setup command all import it directly instead of duplicating the `'gemini35f'` literal — no re-export shim (the local `AgentConfig` export was removed per the "Flattening Abstraction Layers" guideline).
- **`ParseDelegationToolInput.vitest.ts`** added — covers routing, model default, shorthand mapping, legacy migration, and null/invalid cases (9 tests).

Note: `DEFAULT_MODELS` in `modelOptionsBasic.ts` still lists `'gemini35f'` — that's the curated model catalog (a distinct concept) and is intentionally left alone.

## Verification

- `npm run typecheck` — passes (extension + CLI + test-kernel projects)
- `npx eslint` on all changed files — clean
- `npx vitest run src/test-kernel/shared/` — 41 passed (incl. the 9 new tests)
- Proposal-related controller suites (`ProgressViewCommandHandlers`, `ProgressAgentProposalController`) — 15 passed
- Confirmed no domain parsing logic remains in `proposalInputStore.ts` and no stray `'gemini35f'` literal outside the canonical sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRXPFtTVHNxDvno5pA5MvY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRXPFtTVHNxDvno5pA5MvY)_


---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with new unit tests; main user-facing path is progress-view proposal replay, with no auth or persistence contract changes.
>
> **Overview**
> Moves **delegation proposal reconstruction** out of the progress-view `proposalInputStore` into **`@shared/schemas/proposalInput.ts`** via `parseDelegationToolInput`, so tool routing, lenient Zod defaults, legacy file-field migration, and `extractFigures` / `extractTikz` → `toolConfig` mapping live in one schema-layer home. The store now only hashes, registers, and evicts typed proposals for the progress view **Setup** link.
>
> Adds **`DELEGATION_TOOL_CATEGORY`** in `delegationTools.ts` as the single map from proposal-bearing tool names to workflow vs tool-use categories (with an `Object.hasOwn` guard on untrusted logged tool names).
>
> **`DEFAULT_AGENT_MODEL`** is defined once in `@shared/constants/providers` and wired into agent config, main-view persisted state, setup assistant, and proposal parsing—replacing scattered `'gemini35f'` literals (the local export from `AgentConfig` is removed).
>
> New **`ParseDelegationToolInput.vitest.ts`** locks in routing, defaults, shorthand mapping, migration, and invalid-input behavior.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9da094ad238d32ef375e316d944e1a296073374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>