### PR TITLE
Replace ad-hoc utilities with maintained packages (p-retry, yaml, lru-cache)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Shared (all surfaces)
+
+#### Improvements
+
+- **More reliable Lean theorem search** — Loogle queries now retry automatically when the server times out, drops the connection, or returns a transient server error, so a brief hiccup no longer surfaces as a failed search; genuine bad requests still fail fast.
+
 ## [0.38.9] - 2026-06-18
 
 ### Shared (all surfaces)

--- a/src/test-kernel/tools/MemoryFrontmatter.vitest.ts
+++ b/src/test-kernel/tools/MemoryFrontmatter.vitest.ts
@@ -1,0 +1,132 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - memory metadata
+import {
+  buildFile,
+  createMeta,
+  parseFrontmatter,
+  setPinnedMeta,
+  type MemoryFileMeta,
+} from '@tools/memory/memoryMeta';
+
+describe('memory frontmatter (yaml-backed)', () => {
+  it('round-trips metadata through build and parse', () => {
+    const meta: MemoryFileMeta = {
+      modifiedBy: 'reviser-agent',
+      executionId: 'exec_123',
+      modifiedAt: '2026-06-20T14:30:45.123Z',
+      pinned: true,
+    };
+    const file = buildFile('the body\nmore body\n', meta);
+
+    const parsed = parseFrontmatter(file);
+    expect(parsed.meta).toEqual(meta);
+    expect(parsed.content).toBe('the body\nmore body\n');
+  });
+
+  it('omits optional fields when not set', () => {
+    const meta: MemoryFileMeta = {
+      modifiedBy: 'agent',
+      modifiedAt: '2026-06-20T14:30:45.123Z',
+    };
+    const file = buildFile('body', meta);
+
+    // executionId and pinned must not appear in the serialized block.
+    expect(file).not.toContain('executionId');
+    expect(file).not.toContain('pinned');
+
+    const parsed = parseFrontmatter(file);
+    expect(parsed.meta).toEqual(meta);
+    expect(parsed.meta?.executionId).toBeUndefined();
+    expect(parsed.meta?.pinned).toBeUndefined();
+  });
+
+  it('parses a legacy hand-written block (unquoted values)', () => {
+    const legacy = [
+      '---',
+      'modifiedBy: agent-name',
+      'executionId: abc',
+      'modifiedAt: 2026-06-20T14:30:45.123Z',
+      'pinned: true',
+      '---',
+      'legacy body',
+    ].join('\n');
+
+    const parsed = parseFrontmatter(legacy);
+    expect(parsed.meta).toEqual({
+      modifiedBy: 'agent-name',
+      executionId: 'abc',
+      modifiedAt: '2026-06-20T14:30:45.123Z',
+      pinned: true,
+    });
+    expect(parsed.content).toBe('legacy body');
+  });
+
+  it('returns null metadata with full content when no frontmatter fence', () => {
+    const raw = 'just some content\nwith no frontmatter';
+    const parsed = parseFrontmatter(raw);
+    expect(parsed.meta).toBeNull();
+    expect(parsed.content).toBe(raw);
+  });
+
+  it('returns null metadata when the block lacks modifiedBy', () => {
+    const raw = [
+      '---',
+      'foo: bar',
+      'modifiedAt: 2026-01-01',
+      '---',
+      'body',
+    ].join('\n');
+    const parsed = parseFrontmatter(raw);
+    expect(parsed.meta).toBeNull();
+    // Full raw is preserved as content (back-compat with the old parser).
+    expect(parsed.content).toBe(raw);
+  });
+
+  it('degrades to null metadata on malformed YAML rather than throwing', () => {
+    const raw = ['---', 'modifiedBy: "unterminated', '---', 'body'].join('\n');
+    const parsed = parseFrontmatter(raw);
+    expect(parsed.meta).toBeNull();
+    expect(parsed.content).toBe(raw);
+  });
+
+  it('quotes pathological values so they survive a round-trip', () => {
+    const meta: MemoryFileMeta = {
+      modifiedBy: 'agent: with colon',
+      modifiedAt: '2026-06-20T14:30:45.123Z',
+    };
+    const file = buildFile('body', meta);
+    const parsed = parseFrontmatter(file);
+    expect(parsed.meta?.modifiedBy).toBe('agent: with colon');
+  });
+
+  it('buildFile returns content unchanged when meta is null', () => {
+    expect(buildFile('raw content', null)).toBe('raw content');
+  });
+
+  it('createMeta carries the pinned flag from existing metadata', () => {
+    const existing: MemoryFileMeta = {
+      modifiedBy: 'old',
+      modifiedAt: '2026-01-01T00:00:00.000Z',
+      pinned: true,
+    };
+    const meta = createMeta('new-agent', 'exec_9', existing);
+    expect(meta?.modifiedBy).toBe('new-agent');
+    expect(meta?.executionId).toBe('exec_9');
+    expect(meta?.pinned).toBe(true);
+  });
+
+  it('createMeta returns null when no agent name is available', () => {
+    expect(createMeta(undefined, 'exec_9')).toBeNull();
+  });
+
+  it('setPinnedMeta toggles the pinned flag, synthesizing meta when absent', () => {
+    const pinned = setPinnedMeta(null, true);
+    expect(pinned.pinned).toBe(true);
+    expect(pinned.modifiedBy).toBe('user');
+
+    const unpinned = setPinnedMeta(pinned, false);
+    expect(unpinned.pinned).toBeUndefined();
+  });
+});

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -34,7 +34,8 @@ describe('isTransientHttpError', () => {
     );
   });
 
-  it('treats 5xx server errors as transient', () => {
+  it('treats rate limits and 5xx server errors as transient', () => {
+    expect(isTransientHttpError(axiosErrorWithStatus(429))).toBe(true);
     expect(isTransientHttpError(axiosErrorWithStatus(500))).toBe(true);
     expect(isTransientHttpError(axiosErrorWithStatus(503))).toBe(true);
   });
@@ -42,7 +43,6 @@ describe('isTransientHttpError', () => {
   it('treats 4xx responses as permanent', () => {
     expect(isTransientHttpError(axiosErrorWithStatus(400))).toBe(false);
     expect(isTransientHttpError(axiosErrorWithStatus(404))).toBe(false);
-    expect(isTransientHttpError(axiosErrorWithStatus(429))).toBe(false);
   });
 
   it('treats non-axios errors as permanent', () => {

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -1,0 +1,53 @@
+// Third-party imports
+import { AxiosError, AxiosHeaders } from 'axios';
+import { describe, expect, it } from 'vitest';
+
+// Local imports - tools
+import { isTransientHttpError } from '@tools/timeouts';
+
+function axiosErrorWithStatus(status: number): AxiosError {
+  const error = new AxiosError('http error', 'ERR_BAD_RESPONSE');
+  error.response = {
+    status,
+    statusText: '',
+    data: undefined,
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
+
+describe('isTransientHttpError', () => {
+  it('treats request timeouts as transient', () => {
+    expect(
+      isTransientHttpError(new AxiosError('timeout', 'ECONNABORTED')),
+    ).toBe(true);
+    expect(isTransientHttpError(new AxiosError('timeout', 'ETIMEDOUT'))).toBe(
+      true,
+    );
+  });
+
+  it('treats network failures with no response as transient', () => {
+    // No `.response` set — the request never completed.
+    expect(isTransientHttpError(new AxiosError('reset', 'ECONNRESET'))).toBe(
+      true,
+    );
+  });
+
+  it('treats 5xx server errors as transient', () => {
+    expect(isTransientHttpError(axiosErrorWithStatus(500))).toBe(true);
+    expect(isTransientHttpError(axiosErrorWithStatus(503))).toBe(true);
+  });
+
+  it('treats 4xx responses as permanent', () => {
+    expect(isTransientHttpError(axiosErrorWithStatus(400))).toBe(false);
+    expect(isTransientHttpError(axiosErrorWithStatus(404))).toBe(false);
+    expect(isTransientHttpError(axiosErrorWithStatus(429))).toBe(false);
+  });
+
+  it('treats non-axios errors as permanent', () => {
+    expect(isTransientHttpError(new Error('boom'))).toBe(false);
+    expect(isTransientHttpError('nope')).toBe(false);
+    expect(isTransientHttpError(undefined)).toBe(false);
+  });
+});

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -123,12 +123,9 @@ Useful for finding the right lemma when you know roughly what type it should hav
   schema: LeanLoogleInputSchema,
 }) {
   /**
-   * Execute a single Loogle query and return a per-query result.
-   */
-  /**
    * Fetch one Loogle query, retrying transient failures (timeouts, 5xx,
-   * dropped connections) with jittered backoff. A 4xx or any non-axios
-   * error aborts immediately — those won't change on retry.
+   * 429 rate limits, dropped connections) with jittered backoff. Non-429
+   * 4xx responses and non-axios errors abort immediately.
    */
   private async fetchLoogle(query: string): Promise<LoogleResponse> {
     return pRetry(
@@ -164,6 +161,9 @@ Useful for finding the right lemma when you know roughly what type it should hav
     );
   }
 
+  /**
+   * Execute a single Loogle query and return a per-query result.
+   */
   private async executeSingle(
     query: string,
     limit: number,

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -5,15 +5,20 @@
  */
 
 import axios from 'axios';
+import pRetry, { AbortError } from 'p-retry';
 import { z } from 'zod';
 
 import { toErrorMessage } from '@common/errors';
+import * as logger from '@logger/logUtils';
 import { ToolResult } from '@tools/result';
-import { isTimeoutErrorCode } from '@tools/timeouts';
+import { isTimeoutErrorCode, isTransientHttpError } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 import { ensureArray } from '@utils/core';
 
 const LOOGLE_TIMEOUT_MS = 10_000; // 10 s
+const LOOGLE_CHANNEL = 'lean_loogle';
+/** Retry transient Loogle failures (timeouts, 5xx, dropped connections). */
+const LOOGLE_RETRIES = 2;
 
 // ============================================================================
 // Schema
@@ -120,20 +125,51 @@ Useful for finding the right lemma when you know roughly what type it should hav
   /**
    * Execute a single Loogle query and return a per-query result.
    */
+  /**
+   * Fetch one Loogle query, retrying transient failures (timeouts, 5xx,
+   * dropped connections) with jittered backoff. A 4xx or any non-axios
+   * error aborts immediately — those won't change on retry.
+   */
+  private async fetchLoogle(query: string): Promise<LoogleResponse> {
+    return pRetry(
+      async () => {
+        try {
+          const response = await axios.get<LoogleResponse>(LOOGLE_API_URL, {
+            params: { q: query },
+            headers: {
+              'User-Agent': 'TeXRA-VSCode-Extension',
+            },
+            timeout: LOOGLE_TIMEOUT_MS,
+          });
+          return response.data;
+        } catch (error) {
+          if (isTransientHttpError(error)) throw error;
+          throw new AbortError(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
+      },
+      {
+        retries: LOOGLE_RETRIES,
+        minTimeout: 1000,
+        // Jitter the backoff so batched queries don't retry in lockstep.
+        randomize: true,
+        onFailedAttempt: ({ error, retriesLeft }) => {
+          logger.debug(
+            LOOGLE_CHANNEL,
+            `Loogle query "${query}" failed (${retriesLeft} retries left): ${toErrorMessage(error)}`,
+          );
+        },
+      },
+    );
+  }
+
   private async executeSingle(
     query: string,
     limit: number,
   ): Promise<{ query: string; result: ToolResult }> {
     try {
-      const response = await axios.get<LoogleResponse>(LOOGLE_API_URL, {
-        params: { q: query },
-        headers: {
-          'User-Agent': 'TeXRA-VSCode-Extension',
-        },
-        timeout: LOOGLE_TIMEOUT_MS,
-      });
-
-      const data = response.data;
+      const data = await this.fetchLoogle(query);
 
       if (isErrorResponse(data)) {
         const suggestions = data.suggestions ?? [];

--- a/src/tools/memory/memoryMeta.ts
+++ b/src/tools/memory/memoryMeta.ts
@@ -8,30 +8,54 @@
 
 import * as path from 'node:path';
 
+import * as yaml from 'yaml';
+import { z } from 'zod';
+
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 
 import { MEMORY_STORAGE_ROOT, shouldSkipEntry } from './constants';
 
-export interface MemoryFileMeta {
+/**
+ * Attribution metadata schema. Source of truth for the {@link MemoryFileMeta}
+ * type; also validates the YAML frontmatter parsed back off disk so a
+ * hand-edited or malformed block degrades to "no metadata" rather than
+ * throwing. `modifiedAt` defaults to now for legacy blocks that predate it.
+ */
+const MemoryFileMetaSchema = z.object({
   /** Agent name that last modified this file. */
-  modifiedBy: string;
+  modifiedBy: z.string().min(1),
   /** Execution ID of the run that last modified this file. */
-  executionId?: string;
+  executionId: z.string().optional(),
   /** ISO 8601 timestamp of last modification. */
-  modifiedAt: string;
-  /** Whether this memory is pinned as a core long-term insight. */
-  pinned?: boolean;
-}
+  modifiedAt: z.string().prefault(() => new Date().toISOString()),
+  /**
+   * Whether this memory is pinned as a core long-term insight. A parsed
+   * `false` is treated the same as absent everywhere it is read, and
+   * {@link buildFrontmatter} only ever writes the flag when truthy.
+   */
+  pinned: z.boolean().optional(),
+});
+
+export type MemoryFileMeta = z.infer<typeof MemoryFileMetaSchema>;
 
 const FRONTMATTER_FENCE = '---';
+
+/** Parse a frontmatter YAML block, returning undefined on malformed YAML. */
+function parseYamlBlock(block: string): unknown {
+  try {
+    return yaml.parse(block);
+  } catch {
+    return undefined;
+  }
+}
 
 // ── Parsing ────────────────────────────────────────────────────────
 
 /**
  * Split a raw file string into optional attribution metadata and the
- * user-visible content.  Files without frontmatter return null metadata
- * and the full string as content (backward-compatible).
+ * user-visible content.  Files without (valid) frontmatter return null
+ * metadata and the full string as content (backward-compatible).
  */
 export function parseFrontmatter(raw: string): {
   meta: MemoryFileMeta | null;
@@ -50,25 +74,13 @@ export function parseFrontmatter(raw: string): {
   }
 
   const block = raw.slice(FRONTMATTER_FENCE.length + 1, endIdx);
-  const fields: Record<string, string> = {};
-  for (const line of block.split('\n')) {
-    const colon = line.indexOf(':');
-    if (colon > 0) {
-      fields[line.slice(0, colon).trim()] = line.slice(colon + 1).trim();
-    }
-  }
-
-  if (!fields.modifiedBy) {
+  const parsed = MemoryFileMetaSchema.safeParse(parseYamlBlock(block));
+  if (!parsed.success) {
     return { meta: null, content: raw };
   }
 
   return {
-    meta: {
-      modifiedBy: fields.modifiedBy,
-      executionId: fields.executionId || undefined,
-      modifiedAt: fields.modifiedAt || new Date().toISOString(),
-      pinned: fields.pinned === 'true' ? true : undefined,
-    },
+    meta: parsed.data,
     content: raw.slice(endIdx + FRONTMATTER_FENCE.length + 2), // skip "\n---\n"
   };
 }
@@ -76,16 +88,18 @@ export function parseFrontmatter(raw: string): {
 // ── Building ───────────────────────────────────────────────────────
 
 function buildFrontmatter(meta: MemoryFileMeta): string {
-  const lines = [FRONTMATTER_FENCE, `modifiedBy: ${meta.modifiedBy}`];
-  if (meta.executionId) {
-    lines.push(`executionId: ${meta.executionId}`);
-  }
-  lines.push(`modifiedAt: ${meta.modifiedAt}`);
-  if (meta.pinned) {
-    lines.push('pinned: true');
-  }
-  lines.push(FRONTMATTER_FENCE);
-  return lines.join('\n');
+  // Build the object explicitly so only set fields are serialized, in a
+  // stable key order.
+  const fields: Record<string, string | boolean> = {
+    modifiedBy: meta.modifiedBy,
+  };
+  if (meta.executionId) fields.executionId = meta.executionId;
+  fields.modifiedAt = meta.modifiedAt;
+  if (meta.pinned) fields.pinned = true;
+
+  // yaml.stringify ends with a trailing newline, so the closing fence sits on
+  // its own line: "---\n<fields>---".
+  return `${FRONTMATTER_FENCE}\n${yaml.stringify(fields)}${FRONTMATTER_FENCE}`;
 }
 
 /**

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -5,6 +5,8 @@
  * provides the helpers that enforce a consistent error format across tools.
  */
 
+import axios from 'axios';
+
 /**
  * Check whether an axios error code indicates a timeout.
  *
@@ -13,4 +15,24 @@
  */
 export function isTimeoutErrorCode(code: string | undefined): boolean {
   return code === 'ECONNABORTED' || code === 'ETIMEDOUT';
+}
+
+/**
+ * Whether an error from an axios request is worth retrying.
+ *
+ * Transient = a retry could plausibly succeed: request timeouts, network-level
+ * failures (no response received — DNS hiccup, connection reset), and 5xx
+ * server errors. Permanent = the same request will keep failing: any 4xx
+ * status (bad request, not found, auth), and non-axios/application errors.
+ *
+ * Only safe to use for idempotent requests (GET / read-only RPC); retrying a
+ * non-idempotent write risks duplicate side effects.
+ */
+export function isTransientHttpError(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) return false;
+  if (isTimeoutErrorCode(error.code)) return true;
+  // No response means the request never completed (connection reset, DNS,
+  // socket hang up) — generally worth one more attempt for an external API.
+  if (!error.response) return true;
+  return error.response.status >= 500;
 }

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -21,9 +21,10 @@ export function isTimeoutErrorCode(code: string | undefined): boolean {
  * Whether an error from an axios request is worth retrying.
  *
  * Transient = a retry could plausibly succeed: request timeouts, network-level
- * failures (no response received — DNS hiccup, connection reset), and 5xx
- * server errors. Permanent = the same request will keep failing: any 4xx
- * status (bad request, not found, auth), and non-axios/application errors.
+ * failures (no response received — DNS hiccup, connection reset), 429 rate
+ * limits, and 5xx server errors. Permanent = the same request will keep
+ * failing: other 4xx statuses (bad request, not found, auth), and non-axios /
+ * application errors.
  *
  * Only safe to use for idempotent requests (GET / read-only RPC); retrying a
  * non-idempotent write risks duplicate side effects.
@@ -34,5 +35,5 @@ export function isTransientHttpError(error: unknown): boolean {
   // No response means the request never completed (connection reset, DNS,
   // socket hang up) — generally worth one more attempt for an external API.
   if (!error.response) return true;
-  return error.response.status >= 500;
+  return error.response.status === 429 || error.response.status >= 500;
 }

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 // Third-party imports
 import { globSync } from 'glob';
 import { execaSync } from 'execa';
+import { LRUCache } from 'lru-cache';
 import which from 'which';
 
 // Local imports - log
@@ -211,8 +212,10 @@ function getExtraDirs(): string[] {
   return cachedExtraDirs;
 }
 
-// Cache for extended PATH strings
-const cachedExtendedPaths = new Map<string, string>();
+// Cache for extended PATH strings. Bounded so a process that mutates PATH many
+// times over its lifetime can't grow this unbounded; in practice only a handful
+// of distinct base paths are ever seen.
+const cachedExtendedPaths = new LRUCache<string, string>({ max: 16 });
 
 /**
  * Extend PATH with common directories if they are missing.
@@ -250,7 +253,11 @@ function isPathSafe(filepath: string): boolean {
   return !normalized.includes('..');
 }
 
-const findToolCache = new Map<string, string>();
+// Resolved tool paths, bounded so a long-lived session that probes many
+// distinct tool names can't grow this unbounded. Only hits are cached; misses
+// are always re-checked (see below) so tools installed mid-session are picked
+// up without a reload.
+const findToolCache = new LRUCache<string, string>({ max: 64 });
 
 /**
  * Locate a tool in the common directories.


### PR DESCRIPTION
## Summary

Swaps three pieces of hand-rolled utility code for well-maintained packages **already declared in `package.json`** (no new dependencies), and reports the outcome of a deeper investigation into the citation rate limiter. Scope follows the review request: web tools are left alone, and the bottleneck swap was investigated rather than applied.

### 1. Loogle theorem search → `p-retry` (reliability)

`src/tools/lean/LoogleTool.ts` made a bare `axios.get` with no retry — a transient timeout or 5xx surfaced as a hard failure, and the error copy literally told the user to "Retry the request." It now retries transient failures (timeouts, 429 rate limits, 5xx, dropped connections) with jittered exponential backoff, mirroring the existing `arxivProcessor` download path.

- Shared classifier `isTransientHttpError` in `src/tools/timeouts.ts` decides retry-vs-fail-fast for idempotent GETs.
- Non-429 4xx responses and non-axios errors throw `AbortError` so they fail fast.
- Web tools (`web_fetch` / `web_search`) intentionally left unchanged per the review request.
- Non-idempotent Zotero writes deliberately excluded — retrying `saveItems`/`saveSnapshot` risks duplicate library entries.

### 2. Memory frontmatter → `yaml` + Zod schema (robustness)

`src/tools/memory/memoryMeta.ts` hand-rolled a `key: value` line splitter and a string-concatenation serializer. Now it uses the `yaml` package with a `MemoryFileMetaSchema` (Zod) as the source of truth (`MemoryFileMeta` is derived via `z.infer`).

- Byte-identical output for the common case, preserving existing on-disk memory files.
- Pathological values are quoted correctly instead of producing unparseable blocks.
- Malformed YAML degrades to "no metadata" rather than mis-parsing.

### 3. `platformPaths` caches → `lru-cache` (bounded)

The two module-level `Map<string, string>` caches (extended-PATH strings, resolved tool paths) are now bounded `LRUCache`s, matching the pattern already used in `worktreeInfo.ts`. Miss-revalidation behavior for tool lookup is preserved.

### Bottleneck — investigated, not adopted

The citation rate limiter (`src/tools/citation/rateLimiter.ts`) wraps `p-throttle`. After tracing all callers, bottleneck is not worth adopting:

- The only semantics needed are min-spacing with concurrency 1, which `p-throttle({ limit: 1, interval })` already provides.
- The cache only ever holds two fixed keys (`crossref`, `arxiv`).
- Bottleneck's extra surface buys nothing here and is a heavier dependency.

## Tests

- `src/test-kernel/tools/MemoryFrontmatter.vitest.ts`
- `src/test-kernel/tools/TransientHttpError.vitest.ts`

## Verification

- `npm run format`
- `npx vitest run src/test-kernel/tools/TransientHttpError.vitest.ts src/test-kernel/tools/MemoryFrontmatter.vitest.ts`
- `npx eslint src/tools/lean/LoogleTool.ts src/tools/timeouts.ts src/test-kernel/tools/TransientHttpError.vitest.ts src/tools/memory/memoryMeta.ts src/test-kernel/tools/MemoryFrontmatter.vitest.ts src/utils/system/platformPaths.ts`
- `npm run lint`
- `npm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to read-only Loogle GETs, memory metadata parsing/serialization, and session-scoped path caches; behavior is backward-compatible with fail-fast on bad Loogle queries and safe degradation for invalid frontmatter.
> 
> **Overview**
> Replaces hand-rolled helpers with existing dependencies and tightens reliability in a few hot paths.
> 
> **Loogle (`lean_loogle`)** now retries transient HTTP failures (timeouts, no response, 429, 5xx) via `p-retry` with jittered backoff; permanent 4xx and non-axios errors abort immediately through shared **`isTransientHttpError`** in `timeouts.ts`.
> 
> **Memory file attribution** in `memoryMeta.ts` uses **`yaml` + Zod** (`MemoryFileMetaSchema`) instead of a line-splitting parser/serializer—malformed blocks degrade to no metadata, legacy blocks still parse, and awkward values (e.g. colons in `modifiedBy`) round-trip correctly.
> 
> **`platformPaths`** swaps unbounded `Map` caches for bounded **`LRUCache`** instances (extended PATH and resolved tool paths), preserving miss re-check behavior for mid-session installs.
> 
> Changelog notes more reliable Loogle search; new vitest coverage for frontmatter and the transient-error classifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58604d9c43224d515aafcd62b77ddf191f5d515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->