### PR TITLE
refactor(progress): keep output backups in file actions

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -79,10 +79,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly agentProposalController: ProgressAgentProposalController;
   private readonly apiKeyRetryController: ProgressApiKeyRetryController;
   private readonly followUpController: ProgressFollowUpController;
-  private readonly modelOutputBackups = new Map<
-    StreamTabId,
-    Map<string, { content: string; streamId: StreamTabId }>
-  >();
 
   /**
    * Type-safe handler registry - handlers receive typed data.
@@ -109,14 +105,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       progressTitle: 'Transcribing follow-up message',
     });
 
-    this.handlerRegistry = this.createHandlerRegistry();
-    this.streamLifecycleController = this.createStreamLifecycleController();
-    this.workflowActionsController = this.createWorkflowActionsController();
     this.workflowFileActionsController =
       this.createWorkflowFileActionsController();
+    this.streamLifecycleController = this.createStreamLifecycleController();
+    this.workflowActionsController = this.createWorkflowActionsController();
     this.agentProposalController = this.createAgentProposalController();
     this.apiKeyRetryController = this.createApiKeyRetryController();
     this.followUpController = this.createFollowUpController();
+    this.handlerRegistry = this.createHandlerRegistry();
 
     const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
       void this.streamLifecycleController.deleteStream(streamId);
@@ -399,7 +395,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       },
       host: new ProgressStreamLifecycleHost(
         this.provider,
-        this.modelOutputBackups,
+        this.workflowFileActionsController,
       ),
     });
   }
@@ -515,7 +511,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           text,
         });
       },
-      modelOutputBackups: this.modelOutputBackups,
     });
   }
 

--- a/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
+++ b/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
@@ -14,15 +14,16 @@ import type { ProgressStreamLifecycleHost as ProgressStreamLifecycleHostPort } f
 import type { ProgressViewProvider } from '../ProgressViewProvider';
 
 type StreamTabId = import('@shared/schemas').StreamTabId;
-type ModelOutputBackups = Map<
-  StreamTabId,
-  Map<string, { content: string; streamId: StreamTabId }>
->;
+
+interface ModelOutputBackupCleaner {
+  clearStreamBackups(stream: StreamTabId): void;
+  clearAllBackups(): void;
+}
 
 export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostPort {
   constructor(
     private readonly provider: ProgressViewProvider,
-    private readonly modelOutputBackups: ModelOutputBackups,
+    private readonly backupCleaner: ModelOutputBackupCleaner,
   ) {}
 
   getVisibleStreamIds(): StreamTabId[] {
@@ -49,7 +50,7 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
   cleanupDeletedStream(stream: StreamTabId): void {
     cleanupApprovalsForStream(stream);
     ToolUseFollowUpQueue.release(stream);
-    this.modelOutputBackups.delete(stream);
+    this.backupCleaner.clearStreamBackups(stream);
     this.provider.webviewBridge.clearStream(stream);
   }
 
@@ -58,7 +59,7 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
     for (const stream of streams) {
       ToolUseFollowUpQueue.release(stream);
     }
-    this.modelOutputBackups.clear();
+    this.backupCleaner.clearAllBackups();
     this.provider.webviewBridge.clearAll();
   }
 

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -48,7 +48,6 @@ export interface ProgressWorkflowFileActionsControllerDeps {
   state: ProgressWorkflowFileActionsState;
   host: ProgressWorkflowFileActionsHost;
   sendFollowUp(stream: StreamTabId, text: string): Promise<void>;
-  modelOutputBackups?: Map<StreamTabId, Map<string, ModelOutputBackup>>;
 }
 
 type ModelOutputBackup = {
@@ -57,16 +56,14 @@ type ModelOutputBackup = {
 };
 
 export class ProgressWorkflowFileActionsController {
-  private readonly modelOutputBackups: Map<
+  private readonly modelOutputBackups = new Map<
     StreamTabId,
     Map<string, ModelOutputBackup>
-  >;
+  >();
 
   constructor(
     private readonly deps: ProgressWorkflowFileActionsControllerDeps,
-  ) {
-    this.modelOutputBackups = deps.modelOutputBackups ?? new Map();
-  }
+  ) {}
 
   async openTaskStorage(stream: StreamTabId): Promise<void> {
     try {

--- a/src/test-kernel/controllers/ProgressWorkflowFileActionsHostFlows.vitest.ts
+++ b/src/test-kernel/controllers/ProgressWorkflowFileActionsHostFlows.vitest.ts
@@ -109,38 +109,35 @@ describe('ProgressWorkflowFileActionsController', () => {
     ]);
   });
 
-  it('does not send accept follow-up when the host cancels acceptance', async () => {
-    const backups = new Map([
-      [
-        'workflow',
-        new Map([
-          [
-            '/workspace/edited.tex',
-            {
-              content: 'original model output',
-              streamId: 'workflow' as const,
-            },
-          ],
-        ]),
-      ],
-    ]);
+  it('keeps the accept follow-up backup when the host cancels acceptance', async () => {
     const followUps: string[] = [];
+    const acceptResults = [false, true];
+    const readResults = [
+      'original model output',
+      'user edited output',
+      'user edited output',
+    ];
     const deps = createDeps({
-      acceptEditedFile: async () => false,
-      readFile: async () => 'user edited output',
+      acceptEditedFile: async () => acceptResults.shift(),
+      readFile: async () => readResults.shift() ?? '',
     });
     deps.state.getActiveStream = () => 'workflow';
     deps.sendFollowUp = async (_stream, text) => {
       followUps.push(text);
     };
-    const controller = new ProgressWorkflowFileActionsController({
-      ...deps,
-      modelOutputBackups: backups,
-    });
+    const controller = new ProgressWorkflowFileActionsController(deps);
 
+    await controller.compareOriginal(
+      '/workspace/edited.tex',
+      '/workspace/base.tex',
+    );
     await controller.acceptFile('/workspace/edited.tex', '/workspace/base.tex');
 
     assert.deepEqual(followUps, []);
-    assert.equal(backups.get('workflow')?.has('/workspace/edited.tex'), true);
+
+    await controller.acceptFile('/workspace/edited.tex', '/workspace/base.tex');
+
+    assert.equal(followUps.length, 1);
+    assert.match(followUps[0] ?? '', /edited\.tex/);
   });
 });


### PR DESCRIPTION
## Summary

- move model-output backup ownership into `ProgressWorkflowFileActionsController`
- remove the nested backup map from `ProgressViewMessageHandler`
- make `ProgressStreamLifecycleHost` call backup cleanup methods instead of mutating the controller's storage shape
- keep the cancelled-accept regression covered through public controller behavior

Closes #6376.

## Validation

- `npm test -- src/test-kernel/controllers/ProgressWorkflowFileActionsController.vitest.ts src/test-kernel/controllers/ProgressWorkflowFileActionsHostFlows.vitest.ts src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal ownership refactor in progress view workflow file handling; accept/compare follow-up behavior is unchanged and covered by updated tests.
> 
> **Overview**
> Moves **model-output backup** storage out of `ProgressViewMessageHandler` into `ProgressWorkflowFileActionsController`, which now always owns the per-stream backup map instead of accepting an injected shared map.
> 
> Stream deletion cleanup goes through a small **`ModelOutputBackupCleaner`** port on `ProgressStreamLifecycleHost` (`clearStreamBackups` / `clearAllBackups` on the file-actions controller) so lifecycle no longer mutates backup storage directly. The message handler constructs the file-actions controller before the stream lifecycle host so that host can receive the controller as the cleaner.
> 
> The host-flow test now asserts that a **cancelled accept** leaves the backup in place (via `compareOriginal` + failed then successful `acceptFile`), so a later accept can still send the “user edited before accepting” follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e501a662073515292e5e48a4f9d9d40ca9834da8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->