### PR TITLE
[codex] improve extension ChatGPT onboarding

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -38,6 +38,7 @@ import { getAuthStatus } from '@commands/auth';
 import { hasAnyUsableSetupCredential } from '@commands/setup';
 import { tryResumeFromSnapshot } from '@commands/agent/resumeFromSnapshot';
 import { createSampleProjectWithoutWorkspace } from '@commands/system/sampleProjectCommands';
+import { openGettingStarted } from '@commands/system/walkthroughCommands';
 import { toErrorMessage } from '@common/errors';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
 import { globalSM, initializeStateManagers, workspaceSM } from '@common/state';
@@ -157,6 +158,9 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
       vscode.commands.registerCommand('texra.createSampleProject', () =>
         createSampleProjectWithoutWorkspace(context.extensionPath),
+      ),
+      vscode.commands.registerCommand('texra.openGettingStarted', () =>
+        openGettingStarted(context.extension.id),
       ),
     );
     return;

--- a/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
+++ b/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
@@ -46,8 +46,9 @@ async function runChatGptSignIn(): Promise<CodexSession> {
 export async function signInWithChatGptSubscription(
   channel: string,
 ): Promise<boolean> {
+  let session: CodexSession;
   try {
-    const session = await vscode.window.withProgress(
+    session = await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
         title: 'Signing in with ChatGPT...',
@@ -55,20 +56,32 @@ export async function signInWithChatGptSubscription(
       },
       () => runChatGptSignIn(),
     );
-    const update = await setPreferCodexSubscription(true);
-    const label = session.email ?? session.accountId ?? 'your account';
-    if (update.effective) {
-      void vscode.window.showInformationMessage(
-        `Signed in with ChatGPT as ${label}. ChatGPT subscription is enabled for Codex models.`,
-      );
-      return true;
-    }
-    void vscode.window.showWarningMessage(
-      `Signed in with ChatGPT as ${label}, but a more specific setting kept the subscription preference disabled.`,
-    );
-    return false;
   } catch (error) {
     await showLoggedErrorMessage(channel, 'ChatGPT sign-in failed', error);
     return false;
   }
+
+  const label = session.email ?? session.accountId ?? 'your account';
+  let update: Awaited<ReturnType<typeof setPreferCodexSubscription>>;
+  try {
+    update = await setPreferCodexSubscription(true);
+  } catch (error) {
+    await showLoggedErrorMessage(
+      channel,
+      'ChatGPT sign-in succeeded but subscription preference update failed',
+      error,
+    );
+    return false;
+  }
+
+  if (update.effective) {
+    void vscode.window.showInformationMessage(
+      `Signed in with ChatGPT as ${label}. ChatGPT subscription is enabled for Codex models.`,
+    );
+    return true;
+  }
+  void vscode.window.showWarningMessage(
+    `Signed in with ChatGPT as ${label}, but a more specific setting kept the subscription preference disabled.`,
+  );
+  return false;
 }

--- a/packages/extension/src/frontend/ui/welcomeView.ts
+++ b/packages/extension/src/frontend/ui/welcomeView.ts
@@ -1,6 +1,12 @@
 import { nanoid } from 'nanoid';
 import * as vscode from 'vscode';
 
+import {
+  ONBOARDING_CHOICE_CHATGPT,
+  ONBOARDING_CHOICE_SIGN_IN,
+  ONBOARDING_NARRATIVE,
+} from '@shared/copy/onboarding';
+
 /**
  * No-workspace provider for `texra.mainView`. Keeping the same view id across
  * workspace states is required for VS Code to persist the user's chosen
@@ -22,6 +28,7 @@ function renderWelcomeHtml(): string {
   const openFolder = 'command:workbench.action.files.openFolder';
   const cloneRepo = 'command:git.clone';
   const createSample = 'command:texra.createSampleProject';
+  const openWalkthrough = 'command:texra.openGettingStarted';
   const docs = 'https://texra.ai';
   // CSP nonces must be unpredictable — nanoid is crypto-random.
   const nonce = nanoid();
@@ -44,11 +51,21 @@ function renderWelcomeHtml(): string {
       padding: 16px;
       line-height: 1.5;
     }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 1.25rem;
+      line-height: 1.25;
+    }
     p { margin: 0 0 12px; }
     .muted { color: color-mix(in srgb, var(--vscode-foreground) 70%, transparent); }
-    ol { margin: 0 0 12px; padding-left: 22px; }
+    ol { margin: 0 0 14px; padding-left: 22px; }
     li { margin-bottom: 6px; }
-    .actions { display: flex; flex-direction: column; gap: 6px; margin: 16px 0; }
+    .actions {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 8px;
+      margin: 16px 0;
+    }
     a {
       color: var(--vscode-textLink-foreground);
       text-decoration: none;
@@ -57,27 +74,57 @@ function renderWelcomeHtml(): string {
       color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
       text-decoration: underline;
     }
+    .button {
+      display: block;
+      border: 1px solid var(--vscode-button-border, transparent);
+      border-radius: 4px;
+      padding: 7px 10px;
+      text-align: center;
+      color: var(--vscode-button-foreground);
+      background: var(--vscode-button-background);
+    }
+    .button:hover {
+      color: var(--vscode-button-foreground);
+      background: var(--vscode-button-hoverBackground);
+      text-decoration: none;
+    }
+    .secondary {
+      color: var(--vscode-button-secondaryForeground);
+      background: var(--vscode-button-secondaryBackground);
+    }
+    .secondary:hover {
+      color: var(--vscode-button-secondaryForeground);
+      background: var(--vscode-button-secondaryHoverBackground);
+    }
+    .link-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 12px;
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>
+  <h1>Welcome to TeXRA</h1>
   <p>
-    <strong>Welcome to TeXRA</strong> — an AI theorist. It coordinates
+    TeXRA coordinates
     specialized agents to edit manuscripts, derive results, draw figures,
     and verify proofs.
   </p>
-  <p><strong>To get started:</strong></p>
+  <p>${ONBOARDING_NARRATIVE}</p>
   <ol>
-    <li>Open a folder containing your LaTeX project — or create the bundled
-        sample project if you just want to try TeXRA.</li>
-    <li>TeXRA will reload and walk you through a credential: Researcher
-        Access sign-in, ChatGPT subscription, or a provider API key.</li>
-    <li>Pick an input file, choose the orchestrator, and hit Execute.</li>
+    <li>Open a single-folder workspace containing your LaTeX project.</li>
+    <li>Choose ${ONBOARDING_CHOICE_SIGN_IN.label}, ${ONBOARDING_CHOICE_CHATGPT.label}, or a provider API key.</li>
+    <li>Let the setup assistant check the project and launch the first run.</li>
   </ol>
   <div class="actions">
-    <a href="${openFolder}">Open Folder</a>
-    <a href="${createSample}">Try the Sample Project</a>
-    <a href="${cloneRepo}">Clone Repository</a>
-    <a href="${docs}">Read the docs</a>
+    <a class="button" href="${openFolder}">Open Folder</a>
+    <a class="button secondary" href="${createSample}">Try the Sample Project</a>
+  </div>
+  <div class="link-list">
+    <a href="${openWalkthrough}">Open walkthrough</a>
+    <a href="${cloneRepo}">Clone repository</a>
+    <a href="${docs}">Read docs</a>
   </div>
   <p class="muted">
     TeXRA needs a single-folder workspace. Multi-root workspaces aren't

--- a/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
@@ -71,7 +71,7 @@ export class OnboardingSetupCard extends LitElement {
     return html`
       <wa-callout id="onboardingSetupCard" variant="brand">
         ${waIcon('rocket', { slot: 'icon' })}
-        <span class="title">Ready for setup</span>
+        <span class="title">Credential ready</span>
         <p class="copy">${ONBOARDING_NARRATIVE}</p>
         <div class="actions">
           <wa-button

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -122,8 +122,8 @@ export class OnboardingWelcomeCard extends LitElement {
         ${waIcon('wand-magic-sparkles', { slot: 'icon' })}
         <span class="card-title">${ONBOARDING_CARD_TITLE}</span>
         <p class="card-copy">
-          Choose a credential first. TeXRA will start the setup assistant once
-          it can call a model.
+          Choose how TeXRA should call models. After sign-in, the setup
+          assistant checks this project and starts your first polish.
         </p>
         <div class="choices">
           <div class="choice">

--- a/src/shared/copy/onboarding.ts
+++ b/src/shared/copy/onboarding.ts
@@ -13,8 +13,8 @@ export const ONBOARDING_CARD_TITLE = 'Welcome to TeXRA';
 
 /** State 0 choice 1 — recommended. */
 export const ONBOARDING_CHOICE_SIGN_IN = {
-  label: 'Sign in for free',
-  description: 'Researcher Access: no API key needed (recommended)',
+  label: 'Sign in with Researcher Access',
+  description: 'Free for academics; no API key needed (recommended)',
 } as const;
 
 /** State 0 choice 2. */

--- a/src/shared/copy/onboarding.ts
+++ b/src/shared/copy/onboarding.ts
@@ -13,14 +13,14 @@ export const ONBOARDING_CARD_TITLE = 'Welcome to TeXRA';
 
 /** State 0 choice 1 — recommended. */
 export const ONBOARDING_CHOICE_SIGN_IN = {
-  label: 'Sign in — free for academics',
+  label: 'Sign in for free',
   description: 'Researcher Access: no API key needed (recommended)',
 } as const;
 
 /** State 0 choice 2. */
 export const ONBOARDING_CHOICE_CHATGPT = {
   label: 'Use ChatGPT subscription',
-  description: 'Codex models through your ChatGPT plan',
+  description: 'Codex models through ChatGPT Plus, Pro, or Team',
 } as const;
 
 /** State 0 choice 3. */
@@ -37,4 +37,4 @@ export const ONBOARDING_CHOICE_SKIP_LABEL = 'Skip for now';
  * docs lede; product surfaces express it through behavior, not this sentence.
  */
 export const ONBOARDING_NARRATIVE =
-  'Run setup once to check LaTeX, apply the right agent team, and start your first polish.';
+  'Run setup once: TeXRA checks LaTeX, applies the right agent team, and starts your first polish.';

--- a/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
+++ b/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  loginWithLoopback: vi.fn(),
+  setPreferCodexSubscription: vi.fn(),
+  showLoggedErrorMessage: vi.fn(),
+  showInformationMessage: vi.fn(),
+  showWarningMessage: vi.fn(),
+  openExternal: vi.fn(),
+  withProgress: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  env: {
+    remoteName: undefined,
+    openExternal: mocks.openExternal,
+    clipboard: { writeText: vi.fn() },
+  },
+  ProgressLocation: { Notification: 15 },
+  Uri: {
+    parse: (value: string) => ({ toString: () => value }),
+  },
+  window: {
+    showInformationMessage: mocks.showInformationMessage,
+    showWarningMessage: mocks.showWarningMessage,
+    withProgress: mocks.withProgress,
+  },
+}));
+
+vi.mock('@auth/codex', () => ({
+  codexCoordinator: vi.fn(() => ({})),
+  loginWithDeviceCode: vi.fn(),
+  loginWithLoopback: mocks.loginWithLoopback,
+  setPreferCodexSubscription: mocks.setPreferCodexSubscription,
+}));
+
+vi.mock('@frontend/ui/errorHandlingUtils', () => ({
+  showLoggedErrorMessage: mocks.showLoggedErrorMessage,
+}));
+
+const { signInWithChatGptSubscription } =
+  await import('@frontend/auth/codexSubscriptionSignIn');
+
+describe('signInWithChatGptSubscription', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports OAuth failures as sign-in failures', async () => {
+    mocks.withProgress.mockImplementation((_options, task) => task());
+    mocks.loginWithLoopback.mockRejectedValue(new Error('oauth failed'));
+
+    const signedIn = await signInWithChatGptSubscription('TestChannel');
+
+    expect(signedIn).toBe(false);
+    expect(mocks.showLoggedErrorMessage).toHaveBeenCalledWith(
+      'TestChannel',
+      'ChatGPT sign-in failed',
+      expect.any(Error),
+    );
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+  });
+
+  it('does not call a completed OAuth sign-in a sign-in failure when preference update fails', async () => {
+    mocks.withProgress.mockImplementation((_options, task) => task());
+    mocks.loginWithLoopback.mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAtMs: Date.now() + 60_000,
+      email: 'person@example.com',
+    });
+    mocks.setPreferCodexSubscription.mockRejectedValue(
+      new Error('config write failed'),
+    );
+
+    const signedIn = await signInWithChatGptSubscription('TestChannel');
+
+    expect(signedIn).toBe(false);
+    expect(mocks.showLoggedErrorMessage).toHaveBeenCalledWith(
+      'TestChannel',
+      'ChatGPT sign-in succeeded but subscription preference update failed',
+      expect.any(Error),
+    );
+    expect(mocks.showLoggedErrorMessage).not.toHaveBeenCalledWith(
+      'TestChannel',
+      'ChatGPT sign-in failed',
+      expect.any(Error),
+    );
+  });
+
+  it('returns true when OAuth and preference enablement both succeed', async () => {
+    mocks.withProgress.mockImplementation((_options, task) => task());
+    mocks.loginWithLoopback.mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAtMs: Date.now() + 60_000,
+      email: 'person@example.com',
+    });
+    mocks.setPreferCodexSubscription.mockResolvedValue({
+      effective: true,
+      target: 'global',
+    });
+
+    const signedIn = await signInWithChatGptSubscription('TestChannel');
+
+    expect(signedIn).toBe(true);
+    expect(mocks.showInformationMessage).toHaveBeenCalledWith(
+      'Signed in with ChatGPT as person@example.com. ChatGPT subscription is enabled for Codex models.',
+    );
+  });
+});

--- a/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
+++ b/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
@@ -61,7 +61,7 @@ describe('signInWithChatGptSubscription', () => {
     expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
   });
 
-  it('does not call a completed OAuth sign-in a sign-in failure when preference update fails', async () => {
+  it('does not treat a completed OAuth sign-in as a sign-in failure when preference update fails', async () => {
     mocks.withProgress.mockImplementation((_options, task) => task());
     mocks.loginWithLoopback.mockResolvedValue({
       accessToken: 'access-token',
@@ -85,6 +85,27 @@ describe('signInWithChatGptSubscription', () => {
       'TestChannel',
       'ChatGPT sign-in failed',
       expect.any(Error),
+    );
+  });
+
+  it('warns when a more specific setting keeps subscription preference disabled', async () => {
+    mocks.withProgress.mockImplementation((_options, task) => task());
+    mocks.loginWithLoopback.mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAtMs: Date.now() + 60_000,
+      email: 'person@example.com',
+    });
+    mocks.setPreferCodexSubscription.mockResolvedValue({
+      effective: false,
+      target: 'global',
+    });
+
+    const signedIn = await signInWithChatGptSubscription('TestChannel');
+
+    expect(signedIn).toBe(false);
+    expect(mocks.showWarningMessage).toHaveBeenCalledWith(
+      'Signed in with ChatGPT as person@example.com, but a more specific setting kept the subscription preference disabled.',
     );
   });
 


### PR DESCRIPTION
Fixes #6458.

## Summary
- split ChatGPT OAuth failures from post-login subscription preference write failures so a completed sign-in is not reported as a sign-in failure
- make the no-workspace extension welcome view point at the same first-run path: open a folder, choose Researcher Access/ChatGPT/API key, then run setup
- register `texra.openGettingStarted` on the no-workspace activation path so the welcome view can open the walkthrough before a project folder is opened
- tighten the shared onboarding copy used by the extension first-run cards

## Validation
- `corepack pnpm exec vitest run src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts`
- `npm run typecheck`
- `npm run format`
- `npm run lint` (passes with 4 pre-existing import-order warnings outside this change)
- `npm run compile:fast`
- `git diff --check`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UX and clearer auth error messaging; OAuth flow unchanged aside from error handling after successful login.
> 
> **Overview**
> **ChatGPT subscription sign-in** now treats OAuth and post-login steps separately: if `setPreferCodexSubscription` fails after a successful OAuth session, users see *sign-in succeeded but subscription preference update failed* instead of a generic sign-in failure. New Vitest coverage exercises OAuth failure, preference write failure, overridden settings, and the happy path.
> 
> **No-workspace first run** registers `texra.openGettingStarted` on the early activation path (alongside sample project) so the welcome webview can open the walkthrough before a folder is opened. The welcome view is restyled (primary/secondary actions, link row) and aligned with shared onboarding strings: open folder → credential choice → setup assistant.
> 
> **Shared onboarding copy** in `onboarding.ts` updates credential labels/descriptions and `ONBOARDING_NARRATIVE`; the main-view welcome and setup cards plus the no-workspace HTML consume those strings so messaging stays consistent (setup card title **Credential ready**, refreshed welcome card blurb).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d73d16e0b3dc13e853410c93e2e253c4610099cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->