### PR TITLE
[codex] allow github-actions review bot

### DIFF
--- a/.github/workflows/texra-code-review.yml
+++ b/.github/workflows/texra-code-review.yml
@@ -84,7 +84,7 @@ jobs:
           prompt-file: .trusted-review-prompt/.github/prompts/texra-code-review-prompt.md
           approval-policy: never
           require-write-access: 'true'
-          allow-bots: dependabot[bot]
+          allow-bots: dependabot[bot],github-actions[bot]
           model: ${{ vars.TEXRA_REVIEW_MODEL }}
           model-defaults: ${{ vars.TEXRA_REVIEW_MODEL_DEFAULTS }}
           texra-version: ${{ vars.TEXRA_CLI_VERSION }}


### PR DESCRIPTION
## Summary

Allow `github-actions[bot]` to run the TeXRA code-review action, matching the bot trust already used by other repository automation.

## Why

PR #6276 had green validate checks and approved reviews, but the TeXRA review job failed because Claude/GitHub Actions follow-up commits made the pull request actor `github-actions[bot]`. The action rejected that actor with:

`Actor github-actions[bot] bot actors are not allowed; add 'github-actions[bot]' to allow-bots to override.`

I had to push an empty human-authored commit only to retrigger the same checks. This change removes that unnecessary workaround for future bot-authored fix commits.

## Validation

- `node -e "... yaml.parse(...)"` against `.github/workflows/texra-code-review.yml`
- `git diff --check`

`actionlint` is not installed in this local environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow input change; slightly widens which bot actors may run the review action, with no changes to secrets, permissions, or review logic.
> 
> **Overview**
> Extends the TeXRA code-review workflow’s **`allow-bots`** list so **`github-actions[bot]`** is trusted alongside **`dependabot[bot]`**.
> 
> When follow-up commits on a PR are authored by GitHub Actions (e.g. automation fixes), the TeXRA review step no longer fails with a disallowed-actor error and no longer needs an empty human commit just to retrigger review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 160a5344c64d4e7bacce2bc1e878be7511f83915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->