### PR TITLE
refactor: move progress follow-up polishing

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -6,6 +6,10 @@ import {
   ProgressFollowUpController,
   type ProgressFollowUpPlan,
 } from '@controllers/progressView/ProgressFollowUpController';
+import {
+  ProgressFollowUpPolishController,
+  type ProgressFollowUpPolishResult,
+} from '@controllers/progressView/ProgressFollowUpPolishController';
 import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
 import { ProgressApiKeyRetryController } from '@controllers/progressView/ProgressApiKeyRetryController';
 import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
@@ -17,10 +21,6 @@ import {
   validateExecutionRequest,
   type ExecutionRequest,
 } from '@agent/core/execution/executionRequests';
-import {
-  buildFileContextFromTaskState,
-  polishTextWithAI,
-} from '@agent/runtime/textEnhancement';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { toErrorMessage } from '@common/errors';
@@ -79,6 +79,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly agentProposalController: ProgressAgentProposalController;
   private readonly apiKeyRetryController: ProgressApiKeyRetryController;
   private readonly followUpController: ProgressFollowUpController;
+  private readonly followUpPolishController: ProgressFollowUpPolishController;
 
   /**
    * Type-safe handler registry - handlers receive typed data.
@@ -112,6 +113,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.agentProposalController = this.createAgentProposalController();
     this.apiKeyRetryController = this.createApiKeyRetryController();
     this.followUpController = this.createFollowUpController();
+    this.followUpPolishController = new ProgressFollowUpPolishController();
     this.handlerRegistry = this.createHandlerRegistry();
 
     const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
@@ -643,18 +645,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const taskState = this.provider.state.snapshots.getTaskState(data.stream);
     if (!taskState) return;
 
-    const fileContext = buildFileContextFromTaskState(taskState);
-
-    const sendPolishError = (errorMsg: string): void => {
-      this.postToActiveView({
-        command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
-        stream: data.stream,
-        kind: 'polishError',
-        text: null,
-        error: errorMsg,
-      });
-    };
-
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
@@ -667,26 +657,18 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             message: 'Sending to AI for polishing...',
             increment: 30,
           });
-          const result = await polishTextWithAI(data.text, fileContext);
+          const result = await this.followUpPolishController.polishFollowUp({
+            stream: data.stream,
+            text: data.text,
+            taskState,
+          });
           progress.report({
             message: 'Applying changes...',
             increment: 60,
           });
-
-          if (result.success) {
-            this.postToActiveView({
-              command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
-              stream: data.stream,
-              kind: 'polished',
-              text: result.text,
-            });
-          } else if (result.error) {
-            sendPolishError(result.error);
-            await vscode.window.showErrorMessage(result.error);
-          }
+          await this.applyFollowUpPolishResult(result);
         } catch (error) {
           const errorMsg = toErrorMessage(error);
-          sendPolishError(errorMsg);
           await vscode.window.showErrorMessage(
             `Error polishing follow-up: ${errorMsg}`,
           );
@@ -700,6 +682,29 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         }
       },
     );
+  }
+
+  private async applyFollowUpPolishResult(
+    result: ProgressFollowUpPolishResult,
+  ): Promise<void> {
+    switch (result.kind) {
+      case 'skipped':
+        return;
+      case 'updated':
+        this.postToActiveView(result.update);
+        return;
+      case 'failed':
+        this.postToActiveView(result.update);
+        await vscode.window.showErrorMessage(result.userMessage);
+        return;
+      case 'exception':
+        this.postToActiveView(result.update);
+        await vscode.window.showErrorMessage(result.userMessage);
+        this.logger.error(this.channel, result.logMessage, {
+          data: result.logData,
+        });
+        return;
+    }
   }
 
   private handlePlanApprovalAction(

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -669,6 +669,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           await this.applyFollowUpPolishResult(result);
         } catch (error) {
           const errorMsg = toErrorMessage(error);
+          this.postToActiveView({
+            command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+            stream: data.stream,
+            kind: 'polishError',
+            text: null,
+            error: errorMsg,
+          });
           await vscode.window.showErrorMessage(
             `Error polishing follow-up: ${errorMsg}`,
           );

--- a/src/controllers/progressView/ProgressFollowUpPolishController.ts
+++ b/src/controllers/progressView/ProgressFollowUpPolishController.ts
@@ -1,0 +1,123 @@
+// Local imports - agent
+import type { TaskState } from '@agent/core/execution/TaskState';
+import {
+  buildFileContextFromTaskState,
+  polishTextWithAI,
+  type FileContext,
+} from '@agent/runtime/textEnhancement';
+
+// Local imports - common
+import { toErrorMessage } from '@common/errors';
+
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type { ProgressViewOutboundMessage, StreamTabId } from '@shared/schemas';
+
+type UpdateFollowUpTextMessage = Extract<
+  ProgressViewOutboundMessage,
+  { command: typeof PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT }
+>;
+
+export interface ProgressFollowUpPolishInput {
+  readonly stream: StreamTabId;
+  readonly text: string;
+  readonly taskState: TaskState | undefined;
+}
+
+export interface ProgressFollowUpPolishTextResult {
+  readonly success: boolean;
+  readonly text: string;
+  readonly error?: string;
+}
+
+export type ProgressFollowUpPolishText = (
+  text: string,
+  fileContext?: FileContext,
+) => Promise<ProgressFollowUpPolishTextResult>;
+
+export interface ProgressFollowUpPolishControllerDeps {
+  readonly polishText: ProgressFollowUpPolishText;
+}
+
+export type ProgressFollowUpPolishResult =
+  | { readonly kind: 'skipped' }
+  | {
+      readonly kind: 'updated';
+      readonly update: UpdateFollowUpTextMessage;
+    }
+  | {
+      readonly kind: 'failed';
+      readonly update: UpdateFollowUpTextMessage;
+      readonly userMessage: string;
+    }
+  | {
+      readonly kind: 'exception';
+      readonly update: UpdateFollowUpTextMessage;
+      readonly userMessage: string;
+      readonly logMessage: string;
+      readonly logData?: Error;
+    };
+
+export class ProgressFollowUpPolishController {
+  constructor(
+    private readonly deps: ProgressFollowUpPolishControllerDeps = {
+      polishText: polishTextWithAI,
+    },
+  ) {}
+
+  async polishFollowUp(
+    input: ProgressFollowUpPolishInput,
+  ): Promise<ProgressFollowUpPolishResult> {
+    if (!input.taskState) {
+      return { kind: 'skipped' };
+    }
+
+    try {
+      const fileContext = buildFileContextFromTaskState(input.taskState);
+      const result = await this.deps.polishText(input.text, fileContext);
+      if (result.success) {
+        return {
+          kind: 'updated',
+          update: this.createUpdate(input.stream, 'polished', result.text),
+        };
+      }
+      if (!result.error) {
+        return { kind: 'skipped' };
+      }
+      return {
+        kind: 'failed',
+        update: this.createUpdate(input.stream, 'polishError', null, {
+          error: result.error,
+        }),
+        userMessage: result.error,
+      };
+    } catch (error) {
+      const errorMsg = toErrorMessage(error);
+      const logMessage = `Error polishing follow-up: ${errorMsg}`;
+      return {
+        kind: 'exception',
+        update: this.createUpdate(input.stream, 'polishError', null, {
+          error: errorMsg,
+        }),
+        userMessage: logMessage,
+        logMessage,
+        ...(error instanceof Error && { logData: error }),
+      };
+    }
+  }
+
+  private createUpdate(
+    stream: StreamTabId,
+    kind: 'polished' | 'polishError',
+    text: string | null,
+    options: { readonly error?: string } = {},
+  ): UpdateFollowUpTextMessage {
+    return {
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+      stream,
+      kind,
+      text,
+      ...(options.error && { error: options.error }),
+    };
+  }
+}

--- a/src/test-kernel/controllers/ProgressFollowUpPolishController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpPolishController.vitest.ts
@@ -110,6 +110,23 @@ describe('ProgressFollowUpPolishController', () => {
     });
   });
 
+  it('skips when the model helper reports failure without an error', async () => {
+    const controller = new ProgressFollowUpPolishController({
+      polishText: async () => ({
+        success: false,
+        text: 'draft text',
+      }),
+    });
+
+    const result = await controller.polishFollowUp({
+      stream: 'stream-a',
+      text: 'draft text',
+      taskState: createWorkflowTaskState(),
+    });
+
+    assert.deepEqual(result, { kind: 'skipped' });
+  });
+
   it('returns a logged exception result when polishing throws', async () => {
     const error = new Error('network down');
     const controller = new ProgressFollowUpPolishController({

--- a/src/test-kernel/controllers/ProgressFollowUpPolishController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpPolishController.vitest.ts
@@ -1,0 +1,160 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { describe, it } from 'vitest';
+
+// Local imports - controllers
+import { ProgressFollowUpPolishController } from '@controllers/progressView/ProgressFollowUpPolishController';
+
+// Local imports - agent
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import {
+  AgentConfigSchema,
+  type AgentConfig,
+} from '@agent/core/definition/AgentConfig';
+import type { WorkflowTaskState } from '@agent/core/execution/TaskState';
+import type { FileContext } from '@agent/runtime/textEnhancement';
+
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+
+function createWorkflowTaskState(
+  overrides: Omit<Partial<AgentConfig>, 'agentCategory'> = {},
+): WorkflowTaskState {
+  return {
+    agentConfig: AgentConfigSchema.parse({
+      agent: 'writer',
+      model: 'gemini31p',
+      inputFiles: ['main.tex'],
+      contextFiles: [],
+      mediaFiles: [],
+      outputFiles: ['answer.tex'],
+      agentCategory: AgentCategory.Workflow,
+      ...overrides,
+    }) as AgentConfig & { agentCategory: typeof AgentCategory.Workflow },
+    activeFiles: {
+      input: true,
+      context: false,
+      media: false,
+      output: true,
+    },
+  };
+}
+
+describe('ProgressFollowUpPolishController', () => {
+  it('returns a polished text update and builds file context from task state', async () => {
+    const calls: Array<{ text: string; fileContext?: FileContext }> = [];
+    const controller = new ProgressFollowUpPolishController({
+      polishText: async (text, fileContext) => {
+        calls.push({ text, fileContext });
+        return {
+          success: true,
+          text: 'Please inspect the proof.',
+        };
+      },
+    });
+
+    const result = await controller.polishFollowUp({
+      stream: 'stream-a',
+      text: 'plz check proof',
+      taskState: createWorkflowTaskState(),
+    });
+
+    assert.deepEqual(result, {
+      kind: 'updated',
+      update: {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+        stream: 'stream-a',
+        kind: 'polished',
+        text: 'Please inspect the proof.',
+      },
+    });
+    assert.deepEqual(calls, [
+      {
+        text: 'plz check proof',
+        fileContext: {
+          agent: 'writer',
+          inputFiles: ['main.tex'],
+          outputFiles: ['answer.tex'],
+        },
+      },
+    ]);
+  });
+
+  it('returns an error update when the model helper reports a polish failure', async () => {
+    const controller = new ProgressFollowUpPolishController({
+      polishText: async () => ({
+        success: false,
+        text: 'draft text',
+        error: 'Model returned no text.',
+      }),
+    });
+
+    const result = await controller.polishFollowUp({
+      stream: 'stream-a',
+      text: 'draft text',
+      taskState: createWorkflowTaskState(),
+    });
+
+    assert.deepEqual(result, {
+      kind: 'failed',
+      update: {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+        stream: 'stream-a',
+        kind: 'polishError',
+        text: null,
+        error: 'Model returned no text.',
+      },
+      userMessage: 'Model returned no text.',
+    });
+  });
+
+  it('returns a logged exception result when polishing throws', async () => {
+    const error = new Error('network down');
+    const controller = new ProgressFollowUpPolishController({
+      polishText: async () => {
+        throw error;
+      },
+    });
+
+    const result = await controller.polishFollowUp({
+      stream: 'stream-a',
+      text: 'draft text',
+      taskState: createWorkflowTaskState(),
+    });
+
+    assert.deepEqual(result, {
+      kind: 'exception',
+      update: {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+        stream: 'stream-a',
+        kind: 'polishError',
+        text: null,
+        error: 'network down',
+      },
+      userMessage: 'Error polishing follow-up: network down',
+      logMessage: 'Error polishing follow-up: network down',
+      logData: error,
+    });
+  });
+
+  it('skips polishing when no task state is available', async () => {
+    let calls = 0;
+    const controller = new ProgressFollowUpPolishController({
+      polishText: async () => {
+        calls += 1;
+        return { success: true, text: 'unused' };
+      },
+    });
+
+    const result = await controller.polishFollowUp({
+      stream: 'stream-a',
+      text: 'draft text',
+      taskState: undefined,
+    });
+
+    assert.deepEqual(result, { kind: 'skipped' });
+    assert.equal(calls, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- move follow-up polish planning/result shaping from `ProgressViewMessageHandler` into `ProgressFollowUpPolishController`
- keep VS Code progress notifications, webview posting, and logging in the extension handler
- add controller tests for polished output, model-reported errors, thrown errors, and missing task state

## Abstraction-layer review
- Violation: `ProgressViewMessageHandler` mixed host UI concerns with follow-up polishing policy by building file context, calling the AI helper, and shaping success/error updates. This coupled a VS Code webview handler to domain workflow behavior and made the policy hard to test without extension-host machinery.
- Relocation: the policy now lives in `src/controllers/progressView/ProgressFollowUpPolishController.ts`; `packages/extension/src/progressView/ProgressViewMessageHandler.ts` remains the host adapter for `vscode.window.withProgress`, notifications, logs, and posting returned messages.

Closes #6406.
Closes #6310.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/controllers/ProgressFollowUpPolishController.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with 3 existing unrelated import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved; polish logic is isolated and unit-tested, with no auth or data-model changes.
> 
> **Overview**
> Moves **follow-up message polishing policy** out of `ProgressViewMessageHandler` into a new `ProgressFollowUpPolishController`, aligned with other progress-view controllers.
> 
> The controller builds file context from task state, calls the injectable AI polish helper, and returns a discriminated result (`skipped`, `updated`, `failed`, `exception`) with ready-to-post `UPDATE_FOLLOW_UP_TEXT` payloads. The extension handler keeps VS Code concerns: progress UI, webview posting, notifications, and logging via `applyFollowUpPolishResult`.
> 
> Adds **vitest coverage** for success, model-reported errors, silent failures, thrown errors, and missing task state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05831212dc1be9f028fca43d754a3ddeca0afbb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->