### PR TITLE
refactor: single-source Codex routing/auth-status + fix desktop type import

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1,10 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import {
-  prepareMainViewExecutionRequest,
-  type MainViewExecuteMessage,
-} from '@controllers/mainView/MainViewExecutionController';
+import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionMessageController';
 
 import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
 import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';

--- a/packages/desktop/src/main/desktopExecutionIpc.ts
+++ b/packages/desktop/src/main/desktopExecutionIpc.ts
@@ -3,7 +3,7 @@ import {
   createCommandHandler,
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
-import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionMessageController';
 
 export interface DesktopExecutionIpcOptions {
   executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -25,8 +25,7 @@ import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { getAllActiveExecutionIds } from '@agent/runtime/SessionHandle';
 import {
   codexCoordinator,
-  getCodexStatus,
-  isPreferCodexSubscription,
+  getChatGptAuthStatus,
   loginWithLoopback,
   setPreferCodexSubscription,
 } from '@auth/codex';
@@ -354,10 +353,9 @@ export function createDesktopSettingsIpc(
   }
 
   async function postChatGptAuthStatus(): Promise<void> {
-    const status = await getCodexStatus();
     options.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_CHATGPT_AUTH_STATUS,
-      status: { ...status, preferSubscription: isPreferCodexSubscription() },
+      status: await getChatGptAuthStatus(),
     });
   }
 

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -21,7 +21,7 @@ import {
 import type { DesktopProgressIpc } from './desktopProgressIpc.js';
 import type { DesktopSettingsIpc } from './desktopSettingsIpc.js';
 import type { DesktopFileSelection } from './desktopFileSelection.js';
-import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionMessageController';
 import type { MainViewAuthStatus } from '@controllers/mainView/MainViewTypes';
 import type { MainViewStartupOptions } from '@controllers/mainView/MainViewStartupController';
 import type { BrowserWindow } from 'electron';

--- a/packages/extension/src/settingsView/handlers/chatgptSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/chatgptSubscriptionHandlers.ts
@@ -10,8 +10,7 @@ import * as vscode from 'vscode';
 
 import {
   codexCoordinator,
-  getCodexStatus,
-  isPreferCodexSubscription,
+  getChatGptAuthStatus,
   loginWithDeviceCode,
   loginWithLoopback,
   setPreferCodexSubscription,
@@ -29,10 +28,9 @@ export class ChatGptSubscriptionHandlers {
   ) {}
 
   async sendChatGptAuthStatus(webview: vscode.Webview): Promise<void> {
-    const status = await getCodexStatus();
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_CHATGPT_AUTH_STATUS,
-      status: { ...status, preferSubscription: isPreferCodexSubscription() },
+      status: await getChatGptAuthStatus(),
     });
   }
 

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -7,7 +7,11 @@ import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { LEVEL_TO_EFFORT } from '@agent/modelHandlers/support/reasoningEffort';
-import { isCodexSignedIn, shouldUseCodexSubscription } from '@auth/codex';
+import {
+  codexBackendModelId,
+  isCodexSignedIn,
+  shouldUseCodexSubscription,
+} from '@auth/codex';
 import * as logger from '@logger/logUtils';
 import { isGpt5ModelName } from '@model/modelNames';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -339,13 +343,13 @@ export async function createModelHandler(
     logger.debug(CHANNEL, 'Using ChatGPT subscription (Codex) Handler');
     const { ModelHandlerCodex } =
       await import('@agent/modelHandlers/openai/modelHandlerCodex');
-    // The Codex backend keys on the unpinned model id (e.g. `gpt-5.5`), not the
-    // date-pinned `fullName` (`gpt-5.5-2026-04-23`), so always send the short
-    // name regardless of the "prefer short model names" setting.
+    // The Codex backend keys on the bare model id (e.g. `gpt-5.5`), not the
+    // date-pinned `fullName` (`gpt-5.5-2026-04-23`), so always send it
+    // regardless of the "prefer short model names" setting. Same derivation
+    // eligibility uses, so the dispatched id matches what was judged eligible.
     const codexConfig = {
       ...config,
-      fullName:
-        config.shortName || config.fullName.replace(/-\d{4}-\d{2}-\d{2}$/, ''),
+      fullName: codexBackendModelId(config),
     };
     return withModelHandlerCompatibilityKey(
       withReasoningOverride(new ModelHandlerCodex(codexConfig)),

--- a/src/auth/codex/CodexSessionCoordinator.ts
+++ b/src/auth/codex/CodexSessionCoordinator.ts
@@ -114,12 +114,34 @@ export class CodexSessionCoordinator {
     await this.storage.store(JSON.stringify(session));
   }
 
-  /** Forget the session (sign out). */
-  async signOut(): Promise<void> {
+  /**
+   * Advance the session generation and abandon any in-flight refresh so its
+   * result can no longer overwrite the session that supersedes it. Shared by
+   * sign-out and every successful login.
+   */
+  private async supersedeInFlightRefresh(): Promise<void> {
     this.sessionGeneration += 1;
     const staleStore = this.refreshStoreInFlight;
     this.refreshInFlight = null;
     await staleStore?.catch(() => undefined);
+  }
+
+  /**
+   * Fail an in-flight refresh whose session was superseded (a newer login or
+   * sign-out bumped the generation) so it can't resurrect a stale token.
+   */
+  private assertSameGeneration(generation: number): void {
+    if (generation !== this.sessionGeneration) {
+      throw new CodexAuthError(
+        'ChatGPT session changed while refreshing. Try again.',
+        'expired',
+      );
+    }
+  }
+
+  /** Forget the session (sign out). */
+  async signOut(): Promise<void> {
+    await this.supersedeInFlightRefresh();
     await this.storage.delete();
   }
 
@@ -164,10 +186,7 @@ export class CodexSessionCoordinator {
   }): Promise<CodexSession> {
     const tokens = await this.client.exchangeAuthorizationCode(params);
     const session = this.buildSession(tokens);
-    this.sessionGeneration += 1;
-    const staleStore = this.refreshStoreInFlight;
-    this.refreshInFlight = null;
-    await staleStore?.catch(() => undefined);
+    await this.supersedeInFlightRefresh();
     await this.storeSession(session);
     return session;
   }
@@ -247,12 +266,7 @@ export class CodexSessionCoordinator {
       throw error;
     }
     const session = this.buildSession(tokens, previous);
-    if (generation !== this.sessionGeneration) {
-      throw new CodexAuthError(
-        'ChatGPT session changed while refreshing. Try again.',
-        'expired',
-      );
-    }
+    this.assertSameGeneration(generation);
     const storeTask = this.storeSession(session);
     this.refreshStoreInFlight = storeTask;
     try {
@@ -262,12 +276,7 @@ export class CodexSessionCoordinator {
         this.refreshStoreInFlight = null;
       }
     }
-    if (generation !== this.sessionGeneration) {
-      throw new CodexAuthError(
-        'ChatGPT session changed while refreshing. Try again.',
-        'expired',
-      );
-    }
+    this.assertSameGeneration(generation);
     return session;
   }
 

--- a/src/auth/codex/codexAuthAccess.ts
+++ b/src/auth/codex/codexAuthAccess.ts
@@ -15,6 +15,7 @@ import {
   type CodexSessionCoordinator,
   type CodexSessionStatus,
 } from './CodexSessionCoordinator';
+import { isPreferCodexSubscription } from './codexPreference';
 
 const CHANNEL = 'codexAuth';
 
@@ -58,4 +59,19 @@ export async function getCodexStatus(): Promise<CodexSessionStatus> {
 /** Whether a Codex session is currently signed in (no network, no throw). */
 export async function isCodexSignedIn(): Promise<boolean> {
   return (await getCodexStatus()).signedIn;
+}
+
+/**
+ * The ChatGPT auth status as the settings views consume it: the session status
+ * plus the current subscription preference. One composer so the extension and
+ * desktop hosts post the identical payload (the wire shape is validated by
+ * `ChatGptAuthStatusSchema` at each host's boundary).
+ */
+export async function getChatGptAuthStatus(): Promise<
+  CodexSessionStatus & { preferSubscription: boolean }
+> {
+  return {
+    ...(await getCodexStatus()),
+    preferSubscription: isPreferCodexSubscription(),
+  };
 }

--- a/src/auth/codex/codexConstants.ts
+++ b/src/auth/codex/codexConstants.ts
@@ -99,8 +99,9 @@ export const CODEX_PREFER_SUBSCRIPTION_KEY =
  * is a hardcoded mirror of openai/codex's bundled models.json picker set and
  * WILL go stale; the backend also rejects models above the account's tier. Keep
  * it small and easy to edit. Matched against the model id passed to
- * `isCodexSubscriptionEligible`; routing passes `shortName || fullName` so
- * date-pinned llm-zoo names still match the bare Codex backend ids.
+ * `isCodexSubscriptionEligible`, which callers derive with
+ * {@link codexBackendModelId} (`shortName`, else date-pin-stripped `fullName`)
+ * so date-pinned llm-zoo names still match these bare Codex backend ids.
  */
 export const CODEX_SUBSCRIPTION_MODEL_FULLNAMES: ReadonlySet<string> = new Set([
   'gpt-5.5',

--- a/src/auth/codex/codexConstants.ts
+++ b/src/auth/codex/codexConstants.ts
@@ -111,13 +111,31 @@ export const CODEX_SUBSCRIPTION_MODEL_FULLNAMES: ReadonlySet<string> = new Set([
   'gpt-5.2-codex',
 ]);
 
+/** Trailing llm-zoo date pin (`-2026-04-23`) on a model `fullName`. */
+const CODEX_MODEL_DATE_PIN = /-\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The bare model id the Codex backend keys on: the `shortName` when present,
+ * else the `fullName` with its llm-zoo date pin stripped (`gpt-5.5-2026-04-23`
+ * → `gpt-5.5`). The single source of truth for that mapping, shared by
+ * eligibility ({@link isCodexSubscriptionEligible}) and handler dispatch
+ * (ModelFactory) so the id a model is judged eligible under is the same id it
+ * is dispatched with.
+ */
+export function codexBackendModelId(config: {
+  readonly shortName?: string;
+  readonly fullName: string;
+}): string {
+  return config.shortName || config.fullName.replace(CODEX_MODEL_DATE_PIN, '');
+}
+
 /**
  * Whether a model id is eligible to route through the ChatGPT subscription.
  * True for the curated set above, date-pinned variants of those ids, or any
  * `*-codex*` name so newer Codex models are picked up without a code change.
  */
 export function isCodexSubscriptionEligible(fullName: string): boolean {
-  const unpinnedName = fullName.replace(/-\d{4}-\d{2}-\d{2}$/, '');
+  const unpinnedName = fullName.replace(CODEX_MODEL_DATE_PIN, '');
   if (CODEX_SUBSCRIPTION_MODEL_FULLNAMES.has(unpinnedName)) return true;
   return /codex/i.test(fullName);
 }

--- a/src/auth/codex/codexRouting.ts
+++ b/src/auth/codex/codexRouting.ts
@@ -10,7 +10,10 @@
  */
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
-import { isCodexSubscriptionEligible } from './codexConstants';
+import {
+  codexBackendModelId,
+  isCodexSubscriptionEligible,
+} from './codexConstants';
 import { isPreferCodexSubscription } from './codexPreference';
 
 /**
@@ -26,7 +29,7 @@ export function shouldUseCodexSubscription(
   if (config.provider !== ModelProvider.OPENAI) return false;
   if (config.openRouterOnly) return false;
   if (!isPreferCodexSubscription()) return false;
-  // Match the unpinned id: llm-zoo `fullName`s are date-pinned
-  // (`gpt-5.5-2026-04-23`), but the Codex backend keys on the bare `gpt-5.5`.
-  return isCodexSubscriptionEligible(config.shortName || config.fullName);
+  // Match the bare id the Codex backend keys on (`gpt-5.5`), not the date-pinned
+  // llm-zoo `fullName` (`gpt-5.5-2026-04-23`) — the same derivation dispatch uses.
+  return isCodexSubscriptionEligible(codexBackendModelId(config));
 }

--- a/src/auth/codex/index.ts
+++ b/src/auth/codex/index.ts
@@ -56,6 +56,7 @@ export {
   codexCoordinator,
   resetCodexCoordinator,
   getCodexStatus,
+  getChatGptAuthStatus,
   isCodexSignedIn,
 } from './codexAuthAccess';
 export {


### PR DESCRIPTION
Two follow-ups after #6436/#6439.

## 1. Codex single-source-of-truth / coupling cleanups (audit-driven, behavior-preserving)
- **`codexBackendModelId()`** — the bare Codex backend id (`shortName`, else `fullName` minus its date pin) was derived independently in eligibility (`codexConstants`) and dispatch (`ModelFactory`). One helper now owns it, so the id a model is judged eligible under is the same id it is dispatched with. The date-pin regex is hoisted to a single constant.
- **`getChatGptAuthStatus()`** — the extension and desktop hosts each hand-built the `UPDATE_CHATGPT_AUTH_STATUS` payload (`getCodexStatus()` spread + `preferSubscription`). One `@auth/codex` composer now builds it so the two hosts cannot diverge.
- **`CodexSessionCoordinator`** — extracted `supersedeInFlightRefresh()` (shared by sign-out and login) and `assertSameGeneration()` (the twice-repeated post-refresh generation guard).

## 2. Desktop build fix
- The desktop main-process files imported the `MainViewExecuteMessage` type from `MainViewExecutionController`, which only re-imports it (without re-exporting) from `MainViewExecutionMessageController` — so the desktop package failed to typecheck (TS2459, pre-existing on `main`). Repointed the three importers at the source module the extension already uses.

## Verification
- Workspace typecheck, desktop typecheck (was failing, now clean), `check:architecture`, and the routing/eligibility/auth/desktop/CLI Vitest suites all pass.
- Live-tested in the TUI: `gpt55` still routes through the subscription and a tool-use turn completes (the backend rejects a wrong model id, so this exercises the consolidated id derivation end to end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors and shared helpers are described as behavior-preserving; the desktop change is import-only. Touches OAuth session refresh and subscription routing, but does not introduce new auth flows.
> 
> **Overview**
> Consolidates **ChatGPT/Codex** wiring so extension and desktop hosts cannot drift, and fixes a **desktop main-process** typecheck failure.
> 
> **Codex model id:** Adds `codexBackendModelId()` in `@auth/codex` and uses it in `shouldUseCodexSubscription`, eligibility checks, and `ModelFactory` Codex dispatch so the same bare backend id is used for “can route via subscription” and “what id we send.”
> 
> **Settings auth payload:** Adds `getChatGptAuthStatus()` so desktop and extension both post `UPDATE_CHATGPT_AUTH_STATUS` from one composer (session status + `preferSubscription`) instead of hand-building the object in each host.
> 
> **Session coordinator:** Refactors `CodexSessionCoordinator` with `supersedeInFlightRefresh()` (sign-out + login) and `assertSameGeneration()` (post-refresh guards)—same behavior, less duplication.
> 
> **Desktop:** Repoints `MainViewExecuteMessage` imports in three main files from `MainViewExecutionController` to `MainViewExecutionMessageController` (fixes TS2459 where the type was not re-exported).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48b3bee08cce3ca2f751700018666a17b15c9b38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->