### PR TITLE
[codex] Keep slash status cwd at the TUI boundary

### DIFF
--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -77,6 +77,7 @@ export interface SlashCommandContext {
   readonly session: TuiSession;
   readonly commandName?: string;
   readonly cwd: CliContext['cwd'];
+  readonly processCwd?: CliContext['cwd'];
   readonly initialAgent: string;
   readonly initialModel: string;
   readonly interruptActive: () => void;
@@ -520,7 +521,7 @@ export async function handleTuiSlashCommand(
           sessionId: slice ? context.session.executionId : undefined,
           commandName: context.commandName,
           cwd: context.cwd,
-          processCwd: process.cwd(),
+          processCwd: context.processCwd,
           approvalPolicy: context.getApprovalPolicy(),
           queuedFollowUpMessages:
             activeStreamId === undefined

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -402,6 +402,7 @@ export async function runChat(
     session,
     commandName: context.commandName,
     cwd: context.cwd,
+    processCwd: process.cwd(),
     initialAgent: agent,
     initialModel: model,
     interruptActive,

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -11,11 +11,19 @@ import {
   listSlashCommands,
   unregisterSlashCommand,
 } from '@cli/chat/tui/commands/slashRegistry';
-import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
+import {
+  cliState,
+  patchStream,
+  resetCliState,
+} from '@cli/chat/tui/state/cliState';
 import type { TuiSession } from '@cli/chat/tui/state/sessionRunState';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
-import type { ExecutionId } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
@@ -42,6 +50,7 @@ function createContext(
   return {
     session,
     cwd: '/tmp/workspace',
+    processCwd: '/tmp/launcher',
     initialAgent: 'chat',
     initialModel: 'deepseekT',
     interruptActive: vi.fn(),
@@ -89,5 +98,31 @@ describe('handleTuiSlashCommand', () => {
     expect(interruptActive).toHaveBeenCalledOnce();
     expect(requestInputExit).toHaveBeenCalledOnce();
     expect(cliState.activeStreamId.get()).toBeUndefined();
+  });
+
+  it('uses the provided process cwd when formatting /status resume hints', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const streamId = 'stream-1' as StreamTabId;
+    session.streamId = streamId;
+    session.executionId = 'exec-1' as ExecutionId;
+    cliState.activeStreamId.set(streamId);
+    patchStream(streamId, (slice) => ({
+      ...slice,
+      status: STREAM_STATUS.WAITING,
+    }));
+
+    const handled = await handleTuiSlashCommand(
+      '/status',
+      createContext(session, { processCwd: '/tmp/workspace' }),
+    );
+
+    expect(handled).toBe(true);
+    const statusText = cliState.streams
+      .get()
+      .get(streamId)
+      ?.entries.at(-1)?.text;
+    expect(statusText).toContain('resume later with: texra resume exec-1');
+    expect(statusText).not.toContain('--cwd');
   });
 });


### PR DESCRIPTION
## Summary

- move the ambient `process.cwd()` read for `/status` out of `handleSlashCommand.ts` and into the TUI entry-point context
- keep slash-command status formatting deterministic by consuming `context.processCwd`
- add a focused regression test for resume hints when the session cwd differs from the shell cwd

Closes #6365.

## Design note

This fixes a high-impact abstraction-layer violation: slash-command dispatch should format command output from supplied session context, while host process reads stay at the CLI/TUI boundary. Leaving the read in the dispatcher made the module harder to test and tripped the CLI architecture gate.

## Validation

- `corepack pnpm --filter @texra-ai/cli check:architecture`
- `npm test -- src/test-kernel/cli/SlashCommandDispatch.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js chat --help`
- `npm run validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-frames slash-goal-help backslash-goal-help plan-approval-goal plan-approval-approve-goal`
- live TTY smoke: `node packages/cli/dist/bin/texra.js chat --api-mode personal --approval-policy ask --cwd /tmp/texra-live`, then `/goal`, `/status`, `Ctrl-C`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small boundary refactor with a focused test; behavior unchanged at runtime when the TUI supplies `process.cwd()`.
> 
> **Overview**
> Moves the **`process.cwd()`** read out of slash-command dispatch and into the TUI entry point when building **`SlashCommandContext`**.
> 
> **`/status`** now passes **`context.processCwd`** into **`formatCliSessionStatus`** instead of calling **`process.cwd()`** inside **`handleSlashCommand`**, so status/resume hint formatting uses injected session context and stays testable without host process reads in the dispatcher.
> 
> Adds a regression test that **`/status`** resume hints use the supplied process cwd (no spurious **`--cwd`** when it matches the session cwd).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea120e27461f6f92d70d453d6261261c3ecddac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->