### PR TITLE
[codex] normalize CLI model names

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -42,6 +42,46 @@ export function isKnownCliModel(model: string): boolean {
   return MODEL_CONFIGS[model] != null;
 }
 
+function normalizeCliModelLookupKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]/g, '');
+}
+
+function modelLookupKeys(id: string): string[] {
+  const config = MODEL_CONFIGS[id];
+  return [id, config?.name, config?.fullName, config?.label].filter(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  );
+}
+
+export function resolveKnownCliModelId(model: string): string | undefined {
+  const trimmed = model.trim();
+  if (!trimmed) return undefined;
+  if (Object.hasOwn(MODEL_CONFIGS, trimmed)) return trimmed;
+
+  const lower = trimmed.toLowerCase();
+  const ids = Object.keys(MODEL_CONFIGS);
+  const exactIdMatch = ids.find((id) => id.toLowerCase() === lower);
+  if (exactIdMatch) return exactIdMatch;
+
+  const exactTextMatches = ids.filter((id) =>
+    modelLookupKeys(id).some((key) => key.toLowerCase() === lower),
+  );
+  if (exactTextMatches.length === 1) return exactTextMatches[0];
+  if (exactTextMatches.length > 1) return undefined;
+
+  const normalized = normalizeCliModelLookupKey(trimmed);
+  if (!normalized) return undefined;
+  const normalizedMatches = ids.filter((id) =>
+    modelLookupKeys(id).some(
+      (key) => normalizeCliModelLookupKey(key) === normalized,
+    ),
+  );
+  return normalizedMatches.length === 1 ? normalizedMatches[0] : undefined;
+}
+
 const NonEmptyStringSchema = z.string().trim().min(1);
 const ModelSchema = NonEmptyStringSchema.refine(isKnownCliModel, {
   message: 'unknown model',

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -1,10 +1,8 @@
-// Third-party imports
-import { MODEL_CONFIGS } from 'llm-zoo';
-
 // Local imports - model surfaces
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 
+import { resolveKnownCliModelId } from './cliConfig';
 import { getCliAuthProvider } from './supabaseAuth';
 import type { CliApiMode } from './apiAccessMode';
 
@@ -385,7 +383,14 @@ export function findCliModelAccessEntry(
   if (exact) return exact;
 
   const lower = model.toLowerCase();
-  return models.find((entry) => entry.model.value.toLowerCase() === lower);
+  const lowerMatch = models.find(
+    (entry) => entry.model.value.toLowerCase() === lower,
+  );
+  if (lowerMatch) return lowerMatch;
+
+  const canonical = resolveKnownCliModelId(model);
+  if (!canonical) return undefined;
+  return models.find((entry) => entry.model.value === canonical);
 }
 
 /**
@@ -455,13 +460,6 @@ function withModelAccess(
   return [...models, entry];
 }
 
-function getCanonicalModelConfigId(model: string): string | undefined {
-  if (Object.hasOwn(MODEL_CONFIGS, model)) return model;
-
-  const lower = model.toLowerCase();
-  return Object.keys(MODEL_CONFIGS).find((id) => id.toLowerCase() === lower);
-}
-
 export async function resolveCliModelAccessEntry(
   model: string,
   options: CliModelAccessEntryOptions = {},
@@ -473,7 +471,7 @@ export async function resolveCliModelAccessEntry(
   const listedEntry = findCliModelAccessEntry(models, trimmed);
   if (listedEntry || trimmed.length === 0) return listedEntry;
 
-  const hiddenModelId = getCanonicalModelConfigId(trimmed);
+  const hiddenModelId = resolveKnownCliModelId(trimmed);
   if (hiddenModelId == null) return undefined;
 
   const hiddenModelOption = (await computeModelOptionsData([hiddenModelId]))[0];

--- a/packages/cli/src/runtime/runModel.ts
+++ b/packages/cli/src/runtime/runModel.ts
@@ -2,7 +2,7 @@ import { toErrorMessage } from '@common/errors/errorMessage';
 
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
-  isKnownCliModel,
+  resolveKnownCliModelId,
   resolveConfiguredModel,
 } from './cliConfig';
 import { CliUsageError, type CliContext } from './cliContext';
@@ -29,12 +29,13 @@ export function assertExplicitModelKnown(
 ): string | undefined {
   const trimmed = model?.trim();
   if (!trimmed) return undefined;
-  if (!isKnownCliModel(trimmed)) {
+  const resolved = resolveKnownCliModelId(trimmed);
+  if (!resolved) {
     throw new CliUsageError(
       `Model not found: ${trimmed}. Use \`texra models list\` to see available models.`,
     );
   }
-  return trimmed;
+  return resolved;
 }
 
 /**

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -32,11 +32,20 @@ vi.mock('@cli/runtime/supabaseAuth', () => ({
   getCliAuthProvider: () => mocks.authProvider,
 }));
 
-vi.mock('llm-zoo', () => ({
-  MODEL_CONFIGS: {
-    hiddenFixtureModel: {},
-  },
-}));
+vi.mock('llm-zoo', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('llm-zoo')>();
+  return {
+    ...actual,
+    MODEL_CONFIGS: {
+      ...actual.MODEL_CONFIGS,
+      hiddenFixtureModel: {},
+      userFacingFixture: {
+        fullName: 'user-facing-fixture',
+        label: 'User Facing Fixture',
+      },
+    },
+  };
+});
 
 const computeModelOptionsDataMock = vi.mocked(computeModelOptionsData);
 
@@ -999,6 +1008,41 @@ describe('CLI model access resolution', () => {
     });
     expect(computeModelOptionsDataMock).toHaveBeenCalledWith([
       'hiddenFixtureModel',
+    ]);
+  });
+
+  it('resolves user-facing model names to canonical registry ids', async () => {
+    await expect(
+      resolveModelFromAccessList(
+        [model('userFacingFixture')],
+        'user-facing-fixture',
+        { fallbackSource: 'override' },
+      ),
+    ).resolves.toEqual({ model: 'userFacingFixture' });
+
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('userFacingFixture', {
+        availability: 'missing-key',
+        availabilityLabel: 'Missing API key',
+        disabled: true,
+        requiresKey: true,
+      }),
+    ]);
+
+    await expect(
+      resolveCliModelAccessEntry('User Facing Fixture', {
+        apiMode: 'personal',
+        accessList: [model('sonnet46T')],
+      }),
+    ).resolves.toMatchObject({
+      available: false,
+      model: {
+        value: 'userFacingFixture',
+        availability: 'missing-key',
+      },
+    });
+    expect(computeModelOptionsDataMock).toHaveBeenCalledWith([
+      'userFacingFixture',
     ]);
   });
 

--- a/src/test-kernel/cli/RunModel.vitest.mts
+++ b/src/test-kernel/cli/RunModel.vitest.mts
@@ -15,6 +15,18 @@ describe('assertExplicitModelKnown', () => {
     expect(assertExplicitModelKnown('  deepseekT  ')).toBe('deepseekT');
   });
 
+  it('normalizes user-facing model names to registry ids', () => {
+    expect(assertExplicitModelKnown('glm5.2')).toBe('glm52');
+    expect(assertExplicitModelKnown('GLM-5.2')).toBe('glm52');
+    expect(assertExplicitModelKnown('glm-5.2')).toBe('glm52');
+  });
+
+  it('rejects ambiguous provider model names', () => {
+    expect(() => assertExplicitModelKnown('claude-opus-4-7')).toThrow(
+      CliUsageError,
+    );
+  });
+
   it('throws a CliUsageError for an unknown model id', () => {
     expect(() => assertExplicitModelKnown('nonexistent-model-xyz')).toThrow(
       CliUsageError,


### PR DESCRIPTION
## Summary

- centralize canonical CLI model-id resolution in `cliConfig`
- allow explicit model selection and model diagnostics to resolve unique user-facing names like `glm5.2`, `glm-5.2`, and `GLM-5.2` to `glm52`
- keep workspace/env config strict and reject ambiguous provider full names instead of guessing

## Root Cause

CLI model identity had two paths: `runModel` only accepted exact llm-zoo ids, while `modelAccess` had a private hidden-model resolver. That meant the registry could show GLM-5.2 as `glm52`, but a user-facing spelling such as `glm5.2` failed as unknown before reaching the real access check.

Fixes #6472

## Validation

- `texra-local run correct --cwd /private/tmp/texra-workflow-dogfood.kOrPzK --input math-note.tex --output corrected.tex --model gpt54 --api-mode personal --no-input --instruction 'Correct grammar and LaTeX wording only. Keep the mathematical argument unchanged.' --output-format json`
- `corepack pnpm exec vitest run src/test-kernel/cli/RunModel.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/RunModel.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/CliContext.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts`
- `npm run texra-local:build && npm run texra-local:link && texra-local models show glm5.2 --output-format json; texra-local run correct --cwd /private/tmp/texra-workflow-dogfood.kOrPzK --input math-note.tex --output corrected-glm.tex --model glm5.2 --api-mode personal --no-input --instruction 'No-op check.'; texra-local models show claude-opus-4-7`
- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with 4 pre-existing import-order warnings outside this diff)
- `git diff --check -- packages/cli/src/runtime/cliConfig.ts packages/cli/src/runtime/modelAccess.ts packages/cli/src/runtime/runModel.ts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/RunModel.vitest.mts`
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI model resolution with conservative ambiguity handling; config/env model values remain exact-id only.
> 
> **Overview**
> Adds **`resolveKnownCliModelId`** in `cliConfig` so the CLI can map a **unique** user-facing spelling (registry id, `fullName`, `label`, or punctuation-stripped forms like `glm5.2` / `GLM-5.2`) to the canonical llm-zoo id.
> 
> **`-m` / run validation** (`assertExplicitModelKnown`) and **model access lookup** (`findCliModelAccessEntry`, hidden-model resolution) now share that resolver and return the canonical id instead of failing on display names. **Workspace/config `ModelSchema` and `TEXRA_MODEL` stay strict** (`isKnownCliModel` only); ambiguous strings such as `claude-opus-4-7` resolve to nothing and are rejected rather than guessed.
> 
> Tests cover alias resolution, ambiguity, and diagnostic paths for user-facing names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02adfb15f5a8b5a8861537c3511f7db58bba0400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->