### PR TITLE
[codex] Suppress quiet agent visibility notice

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -29,7 +29,7 @@ export async function listAgents(
   await initLocalCliPlatform(context);
   const result = await loadCliAgentList(options);
 
-  if (context.outputFormat === 'text') {
+  if (context.outputFormat === 'text' && !context.quietLogs) {
     const hiddenNotice = formatCliHiddenAgentsNotice(result.hiddenCount);
     if (hiddenNotice) writeTextStderr(hiddenNotice);
   }

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -123,6 +123,46 @@ describe('CLI agents command', () => {
     );
   });
 
+  it('suppresses hidden-agent notices in quiet text mode', async () => {
+    const visibleAgent = {
+      name: 'polish',
+      source: 'builtInWorkflow',
+      path: '/tmp/resources/agents/polish.yaml',
+      category: AgentCategory.Workflow,
+      description: 'Polishes prose.',
+    };
+    const hiddenAgent = {
+      name: 'correct',
+      source: 'builtInWorkflow',
+      path: '/tmp/resources/agents/correct.yaml',
+      category: AgentCategory.Workflow,
+      description: 'Corrects LaTeX.',
+    };
+    mocks.getVisibleAgents.mockImplementation((category: AgentCategory) =>
+      category === AgentCategory.Workflow ? [visibleAgent] : [],
+    );
+    mocks.getAgentsByCategory.mockImplementation((category: AgentCategory) =>
+      category === AgentCategory.Workflow ? [visibleAgent, hiddenAgent] : [],
+    );
+    const { listAgents } = await import('@cli/commands/agents');
+
+    const exitCode = await listAgents(cliContext({ quietLogs: true }), {
+      category: AgentCategory.Workflow,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.emitCliResult).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        json: [visibleAgent],
+        ndjson: [{ kind: 'agent', agent: visibleAgent }],
+        text: 'workflow\tpolish\tPolishes prose.',
+      },
+      { paged: true },
+    );
+    expect(mocks.writeTextStderr).not.toHaveBeenCalled();
+  });
+
   it('filters agents by category and reports hidden agents in that category', async () => {
     const visibleToolUseAgent = {
       name: 'lean',


### PR DESCRIPTION
## Summary

- Suppress the hidden-agent visibility notice when `agents list` runs with `--quiet`.
- Preserve the notice in normal text output.
- Add a focused CLI agents command regression test for quiet text mode.

Closes #6312.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/AgentsCommand.vitest.mts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI output behavior change with a focused test; no auth, data, or listing logic changes beyond stderr messaging.
> 
> **Overview**
> **`texra agents list`** no longer writes the hidden-agent visibility notice to stderr when the CLI runs with **`--quiet`** (`quietLogs: true`). The notice still appears in normal text mode when some agents are omitted from the visible catalog.
> 
> A regression test asserts that quiet text mode keeps the usual tabular list output via **`emitCliResult`** but does not call **`writeTextStderr`** for the hidden-agent message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aa3a3d143aa885bcf56c3b9bb9a30e952d2eaa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->