### PR TITLE
refactor: eliminate raw Node I/O from VS Code-free zones

### DIFF
--- a/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
+++ b/packages/extension/src/frontend/vscode/vscodeFileSystem.ts
@@ -35,6 +35,14 @@ export class VscodeFileSystem implements FileSystemProvider {
     };
   }
 
+  async isSymlink(target: string): Promise<boolean> {
+    // vscode.workspace.fs.readDirectory does not reliably set the SymbolicLink
+    // bit in the returned FileType bitmask on all platforms. Use lstat directly
+    // (the extension host is always Node) to get the authoritative answer.
+    const lstats = await fs.promises.lstat(target);
+    return lstats.isSymbolicLink();
+  }
+
   async realPath(target: string): Promise<string> {
     return fs.promises.realpath(target);
   }

--- a/src/agent/goal/promptLoader.ts
+++ b/src/agent/goal/promptLoader.ts
@@ -10,13 +10,12 @@
  * yet wired Goal, or under tests), template lookups fall back to the
  * inline copy in `inlineTemplates` so the continuation loop still works.
  */
-import { readFile } from 'node:fs/promises';
-
 import * as yaml from 'yaml';
 import { z } from 'zod';
 
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
+import { AbsoluteFS } from '@utils/files/absoluteFS';
 
 const GoalPromptsYamlSchema = z.object({
   continuation: z.object({ template: z.string().min(1) }),
@@ -83,7 +82,7 @@ async function loadPrompts(): Promise<GoalPrompts> {
     return cached;
   }
   try {
-    const content = await readFile(goalYamlPath, 'utf8');
+    const content = await AbsoluteFS.read(goalYamlPath);
     cached = GoalPromptsYamlSchema.parse(yaml.parse(content));
   } catch (err) {
     // Fall back to inline templates, but warn so a broken/missing bundled

--- a/src/agent/runtime/polishModel.ts
+++ b/src/agent/runtime/polishModel.ts
@@ -1,8 +1,8 @@
-import { readFile } from 'node:fs/promises';
-
 import * as nunjucks from 'nunjucks';
 import * as yaml from 'yaml';
 import { z } from 'zod';
+
+import { AbsoluteFS } from '@utils/files/absoluteFS';
 
 const nunjucksEnv = nunjucks.configure({ autoescape: false });
 
@@ -30,7 +30,7 @@ function loadPromptTemplate(): Promise<string> {
     );
   }
   templatePromise = (async () => {
-    const content = await readFile(polishPromptPath, 'utf8');
+    const content = await AbsoluteFS.read(polishPromptPath);
     return PolishYamlSchema.parse(yaml.parse(content)).prompts.userRequest;
   })();
   return templatePromise;

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -57,7 +57,12 @@ export async function collectTexFiles(
     const absPath = path.join(dir, name);
     // Skip symlinks — they are mirrored dependency copies placed by
     // ensureMirroredInRoundDir, not revised outputs.
-    if (await platform().fs.isSymlink(absPath).catch(() => false)) continue;
+    if (
+      await platform()
+        .fs.isSymlink(absPath)
+        .catch(() => false)
+    )
+      continue;
     if (isFile(type)) {
       if (hasExtension(name, '.tex')) {
         results.push(prefix ? `${prefix}/${name}` : name);

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -30,7 +30,7 @@ import {
   resolveRunDir,
 } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
-import { isDirectory, isFile, isSymlink } from '@utils/files/fsEntryType';
+import { isDirectory, isFile } from '@utils/files/fsEntryType';
 
 import { CHANNEL } from './service';
 
@@ -120,14 +120,20 @@ export async function scanRunDirForOutputs(
     const rounds = new Map<number, OutputFileInfo[]>();
 
     for (const [entryName, fileType] of dirEntries) {
-      // Skip symlinked round dirs, matching the prior strict
-      // `!== FileType.Directory` check (platform FS reports symlinks as
-      // `SymbolicLink | targetType`).
-      if (!isDirectory(fileType) || isSymlink(fileType)) continue;
+      if (!isDirectory(fileType)) continue;
       const round = parseWorkflowOutputRoundDir(entryName);
       if (round == null) continue;
 
       const roundDirAbsolute = path.join(runDirAbsolute, entryName);
+      // Skip symlinked round dirs. Use lstat through the platform because
+      // readDirectory FileType values do not reliably include SymbolicLink.
+      if (
+        await platform()
+          .fs.isSymlink(roundDirAbsolute)
+          .catch(() => false)
+      )
+        continue;
+
       const outputs: OutputFileInfo[] = [];
       // Collect .tex files recursively — extracted docs may live in subdirs
       // (e.g. r0/chapters/main.tex) when source names include path segments.

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -5,7 +5,6 @@
  */
 
 // Standard library imports
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 // Local imports
@@ -57,14 +56,8 @@ export async function collectTexFiles(
   for (const [name, type] of entries) {
     const absPath = path.join(dir, name);
     // Skip symlinks — they are mirrored dependency copies placed by
-    // ensureMirroredInRoundDir, not revised outputs.  Use lstat because
-    // some vscode.workspace.fs implementations don't set the SymbolicLink
-    // flag in the returned FileType bitmask.
-    try {
-      if ((await fs.promises.lstat(absPath)).isSymbolicLink()) continue;
-    } catch {
-      // lstat failed; fall through and include the entry
-    }
+    // ensureMirroredInRoundDir, not revised outputs.
+    if (await platform().fs.isSymlink(absPath).catch(() => false)) continue;
     if (isFile(type)) {
       if (hasExtension(name, '.tex')) {
         results.push(prefix ? `${prefix}/${name}` : name);

--- a/src/platform/defaults/nodeFilesystem.ts
+++ b/src/platform/defaults/nodeFilesystem.ts
@@ -92,6 +92,11 @@ export const nodeFilesystem: FileSystemProvider = {
     };
   },
 
+  async isSymlink(target: string): Promise<boolean> {
+    const lstats = await fs.promises.lstat(target);
+    return lstats.isSymbolicLink();
+  },
+
   async realPath(target: string): Promise<string> {
     return fs.promises.realpath(target);
   },

--- a/src/platform/interfaces/filesystem.ts
+++ b/src/platform/interfaces/filesystem.ts
@@ -29,6 +29,12 @@ export interface FileStat {
 
 export interface FileSystemProvider {
   stat(path: string): Promise<FileStat>;
+  /**
+   * Returns true when `path` is a symbolic link (does NOT follow the link).
+   * Prefer this over checking the `SymbolicLink` bit from `readDirectory`
+   * entries; some `vscode.workspace.fs` implementations do not set that bit.
+   */
+  isSymlink(path: string): Promise<boolean>;
   realPath(path: string): Promise<string>;
   readFile(path: string): Promise<Uint8Array>;
   readFileChunk(

--- a/src/test-kernel/agent/GoalPromptParity.vitest.mts
+++ b/src/test-kernel/agent/GoalPromptParity.vitest.mts
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import * as yaml from 'yaml';
 
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createFakePlatform } from '@test/support/FakePlatform';
 import {
   getContinuationTemplate,
   initializeGoalPrompts,
@@ -58,6 +60,8 @@ describe('Goal prompt parity (YAML ↔ inline fallback)', () => {
   });
 
   it('loads the host-provided goal YAML path directly', async () => {
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
     const yamlPath = resolve(
       REPO_ROOT,
       'packages/extension/resources/goal/goal.yaml',

--- a/src/test-kernel/agent/PolishPromptLoader.vitest.mts
+++ b/src/test-kernel/agent/PolishPromptLoader.vitest.mts
@@ -6,7 +6,6 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - platform
-import { initPlatform } from '@platform/platform';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createFakePlatform } from '@test/support/FakePlatform';
 
@@ -23,6 +22,7 @@ const REPO_ROOT = resolve(
 
 describe('polish prompt loader', () => {
   it('loads the host-provided polish YAML path directly', async () => {
+    const { initPlatform } = await import('@platform/platform');
     initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
     initializePolishModel(
       resolve(

--- a/src/test-kernel/agent/PolishPromptLoader.vitest.mts
+++ b/src/test-kernel/agent/PolishPromptLoader.vitest.mts
@@ -5,6 +5,11 @@ import { fileURLToPath } from 'node:url';
 // Third-party imports
 import { describe, expect, it } from 'vitest';
 
+// Local imports - platform
+import { initPlatform } from '@platform/platform';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createFakePlatform } from '@test/support/FakePlatform';
+
 // Local imports - agent runtime
 import {
   initializePolishModel,
@@ -18,6 +23,7 @@ const REPO_ROOT = resolve(
 
 describe('polish prompt loader', () => {
   it('loads the host-provided polish YAML path directly', async () => {
+    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
     initializePolishModel(
       resolve(
         REPO_ROOT,

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -290,6 +290,11 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     return fileStat(this.requireRecord(target));
   }
 
+  async isSymlink(_target: string): Promise<boolean> {
+    // FakeFileSystemProvider does not model symlinks.
+    return false;
+  }
+
   async realPath(target: string): Promise<string> {
     this.requireRecord(target);
     return normalizePath(target);


### PR DESCRIPTION
## Summary

Three abstraction-layer violations found during a deep audit of VS Code-free zones (`src/agent/`, `src/latex/`) that had raw Node.js I/O bypassing the `platform().fs` abstraction.

- **`polishModel.ts` + `promptLoader.ts`**: Both modules injected a file path from the host correctly, but then read it with `readFile` from `node:fs/promises` directly instead of routing through `AbsoluteFS.read()` → `platform().fs.readFile()`. Replaced with `AbsoluteFS` imported from its specific submodule path (`@utils/files/absoluteFS`) to avoid pulling the barrel's `flexibleFS` re-export — which calls `logger.initialize()` at module scope — into the agent zone at import time.

- **`outputDiscovery.ts`**: Mixed `platform().fs.readDirectory()` (correct) with a raw `fs.promises.lstat().isSymbolicLink()` bypass. The bypass existed because `vscode.workspace.fs.readDirectory` does not reliably set the `SymbolicLink` bitmask in the returned `FileType`. Fixed by adding `isSymlink(path: string): Promise<boolean>` to `FileSystemProvider` and implementing it in all three providers: `nodeFilesystem` (lstat), `VscodeFileSystem` (lstat — extension host is always Node), and `FakeFileSystemProvider` (returns `false`). The `node:fs` import is removed from `outputDiscovery.ts`.

## Files changed

| File | Change |
|------|--------|
| `src/platform/interfaces/filesystem.ts` | Add `isSymlink(path)` to the interface |
| `src/platform/defaults/nodeFilesystem.ts` | Implement via `lstat` |
| `packages/extension/src/frontend/vscode/vscodeFileSystem.ts` | Implement via `lstat` (Node is always available in the extension host) |
| `src/test-kernel/support/FakePlatform.ts` | Implement returning `false` (fake FS has no symlinks) |
| `src/agent/runtime/polishModel.ts` | `readFile` → `AbsoluteFS.read` |
| `src/agent/goal/promptLoader.ts` | `readFile` → `AbsoluteFS.read` |
| `src/latex/latexdiff/outputDiscovery.ts` | Drop `node:fs` import; use `platform().fs.isSymlink()` |
| `src/test-kernel/agent/PolishPromptLoader.vitest.mts` | Init platform with `nodeFilesystem` so `AbsoluteFS.read` can resolve |

## Test plan

- [x] `npm run typecheck` — no new type errors
- [x] `npm test` — 490 test files pass; 1 pre-existing `execUtils` process-abort flake is the only failure (confirmed pre-existing on `main` before this branch)
- [x] `PolishPromptLoader.vitest.mts` — now passes with platform initialized
- [x] `CliInitPlatform.vitest.mts` — continues to pass (submodule import avoids the `flexibleFS` logger.initialize side-effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhUvBde5LGy4E9Q8Z1dPWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhUvBde5LGy4E9Q8Z1dPWR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly abstraction wiring; symlink skipping in latexdiff discovery is behavior-preserving but now depends on the new platform method across hosts.
> 
> **Overview**
> Removes raw `node:fs` usage from VS Code–free agent and latex paths by routing bundled YAML reads through **`AbsoluteFS.read`** (`promptLoader`, `polishModel`) and symlink checks through **`platform().fs.isSymlink`** (`outputDiscovery`).
> 
> Adds **`isSymlink`** to **`FileSystemProvider`**, implemented with **`lstat`** on Node and the VS Code extension host (because **`readDirectory`** / **`FileType`** symlink bits are unreliable there), and as always-**`false`** on the fake FS. Latexdiff output discovery now skips symlinked `.tex` files and round dirs via that API instead of local **`lstat`** or bitmask heuristics.
> 
> Kernel tests that load host YAML paths initialize the platform with **`nodeFilesystem`** so **`AbsoluteFS`** can read real files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a049f59dbd19e965e2c081efdb232cd1eab194e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->