### PR TITLE
[codex] refactor chat slash command dispatch

### DIFF
--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -70,6 +70,7 @@ import {
   listSlashCommands,
   parseSlashInput,
   suggestSlashCommand,
+  type SlashCommand,
 } from './slashRegistry';
 
 export interface SlashCommandContext {
@@ -399,6 +400,15 @@ export async function showCliMemoryPreview(inputPath: string): Promise<void> {
   appendLocalAssistantTranscript(await formatCliMemoryPreview(inputPath));
 }
 
+function openCanonicalSlashForm(
+  commandName: string,
+  registered: SlashCommand | undefined,
+  remainder: string,
+): void {
+  if (registered && openRegisteredCliSlashForm(registered, remainder)) return;
+  openCliSlashCommandForm(commandName, remainder);
+}
+
 export async function handleTuiSlashCommand(
   line: string,
   context: SlashCommandContext,
@@ -408,16 +418,18 @@ export async function handleTuiSlashCommand(
 
   const command = parsed.name.toLowerCase();
   const rest = parsed.remainder.trim();
+  const registered = findSlashCommand(command);
+  const canonicalCommand = registered?.name ?? command;
   // Echo the slash input into the transcript so the user can see what they
   // typed. Slash commands don't go through the agent run, so the usual
   // USER_MESSAGE stream-log entry is never produced. Skip the echo for the
   // exit commands (the TUI is tearing down); /clear still echoes because
   // resetSessionForClear refuses while a run is active and surfaces an
   // error — without the echo the user wouldn't see what triggered it.
-  if (command !== 'exit' && command !== 'quit' && command !== 'login') {
+  if (canonicalCommand !== 'exit' && canonicalCommand !== 'login') {
     appendLocalUserTranscript(line.trim());
   }
-  switch (command) {
+  switch (canonicalCommand) {
     case 'help': {
       appendLocalAssistantTranscript(
         formatSlashCommandHelp(listSlashCommands(), {
@@ -431,13 +443,11 @@ export async function handleTuiSlashCommand(
       context.resetSession();
       return true;
     case 'exit':
-    case 'quit':
       context.session.stopRequested = true;
       context.interruptActive();
       context.requestInputExit();
       return true;
     case 'agent':
-    case 'agents':
       if (!chatTuiCanStartRootRun(context.session) && rest) {
         appendLocalAssistantTranscript(
           'The agent is fixed for this chat session. Start a new chat to use a different agent.',
@@ -445,16 +455,15 @@ export async function handleTuiSlashCommand(
       } else if (rest) {
         applyInitialCliAgentSelection(rest, context);
       } else {
-        openCliSlashCommandForm('agent', rest);
+        openCanonicalSlashForm('agent', registered, rest);
       }
       return true;
     case 'model':
-    case 'models':
-      openCliSlashCommandForm('model', rest);
+      openCanonicalSlashForm('model', registered, rest);
       return true;
     case 'api':
       if (!rest) {
-        openCliSlashCommandForm('api', rest);
+        openCanonicalSlashForm('api', registered, rest);
         return true;
       }
       try {
@@ -480,7 +489,7 @@ export async function handleTuiSlashCommand(
       if (rest) {
         applyCliApprovalPolicySelection(rest, context);
       } else {
-        openCliSlashCommandForm('approval', rest);
+        openCanonicalSlashForm('approval', registered, rest);
       }
       return true;
     case 'yolo':
@@ -522,12 +531,11 @@ export async function handleTuiSlashCommand(
       return true;
     }
     case 'goal':
-    case 'goals':
       appendLocalAssistantTranscript(GOAL_MODE_HELP);
       return true;
     case 'resume': {
       if (!rest) {
-        openCliSlashCommandForm('resume', rest);
+        openCanonicalSlashForm('resume', registered, rest);
         return true;
       }
       const id = parseCliHistoryId(rest);
@@ -541,7 +549,7 @@ export async function handleTuiSlashCommand(
     case 'memory': {
       try {
         if (!rest) {
-          openCliSlashCommandForm('memory', rest);
+          openCanonicalSlashForm('memory', registered, rest);
         } else if (rest.toLowerCase() === 'list') {
           await showCliMemoryList();
         } else {
@@ -562,7 +570,6 @@ export async function handleTuiSlashCommand(
       });
       return true;
     default: {
-      const registered = findSlashCommand(command);
       if (registered) {
         if (openRegisteredCliSlashForm(registered, parsed.remainder)) {
           return true;

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -1,0 +1,93 @@
+// Slash command execution dispatch.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  handleTuiSlashCommand,
+  type SlashCommandContext,
+} from '@cli/chat/tui/commands/handleSlashCommand';
+import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
+import {
+  listSlashCommands,
+  unregisterSlashCommand,
+} from '@cli/chat/tui/commands/slashRegistry';
+import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
+import type { TuiSession } from '@cli/chat/tui/state/sessionRunState';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import type { ExecutionId } from '@shared/schemas';
+
+afterEach(() => {
+  for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
+  resetCliState();
+  vi.restoreAllMocks();
+});
+
+function createSession(): TuiSession {
+  return {
+    streamId: undefined,
+    executionId: undefined,
+    runPromise: undefined,
+    runExitCode: CliExitCode.Success,
+    runCompleted: false,
+    stopRequested: false,
+  };
+}
+
+function createContext(
+  session: TuiSession,
+  overrides: Partial<SlashCommandContext> = {},
+): SlashCommandContext {
+  let approvalPolicy: CliApprovalPolicy = 'ask';
+  return {
+    session,
+    cwd: '/tmp/workspace',
+    initialAgent: 'chat',
+    initialModel: 'deepseekT',
+    interruptActive: vi.fn(),
+    requestInputExit: vi.fn(),
+    getApprovalPolicy: () => approvalPolicy,
+    setApprovalPolicy: (policy) => {
+      approvalPolicy = policy;
+    },
+    canSelectModel: () => true,
+    resetSession: vi.fn(),
+    resumeExecution: (_id: ExecutionId) => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+describe('handleTuiSlashCommand', () => {
+  it('opens alias-addressed structured forms through the canonical command', async () => {
+    registerBuiltinSlashCommands();
+
+    const handled = await handleTuiSlashCommand(
+      '/models',
+      createContext(createSession()),
+    );
+
+    expect(handled).toBe(true);
+    expect(cliState.activeForm.get()?.commandName).toBe('model');
+  });
+
+  it('treats /quit as the canonical exit command without echoing it', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const interruptActive = vi.fn();
+    const requestInputExit = vi.fn();
+
+    const handled = await handleTuiSlashCommand(
+      '/quit',
+      createContext(session, {
+        interruptActive,
+        requestInputExit,
+      }),
+    );
+
+    expect(handled).toBe(true);
+    expect(session.stopRequested).toBe(true);
+    expect(interruptActive).toHaveBeenCalledOnce();
+    expect(requestInputExit).toHaveBeenCalledOnce();
+    expect(cliState.activeStreamId.get()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6344.

This refactor makes the chat slash-command registry the source of truth for alias canonicalization and structured-form metadata before `handleTuiSlashCommand` dispatches behavior.

## Design Issue

`handleTuiSlashCommand` duplicated aliases such as `/quit`, `/agents`, `/models`, and `/goals`, plus direct form-opening paths already described by the registry. That created change amplification: adding or changing a command meant keeping registry metadata and switch cases in sync.

## Changes

- Canonicalize parsed slash-command names once with `findSlashCommand()` before the dispatch switch.
- Switch on the canonical registered command name, removing duplicated alias cases.
- Route built-in structured forms through registered command metadata via a small form fallback helper.
- Add focused dispatch tests for alias-addressed forms and `/quit` exit behavior.

## Validation

- `npm run format`
- `npx vitest run src/test-kernel/cli/SlashCommandDispatch.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/SlashHelpText.vitest.mts`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `npm test`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-slash-dispatch-20260620-1053 slash-palette-overflow model-form slash-goal-help slash-resume-empty`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of CLI slash routing with registry-driven aliases and focused tests; behavior should match prior alias handling with less duplication.
> 
> **Overview**
> **Chat slash dispatch** now resolves the parsed name through `findSlashCommand()` once and switches on the **canonical** registered command, so aliases like `/agents`, `/models`, `/goals`, and `/quit` no longer need duplicate `case` branches in `handleTuiSlashCommand`.
> 
> Structured built-in forms (`agent`, `model`, `api`, `approval`, `resume`, `memory`) open through **`openCanonicalSlashForm`**, which prefers registered form metadata via `openRegisteredCliSlashForm` and falls back to `openCliSlashCommandForm`. Transcript echo for teardown-sensitive commands uses the canonical name (still skipping echo for `exit` and `login`).
> 
> Adds **`SlashCommandDispatch.vitest.mts`** covering alias `/models` opening the `model` form and `/quit` behaving as exit without user echo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc6e8665d6c1a545633c1b143d6dc441c1312287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->