### PR TITLE
[codex] Move chat slash commands to command layer

### DIFF
--- a/docs/architecture/cli-runtime-round-trips.md
+++ b/docs/architecture/cli-runtime-round-trips.md
@@ -221,9 +221,10 @@ team planning. Startup should need only names, descriptions, and availability.
   Move viewport repaint ownership into a small TUI viewport controller so render mode
   and terminal clear policy live together.
 - Slash command dispatch:
-  Built-in commands are registered, but `handleTuiSlashCommand` still owns a large
-  switch with special cases. Move command handlers into the registry incrementally,
-  keeping `runChatTui` as dispatcher plus session lifecycle owner.
+  `runChatTui` now delegates slash commands to the command layer, but
+  `handleTuiSlashCommand` still owns a large switch with special cases. Move
+  command handlers into the registry incrementally so the command layer becomes
+  data-driven.
 - Skills startup:
   Skills should be discoverable without injecting bodies into every tool-use prompt.
   Keep discovery metadata cached; load `SKILL.md` only on activation for the next message.

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -1,0 +1,576 @@
+import { getAgent } from '@agent/index';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { notifyFollowUpSent } from '@agent/toolUse/ToolUseFollowUp';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import {
+  formatCliApiMode,
+  parseCliApiMode,
+  setCliApiMode,
+  type CliApiMode,
+} from '@cli/runtime/apiAccessMode';
+import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
+import { assertCliAgentLaunch } from '@cli/runtime/agents';
+import { type CliContext, CliUsageError } from '@cli/runtime/cliContext';
+import { setCliHelperModel } from '@cli/runtime/initPlatform';
+import {
+  githubSelectAccountWarning,
+  parseChatLoginSlashArgs,
+  type CliLoginSlashArgs,
+} from '@cli/runtime/loginOptions';
+import {
+  formatCliMemoryList,
+  formatCliMemoryPreview,
+} from '@cli/runtime/memory';
+import {
+  formatCliNoAvailableModelsRecovery,
+  resolveCliRunnableModel,
+  type CliNoAvailableModelsRecoveryOptions,
+} from '@cli/runtime/modelAccess';
+import {
+  formatCliApprovalPolicy,
+  parseCliApprovalPolicy,
+} from '@cli/runtime/approvalPolicyText';
+import { parseCliHistoryId } from '@cli/runtime/history';
+import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
+import {
+  formatCliManualAuthUrlMessage,
+  relayTokenStillActiveNotice,
+  signInCliSupabase,
+  signInCliSupabaseDeviceCode,
+  signOutCliSupabase,
+} from '@cli/runtime/supabaseAuth';
+import { formatCliDeviceAuthMessage } from '@cli/runtime/supabaseAuthDeviceCode';
+import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import { toErrorMessage } from '@common/errors/errorMessage';
+import { type ExecutionId } from '@shared/schemas';
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { GoalStore } from '@tools/goal';
+import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
+
+import { formatCliSessionStatus } from '../sessionStatus';
+import { requestCliCompaction } from '../state/compactionRequest';
+import { cliState, setCliSessionModelOverride } from '../state/cliState';
+import {
+  chatTuiCanStartRootRun,
+  type TuiSession,
+} from '../state/sessionRunState';
+import { terminalCapabilities } from '../state/terminalCapabilities';
+import {
+  appendLocalAssistantTranscript,
+  appendLocalUserTranscript,
+} from '../state/transcript';
+import { formatSlashCommandHelp, GOAL_MODE_HELP } from './helpText';
+import {
+  openCliSlashCommandForm,
+  openRegisteredCliSlashForm,
+} from './slashForms';
+import {
+  findSlashCommand,
+  listSlashCommands,
+  parseSlashInput,
+  suggestSlashCommand,
+} from './slashRegistry';
+
+export interface SlashCommandContext {
+  readonly session: TuiSession;
+  readonly commandName?: string;
+  readonly cwd: CliContext['cwd'];
+  readonly initialAgent: string;
+  readonly initialModel: string;
+  readonly interruptActive: () => void;
+  readonly requestInputExit: () => void;
+  readonly getApprovalPolicy: () => CliApprovalPolicy;
+  readonly setApprovalPolicy: (policy: CliApprovalPolicy) => void;
+  readonly canSelectModel: () => boolean;
+  readonly resetSession: () => void;
+  readonly resumeExecution: (id: ExecutionId) => Promise<void>;
+}
+
+export const CHAT_API_MODE_MODEL_RECOVERY = {
+  includedModeAction: 'switch to included relay with `/api included`',
+  loginAction: 'run `/login`',
+  personalModeAction: 'switch to personal API keys with `/api personal`',
+  configureKeyAction: 'configure a provider API key',
+} satisfies CliNoAvailableModelsRecoveryOptions;
+
+export function chatAgentSupportsDelegation(agentName: string): boolean {
+  return (
+    getAgent(agentName, AgentCategory.ToolUse)?.tools?.some((toolName) =>
+      DELEGATION_TOOLS.has(toolName),
+    ) ?? false
+  );
+}
+
+export function chatToolUseAgentUsageError(
+  agentName: string,
+): string | undefined {
+  try {
+    assertCliAgentLaunch(
+      agentName,
+      getAgent(agentName, AgentCategory.ToolUse),
+      'chat',
+    );
+    return undefined;
+  } catch (error) {
+    if (error instanceof CliUsageError) return error.message;
+    throw error;
+  }
+}
+
+export function applyInitialCliAgentSelection(
+  agentName: string,
+  context: SlashCommandContext,
+): void {
+  if (!chatTuiCanStartRootRun(context.session)) {
+    appendLocalAssistantTranscript(
+      'Agent changes are only available before the first message. Start a new chat with texra chat --agent=<name> to choose a different root agent.',
+    );
+    return;
+  }
+
+  const nextAgent = agentName.trim();
+  const usageError = chatToolUseAgentUsageError(nextAgent);
+  if (usageError) {
+    appendLocalAssistantTranscript(usageError);
+    return;
+  }
+  cliState.sessionMeta.set({
+    ...cliState.sessionMeta.get(),
+    agent: nextAgent,
+    canDelegate: chatAgentSupportsDelegation(nextAgent),
+  });
+  appendLocalAssistantTranscript(`Root agent set to ${nextAgent}.`);
+}
+
+export async function applyCliModelSelection(
+  model: string,
+  context: SlashCommandContext,
+): Promise<void> {
+  const nextModel = model.trim();
+  if (chatTuiCanStartRootRun(context.session)) {
+    try {
+      await setCliHelperModel(nextModel);
+      setCliSessionModelOverride(nextModel);
+      appendLocalAssistantTranscript(`Root model set to ${nextModel}.`);
+    } catch (error: unknown) {
+      appendLocalAssistantTranscript(toErrorMessage(error));
+    }
+    return;
+  }
+
+  if (!context.canSelectModel()) {
+    appendLocalAssistantTranscript(
+      'Finish the active response before switching models.',
+    );
+    return;
+  }
+
+  const activeFlow = context.session.streamId
+    ? executionRegistry.getToolUseFlowContext(context.session.streamId)
+    : undefined;
+  if (!activeFlow) {
+    appendLocalAssistantTranscript(
+      'Model switching is only available for an active tool-use chat. Start a new chat with texra chat --model=<name> to choose a different root model.',
+    );
+    return;
+  }
+
+  try {
+    await activeFlow.switchModel(nextModel);
+    setCliSessionModelOverride(nextModel);
+  } catch (error: unknown) {
+    appendLocalAssistantTranscript(toErrorMessage(error));
+    return;
+  }
+
+  try {
+    await setCliHelperModel(nextModel);
+  } catch (error: unknown) {
+    appendLocalAssistantTranscript(
+      `Model switched to ${nextModel}. Could not persist it as the default helper model: ${toErrorMessage(error)}`,
+    );
+    return;
+  }
+
+  appendLocalAssistantTranscript(
+    `Model switched to ${nextModel}. Future turns will use it.`,
+  );
+}
+
+async function reconcileRootModelAfterApiModeChange(
+  context: SlashCommandContext | undefined,
+  apiMode: CliApiMode,
+): Promise<string | undefined> {
+  if (!context || !chatTuiCanStartRootRun(context.session)) return undefined;
+
+  const { model: currentModel, modelSource } = cliState.sessionMeta.get();
+  const selection = await resolveCliRunnableModel(currentModel, {
+    fallbackSource: modelSource,
+    apiMode,
+    noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
+      apiMode,
+      CHAT_API_MODE_MODEL_RECOVERY,
+    ),
+  });
+  if (selection.model === currentModel) return undefined;
+
+  await setCliHelperModel(selection.model);
+  cliState.sessionMeta.set({
+    ...cliState.sessionMeta.get(),
+    model: selection.model,
+  });
+  return selection.notice;
+}
+
+function setCliSessionApiMode(apiMode: CliApiMode): void {
+  cliState.sessionMeta.set({
+    ...cliState.sessionMeta.get(),
+    apiMode,
+  });
+}
+
+export async function applyCliApiModeSelection(
+  mode: string | CliApiMode,
+  context?: SlashCommandContext,
+): Promise<void> {
+  const normalized = mode.trim().toLowerCase();
+
+  if (!normalized || normalized === 'status') {
+    const lines = await loadCliApiStatusLines({
+      apiMode: cliState.sessionMeta.get().apiMode,
+    });
+    appendLocalAssistantTranscript(
+      [...lines, 'Usage: /api personal | /api included'].join('\n'),
+    );
+    return;
+  }
+
+  const apiMode = parseCliApiMode(normalized);
+  if (apiMode) {
+    await setCliApiMode(apiMode);
+    setCliSessionApiMode(apiMode);
+    let modelNotice: string | undefined;
+    try {
+      modelNotice = await reconcileRootModelAfterApiModeChange(
+        context,
+        apiMode,
+      );
+    } catch (error: unknown) {
+      modelNotice = toErrorMessage(error);
+    }
+    appendLocalAssistantTranscript(
+      [
+        `API mode set to ${formatCliApiMode(apiMode)}.`,
+        ...(modelNotice ? [modelNotice] : []),
+      ].join('\n'),
+    );
+    return;
+  }
+
+  appendLocalAssistantTranscript('Usage: /api personal | /api included');
+}
+
+async function showCliAuthStatus(): Promise<void> {
+  appendLocalAssistantTranscript(
+    (
+      await loadCliApiStatusLines({
+        apiMode: cliState.sessionMeta.get().apiMode,
+      })
+    ).join('\n'),
+  );
+}
+
+const CHAT_LOGIN_USAGE =
+  'Usage: /login [github | google] [--no-browser] [--device] [--select-account] [--login-hint <account>]';
+
+function loginStartMessage(args: CliLoginSlashArgs): string {
+  if (args.device) return 'Starting TeXRA device-code sign-in.';
+  if (args.noBrowser) return `Starting TeXRA ${args.provider} sign-in.`;
+  return `Opening browser for TeXRA ${args.provider} sign-in...`;
+}
+
+async function loginFromChat(input: string): Promise<void> {
+  const args = parseChatLoginSlashArgs(input);
+  if (!args) {
+    appendLocalAssistantTranscript(CHAT_LOGIN_USAGE);
+    return;
+  }
+
+  const accountWarning = githubSelectAccountWarning(args);
+  if (accountWarning) appendLocalAssistantTranscript(accountWarning);
+  appendLocalAssistantTranscript(loginStartMessage(args));
+
+  try {
+    const session = args.device
+      ? await signInCliSupabaseDeviceCode({
+          onDeviceCode: (authorization) => {
+            appendLocalAssistantTranscript(
+              formatCliDeviceAuthMessage(authorization),
+            );
+          },
+        })
+      : await signInCliSupabase({
+          provider: args.provider,
+          openBrowser: !args.noBrowser,
+          selectAccount: args.selectAccount,
+          loginHint: args.loginHint,
+          manualBrowserHint: '/login --no-browser',
+          onAuthUrl: (url) => {
+            if (args.noBrowser) {
+              appendLocalAssistantTranscript(
+                formatCliManualAuthUrlMessage(url),
+              );
+            }
+          },
+        });
+    setCliSessionApiMode('included');
+    appendLocalAssistantTranscript(
+      [
+        `Signed in as ${session.account.label}.`,
+        ...(await loadCliApiStatusLines({ apiMode: 'included' })),
+      ].join('\n'),
+    );
+  } catch (error: unknown) {
+    appendLocalAssistantTranscript(toErrorMessage(error));
+  }
+}
+
+async function logoutFromChat(): Promise<void> {
+  try {
+    await signOutCliSupabase();
+    // Sign-out only clears the stored session; a configured TEXRA_RELAY_TOKEN
+    // keeps authenticating relay calls, so report it — and keep the session
+    // in included mode so the notice matches what actually happens.
+    const relayNotice = relayTokenStillActiveNotice();
+    const apiMode = relayNotice ? 'included' : 'personal';
+    setCliSessionApiMode(apiMode);
+    appendLocalAssistantTranscript(
+      [
+        'Signed out.',
+        ...(relayNotice ? [relayNotice] : []),
+        ...(await loadCliApiStatusLines({ apiMode })),
+      ].join('\n'),
+    );
+  } catch (error: unknown) {
+    appendLocalAssistantTranscript(toErrorMessage(error));
+  }
+}
+
+const YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
+
+function applyCliApprovalPolicySelection(
+  input: string,
+  context: SlashCommandContext,
+  usage = YOLO_USAGE,
+): void {
+  const normalized = input.trim().toLowerCase();
+  if (!normalized || normalized === 'status') {
+    openCliSlashCommandForm('approval', '');
+    return;
+  }
+
+  const policy = parseCliApprovalPolicy(normalized);
+  if (!policy) {
+    appendLocalAssistantTranscript(usage);
+    return;
+  }
+
+  context.setApprovalPolicy(policy);
+  appendLocalAssistantTranscript(
+    `Approval mode set to ${formatCliApprovalPolicy(policy)}.`,
+  );
+}
+
+async function showCliMemoryList(): Promise<void> {
+  appendLocalAssistantTranscript(formatCliMemoryList(await loadMemoryItems()));
+}
+
+export async function showCliMemoryPreview(inputPath: string): Promise<void> {
+  appendLocalAssistantTranscript(await formatCliMemoryPreview(inputPath));
+}
+
+export async function handleTuiSlashCommand(
+  line: string,
+  context: SlashCommandContext,
+): Promise<boolean> {
+  const parsed = parseSlashInput(line);
+  if (!parsed) return false;
+
+  const command = parsed.name.toLowerCase();
+  const rest = parsed.remainder.trim();
+  // Echo the slash input into the transcript so the user can see what they
+  // typed. Slash commands don't go through the agent run, so the usual
+  // USER_MESSAGE stream-log entry is never produced. Skip the echo for the
+  // exit commands (the TUI is tearing down); /clear still echoes because
+  // resetSessionForClear refuses while a run is active and surfaces an
+  // error — without the echo the user wouldn't see what triggered it.
+  if (command !== 'exit' && command !== 'quit' && command !== 'login') {
+    appendLocalUserTranscript(line.trim());
+  }
+  switch (command) {
+    case 'help': {
+      appendLocalAssistantTranscript(
+        formatSlashCommandHelp(listSlashCommands(), {
+          shortcutModifierLabel: defaultShortcutModifierLabel(),
+          shiftEnterNewline: terminalCapabilities.get().kittyKeyboard,
+        }),
+      );
+      return true;
+    }
+    case 'clear':
+      context.resetSession();
+      return true;
+    case 'exit':
+    case 'quit':
+      context.session.stopRequested = true;
+      context.interruptActive();
+      context.requestInputExit();
+      return true;
+    case 'agent':
+    case 'agents':
+      if (!chatTuiCanStartRootRun(context.session) && rest) {
+        appendLocalAssistantTranscript(
+          'The agent is fixed for this chat session. Start a new chat to use a different agent.',
+        );
+      } else if (rest) {
+        applyInitialCliAgentSelection(rest, context);
+      } else {
+        openCliSlashCommandForm('agent', rest);
+      }
+      return true;
+    case 'model':
+    case 'models':
+      openCliSlashCommandForm('model', rest);
+      return true;
+    case 'api':
+      if (!rest) {
+        openCliSlashCommandForm('api', rest);
+        return true;
+      }
+      try {
+        await applyCliApiModeSelection(rest, context);
+      } catch (error: unknown) {
+        appendLocalAssistantTranscript(toErrorMessage(error));
+      }
+      return true;
+    case 'auth':
+      try {
+        await showCliAuthStatus();
+      } catch (error: unknown) {
+        appendLocalAssistantTranscript(toErrorMessage(error));
+      }
+      return true;
+    case 'login':
+      await loginFromChat(rest);
+      return true;
+    case 'logout':
+      await logoutFromChat();
+      return true;
+    case 'approval':
+      if (rest) {
+        applyCliApprovalPolicySelection(rest, context);
+      } else {
+        openCliSlashCommandForm('approval', rest);
+      }
+      return true;
+    case 'yolo':
+      applyCliApprovalPolicySelection(rest || 'yolo', context, YOLO_USAGE);
+      return true;
+    case 'status': {
+      const meta = cliState.sessionMeta.get();
+      const activeStreamId = cliState.activeStreamId.get();
+      const slice = activeStreamId
+        ? cliState.streams.get().get(activeStreamId)
+        : undefined;
+      appendLocalAssistantTranscript(
+        formatCliSessionStatus({
+          agent: meta.agent || context.initialAgent,
+          model: meta.model || context.initialModel,
+          teamName: meta.teamName,
+          // Read the session's own mode (which honors a --api-mode/env override)
+          // so /status agrees with the header instead of re-reading the global.
+          api: formatCliApiMode(meta.apiMode),
+          approval: formatCliApprovalPolicy(context.getApprovalPolicy()),
+          approvalBypasses: slice?.bypass,
+          status: slice?.status ?? 'not started',
+          goal: activeStreamId
+            ? GoalStore.getForStream(activeStreamId)
+            : undefined,
+          // Only surface the resume id once a stream exists — never next to
+          // a "not started" status.
+          sessionId: slice ? context.session.executionId : undefined,
+          commandName: context.commandName,
+          cwd: context.cwd,
+          processCwd: process.cwd(),
+          approvalPolicy: context.getApprovalPolicy(),
+          queuedFollowUpMessages:
+            activeStreamId === undefined
+              ? []
+              : ToolUseFollowUpQueue.getAll(activeStreamId),
+        }),
+      );
+      return true;
+    }
+    case 'goal':
+    case 'goals':
+      appendLocalAssistantTranscript(GOAL_MODE_HELP);
+      return true;
+    case 'resume': {
+      if (!rest) {
+        openCliSlashCommandForm('resume', rest);
+        return true;
+      }
+      const id = parseCliHistoryId(rest);
+      if (!id) {
+        appendLocalAssistantTranscript(`Invalid execution id: ${rest}`);
+        return true;
+      }
+      await context.resumeExecution(id);
+      return true;
+    }
+    case 'memory': {
+      try {
+        if (!rest) {
+          openCliSlashCommandForm('memory', rest);
+        } else if (rest.toLowerCase() === 'list') {
+          await showCliMemoryList();
+        } else {
+          await showCliMemoryPreview(rest);
+        }
+      } catch (error: unknown) {
+        appendLocalAssistantTranscript(toErrorMessage(error));
+      }
+      return true;
+    }
+    case 'compact':
+      requestCliCompaction({
+        streamId: cliState.activeStreamId.get(),
+        getFlowContext: (streamId) =>
+          executionRegistry.getToolUseFlowContext(streamId),
+        notifyFollowUpSent,
+        appendTranscript: appendLocalAssistantTranscript,
+      });
+      return true;
+    default: {
+      const registered = findSlashCommand(command);
+      if (registered) {
+        if (openRegisteredCliSlashForm(registered, parsed.remainder)) {
+          return true;
+        }
+        appendLocalAssistantTranscript(
+          `/${parsed.name} is registered but is not available in this CLI view yet.`,
+        );
+      } else {
+        const suggestion = suggestSlashCommand(command);
+        const didYouMean = suggestion
+          ? ` Did you mean /${suggestion.name}?`
+          : '';
+        appendLocalAssistantTranscript(
+          `Unknown command: /${parsed.name}.${didYouMean} Type /help to list commands.`,
+        );
+      }
+      return true;
+    }
+  }
+}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -17,7 +17,7 @@ import {
 } from '@transcript';
 import { platform, tryPlatform } from '@platform/platform';
 import { getFirstRunDone } from '@controllers/onboarding/onboardingFunnel';
-import { getAgent, loadAgents } from '@agent/index';
+import { loadAgents } from '@agent/index';
 import { registerExecution, writeTerminalStatus } from '@agent/storage';
 import {
   AgentConfigSchema,
@@ -32,25 +32,12 @@ import {
 } from '@agent/runtime/executeAgent';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
-import {
-  notifyFollowUpSent,
-  sendFollowUp,
-} from '@agent/toolUse/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
 import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
-import {
-  effectiveCliApiMode,
-  formatCliApiMode,
-  parseCliApiMode,
-  setCliApiMode,
-  type CliApiMode,
-} from '@cli/runtime/apiAccessMode';
-import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
+import { effectiveCliApiMode } from '@cli/runtime/apiAccessMode';
 import { firstRunSetupAgentOverride } from '@cli/onboarding/setupContinuation';
 import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
-import { assertCliAgentLaunch } from '@cli/runtime/agents';
-import { CliUsageError } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
@@ -60,21 +47,8 @@ import {
   type CliModelSelectionSource,
   type CliRunnableModelResolution,
 } from '@cli/runtime/modelAccess';
-import {
-  githubSelectAccountWarning,
-  parseChatLoginSlashArgs,
-  type CliLoginSlashArgs,
-} from '@cli/runtime/loginOptions';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { writeTextStderr, writeTextStdout } from '@cli/runtime/logSinks';
-import {
-  formatCliManualAuthUrlMessage,
-  signInCliSupabase,
-  relayTokenStillActiveNotice,
-  signInCliSupabaseDeviceCode,
-  signOutCliSupabase,
-} from '@cli/runtime/supabaseAuth';
-import { formatCliDeviceAuthMessage } from '@cli/runtime/supabaseAuthDeviceCode';
 import {
   formatInteractiveTerminalFailure,
   interactiveTerminalFailure,
@@ -83,22 +57,13 @@ import {
   cliTerminalStatus,
   terminalStatusExitCode,
 } from '@cli/runtime/terminalStatus';
-import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
-import {
-  formatCliApprovalPolicy,
-  parseCliApprovalPolicy,
-} from '@cli/runtime/approvalPolicyText';
-import { parseCliHistoryId } from '@cli/runtime/history';
+import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
 import {
   explainNonResumable,
   resolveCliResumeSnapshot,
   type CliToolUseResumeResolution,
 } from '@cli/runtime/sessionResume';
-import {
-  formatCliMemoryList,
-  formatCliMemoryPreview,
-} from '@cli/runtime/memory';
 import { isLiveElapsedStatus } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -111,40 +76,31 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { escapeText } from '@shared/utils/xmlEscape';
-import { GoalStore } from '@tools/goal';
-import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 import { generateExecutionId } from '@utils/core/executionId';
 
 import { App } from './App';
 import { assertNever } from './assertNever';
+import {
+  applyCliApiModeSelection,
+  applyCliModelSelection,
+  applyInitialCliAgentSelection,
+  CHAT_API_MODE_MODEL_RECOVERY,
+  chatAgentSupportsDelegation,
+  chatToolUseAgentUsageError,
+  handleTuiSlashCommand,
+  showCliMemoryPreview,
+  type SlashCommandContext,
+} from './commands/handleSlashCommand';
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
-import {
-  openCliSlashCommandForm,
-  openRegisteredCliSlashForm,
-} from './commands/slashForms';
-import { formatSlashCommandHelp, GOAL_MODE_HELP } from './commands/helpText';
-import {
-  findSlashCommand,
-  listSlashCommands,
-  parseSlashInput,
-  suggestSlashCommand,
-} from './commands/slashRegistry';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
 import {
   installTuiStdoutListenerLimit,
   tuiOutputStreamForColor,
 } from './render/noColorOutput';
-import { formatCliSessionStatus } from './sessionStatus';
 import { clearApprovals } from './state/approvalQueue';
-import {
-  cliState,
-  patchStream,
-  resetCliState,
-  setCliSessionModelOverride,
-} from './state/cliState';
+import { cliState, patchStream, resetCliState } from './state/cliState';
 import {
   focusedChildFollowUpRoute,
   stoppedFocusedChildFollowUpMessage as focusedChildStoppedMessage,
@@ -163,11 +119,7 @@ import {
   onStreamStatusChange,
   streamStatusFromState,
 } from './state/streamStatus';
-import {
-  discoverTerminalCapabilities,
-  terminalCapabilities,
-} from './state/terminalCapabilities';
-import { requestCliCompaction } from './state/compactionRequest';
+import { discoverTerminalCapabilities } from './state/terminalCapabilities';
 import {
   appendLocalAssistantTranscript,
   appendLocalErrorTranscript,
@@ -341,513 +293,10 @@ function stoppedFocusedChildFollowUpMessage(streamId: StreamTabId): string {
   });
 }
 
-interface SlashCommandContext {
-  readonly session: TuiSession;
-  readonly commandName?: string;
-  readonly cwd: string;
-  readonly initialAgent: string;
-  readonly initialModel: string;
-  readonly interruptActive: () => void;
-  readonly requestInputExit: () => void;
-  readonly getApprovalPolicy: () => CliApprovalPolicy;
-  readonly setApprovalPolicy: (policy: CliApprovalPolicy) => void;
-  readonly canSelectModel: () => boolean;
-  readonly resetSession: () => void;
-  readonly resumeExecution: (id: ExecutionId) => Promise<void>;
-}
-
-function agentSupportsDelegation(agentName: string): boolean {
-  return (
-    getAgent(agentName, AgentCategory.ToolUse)?.tools?.some((toolName) =>
-      DELEGATION_TOOLS.has(toolName),
-    ) ?? false
-  );
-}
-
-export function chatToolUseAgentUsageError(
-  agentName: string,
-): string | undefined {
-  try {
-    assertCliAgentLaunch(
-      agentName,
-      getAgent(agentName, AgentCategory.ToolUse),
-      'chat',
-    );
-    return undefined;
-  } catch (error) {
-    if (error instanceof CliUsageError) return error.message;
-    throw error;
-  }
-}
-
-function applyInitialCliAgentSelection(
-  agentName: string,
-  context: SlashCommandContext,
-): void {
-  if (!chatTuiCanStartRootRun(context.session)) {
-    appendLocalAssistantTranscript(
-      'Agent changes are only available before the first message. Start a new chat with texra chat --agent=<name> to choose a different root agent.',
-    );
-    return;
-  }
-
-  const nextAgent = agentName.trim();
-  const usageError = chatToolUseAgentUsageError(nextAgent);
-  if (usageError) {
-    appendLocalAssistantTranscript(usageError);
-    return;
-  }
-  cliState.sessionMeta.set({
-    ...cliState.sessionMeta.get(),
-    agent: nextAgent,
-    canDelegate: agentSupportsDelegation(nextAgent),
-  });
-  appendLocalAssistantTranscript(`Root agent set to ${nextAgent}.`);
-}
-
-async function applyCliModelSelection(
-  model: string,
-  context: SlashCommandContext,
-): Promise<void> {
-  const nextModel = model.trim();
-  if (chatTuiCanStartRootRun(context.session)) {
-    try {
-      await setCliHelperModel(nextModel);
-      setCliSessionModelOverride(nextModel);
-      appendLocalAssistantTranscript(`Root model set to ${nextModel}.`);
-    } catch (error: unknown) {
-      appendLocalAssistantTranscript(toErrorMessage(error));
-    }
-    return;
-  }
-
-  if (!context.canSelectModel()) {
-    appendLocalAssistantTranscript(
-      'Finish the active response before switching models.',
-    );
-    return;
-  }
-
-  const activeFlow = context.session.streamId
-    ? executionRegistry.getToolUseFlowContext(context.session.streamId)
-    : undefined;
-  if (!activeFlow) {
-    appendLocalAssistantTranscript(
-      'Model switching is only available for an active tool-use chat. Start a new chat with texra chat --model=<name> to choose a different root model.',
-    );
-    return;
-  }
-
-  try {
-    await activeFlow.switchModel(nextModel);
-    setCliSessionModelOverride(nextModel);
-  } catch (error: unknown) {
-    appendLocalAssistantTranscript(toErrorMessage(error));
-    return;
-  }
-
-  try {
-    await setCliHelperModel(nextModel);
-  } catch (error: unknown) {
-    appendLocalAssistantTranscript(
-      `Model switched to ${nextModel}. Could not persist it as the default helper model: ${toErrorMessage(error)}`,
-    );
-    return;
-  }
-
-  appendLocalAssistantTranscript(
-    `Model switched to ${nextModel}. Future turns will use it.`,
-  );
-}
-
-async function reconcileRootModelAfterApiModeChange(
-  context: SlashCommandContext | undefined,
-  apiMode: CliApiMode,
-): Promise<string | undefined> {
-  if (!context || !chatTuiCanStartRootRun(context.session)) return undefined;
-
-  const { model: currentModel, modelSource } = cliState.sessionMeta.get();
-  const selection = await resolveCliRunnableModel(currentModel, {
-    fallbackSource: modelSource,
-    apiMode,
-    noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
-      apiMode,
-      CHAT_API_MODE_MODEL_RECOVERY,
-    ),
-  });
-  if (selection.model === currentModel) return undefined;
-
-  await setCliHelperModel(selection.model);
-  cliState.sessionMeta.set({
-    ...cliState.sessionMeta.get(),
-    model: selection.model,
-  });
-  return selection.notice;
-}
-
-function setCliSessionApiMode(apiMode: CliApiMode): void {
-  cliState.sessionMeta.set({
-    ...cliState.sessionMeta.get(),
-    apiMode,
-  });
-}
-
-async function applyCliApiModeSelection(
-  mode: string | CliApiMode,
-  context?: SlashCommandContext,
-): Promise<void> {
-  const normalized = mode.trim().toLowerCase();
-
-  if (!normalized || normalized === 'status') {
-    const lines = await loadCliApiStatusLines({
-      apiMode: cliState.sessionMeta.get().apiMode,
-    });
-    appendLocalAssistantTranscript(
-      [...lines, 'Usage: /api personal | /api included'].join('\n'),
-    );
-    return;
-  }
-
-  const apiMode = parseCliApiMode(normalized);
-  if (apiMode) {
-    await setCliApiMode(apiMode);
-    setCliSessionApiMode(apiMode);
-    let modelNotice: string | undefined;
-    try {
-      modelNotice = await reconcileRootModelAfterApiModeChange(
-        context,
-        apiMode,
-      );
-    } catch (error: unknown) {
-      modelNotice = toErrorMessage(error);
-    }
-    appendLocalAssistantTranscript(
-      [
-        `API mode set to ${formatCliApiMode(apiMode)}.`,
-        ...(modelNotice ? [modelNotice] : []),
-      ].join('\n'),
-    );
-    return;
-  }
-
-  appendLocalAssistantTranscript('Usage: /api personal | /api included');
-}
-
-async function showCliAuthStatus(): Promise<void> {
-  appendLocalAssistantTranscript(
-    (
-      await loadCliApiStatusLines({
-        apiMode: cliState.sessionMeta.get().apiMode,
-      })
-    ).join('\n'),
-  );
-}
-
-const CHAT_LOGIN_USAGE =
-  'Usage: /login [github | google] [--no-browser] [--device] [--select-account] [--login-hint <account>]';
-
-const CHAT_API_MODE_MODEL_RECOVERY = {
-  includedModeAction: 'switch to included relay with `/api included`',
-  loginAction: 'run `/login`',
-  personalModeAction: 'switch to personal API keys with `/api personal`',
-  configureKeyAction: 'configure a provider API key',
-} satisfies CliNoAvailableModelsRecoveryOptions;
-
 const CHAT_STARTUP_MODEL_RECOVERY = {
   includedModeAction: 'retry with `texra chat --api-mode included`',
   personalModeAction: 'retry with `texra chat --api-mode personal`',
 } satisfies CliNoAvailableModelsRecoveryOptions;
-
-function loginStartMessage(args: CliLoginSlashArgs): string {
-  if (args.device) return 'Starting TeXRA device-code sign-in.';
-  if (args.noBrowser) return `Starting TeXRA ${args.provider} sign-in.`;
-  return `Opening browser for TeXRA ${args.provider} sign-in...`;
-}
-
-async function loginFromChat(input: string): Promise<void> {
-  const args = parseChatLoginSlashArgs(input);
-  if (!args) {
-    appendLocalAssistantTranscript(CHAT_LOGIN_USAGE);
-    return;
-  }
-
-  const accountWarning = githubSelectAccountWarning(args);
-  if (accountWarning) appendLocalAssistantTranscript(accountWarning);
-  appendLocalAssistantTranscript(loginStartMessage(args));
-
-  try {
-    const session = args.device
-      ? await signInCliSupabaseDeviceCode({
-          onDeviceCode: (authorization) => {
-            appendLocalAssistantTranscript(
-              formatCliDeviceAuthMessage(authorization),
-            );
-          },
-        })
-      : await signInCliSupabase({
-          provider: args.provider,
-          openBrowser: !args.noBrowser,
-          selectAccount: args.selectAccount,
-          loginHint: args.loginHint,
-          manualBrowserHint: '/login --no-browser',
-          onAuthUrl: (url) => {
-            if (args.noBrowser) {
-              appendLocalAssistantTranscript(
-                formatCliManualAuthUrlMessage(url),
-              );
-            }
-          },
-        });
-    setCliSessionApiMode('included');
-    appendLocalAssistantTranscript(
-      [
-        `Signed in as ${session.account.label}.`,
-        ...(await loadCliApiStatusLines({ apiMode: 'included' })),
-      ].join('\n'),
-    );
-  } catch (error: unknown) {
-    appendLocalAssistantTranscript(toErrorMessage(error));
-  }
-}
-
-async function logoutFromChat(): Promise<void> {
-  try {
-    await signOutCliSupabase();
-    // Sign-out only clears the stored session; a configured TEXRA_RELAY_TOKEN
-    // keeps authenticating relay calls, so report it — and keep the session
-    // in included mode so the notice matches what actually happens.
-    const relayNotice = relayTokenStillActiveNotice();
-    const apiMode = relayNotice ? 'included' : 'personal';
-    setCliSessionApiMode(apiMode);
-    appendLocalAssistantTranscript(
-      [
-        'Signed out.',
-        ...(relayNotice ? [relayNotice] : []),
-        ...(await loadCliApiStatusLines({ apiMode })),
-      ].join('\n'),
-    );
-  } catch (error: unknown) {
-    appendLocalAssistantTranscript(toErrorMessage(error));
-  }
-}
-
-const YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
-
-function applyCliApprovalPolicySelection(
-  input: string,
-  context: SlashCommandContext,
-  usage = YOLO_USAGE,
-): void {
-  const normalized = input.trim().toLowerCase();
-  if (!normalized || normalized === 'status') {
-    openCliSlashCommandForm('approval', '');
-    return;
-  }
-
-  const policy = parseCliApprovalPolicy(normalized);
-  if (!policy) {
-    appendLocalAssistantTranscript(usage);
-    return;
-  }
-
-  context.setApprovalPolicy(policy);
-  appendLocalAssistantTranscript(
-    `Approval mode set to ${formatCliApprovalPolicy(policy)}.`,
-  );
-}
-
-async function showCliMemoryList(): Promise<void> {
-  appendLocalAssistantTranscript(formatCliMemoryList(await loadMemoryItems()));
-}
-
-async function showCliMemoryPreview(inputPath: string): Promise<void> {
-  appendLocalAssistantTranscript(await formatCliMemoryPreview(inputPath));
-}
-
-async function handleTuiSlashCommand(
-  line: string,
-  context: SlashCommandContext,
-): Promise<boolean> {
-  const parsed = parseSlashInput(line);
-  if (!parsed) return false;
-
-  const command = parsed.name.toLowerCase();
-  const rest = parsed.remainder.trim();
-  // Echo the slash input into the transcript so the user can see what they
-  // typed. Slash commands don't go through the agent run, so the usual
-  // USER_MESSAGE stream-log entry is never produced. Skip the echo for the
-  // exit commands (the TUI is tearing down); /clear still echoes because
-  // resetSessionForClear refuses while a run is active and surfaces an
-  // error — without the echo the user wouldn't see what triggered it.
-  if (command !== 'exit' && command !== 'quit' && command !== 'login') {
-    appendLocalUserTranscript(line.trim());
-  }
-  switch (command) {
-    case 'help': {
-      appendLocalAssistantTranscript(
-        formatSlashCommandHelp(listSlashCommands(), {
-          shortcutModifierLabel: defaultShortcutModifierLabel(),
-          shiftEnterNewline: terminalCapabilities.get().kittyKeyboard,
-        }),
-      );
-      return true;
-    }
-    case 'clear':
-      context.resetSession();
-      return true;
-    case 'exit':
-    case 'quit':
-      context.session.stopRequested = true;
-      context.interruptActive();
-      context.requestInputExit();
-      return true;
-    case 'agent':
-    case 'agents':
-      if (!chatTuiCanStartRootRun(context.session) && rest) {
-        appendLocalAssistantTranscript(
-          'The agent is fixed for this chat session. Start a new chat to use a different agent.',
-        );
-      } else if (rest) {
-        applyInitialCliAgentSelection(rest, context);
-      } else {
-        openCliSlashCommandForm('agent', rest);
-      }
-      return true;
-    case 'model':
-    case 'models':
-      openCliSlashCommandForm('model', rest);
-      return true;
-    case 'api':
-      if (!rest) {
-        openCliSlashCommandForm('api', rest);
-        return true;
-      }
-      try {
-        await applyCliApiModeSelection(rest, context);
-      } catch (error: unknown) {
-        appendLocalAssistantTranscript(toErrorMessage(error));
-      }
-      return true;
-    case 'auth':
-      try {
-        await showCliAuthStatus();
-      } catch (error: unknown) {
-        appendLocalAssistantTranscript(toErrorMessage(error));
-      }
-      return true;
-    case 'login':
-      await loginFromChat(rest);
-      return true;
-    case 'logout':
-      await logoutFromChat();
-      return true;
-    case 'approval':
-      if (rest) {
-        applyCliApprovalPolicySelection(rest, context);
-      } else {
-        openCliSlashCommandForm('approval', rest);
-      }
-      return true;
-    case 'yolo':
-      applyCliApprovalPolicySelection(rest || 'yolo', context, YOLO_USAGE);
-      return true;
-    case 'status': {
-      const meta = cliState.sessionMeta.get();
-      const activeStreamId = cliState.activeStreamId.get();
-      const slice = activeStreamId
-        ? cliState.streams.get().get(activeStreamId)
-        : undefined;
-      appendLocalAssistantTranscript(
-        formatCliSessionStatus({
-          agent: meta.agent || context.initialAgent,
-          model: meta.model || context.initialModel,
-          teamName: meta.teamName,
-          // Read the session's own mode (which honors a --api-mode/env override)
-          // so /status agrees with the header instead of re-reading the global.
-          api: formatCliApiMode(meta.apiMode),
-          approval: formatCliApprovalPolicy(context.getApprovalPolicy()),
-          approvalBypasses: slice?.bypass,
-          status: slice?.status ?? 'not started',
-          goal: activeStreamId
-            ? GoalStore.getForStream(activeStreamId)
-            : undefined,
-          // Only surface the resume id once a stream exists — never next to
-          // a "not started" status.
-          sessionId: slice ? context.session.executionId : undefined,
-          commandName: context.commandName,
-          cwd: context.cwd,
-          processCwd: process.cwd(),
-          approvalPolicy: context.getApprovalPolicy(),
-          queuedFollowUpMessages:
-            activeStreamId === undefined
-              ? []
-              : ToolUseFollowUpQueue.getAll(activeStreamId),
-        }),
-      );
-      return true;
-    }
-    case 'goal':
-    case 'goals':
-      appendLocalAssistantTranscript(GOAL_MODE_HELP);
-      return true;
-    case 'resume': {
-      if (!rest) {
-        openCliSlashCommandForm('resume', rest);
-        return true;
-      }
-      const id = parseCliHistoryId(rest);
-      if (!id) {
-        appendLocalAssistantTranscript(`Invalid execution id: ${rest}`);
-        return true;
-      }
-      await context.resumeExecution(id);
-      return true;
-    }
-    case 'memory': {
-      try {
-        if (!rest) {
-          openCliSlashCommandForm('memory', rest);
-        } else if (rest.toLowerCase() === 'list') {
-          await showCliMemoryList();
-        } else {
-          await showCliMemoryPreview(rest);
-        }
-      } catch (error: unknown) {
-        appendLocalAssistantTranscript(toErrorMessage(error));
-      }
-      return true;
-    }
-    case 'compact':
-      requestCliCompaction({
-        streamId: cliState.activeStreamId.get(),
-        getFlowContext: (streamId) =>
-          executionRegistry.getToolUseFlowContext(streamId),
-        notifyFollowUpSent,
-        appendTranscript: appendLocalAssistantTranscript,
-      });
-      return true;
-    default: {
-      const registered = findSlashCommand(command);
-      if (registered) {
-        if (openRegisteredCliSlashForm(registered, parsed.remainder)) {
-          return true;
-        }
-        appendLocalAssistantTranscript(
-          `/${parsed.name} is registered but is not available in this CLI view yet.`,
-        );
-      } else {
-        const suggestion = suggestSlashCommand(command);
-        const didYouMean = suggestion
-          ? ` Did you mean /${suggestion.name}?`
-          : '';
-        appendLocalAssistantTranscript(
-          `Unknown command: /${parsed.name}.${didYouMean} Type /help to list commands.`,
-        );
-      }
-      return true;
-    }
-  }
-}
 
 export async function runChat(
   context: CliContext,
@@ -978,7 +427,7 @@ export async function runChat(
     cwd: context.cwd,
     apiMode,
     approvalPolicy: activeApprovalPolicy,
-    canDelegate: agentSupportsDelegation(agent),
+    canDelegate: chatAgentSupportsDelegation(agent),
     teamName: init.teamName,
     version,
   });
@@ -1142,7 +591,7 @@ export async function runChat(
       ...cliState.sessionMeta.get(),
       agent: config.agent,
       model: config.model,
-      canDelegate: agentSupportsDelegation(config.agent),
+      canDelegate: chatAgentSupportsDelegation(config.agent),
     });
     const runtimeHost = createCliRuntimeHost(sessionContext);
     const wrapped = wrapRuntimeHost(runtimeHost);
@@ -1279,7 +728,7 @@ export async function runChat(
       agent: resolution.config.agent,
       model: resolution.config.model,
       modelSource: 'history',
-      canDelegate: agentSupportsDelegation(resolution.config.agent),
+      canDelegate: chatAgentSupportsDelegation(resolution.config.agent),
     });
 
     // Rehydrate the prior transcript so the user sees the conversation they're

--- a/src/test-kernel/cli/RunChatConfig.vitest.mts
+++ b/src/test-kernel/cli/RunChatConfig.vitest.mts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getAgent, type AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { chatToolUseAgentUsageError } from '@cli/chat/tui/commands/handleSlashCommand';
 import {
   buildInitialChatAgentConfig,
-  chatToolUseAgentUsageError,
   restorePendingSkillActivations,
   takePendingSkillActivations,
 } from '@cli/chat/tui/runChatTui';


### PR DESCRIPTION
## Summary

- Move CLI chat slash-command dispatch and command-specific helpers from `runChatTui.tsx` into `packages/cli/src/chat/tui/commands/handleSlashCommand.ts`.
- Keep `runChatTui.tsx` focused on session lifecycle, rendering glue, startup/resume, and execution wiring.
- Update the CLI runtime architecture note to reflect that command dispatch now lives in the command layer, with the remaining follow-up being registry-driven handlers.

## Design Issue

`runChatTui.tsx` mixed the Ink entrypoint with slash-command parsing, auth/login/logout flows, approval mutation, `/status`, `/memory`, `/compact`, `/resume`, and model/API mode command handling. That made a UI composition module depend directly on command-layer details and forced unrelated CLI command changes through a large TUI lifecycle file.

This relocates that logic to the existing `commands/` layer and leaves a narrow `SlashCommandContext` boundary for the TUI-owned lifecycle callbacks.

Refs #6328.

## Validation

- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npx vitest run src/test-kernel/cli/RunChatConfig.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a file move with unchanged behavior; auth/API/model paths are relocated but not redesigned, so regression risk is limited to import/wiring mistakes.
> 
> **Overview**
> **Moves** CLI chat slash-command dispatch and related helpers out of `runChatTui.tsx` into new `commands/handleSlashCommand.ts`, so the Ink entrypoint stays focused on session lifecycle, rendering, and execution wiring.
> 
> `handleTuiSlashCommand` and helpers for `/login`, `/api`, `/model`, `/status`, memory, compaction, agent/model selection, and delegation checks now live in the command module. `runChatTui` builds a **`SlashCommandContext`** (session callbacks only) and delegates input to `handleTuiSlashCommand`; builtin slash forms still register via the same exported `apply*` / `showCliMemoryPreview` hooks.
> 
> Tests import `chatToolUseAgentUsageError` from the command module instead of `runChatTui`. The CLI architecture note now records that dispatch is in the command layer, with a follow-up to make handlers registry-driven instead of the large switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211bf8a612c652a6f7c35fe3de9e67d85d9826ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->