### PR TITLE
refactor: validate Kimi token-count response with a zod schema

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { ToolDefinition } from '@model';
@@ -15,11 +17,9 @@ function isKimiK27Code(fullName: string): boolean {
 }
 
 /** Response from Kimi's token estimation API */
-interface KimiTokenEstimateResponse {
-  data: {
-    total_tokens: number;
-  };
-}
+const KimiTokenEstimateResponseSchema = z.object({
+  data: z.object({ total_tokens: z.number() }),
+});
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
@@ -144,7 +144,14 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
       );
     }
 
-    const result = (await response.json()) as KimiTokenEstimateResponse;
-    return result.data.total_tokens;
+    const parsed = KimiTokenEstimateResponseSchema.safeParse(
+      await response.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      throw new Error(
+        `Kimi token estimation returned an unexpected response shape: ${parsed.error.message}`,
+      );
+    }
+    return parsed.data.data.total_tokens;
   }
 }


### PR DESCRIPTION
## What

`modelHandlerKimi.estimateTokenCount` parsed the Moonshot `/tokenizers/estimate-token-count` response with `(await response.json()) as KimiTokenEstimateResponse` and immediately dereferenced `.data.total_tokens`. A changed or error envelope surfaced as a cryptic `Cannot read properties of undefined (reading 'total_tokens')`.

Now the response is validated at the network boundary with a Zod schema + `safeParse`, matching the established sibling convention (`auth/codex/codexOAuthClient.ts`, `auth/relayToken.ts`). The hand-written `interface` is replaced by `KimiTokenEstimateResponseSchema` (schema as the single source of truth), and a malformed body throws a clear shape error.

## Verification

- `tsc --noEmit` clean for the file (the 14 pre-existing `@openrouter/sdk` / `vscode-jsonrpc` errors are unrelated and on `main`).
- Behavior preserved for valid responses (same `Promise<number>`); a malformed response still throws, now with an actionable message instead of a `TypeError`. The interface was referenced nowhere else.
- No user-facing change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Kimi pre-flight token counting; success path unchanged and only error messaging improves on bad API responses.
> 
> **Overview**
> **Kimi `estimateTokenCount`** no longer trusts the Moonshot `/tokenizers/estimate-token-count` JSON via a type assertion. The hand-written `KimiTokenEstimateResponse` interface is replaced by **`KimiTokenEstimateResponseSchema`**, and the body is validated with **`safeParse`** (including **`response.json().catch(() => null)`** for invalid JSON).
> 
> Valid responses still return the same **`total_tokens`** number. Malformed or unexpected envelopes now throw an explicit shape error instead of a **`TypeError`** on **`undefined.total_tokens`**, aligned with other network-boundary Zod usage in auth clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad46d48b8566ee9bbc224dffe0c6c254f2d6d08f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->