### PR TITLE
refactor: dedup pasted-image filename generation

### DIFF
--- a/src/shared/files/pastedImageConstants.ts
+++ b/src/shared/files/pastedImageConstants.ts
@@ -1,1 +1,17 @@
+import { nanoid } from 'nanoid';
+
 export const PASTED_PREFIX = 'pasted_';
+
+/**
+ * Generate a pasted-image filename: `pasted_<timestamp>_<rand>.<ext>`. The
+ * `PASTED_PREFIX` lets `isPastedImage` recognize it later.
+ *
+ * This is the single source of truth shared by the Node host
+ * (`@utils/files/pastedImageUtils`) and the browser-safe webview helper
+ * (`@shared/utils/clipboardImages`) so both produce identical names. It depends
+ * only on `nanoid` (isomorphic) and the prefix constant, so it stays safe in
+ * both bundles.
+ */
+export function generatePastedImageName(ext: string): string {
+  return `${PASTED_PREFIX}${Date.now()}_${nanoid(6)}.${ext}`;
+}

--- a/src/shared/utils/clipboardImages.ts
+++ b/src/shared/utils/clipboardImages.ts
@@ -2,9 +2,10 @@
 // progress-view follow-up). Browser-only — relies on FileReader/DataTransfer
 // and has no Node imports, so it is safe in both webview bundles.
 
-import { nanoid } from 'nanoid';
+import { generatePastedImageName } from '@shared/files/pastedImageConstants';
 
-import { PASTED_PREFIX } from '@shared/files/pastedImageConstants';
+// Re-exported so existing webview callers can keep importing it from this module.
+export { generatePastedImageName };
 
 const IMAGE_MIME_TYPES: Record<string, string> = {
   'image/jpeg': 'jpg',
@@ -32,10 +33,6 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 
 export function getExtensionFromMimeType(mimeType: string): string {
   return IMAGE_MIME_TYPES[mimeType] || mimeType.split('/')[1] || 'png';
-}
-
-export function generatePastedImageName(extension: string): string {
-  return `${PASTED_PREFIX}${Date.now()}_${nanoid(6)}.${extension}`;
 }
 
 export interface ExtractedClipboardImage {

--- a/src/utils/files/pastedImageUtils.ts
+++ b/src/utils/files/pastedImageUtils.ts
@@ -1,14 +1,18 @@
 // Standard library imports
 import * as path from 'node:path';
 
-import { nanoid } from 'nanoid';
-
 // Local imports
-import { PASTED_PREFIX } from '@shared/files/pastedImageConstants';
+import {
+  PASTED_PREFIX,
+  generatePastedImageName,
+} from '@shared/files/pastedImageConstants';
 import { THREE_DAYS_MS } from '@utils/config/constants';
 import { StorageFS } from './storageFS';
 
 export const PASTED_DIR = 'pasted';
+
+// Re-exported so existing callers can keep importing it from this module.
+export { generatePastedImageName };
 
 /**
  * Check if a filename is a pasted image
@@ -24,14 +28,6 @@ export function getPastedImageFullPath(filename: string): string {
   return StorageFS.fullPath(
     path.join(PASTED_DIR, pastedImageFileName(filename)),
   );
-}
-
-/**
- * Generate a pasted-image filename: `pasted_<timestamp>_<rand>.<ext>`. The
- * `PASTED_PREFIX` lets {@link isPastedImage} recognize it later.
- */
-export function generatePastedImageName(ext: string): string {
-  return `${PASTED_PREFIX}${Date.now()}_${nanoid(6)}.${ext}`;
 }
 
 /**


### PR DESCRIPTION
## What

`generatePastedImageName(ext)` was defined **identically** in two modules:

- `src/shared/utils/clipboardImages.ts` (browser-safe webview helper)
- `src/utils/files/pastedImageUtils.ts` (Node host helper)

Both produced `pasted_<timestamp>_<rand>.<ext>` from `nanoid` + `PASTED_PREFIX`. This consolidates the function into the shared, dependency-free `src/shared/files/pastedImageConstants.ts` module — which both files already import for `PASTED_PREFIX` — as the single source of truth.

Both original modules now re-export it, so **every existing import path keeps working** (CLI `runtime/clipboardImage.ts`, webview `pasteHandler.ts`, progress-view `FollowUpInput.ts`, and the `PasteHandler` test mock are all unaffected).

## Why

A drift between the two copies would silently produce mismatched filenames across the webview and Node paths. One definition removes that risk and keeps `nanoid` out of the bundles that don't otherwise need it.

## Behavior

Byte-identical — pure code move. No user-facing change, so no CHANGELOG entry.

## Verification

- `npm run typecheck` — passes (all 4 projects: root, test-kernel, extension, CLI)
- `npx vitest run PasteHandler pastedImage clipboard` — 4 files / 7 tests pass
- `eslint` on the 3 changed files — clean

## Context

This came out of a broader tech-debt audit of the repo. Notably, most of the larger duplication candidates (provider usage normalization, streaming tool-call accumulation, settings event forwarding, error/JSON/config helpers) turned out to be **already refactored** behind shared factories — the codebase is in good shape. This was the one clean, multi-consumer duplication still left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZRHiGN4rsbRQ5hRBTPjPs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure code move with identical naming logic; no API or runtime behavior change beyond import paths.
> 
> **Overview**
> **`generatePastedImageName`** is now defined once in `pastedImageConstants.ts` (alongside `PASTED_PREFIX`) instead of being duplicated in the webview clipboard helper and the Node `pastedImageUtils` module.
> 
> Both former locations import from shared constants and **re-export** the function so existing import paths stay unchanged. Filename format and behavior are unchanged (`pasted_<timestamp>_<nanoid>.<ext>`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a0040446646495c5a982c852314b079c067d7a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->