### PR TITLE
refactor: extract chat tui run state

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -30,7 +30,6 @@ import {
   executeAgent,
   resumeToolUseFromSnapshot,
 } from '@agent/runtime/executeAgent';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import {
@@ -188,6 +187,20 @@ import {
   transcriptViewportRepaintOptions,
   type TranscriptViewportChange,
 } from './state/transcriptViewportMode';
+import {
+  chatTuiCanInterruptActiveRun,
+  chatTuiCanSelectModel,
+  chatTuiCanStartRootRun,
+  chatTuiCanStopActiveRun,
+  chatTuiCanStopVisibleRun,
+  chatTuiIsResumableIdleOnExit,
+  chatTuiSigintAction,
+  clearTuiSessionRunState,
+  markChatTuiRunCompleted,
+  markChatTuiRunPending,
+  publishChatTuiRootRunStartAvailability,
+  type TuiSession,
+} from './state/sessionRunState';
 import type { SkillActivation } from './forms/SkillsListForm';
 
 export interface ChatResult {
@@ -306,154 +319,6 @@ export async function markRegisteredChatExecutionError(
 ): Promise<void> {
   if (!options.executionRegistered || options.agentSettled) return;
   await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
-}
-
-export interface ClearableTuiSessionState {
-  streamId: StreamTabId | undefined;
-  executionId: string | undefined;
-  runtimeHost?: AgentRuntimeHost;
-  runPromise: Promise<void> | undefined;
-  runExitCode: CliExitCode;
-  runCompleted: boolean;
-  stopRequested: boolean;
-}
-
-type TuiSession = ClearableTuiSessionState;
-type InterruptibleTuiSessionState = Pick<
-  ClearableTuiSessionState,
-  'streamId' | 'runPromise' | 'runCompleted'
->;
-type PendingTuiRunSessionState = Pick<
-  ClearableTuiSessionState,
-  'runPromise' | 'runCompleted'
->;
-
-export function clearTuiSessionRunState(
-  session: ClearableTuiSessionState,
-): void {
-  session.streamId = undefined;
-  session.executionId = undefined;
-  session.runtimeHost = undefined;
-  session.runPromise = undefined;
-  session.runExitCode = CliExitCode.Success;
-  session.runCompleted = false;
-  session.stopRequested = false;
-  publishRootRunStartAvailability(session);
-}
-
-export function markChatTuiRunPending(
-  session: ClearableTuiSessionState,
-  runPromise: Promise<void>,
-  runtimeHost?: AgentRuntimeHost,
-): void {
-  session.streamId = undefined;
-  session.runtimeHost = runtimeHost;
-  session.runPromise = runPromise;
-  session.runExitCode = CliExitCode.Success;
-  session.runCompleted = false;
-  session.stopRequested = false;
-  publishRootRunStartAvailability(session);
-}
-
-export function chatTuiCanInterruptActiveRun(
-  session: InterruptibleTuiSessionState,
-): boolean {
-  return Boolean(
-    session.streamId && session.runPromise && !session.runCompleted,
-  );
-}
-
-export function chatTuiCanStopActiveRun(
-  session: InterruptibleTuiSessionState,
-  status: StreamStatus | undefined,
-): boolean {
-  if (!session.runPromise || session.runCompleted) return false;
-  if (!session.streamId) return true;
-  return status === undefined || isLiveElapsedStatus(status);
-}
-
-export function chatTuiCanStopVisibleRun(
-  session: InterruptibleTuiSessionState,
-  status: StreamStatus | undefined,
-): boolean {
-  return (
-    chatTuiCanStopActiveRun(session, status) ||
-    Boolean(session.streamId && isLiveElapsedStatus(status))
-  );
-}
-
-export function chatTuiCanStartRootRun(
-  session: PendingTuiRunSessionState,
-): boolean {
-  return !session.runPromise || session.runCompleted;
-}
-
-function publishRootRunStartAvailability(
-  session: PendingTuiRunSessionState,
-): void {
-  cliState.rootRunStartAvailable.set(chatTuiCanStartRootRun(session));
-}
-
-function markChatTuiRunCompleted(session: PendingTuiRunSessionState): void {
-  session.runCompleted = true;
-  publishRootRunStartAvailability(session);
-}
-
-export function chatTuiCanSelectModel(input: {
-  readonly canStartRootRun: boolean;
-  readonly streamId: StreamTabId | undefined;
-  readonly status: StreamStatus | undefined;
-  readonly hasActiveToolUseFlow: boolean;
-}): boolean {
-  return (
-    input.canStartRootRun ||
-    Boolean(
-      input.streamId &&
-      input.status === STREAM_STATUS.WAITING &&
-      input.hasActiveToolUseFlow,
-    )
-  );
-}
-
-export type ChatTuiSigintAction =
-  | 'clean-exit'
-  | 'force-exit'
-  | 'preserve-exit'
-  | 'interrupt-and-arm-exit';
-
-export function chatTuiSigintAction(input: {
-  readonly exitArmed: boolean;
-  readonly canStopActiveRun: boolean;
-  readonly canInterruptActiveRun: boolean;
-}): ChatTuiSigintAction {
-  if (input.exitArmed) return 'force-exit';
-  if (input.canStopActiveRun) return 'interrupt-and-arm-exit';
-  // Resumable-idle (interruptible but not actively running): exit WITHOUT
-  // interrupting so the suspended tool-use flow record survives for resume —
-  // interrupting would clear it in runToolUseFlow's finally. preserve-exit
-  // calls process.exit, leaving the suspended flow on disk for `texra resume`.
-  if (input.canInterruptActiveRun) return 'preserve-exit';
-  return 'clean-exit';
-}
-
-/**
- * On exit, a tool-use session suspended at the WAIT node (idle/WAITING) must
- * NOT be interrupted: interrupting clears its per-execution flow record in
- * `runToolUseFlow`'s finally, destroying the only resumable state. The record
- * survives only when the process dies while the flow is still suspended.
- *
- * The discriminator: `canInterruptActiveRun` is true for any pending run, but
- * `canStopActiveRun` is true only while a turn is *actively* running. So
- * "interruptible but not stoppable" is exactly the resumable-idle case. Kept
- * pure (takes the two precomputed booleans) so the exit policy is unit-testable
- * without the live status plumbing. Used by the graceful-exit `finally`; the
- * SIGINT path encodes the same idle→preserve rule via `chatTuiSigintAction`.
- */
-export function chatTuiIsResumableIdleOnExit(input: {
-  readonly canInterruptActiveRun: boolean;
-  readonly canStopActiveRun: boolean;
-}): boolean {
-  return input.canInterruptActiveRun && !input.canStopActiveRun;
 }
 
 export type ChatTuiFocusedChildFollowUpRoute = FocusedChildFollowUpRoute;
@@ -1401,7 +1266,7 @@ export async function runChat(
     clearLocalTranscript();
     followUpQueue.clear();
     session.runCompleted = false;
-    publishRootRunStartAvailability(session);
+    publishChatTuiRootRunStartAvailability(session);
     session.stopRequested = false;
     session.runExitCode = CliExitCode.Success;
     session.streamId = resolution.streamId;
@@ -1487,7 +1352,7 @@ export async function runChat(
         markChatTuiRunCompleted(session);
         void runtimeHost.close();
       });
-    publishRootRunStartAvailability(session);
+    publishChatTuiRootRunStartAvailability(session);
     // Don't await session.runPromise here: a resumed session that suspends at
     // the WAIT node leaves runPromise unresolved (mirrors startAgentRun's
     // fire-and-forget). The exit `finally` handles the dangling-promise case.

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -191,7 +191,6 @@ import {
   chatTuiCanInterruptActiveRun,
   chatTuiCanSelectModel,
   chatTuiCanStartRootRun,
-  chatTuiCanStopActiveRun,
   chatTuiCanStopVisibleRun,
   chatTuiIsResumableIdleOnExit,
   chatTuiSigintAction,

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -1,0 +1,152 @@
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import { isLiveElapsedStatus } from '@common/constants/streamStatus';
+import {
+  STREAM_STATUS,
+  type StreamStatus,
+  type StreamTabId,
+} from '@shared/schemas';
+
+import { cliState } from './cliState';
+
+export interface ClearableTuiSessionState {
+  streamId: StreamTabId | undefined;
+  executionId: string | undefined;
+  runtimeHost?: AgentRuntimeHost;
+  runPromise: Promise<void> | undefined;
+  runExitCode: CliExitCode;
+  runCompleted: boolean;
+  stopRequested: boolean;
+}
+
+export type TuiSession = ClearableTuiSessionState;
+
+type InterruptibleTuiSessionState = Pick<
+  ClearableTuiSessionState,
+  'streamId' | 'runPromise' | 'runCompleted'
+>;
+
+type PendingTuiRunSessionState = Pick<
+  ClearableTuiSessionState,
+  'runPromise' | 'runCompleted'
+>;
+
+export function clearTuiSessionRunState(
+  session: ClearableTuiSessionState,
+): void {
+  session.streamId = undefined;
+  session.executionId = undefined;
+  session.runtimeHost = undefined;
+  session.runPromise = undefined;
+  session.runExitCode = CliExitCode.Success;
+  session.runCompleted = false;
+  session.stopRequested = false;
+  publishChatTuiRootRunStartAvailability(session);
+}
+
+export function markChatTuiRunPending(
+  session: ClearableTuiSessionState,
+  runPromise: Promise<void>,
+  runtimeHost?: AgentRuntimeHost,
+): void {
+  session.streamId = undefined;
+  session.runtimeHost = runtimeHost;
+  session.runPromise = runPromise;
+  session.runExitCode = CliExitCode.Success;
+  session.runCompleted = false;
+  session.stopRequested = false;
+  publishChatTuiRootRunStartAvailability(session);
+}
+
+export function markChatTuiRunCompleted(
+  session: PendingTuiRunSessionState,
+): void {
+  session.runCompleted = true;
+  publishChatTuiRootRunStartAvailability(session);
+}
+
+export function chatTuiCanInterruptActiveRun(
+  session: InterruptibleTuiSessionState,
+): boolean {
+  return Boolean(
+    session.streamId && session.runPromise && !session.runCompleted,
+  );
+}
+
+export function chatTuiCanStopActiveRun(
+  session: InterruptibleTuiSessionState,
+  status: StreamStatus | undefined,
+): boolean {
+  if (!session.runPromise || session.runCompleted) return false;
+  if (!session.streamId) return true;
+  return status === undefined || isLiveElapsedStatus(status);
+}
+
+export function chatTuiCanStopVisibleRun(
+  session: InterruptibleTuiSessionState,
+  status: StreamStatus | undefined,
+): boolean {
+  return (
+    chatTuiCanStopActiveRun(session, status) ||
+    Boolean(session.streamId && isLiveElapsedStatus(status))
+  );
+}
+
+export function chatTuiCanStartRootRun(
+  session: PendingTuiRunSessionState,
+): boolean {
+  return !session.runPromise || session.runCompleted;
+}
+
+export function publishChatTuiRootRunStartAvailability(
+  session: PendingTuiRunSessionState,
+): void {
+  cliState.rootRunStartAvailable.set(chatTuiCanStartRootRun(session));
+}
+
+export function chatTuiCanSelectModel(input: {
+  readonly canStartRootRun: boolean;
+  readonly streamId: StreamTabId | undefined;
+  readonly status: StreamStatus | undefined;
+  readonly hasActiveToolUseFlow: boolean;
+}): boolean {
+  return (
+    input.canStartRootRun ||
+    Boolean(
+      input.streamId &&
+      input.status === STREAM_STATUS.WAITING &&
+      input.hasActiveToolUseFlow,
+    )
+  );
+}
+
+export type ChatTuiSigintAction =
+  | 'clean-exit'
+  | 'force-exit'
+  | 'preserve-exit'
+  | 'interrupt-and-arm-exit';
+
+export function chatTuiSigintAction(input: {
+  readonly exitArmed: boolean;
+  readonly canStopActiveRun: boolean;
+  readonly canInterruptActiveRun: boolean;
+}): ChatTuiSigintAction {
+  if (input.exitArmed) return 'force-exit';
+  if (input.canStopActiveRun) return 'interrupt-and-arm-exit';
+  // Resumable-idle (interruptible, not actively running): exit WITHOUT
+  // interrupting so the suspended tool-use flow record survives for resume.
+  if (input.canInterruptActiveRun) return 'preserve-exit';
+  return 'clean-exit';
+}
+
+/**
+ * On exit, a tool-use session suspended at the WAIT node (idle/WAITING) must
+ * NOT be interrupted: interrupting clears its per-execution flow record in
+ * `runToolUseFlow`'s finally, destroying the only resumable state.
+ */
+export function chatTuiIsResumableIdleOnExit(input: {
+  readonly canInterruptActiveRun: boolean;
+  readonly canStopActiveRun: boolean;
+}): boolean {
+  return input.canInterruptActiveRun && !input.canStopActiveRun;
+}

--- a/src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts
+++ b/src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { chatTuiIsResumableIdleOnExit } from '@cli/chat/tui/runChatTui';
+import { chatTuiIsResumableIdleOnExit } from '@cli/chat/tui/state/sessionRunState';
 
 describe('chatTuiIsResumableIdleOnExit', () => {
   it('preserves an idle/WAITING session (interruptible, not stoppable)', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -71,10 +71,10 @@ import {
   chatTuiCanStartRootRun,
   chatTuiCanSelectModel,
   chatTuiSigintAction,
-  chatTuiFocusedChildFollowUpRoute,
   clearTuiSessionRunState,
   markChatTuiRunPending,
-} from '@cli/chat/tui/runChatTui';
+} from '@cli/chat/tui/state/sessionRunState';
+import { chatTuiFocusedChildFollowUpRoute } from '@cli/chat/tui/runChatTui';
 import { installTuiStdoutListenerLimit } from '@cli/chat/tui/render/noColorOutput';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import {


### PR DESCRIPTION
## Finding

`packages/cli/src/chat/tui/runChatTui.tsx` was carrying reusable session lifecycle state and policy: run start/complete mutation, root-run availability publication, stop/interrupt predicates, model-selection availability, and SIGINT/resumable-idle exit policy. That mixed UI composition with session-state rules, so unrelated changes to slash commands, `/goal`, `/resume`, approvals, or rendering had to reason about runtime invariants in the same large entrypoint.

## Refactor

- Extract `packages/cli/src/chat/tui/state/sessionRunState.ts` as the TUI state-layer home for chat session lifecycle mutation and predicates.
- Leave `runChatTui.tsx` responsible for wiring, rendering, and orchestration calls, while importing the session-state API from the new module.
- Update focused tests to target the new state module directly.

Refs #6328

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical move with no intended behavior change; risk is limited to import wiring or a missed call site for root-run availability.
> 
> **Overview**
> Moves chat session **lifecycle and policy** out of `runChatTui.tsx` into **`packages/cli/src/chat/tui/state/sessionRunState.ts`**, so the entrypoint stays focused on Ink wiring and orchestration.
> 
> The new module owns run-state mutation (`clearTuiSessionRunState`, `markChatTuiRunPending` / `markChatTuiRunCompleted`), **`cliState.rootRunStartAvailable`** updates via exported `publishChatTuiRootRunStartAvailability`, and pure predicates for interrupt/stop, root-run start, model selection, SIGINT routing, and resumable-idle exit. **`TuiSession`** types live there as well.
> 
> `runChatTui.tsx` imports that API and only renames internal resume-path calls to the new publisher. Kernel tests import session-run helpers from `sessionRunState` instead of the monolithic entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5376e88a68feb64e528c2bfee88fad8653a474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->