### PR TITLE
[codex] clear ChatGPT preference on CLI logout

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -4,8 +4,10 @@ import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import {
   chatGptAccountLabel,
+  chatGptSignOutPreferenceMessage,
   shouldUseChatGptDeviceCode,
   signInCliChatGpt,
+  signOutCliChatGpt,
 } from '@cli/runtime/chatgptLogin';
 import { type CliContext } from '@cli/runtime/cliContext';
 import {
@@ -126,22 +128,40 @@ export async function loginFromChat(
 }
 
 export async function logoutFromChat(): Promise<void> {
+  const lines: string[] = [];
+  let texraSignedOut = false;
+
   try {
     await signOutCliSupabase();
+    texraSignedOut = true;
+  } catch (error: unknown) {
+    lines.push(`TeXRA sign-out failed: ${toErrorMessage(error)}`);
+  }
+
+  try {
+    const chatGptUpdate = await signOutCliChatGpt();
+    invalidateModelOptionsCache();
+    bumpCodexPreferenceVersion();
+    lines.push(chatGptSignOutPreferenceMessage(chatGptUpdate));
+  } catch (error: unknown) {
+    lines.push(`ChatGPT sign-out failed: ${toErrorMessage(error)}`);
+  }
+
+  if (texraSignedOut) {
     // Sign-out only clears the stored session; a configured TEXRA_RELAY_TOKEN
     // keeps authenticating relay calls, so report it — and keep the session
     // in included mode so the notice matches what actually happens.
     const relayNotice = relayTokenStillActiveNotice();
     const apiMode = relayNotice ? 'included' : 'personal';
     setCliSessionApiMode(apiMode);
-    appendLocalAssistantTranscript(
-      [
-        'Signed out.',
-        ...(relayNotice ? [relayNotice] : []),
-        ...(await loadCliApiStatusLines({ apiMode })),
-      ].join('\n'),
-    );
-  } catch (error: unknown) {
-    appendLocalAssistantTranscript(toErrorMessage(error));
+    lines.unshift('Signed out.');
+    if (relayNotice) lines.push(relayNotice);
+    try {
+      lines.push(...(await loadCliApiStatusLines({ apiMode })));
+    } catch (error: unknown) {
+      lines.push(toErrorMessage(error));
+    }
   }
+
+  appendLocalAssistantTranscript(lines.join('\n'));
 }

--- a/packages/cli/src/commands/chatgptAuth.ts
+++ b/packages/cli/src/commands/chatgptAuth.ts
@@ -9,8 +9,10 @@ import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 import {
   chatGptAccountLabel,
+  chatGptSignOutPreferenceMessage,
   shouldUseChatGptDeviceCode,
   signInCliChatGpt,
+  signOutCliChatGpt,
 } from '../runtime/chatgptLogin';
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
@@ -114,17 +116,31 @@ const chatgptLogoutCommand = defineCliCommand({
   args: { ...GLOBAL_ARGS },
   async run(context) {
     await initCliPlatform({ ...context, quietLogs: true });
+    let update: Awaited<ReturnType<typeof signOutCliChatGpt>>;
     try {
-      await codexCoordinator().signOut();
+      update = await signOutCliChatGpt();
     } catch (error) {
       writeErrorStderr(error);
       return CliExitCode.ModelOrNetworkError;
     }
     invalidateModelOptionsCache();
     emitCliResult(context, {
-      json: { authenticated: false },
-      ndjson: { kind: 'chatgpt-auth', authenticated: false },
-      text: 'Signed out of ChatGPT.',
+      json: {
+        authenticated: false,
+        preferSubscription: update.preferenceUpdate?.effective ?? null,
+        ...(update.preferenceError
+          ? { preferenceError: update.preferenceError }
+          : {}),
+      },
+      ndjson: {
+        kind: 'chatgpt-auth',
+        authenticated: false,
+        preferSubscription: update.preferenceUpdate?.effective ?? null,
+        ...(update.preferenceError
+          ? { preferenceError: update.preferenceError }
+          : {}),
+      },
+      text: `Signed out of ChatGPT.\n${chatGptSignOutPreferenceMessage(update)}`,
     });
     return CliExitCode.Success;
   },

--- a/packages/cli/src/runtime/chatgptLogin.ts
+++ b/packages/cli/src/runtime/chatgptLogin.ts
@@ -2,8 +2,11 @@ import {
   codexCoordinator,
   loginWithDeviceCode,
   loginWithLoopback,
+  setPreferCodexSubscription,
   type CodexSession,
+  type CodexSubscriptionPreferenceUpdate,
 } from '@auth/codex';
+import { toErrorMessage } from '@common/errors/errorMessage';
 
 import { tryOpenBrowser } from './browser';
 import { isLikelyRemoteSession } from './remoteSession';
@@ -18,6 +21,16 @@ export interface CliChatGptLoginInit {
 export interface CliChatGptLoginOptions {
   readonly writeProgress: (message: string) => void;
 }
+
+export type CliChatGptSignOutResult =
+  | {
+      readonly preferenceUpdate: CodexSubscriptionPreferenceUpdate;
+      readonly preferenceError?: undefined;
+    }
+  | {
+      readonly preferenceUpdate?: undefined;
+      readonly preferenceError: string;
+    };
 
 /**
  * Device-code is the right default when the browser callback is likely
@@ -72,4 +85,25 @@ export async function signInCliChatGpt(
       options.writeProgress(`Open this URL to sign in with ChatGPT:\n${url}`);
     },
   });
+}
+
+export function chatGptSignOutPreferenceMessage(
+  result: CliChatGptSignOutResult,
+): string {
+  const update = result.preferenceUpdate;
+  if (!update) {
+    return `ChatGPT subscription preference could not be disabled: ${result.preferenceError}`;
+  }
+  return update.effective
+    ? `ChatGPT subscription preference is still enabled because a more specific setting overrides ${update.target} config.`
+    : 'ChatGPT subscription disabled for Codex models.';
+}
+
+export async function signOutCliChatGpt(): Promise<CliChatGptSignOutResult> {
+  await codexCoordinator().signOut();
+  try {
+    return { preferenceUpdate: await setPreferCodexSubscription(false) };
+  } catch (error: unknown) {
+    return { preferenceError: toErrorMessage(error) };
+  }
 }

--- a/src/test-kernel/cli/AuthCommand.vitest.mts
+++ b/src/test-kernel/cli/AuthCommand.vitest.mts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   getCliAuthProfile: vi.fn(),
   initCliPlatform: vi.fn(),
+  signOutCliChatGpt: vi.fn(),
 }));
 
 vi.mock('@cli/runtime/initPlatform', () => ({
@@ -15,6 +16,15 @@ vi.mock('@cli/runtime/supabaseAuth', async (importOriginal) => {
   return {
     ...actual,
     getCliAuthProfile: mocks.getCliAuthProfile,
+  };
+});
+
+vi.mock('@cli/runtime/chatgptLogin', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@cli/runtime/chatgptLogin')>();
+  return {
+    ...actual,
+    signOutCliChatGpt: mocks.signOutCliChatGpt,
   };
 });
 
@@ -33,6 +43,9 @@ describe('CLI auth command', () => {
       authenticated: false,
     });
     mocks.initCliPlatform.mockReset().mockResolvedValue(undefined);
+    mocks.signOutCliChatGpt.mockReset().mockResolvedValue({
+      preferenceUpdate: { effective: false, target: 'global' },
+    });
     stdoutSpy = vi
       .spyOn(process.stdout, 'write')
       .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
@@ -109,6 +122,40 @@ describe('CLI auth command', () => {
       accountLabel: 'user@example.edu',
       tier: 'Max',
     });
+    expect(stderr).toBe('');
+  });
+
+  it('clears ChatGPT subscription preference on chatgpt logout', async () => {
+    const result = await runCli([
+      'auth',
+      'chatgpt',
+      'logout',
+      '--output-format',
+      'json',
+      '--no-input',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(mocks.signOutCliChatGpt).toHaveBeenCalledOnce();
+    expect(JSON.parse(stdout)).toEqual({
+      authenticated: false,
+      preferSubscription: false,
+    });
+    expect(stderr).toBe('');
+  });
+
+  it('reports ChatGPT logout success when preference cleanup fails', async () => {
+    mocks.signOutCliChatGpt.mockResolvedValueOnce({
+      preferenceError: 'Config write failed',
+    });
+
+    const result = await runCli(['auth', 'chatgpt', 'logout']);
+
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('Signed out of ChatGPT.');
+    expect(stdout).toContain(
+      'ChatGPT subscription preference could not be disabled: Config write failed',
+    );
     expect(stderr).toBe('');
   });
 });

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -10,13 +10,16 @@ import {
   listSlashCommands,
   unregisterSlashCommand,
 } from '@cli/chat/tui/commands/slashRegistry';
+import { CLI_LOCAL_STREAM_ID } from '@cli/chat/tui/state/transcript';
 import {
   cliState,
   patchStream,
   resetCliState,
 } from '@cli/chat/tui/state/cliState';
+import * as apiStatus from '@cli/runtime/apiStatus';
 import * as chatGptLogin from '@cli/runtime/chatgptLogin';
 import type { CliContext } from '@cli/runtime/cliContext';
+import * as supabaseAuth from '@cli/runtime/supabaseAuth';
 import type { TuiSession } from '@cli/chat/tui/state/sessionRunState';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
@@ -133,6 +136,87 @@ describe('handleTuiSlashCommand', () => {
       expect.objectContaining({ device: true, noBrowser: false }),
       expect.any(Object),
     );
+  });
+
+  it('clears TeXRA and ChatGPT credentials on /logout', async () => {
+    registerBuiltinSlashCommands();
+    const signOutSupabase = vi
+      .spyOn(supabaseAuth, 'signOutCliSupabase')
+      .mockResolvedValue(undefined);
+    const signOutChatGpt = vi
+      .spyOn(chatGptLogin, 'signOutCliChatGpt')
+      .mockResolvedValue({
+        preferenceUpdate: { effective: false, target: 'global' },
+      });
+    vi.spyOn(apiStatus, 'loadCliApiStatusLines').mockResolvedValue([
+      'API mode: personal',
+    ]);
+
+    const handled = await handleTuiSlashCommand(
+      '/logout',
+      createContext(createSession()),
+    );
+
+    expect(handled).toBe(true);
+    expect(signOutSupabase).toHaveBeenCalledOnce();
+    expect(signOutChatGpt).toHaveBeenCalledOnce();
+    const entry = cliState.streams
+      .get()
+      .get(CLI_LOCAL_STREAM_ID)
+      ?.entries.at(-1)?.text;
+    expect(entry).toContain('Signed out.');
+    expect(entry).toContain('ChatGPT subscription disabled for Codex models.');
+  });
+
+  it('reports successful TeXRA sign-out when ChatGPT logout fails', async () => {
+    registerBuiltinSlashCommands();
+    vi.spyOn(supabaseAuth, 'signOutCliSupabase').mockResolvedValue(undefined);
+    vi.spyOn(chatGptLogin, 'signOutCliChatGpt').mockRejectedValue(
+      new Error('Codex logout failed'),
+    );
+    vi.spyOn(apiStatus, 'loadCliApiStatusLines').mockResolvedValue([
+      'API mode: personal',
+    ]);
+
+    const handled = await handleTuiSlashCommand(
+      '/logout',
+      createContext(createSession()),
+    );
+
+    expect(handled).toBe(true);
+    const entry = cliState.streams
+      .get()
+      .get(CLI_LOCAL_STREAM_ID)
+      ?.entries.at(-1)?.text;
+    expect(entry).toContain('Signed out.');
+    expect(entry).toContain('ChatGPT sign-out failed: Codex logout failed');
+  });
+
+  it('reports ChatGPT sign-out success when only preference cleanup fails', async () => {
+    registerBuiltinSlashCommands();
+    vi.spyOn(supabaseAuth, 'signOutCliSupabase').mockResolvedValue(undefined);
+    vi.spyOn(chatGptLogin, 'signOutCliChatGpt').mockResolvedValue({
+      preferenceError: 'Config write failed',
+    });
+    vi.spyOn(apiStatus, 'loadCliApiStatusLines').mockResolvedValue([
+      'API mode: personal',
+    ]);
+
+    const handled = await handleTuiSlashCommand(
+      '/logout',
+      createContext(createSession()),
+    );
+
+    expect(handled).toBe(true);
+    const entry = cliState.streams
+      .get()
+      .get(CLI_LOCAL_STREAM_ID)
+      ?.entries.at(-1)?.text;
+    expect(entry).toContain('Signed out.');
+    expect(entry).toContain(
+      'ChatGPT subscription preference could not be disabled: Config write failed',
+    );
+    expect(entry).not.toContain('ChatGPT sign-out failed');
   });
 
   it('treats /quit as the canonical exit command without echoing it', async () => {


### PR DESCRIPTION
## Summary

Fixes #6457.

- add a shared `signOutCliChatGpt()` runtime helper that signs out ChatGPT and disables the Codex subscription preference
- use that helper from both `texra auth chatgpt logout` and chat `/logout`
- update logout output so users can see whether the subscription preference was disabled or still overridden by a more specific config scope

## Why

After `/login chatgpt`, chat `/logout` only cleared the TeXRA included-access session. That could leave the ChatGPT OAuth session and `preferSubscription` setting active while the transcript said the user was signed out. The root ChatGPT logout command also cleared the session without clearing the preference, so the cleanup policy belonged in one CLI runtime helper rather than two command handlers.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/SlashCommandDispatch.vitest.mts src/test-kernel/cli/AuthCommand.vitest.mts`
- `npm run typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-logout-pref-1782094276 login-form slash-palette`
- `npm run lint` (passes with four unrelated existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication logout and Codex subscription preference config; behavior changes for users who relied on `/logout` leaving ChatGPT signed in.
> 
> **Overview**
> Chat **`/logout`** and **`auth chatgpt logout`** now share **`signOutCliChatGpt()`**, which signs out the ChatGPT/Codex session and turns off the Codex subscription preference (`setPreferCodexSubscription(false)`).
> 
> **`/logout`** no longer stops at TeXRA sign-out: it also runs ChatGPT sign-out, invalidates model options, and reports TeXRA/ChatGPT failures separately while still showing “Signed out.” when TeXRA succeeds. **`auth chatgpt logout`** JSON/ndjson/text output includes whether the preference was actually disabled (`preferSubscription`) or only partially cleaned up (`preferenceError` / override messaging via **`chatGptSignOutPreferenceMessage`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d751cbd74f18e61e0ac528aacff3ffe14efa6f69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->