### PR TITLE
fix: make software-engineer team complete locally

### DIFF
--- a/packages/extension/resources/tool_use_agents/engineer.yaml
+++ b/packages/extension/resources/tool_use_agents/engineer.yaml
@@ -1,6 +1,6 @@
 name: engineer
 displayName: Engineer — software team lead
-description: Software engineering team lead. Turns a coding goal into focused tasks, delegates each to the right specialist (coder, codeReviewer, testEngineer, codeSimplifier, progressCheck), reviews their work, and keeps the codebase coherent.
+description: Software engineering team lead. Turns a coding goal into focused tasks, delegates to coder, codeReviewer, testEngineer, and codeSimplifier, reviews their work, and keeps the codebase coherent.
 
 settings:
   agentCategory: toolUse
@@ -46,10 +46,6 @@ prompts:
       - `codeSimplifier` — refactors working code for clarity, reuse, and
         efficiency without changing its behaviour, then confirms the tests
         still pass. Use it to pay down complexity, not to hunt for bugs.
-      - `progressCheck` — when available after `texra login`, an
-        outside-the-loop, read-only audit of what actually landed versus the
-        standing goal and the git/PR state. It advises; it does not edit or
-        delegate.
 
     Match the scale of your response to the request. For a quick lookup, a
     one-line edit, or a `grep`, use your own tools directly — do not spin up a
@@ -113,14 +109,6 @@ prompts:
     essential point briefly rather than referring back.
 
     ## Before you finish
-
-    For a substantial session — two or more delegations, a commit or PR, or a
-    multi-part request — delegate to `progressCheck` when it is available
-    (after `texra login`) for an outside-the-loop audit of what actually landed
-    versus the goal and the git/PR state. Treat its reply as advisory: pick up
-    actionable, low-risk follow-ups, summarise the rest for the user, or stop
-    with a brief note. Skip it for trivial one-shots (a single lookup or a
-    one-line fix) or when `progressCheck` is unavailable.
 
     Confirm the change builds and tests pass (or say plainly which do not and
     why). Summarise what landed, where, and any follow-ups you deliberately

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -187,7 +187,6 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
       'codeReviewer',
       'testEngineer',
       'codeSimplifier',
-      'progressCheck',
     ],
   },
 ];

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -255,8 +255,8 @@ describe('CLI multi-agent presets', () => {
     expect(cliMultiAgentPlanHasGaps(plan)).toBe(false);
     expect(cliMultiAgentPresetCanLaunchTeam(plan)).toBe(true);
     expect(cliMultiAgentPresetAvailability(plan).toolUse).toMatchObject({
-      available: 6,
-      total: 6,
+      available: 5,
+      total: 5,
     });
   });
 


### PR DESCRIPTION
## Summary

- Remove optional hosted `progressCheck` from the required `software-engineer` preset roster.
- Keep the visible engineer summary aligned with the bundled local software-engineering agents.
- Update the preset test to expect the bundled software-engineer team to be complete with five tool-use agents.

Fixes #6420

## Dogfood evidence

Before this change, `texra-local multi-agent list` reported `software-engineer` as `tool-use:5/6 degraded`, and `texra-local multi-agent inspect software-engineer` showed only `progressCheck` missing.

After rebuilding `texra-local`, the local CLI reports:

```text
built-in	software-engineer	Software Engineer	workflow:0	tool-use:5
```

and inspection reports no missing workflow or tool-use agents.

The PTY launcher snapshot also renders:

```text
Team Software Engineer — ready; 5 tools
```

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run lint` (passes with 3 existing import-order warnings outside this change)
- `npm run typecheck`
- `npm run texra-local:build`
- `texra-local multi-agent list`
- `texra-local multi-agent inspect software-engineer`
- `texra-local multi-agent show software-engineer`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-software-engineer-team --skip-if-missing-deps orchestrate-launcher orchestrate-personal-model-pick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preset roster and engineer prompt text only; no runtime auth, data, or delegation logic changes beyond what agents the preset requires.
> 
> **Overview**
> The **software-engineer** built-in team no longer lists **`progressCheck`**, so local installs treat the preset as **5/5** complete instead of **5/6 degraded** when that relay-only agent is missing.
> 
> The **`engineer`** agent prompt is updated in the same spirit: the team roster and closing workflow no longer mention delegating to **`progressCheck`** after substantial sessions.
> 
> A **`MultiAgentPresets`** test now expects **5** available tool-use agents for a fully bundled software-engineer team.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f99b3155fcc949571098804e5f3f9f0a3f66a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->