### PR TITLE
[codex] tighten shared resource boundaries

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -3,10 +3,10 @@ import { readFile } from 'node:fs/promises';
 import { MODEL_CONFIGS } from 'llm-zoo';
 import { z } from 'zod';
 
-import { configKeyVariants } from '@platform/defaults/configKeyHelpers';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { isFileNotFoundError } from '@common/errors';
 import { toErrorMessage } from '@common/errors/errorMessage';
+import { configKeyVariants } from '@shared/config/configKeys';
 import { isObject } from '@utils/core/typeGuards';
 
 import {

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -20,6 +20,7 @@ import {
   TEXRA_CONFIG_FILE_NAME,
   workspaceTexraConfigPath,
 } from '@platform/defaults/nodeStorage';
+import { initializeGoalPrompts } from '@agent/goal';
 import { bootstrapPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 import { PathAgentDirectoryBundleSource } from '@agent/index/AgentDirectorySync';
 
@@ -257,6 +258,9 @@ export async function initCliPlatform(
   }
   await getServerSideKeyService().setUseIncludedModelAccess(authed);
   await setCliHelperModel(context.helperModel);
+  initializeGoalPrompts(
+    nodePath.join(context.resourcesPath, 'goal', 'goal.yaml'),
+  );
 
   if (bootstrappedResourcesPath !== context.resourcesPath) {
     const globalState = tryPlatform()?.globalState;

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path';
 import { app } from 'electron';
 
 import { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
-import { configKeyVariants } from '@platform/defaults/configKeyHelpers';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
@@ -15,8 +14,10 @@ import { initPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { StreamSnapshotStore } from '@transcript';
 import { registerAgentFeatures } from '@agent/features';
+import { initializeGoalPrompts } from '@agent/goal';
 import { toErrorMessage } from '@common/errors';
 import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
+import { configKeyVariants } from '@shared/config/configKeys';
 import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 
 import { bootstrapElectronAgentDirectories } from './agentDirectories.js';
@@ -139,6 +140,8 @@ export async function initializeElectronPlatform(
     toolAvailability: NO_TOOL_AVAILABILITY_HOST,
   });
   registerAgentFeatures();
+  const resourcesPath = resolveResourcesPath(mainDirname);
+  initializeGoalPrompts(join(resourcesPath, 'goal', 'goal.yaml'));
 
   // Persist per-stream sidecar data (todos, plan, usage, output files) via the
   // shared, host-agnostic snapshot store. The desktop progress backend owns the
@@ -150,10 +153,7 @@ export async function initializeElectronPlatform(
   // Lean tools talk to `lake env lean --server` directly in the desktop build.
   registerDirectLeanLanguageServices(lifecycle);
 
-  await bootstrapElectronAgentDirectories(
-    resolveResourcesPath(mainDirname),
-    app.getVersion(),
-  );
+  await bootstrapElectronAgentDirectories(resourcesPath, app.getVersion());
 
   return { workspacePath, lifecycle, progressSnapshotStore: snapshotStore };
 }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -176,8 +176,17 @@ export async function activate(context: vscode.ExtensionContext) {
   logger.setOutputChannelFactory((name) =>
     vscode.window.createOutputChannel(name),
   );
-  initializePolishModel(context.extensionPath);
-  initializeGoalPrompts(context.extensionPath);
+  initializePolishModel(
+    path.join(
+      context.extensionPath,
+      'resources',
+      'templates',
+      'instructionPolish.yaml',
+    ),
+  );
+  initializeGoalPrompts(
+    path.join(context.extensionPath, 'resources', 'goal', 'goal.yaml'),
+  );
   initializeStateManagers(context, gitRepoRoot);
   const lifecycle = createLifecycleHost({
     onError: (phase, error) =>

--- a/packages/extension/src/schemas/texraSettings.ts
+++ b/packages/extension/src/schemas/texraSettings.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 /* eslint-disable local/prefer-alias-for-deep-relative-imports -- This module
  * must remain require-able after tsc emit by the plain Node settings sync
  * script, which does not install tsconfig alias hooks. */
-import { stripPrefix } from '../../../../src/platform/defaults/configKeyHelpers';
+import { stripPrefix } from '../../../../src/shared/config/configKeys';
 import {
   CORE_SETTING_PATHS,
   CoreSettingsShape,

--- a/src/agent/goal/promptLoader.ts
+++ b/src/agent/goal/promptLoader.ts
@@ -1,24 +1,22 @@
 /**
- * Loader for the packaged Goal prompt templates
- * (`<extension>/resources/goal/goal.yaml`).
+ * Loader for the packaged Goal prompt templates.
  *
- * Mirrors the shape of `src/agent/runtime/polishModel.ts`: each host calls
- * `initializeGoalPrompts(extensionPath)` once at startup with the path
- * to its own resource bundle. The agent code path is host-neutral and
- * reads through this loader; no `vscode` import is required.
+ * Each host calls `initializeGoalPrompts(goalYamlPath)` once at startup with
+ * the concrete YAML path from its own resource bundle. The agent code path is
+ * host-neutral and reads through this loader; no `vscode` import or package
+ * layout knowledge is required.
  *
  * When the loader has not been initialized (e.g. on a host that has not
  * yet wired Goal, or under tests), template lookups fall back to the
  * inline copy in `inlineTemplates` so the continuation loop still works.
  */
-import * as path from 'node:path';
+import { readFile } from 'node:fs/promises';
 
 import * as yaml from 'yaml';
 import { z } from 'zod';
 
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { AbsoluteFS } from '@utils/files';
 
 const GoalPromptsYamlSchema = z.object({
   continuation: z.object({ template: z.string().min(1) }),
@@ -63,31 +61,29 @@ const inlineTemplates: GoalPrompts = {
   },
 };
 
-let extensionPath: string | null = null;
+let goalYamlPath: string | null = null;
 let cached: GoalPrompts | null = null;
 
 /**
- * Register the host's resource root. The Goal YAML is resolved at
- * `<extensionPath>/resources/goal/goal.yaml` on first use.
+ * Register the host's Goal prompt YAML path.
  *
  * Safe to call multiple times; later calls replace the path and bust the
  * cache so a previously-loaded inline fallback won't stick once the host
  * is wired.
  */
-export function initializeGoalPrompts(extPath: string): void {
-  extensionPath = extPath;
+export function initializeGoalPrompts(pathToGoalYaml: string): void {
+  goalYamlPath = pathToGoalYaml;
   cached = null;
 }
 
 async function loadPrompts(): Promise<GoalPrompts> {
   if (cached) return cached;
-  if (!extensionPath) {
+  if (!goalYamlPath) {
     cached = inlineTemplates;
     return cached;
   }
   try {
-    const yamlPath = path.join(extensionPath, 'resources', 'goal', 'goal.yaml');
-    const content = await AbsoluteFS.read(yamlPath);
+    const content = await readFile(goalYamlPath, 'utf8');
     cached = GoalPromptsYamlSchema.parse(yaml.parse(content));
   } catch (err) {
     // Fall back to inline templates, but warn so a broken/missing bundled

--- a/src/agent/runtime/polishModel.ts
+++ b/src/agent/runtime/polishModel.ts
@@ -1,14 +1,12 @@
-import * as path from 'node:path';
+import { readFile } from 'node:fs/promises';
 
 import * as nunjucks from 'nunjucks';
 import * as yaml from 'yaml';
 import { z } from 'zod';
 
-import { AbsoluteFS } from '@utils/files';
-
 const nunjucksEnv = nunjucks.configure({ autoescape: false });
 
-let extensionPath: string | null = null;
+let polishPromptPath: string | null = null;
 let templatePromise: Promise<string> | null = null;
 
 const PolishYamlSchema = z.object({
@@ -16,28 +14,23 @@ const PolishYamlSchema = z.object({
 });
 
 /**
- * Store the extension path so the YAML template can be located later.
- * Call once during extension activation.
+ * Store the host-provided polish prompt YAML path. Call once during host
+ * startup before text enhancement is used.
  */
-export function initializePolishModel(extPath: string): void {
-  extensionPath = extPath;
+export function initializePolishModel(pathToPromptYaml: string): void {
+  polishPromptPath = pathToPromptYaml;
+  templatePromise = null;
 }
 
 function loadPromptTemplate(): Promise<string> {
   if (templatePromise) return templatePromise;
-  if (!extensionPath) {
+  if (!polishPromptPath) {
     throw new Error(
       'Polish model not initialized. Call initializePolishModel() first.',
     );
   }
-  const yamlPath = path.join(
-    extensionPath,
-    'resources',
-    'templates',
-    'instructionPolish.yaml',
-  );
   templatePromise = (async () => {
-    const content = await AbsoluteFS.read(yamlPath);
+    const content = await readFile(polishPromptPath, 'utf8');
     return PolishYamlSchema.parse(yaml.parse(content)).prompts.userRequest;
   })();
   return templatePromise;

--- a/src/platform/defaults/jsonConfigProvider.ts
+++ b/src/platform/defaults/jsonConfigProvider.ts
@@ -3,7 +3,7 @@ import {
   configKeyVariants,
   createWatcherRegistry,
   firstStoredValue,
-} from './configKeyHelpers';
+} from '@shared/config/configKeys';
 
 import type { JsonStore } from './jsonStore';
 import type {

--- a/src/shared/config/configKeys.ts
+++ b/src/shared/config/configKeys.ts
@@ -1,14 +1,20 @@
-import type { Disposable } from '@platform/interfaces/disposable';
-import type { JsonStore } from './jsonStore';
-
 /**
- * Helpers shared by file-backed `ConfigProvider` implementations (Electron,
- * CLI). Keys are stored flat in a JSON file. Both `texra.<key>` and bare
- * `<key>` are accepted on read (canonical prefixed form tried first). Writes
- * always use the canonical `texra.<key>` form unless an unprefixed legacy
- * entry already exists for that key.
+ * Shared TeXRA configuration key helpers.
+ *
+ * Hosts store settings as flat keys. Both `texra.<key>` and bare `<key>` are
+ * accepted on read for legacy compatibility; writes use the canonical prefixed
+ * form unless a legacy bare key already exists.
  */
 const TEXRA_PREFIX = 'texra.';
+
+export interface ConfigKeyValueStore {
+  has(key: string): boolean;
+  get<T>(key: string): T | undefined;
+}
+
+export interface ConfigWatcherDisposable {
+  dispose(): void;
+}
 
 export function stripPrefix(key: string): string {
   return key.startsWith(TEXRA_PREFIX) ? key.slice(TEXRA_PREFIX.length) : key;
@@ -55,7 +61,7 @@ function watcherMatches(
 }
 
 export function firstStoredValue<T>(
-  store: JsonStore,
+  store: ConfigKeyValueStore,
   keys: readonly string[],
 ): T | undefined {
   for (const candidate of keys) {
@@ -65,7 +71,7 @@ export function firstStoredValue<T>(
 }
 
 export function createWatcherRegistry(): {
-  add(watcher: ConfigWatcher): Disposable;
+  add(watcher: ConfigWatcher): ConfigWatcherDisposable;
   notify(changedKey: string): void;
 } {
   const watchers = new Set<ConfigWatcher>();

--- a/src/test-kernel/agent/GoalPromptParity.vitest.mts
+++ b/src/test-kernel/agent/GoalPromptParity.vitest.mts
@@ -7,6 +7,11 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import * as yaml from 'yaml';
 
+import {
+  getContinuationTemplate,
+  initializeGoalPrompts,
+} from '@agent/goal/promptLoader';
+
 const REPO_ROOT = resolve(
   fileURLToPath(new URL('.', import.meta.url)),
   '../../..',
@@ -50,5 +55,17 @@ describe('Goal prompt parity (YAML ↔ inline fallback)', () => {
         `Inline fallback in promptLoader.ts is missing this continuation line — update both files in lockstep:\n  ${line}`,
       ).toContain(line);
     }
+  });
+
+  it('loads the host-provided goal YAML path directly', async () => {
+    const yamlPath = resolve(
+      REPO_ROOT,
+      'packages/extension/resources/goal/goal.yaml',
+    );
+    initializeGoalPrompts(yamlPath);
+
+    await expect(getContinuationTemplate()).resolves.toBe(
+      readYaml().continuation.template,
+    );
   });
 });

--- a/src/test-kernel/agent/PolishPromptLoader.vitest.mts
+++ b/src/test-kernel/agent/PolishPromptLoader.vitest.mts
@@ -1,0 +1,33 @@
+// Node imports
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - agent runtime
+import {
+  initializePolishModel,
+  renderPolishPrompt,
+} from '@agent/runtime/polishModel';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+describe('polish prompt loader', () => {
+  it('loads the host-provided polish YAML path directly', async () => {
+    initializePolishModel(
+      resolve(
+        REPO_ROOT,
+        'packages/extension/resources/templates/instructionPolish.yaml',
+      ),
+    );
+
+    const prompt = await renderPolishPrompt('', 'Fix teh typo.');
+
+    expect(prompt).toContain('Please review the following instruction text');
+    expect(prompt).toContain('Fix teh typo.');
+  });
+});

--- a/src/test-kernel/desktop/loadPlatformDefaultsModule.mts
+++ b/src/test-kernel/desktop/loadPlatformDefaultsModule.mts
@@ -6,8 +6,8 @@ import { moduleFileUrl, repoPath } from './desktopTestPaths.mjs';
  *
  * Mirrors `loadDesktopPlatformModule` but resolves against the shared
  * platform-defaults directory rather than the desktop-only `main/platform`
- * tree. Use this for modules (e.g. `JsonStore`, `configKeyHelpers`) that
- * moved out of the desktop package after consolidation.
+ * tree. Use this for modules (e.g. `JsonStore`) that moved out of the desktop
+ * package after consolidation.
  */
 export async function loadPlatformDefaultsModule<T>(
   moduleName: string,


### PR DESCRIPTION
## Summary
- make goal and polish prompt loaders accept host-resolved YAML paths instead of extension-root paths
- wire goal prompt YAML from CLI and desktop resource bundles, not just the VS Code extension
- move config key normalization from `src/platform/defaults` into `src/shared/config`

## Abstraction issues addressed
- Fixes #6304: agent/runtime prompt loaders no longer know the extension resource layout; hosts resolve their own resource files and core only parses the YAML path it is given.
- Fixes #6305: shared config-key semantics no longer live under the default provider implementation layer.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/GoalPromptParity.vitest.mts src/test-kernel/agent/PolishPromptLoader.vitest.mts src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `npm run check:settings-configuration`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of initialization and import paths with parity tests; behavior should match prior bundled YAML and config key semantics.
> 
> **Overview**
> Tightens boundaries between shared agent code and host-specific packaging.
> 
> **Goal and polish prompt loaders** now take explicit YAML file paths instead of an extension root. Core loads with `readFile` and no longer assumes `resources/goal` or `resources/templates` layout. **CLI** and **desktop** call `initializeGoalPrompts` with their bundled `goal.yaml`; **VS Code** passes full paths for goal and `instructionPolish.yaml`.
> 
> **Config key normalization** moves from `src/platform/defaults` to **`src/shared/config/configKeys`**, with small store/disposable interfaces so helpers are not tied to `JsonStore`. CLI, desktop, `JsonConfigProvider`, and extension settings sync import from the shared module.
> 
> Tests add direct-path coverage for goal and polish loaders; desktop test helper comment drops the moved module name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcccd83c41f23fd05b06f3f07a18d6b514e0356e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->