### PR TITLE
[codex] move settings tool dashboard builder out of shared

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
+++ b/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
@@ -24,7 +24,7 @@ export async function buildDefaultToolDashboardItems(
   cachedResults?: ExternalToolCheckResult[],
 ): Promise<ToolDashboardItem[]> {
   const { buildToolDashboardItems } =
-    await import('@shared/settingsView/toolDashboardData');
+    await import('@controllers/settingsView/ToolDashboardData');
   return buildToolDashboardItems(cachedResults);
 }
 

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -14,6 +14,7 @@ import * as vscode from 'vscode';
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { SettingsProfileController } from '@controllers/settingsView/SettingsProfileController';
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
+import { buildToolDashboardItems } from '@controllers/settingsView/ToolDashboardData';
 import { platform } from '@platform/platform';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -68,7 +69,6 @@ import {
   PROVIDER_URLS,
   PROVIDER_VSCODE_SETTINGS,
 } from '@shared/constants/providers';
-import { buildToolDashboardItems } from '@shared/settingsView/toolDashboardData';
 import { GoalStore } from '@tools/goal';
 import {
   getLastCheckResults,

--- a/src/controllers/settingsView/ToolDashboardData.ts
+++ b/src/controllers/settingsView/ToolDashboardData.ts
@@ -1,8 +1,9 @@
 /**
  * Tool dashboard data builder.
  *
- * Enriches tool groups with runtime availability. External tool definitions
- * (SSOT) live in {@link @tools/externalToolDefs}.
+ * Enriches settings-view tool groups with runtime availability. External tool
+ * definitions live in {@link @tools/externalToolDefs}; this controller module
+ * keeps that tool-layer dependency out of shared settings-view code.
  */
 
 // Local imports
@@ -127,7 +128,7 @@ const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
 /**
  * Build the complete tool dashboard items list.
  *
- * @param cachedResults — when provided, skips network probes and uses
+ * @param cachedResults - when provided, skips network probes and uses
  *   these results (including their `statusDetail`). Used by the toggle
  *   handler for instant UI updates.
  */

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -8,7 +8,7 @@
  *
  * Consumed by:
  *   - {@link @tools/toolAvailability} — reads id/tools/check for caching
- *   - {@link @shared/settingsView/toolDashboardData} — reads everything for the UI
+ *   - {@link @controllers/settingsView/ToolDashboardData} — reads everything for the UI
  */
 
 // Local imports


### PR DESCRIPTION
## Summary
- Move the settings tool-dashboard data builder from `src/shared/settingsView` into `src/controllers/settingsView`.
- Update extension and desktop hosts to import the builder from the settings controller layer.
- Leave the remaining memory and approval shared-settings tool imports tracked by #6353.

## Abstraction issue addressed
`src/shared/settingsView/toolDashboardData.ts` looked like shared view code but directly imported tool definitions, tool availability probes, and tool enablement config. That made the shared settings-view layer depend on concrete tool runtime state. The builder now lives in the controller/composition layer, where combining shared message shapes with `@tools/*` infrastructure belongs.

Refs #6353

## Validation
- `npx prettier --write src/controllers/settingsView/ToolDashboardData.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts packages/desktop/src/main/desktopSettingsIpcHelpers.ts src/tools/externalToolDefs.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layering/import-path refactor with no described behavior changes; risk is limited to missed import sites or build aliases.
> 
> **Overview**
> Moves **`buildToolDashboardItems`** from `src/shared/settingsView` into **`src/controllers/settingsView/ToolDashboardData`**, so shared settings-view code no longer depends on `@tools/*` (definitions, availability probes, enablement).
> 
> The **extension** settings handler and **desktop** IPC helper now import the builder from `@controllers/settingsView/ToolDashboardData` (desktop keeps a dynamic import). **`externalToolDefs`** docs point at the new consumer path; module comments clarify the controller owns composition with tool runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d626c867df4ce280c35fc4a0047c29892c7f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->