### PR TITLE
[codex] inline multi-agent root selection

### DIFF
--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -491,12 +491,14 @@ function selectPresetRootAgent(
   const delegatingAgents = implicitDefaultToolUseAgents(agents).filter(
     agentHasDelegationTools,
   );
-  const preferredRoot = findPreferredRootAgent(
-    delegatingAgents,
-    options.presetSource,
-    options.presetOrder,
-  );
-  if (preferredRoot) return preferredRoot;
+  const searchOrder =
+    options.presetSource === 'built-in'
+      ? BUILTIN_TEAM_ROOT_AGENT_NAMES
+      : [...options.presetOrder, ...BUILTIN_TEAM_ROOT_AGENT_NAMES];
+  for (const name of searchOrder) {
+    const preferredRoot = delegatingAgents.find((agent) => agent.name === name);
+    if (preferredRoot) return preferredRoot;
+  }
 
   if (options.presetSource === 'built-in') {
     // Built-in teams have dedicated orchestrator roots. Local specialists such
@@ -505,22 +507,6 @@ function selectPresetRootAgent(
   }
 
   return delegatingAgents[0];
-}
-
-function findPreferredRootAgent(
-  agents: readonly AgentEntry[],
-  presetSource: CliMultiAgentPresetSource,
-  presetOrder: readonly string[],
-): AgentEntry | undefined {
-  const searchOrder =
-    presetSource === 'built-in'
-      ? BUILTIN_TEAM_ROOT_AGENT_NAMES
-      : [...presetOrder, ...BUILTIN_TEAM_ROOT_AGENT_NAMES];
-  for (const name of searchOrder) {
-    const entry = agents.find((agent) => agent.name === name);
-    if (entry) return entry;
-  }
-  return undefined;
 }
 
 function includeAgent(


### PR DESCRIPTION
## Summary
- inline the single-use multi-agent preferred-root resolver into `selectPresetRootAgent`
- keep the built-in team root ownership rule in the root selection code path
- remove one shallow helper without changing launcher behavior

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-refactor-20260620 orchestrate-launcher orchestrate-delegated-history team-status-empty-subagents-hidden`
- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm test`

## Dogfood
- `texra-local run correct --print --quiet --no-input --input - --instruction ... --output-format json --no-color` on a compactness proof; verified the workflow corrected grammar and preserved the math, with a clean compile after adding the required AMS package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with tests cited in the PR; root-selection rules are preserved, only code organization changes.
> 
> **Overview**
> **Refactors** how multi-agent presets pick a team root in `selectPresetRootAgent` by folding the old `findPreferredRootAgent` helper into that function and deleting the extra layer.
> 
> Preferred roots are still resolved by walking `BUILTIN_TEAM_ROOT_AGENT_NAMES` for built-in presets, or preset tool-use order plus builtins for custom presets, but only among agents that pass `implicitDefaultToolUseAgents` and have delegation tools. Built-in presets still return no fallback root when no preferred name matches; custom presets still fall back to the first delegating agent.
> 
> No intended behavior change for preset planning or team launch—this is structure-only cleanup in the root-selection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6054345ea3bddc3ae37d9076a4f46d210b8f4cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->