### PR TITLE
refactor(ui): consolidate warning-banner frame and name CLI clear-line escape

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -21,6 +21,10 @@ import type { CliContext } from './cliContext';
 
 type ProgressEvent = keyof ProgressEventPayloads;
 
+// Carriage return + erase-line (CSI 2K): rewind to column 0 and clear the row
+// so the single live status line can be repainted in place.
+const CLEAR_LINE = '\r\x1b[2K';
+
 interface RenderState {
   round?: number;
   plannedRounds?: number;
@@ -168,7 +172,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   clear(): void {
     this.stopHeartbeat();
     if (this.ansi && this.liveLine) {
-      this.write('\r\x1b[2K');
+      this.write(CLEAR_LINE);
       this.liveLine = false;
     }
   }
@@ -249,7 +253,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     if (!line || line === this.lastLine) return;
 
     if (this.ansi) {
-      this.write(`\r\x1b[2K${line}`);
+      this.write(`${CLEAR_LINE}${line}`);
       this.liveLine = true;
     } else {
       this.write(`${line}\n`);

--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -1,6 +1,4 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
-import '@awesome.me/webawesome/dist/components/callout/callout.js';
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import {
   LitElement,
   html,
@@ -13,6 +11,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import type { AgentConfigBannerState } from '@shared/schemas';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
+import { renderWarningBanner } from './bannerFrame';
 import { MainViewEvents } from '../events';
 
 @customElement('agent-config-banner')
@@ -39,51 +38,43 @@ export class AgentConfigBanner extends LitElement {
   }
 
   override render(): TemplateResult {
-    return html`
-      <div class="banner-frame">
-        <wa-callout
-          id="agentConfigBanner"
-          variant="warning"
-          data-custom-dir-set=${this.state.customDirSet ? 'true' : 'false'}
-        >
-          ${waIcon('triangle-exclamation', { slot: 'icon' })}
-          <div class="banner-row">
-            <span>
-              ${this.state.agentName
-                ? `Agent file for "${this.state.agentName}" is missing.`
-                : 'Agent configuration is missing.'}
-            </span>
-            <div class="actions">
-              <wa-button
-                id="agentConfigEditButton"
-                appearance="plain"
-                size="small"
-                @click=${() => this.handleAction('edit')}
-              >
-                ${waIcon('pencil', { slot: 'start' })} Edit Agents
-              </wa-button>
-              <wa-button
-                id="agentConfigDirButton"
-                appearance="plain"
-                size="small"
-                @click=${() => this.handleAction('dir')}
-              >
-                ${waIcon('folder', { slot: 'start' })}
-                ${this.state.customDirSet ? 'Open Directory' : 'Set Directory'}
-              </wa-button>
-              <wa-button
-                id="agentConfigDocButton"
-                appearance="plain"
-                size="small"
-                @click=${() => this.handleAction('docs')}
-              >
-                ${waIcon('book', { slot: 'start' })} Docs
-              </wa-button>
-            </div>
-          </div>
-        </wa-callout>
-      </div>
-    `;
+    return renderWarningBanner({
+      id: 'agentConfigBanner',
+      body: html`
+        <span>
+          ${this.state.agentName
+            ? `Agent file for "${this.state.agentName}" is missing.`
+            : 'Agent configuration is missing.'}
+        </span>
+        <div class="actions">
+          <wa-button
+            id="agentConfigEditButton"
+            appearance="plain"
+            size="small"
+            @click=${() => this.handleAction('edit')}
+          >
+            ${waIcon('pencil', { slot: 'start' })} Edit Agents
+          </wa-button>
+          <wa-button
+            id="agentConfigDirButton"
+            appearance="plain"
+            size="small"
+            @click=${() => this.handleAction('dir')}
+          >
+            ${waIcon('folder', { slot: 'start' })}
+            ${this.state.customDirSet ? 'Open Directory' : 'Set Directory'}
+          </wa-button>
+          <wa-button
+            id="agentConfigDocButton"
+            appearance="plain"
+            size="small"
+            @click=${() => this.handleAction('docs')}
+          >
+            ${waIcon('book', { slot: 'start' })} Docs
+          </wa-button>
+        </div>
+      `,
+    });
   }
 }
 

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -1,6 +1,4 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
-import '@awesome.me/webawesome/dist/components/callout/callout.js';
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import {
   LitElement,
   html,
@@ -14,6 +12,7 @@ import type { ApiKeyBannerState } from '@shared/schemas';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { capitalize } from '@utils/text/stringUtils';
 import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
+import { renderWarningBanner } from './bannerFrame';
 import { MainViewEvents } from '../events';
 
 @customElement('api-key-banner')
@@ -39,45 +38,41 @@ export class ApiKeyBanner extends LitElement {
     const provider = this.state.provider ?? '';
     const providerLabel = provider ? capitalize(provider) : '';
 
-    return html`
-      <div class="banner-frame">
-        <wa-callout id="apiKeyBanner" variant="warning">
-          ${waIcon('triangle-exclamation', { slot: 'icon' })}
-          <div class="banner-row">
-            <span>
-              ${provider
-                ? html`<strong>${providerLabel}</strong> API key missing.`
-                : 'TeXRA requires an API key to run.'}
-            </span>
-            <div class="actions">
-              <wa-button
-                id="apiKeyBannerButton"
-                appearance="plain"
-                size="small"
-                @click=${() => this.handleAction('set')}
-              >
-                ${waIcon('key', { slot: 'start' })}
-                ${provider ? 'Set Key' : 'Set API Key'}
-              </wa-button>
-              <wa-button
-                id="apiKeyGuideButton"
-                appearance="plain"
-                size="small"
-                @click=${() => this.handleAction('guide')}
-              >
-                ${waIcon('book', { slot: 'start' })}
-                ${provider ? 'Get Key' : 'API Key Guide'}
-              </wa-button>
-            </div>
-            <span class="hint">
-              Chat subscriptions (ChatGPT Plus, Claude Pro, etc.) do not include
-              API access. You need a separate API key from the provider's
-              developer platform.
-            </span>
-          </div>
-        </wa-callout>
-      </div>
-    `;
+    return renderWarningBanner({
+      id: 'apiKeyBanner',
+      body: html`
+        <span>
+          ${provider
+            ? html`<strong>${providerLabel}</strong> API key missing.`
+            : 'TeXRA requires an API key to run.'}
+        </span>
+        <div class="actions">
+          <wa-button
+            id="apiKeyBannerButton"
+            appearance="plain"
+            size="small"
+            @click=${() => this.handleAction('set')}
+          >
+            ${waIcon('key', { slot: 'start' })}
+            ${provider ? 'Set Key' : 'Set API Key'}
+          </wa-button>
+          <wa-button
+            id="apiKeyGuideButton"
+            appearance="plain"
+            size="small"
+            @click=${() => this.handleAction('guide')}
+          >
+            ${waIcon('book', { slot: 'start' })}
+            ${provider ? 'Get Key' : 'API Key Guide'}
+          </wa-button>
+        </div>
+        <span class="hint">
+          Chat subscriptions (ChatGPT Plus, Claude Pro, etc.) do not include API
+          access. You need a separate API key from the provider's developer
+          platform.
+        </span>
+      `,
+    });
   }
 }
 

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -98,8 +98,7 @@ export class DependencyBanner extends LitElement {
                       size="small"
                       @click=${() => this.handleInstall(tool)}
                     >
-                      ${waIcon('cloud-arrow-down', { slot: 'start' })}
-                      Install
+                      ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
                     </wa-button>
                   </div>
                 `,

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -1,6 +1,4 @@
 import '@awesome.me/webawesome/dist/components/button/button.js';
-import '@awesome.me/webawesome/dist/components/callout/callout.js';
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import {
   LitElement,
   html,
@@ -16,6 +14,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import type { DependencyBannerState } from '@shared/schemas';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
+import { renderWarningBanner } from './bannerFrame';
 import { MainViewEvents } from '../events';
 
 @customElement('dependency-banner')
@@ -79,59 +78,55 @@ export class DependencyBanner extends LitElement {
       tool === 'gm/magick' ? ['gm', 'magick'] : [tool],
     );
 
-    return html`
-      <div class="banner-frame">
-        <wa-callout id="dependencyBanner" variant="warning">
-          ${waIcon('triangle-exclamation', { slot: 'icon' })}
-          <div class="banner-row">
-            <div class="missing-tools">
-              ${when(
-                tools.length === 0,
-                () => html`Missing dependencies: none`,
-                () =>
-                  repeat(
-                    tools,
-                    (tool) => tool,
-                    (tool) => html`
-                      <div class="dependency-item">
-                        <span>${this.getToolLabel(tool)}</span>
-                        <wa-button
-                          class="dependency-install-button"
-                          appearance="plain"
-                          size="small"
-                          @click=${() => this.handleInstall(tool)}
-                        >
-                          ${waIcon('cloud-arrow-down', { slot: 'start' })}
-                          Install
-                        </wa-button>
-                      </div>
-                    `,
-                  ),
-              )}
-            </div>
-            <div class="actions">
-              <wa-button
-                id="dependencyRecheckButton"
-                appearance="plain"
-                size="small"
-                @click=${this.handleRecheck}
-              >
-                ${waIcon('rotate-right', { slot: 'start' })} Re-check
-              </wa-button>
-              <wa-button
-                id="dependencyDismissButton"
-                appearance="plain"
-                size="small"
-                title="Dismiss (can be re-enabled in settings)"
-                @click=${this.handleDismiss}
-              >
-                ${waIcon('xmark', { slot: 'start' })} Dismiss
-              </wa-button>
-            </div>
-          </div>
-        </wa-callout>
-      </div>
-    `;
+    return renderWarningBanner({
+      id: 'dependencyBanner',
+      body: html`
+        <div class="missing-tools">
+          ${when(
+            tools.length === 0,
+            () => html`Missing dependencies: none`,
+            () =>
+              repeat(
+                tools,
+                (tool) => tool,
+                (tool) => html`
+                  <div class="dependency-item">
+                    <span>${this.getToolLabel(tool)}</span>
+                    <wa-button
+                      class="dependency-install-button"
+                      appearance="plain"
+                      size="small"
+                      @click=${() => this.handleInstall(tool)}
+                    >
+                      ${waIcon('cloud-arrow-down', { slot: 'start' })}
+                      Install
+                    </wa-button>
+                  </div>
+                `,
+              ),
+          )}
+        </div>
+        <div class="actions">
+          <wa-button
+            id="dependencyRecheckButton"
+            appearance="plain"
+            size="small"
+            @click=${this.handleRecheck}
+          >
+            ${waIcon('rotate-right', { slot: 'start' })} Re-check
+          </wa-button>
+          <wa-button
+            id="dependencyDismissButton"
+            appearance="plain"
+            size="small"
+            title="Dismiss (can be re-enabled in settings)"
+            @click=${this.handleDismiss}
+          >
+            ${waIcon('xmark', { slot: 'start' })} Dismiss
+          </wa-button>
+        </div>
+      `,
+    });
   }
 }
 

--- a/packages/extension/src/webview/frontend/components/bannerFrame.ts
+++ b/packages/extension/src/webview/frontend/components/bannerFrame.ts
@@ -1,0 +1,30 @@
+// Side-effect imports — register the WA elements the frame renders.
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import { html, type TemplateResult } from 'lit';
+
+import { waIcon } from '@shared/wa/webAwesomeIcons';
+
+/**
+ * Shared chrome for the inline warning banners (agent-config, api-key,
+ * dependency): the `.banner-frame` wrapper, a `warning` `wa-callout`, the
+ * triangle-exclamation icon, and the `.banner-row` body container. Layout and
+ * spacing live in `bannerStyles`.
+ *
+ * Keeping the frame in one place makes it the single source of truth for what a
+ * warning banner looks like — a change to the chrome (icon, variant, row
+ * structure) lands here instead of in three near-identical component templates.
+ */
+export function renderWarningBanner(options: {
+  readonly id: string;
+  readonly body: TemplateResult;
+}): TemplateResult {
+  return html`
+    <div class="banner-frame">
+      <wa-callout id=${options.id} variant="warning">
+        ${waIcon('triangle-exclamation', { slot: 'icon' })}
+        <div class="banner-row">${options.body}</div>
+      </wa-callout>
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary

A UI-standardization audit of the webviews and CLI/Ink TUI. After deeper investigation, **most of the initial audit findings did not hold up** — the codebase is already well-standardized (see "Audit findings that were *not* acted on" below). This PR implements the two genuinely-defensible refactors that survived scrutiny.

### 1. Shared warning-banner frame (webview)

The three inline **warning** banners each re-implemented an identical frame:

```
<div class="banner-frame">
  <wa-callout variant="warning">
    {triangle-exclamation icon, slot=icon}
    <div class="banner-row"> …body… </div>
  </wa-callout>
</div>
```

Extracted into a single `renderWarningBanner({ id, body })` helper (`components/bannerFrame.ts`), now used by:

- `AgentConfigBanner.ts`
- `ApiKeyBanner.ts`
- `DependencyBanner.ts`

The warning-banner chrome now has one source of truth — a future change to the icon, variant, or row structure lands in one place instead of three near-identical templates. The two **brand** banners (`LoginBanner`, `GettingStartedBanner`) use a different variant/icon/row structure and are deliberately left out of scope.

**Dead-code removal:** dropped `AgentConfigBanner`'s `data-custom-dir-set` callout attribute — it was set on the DOM but never read by any CSS selector, DOM query, or test. The `customDirSet` flag itself is untouched (still drives the button label and is threaded through state); only the unused DOM hook is gone.

### 2. Named CLI clear-line escape

`runProgressRenderer.ts` repeated the magic escape `'\r\x1b[2K'` (carriage-return + erase-line) in two places. Replaced with a documented `CLEAR_LINE` constant, matching the named-constant convention already used in the sibling `terminalCleanup.ts`.

## Why these two, and not the rest

The audit surfaced ~20 candidate findings. Most were **false positives** once the underlying modules were read:

- **"Inconsistent icon naming / texra vs Font Awesome" (icons):** `src/shared/wa/webAwesomeIcons.ts` is already a centralized Font Awesome registry — `library="texra"` *is* Font Awesome (FA icons registered under that library name), with canonical names plus codicon aliases all resolving through one source. The three status-icon maps (`todoDisplay`, `LatexdiffResults`, `webFormatters`) hold different domain enums (TodoStatus / DiffStatus / web-search status) and all resolve through that single registry — not real duplication, and merging them would risk changing rendered icons.
- **"Scattered ANSI codes in terminalCleanup":** already uses well-named, heavily-documented constants.
- **"Duplicated truncation/wrapping logic":** already consolidated in `render/terminalText.ts` (`truncateToWidth`, `truncateSummaryToWidth`, `textDisplayWidth`), imported across the TUI.
- **"Wrap a `<LoadingSpinner>` around `@inkjs/ui` Spinner":** would be exactly the trivial identity factory `CLAUDE.md` discourages.
- **"`::part()` overuse in webview styles":** that's the sanctioned WebAwesome shadow-DOM theming approach, not an anti-pattern.

## Verification

- `npm run typecheck` — passes
- `npx eslint` on all changed files — clean
- `npm test` — 3403 passed; the single failure (`execUtils.vitest.ts` process-group abort) is an environment-sensitive pre-existing flake, unrelated to this diff (no process/exec code touched)
- No rendered-output change for any banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVdQEQNW7iWXXPiaXQDfQF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVdQEQNW7iWXXPiaXQDfQF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only UI/terminal formatting with no auth, data, or API changes; banner output and CLI behavior are intended to be unchanged aside from removing dead markup.
> 
> **Overview**
> Introduces **`renderWarningBanner({ id, body })`** in `bannerFrame.ts` so agent-config, API-key, and dependency banners share one warning callout frame (wrapper, icon, row) instead of three copy-pasted templates; per-banner content and actions stay in each component. **`AgentConfigBanner`** no longer sets unused **`data-custom-dir-set`** on the callout (behavior for **`customDirSet`** is unchanged).
> 
> In the CLI run progress renderer, the repeated **`'\r\x1b[2K'`** erase-line sequence is replaced with a documented **`CLEAR_LINE`** constant used when clearing and repainting the live status line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed30d584e2385a2417fa70b2eabdcd43bae0e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->