### PR TITLE
fix: pluralize edit approval hunk count

### DIFF
--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -92,6 +92,10 @@ export function editApprovalFeedbackRows({
   );
 }
 
+export function formatEditApprovalHunkCount(count: number): string {
+  return `${count} ${count === 1 ? 'hunk' : 'hunks'}`;
+}
+
 export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const [feedbackMode, setFeedbackMode] = useState(false);
@@ -148,7 +152,8 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
       onDecide={props.onDecide}
     >
       <Text dimColor>
-        +{stats.added} / −{stats.removed} · {stats.hunks} hunks · source:{' '}
+        +{stats.added} / −{stats.removed} ·{' '}
+        {formatEditApprovalHunkCount(stats.hunks)} · source:{' '}
         {props.request.sourceTool}
       </Text>
       <Box marginY={compactDiffLayout ? 0 : 1} flexDirection="column">

--- a/src/test-kernel/cli/EditApproval.vitest.mts
+++ b/src/test-kernel/cli/EditApproval.vitest.mts
@@ -4,6 +4,7 @@ import {
   COMPACT_EDIT_APPROVAL_MAX_ROWS,
   editApprovalDiffRowsBudget,
   editApprovalFeedbackRows,
+  formatEditApprovalHunkCount,
 } from '@cli/chat/tui/modals/EditApproval';
 
 describe('CLI edit approval layout', () => {
@@ -79,5 +80,10 @@ describe('CLI edit approval layout', () => {
         title: 'Apply edit to proof.tex?',
       }),
     ).toBe(30);
+  });
+
+  it('pluralizes the hunk count in the summary line', () => {
+    expect(formatEditApprovalHunkCount(1)).toBe('1 hunk');
+    expect(formatEditApprovalHunkCount(2)).toBe('2 hunks');
   });
 });


### PR DESCRIPTION
## Summary

- Closes #6331 by formatting the edit approval hunk count as singular/plural text.
- Adds regression coverage in the existing edit approval layout tests.
- Re-ran the PTY-backed `narrow-edit-approval` scenario and verified the frame now shows `1 hunk`.

## Validation

- `npx vitest run src/test-kernel/cli/EditApproval.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-snapshots-2026-06-20-hunk-label narrow-edit-approval`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`
- `npm run typecheck`

Frame evidence: `/private/tmp/texra-tui-snapshots-2026-06-20-hunk-label/01-narrow-edit-approval.txt` now contains `+24 / −24 · 1 hunk · source: harness`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only TUI change with a small exported formatter and tests; no approval or edit logic affected.
> 
> **Overview**
> Fixes the edit approval summary line so a single diff hunk reads **1 hunk** instead of **1 hunks**.
> 
> Adds exported helper `formatEditApprovalHunkCount` and wires it into the dim summary text above the inline diff. Regression tests cover singular and plural counts in `EditApproval.vitest.mts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eccc5b5e44e05e8a991511d66c56de87661e9940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->