### PR TITLE
fix: preserve nested workflow output paths

### DIFF
--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -96,12 +96,79 @@ function outputCopyRelativePath(output: OutputFileSummary): string {
   return getSafeDocumentRelativePath(withoutRoundDir.join('/'));
 }
 
+function outputCopyRelativePathForExpectedOutput(
+  output: OutputFileSummary,
+  expectedOutputFiles: readonly string[],
+): string {
+  const generatedRelativePath = outputCopyRelativePath(output);
+  if (expectedOutputFiles.length === 0) return generatedRelativePath;
+  const expectedRelativePaths = expectedOutputFiles.map((file) =>
+    getSafeDocumentRelativePath(file),
+  );
+
+  const normalizedGeneratedPath = generatedRelativePath.replaceAll('\\', '/');
+  const generatedName = path.posix.basename(normalizedGeneratedPath);
+  const normalizedOriginalPath = output.originalPath?.replaceAll('\\', '/');
+  const matchingExpectedPaths =
+    normalizedOriginalPath == null
+      ? []
+      : expectedRelativePaths.filter((expected) => {
+          const normalizedExpected = expected.replaceAll('\\', '/');
+          if (path.posix.basename(normalizedExpected) !== generatedName) {
+            return false;
+          }
+          return (
+            normalizedOriginalPath === normalizedExpected ||
+            normalizedOriginalPath.endsWith(`/${normalizedExpected}`)
+          );
+        });
+  return matchingExpectedPaths.length === 1
+    ? matchingExpectedPaths[0]
+    : generatedRelativePath;
+}
+
+function commonDirectory(paths: readonly string[]): string {
+  if (paths.length === 0) return '';
+  const root = path.parse(paths[0]!).root;
+  const [first, ...rest] = paths.map((file) =>
+    path.resolve(file).split(path.sep),
+  );
+  let sharedLength = first.length;
+  for (const parts of rest) {
+    sharedLength = Math.min(sharedLength, parts.length);
+    while (
+      sharedLength > 0 &&
+      first.slice(0, sharedLength).join(path.sep) !==
+        parts.slice(0, sharedLength).join(path.sep)
+    ) {
+      sharedLength -= 1;
+    }
+  }
+  return first.slice(0, Math.max(1, sharedLength)).join(path.sep) || root;
+}
+
+function expectedInputOutputFiles(
+  inputFiles: readonly string[],
+): readonly string[] {
+  const absoluteInputs = inputFiles
+    .filter((input) => path.isAbsolute(input))
+    .map((input) => path.resolve(input));
+  const absoluteRoot = commonDirectory(absoluteInputs.map(path.dirname));
+
+  return inputFiles.map((input) => {
+    if (!path.isAbsolute(input)) return getSafeDocumentRelativePath(input);
+    return getSafeDocumentRelativePath(path.relative(absoluteRoot, input));
+  });
+}
+
 export function expectedOutputFilesForOutputDir(
   agent: AgentEntry | undefined,
   inputFiles: readonly string[],
 ): readonly string[] {
   const defaultOutputFiles = (agent?.defaultOutputFiles ?? []).filter(Boolean);
-  return defaultOutputFiles.length > 0 ? defaultOutputFiles : inputFiles;
+  return defaultOutputFiles.length > 0
+    ? defaultOutputFiles
+    : expectedInputOutputFiles(inputFiles);
 }
 
 function shouldUseOutputForCopy(
@@ -165,9 +232,13 @@ export async function resolveWorkflowOutput(
       : undefined;
   if (outputDir && result.category === AgentCategory.Workflow) {
     const targetRoot = joinCwdRelative(outputDir, context.cwd);
+    const expectedOutputFiles = options.expectedOutputFiles ?? [];
     const outputsByRelativePath = new Map<string, OutputFileSummary>();
     for (const output of result.outputs) {
-      const relativePath = outputCopyRelativePath(output);
+      const relativePath = outputCopyRelativePathForExpectedOutput(
+        output,
+        expectedOutputFiles,
+      );
       if (
         shouldUseOutputForCopy(outputsByRelativePath.get(relativePath), output)
       ) {
@@ -183,7 +254,6 @@ export async function resolveWorkflowOutput(
       copiedOutputs.push(targetPath);
     }
 
-    const expectedOutputFiles = options.expectedOutputFiles ?? [];
     const missing = expectedOutputFiles
       .map((f) => getSafeDocumentRelativePath(f))
       .filter((expected) => !outputsByRelativePath.has(expected));

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -5,7 +5,10 @@ import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { resolveWorkflowOutput } from '@cli/runtime/workflowOutput';
+import {
+  expectedOutputFilesForOutputDir,
+  resolveWorkflowOutput,
+} from '@cli/runtime/workflowOutput';
 import type { CliContext } from '@cli/runtime/cliContext';
 import {
   END_GROUP_STATUS,
@@ -47,6 +50,7 @@ function workflowResult(
   outputs: Array<{
     absolutePath: string;
     relativePath: string;
+    originalPath?: string | null;
     round?: number;
   }>,
 ): WorkflowResult {
@@ -61,7 +65,7 @@ function workflowResult(
       relativePath: output.relativePath,
       absolutePath: output.absolutePath,
       location: 'runStorage',
-      originalPath: null,
+      originalPath: output.originalPath ?? null,
       added: null,
       removed: null,
     })),
@@ -130,6 +134,188 @@ describe('CLI workflow output resolution', () => {
     await expect(readFile(join(cwd, 'out', 'b.tex'), 'utf8')).resolves.toBe(
       'B',
     );
+  });
+
+  it('preserves expected nested input paths when copying flattened workflow outputs', async () => {
+    const cwd = await makeTempDir();
+    const runMain = join(cwd, 'run', 'r1', 'main.tex');
+    const runSeries = join(cwd, 'run', 'r1', 'series.tex');
+    await mkdir(join(cwd, 'run', 'r1'), { recursive: true });
+    await writeFile(runMain, 'main');
+    await writeFile(runSeries, 'series');
+
+    const { displayResult } = await resolveWorkflowOutput(
+      undefined,
+      'out',
+      workflowResult([
+        {
+          absolutePath: runMain,
+          relativePath: 'r1/main.tex',
+          originalPath: join(cwd, 'run', 'original', 'paper', 'main.tex'),
+        },
+        {
+          absolutePath: runSeries,
+          relativePath: 'r1/series.tex',
+          originalPath: join(
+            cwd,
+            'run',
+            'original',
+            'paper',
+            'chapters',
+            'series.tex',
+          ),
+        },
+      ]),
+      testContext(cwd),
+      {
+        expectedOutputFiles: ['paper/main.tex', 'paper/chapters/series.tex'],
+        runDirectory: join(cwd, 'run'),
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      },
+    );
+
+    expect(displayResult).toMatchObject({
+      copiedOutputs: [
+        join(cwd, 'out', 'paper', 'main.tex'),
+        join(cwd, 'out', 'paper', 'chapters', 'series.tex'),
+      ],
+    });
+    await expect(
+      readFile(join(cwd, 'out', 'paper', 'main.tex'), 'utf8'),
+    ).resolves.toBe('main');
+    await expect(
+      readFile(join(cwd, 'out', 'paper', 'chapters', 'series.tex'), 'utf8'),
+    ).resolves.toBe('series');
+  });
+
+  it('uses original-path lineage before flat generated names when basenames collide', async () => {
+    const cwd = await makeTempDir();
+    const runRoot = join(cwd, 'run', 'root', 'main.tex');
+    const runNested = join(cwd, 'run', 'nested', 'main.tex');
+    await mkdir(join(cwd, 'run', 'root'), { recursive: true });
+    await mkdir(join(cwd, 'run', 'nested'), { recursive: true });
+    await writeFile(runRoot, 'root');
+    await writeFile(runNested, 'nested');
+
+    const { displayResult } = await resolveWorkflowOutput(
+      undefined,
+      'out',
+      workflowResult([
+        {
+          absolutePath: runRoot,
+          relativePath: 'r1/main.tex',
+          originalPath: join(cwd, 'run', 'original', 'paper', 'main.tex'),
+        },
+        {
+          absolutePath: runNested,
+          relativePath: 'r1/main.tex',
+          originalPath: join(
+            cwd,
+            'run',
+            'original',
+            'paper',
+            'chapters',
+            'main.tex',
+          ),
+        },
+      ]),
+      testContext(cwd),
+      {
+        expectedOutputFiles: ['paper/main.tex', 'paper/chapters/main.tex'],
+        runDirectory: join(cwd, 'run'),
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      },
+    );
+
+    expect(displayResult).toMatchObject({
+      copiedOutputs: [
+        join(cwd, 'out', 'paper', 'main.tex'),
+        join(cwd, 'out', 'paper', 'chapters', 'main.tex'),
+      ],
+    });
+    await expect(
+      readFile(join(cwd, 'out', 'paper', 'main.tex'), 'utf8'),
+    ).resolves.toBe('root');
+    await expect(
+      readFile(join(cwd, 'out', 'paper', 'chapters', 'main.tex'), 'utf8'),
+    ).resolves.toBe('nested');
+  });
+
+  it('does not remap arbitrary same-source outputs to an expected input name', async () => {
+    const cwd = await makeTempDir();
+    const runDerived = join(cwd, 'run', 'r1', 'derived.tex');
+    await mkdir(join(cwd, 'run', 'r1'), { recursive: true });
+    await writeFile(runDerived, 'derived');
+
+    await expect(
+      resolveWorkflowOutput(
+        undefined,
+        'out',
+        workflowResult([
+          {
+            absolutePath: runDerived,
+            relativePath: 'r1/derived.tex',
+            originalPath: join(cwd, 'run', 'original', 'paper', 'input.tex'),
+          },
+        ]),
+        testContext(cwd),
+        {
+          expectedOutputFiles: ['paper/input.tex'],
+          runDirectory: join(cwd, 'run'),
+          terminalStatus: EXECUTION_STATUS.COMPLETED,
+        },
+      ),
+    ).rejects.toThrow(/paper[/\\]input\.tex/);
+  });
+
+  it('derives safe expected --output-dir paths from relative and absolute inputs', async () => {
+    const external = await makeTempDir();
+
+    expect(
+      expectedOutputFilesForOutputDir(undefined, [
+        'paper/main.tex',
+        'paper/chapters/series.tex',
+      ]),
+    ).toEqual(['paper/main.tex', 'paper/chapters/series.tex']);
+    expect(
+      expectedOutputFilesForOutputDir(undefined, [
+        join(external, 'paper', 'main.tex'),
+        join(external, 'paper', 'chapters', 'series.tex'),
+      ]),
+    ).toEqual(['main.tex', join('chapters', 'series.tex')]);
+  });
+
+  it('does not remap output paths on partial original-path segment matches', async () => {
+    const cwd = await makeTempDir();
+    const runSeries = join(cwd, 'run', 'r1', 'series.tex');
+    await mkdir(join(cwd, 'run', 'r1'), { recursive: true });
+    await writeFile(runSeries, 'series');
+
+    await expect(
+      resolveWorkflowOutput(
+        undefined,
+        'out',
+        workflowResult([
+          {
+            absolutePath: runSeries,
+            relativePath: 'r1/series.tex',
+            originalPath: join(
+              cwd,
+              'run',
+              'original',
+              'mychapters',
+              'series.tex',
+            ),
+          },
+        ]),
+        testContext(cwd),
+        {
+          expectedOutputFiles: ['chapters/series.tex'],
+          runDirectory: join(cwd, 'run'),
+          terminalStatus: EXECUTION_STATUS.COMPLETED,
+        },
+      ),
+    ).rejects.toThrow(/chapters[/\\]series\.tex/);
   });
 
   it('uses the latest round when --output-dir workflow outputs arrive out of order', async () => {


### PR DESCRIPTION
## Summary

- Preserve nested input document paths when copying workflow outputs to --output-dir.
- Derive expected copy paths from workflow inputs and match generated outputs back to those paths through OutputFileSummary.originalPath.
- Keep generated output names as the fallback when no lineage match exists.

Closes #6432

## Dogfood evidence

Before this change, a real texra-local workflow run with input files:

- paper/main.tex
- paper/chapters/series.tex

copied outputs as:

- out/main.tex
- out/series.tex

After this change, the same texra-local run copied:

- out/main.tex
- out/chapters/series.tex

## Validation

- texra-local run correct --input <paper-dir> --output-dir <out-dir> --api-mode personal --model gpt54 --output-format=json --print --no-input
- corepack pnpm vitest run src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
- corepack pnpm --filter @texra-ai/cli build
- npm run lint
- npm run typecheck
- npm test
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where workflow files land on disk and when copy resolution errors; behavior is scoped to CLI workflow output with strict single-match remapping, but multi-input workflows may see different output layouts.
> 
> **Overview**
> Fixes **`--output-dir`** copying so workflow outputs keep the **nested layout of the input documents** instead of flattening to basenames only.
> 
> When expected output paths are known, copy keys now go through **`outputCopyRelativePathForExpectedOutput`**, which remaps a generated file to an expected relative path only when **`OutputFileSummary.originalPath`** uniquely matches that expected path (same basename, full path or `endsWith` suffix). Otherwise the prior flat generated name is used, and missing expected files still fail the run.
> 
> **`expectedOutputFilesForOutputDir`** no longer passes through raw input paths for the default case: it builds safe relative expectations via **`expectedInputOutputFiles`** (preserve relative inputs; for absolute inputs, strip a shared parent directory). The copy loop computes expected paths before building the output map so remapping and missing-output checks use the same keys.
> 
> Vitest coverage adds nested paths, basename collisions, derived vs input filenames, partial path mismatches, and absolute/relative input derivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a275beab0fdd4d01ca3ba8ef34333c8418e65e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->