### PR TITLE
[codex] centralize CLI model override state

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -61,6 +61,7 @@ import {
   cliState,
   patchStream,
   resetCliState,
+  setCliSessionModelOverride,
   setParentStream,
   type ConversationEntry,
 } from '../src/chat/tui/state/cliState';
@@ -1572,7 +1573,7 @@ registerBuiltinSlashCommands({
   getApprovalPolicy: () => harnessApprovalPolicy,
   onApprovalPolicySelect: setHarnessApprovalPolicy,
   onModelSelect: (model) => {
-    cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), model });
+    setCliSessionModelOverride(model);
     appendHarnessAssistantTranscript(
       `Harness model selected. Future turns: ${model}.`,
     );

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -13,7 +13,7 @@ import { ModelListForm } from '../forms/ModelListForm';
 import { ResumeListForm } from '../forms/ResumeListForm';
 import { SkillsListForm, type SkillActivation } from '../forms/SkillsListForm';
 import { ToolsListForm } from '../forms/ToolsListForm';
-import { cliState } from '../state/cliState';
+import { cliState, setCliSessionModelOverride } from '../state/cliState';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
 
 type AgentSelectHandler = (value: string) => void | Promise<void>;
@@ -27,18 +27,6 @@ type ResumeSelectHandler = (id: ExecutionId) => void | Promise<void>;
 type SkillSelectHandler = (value: SkillActivation) => void | Promise<void>;
 type ErrorHandler = (error: unknown) => void | Promise<void>;
 type SelectionCompletion = 'afterAction' | 'beforeAction';
-
-function patchSessionMeta<K extends 'agent' | 'model' | 'apiMode'>(
-  key: K,
-  value: K extends 'apiMode' ? CliApiMode : string,
-): void {
-  const meta = cliState.sessionMeta.get();
-  cliState.sessionMeta.set({
-    ...meta,
-    [key]: value,
-    ...(key === 'model' ? { modelSource: 'override' } : {}),
-  });
-}
 
 /** Run a form selection handler with consistent completion and error routing. */
 function runFormSelection<T>({
@@ -90,11 +78,17 @@ export function registerBuiltinSlashCommands(options?: {
   onError?: ErrorHandler;
 }): void {
   const onAgentSelect: AgentSelectHandler =
-    options?.onAgentSelect ?? ((value) => patchSessionMeta('agent', value));
+    options?.onAgentSelect ??
+    ((agent) => {
+      cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), agent });
+    });
   const onModelSelect: ModelSelectHandler =
-    options?.onModelSelect ?? ((value) => patchSessionMeta('model', value));
+    options?.onModelSelect ?? setCliSessionModelOverride;
   const onApiModeSelect: ApiModeSelectHandler =
-    options?.onApiModeSelect ?? ((value) => patchSessionMeta('apiMode', value));
+    options?.onApiModeSelect ??
+    ((apiMode) => {
+      cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), apiMode });
+    });
   const canSelectAgent = options?.canSelectAgent ?? (() => true);
   const canSelectModel = options?.canSelectModel ?? (() => true);
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -140,7 +140,12 @@ import {
 } from './render/noColorOutput';
 import { formatCliSessionStatus } from './sessionStatus';
 import { clearApprovals } from './state/approvalQueue';
-import { cliState, patchStream, resetCliState } from './state/cliState';
+import {
+  cliState,
+  patchStream,
+  resetCliState,
+  setCliSessionModelOverride,
+} from './state/cliState';
 import {
   focusedChildFollowUpRoute,
   stoppedFocusedChildFollowUpMessage as focusedChildStoppedMessage,
@@ -544,11 +549,7 @@ async function applyCliModelSelection(
   if (chatTuiCanStartRootRun(context.session)) {
     try {
       await setCliHelperModel(nextModel);
-      cliState.sessionMeta.set({
-        ...cliState.sessionMeta.get(),
-        model: nextModel,
-        modelSource: 'override',
-      });
+      setCliSessionModelOverride(nextModel);
       appendLocalAssistantTranscript(`Root model set to ${nextModel}.`);
     } catch (error: unknown) {
       appendLocalAssistantTranscript(toErrorMessage(error));
@@ -575,11 +576,7 @@ async function applyCliModelSelection(
 
   try {
     await activeFlow.switchModel(nextModel);
-    cliState.sessionMeta.set({
-      ...cliState.sessionMeta.get(),
-      model: nextModel,
-      modelSource: 'override',
-    });
+    setCliSessionModelOverride(nextModel);
   } catch (error: unknown) {
     appendLocalAssistantTranscript(toErrorMessage(error));
     return;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -220,6 +220,14 @@ export const cliState = {
   >,
 };
 
+export function setCliSessionModelOverride(model: string): void {
+  cliState.sessionMeta.set({
+    ...cliState.sessionMeta.get(),
+    model,
+    modelSource: 'override',
+  });
+}
+
 export const NO_BYPASS: BypassState = {
   bash: false,
   toolEdit: false,


### PR DESCRIPTION
## Summary

Closes #6289.

- moves the `model` + `modelSource: override` invariant into the CLI TUI state layer
- removes the generic conditional session-meta patcher from the slash-command registry
- makes the PTY TUI harness use the same model override state operation as the real `/model` path

## Why

The harness was patching `model` directly while the product path also updates `modelSource`. That let TUI validation exercise a state shape users do not get from real `/model` selection, weakening long-running CLI dogfood evidence.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/chat/tui/state/cliState.ts packages/cli/src/chat/tui/commands/registerBuiltins.tsx packages/cli/src/chat/tui/runChatTui.tsx packages/cli/scripts/tui-harness.tsx`
- `corepack pnpm vitest run src/test-kernel/cli/SlashRegistry.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-harness-model-source-20260620 model-form-selectable-submit model-form-buffered-hotkey`
- `npm run compile:fast`
- `npm run lint`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor of TUI session metadata with no auth or runtime behavior changes beyond consistent `modelSource` tagging.
> 
> **Overview**
> Introduces **`setCliSessionModelOverride`** in `cliState` so every user-driven model pick sets **`model`** and **`modelSource: 'override'`** together.
> 
> The slash-command registry no longer uses a generic **`patchSessionMeta`** helper; default **`/model`** handling and **`applyCliModelSelection`** in **`runChatTui`** call the shared helper. The TUI harness’s model picker does the same, so validation matches real **`/model`** behavior instead of updating **`model`** alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d4781c7fb193ab5ae2b70a4b66d43bf88289eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->