### PR TITLE
refactor: extract ChatExportController from history handler

### DIFF
--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -4,9 +4,14 @@
  * Handles rerun/restore/delete of past executions, clearing history,
  * and exporting a conversation as Markdown, LaTeX/PDF, or self-contained HTML.
  */
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
+import {
+  ChatExportController,
+  type ExportInputStatus,
+} from '@controllers/settingsView/ChatExportController';
 import {
   getExecutionStore,
   deleteExecution,
@@ -19,22 +24,13 @@ import {
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
-import {
-  formatChatAsMarkdown,
-  formatChatAsLatex,
-  generateExportFilename,
-  generateExportFolderName,
-  type ChatExportInput,
-} from '@commands/history/chatExportFormatter';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
-import { compileLatex2Pdf } from '@latex/texTools';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ExecutionId } from '@shared/schemas';
 import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
 } from '@shared/schemas/settingsViewMessages';
-import { StorageFS } from '@utils/files';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
 
@@ -42,11 +38,17 @@ type ChatExportFormat = 'md' | 'tex' | 'html';
 
 /** History and chat-export handler delegate. */
 export class HistoryHandlers {
-  /** Used by HTML export to locate the bundled assets. */
-  private readonly extensionPath: string;
+  private readonly chatExportController = new ChatExportController();
+
+  /** Path to the bundled HTML export assets (under extension resources). */
+  private readonly htmlAssetsSrc: string;
 
   constructor(private readonly ctx: SettingsHandlerContext) {
-    this.extensionPath = ctx.extensionContext.extensionPath;
+    this.htmlAssetsSrc = path.join(
+      ctx.extensionContext.extensionPath,
+      'resources',
+      'htmlExport',
+    );
   }
 
   async sendHistoryData(webview: vscode.Webview): Promise<void> {
@@ -132,85 +134,25 @@ export class HistoryHandlers {
     format: ChatExportFormat,
   ): Promise<void> {
     try {
-      const store = getExecutionStore(data.historyId as ExecutionId);
-      const [rawConfig, conversation, meta] = await Promise.all([
-        store.readConfig(),
-        store.readConversation(),
-        store.readMeta(),
-      ]);
+      const result = await this.chatExportController.buildExportInput(
+        data.historyId,
+      );
 
-      if (!rawConfig) {
-        await vscode.window.showErrorMessage('History item not found');
+      if (!this.reportExportInputError(result.status)) {
         return;
       }
 
-      if (!conversation) {
-        await vscode.window.showErrorMessage(
-          'No conversation data available for this execution',
-        );
-        return;
-      }
-
-      const config = AgentConfigSchema.parse(rawConfig);
-
-      const exportInput: ChatExportInput = {
-        timestamp: meta?.timestamp ?? new Date().toISOString(),
-        description: meta?.description,
-        config: {
-          agent: config.agent,
-          model: config.model,
-          instruction: config.instruction,
-          inputFiles: config.inputFiles,
-          mediaFiles: config.mediaFiles,
-          contextFiles: config.contextFiles,
-          outputFiles: config.outputFiles,
-        },
-        messages: conversation,
-      };
+      const exportInput = result.exportInput!;
 
       if (format === 'html') {
-        await this.exportChatAsHtml(data.historyId, exportInput);
+        await this.exportAndOpenHtml(data.historyId, exportInput);
         return;
       }
 
-      const filename = generateExportFilename(exportInput, format);
-      const storagePath = `executions/${data.historyId}/${filename}`;
-
-      const content =
-        format === 'md'
-          ? formatChatAsMarkdown(exportInput)
-          : formatChatAsLatex(exportInput);
-
-      await StorageFS.write(storagePath, content);
-      const absolutePath = StorageFS.fullPath(storagePath);
-
-      if (format === 'tex') {
-        // Compile LaTeX to PDF
-        const { pathToLocation } = await import('@utils/files');
-        const location = pathToLocation(absolutePath);
-        const compiled = await compileLatex2Pdf(location);
-
-        if (compiled) {
-          // Open the generated PDF
-          const pdfPath = absolutePath.replace(/\.tex$/, '.pdf');
-          const pdfUri = vscode.Uri.file(pdfPath);
-          await vscode.commands.executeCommand('vscode.open', pdfUri);
-          void vscode.window.showInformationMessage(
-            `Chat exported and compiled: ${filename.replace('.tex', '.pdf')}`,
-          );
-        } else {
-          // Compilation failed — open the .tex source instead
-          const doc = await vscode.workspace.openTextDocument(absolutePath);
-          await vscode.window.showTextDocument(doc, { preview: false });
-          void vscode.window.showWarningMessage(
-            'LaTeX compilation failed. The .tex source file has been opened instead.',
-          );
-        }
+      if (format === 'md') {
+        await this.exportAndOpenMarkdown(data.historyId, exportInput);
       } else {
-        // Open Markdown file
-        const doc = await vscode.workspace.openTextDocument(absolutePath);
-        await vscode.window.showTextDocument(doc, { preview: false });
-        void vscode.window.showInformationMessage(`Chat exported: ${filename}`);
+        await this.exportAndOpenLatex(data.historyId, exportInput);
       }
     } catch (error) {
       await showLoggedErrorMessage(
@@ -221,49 +163,80 @@ export class HistoryHandlers {
     }
   }
 
+  // ==========================================================
+  // Private helpers
+  // ==========================================================
+
   /**
-   * Build a self-contained HTML chat export.
-   *
-   * Layout (under the execution's storage folder):
-   *   texra-chat-{date}-{slug}/
-   *     index.html           ← TeXRA styling inlined; references ./assets/*
-   *     assets/              ← katex.min.css, texmath.css, hljs themes, fonts
-   *
-   * Opens index.html in the user's default browser so they see the same
-   * KaTeX/highlight.js rendering an audience would see.
+   * Translate the controller's export-input status into a user-visible
+   * error message. Returns `true` when the caller should proceed.
    */
-  private async exportChatAsHtml(
+  private reportExportInputError(status: ExportInputStatus): boolean {
+    switch (status) {
+      case 'config_missing':
+        void vscode.window.showErrorMessage('History item not found');
+        return false;
+      case 'conversation_missing':
+        void vscode.window.showErrorMessage(
+          'No conversation data available for this execution',
+        );
+        return false;
+      case 'ok':
+        return true;
+    }
+  }
+
+  private async exportAndOpenMarkdown(
     historyId: string,
-    exportInput: ChatExportInput,
+    exportInput: Parameters<
+      ChatExportController['exportAsMarkdown']
+    >[1],
   ): Promise<void> {
-    const path = await import('node:path');
-    const { formatChatAsHtml } =
-      await import('@commands/history/htmlExport/htmlFormatter');
+    const { absolutePath, storagePath } =
+      await this.chatExportController.exportAsMarkdown(historyId, exportInput);
+    const doc = await vscode.workspace.openTextDocument(absolutePath);
+    await vscode.window.showTextDocument(doc, { preview: false });
+    const filename = storagePath.split('/').pop() ?? storagePath;
+    void vscode.window.showInformationMessage(`Chat exported: ${filename}`);
+  }
 
-    const folderName = generateExportFolderName(exportInput);
-    const folderPath = `executions/${historyId}/${folderName}`;
-    const assetsPath = `${folderPath}/assets`;
+  private async exportAndOpenLatex(
+    historyId: string,
+    exportInput: Parameters<ChatExportController['exportAsLatex']>[1],
+  ): Promise<void> {
+    const { absolutePath, storagePath, pdfPath } =
+      await this.chatExportController.exportAsLatex(historyId, exportInput);
 
-    // Stage assets BEFORE writing index.html so a missing/failed asset
-    // copy can never leave behind an HTML file pointing at empty `./assets`.
-    const assetsSrc = path.join(this.extensionPath, 'resources', 'htmlExport');
-    const fsExtra = (await import('fs-extra')).default;
-    if (!(await fsExtra.pathExists(assetsSrc))) {
-      throw new Error(
-        `HTML export assets missing at ${assetsSrc} — rebuild the extension ` +
-          `(npm run package:fast) so scripts/copy-html-export-assets.mjs runs.`,
+    if (pdfPath) {
+      // Open the generated PDF
+      const pdfUri = vscode.Uri.file(pdfPath);
+      await vscode.commands.executeCommand('vscode.open', pdfUri);
+      const filename = storagePath.split('/').pop() ?? storagePath;
+      void vscode.window.showInformationMessage(
+        `Chat exported and compiled: ${filename.replace('.tex', '.pdf')}`,
+      );
+    } else {
+      // Compilation failed — open the .tex source instead
+      const doc = await vscode.workspace.openTextDocument(absolutePath);
+      await vscode.window.showTextDocument(doc, { preview: false });
+      void vscode.window.showWarningMessage(
+        'LaTeX compilation failed. The .tex source file has been opened instead.',
       );
     }
-    await StorageFS.ensureDir(folderPath);
-    await fsExtra.copy(assetsSrc, StorageFS.fullPath(assetsPath), {
-      overwrite: true,
-    });
+  }
 
-    const html = formatChatAsHtml(exportInput);
-    await StorageFS.write(`${folderPath}/index.html`, html);
+  private async exportAndOpenHtml(
+    historyId: string,
+    exportInput: Parameters<ChatExportController['exportAsHtml']>[1],
+  ): Promise<void> {
+    const { absolutePath, folderName } =
+      await this.chatExportController.exportAsHtml(
+        historyId,
+        exportInput,
+        this.htmlAssetsSrc,
+      );
 
-    const htmlAbsolute = StorageFS.fullPath(`${folderPath}/index.html`);
-    await vscode.env.openExternal(vscode.Uri.file(htmlAbsolute));
+    await vscode.env.openExternal(vscode.Uri.file(absolutePath));
     void vscode.window.showInformationMessage(
       `Chat exported to ${folderName}/index.html`,
     );

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import {
   ChatExportController,
+  type ChatExportInput,
   type ExportInputStatus,
 } from '@controllers/settingsView/ChatExportController';
 import {
@@ -138,11 +139,12 @@ export class HistoryHandlers {
         data.historyId,
       );
 
-      if (!this.reportExportInputError(result.status)) {
+      if (result.status !== 'ok') {
+        this.reportExportInputError(result.status);
         return;
       }
 
-      const exportInput = result.exportInput!;
+      const { exportInput } = result;
 
       if (format === 'html') {
         await this.exportAndOpenHtml(data.historyId, exportInput);
@@ -169,26 +171,26 @@ export class HistoryHandlers {
 
   /**
    * Translate the controller's export-input status into a user-visible
-   * error message. Returns `true` when the caller should proceed.
+   * error message.
    */
-  private reportExportInputError(status: ExportInputStatus): boolean {
+  private reportExportInputError(
+    status: Exclude<ExportInputStatus, 'ok'>,
+  ): void {
     switch (status) {
       case 'config_missing':
         void vscode.window.showErrorMessage('History item not found');
-        return false;
+        return;
       case 'conversation_missing':
         void vscode.window.showErrorMessage(
           'No conversation data available for this execution',
         );
-        return false;
-      case 'ok':
-        return true;
+        return;
     }
   }
 
   private async exportAndOpenMarkdown(
     historyId: string,
-    exportInput: Parameters<ChatExportController['exportAsMarkdown']>[1],
+    exportInput: ChatExportInput,
   ): Promise<void> {
     const { absolutePath, storagePath } =
       await this.chatExportController.exportAsMarkdown(historyId, exportInput);
@@ -200,7 +202,7 @@ export class HistoryHandlers {
 
   private async exportAndOpenLatex(
     historyId: string,
-    exportInput: Parameters<ChatExportController['exportAsLatex']>[1],
+    exportInput: ChatExportInput,
   ): Promise<void> {
     const { absolutePath, storagePath, pdfPath } =
       await this.chatExportController.exportAsLatex(historyId, exportInput);
@@ -225,7 +227,7 @@ export class HistoryHandlers {
 
   private async exportAndOpenHtml(
     historyId: string,
-    exportInput: Parameters<ChatExportController['exportAsHtml']>[1],
+    exportInput: ChatExportInput,
   ): Promise<void> {
     const { absolutePath, folderName } =
       await this.chatExportController.exportAsHtml(

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -188,9 +188,7 @@ export class HistoryHandlers {
 
   private async exportAndOpenMarkdown(
     historyId: string,
-    exportInput: Parameters<
-      ChatExportController['exportAsMarkdown']
-    >[1],
+    exportInput: Parameters<ChatExportController['exportAsMarkdown']>[1],
   ): Promise<void> {
     const { absolutePath, storagePath } =
       await this.chatExportController.exportAsMarkdown(historyId, exportInput);

--- a/src/controllers/settingsView/ChatExportController.ts
+++ b/src/controllers/settingsView/ChatExportController.ts
@@ -22,6 +22,8 @@ import {
   type ChatExportInput,
 } from '@commands/history/chatExportFormatter';
 
+export type { ChatExportInput };
+
 // Local imports - LaTeX
 import { compileLatex2Pdf } from '@latex/texTools';
 
@@ -41,10 +43,9 @@ export type ExportInputStatus =
   | 'config_missing'
   | 'conversation_missing';
 
-export interface ExportInputResult {
-  readonly status: ExportInputStatus;
-  readonly exportInput?: ChatExportInput;
-}
+export type ExportInputResult =
+  | { readonly status: 'ok'; readonly exportInput: ChatExportInput }
+  | { readonly status: Exclude<ExportInputStatus, 'ok'> };
 
 export interface ChatExportResult {
   /** Storage-relative path to the exported file. */
@@ -163,7 +164,6 @@ export class ChatExportController {
     exportInput: ChatExportInput,
     assetsSrc: string,
   ): Promise<HtmlExportResult> {
-    const path = await import('node:path');
     const { formatChatAsHtml } =
       await import('@commands/history/htmlExport/htmlFormatter');
     const fsExtra = (await import('fs-extra')).default;

--- a/src/controllers/settingsView/ChatExportController.ts
+++ b/src/controllers/settingsView/ChatExportController.ts
@@ -1,0 +1,197 @@
+/**
+ * Chat export orchestration controller.
+ *
+ * Owns execution loading, export input construction, formatter selection,
+ * storage writes, HTML asset staging, and LaTeX compilation. The Settings
+ * handler calls this controller and performs only host UI actions (opening
+ * a file, showing a message, opening a browser).
+ *
+ * This module is VS Code-free — all platform wiring lives in the caller.
+ */
+
+// Local imports - agent
+import { getExecutionStore } from '@agent/storage';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+
+// Local imports - commands (VS Code-free modules)
+import {
+  formatChatAsMarkdown,
+  formatChatAsLatex,
+  generateExportFilename,
+  generateExportFolderName,
+  type ChatExportInput,
+} from '@commands/history/chatExportFormatter';
+
+// Local imports - LaTeX
+import { compileLatex2Pdf } from '@latex/texTools';
+
+// Local imports - schemas
+import type { ExecutionId } from '@shared/schemas';
+
+// Local imports - utils
+import { StorageFS, pathToLocation } from '@utils/files';
+
+// ============================================================
+// Result types
+// ============================================================
+
+/** Outcome of loading execution data for export. */
+export type ExportInputStatus =
+  | 'ok'
+  | 'config_missing'
+  | 'conversation_missing';
+
+export interface ExportInputResult {
+  readonly status: ExportInputStatus;
+  readonly exportInput?: ChatExportInput;
+}
+
+export interface ChatExportResult {
+  /** Storage-relative path to the exported file. */
+  readonly storagePath: string;
+  /** Absolute filesystem path to the exported file. */
+  readonly absolutePath: string;
+}
+
+export interface LatexExportResult extends ChatExportResult {
+  /** Absolute path to the compiled PDF, or undefined if compilation failed. */
+  readonly pdfPath?: string;
+}
+
+export interface HtmlExportResult extends ChatExportResult {
+  /** Folder name relative to the execution storage. */
+  readonly folderName: string;
+}
+
+// ============================================================
+// Controller
+// ============================================================
+
+export class ChatExportController {
+  /**
+   * Load execution data and construct the format-agnostic {@link ChatExportInput}.
+   *
+   * Returns a discriminated status so the caller can show the right error
+   * message for each missing piece without coupling to storage details.
+   */
+  async buildExportInput(historyId: string): Promise<ExportInputResult> {
+    const store = getExecutionStore(historyId as ExecutionId);
+    const [rawConfig, conversation, meta] = await Promise.all([
+      store.readConfig(),
+      store.readConversation(),
+      store.readMeta(),
+    ]);
+
+    if (!rawConfig) {
+      return { status: 'config_missing' };
+    }
+
+    if (!conversation) {
+      return { status: 'conversation_missing' };
+    }
+
+    const config = AgentConfigSchema.parse(rawConfig);
+
+    const exportInput: ChatExportInput = {
+      timestamp: meta?.timestamp ?? new Date().toISOString(),
+      description: meta?.description,
+      config: {
+        agent: config.agent,
+        model: config.model,
+        instruction: config.instruction,
+        inputFiles: config.inputFiles,
+        mediaFiles: config.mediaFiles,
+        contextFiles: config.contextFiles,
+        outputFiles: config.outputFiles,
+      },
+      messages: conversation,
+    };
+
+    return { status: 'ok', exportInput };
+  }
+
+  /**
+   * Format and write a Markdown export.
+   */
+  async exportAsMarkdown(
+    historyId: string,
+    exportInput: ChatExportInput,
+  ): Promise<ChatExportResult> {
+    const filename = generateExportFilename(exportInput, 'md');
+    const storagePath = `executions/${historyId}/${filename}`;
+    const content = formatChatAsMarkdown(exportInput);
+    await StorageFS.write(storagePath, content);
+    return { storagePath, absolutePath: StorageFS.fullPath(storagePath) };
+  }
+
+  /**
+   * Format, write, and compile a LaTeX export.
+   *
+   * Stores the `.tex` source and runs `pdflatex` / `latexmk` on it.
+   * Returns the compiled PDF path when compilation succeeds so the caller
+   * can decide whether to open the PDF or fall back to the `.tex` source.
+   */
+  async exportAsLatex(
+    historyId: string,
+    exportInput: ChatExportInput,
+  ): Promise<LatexExportResult> {
+    const filename = generateExportFilename(exportInput, 'tex');
+    const storagePath = `executions/${historyId}/${filename}`;
+    const content = formatChatAsLatex(exportInput);
+    await StorageFS.write(storagePath, content);
+
+    const absolutePath = StorageFS.fullPath(storagePath);
+    const location = pathToLocation(absolutePath);
+    const compiled = await compileLatex2Pdf(location);
+
+    const pdfPath = compiled
+      ? absolutePath.replace(/\.tex$/, '.pdf')
+      : undefined;
+
+    return { storagePath, absolutePath, pdfPath };
+  }
+
+  /**
+   * Format and write a self-contained HTML export.
+   *
+   * Stages third-party assets (KaTeX CSS, highlight.js themes) from
+   * `assetsSrc` next to the generated `index.html` so the exported page
+   * is fully self-contained and opens correctly in any browser.
+   */
+  async exportAsHtml(
+    historyId: string,
+    exportInput: ChatExportInput,
+    assetsSrc: string,
+  ): Promise<HtmlExportResult> {
+    const path = await import('node:path');
+    const { formatChatAsHtml } =
+      await import('@commands/history/htmlExport/htmlFormatter');
+    const fsExtra = (await import('fs-extra')).default;
+
+    const folderName = generateExportFolderName(exportInput);
+    const folderPath = `executions/${historyId}/${folderName}`;
+    const assetsPath = `${folderPath}/assets`;
+
+    if (!(await fsExtra.pathExists(assetsSrc))) {
+      throw new Error(
+        `HTML export assets missing at ${assetsSrc} — rebuild the extension ` +
+          `(npm run package:fast) so scripts/copy-html-export-assets.mjs runs.`,
+      );
+    }
+
+    await StorageFS.ensureDir(folderPath);
+    await fsExtra.copy(assetsSrc, StorageFS.fullPath(assetsPath), {
+      overwrite: true,
+    });
+
+    const html = formatChatAsHtml(exportInput);
+    const indexPath = `${folderPath}/index.html`;
+    await StorageFS.write(indexPath, html);
+
+    return {
+      storagePath: indexPath,
+      absolutePath: StorageFS.fullPath(indexPath),
+      folderName,
+    };
+  }
+}


### PR DESCRIPTION
Moves execution loading, export input construction, formatter selection, storage writes, HTML asset staging, and LaTeX compilation into a new VS Code-free `ChatExportController`.

The Settings history handler now delegates to this controller and handles only VS Code host UI actions (opening files, showing messages, opening the browser).

Closes #6381

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with logic moved, not rewritten; export paths and user-facing errors are preserved.
> 
> **Overview**
> Chat export logic moves out of **`HistoryHandlers`** into a new VS Code-free **`ChatExportController`** that loads execution data, builds **`ChatExportInput`**, writes exports to storage, stages HTML assets, and runs LaTeX compilation.
> 
> **`handleExportChat`** now calls **`buildExportInput`** (with **`config_missing`** / **`conversation_missing`** statuses mapped to the same user messages), then delegates to **`exportAsMarkdown`**, **`exportAsLatex`**, or **`exportAsHtml`** before opening files, the PDF, or the browser. Export behavior is intended to stay the same; the handler only wires host UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77782bb5e025ee3322ec2ba530d188c0e9536d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->