### PR TITLE
refactor: simplify task active-file state

### DIFF
--- a/src/agent/utils/agentConfigToTaskState.ts
+++ b/src/agent/utils/agentConfigToTaskState.ts
@@ -5,24 +5,6 @@ import {
   type ToolUseTaskState,
   type WorkflowTaskState,
 } from '@agent/core/execution/TaskState';
-import {
-  MULTIPLE_DOCUMENT_FILE_TYPES,
-  type MultipleDocumentFileType,
-} from '@shared/schemas/mainView';
-
-/** Check if a file type is active based on the config fields. */
-function isFileTypeActive(
-  config: Record<string, unknown>,
-  type: MultipleDocumentFileType,
-): boolean {
-  const filesField = `${type}Files`;
-  const flagField = `${filesField}Active`;
-  const files = config[filesField];
-
-  if (Array.isArray(files) && files.length > 0) return true;
-  if (config[flagField]) return true;
-  return false;
-}
 
 /**
  * Converts an AgentConfig object to a TaskState object.
@@ -34,19 +16,16 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
         agentConfig: config as ToolUseTaskState['agentConfig'],
         toolSessionState: {},
       };
-    case AgentCategory.Workflow: {
-      const configRecord = config as Record<string, unknown>;
-      const activeFiles = {} as Record<MultipleDocumentFileType, boolean>;
-
-      for (const type of MULTIPLE_DOCUMENT_FILE_TYPES) {
-        activeFiles[type] = isFileTypeActive(configRecord, type);
-      }
-
+    case AgentCategory.Workflow:
       return {
         agentConfig: config as WorkflowTaskState['agentConfig'],
-        activeFiles,
+        activeFiles: {
+          input: (config.inputFiles?.length ?? 0) > 0,
+          context: (config.contextFiles?.length ?? 0) > 0,
+          media: (config.mediaFiles?.length ?? 0) > 0,
+          output: (config.outputFiles?.length ?? 0) > 0,
+        },
       };
-    }
     default: {
       const _exhaustive: never = config.agentCategory;
       throw new Error(`Unknown agent category: ${_exhaustive}`);

--- a/src/test-kernel/agent/AgentConfigToTaskState.vitest.ts
+++ b/src/test-kernel/agent/AgentConfigToTaskState.vitest.ts
@@ -1,0 +1,93 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { describe, it } from 'vitest';
+
+// Local imports - agent
+import {
+  AgentConfigSchema,
+  type AgentConfig,
+} from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import {
+  isToolUseTaskState,
+  isWorkflowTaskState,
+} from '@agent/core/execution/TaskState';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+
+// Local imports - shared
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+describe('agentConfigToTaskState', () => {
+  it('derives workflow active files from normalized file lists', () => {
+    const config = AgentConfigSchema.parse({
+      agentCategory: AgentCategory.Workflow,
+      agent: 'correct',
+      model: 'sonnet46T',
+      instruction: 'Polish the draft.',
+      inputFiles: ['main.tex'],
+      contextFiles: [],
+      mediaFiles: ['figure.png'],
+      outputFiles: [],
+      inputFilesActive: false,
+      mediaFilesActive: false,
+      toolConfig: DEFAULT_TOOL_CONFIG,
+    });
+
+    const taskState = agentConfigToTaskState(config);
+
+    if (!isWorkflowTaskState(taskState)) {
+      assert.fail('Expected a workflow task state');
+    }
+    assert.equal(taskState.agentConfig, config);
+    assert.deepEqual(taskState.activeFiles, {
+      input: true,
+      context: false,
+      media: true,
+      output: false,
+    });
+  });
+
+  it('keeps tool-use configs out of workflow active-file state', () => {
+    const config = AgentConfigSchema.parse({
+      agentCategory: AgentCategory.ToolUse,
+      agent: 'assistant',
+      model: 'sonnet46T',
+      instruction: 'Check the proof.',
+      inputFiles: ['main.tex'],
+      toolConfig: DEFAULT_TOOL_CONFIG,
+    });
+
+    const taskState = agentConfigToTaskState(config);
+
+    if (!isToolUseTaskState(taskState)) {
+      assert.fail('Expected a tool-use task state');
+    }
+    assert.equal(taskState.agentConfig, config);
+    assert.deepEqual(taskState.toolSessionState, {});
+  });
+
+  it('tolerates minimal workflow configs from tests and legacy callers', () => {
+    const config = {
+      agentCategory: AgentCategory.Workflow,
+      agent: 'correct',
+      model: 'sonnet46T',
+      inputFiles: [],
+      outputFiles: [],
+    } as unknown as AgentConfig;
+
+    const taskState = agentConfigToTaskState(config);
+
+    if (!isWorkflowTaskState(taskState)) {
+      assert.fail('Expected a workflow task state');
+    }
+    assert.equal(taskState.agentConfig, config);
+    assert.deepEqual(taskState.activeFiles, {
+      input: false,
+      context: false,
+      media: false,
+      output: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Removes the string-indexed `*FilesActive` lookup from `agentConfigToTaskState`
- Derives workflow `activeFiles` directly from the normalized file lists that survive `AgentConfigSchema`
- Adds focused coverage for workflow, tool-use, and minimal legacy/test configs

## Design issue

`agentConfigToTaskState` took a typed `AgentConfig` but treated it like an untyped UI payload, casting to `Record<string, unknown>` and searching dynamic field names. That made ownership unclear: UI activity flags do not belong to the persisted agent config shape, while the normalized file arrays are the real source of truth at task-state restoration time.

This refactor keeps task-state reconstruction local and explicit, without introducing another resolver/helper layer.

Closes #6394

## Validation

- `corepack pnpm exec prettier --write src/agent/utils/agentConfigToTaskState.ts src/test-kernel/agent/AgentConfigToTaskState.vitest.ts`
- `corepack pnpm exec eslint src/agent/utils/agentConfigToTaskState.ts src/test-kernel/agent/AgentConfigToTaskState.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/agent/AgentConfigToTaskState.vitest.ts src/test-kernel/cli/SessionResumeResolution.vitest.mts`
- `corepack pnpm exec tsc --noEmit --project tsconfig.json --pretty false`
- `npm run lint` (passes with 3 pre-existing import-order warnings)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how workflow UI “active” slots are restored from persisted config; configs that relied on `*FilesActive` without file lists will behave differently.
> 
> **Overview**
> Workflow task state no longer rebuilds `activeFiles` by scanning dynamic `*FilesActive` flags on an untyped config record. **`agentConfigToTaskState`** now sets each slot (`input`, `context`, `media`, `output`) to **true only when the corresponding normalized file array is non-empty**, ignoring UI-style activity flags that may still appear on parsed configs.
> 
> The helper **`isFileTypeActive`** and the **`MULTIPLE_DOCUMENT_FILE_TYPES`** loop are removed in favor of explicit checks on `inputFiles`, `contextFiles`, `mediaFiles`, and `outputFiles`. New Vitest coverage locks in list-based derivation, tool-use isolation, and minimal legacy workflow configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f518a838b75886ae6f0965a799262ce5c9fa85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->