### PR TITLE
refactor: centralize TUI viewport repaint policy

### DIFF
--- a/docs/architecture/cli-runtime-round-trips.md
+++ b/docs/architecture/cli-runtime-round-trips.md
@@ -218,9 +218,9 @@ team planning. Startup should need only names, descriptions, and availability.
   Normalize once in the subscriber and make UI read `StreamSlice` only. Keep the
   service as an input source, not a UI fallback.
 - Transcript viewport repaint:
-  `App` detects root/scoped changes and calls back into `runChatTui` to repaint Ink.
-  Move viewport repaint ownership into a small TUI viewport controller so render mode
-  and terminal clear policy live together.
+  `App` detects root/scoped changes and `runChatTui` wires them to
+  `render/tuiViewportController`. Keep repaint options and SIGCONT clear-repaint
+  policy in that render controller, not in state or the session entrypoint.
 - Slash command dispatch:
   `runChatTui` now delegates slash commands to the command layer, but
   `handleTuiSlashCommand` still owns a large switch with special cases. Move

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -38,10 +38,6 @@ import { GoalStore } from '@tools/goal';
 import { getDefaultStreamLogStore } from '@transcript';
 
 import { App } from '../src/chat/tui/App';
-import {
-  transcriptViewportRepaintOptions,
-  type TranscriptViewportChange,
-} from '../src/chat/tui/state/transcriptViewportMode';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
 import {
   formatSlashCommandHelp,
@@ -75,6 +71,7 @@ import {
   installTuiStdoutListenerLimit,
   tuiOutputStreamForColor,
 } from '../src/chat/tui/render/noColorOutput';
+import { createTuiViewportController } from '../src/chat/tui/render/tuiViewportController';
 import {
   clearApprovals,
   enqueueApproval,
@@ -1589,11 +1586,7 @@ registerBuiltinSlashCommands({
 cliState.rootRunStartAvailable.set(CAN_SELECT_AGENT);
 
 const inkRef: { current?: ReturnType<typeof render> } = {};
-function repaintHarnessTranscriptViewport(
-  change: TranscriptViewportChange,
-): void {
-  inkRef.current?.repaint(transcriptViewportRepaintOptions(change));
-}
+const viewportController = createTuiViewportController(inkRef);
 
 function handleHarnessCtrlC(): void {
   if (canInterrupt) {
@@ -1614,7 +1607,9 @@ const ink = render(
     canStopActiveRun={() => canInterrupt}
     colorEnabled={HARNESS_COLOR_ENABLED}
     onInterruptActive={markHarnessInterrupted}
-    onTranscriptViewportChange={repaintHarnessTranscriptViewport}
+    onTranscriptViewportChange={
+      viewportController.handleTranscriptViewportChange
+    }
     onCtrlC={handleHarnessCtrlC}
   />,
   {

--- a/packages/cli/src/chat/tui/render/tuiViewportController.ts
+++ b/packages/cli/src/chat/tui/render/tuiViewportController.ts
@@ -1,0 +1,39 @@
+import type { TranscriptViewportChange } from '../state/transcriptViewportMode';
+
+export interface TuiRepaintOptions {
+  readonly clearScrollback?: boolean;
+  readonly preserveStatic?: boolean;
+}
+
+export interface TuiRepaintTarget {
+  repaint(options: TuiRepaintOptions): void;
+}
+
+const TRANSCRIPT_VIEWPORT_REPAINT_OPTIONS = {
+  clearScrollback: true,
+  preserveStatic: false,
+} satisfies TuiRepaintOptions;
+
+const TERMINAL_RESUME_REPAINT_OPTIONS = {
+  clearScrollback: true,
+} satisfies TuiRepaintOptions;
+
+export interface TuiViewportController {
+  readonly handleTranscriptViewportChange: (
+    change: TranscriptViewportChange,
+  ) => void;
+  readonly repaintAfterTerminalResume: () => void;
+}
+
+export function createTuiViewportController(inkRef: {
+  readonly current?: TuiRepaintTarget;
+}): TuiViewportController {
+  return {
+    handleTranscriptViewportChange(): void {
+      inkRef.current?.repaint(TRANSCRIPT_VIEWPORT_REPAINT_OPTIONS);
+    },
+    repaintAfterTerminalResume(): void {
+      inkRef.current?.repaint(TERMINAL_RESUME_REPAINT_OPTIONS);
+    },
+  };
+}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -98,6 +98,7 @@ import {
   installTuiStdoutListenerLimit,
   tuiOutputStreamForColor,
 } from './render/noColorOutput';
+import { createTuiViewportController } from './render/tuiViewportController';
 import { clearApprovals } from './state/approvalQueue';
 import { cliState, patchStream, resetCliState } from './state/cliState';
 import {
@@ -134,10 +135,6 @@ import {
   restoreTuiInputModes,
   supportsTerminalJobControl,
 } from './terminalCleanup';
-import {
-  transcriptViewportRepaintOptions,
-  type TranscriptViewportChange,
-} from './state/transcriptViewportMode';
 import {
   chatTuiCanInterruptActiveRun,
   chatTuiCanSelectModel,
@@ -984,11 +981,7 @@ export async function runChat(
 
   const stdoutColorEnabled = context.stdoutColorEnabled ?? context.colorEnabled;
   const inkRef: { current?: InkInstance } = {};
-  const repaintTranscriptViewport = (
-    change: TranscriptViewportChange,
-  ): void => {
-    inkRef.current?.repaint(transcriptViewportRepaintOptions(change));
-  };
+  const viewportController = createTuiViewportController(inkRef);
   const ink = render(
     <App
       onSubmit={handleSubmit}
@@ -998,7 +991,9 @@ export async function runChat(
       colorEnabled={stdoutColorEnabled}
       commandName={context.commandName}
       onInterruptActive={interruptActive}
-      onTranscriptViewportChange={repaintTranscriptViewport}
+      onTranscriptViewportChange={
+        viewportController.handleTranscriptViewportChange
+      }
       onCtrlC={() => handleSigint()}
       onSuspend={() => handleSigtstp()}
       onKillExecution={(executionId) => {
@@ -1191,7 +1186,7 @@ export async function runChat(
   const handleSigcont = (): void => {
     if (process.stdin.isTTY) process.stdin.setRawMode(true);
     restoreTuiInputModes({ kittyKeyboard: terminalCaps.kittyKeyboard });
-    inkRef.current?.repaint({ clearScrollback: true });
+    viewportController.repaintAfterTerminalResume();
   };
   function requestInputExit(): void {
     removeProcessHandlers();

--- a/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
+++ b/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
@@ -39,11 +39,6 @@ export interface TranscriptViewportChange {
   readonly nextViewportKey: string;
 }
 
-export interface TranscriptViewportRepaintOptions {
-  readonly clearScrollback: boolean;
-  readonly preserveStatic: false;
-}
-
 export function transcriptViewportChange({
   nextViewportKey,
   previousViewportKey,
@@ -54,13 +49,4 @@ export function transcriptViewportChange({
   if (previousViewportKey === undefined) return undefined;
   if (previousViewportKey === nextViewportKey) return undefined;
   return { previousViewportKey, nextViewportKey };
-}
-
-export function transcriptViewportRepaintOptions(
-  _change: TranscriptViewportChange,
-): TranscriptViewportRepaintOptions {
-  return {
-    clearScrollback: true,
-    preserveStatic: false,
-  };
 }

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -20,8 +20,11 @@ import { staticScrollbackTarget } from '@cli/chat/tui/App';
 import {
   transcriptViewportChange,
   transcriptViewportKey,
-  transcriptViewportRepaintOptions,
 } from '@cli/chat/tui/state/transcriptViewportMode';
+import {
+  createTuiViewportController,
+  type TuiRepaintOptions,
+} from '@cli/chat/tui/render/tuiViewportController';
 import {
   estimateTranscriptEntryRows,
   selectTranscriptEntriesForViewport,
@@ -1088,18 +1091,26 @@ describe('CLI conversation transcript splitting', () => {
     expect(rootToChild).toBeDefined();
     expect(childToRoot).toBeDefined();
     expect(childToChild).toBeDefined();
-    expect(transcriptViewportRepaintOptions(rootToChild!)).toEqual({
-      clearScrollback: true,
-      preserveStatic: false,
+    const calls: TuiRepaintOptions[] = [];
+    const controller = createTuiViewportController({
+      current: {
+        repaint: (options) => {
+          calls.push(options);
+        },
+      },
     });
-    expect(transcriptViewportRepaintOptions(childToRoot!)).toEqual({
-      clearScrollback: true,
-      preserveStatic: false,
-    });
-    expect(transcriptViewportRepaintOptions(childToChild!)).toEqual({
-      clearScrollback: true,
-      preserveStatic: false,
-    });
+
+    controller.handleTranscriptViewportChange(rootToChild!);
+    controller.handleTranscriptViewportChange(childToRoot!);
+    controller.handleTranscriptViewportChange(childToChild!);
+    controller.repaintAfterTerminalResume();
+
+    expect(calls).toEqual([
+      { clearScrollback: true, preserveStatic: false },
+      { clearScrollback: true, preserveStatic: false },
+      { clearScrollback: true, preserveStatic: false },
+      { clearScrollback: true },
+    ]);
   });
 
   it('shows the thinking liveness row only while a running stream is thinking', () => {


### PR DESCRIPTION
## Summary

Fixes #6338.

- move transcript viewport repaint policy out of `state/transcriptViewportMode` into `render/tuiViewportController`
- wire both `runChatTui` and the PTY TUI harness through the controller
- keep transcript viewport state focused on viewport identity/change detection
- update the CLI runtime architecture note and regression coverage

## Abstraction Review

The addressed violation was render ownership leaking across layers: state computed repaint options, `runChatTui` held terminal clear policy, and `App` reported viewport transitions. That split made transcript focus, scrollback ownership, and suspend/resume repaint behavior harder to change together. The refactor leaves state as state, `App` as the change reporter, and a render-layer controller as the owner of repaint policy.

Other abstraction-layer findings from the review are already tracked separately: #6328 for `runChatTui` session orchestration, #6318 for webview action planning in `MainApp`, #6319 for file-selection policy in `MainView FileManager`, #6310 for progress-view follow-up polishing policy, #6314 for provider SDK shapes leaking into chat export normalization, and #6341 for normalizing CLI stream status reads to `StreamSlice`.

## Validation

- `npx vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TerminalCleanup.vitest.mts`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-viewport-20260620-1027 subagent-focused-status-stays-scoped subagent-focus-return-root-scrollback-deduped ctrl-c-interrupt-active`
