### PR TITLE
[codex] move memory settings wiring to controller layer

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -5,6 +5,7 @@ import {
   isAllowedLatexInstallCommand,
   LatexToolingController,
 } from '@controllers/settingsView/LatexToolingController';
+import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
 import { deleteAllExecutions, deleteExecution } from '@agent/storage';
 import {
   computeAgentOptionsData,
@@ -61,7 +62,6 @@ import {
   createModelSelectionController,
 } from '@shared/settingsView/handlers/modelSelectionHandlers';
 import { createSettingsAgentControllers } from '@shared/settingsView/handlers/agentControllerFactory';
-import { createSettingsMemoryController } from '@shared/settingsView/handlers/memoryControllerFactory';
 import {
   buildSuperYoloMessage,
   setNestedDelegationMaxDepth,
@@ -222,7 +222,6 @@ export function createDesktopSettingsIpc(
       onError,
     });
   const memoryController = createSettingsMemoryController({
-    workspaceState,
     globalState,
     prompt: {
       confirm: (message, promptOptions) =>

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -16,6 +16,7 @@ import { SettingsProfileController } from '@controllers/settingsView/SettingsPro
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
 import { buildToolDashboardItems } from '@controllers/settingsView/ToolDashboardData';
 import { platform } from '@platform/platform';
+import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { BaseViewMessageHandler } from '@common/webview';
@@ -63,7 +64,6 @@ import {
   buildSuperYoloMessage,
   setNestedDelegationMaxDepth,
 } from '@shared/settingsView/handlers/superYoloHandlers';
-import { createSettingsMemoryController } from '@shared/settingsView/handlers/memoryControllerFactory';
 import {
   PROVIDER_DISPLAY_NAMES,
   PROVIDER_URLS,
@@ -133,7 +133,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     };
 
     this.memoryController = createSettingsMemoryController({
-      workspaceState: workspaceSM,
       globalState: globalSM,
       prompt: new VscodePromptHost(),
       setMemoryEnabled: setToolUseMemoryEnabled,

--- a/src/controllers/settingsView/SettingsMemoryControllerFactory.ts
+++ b/src/controllers/settingsView/SettingsMemoryControllerFactory.ts
@@ -1,13 +1,16 @@
 /**
- * Shared `SettingsMemoryController` factory.
+ * Concrete settings-memory controller composition shared by extension and
+ * desktop hosts.
  *
- * The controller's dependencies fall into two groups: filesystem/format
- * primitives that are platform-agnostic (already wired here), and host-only
- * pieces — the prompt host and the memory-enabled toggle — that callers
- * supply.
+ * The controller remains dependency-injected for tests; this factory owns the
+ * production memory storage/format wiring so `src/shared/settingsView` stays
+ * free of tool-layer implementation imports.
  */
-import { SettingsMemoryController } from '@controllers/settingsView/SettingsMemoryController';
+
+// Local imports - shared state
 import { GlobalStateKey } from '@shared/state/stateKeys';
+
+// Local imports - memory tooling
 import {
   loadMemoryItems,
   loadMemoryPreview,
@@ -20,22 +23,29 @@ import {
   setPinnedMeta,
 } from '@tools/memory/memoryMeta';
 import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
+
+// Local imports - file system
 import { StorageFS } from '@utils/files';
 
-import type { SettingsStatePorts } from './types';
+// Local imports - controller
+import { SettingsMemoryController } from './SettingsMemoryController';
+
+// Type-only imports
+import type { StateStore } from '@platform/interfaces/state';
 
 type ConstructorArgs = ConstructorParameters<
   typeof SettingsMemoryController
 >[0];
 
-export interface MemoryControllerFactoryOptions extends SettingsStatePorts {
+export interface SettingsMemoryControllerFactoryOptions {
+  readonly globalState: StateStore;
   readonly prompt: ConstructorArgs['prompt'];
   /** Optional override for persisting the memory-enabled flag. */
   readonly setMemoryEnabled?: ConstructorArgs['setMemoryEnabled'];
 }
 
 export function createSettingsMemoryController(
-  options: MemoryControllerFactoryOptions,
+  options: SettingsMemoryControllerFactoryOptions,
 ): SettingsMemoryController {
   const { globalState } = options;
   return new SettingsMemoryController({

--- a/src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts
+++ b/src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts
@@ -1,0 +1,43 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+import { readdir, readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+
+// Third-party imports
+import { describe, it } from 'vitest';
+
+async function collectTypeScriptFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectTypeScriptFiles(entryPath)));
+    } else if (entry.name.endsWith('.ts')) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+describe('shared settings-view import boundaries', () => {
+  it('does not import tool-layer implementations directly', async () => {
+    const sharedSettingsRoot = path.join(
+      process.cwd(),
+      'src/shared/settingsView',
+    );
+    const files = await collectTypeScriptFiles(sharedSettingsRoot);
+    const directToolImport =
+      /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)['"]@tools\//;
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const source = await readFile(file, 'utf8');
+      if (directToolImport.test(source)) {
+        offenders.push(path.relative(process.cwd(), file));
+      }
+    }
+
+    assert.deepEqual(offenders, []);
+  });
+});


### PR DESCRIPTION
Closes #6353.

## Summary
- move the production `SettingsMemoryController` factory from `src/shared/settingsView/handlers` into `src/controllers/settingsView`
- update extension and desktop settings hosts to import the controller-layer factory directly
- remove the unused `workspaceState` factory input
- add a boundary test that prevents `src/shared/settingsView/**` from importing `@tools/*` directly

## Design issue
`src/shared/settingsView/handlers/memoryControllerFactory.ts` looked host-neutral but imported memory storage, metadata, and filesystem helpers from `@tools/memory/*`. That made the shared settings-view layer a composition owner for tool implementation details.

The controller layer is the clearer owner for this production wiring: `SettingsMemoryController` remains dependency-injected and testable, while the concrete memory file/meta/storage dependencies live next to the controller instead of inside shared IPC handlers.

## Validation
- `npx prettier --write` on touched files
- `npm run typecheck`
- `npm test -- src/test-kernel/controllers/SettingsMemoryController.vitest.ts src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts`
- `npm run lint`
- `npm run compile:fast`
- `npm test`
- `git diff --check`
- `rg -n "@tools/" src/shared/settingsView || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only wiring move with no behavior change; factory surface shrinks by removing an unused option.
> 
> **Overview**
> Moves **production wiring** for `SettingsMemoryController` out of `src/shared/settingsView/handlers` into `src/controllers/settingsView/SettingsMemoryControllerFactory`, so the shared settings-view IPC layer no longer composes `@tools/memory/*` dependencies.
> 
> **Extension** and **desktop** settings hosts now import `createSettingsMemoryController` from the controller factory directly. The factory API drops the unused `workspaceState` argument; callers pass `globalState`, host `prompt`, and (on VS Code) an optional `setMemoryEnabled` override.
> 
> Adds `SharedSettingsViewBoundary.vitest.ts` to assert that nothing under `src/shared/settingsView/**` imports `@tools/*` directly, locking in the layering change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e7e92e390c8b3cc4d4191d6d3c40a5311528560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->