### PR TITLE
refactor(cli): validate untrusted boundary JSON with zod schemas

### DIFF
--- a/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
+++ b/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
@@ -6,6 +6,8 @@ import {
   type ServerResponse,
 } from 'node:http';
 
+import { z } from 'zod';
+
 // Local imports - auth
 import { AUTH_CALLBACK_TIMEOUT_MS } from '@auth/config';
 import {
@@ -173,29 +175,33 @@ function readRequestBody(request: IncomingMessage): Promise<string> {
   });
 }
 
+/**
+ * The loopback callback body we accept. A non-object body is rejected; a
+ * present-but-non-string field degrades to `undefined` (per-field `.catch`),
+ * matching the previous manual `typeof === 'string'` guards.
+ */
+const CallbackBodySchema = z.object({
+  query: z.string().nullish().catch(undefined),
+  fragment: z.string().nullish().catch(undefined),
+  nonce: z.string().nullish().catch(undefined),
+});
+
 function parseCallbackBody(rawBody: string): {
   query?: string;
   fragment?: string;
   nonce?: string;
 } {
   try {
-    const body = JSON.parse(rawBody) as unknown;
-    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    const parsed = CallbackBodySchema.safeParse(JSON.parse(rawBody));
+    if (!parsed.success) {
       throw new RecoverableCallbackRequestError(
         'Authentication callback request was malformed.',
       );
     }
-
-    const candidate = body as {
-      query?: unknown;
-      fragment?: unknown;
-      nonce?: unknown;
-    };
     return {
-      query: typeof candidate.query === 'string' ? candidate.query : undefined,
-      fragment:
-        typeof candidate.fragment === 'string' ? candidate.fragment : undefined,
-      nonce: typeof candidate.nonce === 'string' ? candidate.nonce : undefined,
+      query: parsed.data.query ?? undefined,
+      fragment: parsed.data.fragment ?? undefined,
+      nonce: parsed.data.nonce ?? undefined,
     };
   } catch (error) {
     if (isRecoverableCallbackRequestError(error)) throw error;

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -3,6 +3,7 @@ import { constants as osConstants } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import { gt as semverGt, valid as semverValid } from 'semver';
+import { z } from 'zod';
 
 import {
   cliEnvValue,
@@ -179,23 +180,39 @@ async function readCommandStdout(
   });
 }
 
+/**
+ * Shape of `brew info --json=v2` that we read. Tolerant by design: a single
+ * malformed formula entry degrades to `null` (skipped) rather than failing the
+ * whole parse, matching the previous per-entry type guards.
+ */
+const HomebrewInfoSchema = z.object({
+  formulae: z
+    .array(
+      z
+        .object({
+          name: z.string(),
+          versions: z.object({ stable: z.string().nullish() }).nullish(),
+        })
+        .nullable()
+        .catch(null),
+    )
+    .nullish(),
+});
+
 function parseHomebrewFormulaVersion(
   stdout: string,
   formula = CLI_HOMEBREW_FORMULA,
 ): string | undefined {
+  let raw: unknown;
   try {
-    const body = JSON.parse(stdout) as { formulae?: unknown };
-    if (!Array.isArray(body.formulae)) return undefined;
-    const entry = body.formulae.find((candidate) => {
-      if (typeof candidate !== 'object' || candidate === null) return false;
-      return (candidate as { name?: unknown }).name === formula;
-    });
-    if (typeof entry !== 'object' || entry === null) return undefined;
-    const { versions } = entry as { versions?: { stable?: unknown } };
-    return typeof versions?.stable === 'string' ? versions.stable : undefined;
+    raw = JSON.parse(stdout);
   } catch {
     return undefined;
   }
+  const parsed = HomebrewInfoSchema.safeParse(raw);
+  if (!parsed.success) return undefined;
+  const entry = parsed.data.formulae?.find((f) => f?.name === formula);
+  return entry?.versions?.stable ?? undefined;
 }
 
 /**


### PR DESCRIPTION
## What

Two CLI runtime parsers narrowed untrusted external JSON by hand (`JSON.parse` + `as` cast + `typeof`/`Array.isArray` guards) instead of a schema + `safeParse`, the boundary-validation idiom sibling files (`relayTokensClient.ts`, `cliConfig.ts`, `inputHistory.ts`) already use. Both are genuine trust boundaries.

- **`updateChecker.ts`** — `brew info --json=v2` subprocess stdout now parses through a tolerant `HomebrewInfoSchema`. A malformed formula entry degrades to `null` and is skipped (preserving the old per-entry `typeof`/`Array.isArray` guards), so one odd entry never drops a valid match.
- **`supabaseAuthCallbackServer.ts`** — the loopback OAuth callback HTTP request body now parses through `CallbackBodySchema`. A non-object body is rejected (throws `RecoverableCallbackRequestError`), and a present-but-non-string field degrades to `undefined` via per-field `.catch(undefined)`, matching the previous manual guards exactly.

## Why

These were the only two clean, untrusted-boundary parsers in the CLI still hand-narrowing cast output. Validating at the boundary with a schema is the house rule (CLAUDE.md: "validate untrusted data with a schema + safeParse at the boundary instead of JSON.parse + as cast") and keeps the schema as the single source of truth for the accepted shape.

## Verification

- Behavior verified **identical** to the prior hand-rolled logic across a differential battery: malformed / mixed-validity / array / primitive / null / extra-key / non-JSON inputs (brew 12/12, callback 11/11 match). Notably this preserves the subtle cases (array body rejected, non-string field coalesced to `undefined`, malformed array element skipped).
- `npm run typecheck` clean for both files (the 14 pre-existing `@openrouter/sdk` / `vscode-jsonrpc` errors are unrelated and present on `main`); function return-type contracts unchanged.
- No user-facing behavior change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only boundary validation on OAuth callback and Homebrew JSON; behavior is documented as identical with no API contract changes.
> 
> **Overview**
> Replaces hand-rolled `JSON.parse` + type guards with **Zod `safeParse`** at two CLI trust boundaries, aligned with other runtime clients.
> 
> In **`supabaseAuthCallbackServer.ts`**, the loopback OAuth callback POST body is validated via `CallbackBodySchema`. Non-object JSON still fails with `RecoverableCallbackRequestError`; non-string `query` / `fragment` / `nonce` still become `undefined` through per-field `.catch(undefined)`.
> 
> In **`updateChecker.ts`**, `brew info --json=v2` stdout is validated via tolerant `HomebrewInfoSchema`. Bad formula entries still degrade to `null` and are skipped so a single bad row does not block version lookup.
> 
> No intended user-facing behavior change—schemas document the accepted shape and centralize boundary validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 492ce19c4ef6ca4cbe0e85362affab3cb6980fa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->