### PR TITLE
refactor: simplify CLI approval queue ownership

### DIFF
--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -77,11 +77,14 @@ export const approvalQueueStatus = STATUS as Signal.State<ApprovalQueueStatus>;
 
 const queue = new PQueue({ concurrency: 1 });
 
-const pendingPayloads = new Map<
-  (decision: ApprovalDecision) => void,
-  ApprovalPayload
->();
-let currentAdvance: (() => void) | undefined;
+interface ApprovalQueueItem {
+  readonly payload: ApprovalPayload;
+  readonly resolve: (decision: ApprovalDecision) => void;
+  advance: (() => void) | undefined;
+}
+
+const pendingItems = new Set<ApprovalQueueItem>();
+let currentItem: ApprovalQueueItem | undefined;
 
 const INTERRUPT: ApprovalDecision = {
   accepted: false,
@@ -120,6 +123,10 @@ function approvalQueueStatusKind(
   return sawQuestion ? 'question' : 'approval';
 }
 
+function* pendingApprovalPayloads(): Iterable<ApprovalPayload> {
+  for (const item of pendingItems) yield item.payload;
+}
+
 export function approvalPayloadStreamId(
   payload: ApprovalPayload,
 ): StreamTabId | undefined {
@@ -139,13 +146,13 @@ export function approvalPayloadStreamId(
 }
 
 function syncApprovalStatus(): void {
-  const depth = pendingPayloads.size;
+  const depth = pendingItems.size;
   STATUS.set({
     depth,
     kind:
       depth === 0
         ? 'approval'
-        : approvalQueueStatusKind(pendingPayloads.values()),
+        : approvalQueueStatusKind(pendingApprovalPayloads()),
   });
 }
 
@@ -153,20 +160,20 @@ export function enqueueApproval(
   payload: ApprovalPayload,
   options: EnqueueApprovalOptions = {},
 ): Promise<ApprovalDecision> {
-  let resolveOuter!: (decision: ApprovalDecision) => void;
+  let item!: ApprovalQueueItem;
   const outer = new Promise<ApprovalDecision>((resolve) => {
-    resolveOuter = resolve;
+    item = { payload, resolve, advance: undefined };
   });
-  pendingPayloads.set(resolveOuter, payload);
+  pendingItems.add(item);
   syncApprovalStatus();
 
   void queue
     .add(async () => {
-      // Already cleared before scheduling — resolveOuter was settled
-      // by clearApprovals; nothing more to do.
-      if (!pendingPayloads.has(resolveOuter)) return;
+      // Already cleared before scheduling: clearApprovals settled the caller.
+      if (!pendingItems.has(item)) return;
       await new Promise<void>((advance) => {
-        currentAdvance = advance;
+        item.advance = advance;
+        currentItem = item;
         try {
           options.onPresent?.();
         } catch {
@@ -176,11 +183,12 @@ export function enqueueApproval(
         CURRENT.set({
           payload,
           decide: (decision) => {
-            if (!pendingPayloads.delete(resolveOuter)) return;
+            if (!pendingItems.delete(item)) return;
             syncApprovalStatus();
             CURRENT.set(undefined);
-            currentAdvance = undefined;
-            resolveOuter(decision);
+            if (currentItem === item) currentItem = undefined;
+            item.advance = undefined;
+            item.resolve(decision);
             advance();
           },
         });
@@ -190,9 +198,9 @@ export function enqueueApproval(
       // p-queue rejects when `queue.clear()` drops the task. Settle the
       // outer promise so the requester (e.g. ToolEditApprovalHandler)
       // doesn't hang forever.
-      if (pendingPayloads.delete(resolveOuter)) {
+      if (pendingItems.delete(item)) {
         syncApprovalStatus();
-        resolveOuter(INTERRUPT);
+        item.resolve(INTERRUPT);
       }
     });
 
@@ -207,13 +215,15 @@ export function enqueueApproval(
 export function clearApprovals(): void {
   queue.clear();
   CURRENT.set(undefined);
-  const pendingResolves = [...pendingPayloads.keys()];
-  pendingPayloads.clear();
+  const items = [...pendingItems];
+  pendingItems.clear();
   syncApprovalStatus();
-  for (const resolve of pendingResolves) resolve(INTERRUPT);
-  if (currentAdvance) {
-    const advance = currentAdvance;
-    currentAdvance = undefined;
-    advance();
+  const activeItem = currentItem;
+  currentItem = undefined;
+  for (const item of items) {
+    const advance = item.advance;
+    item.advance = undefined;
+    item.resolve(INTERRUPT);
+    if (item === activeItem) advance?.();
   }
 }

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -122,6 +122,44 @@ describe('CLI approval queue', () => {
     await expect(mixedQuestionResult).resolves.toEqual({ accepted: false });
   });
 
+  it('interrupts active and queued approvals without wedging the queue', async () => {
+    const first = bashPayload('child-1');
+    const second = bashPayload('child-2');
+    const firstResult = enqueueApproval(first);
+    const secondResult = enqueueApproval(second);
+
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(first);
+    });
+    expect(approvalQueueStatus.get()).toEqual({
+      depth: 2,
+      kind: 'approval',
+    });
+
+    clearApprovals();
+
+    const interrupted = {
+      accepted: false,
+      userMessage: 'Session interrupted.',
+    };
+    await expect(firstResult).resolves.toEqual(interrupted);
+    await expect(secondResult).resolves.toEqual(interrupted);
+    expect(currentApproval.get()).toBeUndefined();
+    expect(approvalQueueStatus.get()).toEqual({
+      depth: 0,
+      kind: 'approval',
+    });
+
+    const next = bashPayload('child-3');
+    const nextResult = enqueueApproval(next);
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(next);
+    });
+
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(nextResult).resolves.toEqual({ accepted: true });
+  });
+
   it('notifies only when a TUI approval becomes the foreground modal', async () => {
     const host = { emit: vi.fn() } as unknown as CliRuntimeHost;
     const first = bashPayload('child-1');


### PR DESCRIPTION
## Summary

- Replace the resolver-keyed pending approval map with explicit approval queue item objects that own payload, resolver, and active unblock callback.
- Derive queue status from pending item payloads and interrupt item objects directly in `clearApprovals()`.
- Add a regression test that clears active plus queued approvals and verifies the queue can foreground a later approval.

Fixes #6418

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/ApprovalQueue.vitest.mts`
- `npm run lint` (passes with 3 existing import-order warnings outside this change)
- `npm run typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-approval-queue-refactor --skip-if-missing-deps edit-approval bash-approval bash-approval-approve-twice ctrl-c-interrupt-active`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session-interrupt and approval-modal flow in the CLI TUI; behavior change is localized but user-visible if unblock logic is wrong.
> 
> **Overview**
> Refactors the CLI TUI **approval queue** so each pending approval is an **`ApprovalQueueItem`** (payload, resolver, and optional `advance` unblock) in a **`Set`**, instead of a **`Map` keyed by the resolve function** plus a separate **`currentAdvance`**.
> 
> **`clearApprovals()`** now settles every pending item with the session-interrupt decision and calls **`advance` on the currently active item**, so a Ctrl-C / hard cancel does not leave the single-concurrency **`p-queue`** slot stuck. Queue depth/status still comes from pending payloads via a small **`pendingApprovalPayloads()`** helper.
> 
> Adds a regression test that **`clearApprovals()`** interrupts both the foreground and queued approvals, then verifies a later **`enqueueApproval`** can present normally again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d896aa6a7662de7403d52c9fc364b3237a4c29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->