### PR TITLE
refactor: isolate main view dropped file planning

### DIFF
--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -3,6 +3,12 @@ import { fileURLToPath } from 'node:url';
 
 import * as vscode from 'vscode';
 
+import {
+  MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES,
+  normalizeMainViewFileExtension,
+  planMainViewDroppedFileAttachments,
+  type MainViewAllowedDropExtensions,
+} from '@controllers/mainView/MainViewDroppedFilesController';
 import { ExtensionCategory, getIncludedExtensions } from '@common/files';
 import {
   FILE_SELECTION_COMMAND_IDS,
@@ -17,10 +23,7 @@ import {
 import { selectFiles } from '@frontend/ui/dialogs';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import type {
-  MainViewInboundMessage,
-  MultipleDocumentFileType,
-} from '@shared/schemas';
+import type { MainViewInboundMessage } from '@shared/schemas';
 import {
   WorkspaceFS,
   parseLatexDiffMetadata,
@@ -79,15 +82,6 @@ type UpdateFilesMessage = MessageFor<
 
 const CHANNEL = 'FileManager';
 logger.initialize(CHANNEL);
-
-const ATTACHABLE_DROP_CATEGORIES = [
-  'input',
-  'context',
-  'media',
-] as const satisfies readonly MultipleDocumentFileType[];
-
-type AttachableDropCategory = (typeof ATTACHABLE_DROP_CATEGORIES)[number];
-type AllowedDropExtensions = Map<AttachableDropCategory, Set<string>>;
 
 type FileUpdateOptions = {
   notifyWhenEmpty?: boolean;
@@ -303,17 +297,15 @@ export class FileManager extends BaseWebviewManager {
   async handleAddOpenedFiles(fileType: string): Promise<void> {
     const openedFiles = await this.getOpenedFiles();
     const allowedExtensions = new Set(
-      getIncludedExtensions(fileType as ExtensionCategory).map((ext) =>
-        ext.replace('.', '').toLowerCase(),
+      getIncludedExtensions(fileType as ExtensionCategory).map(
+        normalizeMainViewFileExtension,
       ),
     );
 
     const filteredFiles =
       allowedExtensions.size > 0
         ? openedFiles.filter((file) =>
-            allowedExtensions.has(
-              path.extname(file).toLowerCase().replace('.', ''),
-            ),
+            allowedExtensions.has(normalizeMainViewFileExtension(file)),
           )
         : openedFiles;
 
@@ -328,33 +320,18 @@ export class FileManager extends BaseWebviewManager {
   async handleAttachDroppedFiles(
     message: AttachDroppedFilesMessage,
   ): Promise<void> {
-    const grouped = new Map<AttachableDropCategory, Set<string>>(
-      ATTACHABLE_DROP_CATEGORIES.map((category) => [category, new Set()]),
+    const paths = await Promise.all(
+      message.paths.map((rawPath) => this.resolveWorkspaceDropFile(rawPath)),
     );
-    const allowedExtensions = this.getAllowedDropExtensions();
-    let rejectedCount = 0;
+    const plan = planMainViewDroppedFileAttachments({
+      paths,
+      allowedExtensions: this.getAllowedDropExtensions(),
+      target: message.target ?? undefined,
+    });
 
-    for (const rawPath of message.paths) {
-      const filePath = await this.resolveWorkspaceDropFile(rawPath);
-      const category = filePath
-        ? this.resolveDroppedFileCategory(
-            filePath,
-            allowedExtensions,
-            message.target ?? undefined,
-          )
-        : null;
-      if (!filePath || !category) {
-        rejectedCount += 1;
-        continue;
-      }
-      grouped.get(category)?.add(filePath);
-    }
-
-    let attachedCount = 0;
-    for (const [fileType, files] of grouped) {
-      if (files.size === 0) continue;
-      const droppedFiles = [...files];
-      attachedCount += droppedFiles.length;
+    for (const fileType of MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES) {
+      const droppedFiles = plan.filesByCategory[fileType];
+      if (droppedFiles.length === 0) continue;
       this.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_OPENED_FILES,
         files: droppedFiles,
@@ -363,7 +340,7 @@ export class FileManager extends BaseWebviewManager {
       });
     }
 
-    this.showDroppedFilesResult(attachedCount, rejectedCount);
+    this.showDroppedFilesResult(plan.attachedCount, plan.rejectedCount);
   }
 
   handleUpdateFiles(message: UpdateFilesMessage): void {
@@ -498,72 +475,12 @@ export class FileManager extends BaseWebviewManager {
     }
   }
 
-  private resolveDroppedFileCategory(
-    filePath: string,
-    allowedExtensions: AllowedDropExtensions,
-    target?: MultipleDocumentFileType,
-  ): AttachableDropCategory | null {
-    if (target) {
-      return this.isAttachableDropCategory(target) &&
-        this.isExtensionAllowed(target, filePath, allowedExtensions)
-        ? target
-        : null;
-    }
-
-    const extension = this.normalizedExtension(filePath);
-    if (this.isExtensionAllowed('media', filePath, allowedExtensions)) {
-      return 'media';
-    }
-    if (
-      (extension === 'bib' ||
-        extension === 'bbl' ||
-        extension === 'cls' ||
-        extension === 'sty') &&
-      this.isExtensionAllowed('context', filePath, allowedExtensions)
-    ) {
-      return 'context';
-    }
-    if (this.isExtensionAllowed('input', filePath, allowedExtensions)) {
-      return 'input';
-    }
-    if (this.isExtensionAllowed('context', filePath, allowedExtensions)) {
-      return 'context';
-    }
-    return null;
-  }
-
-  private isAttachableDropCategory(
-    category: MultipleDocumentFileType,
-  ): category is AttachableDropCategory {
-    return (ATTACHABLE_DROP_CATEGORIES as readonly string[]).includes(category);
-  }
-
-  private isExtensionAllowed(
-    category: AttachableDropCategory,
-    filePath: string,
-    allowedExtensions: AllowedDropExtensions,
-  ): boolean {
-    const extension = this.normalizedExtension(filePath);
-    if (!extension) return false;
-    return allowedExtensions.get(category)?.has(extension) ?? false;
-  }
-
-  private getAllowedDropExtensions(): AllowedDropExtensions {
-    return new Map(
-      ATTACHABLE_DROP_CATEGORIES.map((category) => [
-        category,
-        new Set(
-          getIncludedExtensions(category).map((ext) =>
-            this.normalizedExtension(ext),
-          ),
-        ),
-      ]),
-    );
-  }
-
-  private normalizedExtension(filePath: string): string {
-    const extension = path.extname(filePath) || filePath;
-    return extension.trim().toLowerCase().replace(/^\./, '');
+  private getAllowedDropExtensions(): MainViewAllowedDropExtensions {
+    return {
+      input: getIncludedExtensions('input'),
+      context: getIncludedExtensions('context'),
+      media: getIncludedExtensions('media'),
+    };
   }
 
   private showDroppedFilesResult(

--- a/src/controllers/mainView/MainViewDroppedFilesController.ts
+++ b/src/controllers/mainView/MainViewDroppedFilesController.ts
@@ -1,0 +1,135 @@
+// Standard library imports
+import * as path from 'node:path';
+
+// Local imports - shared schemas
+import type { MultipleDocumentFileType } from '@shared/schemas';
+
+export const MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES = [
+  'input',
+  'context',
+  'media',
+] as const satisfies readonly MultipleDocumentFileType[];
+
+export type MainViewAttachableDropCategory =
+  (typeof MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES)[number];
+
+export type MainViewAllowedDropExtensions = Readonly<
+  Record<MainViewAttachableDropCategory, readonly string[]>
+>;
+
+export interface MainViewDroppedFileAttachmentPlan {
+  readonly filesByCategory: Readonly<
+    Record<MainViewAttachableDropCategory, readonly string[]>
+  >;
+  readonly attachedCount: number;
+  readonly rejectedCount: number;
+}
+
+export interface MainViewDroppedFileAttachmentInput {
+  readonly paths: readonly (string | null)[];
+  readonly allowedExtensions: MainViewAllowedDropExtensions;
+  readonly target?: MultipleDocumentFileType;
+}
+
+export function planMainViewDroppedFileAttachments(
+  input: MainViewDroppedFileAttachmentInput,
+): MainViewDroppedFileAttachmentPlan {
+  const grouped = createEmptyCategorySets();
+  let rejectedCount = 0;
+
+  for (const filePath of input.paths) {
+    const category = filePath
+      ? resolveDroppedFileCategory(
+          filePath,
+          input.allowedExtensions,
+          input.target,
+        )
+      : null;
+    if (!filePath || !category) {
+      rejectedCount += 1;
+      continue;
+    }
+    grouped[category].add(filePath);
+  }
+
+  const filesByCategory = {
+    input: [...grouped.input],
+    context: [...grouped.context],
+    media: [...grouped.media],
+  };
+
+  return {
+    filesByCategory,
+    attachedCount: MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES.reduce(
+      (count, category) => count + filesByCategory[category].length,
+      0,
+    ),
+    rejectedCount,
+  };
+}
+
+export function normalizeMainViewFileExtension(filePath: string): string {
+  const trimmed = filePath.trim();
+  const extension = path.extname(trimmed) || trimmed;
+  return extension.toLowerCase().replace(/^\./, '');
+}
+
+function createEmptyCategorySets(): Record<
+  MainViewAttachableDropCategory,
+  Set<string>
+> {
+  return {
+    input: new Set(),
+    context: new Set(),
+    media: new Set(),
+  };
+}
+
+function resolveDroppedFileCategory(
+  filePath: string,
+  allowedExtensions: MainViewAllowedDropExtensions,
+  target?: MultipleDocumentFileType,
+): MainViewAttachableDropCategory | null {
+  if (target) {
+    return isAttachableDropCategory(target) &&
+      isExtensionAllowed(target, filePath, allowedExtensions)
+      ? target
+      : null;
+  }
+
+  const extension = normalizeMainViewFileExtension(filePath);
+  if (isExtensionAllowed('media', filePath, allowedExtensions)) {
+    return 'media';
+  }
+  if (
+    ['bib', 'bbl', 'cls', 'sty'].includes(extension) &&
+    isExtensionAllowed('context', filePath, allowedExtensions)
+  ) {
+    return 'context';
+  }
+  if (isExtensionAllowed('input', filePath, allowedExtensions)) {
+    return 'input';
+  }
+  if (isExtensionAllowed('context', filePath, allowedExtensions)) {
+    return 'context';
+  }
+  return null;
+}
+
+function isAttachableDropCategory(
+  category: MultipleDocumentFileType,
+): category is MainViewAttachableDropCategory {
+  return category === 'input' || category === 'context' || category === 'media';
+}
+
+function isExtensionAllowed(
+  category: MainViewAttachableDropCategory,
+  filePath: string,
+  allowedExtensions: MainViewAllowedDropExtensions,
+): boolean {
+  const extension = normalizeMainViewFileExtension(filePath);
+  if (!extension) return false;
+  return allowedExtensions[category].some(
+    (candidate) => normalizeMainViewFileExtension(candidate) === extension,
+  );
+}

--- a/src/test-kernel/controllers/MainViewDroppedFilesController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewDroppedFilesController.vitest.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeMainViewFileExtension,
+  planMainViewDroppedFileAttachments,
+  type MainViewAllowedDropExtensions,
+} from '@controllers/mainView/MainViewDroppedFilesController';
+
+const ALLOWED_EXTENSIONS = {
+  input: ['.tex'],
+  context: ['.bib', '.bbl', '.cls', '.sty', '.txt'],
+  media: ['.png', '.pdf'],
+} as const satisfies MainViewAllowedDropExtensions;
+
+describe('MainViewDroppedFilesController', () => {
+  it('plans automatic dropped-file categories without VS Code state', () => {
+    const plan = planMainViewDroppedFileAttachments({
+      paths: [
+        'paper/main.tex',
+        'refs/library.bib',
+        'styles/local.sty',
+        'notes.txt',
+        'figures/plot.png',
+      ],
+      allowedExtensions: ALLOWED_EXTENSIONS,
+    });
+
+    expect(plan).toEqual({
+      filesByCategory: {
+        input: ['paper/main.tex'],
+        context: ['refs/library.bib', 'styles/local.sty', 'notes.txt'],
+        media: ['figures/plot.png'],
+      },
+      attachedCount: 5,
+      rejectedCount: 0,
+    });
+  });
+
+  it('honors an explicit drop target and rejects unsupported targets', () => {
+    expect(
+      planMainViewDroppedFileAttachments({
+        paths: ['notes.txt', 'paper/main.tex'],
+        allowedExtensions: ALLOWED_EXTENSIONS,
+        target: 'context',
+      }),
+    ).toMatchObject({
+      filesByCategory: {
+        input: [],
+        context: ['notes.txt'],
+        media: [],
+      },
+      attachedCount: 1,
+      rejectedCount: 1,
+    });
+
+    expect(
+      planMainViewDroppedFileAttachments({
+        paths: ['paper/main.tex'],
+        allowedExtensions: ALLOWED_EXTENSIONS,
+        target: 'output',
+      }),
+    ).toMatchObject({
+      attachedCount: 0,
+      rejectedCount: 1,
+    });
+  });
+
+  it('deduplicates accepted files while counting invalid candidates', () => {
+    const plan = planMainViewDroppedFileAttachments({
+      paths: ['paper/main.tex', 'paper/main.tex', null, 'build/cache.tmp'],
+      allowedExtensions: ALLOWED_EXTENSIONS,
+    });
+
+    expect(plan.filesByCategory.input).toEqual(['paper/main.tex']);
+    expect(plan.attachedCount).toBe(1);
+    expect(plan.rejectedCount).toBe(2);
+  });
+
+  it('normalizes extension strings used by manager filters', () => {
+    expect(normalizeMainViewFileExtension('FIGURE.PNG')).toBe('png');
+    expect(normalizeMainViewFileExtension('.TeX')).toBe('tex');
+    expect(normalizeMainViewFileExtension('tex')).toBe('tex');
+  });
+});


### PR DESCRIPTION
Closes #6404.

## Summary

- move main-view dropped-file categorization and reject/attach planning out of `FileManager` into a host-neutral controller
- keep `FileManager` focused on VS Code filesystem resolution, webview messages, and user notifications
- add direct controller coverage for automatic categorization, explicit targets, unsupported targets, deduplication, and extension normalization

## Abstraction review

Highest-impact violation addressed here: `packages/extension/src/webview/managers/FileManager.ts` mixed host/UI responsibilities with deterministic attachment policy for dropped files. That forced policy changes through a VS Code webview manager and made the behavior difficult to test without extension scaffolding.

The remaining lower-priority findings are tracked in #6404: progress follow-up polishing still deserves a controller boundary, and settings tool command selection should move behind a settings/tool-dashboard action planner.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/controllers/MainViewDroppedFilesController.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with the existing three import-order warnings in unrelated files)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of file-drop and extension filtering with dedicated unit tests; no auth, data, or security-sensitive paths.
> 
> **Overview**
> Moves **main-view dropped-file categorization** (input/context/media), extension checks, deduplication, and attach/reject counts out of `FileManager` into a host-neutral `MainViewDroppedFilesController` via `planMainViewDroppedFileAttachments` and `normalizeMainViewFileExtension`.
> 
> `FileManager` now resolves workspace paths and posts webview messages from the plan; **Add opened files** filtering reuses the same extension normalizer. Adds **Vitest** coverage for auto-categorization, explicit targets, unsupported targets, deduplication, and normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b342173407305db4e02cbe6c094eccd9347bfeb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->