### PR TITLE
fix: show hidden CLI models

### DIFF
--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -6,11 +6,11 @@ import { writeTextStderr } from '../runtime/logSinks';
 import { effectiveCliApiMode } from '../runtime/apiAccessMode';
 import {
   cliModelRecord,
-  findCliModelAccessEntry,
   formatCliModelDetails,
   getCliModelAccessList,
   formatNoListableModelsMessage,
   listableModelAccessEntries,
+  resolveCliModelAccessEntry,
   type CliModelListOptions,
 } from '../runtime/modelAccess';
 
@@ -81,7 +81,19 @@ async function showModel(context: CliContext, id: string): Promise<number> {
     return CliExitCode.ModelOrNetworkError;
   }
 
-  const entry = findCliModelAccessEntry(result.models, id);
+  let entry: Awaited<ReturnType<typeof resolveCliModelAccessEntry>>;
+  try {
+    entry = await suppressCliFetchStackLogs(() =>
+      resolveCliModelAccessEntry(id, {
+        apiMode: result.apiMode,
+        accessList: result.models,
+      }),
+    );
+  } catch (error) {
+    writeTextStderr(formatCliModelListError(error));
+    return CliExitCode.ModelOrNetworkError;
+  }
+
   if (!entry) {
     writeTextStderr(`Model not found: ${id}`);
     return CliExitCode.Usage;

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -38,6 +38,11 @@ export interface CliRunnableModelOptions {
   readonly noAvailableModelsMessage?: string;
 }
 
+export interface CliModelAccessEntryOptions extends CliModelAccessListOptions {
+  /** Optional preloaded list, used by commands that already fetched access. */
+  readonly accessList?: readonly CliModelAccess[];
+}
+
 export type CliModelSelectionSource =
   | 'override'
   | 'env'
@@ -445,6 +450,34 @@ function getCanonicalModelConfigId(model: string): string | undefined {
   return Object.keys(MODEL_CONFIGS).find((id) => id.toLowerCase() === lower);
 }
 
+export async function resolveCliModelAccessEntry(
+  model: string,
+  options: CliModelAccessEntryOptions = {},
+): Promise<CliModelAccess | undefined> {
+  const models =
+    options.accessList ??
+    (await getCliModelAccessList({ apiMode: options.apiMode }));
+  const trimmed = model.trim();
+  const listedEntry = findCliModelAccessEntry(models, trimmed);
+  if (listedEntry || trimmed.length === 0) return listedEntry;
+
+  const hiddenModelId = getCanonicalModelConfigId(trimmed);
+  if (hiddenModelId == null) return undefined;
+
+  const hiddenModelOption = (await computeModelOptionsData([hiddenModelId]))[0];
+  if (!hiddenModelOption) {
+    throw new Error(
+      `Model "${hiddenModelId}" is configured but has no option data.`,
+    );
+  }
+
+  let hiddenModel = toCliModelAccess(hiddenModelOption, options.apiMode);
+  if (await includedAccessRequiresLogin(options)) {
+    hiddenModel = toIncludedLoginRequiredAccess(hiddenModel);
+  }
+  return hiddenModel;
+}
+
 function formatAvailableModels(
   ids: readonly string[],
   options: Pick<
@@ -515,28 +548,13 @@ export async function resolveCliRunnableModel(
     options.accessList ??
     (await getCliModelAccessList({ apiMode: options.apiMode }));
   const trimmed = model.trim();
-  const hiddenModelId =
-    trimmed && !findCliModelAccessEntry(models, trimmed)
-      ? getCanonicalModelConfigId(trimmed)
-      : undefined;
-  let hiddenModel: CliModelAccess | undefined;
-  if (hiddenModelId != null) {
-    const hiddenModelOption = (
-      await computeModelOptionsData([hiddenModelId])
-    )[0];
-    if (!hiddenModelOption) {
-      throw new Error(
-        `Model "${hiddenModelId}" is configured but has no option data.`,
-      );
-    }
-    hiddenModel = toCliModelAccess(hiddenModelOption, options.apiMode);
-    if (await includedAccessRequiresLogin(options)) {
-      hiddenModel = toIncludedLoginRequiredAccess(hiddenModel);
-    }
-  }
+  const modelEntry = await resolveCliModelAccessEntry(trimmed, {
+    apiMode: options.apiMode,
+    accessList: models,
+  });
 
   return resolveCliRunnableModelFromAccessList(
-    withModelAccess(models, hiddenModel),
+    withModelAccess(models, modelEntry),
     trimmed,
     options,
   );

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -11,6 +11,7 @@ import {
   modelSelectItemsForCliMode,
   noRunnableModelAccessReason,
   runnableCliModelAccessEntries,
+  resolveCliModelAccessEntry,
   resolveCliRunnableModel,
   type CliModelAccess,
 } from '@cli/runtime/modelAccess';
@@ -967,6 +968,35 @@ describe('CLI model access resolution', () => {
         ],
       }),
     ).resolves.toEqual({ model: 'hiddenFixtureModel' });
+    expect(computeModelOptionsDataMock).toHaveBeenCalledWith([
+      'hiddenFixtureModel',
+    ]);
+  });
+
+  it('resolves hidden model entries for diagnostic commands', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('hiddenFixtureModel', {
+        availability: 'missing-key',
+        availabilityLabel: 'Missing API key',
+        disabled: true,
+        requiresKey: true,
+      }),
+    ]);
+
+    await expect(
+      resolveCliModelAccessEntry('HIDDENFIXTUREMODEL', {
+        apiMode: 'personal',
+        accessList: [model('sonnet46T')],
+      }),
+    ).resolves.toMatchObject({
+      available: false,
+      status: 'missing api key',
+      model: {
+        value: 'hiddenFixtureModel',
+        availability: 'missing-key',
+        availabilityLabel: 'Missing API key',
+      },
+    });
     expect(computeModelOptionsDataMock).toHaveBeenCalledWith([
       'hiddenFixtureModel',
     ]);


### PR DESCRIPTION
## Summary
- centralize hidden model access lookup in the CLI model-access layer
- make texra models show reuse that lookup so hidden known ids like glm52 report access status instead of not found
- keep run-time model resolution on the same shared path

Closes #6413.

## Dogfood evidence
- texra-local run correct on a small math input completed and produced the corrected artifact
- before this fix, texra-local run --model glm52 recognized glm52 but texra-local models show glm52 said Model not found
- after this fix, texra-local models show glm52 reports GLM-5.2 with Missing API key status
- texra-local models show GLM52 also works case-insensitively
- texra-local models show glm5.2 still correctly reports Model not found because that spelling is not a canonical id

## Validation
- corepack pnpm exec vitest run src/test-kernel/cli/ModelAccess.vitest.mts
- npm run texra-local:build
- npm run typecheck
- npm run lint (passes with 3 existing import-order warnings in unrelated files)
- npm run compile:fast
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor in CLI model-access with no auth or data-path changes; behavior is covered by existing and new unit tests.
> 
> **Overview**
> **`texra models show`** now resolves **hidden** model ids (configured in `MODEL_CONFIGS` but omitted from the default list) instead of returning *Model not found*, matching behavior already used when running with `--model`.
> 
> Hidden lookup is centralized in **`resolveCliModelAccessEntry`**: it checks the access list first, then canonical id (case-insensitive), loads option data via `computeModelOptionsData`, and applies the same included-mode login-required shaping as the list path. **`resolveCliRunnableModel`** delegates to this helper so run and show stay aligned.
> 
> The show command wraps resolution in the same fetch-stack suppression and error formatting as list loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c442665c6ab9644fa769a317cfc868d2e9a2ae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->