### PR TITLE
[codex] Extract settings profile controller

### DIFF
--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -12,16 +12,12 @@ import * as vscode from 'vscode';
 
 // Shared schemas and dispatchers
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
+import { SettingsProfileController } from '@controllers/settingsView/SettingsProfileController';
 import { platform } from '@platform/platform';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { BaseViewMessageHandler } from '@common/webview';
-import {
-  GlobalStateKey,
-  WorkspaceStateKey,
-  globalSM,
-  workspaceSM,
-} from '@common/state';
+import { WorkspaceStateKey, globalSM, workspaceSM } from '@common/state';
 import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
@@ -45,7 +41,6 @@ import {
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { StreamTabId } from '@shared/schemas';
-import { buildProfileMessage } from '@shared/settingsView/handlers/profileHandlers';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import {
   dispatchSettingsViewInbound,
@@ -73,11 +68,6 @@ import {
   PROVIDER_URLS,
   PROVIDER_VSCODE_SETTINGS,
 } from '@shared/constants/providers';
-import type {
-  ProviderKeyStatus,
-  ProviderVscodeSetting,
-  NumberVscodeSetting,
-} from '@shared/schemas/profileViewMessages';
 import { buildToolDashboardItems } from '@shared/settingsView/toolDashboardData';
 import { GoalStore } from '@tools/goal';
 import {
@@ -116,84 +106,6 @@ import type { SettingsHandlerContext } from './handlers/SettingsHandlerContext';
 type MessageFor<C extends SettingsViewInboundMessage['command']> =
   SettingsMessageFor<C>;
 
-/** Reliability settings surfaced in the Models tab. */
-const RELIABILITY_SETTINGS: (Omit<NumberVscodeSetting, 'value'> & {
-  defaultValue: number;
-})[] = [
-  {
-    key: 'texra.model.compactionThresholdPercent',
-    label: 'Compaction threshold',
-    description:
-      'Context window percentage to trigger automatic context compaction. Set to 0 to disable.',
-    min: 0,
-    max: 100,
-    unit: '%',
-    defaultValue: 75,
-  },
-  {
-    key: 'texra.model.retry.maxAttempts',
-    label: 'Retry attempts',
-    description:
-      'Automatic retry attempts before showing a manual retry button. Set to 0 for manual-only.',
-    min: 0,
-    defaultValue: 0,
-  },
-  {
-    key: 'texra.model.retry.backoffMs',
-    label: 'Retry backoff',
-    description: 'Base delay between retry attempts.',
-    min: 0,
-    unit: 'ms',
-    defaultValue: 1000,
-  },
-];
-
-/** Allowed setting keys that the frontend can toggle (whitelist for safety). */
-const ALLOWED_VSCODE_SETTING_KEYS = new Set([
-  ...Object.values(PROVIDER_VSCODE_SETTINGS)
-    .flat()
-    .map((s) => s.key),
-  ...RELIABILITY_SETTINGS.map((s) => s.key),
-]);
-
-function getProviderVscodeSettings(provider: string): ProviderVscodeSetting[] {
-  const defs = PROVIDER_VSCODE_SETTINGS[provider.toLowerCase()];
-  if (!defs) return [];
-  return defs.map((def) => ({
-    ...def,
-    value: def.globalStateKey
-      ? (globalSM?.get<boolean>(def.globalStateKey, false) ?? false)
-      : getConfig<boolean>(def.key, false),
-  }));
-}
-
-function getReliabilitySettings(): NumberVscodeSetting[] {
-  return RELIABILITY_SETTINGS.map(({ defaultValue, ...def }) => ({
-    ...def,
-    value: getConfig<number>(def.key, defaultValue),
-  }));
-}
-
-async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
-  const secretStatuses = await loadApiKeyStatusMap(
-    platform().secrets,
-    SecretManager.API_PROVIDERS,
-  );
-  return SecretManager.API_PROVIDERS.map((provider) => ({
-    provider,
-    displayName: getProviderDisplayName(
-      provider,
-      PROVIDER_DISPLAY_NAMES[provider],
-    ),
-    status: secretStatuses[provider],
-    keyUrl: getProviderKeyUrl(provider, PROVIDER_URLS[provider]),
-    streaming: getProviderStreaming(provider),
-    customEndpoint: getProviderEndpoint(provider),
-    supportsCustomEndpoint: supportsCustomEndpoint(provider),
-    vscodeSettings: getProviderVscodeSettings(provider),
-  }));
-}
-
 export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
@@ -206,6 +118,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly githubHandlers: GitHubSubscriptionHandlers;
   private readonly memoryController: SettingsMemoryController;
   private readonly modelSelectionController: SettingsModelSelectionController;
+  private readonly profileController: SettingsProfileController;
   private readonly profileKeyController: SettingsProfileKeyController;
 
   constructor(context: vscode.ExtensionContext) {
@@ -236,13 +149,33 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         getUserTier: () => getServerSideKeyService().getUserTier() ?? undefined,
       },
     );
+    this.profileController = new SettingsProfileController({
+      globalState: globalSM,
+      providerIds: SecretManager.API_PROVIDERS,
+      providerVscodeSettings: PROVIDER_VSCODE_SETTINGS,
+      providerDisplayNames: PROVIDER_DISPLAY_NAMES,
+      providerKeyUrls: PROVIDER_URLS,
+      loadProviderKeyStatuses: () =>
+        loadApiKeyStatusMap(platform().secrets, SecretManager.API_PROVIDERS),
+      getProviderDisplayName,
+      getProviderKeyUrl,
+      getProviderStreaming,
+      getProviderEndpoint,
+      supportsCustomEndpoint,
+      getConfig,
+      updateConfig: (key, value) =>
+        updateConfig(key, value, { target: 'global', prefix: false }),
+      setUseIncludedModelAccess: (enabled) =>
+        getServerSideKeyService().setUseIncludedModelAccess(enabled),
+      invalidateModelOptionsCache,
+    });
     this.profileKeyController = new SettingsProfileKeyController({
       prompt: new VscodePromptHost(),
       externalOpener: new VscodeExternalOpener(),
       getProviderDisplayName: (provider) =>
-        PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+        this.profileController.getProviderDisplayName(provider),
       getProviderKeyUrl: (provider) =>
-        getProviderKeyUrl(provider, PROVIDER_URLS[provider]),
+        this.profileController.getProviderKeyUrl(provider),
       getApiKeySecretName: (provider) =>
         SecretManager.getApiKeySecretName(provider as ApiProvider),
       setSecret: (key, value) => SecretManager.set(key, value),
@@ -703,10 +636,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendProfileData(webview: vscode.Webview): Promise<void> {
-    const message = await buildProfileMessage({
-      getProviderKeyStatuses: () => getProviderKeyStatuses(),
-    });
-    await webview.postMessage(message);
+    await webview.postMessage(
+      await this.profileController.buildProfileMessage(),
+    );
   }
 
   public async sendModelSelectionData(webview: vscode.Webview): Promise<void> {
@@ -731,7 +663,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       buildSuperYoloMessage({
         workspaceState: workspaceSM,
         globalState: globalSM,
-        getReliabilitySettings,
+        getReliabilitySettings: () =>
+          this.profileController.getReliabilitySettings(),
       }),
     );
   }
@@ -944,30 +877,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetApiAccessMode(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_API_ACCESS_MODE>,
   ): Promise<void> {
-    await getServerSideKeyService().setUseIncludedModelAccess(
-      data.mode === 'included',
-    );
-
-    // Included Access routes through the TeXRA relay — OpenRouter bypasses it.
-    // Disable OpenRouter when switching to Included Access so routing is consistent.
-    let openRouterDisabled = false;
-    if (
-      data.mode === 'included' &&
-      globalSM?.get<boolean>(GlobalStateKey.USE_OPENROUTER, false)
-    ) {
-      await globalSM.update(GlobalStateKey.USE_OPENROUTER, false);
-      openRouterDisabled = true;
-    }
-
-    // Access mode affects model availability — invalidate cached options.
-    invalidateModelOptionsCache();
+    const update = await this.profileController.setApiAccessMode(data.mode);
     await this.withActiveWebview(async (w) => {
       await this.sendProfileAndModelSelectionData(w);
     });
-
     const modeLabel =
-      data.mode === 'included' ? 'Included Access' : 'My Own Keys';
-    const suffix = openRouterDisabled
+      update.mode === 'included' ? 'Included Access' : 'My Own Keys';
+    const suffix = update.openRouterDisabled
       ? ' OpenRouter has been turned off (not compatible with Included Access).'
       : '';
     void vscode.window.showInformationMessage(
@@ -1001,7 +917,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
-        `Failed to ${verb} ${PROVIDER_DISPLAY_NAMES[provider] ?? provider} API key`,
+        `Failed to ${verb} ${this.profileController.getProviderDisplayName(provider)} API key`,
         error,
       );
       // On error, still refresh settings view to reflect current key state.
@@ -1072,44 +988,26 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetProviderVscodeSetting(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PROVIDER_VSCODE_SETTING>,
   ): Promise<void> {
-    if (!ALLOWED_VSCODE_SETTING_KEYS.has(data.key)) {
+    const result = await this.profileController.setProviderVscodeSetting(data);
+    if (result.kind === 'rejected') {
       this.logger.warn(
         this.channel,
-        `Rejected unknown vscode setting key: ${data.key}`,
+        `Rejected unknown vscode setting key: ${result.key}`,
       );
       return;
-    }
-
-    // Check if this setting is backed by globalSM instead of VS Code config
-    const def = Object.values(PROVIDER_VSCODE_SETTINGS)
-      .flat()
-      .find((s) => s.key === data.key);
-    if (def?.globalStateKey) {
-      await globalSM?.update(def.globalStateKey, data.value);
-    } else {
-      await updateConfig(data.key, data.value, {
-        target: 'global',
-        prefix: false,
-      });
-    }
-
-    const affectsModelAvailability =
-      def?.globalStateKey === GlobalStateKey.USE_OPENROUTER;
-    if (affectsModelAvailability) {
-      invalidateModelOptionsCache();
     }
 
     await this.withActiveWebview(async (w) => {
       await Promise.all([
         this.sendProfileData(w),
         this.sendSuperYoloEnabled(w),
-        affectsModelAvailability
+        result.affectsModelAvailability
           ? this.sendModelSelectionData(w)
           : Promise.resolve(),
       ]);
     });
 
-    if (affectsModelAvailability) {
+    if (result.affectsModelAvailability) {
       await vscode.commands.executeCommand('texra.refreshAllOptions');
     }
   }

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -1,0 +1,202 @@
+import { GlobalStateKey } from '@shared/state/stateKeys';
+import { buildProfileMessage } from '@shared/settingsView/handlers/profileHandlers';
+import type {
+  ApiAccessMode,
+  NumberVscodeSetting,
+  ProviderKeyStatus,
+  ProviderVscodeSetting,
+  UpdateProfileMessage,
+} from '@shared/schemas/profileViewMessages';
+import type { ProviderVscodeSettingDef } from '@shared/constants/providers';
+import type { StateStore } from '@platform/interfaces/state';
+
+export type SettingsReliabilitySetting = Omit<NumberVscodeSetting, 'value'> & {
+  defaultValue: number;
+};
+
+export const SETTINGS_RELIABILITY_SETTINGS: readonly SettingsReliabilitySetting[] =
+  [
+    {
+      key: 'texra.model.compactionThresholdPercent',
+      label: 'Compaction threshold',
+      description:
+        'Context window percentage to trigger automatic context compaction. Set to 0 to disable.',
+      min: 0,
+      max: 100,
+      unit: '%',
+      defaultValue: 75,
+    },
+    {
+      key: 'texra.model.retry.maxAttempts',
+      label: 'Retry attempts',
+      description:
+        'Automatic retry attempts before showing a manual retry button. Set to 0 for manual-only.',
+      min: 0,
+      defaultValue: 0,
+    },
+    {
+      key: 'texra.model.retry.backoffMs',
+      label: 'Retry backoff',
+      description: 'Base delay between retry attempts.',
+      min: 0,
+      unit: 'ms',
+      defaultValue: 1000,
+    },
+  ];
+
+export type SettingsProfileConfigValue = boolean | number;
+
+export type ProviderVscodeSettingUpdateResult =
+  | { kind: 'updated'; affectsModelAvailability: boolean }
+  | { kind: 'rejected'; key: string };
+
+export interface ApiAccessModeUpdate {
+  readonly mode: ApiAccessMode;
+  readonly openRouterDisabled: boolean;
+}
+
+export interface SettingsProfileControllerDeps {
+  readonly globalState: StateStore;
+  readonly providerIds: readonly string[];
+  readonly providerVscodeSettings: Record<
+    string,
+    readonly ProviderVscodeSettingDef[]
+  >;
+  readonly providerDisplayNames: Record<string, string>;
+  readonly providerKeyUrls: Record<string, string>;
+  loadProviderKeyStatuses(): Promise<
+    Record<string, ProviderKeyStatus['status']>
+  >;
+  getProviderDisplayName(provider: string, defaultName: string): string;
+  getProviderKeyUrl(provider: string, defaultUrl: string): string;
+  getProviderStreaming(provider: string): boolean;
+  getProviderEndpoint(provider: string): string;
+  supportsCustomEndpoint(provider: string): boolean;
+  getConfig<T>(key: string, defaultValue: T): T;
+  updateConfig(key: string, value: SettingsProfileConfigValue): Promise<void>;
+  setUseIncludedModelAccess(enabled: boolean): Promise<void>;
+  invalidateModelOptionsCache(): void;
+}
+
+export class SettingsProfileController {
+  private readonly allowedProviderSettingKeys: Set<string>;
+  private readonly reliabilitySettingKeys = new Set(
+    SETTINGS_RELIABILITY_SETTINGS.map((setting) => setting.key),
+  );
+
+  constructor(private readonly deps: SettingsProfileControllerDeps) {
+    this.allowedProviderSettingKeys = new Set(
+      Object.values(deps.providerVscodeSettings)
+        .flat()
+        .map((setting) => setting.key),
+    );
+  }
+
+  async buildProfileMessage(): Promise<UpdateProfileMessage> {
+    return buildProfileMessage({
+      getProviderKeyStatuses: () => this.getProviderKeyStatuses(),
+    });
+  }
+
+  getReliabilitySettings(): NumberVscodeSetting[] {
+    return SETTINGS_RELIABILITY_SETTINGS.map(
+      ({ defaultValue, ...setting }) => ({
+        ...setting,
+        value: this.deps.getConfig<number>(setting.key, defaultValue),
+      }),
+    );
+  }
+
+  getProviderDisplayName(provider: string): string {
+    return this.deps.getProviderDisplayName(
+      provider,
+      this.deps.providerDisplayNames[provider] ?? provider,
+    );
+  }
+
+  getProviderKeyUrl(provider: string): string | undefined {
+    const defaultUrl = this.deps.providerKeyUrls[provider];
+    if (!defaultUrl) return undefined;
+    return this.deps.getProviderKeyUrl(provider, defaultUrl);
+  }
+
+  async setApiAccessMode(mode: ApiAccessMode): Promise<ApiAccessModeUpdate> {
+    const includedAccess = mode === 'included';
+    await this.deps.setUseIncludedModelAccess(includedAccess);
+
+    let openRouterDisabled = false;
+    if (
+      includedAccess &&
+      this.deps.globalState.get<boolean>(GlobalStateKey.USE_OPENROUTER, false)
+    ) {
+      // Included Access routes through the TeXRA relay; OpenRouter bypasses it.
+      await this.deps.globalState.update(GlobalStateKey.USE_OPENROUTER, false);
+      openRouterDisabled = true;
+    }
+
+    this.deps.invalidateModelOptionsCache();
+    return { mode, openRouterDisabled };
+  }
+
+  async setProviderVscodeSetting(input: {
+    key: string;
+    value: SettingsProfileConfigValue;
+  }): Promise<ProviderVscodeSettingUpdateResult> {
+    const providerSetting = this.findProviderSetting(input.key);
+    const isReliabilitySetting = this.reliabilitySettingKeys.has(input.key);
+    if (!providerSetting && !isReliabilitySetting) {
+      return { kind: 'rejected', key: input.key };
+    }
+
+    if (providerSetting?.globalStateKey) {
+      await this.deps.globalState.update(
+        providerSetting.globalStateKey,
+        input.value,
+      );
+    } else {
+      await this.deps.updateConfig(input.key, input.value);
+    }
+
+    const affectsModelAvailability =
+      providerSetting?.globalStateKey === GlobalStateKey.USE_OPENROUTER;
+    if (affectsModelAvailability) {
+      this.deps.invalidateModelOptionsCache();
+    }
+    return { kind: 'updated', affectsModelAvailability };
+  }
+
+  private async getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
+    const secretStatuses = await this.deps.loadProviderKeyStatuses();
+    return this.deps.providerIds.map((provider) => ({
+      provider,
+      displayName: this.getProviderDisplayName(provider),
+      status: secretStatuses[provider] ?? 'not-set',
+      keyUrl: this.getProviderKeyUrl(provider) ?? '',
+      streaming: this.deps.getProviderStreaming(provider),
+      customEndpoint: this.deps.getProviderEndpoint(provider),
+      supportsCustomEndpoint: this.deps.supportsCustomEndpoint(provider),
+      vscodeSettings: this.getProviderVscodeSettings(provider),
+    }));
+  }
+
+  private getProviderVscodeSettings(provider: string): ProviderVscodeSetting[] {
+    const defs = this.deps.providerVscodeSettings[provider.toLowerCase()];
+    if (!defs) return [];
+    return defs.map((def) => ({
+      ...def,
+      value: def.globalStateKey
+        ? (this.deps.globalState.get<boolean>(def.globalStateKey, false) ??
+          false)
+        : this.deps.getConfig<boolean>(def.key, false),
+    }));
+  }
+
+  private findProviderSetting(
+    key: string,
+  ): ProviderVscodeSettingDef | undefined {
+    if (!this.allowedProviderSettingKeys.has(key)) return undefined;
+    return Object.values(this.deps.providerVscodeSettings)
+      .flat()
+      .find((setting) => setting.key === key);
+  }
+}

--- a/src/test-kernel/controllers/SettingsProfileController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileController.vitest.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SettingsProfileController,
+  type SettingsProfileConfigValue,
+} from '@controllers/settingsView/SettingsProfileController';
+import type { ProviderVscodeSettingDef } from '@shared/constants/providers';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+import type { StateStore } from '@platform/interfaces/state';
+
+const providerVscodeSettings = {
+  openai: [
+    {
+      key: 'texra.model.useOpenAIResponsesAPI',
+      label: 'Responses API',
+      description: 'Use Responses API',
+    },
+  ],
+  openrouter: [
+    {
+      key: GlobalStateKey.USE_OPENROUTER,
+      label: 'Use OpenRouter',
+      description: 'Route through OpenRouter',
+      globalStateKey: GlobalStateKey.USE_OPENROUTER,
+    },
+  ],
+} satisfies Record<string, readonly ProviderVscodeSettingDef[]>;
+
+function createState(initial: Record<string, unknown> = {}): StateStore & {
+  data: Record<string, unknown>;
+} {
+  const data = { ...initial };
+  return {
+    data,
+    get: <T>(key: string, defaultValue?: T): T => {
+      return (Object.hasOwn(data, key) ? data[key] : defaultValue) as T;
+    },
+    update: async (key: string, value: unknown) => {
+      data[key] = value;
+    },
+  };
+}
+
+function createController(
+  options: {
+    state?: StateStore;
+    config?: Record<string, SettingsProfileConfigValue>;
+  } = {},
+): {
+  controller: SettingsProfileController;
+  includedAccessUpdates: boolean[];
+  invalidations: { count: number };
+  config: Record<string, SettingsProfileConfigValue>;
+} {
+  const includedAccessUpdates: boolean[] = [];
+  const invalidations = { count: 0 };
+  const config = options.config ?? {};
+  const state = options.state ?? createState();
+
+  return {
+    controller: new SettingsProfileController({
+      globalState: state,
+      providerIds: ['openai', 'openrouter'],
+      providerVscodeSettings,
+      providerDisplayNames: { openai: 'OpenAI', openrouter: 'OpenRouter' },
+      providerKeyUrls: {
+        openai: 'https://platform.openai.com/api-keys',
+        openrouter: 'https://openrouter.ai/keys',
+      },
+      loadProviderKeyStatuses: async () => ({
+        openai: 'set',
+        openrouter: 'not-set',
+      }),
+      getProviderDisplayName: (_provider, defaultName) => defaultName,
+      getProviderKeyUrl: (_provider, defaultUrl) => defaultUrl,
+      getProviderStreaming: () => true,
+      getProviderEndpoint: () => '',
+      supportsCustomEndpoint: () => false,
+      getConfig: <T>(key: string, defaultValue: T): T =>
+        (Object.hasOwn(config, key) ? config[key] : defaultValue) as T,
+      updateConfig: async (key, value) => {
+        config[key] = value;
+      },
+      setUseIncludedModelAccess: async (enabled) => {
+        includedAccessUpdates.push(enabled);
+      },
+      invalidateModelOptionsCache: () => {
+        invalidations.count += 1;
+      },
+    }),
+    includedAccessUpdates,
+    invalidations,
+    config,
+  };
+}
+
+describe('SettingsProfileController', () => {
+  it('turns off OpenRouter when switching to included access', async () => {
+    const state = createState({ [GlobalStateKey.USE_OPENROUTER]: true });
+    const { controller, includedAccessUpdates, invalidations } =
+      createController({ state });
+
+    const update = await controller.setApiAccessMode('included');
+
+    expect(includedAccessUpdates).toEqual([true]);
+    expect(state.get(GlobalStateKey.USE_OPENROUTER, true)).toBe(false);
+    expect(invalidations.count).toBe(1);
+    expect(update).toEqual({
+      mode: 'included',
+      openRouterDisabled: true,
+    });
+  });
+
+  it('keeps OpenRouter unchanged when switching to personal keys', async () => {
+    const state = createState({ [GlobalStateKey.USE_OPENROUTER]: true });
+    const { controller, includedAccessUpdates, invalidations } =
+      createController({ state });
+
+    const update = await controller.setApiAccessMode('personal');
+
+    expect(includedAccessUpdates).toEqual([false]);
+    expect(state.get(GlobalStateKey.USE_OPENROUTER, false)).toBe(true);
+    expect(invalidations.count).toBe(1);
+    expect(update).toEqual({
+      mode: 'personal',
+      openRouterDisabled: false,
+    });
+  });
+
+  it('updates only whitelisted provider settings', async () => {
+    const state = createState();
+    const { controller, invalidations } = createController({ state });
+
+    const rejected = await controller.setProviderVscodeSetting({
+      key: 'texra.unknownSetting',
+      value: true,
+    });
+    const updated = await controller.setProviderVscodeSetting({
+      key: GlobalStateKey.USE_OPENROUTER,
+      value: true,
+    });
+
+    expect(rejected).toEqual({
+      kind: 'rejected',
+      key: 'texra.unknownSetting',
+    });
+    expect(updated).toEqual({
+      kind: 'updated',
+      affectsModelAvailability: true,
+    });
+    expect(state.get(GlobalStateKey.USE_OPENROUTER, false)).toBe(true);
+    expect(invalidations.count).toBe(1);
+  });
+
+  it('keeps reliability settings in config-backed model policy', async () => {
+    const { controller, config, invalidations } = createController();
+
+    const result = await controller.setProviderVscodeSetting({
+      key: 'texra.model.retry.maxAttempts',
+      value: 3,
+    });
+
+    expect(result).toEqual({
+      kind: 'updated',
+      affectsModelAvailability: false,
+    });
+    expect(config['texra.model.retry.maxAttempts']).toBe(3);
+    expect(invalidations.count).toBe(0);
+    expect(controller.getReliabilitySettings()).toContainEqual(
+      expect.objectContaining({
+        key: 'texra.model.retry.maxAttempts',
+        value: 3,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extract profile/provider settings policy from `SettingsViewMessageHandler` into `SettingsProfileController`.
- Keep the Settings handler focused on VS Code message routing, webview refreshes, and host commands.
- Add controller tests for included-access/OpenRouter behavior, provider setting whitelisting, and reliability setting persistence.

Closes #6313.

## Abstraction Review

High impact: `SettingsViewMessageHandler` owned provider/API-key status construction, provider setting whitelist policy, included-access side effects, OpenRouter compatibility, config writes, and model cache invalidation. That made the VS Code webview host layer a policy owner for provider/model behavior; the PR moves that policy behind a controller with explicit state/config/provider ports.

Follow-up: #6314 tracks command-layer chat export importing provider SDK message shapes directly. That should move to a provider-normalization API below the command renderer.

Follow-up: #6315 tracks Settings goal navigation reaching into Progress provider state directly. That should move behind a Progress-owned navigation service.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/controllers/SettingsProfileController.vitest.ts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model access mode, OpenRouter global state, and provider setting whitelist—behavior should stay the same but these paths affect which models and keys are available.
> 
> **Overview**
> Moves **provider/profile policy** out of `SettingsViewMessageHandler` into a new **`SettingsProfileController`**, matching the existing model-selection controller split so the handler mainly routes webview messages and refreshes UI.
> 
> The controller now owns building profile payloads (provider key status, VS Code toggles), **reliability** settings (`SETTINGS_RELIABILITY_SETTINGS`), **API access mode** (including auto-disabling OpenRouter on Included Access), **whitelisted** provider/reliability setting writes, and **model-options cache** invalidation when routing changes. The handler wires it with injected deps (global state, secrets, config) and still handles toasts, `texra.refreshAllOptions`, and webview updates.
> 
> Adds **`SettingsProfileController.vitest.ts`** for included-access/OpenRouter behavior, setting whitelist rejection, and reliability config persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60beb985873a31859539a7ed530eba543de674b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->