### PR TITLE
feat: surface ChatGPT subscription onboarding

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -567,7 +567,7 @@ const SCENARIOS = [
       '/auth',
       'Show TeXRA login status',
       '/login',
-      'Sign in to TeXRA included',
+      'Sign in to TeXRA or ChatGPT',
       '… 11 more',
     ],
     unexpect: [
@@ -577,6 +577,29 @@ const SCENARIOS = [
       'automatically',
     ],
     maxLineColumns: 52,
+  },
+  {
+    name: 'login-form',
+    rows: 16,
+    cols: 80,
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['/login\r'],
+    frame: 'tail',
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: [
+      '/login',
+      'TeXRA included access',
+      'ChatGPT subscription',
+      'TeXRA device code',
+      'ChatGPT device code',
+      '↑/↓ navigate',
+      '1-4 select now',
+      'Enter select highlighted',
+      'Esc cancel',
+    ],
+    maxBlankLinesBetween: [
+      { from: 'entry-4 chat history line', to: '/login', max: 2 },
+    ],
   },
   {
     name: 'slash-palette-ctrl-u-clears-raw-control',

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -121,6 +121,10 @@ export async function handleTuiSlashCommand(
       }
       return true;
     case 'login':
+      if (!rest) {
+        openCanonicalSlashForm('login', registered, rest);
+        return true;
+      }
       await loginFromChat(rest);
       return true;
     case 'logout':

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -1,8 +1,16 @@
+import { setPreferCodexSubscription } from '@auth/codex';
+import { bumpCodexPreferenceVersion } from '@cli/chat/tui/state/cliState';
+import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
+import {
+  chatGptAccountLabel,
+  signInCliChatGpt,
+} from '@cli/runtime/chatgptLogin';
 import {
   githubSelectAccountWarning,
   parseChatLoginSlashArgs,
   type CliLoginSlashArgs,
+  type CliTexraLoginSlashArgs,
 } from '@cli/runtime/loginOptions';
 import {
   formatCliManualAuthUrlMessage,
@@ -12,18 +20,80 @@ import {
   signOutCliSupabase,
 } from '@cli/runtime/supabaseAuth';
 import { formatCliDeviceAuthMessage } from '@cli/runtime/supabaseAuthDeviceCode';
-import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { toErrorMessage } from '@common/errors/errorMessage';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 import { setCliSessionApiMode } from './apiModeCommands';
 
-export const CHAT_LOGIN_USAGE =
-  'Usage: /login [github | google] [--no-browser] [--device] [--select-account] [--login-hint <account>]';
+export const CHAT_LOGIN_USAGE = [
+  'Usage: /login [texra [github | google]] [--no-browser] [--device] [--select-account] [--login-hint <account>]',
+  '       /login chatgpt [--no-browser] [--device]',
+].join('\n');
 
 function loginStartMessage(args: CliLoginSlashArgs): string {
+  if (args.target === 'chatgpt') {
+    if (args.device) return 'Starting ChatGPT device-code sign-in.';
+    if (args.noBrowser) return 'Starting ChatGPT sign-in.';
+    return 'Opening browser for ChatGPT sign-in...';
+  }
   if (args.device) return 'Starting TeXRA device-code sign-in.';
   if (args.noBrowser) return `Starting TeXRA ${args.provider} sign-in.`;
   return `Opening browser for TeXRA ${args.provider} sign-in...`;
+}
+
+async function loginToChatGptSubscription(
+  args: Extract<CliLoginSlashArgs, { target: 'chatgpt' }>,
+): Promise<void> {
+  const session = await signInCliChatGpt(args, {
+    writeProgress: appendLocalAssistantTranscript,
+  });
+  const update = await setPreferCodexSubscription(true);
+  invalidateModelOptionsCache();
+  bumpCodexPreferenceVersion();
+
+  appendLocalAssistantTranscript(
+    [
+      `Signed in with ChatGPT as ${chatGptAccountLabel(session)}.`,
+      update.effective
+        ? 'ChatGPT subscription enabled for Codex models.'
+        : `ChatGPT subscription preference is still disabled because a more specific setting overrides ${update.target} config.`,
+    ].join('\n'),
+  );
+}
+
+async function loginToTexraIncludedAccess(
+  args: CliTexraLoginSlashArgs,
+): Promise<void> {
+  const accountWarning = githubSelectAccountWarning(args);
+  if (accountWarning) appendLocalAssistantTranscript(accountWarning);
+
+  const session = args.device
+    ? await signInCliSupabaseDeviceCode({
+        onDeviceCode: (authorization) => {
+          appendLocalAssistantTranscript(
+            formatCliDeviceAuthMessage(authorization),
+          );
+        },
+      })
+    : await signInCliSupabase({
+        provider: args.provider,
+        openBrowser: !args.noBrowser,
+        selectAccount: args.selectAccount,
+        loginHint: args.loginHint,
+        manualBrowserHint: '/login --no-browser',
+        onAuthUrl: (url) => {
+          if (args.noBrowser) {
+            appendLocalAssistantTranscript(formatCliManualAuthUrlMessage(url));
+          }
+        },
+      });
+  setCliSessionApiMode('included');
+  appendLocalAssistantTranscript(
+    [
+      `Signed in as ${session.account.label}.`,
+      ...(await loadCliApiStatusLines({ apiMode: 'included' })),
+    ].join('\n'),
+  );
 }
 
 export async function loginFromChat(input: string): Promise<void> {
@@ -33,40 +103,14 @@ export async function loginFromChat(input: string): Promise<void> {
     return;
   }
 
-  const accountWarning = githubSelectAccountWarning(args);
-  if (accountWarning) appendLocalAssistantTranscript(accountWarning);
   appendLocalAssistantTranscript(loginStartMessage(args));
 
   try {
-    const session = args.device
-      ? await signInCliSupabaseDeviceCode({
-          onDeviceCode: (authorization) => {
-            appendLocalAssistantTranscript(
-              formatCliDeviceAuthMessage(authorization),
-            );
-          },
-        })
-      : await signInCliSupabase({
-          provider: args.provider,
-          openBrowser: !args.noBrowser,
-          selectAccount: args.selectAccount,
-          loginHint: args.loginHint,
-          manualBrowserHint: '/login --no-browser',
-          onAuthUrl: (url) => {
-            if (args.noBrowser) {
-              appendLocalAssistantTranscript(
-                formatCliManualAuthUrlMessage(url),
-              );
-            }
-          },
-        });
-    setCliSessionApiMode('included');
-    appendLocalAssistantTranscript(
-      [
-        `Signed in as ${session.account.label}.`,
-        ...(await loadCliApiStatusLines({ apiMode: 'included' })),
-      ].join('\n'),
-    );
+    if (args.target === 'chatgpt') {
+      await loginToChatGptSubscription(args);
+      return;
+    }
+    await loginToTexraIncludedAccess(args);
   } catch (error: unknown) {
     appendLocalAssistantTranscript(toErrorMessage(error));
   }

--- a/packages/cli/src/chat/tui/commands/handlers/subscriptionCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/subscriptionCommand.ts
@@ -28,7 +28,7 @@ export async function applyCliSubscriptionToggle(input: string): Promise<void> {
   const status = await getCodexStatus();
   const accountLine = status.signedIn
     ? `Signed in with ChatGPT as ${status.email ?? status.accountId ?? 'your account'}.`
-    : 'Not signed in with ChatGPT — run `texra auth chatgpt login`.';
+    : 'Not signed in with ChatGPT - run `/login chatgpt`.';
 
   if (!normalized || normalized === 'status') {
     appendLocalAssistantTranscript(
@@ -58,7 +58,7 @@ export async function applyCliSubscriptionToggle(input: string): Promise<void> {
   ];
   if (enabled && update.effective && !status.signedIn) {
     lines.push(
-      'You are not signed in with ChatGPT yet — run `texra auth chatgpt login` to use it.',
+      'You are not signed in with ChatGPT yet - run `/login chatgpt` to use it.',
     );
   } else if (enabled && update.effective) {
     lines.push(accountLine);

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -8,12 +8,14 @@ import type { ExecutionId } from '@shared/schemas';
 import { ApiModeForm } from '../forms/ApiModeForm';
 import { AgentListForm } from '../forms/AgentListForm';
 import { ApprovalPolicyForm } from '../forms/ApprovalPolicyForm';
+import { LoginForm, type LoginFormValue } from '../forms/LoginForm';
 import { MemoryListForm } from '../forms/MemoryListForm';
 import { ModelListForm } from '../forms/ModelListForm';
 import { ResumeListForm } from '../forms/ResumeListForm';
 import { SkillsListForm, type SkillActivation } from '../forms/SkillsListForm';
 import { ToolsListForm } from '../forms/ToolsListForm';
 import { cliState, setCliSessionModelOverride } from '../state/cliState';
+import { loginFromChat } from './handlers/loginCommands';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
 
 type AgentSelectHandler = (value: string) => void | Promise<void>;
@@ -22,6 +24,7 @@ type ApprovalPolicySelectHandler = (
 ) => void | Promise<void>;
 type ModelSelectHandler = (value: string) => void | Promise<void>;
 type ApiModeSelectHandler = (value: CliApiMode) => void | Promise<void>;
+type LoginSelectHandler = (value: LoginFormValue) => void | Promise<void>;
 type MemorySelectHandler = (storagePath: string) => void | Promise<void>;
 type ResumeSelectHandler = (id: ExecutionId) => void | Promise<void>;
 type SkillSelectHandler = (value: SkillActivation) => void | Promise<void>;
@@ -72,6 +75,7 @@ export function registerBuiltinSlashCommands(options?: {
   canSelectModel?: () => boolean;
   getModelSwitchDisabledReason?: GetModelSwitchDisabledReason;
   onApiModeSelect?: ApiModeSelectHandler;
+  onLoginSelect?: LoginSelectHandler;
   onMemorySelect?: MemorySelectHandler;
   onResumeSelect?: ResumeSelectHandler;
   onSkillSelect?: SkillSelectHandler;
@@ -89,6 +93,8 @@ export function registerBuiltinSlashCommands(options?: {
     ((apiMode) => {
       cliState.sessionMeta.set({ ...cliState.sessionMeta.get(), apiMode });
     });
+  const onLoginSelect: LoginSelectHandler =
+    options?.onLoginSelect ?? loginFromChat;
   const canSelectAgent = options?.canSelectAgent ?? (() => true);
   const canSelectModel = options?.canSelectModel ?? (() => true);
 
@@ -163,6 +169,24 @@ export function registerBuiltinSlashCommands(options?: {
             action: () => options?.onApprovalPolicySelect?.(value),
             value,
             onDone: props.onDone,
+            completion: 'beforeAction',
+          })
+        }
+        onCancel={() => props.onDone(undefined)}
+      />
+    );
+  }
+
+  function LoginFormAdapter(props: SlashFormProps): React.JSX.Element {
+    return (
+      <LoginForm
+        availableRows={props.availableRows}
+        onSelect={(value) =>
+          runFormSelection({
+            action: () => onLoginSelect(value),
+            value,
+            onDone: props.onDone,
+            onError: options?.onError,
             completion: 'beforeAction',
           })
         }
@@ -301,8 +325,9 @@ export function registerBuiltinSlashCommands(options?: {
   });
   registerSlashCommand({
     name: 'login',
-    description: 'Sign in to TeXRA included access',
+    description: 'Sign in to TeXRA or ChatGPT subscription',
     category: 'account',
+    formComponent: LoginFormAdapter,
   });
   registerSlashCommand({
     name: 'logout',

--- a/packages/cli/src/chat/tui/forms/LoginForm.tsx
+++ b/packages/cli/src/chat/tui/forms/LoginForm.tsx
@@ -1,0 +1,93 @@
+import { Box, Text } from 'ink';
+
+import { KeyHints } from '../ui/KeyHints';
+import { Select, type SelectItem } from '../ui/Select';
+import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
+import { isCompactFormRows } from './_shared/selectWindow';
+
+export type LoginFormValue =
+  | 'texra'
+  | 'chatgpt'
+  | 'texra --device'
+  | 'chatgpt --device';
+
+export interface LoginFormProps {
+  readonly availableRows?: number;
+  readonly onSelect: (value: LoginFormValue) => void;
+  readonly onCancel: () => void;
+}
+
+export const LOGIN_FORM_ITEMS = [
+  {
+    value: 'texra',
+    label: 'TeXRA included access',
+    description: 'Researcher Access relay and remote agents',
+  },
+  {
+    value: 'chatgpt',
+    label: 'ChatGPT subscription',
+    description: 'route Codex models through your ChatGPT plan',
+  },
+  {
+    value: 'texra --device',
+    label: 'TeXRA device code',
+    description: 'sign in from SSH or another browser',
+  },
+  {
+    value: 'chatgpt --device',
+    label: 'ChatGPT device code',
+    description: 'sign in from SSH or another browser',
+  },
+] as const satisfies ReadonlyArray<SelectItem<LoginFormValue>>;
+
+export function LoginForm(props: LoginFormProps): React.JSX.Element {
+  if (isCompactFormRows(props.availableRows)) {
+    return (
+      <FormFrame color="cyan" title="/login" showCloseHint={false}>
+        <Select
+          items={LOGIN_FORM_ITEMS}
+          maxVisibleItems={LOGIN_FORM_ITEMS.length}
+          showOverflow={false}
+          onSelect={props.onSelect}
+          onCancel={props.onCancel}
+        />
+        <CompactFormKeyHints
+          primary={{ key: '1-4/Enter', action: 'select' }}
+          escapeAction="cancel"
+        />
+      </FormFrame>
+    );
+  }
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor="cyan"
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color="cyan">
+        /login
+      </Text>
+      <Text dimColor>Choose how TeXRA should authenticate model calls.</Text>
+      <Box marginTop={1} flexDirection="column">
+        <Select
+          items={LOGIN_FORM_ITEMS}
+          onSelect={props.onSelect}
+          onCancel={props.onCancel}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            { key: '1-4', action: 'select now' },
+            { key: 'Enter', action: 'select highlighted' },
+            { key: 'Esc', action: 'cancel' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/commands/chatgptAuth.ts
+++ b/packages/cli/src/commands/chatgptAuth.ts
@@ -2,13 +2,16 @@ import { defineCommand } from 'citty';
 
 import {
   codexCoordinator,
-  loginWithDeviceCode,
-  loginWithLoopback,
+  setPreferCodexSubscription,
   type CodexSession,
 } from '@auth/codex';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
-import { tryOpenBrowser } from '../runtime/browser';
+import {
+  chatGptAccountLabel,
+  shouldUseChatGptDeviceCode,
+  signInCliChatGpt,
+} from '../runtime/chatgptLogin';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import {
@@ -16,51 +19,34 @@ import {
   writeTextStderr,
   writeTextStdout,
 } from '../runtime/logSinks';
-import { interactiveTerminalFailure } from '../runtime/terminalRequirements';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
 
-/**
- * Device-code is the right default when there's no interactive browser to reach:
- * non-text output, a non-TTY/headless/dumb terminal, or `--no-input`. An
- * explicit `--no-browser` keeps the loopback flow but prints the URL to paste.
- */
-function shouldUseDeviceCode(
+function emitLogin(
   context: CliContext,
-  deviceFlag: boolean,
-  noBrowser: boolean,
-): boolean {
-  if (deviceFlag) return true;
-  if (noBrowser) return false;
-  // `interactiveTerminalFailure` already returns a reason for headless mode
-  // (which `--no-input` forces), non-TTY stdout, and dumb terminals.
-  return (
-    context.outputFormat !== 'text' ||
-    interactiveTerminalFailure(context) !== undefined
-  );
-}
-
-function accountLabel(session: CodexSession): string {
-  return session.email ?? session.accountId ?? 'your ChatGPT account';
-}
-
-function emitLogin(context: CliContext, session: CodexSession): void {
+  session: CodexSession,
+  preferenceEffective: boolean,
+): void {
   emitCliResult(context, {
     json: {
       authenticated: true,
       email: session.email ?? null,
       accountId: session.accountId ?? null,
+      preferSubscription: preferenceEffective,
     },
     ndjson: {
       kind: 'chatgpt-auth',
       authenticated: true,
       email: session.email ?? null,
       accountId: session.accountId ?? null,
+      preferSubscription: preferenceEffective,
     },
-    text: `Signed in with ChatGPT as ${accountLabel(session)}.\nEnable "chatgptCodex.preferSubscription" in your TeXRA config to route Codex models through your subscription.`,
+    text: preferenceEffective
+      ? `Signed in with ChatGPT as ${chatGptAccountLabel(session)}.\nChatGPT subscription enabled for Codex models.`
+      : `Signed in with ChatGPT as ${chatGptAccountLabel(session)}.\nChatGPT subscription preference could not be enabled because a more specific setting overrides the config.`,
   });
 }
 
@@ -69,40 +55,25 @@ async function runChatgptLogin(
   init: { device: boolean; noBrowser: boolean },
 ): Promise<number> {
   await initCliPlatform({ ...context, quietLogs: true });
-  const coordinator = codexCoordinator();
   const writeProgress =
     context.outputFormat === 'text' ? writeTextStdout : writeTextStderr;
 
   let session: CodexSession;
   try {
-    if (shouldUseDeviceCode(context, init.device, init.noBrowser)) {
-      session = await loginWithDeviceCode({
-        coordinator,
-        onPrompt: ({ userCode, verificationUrl }) => {
-          writeProgress(
-            `To sign in with ChatGPT:\n  1. Open ${verificationUrl}\n  2. Enter the one-time code: ${userCode}\nWaiting for approval… (Ctrl-C cancels)`,
-          );
-        },
-      });
-    } else {
-      session = await loginWithLoopback({
-        coordinator,
-        openBrowser: async (url) => {
-          if (!init.noBrowser) {
-            writeProgress('Opening your browser to sign in with ChatGPT…');
-            const opened = await tryOpenBrowser(url);
-            if (opened) return;
-          }
-          writeProgress(`Open this URL to sign in with ChatGPT:\n${url}`);
-        },
-      });
-    }
+    session = await signInCliChatGpt(
+      {
+        ...init,
+        device: shouldUseChatGptDeviceCode(context, init),
+      },
+      { writeProgress },
+    );
   } catch (error) {
     writeErrorStderr(error);
     return CliExitCode.ModelOrNetworkError;
   }
 
-  emitLogin(context, session);
+  const update = await setPreferCodexSubscription(true);
+  emitLogin(context, session, update.effective);
   invalidateModelOptionsCache();
   return CliExitCode.Success;
 }

--- a/packages/cli/src/runtime/chatgptLogin.ts
+++ b/packages/cli/src/runtime/chatgptLogin.ts
@@ -1,0 +1,72 @@
+import {
+  codexCoordinator,
+  loginWithDeviceCode,
+  loginWithLoopback,
+  type CodexSession,
+} from '@auth/codex';
+
+import { tryOpenBrowser } from './browser';
+import { interactiveTerminalFailure } from './terminalRequirements';
+import type { CliContext } from './cliContext';
+
+export interface CliChatGptLoginInit {
+  readonly device: boolean;
+  readonly noBrowser: boolean;
+}
+
+export interface CliChatGptLoginOptions {
+  readonly writeProgress: (message: string) => void;
+}
+
+/**
+ * Device-code is the right default when there's no interactive browser to reach:
+ * non-text output, a non-TTY/headless/dumb terminal, or `--no-input`. An
+ * explicit `--no-browser` keeps the loopback flow but prints the URL to paste.
+ */
+export function shouldUseChatGptDeviceCode(
+  context: CliContext,
+  init: CliChatGptLoginInit,
+): boolean {
+  if (init.device) return true;
+  if (init.noBrowser) return false;
+  return (
+    context.outputFormat !== 'text' ||
+    interactiveTerminalFailure(context) !== undefined
+  );
+}
+
+export function chatGptAccountLabel(session: CodexSession): string {
+  return session.email ?? session.accountId ?? 'your ChatGPT account';
+}
+
+export async function signInCliChatGpt(
+  init: CliChatGptLoginInit,
+  options: CliChatGptLoginOptions,
+): Promise<CodexSession> {
+  const coordinator = codexCoordinator();
+
+  if (init.device) {
+    return loginWithDeviceCode({
+      coordinator,
+      onPrompt: ({ userCode, verificationUrl }) => {
+        options.writeProgress(
+          `To sign in with ChatGPT:\n  1. Open ${verificationUrl}\n  2. Enter the one-time code: ${userCode}\nWaiting for approval... (Ctrl-C cancels)`,
+        );
+      },
+    });
+  }
+
+  return loginWithLoopback({
+    coordinator,
+    openBrowser: async (url) => {
+      if (!init.noBrowser) {
+        options.writeProgress(
+          'Opening your browser to sign in with ChatGPT...',
+        );
+        const opened = await tryOpenBrowser(url);
+        if (opened) return;
+      }
+      options.writeProgress(`Open this URL to sign in with ChatGPT:\n${url}`);
+    },
+  });
+}

--- a/packages/cli/src/runtime/loginOptions.ts
+++ b/packages/cli/src/runtime/loginOptions.ts
@@ -13,13 +13,26 @@ export interface CliLoginInit {
   readonly loginHint?: string;
 }
 
-export interface CliLoginSlashArgs {
+export interface CliTexraLoginSlashArgs {
+  readonly target: 'texra';
   readonly provider: OAuthProvider;
   readonly noBrowser: boolean;
   readonly device: boolean;
   readonly selectAccount: boolean;
   readonly loginHint?: string;
 }
+
+export interface CliChatGptLoginSlashArgs {
+  readonly target: 'chatgpt';
+  readonly noBrowser: boolean;
+  readonly device: boolean;
+}
+
+export type CliLoginSlashArgs =
+  | CliTexraLoginSlashArgs
+  | CliChatGptLoginSlashArgs;
+
+const CHATGPT_LOGIN_TARGETS = new Set(['chatgpt', 'codex', 'subscription']);
 
 export function resolveLoginProvider(
   positional: string | undefined,
@@ -56,8 +69,7 @@ export function parseChatLoginSlashArgs(
   input: string,
 ): CliLoginSlashArgs | undefined {
   const tokens = input.trim().split(/\s+/).filter(Boolean);
-  let provider: string = DEFAULT_OAUTH_PROVIDER;
-  let providerSet = false;
+  const positionals: string[] = [];
   let noBrowser = false;
   let device = false;
   let selectAccount = false;
@@ -90,11 +102,27 @@ export function parseChatLoginSlashArgs(
       loginHint = value;
       continue;
     }
-    if (token.startsWith('--') || providerSet) return undefined;
-    provider = token;
-    providerSet = true;
+    if (token.startsWith('--')) return undefined;
+    positionals.push(token);
   }
 
+  let target: CliLoginSlashArgs['target'] = 'texra';
+  if (positionals[0] === 'texra') {
+    positionals.shift();
+  } else if (positionals[0] && CHATGPT_LOGIN_TARGETS.has(positionals[0])) {
+    target = 'chatgpt';
+    positionals.shift();
+  }
+
+  if (target === 'chatgpt') {
+    if (positionals.length > 0 || selectAccount || loginHint !== undefined) {
+      return undefined;
+    }
+    return { target, noBrowser, device };
+  }
+
+  if (positionals.length > 1) return undefined;
+  const provider = positionals[0] ?? DEFAULT_OAUTH_PROVIDER;
   if (!isCliLoginProvider(provider)) return undefined;
-  return { provider, noBrowser, device, selectAccount, loginHint };
+  return { target, provider, noBrowser, device, selectAccount, loginHint };
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1101,18 +1101,19 @@
       {
         "id": "texra.gettingStarted",
         "title": "Get started with TeXRA",
-        "description": "Sign in or add a key, let the setup assistant run your first polish, then meet the orchestrator. Setup is the doorman, polish is the demo, the orchestrator is the habit.",
+        "description": "Choose a credential, let the setup assistant run your first polish, then meet the orchestrator. Setup is the doorman, polish is the demo, the orchestrator is the habit.",
         "steps": [
           {
             "id": "texra.gettingStarted.signIn",
-            "title": "Sign in — free for academics — or add a key",
-            "description": "A credential is the one step no agent can do for you. Two ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Heads up: chat subscriptions (ChatGPT Plus, Claude Pro) don't come with API access.\n\n[Set API key](command:texra.setApiKey)",
+            "title": "Choose how TeXRA should sign in",
+            "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Open Models & ChatGPT](command:texra.showModels)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
             "media": {
               "image": "resources/walkthroughs/media/api-key-setup.png",
-              "altText": "Screenshot of the API key configuration view"
+              "altText": "Screenshot of the model credential configuration view"
             },
             "completionEvents": [
               "onCommand:texra.auth.signIn",
+              "onCommand:texra.showModels",
               "onCommand:texra.setApiKey"
             ]
           },

--- a/packages/extension/resources/tool_use_agents/setup.yaml
+++ b/packages/extension/resources/tool_use_agents/setup.yaml
@@ -177,15 +177,21 @@ prompts:
 
     ## Setting up credentials (phase D — required)
 
-    TeXRA needs one of: a Researcher Access sign-in, or a real API key
-    for one of the supported providers. Pick the path that fits the
-    user; don't push both.
+    TeXRA needs one credential path: Researcher Access, ChatGPT
+    subscription for Codex models, or a real API key for one of the
+    supported providers. Pick the path that fits the user; don't push
+    more than one.
 
       - **Researcher Access (recommended, free):** call `invoke_command`
         with `texra.auth.signIn`. The browser flow handles the rest.
         After the user finishes, re-run `probe_environment` to confirm
         `auth.authenticated` flipped to `true`. Mention that signing in
         also unlocks remote agents like the orchestrator.
+      - **ChatGPT subscription for Codex models:** if the user already
+        has ChatGPT Plus/Pro/Team and wants Codex models, call
+        `invoke_command` with `texra.showModels`. Tell them to use the
+        ChatGPT subscription section to sign in and enable the preference.
+        This does not unlock non-Codex providers or remote TeXRA agents.
       - **Bring-your-own API key:** ask the user which provider they
         already have an account with. If they don't have one, briefly
         explain the options:
@@ -198,9 +204,10 @@ prompts:
           - **DeepSeek**, **xAI** (Grok), **OpenRouter**, **Together**,
             and others are also supported — list only the one(s) the
             user mentions; don't dump every option.
-        Note that ChatGPT Plus / Claude Pro chat subscriptions do NOT
-        include API access — the user needs an API key from the
-        provider's developer console specifically.
+        Except for Codex models through ChatGPT subscription, chat
+        subscriptions such as Claude Pro or ChatGPT do NOT include API
+        access — the user needs an API key from the provider's developer
+        console specifically.
         Ask the user to paste the key in chat. Once they do, call
         `set_api_key` with `{ provider, key }`. The tool masks the key
         in its summary; never echo the raw value back. If the pasted

--- a/packages/extension/resources/walkthroughs/getting-started.md
+++ b/packages/extension/resources/walkthroughs/getting-started.md
@@ -4,12 +4,13 @@ TeXRA helps you write better papers. It uses AI to correct, polish, review, and 
 
 One story, three beats: **Setup is the doorman, polish is the demo, the orchestrator is the habit.**
 
-## 1. Sign in — free for academics — or add a key
+## 1. Choose a credential
 
-A credential is the one step no agent can do for you. Two ways in:
+A credential is the one step no agent can do for you. Three ways in:
 
 - **Sign in — free for academics** -- Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.
-- **Use your own provider API key** -- Anthropic, OpenAI, Google, and more. Note: chat subscriptions (ChatGPT Plus, Claude Pro) don't include API access; you need a key from the provider's developer platform.
+- **Use ChatGPT subscription** -- ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan from the Models tab.
+- **Use your own provider API key** -- Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions (Claude Pro, ChatGPT for non-Codex models, etc.) do not include API access; you need a key from the provider's developer platform.
 
 You can also pick **Skip for now** and come back later, but nothing below runs without a credential.
 

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -7,6 +7,7 @@ import { registerExecution } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { isCodexSubscriptionActive } from '@auth/codex';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
@@ -69,6 +70,8 @@ interface LaunchModelResolution {
  * launching with a model that will crash on tier enforcement.
  *
  * Order:
+ *   0. ChatGPT subscription — when enabled and signed in, use the
+ *      Codex-eligible OpenAI setup model.
  *   1. Researcher Access — only when "Use Included Access" is actually
  *      on AND the signed-in setup model is in the user's tier. A plain
  *      `canUseServerSideKeys()` pass is insufficient because a lower-tier
@@ -100,6 +103,13 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
     return {
       model: API_KEY_MODEL_BY_PROVIDER.openRouter,
       requiresOpenRouter: true,
+    };
+  }
+
+  if (await isCodexSubscriptionActive(API_KEY_MODEL_BY_PROVIDER.openai)) {
+    return {
+      model: API_KEY_MODEL_BY_PROVIDER.openai,
+      requiresOpenRouter: false,
     };
   }
 
@@ -190,6 +200,9 @@ async function withOpenRouterFlagOn<T>(fn: () => Promise<T>): Promise<T> {
  * means.
  */
 export async function hasAnyUsableSetupCredential(): Promise<boolean> {
+  if (await isCodexSubscriptionActive(API_KEY_MODEL_BY_PROVIDER.openai)) {
+    return true;
+  }
   for (const provider of SecretManager.API_PROVIDERS) {
     if (await SecretManager.hasUsableApiKey(provider)) return true;
   }
@@ -204,6 +217,11 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
       label: '$(sign-in) Sign in for free (recommended)',
       description: 'Researcher Access Program — no API key needed',
       id: 'signIn' as const,
+    },
+    {
+      label: '$(comment-discussion) Use ChatGPT subscription',
+      description: 'Codex models through your ChatGPT plan',
+      id: 'chatgpt' as const,
     },
     {
       label: '$(key) I have an API key',
@@ -233,6 +251,14 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
   if (picked.id === 'apiKey') {
     await vscode.commands.executeCommand(apiKeyCommands.setApiKey);
     return hasAnyUsableSetupCredential();
+  }
+
+  if (picked.id === 'chatgpt') {
+    await vscode.commands.executeCommand('texra.showModels');
+    void vscode.window.showInformationMessage(
+      'Sign in with ChatGPT in the Models tab, then run the setup assistant again.',
+    );
+    return false;
   }
 
   // walkthrough
@@ -301,7 +327,7 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
     const proceed = await ensureCredentialOrPrompt();
     if (!proceed) {
       void vscode.window.showInformationMessage(
-        'Setup assistant cancelled. Run `TeXRA: Run Setup Assistant` again once you have signed in or set an API key.',
+        'Setup assistant cancelled. Run `TeXRA: Run Setup Assistant` again once you have signed in, enabled ChatGPT subscription, or set an API key.',
       );
       return 'not-started';
     }
@@ -319,15 +345,15 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
       // setup-model candidate, and no direct/OR keys to fall back on.
       // Refuse launch rather than pick a model that crashes at runtime.
       const choice = await vscode.window.showWarningMessage(
-        'No model is available for your current credentials and tier. Add a provider API key or upgrade your Researcher Access tier, then retry.',
+        'No model is available for your current credentials and tier. Sign in with ChatGPT for Codex models, add a provider API key, or upgrade your Researcher Access tier, then retry.',
         { modal: true },
-        'Set API key',
         'Open Models tab',
+        'Set API key',
       );
-      if (choice === 'Set API key') {
-        await vscode.commands.executeCommand(apiKeyCommands.setApiKey);
-      } else if (choice === 'Open Models tab') {
+      if (choice === 'Open Models tab') {
         await vscode.commands.executeCommand('texra.showModels');
+      } else if (choice === 'Set API key') {
+        await vscode.commands.executeCommand(apiKeyCommands.setApiKey);
       }
       return 'not-started';
     }

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -265,7 +265,7 @@ export class ProviderKeyList extends LitElement {
     const description =
       this.apiAccessMode === 'included'
         ? 'You are using included access. Personal keys below are optional overrides.'
-        : 'Chat subscriptions (ChatGPT Plus, Claude Pro, etc.) do not include API access\u2014you need a key from the provider\u2019s developer platform.';
+        : 'Except for Codex models through the ChatGPT subscription section above, chat subscriptions do not include API access - use a key from the provider developer platform.';
 
     return html`
       <div class="provider-keys-section">

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -103,9 +103,12 @@ export class ModelsTab extends LitElement {
   @property({ type: Boolean }) preferShortModelNames = false;
 
   private scrollToSection(
-    tagName: 'api-access-section' | 'provider-key-list',
+    selector:
+      | 'api-access-section'
+      | 'provider-key-list'
+      | '#chatgpt-subscription',
   ): void {
-    const el = this.shadowRoot?.querySelector(tagName);
+    const el = this.shadowRoot?.querySelector(selector);
     if (el instanceof HTMLElement) {
       el.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
@@ -117,11 +120,14 @@ export class ModelsTab extends LitElement {
   private readonly handleScrollToApiConfig = (): void =>
     this.scrollToSection('provider-key-list');
 
+  private readonly handleScrollToChatGpt = (): void =>
+    this.scrollToSection('#chatgpt-subscription');
+
   private renderTabHint(): TemplateResult {
     const description =
       this.apiAccessMode === 'included'
-        ? 'Personal provider API keys are optional overrides—configure them in the API Configuration section below.'
-        : 'To use your own keys for OpenAI, Anthropic, Google, and other providers, scroll to the API Configuration section below.';
+        ? 'Use included access, ChatGPT subscription for Codex models, or personal provider API keys.'
+        : 'Use ChatGPT subscription for Codex models, or configure personal API keys for OpenAI, Anthropic, Google, and other providers.';
 
     const accessJump = this.authenticated
       ? html`<wa-button
@@ -138,10 +144,19 @@ export class ModelsTab extends LitElement {
       <div class="settings-reminder">
         ${waIcon('info', { className: 'settings-reminder-icon' })}
         <div class="settings-reminder-body">
-          <div class="settings-reminder-title">API key settings</div>
+          <div class="settings-reminder-title">Model credentials</div>
           <div class="settings-reminder-description">${description}</div>
           <div class="settings-reminder-actions">
             ${accessJump}
+            <wa-button
+              appearance="outlined"
+              variant="neutral"
+              size="small"
+              @click=${this.handleScrollToChatGpt}
+            >
+              ${waIcon('comment-discussion', { slot: 'start' })} ChatGPT
+              Subscription
+            </wa-button>
             <wa-button
               appearance="outlined"
               variant="neutral"
@@ -174,12 +189,12 @@ export class ModelsTab extends LitElement {
     return html`
       <div class="models-container tab-content-container">
         ${this.renderTabHint()} ${apiAccessSection} ${quotaMeter}
+        ${this.renderChatGptSection()}
         <provider-key-list
           .providerKeyStatuses=${this.providerKeyStatuses}
           .apiAccessMode=${this.apiAccessMode}
           .globalStreamingDefault=${this.globalStreamingDefault}
         ></provider-key-list>
-        ${this.renderChatGptSection()}
         <model-selection-list
           .models=${this.modelSelectionItems}
           .helperModel=${this.helperModel}
@@ -204,7 +219,7 @@ export class ModelsTab extends LitElement {
     const account =
       this.chatgptAuth?.email ?? this.chatgptAuth?.accountId ?? 'your account';
     return html`
-      <section class="chatgpt-subscription">
+      <section id="chatgpt-subscription" class="chatgpt-subscription">
         <div class="chatgpt-subscription__header">
           <span class="chatgpt-subscription__title">ChatGPT subscription</span>
           <span class="chatgpt-subscription__badge">experimental</span>

--- a/packages/extension/src/settingsView/handlers/chatgptSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/chatgptSubscriptionHandlers.ts
@@ -84,8 +84,11 @@ export class ChatGptSubscriptionHandlers {
         },
         () => this.runSignIn(),
       );
+      const update = await setPreferCodexSubscription(true);
       void vscode.window.showInformationMessage(
-        `Signed in with ChatGPT as ${session.email ?? session.accountId ?? 'your account'}.`,
+        update.effective
+          ? `Signed in with ChatGPT as ${session.email ?? session.accountId ?? 'your account'}. ChatGPT subscription is enabled for Codex models.`
+          : `Signed in with ChatGPT as ${session.email ?? session.accountId ?? 'your account'}, but a more specific setting kept the subscription preference disabled.`,
       );
       await this.refreshChatGptState();
     } catch (error) {

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1441,9 +1441,13 @@ export class MainApp extends MainAppBase {
   }
 
   // Welcome-card choices reuse the existing host flows: sign-in reuses
-  // handleComponentSignIn (SIGN_IN_FROM_BANNER → texra.auth.signIn), API key
-  // invokes texra.setApiKey (OPEN_SET_API_KEY); only skip is onboarding-specific
-  // (declined flag).
+  // handleComponentSignIn (SIGN_IN_FROM_BANNER -> texra.auth.signIn), ChatGPT
+  // opens Models, API key invokes texra.setApiKey (OPEN_SET_API_KEY); only skip
+  // is onboarding-specific (declined flag).
+  private handleWelcomeChatGpt(): void {
+    postMessage(MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS);
+  }
+
   private handleWelcomeApiKey(): void {
     postMessage(MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY);
   }
@@ -1732,6 +1736,7 @@ export class MainApp extends MainAppBase {
           <div class="main-content">
             <onboarding-welcome-card
               @welcome-sign-in=${this.handleComponentSignIn}
+              @welcome-chatgpt=${this.handleWelcomeChatGpt}
               @welcome-api-key=${this.handleWelcomeApiKey}
               @welcome-skip=${this.handleWelcomeSkip}
             ></onboarding-welcome-card>

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -67,9 +67,9 @@ export class ApiKeyBanner extends LitElement {
           </wa-button>
         </div>
         <span class="hint">
-          Chat subscriptions (ChatGPT Plus, Claude Pro, etc.) do not include API
-          access. You need a separate API key from the provider's developer
-          platform.
+          Except for Codex models through ChatGPT subscription, chat
+          subscriptions do not include API access. Use a provider developer key
+          for other models.
         </span>
       `,
     });

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -9,6 +9,7 @@ import { waIcon } from '@shared/wa/webAwesomeIcons';
 import {
   ONBOARDING_CARD_TITLE,
   ONBOARDING_CHOICE_API_KEY,
+  ONBOARDING_CHOICE_CHATGPT,
   ONBOARDING_CHOICE_SIGN_IN,
   ONBOARDING_CHOICE_SKIP_LABEL,
 } from '@shared/copy/onboarding';
@@ -18,9 +19,11 @@ import { MainViewEvents } from '../events';
 /**
  * State 0 welcome card (PRD: agent-native onboarding) — a port of the CLI
  * first-run picker, not a new design: sign-in recommended first, provider
- * API key second, a quiet "Skip for now" link last. Stateless: renders the
+ * ChatGPT/API key alternatives, and a quiet "Skip for now" link last.
+ * Stateless: renders the
  * shared onboarding copy verbatim and emits `welcome-sign-in` /
- * `welcome-api-key` / `welcome-skip`; the host owns the funnel state.
+ * `welcome-chatgpt` / `welcome-api-key` / `welcome-skip`; the host owns the
+ * funnel state.
  */
 @customElement('onboarding-welcome-card')
 export class OnboardingWelcomeCard extends LitElement {
@@ -92,6 +95,10 @@ export class OnboardingWelcomeCard extends LitElement {
     this.dispatchEvent(MainViewEvents.welcomeApiKey());
   }
 
+  private handleChatGpt(): void {
+    this.dispatchEvent(MainViewEvents.welcomeChatGpt());
+  }
+
   private handleSkip(): void {
     this.dispatchEvent(MainViewEvents.welcomeSkip());
   }
@@ -113,6 +120,18 @@ export class OnboardingWelcomeCard extends LitElement {
             </wa-button>
             <span class="choice-description">
               ${ONBOARDING_CHOICE_SIGN_IN.description}
+            </span>
+          </div>
+          <div class="choice">
+            <wa-button
+              id="onboardingChatGptButton"
+              appearance="outlined"
+              @click=${this.handleChatGpt}
+            >
+              ${waIcon('comment-discussion')} ${ONBOARDING_CHOICE_CHATGPT.label}
+            </wa-button>
+            <span class="choice-description">
+              ${ONBOARDING_CHOICE_CHATGPT.description}
             </span>
           </div>
           <div class="choice">

--- a/packages/extension/src/webview/frontend/events.ts
+++ b/packages/extension/src/webview/frontend/events.ts
@@ -88,6 +88,8 @@ export const MainViewEvents = {
   // Onboarding welcome card events (State 0 of the onboarding funnel)
   welcomeSignIn: () => createEvent('welcome-sign-in', undefined),
 
+  welcomeChatGpt: () => createEvent('welcome-chatgpt', undefined),
+
   welcomeApiKey: () => createEvent('welcome-api-key', undefined),
 
   welcomeSkip: () => createEvent('welcome-skip', undefined),

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -17,7 +17,10 @@
       "Education",
       "Data Science"
     ],
-    "activationEvents": ["onStartupFinished", "onColorTheme"],
+    "activationEvents": [
+      "onStartupFinished",
+      "onColorTheme"
+    ],
     "main": "./dist/extension.js",
     "capabilities": {
       "untrustedWorkspaces": {
@@ -655,7 +658,10 @@
               "type": "array"
             },
             "texra.files.included.editedExtensions": {
-              "default": [".txt", ".tex"],
+              "default": [
+                ".txt",
+                ".tex"
+              ],
               "description": "File extensions to include when searching for edited files",
               "editPresentation": "multilineText",
               "items": {
@@ -665,7 +671,11 @@
               "type": "array"
             },
             "texra.files.included.inputExtensions": {
-              "default": [".txt", ".tex", ".md"],
+              "default": [
+                ".txt",
+                ".tex",
+                ".md"
+              ],
               "description": "File extensions to include when searching for input files",
               "editPresentation": "multilineText",
               "items": {
@@ -893,7 +903,10 @@
             "texra.latexdiff.tempFileLocation": {
               "default": "sameDirectory",
               "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
-              "enum": ["sameDirectory", "workspaceTemp"],
+              "enum": [
+                "sameDirectory",
+                "workspaceTemp"
+              ],
               "enumDescriptions": [
                 "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
                 "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
@@ -929,7 +942,10 @@
             "texra.agentReview.approach": {
               "default": "quick",
               "description": "Choose between quick or more thorough, higher-cost analysis.",
-              "enum": ["quick", "thorough"],
+              "enum": [
+                "quick",
+                "thorough"
+              ],
               "enumDescriptions": [
                 "The reviewer verifies only its strongest suspicions with tools — fast and cheap.",
                 "The reviewer reads every changed file in full, checks callers, and pulls diagnostics before reporting — deeper, higher-cost analysis."
@@ -1533,24 +1549,27 @@
       ],
       "walkthroughs": [
         {
-          "description": "Sign in or add a key, let the setup assistant run your first polish, then meet the orchestrator. Setup is the doorman, polish is the demo, the orchestrator is the habit.",
+          "description": "Choose a credential, let the setup assistant run your first polish, then meet the orchestrator. Setup is the doorman, polish is the demo, the orchestrator is the habit.",
           "id": "texra.gettingStarted",
           "steps": [
             {
               "completionEvents": [
                 "onCommand:texra.auth.signIn",
+                "onCommand:texra.showModels",
                 "onCommand:texra.setApiKey"
               ],
-              "description": "A credential is the one step no agent can do for you. Two ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Heads up: chat subscriptions (ChatGPT Plus, Claude Pro) don't come with API access.\n\n[Set API key](command:texra.setApiKey)",
+              "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Open Models & ChatGPT](command:texra.showModels)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
               "id": "texra.gettingStarted.signIn",
               "media": {
-                "altText": "Screenshot of the API key configuration view",
+                "altText": "Screenshot of the model credential configuration view",
                 "image": "resources/walkthroughs/media/api-key-setup.png"
               },
-              "title": "Sign in — free for academics — or add a key"
+              "title": "Choose how TeXRA should sign in"
             },
             {
-              "completionEvents": ["onCommand:texra.runSetupAssistant"],
+              "completionEvents": [
+                "onCommand:texra.runSetupAssistant"
+              ],
               "description": "One conversation covers the rest. The setup assistant checks your environment and installs any missing LaTeX tools, asks what you're working on and applies the matching team, then runs your first polish -- ending at a diff so you can see every change. It asks before every command and explains what it's about to do; you stay in control.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The manual steps below walk the same loop.",
               "id": "texra.gettingStarted.setupAssistant",
               "media": {
@@ -1559,7 +1578,9 @@
               "title": "The setup assistant takes it from here"
             },
             {
-              "completionEvents": ["onCommand:texra.showMultiAgent"],
+              "completionEvents": [
+                "onCommand:texra.showMultiAgent"
+              ],
               "description": "After setup, the **orchestrator** is the habit. You don't pick from 23 agents -- it reads your paper, figures out what needs work, and hands each task to the right agent. You just approve the proposals as they come in.\n\nPick **orchestrator** from the agent dropdown and choose a model -- bigger models give better results, smaller ones are faster and cheaper. On your own API key, start with **assistant** instead; the orchestrator is served through Researcher Access.\n\nTeams give the orchestrator the right tools for your field. The setup assistant applies one for you, or pick one yourself:\n\n[Pick a team](command:texra.showMultiAgent)",
               "id": "texra.gettingStarted.agentModel",
               "media": {
@@ -1569,7 +1590,9 @@
               "title": "Meet the orchestrator"
             },
             {
-              "completionEvents": ["onCommand:texra.createSampleProject"],
+              "completionEvents": [
+                "onCommand:texra.createSampleProject"
+              ],
               "description": "The steps from here mirror what the setup assistant does, for when you'd rather drive yourself.\n\nNot sure where to start? We've bundled a small LaTeX project you can play with.\n\n[Create the sample project](command:texra.createSampleProject)\n\nYou'll get a folder with example `.tex` files and a README that explains the layout.",
               "id": "texra.gettingStarted.sampleWorkspace",
               "media": {
@@ -1578,7 +1601,9 @@
               "title": "Prefer to do it manually? Try the sample project"
             },
             {
-              "completionEvents": ["onCommand:texra.showMainView"],
+              "completionEvents": [
+                "onCommand:texra.showMainView"
+              ],
               "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Context** -- bib/style files, reference papers, or any read-only context (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
               "id": "texra.gettingStarted.stageFiles",
               "media": {
@@ -1601,7 +1626,9 @@
               "title": "Manual path: auto-extract figures (optional)"
             },
             {
-              "completionEvents": ["onCommand:texra.execute"],
+              "completionEvents": [
+                "onCommand:texra.execute"
+              ],
               "description": "You're all set. Click Execute and the orchestrator will start working through your paper.\n\n[Execute](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
               "id": "texra.gettingStarted.progress",
               "media": {

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -17,10 +17,7 @@
       "Education",
       "Data Science"
     ],
-    "activationEvents": [
-      "onStartupFinished",
-      "onColorTheme"
-    ],
+    "activationEvents": ["onStartupFinished", "onColorTheme"],
     "main": "./dist/extension.js",
     "capabilities": {
       "untrustedWorkspaces": {
@@ -658,10 +655,7 @@
               "type": "array"
             },
             "texra.files.included.editedExtensions": {
-              "default": [
-                ".txt",
-                ".tex"
-              ],
+              "default": [".txt", ".tex"],
               "description": "File extensions to include when searching for edited files",
               "editPresentation": "multilineText",
               "items": {
@@ -671,11 +665,7 @@
               "type": "array"
             },
             "texra.files.included.inputExtensions": {
-              "default": [
-                ".txt",
-                ".tex",
-                ".md"
-              ],
+              "default": [".txt", ".tex", ".md"],
               "description": "File extensions to include when searching for input files",
               "editPresentation": "multilineText",
               "items": {
@@ -903,10 +893,7 @@
             "texra.latexdiff.tempFileLocation": {
               "default": "sameDirectory",
               "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
-              "enum": [
-                "sameDirectory",
-                "workspaceTemp"
-              ],
+              "enum": ["sameDirectory", "workspaceTemp"],
               "enumDescriptions": [
                 "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
                 "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
@@ -942,10 +929,7 @@
             "texra.agentReview.approach": {
               "default": "quick",
               "description": "Choose between quick or more thorough, higher-cost analysis.",
-              "enum": [
-                "quick",
-                "thorough"
-              ],
+              "enum": ["quick", "thorough"],
               "enumDescriptions": [
                 "The reviewer verifies only its strongest suspicions with tools — fast and cheap.",
                 "The reviewer reads every changed file in full, checks callers, and pulls diagnostics before reporting — deeper, higher-cost analysis."
@@ -1567,9 +1551,7 @@
               "title": "Choose how TeXRA should sign in"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.runSetupAssistant"
-              ],
+              "completionEvents": ["onCommand:texra.runSetupAssistant"],
               "description": "One conversation covers the rest. The setup assistant checks your environment and installs any missing LaTeX tools, asks what you're working on and applies the matching team, then runs your first polish -- ending at a diff so you can see every change. It asks before every command and explains what it's about to do; you stay in control.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The manual steps below walk the same loop.",
               "id": "texra.gettingStarted.setupAssistant",
               "media": {
@@ -1578,9 +1560,7 @@
               "title": "The setup assistant takes it from here"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.showMultiAgent"
-              ],
+              "completionEvents": ["onCommand:texra.showMultiAgent"],
               "description": "After setup, the **orchestrator** is the habit. You don't pick from 23 agents -- it reads your paper, figures out what needs work, and hands each task to the right agent. You just approve the proposals as they come in.\n\nPick **orchestrator** from the agent dropdown and choose a model -- bigger models give better results, smaller ones are faster and cheaper. On your own API key, start with **assistant** instead; the orchestrator is served through Researcher Access.\n\nTeams give the orchestrator the right tools for your field. The setup assistant applies one for you, or pick one yourself:\n\n[Pick a team](command:texra.showMultiAgent)",
               "id": "texra.gettingStarted.agentModel",
               "media": {
@@ -1590,9 +1570,7 @@
               "title": "Meet the orchestrator"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.createSampleProject"
-              ],
+              "completionEvents": ["onCommand:texra.createSampleProject"],
               "description": "The steps from here mirror what the setup assistant does, for when you'd rather drive yourself.\n\nNot sure where to start? We've bundled a small LaTeX project you can play with.\n\n[Create the sample project](command:texra.createSampleProject)\n\nYou'll get a folder with example `.tex` files and a README that explains the layout.",
               "id": "texra.gettingStarted.sampleWorkspace",
               "media": {
@@ -1601,9 +1579,7 @@
               "title": "Prefer to do it manually? Try the sample project"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.showMainView"
-              ],
+              "completionEvents": ["onCommand:texra.showMainView"],
               "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Context** -- bib/style files, reference papers, or any read-only context (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
               "id": "texra.gettingStarted.stageFiles",
               "media": {
@@ -1626,9 +1602,7 @@
               "title": "Manual path: auto-extract figures (optional)"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.execute"
-              ],
+              "completionEvents": ["onCommand:texra.execute"],
               "description": "You're all set. Click Execute and the orchestrator will start working through your paper.\n\n[Execute](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
               "id": "texra.gettingStarted.progress",
               "media": {

--- a/src/shared/copy/onboarding.ts
+++ b/src/shared/copy/onboarding.ts
@@ -18,12 +18,18 @@ export const ONBOARDING_CHOICE_SIGN_IN = {
 } as const;
 
 /** State 0 choice 2. */
+export const ONBOARDING_CHOICE_CHATGPT = {
+  label: 'Use ChatGPT subscription',
+  description: 'Codex models through your ChatGPT plan',
+} as const;
+
+/** State 0 choice 3. */
 export const ONBOARDING_CHOICE_API_KEY = {
   label: 'Use your own provider API key',
   description: 'Anthropic, OpenAI, Google, and more',
 } as const;
 
-/** State 0 choice 3 — quiet link, persists the shared declined flag. */
+/** State 0 choice 4 - quiet link, persists the shared declined flag. */
 export const ONBOARDING_CHOICE_SKIP_LABEL = 'Skip for now';
 
 /**

--- a/src/test-kernel/cli/LoginArgs.vitest.mts
+++ b/src/test-kernel/cli/LoginArgs.vitest.mts
@@ -86,6 +86,7 @@ describe('CLI login arguments (texra login)', () => {
 
   it('parses in-chat login slash command options through the same runtime owner', () => {
     expect(parseChatLoginSlashArgs('')).toEqual({
+      target: 'texra',
       provider: 'github',
       noBrowser: false,
       device: false,
@@ -95,6 +96,7 @@ describe('CLI login arguments (texra login)', () => {
     expect(
       parseChatLoginSlashArgs('google --no-browser --select-account'),
     ).toEqual({
+      target: 'texra',
       provider: 'google',
       noBrowser: true,
       device: false,
@@ -102,6 +104,7 @@ describe('CLI login arguments (texra login)', () => {
       loginHint: undefined,
     });
     expect(parseChatLoginSlashArgs('--login-hint user@example.edu')).toEqual({
+      target: 'texra',
       provider: 'github',
       noBrowser: false,
       device: false,
@@ -109,13 +112,38 @@ describe('CLI login arguments (texra login)', () => {
       loginHint: 'user@example.edu',
     });
     expect(parseChatLoginSlashArgs('github --login-hint=octocat')).toEqual({
+      target: 'texra',
       provider: 'github',
       noBrowser: false,
       device: false,
       selectAccount: false,
       loginHint: 'octocat',
     });
+    expect(parseChatLoginSlashArgs('texra github --device')).toEqual({
+      target: 'texra',
+      provider: 'github',
+      noBrowser: false,
+      device: true,
+      selectAccount: false,
+      loginHint: undefined,
+    });
+    expect(parseChatLoginSlashArgs('chatgpt')).toEqual({
+      target: 'chatgpt',
+      noBrowser: false,
+      device: false,
+    });
+    expect(parseChatLoginSlashArgs('chatgpt --device')).toEqual({
+      target: 'chatgpt',
+      noBrowser: false,
+      device: true,
+    });
+    expect(parseChatLoginSlashArgs('codex --no-browser')).toEqual({
+      target: 'chatgpt',
+      noBrowser: true,
+      device: false,
+    });
     expect(parseChatLoginSlashArgs('--device')).toMatchObject({
+      target: 'texra',
       device: true,
       noBrowser: false,
     });
@@ -124,6 +152,11 @@ describe('CLI login arguments (texra login)', () => {
   it('rejects invalid in-chat login slash command options', () => {
     expect(parseChatLoginSlashArgs('slack')).toBeUndefined();
     expect(parseChatLoginSlashArgs('github google')).toBeUndefined();
+    expect(parseChatLoginSlashArgs('chatgpt github')).toBeUndefined();
+    expect(parseChatLoginSlashArgs('chatgpt --select-account')).toBeUndefined();
+    expect(
+      parseChatLoginSlashArgs('chatgpt --login-hint user@example.edu'),
+    ).toBeUndefined();
     expect(parseChatLoginSlashArgs('--login-hint')).toBeUndefined();
     expect(
       parseChatLoginSlashArgs('--login-hint --no-browser'),

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -77,6 +77,18 @@ describe('handleTuiSlashCommand', () => {
     expect(cliState.activeForm.get()?.commandName).toBe('model');
   });
 
+  it('opens the login form for bare /login', async () => {
+    registerBuiltinSlashCommands();
+
+    const handled = await handleTuiSlashCommand(
+      '/login',
+      createContext(createSession()),
+    );
+
+    expect(handled).toBe(true);
+    expect(cliState.activeForm.get()?.commandName).toBe('login');
+  });
+
   it('treats /quit as the canonical exit command without echoing it', async () => {
     registerBuiltinSlashCommands();
     const session = createSession();

--- a/src/test-kernel/cli/SlashHelpText.vitest.mts
+++ b/src/test-kernel/cli/SlashHelpText.vitest.mts
@@ -39,6 +39,9 @@ describe('formatSlashCommandHelp', () => {
     );
     expect(help).toContain('- `/exit` (`/quit`) — Exit the CLI session');
     expect(help).toContain('- `/model` (`/models`) — List available models');
+    expect(help).toContain(
+      '- `/login` — Sign in to TeXRA or ChatGPT subscription',
+    );
   });
 
   it('collects uncategorized commands under a trailing Other section', () => {

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -136,6 +136,12 @@ describe('slashRegistry', () => {
         formComponent: expect.any(Function),
       }),
     );
+    expect(listSlashCommands().find((cmd) => cmd.name === 'login')).toEqual(
+      expect.objectContaining({
+        description: 'Sign in to TeXRA or ChatGPT subscription',
+        formComponent: expect.any(Function),
+      }),
+    );
     expect(listSlashCommands().find((cmd) => cmd.name === 'compact')).toEqual(
       expect.objectContaining({
         description: 'Request context compaction',
@@ -450,6 +456,37 @@ describe('slashRegistry', () => {
     await settleFormSelection();
 
     expect(apiNode.isClosed()).toBe(true);
+  });
+
+  it('closes the login picker before running the selected login path', async () => {
+    const selected: string[] = [];
+    let closed = false;
+    let sawClosedBeforeLogin = false;
+    registerBuiltinSlashCommands({
+      onLoginSelect: (value) => {
+        sawClosedBeforeLogin = closed;
+        selected.push(value);
+      },
+    });
+    const login = listSlashCommands().find((cmd) => cmd.name === 'login');
+
+    if (!login) throw new Error('Expected /login to be registered');
+
+    expect(openRegisteredCliSlashForm(login, '')).toBe(true);
+
+    const loginNode = renderFormAdapter<{
+      onSelect?: (value: string) => void;
+    }>(
+      cliState.activeForm.get()?.render(() => {
+        closed = true;
+      }, 20),
+    );
+    loginNode.props?.onSelect?.('chatgpt');
+    await settleFormSelection();
+
+    expect(selected).toEqual(['chatgpt']);
+    expect(closed).toBe(true);
+    expect(sawClosedBeforeLogin).toBe(true);
   });
 
   it('closes the approval policy picker before applying the new policy', async () => {


### PR DESCRIPTION
## Summary
- Make `/login` a structured TUI form with TeXRA included access and ChatGPT subscription side by side.
- Reuse a shared CLI ChatGPT login helper and enable the Codex subscription preference after ChatGPT sign-in.
- Add ChatGPT subscription as a first-class extension onboarding credential path across the welcome card, walkthrough, setup assistant, and Models tab.

Closes #6452

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/LoginArgs.vitest.mts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/SlashHelpText.vitest.mts src/test-kernel/cli/SlashCommandDispatch.vitest.mts src/test-kernel/settings/SettingsReliabilityPlacement.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-chatgpt-onboarding-review-1782084809 narrow-slash-palette-command-names slash-palette-overflow login-form`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm test`
- Manual GitHub CI run 27920782437 passed before review-cleanup amend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication entry points and auto-enables subscription preferences after ChatGPT sign-in, but behavior is covered by CLI/TUI tests and mostly reuses existing auth helpers.
> 
> **Overview**
> Surfaces **ChatGPT subscription** as a first-class credential alongside TeXRA included access and personal API keys, in both the CLI TUI and the VS Code extension onboarding.
> 
> **CLI:** Bare `/login` opens a structured picker (TeXRA included, ChatGPT subscription, and device-code variants). `/login chatgpt` (and aliases) runs ChatGPT sign-in via a shared `signInCliChatGpt` helper; successful ChatGPT login **turns on** the Codex subscription preference, refreshes model options, and reports whether the preference actually took effect. `texra auth chatgpt login` uses the same helper and behavior. `/subscription` messaging now points users to `/login chatgpt` instead of separate auth CLI commands.
> 
> **Extension:** Welcome card, walkthrough, setup assistant preflight, Models tab copy, and related UI add a **ChatGPT subscription** path (Models tab sign-in); setup can treat an active Codex subscription as a usable credential for launch. Extension ChatGPT sign-in also enables the subscription preference when possible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd04cf7fd33d0d2fdedb3a4d25a6e9338a29a4e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->