### PR TITLE
[codex] Validate workflow inputs before model lookup

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -83,13 +83,10 @@ export async function runWorkflowAgent(
     );
   }
 
-  const model = await resolveCliRunModel(context, init.model, 'run');
-  const runContext = buildHeadlessRunContext(context, model);
-
   return withExpandedRunInputs(
     init.inputFiles,
     init.contextFiles,
-    runContext.cwd,
+    context.cwd,
     { readStdinText: readCliStdinText },
     async ({ inputFiles, contextFiles }) => {
       if (init.output && inputFiles.length > 1) {
@@ -98,6 +95,8 @@ export async function runWorkflowAgent(
         );
       }
 
+      const model = await resolveCliRunModel(context, init.model, 'run');
+      const runContext = buildHeadlessRunContext(context, model);
       const config: AgentConfigPayload = {
         agent: init.agent,
         model,

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -233,6 +233,34 @@ describe('CLI workflow run command', () => {
     expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
   });
 
+  it('reports input expansion errors before resolving the model', async () => {
+    mocks.withExpandedRunInputs.mockRejectedValueOnce(
+      new Error('At least one workflow input file is required.'),
+    );
+    const { runWorkflowAgent } = await import('@cli/commands/workflow');
+
+    await expect(
+      runWorkflowAgent(cliContext(), {
+        agent: 'polish',
+        inputFiles: [],
+        contextFiles: [],
+        instruction: '',
+      }),
+    ).rejects.toThrow('At least one workflow input file is required.');
+
+    expect(mocks.initLocalCliPlatform).toHaveBeenCalled();
+    expect(mocks.resolveCliLaunchAgent).toHaveBeenCalledWith('polish', 'run');
+    expect(mocks.withExpandedRunInputs).toHaveBeenCalledWith(
+      [],
+      [],
+      '/tmp/project',
+      { readStdinText: expect.any(Function) },
+      expect.any(Function),
+    );
+    expect(mocks.resolveCliRunModel).not.toHaveBeenCalled();
+    expect(mocks.executeCliConfig).not.toHaveBeenCalled();
+  });
+
   it('passes instruction file contents before inline workflow instructions', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-workflow-'));
     try {


### PR DESCRIPTION
## Summary

- Move `texra run` workflow input expansion ahead of model selection.
- Preserve the existing workflow-agent validation gate, then let `workflowInputs.ts` own input/path usage errors before provider/model setup.
- Add a regression test proving model lookup is not called when workflow input expansion fails.

## Dogfood evidence

Before this change, running a workflow without `--input` could print an unrelated model fallback warning before the actual usage error:

```text
Model "gemini31p" is not available in the active API mode (missing api key). Available models: sonnet46T, opus48T, fable5, gpt55. Using "sonnet46T" instead.
At least one workflow input file is required.
```

After the fix:

```text
At least one workflow input file is required.
```

And a missing path now reports directly:

```text
--input: file not found: missing.tex
```

## Abstraction issue

`workflowInputs.ts` already owns workflow input expansion and validation, but `workflow.ts` called it after resolving the model and building the headless run context. This made command-shape/input errors depend on unrelated provider setup. The command now validates the workflow input specs before model selection while leaving the validation rules in the input runtime module.

Closes #6369

## Validation

- `npx prettier --write packages/cli/src/commands/workflow.ts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `npm test -- src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run lint`
- `git diff --check`
- `node packages/cli/dist/bin/texra.js run correct --instruction "Fix mathematical clarity only." --no-color --no-input --api-mode personal 2>&1 | sed -n '1,120p'`
- `node packages/cli/dist/bin/texra.js run correct --input missing.tex --instruction "Fix mathematical clarity only." --no-color --no-input --api-mode personal 2>&1 | sed -n '1,120p'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reorders CLI setup only; validation rules stay in `workflowInputs.ts` with added test coverage.
> 
> **Overview**
> **`texra run` workflow** now expands and validates inputs via `withExpandedRunInputs` **before** `resolveCliRunModel` and headless run context setup. Model/provider work only runs inside the expansion callback after inputs succeed; expansion uses `context.cwd` directly instead of waiting on `runContext`.
> 
> This stops misleading **model fallback warnings** from appearing ahead of real usage errors (e.g. missing `--input` or bad paths).
> 
> A regression test asserts **`resolveCliRunModel` and `executeCliConfig` are not called** when input expansion fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95fac32831bfa2baa2be437a11357622f939879c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->