### PR TITLE
fix: submit agent picker ids

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -181,15 +181,15 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   const agents: AgentGroups = data ?? { toolUse: [], workflow: [] };
   const primarySectionTitle = agentPickerPrimarySectionTitle(agents.toolUse);
   const items = agents.toolUse.map((agent) => ({
-    value: agent.label,
+    value: agent.value,
     label: agent.label,
     description: agentDescription(agent),
   }));
   // The current agent may be stored as a canonical key (`source:name`) or a
-  // bare name; rows are keyed by bare name, so resolve to the matching label
-  // so Select can render the ✓ on the active row.
+  // bare name; rows are keyed by canonical value, so match Select in that same
+  // identity space when rendering the ✓ on the active row.
   const activeAgent = currentVisibleAgent(agents.toolUse, props.currentAgent);
-  const activeValue = activeAgent?.label ?? props.currentAgent;
+  const activeValue = activeAgent?.value ?? props.currentAgent;
   const currentAgentHint = hiddenCurrentAgentHint(
     agents.toolUse,
     props.currentAgent,

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -36,9 +36,10 @@ describe('CLI AgentListForm row budget', () => {
       { value: 'remote:orchestrator', label: 'Orchestrator' },
     ];
 
-    expect(currentVisibleAgent(displayAgents, 'setup')?.label).toBe(
-      'Setup assistant',
-    );
+    const setupAgent = currentVisibleAgent(displayAgents, 'setup');
+
+    expect(setupAgent?.label).toBe('Setup assistant');
+    expect(setupAgent?.value).toBe('builtInToolUse:setup');
     expect(
       currentVisibleAgent(displayAgents, 'remote:orchestrator')?.label,
     ).toBe('Orchestrator');


### PR DESCRIPTION
## Summary

- fix `/agent` picker rows to submit the canonical `AgentOptionData.value` instead of the display label
- keep labels/descriptions purely presentational in the CLI agent form

Closes #6434.

## Dogfood evidence

Before the fix, in a real PTY:

```text
texra-local chat --api-mode personal --model gpt54 --agent chat --no-color
/agent
Enter on first row
```

failed with:

```text
Tool-use agent not found: Engineer — software team lead.
```

After the fix and CLI rebuild, the same path reports:

```text
Root agent set to builtInToolUse:engineer.
```

and advances to `/model`.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-agent-form-fix.8eqdUy agent-form agent-form-80-cols compact-agent-form model-form`
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm vitest run src/test-kernel/cli/AgentListForm.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npm run lint` (passes with 3 pre-existing import-order warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI form identity fix with targeted unit test updates; no auth, data, or server paths touched.
> 
> **Overview**
> Fixes the CLI **`/agent`** picker so selection and the active-row checkmark use **`AgentOptionData.value`** (e.g. `builtInToolUse:engineer`) instead of the display **label**, which could include descriptions and caused “agent not found” when setting the root agent.
> 
> **`activeValue`** for `Select` is aligned to the same canonical identity space as row keys. Labels and descriptions stay presentational only.
> 
> Tests in **`AgentListForm.vitest.mts`** now assert the resolved setup agent’s **`value`**, not only its label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff76d1bc990ed396be30982d196e3affbea90fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->