### PR TITLE
refactor(auth): back TierService cache with lru-cache

### DIFF
--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -239,8 +239,8 @@ export class ServerSideKeyService {
       this.clearAllCaches(cacheOptions);
       // No pre-fetch on enable — the next canUseServerSideKeys() does
       // its own auth'd fetch in parallel with fetchAccessStatus(), and
-      // an anonymous pre-fetch here would just be discarded by the
-      // cachedWithAuth mismatch in TierService.getConfig.
+      // an anonymous pre-fetch here would populate the 'anon' cache slot
+      // rather than the 'auth' slot needed for the access check.
       this._onDidChangeModelAccess.fire(value);
     }
   }

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -13,6 +13,8 @@
  * - Ultra: All models above $3/M input
  */
 
+import { LRUCache } from 'lru-cache';
+
 import { toErrorMessage } from '@common/errors/errorMessage';
 import {
   SpendingStatusSchema,
@@ -35,21 +37,46 @@ import type { z } from 'zod';
 
 const CHANNEL = 'TierService';
 
+/** Cache slot key — auth and anonymous responses never share a slot. */
+type TierCacheKey = 'auth' | 'anon';
+
+/** Per-fetch context threaded through {@link LRUCache.fetch} to fetchMethod. */
+interface TierFetchContext {
+  authToken: string | undefined;
+}
+
+/** Result of a single relay `/tier-config` response. */
+interface TierFetchResult {
+  config: TierModelConfig | null;
+  userStatus: UserAccessStatus | null;
+  spendingStatus: SpendingStatus | null;
+}
+
 /**
  * Service for managing tier-based model access configuration.
  */
 export class TierService {
-  private cache: TierModelConfig | null = null;
-  private cacheTimestamp = 0;
-  private fetchPromise: Promise<TierModelConfig | null> | null = null;
-  private fetchGeneration = 0;
   /**
-   * True when the latest cached fetch carried an Authorization header.
-   * A later authenticated call must refresh the cache so userStatus and
-   * spendingStatus are populated; otherwise the 5-min TTL would serve
-   * stale `null`s until expiry.
+   * Dedupes concurrent `/tier-config` fetches and gates them on the 5-min TTL.
+   *
+   * Keyed by auth state so an anonymous fetch and an authenticated fetch never
+   * share a slot: a late anonymous response can't clobber the authenticated
+   * spend snapshot (this is structural, not timing-dependent — it replaces the
+   * former `fetchGeneration` guard). Clearing the cache aborts any in-flight
+   * fetch via its `AbortSignal`, so a response that lands after sign-out can't
+   * repopulate the snapshots below.
    */
-  private cachedWithAuth = false;
+  private readonly configCache: LRUCache<
+    TierCacheKey,
+    TierModelConfig,
+    TierFetchContext
+  >;
+
+  /**
+   * Last successfully fetched config, backing the synchronous accessors.
+   * Persists past the cache TTL until the next fetch or {@link clearCache}.
+   */
+  private configSnapshot: TierModelConfig | null = null;
 
   /** User's access status including expiration (populated when fetching with auth) */
   private userStatus: UserAccessStatus | null = null;
@@ -64,32 +91,51 @@ export class TierService {
   constructor(
     private readonly baseUrl: string,
     private readonly logger: AuthServiceLogger = NOOP_AUTH_SERVICE_LOGGER,
-  ) {}
+  ) {
+    this.configCache = new LRUCache<
+      TierCacheKey,
+      TierModelConfig,
+      TierFetchContext
+    >({
+      max: 2,
+      ttl: SERVER_SIDE_CACHE_TTL_MS,
+      fetchMethod: async (key, _staleValue, { signal, context }) => {
+        const result = await this.fetchFromServer(context.authToken, signal);
+        // A sign-out (clearCache) during the fetch aborts the signal; never let
+        // a stale response repopulate the snapshots after invalidation.
+        if (signal.aborted) {
+          throw new Error('tier-config fetch aborted');
+        }
+        // An authenticated response carries the user blocks even when the tiers
+        // block fails validation; mirror the previous behaviour of refreshing
+        // the quota snapshot whenever auth was present. Anonymous responses
+        // never touch these — that is what protects an authenticated snapshot.
+        if (key === 'auth') {
+          this.userStatus = result.userStatus;
+          this.spendingStatus = result.spendingStatus;
+        }
+        if (result.config === null) {
+          // Throw so lru-cache drops the entry and the next call retries,
+          // matching the previous "reset timestamp on failure" behaviour
+          // (no negative caching of a missing/invalid config).
+          throw new Error('tier-config response had no usable config');
+        }
+        this.configSnapshot = result.config;
+        return result.config;
+      },
+    });
+  }
 
   /**
    * Clear the tier config cache.
    * Call this when user signs in/out.
    */
   clearCache(): void {
-    this.cache = null;
-    this.cacheTimestamp = 0;
-    this.fetchPromise = null;
-    this.fetchGeneration += 1;
+    // clear() aborts any in-flight fetch (see fetchMethod's signal guard).
+    this.configCache.clear();
+    this.configSnapshot = null;
     this.userStatus = null;
     this.spendingStatus = null;
-    this.cachedWithAuth = false;
-  }
-
-  /**
-   * Check if a fetch is in progress or cache is valid (not expired).
-   * Does NOT require cache data to be present - checking fetchPromise !== null
-   * with valid timestamp is enough to avoid duplicate fetches.
-   */
-  private isCacheValid(): boolean {
-    return (
-      this.fetchPromise !== null &&
-      Date.now() - this.cacheTimestamp < SERVER_SIDE_CACHE_TTL_MS
-    );
   }
 
   /**
@@ -114,79 +160,87 @@ export class TierService {
 
   /**
    * Fetch tier configuration from the relay server.
+   *
+   * Pure with respect to instance state — the caller (fetchMethod) owns the
+   * snapshot updates so invalidation stays in one place. Throws on a transport
+   * failure (network error, non-OK, 404) so the cache drops the entry and the
+   * next call retries; returns a result with `config: null` when a real 200
+   * response failed config validation but may still carry the user blocks.
+   *
    * @param authToken - Optional JWT token to include user access status in response
+   * @param signal - Abort signal from the cache; cancels the in-flight request
    */
   private async fetchFromServer(
     authToken: string | undefined,
-    generation: number,
-  ): Promise<TierModelConfig | null> {
+    signal: AbortSignal,
+  ): Promise<TierFetchResult> {
+    const url = `${this.baseUrl}/functions/v1/relay/tier-config`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    // Include auth token if provided to get user-specific status
+    if (authToken) {
+      headers['Authorization'] = `Bearer ${authToken}`;
+    }
+
+    let response: Response;
     try {
-      const url = `${this.baseUrl}/functions/v1/relay/tier-config`;
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-      };
-
-      // Include auth token if provided to get user-specific status
-      if (authToken) {
-        headers['Authorization'] = `Bearer ${authToken}`;
+      response = await fetch(url, { method: 'GET', headers, signal });
+    } catch (error) {
+      // A sign-out (clearCache) aborts the request; that is expected, so stay
+      // quiet. Genuine network failures keep the previous error log.
+      if (!signal.aborted) {
+        this.logger.error(
+          CHANNEL,
+          `Error fetching tier config: ${toErrorMessage(error)}`,
+        );
       }
+      throw error;
+    }
 
-      const response = await fetch(url, { method: 'GET', headers });
-
-      if (!response.ok) {
-        if (response.status === 404) {
-          this.logger.info(
-            CHANNEL,
-            'Tier-config endpoint not available, using defaults',
-          );
-          return null;
-        }
+    if (!response.ok) {
+      if (response.status === 404) {
+        this.logger.info(
+          CHANNEL,
+          'Tier-config endpoint not available, using defaults',
+        );
+      } else {
         this.logger.error(
           CHANNEL,
           `Failed to fetch tier config: ${response.status}`,
         );
-        return null;
       }
+      throw new Error(`tier-config request failed: HTTP ${response.status}`);
+    }
 
-      const data = await response.json();
+    const data = await response.json();
 
-      // Parse user-specific blocks. Both are only present when the
-      // request carries auth, so clear them on absence (anonymous fetch)
-      // and on parse failure — a relay-side schema drift should not
-      // silently serve stale values to the quota meter / BYOK switch.
-      const userStatus = this.parseOptionalBlock(
-        data.userStatus,
-        UserAccessStatusSchema,
-        'userStatus',
-      );
-      const spendingStatus = this.parseOptionalBlock(
-        data.spendingStatus,
-        SpendingStatusSchema,
-        'spendingStatus',
-      );
-      if (generation === this.fetchGeneration) {
-        this.userStatus = userStatus;
-        this.spendingStatus = spendingStatus;
-      }
+    // Parse user-specific blocks. Both are only present when the request
+    // carries auth, so they resolve to null on an anonymous fetch and on parse
+    // failure — a relay-side schema drift should not silently serve stale
+    // values to the quota meter / BYOK switch.
+    const userStatus = this.parseOptionalBlock(
+      data.userStatus,
+      UserAccessStatusSchema,
+      'userStatus',
+    );
+    const spendingStatus = this.parseOptionalBlock(
+      data.spendingStatus,
+      SpendingStatusSchema,
+      'spendingStatus',
+    );
 
-      const parsed = TierModelConfigSchema.safeParse(data);
-
-      if (!parsed.success) {
-        this.logger.error(
-          CHANNEL,
-          `Invalid tier config response: ${parsed.error.message}`,
-        );
-        return null;
-      }
-
-      return parsed.data;
-    } catch (error) {
+    const parsed = TierModelConfigSchema.safeParse(data);
+    if (!parsed.success) {
       this.logger.error(
         CHANNEL,
-        `Error fetching tier config: ${toErrorMessage(error)}`,
+        `Invalid tier config response: ${parsed.error.message}`,
       );
-      return null;
+      return { config: null, userStatus, spendingStatus };
     }
+
+    return { config: parsed.data, userStatus, spendingStatus };
   }
 
   /**
@@ -195,37 +249,21 @@ export class TierService {
    * @param authToken - Optional JWT to get user-specific access status
    */
   async getConfig(authToken?: string): Promise<TierModelConfig | null> {
-    // Reuse an in-flight or fresh cache only when it matches the
-    // current auth state. A previous anonymous fetch leaves
-    // userStatus/spendingStatus as null; reusing it here would mask
-    // the user's quota for 5 minutes after sign-in.
-    const tokenPresent = Boolean(authToken);
-    if (this.isCacheValid() && this.cachedWithAuth === tokenPresent) {
-      return this.fetchPromise;
+    const key: TierCacheKey = authToken ? 'auth' : 'anon';
+    try {
+      // lru-cache dedupes concurrent fetches for the same key and serves a
+      // cached value within the TTL; fetchMethod owns the snapshot updates.
+      const config = await this.configCache.fetch(key, {
+        context: { authToken },
+      });
+      return config ?? null;
+    } catch {
+      // fetchMethod throws on transport failure, a missing/invalid config, or a
+      // post-sign-out abort; lru-cache drops the rejected entry so the next
+      // call retries. fetchFromServer has already logged any genuine failure;
+      // a missing config or sign-out abort is expected and stays quiet.
+      return null;
     }
-
-    // Set timestamp BEFORE creating promise to prevent race conditions
-    // where concurrent calls see fetchPromise !== null but timestamp is stale
-    this.cacheTimestamp = Date.now();
-    this.cachedWithAuth = tokenPresent;
-    const generation = ++this.fetchGeneration;
-    this.fetchPromise = this.fetchFromServer(authToken, generation).then(
-      (result) => {
-        if (generation !== this.fetchGeneration) {
-          return this.cache;
-        }
-        if (result !== null) {
-          this.cache = result;
-        } else {
-          // Reset timestamp on failure so next call retries
-          this.cacheTimestamp = 0;
-          this.cachedWithAuth = false;
-        }
-        return result;
-      },
-    );
-
-    return this.fetchPromise;
   }
 
   /**
@@ -233,7 +271,7 @@ export class TierService {
    * Returns null if config hasn't been fetched yet.
    */
   getConfigSync(): TierModelConfig | null {
-    return this.cache;
+    return this.configSnapshot;
   }
 
   /**
@@ -244,7 +282,7 @@ export class TierService {
     tier: UserTier,
     config?: TierModelConfig | null,
   ): TierModelsConfig | null {
-    return (config ?? this.cache)?.tiers[tier] ?? null;
+    return (config ?? this.configSnapshot)?.tiers[tier] ?? null;
   }
 
   /**
@@ -270,7 +308,7 @@ export class TierService {
    * All tiers have access to the same providers.
    */
   getProviders(config?: TierModelConfig | null): string[] {
-    return (config ?? this.cache)?.providers ?? [];
+    return (config ?? this.configSnapshot)?.providers ?? [];
   }
 
   /**

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -214,19 +214,28 @@ export class TierService {
       throw new Error(`tier-config request failed: HTTP ${response.status}`);
     }
 
-    const data = await response.json();
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch (error) {
+      this.logger.error(
+        CHANNEL,
+        `Failed to parse tier config JSON: ${toErrorMessage(error)}`,
+      );
+      throw error;
+    }
 
     // Parse user-specific blocks. Both are only present when the request
     // carries auth, so they resolve to null on an anonymous fetch and on parse
     // failure — a relay-side schema drift should not silently serve stale
     // values to the quota meter / BYOK switch.
     const userStatus = this.parseOptionalBlock(
-      data.userStatus,
+      (data as Record<string, unknown>).userStatus,
       UserAccessStatusSchema,
       'userStatus',
     );
     const spendingStatus = this.parseOptionalBlock(
-      data.spendingStatus,
+      (data as Record<string, unknown>).spendingStatus,
       SpendingStatusSchema,
       'spendingStatus',
     );

--- a/src/test-kernel/auth/TierService.vitest.ts
+++ b/src/test-kernel/auth/TierService.vitest.ts
@@ -79,4 +79,67 @@ describe('TierService', () => {
 
     expect(service.getSpendingStatus()?.remaining).toBe(0);
   });
+
+  it('dedupes concurrent fetches for the same auth state', async () => {
+    const pending: PendingFetch[] = [];
+    const fetchMock = vi.fn(
+      (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+        new Promise<Response>((resolve) => {
+          pending.push({
+            hasAuth: Boolean(
+              (init?.headers as Record<string, string> | undefined)
+                ?.Authorization,
+            ),
+            resolve,
+          });
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new TierService('https://example.test');
+
+    const first = service.getConfig('token');
+    const second = service.getConfig('token');
+    // Let the synchronous fetch initiation settle before asserting.
+    await Promise.resolve();
+
+    // Both callers share a single in-flight request for the same key.
+    expect(pending).toHaveLength(1);
+
+    pending[0].resolve(jsonResponse(tierConfig()));
+
+    expect(await first).not.toBeNull();
+    expect(await second).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the synchronous snapshots on clearCache', async () => {
+    const fetchMock = vi.fn(
+      (): Promise<Response> =>
+        Promise.resolve(
+          jsonResponse(
+            tierConfig({
+              spendingStatus: {
+                currentSpend: 100,
+                limit: 300,
+                remaining: 200,
+                percentUsed: 33,
+              },
+            }),
+          ),
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new TierService('https://example.test');
+
+    await service.getConfig('token');
+    expect(service.getConfigSync()).not.toBeNull();
+    expect(service.getSpendingStatus()?.remaining).toBe(200);
+
+    service.clearCache();
+
+    expect(service.getConfigSync()).toBeNull();
+    expect(service.getSpendingStatus()).toBeNull();
+  });
 });

--- a/src/test-kernel/auth/TierService.vitest.ts
+++ b/src/test-kernel/auth/TierService.vitest.ts
@@ -113,6 +113,53 @@ describe('TierService', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('prevents an in-flight auth fetch from repopulating snapshots after clearCache', async () => {
+    const pending: PendingFetch[] = [];
+    const fetchMock = vi.fn(
+      (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+        new Promise<Response>((resolve) => {
+          pending.push({
+            hasAuth: Boolean(
+              (init?.headers as Record<string, string> | undefined)
+                ?.Authorization,
+            ),
+            resolve,
+          });
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new TierService('https://example.test');
+
+    // Start an auth fetch that will remain in-flight.
+    const authPromise = service.getConfig('token');
+    // Let the synchronous fetch-initiation and cache-registration settle.
+    await Promise.resolve();
+
+    // Sign-out during the fetch — this must abort the signal and reset
+    // snapshots so the late-arriving response can't repopulate them.
+    service.clearCache();
+
+    // Now resolve the in-flight request with spend data.
+    pending[0].resolve(
+      jsonResponse(
+        tierConfig({
+          spendingStatus: {
+            currentSpend: 50,
+            limit: 300,
+            remaining: 250,
+            percentUsed: 16,
+          },
+        }),
+      ),
+    );
+    await authPromise;
+
+    // The response was aborted — snapshots must stay null.
+    expect(service.getSpendingStatus()).toBeNull();
+    expect(service.getConfigSync()).toBeNull();
+  });
+
   it('clears the synchronous snapshots on clearCache', async () => {
     const fetchMock = vi.fn(
       (): Promise<Response> =>


### PR DESCRIPTION
## Summary

Replaces `TierService`'s bespoke single-slot promise cache with the already-present `lru-cache@11` (no new dependency). This came out of a "reinvented wheels" audit; after checking both audit candidates deeply, this is the one that's a genuine improvement.

The old cache hand-rolled five interacting pieces — `cache` + `cacheTimestamp` + `fetchPromise` + `fetchGeneration` + `cachedWithAuth` + `isCacheValid()` — to get TTL, concurrent-fetch dedup, auth-state invalidation, and out-of-order-resolution protection. lru-cache provides the first three; keying by auth state (`'auth'` / `'anon'`) replaces the fourth.

## Why this is cleaner, not just different

- **TTL, concurrent-fetch dedup, and in-flight abort** move to a maintained library instead of hand-rolled timestamp/promise plumbing.
- The **"a late anonymous response must never clobber the authenticated spend snapshot"** guarantee becomes **structural** (separate cache slots) rather than **timing-dependent** (the old `fetchGeneration` counter that compared generations after each await).
- **Sign-out** (`clearCache`) now aborts any in-flight fetch via its `AbortSignal`, so a response that lands after invalidation can't repopulate the snapshots.
- `fetchFromServer` is now **pure** with respect to instance state and signal-aware; `fetchMethod` owns the snapshot updates, so invalidation lives in one place.

## Behavior parity

Preserved for every reachable flow:
- The **sole** `getConfig` caller (`ServerSideKeyService.canUseServerSideKeys`) derives the token from real auth state, so the `'auth'`/`'anon'` key always tracks reality.
- Sign-out routes through `clearCache()` (wired via the `onCacheCleared` subscription), which resets the snapshots.
- Synchronous accessors (`getConfigSync`, `getProviders`, `getSpendingStatus`, …) keep their persist-past-TTL semantics via the `configSnapshot` / `userStatus` / `spendingStatus` fields.
- Failure handling matches the old "reset on failure, no negative caching" behavior: `fetchMethod` throws on transport failure / missing config / post-sign-out abort, so lru-cache drops the entry and the next call retries.

One deliberate, safer difference: an anonymous fetch no longer clears an authenticated snapshot on its own (only an explicit `clearCache` does) — which also aligns with the `preserveTierCache` intent.

## Not changed (and why)

The audit also flagged `logUtils.getTimestamp` for `Intl.DateTimeFormat`. On a deeper look that's **not** a clean win: the format is a fixed `YYYY-MM-DD HH:mm:ss.mmm` in **local** time. `Intl.DateTimeFormat` is locale-dependent and can't reproduce it without `formatToParts` reassembly that's longer than the current 6 lines; `toISOString()` would silently switch every log line to UTC; and no date library is a dependency. The explicit version is the simplest correct option, so it's left as-is.

## Testing

- `tsc --noEmit` on root + test-kernel projects: clean
- ESLint on changed files: clean
- `src/test-kernel/auth` (9 files, 59 tests): pass
- Added tests: concurrent-fetch dedup, `clearCache` snapshot reset. The existing "stale anonymous fetch can't clear authenticated spend" test stays green.
- Full suite: 3355/3356 relevant tests pass; the lone failure (`execUtils.vitest.ts` process-group kill) reproduces identically on the clean baseline — it's an environment/container process-kill timing issue, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114wfchJHdpqE4SWZmx98RL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes relay tier-config caching and quota/access snapshot timing on sign-in/out, but intent is behavioral parity with stronger isolation between auth and anonymous fetches.
> 
> **Overview**
> **`TierService`** drops its hand-rolled TTL/promise/`fetchGeneration` cache in favor of **`lru-cache`**, with separate **`'auth'`** and **`'anon'`** slots so anonymous `/tier-config` responses cannot overwrite authenticated spend or access snapshots.
> 
> **`getConfig`** now routes through `configCache.fetch`; **`fetchFromServer`** is stateless, passes **`AbortSignal`** into `fetch`, and throws on transport errors so failed entries are not negatively cached. Snapshot fields (`configSnapshot`, `userStatus`, `spendingStatus`) are updated only in the cache **`fetchMethod`**, and **`clearCache`** clears the LRU (aborting in-flight work) and resets those snapshots. Sync helpers read **`configSnapshot`** instead of the old single cache field.
> 
> **`ServerSideKeyService`** only clarifies why enabling included access does not pre-fetch tier config anonymously (that would fill the wrong cache slot).
> 
> Tests add coverage for concurrent dedup, post-**`clearCache`** abort behavior, and snapshot reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5b14cddc0a93846ea0ac32728cfef025a76d3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->