### PR TITLE
refactor(tools/schemas): consolidate duplicated agent config keys, defaults, and value lists

### DIFF
--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+/**
+ * Agent CLI setting value schemas shared by settings IPC and tool runtimes.
+ *
+ * Keep this module dependency-free: tool modules import it while defining their
+ * own runtime schemas, so it must not pull in settings-view or tool code.
+ */
+
+/** Valid Codex sandbox modes. */
+export const CodexSandboxModeSchema = z.enum([
+  'read-only',
+  'workspace-write',
+  'danger-full-access',
+]);
+export type CodexSandboxMode = z.infer<typeof CodexSandboxModeSchema>;
+
+/** Valid Codex reasoning effort levels. */
+export const CodexReasoningEffortSchema = z.enum([
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+]);
+export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>;
+
+/** Valid Codex approval policies. */
+export const CodexApprovalPolicySchema = z.enum([
+  'never',
+  'on-request',
+  'on-failure',
+  'untrusted',
+]);
+export type CodexApprovalPolicy = z.infer<typeof CodexApprovalPolicySchema>;
+
+/** Claude Code CLI model options surfaced in the picker. */
+export const ClaudeAgentModelSchema = z.enum([
+  'claude-sonnet-4-6',
+  'claude-fable-5',
+  'claude-opus-4-8',
+  'claude-haiku-4-5-20251001',
+]);
+export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
+
+/** Claude Code CLI permission modes exposed in settings. */
+export const ClaudeAgentPermissionModeSchema = z.enum([
+  'default',
+  'acceptEdits',
+  'bypassPermissions',
+  'plan',
+]);
+export type ClaudeAgentPermissionMode = z.infer<
+  typeof ClaudeAgentPermissionModeSchema
+>;
+
+/**
+ * Claude Code CLI effort levels. `claudeAgentShared.ts` guards this against the
+ * SDK's `EffortLevel` union at compile time.
+ */
+export const ClaudeAgentEffortSchema = z.enum([
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+]);
+export type ClaudeAgentEffort = z.infer<typeof ClaudeAgentEffortSchema>;

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -1,6 +1,7 @@
 // Layer 1: Base types (no dependencies on other schema files)
 export * from './identifiers';
 export * from './agent';
+export * from './agentCliSettings';
 export * from './fileFields';
 export * from './proposalFields';
 export * from './toolConfig';

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -281,7 +281,14 @@ export type UpdateToolDashboardMessage = z.infer<
 // Approval settings data schema
 // ============================================================
 
-/** Valid Codex sandbox modes (mirrors CODEX_SANDBOX_MODES in codexConfig.ts). */
+/**
+ * Single source of truth for the Codex/Claude agent value lists. These schemas
+ * are vscode/SDK-runtime-free, so the SDK-aware `@tools` config modules derive
+ * their runtime const arrays from `.options` (and guard SDK alignment with
+ * `satisfies`) instead of repeating the literals.
+ */
+
+/** Valid Codex sandbox modes. */
 export const CodexSandboxModeSchema = z.enum([
   'read-only',
   'workspace-write',
@@ -289,7 +296,7 @@ export const CodexSandboxModeSchema = z.enum([
 ]);
 export type CodexSandboxMode = z.infer<typeof CodexSandboxModeSchema>;
 
-/** Valid Codex reasoning effort levels (mirrors CODEX_REASONING_EFFORTS in codexConfig.ts). */
+/** Valid Codex reasoning effort levels. */
 export const CodexReasoningEffortSchema = z.enum([
   'low',
   'medium',
@@ -298,7 +305,7 @@ export const CodexReasoningEffortSchema = z.enum([
 ]);
 export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>;
 
-/** Valid Codex approval policies (mirrors CODEX_APPROVAL_POLICIES in codexConfig.ts). */
+/** Valid Codex approval policies. */
 export const CodexApprovalPolicySchema = z.enum([
   'never',
   'on-request',
@@ -317,7 +324,8 @@ export const ClaudeAgentModelSchema = z.enum([
 ]);
 export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
 
-/** Claude Code CLI permission modes (mirrors CLAUDE_AGENT_PERMISSION_MODES). */
+/** Claude Code CLI permission modes (subset of the SDK's PermissionMode;
+ * 'dontAsk' and 'auto' are internal only). */
 export const ClaudeAgentPermissionModeSchema = z.enum([
   'default',
   'acceptEdits',
@@ -328,7 +336,8 @@ export type ClaudeAgentPermissionMode = z.infer<
   typeof ClaudeAgentPermissionModeSchema
 >;
 
-/** Claude Code CLI effort levels — mirrors the SDK's EffortLevel. */
+/** Claude Code CLI effort levels — kept aligned with the SDK's EffortLevel via
+ * a compile-time guard in claudeAgentShared.ts. */
 export const ClaudeAgentEffortSchema = z.enum([
   'low',
   'medium',

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -42,6 +42,30 @@ import {
   HistoryClearedMessageSchema,
   UpdateHistoryMessageSchema,
 } from '../historyViewMessages';
+import {
+  ClaudeAgentEffortSchema,
+  ClaudeAgentModelSchema,
+  ClaudeAgentPermissionModeSchema,
+  CodexApprovalPolicySchema,
+  CodexReasoningEffortSchema,
+  CodexSandboxModeSchema,
+} from '../agentCliSettings';
+export {
+  ClaudeAgentEffortSchema,
+  ClaudeAgentModelSchema,
+  ClaudeAgentPermissionModeSchema,
+  CodexApprovalPolicySchema,
+  CodexReasoningEffortSchema,
+  CodexSandboxModeSchema,
+} from '../agentCliSettings';
+export type {
+  ClaudeAgentEffort,
+  ClaudeAgentModel,
+  ClaudeAgentPermissionMode,
+  CodexApprovalPolicy,
+  CodexReasoningEffort,
+  CodexSandboxMode,
+} from '../agentCliSettings';
 
 /** Tab name order - single source of truth for tab indices */
 export const SETTINGS_TAB_ORDER = [
@@ -280,72 +304,6 @@ export type UpdateToolDashboardMessage = z.infer<
 // ============================================================
 // Approval settings data schema
 // ============================================================
-
-/**
- * Single source of truth for the Codex/Claude agent value lists. These schemas
- * are vscode/SDK-runtime-free, so the SDK-aware `@tools` config modules derive
- * their runtime const arrays from `.options` (and guard SDK alignment with
- * `satisfies`) instead of repeating the literals.
- */
-
-/** Valid Codex sandbox modes. */
-export const CodexSandboxModeSchema = z.enum([
-  'read-only',
-  'workspace-write',
-  'danger-full-access',
-]);
-export type CodexSandboxMode = z.infer<typeof CodexSandboxModeSchema>;
-
-/** Valid Codex reasoning effort levels. */
-export const CodexReasoningEffortSchema = z.enum([
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-]);
-export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>;
-
-/** Valid Codex approval policies. */
-export const CodexApprovalPolicySchema = z.enum([
-  'never',
-  'on-request',
-  'on-failure',
-  'untrusted',
-]);
-export type CodexApprovalPolicy = z.infer<typeof CodexApprovalPolicySchema>;
-
-/** Claude Code CLI model options surfaced in the picker. The SDK accepts any
- * string, but the dropdown is fixed to the canonical Anthropic families. */
-export const ClaudeAgentModelSchema = z.enum([
-  'claude-sonnet-4-6',
-  'claude-fable-5',
-  'claude-opus-4-8',
-  'claude-haiku-4-5-20251001',
-]);
-export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
-
-/** Claude Code CLI permission modes (subset of the SDK's PermissionMode;
- * 'dontAsk' and 'auto' are internal only). */
-export const ClaudeAgentPermissionModeSchema = z.enum([
-  'default',
-  'acceptEdits',
-  'bypassPermissions',
-  'plan',
-]);
-export type ClaudeAgentPermissionMode = z.infer<
-  typeof ClaudeAgentPermissionModeSchema
->;
-
-/** Claude Code CLI effort levels — kept aligned with the SDK's EffortLevel via
- * a compile-time guard in claudeAgentShared.ts. */
-export const ClaudeAgentEffortSchema = z.enum([
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-  'max',
-]);
-export type ClaudeAgentEffort = z.infer<typeof ClaudeAgentEffortSchema>;
 
 /** Outbound: backend → frontend approval settings */
 export const UpdateApprovalSettingsMessageSchema = z.object({

--- a/src/shared/schemas/settingsView/inbound.ts
+++ b/src/shared/schemas/settingsView/inbound.ts
@@ -52,8 +52,8 @@ import {
   CodexApprovalPolicySchema,
   CodexReasoningEffortSchema,
   CodexSandboxModeSchema,
-  ReasoningLevelSchema,
-} from './data';
+} from '../agentCliSettings';
+import { ReasoningLevelSchema } from './data';
 
 const CMD = SETTINGS_VIEW_CMD;
 

--- a/src/shared/settingsView/handlers/approvalHandlers.ts
+++ b/src/shared/settingsView/handlers/approvalHandlers.ts
@@ -13,9 +13,14 @@ import {
   parseCodexApprovalPolicy,
   parseCodexReasoningEffort,
   parseCodexSandboxMode,
+  CODEX_APPROVAL_POLICY_DEFAULT,
+  CODEX_REASONING_EFFORT_DEFAULT,
+  CODEX_SANDBOX_MODE_DEFAULT,
 } from '@tools/codexConfig';
 import {
   CLAUDE_AGENT_DEFAULT_MODEL,
+  CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
+  CLAUDE_AGENT_DEFAULT_EFFORT,
   parseClaudeAgentEffort,
   parseClaudeAgentModel,
   parseClaudeAgentPermissionMode,
@@ -39,19 +44,19 @@ export function buildApprovalSettingsMessage(
     codexSandboxMode: parseCodexSandboxMode(
       workspaceState.get<string>(
         WorkspaceStateKey.CODEX_SANDBOX_MODE,
-        'workspace-write',
+        CODEX_SANDBOX_MODE_DEFAULT,
       ),
     ),
     codexReasoningEffort: parseCodexReasoningEffort(
       workspaceState.get<string>(
         WorkspaceStateKey.CODEX_REASONING_EFFORT,
-        'high',
+        CODEX_REASONING_EFFORT_DEFAULT,
       ),
     ),
     codexApprovalPolicy: parseCodexApprovalPolicy(
       workspaceState.get<string>(
         WorkspaceStateKey.CODEX_APPROVAL_POLICY,
-        'never',
+        CODEX_APPROVAL_POLICY_DEFAULT,
       ),
     ),
     claudeAgentModel: parseClaudeAgentModel(
@@ -63,11 +68,14 @@ export function buildApprovalSettingsMessage(
     claudeAgentPermissionMode: parseClaudeAgentPermissionMode(
       workspaceState.get<string>(
         WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
-        'acceptEdits',
+        CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
       ),
     ),
     claudeAgentEffort: parseClaudeAgentEffort(
-      workspaceState.get<string>(WorkspaceStateKey.CLAUDE_AGENT_EFFORT, 'high'),
+      workspaceState.get<string>(
+        WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
+        CLAUDE_AGENT_DEFAULT_EFFORT,
+      ),
     ),
   };
 }

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -63,19 +63,19 @@ export const getClaudeAgentModel: () => ClaudeAgentModel =
 // Permission mode
 // ============================================================================
 
-const PERMISSION_MODE_DEFAULT: ClaudeAgentPermissionMode = 'acceptEdits';
+export const CLAUDE_AGENT_DEFAULT_PERMISSION_MODE: ClaudeAgentPermissionMode = 'acceptEdits';
 
 export const parseClaudeAgentPermissionMode: (
   raw: string,
 ) => ClaudeAgentPermissionMode = createEnumParser(
   CLAUDE_AGENT_PERMISSION_MODES,
-  PERMISSION_MODE_DEFAULT,
+  CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
 );
 
 export const getClaudeAgentPermissionMode: () => ClaudeAgentPermissionMode =
   createEnumStateGetter(
     WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
-    PERMISSION_MODE_DEFAULT,
+    CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
     parseClaudeAgentPermissionMode,
   );
 
@@ -83,15 +83,15 @@ export const getClaudeAgentPermissionMode: () => ClaudeAgentPermissionMode =
 // Effort — adaptive thinking depth hint passed via `effort` SDK option
 // ============================================================================
 
-const EFFORT_DEFAULT: ClaudeAgentEffort = 'high';
+export const CLAUDE_AGENT_DEFAULT_EFFORT: ClaudeAgentEffort = 'high';
 
 export const parseClaudeAgentEffort: (raw: string) => ClaudeAgentEffort =
-  createEnumParser(CLAUDE_AGENT_EFFORT_LEVELS, EFFORT_DEFAULT);
+  createEnumParser(CLAUDE_AGENT_EFFORT_LEVELS, CLAUDE_AGENT_DEFAULT_EFFORT);
 
 export const getClaudeAgentEffort: () => ClaudeAgentEffort =
   createEnumStateGetter(
     WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
-    EFFORT_DEFAULT,
+    CLAUDE_AGENT_DEFAULT_EFFORT,
     parseClaudeAgentEffort,
   );
 

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -63,7 +63,8 @@ export const getClaudeAgentModel: () => ClaudeAgentModel =
 // Permission mode
 // ============================================================================
 
-export const CLAUDE_AGENT_DEFAULT_PERMISSION_MODE: ClaudeAgentPermissionMode = 'acceptEdits';
+export const CLAUDE_AGENT_DEFAULT_PERMISSION_MODE: ClaudeAgentPermissionMode =
+  'acceptEdits';
 
 export const parseClaudeAgentPermissionMode: (
   raw: string,

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -1,6 +1,11 @@
 // Shared constants and helpers for the Claude Code CLI tool.
 
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
+import {
+  ClaudeAgentEffortSchema,
+  ClaudeAgentModelSchema,
+  ClaudeAgentPermissionModeSchema,
+} from '@shared/schemas/settingsView/data';
 import { truncateSummary } from '@utils/text/stringUtils';
 
 import type { EffortLevel } from '@anthropic-ai/claude-agent-sdk';
@@ -9,10 +14,10 @@ import type { EffortLevel } from '@anthropic-ai/claude-agent-sdk';
 export type ClaudeAgentEffort = EffortLevel;
 
 /**
- * Compile-time guard: our const array and the SDK's `EffortLevel` union must
- * stay synchronized in both directions. If the SDK adds or removes an effort
- * level, this line produces a type error so `CLAUDE_AGENT_EFFORT_LEVELS` and
- * `ClaudeAgentEffortSchema` are reviewed together.
+ * Compile-time guard: the effort-level schema and the SDK's `EffortLevel`
+ * union must stay synchronized in both directions. If the SDK adds or removes
+ * an effort level, this line produces a type error so `ClaudeAgentEffortSchema`
+ * (the source of truth) and the SDK type are reviewed together.
  */
 type _AssertExact<T extends true> = T;
 type _IsExact<A, B> = [A] extends [B]
@@ -31,38 +36,25 @@ export const CLAUDE_AGENT_DISPLAY_MODEL = 'claude';
 /**
  * Permission modes exposed in the settings UI.
  * Subset of the SDK's PermissionMode — 'dontAsk' and 'auto' are internal only.
- * The type is derived from this subset so it stays narrower than the SDK type.
+ * Derived from `ClaudeAgentPermissionModeSchema` (the single source of truth in
+ * `@shared`) so the runtime list and the IPC schema can't drift.
  */
-export const CLAUDE_AGENT_PERMISSION_MODES = [
-  'default',
-  'acceptEdits',
-  'bypassPermissions',
-  'plan',
-] as const;
+export const CLAUDE_AGENT_PERMISSION_MODES =
+  ClaudeAgentPermissionModeSchema.options;
 export type ClaudeAgentPermissionMode =
   (typeof CLAUDE_AGENT_PERMISSION_MODES)[number];
 
 /** Effort levels mirror the SDK's `EffortLevel` (low → max). Claude decides
- * adaptively how much thinking to do, scaled by this hint. */
-export const CLAUDE_AGENT_EFFORT_LEVELS = [
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-  'max',
-] as const;
+ * adaptively how much thinking to do, scaled by this hint. Derived from
+ * `ClaudeAgentEffortSchema` (the single source of truth in `@shared`). */
+export const CLAUDE_AGENT_EFFORT_LEVELS = ClaudeAgentEffortSchema.options;
 
 /** Canonical Claude model IDs surfaced by the settings dropdown.
  * The SDK accepts arbitrary model strings; this list is what we expose in the
- * UI. Keep it in sync with `ClaudeAgentModelSchema` in settingsViewMessages.ts.
- * Sonnet, Fable, and Opus use the alias form; Haiku 4.5 ships with a dated
- * snapshot suffix (its only published identifier at time of writing). */
-export const CLAUDE_AGENT_MODELS = [
-  'claude-sonnet-4-6',
-  'claude-fable-5',
-  'claude-opus-4-8',
-  'claude-haiku-4-5-20251001',
-] as const;
+ * UI. Derived from `ClaudeAgentModelSchema` (the single source of truth in
+ * `@shared`). Sonnet, Fable, and Opus use the alias form; Haiku 4.5 ships with
+ * a dated snapshot suffix (its only published identifier at time of writing). */
+export const CLAUDE_AGENT_MODELS = ClaudeAgentModelSchema.options;
 export type ClaudeAgentModel = (typeof CLAUDE_AGENT_MODELS)[number];
 
 /**

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -5,7 +5,7 @@ import {
   ClaudeAgentEffortSchema,
   ClaudeAgentModelSchema,
   ClaudeAgentPermissionModeSchema,
-} from '@shared/schemas/settingsView/data';
+} from '@shared/schemas/agentCliSettings';
 import { truncateSummary } from '@utils/text/stringUtils';
 
 import type { EffortLevel } from '@anthropic-ai/claude-agent-sdk';

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -42,6 +42,7 @@ import type {
   ToolUseLog,
 } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
+import { CodexSandboxModeSchema } from '@shared/schemas/settingsView/data';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { ToolError, type ToolResult } from '@tools/result';
 import { parseWorkingDirectory } from '@tools/pathResolution';
@@ -76,7 +77,6 @@ import {
 import type {
   McpToolCallItem,
   RunResult,
-  SandboxMode,
   Thread,
   ThreadItem,
   ThreadOptions,
@@ -88,17 +88,11 @@ import type {
 // Codex config
 // ============================================================================
 
-// CODEX_SANDBOX_MODES must be inlined (used at module-level by the schema).
+// The sandbox-mode schema is imported eagerly from `@shared` (a light,
+// dependency-free leaf) since it is used at module level by the input schema.
 // All other config (model, reasoning, buildCodexConfig, sandbox getter) is
-// lazy-imported from codexConfig.ts at runtime to avoid pulling vscode into
-// the module graph — src/tools/ is a VS Code-free zone.
-
-/** All sandbox modes from the SDK, exposed to the LLM. */
-const CODEX_SANDBOX_MODES = [
-  'read-only',
-  'workspace-write',
-  'danger-full-access',
-] as const satisfies readonly SandboxMode[];
+// lazy-imported from codexConfig.ts at runtime to avoid pulling the heavy
+// platform/SDK graph into the tool-registration path.
 
 /** Lazy accessor for codexConfig.ts exports (loaded once, cached). */
 let _configModule: typeof import('./codexConfig') | null = null;
@@ -116,12 +110,9 @@ const CodexInputSchema = z.strictObject({
     .describe(
       'Instruction for the Codex agent. For a new session, describe the task. For a resume (thread_id set), describe the follow-up.',
     ),
-  sandbox_mode: z
-    .enum(CODEX_SANDBOX_MODES)
-    .nullish()
-    .describe(
-      'File access level for the Codex agent (defaults to user-configured mode, typically workspace-write)',
-    ),
+  sandbox_mode: CodexSandboxModeSchema.nullish().describe(
+    'File access level for the Codex agent (defaults to user-configured mode, typically workspace-write)',
+  ),
   thread_id: z
     .string()
     .nullish()

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -42,7 +42,7 @@ import type {
   ToolUseLog,
 } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
-import { CodexSandboxModeSchema } from '@shared/schemas/settingsView/data';
+import { CodexSandboxModeSchema } from '@shared/schemas/agentCliSettings';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { ToolError, type ToolResult } from '@tools/result';
 import { parseWorkingDirectory } from '@tools/pathResolution';

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -4,6 +4,11 @@ import {
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import {
+  CodexApprovalPolicySchema,
+  CodexReasoningEffortSchema,
+  CodexSandboxModeSchema,
+} from '@shared/schemas/settingsView/data';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { createEnumParser, createEnumStateGetter } from './support/enumConfig';
 import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
@@ -26,7 +31,9 @@ export const CODEX_CLI_MODEL = 'gpt-5.5';
 // Reasoning effort
 // ============================================================================
 
-const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const;
+// Derived from `CodexReasoningEffortSchema` (the single source of truth in
+// `@shared`) so the runtime list and the IPC schema can't drift.
+const REASONING_EFFORTS = CodexReasoningEffortSchema.options;
 export const CODEX_REASONING_EFFORTS = REASONING_EFFORTS;
 export type CodexReasoningEffort = (typeof REASONING_EFFORTS)[number];
 
@@ -68,12 +75,9 @@ export function getCodexCliReasoningEffort(): CodexCliReasoningEffort {
 // Approval policy
 // ============================================================================
 
-const APPROVAL_POLICIES = [
-  'never',
-  'on-request',
-  'on-failure',
-  'untrusted',
-] as const;
+// Derived from `CodexApprovalPolicySchema` (the single source of truth in
+// `@shared`); `satisfies` keeps the schema values aligned with the SDK union.
+const APPROVAL_POLICIES = CodexApprovalPolicySchema.options;
 export const CODEX_APPROVAL_POLICIES =
   APPROVAL_POLICIES satisfies readonly ApprovalMode[];
 export type CodexApprovalPolicy = ApprovalMode;
@@ -94,11 +98,9 @@ export const getCodexApprovalPolicy: () => CodexApprovalPolicy =
 // Sandbox mode
 // ============================================================================
 
-const SANDBOX_MODES = [
-  'read-only',
-  'workspace-write',
-  'danger-full-access',
-] as const;
+// Derived from `CodexSandboxModeSchema` (the single source of truth in
+// `@shared`); `satisfies` keeps the schema values aligned with the SDK union.
+const SANDBOX_MODES = CodexSandboxModeSchema.options;
 export const CODEX_SANDBOX_MODES =
   SANDBOX_MODES satisfies readonly SandboxMode[];
 export type CodexSandboxMode = SandboxMode;

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -8,7 +8,7 @@ import {
   CodexApprovalPolicySchema,
   CodexReasoningEffortSchema,
   CodexSandboxModeSchema,
-} from '@shared/schemas/settingsView/data';
+} from '@shared/schemas/agentCliSettings';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { createEnumParser, createEnumStateGetter } from './support/enumConfig';
 import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -4,6 +4,7 @@ import {
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { createEnumParser, createEnumStateGetter } from './support/enumConfig';
 import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
 
@@ -29,17 +30,16 @@ const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const;
 export const CODEX_REASONING_EFFORTS = REASONING_EFFORTS;
 export type CodexReasoningEffort = (typeof REASONING_EFFORTS)[number];
 
-const REASONING_EFFORT_KEY = 'texra.codexReasoningEffort';
-const REASONING_EFFORT_DEFAULT: CodexReasoningEffort = 'high';
+export const CODEX_REASONING_EFFORT_DEFAULT: CodexReasoningEffort = 'high';
 
 export const parseCodexReasoningEffort = createEnumParser(
   REASONING_EFFORTS,
-  REASONING_EFFORT_DEFAULT,
+  CODEX_REASONING_EFFORT_DEFAULT,
 );
 
 export const getCodexReasoningEffort = createEnumStateGetter(
-  REASONING_EFFORT_KEY,
-  REASONING_EFFORT_DEFAULT,
+  WorkspaceStateKey.CODEX_REASONING_EFFORT,
+  CODEX_REASONING_EFFORT_DEFAULT,
   parseCodexReasoningEffort,
 );
 
@@ -78,16 +78,15 @@ export const CODEX_APPROVAL_POLICIES =
   APPROVAL_POLICIES satisfies readonly ApprovalMode[];
 export type CodexApprovalPolicy = ApprovalMode;
 
-const APPROVAL_POLICY_KEY = 'texra.codexApprovalPolicy';
-const APPROVAL_POLICY_DEFAULT: CodexApprovalPolicy = 'never';
+export const CODEX_APPROVAL_POLICY_DEFAULT: CodexApprovalPolicy = 'never';
 
 export const parseCodexApprovalPolicy: (raw: string) => CodexApprovalPolicy =
-  createEnumParser(APPROVAL_POLICIES, APPROVAL_POLICY_DEFAULT);
+  createEnumParser(APPROVAL_POLICIES, CODEX_APPROVAL_POLICY_DEFAULT);
 
 export const getCodexApprovalPolicy: () => CodexApprovalPolicy =
   createEnumStateGetter(
-    APPROVAL_POLICY_KEY,
-    APPROVAL_POLICY_DEFAULT,
+    WorkspaceStateKey.CODEX_APPROVAL_POLICY,
+    CODEX_APPROVAL_POLICY_DEFAULT,
     parseCodexApprovalPolicy,
   );
 
@@ -104,16 +103,15 @@ export const CODEX_SANDBOX_MODES =
   SANDBOX_MODES satisfies readonly SandboxMode[];
 export type CodexSandboxMode = SandboxMode;
 
-const SANDBOX_MODE_KEY = 'texra.codexSandboxMode';
-const SANDBOX_MODE_DEFAULT: CodexSandboxMode = 'workspace-write';
+export const CODEX_SANDBOX_MODE_DEFAULT: CodexSandboxMode = 'workspace-write';
 
 export const parseCodexSandboxMode: (raw: string) => CodexSandboxMode =
-  createEnumParser(SANDBOX_MODES, SANDBOX_MODE_DEFAULT);
+  createEnumParser(SANDBOX_MODES, CODEX_SANDBOX_MODE_DEFAULT);
 
 export const getCodexSandboxMode: () => CodexSandboxMode =
   createEnumStateGetter(
-    SANDBOX_MODE_KEY,
-    SANDBOX_MODE_DEFAULT,
+    WorkspaceStateKey.CODEX_SANDBOX_MODE,
+    CODEX_SANDBOX_MODE_DEFAULT,
     parseCodexSandboxMode,
   );
 


### PR DESCRIPTION
## Summary

A codebase responsibility audit found Codex and Claude Code agent configuration data duplicated across `@tools` and `@shared`, with several values kept in sync only by repeated literals and comments. This PR keeps each fact in one place while preserving the intended dependency direction.

Closes #6351.

## Changes

### Shared ownership for agent CLI setting values

- Added `src/shared/schemas/agentCliSettings.ts` as a narrow, dependency-free owner for Codex/Claude CLI setting schemas and types.
- `settingsView/data.ts` re-exports those schemas so existing settings-view consumers keep the same surface.
- `settingsView/inbound.ts`, `codex.ts`, `codexConfig.ts`, and `claudeAgentShared.ts` import the leaf directly instead of importing the broad settings-view data module.

### Removed duplicated config facts

- `codexConfig.ts` now uses `WorkspaceStateKey` instead of private duplicated workspace-state strings.
- Codex and Claude config default constants are exported and reused by `approvalHandlers.ts` instead of re-hardcoding fallback literals.
- Tool-side value lists derive from the shared Zod schemas via `.options`, with SDK alignment guards preserved where relevant.
- `codex.ts` uses the shared sandbox-mode schema for tool input validation instead of a fourth inlined sandbox-mode list.

## Why it matters

- Avoids silent drift between settings IPC schemas, tool runtime lists, and SDK-facing config values.
- Keeps tool runtime code away from the broad settings-view message module, which is not a dependency-free shared leaf.
- Reduces duplicated literals without introducing a generic resolver layer.

## Follow-up

#6352 tracks the older `GoalSchema` ownership leak from shared schema modules into `@tools/goal/goalMeta`. That is a wider public-surface move and intentionally separate from this PR.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/test-kernel/tools/codexConfig.vitest.ts src/test-kernel/tools/ClaudeAgentConfig.vitest.ts src/test-kernel/shared/SettingsViewSchemas.vitest.ts`
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: same allowed values and defaults, with less duplication across IPC and tools. No auth or data-path changes; risk is limited to miswired imports or schema drift if SDK guards are bypassed.
> 
> **Overview**
> Introduces **`agentCliSettings.ts`** as the shared home for Codex and Claude Code CLI Zod enums (sandbox, reasoning, approval, models, permission modes, effort) used by settings IPC and tool runtimes, and removes the duplicate inline definitions from **`settingsView/data.ts`**.
> 
> **`codexConfig.ts`** and **`claudeAgentShared.ts`** now derive runtime value lists from those schemas via `.options` (with SDK alignment guards where applicable) instead of parallel const arrays. **`codex.ts`** validates `sandbox_mode` with `CodexSandboxModeSchema` instead of a fourth inlined list.
> 
> Codex workspace persistence switches from private `'texra.*'` strings to **`WorkspaceStateKey`**, and **`approvalHandlers.ts`** uses exported **`CODEX_*_DEFAULT`** / **`CLAUDE_AGENT_DEFAULT_*`** constants instead of hardcoded fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86ccb31a27039f2529ca65e2c318e28abe3206e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->