### PR TITLE
refactor: inject model option access

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -14,8 +14,10 @@ import {
 } from '@common/webview';
 import { workspaceSM } from '@common/state';
 import { createChannelTrace } from '@logger';
-import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
-import { computeModelOptionsData } from '@model/computeModelOptions';
+import {
+  buildVisibleBasicModelOptionsData,
+  computeModelOptionsData,
+} from '@model/computeModelOptions';
 import { ApprovalRequestHandler } from '@progressView/managers/ApprovalRequestHandler';
 import type {
   AgentProposalPermission,
@@ -152,7 +154,7 @@ export class ProgressViewProvider
             u.showPermission({
               kind: PERMISSION_KIND.PROPOSAL,
               data: p,
-              modelOptionsData: buildBasicModelOptionsData(),
+              modelOptionsData: buildVisibleBasicModelOptionsData(),
             });
             // Then upgrade with availability metadata if possible
             void this.sendProposalModelOptions(p);
@@ -314,7 +316,7 @@ export class ProgressViewProvider
       return raw.map((opt) => ({ ...opt, value: opt.label }));
     };
     const [modelOptions, agentOptions] = await Promise.all([
-      computeModelOptionsData().catch(() => buildBasicModelOptionsData()),
+      computeModelOptionsData().catch(() => buildVisibleBasicModelOptionsData()),
       loadAgentOptions().catch(() => undefined),
     ]);
     if (!this.agentProposalHandler.get(proposal.proposalId)) return;

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -316,7 +316,9 @@ export class ProgressViewProvider
       return raw.map((opt) => ({ ...opt, value: opt.label }));
     };
     const [modelOptions, agentOptions] = await Promise.all([
-      computeModelOptionsData().catch(() => buildVisibleBasicModelOptionsData()),
+      computeModelOptionsData().catch(() =>
+        buildVisibleBasicModelOptionsData(),
+      ),
       loadAgentOptions().catch(() => undefined),
     ]);
     if (!this.agentProposalHandler.get(proposal.proposalId)) return;

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -304,10 +304,10 @@ export class ProgressViewProvider
   private async sendProposalModelOptions(
     proposal: AgentProposalPermission,
   ): Promise<void> {
-    // Model options have a static fallback (buildBasicModelOptionsData) so
-    // the dropdown still appears if ServerSideKeyService isn't ready. Agent
-    // options have no static equivalent, so the agent dropdown is omitted
-    // when the registry fetch fails.
+    // Model options have a visible-model fallback that does not require
+    // ServerSideKeyService, so the dropdown still appears if availability
+    // loading fails. Agent options have no static equivalent, so the agent
+    // dropdown is omitted when the registry fetch fails.
     const isWorkflow = proposal.agentCategory === AgentCategory.Workflow;
     const loadAgentOptions = async () => {
       const all = await computeAgentOptionsData();

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -167,5 +167,5 @@ export async function apiKeyExistsUncached(
 ): Promise<boolean> {
   const stored = await secrets.get(apiKeySecretName(provider));
   if (stored) return true;
-  return process.env[apiKeyEnvName(provider)] !== undefined;
+  return Boolean(process.env[apiKeyEnvName(provider)]);
 }

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -159,3 +159,13 @@ export async function apiKeyExists(
 ): Promise<boolean> {
   return (await lookupApiKey(secrets, provider)) !== undefined;
 }
+
+/** Check if an API key exists without using the process-wide provider cache. */
+export async function apiKeyExistsUncached(
+  secrets: PlatformSecrets,
+  provider: ApiProvider,
+): Promise<boolean> {
+  const stored = await secrets.get(apiKeySecretName(provider));
+  if (stored) return true;
+  return process.env[apiKeyEnvName(provider)] !== undefined;
+}

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -353,9 +353,9 @@ function getModelOptionsCacheKey(models?: readonly string[]): string {
 }
 
 async function computeModelOptionsDataUncached(
-  modelsOverride?: readonly string[],
-  access: ModelOptionsAccess = buildDefaultModelOptionsAccess(),
-  useApiKeyCache = true,
+  modelsOverride: readonly string[] | undefined,
+  access: ModelOptionsAccess,
+  useApiKeyCache: boolean,
 ): Promise<ModelOptionData[]> {
   const models = modelsOverride ?? access.visibleModels;
   const availabilityCtx = await buildAvailabilityContext(

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -6,7 +6,12 @@ import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
-import { apiKeyExists, isApiProvider } from './apiProviders';
+import {
+  apiKeyExists,
+  apiKeyExistsUncached,
+  isApiProvider,
+  type ApiProvider,
+} from './apiProviders';
 import {
   buildBaseModelOption,
   buildBasicModelOptionsData,
@@ -99,7 +104,7 @@ async function getPersonalAccessKindForModel(
   }
 
   try {
-    if (await apiKeyExists(ctx.secrets, provider)) {
+    if (await ctx.apiKeyExists(provider)) {
       return 'provider-key';
     }
   } catch {
@@ -113,7 +118,7 @@ async function getPersonalAccessKindForModel(
 }
 
 interface ModelAvailabilityContext {
-  secrets: PlatformSecrets;
+  apiKeyExists(provider: ApiProvider): Promise<boolean>;
   hasOpenRouter: boolean;
   hasServerAccess: boolean;
   relayQuotaExhausted: boolean;
@@ -171,15 +176,20 @@ async function resolveModelAvailability(
 
 async function buildAvailabilityContext(
   access: ModelOptionsAccess,
+  useApiKeyCache: boolean,
 ): Promise<ModelAvailabilityContext> {
   const { serverSideKeyService } = access;
+  const hasApiKey = (provider: ApiProvider) =>
+    useApiKeyCache
+      ? apiKeyExists(access.secrets, provider)
+      : apiKeyExistsUncached(access.secrets, provider);
   const useIncludedAccess = serverSideKeyService.getUseIncludedModelAccess();
   const [hasOpenRouter, hasServerAccess] = await Promise.all([
-    apiKeyExists(access.secrets, 'openRouter'),
+    hasApiKey('openRouter'),
     serverSideKeyService.canUseServerSideKeys(),
   ]);
   return {
-    secrets: access.secrets,
+    apiKeyExists: hasApiKey,
     hasOpenRouter,
     hasServerAccess,
     relayQuotaExhausted:
@@ -201,13 +211,9 @@ function buildDefaultModelOptionsAccess(): ModelOptionsAccess {
   };
 }
 
-function getDefaultVisibleModels(): string[] {
-  return getVisibleModels(platform().globalState);
-}
-
 /** Build synchronous fallback options from the current host-visible model list. */
 export function buildVisibleBasicModelOptionsData(
-  visibleModels: readonly string[] = getDefaultVisibleModels(),
+  visibleModels: readonly string[] = getVisibleModels(platform().globalState),
 ): ModelOptionData[] {
   return buildBasicModelOptionsData(visibleModels);
 }
@@ -215,12 +221,13 @@ export function buildVisibleBasicModelOptionsData(
 /** Returns a human-readable reason why a model is unavailable, or `null` if available. */
 export async function getModelUnavailableReason(
   model: string,
-  access: ModelOptionsAccess = buildDefaultModelOptionsAccess(),
+  access?: ModelOptionsAccess,
 ): Promise<string | null> {
   const config = MODEL_CONFIGS[model];
   if (!config) return `Model "${model}" is not recognized.`;
 
-  const ctx = await buildAvailabilityContext(access);
+  const effectiveAccess = access ?? buildDefaultModelOptionsAccess();
+  const ctx = await buildAvailabilityContext(effectiveAccess, access == null);
   const availability = await resolveModelAvailability(model, config, ctx);
   if (availability.available) return null;
 
@@ -305,7 +312,7 @@ export async function computeModelOptionsData(
   access?: ModelOptionsAccess,
 ): Promise<ModelOptionData[]> {
   if (access) {
-    return computeModelOptionsDataUncached(models, access);
+    return computeModelOptionsDataUncached(models, access, false);
   }
 
   const cacheKey = getModelOptionsCacheKey(models);
@@ -318,6 +325,7 @@ export async function computeModelOptionsData(
   const request = computeModelOptionsDataUncached(
     models,
     buildDefaultModelOptionsAccess(),
+    true,
   );
   pendingModelOptions.set(cacheKey, request);
 
@@ -347,9 +355,13 @@ function getModelOptionsCacheKey(models?: readonly string[]): string {
 async function computeModelOptionsDataUncached(
   modelsOverride?: readonly string[],
   access: ModelOptionsAccess = buildDefaultModelOptionsAccess(),
+  useApiKeyCache = true,
 ): Promise<ModelOptionData[]> {
   const models = modelsOverride ?? access.visibleModels;
-  const availabilityCtx = await buildAvailabilityContext(access);
+  const availabilityCtx = await buildAvailabilityContext(
+    access,
+    useApiKeyCache,
+  );
 
   return Promise.all(
     models.map((model) => buildModelOptionData(model, availabilityCtx)),

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -7,10 +7,31 @@ import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 import { apiKeyExists, isApiProvider } from './apiProviders';
-import { buildBaseModelOption, getVisibleModels } from './modelOptionsBasic';
+import {
+  buildBaseModelOption,
+  buildBasicModelOptionsData,
+} from './modelOptionsBasic';
+import { getVisibleModels } from './modelOptionsState';
 import { shouldRouteModelThroughOpenRouter } from './openRouterRouting';
+import type { PlatformSecrets } from '@platform/secrets';
 
 type PersonalModelAccessKind = 'provider-key' | 'openrouter-key';
+
+export interface ModelOptionsServerAccess {
+  canUseServerSideKeys(): Promise<boolean>;
+  getUseIncludedModelAccess(): boolean;
+  wasQuotaAutoSwitched(): boolean;
+  isRelayQuotaExceeded(): boolean;
+  isProviderOnServer(provider: string): boolean;
+  canUseModelSync(model: string): boolean;
+}
+
+export interface ModelOptionsAccess {
+  readonly visibleModels: readonly string[];
+  readonly secrets: PlatformSecrets;
+  readonly useOpenRouter: boolean;
+  readonly serverSideKeyService: ModelOptionsServerAccess;
+}
 
 interface ModelAvailabilityStatus {
   kind: ModelAvailabilityKind;
@@ -70,7 +91,7 @@ const AVAILABILITY_STATUS: Record<
 /** Check whether a model is available through a personal provider or OpenRouter key. */
 async function getPersonalAccessKindForModel(
   config: ModelConfig,
-  hasOpenRouter: boolean,
+  ctx: ModelAvailabilityContext,
 ): Promise<PersonalModelAccessKind | null> {
   const { provider } = config;
   if (!isApiProvider(provider)) {
@@ -78,7 +99,7 @@ async function getPersonalAccessKindForModel(
   }
 
   try {
-    if (await apiKeyExists(platform().secrets, provider)) {
+    if (await apiKeyExists(ctx.secrets, provider)) {
       return 'provider-key';
     }
   } catch {
@@ -86,16 +107,19 @@ async function getPersonalAccessKindForModel(
     // fallback below when this model has an OpenRouter route.
   }
 
-  return config.openrouterFullName && hasOpenRouter ? 'openrouter-key' : null;
+  return config.openrouterFullName && ctx.hasOpenRouter
+    ? 'openrouter-key'
+    : null;
 }
 
 interface ModelAvailabilityContext {
+  secrets: PlatformSecrets;
   hasOpenRouter: boolean;
   hasServerAccess: boolean;
   relayQuotaExhausted: boolean;
   useOpenRouter: boolean;
   useIncludedAccess: boolean;
-  serverSideKeyService: ReturnType<typeof getServerSideKeyService>;
+  serverSideKeyService: ModelOptionsServerAccess;
 }
 
 function canUseIncludedAccessForModel(
@@ -139,42 +163,60 @@ async function resolveModelAvailability(
     return AVAILABILITY_STATUS['not-included'];
   }
 
-  const personalAccess = await getPersonalAccessKindForModel(
-    config,
-    ctx.hasOpenRouter,
-  );
+  const personalAccess = await getPersonalAccessKindForModel(config, ctx);
   return personalAccess
     ? AVAILABILITY_STATUS[personalAccess]
     : AVAILABILITY_STATUS['missing-key'];
 }
 
-async function buildAvailabilityContext(): Promise<ModelAvailabilityContext> {
-  const serverSideKeyService = getServerSideKeyService();
+async function buildAvailabilityContext(
+  access: ModelOptionsAccess,
+): Promise<ModelAvailabilityContext> {
+  const { serverSideKeyService } = access;
   const useIncludedAccess = serverSideKeyService.getUseIncludedModelAccess();
   const [hasOpenRouter, hasServerAccess] = await Promise.all([
-    apiKeyExists(platform().secrets, 'openRouter'),
+    apiKeyExists(access.secrets, 'openRouter'),
     serverSideKeyService.canUseServerSideKeys(),
   ]);
   return {
+    secrets: access.secrets,
     hasOpenRouter,
     hasServerAccess,
     relayQuotaExhausted:
       serverSideKeyService.wasQuotaAutoSwitched() ||
       (useIncludedAccess && serverSideKeyService.isRelayQuotaExceeded()),
-    useOpenRouter: getUseOpenRouter(),
+    useOpenRouter: access.useOpenRouter,
     useIncludedAccess,
     serverSideKeyService,
   };
 }
 
+function buildDefaultModelOptionsAccess(): ModelOptionsAccess {
+  const host = platform();
+  return {
+    visibleModels: getVisibleModels(host.globalState),
+    secrets: host.secrets,
+    useOpenRouter: getUseOpenRouter(),
+    serverSideKeyService: getServerSideKeyService(),
+  };
+}
+
+/** Build synchronous fallback options from the current host-visible model list. */
+export function buildVisibleBasicModelOptionsData(
+  access: ModelOptionsAccess = buildDefaultModelOptionsAccess(),
+): ModelOptionData[] {
+  return buildBasicModelOptionsData(access.visibleModels);
+}
+
 /** Returns a human-readable reason why a model is unavailable, or `null` if available. */
 export async function getModelUnavailableReason(
   model: string,
+  access: ModelOptionsAccess = buildDefaultModelOptionsAccess(),
 ): Promise<string | null> {
   const config = MODEL_CONFIGS[model];
   if (!config) return `Model "${model}" is not recognized.`;
 
-  const ctx = await buildAvailabilityContext();
+  const ctx = await buildAvailabilityContext(access);
   const availability = await resolveModelAvailability(model, config, ctx);
   if (availability.available) return null;
 
@@ -252,7 +294,12 @@ export function invalidateModelOptionsCache(): void {
  */
 export async function computeModelOptionsData(
   models?: readonly string[],
+  access?: ModelOptionsAccess,
 ): Promise<ModelOptionData[]> {
+  if (access) {
+    return computeModelOptionsDataUncached(models, access);
+  }
+
   const cacheKey = getModelOptionsCacheKey(models);
   const cached = resolvedModelOptions.get(cacheKey);
   if (cached && Date.now() < cached.expiry) return cached.data;
@@ -260,7 +307,10 @@ export async function computeModelOptionsData(
   const pending = pendingModelOptions.get(cacheKey);
   if (pending) return pending;
 
-  const request = computeModelOptionsDataUncached(models);
+  const request = computeModelOptionsDataUncached(
+    models,
+    buildDefaultModelOptionsAccess(),
+  );
   pendingModelOptions.set(cacheKey, request);
 
   try {
@@ -288,9 +338,10 @@ function getModelOptionsCacheKey(models?: readonly string[]): string {
 
 async function computeModelOptionsDataUncached(
   modelsOverride?: readonly string[],
+  access: ModelOptionsAccess = buildDefaultModelOptionsAccess(),
 ): Promise<ModelOptionData[]> {
-  const models = modelsOverride ?? getVisibleModels();
-  const availabilityCtx = await buildAvailabilityContext();
+  const models = modelsOverride ?? access.visibleModels;
+  const availabilityCtx = await buildAvailabilityContext(access);
 
   return Promise.all(
     models.map((model) => buildModelOptionData(model, availabilityCtx)),

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -201,11 +201,15 @@ function buildDefaultModelOptionsAccess(): ModelOptionsAccess {
   };
 }
 
+function getDefaultVisibleModels(): string[] {
+  return getVisibleModels(platform().globalState);
+}
+
 /** Build synchronous fallback options from the current host-visible model list. */
 export function buildVisibleBasicModelOptionsData(
-  access: ModelOptionsAccess = buildDefaultModelOptionsAccess(),
+  visibleModels: readonly string[] = getDefaultVisibleModels(),
 ): ModelOptionData[] {
-  return buildBasicModelOptionsData(access.visibleModels);
+  return buildBasicModelOptionsData(visibleModels);
 }
 
 /** Returns a human-readable reason why a model is unavailable, or `null` if available. */
@@ -291,6 +295,10 @@ export function invalidateModelOptionsCache(): void {
  * honored verbatim. Explicit lists are cached by their exact ordered contents,
  * so alternate global-state views stay isolated while repeated settings/CLI
  * refreshes do not redo secret and server-side key checks.
+ *
+ * Passing `access` computes directly from that dependency snapshot and skips
+ * the shared TTL cache. Use it when the caller owns access-state freshness,
+ * such as tests or host adapters with explicitly supplied state.
  */
 export async function computeModelOptionsData(
   models?: readonly string[],

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -84,7 +84,7 @@ export function buildBaseModelOption(
 
 /** Build model options from static config without provider availability checks. */
 export function buildBasicModelOptionsData(
-  visibleModels: readonly string[] = DEFAULT_MODELS,
+  visibleModels: readonly string[],
 ): ModelOptionData[] {
   return visibleModels.map((model) => {
     const config = MODEL_CONFIGS[model];

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -1,8 +1,6 @@
 import { MODEL_CONFIGS, hint, type ModelConfig } from 'llm-zoo';
 
-import { platform } from '@platform/platform';
 import type { ModelOptionData } from '@shared/schemas';
-import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
   EXPENSIVE_MODEL_HINT,
   isExpensiveModel,
@@ -30,14 +28,6 @@ export const MODEL_LIST_VERSION = 20;
 
 const MILLION = 1_000_000;
 const THOUSAND = 1_000;
-
-/** Get the list of visible models from extension global state. */
-export function getVisibleModels(): string[] {
-  return platform().globalState.get<string[]>(
-    GlobalStateKey.ENABLED_MODELS,
-    DEFAULT_MODELS,
-  );
-}
 
 /** Return whether the registry marks a model as deprecated. */
 export function isDeprecatedModel(model: string): boolean {
@@ -94,7 +84,7 @@ export function buildBaseModelOption(
 
 /** Build model options from static config without provider availability checks. */
 export function buildBasicModelOptionsData(
-  visibleModels: readonly string[] = getVisibleModels(),
+  visibleModels: readonly string[] = DEFAULT_MODELS,
 ): ModelOptionData[] {
   return visibleModels.map((model) => {
     const config = MODEL_CONFIGS[model];

--- a/src/model/modelOptionsState.ts
+++ b/src/model/modelOptionsState.ts
@@ -1,0 +1,9 @@
+import { GlobalStateKey } from '@shared/state/stateKeys';
+
+import { DEFAULT_MODELS } from './modelOptionsBasic';
+import type { StateStore } from '@platform/interfaces/state';
+
+/** Read the enabled model list from host state at the composition boundary. */
+export function getVisibleModels(state: Pick<StateStore, 'get'>): string[] {
+  return state.get<string[]>(GlobalStateKey.ENABLED_MODELS, DEFAULT_MODELS);
+}

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import {
+  apiKeyExistsUncached,
   apiKeySecretName,
   invalidateApiKeyCache,
   loadApiKeyStatusMap,
@@ -144,6 +145,14 @@ describe('API provider key caches', () => {
     ).resolves.toEqual({
       openai: 'env',
     });
+  });
+
+  it('treats empty env keys as missing in uncached lookups', async () => {
+    process.env.OPENAI_API_KEY = '';
+
+    await expect(
+      apiKeyExistsUncached(createSecrets().secrets, 'openai'),
+    ).resolves.toBe(false);
   });
 
   it('set_api_key invalidates stale missing-key lookups', async () => {

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -47,12 +47,14 @@ function installServerSideKeyService(
 
 function createModelOptionsAccess(
   options: Parameters<typeof createServerSideKeyService>[0],
+  secrets: Record<string, string> = {
+    [apiKeySecretName('openai')]: 'sk-openai',
+  },
 ): ModelOptionsAccess {
   return {
     visibleModels: ['gpt55'],
     secrets: {
-      get: async (key) =>
-        key === apiKeySecretName('openai') ? 'sk-openai' : undefined,
+      get: async (key) => secrets[key],
       set: async () => {},
       delete: async () => {},
     },
@@ -72,7 +74,10 @@ describe('computeModelOptionsData relay quota state', () => {
     initPlatform(
       createFakePlatform({
         globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
-        secrets: { [apiKeySecretName('openai')]: 'sk-openai' },
+        secrets: {
+          [apiKeySecretName('openai')]: 'sk-openai',
+          [apiKeySecretName('deepseek')]: 'sk-deepseek',
+        },
       }),
     );
   });
@@ -115,6 +120,39 @@ describe('computeModelOptionsData relay quota state', () => {
 
     expect(model.availability).toBe('provider-key');
     expect(model.disabled).toBe(false);
+  });
+
+  it('does not reuse cached provider keys for injected access', async () => {
+    const previousDeepseekKey = process.env.DEEPSEEK_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
+    try {
+      installServerSideKeyService({
+        useIncludedAccess: false,
+        relayQuotaExceeded: false,
+        quotaAutoSwitched: false,
+      });
+      await computeModelOptionsData(['deepseekproT']);
+
+      const access = createModelOptionsAccess(
+        {
+          useIncludedAccess: false,
+          relayQuotaExceeded: false,
+          quotaAutoSwitched: false,
+        },
+        {},
+      );
+
+      const [model] = await computeModelOptionsData(['deepseekproT'], access);
+
+      expect(model.availability).toBe('missing-key');
+      expect(model.disabled).toBe(true);
+    } finally {
+      if (previousDeepseekKey === undefined) {
+        delete process.env.DEEPSEEK_API_KEY;
+      } else {
+        process.env.DEEPSEEK_API_KEY = previousDeepseekKey;
+      }
+    }
   });
 
   it('caches explicit model-list availability until invalidated', async () => {

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -9,17 +9,19 @@ import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 import {
   computeModelOptionsData,
   invalidateModelOptionsCache,
+  type ModelOptionsAccess,
+  type ModelOptionsServerAccess,
 } from '@model/computeModelOptions';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
-function installServerSideKeyService(options: {
+function createServerSideKeyService(options: {
   useIncludedAccess: boolean;
   readonly relayQuotaExceeded: boolean;
   readonly quotaAutoSwitched: boolean;
   readonly autoSwitchDuringAccessCheck?: boolean;
   readonly onAccessCheck?: () => void;
-}): void {
-  setServerSideKeyService({
+}): ModelOptionsServerAccess {
+  return {
     canUseServerSideKeys: async () => {
       options.onAccessCheck?.();
       if (options.autoSwitchDuringAccessCheck) {
@@ -32,7 +34,31 @@ function installServerSideKeyService(options: {
     wasQuotaAutoSwitched: () => options.quotaAutoSwitched,
     isProviderOnServer: () => true,
     canUseModelSync: () => false,
-  } as unknown as ServerSideKeyService);
+  };
+}
+
+function installServerSideKeyService(
+  options: Parameters<typeof createServerSideKeyService>[0],
+): void {
+  setServerSideKeyService(
+    createServerSideKeyService(options) as unknown as ServerSideKeyService,
+  );
+}
+
+function createModelOptionsAccess(
+  options: Parameters<typeof createServerSideKeyService>[0],
+): ModelOptionsAccess {
+  return {
+    visibleModels: ['gpt55'],
+    secrets: {
+      get: async (key) =>
+        key === apiKeySecretName('openai') ? 'sk-openai' : undefined,
+      set: async () => {},
+      delete: async () => {},
+    },
+    useOpenRouter: false,
+    serverSideKeyService: createServerSideKeyService(options),
+  };
 }
 
 describe('computeModelOptionsData relay quota state', () => {
@@ -52,40 +78,40 @@ describe('computeModelOptionsData relay quota state', () => {
   });
 
   it('shows relay quota exhaustion while included access remains selected', async () => {
-    installServerSideKeyService({
+    const access = createModelOptionsAccess({
       useIncludedAccess: true,
       relayQuotaExceeded: true,
       quotaAutoSwitched: false,
     });
 
-    const [model] = await computeModelOptionsData();
+    const [model] = await computeModelOptionsData(undefined, access);
 
     expect(model.availability).toBe('relay-quota-exhausted');
     expect(model.disabled).toBe(true);
   });
 
   it('preserves the quota label when access check auto-switches included access off', async () => {
-    installServerSideKeyService({
+    const access = createModelOptionsAccess({
       useIncludedAccess: true,
       relayQuotaExceeded: true,
       quotaAutoSwitched: true,
       autoSwitchDuringAccessCheck: true,
     });
 
-    const [model] = await computeModelOptionsData();
+    const [model] = await computeModelOptionsData(undefined, access);
 
     expect(model.availability).toBe('relay-quota-exhausted');
     expect(model.disabled).toBe(true);
   });
 
   it('falls back to personal keys when included access is disabled without quota auto-switch', async () => {
-    installServerSideKeyService({
+    const access = createModelOptionsAccess({
       useIncludedAccess: false,
       relayQuotaExceeded: true,
       quotaAutoSwitched: false,
     });
 
-    const [model] = await computeModelOptionsData();
+    const [model] = await computeModelOptionsData(undefined, access);
 
     expect(model.availability).toBe('provider-key');
     expect(model.disabled).toBe(false);


### PR DESCRIPTION
## Summary

- Closes #6327 by moving visible-model state reads into a small boundary helper and making model availability consume explicit access dependencies.
- Keeps the existing cached `computeModelOptionsData()` wrapper for current callers, while allowing tests and future host wiring to pass `ModelOptionsAccess` directly.
- Updates the progress-view proposal fallback to use the host-visible model list without relying on `modelOptionsBasic` reading from `platform()`.

## Validation

- `npx vitest run src/test-kernel/model/ComputeModelOptions.vitest.ts src/test-kernel/model/ModelOptionsBasic.vitest.ts`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how model availability resolves API keys and visible models across proposal UI and settings paths; default cached behavior is preserved, but injected-access paths alter cache semantics and could affect correctness if mis-wired.
> 
> **Overview**
> Refactors model dropdown availability so callers can supply an explicit **`ModelOptionsAccess`** snapshot (visible models, secrets, OpenRouter flag, server-side key service) instead of always reading from **`platform()`** inside the model layer.
> 
> **`computeModelOptionsData`** and **`getModelUnavailableReason`** still default to the host when `access` is omitted, but passing `access` computes from that snapshot, **skips the shared TTL cache**, and uses **uncached** API-key checks so tests and future adapters do not inherit stale provider-key cache state. **`apiKeyExistsUncached`** adds a direct secrets/env lookup (empty env vars count as missing).
> 
> Enabled-model reads move to **`getVisibleModels(state)`** in **`modelOptionsState`**, and static option building (**`buildBasicModelOptionsData`**) now requires an explicit model list. **`buildVisibleBasicModelOptionsData`** provides the synchronous proposal fallback from the host-visible list; the progress view uses it for immediate agent-proposal dropdowns and when async availability loading fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b748456d808247b91e592f25241bd9644a315644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->