### PR TITLE
refactor: refresh bundled agent cache

### DIFF
--- a/packages/extension/src/frontend/setup.ts
+++ b/packages/extension/src/frontend/setup.ts
@@ -67,10 +67,10 @@ export async function initializeToolDefaults(): Promise<void> {
 /**
  * Reconciles bundled agents in global storage:
  *  - Always prunes renamed/removed legacy files (idempotent; cheap).
- *  - Re-copies bundled agents only on version bump or when files are missing.
+ *  - Refreshes bundled agents from packaged resources.
  *
- * Splitting these concerns means a stale legacy file gets cleaned up on
- * every activation, even when the bundled set is otherwise unchanged.
+ * Built-in agent directories are generated cache; user-owned edits belong in
+ * custom agent directories.
  */
 export async function copyDefaultAgents(
   context: vscode.ExtensionContext,

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -3,7 +3,6 @@ import * as path from 'node:path';
 
 // Third-party imports
 import fsExtra from 'fs-extra';
-import { glob } from 'glob';
 
 // Local imports
 import { toErrorMessage } from '@common/errors';
@@ -26,7 +25,6 @@ const LEGACY_AGENT_FILES = [
 ];
 
 export interface AgentDirectoryBundleSource {
-  listYamlFiles(directoryName: BundledAgentDirectoryName): Promise<string[]>;
   copyDirectory(
     directoryName: BundledAgentDirectoryName,
     destinationPath: string,
@@ -59,13 +57,6 @@ export interface BundledAgentDirectorySyncOptions {
 
 export class PathAgentDirectoryBundleSource implements AgentDirectoryBundleSource {
   constructor(private readonly resourcesBasePath: string) {}
-
-  listYamlFiles(directoryName: BundledAgentDirectoryName): Promise<string[]> {
-    return glob('**/*.yaml', {
-      cwd: path.join(this.resourcesBasePath, directoryName),
-      nodir: true,
-    });
-  }
 
   async copyDirectory(
     directoryName: BundledAgentDirectoryName,
@@ -103,14 +94,6 @@ export class BundledAgentDirectorySync {
   async reconcile(currentVersion: string | undefined): Promise<boolean> {
     await this.deleteLegacyAgentFiles();
 
-    const lastKnownVersion = this.options.versionStore.get();
-    if (
-      currentVersion === lastKnownVersion &&
-      !(await this.hasMissingBundledAgentFiles())
-    ) {
-      return false;
-    }
-
     for (const directoryName of BUNDLED_AGENT_DIRECTORY_NAMES) {
       await this.options.storage.ensureDir(directoryName);
       await this.options.bundleSource.copyDirectory(
@@ -121,27 +104,6 @@ export class BundledAgentDirectorySync {
 
     await this.options.versionStore.update(currentVersion);
     return true;
-  }
-
-  private async hasMissingBundledAgentFiles(): Promise<boolean> {
-    for (const directoryName of BUNDLED_AGENT_DIRECTORY_NAMES) {
-      const bundledFiles =
-        await this.options.bundleSource.listYamlFiles(directoryName);
-
-      for (const relativePath of bundledFiles) {
-        const storagePath = path.join(directoryName, relativePath);
-        if (await this.options.storage.exists(storagePath)) {
-          continue;
-        }
-
-        this.options.logger.info(
-          `Bundled agent missing from global storage, re-syncing defaults: ${storagePath}`,
-        );
-        return true;
-      }
-    }
-
-    return false;
   }
 
   private async deleteLegacyAgentFiles(): Promise<void> {

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -159,7 +159,7 @@ describe('desktop agent directory bootstrap', () => {
     );
   });
 
-  it('preserves current copied agents on same-version runs and restores missing bundled files', async () => {
+  it('refreshes copied bundled agents on same-version runs', async () => {
     const { bootstrapElectronAgentDirectories, resourcesPath, storage } =
       await createHarness();
 
@@ -172,13 +172,6 @@ describe('desktop agent directory bootstrap', () => {
     await writeFile(copiedAgent, 'name: locally-edited\n');
 
     await bootstrapElectronAgentDirectories(resourcesPath, '1.2.3');
-    await expect(readFile(copiedAgent, 'utf8')).resolves.toBe(
-      'name: locally-edited\n',
-    );
-
-    await rm(copiedAgent);
-    await bootstrapElectronAgentDirectories(resourcesPath, '1.2.3');
-
     await expect(readFile(copiedAgent, 'utf8')).resolves.toBe('name: writer\n');
   });
 });


### PR DESCRIPTION
Closes #6422

## Summary

- treat copied built-in agent directories as generated cache and refresh them from packaged resources on bootstrap
- remove the same-version YAML existence scan from `BundledAgentDirectorySync`
- update the desktop bootstrap test to assert same-version refresh instead of preserving copied built-ins

## Design note

The previous version gate made global-storage built-ins act like user-owned source files, which let `texra-local` keep stale built-in YAML after local resource changes. User-owned edits already live in custom agent directories, so the built-in cache can stay simple: prune legacy files, copy packaged resources, record the version marker.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts src/test-kernel/cli/CliInitPlatform.vitest.mts`
- `npm run texra-local:build`
- `texra-local agents show engineer`
- `rg "progressCheck" packages/cli/dist/resources/tool_use_agents/engineer.yaml packages/extension/resources/tool_use_agents/engineer.yaml /Users/siruilu/.texra/global-storage/tool_use_agents/engineer.yaml || true`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings in unrelated files)
- `corepack pnpm exec prettier --write src/agent/index/AgentDirectorySync.ts packages/extension/src/frontend/setup.ts src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: any edits stored under global-storage built-in agent paths are overwritten on the next bootstrap; users must use custom agent dirs for durable overrides.
> 
> **Overview**
> **Bundled built-in agent directories are treated as a generated cache**, not user-owned source. On every `BundledAgentDirectorySync.reconcile()` (extension activation and desktop bootstrap), legacy agent files are still pruned, then **all bundled directories are re-copied from packaged resources with overwrite**—the previous same-version skip and per-YAML “missing file” resync are removed.
> 
> `PathAgentDirectoryBundleSource` no longer lists YAML via `glob`; sync always uses full directory copy. Extension `copyDefaultAgents` comments now state that **custom agent directories** are where user edits belong.
> 
> The desktop bootstrap test now expects **same-version runs to restore packaged content** after a local edit to a copied built-in YAML, instead of preserving that edit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d9ce66aefba7c661d3fa707ae13e33b3b4335d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->