### PR TITLE
[codex] move CLI launch behavior into runtime

### DIFF
--- a/docs/architecture/cli-runtime-round-trips.md
+++ b/docs/architecture/cli-runtime-round-trips.md
@@ -14,7 +14,7 @@ flowchart TD
   onboarding[onboarding maybeRunCliOnboarding]
   history[runtime/history listCliHistoryEntries]
   presets[runtime/multiAgentPresets readCliMultiAgentPresets]
-  plans[commands/multiAgent loadCliMultiAgentPresetPlans]
+  plans[runtime/multiAgentRunPlan loadCliMultiAgentPresetPlanSet]
   agentsLocal[agentRegistry loadAgents includeRemote false]
   auth[supabaseAuth isAuthenticated]
   agentsRemote[agentRegistry loadAgents includeRemote true]
@@ -24,7 +24,7 @@ flowchart TD
   defaultModel[resolveChatDefaults + resolveCliRunnableModel]
   picker[orchestration/runOrchestrationTui]
   chat[chat/tui/runChatTui runChat]
-  presetRun[commands/multiAgent loadCliMultiAgentRunPlan]
+  presetRun[runtime/multiAgentRunPlan loadCliMultiAgentRunPlan]
 
   user --> orch
   orch --> platform
@@ -57,7 +57,7 @@ Current ownership:
   `commands/orchestrate.ts` and `chat/tui/runChatTui.tsx`.
   The launcher can run onboarding, then a selected chat runs the same gate again.
 - Team availability:
-  `commands/multiAgent.ts` plus `runtime/multiAgentPresets.ts`.
+  `runtime/multiAgentRunPlan.ts` plus `runtime/multiAgentPresets.ts`.
   List, inspect, and run all use the same planner, but launch replans after selection.
 - Agent registry load scope:
   `agentRegistry.loadAgents()` call sites.

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -1,6 +1,5 @@
 import { defineCommand } from 'citty';
 
-import { getAgentsByCategory, loadAgents } from '@agent/index';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
@@ -27,21 +26,21 @@ import {
   formatCliMultiAgentPresetDetails,
   formatCliMultiAgentPresetInspection,
   formatCliMultiAgentPresetList,
-  formatCliMultiAgentPresetRunWarnings,
-  planCliMultiAgentPresets,
-  planCliMultiAgentPresetRun,
   readCliMultiAgentPresets,
   withCliMultiAgentPresetVisibility,
   MULTI_AGENT_TEAM_ROOT_AGENT_DESCRIPTION,
   MULTI_AGENT_TEAM_ROOT_MODEL_DESCRIPTION,
-  type CliMultiAgentPreset,
   type CliMultiAgentPresetRunPlan,
 } from '../runtime/multiAgentPresets';
+import {
+  loadCliMultiAgentPresetPlanSet,
+  loadCliMultiAgentRunPlan,
+  writeMissingPresetAgents,
+} from '../runtime/multiAgentRunPlan';
 import {
   buildHeadlessRunContext,
   resolveCliRunModel,
 } from '../runtime/runModel';
-import { getCliAuthProvider } from '../runtime/supabaseAuth';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { withUsageSections } from './_helpers/dispatch/usage';
@@ -74,112 +73,8 @@ interface MultiAgentRunInit {
   readonly instructionFile?: string;
 }
 
-interface RemoteAgentPlanReloadResult<T> {
-  readonly value: T;
-  readonly remoteAgentLoadAttempted: boolean;
-}
-
-export interface MultiAgentRunPlanLoadResult {
-  readonly plan: CliMultiAgentPresetRunPlan;
-  readonly remoteAgentLoadAttempted: boolean;
-}
-
-export interface MultiAgentPresetPlansLoadResult {
-  readonly plans: readonly CliMultiAgentPresetRunPlan[];
-  readonly remoteAgentLoadAttempted: boolean;
-}
-
 const MULTI_AGENT_TASK_REQUIRED_MESSAGE =
   'Provide --input, --instruction, or --instruction-file for the team task. Example: texra multi-agent run physicist --instruction "Check this derivation"';
-
-function planCurrentMultiAgentRun(
-  init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
-): CliMultiAgentPresetRunPlan {
-  const preset = findCliMultiAgentPreset(
-    readCliMultiAgentPresets(),
-    init.preset,
-  );
-  if (!preset) {
-    throw new CliUsageError(missingMultiAgentPresetMessage(init.preset));
-  }
-  return planCliMultiAgentPresetRun(preset, {
-    workflowAgents: getAgentsByCategory(AgentCategory.Workflow),
-    toolUseAgents: getAgentsByCategory(AgentCategory.ToolUse),
-    agentOverride: init.agent,
-  });
-}
-
-function planLoadedCliMultiAgentPresets(
-  presets: readonly CliMultiAgentPreset[],
-): CliMultiAgentPresetRunPlan[] {
-  return planCliMultiAgentPresets(presets, {
-    workflowAgents: getAgentsByCategory(AgentCategory.Workflow),
-    toolUseAgents: getAgentsByCategory(AgentCategory.ToolUse),
-  });
-}
-
-/**
- * Resolve a preset plan, then — when it still has gaps and the user is
- * authenticated — perform a remote load and replan. Relay-served premium agents
- * (the team orchestrator and delegation specialists most presets name) are only
- * visible after a remote load. Until then, built-in presets report no runnable
- * root instead of promoting a local specialist; custom presets can still use
- * their own delegating member root. Both the headless `multi-agent run` path and
- * the interactive `orchestrate` menu route through here so they can't drift
- * apart again.
- *
- * Owns the local agent registry load (`loadAgents({ includeRemote: false })`)
- * before planning, so callers no longer need to pre-load local agents.
- */
-export async function loadCliMultiAgentRunPlan(
-  init: Pick<MultiAgentRunInit, 'preset' | 'agent'>,
-): Promise<MultiAgentRunPlanLoadResult> {
-  await loadAgents({ includeRemote: false });
-  const result = await reloadRemoteAgentsForGaps(
-    planCurrentMultiAgentRun(init),
-    cliMultiAgentPlanHasGaps,
-    () => planCurrentMultiAgentRun(init),
-  );
-  return {
-    plan: result.value,
-    remoteAgentLoadAttempted: result.remoteAgentLoadAttempted,
-  };
-}
-
-export async function loadCliMultiAgentPresetPlanSet(
-  presets: readonly CliMultiAgentPreset[],
-): Promise<MultiAgentPresetPlansLoadResult> {
-  await loadAgents({ includeRemote: false });
-  const result = await reloadRemoteAgentsForGaps(
-    planLoadedCliMultiAgentPresets(presets),
-    (plans) => plans.some(cliMultiAgentPlanHasGaps),
-    () => planLoadedCliMultiAgentPresets(presets),
-  );
-  return {
-    plans: result.value,
-    remoteAgentLoadAttempted: result.remoteAgentLoadAttempted,
-  };
-}
-
-async function reloadRemoteAgentsForGaps<T>(
-  value: T,
-  hasGaps: (value: T) => boolean,
-  replan: () => T,
-): Promise<RemoteAgentPlanReloadResult<T>> {
-  if (hasGaps(value) && (await getCliAuthProvider().isAuthenticated())) {
-    await loadAgents();
-    return { value: replan(), remoteAgentLoadAttempted: true };
-  }
-  return { value, remoteAgentLoadAttempted: false };
-}
-
-export function writeMissingPresetAgents(
-  plan: CliMultiAgentPresetRunPlan,
-): void {
-  for (const warning of formatCliMultiAgentPresetRunWarnings(plan)) {
-    writeTextStderr(warning);
-  }
-}
 
 function writeMultiAgentRunResult(
   context: CliContext,

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -20,6 +20,11 @@ import {
   readCliMultiAgentPresets,
   withCliMultiAgentPresetVisibility,
 } from '../runtime/multiAgentPresets';
+import {
+  loadCliMultiAgentRunPlan,
+  loadCliMultiAgentPresetPlanSet,
+  writeMissingPresetAgents,
+} from '../runtime/multiAgentRunPlan';
 import { buildCliOrchestrationItems } from '../runtime/orchestration';
 import {
   getCliModelAccessList,
@@ -38,12 +43,7 @@ import {
   INTERACTIVE_AGENT_GLOBAL_ARGS,
   rejectHeadlessOnlyFlags,
 } from './_helpers/globalArgs';
-import {
-  loadCliMultiAgentRunPlan,
-  loadCliMultiAgentPresetPlanSet,
-  writeMissingPresetAgents,
-} from './multiAgent';
-import { runResumeExecution } from './resume';
+import { runResumeExecution } from '../runtime/resumeExecution';
 import type { CliContext } from '../runtime/cliContext';
 
 async function canLaunchWithDefaultModel(

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -1,19 +1,9 @@
 import { defineCommand } from 'citty';
-import type { ExecutionId } from '@shared/schemas';
 
 import { CliExitCode } from '../runtime/exitCodes';
 import { parseCliHistoryId } from '../runtime/history';
-import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
-import {
-  explainNonResumable,
-  resolveCliResumeSnapshot,
-} from '../runtime/sessionResume';
-import { formatResumeCommand } from '../chat/tui/state/resumeHint';
-import {
-  formatInteractiveTerminalFailure,
-  interactiveTerminalFailure,
-} from '../runtime/terminalRequirements';
+import { runResumeExecution } from '../runtime/resumeExecution';
 
 import { contextFromArgs } from './_helpers/context';
 import { setExitCode } from './_helpers/exitCode';
@@ -21,69 +11,6 @@ import {
   INTERACTIVE_GLOBAL_ARGS,
   rejectHeadlessOnlyFlags,
 } from './_helpers/globalArgs';
-
-import type { CliContext } from '../runtime/cliContext';
-
-/**
- * `texra resume <id>` continues (resumes) a stored tool-use session by
- * reopening the interactive chat TUI, which rehydrates the prior transcript and
- * continues the suspended flow.
- *
- * Resume is interactive by nature: a resumed tool-use session returns to
- * WAITING for the user's next message, so there is no meaningful non-interactive
- * continuation without an input channel — a headless run would simply block at
- * the WAIT node. Headless callers are therefore pointed at `texra run`.
- */
-export async function runResumeExecution(
-  context: CliContext,
-  id: ExecutionId,
-): Promise<number> {
-  const terminalFailure = interactiveTerminalFailure(context);
-  if (terminalFailure) {
-    const commandName = context.commandName || 'texra';
-    const runCommand = `${commandName} run`;
-    // A resumed tool-use session goes back to WAITING for the next message;
-    // headless has no input channel to provide one, so continuing here would
-    // block forever. Reject before platform/snapshot work; no terminal means no
-    // interactive resume regardless of whether the id is otherwise resumable.
-    writeTextStderr(
-      formatInteractiveTerminalFailure(terminalFailure, {
-        headlessMessage: `Resuming continues an interactive chat session — run \`${formatResumeCommand(
-          commandName,
-          id,
-          { approvalPolicy: context.approvalPolicy },
-        )}\` in a terminal. For scripting, use \`${runCommand}\`.`,
-        dumbTerminalCommand: 'resume',
-        dumbTerminalOptions: {
-          commandName,
-          nonInteractiveFallback: `\`${runCommand}\``,
-        },
-      }),
-    );
-    return CliExitCode.Usage;
-  }
-
-  await initCliPlatform({ ...context, quietLogs: true });
-
-  // Resolve the stored session up front so we (a) fail fast with a clear
-  // message for non-resumable ids (workflow / missing / no live snapshot) and
-  // (b) reopen the TUI on the SAVED model/agent rather than the current chat
-  // defaults — those could be unavailable while the saved model is still
-  // runnable, which would otherwise fail resume for the wrong reason.
-  const resolution = await resolveCliResumeSnapshot(id);
-  if (resolution.kind !== 'toolUse') {
-    writeTextStderr(explainNonResumable(resolution, id));
-    return resolution.kind === 'load-failed'
-      ? CliExitCode.AgentError
-      : CliExitCode.Usage;
-  }
-
-  const { runChat } = await import('../chat/tui/runChatTui');
-  const result = await runChat(context, {
-    initialResume: { id, resolution },
-  });
-  return result.exitCode;
-}
 
 export const resumeCommand = defineCommand({
   meta: {

--- a/packages/cli/src/runtime/multiAgentRunPlan.ts
+++ b/packages/cli/src/runtime/multiAgentRunPlan.ts
@@ -1,0 +1,120 @@
+import { getAgentsByCategory, loadAgents } from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+
+import { missingMultiAgentPresetMessage } from './agents';
+import { CliUsageError } from './cliContext';
+import { writeTextStderr } from './logSinks';
+import {
+  cliMultiAgentPlanHasGaps,
+  findCliMultiAgentPreset,
+  formatCliMultiAgentPresetRunWarnings,
+  planCliMultiAgentPresetRun,
+  planCliMultiAgentPresets,
+  readCliMultiAgentPresets,
+  type CliMultiAgentPreset,
+  type CliMultiAgentPresetRunPlan,
+} from './multiAgentPresets';
+import { getCliAuthProvider } from './supabaseAuth';
+
+interface MultiAgentRunPlanInit {
+  readonly preset: string;
+  readonly agent?: string;
+}
+
+interface RemoteAgentPlanReloadResult<T> {
+  readonly value: T;
+  readonly remoteAgentLoadAttempted: boolean;
+}
+
+export interface MultiAgentRunPlanLoadResult {
+  readonly plan: CliMultiAgentPresetRunPlan;
+  readonly remoteAgentLoadAttempted: boolean;
+}
+
+export interface MultiAgentPresetPlansLoadResult {
+  readonly plans: readonly CliMultiAgentPresetRunPlan[];
+  readonly remoteAgentLoadAttempted: boolean;
+}
+
+function planCurrentMultiAgentRun(
+  init: MultiAgentRunPlanInit,
+): CliMultiAgentPresetRunPlan {
+  const preset = findCliMultiAgentPreset(
+    readCliMultiAgentPresets(),
+    init.preset,
+  );
+  if (!preset) {
+    throw new CliUsageError(missingMultiAgentPresetMessage(init.preset));
+  }
+  return planCliMultiAgentPresetRun(preset, {
+    workflowAgents: getAgentsByCategory(AgentCategory.Workflow),
+    toolUseAgents: getAgentsByCategory(AgentCategory.ToolUse),
+    agentOverride: init.agent,
+  });
+}
+
+function planLoadedCliMultiAgentPresets(
+  presets: readonly CliMultiAgentPreset[],
+): CliMultiAgentPresetRunPlan[] {
+  return planCliMultiAgentPresets(presets, {
+    workflowAgents: getAgentsByCategory(AgentCategory.Workflow),
+    toolUseAgents: getAgentsByCategory(AgentCategory.ToolUse),
+  });
+}
+
+/**
+ * Resolve a preset plan, then when it still has gaps and the user is
+ * authenticated, perform a remote load and replan. Relay-served premium agents
+ * are only visible after a remote load. Both headless `multi-agent run` and the
+ * interactive `orchestrate` menu route through this runtime helper so command
+ * entrypoints cannot drift.
+ */
+export async function loadCliMultiAgentRunPlan(
+  init: MultiAgentRunPlanInit,
+): Promise<MultiAgentRunPlanLoadResult> {
+  await loadAgents({ includeRemote: false });
+  const result = await reloadRemoteAgentsForGaps(
+    planCurrentMultiAgentRun(init),
+    cliMultiAgentPlanHasGaps,
+    () => planCurrentMultiAgentRun(init),
+  );
+  return {
+    plan: result.value,
+    remoteAgentLoadAttempted: result.remoteAgentLoadAttempted,
+  };
+}
+
+export async function loadCliMultiAgentPresetPlanSet(
+  presets: readonly CliMultiAgentPreset[],
+): Promise<MultiAgentPresetPlansLoadResult> {
+  await loadAgents({ includeRemote: false });
+  const result = await reloadRemoteAgentsForGaps(
+    planLoadedCliMultiAgentPresets(presets),
+    (plans) => plans.some(cliMultiAgentPlanHasGaps),
+    () => planLoadedCliMultiAgentPresets(presets),
+  );
+  return {
+    plans: result.value,
+    remoteAgentLoadAttempted: result.remoteAgentLoadAttempted,
+  };
+}
+
+async function reloadRemoteAgentsForGaps<T>(
+  value: T,
+  hasGaps: (value: T) => boolean,
+  replan: () => T,
+): Promise<RemoteAgentPlanReloadResult<T>> {
+  if (hasGaps(value) && (await getCliAuthProvider().isAuthenticated())) {
+    await loadAgents();
+    return { value: replan(), remoteAgentLoadAttempted: true };
+  }
+  return { value, remoteAgentLoadAttempted: false };
+}
+
+export function writeMissingPresetAgents(
+  plan: CliMultiAgentPresetRunPlan,
+): void {
+  for (const warning of formatCliMultiAgentPresetRunWarnings(plan)) {
+    writeTextStderr(warning);
+  }
+}

--- a/packages/cli/src/runtime/resumeExecution.ts
+++ b/packages/cli/src/runtime/resumeExecution.ts
@@ -1,0 +1,60 @@
+import type { ExecutionId } from '@shared/schemas';
+
+import { formatResumeCommand } from '../chat/tui/state/resumeHint';
+import { CliExitCode } from './exitCodes';
+import { initCliPlatform } from './initPlatform';
+import { writeTextStderr } from './logSinks';
+import { explainNonResumable, resolveCliResumeSnapshot } from './sessionResume';
+import {
+  formatInteractiveTerminalFailure,
+  interactiveTerminalFailure,
+} from './terminalRequirements';
+import type { CliContext } from './cliContext';
+
+/**
+ * Continue a stored tool-use session by reopening the interactive chat TUI.
+ * Resume is interactive by nature: a resumed session returns to WAITING for
+ * the user's next message, so headless callers are rejected before snapshot
+ * loading.
+ */
+export async function runResumeExecution(
+  context: CliContext,
+  id: ExecutionId,
+): Promise<number> {
+  const terminalFailure = interactiveTerminalFailure(context);
+  if (terminalFailure) {
+    const commandName = context.commandName || 'texra';
+    const runCommand = `${commandName} run`;
+    writeTextStderr(
+      formatInteractiveTerminalFailure(terminalFailure, {
+        headlessMessage: `Resuming continues an interactive chat session — run \`${formatResumeCommand(
+          commandName,
+          id,
+          { approvalPolicy: context.approvalPolicy },
+        )}\` in a terminal. For scripting, use \`${runCommand}\`.`,
+        dumbTerminalCommand: 'resume',
+        dumbTerminalOptions: {
+          commandName,
+          nonInteractiveFallback: `\`${runCommand}\``,
+        },
+      }),
+    );
+    return CliExitCode.Usage;
+  }
+
+  await initCliPlatform({ ...context, quietLogs: true });
+
+  const resolution = await resolveCliResumeSnapshot(id);
+  if (resolution.kind !== 'toolUse') {
+    writeTextStderr(explainNonResumable(resolution, id));
+    return resolution.kind === 'load-failed'
+      ? CliExitCode.AgentError
+      : CliExitCode.Usage;
+  }
+
+  const { runChat } = await import('../chat/tui/runChatTui');
+  const result = await runChat(context, {
+    initialResume: { id, resolution },
+  });
+  return result.exitCode;
+}

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -259,7 +259,7 @@ describe('CLI multi-agent run command', () => {
 
   it('marks run-plan resolution when authenticated gaps triggered a remote load', async () => {
     const { loadCliMultiAgentRunPlan } =
-      await import('@cli/commands/multiAgent');
+      await import('@cli/runtime/multiAgentRunPlan');
     mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
     mocks.isAuthenticated.mockResolvedValueOnce(true);
 
@@ -279,7 +279,7 @@ describe('CLI multi-agent run command', () => {
 
   it('does not mark run-plan resolution when unauthenticated gaps stay local-only', async () => {
     const { loadCliMultiAgentRunPlan } =
-      await import('@cli/commands/multiAgent');
+      await import('@cli/runtime/multiAgentRunPlan');
     mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
     mocks.isAuthenticated.mockResolvedValueOnce(false);
 
@@ -295,7 +295,7 @@ describe('CLI multi-agent run command', () => {
 
   it('marks preset-list resolution when authenticated gaps triggered a remote load', async () => {
     const { loadCliMultiAgentPresetPlanSet } =
-      await import('@cli/commands/multiAgent');
+      await import('@cli/runtime/multiAgentRunPlan');
     mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
     mocks.isAuthenticated.mockResolvedValueOnce(true);
 

--- a/src/test-kernel/cli/ResumeCommand.vitest.mts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.mts
@@ -70,7 +70,7 @@ describe('runResumeExecution', () => {
   it('uses the CLI context TTY snapshot before reopening chat', async () => {
     const resolution = resumableResolution();
     mocks.resolveCliResumeSnapshot.mockResolvedValueOnce(resolution);
-    const { runResumeExecution } = await import('@cli/commands/resume');
+    const { runResumeExecution } = await import('@cli/runtime/resumeExecution');
 
     await expect(
       runResumeExecution(cliContext({ stdoutIsTty: true }), EXECUTION_ID),
@@ -89,7 +89,7 @@ describe('runResumeExecution', () => {
   });
 
   it('rejects resume when the context says stdout is not a TTY', async () => {
-    const { runResumeExecution } = await import('@cli/commands/resume');
+    const { runResumeExecution } = await import('@cli/runtime/resumeExecution');
 
     await expect(
       runResumeExecution(cliContext({ stdoutIsTty: false }), EXECUTION_ID),
@@ -107,7 +107,7 @@ describe('runResumeExecution', () => {
   });
 
   it('uses the local launcher in headless resume guidance', async () => {
-    const { runResumeExecution } = await import('@cli/commands/resume');
+    const { runResumeExecution } = await import('@cli/runtime/resumeExecution');
 
     await expect(
       runResumeExecution(
@@ -125,7 +125,7 @@ describe('runResumeExecution', () => {
   });
 
   it('rejects resume in dumb terminals before falling through to chat', async () => {
-    const { runResumeExecution } = await import('@cli/commands/resume');
+    const { runResumeExecution } = await import('@cli/runtime/resumeExecution');
 
     await expect(
       runResumeExecution(cliContext({ termIsDumb: true }), EXECUTION_ID),
@@ -140,7 +140,7 @@ describe('runResumeExecution', () => {
   });
 
   it('uses the local launcher in dumb-terminal resume guidance', async () => {
-    const { runResumeExecution } = await import('@cli/commands/resume');
+    const { runResumeExecution } = await import('@cli/runtime/resumeExecution');
 
     await expect(
       runResumeExecution(
@@ -162,7 +162,7 @@ describe('runResumeExecution', () => {
     mocks.explainNonResumable.mockReturnValue(
       `Failed to load resumable session ${EXECUTION_ID}: KV timeout`,
     );
-    const { runResumeExecution } = await import('@cli/commands/resume');
+    const { runResumeExecution } = await import('@cli/runtime/resumeExecution');
 
     await expect(
       runResumeExecution(cliContext({ stdoutIsTty: true }), EXECUTION_ID),


### PR DESCRIPTION
## Summary

- Move multi-agent run-plan loading and missing-agent warning output from `commands/multiAgent.ts` into `runtime/multiAgentRunPlan.ts`.
- Move reusable resume execution flow from `commands/resume.ts` into `runtime/resumeExecution.ts`.
- Update `orchestrate`, `multi-agent`, and `resume` commands to depend on runtime helpers instead of sibling command modules.
- Update focused CLI tests to import the reusable behavior from the runtime layer.
- Refresh `docs/architecture/cli-runtime-round-trips.md` ownership labels for the moved runtime helpers.

Closes #6293.

Follow-up abstraction issues from the same review: #6294 and #6295.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/runtime/multiAgentRunPlan.ts packages/cli/src/runtime/resumeExecution.ts packages/cli/src/commands/multiAgent.ts packages/cli/src/commands/orchestrate.ts packages/cli/src/commands/resume.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/ResumeCommand.vitest.mts`
- `corepack pnpm exec prettier --check docs/architecture/cli-runtime-round-trips.md`
- `corepack pnpm exec vitest run src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/ResumeCommand.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving module moves with existing tests retargeted; no new launch semantics.
> 
> **Overview**
> **Moves reusable CLI launch behavior out of command modules** so `orchestrate`, `multi-agent`, and `resume` share one implementation instead of importing sibling commands.
> 
> Multi-agent **run-plan loading** (local agent registry, authenticated remote reload when plans have gaps, missing-agent warnings) now lives in `runtime/multiAgentRunPlan.ts`. **`runResumeExecution`** (TTY/dumb-terminal rejection, snapshot resolution, reopening chat) moves to `runtime/resumeExecution.ts`. Command files keep citty wiring and call these helpers; `orchestrate` no longer pulls resume logic from `commands/resume`.
> 
> Architecture doc **cli-runtime-round-trips** is updated to point team planning and preset run at the new runtime modules. Focused vitests import the runtime paths directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7180a0d8f2dff041de07554d2177ee953b42559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->