### PR TITLE
[codex] Extract progress API key retry policy

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -7,6 +7,7 @@ import {
   type ProgressFollowUpPlan,
 } from '@controllers/progressView/ProgressFollowUpController';
 import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
+import { ProgressApiKeyRetryController } from '@controllers/progressView/ProgressApiKeyRetryController';
 import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { getAgent } from '@agent/index';
@@ -75,6 +76,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly workflowActionsController: ProgressWorkflowActionsController;
   private readonly workflowFileActionsController: ProgressWorkflowFileActionsController;
   private readonly agentProposalController: ProgressAgentProposalController;
+  private readonly apiKeyRetryController: ProgressApiKeyRetryController;
   private readonly followUpController: ProgressFollowUpController;
   private readonly modelOutputBackups = new Map<
     StreamTabId,
@@ -112,6 +114,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.workflowFileActionsController =
       this.createWorkflowFileActionsController();
     this.agentProposalController = this.createAgentProposalController();
+    this.apiKeyRetryController = this.createApiKeyRetryController();
     this.followUpController = this.createFollowUpController();
 
     const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
@@ -553,6 +556,25 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
+  private createApiKeyRetryController(): ProgressApiKeyRetryController {
+    return new ProgressApiKeyRetryController({
+      providers: SecretManager.API_PROVIDERS,
+      readKey: (provider) =>
+        SecretManager.get(SecretManager.getApiKeySecretName(provider)),
+      hasUsableKey: (provider) => SecretManager.hasUsableApiKey(provider),
+      promptForApiKey: async (provider) => {
+        await vscode.commands.executeCommand(
+          apiKeyCommands.setApiKey,
+          provider,
+        );
+      },
+      setUseIncludedModelAccess: (enabled) =>
+        getServerSideKeyService().setUseIncludedModelAccess(enabled),
+      invalidateModelOptionsCache,
+      triggerRetry: (stream) => runCoordinatorBridge.triggerRetry(stream),
+    });
+  }
+
   private createFollowUpController(): ProgressFollowUpController {
     return new ProgressFollowUpController({
       getAgentCategory: (agent) =>
@@ -606,69 +628,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         ? data.provider
         : undefined;
 
-    // The gate depends on WHICH credential is exhausted:
-    //   - Upstream credit depletion (Anthropic 400 "credit balance is
-    //     too low"): the STORED key is the broken one, so we require
-    //     evidence of a key change.
-    //   - Relay monthly limit (or unknown provider): the stored key is
-    //     fine, so any usable key counts as consent.
-    // `anyApiKeyExists()` is deliberately NOT used — it also returns
-    // true when only relay access is available.
-    const providersToCheck = providerArg
-      ? [providerArg]
-      : SecretManager.API_PROVIDERS;
-    const readKey = (p: ApiProvider) =>
-      SecretManager.get(SecretManager.getApiKeySecretName(p));
-
-    const requireChange = data.upstreamCreditDepleted === true;
-    const before = requireChange
-      ? new Map(
-          await Promise.all(
-            providersToCheck.map(async (p) => [p, await readKey(p)] as const),
-          ),
-        )
-      : undefined;
-
-    await vscode.commands.executeCommand(apiKeyCommands.setApiKey, providerArg);
-
-    let shouldProceed: boolean;
-    if (requireChange) {
-      const after = new Map(
-        await Promise.all(
-          providersToCheck.map(async (p) => [p, await readKey(p)] as const),
-        ),
-      );
-      shouldProceed = providersToCheck.some((p) => {
-        const next = after.get(p);
-        return (
-          typeof next === 'string' &&
-          next.trim().length > 0 &&
-          next !== before!.get(p)
-        );
-      });
-    } else {
-      const usable = await Promise.all(
-        providersToCheck.map((p) => SecretManager.hasUsableApiKey(p)),
-      );
-      shouldProceed = usable.some(Boolean);
-    }
-
-    if (!shouldProceed) {
-      return;
-    }
-
-    // Only disable relay access when the failing call actually went
-    // through relay. If the error came from a direct-key call (e.g.
-    // user's own Anthropic key ran out of credit on a tier that
-    // routes Anthropic directly while other providers still go via
-    // relay), flipping the global mode would revoke relay for the
-    // other providers too.
-    if (data.viaRelay === true) {
-      await getServerSideKeyService().setUseIncludedModelAccess(false);
-      invalidateModelOptionsCache();
-    }
-    const retried = runCoordinatorBridge.triggerRetry(data.stream);
-    if (!retried) {
+    const result = await this.apiKeyRetryController.useOwnApiKey({
+      stream: data.stream,
+      provider: providerArg,
+      upstreamCreditDepleted: data.upstreamCreditDepleted,
+      viaRelay: data.viaRelay,
+    });
+    if (result.proceeded && !result.retried) {
       await vscode.window.showInformationMessage(
         'Switched to your own API key. No pending retry to resume — run the agent again when ready.',
       );

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -43,15 +43,23 @@ export class ProgressApiKeyRetryController {
       ? [request.provider]
       : this.deps.providers;
     const requireChange = request.upstreamCreditDepleted === true;
-    const before = requireChange
-      ? await this.readKeys(providersToCheck)
-      : undefined;
 
-    await this.deps.promptForApiKey(request.provider);
-
-    const shouldProceed = requireChange
-      ? await this.hasChangedUsableKey(providersToCheck, before)
-      : await this.hasAnyUsableKey(providersToCheck);
+    // The gate depends on which credential failed:
+    // - Upstream credit depletion means the stored direct key is the broken
+    //   credential, so the user must provide a changed usable key.
+    // - Relay monthly limits do not imply a broken direct key, so any usable
+    //   direct key is enough consent to retry outside the relay.
+    // Do not use "any API key exists" here; that also treats relay access as a
+    // credential, which would allow retrying without a usable direct key.
+    let shouldProceed: boolean;
+    if (requireChange) {
+      const before = await this.readKeys(providersToCheck);
+      await this.deps.promptForApiKey(request.provider);
+      shouldProceed = await this.hasChangedUsableKey(providersToCheck, before);
+    } else {
+      await this.deps.promptForApiKey(request.provider);
+      shouldProceed = await this.hasAnyUsableKey(providersToCheck);
+    }
 
     if (!shouldProceed) {
       return {
@@ -62,6 +70,8 @@ export class ProgressApiKeyRetryController {
     }
 
     let disabledIncludedModelAccess = false;
+    // Only disable relay access when the failing call actually went through
+    // relay. Direct-key failures should not revoke relay for other providers.
     if (request.viaRelay === true) {
       await this.deps.setUseIncludedModelAccess(false);
       this.deps.invalidateModelOptionsCache();
@@ -86,7 +96,7 @@ export class ProgressApiKeyRetryController {
 
   private async hasChangedUsableKey(
     providers: readonly ApiProvider[],
-    before: ReadonlyMap<ApiProvider, string | undefined> | undefined,
+    before: ReadonlyMap<ApiProvider, string | undefined>,
   ): Promise<boolean> {
     const after = await this.readKeys(providers);
     return providers.some((provider) => {
@@ -94,7 +104,7 @@ export class ProgressApiKeyRetryController {
       return (
         typeof next === 'string' &&
         next.trim().length > 0 &&
-        next !== before?.get(provider)
+        next !== before.get(provider)
       );
     });
   }

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -1,0 +1,114 @@
+// Local imports - model
+import type { ApiProvider } from '@model/apiProviders';
+
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
+export interface ProgressApiKeyRetryRequest {
+  stream: StreamTabId;
+  provider?: ApiProvider;
+  upstreamCreditDepleted?: boolean;
+  viaRelay?: boolean;
+}
+
+export interface ProgressApiKeyRetryResult {
+  proceeded: boolean;
+  retried: boolean;
+  disabledIncludedModelAccess: boolean;
+}
+
+export interface ProgressApiKeyRetryControllerDeps {
+  providers: readonly ApiProvider[];
+  readKey(provider: ApiProvider): Promise<string | undefined>;
+  hasUsableKey(provider: ApiProvider): Promise<boolean>;
+  promptForApiKey(provider?: ApiProvider): Promise<void>;
+  setUseIncludedModelAccess(enabled: boolean): Promise<void>;
+  invalidateModelOptionsCache(): void;
+  triggerRetry(stream: StreamTabId): boolean;
+}
+
+/**
+ * Owns the policy for switching from relay access to user-provided keys.
+ *
+ * The progress view host still owns prompts and messages; this controller keeps
+ * the credential/retry rules testable without depending on VS Code APIs.
+ */
+export class ProgressApiKeyRetryController {
+  constructor(private readonly deps: ProgressApiKeyRetryControllerDeps) {}
+
+  async useOwnApiKey(
+    request: ProgressApiKeyRetryRequest,
+  ): Promise<ProgressApiKeyRetryResult> {
+    const providersToCheck = request.provider
+      ? [request.provider]
+      : this.deps.providers;
+    const requireChange = request.upstreamCreditDepleted === true;
+    const before = requireChange
+      ? await this.readKeys(providersToCheck)
+      : undefined;
+
+    await this.deps.promptForApiKey(request.provider);
+
+    const shouldProceed = requireChange
+      ? await this.hasChangedUsableKey(providersToCheck, before)
+      : await this.hasAnyUsableKey(providersToCheck);
+
+    if (!shouldProceed) {
+      return {
+        proceeded: false,
+        retried: false,
+        disabledIncludedModelAccess: false,
+      };
+    }
+
+    let disabledIncludedModelAccess = false;
+    if (request.viaRelay === true) {
+      await this.deps.setUseIncludedModelAccess(false);
+      this.deps.invalidateModelOptionsCache();
+      disabledIncludedModelAccess = true;
+    }
+
+    return {
+      proceeded: true,
+      retried: this.deps.triggerRetry(request.stream),
+      disabledIncludedModelAccess,
+    };
+  }
+
+  private async hasAnyUsableKey(
+    providers: readonly ApiProvider[],
+  ): Promise<boolean> {
+    const checks = await Promise.all(
+      providers.map((provider) => this.deps.hasUsableKey(provider)),
+    );
+    return checks.some(Boolean);
+  }
+
+  private async hasChangedUsableKey(
+    providers: readonly ApiProvider[],
+    before: ReadonlyMap<ApiProvider, string | undefined> | undefined,
+  ): Promise<boolean> {
+    const after = await this.readKeys(providers);
+    return providers.some((provider) => {
+      const next = after.get(provider);
+      return (
+        typeof next === 'string' &&
+        next.trim().length > 0 &&
+        next !== before?.get(provider)
+      );
+    });
+  }
+
+  private async readKeys(
+    providers: readonly ApiProvider[],
+  ): Promise<Map<ApiProvider, string | undefined>> {
+    return new Map(
+      await Promise.all(
+        providers.map(
+          async (provider) =>
+            [provider, await this.deps.readKey(provider)] as const,
+        ),
+      ),
+    );
+  }
+}

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -123,6 +123,31 @@ describe('ProgressApiKeyRetryController', () => {
     assert.deepEqual(harness.retries, []);
   });
 
+  it('accepts a changed key from any provider when depletion has no provider hint', async () => {
+    const harness = createHarness({
+      keys: { openai: 'old-openai', anthropic: undefined },
+      prompt: (keys) => {
+        keys.set('anthropic', 'new-anthropic');
+      },
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-b',
+      upstreamCreditDepleted: true,
+      viaRelay: true,
+    });
+
+    assert.deepEqual(result, {
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: true,
+    });
+    assert.deepEqual(harness.prompts, [undefined]);
+    assert.deepEqual(harness.includedAccessValues, [false]);
+    assert.equal(harness.invalidations, 1);
+    assert.deepEqual(harness.retries, ['stream-b']);
+  });
+
   it('uses any existing usable key for relay-limit consent', async () => {
     const harness = createHarness({
       keys: { openai: 'stored-key' },

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -1,0 +1,168 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { describe, it } from 'vitest';
+
+// Local imports - controllers
+import { ProgressApiKeyRetryController } from '@controllers/progressView/ProgressApiKeyRetryController';
+
+// Local imports - model
+import type { ApiProvider } from '@model/apiProviders';
+
+const PROVIDERS = [
+  'openai',
+  'anthropic',
+] as const satisfies readonly ApiProvider[];
+
+interface HarnessOptions {
+  keys?: Partial<Record<ApiProvider, string | undefined>>;
+  prompt?(keys: Map<ApiProvider, string | undefined>): void;
+  retryAvailable?: boolean;
+}
+
+function createHarness(options: HarnessOptions = {}): {
+  controller: ProgressApiKeyRetryController;
+  keys: Map<ApiProvider, string | undefined>;
+  prompts: Array<ApiProvider | undefined>;
+  includedAccessValues: boolean[];
+  invalidations: number;
+  retries: string[];
+} {
+  const keys = new Map<ApiProvider, string | undefined>(
+    Object.entries(options.keys ?? {}) as Array<
+      [ApiProvider, string | undefined]
+    >,
+  );
+  const prompts: Array<ApiProvider | undefined> = [];
+  const includedAccessValues: boolean[] = [];
+  let invalidations = 0;
+  const retries: string[] = [];
+
+  return {
+    keys,
+    prompts,
+    includedAccessValues,
+    get invalidations() {
+      return invalidations;
+    },
+    retries,
+    controller: new ProgressApiKeyRetryController({
+      providers: PROVIDERS,
+      readKey: async (provider) => keys.get(provider),
+      hasUsableKey: async (provider) =>
+        (keys.get(provider)?.trim().length ?? 0) > 0,
+      promptForApiKey: async (provider) => {
+        prompts.push(provider);
+        options.prompt?.(keys);
+      },
+      setUseIncludedModelAccess: async (enabled) => {
+        includedAccessValues.push(enabled);
+      },
+      invalidateModelOptionsCache: () => {
+        invalidations += 1;
+      },
+      triggerRetry: (stream) => {
+        retries.push(stream);
+        return options.retryAvailable ?? true;
+      },
+    }),
+  };
+}
+
+describe('ProgressApiKeyRetryController', () => {
+  it('requires a changed usable key after upstream credit depletion', async () => {
+    const harness = createHarness({
+      keys: { anthropic: 'old-key' },
+      prompt: (keys) => {
+        keys.set('anthropic', 'new-key');
+      },
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-a',
+      provider: 'anthropic',
+      upstreamCreditDepleted: true,
+      viaRelay: true,
+    });
+
+    assert.deepEqual(result, {
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: true,
+    });
+    assert.deepEqual(harness.prompts, ['anthropic']);
+    assert.deepEqual(harness.includedAccessValues, [false]);
+    assert.equal(harness.invalidations, 1);
+    assert.deepEqual(harness.retries, ['stream-a']);
+  });
+
+  it('does not retry when a depleted provider key was not changed', async () => {
+    const harness = createHarness({
+      keys: { anthropic: 'old-key' },
+      prompt: (keys) => {
+        keys.set('anthropic', 'old-key');
+      },
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-a',
+      provider: 'anthropic',
+      upstreamCreditDepleted: true,
+      viaRelay: true,
+    });
+
+    assert.deepEqual(result, {
+      proceeded: false,
+      retried: false,
+      disabledIncludedModelAccess: false,
+    });
+    assert.deepEqual(harness.prompts, ['anthropic']);
+    assert.deepEqual(harness.includedAccessValues, []);
+    assert.equal(harness.invalidations, 0);
+    assert.deepEqual(harness.retries, []);
+  });
+
+  it('uses any existing usable key for relay-limit consent', async () => {
+    const harness = createHarness({
+      keys: { openai: 'stored-key' },
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-b',
+      viaRelay: true,
+    });
+
+    assert.deepEqual(result, {
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: true,
+    });
+    assert.deepEqual(harness.prompts, [undefined]);
+    assert.deepEqual(harness.includedAccessValues, [false]);
+    assert.equal(harness.invalidations, 1);
+    assert.deepEqual(harness.retries, ['stream-b']);
+  });
+
+  it('keeps relay enabled for direct-key failures', async () => {
+    const harness = createHarness({
+      keys: { anthropic: 'new-key' },
+      retryAvailable: false,
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-c',
+      provider: 'anthropic',
+      viaRelay: false,
+    });
+
+    assert.deepEqual(result, {
+      proceeded: true,
+      retried: false,
+      disabledIncludedModelAccess: false,
+    });
+    assert.deepEqual(harness.includedAccessValues, []);
+    assert.equal(harness.invalidations, 0);
+    assert.deepEqual(harness.retries, ['stream-c']);
+  });
+});


### PR DESCRIPTION
## Summary

- reviewed the progress-view layer boundary and found credential/retry policy embedded in the VS Code message handler
- extracted `USE_OWN_API_KEY` policy into `ProgressApiKeyRetryController` with explicit host ports
- added focused controller tests for changed-key detection, relay-limit consent, relay disabling, and missing retry handling

## Abstraction Findings

1. High impact, fixed here: `packages/extension/src/progressView/ProgressViewMessageHandler.ts` handled secret reads, upstream depleted-key comparison, included-access toggling, model option cache invalidation, and coordinator retry directly in the message adapter. This coupled UI dispatch to credential/model-access policy and made edge cases hard to test; the policy now lives in `src/controllers/progressView/ProgressApiKeyRetryController.ts`, while VS Code prompts and notifications stay in the extension host. Closes #6309.

2. Medium impact, follow-up tracked: `handlePolishFollowUp` in `ProgressViewMessageHandler` still combines task-state extraction, AI polishing, webview updates, progress UI, and error notification. That should move into a controller beside `ProgressFollowUpController`, with the extension layer retaining only host progress/notification wiring. Tracked in #6310.

## Validation

- `corepack pnpm exec prettier --check packages/extension/src/progressView/ProgressViewMessageHandler.ts src/controllers/progressView/ProgressApiKeyRetryController.ts src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`
- `npm run compile:fast`

Closes #6309

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches API credential validation, included-model-access mode, and agent retry—behavior is refactored but guarded by new tests; regressions could block retries or wrongly disable relay access.
> 
> **Overview**
> Moves **USE_OWN_API_KEY** handling out of `ProgressViewMessageHandler` into **`ProgressApiKeyRetryController`**, so credential gates, included-model-access toggling, cache invalidation, and stream retry are testable without VS Code.
> 
> The extension host still wires secrets, the set-API-key command, and coordinator retry; **`handleUseOwnApiKey`** now calls the controller and only shows the “no pending retry” info message when the user proceeded but **`triggerRetry`** returned false.
> 
> Policy is unchanged in intent: after **upstream credit depletion**, require a **changed** usable direct key; for **relay limits**, any usable direct key suffices; **disable included model access** only when **`viaRelay`** was true. Adds **vitest** coverage for those branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 289cc43d6d9ece54a06214e7754066ec94a05da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->