### PR TITLE
refactor: move document file type schemas

### DIFF
--- a/src/agent/core/execution/TaskState.ts
+++ b/src/agent/core/execution/TaskState.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   MULTIPLE_DOCUMENT_FILE_TYPES,
   type MultipleDocumentFileType,
-} from '@shared/schemas/mainView';
+} from '@shared/schemas/fileTypes';
 
 import { AgentCategory } from '../definition/AgentDataclass';
 import { AgentConfigSchema, type AgentConfig } from '../definition/AgentConfig';

--- a/src/shared/schemas/fileTypes.ts
+++ b/src/shared/schemas/fileTypes.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const DocumentFileTypeSchema = z.enum(['input', 'context', 'media']);
+export type DocumentFileType = z.infer<typeof DocumentFileTypeSchema>;
+
+export const MultipleDocumentFileTypeSchema = z.enum([
+  ...DocumentFileTypeSchema.options,
+  'output',
+]);
+export type MultipleDocumentFileType = z.infer<
+  typeof MultipleDocumentFileTypeSchema
+>;
+export const MULTIPLE_DOCUMENT_FILE_TYPES =
+  MultipleDocumentFileTypeSchema.options;
+
+export const ExtendedDocumentFileTypeSchema = z.enum([
+  ...DocumentFileTypeSchema.options,
+  'edited',
+  'output',
+]);
+export type ExtendedDocumentFileType = z.infer<
+  typeof ExtendedDocumentFileTypeSchema
+>;

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -3,6 +3,7 @@ export * from './identifiers';
 export * from './agent';
 export * from './agentCliSettings';
 export * from './fileFields';
+export * from './fileTypes';
 export * from './lineChanges';
 export * from './goal';
 export * from './proposalFields';

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -23,8 +23,8 @@ import {
 import {
   ExtendedDocumentFileTypeSchema,
   MultipleDocumentFileTypeSchema,
-  SessionTypeSchema,
-} from './state';
+} from '../fileTypes';
+import { SessionTypeSchema } from './state';
 
 const CommonMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.WEBVIEW_READY),

--- a/src/shared/schemas/mainView/index.ts
+++ b/src/shared/schemas/mainView/index.ts
@@ -6,12 +6,23 @@
  * are split into focused modules; this file re-exports them so import sites
  * stay unchanged.
  *
- * - `./state`    - session/file types, picker options, persisted state,
- *                  banner state, and event detail shapes
+ * - `./state`    - session type, picker options, persisted state, banner
+ *                  state, and event detail shapes
+ * - `../fileTypes` - document file category vocabulary, owned by the shared
+ *                    schema layer and re-exported for subpath compatibility
  * - `./outbound` - backend → frontend messages (SET_*, banners) + dispatcher
  * - `./inbound`  - frontend → backend messages (SELECT_*, EXECUTE, git diff,
  *                  housekeeping) + dispatcher
  */
+export {
+  DocumentFileTypeSchema,
+  ExtendedDocumentFileTypeSchema,
+  MULTIPLE_DOCUMENT_FILE_TYPES,
+  MultipleDocumentFileTypeSchema,
+  type DocumentFileType,
+  type ExtendedDocumentFileType,
+  type MultipleDocumentFileType,
+} from '../fileTypes';
 export * from './state';
 export * from './outbound';
 export * from './inbound';

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -10,40 +10,18 @@ import {
   UIFileFieldsSchema,
   migrateLegacyContextFileFields,
 } from '../fileFields';
+import {
+  DocumentFileTypeSchema,
+  MultipleDocumentFileTypeSchema,
+} from '../fileTypes';
 import { ToolConfigFieldsSchema } from '../toolConfig';
 
 // ============================================================
-// Session and File Type Schemas
+// Session Schemas
 // ============================================================
 
 export const SessionTypeSchema = z.enum(['toolUse', 'workflow']);
 export type SessionType = z.infer<typeof SessionTypeSchema>;
-
-export const DocumentFileTypeSchema = z.enum(['input', 'context', 'media']);
-export type DocumentFileType = z.infer<typeof DocumentFileTypeSchema>;
-
-export const MultipleDocumentFileTypeSchema = z.enum([
-  'input',
-  'context',
-  'media',
-  'output',
-]);
-export type MultipleDocumentFileType = z.infer<
-  typeof MultipleDocumentFileTypeSchema
->;
-export const MULTIPLE_DOCUMENT_FILE_TYPES =
-  MultipleDocumentFileTypeSchema.options;
-
-export const ExtendedDocumentFileTypeSchema = z.enum([
-  'input',
-  'context',
-  'media',
-  'edited',
-  'output',
-]);
-export type ExtendedDocumentFileType = z.infer<
-  typeof ExtendedDocumentFileTypeSchema
->;
 
 // ============================================================
 // Option Data Schemas


### PR DESCRIPTION
## Summary

- Adds `src/shared/schemas/fileTypes.ts` as the neutral source for document file category schemas and types.
- Re-exports those schemas from the root schema barrel before main-view schemas.
- Updates main-view schemas to consume the neutral vocabulary and updates agent task state to import `MultipleDocumentFileType` from `@shared/schemas/fileTypes` directly.
- Keeps the documented `@shared/schemas/mainView` subpath compatible by explicitly re-exporting the file type vocabulary from the main-view barrel, while leaving ownership in `fileTypes.ts`.

Closes #6397.

## Abstraction finding

`src/agent/core/execution/TaskState.ts` needed `MultipleDocumentFileType`, but the source of truth lived in `src/shared/schemas/mainView/state.ts`. That made core agent execution depend on a main-view state module for a cross-cutting file category vocabulary.

The file type vocabulary is now in a layer-1 shared schema module. Main-view schemas still use and re-export it for their public subpath, but they no longer define or own it.

## Verification

- `corepack pnpm exec prettier --write src/shared/schemas/fileTypes.ts src/shared/schemas/mainView/index.ts src/shared/schemas/mainView/state.ts src/shared/schemas/index.ts src/shared/schemas/mainView/inbound.ts src/agent/core/execution/TaskState.ts`
- `corepack pnpm exec eslint src/shared/schemas/fileTypes.ts src/shared/schemas/index.ts src/shared/schemas/mainView/state.ts src/shared/schemas/mainView/index.ts src/shared/schemas/mainView/inbound.ts src/agent/core/execution/TaskState.ts`
- `npm run typecheck`
- `corepack pnpm exec vitest run src/test-kernel/agent/AgentConfigToTaskState.vitest.ts src/test-kernel/agent/core/ConfigSchemas.vitest.ts src/test-kernel/schemas/MainViewHousekeeping.vitest.ts`
- `npm run lint` (passes with the same three unrelated import-order warnings)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import and module-boundary refactor only; schema shapes and public main-view exports stay equivalent via re-exports.
> 
> **Overview**
> Moves document file category Zod schemas (`DocumentFileType`, `MultipleDocumentFileType`, `ExtendedDocumentFileType`, and `MULTIPLE_DOCUMENT_FILE_TYPES`) out of `mainView/state` into a new layer-1 module `fileTypes.ts`, with the root `@shared/schemas` barrel exporting it.
> 
> Main-view `state` and `inbound` now import those schemas from `fileTypes`; `mainView/index` re-exports them so `@shared/schemas/mainView` consumers keep the same surface. **Agent `TaskState`** now imports `MultipleDocumentFileType` from `@shared/schemas/fileTypes` instead of pulling it through main-view state.
> 
> The multiple/extended enums are composed from `DocumentFileTypeSchema.options` (plus `output` / `edited`) rather than duplicating literal lists inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 213b64ba2bf27cef7bce603906756a7a123df4b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->