### PR TITLE
refactor: move settings tool command planning

### DIFF
--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -14,7 +14,10 @@ import * as vscode from 'vscode';
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { SettingsProfileController } from '@controllers/settingsView/SettingsProfileController';
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
-import { buildToolDashboardItems } from '@controllers/settingsView/ToolDashboardData';
+import {
+  buildToolDashboardItems,
+  buildToolDashboardTerminalAction,
+} from '@controllers/settingsView/ToolDashboardData';
 import { platform } from '@platform/platform';
 import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
 import {
@@ -75,7 +78,6 @@ import {
   refreshToolAvailability,
   refreshDisabledToolCache,
 } from '@tools/toolAvailability';
-import { findExternalToolDef } from '@tools/externalToolDefs';
 import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
 import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
 import { StorageFS } from '@utils/files';
@@ -510,18 +512,21 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private handleRunToolCommand(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.RUN_TOOL_COMMAND>,
   ): void {
-    const def = findExternalToolDef(data.toolId);
-    const command =
-      data.kind === 'install' ? def?.installCommand : def?.authCommand;
-    if (!command) {
-      this.logger.debug(this.channel, 'No command for tool', { data });
+    const action = buildToolDashboardTerminalAction({
+      toolId: data.toolId,
+      commandKind: data.kind,
+    });
+    if (action.kind === 'none') {
+      this.logger.debug(this.channel, 'No command for tool', {
+        data: { ...data, reason: action.reason },
+      });
       return;
     }
     const terminal = vscode.window.createTerminal({
-      name: `TeXRA: ${def?.name ?? data.toolId}`,
+      name: action.name,
     });
     terminal.show();
-    terminal.sendText(command);
+    terminal.sendText(action.command);
   }
 
   public override async handleMessage(

--- a/src/controllers/settingsView/ToolDashboardData.ts
+++ b/src/controllers/settingsView/ToolDashboardData.ts
@@ -9,6 +9,7 @@
 // Local imports
 import type {
   ToolDashboardItem,
+  ToolCommandKind,
   ToolInfo,
 } from '@shared/schemas/settingsViewMessages';
 import { findExternalToolDef } from '@tools/externalToolDefs';
@@ -18,6 +19,17 @@ import {
   type ExternalToolCheckResult,
 } from '@tools/toolAvailability';
 import { getDisabledToolIds } from '@utils/config/constants';
+
+export type ToolDashboardTerminalAction =
+  | {
+      readonly kind: 'terminal';
+      readonly name: string;
+      readonly command: string;
+    }
+  | {
+      readonly kind: 'none';
+      readonly reason: 'unknownTool' | 'missingCommand';
+    };
 
 // ============================================================
 // Tool description enrichment
@@ -173,4 +185,22 @@ export async function buildToolDashboardItems(
   }
 
   return [...builtinItems, ...externalItems];
+}
+
+export function buildToolDashboardTerminalAction(input: {
+  readonly toolId: string;
+  readonly commandKind: ToolCommandKind;
+}): ToolDashboardTerminalAction {
+  const def = findExternalToolDef(input.toolId);
+  if (!def) return { kind: 'none', reason: 'unknownTool' };
+
+  const command =
+    input.commandKind === 'install' ? def.installCommand : def.authCommand;
+  if (!command) return { kind: 'none', reason: 'missingCommand' };
+
+  return {
+    kind: 'terminal',
+    name: `TeXRA: ${def.name}`,
+    command,
+  };
 }

--- a/src/test-kernel/controllers/ToolDashboardData.vitest.ts
+++ b/src/test-kernel/controllers/ToolDashboardData.vitest.ts
@@ -1,0 +1,52 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+
+import { buildToolDashboardTerminalAction } from '@controllers/settingsView/ToolDashboardData';
+
+describe('ToolDashboardData', () => {
+  it('plans install terminal actions from tool definitions', () => {
+    assert.deepEqual(
+      buildToolDashboardTerminalAction({
+        toolId: 'codex',
+        commandKind: 'install',
+      }),
+      {
+        kind: 'terminal',
+        name: 'TeXRA: OpenAI Codex CLI',
+        command: 'npm install -g @openai/codex',
+      },
+    );
+  });
+
+  it('plans auth terminal actions from tool definitions', () => {
+    assert.deepEqual(
+      buildToolDashboardTerminalAction({
+        toolId: 'claude-agent',
+        commandKind: 'auth',
+      }),
+      {
+        kind: 'terminal',
+        name: 'TeXRA: Claude Code CLI',
+        command: 'claude login',
+      },
+    );
+  });
+
+  it('does not ask the handler to open a terminal without a command', () => {
+    assert.deepEqual(
+      buildToolDashboardTerminalAction({
+        toolId: 'texra-cli',
+        commandKind: 'auth',
+      }),
+      { kind: 'none', reason: 'missingCommand' },
+    );
+
+    assert.deepEqual(
+      buildToolDashboardTerminalAction({
+        toolId: 'missing-tool',
+        commandKind: 'install',
+      }),
+      { kind: 'none', reason: 'unknownTool' },
+    );
+  });
+});


### PR DESCRIPTION
Closes #6407.

## Summary

- move settings Tools-tab install/auth command selection into `ToolDashboardData`
- keep `SettingsViewMessageHandler` as the VS Code terminal adapter for planned terminal actions
- add controller coverage for install commands, auth commands, missing commands, and unknown tools

## Validation

- `corepack pnpm exec vitest run src/test-kernel/controllers/ToolDashboardData.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with the existing three unrelated import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no behavior change beyond richer debug metadata; settings UI terminal wiring only, no auth or data-path changes.
> 
> **Overview**
> Moves **install/auth command resolution** for the Settings Tools tab out of `SettingsViewMessageHandler` into `buildToolDashboardTerminalAction` in `ToolDashboardData`, alongside existing dashboard data building.
> 
> The new helper returns a discriminated result: either a **terminal** action (`name` + `command` from external tool defs) or **`none`** with `unknownTool` / `missingCommand`. The message handler only opens a VS Code terminal and runs the planned command; debug logs now include the skip **reason** when no terminal is opened.
> 
> Adds **vitest** coverage for install, auth, missing commands, and unknown tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36f074b27d457221e74c8f371b874664c1b7f29b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->