### PR TITLE
[codex] Extract settings goal navigation

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -31,6 +31,7 @@ import type {
 } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
+import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
 import {
@@ -46,6 +47,8 @@ import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 import type { MainViewProvider } from '../MainViewProvider';
 
 const MAX_INQUIRY_THREAD_HYDRATION = 100;
+
+export type ProgressStreamRevealResult = 'revealed' | 'missing';
 
 /**
  * Orchestrates the progress view webview with exclusive rendering:
@@ -578,6 +581,28 @@ export class ProgressViewProvider
     this.webviewUpdater.setActiveStream(streamId);
     // Hydrate content (logs, todos, follow-ups, instruction, bypass state) + active-state metadata
     this.eventHandler.syncStreamContent(streamId, { includeActiveState: true });
+  }
+
+  public async revealStream(
+    streamId: StreamTabId,
+  ): Promise<ProgressStreamRevealResult> {
+    if (!this.state.streamLogs.has(streamId)) return 'missing';
+
+    await this.showProgressView();
+
+    // Clear filters owned by the progress view before selecting the stream;
+    // otherwise SET_ACTIVE_STREAM can target a stream hidden by the current
+    // category filter and appear to do nothing.
+    if (
+      buildStreamInfo(this.state, streamId, this.state.agentCategoryFilter) ===
+      null
+    ) {
+      this.state.agentCategoryFilter = 'all';
+      this.syncFullView();
+    }
+
+    await this.setActiveStream(streamId);
+    return 'revealed';
   }
 
   public isEditorMode(): boolean {

--- a/packages/extension/src/progressView/progressNavigation.ts
+++ b/packages/extension/src/progressView/progressNavigation.ts
@@ -1,0 +1,17 @@
+import type { StreamTabId } from '@shared/schemas';
+
+import {
+  ProgressViewProvider,
+  type ProgressStreamRevealResult,
+} from './ProgressViewProvider';
+
+export type ProgressNavigationRevealResult =
+  | ProgressStreamRevealResult
+  | 'unavailable';
+
+export async function revealProgressStream(
+  streamId: StreamTabId,
+): Promise<ProgressNavigationRevealResult> {
+  const provider = ProgressViewProvider.getInstance();
+  return provider ? provider.revealStream(streamId) : 'unavailable';
+}

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -13,6 +13,7 @@ import * as vscode from 'vscode';
 // Shared schemas and dispatchers
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { SettingsProfileController } from '@controllers/settingsView/SettingsProfileController';
+import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
 import { platform } from '@platform/platform';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -38,10 +39,9 @@ import {
   invalidateApiKeyCache,
   loadApiKeyStatusMap,
 } from '@model/apiProviders';
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { revealProgressStream } from '@progressView/progressNavigation';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { StreamTabId } from '@shared/schemas';
-import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import {
   dispatchSettingsViewInbound,
   type SettingsViewInboundHandlerRegistry,
@@ -120,6 +120,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly modelSelectionController: SettingsModelSelectionController;
   private readonly profileController: SettingsProfileController;
   private readonly profileKeyController: SettingsProfileKeyController;
+  private readonly goalController: SettingsGoalController;
 
   constructor(context: vscode.ExtensionContext) {
     super('SettingsView', { trackActiveView: true });
@@ -188,6 +189,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     this.latexHandlers = new LatexSettingsHandlers(ctx);
     this.historyHandlers = new HistoryHandlers(ctx);
     this.githubHandlers = new GitHubSubscriptionHandlers(ctx);
+    this.goalController = new SettingsGoalController({
+      listGoals: () => GoalStore.list(),
+    });
 
     this.handlerRegistry = this.createHandlerRegistry();
 
@@ -497,28 +501,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendGoalList(webview: vscode.Webview): Promise<void> {
-    await webview.postMessage({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
-      items: GoalStore.list(),
-    });
+    await webview.postMessage(this.goalController.getGoalListMessage());
   }
 
   private async handleRevealGoalStream(streamId: StreamTabId): Promise<void> {
-    const provider = ProgressViewProvider.getInstance();
-    if (!provider) return;
-    if (!provider.state.streamLogs.has(streamId)) return;
-    await provider.showProgressView();
-    if (
-      buildStreamInfo(
-        provider.state,
-        streamId,
-        provider.state.agentCategoryFilter,
-      ) === null
-    ) {
-      provider.state.agentCategoryFilter = 'all';
-      provider.syncFullView();
-    }
-    await provider.setActiveStream(streamId);
+    await revealProgressStream(streamId);
   }
 
   private handleRunToolCommand(

--- a/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
@@ -11,6 +11,7 @@ import { SecretManager } from '@frontend/secretManager';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { revealProgressStream } from '@progressView/progressNavigation';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import {
@@ -145,33 +146,18 @@ export class GitHubSubscriptionHandlers {
       typeof SETTINGS_VIEW_CMD.OPEN_PR_SUBSCRIPTION_STREAM
     >,
   ): Promise<void> {
-    const provider = ProgressViewProvider.getInstance();
-    if (!provider) {
+    const result = await revealProgressStream(data.streamId);
+    if (result === 'unavailable') {
       await vscode.window.showErrorMessage(
         'Progress View is not available. Please try again.',
       );
       return;
     }
 
-    const { state } = provider;
-    if (!state.streamLogs.has(data.streamId)) {
+    if (result === 'missing') {
       await vscode.window.showWarningMessage(
         'The agent stream is no longer available.',
       );
-      return;
     }
-
-    await provider.showProgressView();
-
-    // If the current filter would hide the target stream, clear it to 'all'
-    // so SET_ACTIVE_STREAM doesn't silently land on the wrong tab.
-    if (
-      buildStreamInfo(state, data.streamId, state.agentCategoryFilter) === null
-    ) {
-      state.agentCategoryFilter = 'all';
-      provider.syncFullView();
-    }
-
-    provider.setActiveStream(data.streamId);
   }
 }

--- a/src/controllers/settingsView/SettingsGoalController.ts
+++ b/src/controllers/settingsView/SettingsGoalController.ts
@@ -1,0 +1,20 @@
+import type {
+  Goal,
+  UpdateGoalListMessage,
+} from '@shared/schemas/settingsViewMessages';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc/settingsViewCommands';
+
+export interface SettingsGoalControllerDeps {
+  listGoals(): readonly Goal[];
+}
+
+export class SettingsGoalController {
+  constructor(private readonly deps: SettingsGoalControllerDeps) {}
+
+  getGoalListMessage(): UpdateGoalListMessage {
+    return {
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
+      items: [...this.deps.listGoals()],
+    };
+  }
+}

--- a/src/test-kernel/controllers/SettingsGoalController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsGoalController.vitest.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
+import type { Goal } from '@shared/schemas/settingsViewMessages';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc/settingsViewCommands';
+
+const GOAL: Goal = {
+  goalId: 'goal-1',
+  streamId: 'stream-1',
+  objective: 'Finish the autonomous proof audit.',
+  status: 'active',
+  createdAt: '2026-06-20T00:00:00.000Z',
+  updatedAt: '2026-06-20T00:01:00.000Z',
+};
+
+describe('SettingsGoalController', () => {
+  it('builds the settings goal-list message from the injected goal source', () => {
+    const controller = new SettingsGoalController({
+      listGoals: () => [GOAL],
+    });
+
+    expect(controller.getGoalListMessage()).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
+      items: [GOAL],
+    });
+  });
+
+  it('reads the goal source every time a list message is requested', () => {
+    const goals: Goal[] = [];
+    const controller = new SettingsGoalController({
+      listGoals: () => goals,
+    });
+
+    expect(controller.getGoalListMessage().items).toEqual([]);
+    goals.push(GOAL);
+    expect(controller.getGoalListMessage().items).toEqual([GOAL]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `SettingsGoalController` to own Settings goal-list messages and reveal delegation.
- Add Progress-owned stream reveal behavior so filter reset and active-stream selection no longer live in Settings handlers.
- Reuse the Progress reveal method from PR subscription stream navigation.

## Design issue

Closes #6315.

`SettingsViewMessageHandler` previously reached into `ProgressViewProvider.getInstance()`, inspected Progress state, reset the Progress filter, called `syncFullView()`, and selected the active stream. That leaked Progress view internals into the Settings message handler and duplicated the same reveal/filter-reset behavior used by PR subscription navigation.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/controllers/SettingsGoalController.vitest.ts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-snapshots-goal-navigation-refactor slash-goal-help backslash-goal-help plan-approval-goal compact-plan-approval-goal plan-approval-approve-goal subagents subagent-picker task-picker`
- `corepack pnpm --filter @texra-ai/cli check:architecture`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation refactor with no auth or data-model changes; goal reveal no longer surfaces missing-stream warnings (behavioral nuance only).
> 
> **Overview**
> Moves **“open this agent stream in Progress”** out of Settings handlers into Progress-owned APIs, and adds a thin **Settings goal-list** controller.
> 
> **Progress** gains `revealStream` on `ProgressViewProvider` (show view, reset category filter when the stream would be hidden, then `setActiveStream`) plus `revealProgressStream` in `progressNavigation.ts`, which returns `revealed` / `missing` / `unavailable`.
> 
> **Settings** goal reveal and GitHub subscription “open stream” now call `revealProgressStream` instead of reaching into `ProgressViewProvider` state. PR subscription navigation keeps user-facing errors for unavailable or missing streams; goal reveal delegates without duplicating filter-reset logic.
> 
> **`SettingsGoalController`** builds `UPDATE_GOAL_LIST` messages from an injected `GoalStore.list()`; `sendGoalList` uses it. Vitest covers the controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f3edee91e956ae46672b6c9a60200373f6ad85b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->