### PR TITLE
[codex] move model selection wiring to controller layer

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -8,6 +8,10 @@ import {
 import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
 import { buildProfileMessage } from '@controllers/settingsView/ProfileMessageBuilder';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
+import {
+  buildModelSelectionMessage,
+  createModelSelectionController,
+} from '@controllers/settingsView/SettingsModelSelectionControllerFactory';
 import { deleteAllExecutions, deleteExecution } from '@agent/storage';
 import {
   computeAgentOptionsData,
@@ -57,10 +61,6 @@ import {
   setBashApprovalEnabled,
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
-import {
-  buildModelSelectionMessage,
-  createModelSelectionController,
-} from '@shared/settingsView/handlers/modelSelectionHandlers';
 import { createSettingsAgentControllers } from '@shared/settingsView/handlers/agentControllerFactory';
 import {
   buildSuperYoloMessage,

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -17,6 +17,10 @@ import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalCo
 import { buildToolDashboardItems } from '@controllers/settingsView/ToolDashboardData';
 import { platform } from '@platform/platform';
 import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
+import {
+  buildModelSelectionMessage,
+  createModelSelectionController,
+} from '@controllers/settingsView/SettingsModelSelectionControllerFactory';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { BaseViewMessageHandler } from '@common/webview';
@@ -56,10 +60,6 @@ import {
   setBashApprovalEnabled as setBashApprovalEnabledShared,
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
-import {
-  buildModelSelectionMessage,
-  createModelSelectionController,
-} from '@shared/settingsView/handlers/modelSelectionHandlers';
 import {
   buildSuperYoloMessage,
   setNestedDelegationMaxDepth,

--- a/src/controllers/settingsView/SettingsModelSelectionControllerFactory.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionControllerFactory.ts
@@ -1,7 +1,7 @@
 /**
- * Model selection controller factory + outbound message builder.
+ * Model selection controller-layer factory + outbound message builder.
  *
- * Both hosts wire the same five global-state pairs into the controller, so
+ * Both hosts wire the same four global-state pairs into the controller, so
  * the factory captures that. The outbound message is also shared.
  */
 import {
@@ -13,7 +13,7 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc/settingsViewCommands';
 import type { UpdateModelSelectionMessage } from '@shared/schemas/settingsViewMessages';
 
-import type { SettingsStatePorts } from './types';
+import type { SettingsStatePorts } from '@shared/settingsView/types';
 
 export type ModelSelectionExtras = Omit<
   SettingsModelSelectionControllerDeps,

--- a/src/shared/settingsView/handlers/agentControllerFactory.ts
+++ b/src/shared/settingsView/handlers/agentControllerFactory.ts
@@ -20,7 +20,7 @@ import {
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
 
-import type { SettingsStatePorts } from './types';
+import type { SettingsStatePorts } from '@shared/settingsView/types';
 
 export interface AgentControllerFactoryOptions extends SettingsStatePorts {
   readonly getCustomAgentDirectory: () => Promise<string>;

--- a/src/shared/settingsView/handlers/approvalHandlers.ts
+++ b/src/shared/settingsView/handlers/approvalHandlers.ts
@@ -24,9 +24,8 @@ import {
   parseCodexReasoningEffort,
   parseCodexSandboxMode,
 } from '@shared/schemas/agentCliSettings';
+import type { SettingsStatePorts } from '@shared/settingsView/types';
 import type { ConfigProvider, ConfigTarget } from '@platform/interfaces/config';
-
-import type { SettingsStatePorts } from './types';
 
 export interface ApprovalHandlerPorts extends SettingsStatePorts {
   readonly config: ConfigProvider;

--- a/src/shared/settingsView/handlers/superYoloHandlers.ts
+++ b/src/shared/settingsView/handlers/superYoloHandlers.ts
@@ -15,7 +15,7 @@ import {
 import type { NumberVscodeSetting } from '@shared/schemas/profileViewMessages';
 import type { UpdateSuperYoloEnabledMessage } from '@shared/schemas/settingsViewMessages';
 
-import type { SettingsStatePorts } from './types';
+import type { SettingsStatePorts } from '@shared/settingsView/types';
 
 export interface SuperYoloHandlerPorts extends SettingsStatePorts {
   /** Host-provided reliability settings (extension only — desktop returns []). */

--- a/src/shared/settingsView/types.ts
+++ b/src/shared/settingsView/types.ts
@@ -1,7 +1,7 @@
 /**
- * Host-neutral types used by shared settings-view handler modules.
+ * Host-neutral types used by settings-view controller and handler wiring.
  *
- * Each handler accepts a minimal "host port" so extension (VS Code) and
+ * Each wiring helper accepts a minimal "host port" so extension (VS Code) and
  * desktop (Electron) can share the per-domain logic without coupling to a
  * particular transport or UI surface.
  */
@@ -10,7 +10,7 @@ import type { StateStore } from '@platform/interfaces/state';
 /** Sends a single message to the settings webview. */
 export type SettingsRespond = (message: unknown) => void | PromiseLike<unknown>;
 
-/** Host-neutral state ports used across most domains. */
+/** Host-neutral state ports used across most settings-view domains. */
 export interface SettingsStatePorts {
   readonly workspaceState: StateStore;
   readonly globalState: StateStore;

--- a/src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts
+++ b/src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts
@@ -21,14 +21,14 @@ async function collectTypeScriptFiles(root: string): Promise<string[]> {
 }
 
 describe('shared settings-view import boundaries', () => {
-  it('does not import tool, auth, or execution-storage implementations directly', async () => {
+  it('does not import tool, auth, execution-storage, or model implementations directly', async () => {
     const sharedSettingsRoot = path.join(
       process.cwd(),
       'src/shared/settingsView',
     );
     const files = await collectTypeScriptFiles(sharedSettingsRoot);
     const directImplementationImport =
-      /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)['"](?:@tools\/|@auth\/|@agent\/storage(?:\/|['"]))/;
+      /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)['"](?:@tools\/|@auth\/|@model\/|@agent\/storage(?:\/|['"]))/;
     const offenders: string[] = [];
 
     for (const file of files) {


### PR DESCRIPTION
Part of #6359.

## Summary
- Move model-selection controller wiring and outbound message construction from `src/shared/settingsView/handlers` into `src/controllers/settingsView/SettingsModelSelectionControllerFactory.ts`.
- Move `SettingsStatePorts` to neutral `src/shared/settingsView/types.ts` so controller-layer wiring does not import from a shared `handlers/` path.
- Extend the shared settings-view boundary test to block direct `@model/*` imports alongside tool/auth/execution-storage implementation imports.

## Design issue
`src/shared/settingsView` should stay close to shared IPC/message helpers, but the old model-selection handler imported `DEFAULT_MODELS` from the model layer and constructed a concrete settings controller. That made the shared settings layer depend on model implementation details. The controller layer is the better owner for this host-neutral wiring.

## Validation
- `npx prettier --write packages/desktop/src/main/desktopSettingsIpc.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts src/controllers/settingsView/SettingsModelSelectionControllerFactory.ts src/shared/settingsView/types.ts src/shared/settingsView/handlers/approvalHandlers.ts src/shared/settingsView/handlers/superYoloHandlers.ts src/shared/settingsView/handlers/agentControllerFactory.ts src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts`
- `npm run typecheck`
- `npm test -- src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts`
- `npm run lint`
- `npm run compile:fast`
- `npm test`
- `git diff --check`
- `rg -n "modelSelectionHandlers|@shared/settingsView/handlers/modelSelectionHandlers" src packages || true`
- `rg -n "@model/|@agent/storage|@auth/|@tools/" src/shared/settingsView || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only import moves and boundary enforcement; settings model-selection behavior should be unchanged for both hosts.
> 
> **Overview**
> Moves **model-selection** host wiring (`createModelSelectionController`, `buildModelSelectionMessage`) out of `src/shared/settingsView/handlers` into `SettingsModelSelectionControllerFactory`, so `@model/*` and concrete controller construction live in the controller layer instead of shared handlers.
> 
> Desktop and extension settings IPC/message handlers now import that factory from `@controllers/settingsView/...` rather than `@shared/settingsView/handlers/modelSelectionHandlers` (removed).
> 
> `SettingsStatePorts` is centralized in `src/shared/settingsView/types.ts`; remaining shared handler modules import it from there instead of a local `./types` under `handlers/`.
> 
> The shared settings-view boundary test now forbids direct `@model/*` imports under `src/shared/settingsView`, alongside existing tool/auth/storage guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7610270928fe2819738ebed85314a835e53dbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->