### PR TITLE
fix(cli): show workflow output in history details

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -321,6 +321,7 @@ export function formatCliHistoryDetailsText(
   const { config, meta } = details;
   const model = details.currentModel ?? config?.model;
   const teamPreset = teamPresetId(config);
+  const cliOutputFile = config?.cliOutputFile?.trim();
   const lines = [
     `Execution: ${details.id}`,
     `Status: ${details.status}`,
@@ -340,6 +341,7 @@ export function formatCliHistoryDetailsText(
     lines.push(`Startup model: ${config.model}`);
   }
   if (config?.agentCategory) lines.push(`Category: ${config.agentCategory}`);
+  if (cliOutputFile) lines.push(`CLI output: ${cliOutputFile}`);
   if (meta?.parentExecutionId) lines.push(`Parent: ${meta.parentExecutionId}`);
   if (meta?.delegationDepth !== undefined) {
     lines.push(`Delegation depth: ${meta.delegationDepth}`);

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -288,6 +288,19 @@ describe('CLI history runtime', () => {
     expect(text).not.toContain('Team:  software-engineer ');
   });
 
+  it('surfaces the explicit CLI output file in history details', async () => {
+    mocks.readConfig.mockResolvedValue({
+      ...config,
+      cliOutputFile: ' /tmp/texra-output/polished.tex ',
+    } as AgentConfig);
+
+    const details = await readCliHistoryDetails('a1' as ExecutionId);
+    const text = formatCliHistoryDetailsText(details!);
+
+    expect(text).toContain('CLI output: /tmp/texra-output/polished.tex');
+    expect(text).not.toContain('CLI output:  /tmp/texra-output/polished.tex ');
+  });
+
   it('shows a bounded final assistant preview when no report is stored', async () => {
     mocks.readConversation.mockResolvedValue([
       { role: 'user', content: 'Review the proof.' },


### PR DESCRIPTION
## Summary

- show `AgentConfig.cliOutputFile` as a top-level `CLI output:` line in `texra history show`
- trim whitespace-only/padded output values before rendering
- add formatter coverage for the workflow output target

Closes #6378.

## Dogfood evidence

A real workflow run completed with:

`texra-local run polish --input /tmp/texra-math-workflow.kIh0Q5/main.tex --output /tmp/texra-math-workflow.kIh0Q5/polished.tex --instruction ... --no-input --approval-policy never --no-color`

Before this change, `history show a1469866d9c0` only exposed that output path inside raw config JSON. After rebuilding, the summary includes:

`CLI output: /tmp/texra-math-workflow.kIh0Q5/polished.tex`

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-workflow-goal-frames slash-goal-help backslash-goal-help plan-approval-goal compact-plan-approval-goal plan-approval-approve-goal task-picker task-subworkflow-detail task-subworkflow-detail-long-output task-process-detail compact-task-picker-process-overflow approval-policy-status-bar bash-approval-session-status`
- `npm test -- src/test-kernel/cli/History.vitest.mts src/test-kernel/cli/HistoryStatus.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli build`
- `npm run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI formatting change with no impact on execution, storage, or auth.
> 
> **Overview**
> **`texra history show`** now prints a dedicated **`CLI output:`** line when the run stored **`AgentConfig.cliOutputFile`** (e.g. workflow **`--output`**), so the target path is visible in the summary instead of only inside the dumped config JSON.
> 
> The value is **trimmed** before display; whitespace-only values are omitted. A formatter test covers padded paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b2514bb33d31dbdc473ccd9be7b1c7e1702686f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->