### PR TITLE
refactor: read CLI stream status from slices

### DIFF
--- a/docs/architecture/cli-runtime-round-trips.md
+++ b/docs/architecture/cli-runtime-round-trips.md
@@ -214,9 +214,10 @@ team planning. Startup should need only names, descriptions, and availability.
   entrypoint-specific (`chat` defaults, headless `run`, resume history), but do
   not reintroduce direct resolve-and-persist pairs outside the runtime helper.
 - Stream status lookup:
-  UI helpers read child status from parent slice, child slice, and `StreamStatusService`.
-  Normalize once in the subscriber and make UI read `StreamSlice` only. Keep the
-  service as an input source, not a UI fallback.
+  `subscribeStreamStatus` mirrors `StreamStatusService` events into `StreamSlice`
+  once, including retained parent child rows. TUI routing and rendering should
+  read status from that normalized stream map, keeping the service as an input
+  source rather than a UI/session fallback.
 - Transcript viewport repaint:
   `App` detects root/scoped changes and `runChatTui` wires them to
   `render/tuiViewportController`. Keep repaint options and SIGCONT clear-repaint

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -78,7 +78,6 @@ import {
   type ApprovalDecision,
 } from '../src/chat/tui/state/approvalQueue';
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
-import { streamStatusFromState } from '../src/chat/tui/state/streamStatus';
 import { resolveLocalTranscriptStreamId } from '../src/chat/tui/state/transcript';
 import { defaultShortcutModifierLabel } from '../src/runtime/shortcutLabels';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
@@ -1436,13 +1435,12 @@ function handleHarnessSubmit(line: string): void {
   const focusedChildRoute = focusedChildFollowUpRoute({
     activeStreamId: cliState.activeStreamId.get(),
     parentStream: cliState.parentStream.get(),
-    statusForStream: streamStatusFromState,
+    streams: cliState.streams.get(),
   });
   if (focusedChildRoute.kind === 'reject') {
     appendHarnessAssistantTranscript(
       stoppedFocusedChildFollowUpMessage({
         parentStream: cliState.parentStream.get(),
-        status: streamStatusFromState(focusedChildRoute.streamId),
         streamId: focusedChildRoute.streamId,
         streams: cliState.streams.get(),
       }),

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -115,10 +115,7 @@ import { installTuiApprovals } from './state/subscribeApprovals';
 import { wrapRuntimeHost } from './state/subscribeRuntimeHost';
 import { subscribeStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
-import {
-  onStreamStatusChange,
-  streamStatusFromState,
-} from './state/streamStatus';
+import { onStreamStatusChange } from './state/streamStatus';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
 import {
   appendLocalAssistantTranscript,
@@ -274,7 +271,7 @@ export function chatTuiFocusedChildFollowUpRoute(): ChatTuiFocusedChildFollowUpR
   return focusedChildFollowUpRoute({
     activeStreamId: cliState.activeStreamId.get(),
     parentStream: cliState.parentStream.get(),
-    statusForStream: streamStatusFromState,
+    streams: cliState.streams.get(),
   });
 }
 
@@ -283,7 +280,6 @@ function stoppedFocusedChildFollowUpMessage(streamId: StreamTabId): string {
   const streams = cliState.streams.get();
   return focusedChildStoppedMessage({
     parentStream,
-    status: streamStatusFromState(streamId),
     streamId,
     streams,
   });
@@ -488,7 +484,9 @@ export async function runChat(
   const pendingSkillActivations = new Map<string, string>();
   let pendingSkillActivationClearEpoch = 0;
   const rootStreamStatus = (): StreamStatus | undefined =>
-    session.streamId ? streamStatusFromState(session.streamId) : undefined;
+    session.streamId
+      ? cliState.streams.get().get(session.streamId)?.status
+      : undefined;
   const hasActiveToolUseFlow = (): boolean =>
     Boolean(
       session.streamId &&
@@ -545,7 +543,7 @@ export async function runChat(
   const resetSessionForClear = (): void => {
     const activeStreamId = session.streamId ?? cliState.activeStreamId.get();
     const activeStatus = activeStreamId
-      ? streamStatusFromState(activeStreamId)
+      ? cliState.streams.get().get(activeStreamId)?.status
       : undefined;
     const isRunPending = Boolean(session.runPromise && !session.runCompleted);
 

--- a/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
+++ b/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
@@ -17,7 +17,7 @@ export type FocusedChildFollowUpRoute =
 export function focusedChildFollowUpRoute(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
-  readonly statusForStream: (streamId: StreamTabId) => StreamStatus | undefined;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): FocusedChildFollowUpRoute {
   const scope = activeStreamScope({
     activeStreamId: init.activeStreamId,
@@ -27,7 +27,7 @@ export function focusedChildFollowUpRoute(init: {
     return { kind: 'none' };
   }
 
-  const status = init.statusForStream(scope.streamId);
+  const status = init.streams.get(scope.streamId)?.status;
   // A focused child normally has a status. Keep the previous permissive
   // behavior during the brief edge where parent focus arrives first.
   if (status !== undefined && !isInFlightStatus(status)) {
@@ -77,7 +77,6 @@ export function focusedChildInputDisabledMessage(init: {
 
 export function stoppedFocusedChildFollowUpMessage(init: {
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
-  readonly status: StreamStatus | undefined;
   readonly streamId: StreamTabId;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): string {
@@ -91,7 +90,7 @@ export function stoppedFocusedChildFollowUpMessage(init: {
     focusedChildInputDisabledMessage({
       activeStreamId: init.streamId,
       parentStream: init.parentStream,
-      status: init.status,
+      status: init.streams.get(init.streamId)?.status,
       subagentControlsAvailable: controls.subagents.hasItems,
       taskControlsAvailable: controls.tasks.hasItems,
     }) ?? 'The selected subagent is no longer accepting follow-ups.'

--- a/packages/cli/src/chat/tui/state/streamStatus.ts
+++ b/packages/cli/src/chat/tui/state/streamStatus.ts
@@ -2,8 +2,6 @@ import {
   StreamStatusService,
   type StreamStatusChange,
 } from '@agent/runtime/StreamStatusService';
-import { type StreamStatus, type StreamTabId } from '@shared/schemas';
-
 import { cliState, setStreamStatusInCliState } from './cliState';
 
 export function applyStreamStatusChange(change: StreamStatusChange): void {
@@ -11,12 +9,6 @@ export function applyStreamStatusChange(change: StreamStatusChange): void {
     streamId: change.streamId,
     status: change.status,
   });
-}
-
-export function streamStatusFromState(
-  streamId: StreamTabId,
-): StreamStatus | undefined {
-  return cliState.streams.get().get(streamId)?.status;
 }
 
 export function onStreamStatusChange(


### PR DESCRIPTION
## Summary

Fixes #6341.

- remove the exported `streamStatusFromState()` helper
- route focused-child follow-up decisions through the normalized `StreamSlice` map
- make the TUI harness use the same stream-slice status path as `runChatTui`
- update the CLI runtime architecture note to describe `StreamStatusService` as an input source only

## Abstraction Review

The previous shape kept two ways to ask for stream status: most TUI rendering read `StreamSlice`, while session/focused-child paths called a helper that reached into global CLI state by stream id. That kept status ownership split even though `subscribeStreamStatus` already mirrors service events into `StreamSlice` and retained parent child rows.

This refactor keeps the bridge in `subscribeStreamStatus`/`setStreamStatusInCliState`, then makes routing and stopped-child messaging read the same normalized stream map used by the rest of the TUI.

## Validation

- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-stream-status-20260620-1038 subagent-focused-status-stays-scoped subagent-focus-return-root-scrollback-deduped ctrl-c-interrupt-active`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only status read path consolidation with no auth, persistence, or execution semantics changes; behavior should match prior slice-backed status when the subscriber is active.
> 
> **Overview**
> **Unifies CLI TUI stream status lookups** so routing and session logic use the same normalized `cliState.streams` map that rendering already uses, instead of a separate `streamStatusFromState()` helper.
> 
> The exported **`streamStatusFromState()`** is removed from `streamStatus.ts`. **`focusedChildFollowUpRoute`** and **`stoppedFocusedChildFollowUpMessage`** now take the full **`streams`** map and read **`slice.status`** directly. **`runChatTui`** and the **TUI harness** follow the same path for focused-child follow-ups, root run status, and **`/clear`** guards.
> 
> The **CLI runtime architecture** note is updated to state that **`subscribeStreamStatus`** mirrors **`StreamStatusService`** into **`StreamSlice`** once, and the UI should treat the service as an input source only—not a parallel lookup path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a6764cbf8a47853a379f4201d395d3f64934e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->