### PR TITLE
refactor: move webview html builder to common layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,12 +79,11 @@ This repository is a pnpm workspace. Repo-root `src/` contains shared core logic
   - `frontend/editor/` - Active file guards and editor utilities
   - `frontend/agents/` - Agent directory management (`AgentDirectoryManager`)
   - `frontend/files/` - File lister and discovery utilities
-  - `frontend/webview/` - Webview HTML builder (`buildWebviewHtml`)
   - `frontend/latex/` - LaTeX build integration, linting
   - `frontend/media/` - Image and audio handling
 - `src/common/` holds backend-only helpers (errors, state, files, base webview classes). Import them through the `@common/*` alias for clarity.
   - `common/state/` - State managers including `pendingStateManager`
-  - `common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), command constants
+  - `common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), webview HTML builder (`buildWebviewHtml`), command constants
 - `src/utils/` is reserved for utilities used by both the extension host and webviews. If a helper is specific to one side, place it under `frontend/` or `common/` instead of `utils/`.
   - `utils/core/` - Async utilities (`debounce`, `delay`)
   - `utils/files/` - Filesystem utilities, rules, and vars
@@ -333,7 +332,7 @@ See `docs/pocketflow/` for full framework documentation.
 
 **Webviews and UI**
 
-- Generate HTML through `BaseViewContentProvider` (`src/common/webview/BaseViewContentProvider.ts`) and `buildWebviewHtml` (`packages/extension/src/frontend/webview/html.ts`). Extend `BaseViewMessageHandler` for consistent lifecycle management across views.
+- Generate HTML through `BaseViewContentProvider` (`packages/extension/src/common/webview/BaseViewContentProvider.ts`) and `buildWebviewHtml` (`packages/extension/src/common/webview/html.ts`). Extend `BaseViewMessageHandler` for consistent lifecycle management across views.
 - Use Web Awesome (`<wa-icon>` via `waIcon()` from `@shared/wa/webAwesomeIcons`) and shared utilities from `@utils/text/stringUtils` and `@shared/utils/path` for consistent interactions.
 - For webview dependencies, prefer CDN builds (jsdelivr for static assets, esm.sh for ES modules) for complex packages like markdown-it, KaTeX, or highlight.js, while keeping lightweight bundles (split.js) local to reduce extension size.
 - Keep CSS modular (per-component styles as TypeScript in each view's `frontend/` directory, shared tokens in `packages/extension/src/common/styles/common.css`) and use Web Awesome icons (e.g., `${waIcon('chevron-down')}`) for toggle affordances.

--- a/packages/extension/src/common/webview/BaseViewContentProvider.ts
+++ b/packages/extension/src/common/webview/BaseViewContentProvider.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 
 import { toErrorMessage } from '@common/errors';
-import { buildWebviewHtml } from '@frontend/webview/html';
 import * as logger from '@logger/logUtils';
+
+import { buildWebviewHtml } from './html';
 
 export interface ModuleDescriptor {
   key: string;

--- a/packages/extension/src/common/webview/html.ts
+++ b/packages/extension/src/common/webview/html.ts
@@ -1,5 +1,7 @@
 // VS Code imports
 import * as vscode from 'vscode';
+
+// Third-party imports
 import { nanoid } from 'nanoid';
 
 // Local imports


### PR DESCRIPTION
## Summary

- Move `buildWebviewHtml` from the frontend webview folder into the common webview layer.
- Update `BaseViewContentProvider` to import the helper locally, removing the upward `@frontend` dependency.
- Update `AGENTS.md` so the documented webview helper ownership matches the new location.

Closes #6400

## Validation

- `corepack pnpm exec eslint packages/extension/src/common/webview/BaseViewContentProvider.ts packages/extension/src/common/webview/html.ts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm test`
- `corepack pnpm exec prettier --check AGENTS.md packages/extension/src/common/webview/BaseViewContentProvider.ts packages/extension/src/common/webview/html.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and documentation-only layering change; webview HTML behavior is unchanged.
> 
> **Overview**
> **`buildWebviewHtml`** is relocated from `frontend/webview` into **`common/webview/html.ts`**, and **`BaseViewContentProvider`** now imports it via a sibling `./html` path instead of **`@frontend/webview/html`**.
> 
> That removes an upward dependency from the shared webview base class into the frontend layer. **AGENTS.md** is updated so webview HTML generation is documented under **`common/webview`** rather than **`frontend/webview`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c2ea62474ef347acf5e879d70403a74c26ea64b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->