### PR TITLE
fix: shorten agent picker labels

### DIFF
--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -19,7 +19,15 @@ import { AGENT_DECORATORS, getModelProviderDecorator } from './icons';
  */
 export const BROWSE_ALL_AGENTS_OPTION_VALUE = '__browse-all-agents__';
 
-function buildAgentTooltip(opt: AgentOptionData): string {
+const AGENT_LABEL_SEPARATOR_PATTERN =
+  /^(.*?)(?:\s*---\s*|\s*[\u2013\u2014]\s*)/u;
+
+export function formatAgentOptionLabel(label: string): string {
+  const shortLabel = label.match(AGENT_LABEL_SEPARATOR_PATTERN)?.[1]?.trim();
+  return shortLabel || label;
+}
+
+function buildAgentTooltip(opt: AgentOptionData, displayLabel: string): string {
   const { properties } = AGENT_DECORATORS;
   const hints: string[] = [];
 
@@ -29,6 +37,7 @@ function buildAgentTooltip(opt: AgentOptionData): string {
     );
   if (opt.isRemote) hints.push(properties.remote.hint);
   if (opt.isCustom) hints.push(properties.custom.hint);
+  if (opt.label !== displayLabel) hints.push(opt.label);
   if (opt.description) hints.push(opt.description);
   if (opt.isToolUse) hints.push('Can execute tools and code');
   // When a displayName label hides the canonical identifier, surface it
@@ -40,14 +49,15 @@ function buildAgentTooltip(opt: AgentOptionData): string {
 }
 
 function renderAgentOption(opt: AgentOptionData): TemplateResult {
-  const tooltip = buildAgentTooltip(opt);
+  const displayLabel = formatAgentOptionLabel(opt.label);
+  const tooltip = buildAgentTooltip(opt, displayLabel);
 
   const isOrch = opt.isOrchestrator;
   return html`
     <wa-option
       value=${opt.value}
       title=${tooltip || nothing}
-      data-label=${opt.label}
+      data-label=${displayLabel}
       data-tool-use=${opt.isToolUse ? 'true' : nothing}
       data-remote=${opt.isRemote ? 'true' : nothing}
       data-custom=${opt.isCustom ? 'true' : nothing}
@@ -55,7 +65,7 @@ function renderAgentOption(opt: AgentOptionData): TemplateResult {
     >
       ${isOrch
         ? html`<span class="agent-icon">${waIcon('bullseye')} </span>`
-        : nothing}${opt.label}
+        : nothing}${displayLabel}
       ${opt.isRemote
         ? html`<span class="agent-icon">
             ${waIcon(AGENT_DECORATORS.properties.remote.icon)}</span

--- a/src/test-kernel/shared/SelectTemplates.vitest.ts
+++ b/src/test-kernel/shared/SelectTemplates.vitest.ts
@@ -1,0 +1,22 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { describe, it } from 'vitest';
+
+// Local imports - shared
+import { formatAgentOptionLabel } from '@shared/utils/selectTemplates';
+
+describe('select template labels', () => {
+  it('trims agent picker labels before description separators', () => {
+    assert.equal(
+      formatAgentOptionLabel('Engineer \u2014 software team lead'),
+      'Engineer',
+    );
+    assert.equal(
+      formatAgentOptionLabel('Research --- derivations & numerics'),
+      'Research',
+    );
+    assert.equal(formatAgentOptionLabel('changeReviewer'), 'changeReviewer');
+  });
+});


### PR DESCRIPTION
## Summary
- Trim agent picker display labels before description separators: triple hyphen, en dash, or em dash.
- Keep option values, full labels, descriptions, and tooltip context intact.

Closes #6410.

## Validation
- corepack pnpm exec vitest run src/test-kernel/shared/SelectTemplates.vitest.ts
- npm run typecheck
- npm run lint (passes with 3 existing import-order warnings in unrelated files)
- npm run compile:fast
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in agent dropdown rendering with values unchanged and full labels preserved in tooltips.
> 
> **Overview**
> Agent picker options now show a **short title** by trimming everything after common description separators (`---`, en dash, em dash) via new `formatAgentOptionLabel`, while **option values and selection behavior stay the same**.
> 
> The shortened string is used for the visible row text and `data-label`; when trimming happens, the **full original label** is added to the tooltip so longer descriptions are still discoverable on hover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22791bc235f81deb20ea20096969a46347f12876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->