### PR TITLE
[codex] Extract main view execute message

### DIFF
--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -29,7 +29,7 @@ import * as executionHandlers from './managers/executionHandlers';
 import { FileManager } from './managers/FileManager';
 import { InstructionManager } from './managers/InstructionManager';
 import type { CommandMessage } from './managers/executionHandlers';
-import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionMessageController';
 
 export interface MainViewOnboardingHooks {
   /**

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -7,6 +7,10 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/divider/divider.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
+import {
+  buildMainViewExecuteMessage,
+  type MainViewExecuteMessage,
+} from '@controllers/mainView/MainViewExecutionMessageController';
 import { PREFERRED_TOOL_USE_AGENTS } from '@agent/index/agentRegistryConstants';
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { SignalWatcher, signal, Signal } from '@shared/signals';
@@ -1128,77 +1132,42 @@ export class MainApp extends MainAppBase {
   }
 
   private executeAgent(): void {
-    const {
-      agent,
-      isToolUseAgent,
-      singleFileSelections,
-      multipleFileSelections,
-      checkboxValues,
-    } = this.collectCurrentContext();
-    postMessage(MAIN_VIEW_COMMANDS.EXECUTE, {
-      agent,
-      model: this.model.get(),
-      instruction: this.instruction.get(),
-      isToolUseAgent,
-      ...singleFileSelections,
-      ...multipleFileSelections,
-      ...checkboxValues,
-    });
+    postMessage(MAIN_VIEW_COMMANDS.EXECUTE, this.buildExecuteMessage());
   }
 
-  private collectCurrentContext(): {
-    agent: string;
-    isToolUseAgent: boolean;
-    singleFileSelections: Record<string, string>;
-    multipleFileSelections: Record<string, string[] | boolean>;
-    checkboxValues: Record<string, boolean>;
-  } {
-    const st = this.sessionType.get();
-    const agent =
-      st === SESSION_TYPES.TOOL_USE
-        ? this.toolUseAgent.get()
-        : this.workflowAgent.get();
-
-    const sf = this.singleFiles.get();
-    const singleFileSelections = {
-      editedFile: sf.editedFile,
-      baseFile: sf.baseFile,
-    };
-
-    const mf = this.multiFiles.get();
-    const multipleFileSelections: Record<string, string[] | boolean> = {};
-    MULTIPLE_DOCUMENT_FILE_TYPES.forEach((type) => {
-      const listId = `${type}Files` as keyof MultiFiles;
-      const files = type === 'output' ? [] : (mf[listId] ?? []);
-      const isActive = type !== 'output' && files.length > 0;
-      multipleFileSelections[listId] = files;
-      multipleFileSelections[`${listId}Active`] = isActive;
+  private buildExecuteMessage(): MainViewExecuteMessage {
+    return buildMainViewExecuteMessage({
+      sessionType: this.sessionType.get(),
+      workflowAgent: this.workflowAgent.get(),
+      toolUseAgent: this.toolUseAgent.get(),
+      model: this.model.get(),
+      instruction: this.instruction.get(),
+      singleFiles: this.singleFiles.get(),
+      multiFiles: this.multiFiles.get(),
+      checkboxValues: this.checkboxValues.get(),
     });
-
-    const checkboxValues = this.checkboxValues.get();
-
-    return {
-      agent,
-      isToolUseAgent: st === SESSION_TYPES.TOOL_USE,
-      singleFileSelections,
-      multipleFileSelections,
-      checkboxValues,
-    };
   }
 
   private handlePolishInstruction(): void {
     const instructionText = this.instruction.get();
     if (!instructionText.trim()) return;
 
-    const { agent, singleFileSelections, multipleFileSelections } =
-      this.collectCurrentContext();
+    const executionMessage = this.buildExecuteMessage();
     this.isPolishing.set(true);
     postMessage(MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT, {
       text: instructionText,
-      agent,
+      agent: executionMessage.agent,
       model: this.model.get(),
-      ...singleFileSelections,
-      ...multipleFileSelections,
+      editedFile: executionMessage.editedFile,
+      baseFile: executionMessage.baseFile,
+      inputFiles: executionMessage.inputFiles,
+      inputFilesActive: executionMessage.inputFilesActive,
+      contextFiles: executionMessage.contextFiles,
+      contextFilesActive: executionMessage.contextFilesActive,
+      mediaFiles: executionMessage.mediaFiles,
+      mediaFilesActive: executionMessage.mediaFilesActive,
+      outputFiles: executionMessage.outputFiles,
+      outputFilesActive: executionMessage.outputFilesActive,
     });
   }
 

--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -1,10 +1,8 @@
 import * as vscode from 'vscode';
 
-import {
-  prepareMainViewExecutionRequest,
-  type MainViewExecuteMessage,
-} from '@controllers/mainView/MainViewExecutionController';
+import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
 import * as logger from '@logger/logUtils';
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionMessageController';
 
 const CHANNEL = 'ExecutionHandlers';
 logger.initialize(CHANNEL);

--- a/src/controllers/mainView/MainViewExecutionController.ts
+++ b/src/controllers/mainView/MainViewExecutionController.ts
@@ -1,7 +1,6 @@
 // Third-party imports
 
 // Local imports - agent
-import type { AgentConfigInput } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   validateExecutionRequest,
@@ -20,18 +19,8 @@ import {
   getPastedImageFullPath,
   isPastedImage,
 } from '@utils/files/pastedImageUtils';
-import type { z } from 'zod';
 
-/**
- * Message shape from the main view for agent execution.
- * ToolConfig fields are sent flat from the UI form.
- */
-export type MainViewExecuteMessage = Omit<AgentConfigInput, 'mediaFiles'> & {
-  /** UI toggle indicating tool-use vs workflow agent. */
-  isToolUseAgent?: boolean;
-  /** Media files may contain nulls from UI and are filtered during processing. */
-  mediaFiles?: (string | null)[];
-} & z.input<typeof ToolConfigSchema>;
+import type { MainViewExecuteMessage } from './MainViewExecutionMessageController';
 
 export type MainViewExecutionPreparationResult =
   | { valid: true; request: ValidatedExecutionRequest }

--- a/src/controllers/mainView/MainViewExecutionMessageController.ts
+++ b/src/controllers/mainView/MainViewExecutionMessageController.ts
@@ -1,0 +1,74 @@
+// Third-party imports
+
+// Local imports - agent
+import type { AgentConfigInput } from '@agent/core/definition/AgentConfig';
+
+// Local imports - shared schemas
+import {
+  MULTIPLE_DOCUMENT_FILE_TYPES,
+  type CheckboxValues,
+  type MultiFiles,
+  type SessionType,
+  type SingleFiles,
+} from '@shared/schemas';
+import type { ToolConfigSchema } from '@shared/schemas/toolConfig';
+import type { z } from 'zod';
+
+/**
+ * Message shape from the main view for agent execution.
+ * ToolConfig fields are sent flat from the UI form.
+ */
+export type MainViewExecuteMessage = Omit<AgentConfigInput, 'mediaFiles'> & {
+  /** UI toggle indicating tool-use vs workflow agent. */
+  isToolUseAgent?: boolean;
+  /** File used as the base/reference for diff-oriented flows. */
+  baseFile?: string;
+  /** Media files may contain nulls from UI and are filtered during processing. */
+  mediaFiles?: (string | null)[];
+  inputFilesActive?: boolean;
+  contextFilesActive?: boolean;
+  mediaFilesActive?: boolean;
+  outputFilesActive?: boolean;
+} & z.input<typeof ToolConfigSchema>;
+
+export interface MainViewExecutionFormState {
+  readonly sessionType: SessionType;
+  readonly workflowAgent: string;
+  readonly toolUseAgent: string;
+  readonly model: string;
+  readonly instruction: string;
+  readonly singleFiles: SingleFiles;
+  readonly multiFiles: MultiFiles;
+  readonly checkboxValues: CheckboxValues;
+}
+
+type MainViewMultipleFileSelections = Record<string, string[] | boolean>;
+
+export function buildMainViewExecuteMessage(
+  state: MainViewExecutionFormState,
+): MainViewExecuteMessage {
+  const isToolUseAgent = state.sessionType === 'toolUse';
+  return {
+    agent: isToolUseAgent ? state.toolUseAgent : state.workflowAgent,
+    model: state.model,
+    instruction: state.instruction,
+    isToolUseAgent,
+    editedFile: state.singleFiles.editedFile,
+    baseFile: state.singleFiles.baseFile,
+    ...buildMainViewMultipleFileSelections(state.multiFiles),
+    ...state.checkboxValues,
+  };
+}
+
+function buildMainViewMultipleFileSelections(
+  multiFiles: MultiFiles,
+): MainViewMultipleFileSelections {
+  const selections: MainViewMultipleFileSelections = {};
+  for (const type of MULTIPLE_DOCUMENT_FILE_TYPES) {
+    const listId = `${type}Files` as keyof MultiFiles;
+    const files = type === 'output' ? [] : (multiFiles[listId] ?? []);
+    selections[listId] = files;
+    selections[`${listId}Active`] = type !== 'output' && files.length > 0;
+  }
+  return selections;
+}

--- a/src/test-kernel/controllers/MainViewExecutionController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewExecutionController.vitest.ts
@@ -1,9 +1,81 @@
 import { describe, expect, it } from 'vitest';
 
 import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
+import { buildMainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionMessageController';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 describe('MainViewExecutionController', () => {
+  it('builds tool-use execute messages from form state', () => {
+    expect(
+      buildMainViewExecuteMessage({
+        sessionType: 'toolUse',
+        workflowAgent: 'correct',
+        toolUseAgent: 'orchestrator',
+        model: 'gpt-5.4',
+        instruction: 'Solve a small enumeration problem.',
+        singleFiles: { baseFile: 'old.tex', editedFile: 'new.tex' },
+        multiFiles: {
+          inputFiles: ['main.tex'],
+          contextFiles: ['refs.bib'],
+          mediaFiles: ['figure.png'],
+          outputFiles: ['stale-output.tex'],
+        },
+        checkboxValues: {
+          autoExtractFigure: true,
+          autoExtractTikzFigure: false,
+          autoCompileInputPdf: true,
+          attachTeXCount: false,
+        },
+      }),
+    ).toMatchObject({
+      agent: 'orchestrator',
+      model: 'gpt-5.4',
+      instruction: 'Solve a small enumeration problem.',
+      isToolUseAgent: true,
+      baseFile: 'old.tex',
+      editedFile: 'new.tex',
+      inputFiles: ['main.tex'],
+      inputFilesActive: true,
+      contextFiles: ['refs.bib'],
+      contextFilesActive: true,
+      mediaFiles: ['figure.png'],
+      mediaFilesActive: true,
+      outputFiles: [],
+      outputFilesActive: false,
+      autoExtractFigure: true,
+      autoExtractTikzFigure: false,
+      autoCompileInputPdf: true,
+      attachTeXCount: false,
+    });
+  });
+
+  it('builds workflow execute messages with the workflow agent', () => {
+    const message = buildMainViewExecuteMessage({
+      sessionType: 'workflow',
+      workflowAgent: 'correct',
+      toolUseAgent: 'orchestrator',
+      model: 'gpt-5.4',
+      instruction: 'Correct this file.',
+      singleFiles: { baseFile: '', editedFile: '' },
+      multiFiles: {
+        inputFiles: [],
+        contextFiles: [],
+        mediaFiles: [],
+        outputFiles: [],
+      },
+      checkboxValues: {
+        autoExtractFigure: false,
+        autoExtractTikzFigure: false,
+        autoCompileInputPdf: false,
+        attachTeXCount: true,
+      },
+    });
+
+    expect(message.agent).toBe('correct');
+    expect(message.isToolUseAgent).toBe(false);
+    expect(message.inputFilesActive).toBe(false);
+  });
+
   it('keeps missing selections explicit before schema prefaults apply', () => {
     expect(prepareMainViewExecutionRequest({ model: 'gpt-5.4' }).valid).toBe(
       false,


### PR DESCRIPTION
## Summary

- Add a frontend-safe `MainViewExecutionMessageController` that builds execute IPC payloads from main-view form state.
- Remove execute-message/file-selection shaping from `MainApp` so the component only reads signals and posts messages.
- Keep backend execution validation in `MainViewExecutionController`, re-exporting the shared execute-message builder/type for the existing test surface.

## Design issue

Related to #6318.

`MainApp` was deciding which agent, file lists, active-file flags, and workflow checkboxes became the `execute` payload. That made a 1900-line Lit component own workflow policy that is easier to test as a pure function. This PR extracts the first narrow slice: execute-message construction. Larger action-planning moves for pack/clean, merge, compare, and latexdiff remain tracked in #6318.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-snapshots-2026-06-20-goal-probe slash-goal-help backslash-goal-help plan-approval-goal compact-plan-approval-goal plan-approval-approve-goal subagents subagent-picker nested-subagent-picker nested-task-picker task-picker task-subworkflow-detail task-process-detail bash-approval long-bash-approval external-inquiry-submit-answer`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/controllers/MainViewExecutionController.vitest.ts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with new unit tests; execution validation stays in `MainViewExecutionController` unchanged aside from type location.
> 
> **Overview**
> Moves **main-view execute IPC payload construction** out of `MainApp` into a new `MainViewExecutionMessageController` with `buildMainViewExecuteMessage`, so agent choice, file lists, `*Active` flags, workflow checkboxes, and output-file normalization are built in one **testable pure function** instead of inline in the Lit component.
> 
> `MainApp` now reads signals and calls `buildExecuteMessage()` for **EXECUTE** and **POLISH_INSTRUCTION_TEXT** (polish passes explicit file fields from the same payload). `MainViewExecutionController` keeps **validation/preparation** only and imports `MainViewExecuteMessage` from the new module; handlers and the message handler follow the same type import path.
> 
> Vitest adds coverage for tool-use vs workflow agent selection and the existing output-file / active-flag rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c228dc5e39f35d6989bd20ee1dcb11456b9f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->