### PR TITLE
[codex] reuse ChatGPT device login policy in chat

### DIFF
--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -125,7 +125,7 @@ export async function handleTuiSlashCommand(
         openCanonicalSlashForm('login', registered, rest);
         return true;
       }
-      await loginFromChat(rest);
+      await loginFromChat(rest, context.cliContext);
       return true;
     case 'logout':
       await logoutFromChat();

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -4,8 +4,10 @@ import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import {
   chatGptAccountLabel,
+  shouldUseChatGptDeviceCode,
   signInCliChatGpt,
 } from '@cli/runtime/chatgptLogin';
+import { type CliContext } from '@cli/runtime/cliContext';
 import {
   githubSelectAccountWarning,
   parseChatLoginSlashArgs,
@@ -96,21 +98,28 @@ async function loginToTexraIncludedAccess(
   );
 }
 
-export async function loginFromChat(input: string): Promise<void> {
+export async function loginFromChat(
+  input: string,
+  context?: CliContext,
+): Promise<void> {
   const args = parseChatLoginSlashArgs(input);
   if (!args) {
     appendLocalAssistantTranscript(CHAT_LOGIN_USAGE);
     return;
   }
 
-  appendLocalAssistantTranscript(loginStartMessage(args));
+  const loginArgs =
+    args.target === 'chatgpt' && context
+      ? { ...args, device: shouldUseChatGptDeviceCode(context, args) }
+      : args;
+  appendLocalAssistantTranscript(loginStartMessage(loginArgs));
 
   try {
-    if (args.target === 'chatgpt') {
-      await loginToChatGptSubscription(args);
+    if (loginArgs.target === 'chatgpt') {
+      await loginToChatGptSubscription(loginArgs);
       return;
     }
-    await loginToTexraIncludedAccess(args);
+    await loginToTexraIncludedAccess(loginArgs);
   } catch (error: unknown) {
     appendLocalAssistantTranscript(toErrorMessage(error));
   }

--- a/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
@@ -12,6 +12,7 @@ import { type SlashCommand } from '../slashRegistry';
 
 /** Shared context every slash-command handler receives from the chat TUI. */
 export interface SlashCommandContext {
+  readonly cliContext: CliContext;
   readonly session: TuiSession;
   readonly commandName?: string;
   readonly cwd: CliContext['cwd'];

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -89,6 +89,7 @@ import {
 } from './commands/handlers/agentModelCommands';
 import { applyCliApiModeSelection } from './commands/handlers/apiModeCommands';
 import { showCliMemoryPreview } from './commands/handlers/memoryCommands';
+import { loginFromChat } from './commands/handlers/loginCommands';
 import {
   CHAT_API_MODE_MODEL_RECOVERY,
   type SlashCommandContext,
@@ -401,6 +402,7 @@ export async function runChat(
   // lazily so the closures it captures (interruptActive, resetSessionForClear,
   // resumeAgentRun) are all defined before the first use.
   const slashCommandContext = (): SlashCommandContext => ({
+    cliContext: context,
     session,
     commandName: context.commandName,
     cwd: context.cwd,
@@ -820,6 +822,7 @@ export async function runChat(
       applyCliModelSelection(nextModel, slashCommandContext()),
     onApiModeSelect: (nextMode) =>
       applyCliApiModeSelection(nextMode, slashCommandContext()),
+    onLoginSelect: (value) => loginFromChat(value, context),
     onMemorySelect: showCliMemoryPreview,
     onSkillSelect: activateSkillForNextMessage,
     onResumeSelect: resumeAgentRun,

--- a/packages/cli/src/runtime/chatgptLogin.ts
+++ b/packages/cli/src/runtime/chatgptLogin.ts
@@ -6,6 +6,7 @@ import {
 } from '@auth/codex';
 
 import { tryOpenBrowser } from './browser';
+import { isLikelyRemoteSession } from './remoteSession';
 import { interactiveTerminalFailure } from './terminalRequirements';
 import type { CliContext } from './cliContext';
 
@@ -19,9 +20,10 @@ export interface CliChatGptLoginOptions {
 }
 
 /**
- * Device-code is the right default when there's no interactive browser to reach:
- * non-text output, a non-TTY/headless/dumb terminal, or `--no-input`. An
- * explicit `--no-browser` keeps the loopback flow but prints the URL to paste.
+ * Device-code is the right default when the browser callback is likely
+ * unreachable: remote shells, non-text output, non-TTY/headless/dumb terminals,
+ * or `--no-input`. An explicit `--no-browser` keeps the loopback flow but
+ * prints the URL to paste.
  */
 export function shouldUseChatGptDeviceCode(
   context: CliContext,
@@ -31,7 +33,8 @@ export function shouldUseChatGptDeviceCode(
   if (init.noBrowser) return false;
   return (
     context.outputFormat !== 'text' ||
-    interactiveTerminalFailure(context) !== undefined
+    interactiveTerminalFailure(context) !== undefined ||
+    isLikelyRemoteSession()
   );
 }
 

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -2,6 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import * as codexAuth from '@auth/codex';
 import { handleTuiSlashCommand } from '@cli/chat/tui/commands/handleSlashCommand';
 import { type SlashCommandContext } from '@cli/chat/tui/commands/handlers/slashContext';
 import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
@@ -14,6 +15,8 @@ import {
   patchStream,
   resetCliState,
 } from '@cli/chat/tui/state/cliState';
+import * as chatGptLogin from '@cli/runtime/chatgptLogin';
+import type { CliContext } from '@cli/runtime/cliContext';
 import type { TuiSession } from '@cli/chat/tui/state/sessionRunState';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
@@ -27,6 +30,7 @@ afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
   resetCliState();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 function createSession(): TuiSession {
@@ -40,12 +44,28 @@ function createSession(): TuiSession {
   };
 }
 
+function createCliContext(overrides: Partial<CliContext> = {}): CliContext {
+  return {
+    cwd: '/tmp/workspace',
+    mode: 'interactive',
+    outputFormat: 'text',
+    approvalPolicy: 'ask',
+    stdoutIsTty: true,
+    termIsDumb: false,
+    colorEnabled: false,
+    version: '0.0.0-test',
+    resourcesPath: '/tmp/resources',
+    ...overrides,
+  };
+}
+
 function createContext(
   session: TuiSession,
   overrides: Partial<SlashCommandContext> = {},
 ): SlashCommandContext {
   let approvalPolicy: CliApprovalPolicy = 'ask';
   return {
+    cliContext: createCliContext(),
     session,
     cwd: '/tmp/workspace',
     processCwd: '/tmp/launcher',
@@ -87,6 +107,32 @@ describe('handleTuiSlashCommand', () => {
 
     expect(handled).toBe(true);
     expect(cliState.activeForm.get()?.commandName).toBe('login');
+  });
+
+  it('uses ChatGPT device-code login from a likely remote shell', async () => {
+    registerBuiltinSlashCommands();
+    vi.stubEnv('SSH_TTY', '/dev/pts/3');
+    vi.spyOn(chatGptLogin, 'signInCliChatGpt').mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAtMs: Date.now() + 60_000,
+      email: 'person@example.com',
+    });
+    vi.spyOn(codexAuth, 'setPreferCodexSubscription').mockResolvedValue({
+      effective: true,
+      target: 'global',
+    });
+
+    const handled = await handleTuiSlashCommand(
+      '/login chatgpt',
+      createContext(createSession()),
+    );
+
+    expect(handled).toBe(true);
+    expect(chatGptLogin.signInCliChatGpt).toHaveBeenCalledWith(
+      expect.objectContaining({ device: true, noBrowser: false }),
+      expect.any(Object),
+    );
   });
 
   it('treats /quit as the canonical exit command without echoing it', async () => {


### PR DESCRIPTION
## Summary

Fixes #6456.

- thread the existing `CliContext` into chat slash-command handlers
- make `/login chatgpt` and the `/login` form reuse `shouldUseChatGptDeviceCode()` before calling `signInCliChatGpt`
- include likely SSH sessions in the shared ChatGPT device-code policy, matching first-run onboarding's remote-shell behavior

## Why

`texra auth chatgpt login` already applies the shared device-code policy, but chat `/login chatgpt` passed parsed slash args directly to `signInCliChatGpt`. That left the in-chat path on loopback auth unless the user explicitly typed `--device`, even in remote shells where a browser callback is likely unreachable.

## Validation

- `texra-local doctor --output-format json`
- `corepack pnpm exec vitest run src/test-kernel/cli/SlashCommandDispatch.vitest.mts src/test-kernel/cli/LoginArgs.vitest.mts src/test-kernel/cli/DeviceCodeAuth.vitest.mts`
- `npm run typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-login-chatgpt-ssh-1782092473 login-form`
- `npm run lint` (passes with four unrelated existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auth-path behavior change limited to when device-code vs loopback is chosen in chat login; no credential storage or token handling changes.
> 
> **Overview**
> Chat **`/login chatgpt`** and the login form now use the same **`shouldUseChatGptDeviceCode()`** rules as **`texra auth chatgpt login`**, instead of defaulting to loopback unless the user typed **`--device`**.
> 
> **`CliContext`** is threaded through **`SlashCommandContext`** into **`loginFromChat`**, which merges the policy into parsed slash args before **`signInCliChatGpt`**. The shared policy also treats **likely SSH/remote sessions** (`isLikelyRemoteSession()`) as device-code defaults, matching first-run onboarding.
> 
> A dispatch test stubs **`SSH_TTY`** and asserts **`signInCliChatGpt`** is called with **`device: true`** for **`/login chatgpt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d80095a833ff06ea9609024811f2c825c11ae51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->