### PR TITLE
refactor: inject workflow output policy

### DIFF
--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -12,6 +12,11 @@ import type { AgentFileLocation, WorkspaceFileLocation } from '@shared/schemas';
 import type { PromptBuilder } from '@utils/prompt';
 import type { TaskRunFileService } from '@utils/files';
 
+export interface WorkflowOutputPolicy {
+  readonly shouldAutoOpenPdfOrLog: () => boolean;
+  readonly shouldRejectOnCompileFailure: () => boolean;
+}
+
 export interface ReflectionServices<
   C = unknown,
 > extends BaseFlowContextInit<C> {
@@ -25,6 +30,7 @@ export interface ReflectionServices<
   readonly getOutputFileLocation: (
     round: number,
   ) => AgentFileLocation | Promise<AgentFileLocation>;
+  readonly workflowOutputPolicy: WorkflowOutputPolicy;
   readonly baseFiles: WorkspaceFileLocation[];
   readonly onRoundFinalized: RoundFinalizedCallback;
 }

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -1,4 +1,3 @@
-import { platform } from '@platform/platform';
 import { Node } from '@agent/node';
 import type { RoundFileMapping } from '@agent/output/types';
 import type { CompiledPdfArtifact } from '@agent/output/compiledPdfArtifacts';
@@ -33,8 +32,6 @@ import {
   type FileLocation,
   type RoundOutput,
 } from '@shared/schemas';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { flexibleFS } from '@utils/files';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
@@ -278,7 +275,8 @@ export class OutputNode<C = unknown> extends Node<
     prepRes: OutputPrepInput,
     execRes: OutputExecResult,
   ): Promise<string | undefined> {
-    const { streamId, logger, outputState, runtimeHost } = this.services;
+    const { streamId, logger, outputState, runtimeHost, workflowOutputPolicy } =
+      this.services;
     const { outputLocation, currentRound, endTurn } = prepRes;
     const { summary, roundOutput } = execRes;
 
@@ -300,7 +298,7 @@ export class OutputNode<C = unknown> extends Node<
       runtimeHost.emit('requestOpenFile', { location, preserveFocus: true });
     }
 
-    if (endTurn && shouldAutoOpenPdfOrLog()) {
+    if (endTurn && workflowOutputPolicy.shouldAutoOpenPdfOrLog()) {
       if (execRes.compileFailures.length > 0) {
         for (const failure of execRes.compileFailures) {
           runtimeHost.emit('requestOpenFile', {
@@ -358,7 +356,7 @@ export class OutputNode<C = unknown> extends Node<
       shared.lastCompileResult = execRes.compileResult;
       const compileFailureContext = shouldUseCompileFailureRepairContext(
         execRes.compileResult,
-        shouldRejectOnCompileFailure(),
+        workflowOutputPolicy.shouldRejectOnCompileFailure(),
       )
         ? formatCompileFailureRoundContext(execRes.compileResult)
         : undefined;
@@ -393,18 +391,4 @@ export class OutputNode<C = unknown> extends Node<
 
     return diffManager.handleLatexdiffofOutput(currentRound, mapping);
   }
-}
-
-function shouldAutoOpenPdfOrLog(): boolean {
-  return platform().workspaceState.get<boolean>(
-    WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
-    LATEX_CONFIG_DEFAULTS.workflowAutoOpenPdf,
-  );
-}
-
-function shouldRejectOnCompileFailure(): boolean {
-  return platform().workspaceState.get<boolean>(
-    WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
-    LATEX_CONFIG_DEFAULTS.workflowRejectOnCompileFailure,
-  );
 }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { platform } from '@platform/platform';
 import { getExecutionStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';
 import {
@@ -32,6 +33,8 @@ import {
   type StorageKey,
   type WorkspaceFileLocation,
 } from '@shared/schemas';
+import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   AbsoluteFS,
   TaskRunFileService,
@@ -49,7 +52,10 @@ import {
   ReflectionFlowStateSchema,
   type ReflectionFlowShared,
 } from './ReflectionFlowState';
-import type { ReflectionServices } from './ReflectionServices';
+import type {
+  ReflectionServices,
+  WorkflowOutputPolicy,
+} from './ReflectionServices';
 
 export interface RunReflectionFlowInput<
   C = unknown,
@@ -65,6 +71,7 @@ export interface RunReflectionFlowInput<
     totalRounds: number,
     outputPaths: readonly string[],
   ) => void;
+  workflowOutputPolicy?: WorkflowOutputPolicy;
 }
 
 export interface RunReflectionFlowResult {
@@ -276,6 +283,9 @@ export async function runReflectionFlow<C = unknown>(
       promptBuilder,
       fileService,
       getOutputFileLocation,
+      workflowOutputPolicy:
+        input.workflowOutputPolicy ??
+        createWorkspaceStateWorkflowOutputPolicy(),
       baseFiles,
     };
     pf.setServices(services);
@@ -326,5 +336,20 @@ export async function runReflectionFlow<C = unknown>(
     roundOutputs: shared?.roundOutputs ?? [],
     outcome,
     ...(totalCostUsd > 0 ? { totalCostUsd } : {}),
+  };
+}
+
+function createWorkspaceStateWorkflowOutputPolicy(): WorkflowOutputPolicy {
+  return {
+    shouldAutoOpenPdfOrLog: () =>
+      platform().workspaceState.get<boolean>(
+        WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
+        LATEX_CONFIG_DEFAULTS.workflowAutoOpenPdf,
+      ),
+    shouldRejectOnCompileFailure: () =>
+      platform().workspaceState.get<boolean>(
+        WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
+        LATEX_CONFIG_DEFAULTS.workflowRejectOnCompileFailure,
+      ),
   };
 }

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports
 import type { AgentTrace } from '@agent/trace';
@@ -23,7 +23,6 @@ import type {
   OutputXmlSummary,
   RoundOutput,
 } from '@shared/schemas';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { createRecordingHost } from '../progressTestUtils';
 
 function createLocation(path: string): FileLocation {
@@ -83,21 +82,12 @@ function createCompileFailureFixture() {
   };
 }
 
-async function initFakePlatform(
-  workspaceState: Record<string, unknown> = {},
-): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(createFakePlatform({ workspaceState }));
-}
+const defaultWorkflowOutputPolicy = {
+  shouldAutoOpenPdfOrLog: () => true,
+  shouldRejectOnCompileFailure: () => true,
+};
 
 describe('output progress events', () => {
-  beforeEach(async () => {
-    await initFakePlatform();
-  });
-
   it('publishes reflection output-node events through the runtime host', async () => {
     const { events, host } = createRecordingHost();
     const outputNode = new OutputNode().setServices({
@@ -105,6 +95,7 @@ describe('output progress events', () => {
       logger: { warn: () => {} },
       outputState: createOutputState(),
       runtimeHost: host,
+      workflowOutputPolicy: defaultWorkflowOutputPolicy,
     } as unknown as ReflectionServices);
     const outputLocation = createAgentLocation('/tmp/output.xml');
     const openedLocation = createLocation('/tmp/rendered.tex');
@@ -169,6 +160,7 @@ describe('output progress events', () => {
       logger: { warn: () => {} },
       outputState: createOutputState(),
       runtimeHost: host,
+      workflowOutputPolicy: defaultWorkflowOutputPolicy,
     } as unknown as ReflectionServices);
     const {
       outputLocation,
@@ -204,15 +196,16 @@ describe('output progress events', () => {
   });
 
   it('honors disabled compile-failure repair context setting', async () => {
-    await initFakePlatform({
-      [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]: false,
-    });
     const { host } = createRecordingHost();
     const outputNode = new OutputNode().setServices({
       streamId: 'stream:compile-context-disabled',
       logger: { warn: () => {} },
       outputState: createOutputState(),
       runtimeHost: host,
+      workflowOutputPolicy: {
+        ...defaultWorkflowOutputPolicy,
+        shouldRejectOnCompileFailure: () => false,
+      },
     } as unknown as ReflectionServices);
     const {
       outputLocation,
@@ -251,6 +244,7 @@ describe('output progress events', () => {
       logger: { warn: () => {} },
       outputState: createOutputState(),
       runtimeHost: host,
+      workflowOutputPolicy: defaultWorkflowOutputPolicy,
     } as unknown as ReflectionServices);
     const { outputLocation, roundOutput, summary } =
       createCompileFailureFixture();


### PR DESCRIPTION
## Summary

- Closes #6326 by moving workflow output decisions out of `OutputNode` and into an injected `WorkflowOutputPolicy` service.
- Wires the default policy in `runReflectionFlow`, where flow dependencies are assembled from workspace state.
- Updates output-node tests to inject policy directly instead of booting a fake platform.

## Abstraction review follow-ups

- #6327: separate model-option projection from host access state.
- #6328: extract CLI chat session orchestration from `runChatTui`.
- #6329: split desktop agent execution into focused host controllers.

## Validation

- `npx vitest run src/test-kernel/agent/output/OutputProgressEvents.vitest.ts`
- `npx tsc --noEmit`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure dependency-injection refactor with the same default workspace-state behavior; no auth or data-path changes.
> 
> **Overview**
> Introduces an injectable **`WorkflowOutputPolicy`** on reflection flow services so **`OutputNode`** no longer reads workspace settings via **`platform()`** for auto-opening PDFs/logs or for compile-failure “reject/repair” context.
> 
> **`runReflectionFlow`** assembles the default policy from workspace state (`WORKFLOW_AUTO_OPEN_PDF`, `WORKFLOW_REJECT_ON_COMPILE_FAILURE`) and allows callers to override via optional **`workflowOutputPolicy`**. Output-node tests now stub the policy directly instead of initializing a fake platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96396e345c519fc3f45f5b901a922eb6cad49b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->