### PR TITLE
[codex] Show team identity in CLI history

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -26,6 +26,7 @@ import { isDirectory } from '@utils/files/fsEntryType';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 
 import { readCliToolUseResumeDataForListing } from './toolUseResumeData';
+import { formatCliHistoryAgentLabel } from './historyLabels';
 
 const HISTORY_FILE_SCAN_DEPTH = 2;
 const CONVERSATION_PREVIEW_MESSAGE_LIMIT = 3;
@@ -57,6 +58,7 @@ export interface CliHistoryEntry {
   readonly inputBasename: string;
   readonly category?: string;
   readonly description?: string;
+  readonly teamPresetId?: string;
   readonly parentExecutionId?: ExecutionId;
   readonly delegationDepth?: number;
 }
@@ -269,7 +271,7 @@ export function formatCliHistoryText(
       [
         entry.id,
         entry.timestamp,
-        entry.agent,
+        formatCliHistoryAgentLabel(entry),
         entry.status,
         entry.inputBasename,
       ].join('\t'),
@@ -318,6 +320,7 @@ export function formatCliHistoryDetailsText(
 ): string {
   const { config, meta } = details;
   const model = details.currentModel ?? config?.model;
+  const teamPreset = teamPresetId(config);
   const lines = [
     `Execution: ${details.id}`,
     `Status: ${details.status}`,
@@ -326,6 +329,9 @@ export function formatCliHistoryDetailsText(
     `Model: ${model ?? 'unknown'}`,
   ];
 
+  if (teamPreset) {
+    lines.push(`Team: ${teamPreset}`);
+  }
   if (
     details.currentModel &&
     config?.model &&
@@ -388,9 +394,15 @@ async function toCliHistoryEntry(
     inputBasename,
     category: entry.category,
     description: entry.description,
+    teamPresetId: teamPresetId(entry.agentConfig),
     parentExecutionId: entry.parentExecutionId,
     delegationDepth: entry.delegationDepth,
   };
+}
+
+function teamPresetId(config: AgentConfig | null): string | undefined {
+  const preset = config?.cliMultiAgentPresetId?.trim();
+  return preset ? preset : undefined;
 }
 
 function firstInputBasename(config: AgentConfig | null): string {

--- a/packages/cli/src/runtime/historyLabels.ts
+++ b/packages/cli/src/runtime/historyLabels.ts
@@ -13,11 +13,17 @@ function formatCliHistoryResumeInputLabel(
   return entry.description?.trim() || 'no input';
 }
 
+export function formatCliHistoryAgentLabel(
+  entry: Pick<CliHistoryEntry, 'agent' | 'teamPresetId'>,
+): string {
+  return entry.teamPresetId ? `team:${entry.teamPresetId}` : entry.agent;
+}
+
 export function formatCliHistoryResumeSummary(
   entry: Pick<
     CliHistoryEntry,
-    'agent' | 'description' | 'inputBasename' | 'status'
+    'agent' | 'description' | 'inputBasename' | 'status' | 'teamPresetId'
   >,
 ): string {
-  return `${entry.agent}; ${entry.status}; ${formatCliHistoryResumeInputLabel(entry)}`;
+  return `${formatCliHistoryAgentLabel(entry)}; ${entry.status}; ${formatCliHistoryResumeInputLabel(entry)}`;
 }

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -133,6 +133,35 @@ describe('CLI history runtime', () => {
     ]);
   });
 
+  it('labels multi-agent team runs by preset in history lists', async () => {
+    const teamConfig = {
+      ...config,
+      agent: 'engineer',
+      agentCategory: 'toolUse',
+      inputFiles: [],
+      outputFiles: [],
+      cliMultiAgentPresetId: ' software-engineer ',
+    } as AgentConfig;
+    mocks.listExecutions.mockResolvedValue([
+      {
+        id: 'team1' as ExecutionId,
+        timestamp: '2026-05-18T10:00:00.000Z',
+        agent: 'engineer',
+        model: 'sonnet46T',
+        agentConfig: teamConfig,
+        terminalStatus: 'resumable',
+      },
+    ]);
+
+    const entries = await listCliHistoryEntries();
+
+    expect(entries[0]?.agent).toBe('engineer');
+    expect(entries[0]?.teamPresetId).toBe('software-engineer');
+    expect(formatCliHistoryText(entries)).toBe(
+      'team1\t2026-05-18T10:00:00.000Z\tteam:software-engineer\tresumable\t-',
+    );
+  });
+
   it('parses positive history list limits', () => {
     expect(parseHistoryListLimit('1')).toBe(1);
     expect(parseHistoryListLimit('25')).toBe(25);
@@ -240,6 +269,23 @@ describe('CLI history runtime', () => {
     expect(details?.currentModel).toBe('gpt55');
     expect(text).toContain('Model: gpt55');
     expect(text).toContain('Startup model: gpt54');
+  });
+
+  it('shows the team preset in details without hiding the root agent', async () => {
+    mocks.readConfig.mockResolvedValue({
+      ...config,
+      agent: 'engineer',
+      model: 'sonnet46T',
+      agentCategory: 'toolUse',
+      cliMultiAgentPresetId: ' software-engineer ',
+    } as AgentConfig);
+
+    const details = await readCliHistoryDetails('team1' as ExecutionId);
+    const text = formatCliHistoryDetailsText(details!);
+
+    expect(text).toContain('Agent: engineer');
+    expect(text).toContain('Team: software-engineer');
+    expect(text).not.toContain('Team:  software-engineer ');
   });
 
   it('shows a bounded final assistant preview when no report is stored', async () => {


### PR DESCRIPTION
## Summary
- derive a `teamPresetId` on CLI history entries from persisted `cliMultiAgentPresetId`
- display team runs as `team:<preset>` in history rows and resume summaries
- show the team preset in `history show` while preserving the raw root agent

## Why
Dogfooding `texra multi-agent run software-engineer --instruction ...` and interrupting it left a resumable history entry labeled only as `engineer`. The saved config already had `cliMultiAgentPresetId: "software-engineer"`, so the history layer was leaking the implementation root agent into the user-facing team history surface.

Fixes #6374

## Validation
- `npm test -- src/test-kernel/cli/History.vitest.mts src/test-kernel/cli/HistoryStatus.vitest.ts`
- `npm test -- src/test-kernel/cli/ResumeListForm.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `git diff --check`
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run lint`
- `node packages/cli/dist/bin/texra.js history list --limit 5 --no-color`
- `node packages/cli/dist/bin/texra.js history show 524e1c69f2e0 --no-color | sed -n '1,28p'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes to CLI history formatting and entry shape; no execution, storage, or auth behavior changes.
> 
> **Overview**
> Multi-agent team runs were showing only the root agent (e.g. `engineer`) in CLI history even when `cliMultiAgentPresetId` was saved on the run config.
> 
> History entries now carry an optional **`teamPresetId`** (trimmed from `cliMultiAgentPresetId`). **List rows** and **resume summaries** use **`team:<preset>`** via `formatCliHistoryAgentLabel` when a preset is present; single-agent runs are unchanged. **`history show`** adds a **`Team:`** line with the preset while still printing **`Agent:`** for the root agent. NDJSON history entries include `teamPresetId` for structured consumers (e.g. resume TUI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a66ec6335dd4304c16d7ee4efa0e5b53e2a1cc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->