### PR TITLE
[codex] Improve extension onboarding actions

### DIFF
--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -26,24 +26,77 @@ export class GettingStartedBanner extends LitElement {
     bannerStyles,
     css`
       wa-callout.getting-started-banner a {
-        color: var(--color-text-link);
         text-decoration: none;
-        font-weight: var(--font-weight-medium, 500);
-        border-bottom: 1px dotted
-          color-mix(in srgb, currentColor 40%, transparent);
-        transition: border-color var(--transition-fast);
-      }
-
-      wa-callout.getting-started-banner a:hover {
-        border-bottom-color: currentColor;
       }
 
       .getting-started-row {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
-        gap: var(--wa-space-2xs);
+        gap: var(--wa-space-xs);
         font-size: var(--font-size-sm);
+      }
+
+      .getting-started-body {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        gap: var(--wa-space-2xs);
+      }
+
+      .getting-started-title {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: var(--wa-space-3xs);
+        line-height: var(--line-height-normal);
+      }
+
+      .getting-started-title strong {
+        font-weight: var(--font-weight-semibold, 600);
+      }
+
+      .getting-started-title span {
+        color: var(--vscode-descriptionForeground);
+      }
+
+      .getting-started-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--wa-space-3xs);
+      }
+
+      .action-link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--wa-space-3xs);
+        min-height: 24px;
+        max-width: 100%;
+        padding: 2px var(--wa-space-xs);
+        border: 1px solid var(--vscode-button-border, transparent);
+        border-radius: var(--wa-border-radius-s, 4px);
+        background: var(--vscode-button-secondaryBackground);
+        color: var(--vscode-button-secondaryForeground);
+        line-height: var(--line-height-normal);
+        white-space: nowrap;
+      }
+
+      .action-link:hover {
+        background: var(--vscode-button-secondaryHoverBackground);
+      }
+
+      .action-link--primary {
+        background: var(--vscode-button-background);
+        color: var(--vscode-button-foreground);
+      }
+
+      .action-link--primary:hover {
+        background: var(--vscode-button-hoverBackground);
+      }
+
+      .dismiss-button {
+        flex: 0 0 auto;
       }
     `,
   ];
@@ -69,16 +122,37 @@ export class GettingStartedBanner extends LitElement {
           variant="brand"
         >
           <div class="getting-started-row">
-            <span>
-              Empty folder —
-              <a href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}>Sample project</a>
-              ·
-              <a href=${COMMAND_LINKS.CLONE_OVERLEAF}>Pull from Overleaf</a>
-              ·
-              <a href=${COMMAND_LINKS.DOWNLOAD_ARXIV}>Grab from arXiv</a>
-              — or just ask below.
-            </span>
+            <div class="getting-started-body">
+              <div class="getting-started-title">
+                <strong>Empty project</strong>
+                <span>Start with setup or bring in a LaTeX source.</span>
+              </div>
+              <div class="getting-started-actions">
+                <a
+                  class="action-link action-link--primary"
+                  href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}
+                >
+                  ${waIcon('rocket')} Run setup
+                </a>
+                <a
+                  class="action-link"
+                  href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
+                >
+                  ${waIcon('file-circle-plus')} Sample project
+                </a>
+                <a class="action-link" href=${COMMAND_LINKS.CLONE_OVERLEAF}>
+                  ${waIcon('cloud-arrow-down')} Overleaf
+                </a>
+                <a class="action-link" href=${COMMAND_LINKS.DOWNLOAD_ARXIV}>
+                  ${waIcon('download')} arXiv
+                </a>
+                <a class="action-link" href=${COMMAND_LINKS.GETTING_STARTED}>
+                  ${waIcon('book')} Walkthrough
+                </a>
+              </div>
+            </div>
             <wa-button
+              class="dismiss-button"
               appearance="plain"
               size="small"
               title="Dismiss for this session"

--- a/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts
@@ -56,6 +56,41 @@ export class OnboardingWelcomeCard extends LitElement {
         line-height: var(--line-height-normal, 1.4);
       }
 
+      .path {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--wa-space-xs);
+        margin: 0 0 var(--wa-space-s);
+      }
+
+      .path-step {
+        min-width: 0;
+        padding: var(--wa-space-xs);
+        border: 1px solid var(--vscode-input-border, transparent);
+        border-radius: var(--wa-border-radius-s, 4px);
+        background: color-mix(
+          in srgb,
+          var(--vscode-editor-background) 76%,
+          transparent
+        );
+      }
+
+      .path-step__label {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-3xs);
+        margin-bottom: var(--wa-space-3xs);
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-semibold, 600);
+      }
+
+      .path-step__copy {
+        margin: 0;
+        color: var(--vscode-descriptionForeground);
+        font-size: var(--font-size-sm);
+        line-height: var(--line-height-normal, 1.4);
+      }
+
       .choices {
         display: flex;
         flex-direction: column;
@@ -93,6 +128,12 @@ export class OnboardingWelcomeCard extends LitElement {
         font-size: var(--font-size-sm);
         opacity: var(--opacity-subtle);
       }
+
+      @media (max-width: 520px) {
+        .path {
+          grid-template-columns: 1fr;
+        }
+      }
     `,
   ];
 
@@ -122,9 +163,33 @@ export class OnboardingWelcomeCard extends LitElement {
         ${waIcon('wand-magic-sparkles', { slot: 'icon' })}
         <span class="card-title">${ONBOARDING_CARD_TITLE}</span>
         <p class="card-copy">
-          Choose how TeXRA should call models. After sign-in, the setup
-          assistant checks this project and starts your first polish.
+          Start with one credential. TeXRA then checks this project, picks the
+          right agent team, and starts your first useful edit.
         </p>
+        <div class="path" aria-label="Getting started path">
+          <div class="path-step">
+            <span class="path-step__label">
+              ${waIcon('right-to-bracket')} 1. Connect
+            </span>
+            <p class="path-step__copy">
+              Researcher Access, ChatGPT subscription, or a provider API key.
+            </p>
+          </div>
+          <div class="path-step">
+            <span class="path-step__label"> ${waIcon('rocket')} 2. Setup </span>
+            <p class="path-step__copy">
+              The setup assistant checks LaTeX and applies a starter team.
+            </p>
+          </div>
+          <div class="path-step">
+            <span class="path-step__label">
+              ${waIcon('code-compare')} 3. Review
+            </span>
+            <p class="path-step__copy">
+              Run a polish pass and inspect the diff before accepting changes.
+            </p>
+          </div>
+        </div>
         <div class="choices">
           <div class="choice">
             <wa-button

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -1,0 +1,37 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - test paths
+import { repoPath } from '../desktop/desktopTestPaths.mjs';
+
+function readWebviewComponent(name: string): string {
+  return readFileSync(
+    repoPath(`packages/extension/src/webview/frontend/components/${name}.ts`),
+    'utf8',
+  );
+}
+
+describe('extension onboarding experience', () => {
+  it('shows the State 0 path from credential to first review', () => {
+    const source = readWebviewComponent('OnboardingWelcomeCard');
+
+    expect(source).toContain('aria-label="Getting started path"');
+    expect(source).toContain('1. Connect');
+    expect(source).toContain('2. Setup');
+    expect(source).toContain('3. Review');
+    expect(source).toContain("waIcon('code-compare')");
+  });
+
+  it('keeps empty-project onboarding action oriented', () => {
+    const source = readWebviewComponent('GettingStartedBanner');
+
+    expect(source).toContain('Empty project');
+    expect(source).toContain('COMMAND_LINKS.RUN_SETUP_ASSISTANT');
+    expect(source).toContain('action-link--primary');
+    expect(source).toContain('COMMAND_LINKS.GETTING_STARTED');
+    expect(source).not.toContain('Empty folder');
+  });
+});


### PR DESCRIPTION
## Summary
- Rework the State 0 extension welcome card into a clear Connect -> Setup -> Review path.
- Replace the empty-folder text row with action-oriented onboarding links for setup, sample project, Overleaf, arXiv, and the walkthrough.
- Add a focused source-level regression test for the onboarding surfaces.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/webview/OnboardingExperience.vitest.mts`
- `git diff --check`
- `corepack pnpm --filter texra typecheck`
- `corepack pnpm exec eslint packages/extension/src/webview/frontend/components/OnboardingWelcomeCard.ts packages/extension/src/webview/frontend/components/GettingStartedBanner.ts src/test-kernel/webview/OnboardingExperience.vitest.mts`
- `corepack pnpm --filter texra compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only webview copy and styling with no auth, backend, or command-handler changes beyond existing COMMAND_LINKS.
> 
> **Overview**
> **State 0 welcome** and **empty-project** onboarding in the extension webview are reworked to emphasize clear next steps instead of inline text links.
> 
> The **OnboardingWelcomeCard** adds a three-step **Connect → Setup → Review** path (with icons and copy), updates the intro paragraph, and styles the path as a responsive grid that stacks on narrow widths. Credential buttons and events are unchanged.
> 
> The **GettingStartedBanner** replaces the single “Empty folder” sentence with a title row plus **button-style action links** (primary **Run setup**, sample project, Overleaf, arXiv, and walkthrough), using VS Code button theme tokens instead of dotted text links.
> 
> A new **OnboardingExperience** vitest file asserts key strings and command links remain in the component sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c858e459124e7e8fdae957c9625d3b3fa9ee3b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->