### PR TITLE
refactor: validate Better BibTeX JSON-RPC at the boundary (SSOT)

### DIFF
--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -21,6 +21,7 @@ import { formatResultCount } from '@utils/text/stringUtils';
 import {
   callBetterBibTeX,
   getZoteroPort,
+  BbtLibrarySchema,
   type BbtCollection,
   type BbtLibrary,
 } from './bbtClient';
@@ -161,10 +162,11 @@ export class ZoteroCollectionsTool extends defineTool({
   protected async execute({ query, library }: ZoteroCollectionsInput) {
     const port = getZoteroPort();
 
-    const libraries = await callBetterBibTeX<BbtLibrary[]>(
+    const libraries = await callBetterBibTeX(
       'user.groups',
       [true],
       port,
+      z.array(BbtLibrarySchema),
     );
 
     if (!Array.isArray(libraries) || libraries.length === 0) {

--- a/src/tools/zotero/ZoteroExportTool.ts
+++ b/src/tools/zotero/ZoteroExportTool.ts
@@ -54,10 +54,11 @@ export class ZoteroExportTool extends defineTool({
       params.push(library);
     }
 
-    const result = await callBetterBibTeX<string>(
+    const result = await callBetterBibTeX(
       'item.export',
       params,
       port,
+      z.string(),
       ZOTERO_EXPORT_TIMEOUT_MS,
     );
 

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -16,6 +16,8 @@ import { formatResultCount } from '@utils/text/stringUtils';
 import {
   callBetterBibTeX,
   getZoteroPort,
+  BbtCollectionChainSchema,
+  BbtSearchResultItemSchema,
   type BbtCollectionChain,
   type BbtSearchResultItem,
 } from './bbtClient';
@@ -155,10 +157,11 @@ export class ZoteroSearchTool extends defineTool({
 
     const params: unknown[] = library ? [searchTerms, library] : [searchTerms];
 
-    const result = await callBetterBibTeX<BbtSearchResultItem[]>(
+    const result = await callBetterBibTeX(
       'item.search',
       params,
       port,
+      z.array(BbtSearchResultItemSchema),
     );
 
     const label = describeSearch({ query, title, author, year });
@@ -200,10 +203,11 @@ export class ZoteroSearchTool extends defineTool({
     port: number,
   ): Promise<Record<string, BbtCollectionChain[]>> {
     if (citekeys.length === 0) return {};
-    return callBetterBibTeX<Record<string, BbtCollectionChain[]>>(
+    return callBetterBibTeX(
       'item.collections',
       [citekeys, true],
       port,
+      z.record(z.string(), z.array(BbtCollectionChainSchema)),
     );
   }
 }

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -10,6 +10,7 @@
 // Third-party imports
 import axios from 'axios';
 import { StatusCodes } from 'http-status-codes';
+import { z } from 'zod';
 
 // Local imports - core
 import { toErrorMessage } from '@common/errors';
@@ -27,14 +28,26 @@ export function getZoteroPort(): number {
   return getConfig<number>('texra.bib.zoteroPort', 23119);
 }
 
-/**
- * JSON-RPC response envelope.
- */
-interface JsonRpcResponse<T = unknown> {
-  jsonrpc: string;
-  id?: number;
-  result?: T;
-  error?: { code: number; message: string };
+// ============================================================================
+// Response schemas — Better BibTeX is an external network boundary, so its
+// JSON-RPC envelope and result shapes are the single source of truth here (the
+// types are derived via z.infer) and validated once in callBetterBibTeX. The
+// result schemas assert only the fields consumers read; z.object strips any
+// extra fields the API adds (it tolerates them rather than rejecting), and the
+// inferred types match the original interfaces exactly.
+// ============================================================================
+
+/** JSON-RPC error object. */
+const JsonRpcErrorSchema = z.object({ code: z.number(), message: z.string() });
+
+/** JSON-RPC response envelope around a method's typed result. */
+function jsonRpcResponseSchema<T>(result: z.ZodType<T>) {
+  return z.object({
+    jsonrpc: z.string(),
+    id: z.number().optional(),
+    result: result.optional(),
+    error: JsonRpcErrorSchema.optional(),
+  });
 }
 
 /**
@@ -43,130 +56,141 @@ interface JsonRpcResponse<T = unknown> {
  *
  * From BBT source: Zotero.Utilities.Item.itemToCSLJSON(item)
  */
-export interface CslCreator {
+const CslCreatorSchema = z.object({
   /** Family name (surname) in CSL format */
-  family?: string;
+  family: z.string().optional(),
   /** Given name (first name) in CSL format */
-  given?: string;
+  given: z.string().optional(),
   /** Institutional or single-field name */
-  literal?: string;
+  literal: z.string().optional(),
   // Zotero native format (may appear in some responses)
-  lastName?: string;
-  firstName?: string;
-  name?: string;
-  creatorType?: string;
-}
+  lastName: z.string().optional(),
+  firstName: z.string().optional(),
+  name: z.string().optional(),
+  creatorType: z.string().optional(),
+});
+export type CslCreator = z.infer<typeof CslCreatorSchema>;
 
-/**
- * CSL JSON date format.
- */
-export interface CslDate {
+/** CSL JSON date format. */
+const CslDateSchema = z.object({
   /** Date parts as [[year, month?, day?]] */
-  'date-parts'?: number[][];
+  'date-parts': z.array(z.array(z.number())).optional(),
   /** Raw date string */
-  raw?: string;
+  raw: z.string().optional(),
   /** Literal date text */
-  literal?: string;
-}
+  literal: z.string().optional(),
+});
+export type CslDate = z.infer<typeof CslDateSchema>;
 
-/**
- * Zotero collection metadata returned by `user.groups(true)`.
- */
-export interface BbtCollection {
-  key: string;
-  name: string;
-  parentCollection?: string | false;
-}
+/** Zotero collection metadata returned by `user.groups(true)`. */
+export const BbtCollectionSchema = z.object({
+  key: z.string(),
+  name: z.string(),
+  parentCollection: z.union([z.string(), z.literal(false)]).optional(),
+});
+export type BbtCollection = z.infer<typeof BbtCollectionSchema>;
 
-/**
- * Library (group) entry returned by `user.groups`.
- */
-export interface BbtLibrary {
-  id: number;
-  name: string;
-  collections?: BbtCollection[];
-}
+/** Library (group) entry returned by `user.groups`. */
+export const BbtLibrarySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  collections: z.array(BbtCollectionSchema).optional(),
+});
+export type BbtLibrary = z.infer<typeof BbtLibrarySchema>;
 
 /**
  * Collection with nested parent chain, returned by `item.collections(citekeys, true)`.
  * When `includeParents` is true, `parentCollection` is recursively expanded
  * into a full object instead of a key string.
+ *
+ * The type is self-referential, so the interface is kept and the recursive
+ * schema is annotated against it (z.lazy).
  */
 export interface BbtCollectionChain {
   key: string;
   name: string;
   parentCollection?: BbtCollectionChain | false;
 }
+export const BbtCollectionChainSchema: z.ZodType<BbtCollectionChain> = z.lazy(
+  () =>
+    z.object({
+      key: z.string(),
+      name: z.string(),
+      parentCollection: z
+        .union([BbtCollectionChainSchema, z.literal(false)])
+        .optional(),
+    }),
+);
 
 /**
  * CSL JSON item returned by Better BibTeX item.search.
  *
- * This is standard CSL JSON (from Zotero.Utilities.Item.itemToCSLJSON)
- * plus BBT-specific `library` and `citekey` fields.
- *
- * Reference: https://github.com/retorquere/zotero-better-bibtex/blob/master/content/json-rpc.ts
+ * This is standard CSL JSON (from Zotero.Utilities.Item.itemToCSLJSON) plus
+ * BBT-specific `library` and `citekey` fields. Reference:
+ * https://github.com/retorquere/zotero-better-bibtex/blob/master/content/json-rpc.ts
  */
-export interface BbtSearchResultItem {
+export const BbtSearchResultItemSchema = z.object({
   // ─── Better BibTeX additions ───────────────────────────────────────
   /** Citation key from Better BibTeX KeyManager */
-  citekey: string;
+  citekey: z.string(),
   /** Library name or fallback `library#${libraryID}` */
-  library: string;
+  library: z.string(),
 
   // ─── CSL JSON core fields ──────────────────────────────────────────
   /** Internal Zotero item ID (as URI or number) */
-  id?: string | number;
+  id: z.union([z.string(), z.number()]).optional(),
   /** CSL item type (article-journal, book, chapter, etc.) */
-  type?: string;
+  type: z.string().optional(),
   /** Item title */
-  title?: string;
+  title: z.string().optional(),
   /** Authors */
-  author?: CslCreator[];
+  author: z.array(CslCreatorSchema).optional(),
   /** Editors */
-  editor?: CslCreator[];
+  editor: z.array(CslCreatorSchema).optional(),
   /** Publication/issue date */
-  issued?: CslDate;
+  issued: CslDateSchema.optional(),
   /** Access date */
-  accessed?: CslDate;
+  accessed: CslDateSchema.optional(),
 
   // ─── Zotero-style fields (legacy, may appear) ──────────────────────
-  itemType?: string;
-  creators?: CslCreator[];
-  date?: string;
+  itemType: z.string().optional(),
+  creators: z.array(CslCreatorSchema).optional(),
+  date: z.string().optional(),
 
   // ─── Identifiers ───────────────────────────────────────────────────
-  DOI?: string;
-  ISBN?: string;
-  ISSN?: string;
-  PMID?: string;
-  PMCID?: string;
-  URL?: string;
+  DOI: z.string().optional(),
+  ISBN: z.string().optional(),
+  ISSN: z.string().optional(),
+  PMID: z.string().optional(),
+  PMCID: z.string().optional(),
+  URL: z.string().optional(),
 
   // ─── Publication info ──────────────────────────────────────────────
   /** Journal/book title */
-  'container-title'?: string;
+  'container-title': z.string().optional(),
   /** Short container title */
-  'container-title-short'?: string;
+  'container-title-short': z.string().optional(),
   /** Publisher name */
-  publisher?: string;
+  publisher: z.string().optional(),
   /** Publisher location */
-  'publisher-place'?: string;
+  'publisher-place': z.string().optional(),
   /** Volume number */
-  volume?: string;
+  volume: z.string().optional(),
   /** Issue number */
-  issue?: string;
+  issue: z.string().optional(),
   /** Page range */
-  page?: string;
+  page: z.string().optional(),
   /** Number of pages */
-  'number-of-pages'?: string;
+  'number-of-pages': z.string().optional(),
   /** Edition */
-  edition?: string;
+  edition: z.string().optional(),
 
   // ─── Content ───────────────────────────────────────────────────────
-  abstract?: string;
-  note?: string;
-  language?: string;
-}
+  abstract: z.string().optional(),
+  note: z.string().optional(),
+  language: z.string().optional(),
+});
+export type BbtSearchResultItem = z.infer<typeof BbtSearchResultItemSchema>;
 
 /**
  * Call Better BibTeX JSON-RPC endpoint.
@@ -174,59 +198,65 @@ export interface BbtSearchResultItem {
  * @param method - JSON-RPC method name (e.g., 'item.search', 'item.export')
  * @param params - Method parameters
  * @param port - Zotero Connector port (default: 23119)
+ * @param resultSchema - Zod schema for the method's `result`, validated at the boundary
  * @param timeout - Request timeout in milliseconds
- * @returns Promise resolving to the typed result
- * @throws ToolError if Zotero is not running or BBT is not installed
+ * @returns Promise resolving to the validated result
+ * @throws ToolError if Zotero is not running, BBT is not installed, or the response is malformed
  */
-export async function callBetterBibTeX<T = unknown>(
+export async function callBetterBibTeX<T>(
   method: string,
   params: unknown[],
   port: number,
+  resultSchema: z.ZodType<T>,
   timeout: number = ZOTERO_BBT_TIMEOUT_MS,
 ): Promise<T> {
   const url = `http://127.0.0.1:${port}/better-bibtex/json-rpc`;
 
-  try {
-    const response = await axios.post<JsonRpcResponse<T>>(
+  const response = await axios
+    .post<unknown>(
       url,
-      {
-        jsonrpc: '2.0',
-        method,
-        params,
-        id: 1,
-      },
-      {
-        timeout,
-        headers: { 'Content-Type': 'application/json' },
-      },
+      { jsonrpc: '2.0', method, params, id: 1 },
+      { timeout, headers: { 'Content-Type': 'application/json' } },
+    )
+    .catch((error: unknown) => {
+      if (axios.isAxiosError(error)) {
+        if (isTimeoutErrorCode(error.code)) {
+          throw new ToolError(
+            `Zotero API request timed out after ${timeout / 1000}s. ` +
+              `Retry the request. If it persists, ask the user to check that Zotero is responsive.`,
+          );
+        }
+        if (error.code === 'ECONNREFUSED') {
+          throw new ToolError(
+            `Zotero is not reachable on port ${port}. ` +
+              `Ask the user to start Zotero or verify the port (setting: texra.bib.zoteroPort).`,
+          );
+        }
+        if (error.response?.status === StatusCodes.NOT_FOUND) {
+          throw new ToolError(
+            'Better BibTeX plugin is not installed in Zotero. ' +
+              'Ask the user to install it from https://retorque.re/zotero-better-bibtex/',
+          );
+        }
+      }
+      throw new ToolError(`Better BibTeX API error: ${toErrorMessage(error)}`);
+    });
+
+  const parsed = jsonRpcResponseSchema(resultSchema).safeParse(response.data);
+  if (!parsed.success) {
+    throw new ToolError(
+      `Better BibTeX returned an unexpected response for ${method}: ${parsed.error.message}`,
     );
-
-    if (response.data.error) {
-      throw new Error(response.data.error.message);
-    }
-
-    return response.data.result as T;
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      if (isTimeoutErrorCode(error.code)) {
-        throw new ToolError(
-          `Zotero API request timed out after ${timeout / 1000}s. ` +
-            `Retry the request. If it persists, ask the user to check that Zotero is responsive.`,
-        );
-      }
-      if (error.code === 'ECONNREFUSED') {
-        throw new ToolError(
-          `Zotero is not reachable on port ${port}. ` +
-            `Ask the user to start Zotero or verify the port (setting: texra.bib.zoteroPort).`,
-        );
-      }
-      if (error.response?.status === StatusCodes.NOT_FOUND) {
-        throw new ToolError(
-          'Better BibTeX plugin is not installed in Zotero. ' +
-            'Ask the user to install it from https://retorque.re/zotero-better-bibtex/',
-        );
-      }
-    }
-    throw new ToolError(`Better BibTeX API error: ${toErrorMessage(error)}`);
   }
+  if (parsed.data.error) {
+    throw new ToolError(
+      `Better BibTeX API error: ${parsed.data.error.message}`,
+    );
+  }
+  if (parsed.data.result === undefined) {
+    throw new ToolError(
+      `Better BibTeX returned an empty response for ${method}.`,
+    );
+  }
+  return parsed.data.result;
 }

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -44,7 +44,7 @@ const JsonRpcErrorSchema = z.object({ code: z.number(), message: z.string() });
 function jsonRpcResponseSchema<T>(result: z.ZodType<T>) {
   return z.object({
     jsonrpc: z.string(),
-    id: z.number().optional(),
+    id: z.number().nullish(),
     result: result.optional(),
     error: JsonRpcErrorSchema.optional(),
   });

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -33,8 +33,10 @@ export function getZoteroPort(): number {
 // JSON-RPC envelope and result shapes are the single source of truth here (the
 // types are derived via z.infer) and validated once in callBetterBibTeX. The
 // result schemas assert only the fields consumers read; z.object strips any
-// extra fields the API adds (it tolerates them rather than rejecting), and the
-// inferred types match the original interfaces exactly.
+// extra fields the API adds (it tolerates them rather than rejecting). Optional
+// fields use .nullish() (not .optional()) because the CSL-JSON BBT emits may send
+// an explicit null as well as omit a field — .optional() alone would reject null.
+// Consumers already guard every such field with truthiness / optional chaining.
 // ============================================================================
 
 /** JSON-RPC error object. */
@@ -58,27 +60,27 @@ function jsonRpcResponseSchema<T>(result: z.ZodType<T>) {
  */
 const CslCreatorSchema = z.object({
   /** Family name (surname) in CSL format */
-  family: z.string().optional(),
+  family: z.string().nullish(),
   /** Given name (first name) in CSL format */
-  given: z.string().optional(),
+  given: z.string().nullish(),
   /** Institutional or single-field name */
-  literal: z.string().optional(),
+  literal: z.string().nullish(),
   // Zotero native format (may appear in some responses)
-  lastName: z.string().optional(),
-  firstName: z.string().optional(),
-  name: z.string().optional(),
-  creatorType: z.string().optional(),
+  lastName: z.string().nullish(),
+  firstName: z.string().nullish(),
+  name: z.string().nullish(),
+  creatorType: z.string().nullish(),
 });
 export type CslCreator = z.infer<typeof CslCreatorSchema>;
 
 /** CSL JSON date format. */
 const CslDateSchema = z.object({
   /** Date parts as [[year, month?, day?]] */
-  'date-parts': z.array(z.array(z.number())).optional(),
+  'date-parts': z.array(z.array(z.number())).nullish(),
   /** Raw date string */
-  raw: z.string().optional(),
+  raw: z.string().nullish(),
   /** Literal date text */
-  literal: z.string().optional(),
+  literal: z.string().nullish(),
 });
 export type CslDate = z.infer<typeof CslDateSchema>;
 
@@ -86,7 +88,7 @@ export type CslDate = z.infer<typeof CslDateSchema>;
 export const BbtCollectionSchema = z.object({
   key: z.string(),
   name: z.string(),
-  parentCollection: z.union([z.string(), z.literal(false)]).optional(),
+  parentCollection: z.union([z.string(), z.literal(false)]).nullish(),
 });
 export type BbtCollection = z.infer<typeof BbtCollectionSchema>;
 
@@ -94,7 +96,7 @@ export type BbtCollection = z.infer<typeof BbtCollectionSchema>;
 export const BbtLibrarySchema = z.object({
   id: z.number(),
   name: z.string(),
-  collections: z.array(BbtCollectionSchema).optional(),
+  collections: z.array(BbtCollectionSchema).nullish(),
 });
 export type BbtLibrary = z.infer<typeof BbtLibrarySchema>;
 
@@ -138,57 +140,57 @@ export const BbtSearchResultItemSchema = z.object({
 
   // ─── CSL JSON core fields ──────────────────────────────────────────
   /** Internal Zotero item ID (as URI or number) */
-  id: z.union([z.string(), z.number()]).optional(),
+  id: z.union([z.string(), z.number()]).nullish(),
   /** CSL item type (article-journal, book, chapter, etc.) */
-  type: z.string().optional(),
+  type: z.string().nullish(),
   /** Item title */
-  title: z.string().optional(),
+  title: z.string().nullish(),
   /** Authors */
-  author: z.array(CslCreatorSchema).optional(),
+  author: z.array(CslCreatorSchema).nullish(),
   /** Editors */
-  editor: z.array(CslCreatorSchema).optional(),
+  editor: z.array(CslCreatorSchema).nullish(),
   /** Publication/issue date */
-  issued: CslDateSchema.optional(),
+  issued: CslDateSchema.nullish(),
   /** Access date */
-  accessed: CslDateSchema.optional(),
+  accessed: CslDateSchema.nullish(),
 
   // ─── Zotero-style fields (legacy, may appear) ──────────────────────
-  itemType: z.string().optional(),
-  creators: z.array(CslCreatorSchema).optional(),
-  date: z.string().optional(),
+  itemType: z.string().nullish(),
+  creators: z.array(CslCreatorSchema).nullish(),
+  date: z.string().nullish(),
 
   // ─── Identifiers ───────────────────────────────────────────────────
-  DOI: z.string().optional(),
-  ISBN: z.string().optional(),
-  ISSN: z.string().optional(),
-  PMID: z.string().optional(),
-  PMCID: z.string().optional(),
-  URL: z.string().optional(),
+  DOI: z.string().nullish(),
+  ISBN: z.string().nullish(),
+  ISSN: z.string().nullish(),
+  PMID: z.string().nullish(),
+  PMCID: z.string().nullish(),
+  URL: z.string().nullish(),
 
   // ─── Publication info ──────────────────────────────────────────────
   /** Journal/book title */
-  'container-title': z.string().optional(),
+  'container-title': z.string().nullish(),
   /** Short container title */
-  'container-title-short': z.string().optional(),
+  'container-title-short': z.string().nullish(),
   /** Publisher name */
-  publisher: z.string().optional(),
+  publisher: z.string().nullish(),
   /** Publisher location */
-  'publisher-place': z.string().optional(),
+  'publisher-place': z.string().nullish(),
   /** Volume number */
-  volume: z.string().optional(),
+  volume: z.string().nullish(),
   /** Issue number */
-  issue: z.string().optional(),
+  issue: z.string().nullish(),
   /** Page range */
-  page: z.string().optional(),
+  page: z.string().nullish(),
   /** Number of pages */
-  'number-of-pages': z.string().optional(),
+  'number-of-pages': z.string().nullish(),
   /** Edition */
-  edition: z.string().optional(),
+  edition: z.string().nullish(),
 
   // ─── Content ───────────────────────────────────────────────────────
-  abstract: z.string().optional(),
-  note: z.string().optional(),
-  language: z.string().optional(),
+  abstract: z.string().nullish(),
+  note: z.string().nullish(),
+  language: z.string().nullish(),
 });
 export type BbtSearchResultItem = z.infer<typeof BbtSearchResultItemSchema>;
 


### PR DESCRIPTION
## What

The Better BibTeX (Zotero) JSON-RPC client cast `response.data.result as T` over hand-written interfaces. This makes the BBT shapes the single source of truth and validates them at the right layer.

- **SSOT**: the envelope and result shapes are now Zod schemas in `bbtClient.ts`; the exported types are derived via `z.infer` (no more parallel interfaces). `z.object` keeps the inferred types **structurally identical** to the old interfaces (it strips unknown keys, tolerating extra API fields without rejecting).
- **Right layer**: validation happens once at the single network entry point, `callBetterBibTeX`, which now takes a `resultSchema: z.ZodType<T>`. The three consumer tools (`Search`/`Collections`/`Export`) pass the schema for their method instead of a `<T>` type argument, so no validation is scattered into the tools.
- `BbtCollectionChain` stays an `interface` (it is self-referential) with an annotated `z.lazy` schema.
- `citekey`/`library` stay required (consumers index results by `citekey`).

## Verification

- `tsc --noEmit` clean across all four files (the 14 pre-existing `@openrouter/sdk` / `vscode-jsonrpc` errors are unrelated and on `main`). Switching from `looseObject` to `object` keeps `CslCreator` assignable where `ZoteroAddTool` types a Crossref `Author[].map` callback.
- Error handling is byte-identical (timeout / `ECONNREFUSED` / 404 / `Better BibTeX API error: <msg>`); empty results (`[]`, `''`) are still returned and handled by the consumers; only a genuinely malformed envelope now throws a clear `ToolError`. No BBT/Zotero test suite exists.
- No user-facing change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal boundary hardening with no intended user-facing behavior change; the only new failures are malformed RPC envelopes that were previously trusted via cast.
> 
> **Overview**
> Replaces unchecked `as T` casts on Better BibTeX JSON-RPC responses with **Zod schemas** in `bbtClient.ts` as the single source of truth; exported types are now `z.infer` from those schemas instead of parallel interfaces.
> 
> **`callBetterBibTeX`** now takes a required `resultSchema` and validates the JSON-RPC envelope plus method `result` in one place. Malformed envelopes, RPC errors, or missing `result` raise explicit `ToolError`s; timeout / connection / 404 handling is unchanged. Optional CSL fields use `.nullish()` so explicit `null` from BBT is accepted.
> 
> **`ZoteroCollectionsTool`**, **`ZoteroExportTool`**, and **`ZoteroSearchTool`** pass per-method schemas (libraries array, export string, search items, collection map) instead of generic type arguments. Recursive **`BbtCollectionChain`** keeps a hand-written interface with a `z.lazy` schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4209d34e9f9651fbdbdd30c6b3b68a06cd9fc8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->