### PR TITLE
fix: clarify CLI personal API status label

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -840,8 +840,8 @@ const SCENARIOS = [
   {
     name: 'approval-policy-status-bar',
     env: { HARNESS_APPROVAL_POLICY: 'never', HARNESS_ENTRIES: '4' },
-    expect: ['deny', '[/status]details'],
-    unexpect: ['approval: deny privileged actions'],
+    expect: ['byok', 'deny', '[/status]details'],
+    unexpect: ['keys deny', 'approval: deny privileged actions'],
   },
   {
     name: 'uninterruptible-running-status-bar',
@@ -2383,8 +2383,8 @@ const SCENARIOS = [
     bootExpect: 'TeXRA',
     keys: [ESC + 's'], // Esc/Alt-s
     frame: 'tail',
-    expect: ['◆ running 1m 15s keys 3 sub'],
-    unexpect: ['◆running', 'keys3', '3 sub 1 proc'],
+    expect: ['◆ running 1m 15s byok 3 sub'],
+    unexpect: ['◆running', 'byok3', '3 sub 1 proc'],
   },
   {
     name: 'tiny-task-subworkflow-detail',
@@ -2747,7 +2747,7 @@ const SCENARIOS = [
     expect: [
       'Harness interrupt requested.',
       '[main](stopped)',
-      '◆ stopped keys',
+      '◆ stopped byok',
       '[Ctrl-C]exit',
     ],
     unexpect: ['[Ctrl-C]stop'],

--- a/packages/cli/src/runtime/apiAccessMode.ts
+++ b/packages/cli/src/runtime/apiAccessMode.ts
@@ -39,7 +39,7 @@ export function formatCliApiMode(mode: CliApiMode): string {
 }
 
 export function shortCliApiMode(mode: CliApiMode): string {
-  return mode === 'included' ? 'relay' : 'keys';
+  return mode === 'included' ? 'relay' : 'byok';
 }
 
 export function parseCliApiMode(input: string): CliApiMode | undefined {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -78,7 +78,7 @@ describe('CLI StatusBar display model', () => {
 
   it('uses clear compact labels for API access mode', () => {
     expect(shortCliApiMode('included')).toBe('relay');
-    expect(shortCliApiMode('personal')).toBe('keys');
+    expect(shortCliApiMode('personal')).toBe('byok');
   });
 
   it('surfaces non-default approval policies in the durable status row', () => {


### PR DESCRIPTION
## Summary

- Change the compact CLI API-mode label for personal-key sessions from `keys` to `byok`.
- Update status bar unit tests and TUI harness expectations so the ambiguous `keys deny` footer cannot regress.

Closes #6402

## Dogfood Evidence

Real TTY before the change, using `texra-local chat --agent codeSimplifier --model gpt54 --api-mode personal --approval-policy never`, rendered:

```text
◆ — keys deny
```

After rebuilding `texra-local`, the same live TTY path renders:

```text
◆ — byok deny
```

The `byok` label keeps the same compact width as `keys`, so tiny status bars still preserve adjacent state like active subagent counts.

## Validation

- `texra-local doctor --output-format json`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- approval-policy-status-bar tiny-status-separators ctrl-c-interrupt-active`
- `corepack pnpm --filter @texra-ai/cli validate:tui`
- `corepack pnpm exec vitest run src/test-kernel/cli/StatusBar.vitest.mts`
- `npm test`
- `npm run texra-local:build && npm run texra-local:link`
- live TTY smoke with `texra-local chat --agent codeSimplifier --model gpt54 --api-mode personal --approval-policy never`
- `npm run lint` (passes with existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label-only change in `shortCliApiMode` with matching test/harness updates; no auth, routing, or API behavior changes.
> 
> **Overview**
> Renames the **compact** CLI status-bar label for personal API-key sessions from `keys` to **`byok`**, while included relay stays **`relay`**. The long-form copy (`personal API keys` / `included relay`) is unchanged; only `shortCliApiMode` drives the narrow footer.
> 
> TUI harness expectations and StatusBar unit tests were updated so footers assert **`byok`** (and reject ambiguous strings like **`keys deny`** next to approval policy text on tight terminals).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d91bf1a08f8e7f1c07050f0edc5869930316284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->