### PR TITLE
[codex] hide inquiry tool syntax in transcript

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -80,6 +80,11 @@ const LONG_BASH_APPROVAL_COMMAND = [
 ].join('\n');
 const LONG_EXTERNAL_INQUIRY_ANSWER =
   'Independent check agrees: there are 22 non-degenerate triples in the displayed list, plus exactly 61 degenerate triples of the form (0,b,b), and the bounded search over integer pairs proves completeness.';
+const LONG_EXTERNAL_INQUIRY_ANSWER_FOR_TRUNCATION = Array.from(
+  { length: 24 },
+  (_, index) =>
+    `Long verification note ${String(index + 1).padStart(2, '0')}: independent enumeration confirms the count and keeps the full answer recoverable by thread id.`,
+).join(' ');
 const FULL_WIDTH_AGENT_PROPOSAL_BORDER_80 = `╔${'═'.repeat(78)}╗`;
 const ASYNC_FORM_SETTLE_MS = 12000;
 const VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT = [
@@ -1409,13 +1414,42 @@ const SCENARIOS = [
     expect: [
       '[inquiry] ei_123456abcdef answered.',
       'A: Independent check agrees',
-      "Full thread: inquiry { command: 'read'",
+      'Full thread: ei_123456abcdef',
       'No other open inquiries on this stream.',
       'Proceed using the new answer.',
       '[/status]details',
       '[/model]models',
     ],
-    unexpect: ['Agent asks:', '1 question', '1 approval'],
+    unexpect: [
+      'Agent asks:',
+      '1 question',
+      '1 approval',
+      "inquiry { command: 'read'",
+    ],
+  },
+  {
+    name: 'external-inquiry-submit-long-answer',
+    rows: 36,
+    cols: 120,
+    env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
+    bootExpect: '[Ctrl-C]',
+    keys: [LONG_EXTERNAL_INQUIRY_ANSWER_FOR_TRUNCATION, '\r'],
+    frame: 'tail',
+    expect: [
+      '[inquiry] ei_123456abcdef answered.',
+      'A: Long verification note 01',
+      'full text',
+      'available in thread ei_123456abcdef',
+      'Full thread: ei_123456abcdef',
+      'No other open inquiries on this stream.',
+      'Proceed using the new answer.',
+    ],
+    unexpect: [
+      'Agent asks:',
+      '1 question',
+      '1 approval',
+      "inquiry { command: 'read'",
+    ],
   },
   {
     name: 'compact-user-question',

--- a/prds/prd-external-inquiry-async.md
+++ b/prds/prd-external-inquiry-async.md
@@ -295,7 +295,8 @@ Continuation text shape — three variants, deterministic templates.
 ```
 [inquiry] ei_b22c answered.
 Q: <question, truncated to 400 chars>
-A: <answer, truncated to 2000 chars; full text via inquiry { command: 'read', thread_id }>
+A: <answer, truncated to 2000 chars; full text available in thread ei_b22c>
+Full thread: ei_b22c
 
 Still open on this stream:
   - ei_a1f0  "Prove Lemma 3.2 …"  (dispatched 12m ago)
@@ -308,7 +309,8 @@ Proceed using the new answer. Do not re-dispatch any open thread_id.
 ```
 [inquiry] ei_b22c answered.
 Q: <question, truncated to 400 chars>
-A: <answer, truncated to 2000 chars; full text via inquiry { command: 'read', thread_id }>
+A: <answer, truncated to 2000 chars; full text available in thread ei_b22c>
+Full thread: ei_b22c
 
 No other open inquiries on this stream.
 
@@ -320,6 +322,7 @@ Proceed using the new answer.
 ```
 [inquiry] ei_b22c dropped by user.
 Q: <question, truncated to 400 chars>
+Full thread: ei_b22c
 
 Still open on this stream:
   - ei_a1f0  "Prove Lemma 3.2 …"  (dispatched 12m ago)

--- a/src/test-kernel/tools/InquiryContinuation.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuation.vitest.ts
@@ -43,7 +43,8 @@ describe('buildContinuationText', () => {
     expect(text).toContain(`[inquiry] ${THREAD} answered.`);
     expect(text).toContain('Q: Q');
     expect(text).toContain('A: A');
-    expect(text).toContain(`Full thread: inquiry { command: 'read'`);
+    expect(text).toContain(`Full thread: ${THREAD}`);
+    expect(text).not.toContain(`inquiry { command: 'read'`);
     expect(text).toContain('Still open on this stream:');
     expect(text).toContain(OTHER_THREAD);
     expect(text).toContain(
@@ -75,7 +76,8 @@ describe('buildContinuationText', () => {
 
     expect(text).toContain(`[inquiry] ${THREAD} dropped by user.`);
     expect(text).toContain('Q: Q');
-    expect(text).toContain(`Full thread: inquiry { command: 'read'`);
+    expect(text).toContain(`Full thread: ${THREAD}`);
+    expect(text).not.toContain(`inquiry { command: 'read'`);
     expect(text).toContain('re-formulate (new thread)');
     expect(text).toContain(`Do not re-dispatch ${THREAD}.`);
   });
@@ -113,9 +115,8 @@ describe('buildContinuationText', () => {
       stillOpen: [],
     });
 
-    expect(text).toContain(
-      `(full text via inquiry { command: 'read', thread_id: '${THREAD}' })`,
-    );
+    expect(text).toContain(`(full text available in thread ${THREAD})`);
+    expect(text).not.toContain(`inquiry { command: 'read'`);
     expect(text.length).toBeLessThan(longQ.length + longA.length);
   });
 });

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -41,10 +41,6 @@ export type InjectionOutcome = 'sent' | 'queued' | 'resumed' | 'archived';
 const QUESTION_TRUNCATION = 400;
 const ANSWER_TRUNCATION = 2000;
 
-function readThreadCommand(threadId: ExternalInquiryThreadId): string {
-  return `inquiry { command: 'read', thread_id: '${threadId}' }`;
-}
-
 function formatStillOpen(threads: ExternalInquiryThreadSummary[]): string[] {
   if (!threads.length) return [];
   const lines = ['', 'Still open on this stream:'];
@@ -74,11 +70,11 @@ export function buildContinuationText(params: {
       lines.push(
         `A: ${truncateSummary(answer, ANSWER_TRUNCATION)}` +
           (answer.length > ANSWER_TRUNCATION
-            ? ` (full text via ${readThreadCommand(threadId)})`
+            ? ` (full text available in thread ${threadId})`
             : ''),
       );
     }
-    lines.push(`Full thread: ${readThreadCommand(threadId)}`);
+    lines.push(`Full thread: ${threadId}`);
     lines.push(...formatStillOpen(stillOpen));
     if (stillOpen.length === 0) {
       lines.push('', 'No other open inquiries on this stream.');
@@ -95,7 +91,7 @@ export function buildContinuationText(params: {
   // dropped
   lines.push(`[inquiry] ${threadId} dropped by user.`);
   lines.push(`Q: ${truncateSummary(question, QUESTION_TRUNCATION)}`);
-  lines.push(`Full thread: ${readThreadCommand(threadId)}`);
+  lines.push(`Full thread: ${threadId}`);
   lines.push(...formatStillOpen(stillOpen));
   lines.push(
     '',


### PR DESCRIPTION
## Summary

- Replace the raw `inquiry { command: 'read', thread_id: ... }` continuation wording with the stable external inquiry thread id.
- Remove the small `readThreadCommand` string helper from the continuation builder.
- Add unit and PTY harness expectations that the CLI transcript no longer exposes the raw tool-call syntax, including the long-answer truncation path.
- Align the external-inquiry PRD continuation templates with the new transcript shape.

Closes #6307.

## Why

A PTY-backed CLI scout run showed that submitting an external inquiry answer renders raw tool invocation syntax in the normal human-visible chat transcript. The continuation still needs to be useful to the agent, but the UI surface should not depend on low-level tool object syntax.

## Validation

- `corepack pnpm vitest run src/test-kernel/tools/InquiryContinuation.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-inquiry-syntax-fix-20260620-035944 external-inquiry-submit-answer`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-inquiry-long-answer-20260620-041018 external-inquiry-submit-answer external-inquiry-submit-long-answer`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build external-inquiry-submit-long-answer`
- `npm run format`
- `npm run lint`
- `npm run compile:fast`
- `npm test`
- `npm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to agent continuation messages plus test/PRD updates; no auth, persistence, or injection logic changes.
> 
> **Overview**
> **Hides low-level inquiry tool-call syntax** from human-visible continuation text when an external inquiry is answered or dropped.
> 
> Continuation copy now uses the stable thread id (`Full thread: ei_…`) and, for truncated answers, `(full text available in thread ei_…)` instead of embedding `inquiry { command: 'read', thread_id: '…' }`. The `readThreadCommand` helper in `inquiryContinuation.ts` is removed.
> 
> **Tests and docs** are aligned: `InquiryContinuation.vitest.ts` asserts the new wording; the async inquiry PRD templates match; CLI `validate-tui` gains `external-inquiry-submit-long-answer` and tightens expectations so PTY runs never show the old read-command string (including the long-answer truncation path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b95cae53c6ec38fad16b4ac4c81af27a10a495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->