### PR TITLE
refactor: type agent-SDK dynamic imports against native SDK signatures

### DIFF
--- a/src/tools/claudeAgentImport.ts
+++ b/src/tools/claudeAgentImport.ts
@@ -21,12 +21,8 @@ import { isModuleNotFoundError } from '@common/errors';
 import { AbsoluteFS } from '@utils/files';
 import { IS_WINDOWS } from '@utils/system/platformPaths';
 import { resolveBinary } from './support/externalBinaryUtils';
-import type { Options, Query } from '@anthropic-ai/claude-agent-sdk';
-
-type QueryFn = (params: {
-  prompt: string | AsyncIterable<unknown>;
-  options?: Options;
-}) => Query;
+// Mirror the native `query` signature exactly (no hand-rolled structural copy).
+type QueryFn = typeof import('@anthropic-ai/claude-agent-sdk').query;
 
 type PlatformInfo = { pkgs: readonly string[] };
 

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -21,7 +21,9 @@ import { AbsoluteFS } from '@utils/files';
 import { IS_WINDOWS } from '@utils/system/platformPaths';
 import { resolveBinary } from './support/externalBinaryUtils';
 
-type CodexConstructor = new (options?: any) => any;
+// The native `Codex` class value; `typeof` gives its construct signature
+// (`new (options?: CodexOptions) => Codex`) so construction stays type-checked.
+type CodexConstructor = typeof import('@openai/codex-sdk').Codex;
 type PlatformInfo = { pkg: string; triple: string };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) and Codex SDK (`@openai/codex-sdk`) tool wrappers load the SDK via dynamic `import()` and cast the result to a local shape. Replace the two hand-rolled cast targets with the SDKs' own signatures:

| File | Before | After |
|---|---|---|
| `src/tools/claudeAgentImport.ts` | `type QueryFn = (params: { prompt: string \| AsyncIterable<unknown>; options?: Options }) => Query` | `type QueryFn = typeof import('@anthropic-ai/claude-agent-sdk').query` (drops the re-declared structural copy + the now-unused `Options`/`Query` import) |
| `src/tools/codexImport.ts` | `type CodexConstructor = new (options?: any) => any` | `type CodexConstructor = typeof import('@openai/codex-sdk').Codex` (drops the `any`s; restores type-checking on `new CodexClass(...)` + `startThread`/`resumeThread` against `CodexOptions`/`ThreadOptions`) |

Both are type-level `import()` queries, so no runtime import is added (the wrappers still resolve the module dynamically and cast the untyped module record).

## Audit context (Opus, both SDKs)

A deep audit found both integrations are **already overwhelmingly native** — no method-level or further type changes were warranted:

- **claude-agent-sdk:** imports `Options`/`EffortLevel` directly; every `Options` field set is genuine; consumes the native async-iterator (`for await`) and native `resume`-based session resumption. The loose `SdkMessage`/`ClaudeMessageBlock` adapter types are a **deliberate, documented boundary** (kept loose to avoid pulling the beta content-block union into this zone); adopting the native `SDKMessage` union would cascade into the block handlers and change error-message extraction (`SDKResultError` has no `result`), so it was intentionally left as-is.
- **codex-sdk:** `Codex`/`Thread`/`ThreadOptions`/`ThreadItem`/`ThreadEvent`/`RunResult`/`Usage`/`ApprovalMode`/`SandboxMode`/`ModelReasoningEffort` all imported and used directly; streaming via `runStreamed`, abort via the native `signal`, resume via `resumeThread`. `codexConfig.ts` even pins TeXRA's Zod enums to the SDK unions with `satisfies`/`Extract<…>`.
- **external tool defs / binary resolution:** TeXRA-own concerns (tool dashboard, Electron `process`, 4-stage binary probe) with no SDK counterpart.

## Verification

No behavior change (type-level only).

- `tsc --noEmit` for root `src/`, test-kernel, extension package, and CLI package — all green (tightening the Codex `any` surfaced no latent mismatches)
- eslint on the changed files — clean
- vitest `CodexProgressEvents` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only alias changes in SDK loader helpers; no runtime or security-sensitive logic is modified.
> 
> **Overview**
> **Type-only tightening** for the Claude Agent and Codex dynamic-import wrappers: local aliases now mirror the SDKs instead of hand-rolled shapes.
> 
> In `claudeAgentImport.ts`, `QueryFn` becomes `typeof import('@anthropic-ai/claude-agent-sdk').query`, removing the duplicated structural signature and the unused `Options` / `Query` type import. In `codexImport.ts`, `CodexConstructor` becomes `typeof import('@openai/codex-sdk').Codex`, replacing `new (options?: any) => any` so `new Codex(...)` and thread APIs are checked against real `CodexOptions` / `ThreadOptions`.
> 
> Runtime behavior is unchanged—the modules are still loaded dynamically and cast from an untyped record; only compile-time checking improves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a915b2c1fc7420a4506e7527bcd91c94d17259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->