### PR TITLE
refactor: extract remote agent prompt loading

### DIFF
--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
+import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import {
   createKey,
   getAgent,
@@ -17,9 +18,8 @@ import {
 } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { BUILTIN_TEAM_ROOT_AGENT_NAMES } from '@agent/index/agentRegistry';
-import { EdgeFunctionResponseSchema } from '@agent/remote/types';
+import { fetchRemoteAgentConfigYaml } from '@agent/remote/remoteAgentConfigClient';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { ULTRA_TIER, SUPABASE_CONFIG } from '@auth/config';
 import { renderAgentTemplateFromBundle } from '@commands/agent/agentTemplateRenderer';
 import { workspaceSM, globalSM } from '@common/state';
 import {
@@ -48,6 +48,12 @@ export class AgentHandlers {
   private readonly catalogController: SettingsAgentCatalogController;
   private readonly directoryController: SettingsAgentDirectoryController;
   private readonly fileController = new SettingsAgentFileController();
+  private readonly remotePromptController =
+    new SettingsRemoteAgentPromptController({
+      getUserTier: () => SupabaseClient.getUserTier(),
+      getAccessToken: () => SupabaseClient.getAccessToken(),
+      fetchPromptConfig: fetchRemoteAgentConfigYaml,
+    });
   private readonly visibilityController: SettingsAgentVisibilityController;
 
   constructor(
@@ -208,45 +214,16 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.VIEW_REMOTE_AGENT_PROMPT>,
   ): Promise<void> {
     try {
-      const tier = await SupabaseClient.getUserTier();
-      if (tier !== ULTRA_TIER) {
-        await vscode.window.showErrorMessage(
-          'Viewing remote agent prompts requires an Ultra plan.',
-        );
-        return;
-      }
-
-      const token = await SupabaseClient.getAccessToken();
-      if (!token) {
-        await vscode.window.showErrorMessage(
-          'Authentication required. Sign in using "TeXRA: Sign In".',
-        );
-        return;
-      }
-
-      const response = await fetch(SUPABASE_CONFIG.edgeFunctionUrl, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ agentName: data.agentName }),
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => 'Unknown error');
-        await vscode.window.showErrorMessage(
-          `Failed to fetch agent prompt: ${errorText}`,
-        );
-        return;
-      }
-
-      const responseData = EdgeFunctionResponseSchema.parse(
-        await response.json(),
+      const result = await this.remotePromptController.getPromptConfig(
+        data.agentName,
       );
+      if (!result.ok) {
+        await vscode.window.showErrorMessage(result.message);
+        return;
+      }
 
       const doc = await vscode.workspace.openTextDocument({
-        content: responseData.config,
+        content: result.config,
         language: 'yaml',
       });
       await vscode.window.showTextDocument(doc, { preview: false });

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -1,4 +1,3 @@
-import { StatusCodes } from 'http-status-codes';
 import yaml from 'yaml';
 import { z } from 'zod';
 
@@ -23,10 +22,10 @@ import { resolveToolDefinitions } from '@tools/registry';
 import { filterNotNull, filterNotNullish } from '@utils/core';
 import {
   RemoteAgentListItemSchema,
-  EdgeFunctionResponseSchema,
   type RemoteAgentListItem,
   type RemoteAgentConfig,
 } from './types';
+import { fetchRemoteAgentConfigYaml } from './remoteAgentConfigClient';
 
 const CHANNEL = 'RemoteAgentLoader';
 logger.initialize(CHANNEL);
@@ -75,37 +74,6 @@ export function isMissingRemoteAgentToolsColumnError(
     text.includes('column');
 
   return schemaError && /\btools\b/.test(text);
-}
-
-/** Maps HTTP status codes to user-friendly error messages. */
-function mapHttpError(
-  status: number,
-  agentName: string,
-  errorText: string,
-): string {
-  switch (status) {
-    case StatusCodes.UNAUTHORIZED:
-      return 'Session expired. Sign in again to continue.';
-
-    case StatusCodes.FORBIDDEN:
-      return `Access denied to agent "${agentName}". Upgrade your account for access.`;
-
-    case StatusCodes.NOT_FOUND:
-      return `Agent "${agentName}" not found or access denied. Verify the agent name and your permissions.`;
-
-    case StatusCodes.INTERNAL_SERVER_ERROR:
-      if (errorText.includes('Failed to load agent configuration')) {
-        return (
-          `Failed to load agent "${agentName}": The agent configuration file could not be retrieved from storage. ` +
-          `This may indicate the agent's YAML file is missing or the storage path in the database is incorrect. ` +
-          `Please contact the TeXRA team if this agent should be available.`
-        );
-      }
-      return `Failed to load agent: ${StatusCodes[status]} - ${errorText}`;
-
-    default:
-      return `Failed to load agent: ${StatusCodes[status] || status} - ${errorText}`;
-  }
 }
 
 /** Parse DB row to RemoteAgentListItem, returning null on validation failure. */
@@ -287,27 +255,10 @@ async function fetchAgentConfig(agentName: string): Promise<{
     throw new Error('Authentication token unavailable. Try signing in again.');
   }
 
-  const response = await fetch(SUPABASE_CONFIG.edgeFunctionUrl, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ agentName }),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => 'Unknown error');
-    const message = mapHttpError(response.status, agentName, errorText);
-    throw new Error(message);
-  }
-
-  const responseData = EdgeFunctionResponseSchema.parse(await response.json());
+  const configYaml = await fetchRemoteAgentConfigYaml(agentName, token);
 
   logger.debug(CHANNEL, `Parsing YAML for remote agent: ${agentName}`);
-  const validated = AgentDefinitionSchema.parse(
-    yaml.parse(responseData.config),
-  );
+  const validated = AgentDefinitionSchema.parse(yaml.parse(configYaml));
 
   // Extract metadata before resolving tools to full definitions (for registry cache)
   const settings: Partial<AgentSetting> = validated.settings;

--- a/src/agent/remote/remoteAgentConfigClient.ts
+++ b/src/agent/remote/remoteAgentConfigClient.ts
@@ -1,0 +1,63 @@
+// Third-party imports
+import { StatusCodes } from 'http-status-codes';
+
+// Local imports - auth
+import { SUPABASE_CONFIG } from '@auth/config';
+
+// Local imports - agent
+import { EdgeFunctionResponseSchema } from './types';
+
+/** Fetch raw remote-agent YAML from the edge function. */
+export async function fetchRemoteAgentConfigYaml(
+  agentName: string,
+  accessToken: string,
+): Promise<string> {
+  const response = await fetch(SUPABASE_CONFIG.edgeFunctionUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ agentName }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'Unknown error');
+    throw new Error(
+      mapRemoteAgentConfigHttpError(response.status, agentName, errorText),
+    );
+  }
+
+  return EdgeFunctionResponseSchema.parse(await response.json()).config;
+}
+
+/** Maps edge-function HTTP status codes to user-friendly error messages. */
+function mapRemoteAgentConfigHttpError(
+  status: number,
+  agentName: string,
+  errorText: string,
+): string {
+  switch (status) {
+    case StatusCodes.UNAUTHORIZED:
+      return 'Session expired. Sign in again to continue.';
+
+    case StatusCodes.FORBIDDEN:
+      return `Access denied to agent "${agentName}". Upgrade your account for access.`;
+
+    case StatusCodes.NOT_FOUND:
+      return `Agent "${agentName}" not found or access denied. Verify the agent name and your permissions.`;
+
+    case StatusCodes.INTERNAL_SERVER_ERROR:
+      if (errorText.includes('Failed to load agent configuration')) {
+        return (
+          `Failed to load agent "${agentName}": The agent configuration file could not be retrieved from storage. ` +
+          `This may indicate the agent's YAML file is missing or the storage path in the database is incorrect. ` +
+          `Please contact the TeXRA team if this agent should be available.`
+        );
+      }
+      return `Failed to load agent: ${StatusCodes[status]} - ${errorText}`;
+
+    default:
+      return `Failed to load agent: ${StatusCodes[status] || status} - ${errorText}`;
+  }
+}

--- a/src/agent/remote/remoteAgentConfigClient.ts
+++ b/src/agent/remote/remoteAgentConfigClient.ts
@@ -42,7 +42,7 @@ function mapRemoteAgentConfigHttpError(
       return 'Session expired. Sign in again to continue.';
 
     case StatusCodes.FORBIDDEN:
-      return `Access denied to agent "${agentName}". Upgrade your account for access.`;
+      return `Access denied to agent "${agentName}". Your account does not have permission to access this remote agent.`;
 
     case StatusCodes.NOT_FOUND:
       return `Agent "${agentName}" not found or access denied. Verify the agent name and your permissions.`;

--- a/src/controllers/settingsView/SettingsRemoteAgentPromptController.ts
+++ b/src/controllers/settingsView/SettingsRemoteAgentPromptController.ts
@@ -5,7 +5,6 @@ export type SettingsRemoteAgentPromptResult =
   | { ok: true; config: string }
   | {
       ok: false;
-      reason: 'requiresUltra' | 'unauthenticated';
       message: string;
     };
 
@@ -25,7 +24,6 @@ export class SettingsRemoteAgentPromptController {
     if (tier !== ULTRA_TIER) {
       return {
         ok: false,
-        reason: 'requiresUltra',
         message: 'Viewing remote agent prompts requires an Ultra plan.',
       };
     }
@@ -34,7 +32,6 @@ export class SettingsRemoteAgentPromptController {
     if (!token) {
       return {
         ok: false,
-        reason: 'unauthenticated',
         message: 'Authentication required. Sign in using "TeXRA: Sign In".',
       };
     }

--- a/src/controllers/settingsView/SettingsRemoteAgentPromptController.ts
+++ b/src/controllers/settingsView/SettingsRemoteAgentPromptController.ts
@@ -1,0 +1,47 @@
+// Local imports - auth
+import { ULTRA_TIER, type UserTier } from '@auth/config';
+
+export type SettingsRemoteAgentPromptResult =
+  | { ok: true; config: string }
+  | {
+      ok: false;
+      reason: 'requiresUltra' | 'unauthenticated';
+      message: string;
+    };
+
+export interface SettingsRemoteAgentPromptControllerDeps {
+  getUserTier(): Promise<UserTier>;
+  getAccessToken(): Promise<string | null>;
+  fetchPromptConfig(agentName: string, accessToken: string): Promise<string>;
+}
+
+export class SettingsRemoteAgentPromptController {
+  constructor(private readonly deps: SettingsRemoteAgentPromptControllerDeps) {}
+
+  async getPromptConfig(
+    agentName: string,
+  ): Promise<SettingsRemoteAgentPromptResult> {
+    const tier = await this.deps.getUserTier();
+    if (tier !== ULTRA_TIER) {
+      return {
+        ok: false,
+        reason: 'requiresUltra',
+        message: 'Viewing remote agent prompts requires an Ultra plan.',
+      };
+    }
+
+    const token = await this.deps.getAccessToken();
+    if (!token) {
+      return {
+        ok: false,
+        reason: 'unauthenticated',
+        message: 'Authentication required. Sign in using "TeXRA: Sign In".',
+      };
+    }
+
+    return {
+      ok: true,
+      config: await this.deps.fetchPromptConfig(agentName, token),
+    };
+  }
+}

--- a/src/test-kernel/agent/remote/RemoteAgentConfigClient.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentConfigClient.vitest.ts
@@ -1,0 +1,47 @@
+import { strict as assert } from 'node:assert';
+
+import { afterEach, describe, it, vi } from 'vitest';
+
+import { fetchRemoteAgentConfigYaml } from '@agent/remote/remoteAgentConfigClient';
+import { SUPABASE_CONFIG } from '@auth/config';
+
+describe('fetchRemoteAgentConfigYaml', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts the agent name and returns the parsed YAML config', async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ config: 'settings: {}\nprompts: {}\n' }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const config = await fetchRemoteAgentConfigYaml('remoteWriter', 'token');
+
+    assert.equal(config, 'settings: {}\nprompts: {}\n');
+    assert.equal(fetchMock.mock.calls.length, 1);
+    assert.deepEqual(fetchMock.mock.calls[0], [
+      SUPABASE_CONFIG.edgeFunctionUrl,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ agentName: 'remoteWriter' }),
+      },
+    ]);
+  });
+
+  it('maps missing agents to the existing user-facing error text', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('not found', { status: 404 })),
+    );
+
+    await assert.rejects(
+      () => fetchRemoteAgentConfigYaml('remoteWriter', 'token'),
+      /Agent "remoteWriter" not found or access denied/,
+    );
+  });
+});

--- a/src/test-kernel/agent/remote/RemoteAgentConfigClient.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentConfigClient.vitest.ts
@@ -44,4 +44,16 @@ describe('fetchRemoteAgentConfigYaml', () => {
       /Agent "remoteWriter" not found or access denied/,
     );
   });
+
+  it('maps forbidden agents to a permission-specific error text', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('forbidden', { status: 403 })),
+    );
+
+    await assert.rejects(
+      () => fetchRemoteAgentConfigYaml('remoteWriter', 'token'),
+      /Your account does not have permission to access this remote agent/,
+    );
+  });
 });

--- a/src/test-kernel/controllers/SettingsRemoteAgentPromptController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsRemoteAgentPromptController.vitest.ts
@@ -1,0 +1,82 @@
+import { strict as assert } from 'node:assert';
+
+import { describe, it, vi } from 'vitest';
+
+import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
+import { FREE_TIER, ULTRA_TIER, type UserTier } from '@auth/config';
+
+function createController(options: {
+  tier: UserTier;
+  token: string | null;
+  fetchPromptConfig?: (
+    agentName: string,
+    accessToken: string,
+  ) => Promise<string>;
+}): {
+  controller: SettingsRemoteAgentPromptController;
+  fetchPromptConfig: ReturnType<typeof vi.fn>;
+} {
+  const fetchPromptConfig = vi.fn(
+    options.fetchPromptConfig ??
+      (async () => 'settings:\n  model: test\nprompts: {}\n'),
+  );
+  return {
+    controller: new SettingsRemoteAgentPromptController({
+      getUserTier: async () => options.tier,
+      getAccessToken: async () => options.token,
+      fetchPromptConfig,
+    }),
+    fetchPromptConfig,
+  };
+}
+
+describe('SettingsRemoteAgentPromptController', () => {
+  it('rejects non-Ultra users before requesting a token', async () => {
+    const { controller, fetchPromptConfig } = createController({
+      tier: FREE_TIER,
+      token: 'token',
+    });
+
+    const result = await controller.getPromptConfig('remoteWriter');
+
+    assert.deepEqual(result, {
+      ok: false,
+      reason: 'requiresUltra',
+      message: 'Viewing remote agent prompts requires an Ultra plan.',
+    });
+    assert.equal(fetchPromptConfig.mock.calls.length, 0);
+  });
+
+  it('rejects Ultra users without an access token', async () => {
+    const { controller, fetchPromptConfig } = createController({
+      tier: ULTRA_TIER,
+      token: null,
+    });
+
+    const result = await controller.getPromptConfig('remoteWriter');
+
+    assert.deepEqual(result, {
+      ok: false,
+      reason: 'unauthenticated',
+      message: 'Authentication required. Sign in using "TeXRA: Sign In".',
+    });
+    assert.equal(fetchPromptConfig.mock.calls.length, 0);
+  });
+
+  it('fetches the remote prompt config for authenticated Ultra users', async () => {
+    const { controller, fetchPromptConfig } = createController({
+      tier: ULTRA_TIER,
+      token: 'access-token',
+    });
+
+    const result = await controller.getPromptConfig('remoteWriter');
+
+    assert.deepEqual(result, {
+      ok: true,
+      config: 'settings:\n  model: test\nprompts: {}\n',
+    });
+    assert.deepEqual(fetchPromptConfig.mock.calls, [
+      ['remoteWriter', 'access-token'],
+    ]);
+  });
+});

--- a/src/test-kernel/controllers/SettingsRemoteAgentPromptController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsRemoteAgentPromptController.vitest.ts
@@ -41,7 +41,6 @@ describe('SettingsRemoteAgentPromptController', () => {
 
     assert.deepEqual(result, {
       ok: false,
-      reason: 'requiresUltra',
       message: 'Viewing remote agent prompts requires an Ultra plan.',
     });
     assert.equal(fetchPromptConfig.mock.calls.length, 0);
@@ -57,7 +56,6 @@ describe('SettingsRemoteAgentPromptController', () => {
 
     assert.deepEqual(result, {
       ok: false,
-      reason: 'unauthenticated',
       message: 'Authentication required. Sign in using "TeXRA: Sign In".',
     });
     assert.equal(fetchPromptConfig.mock.calls.length, 0);


### PR DESCRIPTION
## Summary

- clarify 403 remote-agent access errors as permission-specific instead of upgrade-specific
- move remote-agent YAML fetching into a reusable remote-agent config client
- add a settings-view controller for Ultra/token gating before viewing remote prompts
- simplify the VS Code settings handler so it only shows errors or opens the YAML document
- reuse the same config client from `RemoteAgentLoader`

Closes #6320.

## Abstraction Review Findings

1. High: remote-agent prompt retrieval lived in `AgentHandlers`, mixing subscription/auth checks, Supabase fetch, schema parsing, and VS Code document opening. This PR moves network/schema logic into `src/agent/remote/remoteAgentConfigClient.ts` and access policy into `src/controllers/settingsView/SettingsRemoteAgentPromptController.ts`.
2. High: `MainApp.ts` still owns workflow action planning and command payload construction in the webview component. Tracked in #6318.
3. Medium-high: `FileManager.ts` mixes VS Code tab/workspace access with file-selection policy and dropped-file filtering. Tracked in #6319.
4. Medium: progress/settings cross-view coupling and follow-up polishing policy are already tracked in #6315 and #6310.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/controllers/SettingsRemoteAgentPromptController.vitest.ts src/test-kernel/agent/remote/RemoteAgentConfigClient.vitest.ts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved for tier gating and fetch paths; only user-visible change is the 403 error wording for remote agent access.
> 
> **Overview**
> Remote-agent YAML retrieval is **centralized** in `fetchRemoteAgentConfigYaml` (`remoteAgentConfigClient.ts`), so both **`RemoteAgentLoader`** and the settings UI share one edge-function POST, response parsing, and HTTP error mapping (403 copy is now permission-specific instead of “upgrade”).
> 
> **View remote prompt** in settings is split: **`SettingsRemoteAgentPromptController`** enforces Ultra tier and sign-in before fetch; **`AgentHandlers.handleViewRemoteAgentPrompt`** only shows errors or opens an in-memory YAML document.
> 
> Vitest coverage was added for the client and the prompt controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33d5ae147194469b5693a2d4a5e54a148ff3bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
