### PR TITLE
[codex] Hide progress stream state behind navigation facade

### DIFF
--- a/packages/extension/src/progressView/progressNavigation.ts
+++ b/packages/extension/src/progressView/progressNavigation.ts
@@ -1,4 +1,5 @@
 import type { StreamTabId } from '@shared/schemas';
+import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 
 import {
   ProgressViewProvider,
@@ -14,4 +15,12 @@ export async function revealProgressStream(
 ): Promise<ProgressNavigationRevealResult> {
   const provider = ProgressViewProvider.getInstance();
   return provider ? provider.revealStream(streamId) : 'unavailable';
+}
+
+export function getProgressStreamLabel(
+  streamId: StreamTabId,
+): string | undefined {
+  const state = ProgressViewProvider.getInstance()?.state;
+  if (!state) return undefined;
+  return buildStreamInfo(state, streamId, 'all')?.label;
 }

--- a/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
@@ -10,10 +10,11 @@ import * as vscode from 'vscode';
 import { SecretManager } from '@frontend/secretManager';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
-import { revealProgressStream } from '@progressView/progressNavigation';
+import {
+  getProgressStreamLabel,
+  revealProgressStream,
+} from '@progressView/progressNavigation';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
@@ -89,7 +90,6 @@ export class GitHubSubscriptionHandlers {
   }
 
   async sendPRSubscriptions(webview: vscode.Webview): Promise<void> {
-    const state = ProgressViewProvider.getInstance()?.state;
     const toEntry = (
       key: string,
       streamIds: readonly string[],
@@ -97,9 +97,7 @@ export class GitHubSubscriptionHandlers {
       key,
       owners: streamIds.map((streamId) => ({
         streamId,
-        label: state
-          ? (buildStreamInfo(state, streamId, 'all')?.label ?? streamId)
-          : streamId,
+        label: getProgressStreamLabel(streamId) ?? streamId,
       })),
     });
     const prEntries = listPRSubscriptionBindings(

--- a/src/test-kernel/settings/GitHubSubscriptionHandlersLayering.vitest.ts
+++ b/src/test-kernel/settings/GitHubSubscriptionHandlersLayering.vitest.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+function readGitHubSubscriptionHandlers(): string {
+  return readFileSync(
+    resolve(
+      REPO_ROOT,
+      'packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts',
+    ),
+    'utf8',
+  );
+}
+
+function importSources(source: string): string[] {
+  return [...source.matchAll(/from\s+['"]([^'"]+)['"]/g)].map(
+    (match) => match[1] ?? '',
+  );
+}
+
+describe('GitHubSubscriptionHandlers layering', () => {
+  it('uses the progress navigation facade instead of progress view state', () => {
+    const imports = importSources(readGitHubSubscriptionHandlers());
+
+    expect(imports).not.toContain('@progressView/ProgressViewProvider');
+    expect(imports).not.toContain(
+      '@shared/progressView/backend/streamInfoUtils',
+    );
+    expect(imports).toContain('@progressView/progressNavigation');
+  });
+});


### PR DESCRIPTION
## Summary

- adds `getProgressStreamLabel()` to the progress navigation facade
- updates Settings GitHub subscription rendering to use that facade instead of `ProgressViewProvider.getInstance()?.state`
- adds a small layering regression test so the handler does not import progress provider state or stream-info internals again

Fixes #6382.

## Validation

- `texra-local doctor --output-format json --no-color`
- `texra-local multi-agent list --no-color`
- `texra-local multi-agent inspect software-engineer --no-color`
- `texra-local multi-agent inspect mathematician --no-color`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/settings/GitHubSubscriptionHandlersLayering.vitest.ts`
- `corepack pnpm exec eslint packages/extension/src/progressView/progressNavigation.ts packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts src/test-kernel/settings/GitHubSubscriptionHandlersLayering.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npm run lint`
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small architectural refactor with unchanged user-visible behavior for subscription labels and stream reveal.
> 
> **Overview**
> **Settings GitHub subscriptions** no longer reach into `ProgressViewProvider` state or `buildStreamInfo` directly when building owner labels for PR/repo/issue entries.
> 
> A new **`getProgressStreamLabel()`** on `progressNavigation` centralizes that lookup (same fallback: `streamId` when no label). **`sendPRSubscriptions`** now calls the facade alongside the existing **`revealProgressStream`** usage.
> 
> A **layering vitest** asserts `githubSubscriptionHandlers.ts` only imports `@progressView/progressNavigation` for progress concerns, not provider or stream-info internals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ae5abaa771ceafb7bd09211be40edde63860bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->