### PR TITLE
[codex] Centralize CLI root model selection

### DIFF
--- a/docs/architecture/cli-runtime-round-trips.md
+++ b/docs/architecture/cli-runtime-round-trips.md
@@ -209,9 +209,10 @@ team planning. Startup should need only names, descriptions, and availability.
   Return a `CliMultiAgentPlanSnapshot` from the planner and let launch validate or
   reuse it unless registry/auth state changed.
 - Model selection ownership:
-  Startup, submit-time, and `/model` each reconcile model availability and persistence.
-  Add a `CliRootModelSelection` helper that owns `apiMode`, current model, runnable
-  list loading, and persistence.
+  Root model paths now use `selectCliRootModel` for API-mode-aware runnable
+  resolution plus helper-model persistence. Keep candidate precedence
+  entrypoint-specific (`chat` defaults, headless `run`, resume history), but do
+  not reintroduce direct resolve-and-persist pairs outside the runtime helper.
 - Stream status lookup:
   UI helpers read child status from parent slice, child slice, and `StreamStatusService`.
   Normalize once in the subscriber and make UI read `StreamSlice` only. Keep the

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -24,9 +24,9 @@ import {
 } from '@cli/runtime/memory';
 import {
   formatCliNoAvailableModelsRecovery,
-  resolveCliRunnableModel,
   type CliNoAvailableModelsRecoveryOptions,
 } from '@cli/runtime/modelAccess';
+import { selectCliRootModel } from '@cli/runtime/rootModelSelection';
 import {
   formatCliApprovalPolicy,
   parseCliApprovalPolicy,
@@ -150,9 +150,18 @@ export async function applyCliModelSelection(
   const nextModel = model.trim();
   if (chatTuiCanStartRootRun(context.session)) {
     try {
-      await setCliHelperModel(nextModel);
-      setCliSessionModelOverride(nextModel);
-      appendLocalAssistantTranscript(`Root model set to ${nextModel}.`);
+      const { apiMode } = cliState.sessionMeta.get();
+      const selection = await selectCliRootModel({
+        model: nextModel,
+        modelSource: 'override',
+        apiMode,
+        noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
+          apiMode,
+          CHAT_API_MODE_MODEL_RECOVERY,
+        ),
+      });
+      setCliSessionModelOverride(selection.model);
+      appendLocalAssistantTranscript(`Root model set to ${selection.model}.`);
     } catch (error: unknown) {
       appendLocalAssistantTranscript(toErrorMessage(error));
     }
@@ -205,8 +214,9 @@ async function reconcileRootModelAfterApiModeChange(
   if (!context || !chatTuiCanStartRootRun(context.session)) return undefined;
 
   const { model: currentModel, modelSource } = cliState.sessionMeta.get();
-  const selection = await resolveCliRunnableModel(currentModel, {
-    fallbackSource: modelSource,
+  const selection = await selectCliRootModel({
+    model: currentModel,
+    modelSource,
     apiMode,
     noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
       apiMode,
@@ -215,7 +225,6 @@ async function reconcileRootModelAfterApiModeChange(
   });
   if (selection.model === currentModel) return undefined;
 
-  await setCliHelperModel(selection.model);
   cliState.sessionMeta.set({
     ...cliState.sessionMeta.get(),
     model: selection.model,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -42,11 +42,10 @@ import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform, setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
   formatCliNoAvailableModelsRecovery,
-  resolveCliRunnableModel,
   type CliNoAvailableModelsRecoveryOptions,
-  type CliModelSelectionSource,
   type CliRunnableModelResolution,
 } from '@cli/runtime/modelAccess';
+import { selectCliRootModel } from '@cli/runtime/rootModelSelection';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { writeTextStderr, writeTextStdout } from '@cli/runtime/logSinks';
 import {
@@ -368,8 +367,9 @@ export async function runChat(
   // never disagree.
   let modelSelection: CliRunnableModelResolution;
   try {
-    modelSelection = await resolveCliRunnableModel(defaults.model, {
-      fallbackSource: defaults.modelSource,
+    modelSelection = await selectCliRootModel({
+      model: defaults.model,
+      modelSource: defaults.modelSource,
       apiMode,
       noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
         apiMode,
@@ -382,7 +382,6 @@ export async function runChat(
   }
   const { agent } = defaults;
   const model = modelSelection.model;
-  await setCliHelperModel(model);
   const version = await readCliVersion();
 
   let activeApprovalPolicy = context.approvalPolicy;
@@ -608,8 +607,7 @@ export async function runChat(
     session.executionId = executionId;
     const approvalsUnavailable = approvalPromptsUnavailable(sessionContext);
 
-    const runPromise = setCliHelperModel(currentModel)
-      .then(() => registerFreshChatExecution(executionId, config))
+    const runPromise = registerFreshChatExecution(executionId, config)
       .then((registeredConfig) => {
         executionRegistered = true;
         return executeAgent(registeredConfig, executionId, {
@@ -847,11 +845,9 @@ export async function runChat(
         const meta = cliState.sessionMeta.get();
         const currentAgent = meta.agent || agent;
         const currentModel = meta.model || model;
-        const currentModelSource: CliModelSelectionSource = meta.model
-          ? meta.modelSource
-          : defaults.modelSource;
-        const selection = await resolveCliRunnableModel(currentModel, {
-          fallbackSource: currentModelSource,
+        const selection = await selectCliRootModel({
+          model: currentModel,
+          modelSource: meta.model ? meta.modelSource : defaults.modelSource,
           apiMode: meta.apiMode,
           noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
             meta.apiMode,

--- a/packages/cli/src/runtime/rootModelSelection.ts
+++ b/packages/cli/src/runtime/rootModelSelection.ts
@@ -1,0 +1,27 @@
+import { setCliHelperModel } from './initPlatform';
+import {
+  resolveCliRunnableModel,
+  type CliModelSelectionSource,
+  type CliRunnableModelResolution,
+} from './modelAccess';
+import type { CliApiMode } from './apiAccessMode';
+
+export async function selectCliRootModel({
+  apiMode,
+  model,
+  modelSource,
+  noAvailableModelsMessage,
+}: {
+  readonly apiMode?: CliApiMode;
+  readonly model: string;
+  readonly modelSource: CliModelSelectionSource;
+  readonly noAvailableModelsMessage?: string;
+}): Promise<CliRunnableModelResolution> {
+  const selection = await resolveCliRunnableModel(model, {
+    fallbackSource: modelSource,
+    apiMode,
+    ...(noAvailableModelsMessage == null ? {} : { noAvailableModelsMessage }),
+  });
+  await setCliHelperModel(selection.model);
+  return selection;
+}

--- a/packages/cli/src/runtime/runModel.ts
+++ b/packages/cli/src/runtime/runModel.ts
@@ -6,14 +6,12 @@ import {
   resolveConfiguredModel,
 } from './cliConfig';
 import { CliUsageError, type CliContext } from './cliContext';
-import { initCliPlatform, setCliHelperModel } from './initPlatform';
+import { initCliPlatform } from './initPlatform';
 import { writeTextStderr } from './logSinks';
-import {
-  resolveCliRunnableModel,
-  type CliModelSelectionSource,
-} from './modelAccess';
-import { shouldRenderRunProgress } from './runProgressRenderer';
 import { effectiveCliApiMode } from './apiAccessMode';
+import { selectCliRootModel } from './rootModelSelection';
+import { shouldRenderRunProgress } from './runProgressRenderer';
+import type { CliModelSelectionSource } from './modelAccess';
 
 export type CliRunModelCandidateSource = Extract<
   CliModelSelectionSource,
@@ -69,14 +67,14 @@ export async function resolveCliRunModel(
   await initCliPlatform({ ...context, quietLogs: true });
   const apiMode = effectiveCliApiMode(context);
   try {
-    const resolution = await resolveCliRunnableModel(candidate.model, {
-      fallbackSource: candidate.source,
+    const resolution = await selectCliRootModel({
+      model: candidate.model,
+      modelSource: candidate.source,
       apiMode,
     });
     if (resolution.notice && context.quietLogs !== true) {
       writeTextStderr(resolution.notice);
     }
-    await setCliHelperModel(resolution.model);
     return resolution.model;
   } catch (error: unknown) {
     throw new CliUsageError(toErrorMessage(error));

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -11,6 +11,7 @@ import {
 } from '@cli/runtime/cliConfig';
 import { CliUsageError, type CliContext } from '@cli/runtime/cliContext';
 import { resolveCliRunnableModel } from '@cli/runtime/modelAccess';
+import { selectCliRootModel } from '@cli/runtime/rootModelSelection';
 
 const mocks = vi.hoisted(() => ({
   initCliPlatform: vi.fn(),
@@ -62,6 +63,46 @@ function makeContext(partial: Partial<CliContext> = {}): CliContext {
 }
 
 const runConfig = (model: string): CliConfigValues => ({ run: { model } });
+
+describe('selectCliRootModel', () => {
+  beforeEach(() => {
+    mocks.setCliHelperModel.mockReset();
+    mocks.resolveCliRunnableModel.mockReset();
+    mocks.setCliHelperModel.mockResolvedValue(undefined);
+    resolveCliRunnableModelMock.mockImplementation(async (model) => ({
+      model,
+    }));
+  });
+
+  it('resolves the runnable model and persists the selected helper model', async () => {
+    resolveCliRunnableModelMock.mockResolvedValueOnce({
+      model: 'deepseekT',
+      notice: 'Using deepseekT instead.',
+    });
+
+    await expect(
+      selectCliRootModel({
+        model: 'staleConfiguredModel',
+        modelSource: 'config',
+        apiMode: 'personal',
+        noAvailableModelsMessage: 'No personal models.',
+      }),
+    ).resolves.toEqual({
+      model: 'deepseekT',
+      notice: 'Using deepseekT instead.',
+    });
+
+    expect(resolveCliRunnableModelMock).toHaveBeenCalledWith(
+      'staleConfiguredModel',
+      {
+        apiMode: 'personal',
+        fallbackSource: 'config',
+        noAvailableModelsMessage: 'No personal models.',
+      },
+    );
+    expect(mocks.setCliHelperModel).toHaveBeenCalledWith('deepseekT');
+  });
+});
 
 describe('resolveCliRunModel precedence', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- Add `selectCliRootModel` in `packages/cli/src/runtime/rootModelSelection.ts` to own API-mode-aware runnable-model selection plus helper-model persistence.
- Route chat startup, submit-time root chat startup, pre-run `/model` selection, `/api` root-model reconciliation, and headless `run` model setup through that helper.
- Update the CLI runtime architecture note so the ownership decision is explicit: candidate precedence remains entrypoint-specific, while resolve-and-persist pairs stay in the runtime helper.

## Design Issue

Root model setup was split across the TUI entrypoint, slash-command handlers, and headless run setup. Each place stitched together `resolveCliRunnableModel(...)` and `setCliHelperModel(...)`, so API-mode recovery text, fallback-source handling, and persistence could drift as relay/personal-mode behavior evolves.

This keeps the existing candidate precedence where it belongs (`chat` defaults, headless `run`, resume history), but gives the shared root-model selection rule one owner.

Refs #6337.

## Validation

- `npx vitest run src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/RunChatConfig.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor that centralizes existing model-resolution and persistence behavior without changing precedence rules; mid-run model switches still use the prior flow-specific path.
> 
> **Overview**
> Introduces **`selectCliRootModel`** as the single place that resolves an API-mode-aware runnable root model and persists the helper model, replacing scattered `resolveCliRunnableModel` + `setCliHelperModel` pairs.
> 
> **Chat TUI** startup, first-message submit, pre-run **`/model`**, and **`/api`** root-model reconciliation now call the helper (with existing recovery messaging). **Headless `run`** uses it via **`resolveCliRunModel`**. Model **candidate precedence** stays at each entrypoint (`chat` defaults, `run` flags/env/config, resume history); only resolve-and-persist is shared.
> 
> The architecture note is updated to document that rule. Tests cover the new helper’s resolve + persist behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5665ecc3882bd4f7179c31372932965743d724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->