### PR TITLE
fix: complete hidden launchable agents

### DIFF
--- a/packages/cli/src/runtime/completionBash.ts
+++ b/packages/cli/src/runtime/completionBash.ts
@@ -139,12 +139,12 @@ _texra_agents() {
 
 _texra_workflow_agents() {
   _texra_completion_dynamic || return 0
-  texra agents list --quiet --category workflow 2>/dev/null | awk '{print $2}'
+  texra agents list --quiet --all --category workflow 2>/dev/null | awk '{print $2}'
 }
 
 _texra_tool_use_agents() {
   _texra_completion_dynamic || return 0
-  texra agents list --quiet --category toolUse 2>/dev/null | awk '{print $2}'
+  texra agents list --quiet --all --category toolUse 2>/dev/null | awk '{print $2}'
 }
 
 _texra_models() {

--- a/packages/cli/src/runtime/completionFish.ts
+++ b/packages/cli/src/runtime/completionFish.ts
@@ -9,9 +9,9 @@ import {
 const AGENTS_LIST_SOURCE =
   '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet 2>/dev/null | awk "{print \\$2}")';
 const WORKFLOW_AGENTS_LIST_SOURCE =
-  '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --category workflow 2>/dev/null | awk "{print \\$2}")';
+  '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --all --category workflow 2>/dev/null | awk "{print \\$2}")';
 const TOOL_USE_AGENTS_LIST_SOURCE =
-  '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --category toolUse 2>/dev/null | awk "{print \\$2}")';
+  '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --all --category toolUse 2>/dev/null | awk "{print \\$2}")';
 const MODELS_LIST_SOURCE =
   '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra models list --quiet 2>/dev/null | awk "{print \\$1}")';
 const TOP_LEVEL_RUN_CONDITION =

--- a/packages/cli/src/runtime/completionZsh.ts
+++ b/packages/cli/src/runtime/completionZsh.ts
@@ -63,12 +63,12 @@ _texra_agents() {
 
 _texra_workflow_agents() {
   [[ "\${TEXRA_COMPLETION_DYNAMIC:-1}" == "0" ]] && return
-  texra agents list --quiet --category workflow 2>/dev/null | awk '{print $2}'
+  texra agents list --quiet --all --category workflow 2>/dev/null | awk '{print $2}'
 }
 
 _texra_tool_use_agents() {
   [[ "\${TEXRA_COMPLETION_DYNAMIC:-1}" == "0" ]] && return
-  texra agents list --quiet --category toolUse 2>/dev/null | awk '{print $2}'
+  texra agents list --quiet --all --category toolUse 2>/dev/null | awk '{print $2}'
 }
 
 _texra_models() {

--- a/src/test-kernel/cli/Completion.vitest.mts
+++ b/src/test-kernel/cli/Completion.vitest.mts
@@ -31,8 +31,12 @@ describe('CLI shell completion', () => {
 
     expect(bash).toContain('TEXRA_COMPLETION_DYNAMIC');
     expect(bash).toContain('texra agents list --quiet');
-    expect(bash).toContain('texra agents list --quiet --category workflow');
-    expect(bash).toContain('texra agents list --quiet --category toolUse');
+    expect(bash).toContain(
+      'texra agents list --quiet --all --category workflow',
+    );
+    expect(bash).toContain(
+      'texra agents list --quiet --all --category toolUse',
+    );
     expect(bash).toContain('texra models list --quiet');
   });
 
@@ -126,9 +130,9 @@ describe('CLI shell completion', () => {
       writeFileSync(
         path.join(bin, 'texra'),
         `#!/usr/bin/env bash
-if [[ "$*" == "agents list --quiet --category workflow" ]]; then
+if [[ "$*" == "agents list --quiet --all --category workflow" ]]; then
   printf 'workflow\\tpolish\\nworkflow\\tcorrect\\n'
-elif [[ "$*" == "agents list --quiet --category toolUse" ]]; then
+elif [[ "$*" == "agents list --quiet --all --category toolUse" ]]; then
   printf 'toolUse\\treview\\ntoolUse\\tlean\\n'
 elif [[ "$*" == "agents list --quiet" ]]; then
   printf 'workflow\\tpolish\\ntoolUse\\treview\\n'
@@ -185,10 +189,10 @@ printf 'agents-inspect:%s\\n' "\${COMPREPLY[@]}"
     const fish = await generateCompletionScript(rootCommand, 'fish');
 
     expect(fish).toContain(
-      "complete -c texra -n '__fish_seen_subcommand_from run; and not __fish_seen_subcommand_from agents; and not __fish_seen_subcommand_from multi-agent' -a '(test \"$TEXRA_COMPLETION_DYNAMIC\" != 0; and texra agents list --quiet --category workflow",
+      "complete -c texra -n '__fish_seen_subcommand_from run; and not __fish_seen_subcommand_from agents; and not __fish_seen_subcommand_from multi-agent' -a '(test \"$TEXRA_COMPLETION_DYNAMIC\" != 0; and texra agents list --quiet --all --category workflow",
     );
     expect(fish).toContain(
-      "complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from run' -a '(test \"$TEXRA_COMPLETION_DYNAMIC\" != 0; and texra agents list --quiet --category toolUse",
+      "complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from run' -a '(test \"$TEXRA_COMPLETION_DYNAMIC\" != 0; and texra agents list --quiet --all --category toolUse",
     );
   });
 

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -13,12 +13,12 @@ _texra_agents() {
 
 _texra_workflow_agents() {
   _texra_completion_dynamic || return 0
-  texra agents list --quiet --category workflow 2>/dev/null | awk '{print $2}'
+  texra agents list --quiet --all --category workflow 2>/dev/null | awk '{print $2}'
 }
 
 _texra_tool_use_agents() {
   _texra_completion_dynamic || return 0
-  texra agents list --quiet --category toolUse 2>/dev/null | awk '{print $2}'
+  texra agents list --quiet --all --category toolUse 2>/dev/null | awk '{print $2}'
 }
 
 _texra_models() {
@@ -732,13 +732,13 @@ complete -c texra -n '__fish_seen_subcommand_from version' -l 'color' -d 'Emit A
 complete -c texra -n '__fish_seen_subcommand_from version' -l 'no-color' -d 'Disable ANSI color on every stream'
 complete -c texra -n '__fish_seen_subcommand_from version' -l 'no-input' -d 'For headless commands, disable prompts and default approvals to never'
 complete -c texra -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish'
-complete -c texra -n '__fish_seen_subcommand_from run; and not __fish_seen_subcommand_from agents; and not __fish_seen_subcommand_from multi-agent' -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --category workflow 2>/dev/null | awk "{print \\$2}")'
-complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from run' -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --category toolUse 2>/dev/null | awk "{print \\$2}")'
+complete -c texra -n '__fish_seen_subcommand_from run; and not __fish_seen_subcommand_from agents; and not __fish_seen_subcommand_from multi-agent' -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --all --category workflow 2>/dev/null | awk "{print \\$2}")'
+complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from run' -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --all --category toolUse 2>/dev/null | awk "{print \\$2}")'
 complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from show' -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet 2>/dev/null | awk "{print \\$2}")'
 complete -c texra -n '__fish_seen_subcommand_from agents; and __fish_seen_subcommand_from inspect' -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet 2>/dev/null | awk "{print \\$2}")'
 complete -c texra -n '__fish_seen_subcommand_from models; and __fish_seen_subcommand_from show' -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra models list --quiet 2>/dev/null | awk "{print \\$1}")'
 complete -c texra -l model -s m -r -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra models list --quiet 2>/dev/null | awk "{print \\$1}")'
-complete -c texra -l agent -r -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --category toolUse 2>/dev/null | awk "{print \\$2}")'
+complete -c texra -l agent -r -a '(test "$TEXRA_COMPLETION_DYNAMIC" != 0; and texra agents list --quiet --all --category toolUse 2>/dev/null | awk "{print \\$2}")'
 "
 `;
 
@@ -752,12 +752,12 @@ _texra_agents() {
 
 _texra_workflow_agents() {
   [[ "\${TEXRA_COMPLETION_DYNAMIC:-1}" == "0" ]] && return
-  texra agents list --quiet --category workflow 2>/dev/null | awk '{print $2}'
+  texra agents list --quiet --all --category workflow 2>/dev/null | awk '{print $2}'
 }
 
 _texra_tool_use_agents() {
   [[ "\${TEXRA_COMPLETION_DYNAMIC:-1}" == "0" ]] && return
-  texra agents list --quiet --category toolUse 2>/dev/null | awk '{print $2}'
+  texra agents list --quiet --all --category toolUse 2>/dev/null | awk '{print $2}'
 }
 
 _texra_models() {


### PR DESCRIPTION
## Summary

- Make shell completion launch positions query the full launchable agent catalog with --all.
- Keep plain agent discovery completions on the visible starter-agent list.
- Update Bash, Zsh, and Fish completion snapshots and behavioral tests.

Closes #6428

## Dogfood evidence

- texra-local agents list --category workflow --output-format=json --print returned an empty visible list.
- texra-local agents list --category workflow --all --output-format=json --print returned 7 workflow agents, including correct.
- Simulated Bash completion for texra run c returned correct after the change.

## Validation

- corepack pnpm vitest run src/test-kernel/cli/Completion.vitest.mts
- corepack pnpm --filter @texra-ai/cli build
- npm run lint
- npm run typecheck
- npm test
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to generated shell completion strings and tests; no runtime agent execution or auth changes.
> 
> **Overview**
> Shell tab completion for **launching** agents now calls `texra agents list` with **`--all`** so workflow and tool-use names hidden from the default visible roster still appear when completing `texra run`, `texra agents run`, and `--agent`.
> 
> Bash, Zsh, and Fish generators were updated in `_texra_workflow_agents` / `_texra_tool_use_agents` (and the Fish equivalents). **Unchanged:** completions for `agents show` / `agents inspect` still use the plain quiet list (visible agents only).
> 
> Tests and completion snapshots were refreshed to expect `--quiet --all --category workflow|toolUse`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9338be95c4c5d311d448b2a74110b2b65d4e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->