### PR TITLE
[codex] Extract CLI approval policy text

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -57,7 +57,6 @@ import {
   openCliSlashCommandForm,
   openRegisteredCliSlashForm,
 } from '../src/chat/tui/commands/slashForms';
-import { formatApprovalPolicyForCli } from '../src/chat/tui/forms/ApprovalPolicyForm';
 import {
   cliState,
   patchStream,
@@ -95,6 +94,10 @@ import {
   formatCliApiStatusActionHint,
   formatCliAuthStatusLine,
 } from '../src/runtime/apiStatus';
+import {
+  formatCliApprovalPolicy,
+  parseCliApprovalPolicy,
+} from '../src/runtime/approvalPolicyText';
 import type { CliModelAccess } from '../src/runtime/modelAccess';
 import {
   cliMultiAgentPresets,
@@ -105,10 +108,7 @@ import {
   CLI_HISTORY_RESUMABLE_STATUS,
   type CliHistoryEntry,
 } from '../src/runtime/history';
-import {
-  CLI_APPROVAL_POLICIES,
-  type CliApprovalPolicy,
-} from '../src/schemas/cliSettings';
+import { type CliApprovalPolicy } from '../src/schemas/cliSettings';
 import { initLocalCliPlatform } from '../src/runtime/initPlatform';
 import { resolveCliResourcesPath } from '../src/runtime/resourcesPath';
 
@@ -217,8 +217,7 @@ const FAILED_CHILD_AGENT = process.env.HARNESS_FAILED_CHILD?.trim();
 const TEAM_NAME = process.env.HARNESS_TEAM_NAME?.trim() || undefined;
 let canInterrupt = process.env.HARNESS_CAN_INTERRUPT === '1';
 let harnessApprovalPolicy: CliApprovalPolicy =
-  parseHarnessApprovalPolicy(process.env.HARNESS_APPROVAL_POLICY ?? '') ??
-  'ask';
+  parseCliApprovalPolicy(process.env.HARNESS_APPROVAL_POLICY ?? '') ?? 'ask';
 const EDIT_APPROVAL_DELAY_MS = Number(
   process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
 );
@@ -1344,30 +1343,6 @@ function formatHarnessSlashHelp(): string {
   });
 }
 
-function parseHarnessApprovalPolicy(
-  input: string,
-): CliApprovalPolicy | undefined {
-  const normalized = input.trim().toLowerCase();
-  if ((CLI_APPROVAL_POLICIES as readonly string[]).includes(normalized)) {
-    return normalized as CliApprovalPolicy;
-  }
-  switch (normalized) {
-    case 'default':
-    case 'interactive':
-    case 'on':
-      return 'ask';
-    case 'off':
-    case 'deny':
-      return 'never';
-    case 'auto':
-    case 'full':
-    case 'danger':
-      return 'yolo';
-    default:
-      return undefined;
-  }
-}
-
 function setHarnessApprovalPolicy(policy: CliApprovalPolicy): void {
   harnessApprovalPolicy = policy;
   cliState.sessionMeta.set({
@@ -1375,7 +1350,7 @@ function setHarnessApprovalPolicy(policy: CliApprovalPolicy): void {
     approvalPolicy: policy,
   });
   appendHarnessAssistantTranscript(
-    `Approval mode set to ${formatApprovalPolicyForCli(policy)}.`,
+    `Approval mode set to ${formatCliApprovalPolicy(policy)}.`,
   );
 }
 
@@ -1400,7 +1375,7 @@ function applyHarnessApprovalPolicySelection(
     if (openHarnessApprovalPolicyForm(input)) return;
   }
 
-  const policy = parseHarnessApprovalPolicy(normalized);
+  const policy = parseCliApprovalPolicy(normalized);
   if (!policy) {
     appendHarnessAssistantTranscript(usage);
     return;
@@ -1498,7 +1473,7 @@ function appendHarnessStatus(): void {
       model: meta.model,
       teamName: meta.teamName,
       api: meta.apiMode,
-      approval: formatApprovalPolicyForCli(harnessApprovalPolicy),
+      approval: formatCliApprovalPolicy(harnessApprovalPolicy),
       approvalBypasses: slice?.bypass,
       status: slice?.status ?? 'not started',
       goal: GoalStore.getForStream(streamId),

--- a/packages/cli/src/chat/tui/forms/ApprovalPolicyForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApprovalPolicyForm.tsx
@@ -1,6 +1,8 @@
 import { Box, Text } from 'ink';
 
+import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+
 import { KeyHints } from '../ui/KeyHints';
 import { Select, type SelectItem } from '../ui/Select';
 import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
@@ -13,32 +15,21 @@ export interface ApprovalPolicyFormProps {
   readonly onCancel: () => void;
 }
 
-export function formatApprovalPolicyForCli(policy: CliApprovalPolicy): string {
-  switch (policy) {
-    case 'ask':
-      return 'ask before privileged actions';
-    case 'never':
-      return 'deny privileged actions';
-    case 'yolo':
-      return 'auto-approve privileged actions';
-  }
-}
-
 export const APPROVAL_POLICY_ITEMS = [
   {
     value: 'ask',
     label: 'Ask',
-    description: formatApprovalPolicyForCli('ask'),
+    description: formatCliApprovalPolicy('ask'),
   },
   {
     value: 'never',
     label: 'Never',
-    description: formatApprovalPolicyForCli('never'),
+    description: formatCliApprovalPolicy('never'),
   },
   {
     value: 'yolo',
     label: 'Auto-approve',
-    description: formatApprovalPolicyForCli('yolo'),
+    description: formatCliApprovalPolicy('yolo'),
   },
 ] as const satisfies ReadonlyArray<SelectItem<CliApprovalPolicy>>;
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -85,10 +85,11 @@ import {
   terminalStatusExitCode,
 } from '@cli/runtime/terminalStatus';
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
+import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import {
-  CLI_APPROVAL_POLICIES,
-  type CliApprovalPolicy,
-} from '@cli/schemas/cliSettings';
+  formatCliApprovalPolicy,
+  parseCliApprovalPolicy,
+} from '@cli/runtime/approvalPolicyText';
 import { parseCliHistoryId } from '@cli/runtime/history';
 import {
   explainNonResumable,
@@ -119,7 +120,6 @@ import { generateExecutionId } from '@utils/core/executionId';
 
 import { App } from './App';
 import { assertNever } from './assertNever';
-import { formatApprovalPolicyForCli as formatApprovalPolicy } from './forms/ApprovalPolicyForm';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
 import {
   openCliSlashCommandForm,
@@ -767,28 +767,6 @@ async function logoutFromChat(): Promise<void> {
   }
 }
 
-function parseApprovalPolicy(input: string): CliApprovalPolicy | undefined {
-  const normalized = input.trim().toLowerCase();
-  if ((CLI_APPROVAL_POLICIES as readonly string[]).includes(normalized)) {
-    return normalized as CliApprovalPolicy;
-  }
-  switch (normalized) {
-    case 'default':
-    case 'interactive':
-    case 'on':
-      return 'ask';
-    case 'off':
-    case 'deny':
-      return 'never';
-    case 'auto':
-    case 'full':
-    case 'danger':
-      return 'yolo';
-    default:
-      return undefined;
-  }
-}
-
 const YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
 
 function applyCliApprovalPolicySelection(
@@ -802,7 +780,7 @@ function applyCliApprovalPolicySelection(
     return;
   }
 
-  const policy = parseApprovalPolicy(normalized);
+  const policy = parseCliApprovalPolicy(normalized);
   if (!policy) {
     appendLocalAssistantTranscript(usage);
     return;
@@ -810,7 +788,7 @@ function applyCliApprovalPolicySelection(
 
   context.setApprovalPolicy(policy);
   appendLocalAssistantTranscript(
-    `Approval mode set to ${formatApprovalPolicy(policy)}.`,
+    `Approval mode set to ${formatCliApprovalPolicy(policy)}.`,
   );
 }
 
@@ -923,7 +901,7 @@ async function handleTuiSlashCommand(
           // Read the session's own mode (which honors a --api-mode/env override)
           // so /status agrees with the header instead of re-reading the global.
           api: formatCliApiMode(meta.apiMode),
-          approval: formatApprovalPolicy(context.getApprovalPolicy()),
+          approval: formatCliApprovalPolicy(context.getApprovalPolicy()),
           approvalBypasses: slice?.bypass,
           status: slice?.status ?? 'not started',
           goal: activeStreamId
@@ -1524,7 +1502,7 @@ export async function runChat(
     onApprovalPolicySelect: (policy) => {
       setApprovalPolicy(policy);
       appendLocalAssistantTranscript(
-        `Approval mode set to ${formatApprovalPolicy(policy)}.`,
+        `Approval mode set to ${formatCliApprovalPolicy(policy)}.`,
       );
     },
     canSelectModel: canSelectCurrentModel,

--- a/packages/cli/src/runtime/approvalPolicyText.ts
+++ b/packages/cli/src/runtime/approvalPolicyText.ts
@@ -1,0 +1,39 @@
+import {
+  CLI_APPROVAL_POLICIES,
+  type CliApprovalPolicy,
+} from '../schemas/cliSettings';
+
+export function formatCliApprovalPolicy(policy: CliApprovalPolicy): string {
+  switch (policy) {
+    case 'ask':
+      return 'ask before privileged actions';
+    case 'never':
+      return 'deny privileged actions';
+    case 'yolo':
+      return 'auto-approve privileged actions';
+  }
+}
+
+export function parseCliApprovalPolicy(
+  input: string,
+): CliApprovalPolicy | undefined {
+  const normalized = input.trim().toLowerCase();
+  if ((CLI_APPROVAL_POLICIES as readonly string[]).includes(normalized)) {
+    return normalized as CliApprovalPolicy;
+  }
+  switch (normalized) {
+    case 'default':
+    case 'interactive':
+    case 'on':
+      return 'ask';
+    case 'off':
+    case 'deny':
+      return 'never';
+    case 'auto':
+    case 'full':
+    case 'danger':
+      return 'yolo';
+    default:
+      return undefined;
+  }
+}

--- a/src/test-kernel/cli/ApprovalPolicyForm.vitest.mts
+++ b/src/test-kernel/cli/ApprovalPolicyForm.vitest.mts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  APPROVAL_POLICY_ITEMS,
-  formatApprovalPolicyForCli,
-} from '@cli/chat/tui/forms/ApprovalPolicyForm';
+import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
+import { APPROVAL_POLICY_ITEMS } from '@cli/chat/tui/forms/ApprovalPolicyForm';
 
 describe('ApprovalPolicyForm', () => {
   it('describes approval policies consistently', () => {
@@ -27,7 +25,7 @@ describe('ApprovalPolicyForm', () => {
 
     expect(APPROVAL_POLICY_ITEMS).toEqual(expectedItems);
     for (const item of expectedItems) {
-      expect(formatApprovalPolicyForCli(item.value)).toBe(item.description);
+      expect(formatCliApprovalPolicy(item.value)).toBe(item.description);
     }
   });
 });

--- a/src/test-kernel/cli/ApprovalPolicyText.vitest.mts
+++ b/src/test-kernel/cli/ApprovalPolicyText.vitest.mts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatCliApprovalPolicy,
+  parseCliApprovalPolicy,
+} from '@cli/runtime/approvalPolicyText';
+
+describe('CLI approval policy text', () => {
+  it('formats policies for session-facing CLI text', () => {
+    expect(formatCliApprovalPolicy('ask')).toBe(
+      'ask before privileged actions',
+    );
+    expect(formatCliApprovalPolicy('never')).toBe('deny privileged actions');
+    expect(formatCliApprovalPolicy('yolo')).toBe(
+      'auto-approve privileged actions',
+    );
+  });
+
+  it('parses canonical policies and slash-command aliases', () => {
+    expect(parseCliApprovalPolicy('ask')).toBe('ask');
+    expect(parseCliApprovalPolicy('NEVER')).toBe('never');
+    expect(parseCliApprovalPolicy(' yolo ')).toBe('yolo');
+    expect(parseCliApprovalPolicy('default')).toBe('ask');
+    expect(parseCliApprovalPolicy('interactive')).toBe('ask');
+    expect(parseCliApprovalPolicy('on')).toBe('ask');
+    expect(parseCliApprovalPolicy('off')).toBe('never');
+    expect(parseCliApprovalPolicy('deny')).toBe('never');
+    expect(parseCliApprovalPolicy('auto')).toBe('yolo');
+    expect(parseCliApprovalPolicy('full')).toBe('yolo');
+    expect(parseCliApprovalPolicy('danger')).toBe('yolo');
+    expect(parseCliApprovalPolicy('sometimes')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Move CLI approval-policy formatting and slash-command alias parsing into `packages/cli/src/runtime/approvalPolicyText.ts`.
- Update the chat TUI runner, approval form, and PTY harness to use the runtime helper instead of importing presentation code or duplicating parser logic.
- Add focused tests for approval-policy text and aliases.

## Design issue

Closes #6322.

The TUI runner and harness were using session-facing approval-policy text, but the formatter lived in the Ink approval form component. The harness also had its own parser copy. That made command/session code depend on presentation code and created a drift risk between the validation harness and the real chat TUI.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ApprovalPolicyForm.vitest.mts src/test-kernel/cli/ApprovalPolicyText.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-snapshots-approval-policy-refactor`
- `corepack pnpm --filter @texra-ai/cli check:architecture`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved; risk is limited to string/alias parsing consistency across slash commands and status output, covered by new and updated tests.
> 
> **Overview**
> **Centralizes** session-facing approval-policy **formatting** and **slash-command parsing** (canonical `ask`/`never`/`yolo` plus aliases like `default`, `off`, `auto`) in `packages/cli/src/runtime/approvalPolicyText.ts`, replacing duplicated logic in the chat TUI runner and PTY harness and removing `formatApprovalPolicyForCli` from the Ink `ApprovalPolicyForm`.
> 
> The **approval form** now imports `formatCliApprovalPolicy` for select-item descriptions; **runChatTui** and **tui-harness** use the same helpers for `/approval`, `/yolo`, and `/status` messaging so runtime/session code no longer depends on presentation-layer imports.
> 
> Adds **`ApprovalPolicyText.vitest.mts`** for format/parse behavior and updates **`ApprovalPolicyForm.vitest.mts`** to assert against the shared formatter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5262c53ca83406078739e2aa76bc228a97511011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->