### PR TITLE
[codex] move approval setting parsers to shared

### DIFF
--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -7,6 +7,18 @@ import { z } from 'zod';
  * own runtime schemas, so it must not pull in settings-view or tool code.
  */
 
+function parseEnumSetting<T extends string>(
+  values: readonly T[],
+  fallback: T,
+  aliases?: Readonly<Record<string, T>>,
+): (raw: string) => T {
+  const known = values as readonly string[];
+  return (raw: string): T => {
+    if (known.includes(raw)) return raw as T;
+    return aliases?.[raw] ?? fallback;
+  };
+}
+
 /** Valid Codex sandbox modes. */
 export const CodexSandboxModeSchema = z.enum([
   'read-only',
@@ -14,6 +26,12 @@ export const CodexSandboxModeSchema = z.enum([
   'danger-full-access',
 ]);
 export type CodexSandboxMode = z.infer<typeof CodexSandboxModeSchema>;
+
+export const CODEX_SANDBOX_MODE_DEFAULT: CodexSandboxMode = 'workspace-write';
+export const parseCodexSandboxMode = parseEnumSetting(
+  CodexSandboxModeSchema.options,
+  CODEX_SANDBOX_MODE_DEFAULT,
+);
 
 /** Valid Codex reasoning effort levels. */
 export const CodexReasoningEffortSchema = z.enum([
@@ -24,6 +42,12 @@ export const CodexReasoningEffortSchema = z.enum([
 ]);
 export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>;
 
+export const CODEX_REASONING_EFFORT_DEFAULT: CodexReasoningEffort = 'high';
+export const parseCodexReasoningEffort = parseEnumSetting(
+  CodexReasoningEffortSchema.options,
+  CODEX_REASONING_EFFORT_DEFAULT,
+);
+
 /** Valid Codex approval policies. */
 export const CodexApprovalPolicySchema = z.enum([
   'never',
@@ -33,6 +57,12 @@ export const CodexApprovalPolicySchema = z.enum([
 ]);
 export type CodexApprovalPolicy = z.infer<typeof CodexApprovalPolicySchema>;
 
+export const CODEX_APPROVAL_POLICY_DEFAULT: CodexApprovalPolicy = 'never';
+export const parseCodexApprovalPolicy = parseEnumSetting(
+  CodexApprovalPolicySchema.options,
+  CODEX_APPROVAL_POLICY_DEFAULT,
+);
+
 /** Claude Code CLI model options surfaced in the picker. */
 export const ClaudeAgentModelSchema = z.enum([
   'claude-sonnet-4-6',
@@ -41,6 +71,19 @@ export const ClaudeAgentModelSchema = z.enum([
   'claude-haiku-4-5-20251001',
 ]);
 export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
+
+export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-sonnet-4-6';
+
+const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> =
+  {
+    'claude-opus-4-7': 'claude-opus-4-8',
+  };
+
+export const parseClaudeAgentModel = parseEnumSetting(
+  ClaudeAgentModelSchema.options,
+  CLAUDE_AGENT_DEFAULT_MODEL,
+  RETIRED_CLAUDE_AGENT_MODELS,
+);
 
 /** Claude Code CLI permission modes exposed in settings. */
 export const ClaudeAgentPermissionModeSchema = z.enum([
@@ -52,6 +95,13 @@ export const ClaudeAgentPermissionModeSchema = z.enum([
 export type ClaudeAgentPermissionMode = z.infer<
   typeof ClaudeAgentPermissionModeSchema
 >;
+
+export const CLAUDE_AGENT_DEFAULT_PERMISSION_MODE: ClaudeAgentPermissionMode =
+  'acceptEdits';
+export const parseClaudeAgentPermissionMode = parseEnumSetting(
+  ClaudeAgentPermissionModeSchema.options,
+  CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
+);
 
 /**
  * Claude Code CLI effort levels. `claudeAgentShared.ts` guards this against the
@@ -65,3 +115,11 @@ export const ClaudeAgentEffortSchema = z.enum([
   'max',
 ]);
 export type ClaudeAgentEffort = z.infer<typeof ClaudeAgentEffortSchema>;
+
+export const CLAUDE_AGENT_DEFAULT_EFFORT: ClaudeAgentEffort = 'high';
+export const parseClaudeAgentEffort = parseEnumSetting(
+  ClaudeAgentEffortSchema.options,
+  CLAUDE_AGENT_DEFAULT_EFFORT,
+);
+
+export const BASH_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireBashApproval';

--- a/src/shared/settingsView/handlers/approvalHandlers.ts
+++ b/src/shared/settingsView/handlers/approvalHandlers.ts
@@ -10,22 +10,20 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc/settingsViewCommands';
 import type { UpdateApprovalSettingsMessage } from '@shared/schemas/settingsViewMessages';
 import {
-  parseCodexApprovalPolicy,
-  parseCodexReasoningEffort,
-  parseCodexSandboxMode,
+  BASH_APPROVAL_CONFIG_KEY,
+  CLAUDE_AGENT_DEFAULT_EFFORT,
+  CLAUDE_AGENT_DEFAULT_MODEL,
+  CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
   CODEX_APPROVAL_POLICY_DEFAULT,
   CODEX_REASONING_EFFORT_DEFAULT,
   CODEX_SANDBOX_MODE_DEFAULT,
-} from '@tools/codexConfig';
-import {
-  CLAUDE_AGENT_DEFAULT_MODEL,
-  CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
-  CLAUDE_AGENT_DEFAULT_EFFORT,
   parseClaudeAgentEffort,
   parseClaudeAgentModel,
   parseClaudeAgentPermissionMode,
-} from '@tools/claudeAgentConfig';
-import { BASH_APPROVAL_CONFIG_KEY } from '@tools/approval/bashApproval';
+  parseCodexApprovalPolicy,
+  parseCodexReasoningEffort,
+  parseCodexSandboxMode,
+} from '@shared/schemas/agentCliSettings';
 import type { ConfigProvider, ConfigTarget } from '@platform/interfaces/config';
 
 import type { SettingsStatePorts } from './types';

--- a/src/test-kernel/schemas/agentCliSettings.vitest.ts
+++ b/src/test-kernel/schemas/agentCliSettings.vitest.ts
@@ -1,0 +1,32 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+
+// Local imports
+import {
+  parseClaudeAgentModel,
+  parseCodexApprovalPolicy,
+} from '@shared/schemas/agentCliSettings';
+
+describe('parseCodexApprovalPolicy', () => {
+  it('accepts SDK approval policies', () => {
+    assert.equal(parseCodexApprovalPolicy('never'), 'never');
+    assert.equal(parseCodexApprovalPolicy('on-request'), 'on-request');
+    assert.equal(parseCodexApprovalPolicy('on-failure'), 'on-failure');
+    assert.equal(parseCodexApprovalPolicy('untrusted'), 'untrusted');
+  });
+
+  it('defaults to automatic approval for invalid persisted values', () => {
+    assert.equal(parseCodexApprovalPolicy('ask'), 'never');
+  });
+});
+
+describe('parseClaudeAgentModel', () => {
+  it('maps retired Opus selections to the current Opus model', () => {
+    assert.equal(parseClaudeAgentModel('claude-opus-4-7'), 'claude-opus-4-8');
+  });
+
+  it('defaults invalid persisted selections to Sonnet', () => {
+    assert.equal(parseClaudeAgentModel('claude-opus-3'), 'claude-sonnet-4-6');
+  });
+});

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -9,10 +9,10 @@ import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { extractToolAttachments } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import type { OpenAIResponseToolCall } from '@agent/modelHandlers/types/IModelHandler';
+import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 
 // Local imports - tools
 import { BashTool } from '@tools/bash';
-import { BASH_APPROVAL_CONFIG_KEY } from '@tools/approval/bashApproval';
 import * as agentConfig from '@utils/config/configUtils';
 
 // Local imports - system utilities

--- a/src/test-kernel/tools/codexConfig.vitest.ts
+++ b/src/test-kernel/tools/codexConfig.vitest.ts
@@ -8,7 +8,6 @@ import { describe, it } from 'vitest';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   buildCodexConfig,
-  parseCodexApprovalPolicy,
   toCodexCliReasoningEffort,
 } from '@tools/codexConfig';
 import {
@@ -50,19 +49,6 @@ describe('toCodexCliReasoningEffort', () => {
     // 'xhigh' with `unknown variant 'xhigh', expected one of 'minimal',
     // 'low', 'medium', 'high' in 'model_reasoning_effort'`.
     assert.equal(toCodexCliReasoningEffort('xhigh'), 'high');
-  });
-});
-
-describe('parseCodexApprovalPolicy', () => {
-  it('accepts SDK approval policies', () => {
-    assert.equal(parseCodexApprovalPolicy('never'), 'never');
-    assert.equal(parseCodexApprovalPolicy('on-request'), 'on-request');
-    assert.equal(parseCodexApprovalPolicy('on-failure'), 'on-failure');
-    assert.equal(parseCodexApprovalPolicy('untrusted'), 'untrusted');
-  });
-
-  it('defaults to automatic approval for invalid persisted values', () => {
-    assert.equal(parseCodexApprovalPolicy('ask'), 'never');
   });
 });
 

--- a/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
+++ b/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
@@ -5,7 +5,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it, beforeAll } from 'vitest';
 
 // Local imports
-import { BASH_APPROVAL_CONFIG_KEY } from '@tools/approval/bashApproval';
+import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { SendToTerminalTool } from '@tools/setup/SendToTerminalTool';
 import {
   setSetupPlatform,

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
+import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import {
   BASH_APPROVAL_ACTIONS,
   type BashApprovalAction,
@@ -26,8 +27,6 @@ const BashApprovalResultSchema = z.object({
   userMessage: z.string().optional(),
 });
 export type BashApprovalResult = z.infer<typeof BashApprovalResultSchema>;
-
-export const BASH_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireBashApproval';
 
 // Defined in the schema layer (see @shared/schemas/prompts); re-exported here
 // so existing importers of `@tools/approval/bashApproval` keep working.

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -12,45 +12,29 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { lookupApiKey, apiKeyEnvName } from '@model/apiProviders';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { safeHomedir } from '@utils/system/platformPaths';
-import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
-import { createEnumParser, createEnumStateGetter } from './support/enumConfig';
 import {
-  CLAUDE_AGENT_NAME,
-  CLAUDE_AGENT_DISPLAY_MODEL,
-  CLAUDE_AGENT_EFFORT_LEVELS,
-  CLAUDE_AGENT_MODELS,
-  CLAUDE_AGENT_PERMISSION_MODES,
+  CLAUDE_AGENT_DEFAULT_EFFORT,
+  CLAUDE_AGENT_DEFAULT_MODEL,
+  CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
+  parseClaudeAgentEffort,
+  parseClaudeAgentModel,
+  parseClaudeAgentPermissionMode,
   type ClaudeAgentEffort,
   type ClaudeAgentModel,
   type ClaudeAgentPermissionMode,
+} from '@shared/schemas/agentCliSettings';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { safeHomedir } from '@utils/system/platformPaths';
+import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
+import { createEnumStateGetter } from './support/enumConfig';
+import {
+  CLAUDE_AGENT_NAME,
+  CLAUDE_AGENT_DISPLAY_MODEL,
 } from './claudeAgentShared';
 
 // ============================================================================
 // Model — defaults to Sonnet 4.6; users can override per-call or via workspace state
 // ============================================================================
-
-/** Default Claude model passed to the Agent SDK. */
-export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-sonnet-4-6';
-
-/**
- * Models retired from the picker that should resolve to their successor instead
- * of silently dropping to the Sonnet default. Opus 4.7 was the prior top tier,
- * so a persisted selection maps forward to Opus 4.8 to keep users on the Opus
- * tier across the bump.
- */
-const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> =
-  {
-    'claude-opus-4-7': 'claude-opus-4-8',
-  };
-
-export const parseClaudeAgentModel: (raw: string) => ClaudeAgentModel =
-  createEnumParser(
-    CLAUDE_AGENT_MODELS,
-    CLAUDE_AGENT_DEFAULT_MODEL,
-    RETIRED_CLAUDE_AGENT_MODELS,
-  );
 
 export const getClaudeAgentModel: () => ClaudeAgentModel =
   createEnumStateGetter(
@@ -63,16 +47,6 @@ export const getClaudeAgentModel: () => ClaudeAgentModel =
 // Permission mode
 // ============================================================================
 
-export const CLAUDE_AGENT_DEFAULT_PERMISSION_MODE: ClaudeAgentPermissionMode =
-  'acceptEdits';
-
-export const parseClaudeAgentPermissionMode: (
-  raw: string,
-) => ClaudeAgentPermissionMode = createEnumParser(
-  CLAUDE_AGENT_PERMISSION_MODES,
-  CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
-);
-
 export const getClaudeAgentPermissionMode: () => ClaudeAgentPermissionMode =
   createEnumStateGetter(
     WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
@@ -83,11 +57,6 @@ export const getClaudeAgentPermissionMode: () => ClaudeAgentPermissionMode =
 // ============================================================================
 // Effort — adaptive thinking depth hint passed via `effort` SDK option
 // ============================================================================
-
-export const CLAUDE_AGENT_DEFAULT_EFFORT: ClaudeAgentEffort = 'high';
-
-export const parseClaudeAgentEffort: (raw: string) => ClaudeAgentEffort =
-  createEnumParser(CLAUDE_AGENT_EFFORT_LEVELS, CLAUDE_AGENT_DEFAULT_EFFORT);
 
 export const getClaudeAgentEffort: () => ClaudeAgentEffort =
   createEnumStateGetter(

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -5,12 +5,18 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
+  CODEX_APPROVAL_POLICY_DEFAULT,
+  CODEX_REASONING_EFFORT_DEFAULT,
+  CODEX_SANDBOX_MODE_DEFAULT,
   CodexApprovalPolicySchema,
   CodexReasoningEffortSchema,
   CodexSandboxModeSchema,
+  parseCodexApprovalPolicy,
+  parseCodexReasoningEffort,
+  parseCodexSandboxMode,
 } from '@shared/schemas/agentCliSettings';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { createEnumParser, createEnumStateGetter } from './support/enumConfig';
+import { createEnumStateGetter } from './support/enumConfig';
 import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
 
 // Type-only imports
@@ -36,13 +42,6 @@ export const CODEX_CLI_MODEL = 'gpt-5.5';
 const REASONING_EFFORTS = CodexReasoningEffortSchema.options;
 export const CODEX_REASONING_EFFORTS = REASONING_EFFORTS;
 export type CodexReasoningEffort = (typeof REASONING_EFFORTS)[number];
-
-export const CODEX_REASONING_EFFORT_DEFAULT: CodexReasoningEffort = 'high';
-
-export const parseCodexReasoningEffort = createEnumParser(
-  REASONING_EFFORTS,
-  CODEX_REASONING_EFFORT_DEFAULT,
-);
 
 export const getCodexReasoningEffort = createEnumStateGetter(
   WorkspaceStateKey.CODEX_REASONING_EFFORT,
@@ -82,11 +81,6 @@ export const CODEX_APPROVAL_POLICIES =
   APPROVAL_POLICIES satisfies readonly ApprovalMode[];
 export type CodexApprovalPolicy = ApprovalMode;
 
-export const CODEX_APPROVAL_POLICY_DEFAULT: CodexApprovalPolicy = 'never';
-
-export const parseCodexApprovalPolicy: (raw: string) => CodexApprovalPolicy =
-  createEnumParser(APPROVAL_POLICIES, CODEX_APPROVAL_POLICY_DEFAULT);
-
 export const getCodexApprovalPolicy: () => CodexApprovalPolicy =
   createEnumStateGetter(
     WorkspaceStateKey.CODEX_APPROVAL_POLICY,
@@ -104,11 +98,6 @@ const SANDBOX_MODES = CodexSandboxModeSchema.options;
 export const CODEX_SANDBOX_MODES =
   SANDBOX_MODES satisfies readonly SandboxMode[];
 export type CodexSandboxMode = SandboxMode;
-
-export const CODEX_SANDBOX_MODE_DEFAULT: CodexSandboxMode = 'workspace-write';
-
-export const parseCodexSandboxMode: (raw: string) => CodexSandboxMode =
-  createEnumParser(SANDBOX_MODES, CODEX_SANDBOX_MODE_DEFAULT);
 
 export const getCodexSandboxMode: () => CodexSandboxMode =
   createEnumStateGetter(

--- a/src/tools/support/enumConfig.ts
+++ b/src/tools/support/enumConfig.ts
@@ -1,34 +1,10 @@
 /**
- * Shared helpers for tools that persist an enum-valued setting in workspace
- * state. Both the Codex and Claude Code tools follow the same pattern:
- *
- *   1. A `parse(raw)` that maps an arbitrary string onto a known enum value,
- *      falling back to a default when the string isn't recognised.
- *   2. A `get()` that reads the persisted string from workspace state and runs
- *      it through `parse`.
- *
- * Centralising the pattern keeps the parse-with-default + read-from-state
- * semantics identical across both tools.
+ * Shared helper for tools that persist an enum-valued setting in workspace
+ * state. The schemas own parse/default semantics; tool runtimes only adapt
+ * those parsers to the active workspace state.
  */
 
 import { platform } from '@platform/platform';
-
-/**
- * Build a parser that maps an arbitrary string onto a member of `values`,
- * returning `fallback` for anything not in the set. An optional `aliases` map
- * redirects retired/renamed values onto a current member before the fallback.
- */
-export function createEnumParser<T extends string>(
-  values: readonly T[],
-  fallback: T,
-  aliases?: Readonly<Record<string, T>>,
-): (raw: string) => T {
-  const known = values as readonly string[];
-  return (raw: string): T => {
-    if (known.includes(raw)) return raw as T;
-    return aliases?.[raw] ?? fallback;
-  };
-}
 
 /**
  * Build a workspace-state accessor for an enum setting: reads the persisted


### PR DESCRIPTION
Part of #6353.

## Summary
- move Codex and Claude approval-setting defaults/parsers into `@shared/schemas/agentCliSettings`
- move the bash approval config key out of the approval runtime module
- keep tool modules focused on runtime workspace-state access and SDK/env behavior
- add schema-level parser coverage for persisted approval settings and retired Claude model aliases

## Design issue
`src/shared/settingsView/handlers/approvalHandlers.ts` was importing Codex, Claude, and bash tool implementation modules just to normalize settings values. That inverted the layer dependency: a shared settings handler knew about tool runtime modules, making the settings view harder to reuse and forcing runtime concerns into host-neutral code.

The refactor makes `agentCliSettings` the lower-layer owner of the pure setting shapes, defaults, aliases, parsers, and config key. Tool runtimes now import that shared owner and only adapt those values to workspace state or runtime execution.

## Validation
- `npx prettier --write` on touched files
- `npm run typecheck`
- `npm test -- src/test-kernel/schemas/agentCliSettings.vitest.ts src/test-kernel/tools/codexConfig.vitest.ts src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts src/test-kernel/tools/BashToolErrorFeedback.vitest.ts`
- `npm run lint`
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved via moved tests; approval defaults and alias mapping stay the same, only import boundaries change.
> 
> **Overview**
> **Centralizes** Codex/Claude approval and related CLI setting **defaults, parsers, and `BASH_APPROVAL_CONFIG_KEY`** in `@shared/schemas/agentCliSettings`, with a shared `parseEnumSetting` helper (including retired Claude model aliases like `claude-opus-4-7` → `claude-opus-4-8`).
> 
> **Settings view** `approvalHandlers` now imports normalization from shared schemas instead of `@tools/codexConfig`, `@tools/claudeAgentConfig`, and `@tools/approval/bashApproval`. **Tool configs** (`codexConfig`, `claudeAgentConfig`) keep only workspace-state getters via `createEnumStateGetter`; **`createEnumParser` is removed** from `enumConfig.ts`. **`bashApproval`** re-imports the config key from shared (no local definition).
> 
> Parser tests move to **`agentCliSettings.vitest.ts`**; duplicate `parseCodexApprovalPolicy` tests are dropped from `codexConfig.vitest.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9bb0cf71d35f4932fe2f82249d57a4d9c18501b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->