### PR TITLE
fix: shorten CLI agent picker labels

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '@inkjs/ui';
 import { computeAgentOptionsData } from '@agent/index';
 import type { AgentOptionData } from '@shared/schemas';
 import { agentName } from '@shared/schemas/agent';
+import { formatAgentOptionLabel } from '@shared/utils/agentOptionLabels';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
@@ -32,6 +33,12 @@ interface AgentGroups {
 
 type AgentIdentity = Pick<AgentOptionData, 'label' | 'value'>;
 type AgentDelegationFlag = Pick<AgentOptionData, 'isOrchestrator'>;
+
+export function agentPickerLabel(
+  agent: Pick<AgentOptionData, 'label'>,
+): string {
+  return formatAgentOptionLabel(agent.label);
+}
 
 function agentDescription(agent: AgentOptionData): string {
   const source = agent.isRemote
@@ -182,7 +189,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   const primarySectionTitle = agentPickerPrimarySectionTitle(agents.toolUse);
   const items = agents.toolUse.map((agent) => ({
     value: agent.value,
-    label: agent.label,
+    label: agentPickerLabel(agent),
     description: agentDescription(agent),
   }));
   // The current agent may be stored as a canonical key (`source:name`) or a
@@ -195,7 +202,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     props.currentAgent,
   );
   const workflowRows = agents.workflow.map((agent) => ({
-    name: agent.label,
+    name: agentPickerLabel(agent),
     description: agentDescription(agent),
   }));
   const selectWindow = agentSelectWindow({

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -34,12 +34,6 @@ interface AgentGroups {
 type AgentIdentity = Pick<AgentOptionData, 'label' | 'value'>;
 type AgentDelegationFlag = Pick<AgentOptionData, 'isOrchestrator'>;
 
-export function agentPickerLabel(
-  agent: Pick<AgentOptionData, 'label'>,
-): string {
-  return formatAgentOptionLabel(agent.label);
-}
-
 function agentDescription(agent: AgentOptionData): string {
   const source = agent.isRemote
     ? 'remote'
@@ -189,7 +183,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   const primarySectionTitle = agentPickerPrimarySectionTitle(agents.toolUse);
   const items = agents.toolUse.map((agent) => ({
     value: agent.value,
-    label: agentPickerLabel(agent),
+    label: formatAgentOptionLabel(agent.label),
     description: agentDescription(agent),
   }));
   // The current agent may be stored as a canonical key (`source:name`) or a
@@ -202,7 +196,8 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     props.currentAgent,
   );
   const workflowRows = agents.workflow.map((agent) => ({
-    name: agentPickerLabel(agent),
+    value: agent.value,
+    name: formatAgentOptionLabel(agent.label),
     description: agentDescription(agent),
   }));
   const selectWindow = agentSelectWindow({
@@ -278,7 +273,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
         <Box marginTop={1} flexDirection="column">
           <Text bold>Workflows</Text>
           {visibleWorkflowRows.map((workflow) => (
-            <Text key={workflow.name} wrap="truncate-end">
+            <Text key={workflow.value} wrap="truncate-end">
               {'  '}
               {workflow.name}
               <Text dimColor>{` — ${workflow.description}`}</Text>

--- a/src/shared/utils/agentOptionLabels.ts
+++ b/src/shared/utils/agentOptionLabels.ts
@@ -1,0 +1,7 @@
+const AGENT_LABEL_SEPARATOR_PATTERN =
+  /^(.*?)(?:\s*---\s*|\s*[\u2013\u2014]\s*)/u;
+
+export function formatAgentOptionLabel(label: string): string {
+  const shortLabel = label.match(AGENT_LABEL_SEPARATOR_PATTERN)?.[1]?.trim();
+  return shortLabel || label;
+}

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -20,8 +20,6 @@ import { AGENT_DECORATORS, getModelProviderDecorator } from './icons';
  */
 export const BROWSE_ALL_AGENTS_OPTION_VALUE = '__browse-all-agents__';
 
-export { formatAgentOptionLabel } from './agentOptionLabels';
-
 function buildAgentTooltip(opt: AgentOptionData, displayLabel: string): string {
   const { properties } = AGENT_DECORATORS;
   const hints: string[] = [];

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -10,6 +10,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
 import { agentName } from '@shared/schemas/agent';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { formatAgentOptionLabel } from './agentOptionLabels';
 import { AGENT_DECORATORS, getModelProviderDecorator } from './icons';
 
 /**
@@ -19,13 +20,7 @@ import { AGENT_DECORATORS, getModelProviderDecorator } from './icons';
  */
 export const BROWSE_ALL_AGENTS_OPTION_VALUE = '__browse-all-agents__';
 
-const AGENT_LABEL_SEPARATOR_PATTERN =
-  /^(.*?)(?:\s*---\s*|\s*[\u2013\u2014]\s*)/u;
-
-export function formatAgentOptionLabel(label: string): string {
-  const shortLabel = label.match(AGENT_LABEL_SEPARATOR_PATTERN)?.[1]?.trim();
-  return shortLabel || label;
-}
+export { formatAgentOptionLabel } from './agentOptionLabels';
 
 function buildAgentTooltip(opt: AgentOptionData, displayLabel: string): string {
   const { properties } = AGENT_DECORATORS;

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   agentPickerPrimarySectionTitle,
-  agentPickerLabel,
   agentSelectWindow,
   currentVisibleAgent,
   hiddenCurrentAgentHint,
@@ -45,15 +44,6 @@ describe('CLI AgentListForm row budget', () => {
       currentVisibleAgent(displayAgents, 'remote:orchestrator')?.label,
     ).toBe('Orchestrator');
     expect(hiddenCurrentAgentHint(displayAgents, 'setup')).toBeUndefined();
-  });
-
-  it('trims agent picker labels before description separators', () => {
-    expect(
-      agentPickerLabel({ label: 'Engineer \u2014 software team lead' }),
-    ).toBe('Engineer');
-    expect(
-      agentPickerLabel({ label: 'Research --- derivations & numerics' }),
-    ).toBe('Research');
   });
 
   it('labels the current agent when it is hidden from the picker', () => {

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   agentPickerPrimarySectionTitle,
+  agentPickerLabel,
   agentSelectWindow,
   currentVisibleAgent,
   hiddenCurrentAgentHint,
@@ -44,6 +45,15 @@ describe('CLI AgentListForm row budget', () => {
       currentVisibleAgent(displayAgents, 'remote:orchestrator')?.label,
     ).toBe('Orchestrator');
     expect(hiddenCurrentAgentHint(displayAgents, 'setup')).toBeUndefined();
+  });
+
+  it('trims agent picker labels before description separators', () => {
+    expect(
+      agentPickerLabel({ label: 'Engineer \u2014 software team lead' }),
+    ).toBe('Engineer');
+    expect(
+      agentPickerLabel({ label: 'Research --- derivations & numerics' }),
+    ).toBe('Research');
   });
 
   it('labels the current agent when it is hidden from the picker', () => {

--- a/src/test-kernel/shared/SelectTemplates.vitest.ts
+++ b/src/test-kernel/shared/SelectTemplates.vitest.ts
@@ -5,7 +5,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Local imports - shared
-import { formatAgentOptionLabel } from '@shared/utils/selectTemplates';
+import { formatAgentOptionLabel } from '@shared/utils/agentOptionLabels';
 
 describe('select template labels', () => {
   it('trims agent picker labels before description separators', () => {


### PR DESCRIPTION
## Summary

- Move the pure agent label shortening helper out of the Lit select renderer into `src/shared/utils/agentOptionLabels.ts`.
- Reuse that helper in the CLI `/agent` picker so labels like `Engineer — software team lead` render as `Engineer` in terminal picker rows.
- Keep the extension renderer behavior unchanged by re-exporting the helper from `selectTemplates.ts`.

Fixes #6450.

## Validation

- `texra-local doctor --output-format json`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-goal-continue-known-1782081847 slash-goal-help backslash-goal-help plan-approval-goal compact-plan-approval-goal plan-approval-approve-goal approval-form edit-approval bash-approval`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-agent-labels-1782082053 agent-form agent-form-80-cols compact-agent-form`
- `corepack pnpm exec vitest run src/test-kernel/shared/SelectTemplates.vitest.ts src/test-kernel/cli/AgentListForm.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`
- `npm test`

## Notes

`texra-local models show glm5.2 --output-format json` currently reports `Model not found: glm5.2`; `texra-local models list --all --output-format json` also does not include any GLM model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label formatting and a small workflow list key fix; no auth, selection values, or agent identity logic changes.
> 
> **Overview**
> **Agent label shortening** is moved into `src/shared/utils/agentOptionLabels.ts` (`formatAgentOptionLabel`), stripping text after `---` or en/em dashes so long catalog names fit narrow UIs.
> 
> The CLI **`/agent`** picker now uses that helper for tool-use **Select** rows and workflow list text, matching the extension’s shortened display labels. Workflow rows also carry **`value`** and use it as the React **key** instead of the display name.
> 
> `selectTemplates.ts` imports the helper from the new module (logic unchanged); the unit test import path is updated to `@shared/utils/agentOptionLabels`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b69dd3d108926e3a0ea4be5c6ed70651811edbf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->