### PR TITLE
fix(agent): preserve math style in correct workflow

### DIFF
--- a/packages/extension/resources/agents/correct.yaml
+++ b/packages/extension/resources/agents/correct.yaml
@@ -38,7 +38,8 @@ prompts:
 
     As you review the document, make only proofreading corrections:
     - Preserve every mathematical claim, equation, theorem statement, and factual assertion.
-    - Do not change math tokens inside inline math, display math, theorem statements, or derivations except for LaTeX syntax/formatting fixes such as spacing, delimiters, braces, or indentation.
+    - Do not change the meaning of math expressions inside inline math, display math, theorem statements, or derivations.
+    - Preserve valid math delimiter style (`\(...\)`, `$...$`, `\[...\]`, `$$...$$`, environments), indentation, and spacing by default; only alter those style choices when required to fix invalid or ambiguous LaTeX syntax or an explicit LaTeX style-rule violation. Do not normalize delimiter style merely for preference.
     - Do not replace a false or unsupported mathematical statement with a different true statement. For example, if the input says `(x+1)^2 = x^2 + 1`, keep that equation unchanged.
     - Mathematical verification belongs to review-oriented agents; this agent only proofreads.
 

--- a/src/test-kernel/agent/CorrectAgentPrompt.vitest.mts
+++ b/src/test-kernel/agent/CorrectAgentPrompt.vitest.mts
@@ -41,6 +41,15 @@ describe('correct agent prompt', () => {
       'Preserve every mathematical claim, equation, theorem statement, and factual assertion.',
     );
     expect(promptText).toContain(
+      'Do not change the meaning of math expressions inside inline math, display math, theorem statements, or derivations.',
+    );
+    expect(promptText).toContain(
+      'Preserve valid math delimiter style (`\\(...\\)`, `$...$`, `\\[...\\]`, `$$...$$`, environments), indentation, and spacing by default',
+    );
+    expect(promptText).toContain(
+      'Do not normalize delimiter style merely for preference',
+    );
+    expect(promptText).toContain(
       'Do not replace a false or unsupported mathematical statement with a different true statement.',
     );
     expect(promptText).toContain(


### PR DESCRIPTION
## Summary
- tighten the `correct` workflow prompt so valid math delimiter style and math formatting are preserved by default
- keep the exception narrow: change delimiters/braces/spacing/indentation only when needed for invalid or ambiguous LaTeX syntax
- add prompt regression coverage for the new math-style preservation rule

## CLI Dogfood Evidence
I reproduced this with a real CLI workflow run on a small Pell-equation document:

```sh
texra-local run correct --cwd /tmp/texra-correct-math-style --input main.tex --output corrected.tex --model sonnet46T --approval-policy never --no-color
```

The workflow correctly fixed prose (`becuase` -> `because`) but also changed valid inline math from `\(...\)` to `$...$` and rewrote display-math formatting. That creates noisy diffs and contradicts the workflow description: "without changing your writing style or content."

Closes #6392

## Validation
- `corepack pnpm exec prettier --write packages/extension/resources/agents/correct.yaml src/test-kernel/agent/CorrectAgentPrompt.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/CorrectAgentPrompt.vitest.mts`
- `corepack pnpm exec eslint src/test-kernel/agent/CorrectAgentPrompt.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npm run lint` (passes with 3 pre-existing import-order warnings outside this change)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to a proofreading workflow plus matching vitest assertions; no runtime logic or security-sensitive paths.
> 
> **Overview**
> Tightens the **correct** workflow’s `userRequest` prompt so proofreading no longer rewrites math for style: it must **not change the meaning** of math in inline/display math, theorems, or derivations, and must **keep existing delimiter style** (`\(...\)`, `$...$`, `\[...\]`, `$$...$$`, environments), indentation, and spacing unless fixing invalid/ambiguous LaTeX or an explicit style-rule violation—not for preference.
> 
> The previous narrower rule (only avoid changing math tokens except for syntax/formatting fixes) is replaced by these clearer preservation rules.
> 
> Adds **CorrectAgentPrompt** regression tests that assert the new strings appear in the loaded agent prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb03054bb0117f102eb8b9470981ae2e130ebbd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->