### PR TITLE
[codex] expose ChatGPT in onboarding

### DIFF
--- a/docs/guide/first-run.md
+++ b/docs/guide/first-run.md
@@ -19,15 +19,19 @@ on, and runs this same polish demo, ending at the diff. This page is the
 manual mirror of that conversation.
 :::
 
-## Step 0: sign in or add a key
+## Step 0: sign in, use ChatGPT, or add a key
 
-A credential is the one step no agent can do for you. Two ways in:
+A credential is the one step no agent can do for you. Three ways in:
 
 - **Sign in — free for academics** — Researcher Access: no API key
   needed (recommended). In VS Code, run **TeXRA: Sign In** from the
   command palette; in the terminal, run `texra login`.
+- **Use ChatGPT subscription** — Codex models through your ChatGPT plan.
+  In VS Code, open **Settings → Models** and use the ChatGPT subscription
+  sign-in section; in the terminal, run `texra auth chatgpt login`.
 - **Use your own provider API key** — Anthropic, OpenAI, Google, and
-  more. See [Quick start → Sign in or add a key](./quick-start.md#sign-in-or-add-a-key).
+  more. See
+  [Quick start → Sign in, use ChatGPT, or add a key](./quick-start.md#sign-in-use-chatgpt-or-add-a-key).
 
 ## What you'll do
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -145,7 +145,8 @@ Expand a provider's row (click the chevron) to toggle streaming or, for provider
 
 You can also place a `.env` file in your workspace with variables like `OPENAI_API_KEY`. TeXRA loads this automatically so you don't need to enter keys every time.
 
-Prefer not to manage keys at all? Researcher Access is free for academics — no API key needed. See [Quick Start → Sign in or add a key](./quick-start.md#sign-in-or-add-a-key).
+Prefer not to manage keys at all? Researcher Access is free for academics — no API key needed. See
+[Quick Start → Sign in, use ChatGPT, or add a key](./quick-start.md#sign-in-use-chatgpt-or-add-a-key).
 
 ## Customizing the Model List
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -8,7 +8,7 @@ import CliRunHero from '../.vitepress/components/CliRunHero.vue';
 
 You have a paper draft and a deadline. Let's get TeXRA working for you in under five minutes. On a fresh install, the **setup assistant** offers to run this whole loop for you in one conversation; this page is the reference for the Launcher you'll drive every day after.
 
-The whole story in one line: **Setup is the doorman, polish is the demo, the orchestrator is the habit.**
+The shortest path is: choose a credential, run setup once, then let the orchestrator handle the daily paper work.
 
 <QuickStartHero />
 
@@ -24,7 +24,10 @@ TeXRA sits inside VS Code and helps you polish writing, fix errors, create figur
 4. Click Execute
 5. Review the diff
 
-> 💡 **Tip:** Inside VS Code you can open the **Get started with TeXRA** walkthrough from the Get Started page (or by running `TeXRA: Open Getting Started Walkthrough`). It tells the same story in three beats — sign in or add a key, the setup assistant takes it from here, meet the orchestrator — and links directly to the relevant commands.
+> 💡 **Tip:** Inside VS Code you can open the **Get started with TeXRA** walkthrough from the Get Started page
+> (or by running `TeXRA: Open Getting Started Walkthrough`). It tells the same story in three beats — sign in,
+> use ChatGPT, or add a key; the setup assistant takes it from here; meet the orchestrator — and links directly
+> to the relevant commands.
 
 ::: tip Prefer the terminal?
 This guide walks through the VS Code extension. If you installed the
@@ -34,20 +37,29 @@ interactive session with `texra chat`, or run a single agent with
 available.
 :::
 
-## Sign in or add a key
+## Sign in, use ChatGPT, or add a key
 
-A credential is the one step no agent can do for you. On a fresh install, the **Welcome to TeXRA** card in the TeXRA panel offers the same two choices, in the same order:
+A credential is the one step no agent can do for you. On a fresh install, the **Welcome to TeXRA** card in the
+TeXRA panel offers the same three choices, in the same order:
 
-1. **Sign in — free for academics** — Researcher Access: no API key needed (recommended). Run **TeXRA: Sign In** from the Command Palette, or pick the sign-in option on the welcome card. Signing in also unlocks remote agents, including the orchestrator.
-2. **Use your own provider API key** — Anthropic, OpenAI, Google, and more. Open the Dashboard's **Models** tab (the <wa-icon library="texra" name="settings-gear"></wa-icon> gear icon at the top of the TeXRA panel) and set your provider's key in the **API Configuration** table, or place a `.env` file in your workspace with variables like `OPENAI_API_KEY`.
+1. **Sign in — free for academics** — Researcher Access: no API key needed (recommended). Run **TeXRA: Sign In**
+   from the Command Palette, or pick the sign-in option on the welcome card. Signing in also unlocks remote
+   agents, including the orchestrator.
+2. **Use ChatGPT subscription** — Codex models through your ChatGPT plan. Open the Dashboard's **Models** tab
+   (the <wa-icon library="texra" name="settings-gear"></wa-icon> gear icon at the top of the TeXRA panel) and
+   use the **ChatGPT subscription** sign-in section.
+3. **Use your own provider API key** — Anthropic, OpenAI, Google, and more. In the same **Models** tab, set your
+   provider's key in the **API Configuration** table, or place a `.env` file in your workspace with variables
+   like `OPENAI_API_KEY`.
 
 The full per-provider key reference — the API Configuration table, Set / Get / Remove actions, and per-provider toggles — lives in [Models → Setting API Keys](./models.md#setting-api-keys).
 
 Once a credential is in place, the setup assistant takes it from here: one conversation that checks your environment, applies a team for your field, and runs your first polish, ending at a diff. [First run](./first-run.md) is the manual mirror of that conversation.
 
 ::: tip CLI credentials
-The terminal uses the same two paths — `texra login` for included hosted
-access, or provider env vars for your own keys. See
+The terminal uses the same paths — `texra login` for included hosted
+access, `texra auth chatgpt login` for ChatGPT subscription, or provider
+env vars for your own keys. See
 [Authentication](./texra-cli.md#authentication) on the CLI page.
 :::
 

--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -604,6 +604,7 @@ async function validateOrchestrateOnboardingPickers() {
   const truncatedOnboardingLabels = [
     ...oldTruncatedLabels,
     'Sign in — free for acad…',
+    'Use ChatGPT subscription…',
     'Use your own provider A…',
   ];
 
@@ -614,8 +615,10 @@ async function validateOrchestrateOnboardingPickers() {
     expected: [
       'Not signed in, and no provider API key is configured. Choose how to power model calls:',
       'Sign in — free for academics',
+      'Use ChatGPT subscription',
       'Use your own provider API key',
       'Researcher Access: no API key needed (recommended)',
+      'Codex models through your ChatGPT plan',
       'Anthropic, OpenAI, Google, and more',
     ],
     forbidden: truncatedOnboardingLabels,
@@ -625,9 +628,11 @@ async function validateOrchestrateOnboardingPickers() {
     args: ['orchestrate', '--api-mode', 'included'],
     env: { ANTHROPIC_API_KEY: 'texra-validation-fake-key' },
     expected: [
-      'Included relay access needs sign-in for this run:',
+      'Included relay or subscription access needs sign-in for this run:',
       'Sign in — free for academics',
+      'Use ChatGPT subscription',
       'Researcher Access: no API key needed (recommended)',
+      'Codex models through your ChatGPT plan',
     ],
     forbidden: [
       'Use your own provider API key',
@@ -640,8 +645,10 @@ async function validateOrchestrateOnboardingPickers() {
     args: ['orchestrate', '--api-mode', 'personal'],
     env: {},
     expected: [
-      'Personal API-key mode needs a provider key for this run:',
+      'Personal mode needs ChatGPT sign-in or a provider key for this run:',
+      'Use ChatGPT subscription',
       'Use your own provider API key',
+      'Codex models through your ChatGPT plan',
       'Anthropic, OpenAI, Google, and more',
     ],
     forbidden: [

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -61,7 +61,7 @@ export const setupCommand = withUsageSections(
     meta: {
       name: 'setup',
       description:
-        'Guided setup with the setup agent: environment, agent roster, and your first task (sign-in or API key first if needed)',
+        'Guided setup with the setup agent: environment, agent roster, and your first task (sign-in, ChatGPT, or API key first)',
     },
     args: {
       ...INTERACTIVE_GLOBAL_ARGS,
@@ -78,6 +78,7 @@ export const setupCommand = withUsageSections(
       rows: [
         ['texra setup', 'agent-led setup: environment, roster, first task'],
         ['texra login', 'sign in for included relay access (credentials only)'],
+        ['texra auth chatgpt login', 'sign in with a ChatGPT subscription'],
         ['texra auth status', 'show TeXRA sign-in status'],
       ],
     },

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -1,11 +1,12 @@
 // First-run authentication onboarding for the interactive `texra` CLI.
 //
 // Replaces today's dead-end (a launcher full of "login required" models that
-// errors out when the user picks chat) with a 2-choice picker, modeled on
+// errors out when the user picks chat) with a credential picker, modeled on
 // Claude Code / Gemini CLI / aider: the no-key included-relay login is the
-// recommended default when both modes are viable, bring-your-own provider key is
-// second, and skip is explicit. After credentials are set the caller re-reads
-// availability in the SAME process (the relay/key paths invalidate the relevant
+// recommended default when both modes are viable, ChatGPT subscription and
+// bring-your-own provider key are first-class alternatives, and skip is
+// explicit. After credentials are set the caller re-reads availability in the
+// SAME process (the relay/subscription/key paths invalidate the relevant
 // caches), so the launcher/chat continues with real models — no restart.
 //
 // TTY-only: the gate returns immediately in headless / non-TTY / dumb-terminal
@@ -24,10 +25,12 @@ import {
   setOnboardingDeclined,
 } from '@controllers/onboarding/onboardingFunnel';
 import { listExecutions } from '@agent/storage';
+import { setPreferCodexSubscription, type CodexSession } from '@auth/codex';
 import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
 import { type OAuthProvider } from '@auth/sharedConfig';
 import { type SupabaseSession } from '@auth/SupabaseSession';
 import { toErrorMessage } from '@common/errors/errorMessage';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -35,6 +38,7 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
   ONBOARDING_CARD_TITLE,
   ONBOARDING_CHOICE_API_KEY,
+  ONBOARDING_CHOICE_CHATGPT,
   ONBOARDING_CHOICE_SIGN_IN,
   ONBOARDING_CHOICE_SKIP_LABEL,
 } from '@shared/copy/onboarding';
@@ -45,6 +49,7 @@ import { clearTerminalVisibleScreen } from '../chat/tui/terminalCleanup';
 import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { Select, type SelectItem } from '../chat/tui/ui/Select';
 import { type CliApiMode } from '../runtime/apiAccessMode';
+import { chatGptAccountLabel, signInCliChatGpt } from '../runtime/chatgptLogin';
 import { hasCliCredentialForApiMode } from '../runtime/credentialStatus';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
 import { CLI_OAUTH_PROVIDER_ITEMS } from '../runtime/oauthProviderDisplay';
@@ -257,6 +262,7 @@ type Screen =
   | 'relay-provider'
   | 'relay-progress'
   | 'relay-device-progress'
+  | 'chatgpt-progress'
   | 'key-provider'
   | 'key-entry';
 
@@ -289,9 +295,14 @@ function OnboardingApp(props: OnboardingAppProps): React.JSX.Element {
       <PickerStep
         subtitle={props.pickerSubtitle}
         items={props.pickerItems}
+        error={error}
         onRelay={() => {
           setError(undefined);
           setScreen('relay-provider');
+        }}
+        onChatGpt={() => {
+          setError(undefined);
+          setScreen('chatgpt-progress');
         }}
         onKey={() => {
           setError(undefined);
@@ -340,6 +351,28 @@ function OnboardingApp(props: OnboardingAppProps): React.JSX.Element {
       <RelayProgressStep
         provider={relayProvider}
         noBrowser={noBrowser}
+        onSuccess={onSuccess}
+        onError={onError}
+      />
+    );
+  }
+
+  if (screen === 'chatgpt-progress') {
+    const onSuccess = (session: CodexSession): void => {
+      const label = chatGptAccountLabel(session);
+      finish({
+        configured: true,
+        declined: false,
+        summary: `Signed in with ChatGPT as ${label}. ChatGPT subscription enabled for Codex models.`,
+      });
+    };
+    const onError = (message: string): void => {
+      setError(message);
+      setScreen('picker');
+    };
+    return (
+      <ChatGptProgressStep
+        device={isLikelyRemoteSession()}
         onSuccess={onSuccess}
         onError={onError}
       />
@@ -429,18 +462,18 @@ function onboardingPickerSubtitle(props: {
   readonly apiMode?: CliApiMode;
 }): string {
   if (!props.firstRun) {
-    return 'Choose how to power model calls — sign in, or add a provider API key:';
+    return 'Choose how to power model calls — sign in, use ChatGPT, or add a provider API key:';
   }
   if (props.apiMode === 'included') {
-    return 'Included relay access needs sign-in for this run:';
+    return 'Included relay or subscription access needs sign-in for this run:';
   }
   if (props.apiMode === 'personal') {
-    return 'Personal API-key mode needs a provider key for this run:';
+    return 'Personal mode needs ChatGPT sign-in or a provider key for this run:';
   }
   return 'Not signed in, and no provider API key is configured. Choose how to power model calls:';
 }
 
-type OnboardingChoice = 'relay' | 'key' | 'skip';
+type OnboardingChoice = 'relay' | 'chatgpt' | 'key' | 'skip';
 type OnboardingSetupPath = Exclude<OnboardingChoice, 'skip'>;
 type OnboardingPickerItem = SelectItem<OnboardingChoice>;
 
@@ -456,6 +489,12 @@ const KEY_PICKER_ITEM: OnboardingPickerItem = {
   description: ONBOARDING_CHOICE_API_KEY.description,
 };
 
+const CHATGPT_PICKER_ITEM: OnboardingPickerItem = {
+  value: 'chatgpt',
+  label: ONBOARDING_CHOICE_CHATGPT.label,
+  description: ONBOARDING_CHOICE_CHATGPT.description,
+};
+
 const SKIP_PICKER_ITEM: OnboardingPickerItem = {
   value: 'skip',
   label: ONBOARDING_CHOICE_SKIP_LABEL,
@@ -466,27 +505,36 @@ function onboardingSetupPaths(props: {
   readonly firstRun: boolean;
   readonly apiMode?: CliApiMode;
 }): readonly OnboardingSetupPath[] {
-  if (!props.firstRun) return ['relay', 'key'];
-  if (props.apiMode === 'included') return ['relay'];
-  if (props.apiMode === 'personal') return ['key'];
-  return ['relay', 'key'];
+  if (!props.firstRun) return ['relay', 'chatgpt', 'key'];
+  if (props.apiMode === 'included') return ['relay', 'chatgpt'];
+  if (props.apiMode === 'personal') return ['chatgpt', 'key'];
+  return ['relay', 'chatgpt', 'key'];
 }
 
 function onboardingPickerItems(
   setupPaths: readonly OnboardingSetupPath[],
 ): readonly OnboardingPickerItem[] {
-  return [
-    ...setupPaths.map((path) =>
-      path === 'relay' ? RELAY_PICKER_ITEM : KEY_PICKER_ITEM,
-    ),
-    SKIP_PICKER_ITEM,
-  ];
+  return [...setupPaths.map(onboardingPickerItem), SKIP_PICKER_ITEM];
+}
+
+function onboardingPickerItem(path: OnboardingSetupPath): OnboardingPickerItem {
+  switch (path) {
+    case 'relay':
+      return RELAY_PICKER_ITEM;
+    case 'chatgpt':
+      return CHATGPT_PICKER_ITEM;
+    case 'key':
+      return KEY_PICKER_ITEM;
+  }
+  return assertNever(path, 'Unhandled onboarding setup path');
 }
 
 function PickerStep(props: {
   readonly subtitle: string;
   readonly items: readonly OnboardingPickerItem[];
+  readonly error?: string;
   readonly onRelay: () => void;
+  readonly onChatGpt: () => void;
   readonly onKey: () => void;
   readonly onSkip: () => void;
 }): React.JSX.Element {
@@ -494,6 +542,7 @@ function PickerStep(props: {
     <OnboardingFrame
       title={ONBOARDING_CARD_TITLE}
       subtitle={props.subtitle}
+      error={props.error}
       hints={[
         { key: '↑/↓', action: 'navigate' },
         { key: `1-${props.items.length}/Enter`, action: 'select' },
@@ -505,6 +554,7 @@ function PickerStep(props: {
         labelMaxCols={ONBOARDING_SELECT_LABEL_MAX_COLS}
         onSelect={(value) => {
           if (value === 'relay') props.onRelay();
+          else if (value === 'chatgpt') props.onChatGpt();
           else if (value === 'key') props.onKey();
           else props.onSkip();
         }}
@@ -596,6 +646,7 @@ function useSignInOnMount(
 }
 
 function RelayProgressFrame(props: {
+  readonly title?: string;
   readonly spinnerLabel: string;
   readonly children: React.ReactNode;
 }): React.JSX.Element {
@@ -607,7 +658,7 @@ function RelayProgressFrame(props: {
       paddingX={1}
     >
       <Text bold color="cyan">
-        Sign in · included relay
+        {props.title ?? 'Sign in · included relay'}
       </Text>
       <Box marginTop={1} flexDirection="column">
         {props.children}
@@ -695,6 +746,67 @@ function RelayDeviceProgressStep(
       ) : (
         <Text dimColor>Requesting a sign-in code…</Text>
       )}
+    </RelayProgressFrame>
+  );
+}
+
+interface ChatGptProgressCallbacks {
+  readonly onSuccess: (session: CodexSession) => void;
+  readonly onError: (message: string) => void;
+}
+
+function ChatGptProgressStep(
+  props: ChatGptProgressCallbacks & {
+    readonly device: boolean;
+  },
+): React.JSX.Element {
+  const { device } = props;
+  const [message, setMessage] = useState(
+    device
+      ? 'Requesting a ChatGPT device code...'
+      : 'Preparing ChatGPT sign-in...',
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const session = await signInCliChatGpt(
+          { device, noBrowser: false },
+          {
+            writeProgress: (next) => {
+              if (!cancelled) setMessage(next);
+            },
+          },
+        );
+        const update = await setPreferCodexSubscription(true);
+        if (!update.effective) {
+          if (!cancelled) {
+            props.onError(
+              'Signed in with ChatGPT, but a more specific setting keeps the subscription disabled. Choose Researcher Access or a provider API key instead.',
+            );
+          }
+          return;
+        }
+        invalidateModelOptionsCache();
+        if (!cancelled) props.onSuccess(session);
+      } catch (loginError: unknown) {
+        if (!cancelled) props.onError(toErrorMessage(loginError));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <RelayProgressFrame
+      title="Use ChatGPT subscription"
+      spinnerLabel="Waiting for ChatGPT sign-in… (Ctrl-C cancels)"
+    >
+      {message.split('\n').map((line, index) => (
+        <Text key={`${index}:${line}`}>{line}</Text>
+      ))}
     </RelayProgressFrame>
   );
 }

--- a/packages/cli/src/runtime/credentialStatus.ts
+++ b/packages/cli/src/runtime/credentialStatus.ts
@@ -7,6 +7,8 @@
 
 import { platform } from '@platform/platform';
 import { hasAnyProviderApiKey } from '@controllers/onboarding/onboardingFunnel';
+import { isCodexSubscriptionActive } from '@auth/codex';
+import { CHATGPT_SETUP_MODEL } from '@model/setupModelDefaults';
 
 import { getCliAuthProvider } from './supabaseAuth';
 import type { CliApiMode } from './apiAccessMode';
@@ -20,6 +22,11 @@ async function hasIncludedRelaySignIn(): Promise<boolean> {
 export async function hasCliCredentialForApiMode(
   apiMode: CliApiMode | undefined,
 ): Promise<boolean> {
+  const hasChatGptSubscription = await isCodexSubscriptionActive(
+    CHATGPT_SETUP_MODEL,
+  ).catch(() => false);
+  if (hasChatGptSubscription) return true;
+
   switch (apiMode) {
     case 'included':
       return hasIncludedRelaySignIn();

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -926,6 +926,12 @@
         "icon": "$(sign-in)"
       },
       {
+        "command": "texra.auth.chatgpt.signIn",
+        "title": "Sign In with ChatGPT Subscription",
+        "category": "TeXRA",
+        "icon": "$(comment-discussion)"
+      },
+      {
         "command": "texra.auth.signOut",
         "title": "Sign Out",
         "category": "TeXRA",
@@ -1101,19 +1107,19 @@
       {
         "id": "texra.gettingStarted",
         "title": "Get started with TeXRA",
-        "description": "Choose a credential, let the setup assistant run your first polish, then meet the orchestrator. Setup is the doorman, polish is the demo, the orchestrator is the habit.",
+        "description": "Choose a credential, let the setup assistant check your project and run your first polish, then meet the orchestrator.",
         "steps": [
           {
             "id": "texra.gettingStarted.signIn",
             "title": "Choose how TeXRA should sign in",
-            "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Open Models & ChatGPT](command:texra.showModels)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
+            "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Sign in with ChatGPT](command:texra.auth.chatgpt.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
             "media": {
               "image": "resources/walkthroughs/media/api-key-setup.png",
               "altText": "Screenshot of the model credential configuration view"
             },
             "completionEvents": [
               "onCommand:texra.auth.signIn",
-              "onCommand:texra.showModels",
+              "onCommand:texra.auth.chatgpt.signIn",
               "onCommand:texra.setApiKey"
             ]
           },
@@ -1539,6 +1545,10 @@
         },
         {
           "command": "texra.auth.signIn",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.auth.chatgpt.signIn",
           "when": "texra.activated"
         },
         {

--- a/packages/extension/resources/walkthroughs/getting-started.md
+++ b/packages/extension/resources/walkthroughs/getting-started.md
@@ -2,7 +2,7 @@
 
 TeXRA helps you write better papers. It uses AI to correct, polish, review, and restructure your LaTeX manuscripts -- right inside VS Code.
 
-One story, three beats: **Setup is the doorman, polish is the demo, the orchestrator is the habit.**
+The shortest path is: choose a credential, run setup once, then let the orchestrator handle the daily paper work.
 
 ## 1. Choose a credential
 

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -60,6 +60,7 @@ import { handleParseYaml as sysParseYaml } from '@commands/system/yamlCommands';
 import { handleTestTextEditor as sysTestTextEditor } from '@commands/system/textEditorCommands';
 import { SIDEBAR_VIEWS, getActiveSidebarView } from '@common/webview';
 import { type ApiProvider, SecretManager } from '@frontend/secretManager';
+import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionSignIn';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import { runCleanBuild, runCleanOutput } from '@housekeeping';
 import type { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
@@ -105,6 +106,7 @@ const CreateAgentWithAIArgSchema = AgentCategorySchema.optional();
 const ShowProgressViewArgSchema = z.unknown();
 
 const RESET_CHANNEL = 'mainViewCommands';
+const CHATGPT_SIGN_IN_CHANNEL = 'ChatGptSubscription';
 
 /**
  * Subset of `CommandId` whose registration is now driven by the shared
@@ -133,6 +135,7 @@ export type ExtensionRegistryCommandId = Extract<
   | 'texra.cleanBuild'
   | 'texra.indentTeX'
   | 'texra.auth.signIn'
+  | 'texra.auth.chatgpt.signIn'
   | 'texra.auth.signOut'
   | 'texra.auth.viewProfile'
   | 'texra.runSetupAssistant'
@@ -212,6 +215,7 @@ export interface ExtensionCommandActions {
   cleanOutput(): Promise<void>;
   indentTeX(): Promise<void>;
   signIn(): Promise<boolean>;
+  signInChatGpt(): Promise<boolean>;
   signOut(): Promise<void>;
   viewProfile(): Promise<void>;
   runSetupAssistant(): Promise<void>;
@@ -291,6 +295,16 @@ export function createExtensionCommandActions(
     cleanOutput: runCleanOutput,
     indentTeX: handleIndentTeX,
     signIn: authSignIn,
+    async signInChatGpt() {
+      const signedIn = await signInWithChatGptSubscription(
+        CHATGPT_SIGN_IN_CHANNEL,
+      );
+      await Promise.all([
+        vscode.commands.executeCommand('texra.refreshApiKeyStatus'),
+        vscode.commands.executeCommand('texra.refreshAllOptions'),
+      ]);
+      return signedIn;
+    },
     signOut: authSignOut,
     viewProfile: authViewProfile,
     runSetupAssistant: setupRunAssistant,
@@ -358,6 +372,7 @@ const EXTENSION_COMMAND_HANDLERS = {
   'texra.cleanBuild': (actions) => awaitTrue(actions.cleanBuild()),
   'texra.indentTeX': (actions) => awaitTrue(actions.indentTeX()),
   'texra.auth.signIn': (actions) => awaitTrue(actions.signIn()),
+  'texra.auth.chatgpt.signIn': (actions) => awaitTrue(actions.signInChatGpt()),
   'texra.auth.signOut': (actions) => awaitTrue(actions.signOut()),
   'texra.auth.viewProfile': (actions) => awaitTrue(actions.viewProfile()),
   'texra.runSetupAssistant': (actions) =>

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -15,7 +15,12 @@ import { toErrorMessage } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import { SecretManager } from '@frontend/secretManager';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
+import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionSignIn';
 import * as logger from '@logger/logUtils';
+import {
+  CHATGPT_SETUP_MODEL,
+  SETUP_MODEL_BY_PROVIDER,
+} from '@model/setupModelDefaults';
 import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { agentName } from '@shared/schemas/agent';
@@ -24,24 +29,6 @@ import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 const CHANNEL = 'SetupAssistant';
 logger.initialize(CHANNEL);
-
-/**
- * Provider → model mapping used when the user only has a direct API key.
- * Each mapping points at a model routed through that same provider, so the
- * agent can actually authenticate with the key it's been given.
- */
-const API_KEY_MODEL_BY_PROVIDER: Readonly<Record<string, string>> = {
-  anthropic: 'opus48T',
-  openai: 'gpt55',
-  google: 'gemini31p',
-  deepseek: 'deepseekproT',
-  openRouter: 'sonnet46T',
-  xai: 'grok4',
-  moonshot: 'kimi25T',
-  dashscope: 'qwen3max',
-  minimax: 'minimax01',
-  glm: 'glm5',
-};
 
 const SETUP_INSTRUCTION =
   'Please help me finish installing TeXRA. Probe my environment, install anything missing, and get me a working credential.';
@@ -79,7 +66,7 @@ interface LaunchModelResolution {
  *      `DEFAULT_AGENT_MODEL`; we'd otherwise fall through preflight
  *      and fail at runtime when tier enforcement kicks in.
  *   2. If the user is signed in but `DEFAULT_AGENT_MODEL` is not in
- *      tier, scan `API_KEY_MODEL_BY_PROVIDER` for any model that IS in
+ *      tier, scan `SETUP_MODEL_BY_PROVIDER` for any model that IS in
  *      tier so a lower-tier signed-in user still gets a working launch.
  *   3. Any direct API key for a provider whose default model routes
  *      through that same provider directly (iterating
@@ -101,14 +88,14 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
   // global flag is already on, so this doesn't mutate anything.
   if (getUseOpenRouter()) {
     return {
-      model: API_KEY_MODEL_BY_PROVIDER.openRouter,
+      model: SETUP_MODEL_BY_PROVIDER.openRouter,
       requiresOpenRouter: true,
     };
   }
 
-  if (await isCodexSubscriptionActive(API_KEY_MODEL_BY_PROVIDER.openai)) {
+  if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
     return {
-      model: API_KEY_MODEL_BY_PROVIDER.openai,
+      model: CHATGPT_SETUP_MODEL,
       requiresOpenRouter: false,
     };
   }
@@ -123,7 +110,7 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
   // model (e.g. `sonnet46T`) is specifically for OR-routed calls and
   // routing it direct via server-side keys would pick the wrong backend.
   if (await serverKeys.canUseServerSideKeys()) {
-    for (const [provider, model] of Object.entries(API_KEY_MODEL_BY_PROVIDER)) {
+    for (const [provider, model] of Object.entries(SETUP_MODEL_BY_PROVIDER)) {
       if (provider === 'openRouter') continue;
       if (serverKeys.canUseModelSync(model)) {
         return { model, requiresOpenRouter: false };
@@ -137,7 +124,7 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
   // auth failure with a credential that can't reach Google.
   for (const provider of SecretManager.API_PROVIDERS) {
     if (provider === 'openRouter') continue;
-    const model = API_KEY_MODEL_BY_PROVIDER[provider];
+    const model = SETUP_MODEL_BY_PROVIDER[provider];
     if (!model) continue;
     if (await SecretManager.hasUsableApiKey(provider)) {
       return { model, requiresOpenRouter: false };
@@ -145,11 +132,11 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
   }
 
   // Step 4: only OpenRouter key present. The `openRouter` entry is
-  // statically declared in `API_KEY_MODEL_BY_PROVIDER`, so no fallback
+  // statically declared in `SETUP_MODEL_BY_PROVIDER`, so no fallback
   // is needed.
   if (await SecretManager.hasUsableApiKey('openRouter')) {
     return {
-      model: API_KEY_MODEL_BY_PROVIDER.openRouter,
+      model: SETUP_MODEL_BY_PROVIDER.openRouter,
       requiresOpenRouter: true,
     };
   }
@@ -200,7 +187,7 @@ async function withOpenRouterFlagOn<T>(fn: () => Promise<T>): Promise<T> {
  * agreed on what "has a credential" means.
  */
 export async function hasAnyUsableSetupCredential(): Promise<boolean> {
-  if (await isCodexSubscriptionActive(API_KEY_MODEL_BY_PROVIDER.openai)) {
+  if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
     return true;
   }
   for (const provider of SecretManager.API_PROVIDERS) {
@@ -254,11 +241,8 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
   }
 
   if (picked.id === 'chatgpt') {
-    await vscode.commands.executeCommand('texra.showModels');
-    void vscode.window.showInformationMessage(
-      'Sign in with ChatGPT in the Models tab, then run the setup assistant again.',
-    );
-    return false;
+    await signInWithChatGptSubscription(CHANNEL);
+    return hasAnyUsableSetupCredential();
   }
 
   // walkthrough

--- a/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
+++ b/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
@@ -1,0 +1,74 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import {
+  codexCoordinator,
+  loginWithDeviceCode,
+  loginWithLoopback,
+  setPreferCodexSubscription,
+  type CodexSession,
+} from '@auth/codex';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+
+async function runChatGptSignIn(): Promise<CodexSession> {
+  const coordinator = codexCoordinator();
+  if (vscode.env.remoteName) {
+    return loginWithDeviceCode({
+      coordinator,
+      onPrompt: (prompt) => {
+        void vscode.env.clipboard.writeText(prompt.userCode);
+        void vscode.window
+          .showInformationMessage(
+            `Enter ChatGPT code ${prompt.userCode} at ${prompt.verificationUrl}. The code was copied to the clipboard.`,
+            'Open ChatGPT',
+          )
+          .then((choice) => {
+            if (choice === 'Open ChatGPT') {
+              void vscode.env.openExternal(
+                vscode.Uri.parse(prompt.verificationUrl),
+              );
+            }
+          });
+      },
+    });
+  }
+
+  return loginWithLoopback({
+    coordinator,
+    openBrowser: async (url) => {
+      await vscode.env.openExternal(vscode.Uri.parse(url));
+    },
+  });
+}
+
+/** Run ChatGPT sign-in and enable subscription routing for Codex models. */
+export async function signInWithChatGptSubscription(
+  channel: string,
+): Promise<boolean> {
+  try {
+    const session = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Signing in with ChatGPT...',
+        cancellable: false,
+      },
+      () => runChatGptSignIn(),
+    );
+    const update = await setPreferCodexSubscription(true);
+    const label = session.email ?? session.accountId ?? 'your account';
+    if (update.effective) {
+      void vscode.window.showInformationMessage(
+        `Signed in with ChatGPT as ${label}. ChatGPT subscription is enabled for Codex models.`,
+      );
+      return true;
+    }
+    void vscode.window.showWarningMessage(
+      `Signed in with ChatGPT as ${label}, but a more specific setting kept the subscription preference disabled.`,
+    );
+    return false;
+  } catch (error) {
+    await showLoggedErrorMessage(channel, 'ChatGPT sign-in failed', error);
+    return false;
+  }
+}

--- a/packages/extension/src/frontend/ui/welcomeView.ts
+++ b/packages/extension/src/frontend/ui/welcomeView.ts
@@ -69,7 +69,8 @@ function renderWelcomeHtml(): string {
   <ol>
     <li>Open a folder containing your LaTeX project — or create the bundled
         sample project if you just want to try TeXRA.</li>
-    <li>TeXRA will reload and walk you through sign-in or API key setup.</li>
+    <li>TeXRA will reload and walk you through a credential: Researcher
+        Access sign-in, ChatGPT subscription, or a provider API key.</li>
     <li>Pick an input file, choose the orchestrator, and hit Execute.</li>
   </ol>
   <div class="actions">

--- a/packages/extension/src/settingsView/handlers/chatgptSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/chatgptSubscriptionHandlers.ts
@@ -11,10 +11,9 @@ import * as vscode from 'vscode';
 import {
   codexCoordinator,
   getChatGptAuthStatus,
-  loginWithDeviceCode,
-  loginWithLoopback,
   setPreferCodexSubscription,
 } from '@auth/codex';
+import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionSignIn';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 
@@ -41,63 +40,9 @@ export class ChatGptSubscriptionHandlers {
     ]);
   }
 
-  private async runSignIn(): Promise<
-    Awaited<ReturnType<typeof loginWithLoopback>>
-  > {
-    const coordinator = codexCoordinator();
-    if (vscode.env.remoteName) {
-      return loginWithDeviceCode({
-        coordinator,
-        onPrompt: (prompt) => {
-          void vscode.env.clipboard.writeText(prompt.userCode);
-          void vscode.window
-            .showInformationMessage(
-              `Enter ChatGPT code ${prompt.userCode} at ${prompt.verificationUrl}. The code was copied to the clipboard.`,
-              'Open ChatGPT',
-            )
-            .then((choice) => {
-              if (choice === 'Open ChatGPT') {
-                void vscode.env.openExternal(
-                  vscode.Uri.parse(prompt.verificationUrl),
-                );
-              }
-            });
-        },
-      });
-    }
-
-    return loginWithLoopback({
-      coordinator,
-      openBrowser: async (url) => {
-        await vscode.env.openExternal(vscode.Uri.parse(url));
-      },
-    });
-  }
-
   async handleSignInChatGpt(): Promise<void> {
-    try {
-      const session = await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: 'Signing in with ChatGPT…',
-          cancellable: false,
-        },
-        () => this.runSignIn(),
-      );
-      const update = await setPreferCodexSubscription(true);
-      void vscode.window.showInformationMessage(
-        update.effective
-          ? `Signed in with ChatGPT as ${session.email ?? session.accountId ?? 'your account'}. ChatGPT subscription is enabled for Codex models.`
-          : `Signed in with ChatGPT as ${session.email ?? session.accountId ?? 'your account'}, but a more specific setting kept the subscription preference disabled.`,
-      );
-      await this.refreshChatGptState();
-    } catch (error) {
-      await showLoggedErrorMessage(
-        this.ctx.channel,
-        'ChatGPT sign-in failed',
-        error,
-      );
-    }
+    await signInWithChatGptSubscription(this.ctx.channel);
+    await this.refreshChatGptState();
   }
 
   async handleSignOutChatGpt(): Promise<void> {

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -5,12 +5,16 @@ import {
   type MainViewCommandPlan,
 } from '@controllers/mainView/MainViewInteractionController';
 import { MainViewStartupController } from '@controllers/mainView/MainViewStartupController';
-import { setOnboardingDeclined } from '@controllers/onboarding/onboardingFunnel';
+import {
+  setFirstRunDone,
+  setOnboardingDeclined,
+} from '@controllers/onboarding/onboardingFunnel';
 import { AUTH_COMMANDS, getAuthStatus } from '@commands/auth';
 import { toErrorMessage } from '@common/errors';
 import { BaseViewMessageHandler } from '@common/webview';
 import { agentDirectories } from '@frontend/agents';
 import { loadOptions } from '@frontend/agents/optionsLoader';
+import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionSignIn';
 import { RecordingManager } from '@frontend/media/RecordingManager';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
@@ -290,6 +294,11 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
             this.postToActiveView({
               command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
             });
+            await Promise.all([
+              vscode.commands.executeCommand('texra.refreshApiKeyStatus'),
+              vscode.commands.executeCommand('texra.refreshAllOptions'),
+              this.onboarding?.refreshOnboardingFunnel(),
+            ]);
           }
         } catch (error) {
           this.logger.debug(
@@ -311,6 +320,24 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         // writes), then re-derive so the card disappears and the normal
         // launcher renders.
         await setOnboardingDeclined(this.context.globalState, true);
+        await this.onboarding?.refreshOnboardingFunnel();
+      },
+      [MAIN_VIEW_COMMANDS.ONBOARDING_SIGN_IN_CHATGPT]: async () => {
+        await signInWithChatGptSubscription(this.channel);
+        await Promise.all([
+          vscode.commands.executeCommand('texra.refreshApiKeyStatus'),
+          vscode.commands.executeCommand('texra.refreshAllOptions'),
+          this.onboarding?.refreshOnboardingFunnel(),
+        ]);
+      },
+      [MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP]: async () => {
+        await safeExecuteCommand('texra.runSetupAssistant', [], this.viewName);
+        await this.onboarding?.refreshOnboardingFunnel();
+      },
+      [MAIN_VIEW_COMMANDS.ONBOARDING_OPEN_GETTING_STARTED]: () =>
+        safeExecuteCommand('texra.openGettingStarted', [], this.viewName),
+      [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP_SETUP]: async () => {
+        await setFirstRunDone(this.context.globalState, true);
         await this.onboarding?.refreshOnboardingFunnel();
       },
 

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -71,6 +71,7 @@ import './components/BannerGroup';
 import './components/LatexDiffsSection';
 import './components/InstructionPanel';
 import './components/OnboardingWelcomeCard';
+import './components/OnboardingSetupCard';
 import {
   ELEMENT_IDS,
   DOCUMENT_FILE_TYPES,
@@ -1440,12 +1441,12 @@ export class MainApp extends MainAppBase {
     postMessage(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER);
   }
 
-  // Welcome-card choices reuse the existing host flows: sign-in reuses
-  // handleComponentSignIn (SIGN_IN_FROM_BANNER -> texra.auth.signIn), ChatGPT
-  // opens Models, API key invokes texra.setApiKey (OPEN_SET_API_KEY); only skip
-  // is onboarding-specific (declined flag).
+  // Welcome-card choices reuse the existing host flows where possible: sign-in
+  // reuses handleComponentSignIn (SIGN_IN_FROM_BANNER -> texra.auth.signIn),
+  // API key invokes texra.setApiKey, and ChatGPT uses the extension-host
+  // subscription sign-in helper directly so onboarding can continue in place.
   private handleWelcomeChatGpt(): void {
-    postMessage(MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS);
+    postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_SIGN_IN_CHATGPT);
   }
 
   private handleWelcomeApiKey(): void {
@@ -1454,6 +1455,18 @@ export class MainApp extends MainAppBase {
 
   private handleWelcomeSkip(): void {
     postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_SKIP);
+  }
+
+  private handleOnboardingRunSetup(): void {
+    postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP);
+  }
+
+  private handleOnboardingOpenGettingStarted(): void {
+    postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_OPEN_GETTING_STARTED);
+  }
+
+  private handleOnboardingSkipSetup(): void {
+    postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_SKIP_SETUP);
   }
 
   private handleComponentDismissLogin(): void {
@@ -1739,6 +1752,8 @@ export class MainApp extends MainAppBase {
               @welcome-chatgpt=${this.handleWelcomeChatGpt}
               @welcome-api-key=${this.handleWelcomeApiKey}
               @welcome-skip=${this.handleWelcomeSkip}
+              @onboarding-open-getting-started=${this
+                .handleOnboardingOpenGettingStarted}
             ></onboarding-welcome-card>
           </div>
         </div>
@@ -1766,6 +1781,15 @@ export class MainApp extends MainAppBase {
         ${this.renderViewHeader()}
 
         <div class="main-content">
+          ${onboardingState === 'setup'
+            ? html`<onboarding-setup-card
+                @onboarding-run-setup=${this.handleOnboardingRunSetup}
+                @onboarding-open-getting-started=${this
+                  .handleOnboardingOpenGettingStarted}
+                @onboarding-skip-setup=${this.handleOnboardingSkipSetup}
+              ></onboarding-setup-card>`
+            : nothing}
+
           <instruction-panel
             .showSessionHint=${!this.sessionHintDismissed.get()}
             @session-type-change=${this.handleComponentSessionTypeChange}

--- a/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
@@ -1,0 +1,109 @@
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import { LitElement, css, html, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { ONBOARDING_NARRATIVE } from '@shared/copy/onboarding';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
+
+import { MainViewEvents } from '../events';
+
+/**
+ * State 1 onboarding handoff: a credential exists, but the first setup run has
+ * not completed yet. The setup agent is selected by the host; this card gives
+ * users a direct, visible next action without hiding the normal launcher.
+ */
+@customElement('onboarding-setup-card')
+export class OnboardingSetupCard extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      wa-callout {
+        margin-bottom: var(--wa-space-s);
+        padding: var(--wa-space-s) var(--wa-space-m);
+      }
+
+      .title {
+        display: block;
+        font-weight: var(--font-weight-semibold, 600);
+        font-size: 1.05em;
+        margin-bottom: var(--wa-space-2xs);
+      }
+
+      .copy {
+        margin: 0 0 var(--wa-space-s);
+        color: var(--vscode-descriptionForeground);
+        line-height: var(--line-height-normal, 1.4);
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--wa-space-2xs);
+      }
+
+      wa-button::part(base) {
+        min-height: 28px;
+      }
+    `,
+  ];
+
+  private handleRunSetup(): void {
+    this.dispatchEvent(MainViewEvents.onboardingRunSetup());
+  }
+
+  private handleOpenGettingStarted(): void {
+    this.dispatchEvent(MainViewEvents.onboardingOpenGettingStarted());
+  }
+
+  private handleSkipSetup(): void {
+    this.dispatchEvent(MainViewEvents.onboardingSkipSetup());
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <wa-callout id="onboardingSetupCard" variant="brand">
+        ${waIcon('rocket', { slot: 'icon' })}
+        <span class="title">Ready for setup</span>
+        <p class="copy">${ONBOARDING_NARRATIVE}</p>
+        <div class="actions">
+          <wa-button
+            id="onboardingRunSetupButton"
+            variant="brand"
+            appearance="filled"
+            @click=${this.handleRunSetup}
+          >
+            ${waIcon('rocket')} Run setup assistant
+          </wa-button>
+          <wa-button
+            id="onboardingOpenWalkthroughButton"
+            appearance="outlined"
+            @click=${this.handleOpenGettingStarted}
+          >
+            ${waIcon('book')} Open walkthrough
+          </wa-button>
+          <wa-button
+            id="onboardingSkipSetupButton"
+            appearance="plain"
+            @click=${this.handleSkipSetup}
+          >
+            Skip setup
+          </wa-button>
+        </div>
+      </wa-callout>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'onboarding-setup-card': OnboardingSetupCard;
+  }
+}

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -22,8 +22,8 @@ import { MainViewEvents } from '../events';
  * ChatGPT/API key alternatives, and a quiet "Skip for now" link last.
  * Stateless: renders the
  * shared onboarding copy verbatim and emits `welcome-sign-in` /
- * `welcome-chatgpt` / `welcome-api-key` / `welcome-skip`; the host owns the
- * funnel state.
+ * `welcome-chatgpt` / `welcome-api-key` / setup navigation events; the host
+ * owns the funnel state.
  */
 @customElement('onboarding-welcome-card')
 export class OnboardingWelcomeCard extends LitElement {
@@ -47,7 +47,13 @@ export class OnboardingWelcomeCard extends LitElement {
         font-weight: var(--font-weight-semibold, 600);
         font-size: 1.05em;
         letter-spacing: -0.005em;
-        margin-bottom: var(--wa-space-s);
+        margin-bottom: var(--wa-space-2xs);
+      }
+
+      .card-copy {
+        margin: 0 0 var(--wa-space-s);
+        color: var(--vscode-descriptionForeground);
+        line-height: var(--line-height-normal, 1.4);
       }
 
       .choices {
@@ -76,7 +82,10 @@ export class OnboardingWelcomeCard extends LitElement {
 
       .skip-row {
         display: flex;
+        align-items: center;
         justify-content: center;
+        flex-wrap: wrap;
+        gap: var(--wa-space-2xs);
         margin-top: var(--wa-space-s);
       }
 
@@ -103,11 +112,19 @@ export class OnboardingWelcomeCard extends LitElement {
     this.dispatchEvent(MainViewEvents.welcomeSkip());
   }
 
+  private handleOpenGettingStarted(): void {
+    this.dispatchEvent(MainViewEvents.onboardingOpenGettingStarted());
+  }
+
   override render(): TemplateResult {
     return html`
       <wa-callout id="onboardingWelcomeCard" variant="brand">
         ${waIcon('wand-magic-sparkles', { slot: 'icon' })}
         <span class="card-title">${ONBOARDING_CARD_TITLE}</span>
+        <p class="card-copy">
+          Choose a credential first. TeXRA will start the setup assistant once
+          it can call a model.
+        </p>
         <div class="choices">
           <div class="choice">
             <wa-button
@@ -148,6 +165,14 @@ export class OnboardingWelcomeCard extends LitElement {
           </div>
         </div>
         <div class="skip-row">
+          <wa-button
+            id="onboardingWalkthroughButton"
+            appearance="plain"
+            size="small"
+            @click=${this.handleOpenGettingStarted}
+          >
+            ${waIcon('book')} Open walkthrough
+          </wa-button>
           <wa-button
             id="onboardingSkipButton"
             appearance="plain"

--- a/packages/extension/src/webview/frontend/events.ts
+++ b/packages/extension/src/webview/frontend/events.ts
@@ -94,6 +94,13 @@ export const MainViewEvents = {
 
   welcomeSkip: () => createEvent('welcome-skip', undefined),
 
+  onboardingRunSetup: () => createEvent('onboarding-run-setup', undefined),
+
+  onboardingOpenGettingStarted: () =>
+    createEvent('onboarding-open-getting-started', undefined),
+
+  onboardingSkipSetup: () => createEvent('onboarding-skip-setup', undefined),
+
   dismissGettingStarted: () =>
     createEvent('dismiss-getting-started', undefined),
 

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -238,6 +238,12 @@
         },
         {
           "category": "TeXRA",
+          "command": "texra.auth.chatgpt.signIn",
+          "icon": "$(comment-discussion)",
+          "title": "Sign In with ChatGPT Subscription"
+        },
+        {
+          "category": "TeXRA",
           "command": "texra.auth.signOut",
           "icon": "$(sign-out)",
           "title": "Sign Out"
@@ -1290,6 +1296,10 @@
             "when": "texra.activated"
           },
           {
+            "command": "texra.auth.chatgpt.signIn",
+            "when": "texra.activated"
+          },
+          {
             "command": "texra.auth.signOut",
             "when": "texra.activated"
           },
@@ -1533,16 +1543,16 @@
       ],
       "walkthroughs": [
         {
-          "description": "Choose a credential, let the setup assistant run your first polish, then meet the orchestrator. Setup is the doorman, polish is the demo, the orchestrator is the habit.",
+          "description": "Choose a credential, let the setup assistant check your project and run your first polish, then meet the orchestrator.",
           "id": "texra.gettingStarted",
           "steps": [
             {
               "completionEvents": [
                 "onCommand:texra.auth.signIn",
-                "onCommand:texra.showModels",
+                "onCommand:texra.auth.chatgpt.signIn",
                 "onCommand:texra.setApiKey"
               ],
-              "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Open Models & ChatGPT](command:texra.showModels)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
+              "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Sign in with ChatGPT](command:texra.auth.chatgpt.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
               "id": "texra.gettingStarted.signIn",
               "media": {
                 "altText": "Screenshot of the model credential configuration view",

--- a/src/model/setupModelDefaults.ts
+++ b/src/model/setupModelDefaults.ts
@@ -1,0 +1,20 @@
+/**
+ * Provider-specific models the setup assistant can use when that provider is
+ * the only known usable credential. Kept with model metadata so hosts do not
+ * each define their own setup routing truth.
+ */
+export const SETUP_MODEL_BY_PROVIDER: Readonly<Record<string, string>> = {
+  anthropic: 'opus48T',
+  openai: 'gpt55',
+  google: 'gemini31p',
+  deepseek: 'deepseekproT',
+  openRouter: 'sonnet46T',
+  xai: 'grok4',
+  moonshot: 'kimi25T',
+  dashscope: 'qwen3max',
+  minimax: 'minimax01',
+  glm: 'glm5',
+};
+
+/** Codex-eligible setup model used to prove ChatGPT subscription access. */
+export const CHATGPT_SETUP_MODEL = SETUP_MODEL_BY_PROVIDER.openai;

--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -234,6 +234,12 @@ export const commandCatalog = [
     icon: '$(sign-in)',
   },
   {
+    id: 'texra.auth.chatgpt.signIn',
+    title: 'Sign In with ChatGPT Subscription',
+    category: 'TeXRA',
+    icon: '$(comment-discussion)',
+  },
+  {
     id: 'texra.auth.signOut',
     title: 'Sign Out',
     category: 'TeXRA',

--- a/src/shared/copy/onboarding.ts
+++ b/src/shared/copy/onboarding.ts
@@ -37,4 +37,4 @@ export const ONBOARDING_CHOICE_SKIP_LABEL = 'Skip for now';
  * docs lede; product surfaces express it through behavior, not this sentence.
  */
 export const ONBOARDING_NARRATIVE =
-  'Setup is the doorman, polish is the demo, the orchestrator is the habit.';
+  'Run setup once to check LaTeX, apply the right agent team, and start your first polish.';

--- a/src/shared/ipc/mainViewCommands.ts
+++ b/src/shared/ipc/mainViewCommands.ts
@@ -72,7 +72,11 @@ export const MAIN_VIEW_COMMANDS = {
   HIDE_ORCHESTRATOR_BANNER: 'hideOrchestratorBanner',
 
   // Onboarding funnel (PRD: agent-native onboarding)
+  ONBOARDING_SIGN_IN_CHATGPT: 'onboardingSignInChatGpt',
+  ONBOARDING_RUN_SETUP: 'onboardingRunSetup',
+  ONBOARDING_OPEN_GETTING_STARTED: 'onboardingOpenGettingStarted',
   ONBOARDING_SKIP: 'onboardingSkip',
+  ONBOARDING_SKIP_SETUP: 'onboardingSkipSetup',
   SET_ONBOARDING_FUNNEL: 'setOnboardingFunnel',
 
   // Extension response events

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -314,11 +314,15 @@ const NavigationMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.SHOW_AGENT_HISTORY),
 ] as const;
 
-// Onboarding funnel (PRD: agent-native onboarding). The welcome card's
-// sign-in / api-key choices reuse SIGN_IN_FROM_BANNER / OPEN_SET_API_KEY;
-// only the explicit skip needs its own message (persists the declined flag).
+// Onboarding funnel (PRD: agent-native onboarding). Common commands stay
+// shared where possible; ChatGPT sign-in and State 1 setup actions need
+// explicit messages because they update the funnel after host-side effects.
 const OnboardingMessages = [
+  commandOnly(MAIN_VIEW_COMMANDS.ONBOARDING_SIGN_IN_CHATGPT),
+  commandOnly(MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP),
+  commandOnly(MAIN_VIEW_COMMANDS.ONBOARDING_OPEN_GETTING_STARTED),
   commandOnly(MAIN_VIEW_COMMANDS.ONBOARDING_SKIP),
+  commandOnly(MAIN_VIEW_COMMANDS.ONBOARDING_SKIP_SETUP),
 ] as const;
 
 export const MainViewInboundMessageSchema = z.discriminatedUnion('command', [

--- a/src/test-kernel/cli/CredentialStatus.vitest.mts
+++ b/src/test-kernel/cli/CredentialStatus.vitest.mts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  isCodexSubscriptionActive: vi.fn(),
   isAuthenticated: vi.fn(),
   lookupApiKey: vi.fn(),
+}));
+
+vi.mock('@auth/codex', () => ({
+  isCodexSubscriptionActive: mocks.isCodexSubscriptionActive,
 }));
 
 vi.mock('@cli/runtime/supabaseAuth', () => ({
@@ -23,8 +28,25 @@ const { hasCliCredentialForApiMode } =
 
 describe('CLI credential status', () => {
   beforeEach(() => {
+    mocks.isCodexSubscriptionActive.mockReset().mockResolvedValue(false);
     mocks.isAuthenticated.mockReset();
     mocks.lookupApiKey.mockReset();
+  });
+
+  it('counts an active ChatGPT subscription in every API mode', async () => {
+    mocks.isCodexSubscriptionActive.mockResolvedValue(true);
+    mocks.isAuthenticated.mockRejectedValue(
+      new Error('relay sign-in must not be checked'),
+    );
+    mocks.lookupApiKey.mockRejectedValue(
+      new Error('provider keys must not be checked'),
+    );
+
+    await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(true);
+    await expect(hasCliCredentialForApiMode('included')).resolves.toBe(true);
+    await expect(hasCliCredentialForApiMode('personal')).resolves.toBe(true);
+    expect(mocks.isAuthenticated).not.toHaveBeenCalled();
+    expect(mocks.lookupApiKey).not.toHaveBeenCalled();
   });
 
   it('is true when signed in, without checking any provider key', async () => {

--- a/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
+++ b/src/test-kernel/cli/__snapshots__/Completion.vitest.mts.snap
@@ -184,7 +184,7 @@ complete -c texra -n '__fish_use_subcommand' -a 'orchestrate' -d 'Interactive la
 complete -c texra -n '__fish_use_subcommand' -a 'chat' -d 'Interactive tool-use chat session'
 complete -c texra -n '__fish_use_subcommand' -a 'run' -d 'Run a workflow agent'
 complete -c texra -n '__fish_use_subcommand' -a 'resume' -d 'Continue (resume) a stored tool-use session'
-complete -c texra -n '__fish_use_subcommand' -a 'setup' -d 'Guided setup with the setup agent: environment, agent roster, and your first task (sign-in or API key first if needed)'
+complete -c texra -n '__fish_use_subcommand' -a 'setup' -d 'Guided setup with the setup agent: environment, agent roster, and your first task (sign-in, ChatGPT, or API key first)'
 complete -c texra -n '__fish_use_subcommand' -a 'init' -d 'Bootstrap a .texra/config.json with sensible defaults'
 complete -c texra -n '__fish_use_subcommand' -a 'install-github-action' -d 'Scaffold the TeXRA code-review GitHub Action and open a PR'
 complete -c texra -n '__fish_use_subcommand' -a 'history' -d 'Inspect stored executions'

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -31,6 +31,8 @@ const HANDLERS = {
     awaitTrue(actions.indentTeX()),
   'texra.auth.signIn': (actions: ExtensionCommandActions) =>
     awaitTrue(actions.signIn()),
+  'texra.auth.chatgpt.signIn': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.signInChatGpt()),
   'texra.auth.signOut': (actions: ExtensionCommandActions) =>
     awaitTrue(actions.signOut()),
   'texra.auth.viewProfile': (actions: ExtensionCommandActions) =>
@@ -163,6 +165,7 @@ function makeActions(): ExtensionCommandActions {
     cleanOutput: vi.fn().mockResolvedValue(undefined),
     indentTeX: vi.fn().mockResolvedValue(undefined),
     signIn: vi.fn().mockResolvedValue(false),
+    signInChatGpt: vi.fn().mockResolvedValue(false),
     signOut: vi.fn().mockResolvedValue(undefined),
     viewProfile: vi.fn().mockResolvedValue(undefined),
     runSetupAssistant: vi.fn().mockResolvedValue(undefined),
@@ -209,6 +212,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     ['texra.cleanBuild', 'cleanBuild'],
     ['texra.indentTeX', 'indentTeX'],
     ['texra.auth.signIn', 'signIn'],
+    ['texra.auth.chatgpt.signIn', 'signInChatGpt'],
     ['texra.auth.signOut', 'signOut'],
     ['texra.auth.viewProfile', 'viewProfile'],
     ['texra.runSetupAssistant', 'runSetupAssistant'],


### PR DESCRIPTION
## Summary

- Adds ChatGPT subscription as a first-class CLI first-run onboarding choice.
- Treats an active ChatGPT subscription as a usable CLI setup credential in the shared CLI credential gate.
- Moves setup model defaults into `src/model/setupModelDefaults.ts` so CLI and extension setup checks share the same Codex/OpenAI setup model truth.
- Makes extension onboarding more direct: welcome/setup surfaces can start ChatGPT sign-in directly, a State 1 setup card points users to setup or the walkthrough, and the walkthrough uses a dedicated ChatGPT sign-in command.

Closes #6465.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/CredentialStatus.vitest.mts src/test-kernel/cli/OnboardingGate.vitest.mts src/test-kernel/cli/OnboardingState.vitest.mts src/test-kernel/cli/SetupCommand.vitest.mts src/test-kernel/cli/LoginArgs.vitest.mts src/test-kernel/tools/setup/CredentialReporting.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts src/test-kernel/controllers/OnboardingFunnel.vitest.ts src/test-kernel/cli/OnboardingGate.vitest.mts src/test-kernel/cli/CredentialStatus.vitest.mts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/Completion.vitest.mts -u`
- `npm run typecheck`
- `npm run lint` (passes with the existing unrelated import-order warnings)
- `npm run compile:fast`
- `npm run check:extension-package-invariants`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-chatgpt-onboarding-1782088932 login-form api-form model-form model-form-included-empty orchestrate-no-runnable-models slash-goal-help plan-approval-goal subagent-picker task-picker approval-form`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential gating and multi-surface onboarding/auth flows; it reuses existing Codex sign-in but misconfiguration could block first-run setup until users pick another credential path.
> 
> **Overview**
> **ChatGPT subscription** is now a peer credential alongside Researcher Access sign-in and provider API keys in CLI first-run onboarding, extension onboarding, docs, and the getting-started walkthrough.
> 
> The interactive CLI picker gains a **Use ChatGPT subscription** option with an in-flow sign-in step that enables Codex subscription routing and refreshes model availability without restarting. `hasCliCredentialForApiMode` treats an active ChatGPT/Codex subscription as a usable credential in every API mode, and PTY validation expects the new labels and copy.
> 
> On the extension, **`texra.auth.chatgpt.signIn`** runs shared `signInWithChatGptSubscription` (also used from Models and setup assistant preflight). The welcome card starts ChatGPT sign-in in place instead of sending users only to Models; after credentials exist, a new **`onboarding-setup-card`** nudges users toward the setup assistant or walkthrough. Setup model routing moves to shared **`setupModelDefaults.ts`** so CLI and extension agree on the Codex setup model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15fcf6764ecfecbf5aebee6c6157f7517c0fdfc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->