### PR TITLE
[codex] Keep child picker overflow out of rows

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2118,7 +2118,7 @@ const SCENARIOS = [
       'f focus',
       'Esc close',
     ],
-    unexpect: ['Tasks and sub-workflows'],
+    unexpect: ['Tasks and sub-workflows', 'strategy — +2 more'],
     maxBlankLinesBetween: [
       {
         from: 'entry-4 chat history line',
@@ -2148,7 +2148,7 @@ const SCENARIOS = [
       'k kill',
       'Esc close',
     ],
-    unexpect: ['Subagents'],
+    unexpect: ['Subagents', 'strategy — +3 more'],
     maxBlankLinesBetween: [
       {
         from: 'entry-4 chat history line',
@@ -2176,7 +2176,7 @@ const SCENARIOS = [
       'Enter view',
       'Esc close',
     ],
-    unexpect: ['Subagents'],
+    unexpect: ['Subagents', 'latex build — +3 earlier'],
   },
   {
     name: 'task-subworkflow-detail',

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -334,7 +334,6 @@ function renderItem(
   item: ChildControlItem,
   index: number,
   highlighted: boolean,
-  extraDetail?: string,
   stackedDetail = false,
 ): React.JSX.Element {
   const commandDetail = item.command !== item.label ? item.command : '';
@@ -352,11 +351,6 @@ function renderItem(
               {item.label}
             </Text>
           </Box>
-          {extraDetail ? (
-            <Box flexShrink={0}>
-              <Text dimColor>{` — ${extraDetail}`}</Text>
-            </Box>
-          ) : null}
           {item.description ? (
             <Text dimColor wrap="truncate-end">{` — ${item.description}`}</Text>
           ) : null}
@@ -385,11 +379,6 @@ function renderItem(
           {item.label}
         </Text>
       </Box>
-      {extraDetail ? (
-        <Box flexShrink={0}>
-          <Text dimColor>{` — ${extraDetail}`}</Text>
-        </Box>
-      ) : null}
       {detail ? (
         <Text dimColor wrap="truncate-end">{` — ${detail}`}</Text>
       ) : null}
@@ -1113,15 +1102,18 @@ export function ChildControlPicker({
   }
 
   if (ultraCompact) {
+    const titleParts = [
+      pickerTitle(mode),
+      streamScopeText,
+      compactOverflowText,
+    ].filter((part): part is string => Boolean(part));
     return (
       <Box flexDirection="column" minWidth={0} width={availableColumns}>
         <Text bold color="cyan" wrap="truncate-end">
-          {streamScopeText
-            ? `${pickerTitle(mode)} · ${streamScopeText}`
-            : pickerTitle(mode)}
+          {titleParts.join(' · ')}
         </Text>
         {selectedItem ? (
-          renderItem(selectedItem, selectedIndex, true, compactOverflowText)
+          renderItem(selectedItem, selectedIndex, true)
         ) : (
           <Text dimColor>{emptyPickerText(mode)}</Text>
         )}
@@ -1169,7 +1161,6 @@ export function ChildControlPicker({
                 item,
                 index,
                 index === selectedIndex,
-                undefined,
                 stackSelectedSubagent && index === selectedIndex,
               );
             })}


### PR DESCRIPTION
## Summary
- move ultra-compact child-picker overflow text into the picker title chrome
- keep `renderItem()` focused on selected child execution metadata
- add PTY harness assertions that compact rows do not absorb overflow labels

## Layer review
Priority: high for compact TUI correctness, low blast radius. The violation was in `ChildControlPicker`: picker viewport state (`+N more` / `+N earlier`) was passed into row rendering as `extraDetail`. That made UI chrome look like execution metadata and coupled list-window accounting to item formatting.

The simpler boundary is: the picker layout owns hidden-item summaries; row rendering owns child execution fields. This PR applies that split directly rather than creating another abstraction.

Fixes #6372

## Validation
- `npm test -- src/test-kernel/cli/ChildControls.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-child-picker-overflow compact-subagent-picker compact-task-picker compact-task-picker-process-overflow tiny-task-subworkflow-detail`
- `git diff --check`
- `npm run lint`
- `corepack pnpm --filter @texra-ai/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only presentation change in `ChildControlPicker` with targeted PTY assertions; no auth, data, or API surface changes.
> 
> **Overview**
> Ultra-compact **Subagents** / **Tasks** pickers no longer append hidden-list summaries (`+N more`, `+N earlier`) to the selected row as `label — …` metadata.
> 
> **`ChildControlPicker`** now builds the cyan title from `pickerTitle`, stream scope, and `compactPickerOverflowText`, joined with ` · `. **`renderItem()`** drops the `extraDetail` parameter and only renders execution fields (label, description, command).
> 
> PTY **`validate-tui`** scenarios add **`unexpect`** patterns so compact frames must not show merged overflow on item rows (e.g. `strategy — +2 more`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e4aabebcfd7bfe04d0b73bfc9987ccdf2138f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->