### PR TITLE
refactor: validate the Loogle response at the fetch boundary (SSOT)

### DIFF
--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -43,32 +43,37 @@ const LeanLoogleInputSchema = z.strictObject({
 export type LeanLoogleInput = z.infer<typeof LeanLoogleInputSchema>;
 
 // ============================================================================
-// Types
+// Response schemas (Loogle is an external network boundary — validate it)
 // ============================================================================
 
-interface LoogleHit {
-  name: string;
-  type: string;
-  module: string;
-  doc: string;
-}
+const LoogleHitSchema = z.looseObject({
+  name: z.string(),
+  type: z.string(),
+  module: z.string(),
+  // Loogle may omit or empty `doc`; formatHit already guards on truthiness.
+  doc: z.string().optional(),
+});
+type LoogleHit = z.infer<typeof LoogleHitSchema>;
 
-interface LoogleSuccessResponse {
-  count: number;
-  header: string;
-  hits: LoogleHit[];
-}
+const LoogleSuccessSchema = z.looseObject({
+  count: z.number(),
+  header: z.string(),
+  hits: z.array(LoogleHitSchema),
+});
 
-interface LoogleErrorResponse {
-  error: string;
-  suggestions?: string[];
-}
+const LoogleErrorSchema = z.looseObject({
+  error: z.string(),
+  suggestions: z.array(z.string()).optional(),
+});
 
-type LoogleResponse = LoogleSuccessResponse | LoogleErrorResponse;
+// Not a discriminatedUnion: success/error bodies share no tagged key. Try the
+// error arm first so an `{ error }` body is never mis-read as an empty success.
+const LoogleResponseSchema = z.union([LoogleErrorSchema, LoogleSuccessSchema]);
+type LoogleResponse = z.infer<typeof LoogleResponseSchema>;
 
 function isErrorResponse(
   response: LoogleResponse,
-): response is LoogleErrorResponse {
+): response is z.infer<typeof LoogleErrorSchema> {
   return 'error' in response;
 }
 
@@ -130,21 +135,31 @@ Useful for finding the right lemma when you know roughly what type it should hav
   private async fetchLoogle(query: string): Promise<LoogleResponse> {
     return pRetry(
       async () => {
-        try {
-          const response = await axios.get<LoogleResponse>(LOOGLE_API_URL, {
+        const response = await axios
+          .get<unknown>(LOOGLE_API_URL, {
             params: { q: query },
             headers: {
               'User-Agent': 'TeXRA-VSCode-Extension',
             },
             timeout: LOOGLE_TIMEOUT_MS,
+          })
+          .catch((error: unknown) => {
+            if (isTransientHttpError(error)) throw error;
+            throw new AbortError(
+              error instanceof Error ? error : new Error(String(error)),
+            );
           });
-          return response.data;
-        } catch (error) {
-          if (isTransientHttpError(error)) throw error;
+        // Validate the body at the boundary. A malformed shape is not transient,
+        // so abort retries and let executeSingle surface it as a tool error.
+        const parsed = LoogleResponseSchema.safeParse(response.data);
+        if (!parsed.success) {
           throw new AbortError(
-            error instanceof Error ? error : new Error(String(error)),
+            new Error(
+              `Unexpected Loogle response shape: ${parsed.error.message}`,
+            ),
           );
         }
+        return parsed.data;
       },
       {
         retries: LOOGLE_RETRIES,

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -49,9 +49,12 @@ export type LeanLoogleInput = z.infer<typeof LeanLoogleInputSchema>;
 const LoogleHitSchema = z.looseObject({
   name: z.string(),
   type: z.string(),
-  module: z.string(),
-  // Loogle may omit or empty `doc`; formatHit already guards on truthiness.
-  doc: z.string().optional(),
+  module: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? ''),
+  // Loogle may omit, null, or empty `doc`; formatHit already guards on truthiness.
+  doc: z.string().nullish(),
 });
 type LoogleHit = z.infer<typeof LoogleHitSchema>;
 
@@ -63,7 +66,7 @@ const LoogleSuccessSchema = z.looseObject({
 
 const LoogleErrorSchema = z.looseObject({
   error: z.string(),
-  suggestions: z.array(z.string()).optional(),
+  suggestions: z.array(z.string()).nullish(),
 });
 
 // Not a discriminatedUnion: success/error bodies share no tagged key. Try the


### PR DESCRIPTION
## What

The Loogle (Lean theorem search) network response was cast via `axios.get<LoogleResponse>` over hand-written interfaces, then consumed directly. Replace the interfaces with `z.looseObject` schemas (so the schema is the single source of truth via `z.infer`) and `safeParse` `response.data` inside `fetchLoogle`.

- `success`/`error` bodies share no tagged key, so this is a `z.union` with the **error arm first** (not a `discriminatedUnion`), ensuring an `{ error }` body is never mis-read as an empty success.
- `doc` becomes optional to match reality (Loogle may omit it; `formatHit` already guards `if (hit.doc)`), **preserving** the previous tolerance of docless hits — a required `doc` would have rejected a valid response.
- A malformed body throws an `AbortError`, which the existing retry/`executeSingle` path already converts into a clean `isError` tool result instead of crashing deep in formatting.

## Verification

- `tsc --noEmit` clean for the file (the 14 pre-existing `@openrouter/sdk` / `vscode-jsonrpc` errors are unrelated and on `main`).
- No Loogle test suite exists; behavior is preserved by construction (error-first union keeps classification; optional `doc` keeps docless tolerance; the `AbortError` degradation path is unchanged). `looseObject` keeps the "extra fields tolerated" contract.
- No user-facing change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Boundary validation on a single external search tool; behavior for valid responses and existing retry/error paths is preserved by design.
> 
> **Overview**
> **Loogle HTTP responses are now validated with Zod** instead of trusting `axios.get<LoogleResponse>` and hand-written interfaces. Types come from `z.infer` on `z.looseObject` schemas for hits, success, and error payloads.
> 
> In `fetchLoogle`, the axios call uses `unknown` for the body, then **`LoogleResponseSchema.safeParse`**. Success/error is a **`z.union` with the error schema first** so `{ error: ... }` is not treated as an empty success. **`module`** is normalized when null/omitted; **`doc`** stays optional/nullish to match real API behavior and existing `formatHit` handling.
> 
> **Malformed JSON shapes** throw **`AbortError`** (not retried as transient), so the existing `executeSingle` catch path returns a normal tool error instead of failing later in formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd78521f694a91154a8169085b9c13abe8016d58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->