### PR TITLE
[codex] move launcher model gating to runtime

### DIFF
--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -8,60 +8,13 @@ import { wrapAnsiToWidth } from '../chat/tui/render/ansiWrap';
 import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import { formatCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
 import {
-  modelAccessLaunchBlockDescriptionForCliMode,
-  modelSelectItemsForCliMode,
-  type CliModelAccess,
-  type CliModelPickerItem,
-} from '../runtime/modelAccess';
-import type {
-  CliOrchestrationAction,
-  CliOrchestrationItem,
+  isCliOrchestrationModelPickAction,
+  orchestrationModelAccessView,
+  type CliOrchestrationAction,
+  type CliOrchestrationItem,
+  type CliOrchestrationModelPickAction,
 } from '../runtime/orchestration';
-
-/** Launcher items that chain into a model pick before launching the chat. */
-type ModelPickAction = Extract<
-  CliOrchestrationAction,
-  { kind: 'chat' | 'preset' }
->;
-
-function isModelPickAction(
-  action: CliOrchestrationAction,
-): action is ModelPickAction {
-  return action.kind === 'chat' || action.kind === 'preset';
-}
-
-export function orchestrationModelAccessView(
-  items: readonly CliOrchestrationItem[],
-  models: readonly CliModelAccess[],
-  apiMode: CliApiMode,
-  options: {
-    readonly allowDefaultModelLaunch?: boolean;
-  } = {},
-): {
-  readonly items: readonly CliOrchestrationItem[];
-  readonly modelItems: readonly CliModelPickerItem[];
-} {
-  const modelItems = modelSelectItemsForCliMode(models, apiMode);
-  if (
-    models.length === 0 ||
-    modelItems.length > 0 ||
-    options.allowDefaultModelLaunch === true
-  ) {
-    return { items, modelItems };
-  }
-
-  const description = modelAccessLaunchBlockDescriptionForCliMode(
-    models,
-    apiMode,
-  );
-  return {
-    modelItems,
-    items: items.map((item) => {
-      if (!isModelPickAction(item.value) || item.disabled) return item;
-      return { ...item, description, disabled: true };
-    }),
-  };
-}
+import type { CliModelAccess } from '../runtime/modelAccess';
 
 export interface OrchestrationAppProps {
   readonly items: readonly CliOrchestrationItem[];
@@ -146,9 +99,9 @@ export function OrchestrationApp(
   const statusLines = props.statusLines ?? [];
   // When set, the launcher is on its second step: choosing the model for this
   // chat/team. Esc returns to the item list rather than exiting.
-  const [pending, setPending] = useState<ModelPickAction | undefined>(
-    undefined,
-  );
+  const [pending, setPending] = useState<
+    CliOrchestrationModelPickAction | undefined
+  >(undefined);
   const footerHints = pending ? [] : listFooterHints;
   const textColumns = Math.max(1, columns - 2);
   const maxVisibleItems = Math.max(
@@ -165,7 +118,7 @@ export function OrchestrationApp(
   };
 
   const onItemSelect = (action: CliOrchestrationAction): void => {
-    if (isModelPickAction(action) && modelItems.length > 0) {
+    if (isCliOrchestrationModelPickAction(action) && modelItems.length > 0) {
       setPending(action);
     } else {
       finish(action);

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -22,6 +22,13 @@ import {
   userStartedCliHistoryEntries,
   type CliHistoryEntry,
 } from './history';
+import {
+  modelAccessLaunchBlockDescriptionForCliMode,
+  modelSelectItemsForCliMode,
+  type CliModelAccess,
+  type CliModelPickerItem,
+} from './modelAccess';
+import type { CliApiMode } from './apiAccessMode';
 
 export type CliOrchestrationAction =
   | { readonly kind: 'chat'; readonly agent?: string; readonly model?: string }
@@ -36,6 +43,12 @@ export type CliOrchestrationAction =
   | { readonly kind: 'help' }
   | { readonly kind: 'exit' };
 
+/** Launcher items that chain into a model pick before launching the chat. */
+export type CliOrchestrationModelPickAction = Extract<
+  CliOrchestrationAction,
+  { kind: 'chat' | 'preset' }
+>;
+
 export interface CliOrchestrationItem {
   readonly value: CliOrchestrationAction;
   readonly label: string;
@@ -49,6 +62,47 @@ export interface BuildCliOrchestrationItemsInput {
   readonly history: readonly CliHistoryEntry[];
   readonly toolUseAgents: readonly AgentEntry[];
   readonly includeMultiAgentLoginHint?: boolean;
+}
+
+export function isCliOrchestrationModelPickAction(
+  action: CliOrchestrationAction,
+): action is CliOrchestrationModelPickAction {
+  return action.kind === 'chat' || action.kind === 'preset';
+}
+
+export function orchestrationModelAccessView(
+  items: readonly CliOrchestrationItem[],
+  models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
+  options: {
+    readonly allowDefaultModelLaunch?: boolean;
+  } = {},
+): {
+  readonly items: readonly CliOrchestrationItem[];
+  readonly modelItems: readonly CliModelPickerItem[];
+} {
+  const modelItems = modelSelectItemsForCliMode(models, apiMode);
+  if (
+    models.length === 0 ||
+    modelItems.length > 0 ||
+    options.allowDefaultModelLaunch === true
+  ) {
+    return { items, modelItems };
+  }
+
+  const description = modelAccessLaunchBlockDescriptionForCliMode(
+    models,
+    apiMode,
+  );
+  return {
+    modelItems,
+    items: items.map((item) => {
+      if (!isCliOrchestrationModelPickAction(item.value) || item.disabled) {
+        return item;
+      }
+      return { ...item, description, disabled: true };
+    }),
+  };
 }
 
 const MAX_RECENT_RESUME_ITEMS = 3;

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -6,10 +6,12 @@ import {
   orchestrationBlockRowCost,
   orchestrationFooterHints,
   orchestrationKeyHints,
-  orchestrationModelAccessView,
   orchestrationWrappedLineRows,
 } from '@cli/orchestration/runOrchestrationTui';
-import { buildCliOrchestrationItems } from '@cli/runtime/orchestration';
+import {
+  buildCliOrchestrationItems,
+  orchestrationModelAccessView,
+} from '@cli/runtime/orchestration';
 
 import {
   CLI_HISTORY_RESUMABLE_STATUS,


### PR DESCRIPTION
## Summary

- Moves launcher model-access gating from the Ink orchestration component into the CLI runtime orchestration module.
- Exports the model-pick action guard from runtime so UI code only decides presentation state.
- Updates orchestration tests to cover the runtime-owned helper directly.

## Design issue

The launcher UI was applying launch policy by importing model-access helpers and disabling orchestration actions itself. That mixed runtime launch eligibility with Ink rendering state, increasing coupling and making the component harder to reuse or test without UI concerns.

The runtime now owns the derived launch view, while `runOrchestrationTui.tsx` consumes the view and handles only interaction/rendering state.

Closes #6285.

## Validation

- `npm run format -- packages/cli/src/orchestration/runOrchestrationTui.tsx packages/cli/src/runtime/orchestration.ts src/test-kernel/cli/Orchestration.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/cli/Orchestration.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-model-access-runtime-20260620 orchestrate-launcher compact-orchestrate-launcher`
- `npm run compile:fast`
- `npm run lint`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no launch-policy logic changes; tests and TUI snapshots were run to validate parity.
> 
> **Overview**
> **Launcher model-access gating** moves out of the Ink orchestration TUI into `packages/cli/src/runtime/orchestration.ts`, so launch eligibility (disabled chat/team rows, model picker items, block descriptions) lives with other orchestration logic instead of inside the UI layer.
> 
> The TUI now imports `orchestrationModelAccessView`, `isCliOrchestrationModelPickAction`, and the exported `CliOrchestrationModelPickAction` type from runtime and only handles presentation (pending model step, `Select`, key hints). Behavior is unchanged; tests import `orchestrationModelAccessView` from `@cli/runtime/orchestration` instead of the TUI module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d62e377ec084be0532a10eec1f1448127fd7fdfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->