### PR TITLE
refactor: extract injectable buildLatexInputEnv from compileLatex2Pdf

### DIFF
--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -40,6 +40,34 @@ export function buildKpathseaSearchPath(
 }
 
 /**
+ * Build the kpathsea search-path overrides (TEXINPUTS / BIBINPUTS / BSTINPUTS)
+ * for a LaTeX compile, prepending the workspace and TikZ input directories onto
+ * any inherited values.
+ *
+ * The `env` seam keeps the `process.env` read injectable for tests; this is the
+ * lone environment touch in this VS Code-free module. The subprocess still
+ * inherits the rest of `process.env` via `executeCommand`'s `commandEnv`, so
+ * these keys only override the three search paths that need prepending.
+ */
+export function buildLatexInputEnv(
+  texInputParts: readonly string[],
+  bibSearchParts: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const needsTexInputs = texInputParts.length > 1 || !!env.TEXINPUTS;
+  const texInputs = needsTexInputs
+    ? buildKpathseaSearchPath(texInputParts, env.TEXINPUTS)
+    : undefined;
+  const bibInputs = buildKpathseaSearchPath(bibSearchParts, env.BIBINPUTS);
+  const bstInputs = buildKpathseaSearchPath(bibSearchParts, env.BSTINPUTS);
+  return {
+    ...(texInputs && { TEXINPUTS: texInputs }),
+    ...(bibInputs && { BIBINPUTS: bibInputs }),
+    ...(bstInputs && { BSTINPUTS: bstInputs }),
+  };
+}
+
+/**
  * Compile a LaTeX file to PDF
  * @param latexLocation FileLocation for the LaTeX file
  * @param options Compilation options (channel defaults to module CHANNEL)
@@ -77,27 +105,13 @@ export async function compileLatex2Pdf(
       ...(workspacePath ? [workspacePath] : []),
       ...(tikzInputDirectory?.trim() ? [tikzInputDirectory] : []),
     ];
-
-    // Build environment with TEXINPUTS if we have custom paths or existing TEXINPUTS
-    // Use path.delimiter for cross-platform compatibility (`:` on Unix, `;` on Windows)
-    const needsTexInputs = texInputParts.length > 1 || process.env.TEXINPUTS;
-    const texInputs = needsTexInputs
-      ? buildKpathseaSearchPath(texInputParts, process.env.TEXINPUTS)
-      : undefined;
     const bibSearchParts = workspacePath ? [workspacePath] : [];
-    const bibInputs = buildKpathseaSearchPath(
-      bibSearchParts,
-      process.env.BIBINPUTS,
-    );
-    const bstInputs = buildKpathseaSearchPath(
-      bibSearchParts,
-      process.env.BSTINPUTS,
-    );
-    const env: Record<string, string> = {
-      ...(texInputs && { TEXINPUTS: texInputs }),
-      ...(bibInputs && { BIBINPUTS: bibInputs }),
-      ...(bstInputs && { BSTINPUTS: bstInputs }),
-    };
+
+    // Build kpathsea search-path overrides, prepending workspace/TikZ dirs onto
+    // any inherited values. `path.delimiter` keeps it cross-platform.
+    const env = buildLatexInputEnv(texInputParts, bibSearchParts);
+    const { TEXINPUTS: texInputs, BIBINPUTS: bibInputs, BSTINPUTS: bstInputs } =
+      env;
     if (texInputs) {
       logger.debug(channel, `Setting TEXINPUTS to: ${texInputs}`);
     }

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -110,8 +110,11 @@ export async function compileLatex2Pdf(
     // Build kpathsea search-path overrides, prepending workspace/TikZ dirs onto
     // any inherited values. `path.delimiter` keeps it cross-platform.
     const env = buildLatexInputEnv(texInputParts, bibSearchParts);
-    const { TEXINPUTS: texInputs, BIBINPUTS: bibInputs, BSTINPUTS: bstInputs } =
-      env;
+    const {
+      TEXINPUTS: texInputs,
+      BIBINPUTS: bibInputs,
+      BSTINPUTS: bstInputs,
+    } = env;
     if (texInputs) {
       logger.debug(channel, `Setting TEXINPUTS to: ${texInputs}`);
     }

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -28,6 +28,19 @@ export function apiKeyEnvName(provider: ApiProvider): string {
   return `${provider.toUpperCase()}_API_KEY`;
 }
 
+/**
+ * Read a provider's API key from the process environment. Isolating the lone
+ * `process.env` touch in this VS Code-free module behind a named, injectable
+ * seam keeps the env-fallback source explicit and testable without mutating
+ * global state (mirrors the `env` injection pattern in `claudeAgentConfig.ts`).
+ */
+export function apiKeyFromEnv(
+  provider: ApiProvider,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return env[apiKeyEnvName(provider)];
+}
+
 /** Where a resolved API key came from. */
 export type ApiKeyOrigin = 'secret' | 'env' | 'none';
 
@@ -74,7 +87,7 @@ async function resolveApiKey(
   const request = (async (): Promise<ResolvedApiKey> => {
     const stored = await secrets.get(apiKeySecretName(provider));
     if (stored) return { value: stored, origin: 'secret' };
-    const envValue = process.env[apiKeyEnvName(provider)];
+    const envValue = apiKeyFromEnv(provider);
     if (envValue) return { value: envValue, origin: 'env' };
     return { value: undefined, origin: 'none' };
   })();

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -28,19 +28,6 @@ export function apiKeyEnvName(provider: ApiProvider): string {
   return `${provider.toUpperCase()}_API_KEY`;
 }
 
-/**
- * Read a provider's API key from the process environment. Isolating the lone
- * `process.env` touch in this VS Code-free module behind a named, injectable
- * seam keeps the env-fallback source explicit and testable without mutating
- * global state (mirrors the `env` injection pattern in `claudeAgentConfig.ts`).
- */
-export function apiKeyFromEnv(
-  provider: ApiProvider,
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  return env[apiKeyEnvName(provider)];
-}
-
 /** Where a resolved API key came from. */
 export type ApiKeyOrigin = 'secret' | 'env' | 'none';
 
@@ -87,7 +74,7 @@ async function resolveApiKey(
   const request = (async (): Promise<ResolvedApiKey> => {
     const stored = await secrets.get(apiKeySecretName(provider));
     if (stored) return { value: stored, origin: 'secret' };
-    const envValue = apiKeyFromEnv(provider);
+    const envValue = process.env[apiKeyEnvName(provider)];
     if (envValue) return { value: envValue, origin: 'env' };
     return { value: undefined, origin: 'none' };
   })();

--- a/src/test-kernel/latex/TexInputEnv.vitest.ts
+++ b/src/test-kernel/latex/TexInputEnv.vitest.ts
@@ -18,11 +18,11 @@ describe('buildLatexInputEnv', () => {
   });
 
   it('prepends workspace and TikZ dirs onto inherited TEXINPUTS', () => {
-    const env = buildLatexInputEnv(
-      ['.', '/ws', '/tikz'],
-      ['/ws'],
-      { TEXINPUTS: '/inherited', BIBINPUTS: '/bib', BSTINPUTS: '/bst' },
-    );
+    const env = buildLatexInputEnv(['.', '/ws', '/tikz'], ['/ws'], {
+      TEXINPUTS: '/inherited',
+      BIBINPUTS: '/bib',
+      BSTINPUTS: '/bst',
+    });
     expect(env.TEXINPUTS).toBe(`.${D}/ws${D}/tikz${D}/inherited${D}`);
     expect(env.BIBINPUTS).toBe(`/ws${D}/bib${D}`);
     expect(env.BSTINPUTS).toBe(`/ws${D}/bst${D}`);

--- a/src/test-kernel/latex/TexInputEnv.vitest.ts
+++ b/src/test-kernel/latex/TexInputEnv.vitest.ts
@@ -1,0 +1,41 @@
+// Standard library imports
+import * as path from 'node:path';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - latex
+import { buildLatexInputEnv } from '@latex/texTools';
+
+const D = path.delimiter;
+
+describe('buildLatexInputEnv', () => {
+  it('omits TEXINPUTS when only the implicit "." part is present and none inherited', () => {
+    const env = buildLatexInputEnv(['.'], [], {});
+    expect(env.TEXINPUTS).toBeUndefined();
+    expect(env.BIBINPUTS).toBeUndefined();
+    expect(env.BSTINPUTS).toBeUndefined();
+  });
+
+  it('prepends workspace and TikZ dirs onto inherited TEXINPUTS', () => {
+    const env = buildLatexInputEnv(
+      ['.', '/ws', '/tikz'],
+      ['/ws'],
+      { TEXINPUTS: '/inherited', BIBINPUTS: '/bib', BSTINPUTS: '/bst' },
+    );
+    expect(env.TEXINPUTS).toBe(`.${D}/ws${D}/tikz${D}/inherited${D}`);
+    expect(env.BIBINPUTS).toBe(`/ws${D}/bib${D}`);
+    expect(env.BSTINPUTS).toBe(`/ws${D}/bst${D}`);
+  });
+
+  it('emits TEXINPUTS from inherited value alone even without extra parts', () => {
+    const env = buildLatexInputEnv(['.'], [], { TEXINPUTS: '/inherited' });
+    expect(env.TEXINPUTS).toBe(`.${D}/inherited${D}`);
+  });
+
+  it('does not read the ambient process environment when env is injected', () => {
+    const env = buildLatexInputEnv(['.', '/ws'], ['/ws'], {});
+    expect(env.TEXINPUTS).toBe(`.${D}/ws${D}`);
+    expect(env.BIBINPUTS).toBe(`/ws${D}`);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts a `process.env` read behind an injectable, testable seam in a VS Code-free zone (`src/latex/`), addressing an "infrastructure concern mixed into domain logic" finding from an abstraction-layer audit.

## Changes

**`src/latex/texTools.ts`** — Extracted the `TEXINPUTS`/`BIBINPUTS`/`BSTINPUTS` construction out of the ~130-line `compileLatex2Pdf` into a pure, injectable `buildLatexInputEnv(texInputParts, bibSearchParts, env = process.env)`.
- The subprocess still inherits the rest of `process.env` via `executeCommand`'s `commandEnv`; these keys only override the three kpathsea search paths that need workspace/TikZ prepending.
- The construction is now unit-testable without spawning `latexmk`.

```diff
- const needsTexInputs = texInputParts.length > 1 || process.env.TEXINPUTS;
- const texInputs = needsTexInputs
-   ? buildKpathseaSearchPath(texInputParts, process.env.TEXINPUTS)
-   : undefined;
- const bibInputs = buildKpathseaSearchPath(bibSearchParts, process.env.BIBINPUTS);
- const bstInputs = buildKpathseaSearchPath(bibSearchParts, process.env.BSTINPUTS);
- const env = { ...(texInputs && { TEXINPUTS: texInputs }), ... };
+ const env = buildLatexInputEnv(texInputParts, bibSearchParts);
+ const { TEXINPUTS: texInputs, BIBINPUTS: bibInputs, BSTINPUTS: bstInputs } = env;
```

**`src/test-kernel/latex/TexInputEnv.vitest.ts`** — New unit test covering prepend ordering, inherited-only emission, omission when empty, and env-injection isolation.

## Behavior

No behavioral change — the same env values are produced and passed to the same exec path; `!!env.TEXINPUTS` is equivalent to the prior truthy `process.env.TEXINPUTS` check, and the spread-only-if-truthy return shape is unchanged.

## Verification

- `npm run typecheck` — exit 0
- `vitest run` on `TexInputEnv`, `ApiProviders`, and `LatexProcessingHelpers` — pass
- `eslint` on changed files — clean

## History note

An earlier revision of this PR also added an `apiKeyFromEnv` seam in `src/model/apiProviders.ts`. Review feedback correctly identified it as a single-use pass-through whose injectability was never realized (per `CLAUDE.md`'s "Discouraged Factory Patterns" / "Flattening Abstraction Layers"), so it was inlined back. That file is no longer part of the diff — the final changeset is just the `texTools.ts` extraction and its test.

## Deliberately out of scope

Two further `process.env` findings from the audit were left as-is, with rationale:
- **`src/agent/runtime/ModelFactory.ts`** — the `TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_*` reads are intentional CLI package-validation infrastructure (extensively commented and gated on `CI=1`), not domain coupling.
- **`src/tools/claudeAgentConfig.ts`** — the macOS Keychain / credential detection is genuinely host-specific and already injectable via parameters; relocating it to a dedicated `platform()` credentials port is a larger change worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8xpKRo6yE5SdLBgn5MUQU