### PR TITLE
refactor: use native SDK types in model handlers

### DIFF
--- a/src/agent/modelHandlers/anthropic/anthropicUsage.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicUsage.ts
@@ -7,7 +7,6 @@
  * overrides that delegate here with the model's pricing config.
  */
 
-import type { AnthropicUsage } from '@agent/core/usage/ResponseUsage';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 
@@ -40,12 +39,9 @@ interface AnthropicUsageTokenTotals {
  * Uses per-iteration usage when available so compaction requests are fully billed.
  */
 function getAnthropicUsageTokenTotals(
-  responseUsage: AnthropicUsage,
+  responseUsage: BetaUsage,
 ): AnthropicUsageTokenTotals {
-  const usageWithIterations = responseUsage as AnthropicUsage & {
-    iterations?: BetaUsage['iterations'];
-  };
-  const iterations = usageWithIterations.iterations;
+  const iterations = responseUsage.iterations;
   if (Array.isArray(iterations) && iterations.length > 0) {
     let baseInputTokens = 0;
     let outputTokens = 0;
@@ -89,7 +85,7 @@ function getAnthropicUsageTokenTotals(
 
 /** Calculates API usage cost based on input/output tokens and cache usage if supported. */
 export function computeAnthropicPrice(
-  responseUsage: AnthropicUsage,
+  responseUsage: BetaUsage,
   config: AnthropicPricingConfig,
 ): number {
   if (!responseUsage) {
@@ -158,7 +154,7 @@ export function computeAnthropicPrice(
 
 /** Normalizes Anthropic usage data into a unified format. */
 export function normalizeAnthropicUsage(
-  rawUsage: AnthropicUsage,
+  rawUsage: BetaUsage,
   responseTimeMs: number,
   config: AnthropicPricingConfig,
 ): NormalizedUsage {

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -14,10 +14,7 @@ import {
   type AgentSetting,
   hasEndTag,
 } from '@agent/core/definition/AgentDataclass';
-import type {
-  AnthropicAPIResponseUsage,
-  AnthropicUsage,
-} from '@agent/core/usage/ResponseUsage';
+import type { AnthropicAPIResponseUsage } from '@agent/core/usage/ResponseUsage';
 import type {
   AgentWorkspaceState,
   ThinkingBlock,
@@ -130,6 +127,7 @@ import type {
   BetaRedactedThinkingBlock,
   BetaRequestDocumentBlock,
   BetaThinkingBlock,
+  BetaUsage,
   MessageCountTokensParams,
   MessageCreateParams,
 } from '@anthropic-ai/sdk/resources/beta/messages';
@@ -186,7 +184,7 @@ const INTERLEAVED_THINKING_BETA: AnthropicBeta =
 
 export class ModelHandlerAnthropic extends ModelHandler<
   MessageParam,
-  AnthropicUsage,
+  BetaUsage,
   AnthropicAPIResponseUsage,
   AnthropicToolCall,
   Anthropic,
@@ -1114,15 +1112,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
   }
 
   /** Calculates API usage cost based on input/output tokens and cache usage if supported. */
-  computePrice(responseUsage: AnthropicUsage): number {
+  computePrice(responseUsage: BetaUsage): number {
     return computeAnthropicPrice(responseUsage, this.pricingConfig());
   }
 
   /** Normalizes Anthropic usage data into a unified format. */
-  normalizeUsage(
-    rawUsage: AnthropicUsage,
-    responseTimeMs: number,
-  ): NormalizedUsage {
+  normalizeUsage(rawUsage: BetaUsage, responseTimeMs: number): NormalizedUsage {
     return normalizeAnthropicUsage(
       rawUsage,
       responseTimeMs,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -74,6 +74,7 @@ import { toGoogleTools } from '../toolConversion';
 import type {
   Part,
   Content,
+  Candidate,
   GenerateContentResponse,
   FunctionCall,
   FunctionResponsePart,
@@ -511,9 +512,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         const output = this.createOutputStream();
 
         let baseResponse: GenerateContentResponse | undefined;
-        let latestCandidate:
-          | NonNullable<GenerateContentResponse['candidates']>[number]
-          | undefined;
+        let latestCandidate: Candidate | undefined;
         const aggregatedParts: Part[] = [];
         let usageFromChunks: GenerateContentResponseUsageMetadata | undefined;
 

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -15,6 +15,7 @@ import type { ToolFileAttachment } from '@tools/result';
 import { ModelHandler } from './ModelHandler';
 import type { ModelConfig } from 'llm-zoo';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import type { CompletionUsage } from 'openai/resources/completions';
 import type {
   CreateResponseOptions,
   CreateResponseResult,
@@ -26,11 +27,7 @@ import type { ToolResultPayload } from './utils/toolAttachmentUtils';
 
 interface ValidationResponse {
   text: string;
-  usage: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
+  usage: CompletionUsage;
   stopReason: ProviderStopReason;
 }
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2569,16 +2569,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (!text.trim()) return;
 
     const lastUserMsg = messages.findLast(
-      (m) => (m as { role?: string }).role === 'user',
-    ) as { role: 'user'; content?: unknown } | undefined;
+      (m): m is EasyInputMessage | ResponseInputItem.Message =>
+        isMessageItem(m) && m.role === 'user',
+    );
     if (!lastUserMsg || !Array.isArray(lastUserMsg.content)) return;
 
-    const content = lastUserMsg.content as { type?: string; text?: string }[];
+    const content = lastUserMsg.content;
     const firstTextPart = content.find((part) => part.type === 'input_text');
-    if (firstTextPart && 'text' in firstTextPart) {
+    if (firstTextPart?.type === 'input_text') {
       firstTextPart.text = text + firstTextPart.text;
     } else {
-      content.unshift({ type: 'input_text', text });
+      content.unshift(createInputText(text));
     }
   }
 
@@ -2593,8 +2594,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (!mediaFiles.length || !this.capabilities.supportsVision) return;
 
     const lastUserMsg = messages.findLast(
-      (m) => (m as { role?: string }).role === 'user',
-    ) as { role: 'user'; content?: unknown[] } | undefined;
+      (m): m is EasyInputMessage | ResponseInputItem.Message =>
+        isMessageItem(m) && m.role === 'user',
+    );
     if (!lastUserMsg || !Array.isArray(lastUserMsg.content)) return;
 
     try {

--- a/src/agent/modelHandlers/openai/openAIChatHelpers.ts
+++ b/src/agent/modelHandlers/openai/openAIChatHelpers.ts
@@ -1,5 +1,6 @@
 import { takeTail } from '@common/errors/sdkErrorUtils';
 import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
+import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
 
 // Reasoning content type for DeepSeek, o1 models (not in SDK)
 type ReasoningContent = string | Array<{ type: string; text?: string }>;
@@ -25,9 +26,7 @@ export function extractReasoningDelta(chunk: ChatCompletionChunk): string {
  * suffix because continuation prompts reference the tail of the response.
  */
 export function extractOpenAIPartialTail(
-  snapshot:
-    | { choices?: Array<{ message?: { content?: string | null } }> }
-    | undefined,
+  snapshot: ChatCompletionSnapshot | undefined,
   maxChars: number,
 ): string {
   const content = snapshot?.choices?.[0]?.message?.content ?? '';

--- a/src/agent/modelHandlers/openrouter/openRouterStreaming.ts
+++ b/src/agent/modelHandlers/openrouter/openRouterStreaming.ts
@@ -4,17 +4,13 @@ import { ToolCallAccumulator } from '../utils/toolCallAccumulator';
 import type {
   ChatAssistantMessage,
   ChatFinishReasonEnum,
-  ChatRequest,
+  ChatRequestEffort,
   ChatResult,
   ChatStreamChunk,
   ChatToolCall,
   ChatUsage,
   ReasoningDetailUnion,
 } from '@openrouter/sdk/models';
-
-type OpenRouterReasoningEffort = NonNullable<
-  NonNullable<ChatRequest['reasoning']>['effort']
->;
 
 // OpenRouter's reasoning tiers passed through unchanged. It has no 'max' tier,
 // so 'max' maps to the top tier 'xhigh' and anything unknown falls back to 'low'.
@@ -27,12 +23,10 @@ const OPENROUTER_REASONING_EFFORTS: ReadonlySet<string> = new Set([
   'none',
 ]);
 
-export function toOpenRouterReasoningEffort(
-  effort: string,
-): OpenRouterReasoningEffort {
+export function toOpenRouterReasoningEffort(effort: string): ChatRequestEffort {
   if (effort === 'max') return 'xhigh';
   return OPENROUTER_REASONING_EFFORTS.has(effort)
-    ? (effort as OpenRouterReasoningEffort)
+    ? (effort as ChatRequestEffort)
     : 'low';
 }
 

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -22,7 +22,6 @@ import type {
   WebSearchToolResultBlock,
   WebSearchResultBlock,
   WebFetchToolResultBlock,
-  WebFetchBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 
 /**
@@ -391,27 +390,25 @@ export class AnthropicStreamHandler {
     // Parse URL from accumulated input JSON
     const fetchUrl = this.parseFetchUrl(fetchData?.input);
 
-    // Determine if fetch succeeded or failed
-    const isSuccess =
-      typeof block.content === 'object' &&
-      block.content !== null &&
-      block.content.type === 'web_fetch_result';
-
-    const result: WebFetchResult = isSuccess
-      ? {
-          url: (block.content as WebFetchBlock).url || fetchUrl,
-          title: (block.content as WebFetchBlock).content?.title ?? undefined,
-          provider: 'anthropic',
-          callId: block.tool_use_id,
-          status: 'completed',
-        }
-      : {
-          url: fetchUrl,
-          provider: 'anthropic',
-          callId: block.tool_use_id,
-          status: 'failed',
-          errorCode: (block.content as { error_code?: string }).error_code,
-        };
+    // Native discriminated-union narrowing on block.content
+    // (WebFetchBlock | WebFetchToolResultErrorBlock) replaces the prior
+    // structural casts.
+    const result: WebFetchResult =
+      block.content.type === 'web_fetch_result'
+        ? {
+            url: block.content.url || fetchUrl,
+            title: block.content.content?.title ?? undefined,
+            provider: 'anthropic',
+            callId: block.tool_use_id,
+            status: 'completed',
+          }
+        : {
+            url: fetchUrl,
+            provider: 'anthropic',
+            callId: block.tool_use_id,
+            status: 'failed',
+            errorCode: block.content.error_code,
+          };
 
     // Emit to progress view
     if (result.url || result.status === 'failed') {

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -228,12 +228,10 @@ export class AnthropicStreamHandler {
     switch (event.type) {
       case 'message_start':
         this.diagnostics.messageStartReceived = true;
-        this.diagnostics.anthropicMessageId =
-          (event.message as { id?: string })?.id ?? null;
+        this.diagnostics.anthropicMessageId = event.message.id;
         break;
       case 'message_delta':
-        this.diagnostics.stopReason =
-          (event.delta as { stop_reason?: string | null })?.stop_reason ?? null;
+        this.diagnostics.stopReason = event.delta.stop_reason;
         break;
       case 'message_stop':
         this.diagnostics.messageStopReceived = true;

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -369,14 +369,13 @@ export function extractAnthropicWebFetchResults(
         status: 'completed',
       });
     } else {
-      // Error result
-      const errorBlock = block.content as { error_code?: string };
+      // Error result — block.content is narrowed to WebFetchToolResultErrorBlock
       results.push({
         url: fetchUrl,
         provider: 'anthropic',
         callId: block.tool_use_id,
         status: 'failed',
-        errorCode: errorBlock.error_code,
+        errorCode: block.content.error_code,
       });
     }
   }


### PR DESCRIPTION
## What

Replace ad-hoc structural casts and derived types in the model handlers with the provider Node SDKs' own exported types. Three audit passes (a broad type sweep, a method-level sweep, and an Opus high-effort re-audit) cross-referenced every handler against the installed SDK `.d.ts`/`lib` helpers — Anthropic `^0.104.2`, OpenAI `^6.44.0`, `@google/genai` `^2.9.0`, `@openrouter/sdk` `0.13.7`.

### Type-level swaps (commit 1)

| File | Before | After |
|---|---|---|
| `anthropic/anthropicUsage.ts` + `modelHandlerAnthropic.ts` | `as Usage & { iterations?: BetaUsage['iterations'] }` intersection; usage typed as non-beta `Usage` | native **`BetaUsage`** throughout (the handler uses `client.beta.messages.*`, so the runtime usage object *is* `BetaUsage`) |
| `support/AnthropicStreamHandler.ts` | `(event.message as { id?: string })?.id`, `(event.delta as { stop_reason? })?.stop_reason` | SDK discriminated-union narrowing: `event.message.id`, `event.delta.stop_reason` |
| `modelHandlerValidation.ts` | hand-rolled `{ prompt_tokens; completion_tokens; total_tokens }` | OpenAI **`CompletionUsage`** |
| `openrouter/openRouterStreaming.ts` | derived `NonNullable<NonNullable<ChatRequest['reasoning']>['effort']>` | native **`ChatRequestEffort`** |

### Further casts found by the Opus re-audit (commit 2)

| File | Before | After |
|---|---|---|
| `support/AnthropicStreamHandler.ts` (web fetch) | `(block.content as WebFetchBlock)` ×2 + `(block.content as { error_code?: string })` | narrow `block.content` on its `type` discriminant (`WebFetchBlock \| WebFetchToolResultErrorBlock`) |
| `types/ServerToolTypes.ts` | `block.content as { error_code?: string }` | read `error_code` off the guard-narrowed `WebFetchToolResultErrorBlock` |
| `openai/openAIChatHelpers.ts` | inline `{ choices?: Array<{ message?: { content?: string \| null } }> }` | **`ChatCompletionSnapshot`** (`openai/lib/ChatCompletionStream`) |
| `google/modelHandlerGoogleGenAI.ts` | `NonNullable<GenerateContentResponse['candidates']>[number]` | named **`Candidate`** (`@google/genai`) |
| `openai/modelHandlerOpenAIResponse.ts` (prepend/addMedia) | inline `as { role?: string }` / `as { type?; text? }[]` casts | reuse the file's `isMessageItem` guard + `createInputText` + native `ResponseInputMessageContentList` |

## Methods, too

A dedicated method-level pass confirmed the runtime layer is already idiomatic — these SDK methods/helpers are already in use: `stream.finalMessage()`, `stream.finalChatCompletion()`, `stream.totalUsage()`, `stream.finalResponse()`, `addOutputText()`, `client.*.countTokens()`, `files.upload()`/`toFile()`, `createPartFromBase64/Uri()`, and `instanceof`-based error classification. No method-level changes were warranted.

## Not changed (verified legitimate, with SDK evidence)

The SDK genuinely lacks these, so the hand-rolled code is correct: `reasoning_content`/`thinking`-param extension types in `openai/*` (DeepSeek/Kimi/GLM/MiniMax wire fields); `(msg as { role?: string })` in `ModelHandler.ts` (heterogeneous `ProviderMessage` union with role-less `ResponseInputItem` variants); the documented `CompactedResponse.output as ResponseInputItem[]` cast; raw Anthropic stream-event parsing (needs block-index sequencing the SDK's text/thinking events drop); `BaseReasoningStreamAggregator`/`ToolCallAccumulator`/`parseArguments` (SDKs stream tool-call arguments as raw strings; no generic-path accumulator); the `OpenRouterStreamAggregator` (the OpenRouter chat `EventStream` has no finalizer); and the Anthropic `flattenTopLevelUnion`/`stripDollarSchema` transforms (the SDK's `transformJSONSchema` does the *inverse* — preserves top-level unions, forces `additionalProperties:false`, throws on type-less schemas — and would regress non-Anthropic providers).

## Verification

No behavior change (type-level only).

- `tsc --noEmit` for root `src/`, test-kernel, extension package, and CLI package — all green
- eslint on the changed files — clean
- vitest `src/test-kernel/agent/modelHandlers/` — 217 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor across usage accounting and message/stream parsing; no auth, billing logic, or API payload changes intended.
> 
> **Overview**
> Replaces hand-rolled structural casts and wrapper types in model handlers with **exported provider SDK types**, so usage, streaming events, and message shapes stay aligned with the installed SDKs.
> 
> **Anthropic:** Usage and `ModelHandlerAnthropic` generics now use **`BetaUsage`** (matching `client.beta.messages.*`) instead of a custom `AnthropicUsage` plus an `iterations` intersection cast. Stream diagnostics read **`event.message.id`** and **`event.delta.stop_reason`** directly; **`web_fetch_tool_result`** handling uses discriminated unions on **`block.content`** instead of casting to `WebFetchBlock` / error shapes.
> 
> **OpenAI:** Validation mock usage is **`CompletionUsage`**; chat partial-tail extraction uses **`ChatCompletionSnapshot`**; Responses user-message edits use **`isMessageItem`** type guards and **`createInputText`** instead of `{ role?: string }` casts.
> 
> **Google / OpenRouter:** Streaming state uses the SDK **`Candidate`** type; reasoning effort mapping uses **`ChatRequestEffort`** instead of a derived `NonNullable<…>` alias.
> 
> No intended runtime behavior change—type-level cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8584505f6efe022d9a2198e5ea1b7d14fc6744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->