### PR TITLE
[codex] move profile message builder to controller layer

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -6,6 +6,7 @@ import {
   LatexToolingController,
 } from '@controllers/settingsView/LatexToolingController';
 import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
+import { buildProfileMessage } from '@controllers/settingsView/ProfileMessageBuilder';
 import { deleteAllExecutions, deleteExecution } from '@agent/storage';
 import {
   computeAgentOptionsData,
@@ -56,7 +57,6 @@ import {
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
 import { buildHistoryMessage } from '@shared/settingsView/handlers/historyHandlers';
-import { buildProfileMessage } from '@shared/settingsView/handlers/profileHandlers';
 import {
   buildModelSelectionMessage,
   createModelSelectionController,

--- a/src/controllers/settingsView/ProfileMessageBuilder.ts
+++ b/src/controllers/settingsView/ProfileMessageBuilder.ts
@@ -1,6 +1,6 @@
 /**
  * Profile message construction shared between the VS Code extension and the
- * Electron desktop.
+ * Electron desktop settings controllers.
  *
  * Builds the `UPDATE_PROFILE` wire message from shared auth / tier / agent
  * services so the two hosts can't drift — previously each host hand-assembled

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -1,5 +1,4 @@
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import { buildProfileMessage } from '@shared/settingsView/handlers/profileHandlers';
 import type {
   ApiAccessMode,
   NumberVscodeSetting,
@@ -8,6 +7,7 @@ import type {
   UpdateProfileMessage,
 } from '@shared/schemas/profileViewMessages';
 import type { ProviderVscodeSettingDef } from '@shared/constants/providers';
+import { buildProfileMessage } from './ProfileMessageBuilder';
 import type { StateStore } from '@platform/interfaces/state';
 
 export type SettingsReliabilitySetting = Omit<NumberVscodeSetting, 'value'> & {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { buildProfileMessage } from '@controllers/settingsView/ProfileMessageBuilder';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import * as agentRegistry from '@agent/index/agentRegistry';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -15,7 +16,6 @@ import {
   type DesktopAuthCallbackState,
   type DesktopOAuthClient,
 } from '@desktop/main/desktopSupabaseAuth';
-import { buildProfileMessage } from '@shared/settingsView/handlers/profileHandlers';
 import type { StateStore } from '@platform/interfaces/state';
 
 function createCoordinator() {

--- a/src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts
+++ b/src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts
@@ -21,19 +21,19 @@ async function collectTypeScriptFiles(root: string): Promise<string[]> {
 }
 
 describe('shared settings-view import boundaries', () => {
-  it('does not import tool-layer implementations directly', async () => {
+  it('does not import tool or auth implementations directly', async () => {
     const sharedSettingsRoot = path.join(
       process.cwd(),
       'src/shared/settingsView',
     );
     const files = await collectTypeScriptFiles(sharedSettingsRoot);
-    const directToolImport =
-      /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)['"]@tools\//;
+    const directImplementationImport =
+      /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)['"](?:@tools|@auth)\//;
     const offenders: string[] = [];
 
     for (const file of files) {
       const source = await readFile(file, 'utf8');
-      if (directToolImport.test(source)) {
+      if (directImplementationImport.test(source)) {
         offenders.push(path.relative(process.cwd(), file));
       }
     }


### PR DESCRIPTION
Part of #6359.

## Summary
- move `buildProfileMessage` from `src/shared/settingsView/handlers` to `src/controllers/settingsView/ProfileMessageBuilder.ts`
- update desktop, `SettingsProfileController`, and desktop auth tests to import from the controller layer
- extend the shared settings-view boundary test so `src/shared/settingsView/**` cannot import `@auth/*` or `@tools/*` directly

## Design issue
`profileHandlers.ts` lived under `src/shared/settingsView`, but it reached auth, tier, server-side key, provider config, and agent registry services. That made the shared settings-view layer a domain-service composition root.

The profile message builder is still shared by desktop and extension settings controllers, but the controller layer is the clearer owner for that domain-service wiring. The shared settings-view directory now keeps auth/tool implementation imports out of its boundary.

## Validation
- `npx prettier --write` on touched files
- `npm run typecheck`
- `npm test -- src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts`
- `npm run lint`
- `npm run compile:fast`
- `npm test`
- `git diff --check`
- `rg -n "@auth/|@tools/" src/shared/settingsView || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and layering refactor with no change to profile message logic; boundary test only adds enforcement.
> 
> **Overview**
> Moves **`buildProfileMessage`** out of `src/shared/settingsView/handlers` into **`src/controllers/settingsView/ProfileMessageBuilder.ts`**, so profile `UPDATE_PROFILE` assembly (auth, tier, server-side keys, agents) lives with other settings controllers instead of the shared settings-view layer.
> 
> **Desktop** (`desktopSettingsIpc.ts`), **`SettingsProfileController`**, and **desktop auth tests** now import from `@controllers/settingsView/ProfileMessageBuilder` (extension path uses the same module via the controller’s relative import).
> 
> The **shared settings-view boundary test** is tightened: files under `src/shared/settingsView/**` must not import **`@auth/*`** or **`@tools/*`** directly (previously only `@tools` was checked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193c433654b95ec933eb5dc9571a84d5a6c04b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->