### PR TITLE
refactor: derive duplicated types from their zod schemas (SSOT)

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -1,20 +1,28 @@
 import { z } from 'zod';
 
-import type { AgentRunStateSnapshot } from '@agent/core/execution/AgentState';
-import type {
-  AgentWorkspaceState,
-  AgentWorkspaceSnapshot,
+import {
+  AgentRunStateSnapshotSchema,
+  type AgentRunStateSnapshot,
+} from '@agent/core/execution/AgentState';
+import {
+  AgentWorkspaceStateSnapshotSchema,
+  type AgentWorkspaceState,
 } from '@agent/core/execution/AgentWorkspaceState';
-import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
+import {
+  UserVariableChannelsSchema,
+  type UserVariableChannels,
+} from '@agent/core/definition/AgentCycleOptions';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { FollowUpQueueBatchItem } from '@agent/toolUse/FollowUpQueue';
 import type { RetryErrorInfo } from '@shared/schemas';
 
-export interface StateSlicesSnapshot {
-  runStateSnapshot: AgentRunStateSnapshot;
-  workspaceSnapshot: AgentWorkspaceSnapshot;
-  userChannels: UserVariableChannels;
-}
+export const StateSlicesSchema = z.object({
+  runStateSnapshot: AgentRunStateSnapshotSchema,
+  workspaceSnapshot: AgentWorkspaceStateSnapshotSchema,
+  userChannels: UserVariableChannelsSchema,
+});
+
+export type StateSlicesSnapshot = z.infer<typeof StateSlicesSchema>;
 
 /** Extract edited file paths from a workspace state snapshot. */
 export function extractTouchedFiles(

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -14,10 +14,8 @@ import { z } from 'zod';
 import { getExecutionStore } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
-import { AgentRunStateSnapshotSchema } from '@agent/core/execution/AgentState';
-import { AgentWorkspaceStateSnapshotSchema } from '@agent/core/execution/AgentWorkspaceState';
-import { UserVariableChannelsSchema } from '@agent/core/definition/AgentCycleOptions';
 import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessage';
+import { StateSlicesSchema } from '@agent/implementations/flows/tooluse/nodes/types';
 import {
   TOOL_USE_SNAPSHOT_VERSION,
   ToolUseSessionSnapshotSchema,
@@ -54,13 +52,6 @@ type ToolUseResumeData = z.infer<typeof ToolUseResumeDataSchema>;
 type WorkflowResumeData = z.infer<typeof WorkflowResumeDataSchema>;
 
 export type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
-
-/** State slices schema (shared between flat and legacy formats). */
-const StateSlicesSchema = z.object({
-  runStateSnapshot: AgentRunStateSnapshotSchema,
-  workspaceSnapshot: AgentWorkspaceStateSnapshotSchema,
-  userChannels: UserVariableChannelsSchema,
-});
 
 /** Core fields schema — accepts `messages` (current) or `conversation` (legacy), normalizing to `messages`. */
 const ToolUseStateFieldsSchema = z

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -25,17 +25,13 @@ const STREAM_LOG_LOAD_CONCURRENCY = 8;
 const LOG_TAG = 'StreamLogStore';
 
 type StreamLogListener = (streamId: StreamTabId) => void;
-interface StreamLogSummary {
-  firstTimestamp?: number;
-  lastTimestamp?: number;
-  hasRunningGroup?: boolean;
-}
 
 const StreamLogSummarySchema = z.object({
   firstTimestamp: z.number().finite().optional().catch(undefined),
   lastTimestamp: z.number().finite().optional().catch(undefined),
   hasRunningGroup: z.boolean().optional().catch(undefined),
 });
+type StreamLogSummary = z.infer<typeof StreamLogSummarySchema>;
 
 interface StreamLoadResult {
   streamId: StreamTabId;


### PR DESCRIPTION
## What

Two interfaces re-declared the exact shape of a sibling Zod schema instead of deriving it via `z.infer`, creating drift risk: adding a field to one silently diverges from the other. This makes the schema the single source of truth in both spots.

- **`src/transcript/StreamLogStore.ts`** — `interface StreamLogSummary` sat directly beside an identical `StreamLogSummarySchema`. Reordered schema-first and replaced the interface with `type StreamLogSummary = z.infer<typeof StreamLogSummarySchema>`.
- **`StateSlicesSnapshot`** — the `interface` in `tooluse/nodes/types.ts` duplicated the `StateSlicesSchema` declared locally in `SessionResumeRetrieval.ts` (a real cross-file drift pair). Promoted the schema into `nodes/types.ts` as the single source, derived the type via `z.infer`, and imported the shared schema into `SessionResumeRetrieval.ts` (its three now-unused sub-schema imports drop out).

## Why it is safe

The three `StateSlices` sub-types (`AgentRunStateSnapshot`, `AgentWorkspaceSnapshot`, `UserVariableChannels`) are **already** `z.output`/`z.infer` of their schemas, so `z.infer<typeof StateSlicesSchema>` is structurally identical to the old interface, member-by-member. No circular import (nodes/types does not import runtime).

## Verification

- `npm run typecheck` passes with **zero call-site changes** (type-only change; the build is esbuild type-strip, so typecheck is the real gate).
- Relevant vitest suites pass (StreamLog, SessionResume, tooluse — 125 tests). The one failing *file* in my local run is an unrelated worktree env artifact (`ToolUseRowPatch.vitest.mts` cannot resolve `react` from the CLI package in a git worktree); it does not touch these files.
- No user-facing behavior change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with no runtime or call-site changes; inferred types match the former interfaces.
> 
> **Overview**
> Makes Zod schemas the single source of truth for two shapes that were previously duplicated as hand-written interfaces.
> 
> **`StateSlicesSnapshot`** — Replaces the interface in `tooluse/nodes/types.ts` with `StateSlicesSchema` plus `z.infer`, pulling in the three sub-schemas as value imports. Removes the duplicate `StateSlicesSchema` from `SessionResumeRetrieval.ts` and imports the shared schema from `nodes/types` instead (dropping redundant sub-schema imports there).
> 
> **`StreamLogSummary`** — In `StreamLogStore.ts`, defines the schema first and derives `StreamLogSummary` via `z.infer` instead of a parallel `interface`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 154bc2f2794526fd07cb68bde64e8fbab028d8fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->