### PR TITLE
fix: Codex subscription review follow-ups (badge reactivity, /status parity)

### DIFF
--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -1,6 +1,7 @@
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { notifyFollowUpSent } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { isCodexSubscriptionActive } from '@auth/codex';
 import { formatCliApiMode } from '@cli/runtime/apiAccessMode';
 import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
 import { parseCliHistoryId } from '@cli/runtime/history';
@@ -141,6 +142,10 @@ export async function handleTuiSlashCommand(
       const slice = activeStreamId
         ? cliState.streams.get().get(activeStreamId)
         : undefined;
+      // Mirror the status bar's `subscription` badge so the two never disagree.
+      const subscriptionActive = await isCodexSubscriptionActive(
+        meta.model || context.initialModel,
+      );
       appendLocalAssistantTranscript(
         formatCliSessionStatus({
           agent: meta.agent || context.initialAgent,
@@ -149,6 +154,7 @@ export async function handleTuiSlashCommand(
           // Read the session's own mode (which honors a --api-mode/env override)
           // so /status agrees with the header instead of re-reading the global.
           api: formatCliApiMode(meta.apiMode),
+          subscription: subscriptionActive,
           approval: formatCliApprovalPolicy(context.getApprovalPolicy()),
           approvalBypasses: slice?.bypass,
           status: slice?.status ?? 'not started',

--- a/packages/cli/src/chat/tui/commands/handlers/subscriptionCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/subscriptionCommand.ts
@@ -4,6 +4,7 @@ import {
   setPreferCodexSubscription,
 } from '@auth/codex';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
+import { bumpCodexPreferenceVersion } from '@cli/chat/tui/state/cliState';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 const SUBSCRIPTION_ON = new Set(['on', 'enable', 'enabled', 'true', 'yes']);
@@ -48,6 +49,7 @@ export async function applyCliSubscriptionToggle(input: string): Promise<void> {
 
   const update = await setPreferCodexSubscription(enabled);
   invalidateModelOptionsCache();
+  bumpCodexPreferenceVersion();
 
   const lines = [
     update.effective === enabled

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -4,7 +4,7 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import { useEffect, useState } from 'react';
 import stringWidth from 'string-width';
 
-import { isCodexSignedIn, shouldUseCodexSubscription } from '@auth/codex';
+import { isCodexSubscriptionActive } from '@auth/codex';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   defaultShortcutModifierLabel,
@@ -25,7 +25,6 @@ import {
   formatCompactDuration,
   formatCompactTokenCount,
 } from '@utils/core';
-import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 import { truncateSummaryToWidth } from '../render/terminalText';
 import { formatCliStatusLabel } from '../sessionStatus';
@@ -181,7 +180,7 @@ const STATUS_BAR_HORIZONTAL_PADDING = 2;
 const STATUS_BAR_MIN_RIGHT_PREVIEW = 12;
 // Preserve a readable separator between the left status group and right preview.
 const STATUS_BAR_RIGHT_PREVIEW_GAP = 2;
-const CODEX_SIGN_IN_REFRESH_MS = 10_000;
+const CODEX_SUBSCRIPTION_REFRESH_MS = 10_000;
 // Lower values are removed first when the left status group exceeds the row.
 const STATUS_BAR_COMPACT_PRIORITY = {
   activeProcess: 10,
@@ -827,39 +826,40 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     streams,
   });
   const statusSlice = target.displaySlice;
-  const subscriptionEligible = (() => {
-    const config = MODEL_CONFIGS[sessionMeta.model];
-    return config
-      ? shouldUseCodexSubscription(config, getUseOpenRouter())
-      : false;
-  })();
-  const [codexSignedIn, setCodexSignedIn] = useState(false);
+
+  // Whether the active model is currently routing through the ChatGPT
+  // subscription (preference + eligibility + signed in). Kept in polled state
+  // rather than read on every render: the poll re-reads the preference so an
+  // external config change is reflected within the interval, and an in-process
+  // `/subscription` toggle bumps `codexPreferenceVersion` to refresh at once.
+  const codexPreferenceVersion = useSignal(cliState.codexPreferenceVersion);
+  const [subscriptionActive, setSubscriptionActive] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    const refreshSignedIn = () => {
-      void isCodexSignedIn()
-        .then((signedIn) => {
-          if (!cancelled) setCodexSignedIn(signedIn);
+    let inFlight = false;
+    const refresh = (): void => {
+      if (inFlight) return; // Skip if the previous read has not resolved.
+      inFlight = true;
+      void isCodexSubscriptionActive(sessionMeta.model)
+        .then((active) => {
+          if (!cancelled) setSubscriptionActive(active);
         })
         .catch(() => {
-          if (!cancelled) setCodexSignedIn(false);
+          if (!cancelled) setSubscriptionActive(false);
+        })
+        .finally(() => {
+          inFlight = false;
         });
     };
-    if (!subscriptionEligible) {
-      setCodexSignedIn(false);
-      return () => {
-        cancelled = true;
-      };
-    }
-    refreshSignedIn();
-    const refreshTimer = setInterval(refreshSignedIn, CODEX_SIGN_IN_REFRESH_MS);
+    refresh();
+    const refreshTimer = setInterval(refresh, CODEX_SUBSCRIPTION_REFRESH_MS);
     refreshTimer.unref?.();
     return () => {
       cancelled = true;
       clearInterval(refreshTimer);
     };
-  }, [sessionMeta.model, subscriptionEligible]);
+  }, [sessionMeta.model, codexPreferenceVersion]);
 
   const runStartedAt =
     statusSlice?.status === STREAM_STATUS.RUNNING
@@ -889,7 +889,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     hasMultipleStreams: streams.size > 1,
     model: sessionMeta.model,
     apiMode: shortCliApiMode(sessionMeta.apiMode),
-    subscriptionActive: subscriptionEligible && codexSignedIn,
+    subscriptionActive,
     approvalPolicy: sessionMeta.approvalPolicy,
     shiftEnterNewline: caps.kittyKeyboard,
     transcriptAvailable: props.transcriptAvailable,

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -19,6 +19,9 @@ export interface CliSessionStatusInput {
   readonly model: string;
   readonly teamName?: string;
   readonly api: string;
+  /** True when the active model routes through the ChatGPT subscription, so the
+   *  text command agrees with the status bar's `subscription` badge. */
+  readonly subscription?: boolean;
   readonly approval: string;
   readonly approvalBypasses?: Partial<BypassState>;
   readonly status: string;
@@ -73,6 +76,9 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
     `agent: ${input.agent}`,
     `model: ${input.model}`,
     `api: ${input.api}`,
+    ...(input.subscription
+      ? ['subscription: on (Codex models use your ChatGPT plan)']
+      : []),
     `approval: ${input.approval}`,
     ...(bypassLabels.length > 0
       ? [`auto-approvals: ${bypassLabels.join(', ')}`]

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -197,6 +197,12 @@ const TRANSCRIPT_VIEWER_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 const PENDING_EXIT_HINT = signal<boolean>(false);
 const PENDING_EXIT_RESUME_ID = signal<string | undefined>(undefined);
 
+// Bumped whenever the in-process ChatGPT-subscription preference changes (via
+// `/subscription`) so the status bar re-reads it immediately instead of waiting
+// for its periodic poll. External changes (extension/desktop/config edits) are
+// still picked up by that poll.
+const CODEX_PREFERENCE_VERSION = signal<number>(0);
+
 const RESET_HOOKS = new Set<() => void>();
 
 export const cliState = {
@@ -218,7 +224,15 @@ export const cliState = {
   pendingExitResumeId: PENDING_EXIT_RESUME_ID as Signal.State<
     string | undefined
   >,
+  codexPreferenceVersion: CODEX_PREFERENCE_VERSION as Signal.State<number>,
 };
+
+/** Signal the status bar to re-read the ChatGPT-subscription preference now. */
+export function bumpCodexPreferenceVersion(): void {
+  cliState.codexPreferenceVersion.set(
+    cliState.codexPreferenceVersion.get() + 1,
+  );
+}
 
 export function setCliSessionModelOverride(model: string): void {
   cliState.sessionMeta.set({

--- a/src/auth/codex/codexActive.ts
+++ b/src/auth/codex/codexActive.ts
@@ -1,0 +1,29 @@
+/**
+ * Live "is this model routing through the ChatGPT subscription right now?"
+ * check: the (sync) routing predicate from {@link shouldUseCodexSubscription}
+ * AND a current ChatGPT sign-in. Async because it reads the stored session.
+ *
+ * Shared by the CLI status bar badge and the `/status` text command so the two
+ * never disagree, and the single place that pairs the routing predicate with
+ * `getUseOpenRouter()` — keeping that config read out of the CLI render path.
+ */
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+import { getUseOpenRouter } from '@utils/config/providerConfig';
+
+import { isCodexSignedIn } from './codexAuthAccess';
+import { shouldUseCodexSubscription } from './codexRouting';
+
+/**
+ * Whether a request for `modelId` would be served by the ChatGPT subscription
+ * right now: the model prefers + is eligible for the subscription AND a session
+ * is signed in. Returns `false` for an unknown model id.
+ */
+export async function isCodexSubscriptionActive(
+  modelId: string,
+): Promise<boolean> {
+  const config = MODEL_CONFIGS[modelId];
+  if (!config) return false;
+  if (!shouldUseCodexSubscription(config, getUseOpenRouter())) return false;
+  return isCodexSignedIn();
+}

--- a/src/auth/codex/index.ts
+++ b/src/auth/codex/index.ts
@@ -64,6 +64,7 @@ export {
   type CodexSubscriptionPreferenceUpdate,
 } from './codexPreference';
 export { shouldUseCodexSubscription } from './codexRouting';
+export { isCodexSubscriptionActive } from './codexActive';
 export {
   loginWithLoopback,
   type CodexLoopbackLoginOptions,

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -242,6 +242,40 @@ describe('CLI session status formatter', () => {
     );
   });
 
+  it('shows the subscription line after api when subscription routing is active', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'gpt55',
+      api: 'included relay',
+      subscription: true,
+      approval: 'ask',
+      status: 'running',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).toContain(
+      [
+        'api: included relay',
+        'subscription: on (Codex models use your ChatGPT plan)',
+        'approval: ask',
+      ].join('\n'),
+    );
+  });
+
+  it('omits the subscription line when subscription routing is inactive', () => {
+    const status = formatCliSessionStatus({
+      agent: 'chat',
+      model: 'gpt55',
+      api: 'included relay',
+      subscription: false,
+      approval: 'ask',
+      status: 'running',
+      queuedFollowUpMessages: [],
+    });
+
+    expect(status).not.toContain('subscription:');
+  });
+
   it('includes team identity when a chat was launched from a preset', () => {
     expect(
       formatCliSessionStatus({


### PR DESCRIPTION
Follow-up to the merged #6436 + #6437, resolving the remaining review threads on the CLI status bar's ChatGPT-subscription indicator.

## Changes
- **Status bar badge reactivity.** The `subscription` badge is now driven by polled state via a new shared `@auth/codex` `isCodexSubscriptionActive(model)` helper, refreshed on mount, model change, and a 10s interval — so an external `preferSubscription` change is reflected within the interval instead of latching stale. An in-process `/subscription` toggle bumps a `codexPreferenceVersion` signal for instant feedback.
- **Decoupling / single source of truth.** The eligibility read moves out of the per-render IIFE into that effect, and the new helper owns the `@utils/config/providerConfig` import, so the CLI package no longer imports that module directly. The status bar and `/status` now derive subscription state from the same `isCodexSubscriptionActive` helper, so they cannot disagree.
- **Poll guard.** An in-flight guard prevents overlapping reads from stacking.
- **`/status` parity.** `/status` prints a `subscription:` line, matching the status bar badge.

## Verification
- Typecheck, `check:architecture`, and the CLI/auth Vitest suites pass; added `SessionStatus` tests for the new line.
- Live-tested in the TUI: badge on mount, `/status` line, and `/subscription on|off` updating the badge within ~2s.
- Adversarial multi-agent review confirmed each thread resolved with no TUI-discipline regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and preference reactivity only; routing logic is centralized in auth without changing OAuth or credential handling.
> 
> **Overview**
> The CLI **subscription** indicator and **`/status`** now share one async helper, `isCodexSubscriptionActive(model)`, so eligibility, OpenRouter config, preference, and ChatGPT sign-in are evaluated the same way in both places.
> 
> The **status bar** no longer derives subscription state on every render from a local eligibility check plus sign-in. It **polls** `isCodexSubscriptionActive` on mount, when the model changes, and every **10s**, with an **in-flight guard** so overlapping reads do not stack. **`/subscription on|off`** bumps **`codexPreferenceVersion`** so the bar refreshes immediately; external config edits still show up on the next poll. The **`@utils/config/providerConfig`** read moves into `@auth/codex`, so the CLI render path does not import it directly.
> 
> **`/status`** awaits the same helper and, when active, prints **`subscription: on (Codex models use your ChatGPT plan)`** after the api line. **`SessionStatus`** tests cover the new line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd942309b6cfc0ef4b59a8cd3891f5476809d3dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->