### PR TITLE
fix: refresh onboarding after ChatGPT sign-in

### DIFF
--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -195,9 +195,9 @@ async function withOpenRouterFlagOn<T>(fn: () => Promise<T>): Promise<T> {
  * report a blank `PROVIDER_API_KEY=""` env var as present, which then
  * fails in `resolveLaunchModel` with a confusing "No model is available"
  * modal. `hasAnyUsableSetupCredential()` mirrors the adapter-level check:
- * at least one provider with a non-blank key, or valid server-side
- * access. Keeps preflight and launch agreed on what "has a credential"
- * means.
+ * active ChatGPT subscription for Codex, at least one provider with a
+ * non-blank key, or valid server-side access. Keeps preflight and launch
+ * agreed on what "has a credential" means.
  */
 export async function hasAnyUsableSetupCredential(): Promise<boolean> {
   if (await isCodexSubscriptionActive(API_KEY_MODEL_BY_PROVIDER.openai)) {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -129,15 +129,14 @@ async function refreshApiKeyStatus() {
     return;
   }
 
-  // `anyApiKeyExists()` already falls back to `canUseServerSideKeys()`
-  // internally. Don't catch here: a transient probe failure shouldn't
-  // regress a signed-in user to the "Get Started" CTA — let the outer
-  // wrapper log it and leave the pill in its prior state.
-  const exists = await SecretManager.anyApiKeyExists();
+  // Use the same credential predicate as the setup assistant and onboarding
+  // funnel. This keeps ChatGPT subscription, Researcher Access, and direct API
+  // keys in agreement about whether the first-run CTA should remain visible.
+  const exists = await hasAnyUsableSetupCredential();
   if (!exists) {
     apiKeyStatusBarItem.text = '$(rocket) TeXRA: Get Started';
     apiKeyStatusBarItem.tooltip =
-      'Click to run the setup assistant — sign in for free or add an API key';
+      'Click to run the setup assistant — sign in, use ChatGPT, or add an API key';
     apiKeyStatusBarItem.command = 'texra.runSetupAssistant';
     apiKeyStatusBarItem.show();
   } else {
@@ -502,20 +501,10 @@ export async function activate(context: vscode.ExtensionContext) {
         );
         return stored !== undefined;
       },
-      anyApiKeyExists: async () => {
-        // Shared SecretManager.anyApiKeyExists reports true for
-        // PROVIDER_API_KEY="" — a common stale-env case. For setup
-        // tools (probe/verify) and setup-launch preflight, "any key
-        // present" must mean "launchable", so require at least one
-        // provider with a non-blank key (or server-side access).
-        const usable = await Promise.all(
-          SecretManager.API_PROVIDERS.map((p) =>
-            SecretManager.hasUsableApiKey(p),
-          ),
-        );
-        if (usable.some(Boolean)) return true;
-        return getServerSideKeyService().canUseServerSideKeys();
-      },
+      // Historical adapter name; setup tools treat this as "any usable model
+      // credential" so ChatGPT subscription, Researcher Access, and non-blank
+      // direct keys stay in sync with setup launch and onboarding.
+      anyApiKeyExists: () => hasAnyUsableSetupCredential(),
       gitHubTokenExists: () => SecretManager.gitHubTokenExists(),
     },
     commands: {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -955,6 +955,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async refreshAfterChatGptAuthChange(): Promise<void> {
     invalidateModelOptionsCache();
     await Promise.all([
+      // ChatGPT subscription is now a setup credential, so reuse the same
+      // host refresh path as API-key changes to update the welcome card.
+      vscode.commands.executeCommand('texra.refreshApiKeyStatus'),
       vscode.commands.executeCommand('texra.refreshAllOptions'),
       this.withActiveWebview((w) => this.sendModelSelectionData(w)),
     ]);

--- a/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
+++ b/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
@@ -1,0 +1,49 @@
+// Third-party imports
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+
+// Local imports
+import { ProbeEnvironmentTool } from '@tools/setup/ProbeEnvironmentTool';
+import { VerifySetupTool } from '@tools/setup/VerifySetupTool';
+import { setSetupPlatform } from '@tools/setup/platform';
+
+// Local file imports
+import { createFakeSetupPlatform } from './fixtures';
+
+function installChatGptOnlySetupPlatform(): void {
+  const platform = createFakeSetupPlatform();
+  setSetupPlatform({
+    ...platform,
+    secrets: {
+      ...platform.secrets,
+      async anyApiKeyExists() {
+        return true;
+      },
+    },
+  });
+}
+
+describe('setup credential reporting', () => {
+  it('reports a usable non-API-key credential in the environment probe headline', async () => {
+    installChatGptOnlySetupPlatform();
+
+    const result = await new ProbeEnvironmentTool().call({});
+
+    assert.ok(!result.isError, result.output);
+    assert.match(result.output ?? '', /credentials: usable credential/);
+    assert.match(result.output ?? '', /"hasAnyUsableCredential": true/);
+    assert.match(result.output ?? '', /"anyApiKeySet": false/);
+  });
+
+  it('reports a usable non-API-key credential in setup verification', async () => {
+    installChatGptOnlySetupPlatform();
+
+    const result = await new VerifySetupTool().call({});
+
+    assert.ok(!result.isError, result.output);
+    assert.match(
+      result.output ?? '',
+      /Credentials: usable model credential available\./,
+    );
+  });
+});

--- a/src/tools/setup/ProbeEnvironmentTool.ts
+++ b/src/tools/setup/ProbeEnvironmentTool.ts
@@ -84,7 +84,7 @@ export class ProbeEnvironmentTool extends defineTool({
         ),
         platform.secrets.anyApiKeyExists().catch((err) => {
           throw new ToolError(
-            `Failed to probe API key status: ${toErrorMessage(err)}`,
+            `Failed to probe credential status: ${toErrorMessage(err)}`,
             { cause: err },
           );
         }),
@@ -132,9 +132,9 @@ export class ProbeEnvironmentTool extends defineTool({
         // misled credential planning.
         anyApiKeySet: apiKeys.some((k) => k.hasKey),
         // `hasAnyUsableCredential` is the broader "can setup launch a
-        // model right now" signal — direct key OR server-side
-        // Researcher Access. Kept as a separate field so the agent
-        // can reason about the two independently.
+        // model right now" signal — direct key, ChatGPT subscription,
+        // or server-side Researcher Access. Kept as a separate field
+        // so the agent can reason about API keys separately.
         hasAnyUsableCredential: anyKeySet,
         apiKeys,
         researcherAccess: {
@@ -166,6 +166,7 @@ function buildHeadline(summary: {
   latexWorkshop: { installed: boolean };
   credentials: {
     anyApiKeySet: boolean;
+    hasAnyUsableCredential: boolean;
     researcherAccess: { authenticated: boolean };
   };
 }): string {
@@ -184,6 +185,13 @@ function buildHeadline(summary: {
   if (summary.credentials.anyApiKeySet) creds.push('API key set');
   if (summary.credentials.researcherAccess.authenticated)
     creds.push('signed in');
+  if (
+    summary.credentials.hasAnyUsableCredential &&
+    !summary.credentials.anyApiKeySet &&
+    !summary.credentials.researcherAccess.authenticated
+  ) {
+    creds.push('usable credential');
+  }
   parts.push(`credentials: ${creds.length > 0 ? creds.join(' + ') : 'none'}`);
   return parts.join('; ');
 }

--- a/src/tools/setup/VerifySetupTool.ts
+++ b/src/tools/setup/VerifySetupTool.ts
@@ -97,15 +97,13 @@ export class VerifySetupTool extends defineTool({
     lines.push(
       `LaTeX Workshop extension: ${latexWorkshopInstalled ? 'installed' : 'NOT installed'}.`,
     );
-    // `anyKey` (from SecretManager.anyApiKeyExists) is already the
-    // authoritative signal — it covers both direct provider keys and
-    // Researcher Access signed-in users who have Included Access on. A
-    // bare auth.authenticated without usable server-side keys is NOT a
-    // working credential, so we don't let it count toward "ready".
+    // The setup adapter's historical `anyApiKeyExists` name means "any usable
+    // model credential": direct provider key, ChatGPT subscription, or
+    // Researcher Access with Included Access on. A bare auth.authenticated
+    // without usable server-side keys is NOT a working credential, so we don't
+    // let it count toward "ready".
     const credSummary = anyKey
-      ? auth.authenticated
-        ? 'API key or Researcher Access available'
-        : 'API key set'
+      ? 'usable model credential available'
       : auth.authenticated
         ? 'signed in but Included Access is OFF — need an API key or re-enable it'
         : 'NONE — need an API key or sign-in';


### PR DESCRIPTION
## Summary
- refresh the main onboarding funnel after ChatGPT subscription sign-in/sign-out/preference changes from Settings → Models
- route extension setup credential checks through the existing setup credential helper so ChatGPT subscription, Researcher Access, and direct keys agree
- make setup probe/verify copy credential-neutral and add regression coverage for ChatGPT-only credentials

Closes #6455

## Validation
- corepack pnpm exec vitest run src/test-kernel/tools/setup/CredentialReporting.vitest.ts src/test-kernel/tools/setup/ConfigTools.vitest.ts src/test-kernel/controllers/OnboardingFunnel.vitest.ts src/test-kernel/auth/CodexPreference.vitest.ts
- npm run typecheck
- npm run compile:fast
- npm run lint (passes with 4 pre-existing import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral alignment across onboarding UI and setup tools; no new auth or secret-handling logic beyond routing existing checks through one helper.
> 
> **Overview**
> Onboarding and setup now treat an **active ChatGPT (Codex) subscription** the same as Researcher Access and non-blank API keys when deciding whether the user is credentialed.
> 
> The status bar “Get Started” pill, setup platform `anyApiKeyExists` adapter, and related paths call **`hasAnyUsableSetupCredential()`** instead of `SecretManager.anyApiKeyExists()`, so ChatGPT-only users no longer see stale first-run CTAs. **Settings → Models** ChatGPT sign-in/out/preference changes trigger **`texra.refreshApiKeyStatus`** (same as API key changes) so the welcome card updates.
> 
> Setup **`probe_environment`** and **`verify_setup`** use credential-neutral copy; the probe headline can show **“usable credential”** when only a non-API-key path applies. **`CredentialReporting.vitest.ts`** covers ChatGPT-only credential reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e1642e07854d9d42e1d3b51d4ad032b186f48a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->