### PR TITLE
[codex] extract progress stream tree policy

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -36,36 +36,21 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { layoutStyles } from '../styles/logStyles';
 import { streamTabStyles, streamTabsContainerStyles } from './streamTabsStyles';
-import {
-  ACTIVE_STREAM_STATUSES,
-  ELEMENT_IDS,
-  FILTER_BUTTONS,
-} from '../constants';
+import { ELEMENT_IDS, FILTER_BUTTONS } from '../constants';
 import { ProgressEvents } from '../events';
 import { getComposedPathElement, getRadioValue, setsEqual } from '../utils';
+import {
+  computeStreamTreeProjection,
+  getStreamBranchActivity,
+  type StreamBranchActivity,
+  type StreamTreeExpansionOverride,
+} from '../streamTree';
 import type { StreamState } from '../store';
 import type { StreamFilter } from '../store';
 
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/radio/radio.js';
 import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
-
-type ChildActivity = 'active' | 'finished' | 'unknown';
-
-/**
- * Classify a child stream's lifecycle. Absent entries in `streamStates`
- * (e.g., child just appeared in `childStreamsByParent` before its first
- * status event) are `unknown` — neither active nor finished — so the
- * parent's expand/collapse decision can wait for a real signal.
- */
-function classifyChild(
-  streamStates: ReadonlyMap<StreamTabId, StreamState>,
-  name: StreamTabId,
-): ChildActivity {
-  const status = streamStates.get(name)?.status;
-  if (status === undefined) return 'unknown';
-  return ACTIVE_STREAM_STATUSES.has(status) ? 'active' : 'finished';
-}
 
 function buildTooltip(
   info: StreamTabInfo,
@@ -298,49 +283,25 @@ export class StreamTabs extends LitElement {
    * appearance (new run) starts from auto. One map replaces the former
    * `manuallyCollapsed` + `finishedCollapseHandled` sets.
    */
-  private userOverride: Map<string, 'expanded' | 'collapsed'> = new Map();
-  private branchActivityCache: Map<StreamTabId, ChildActivity> = new Map();
+  private userOverride: Map<string, StreamTreeExpansionOverride> = new Map();
+  private branchActivityByStream: Map<StreamTabId, StreamBranchActivity> =
+    new Map();
 
   protected override willUpdate(changed: import('lit').PropertyValues): void {
     if (!changed.has('childStreamsByParent') && !changed.has('streamStates'))
       return;
 
-    this.branchActivityCache.clear();
+    const projection = computeStreamTreeProjection({
+      streamStates: this.streamStates,
+      childStreamsByParent: this.childStreamsByParent,
+      userOverrides: this.userOverride,
+    });
 
-    for (const parentId of this.userOverride.keys()) {
-      if (!this.childStreamsByParent.has(parentId)) {
-        this.userOverride.delete(parentId);
-      }
+    this.branchActivityByStream = projection.branchActivityByStream;
+    this.userOverride = projection.userOverrides;
+    if (!setsEqual(projection.expandedParents, this.expandedParents)) {
+      this.expandedParents = projection.expandedParents;
     }
-
-    const next = new Set<string>();
-    for (const [parentId, children] of this.childStreamsByParent) {
-      if (this.computeExpanded(parentId, children)) next.add(parentId);
-    }
-
-    if (!setsEqual(next, this.expandedParents)) this.expandedParents = next;
-  }
-
-  /**
-   * Single source of truth for "is this parent's child list expanded?".
-   * Rules (top to bottom):
-   *   1. Honor user intent if set.
-   *   2. Expand if any child or descendant is actively running.
-   *   3. Collapse once every child branch has reached a terminal status.
-   *   4. Otherwise (mixed / still-unknown), keep expanded — default on
-   *      first appearance before status events arrive.
-   */
-  private computeExpanded(
-    parentId: string,
-    children: readonly StreamTabInfo[],
-  ): boolean {
-    const override = this.userOverride.get(parentId);
-    if (override) return override === 'expanded';
-
-    return children.some(
-      (child) =>
-        this.getBranchActivity(child.name, new Set([parentId])) !== 'finished',
-    );
   }
 
   private getStatus(name: StreamTabId): string {
@@ -351,44 +312,19 @@ export class StreamTabs extends LitElement {
     return this.streamStates.get(name)?.lastTimestamp;
   }
 
-  /**
-   * Classify an entire child branch, not just the direct row. Results are
-   * memoized for each reactive update so deep child trees are traversed once
-   * even though expansion and dimming both ask for branch activity.
-   */
   private getBranchActivity(
     streamId: StreamTabId,
     visited: Set<string>,
-  ): ChildActivity {
-    if (visited.has(streamId))
-      return classifyChild(this.streamStates, streamId);
-
-    const cached = this.branchActivityCache.get(streamId);
-    if (cached) return cached;
-
-    const ownActivity = classifyChild(this.streamStates, streamId);
-    if (ownActivity === 'active') {
-      this.branchActivityCache.set(streamId, 'active');
-      return 'active';
-    }
-
-    const nextVisited = new Set(visited);
-    nextVisited.add(streamId);
-
-    let anyUnknown = ownActivity === 'unknown';
-    const children = this.childStreamsByParent.get(streamId) ?? [];
-    for (const child of children) {
-      const childActivity = this.getBranchActivity(child.name, nextVisited);
-      if (childActivity === 'active') {
-        this.branchActivityCache.set(streamId, 'active');
-        return 'active';
-      }
-      if (childActivity === 'unknown') anyUnknown = true;
-    }
-
-    const activity = anyUnknown ? 'unknown' : 'finished';
-    this.branchActivityCache.set(streamId, activity);
-    return activity;
+  ): StreamBranchActivity {
+    return getStreamBranchActivity(
+      {
+        streamStates: this.streamStates,
+        childStreamsByParent: this.childStreamsByParent,
+      },
+      streamId,
+      visited,
+      this.branchActivityByStream,
+    );
   }
 
   private renderStreamNode(

--- a/packages/extension/src/progressView/frontend/streamTree.ts
+++ b/packages/extension/src/progressView/frontend/streamTree.ts
@@ -1,0 +1,140 @@
+import { type StreamTabId, type StreamTabInfo } from '@shared/schemas';
+
+import { ACTIVE_STREAM_STATUSES } from './constants';
+import type { StreamState } from './store';
+
+export type StreamBranchActivity = 'active' | 'finished' | 'unknown';
+export type StreamTreeExpansionOverride = 'expanded' | 'collapsed';
+
+export interface StreamTreeInputs {
+  readonly streamStates: ReadonlyMap<StreamTabId, StreamState>;
+  readonly childStreamsByParent: ReadonlyMap<string, readonly StreamTabInfo[]>;
+}
+
+export interface StreamTreeProjection {
+  readonly expandedParents: Set<string>;
+  readonly branchActivityByStream: Map<StreamTabId, StreamBranchActivity>;
+  readonly userOverrides: Map<string, StreamTreeExpansionOverride>;
+}
+
+export function computeStreamTreeProjection(
+  inputs: StreamTreeInputs & {
+    readonly userOverrides: ReadonlyMap<string, StreamTreeExpansionOverride>;
+  },
+): StreamTreeProjection {
+  const branchActivityByStream = new Map<StreamTabId, StreamBranchActivity>();
+  const userOverrides = pruneStreamTreeUserOverrides(
+    inputs.userOverrides,
+    inputs.childStreamsByParent,
+  );
+  const expandedParents = new Set<string>();
+
+  for (const [parentId, children] of inputs.childStreamsByParent) {
+    if (
+      shouldExpandStreamParent(
+        inputs,
+        parentId,
+        children,
+        userOverrides,
+        branchActivityByStream,
+      )
+    ) {
+      expandedParents.add(parentId);
+    }
+  }
+
+  return {
+    expandedParents,
+    branchActivityByStream,
+    userOverrides,
+  };
+}
+
+function pruneStreamTreeUserOverrides(
+  userOverrides: ReadonlyMap<string, StreamTreeExpansionOverride>,
+  childStreamsByParent: ReadonlyMap<string, readonly StreamTabInfo[]>,
+): Map<string, StreamTreeExpansionOverride> {
+  const next = new Map<string, StreamTreeExpansionOverride>();
+  for (const [parentId, override] of userOverrides) {
+    if (childStreamsByParent.has(parentId)) next.set(parentId, override);
+  }
+  return next;
+}
+
+/**
+ * Classify an entire child branch, not just the direct row. Absent entries in
+ * `streamStates` are `unknown` so expansion can wait for a real lifecycle
+ * signal instead of immediately treating a new child as finished.
+ */
+export function getStreamBranchActivity(
+  inputs: StreamTreeInputs,
+  streamId: StreamTabId,
+  visited: ReadonlySet<string> = new Set(),
+  cache: Map<StreamTabId, StreamBranchActivity> = new Map(),
+): StreamBranchActivity {
+  if (visited.has(streamId)) {
+    return classifyStreamActivity(inputs.streamStates, streamId);
+  }
+
+  const cached = cache.get(streamId);
+  if (cached) return cached;
+
+  const ownActivity = classifyStreamActivity(inputs.streamStates, streamId);
+  if (ownActivity === 'active') {
+    cache.set(streamId, 'active');
+    return 'active';
+  }
+
+  const nextVisited = new Set(visited);
+  nextVisited.add(streamId);
+
+  let anyUnknown = ownActivity === 'unknown';
+  const children = inputs.childStreamsByParent.get(streamId) ?? [];
+  for (const child of children) {
+    const childActivity = getStreamBranchActivity(
+      inputs,
+      child.name,
+      nextVisited,
+      cache,
+    );
+    if (childActivity === 'active') {
+      cache.set(streamId, 'active');
+      return 'active';
+    }
+    if (childActivity === 'unknown') anyUnknown = true;
+  }
+
+  const activity = anyUnknown ? 'unknown' : 'finished';
+  cache.set(streamId, activity);
+  return activity;
+}
+
+function shouldExpandStreamParent(
+  inputs: StreamTreeInputs,
+  parentId: string,
+  children: readonly StreamTabInfo[],
+  userOverrides: ReadonlyMap<string, StreamTreeExpansionOverride>,
+  cache: Map<StreamTabId, StreamBranchActivity>,
+): boolean {
+  const override = userOverrides.get(parentId);
+  if (override) return override === 'expanded';
+
+  return children.some(
+    (child) =>
+      getStreamBranchActivity(
+        inputs,
+        child.name,
+        new Set([parentId]),
+        cache,
+      ) !== 'finished',
+  );
+}
+
+function classifyStreamActivity(
+  streamStates: ReadonlyMap<StreamTabId, StreamState>,
+  streamId: StreamTabId,
+): StreamBranchActivity {
+  const status = streamStates.get(streamId)?.status;
+  if (status === undefined) return 'unknown';
+  return ACTIVE_STREAM_STATUSES.has(status) ? 'active' : 'finished';
+}

--- a/src/test-kernel/progressView/StreamTree.vitest.ts
+++ b/src/test-kernel/progressView/StreamTree.vitest.ts
@@ -1,0 +1,162 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+
+import {
+  computeStreamTreeProjection,
+  getStreamBranchActivity,
+} from '@progressView/frontend/streamTree';
+import type { StreamState } from '@progressView/frontend/store';
+import {
+  AgentCategory,
+  createStreamState,
+  STREAM_STATUS,
+  type StreamStatus,
+  type StreamTabInfo,
+} from '@shared/schemas';
+
+function stream(name: string, parentStreamId?: string): StreamTabInfo {
+  return {
+    name,
+    label: name,
+    agentCategory: AgentCategory.ToolUse,
+    creationTimestamp: 0,
+    ...(parentStreamId && { parentStreamId }),
+  };
+}
+
+function streamState(status: StreamStatus): StreamState {
+  return createStreamState(AgentCategory.ToolUse, { status });
+}
+
+describe('progress stream tree policy', () => {
+  it('keeps a parent expanded while a child has not reported status yet', () => {
+    const childStreamsByParent = new Map([['root', [stream('child', 'root')]]]);
+
+    const projection = computeStreamTreeProjection({
+      streamStates: new Map(),
+      childStreamsByParent,
+      userOverrides: new Map(),
+    });
+
+    assert.equal(projection.expandedParents.has('root'), true);
+    assert.equal(
+      getStreamBranchActivity(
+        { streamStates: new Map(), childStreamsByParent },
+        'child',
+      ),
+      'unknown',
+    );
+  });
+
+  it('collapses a parent once every child branch is finished', () => {
+    const childStreamsByParent = new Map([
+      ['root', [stream('child-a', 'root'), stream('child-b', 'root')]],
+    ]);
+    const streamStates = new Map([
+      ['child-a', streamState(STREAM_STATUS.STOPPED)],
+      ['child-b', streamState(STREAM_STATUS.ERROR)],
+    ]);
+
+    const projection = computeStreamTreeProjection({
+      streamStates,
+      childStreamsByParent,
+      userOverrides: new Map(),
+    });
+
+    assert.equal(projection.expandedParents.has('root'), false);
+    assert.equal(projection.branchActivityByStream.get('child-a'), 'finished');
+    assert.equal(projection.branchActivityByStream.get('child-b'), 'finished');
+  });
+
+  it('expands ancestors when a descendant is active', () => {
+    const childStreamsByParent = new Map([
+      ['root', [stream('child', 'root')]],
+      ['child', [stream('grandchild', 'child')]],
+    ]);
+    const streamStates = new Map([
+      ['child', streamState(STREAM_STATUS.STOPPED)],
+      ['grandchild', streamState(STREAM_STATUS.RUNNING)],
+    ]);
+
+    const projection = computeStreamTreeProjection({
+      streamStates,
+      childStreamsByParent,
+      userOverrides: new Map(),
+    });
+
+    assert.equal(projection.expandedParents.has('root'), true);
+    assert.equal(projection.expandedParents.has('child'), true);
+    assert.equal(projection.branchActivityByStream.get('child'), 'active');
+    assert.equal(projection.branchActivityByStream.get('grandchild'), 'active');
+  });
+
+  it('honors user overrides and drops overrides for missing parents', () => {
+    const childStreamsByParent = new Map([['root', [stream('child', 'root')]]]);
+    const streamStates = new Map([
+      ['child', streamState(STREAM_STATUS.RUNNING)],
+    ]);
+
+    const projection = computeStreamTreeProjection({
+      streamStates,
+      childStreamsByParent,
+      userOverrides: new Map([
+        ['root', 'collapsed'],
+        ['stale-parent', 'expanded'],
+      ]),
+    });
+
+    assert.equal(projection.expandedParents.has('root'), false);
+    assert.deepEqual([...projection.userOverrides], [['root', 'collapsed']]);
+  });
+
+  it('allows users to keep a finished parent expanded', () => {
+    const childStreamsByParent = new Map([['root', [stream('child', 'root')]]]);
+    const streamStates = new Map([
+      ['child', streamState(STREAM_STATUS.STOPPED)],
+    ]);
+
+    const projection = computeStreamTreeProjection({
+      streamStates,
+      childStreamsByParent,
+      userOverrides: new Map([['root', 'expanded']]),
+    });
+
+    assert.equal(projection.expandedParents.has('root'), true);
+  });
+
+  it('guards cycles while preserving the stream own activity', () => {
+    const childStreamsByParent = new Map([
+      ['root', [stream('child', 'root')]],
+      ['child', [stream('root', 'child')]],
+    ]);
+    const streamStates = new Map([
+      ['root', streamState(STREAM_STATUS.STOPPED)],
+      ['child', streamState(STREAM_STATUS.STOPPED)],
+    ]);
+
+    assert.equal(
+      getStreamBranchActivity(
+        { streamStates, childStreamsByParent },
+        'child',
+        new Set(['root']),
+      ),
+      'finished',
+    );
+  });
+
+  it('guards direct self-loops', () => {
+    const childStreamsByParent = new Map([['root', [stream('root', 'root')]]]);
+    const streamStates = new Map([
+      ['root', streamState(STREAM_STATUS.STOPPED)],
+    ]);
+
+    assert.equal(
+      getStreamBranchActivity(
+        { streamStates, childStreamsByParent },
+        'root',
+        new Set(['root']),
+      ),
+      'finished',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extract stream branch activity, parent expansion, override pruning, and cycle handling from `StreamTabs` into `progressView/frontend/streamTree.ts`.
- Keep `StreamTabs` focused on rendering and event dispatch while delegating stream-tree policy to a pure helper.
- Add focused kernel tests for unknown child status, finished branches, active descendants, user overrides, stale override pruning, and cycle guards.

Closes #6295.

## Validation

- `corepack pnpm exec prettier --check packages/extension/src/progressView/frontend/streamTree.ts packages/extension/src/progressView/frontend/components/StreamTabs.ts src/test-kernel/progressView/StreamTree.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/progressView/StreamTree.vitest.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved and new unit tests; UI-only progress view logic with no auth or data-path changes.
> 
> **Overview**
> Moves **parent expand/collapse**, **branch activity** (`active` / `finished` / `unknown`), **user override pruning**, and **cycle-safe tree walks** out of `StreamTabs` into a new pure module `streamTree.ts`. `StreamTabs` now calls `computeStreamTreeProjection` on updates and uses the shared branch-activity cache for rendering (e.g. finished-child dimming).
> 
> Adds kernel tests in `StreamTree.vitest.ts` for unknown child status, finished branches, active descendants, overrides, stale override cleanup, and cycle guards. **No intended UI behavior change**—refactor for testability and separation of concerns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a30af3ba83ed23de2be7a00a40a5488f162c7af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->