### PR TITLE
refactor: rename setup credential port

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -501,10 +501,7 @@ export async function activate(context: vscode.ExtensionContext) {
         );
         return stored !== undefined;
       },
-      // Historical adapter name; setup tools treat this as "any usable model
-      // credential" so ChatGPT subscription, Researcher Access, and non-blank
-      // direct keys stay in sync with setup launch and onboarding.
-      anyApiKeyExists: () => hasAnyUsableSetupCredential(),
+      anyUsableCredentialExists: () => hasAnyUsableSetupCredential(),
       gitHubTokenExists: () => SecretManager.gitHubTokenExists(),
     },
     commands: {

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -71,7 +71,7 @@ function setupApiKeyToolPlatform(store: Map<string, string>): void {
       async storedApiKeyExists(provider) {
         return store.has(keyName(provider));
       },
-      async anyApiKeyExists() {
+      async anyUsableCredentialExists() {
         return store.size > 0;
       },
       async gitHubTokenExists() {

--- a/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
+++ b/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
@@ -16,7 +16,7 @@ function installChatGptOnlySetupPlatform(): void {
     ...platform,
     secrets: {
       ...platform.secrets,
-      async anyApiKeyExists() {
+      async anyUsableCredentialExists() {
         return true;
       },
     },

--- a/src/test-kernel/tools/setup/fixtures.ts
+++ b/src/test-kernel/tools/setup/fixtures.ts
@@ -24,7 +24,7 @@ export function createFakeSetupPlatform(
       async storedApiKeyExists() {
         return false;
       },
-      async anyApiKeyExists() {
+      async anyUsableCredentialExists() {
         return false;
       },
       async gitHubTokenExists() {

--- a/src/tools/setup/ProbeEnvironmentTool.ts
+++ b/src/tools/setup/ProbeEnvironmentTool.ts
@@ -47,13 +47,13 @@ async function checkTool(name: string): Promise<ToolStatus> {
  * Read-only probe of the host environment.
  *
  * Returns a single structured JSON document covering OS, PATH, package
- * manager, core TeXRA dependencies, LaTeX Workshop extension, API-key
- * presence, and Researcher Access status. No approval gate — purely
- * read-only, akin to `ls` / `glob`.
+ * manager, core TeXRA dependencies, LaTeX Workshop extension, literal API-key
+ * presence, broader usable credential status, and Researcher Access status.
+ * No approval gate — purely read-only, akin to `ls` / `glob`.
  */
 export class ProbeEnvironmentTool extends defineTool({
   name: 'probe_environment',
-  description: `Probe the host environment and return a structured JSON summary covering OS, shell, PATH, detected package manager (brew/apt/scoop), installation status of TeXRA's core LaTeX dependencies (pdflatex, latexmk, latexindent, perl, gs, gm/magick, texcount, latexdiff), the LaTeX Workshop VS Code extension, per-provider API-key presence (names only — secrets are never read), and Researcher Access sign-in status. Read-only, no approval required. Call this first in any setup session to decide what to do next.`,
+  description: `Probe the host environment and return a structured JSON summary covering OS, shell, PATH, detected package manager (brew/apt/scoop), installation status of TeXRA's core LaTeX dependencies (pdflatex, latexmk, latexindent, perl, gs, gm/magick, texcount, latexdiff), the LaTeX Workshop VS Code extension, per-provider API-key presence (names only — secrets are never read), broader usable credential status, and Researcher Access sign-in status. Read-only, no approval required. Call this first in any setup session to decide what to do next.`,
   schema: ProbeEnvironmentInputSchema,
 }) {
   protected async execute(_input: ProbeInput): Promise<ToolResult> {
@@ -66,33 +66,39 @@ export class ProbeEnvironmentTool extends defineTool({
     const extendedPath = extendEnvPath();
     const pm = detectPackageManager();
 
-    const [coreTools, optionalTools, apiKeys, anyKeySet, auth, githubToken] =
-      await Promise.all([
-        Promise.all(PROBED_CORE_TOOLS.map(checkTool)),
-        Promise.all(OPTIONAL_TOOLS.map(checkTool)),
-        Promise.all(
-          // Use `hasUsableApiKey` so the per-provider report matches
-          // what the setup-launch path considers a working credential —
-          // a stale `PROVIDER_API_KEY=""` env var must not surface as
-          // `hasKey: true` and mislead the agent's credential planning.
-          platform.secrets.providers.map(async (provider) => ({
-            provider,
-            hasKey: await platform.secrets
-              .hasUsableApiKey(provider)
-              .catch(() => false),
-          })),
-        ),
-        platform.secrets.anyApiKeyExists().catch((err) => {
-          throw new ToolError(
-            `Failed to probe credential status: ${toErrorMessage(err)}`,
-            { cause: err },
-          );
-        }),
-        platform.auth.getStatus().catch(() => ({
-          authenticated: false as const,
+    const [
+      coreTools,
+      optionalTools,
+      apiKeys,
+      hasUsableCredential,
+      auth,
+      githubToken,
+    ] = await Promise.all([
+      Promise.all(PROBED_CORE_TOOLS.map(checkTool)),
+      Promise.all(OPTIONAL_TOOLS.map(checkTool)),
+      Promise.all(
+        // Use `hasUsableApiKey` so the per-provider report matches
+        // what the setup-launch path considers a working credential —
+        // a stale `PROVIDER_API_KEY=""` env var must not surface as
+        // `hasKey: true` and mislead the agent's credential planning.
+        platform.secrets.providers.map(async (provider) => ({
+          provider,
+          hasKey: await platform.secrets
+            .hasUsableApiKey(provider)
+            .catch(() => false),
         })),
-        platform.secrets.gitHubTokenExists().catch(() => 'none' as const),
-      ]);
+      ),
+      platform.secrets.anyUsableCredentialExists().catch((err) => {
+        throw new ToolError(
+          `Failed to probe credential status: ${toErrorMessage(err)}`,
+          { cause: err },
+        );
+      }),
+      platform.auth.getStatus().catch(() => ({
+        authenticated: false as const,
+      })),
+      platform.secrets.gitHubTokenExists().catch(() => 'none' as const),
+    ]);
 
     const missingCore = coreTools
       .filter((t) => !t.installed && t.name !== 'gm' && t.name !== 'magick')
@@ -135,7 +141,7 @@ export class ProbeEnvironmentTool extends defineTool({
         // model right now" signal — direct key, ChatGPT subscription,
         // or server-side Researcher Access. Kept as a separate field
         // so the agent can reason about API keys separately.
-        hasAnyUsableCredential: anyKeySet,
+        hasAnyUsableCredential: hasUsableCredential,
         apiKeys,
         researcherAccess: {
           authenticated: auth.authenticated,

--- a/src/tools/setup/VerifySetupTool.ts
+++ b/src/tools/setup/VerifySetupTool.ts
@@ -69,15 +69,16 @@ export class VerifySetupTool extends defineTool({
       };
     }
 
-    const [coreResults, hasMagick, hasGm, anyKey, auth] = await Promise.all([
-      Promise.all(CORE_LATEX_TOOLS.map(isToolPresent)),
-      isToolPresent('magick'),
-      isToolPresent('gm'),
-      platform.secrets.anyApiKeyExists(),
-      platform.auth.getStatus().catch(() => ({
-        authenticated: false as const,
-      })),
-    ]);
+    const [coreResults, hasMagick, hasGm, hasUsableCredential, auth] =
+      await Promise.all([
+        Promise.all(CORE_LATEX_TOOLS.map(isToolPresent)),
+        isToolPresent('magick'),
+        isToolPresent('gm'),
+        platform.secrets.anyUsableCredentialExists(),
+        platform.auth.getStatus().catch(() => ({
+          authenticated: false as const,
+        })),
+      ]);
 
     const missingCore: string[] = CORE_LATEX_TOOLS.filter(
       (_, i) => !coreResults[i],
@@ -97,19 +98,19 @@ export class VerifySetupTool extends defineTool({
     lines.push(
       `LaTeX Workshop extension: ${latexWorkshopInstalled ? 'installed' : 'NOT installed'}.`,
     );
-    // The setup adapter's historical `anyApiKeyExists` name means "any usable
-    // model credential": direct provider key, ChatGPT subscription, or
-    // Researcher Access with Included Access on. A bare auth.authenticated
-    // without usable server-side keys is NOT a working credential, so we don't
-    // let it count toward "ready".
-    const credSummary = anyKey
+    // A usable model credential can be a direct provider key, ChatGPT
+    // subscription, or Researcher Access with Included Access on. A bare
+    // auth.authenticated without usable server-side keys is NOT a working
+    // credential, so we don't let it count toward "ready".
+    const credSummary = hasUsableCredential
       ? 'usable model credential available'
       : auth.authenticated
         ? 'signed in but Included Access is OFF — need an API key or re-enable it'
         : 'NONE — need an API key or sign-in';
     lines.push(`Credentials: ${credSummary}.`);
 
-    const ready = missingCore.length === 0 && latexWorkshopInstalled && anyKey;
+    const ready =
+      missingCore.length === 0 && latexWorkshopInstalled && hasUsableCredential;
 
     return {
       summary: ready

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -34,7 +34,8 @@ export interface SetupSecretsAdapter {
    * `PROVIDER_API_KEY` in the user's shell.
    */
   storedApiKeyExists(provider: ApiProvider): Promise<boolean>;
-  anyApiKeyExists(): Promise<boolean>;
+  /** True when any credential can launch a setup model right now. */
+  anyUsableCredentialExists(): Promise<boolean>;
   gitHubTokenExists(): Promise<'secret' | 'env' | 'none'>;
   /** List of provider names known to TeXRA (matches SecretManager.API_PROVIDERS). */
   providers: readonly ApiProvider[];


### PR DESCRIPTION
## Summary
- rename the setup platform port from `anyApiKeyExists` to `anyUsableCredentialExists`
- update setup probe/verify tooling and fixtures to use credential wording
- keep literal per-provider API-key checks on the existing API-key methods

Closes #6463

## Dogfood
- `texra-local doctor --output-format json` passed overall; included-access check warns that this local shell is not signed in, models and LaTeX tooling passed
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-dogfood-1782086844 slash-goal-help plan-approval-goal plan-approval-approve-goal subagent-picker task-picker approval-form narrow-edit-approval`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-credential-port-1782086985 slash-goal-help plan-approval-goal subagent-picker task-picker approval-form`

## Validation
- `corepack pnpm exec vitest run src/test-kernel/tools/setup/CredentialReporting.vitest.ts src/test-kernel/tools/setup/ConfigTools.vitest.ts src/test-kernel/tools/setup/InvokeCommandTool.vitest.ts src/test-kernel/controllers/OnboardingFunnel.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with 4 pre-existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Naming and adapter refactor only; behavior stays tied to existing `hasAnyUsableSetupCredential` logic.
> 
> **Overview**
> Renames the setup platform secrets adapter from **`anyApiKeyExists`** to **`anyUsableCredentialExists`**, so the name matches behavior: any credential that can launch a setup model (direct API key, ChatGPT subscription, or Researcher Access), not merely “some API key exists.”
> 
> **`ProbeEnvironmentTool`** and **`VerifySetupTool`** call the new method; probe docs and JSON still expose **`anyApiKeySet`** (literal per-provider keys) separately from **`hasAnyUsableCredential`**. The VS Code extension wires **`anyUsableCredentialExists`** to **`hasAnyUsableSetupCredential()`**. Test fixtures and kernel tests follow the rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eacea9f400de328e35a1a5e359481ec3c53e9836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->