### PR TITLE
[codex] share git settings command routing

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -56,6 +56,7 @@ const DESKTOP_MENU_GROUPS = [
     'texra.showAgents',
     'texra.showTools',
     'texra.showMultiAgent',
+    'texra.showGitSettings',
     'texra.openGettingStarted',
     'texra.cleanOutput',
     'texra.cleanBuild',
@@ -297,6 +298,10 @@ const DESKTOP_COMMAND_HANDLERS = {
   },
   'texra.showMultiAgent': (actions) => {
     actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
+    return true;
+  },
+  'texra.showGitSettings': (actions) => {
+    actions.showSettings(SETTINGS_TAB.GIT);
     return true;
   },
   [DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER]: (actions) => {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -996,6 +996,12 @@
         "icon": "$(organization)"
       },
       {
+        "command": "texra.showGitSettings",
+        "title": "Show Git Settings",
+        "category": "TeXRA",
+        "icon": "$(git-branch)"
+      },
+      {
         "command": "texra.openSettings",
         "title": "Open TeXRA Settings",
         "category": "TeXRA",
@@ -1578,6 +1584,10 @@
         },
         {
           "command": "texra.showMultiAgent",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showGitSettings",
           "when": "texra.activated"
         },
         {

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -126,6 +126,7 @@ export type ExtensionRegistryCommandId = Extract<
   | 'texra.showAgents'
   | 'texra.showTools'
   | 'texra.showMultiAgent'
+  | 'texra.showGitSettings'
   | 'texra.openSettings'
   | 'texra.mainView.reset'
   | 'texra.cleanOutput'
@@ -349,6 +350,8 @@ const EXTENSION_COMMAND_HANDLERS = {
     awaitTrue(actions.showSettings(SETTINGS_TAB.TOOLS)),
   'texra.showMultiAgent': (actions) =>
     awaitTrue(actions.showSettings(SETTINGS_TAB.MULTI_AGENT)),
+  'texra.showGitSettings': (actions) =>
+    awaitTrue(actions.showSettings(SETTINGS_TAB.GIT)),
   'texra.openSettings': (actions) => awaitTrue(actions.openWorkbenchSettings()),
   'texra.mainView.reset': (actions) => awaitTrue(actions.resetMainView()),
   'texra.cleanOutput': (actions) => awaitTrue(actions.cleanOutput()),

--- a/packages/extension/src/commands/settings/settingsCommands.ts
+++ b/packages/extension/src/commands/settings/settingsCommands.ts
@@ -1,23 +1,7 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports
-import { registerCommands } from '@commands/_shared/registerCommands';
 import { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
-import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
-
-const settingsViewCommands = {
-  showSettingsView: 'texra.showSettingsView',
-  showDashboard: 'texra.showDashboard',
-  // Tab-specific commands
-  showMemory: 'texra.showMemory',
-  showHistory: 'texra.showAgentHistory',
-  showModels: 'texra.showModels',
-  showAgents: 'texra.showAgents',
-  showTools: 'texra.showTools',
-  showMultiAgent: 'texra.showMultiAgent',
-  showGitSettings: 'texra.showGitSettings',
-} as const;
 
 let settingsViewProvider: SettingsViewProvider | null = null;
 
@@ -40,23 +24,9 @@ export async function showSettingsView(): Promise<void> {
   await settingsViewProvider.showSettingsView();
 }
 
-/**
- * Most settings view-routing commands are now registered through the
- * shared command registry in `extensionCommandSurface.ts` (mirroring the
- * desktop's `DESKTOP_COMMAND_HANDLERS`). The remaining per-command
- * registration here covers `texra.showGitSettings`, which is not yet on
- * the desktop's menu surface and is also absent from `commandCatalog`,
- * so it stays VS Code-only via direct `registerCommand`.
- */
+/** Initialize the settings provider before registry-backed commands use it. */
 export function registerSettingsViewCommands(
   context: vscode.ExtensionContext,
 ): void {
   initializeSettingsViewProvider(context);
-
-  registerCommands(context, [
-    {
-      id: settingsViewCommands.showGitSettings,
-      handler: () => settingsViewProvider?.showSettingsView(SETTINGS_TAB.GIT),
-    },
-  ]);
 }

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -314,6 +314,12 @@
         },
         {
           "category": "TeXRA",
+          "command": "texra.showGitSettings",
+          "icon": "$(git-branch)",
+          "title": "Show Git Settings"
+        },
+        {
+          "category": "TeXRA",
           "command": "texra.openSettings",
           "icon": "$(settings-gear)",
           "title": "Open TeXRA Settings"
@@ -1327,6 +1333,10 @@
           },
           {
             "command": "texra.showMultiAgent",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showGitSettings",
             "when": "texra.activated"
           },
           {

--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -310,6 +310,12 @@ export const commandCatalog = [
     icon: '$(organization)',
   },
   {
+    id: 'texra.showGitSettings',
+    title: 'Show Git Settings',
+    category: 'TeXRA',
+    icon: '$(git-branch)',
+  },
+  {
     id: 'texra.openSettings',
     title: 'Open TeXRA Settings',
     category: 'TeXRA',

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -207,6 +207,7 @@ describe('desktop command surface', () => {
     expect(dispatchDesktopCommand('texra.mainView.reset', actions)).toBe(true);
     expect(dispatchDesktopCommand('texra.showModels', actions)).toBe(true);
     expect(dispatchDesktopCommand('texra.showAgents', actions)).toBe(true);
+    expect(dispatchDesktopCommand('texra.showGitSettings', actions)).toBe(true);
     expect(
       dispatchDesktopCommand(
         DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
@@ -244,6 +245,7 @@ describe('desktop command surface', () => {
       3,
       SETTINGS_TAB.AGENTS,
     );
+    expect(actions.showSettings).toHaveBeenNthCalledWith(4, SETTINGS_TAB.GIT);
     expect(actions.resetMainView).toHaveBeenCalledOnce();
     expect(actions.openWorkspaceFolder).toHaveBeenCalledOnce();
     expect(actions.openWorkspaceInNewWindow).toHaveBeenCalledOnce();
@@ -352,6 +354,7 @@ describe('desktop command surface', () => {
       'Show Agents',
       'Show Tool Dashboard',
       'Show Multi-Agent Settings',
+      'Show Git Settings',
       'Open Getting Started Walkthrough',
       'Clean LLM Outputs',
       'Clean Build Files',

--- a/src/test-kernel/tools/setup/InvokeCommandTool.vitest.ts
+++ b/src/test-kernel/tools/setup/InvokeCommandTool.vitest.ts
@@ -114,6 +114,8 @@ describe('InvokeCommandTool allowlist', () => {
       'workbench.action.closeAllEditors',
       'editor.action.deleteAllLines',
       'workbench.action.terminal.sendSequence',
+      'texra.refreshApiKeyStatus',
+      'texra.refreshAllOptions',
     ]) {
       const result = await tool.call({ command: cmd, args: [] });
       assert.ok(result.isError, `${cmd} should be rejected`);

--- a/src/tools/setup/InvokeCommandTool.ts
+++ b/src/tools/setup/InvokeCommandTool.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { AUTH_COMMANDS } from '@auth/constants';
+import type { CommandId } from '@shared/commands/catalog';
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local file imports
@@ -19,7 +20,7 @@ import { getSetupPlatform } from './platform';
 // purpose is to *establish* credentials, and signing the user out
 // mid-setup would undo the very credential the assistant just wired up.
 // A user who genuinely wants to sign out has the Profile command for it.
-const ALLOWED_COMMANDS: ReadonlySet<string> = new Set([
+const ALLOWED_COMMAND_IDS = [
   // API keys & auth
   'texra.setApiKey',
   'texra.removeApiKey',
@@ -42,12 +43,11 @@ const ALLOWED_COMMANDS: ReadonlySet<string> = new Set([
   'texra.showMainView',
   'texra.cloneOverleafProject',
   'texra.downloadArXivSource',
-  // Refresh helpers
-  'texra.refreshApiKeyStatus',
-  'texra.refreshAllOptions',
   // Walkthrough re-entry
   'texra.openGettingStarted',
-]);
+] as const satisfies readonly CommandId[];
+
+const ALLOWED_COMMANDS: ReadonlySet<string> = new Set(ALLOWED_COMMAND_IDS);
 
 const InvokeCommandInputSchema = z.strictObject({
   command: z


### PR DESCRIPTION
## Summary
- promote `texra.showGitSettings` into the shared command catalog and extension package contribution
- route the command through the shared VS Code and desktop command registries to the existing Git settings tab
- remove the extension-only direct registration exception and type the setup tool's model-facing command allowlist against shared `CommandId`
- keep internal refresh helper commands available to setup internals but reject them through the public `invoke_command` tool

Closes #6302.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run check:extension-package-invariants`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/commands/CommandCatalog.vitest.ts src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/DesktopCommandPalette.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts src/test-kernel/tools/setup/InvokeCommandTool.vitest.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing and catalog alignment only; behavior is opening the existing Git settings tab, with a small narrowing of which commands the setup agent can invoke.
> 
> **Overview**
> **`texra.showGitSettings`** is now a first-class shared command: it lives in the **command catalog**, is contributed in **`package.json`** / the extension invariants snapshot, and is wired through the **extension** and **desktop** command registries to open settings on **`SETTINGS_TAB.GIT`** (including the desktop TeXRA menu).
> 
> The extension no longer registers this command only in **`settingsCommands.ts`**; **`registerSettingsViewCommands`** just initializes the settings provider, consistent with other settings-tab routes.
> 
> The setup agent’s **`invoke_command`** allowlist is typed as **`CommandId[]`** (still includes **`texra.showGitSettings`**). **`texra.refreshApiKeyStatus`** and **`texra.refreshAllOptions`** are dropped from that public allowlist, with tests asserting they are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f060001ad12f70aa19a6cff375b4430e008e34e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->