### PR TITLE
[codex] move history message builder to controller layer

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -7,6 +7,7 @@ import {
 } from '@controllers/settingsView/LatexToolingController';
 import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
 import { buildProfileMessage } from '@controllers/settingsView/ProfileMessageBuilder';
+import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import { deleteAllExecutions, deleteExecution } from '@agent/storage';
 import {
   computeAgentOptionsData,
@@ -56,7 +57,6 @@ import {
   setBashApprovalEnabled,
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
-import { buildHistoryMessage } from '@shared/settingsView/handlers/historyHandlers';
 import {
   buildModelSelectionMessage,
   createModelSelectionController,

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -6,6 +6,7 @@
  */
 import * as vscode from 'vscode';
 
+import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import {
   getExecutionStore,
   deleteExecution,
@@ -33,7 +34,6 @@ import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
 } from '@shared/schemas/settingsViewMessages';
-import { buildHistoryMessage } from '@shared/settingsView/handlers/historyHandlers';
 import { StorageFS } from '@utils/files';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';

--- a/src/controllers/settingsView/HistoryMessageBuilder.ts
+++ b/src/controllers/settingsView/HistoryMessageBuilder.ts
@@ -1,5 +1,6 @@
 /**
- * History list construction shared between desktop and extension hosts.
+ * History list construction shared between desktop and extension settings
+ * controllers.
  *
  * Both hosts iterate `listExecutions()` and turn each entry into the same
  * `HistoryItem` shape for the settings UI. Action handlers (delete, rerun,

--- a/src/test-kernel/settings/HistoryHandlers.vitest.ts
+++ b/src/test-kernel/settings/HistoryHandlers.vitest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import { AgentCategory } from '@shared/schemas/agent';
 
 const mocks = vi.hoisted(() => ({
@@ -13,8 +14,6 @@ vi.mock('@agent/storage', () => ({
   })),
   listExecutions: mocks.listExecutions,
 }));
-
-import { buildHistoryMessage } from '@shared/settingsView/handlers/historyHandlers';
 
 describe('settings history handlers', () => {
   beforeEach(() => {

--- a/src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts
+++ b/src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts
@@ -21,14 +21,14 @@ async function collectTypeScriptFiles(root: string): Promise<string[]> {
 }
 
 describe('shared settings-view import boundaries', () => {
-  it('does not import tool or auth implementations directly', async () => {
+  it('does not import tool, auth, or execution-storage implementations directly', async () => {
     const sharedSettingsRoot = path.join(
       process.cwd(),
       'src/shared/settingsView',
     );
     const files = await collectTypeScriptFiles(sharedSettingsRoot);
     const directImplementationImport =
-      /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)['"](?:@tools|@auth)\//;
+      /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)['"](?:@tools\/|@auth\/|@agent\/storage(?:\/|['"]))/;
     const offenders: string[] = [];
 
     for (const file of files) {


### PR DESCRIPTION
Part of #6359.

## Summary
- Move history message assembly from `src/shared/settingsView/handlers` into `src/controllers/settingsView/HistoryMessageBuilder.ts`.
- Update desktop, extension, and focused tests to import from the controller layer.
- Extend the shared settings-view boundary test to block direct `@agent/storage` imports alongside tool/auth implementation imports.

## Design issue
`src/shared/settingsView` is a shared UI message/IPC layer, but the old history handler reached directly into execution storage. That leaked agent storage infrastructure into a shared layer and made the shared package harder to reason about.

## Validation
- `npx prettier --write packages/desktop/src/main/desktopSettingsIpc.ts packages/extension/src/settingsView/handlers/historyHandlers.ts src/controllers/settingsView/HistoryMessageBuilder.ts src/test-kernel/settings/HistoryHandlers.vitest.ts src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts`
- `npm run typecheck`
- `npm test -- src/test-kernel/settings/HistoryHandlers.vitest.ts src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts`
- `npm run lint`
- `npm run compile:fast`
- `npm test`
- `git diff --check`
- `rg -n "@agent/storage|@auth/|@tools/" src/shared/settingsView || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only import moves with no behavior change; boundary test prevents regressions into the shared layer.
> 
> **Overview**
> Moves **`buildHistoryMessage`** from `src/shared/settingsView/handlers` into **`src/controllers/settingsView/HistoryMessageBuilder.ts`**, so execution listing and `HistoryItem` assembly live in the controller layer instead of the shared settings-view IPC/message package.
> 
> **Desktop** and **extension** settings code now import the builder from `@controllers/settingsView/HistoryMessageBuilder`; history **actions** (delete, rerun, export) stay in each host. Tests follow the new import path.
> 
> The shared settings-view **boundary test** now also forbids direct **`@agent/storage`** imports (in addition to `@tools/` and `@auth/`), keeping agent storage out of the shared layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ee954ccc8b9fdb7fa4497f879968428fcad889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->