### PR TITLE
[codex] reject unknown CLI commands before help

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -166,6 +166,12 @@ export async function runCli(
   );
   setUsageColorOverrideFromRawArgs(rawArgs);
 
+  const unknownCommand = await detectUnknownCliCommand(rawArgs);
+  if (unknownCommand) {
+    writeTextStderr(formatUnknownCliCommand(unknownCommand));
+    return { exitCode: CliExitCode.Usage };
+  }
+
   // `--help` / `-h` anywhere prints usage for the deepest matched subcommand
   // (e.g. `texra agents list --help` → list-level usage), mirroring citty's
   // own `runMain` behavior without inheriting its `exit(1)` for usage errors.
@@ -173,12 +179,6 @@ export async function runCli(
     const resolved = await resolveDeepestSubCommand(rootCommand, rawArgs);
     await showUsage(resolved.command, resolved.parent, resolved);
     return { exitCode: CliExitCode.Success };
-  }
-
-  const unknownCommand = await detectUnknownCliCommand(rawArgs);
-  if (unknownCommand) {
-    writeTextStderr(formatUnknownCliCommand(unknownCommand));
-    return { exitCode: CliExitCode.Usage };
   }
 
   const unknownFlag = await detectUnknownCliFlag(rawArgs);

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1191,6 +1191,15 @@ describe('runCli usage output stream routing', () => {
     expect(stderr).toBe('');
   });
 
+  it('rejects unknown commands before honoring explicit --help', async () => {
+    const result = await runCli(['workflows', '--help']);
+    expect(result.exitCode).toBe(2);
+    expect(stderr).toContain(
+      'Unknown command: texra workflows. Run `texra --help` for usage.',
+    );
+    expect(stdout).toBe('');
+  });
+
   it('points run-command agent arguments at the full agent catalog', async () => {
     let result = await runCli(['run', '--help']);
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Summary

- reject unknown CLI commands before explicit `--help` handling
- keep valid subcommand help behavior unchanged
- add a regression test for `texra workflows --help`

## Root cause

The root dispatcher honored `--help` before checking whether the command path was registered. As a result, typos like `texra workflows --help` fell back to root help and exited successfully.

Fixes #6470

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run texra-local:build && npm run texra-local:link && texra-local workflows --help; printf 'exit=%s\n' $?; texra-local run --help >/tmp/texra-run-help.txt; printf 'run_help_exit=%s\n' $?; sed -n '1,24p' /tmp/texra-run-help.txt`
- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with 4 pre-existing import-order warnings outside this diff)
- `git diff --check -- packages/cli/src/commands/root.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ordering change in root argument routing with a focused test; no auth, data, or execution-path changes.
> 
> **Overview**
> **Root CLI dispatch** now runs unknown-command detection **before** the explicit `--help` / `-h` branch in `runCli`, so mistyped top-level commands (e.g. `texra workflows --help`) get the usual stderr message and usage exit code **2** instead of printing root help and exiting **0**.
> 
> Valid subcommands are unchanged: `texra run --help` still writes usage to stdout with exit **0**.
> 
> A regression test in `CliRootArgs.vitest.mts` locks in the `workflows --help` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c5859685a9039934ea0bef4bdb5042599b7541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->