### PR TITLE
[codex] Use stable stdin workflow filenames

### DIFF
--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -2,7 +2,6 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { glob, hasMagic } from 'glob';
-import { nanoid } from 'nanoid';
 
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { tryPlatform } from '@platform/platform';
@@ -15,6 +14,8 @@ const STDIN_INPUT_TOKEN = '-';
 // LaTeX derives auxiliary filenames from the input basename; leading-dot
 // job names can be rejected by TeX's file-open policy when it writes `.aux`.
 const STDIN_TEMP_PREFIX = 'texra-stdin-';
+const STDIN_TEMP_DIR_PATTERN = /^texra-stdin-\d+-[A-Za-z0-9]{6}$/;
+export const STDIN_WORKFLOW_INPUT_BASENAME = 'stdin.tex';
 
 function resolveAgainstCwd(candidate: string, cwd: string): string {
   return path.isAbsolute(candidate)
@@ -94,6 +95,17 @@ export function hasMixedStdinWorkflowInputSpecs(
   return distinctSpecs.has(STDIN_INPUT_TOKEN) && distinctSpecs.size > 1;
 }
 
+export function isMaterializedStdinWorkflowInputPath(
+  inputPath: string,
+): boolean {
+  const normalized = inputPath.replaceAll('\\', '/');
+  const parent = path.posix.basename(path.posix.dirname(normalized));
+  return (
+    path.posix.basename(normalized) === STDIN_WORKFLOW_INPUT_BASENAME &&
+    STDIN_TEMP_DIR_PATTERN.test(parent)
+  );
+}
+
 export function createStdinWorkflowInputMaterializer(options: {
   readonly readStdinText: () => Promise<string>;
   readonly tempDir: string;
@@ -108,7 +120,9 @@ export function createStdinWorkflowInputMaterializer(options: {
       (inputPath) => {
         materializedPath = inputPath;
         if (cleanupStarted) {
-          void fs.rm(inputPath, { force: true }).catch(() => undefined);
+          void fs
+            .rm(path.dirname(inputPath), { recursive: true, force: true })
+            .catch(() => undefined);
         }
         return inputPath;
       },
@@ -121,7 +135,10 @@ export function createStdinWorkflowInputMaterializer(options: {
       shutdownCleanup?.dispose();
       shutdownCleanup = undefined;
       if (materializedPath) {
-        await fs.rm(materializedPath, { force: true });
+        await fs.rm(path.dirname(materializedPath), {
+          recursive: true,
+          force: true,
+        });
       }
     })();
     await cleanupPromise;
@@ -143,11 +160,18 @@ async function materializeStdinWorkflowInput(options: {
       'stdin: no data on stdin. Pipe content in and pass `-` to one file-taking flag.',
     );
   }
-  const inputFile = path.join(
-    options.tempDir,
-    `${STDIN_TEMP_PREFIX}${process.pid}-${nanoid()}.tex`,
+  const inputDir = await fs.mkdtemp(
+    path.join(options.tempDir, `${STDIN_TEMP_PREFIX}${process.pid}-`),
   );
-  await fs.writeFile(inputFile, text, { encoding: 'utf8', flag: 'wx' });
+  const inputFile = path.join(inputDir, STDIN_WORKFLOW_INPUT_BASENAME);
+  try {
+    await fs.writeFile(inputFile, text, { encoding: 'utf8', flag: 'wx' });
+  } catch (error) {
+    await fs.rm(inputDir, { recursive: true, force: true }).catch(() => {
+      // Preserve the original write failure for the caller.
+    });
+    throw error;
+  }
   return inputFile;
 }
 

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -16,6 +16,10 @@ import {
   type CliRunResult,
   type ExecuteAgentResult,
 } from './terminalStatus';
+import {
+  isMaterializedStdinWorkflowInputPath,
+  STDIN_WORKFLOW_INPUT_BASENAME,
+} from './workflowInputs';
 
 /** Resolve a user-supplied path against `cwd` when it isn't already absolute. */
 function joinCwdRelative(target: string, cwd: string): string {
@@ -156,6 +160,9 @@ function expectedInputOutputFiles(
   const absoluteRoot = commonDirectory(absoluteInputs.map(path.dirname));
 
   return inputFiles.map((input) => {
+    if (isMaterializedStdinWorkflowInputPath(input)) {
+      return STDIN_WORKFLOW_INPUT_BASENAME;
+    }
     if (!path.isAbsolute(input)) return getSafeDocumentRelativePath(input);
     return getSafeDocumentRelativePath(path.relative(absoluteRoot, input));
   });

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -41,6 +41,7 @@ import {
   expandRunInputs,
   expandWorkflowInputSpecs,
   hasMixedStdinWorkflowInputSpecs,
+  isMaterializedStdinWorkflowInputPath,
 } from '@cli/runtime/workflowInputs';
 import {
   resolveWorkflowOutput,
@@ -533,12 +534,16 @@ describe('CLI root argument routing', () => {
 
       expect(expanded).toHaveLength(1);
       expect(readCount).toBe(1);
-      expect(path.basename(expanded[0])).toMatch(/^texra-stdin-.+\.tex$/);
+      expect(path.basename(expanded[0])).toBe('stdin.tex');
+      expect(isMaterializedStdinWorkflowInputPath(expanded[0])).toBe(true);
       await expect(
         fs.readFile(path.resolve(root, expanded[0]), 'utf8'),
       ).resolves.toContain('\\begin{document}Hi');
       await stdinInputFile.cleanup();
       await expect(fs.stat(path.resolve(root, expanded[0]))).rejects.toThrow();
+      await expect(
+        fs.stat(path.dirname(path.resolve(root, expanded[0]))),
+      ).rejects.toThrow();
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
@@ -563,7 +568,8 @@ describe('CLI root argument routing', () => {
         },
       );
 
-      expect(path.basename(expanded[0])).toMatch(/^texra-stdin-.+\.tex$/);
+      expect(path.basename(expanded[0])).toBe('stdin.tex');
+      expect(isMaterializedStdinWorkflowInputPath(expanded[0])).toBe(true);
       expect(expanded[1]).toBe('paper.tex');
     } finally {
       await fs.rm(root, { recursive: true, force: true });
@@ -591,6 +597,18 @@ describe('CLI root argument routing', () => {
     expect(hasMixedStdinWorkflowInputSpecs(['-', '-'])).toBe(false);
     expect(hasMixedStdinWorkflowInputSpecs(['-', 'paper.tex'])).toBe(true);
     expect(hasMixedStdinWorkflowInputSpecs(['  -  ', 'paper.tex'])).toBe(true);
+  });
+
+  it('does not classify ordinary stdin-named files as materialized stdin', () => {
+    expect(isMaterializedStdinWorkflowInputPath('stdin.tex')).toBe(false);
+    expect(
+      isMaterializedStdinWorkflowInputPath('texra-stdin-workflow/stdin.tex'),
+    ).toBe(false);
+    expect(
+      isMaterializedStdinWorkflowInputPath(
+        'texra-stdin-123-workflow/stdin.tex',
+      ),
+    ).toBe(false);
   });
 
   it('does not read stdin before later --input validation errors', async () => {
@@ -657,7 +675,8 @@ describe('CLI root argument routing', () => {
 
       expect(inputFiles).toEqual(['main.tex']);
       expect(contextFiles).toHaveLength(1);
-      expect(path.basename(contextFiles[0])).toMatch(/^texra-stdin-.+\.tex$/);
+      expect(path.basename(contextFiles[0])).toBe('stdin.tex');
+      expect(isMaterializedStdinWorkflowInputPath(contextFiles[0])).toBe(true);
       await expect(
         fs.readFile(path.resolve(root, contextFiles[0]), 'utf8'),
       ).resolves.toBe('context body');

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -136,6 +136,50 @@ describe('CLI workflow output resolution', () => {
     );
   });
 
+  it('uses a stable output name for materialized stdin input', async () => {
+    const cwd = await makeTempDir();
+    const runOutput = join(cwd, 'run', 'r1', 'stdin.tex');
+    await mkdir(join(cwd, 'run', 'r1'), { recursive: true });
+    await writeFile(runOutput, 'from stdin');
+
+    const expectedOutputFiles = expectedOutputFilesForOutputDir(undefined, [
+      'texra-stdin-123-abc123/stdin.tex',
+    ]);
+
+    expect(expectedOutputFiles).toEqual(['stdin.tex']);
+
+    const { displayResult } = await resolveWorkflowOutput(
+      undefined,
+      'out',
+      workflowResult([
+        {
+          absolutePath: runOutput,
+          relativePath: 'r1/stdin.tex',
+          originalPath: join(
+            cwd,
+            'run',
+            'original',
+            'texra-stdin-123-abc123',
+            'stdin.tex',
+          ),
+        },
+      ]),
+      testContext(cwd),
+      {
+        expectedOutputFiles,
+        runDirectory: join(cwd, 'run'),
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      },
+    );
+
+    expect(displayResult).toMatchObject({
+      copiedOutputs: [join(cwd, 'out', 'stdin.tex')],
+    });
+    await expect(readFile(join(cwd, 'out', 'stdin.tex'), 'utf8')).resolves.toBe(
+      'from stdin',
+    );
+  });
+
   it('preserves expected nested input paths when copying flattened workflow outputs', async () => {
     const cwd = await makeTempDir();
     const runMain = join(cwd, 'run', 'r1', 'main.tex');


### PR DESCRIPTION
Fixes #6475

## Summary
- Materialize piped workflow stdin as `stdin.tex` inside a unique `texra-stdin-<pid>-.../` temp directory.
- Keep cleanup collision-safe by removing the materialization directory after expansion/execution.
- Teach `--output-dir` expected-output resolution to collapse materialized stdin inputs to `stdin.tex` instead of copying into temp-name paths.

## Why
Dogfooding `texra-local run correct --input -` exposed random implementation filenames such as `texra-stdin-49435-C4m3qTvp2l6-kmCcxmzqh.tex` in workflow progress. The temp name was safe but not user meaningful.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/WorkflowInputsLifecycle.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec eslint packages/cli/src/runtime/workflowInputs.ts packages/cli/src/runtime/workflowOutput.ts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts`
- `git diff --check`
- `npm run texra-local:build && npm run texra-local:link`
- No-cost stdin cleanup smoke: piped `texra-local run correct --input - --model definitely-not-a-model ...` exits before model execution and leaves no `texra-stdin-*` temp directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI stdin temp-file and output-path naming changes with targeted tests; no auth, security, or persistence changes.
> 
> **Overview**
> Piped workflow input (`--input -` / `--context -`) is no longer written as a single random `texra-stdin-<pid>-<id>.tex` file. It is materialized as **`stdin.tex`** inside a unique `texra-stdin-<pid>-<suffix>/` temp directory, so progress and logs show a stable, meaningful name.
> 
> **Cleanup** now removes that whole materialization directory (including on shutdown or if cleanup races materialization), with rollback of the temp dir if the write fails.
> 
> **`--output-dir`** expected-output logic recognizes materialized stdin paths via `isMaterializedStdinWorkflowInputPath` and maps them to **`stdin.tex`** when copying workflow outputs, instead of preserving the long temp path. Ordinary `stdin.tex` paths outside that temp-dir pattern are not treated as materialized stdin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6c30f9e8727090e9dd93658e1b3c8337213576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->