### PR TITLE
refactor: move orchestrator catalog logic to controller

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -490,6 +490,7 @@ export function createDesktopSettingsIpc(
     options.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
       customPresets: agentCatalogController.getCustomPresets(),
+      orchestratorAgents: agentCatalogController.getOrchestratorAgentNames(),
     });
   }
 

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -11,14 +11,7 @@ import * as vscode from 'vscode';
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
-import {
-  createKey,
-  getAgent,
-  getAgentsByCategory,
-  loadAgents,
-} from '@agent/index';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { BUILTIN_TEAM_ROOT_AGENT_NAMES } from '@agent/index/agentRegistry';
+import { createKey, getAgent, loadAgents } from '@agent/index';
 import { fetchRemoteAgentConfigYaml } from '@agent/remote/remoteAgentConfigClient';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { workspaceSM, globalSM } from '@common/state';
@@ -29,7 +22,6 @@ import {
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { renderAgentTemplateFromBundle } from '@frontend/agents/agentTemplateBundle';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { hasDelegationTool } from '@shared/constants/delegationTools';
 import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
@@ -399,7 +391,7 @@ export class AgentHandlers {
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
       customPresets: this.catalogController.getCustomPresets(),
-      orchestratorAgents: collectOrchestratorAgentNames(),
+      orchestratorAgents: this.catalogController.getOrchestratorAgentNames(),
     });
   }
 
@@ -550,18 +542,4 @@ export class AgentHandlers {
       vscode.commands.executeCommand('texra.refreshAllOptions'),
     ]);
   }
-}
-
-/**
- * Agent names that can lead a team. Combines the known built-in team roots
- * (valid even before the registry has loaded remote agents) with any loaded
- * tool-use agent that carries delegation tools, so custom orchestrators are
- * recognized by capability instead of by name.
- */
-function collectOrchestratorAgentNames(): string[] {
-  const names = new Set<string>(BUILTIN_TEAM_ROOT_AGENT_NAMES);
-  for (const agent of getAgentsByCategory(AgentCategory.ToolUse)) {
-    if (hasDelegationTool(agent.tools)) names.add(agent.name);
-  }
-  return [...names].sort();
 }

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -10,6 +10,7 @@ import {
   type AgentSource,
 } from '@shared/schemas/agent';
 import type { AgentSelectionItem } from '@shared/schemas/settingsViewMessages';
+import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { byName } from '@utils/core';
 
 export interface SettingsAgentCatalogEntry {
@@ -35,6 +36,7 @@ export interface SettingsAgentCatalogState {
 
 export interface SettingsAgentCatalogControllerDeps {
   state: SettingsAgentCatalogState;
+  builtInOrchestratorAgentNames?: readonly string[];
   now?: () => number;
 }
 
@@ -134,6 +136,14 @@ export class SettingsAgentCatalogController {
     return (
       this.getCustomPresets().find((preset) => preset.id === presetId) ?? null
     );
+  }
+
+  getOrchestratorAgentNames(): string[] {
+    const names = new Set(this.deps.builtInOrchestratorAgentNames ?? []);
+    for (const agent of this.deps.state.getAgents('toolUse')) {
+      if (hasDelegationTool(agent.tools)) names.add(agent.name);
+    }
+    return [...names].sort();
   }
 
   async applyPreset(presetId: string): Promise<SettingsAgentPresetApplyResult> {

--- a/src/controllers/settingsView/SettingsAgentControllerFactory.ts
+++ b/src/controllers/settingsView/SettingsAgentControllerFactory.ts
@@ -12,6 +12,7 @@ import {
 import { SettingsAgentDirectoryController } from '@controllers/settingsView/SettingsAgentDirectoryController';
 import { SettingsAgentVisibilityController } from '@controllers/settingsView/SettingsAgentVisibilityController';
 import {
+  BUILTIN_TEAM_ROOT_AGENT_NAMES,
   getAgent,
   getAgentsByCategory,
   getVisibleAgents as getVisibleRegistryAgents,
@@ -29,6 +30,7 @@ export interface AgentControllerFactoryOptions extends SettingsStatePorts {
   ) => Promise<string | undefined>;
   readonly getAgents?: (category: AgentCategory) => AgentEntry[];
   readonly getVisibleAgents?: (category: AgentCategory) => AgentEntry[];
+  readonly builtInOrchestratorAgentNames?: readonly string[];
 }
 
 export interface SettingsAgentControllers {
@@ -69,7 +71,11 @@ export function createSettingsAgentControllers(
     },
   };
 
-  const catalog = new SettingsAgentCatalogController({ state });
+  const catalog = new SettingsAgentCatalogController({
+    state,
+    builtInOrchestratorAgentNames:
+      options.builtInOrchestratorAgentNames ?? BUILTIN_TEAM_ROOT_AGENT_NAMES,
+  });
   const directory = new SettingsAgentDirectoryController({
     state: {
       getConfiguredCustomDir: () =>

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -47,9 +47,11 @@ const AGENTS: Record<AgentCategory, SettingsAgentCatalogEntry[]> = {
 };
 
 function createController(options?: {
+  agents?: Partial<Record<AgentCategory, SettingsAgentCatalogEntry[]>>;
   enabled?: Partial<Record<AgentCategory, string[] | undefined>>;
   visible?: Partial<Record<AgentCategory, SettingsAgentCatalogEntry[]>>;
   customPresets?: unknown;
+  builtInOrchestratorAgentNames?: readonly string[];
   now?: number;
 }): {
   controller: SettingsAgentCatalogController;
@@ -61,14 +63,18 @@ function createController(options?: {
   return {
     controller: new SettingsAgentCatalogController({
       now: () => options?.now ?? 123,
+      builtInOrchestratorAgentNames: options?.builtInOrchestratorAgentNames,
       state: {
         getEnabledAgentKeys: (category) => enabled[category],
         setEnabledAgentKeys: async (category, enabledKeys) => {
           enabled[category] = enabledKeys;
         },
-        getAgents: (category) => AGENTS[category],
+        getAgents: (category) =>
+          options?.agents?.[category] ?? AGENTS[category],
         getVisibleAgents: (category) =>
-          options?.visible?.[category] ?? AGENTS[category],
+          options?.visible?.[category] ??
+          options?.agents?.[category] ??
+          AGENTS[category],
         getCustomPresetsRaw: () => customPresetsRaw,
         setCustomPresets: async (presets) => {
           customPresetsRaw = presets;
@@ -182,6 +188,28 @@ describe('SettingsAgentCatalogController', () => {
     });
 
     assert.deepEqual(controller.getCustomPresets(), []);
+  });
+
+  it('collects built-in and capability-based orchestrator agent names', () => {
+    const { controller } = createController({
+      agents: {
+        toolUse: [
+          ...AGENTS.toolUse,
+          {
+            source: 'custom',
+            name: 'teamLead',
+            category: 'toolUse',
+            tools: ['delegate_agent'],
+          },
+        ],
+      },
+      builtInOrchestratorAgentNames: ['orchestrator'],
+    });
+
+    assert.deepEqual(controller.getOrchestratorAgentNames(), [
+      'orchestrator',
+      'teamLead',
+    ]);
   });
 
   it('drops only invalid custom presets', () => {

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1342,6 +1342,11 @@ describe('desktop settings IPC', () => {
     expect(infoMessages).toEqual(['Saved team "Paper Team"']);
     expect(posted.at(-1)).toMatchObject({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
+      orchestratorAgents: expect.arrayContaining([
+        'engineer',
+        'leanOrchestrator',
+        'orchestrator',
+      ]),
       customPresets: [
         expect.objectContaining({
           name: 'Paper Team',
@@ -1388,7 +1393,7 @@ describe('desktop settings IPC', () => {
     expect(
       workspaceState.values.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
     ).toEqual([]);
-    expect(posted.at(-1)).toEqual({
+    expect(posted.at(-1)).toMatchObject({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
       customPresets: [],
     });


### PR DESCRIPTION
## Summary
- move team orchestrator-name detection from the VS Code settings handler into `SettingsAgentCatalogController`
- pass built-in team roots through the existing settings agent controller factory dependency path
- have desktop settings IPC post the same controller-derived `orchestratorAgents` field as the extension settings view

## Abstraction Review
### Violation addressed
`packages/extension/src/settingsView/handlers/agentHandlers.ts` was importing agent-registry constants and delegation-tool rules to decide which agents can lead a team. That made the UI/message-handler layer know catalog-domain eligibility rules, increasing coupling and making desktop/extension parity easy to miss.

### Simpler design
`SettingsAgentCatalogController` now owns the catalog query. Host handlers only post controller output, while the factory wires built-in team roots as a dependency.

Closes #6390

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/settings/GitHubSubscriptionHandlersLayering.vitest.ts src/test-kernel/settings/SharedSettingsViewBoundary.vitest.ts`
- `corepack pnpm exec eslint src/controllers/settingsView/SettingsAgentCatalogController.ts src/controllers/settingsView/SettingsAgentControllerFactory.ts packages/extension/src/settingsView/handlers/agentHandlers.ts packages/desktop/src/main/desktopSettingsIpc.ts src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npm run lint` (passes with 3 pre-existing import-order warnings outside this change)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layering refactor with preserved behavior (built-in roots plus delegation-tool detection); limited to settings preset messaging and agent team UI data.
> 
> **Overview**
> Moves **which agents can lead a team** out of the VS Code settings handler and into `SettingsAgentCatalogController`, so desktop and extension both surface the same `orchestratorAgents` list without duplicating registry/delegation rules in the UI layer.
> 
> `getOrchestratorAgentNames()` merges configured built-in team roots (defaulting to `BUILTIN_TEAM_ROOT_AGENT_NAMES` via `createSettingsAgentControllers`) with any loaded **tool-use** agent that has a delegation tool (`hasDelegationTool`). Extension `agentHandlers` and desktop `postAgentModePresets` now only post that controller output on `UPDATE_AGENT_MODE_PRESETS`.
> 
> Tests cover the new catalog method and assert desktop preset save/delete messages include `orchestratorAgents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7700f68eba2abbdcfb1be1bf68648ca107abcd27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->