### PR TITLE
refactor: make Codex auth JWT and device-interval parsing Zod-native

### DIFF
--- a/src/auth/codex/codexDeviceLogin.ts
+++ b/src/auth/codex/codexDeviceLogin.ts
@@ -13,7 +13,6 @@ import {
 } from './CodexSessionCoordinator';
 import { CodexAuthError, type CodexSession } from './codexSessionTypes';
 import {
-  deviceInterval,
   deviceUserCode,
   pollDeviceToken,
   requestDeviceUserCode,
@@ -49,7 +48,7 @@ export async function loginWithDeviceCode(
   if (!userCode) {
     throw new Error('ChatGPT did not return a device code. Try again.');
   }
-  const intervalMs = deviceInterval(userCodeResponse) * 1000;
+  const intervalMs = userCodeResponse.interval * 1000;
 
   options.onPrompt({
     userCode,

--- a/src/auth/codex/codexJwt.ts
+++ b/src/auth/codex/codexJwt.ts
@@ -10,84 +10,79 @@
  *   1. top-level `chatgpt_account_id`
  *   2. `["https://api.openai.com/auth"].chatgpt_account_id`
  *   3. `organizations[0].id`
+ *
+ * The decoded payload is UNTRUSTED, so it is validated through a Zod schema at
+ * the boundary instead of hand-walked with casts. Every claim self-heals
+ * (`.catch`) so a single malformed field degrades to `undefined` rather than
+ * dropping the whole payload — preserving the old per-location probing where a
+ * valid account id survives garbage in a sibling claim. The same schema folds
+ * the three locations into the canonical `{ accountId, email }` shape.
  */
+import { z } from 'zod';
+
 import { CODEX_JWT_AUTH_CLAIM } from './codexConstants';
 
+/** Account id + email distilled from a JWT (either may be absent). */
 export interface CodexJwtClaims {
   accountId?: string;
   email?: string;
 }
 
-/** Decode a JWT payload (the middle base64url segment). Returns null on any error. */
-export function decodeJwtPayload(
-  token: string,
-): Record<string, unknown> | null {
+/** A claim we read as a non-empty string, tolerating any other shape. */
+const NonEmptyClaim = z.string().min(1).optional().catch(undefined);
+
+/** Validates an UNTRUSTED decoded JWT payload and distills the claims we read. */
+const CodexJwtClaimsSchema = z
+  .object({
+    chatgpt_account_id: NonEmptyClaim,
+    [CODEX_JWT_AUTH_CLAIM]: z
+      .object({ chatgpt_account_id: NonEmptyClaim })
+      .optional()
+      .catch(undefined),
+    organizations: z
+      .array(z.object({ id: NonEmptyClaim }).catch({ id: undefined }))
+      .optional()
+      .catch(undefined),
+    email: NonEmptyClaim,
+  })
+  .transform(
+    (claims): CodexJwtClaims => ({
+      accountId:
+        claims.chatgpt_account_id ??
+        claims[CODEX_JWT_AUTH_CLAIM]?.chatgpt_account_id ??
+        claims.organizations?.[0]?.id,
+      email: claims.email,
+    }),
+  );
+
+/**
+ * Decode + validate a JWT's claims (the middle base64url segment). Returns empty
+ * claims on any structural error; never throws.
+ */
+export function decodeJwtPayload(token: string): CodexJwtClaims {
   try {
     const parts = token.split('.');
-    if (parts.length !== 3) return null;
+    if (parts.length !== 3) return {};
     const json = Buffer.from(parts[1], 'base64url').toString('utf-8');
-    const parsed: unknown = JSON.parse(json);
-    return parsed && typeof parsed === 'object'
-      ? (parsed as Record<string, unknown>)
-      : null;
+    const result = CodexJwtClaimsSchema.safeParse(JSON.parse(json));
+    return result.success ? result.data : {};
   } catch {
-    return null;
+    return {};
   }
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-/** Extract the ChatGPT account id from a decoded payload, trying all 3 locations. */
-export function extractAccountId(
-  claims: Record<string, unknown>,
-): string | undefined {
-  const topLevel = asString(claims['chatgpt_account_id']);
-  if (topLevel) return topLevel;
-
-  const auth = claims[CODEX_JWT_AUTH_CLAIM];
-  if (auth && typeof auth === 'object') {
-    const nested = asString(
-      (auth as Record<string, unknown>)['chatgpt_account_id'],
-    );
-    if (nested) return nested;
-  }
-
-  const organizations = claims['organizations'];
-  if (Array.isArray(organizations) && organizations.length > 0) {
-    const first = organizations[0];
-    if (first && typeof first === 'object') {
-      const orgId = asString((first as Record<string, unknown>)['id']);
-      if (orgId) return orgId;
-    }
-  }
-  return undefined;
-}
-
-/** Extract the email claim from a decoded payload. */
-export function extractEmail(
-  claims: Record<string, unknown>,
-): string | undefined {
-  return asString(claims['email']);
 }
 
 /**
  * Extract account id + email, preferring the id_token and falling back to the
- * access_token. Either token may be absent.
+ * access_token field-by-field. Either token may be absent.
  */
 export function extractCodexClaims(
   idToken: string | undefined,
   accessToken: string | undefined,
 ): CodexJwtClaims {
-  const idClaims = idToken ? decodeJwtPayload(idToken) : null;
-  const accessClaims = accessToken ? decodeJwtPayload(accessToken) : null;
+  const idClaims = idToken ? decodeJwtPayload(idToken) : {};
+  const accessClaims = accessToken ? decodeJwtPayload(accessToken) : {};
   return {
-    accountId:
-      (idClaims ? extractAccountId(idClaims) : undefined) ??
-      (accessClaims ? extractAccountId(accessClaims) : undefined),
-    email:
-      (idClaims ? extractEmail(idClaims) : undefined) ??
-      (accessClaims ? extractEmail(accessClaims) : undefined),
+    accountId: idClaims.accountId ?? accessClaims.accountId,
+    email: idClaims.email ?? accessClaims.email,
   };
 }

--- a/src/auth/codex/codexOAuthClient.ts
+++ b/src/auth/codex/codexOAuthClient.ts
@@ -161,15 +161,6 @@ export function deviceUserCode(resp: CodexDeviceUserCode): string | undefined {
   return resp.user_code ?? resp.usercode ?? undefined;
 }
 
-/** The poll interval (seconds) from a device-code response, defaulting to 5. */
-export function deviceInterval(resp: CodexDeviceUserCode): number {
-  const raw = resp.interval;
-  const value = typeof raw === 'string' ? Number.parseInt(raw, 10) : raw;
-  return typeof value === 'number' && Number.isFinite(value) && value > 0
-    ? value
-    : 5;
-}
-
 /**
  * Poll once for the device authorization result. Resolves to the authorization
  * code + verifier on success, or throws a CodexAuthError('pending') while the

--- a/src/auth/codex/codexSessionTypes.ts
+++ b/src/auth/codex/codexSessionTypes.ts
@@ -35,7 +35,10 @@ export const CodexDeviceUserCodeSchema = z.object({
   device_auth_id: z.string().min(1),
   user_code: z.string().min(1).nullish(),
   usercode: z.string().min(1).nullish(),
-  interval: z.union([z.string(), z.number()]).nullish(),
+  // The endpoint sends the poll interval (seconds) as a string or a number, may
+  // omit it, and could send junk. Normalize at the boundary to a positive
+  // number, defaulting to 5 (matches Codex CLI / Zed).
+  interval: z.coerce.number().positive().catch(5).prefault(5),
 });
 export type CodexDeviceUserCode = z.infer<typeof CodexDeviceUserCodeSchema>;
 

--- a/src/auth/codex/index.ts
+++ b/src/auth/codex/index.ts
@@ -15,8 +15,6 @@ export {
 } from './codexPkce';
 export {
   decodeJwtPayload,
-  extractAccountId,
-  extractEmail,
   extractCodexClaims,
   type CodexJwtClaims,
 } from './codexJwt';
@@ -35,7 +33,6 @@ export {
   requestDeviceUserCode,
   pollDeviceToken,
   deviceUserCode,
-  deviceInterval,
   codexDeviceRedirectUri,
 } from './codexOAuthClient';
 export {

--- a/src/test-kernel/auth/CodexJwt.vitest.ts
+++ b/src/test-kernel/auth/CodexJwt.vitest.ts
@@ -70,6 +70,19 @@ describe('codex JWT claim extraction', () => {
     });
   });
 
+  it('keeps a valid claim when a sibling claim is malformed', () => {
+    // A wrong-typed / garbage sibling must degrade to undefined on its own
+    // rather than dropping the whole payload (per-field tolerance).
+    const jwt = makeJwt({
+      chatgpt_account_id: 'acct-top',
+      organizations: 'garbage',
+      email: 123,
+    });
+    expect(extractCodexClaims(jwt, undefined)).toEqual({
+      accountId: 'acct-top',
+    });
+  });
+
   it('returns empty claims for malformed or missing tokens', () => {
     expect(extractCodexClaims(undefined, undefined)).toEqual({});
     expect(extractCodexClaims('not-a-jwt', undefined)).toEqual({});


### PR DESCRIPTION
## What

Brings the last two hand-rolled parsing boundaries in `src/auth/codex` under Zod, so a schema is the single source of truth at every trust boundary in the subsystem.

**JWT claims (`codexJwt.ts`).** The decoded JWT payload is untrusted external data. It was decoded to `Record<string, unknown>` and hand-walked with `as` casts, an `asString` guard, and `Array.isArray`/`typeof` checks across three account-id locations. It now validates through a Zod schema that folds those three locations into the canonical `{ accountId, email }` shape. Each claim self-heals with `.catch(undefined)`, so a malformed sibling claim degrades to `undefined` instead of dropping the whole payload, exactly matching the old per-location probing. `asString` / `extractAccountId` / `extractEmail` are deleted.

**Device interval (`codexSessionTypes.ts` + `codexOAuthClient.ts`).** The poll interval arrives as a string or number, may be absent, and could be junk. It is now normalized at the schema boundary:

```ts
interval: z.coerce.number().positive().catch(5).prefault(5)
```

so the field is always a positive number. The `deviceInterval()` normalizer is deleted and the call site reads `userCodeResponse.interval` directly.

The now-unused `extractAccountId` / `extractEmail` / `deviceInterval` re-exports are dropped (grep-confirmed no external callers).

## Why

The rest of the subsystem already validates external data through Zod and `safeParse` (token responses, device responses, the persisted session bundle). These two were the remaining boundaries still parsed by hand. zod is 4.4.3; the change uses idiomatic v4 (`z.coerce`, `.catch`, `.prefault`, schema-driven `transform`).

## Deliberately left alone (not over-engineered)

Already Zod-native or correctly plain TypeScript, so untouched:
- Token / device-code network responses and the persisted session bundle (already `safeParse` at the boundary).
- OAuth error bodies (only echoed into a human message; a narrow schema would drop text on an unofficial endpoint).
- Config boolean preference (typed `config.get<boolean>` with a default; belongs at the config provider, not bolted on here).
- PKCE crypto, constant tables, routing/active predicates, and the loopback callback query branches (no untrusted JSON/JWT/disk boundary; security-asymmetric control flow, not a parse).

## Verification

- `CodexJwt.vitest.ts` stays green, plus a new mixed-validity case (valid account id alongside garbage sibling claims) that pins the per-field tolerance a naive strict-schema rewrite would regress.
- All 64 codex tests across the repo pass; `npm run typecheck` reports no new errors (the 14 pre-existing `@openrouter/sdk` / `vscode-jsonrpc` module-resolution errors are unrelated and present on `main`).
- No user-facing behavior change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of auth parsing boundaries with behavior preserved via tests; no signature verification or session storage changes.
> 
> **Overview**
> Moves the last hand-rolled parse boundaries in Codex auth onto **Zod**, so external OAuth/JWT data is normalized at the schema layer instead of with casts and helper walkers.
> 
> **JWT claims** (`codexJwt.ts`): `decodeJwtPayload` now returns canonical `{ accountId, email }` via a Zod schema with per-claim `.catch(undefined)` and a transform that merges the three account-id locations. `asString`, `extractAccountId`, and `extractEmail` are removed; `extractCodexClaims` merges id/access tokens from the new shape. Public exports drop `extractAccountId` / `extractEmail`.
> 
> **Device poll interval** (`CodexDeviceUserCodeSchema`): `interval` is coerced to a positive number with default **5** on missing/junk. `deviceInterval()` is deleted; device login uses `userCodeResponse.interval` directly.
> 
> Tests add a mixed-validity JWT case to lock in per-field tolerance when sibling claims are garbage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebbb72021880f8765343f6dfef10c25e7d622fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->