### PR TITLE
[codex] Fix nested workflow output directories

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path';
+
 import { XMLParser } from 'fast-xml-parser';
 
 import {
@@ -32,6 +34,7 @@ async function writeRoundOutput(
   absolutePath: string,
   content: string,
 ): Promise<void> {
+  await AbsoluteFS.ensureDir(path.dirname(absolutePath));
   if (await AbsoluteFS.isSymbolicLink(absolutePath)) {
     await AbsoluteFS.delete(absolutePath);
   }

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -98,6 +98,20 @@ describe('XmlOutputManager', () => {
     );
   });
 
+  it('creates parent directories for extracted document names with subdirectories', async () => {
+    const manager = createXmlManager();
+
+    await manager.processMultipleLatexDocuments(
+      [{ name: 'sections/main.tex', content: 'Nested section.\n' }],
+      createExternalLocation('/tmp/run/output.xml'),
+      0,
+    );
+
+    await expect(AbsoluteFS.read('/tmp/run/sections/main.tex')).resolves.toBe(
+      'Nested section.\n',
+    );
+  });
+
   it('does not auto-format extracted workflow outputs', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',


### PR DESCRIPTION
Fixes #6477.

## Summary
- create parent directories before writing extracted workflow documents
- cover nested document names like `sections/main.tex` in `XmlOutputManager` tests
- verified the real `texra-local run correct --input 'sections/*.tex' --output-dir corrected` path now copies nested outputs\n\n## Dogfood evidence\nBefore the fix, the CLI run completed the model round but exited 1 with:\n\n```text\nWorkflow completed without generated outputs; nothing was copied to corrected.\n```\n\nThe failing history record `6d083f5452ec` had valid model output with `<document name="sections/extrema.tex">...`, but no `result.outputs`. After rebuilding `texra-local`, the same nested-input workflow exited 0 and copied:\n\n- `/private/tmp/texra-workflow-dogfood-fixed.0ZlcM9/corrected/sections/extrema.tex`\n- `/private/tmp/texra-workflow-dogfood-fixed.0ZlcM9/corrected/sections/series.tex`\n\n## Validation\n- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/output/XmlOutputManager.vitest.ts src/test-kernel/agent/output/OutputProgressEvents.vitest.ts src/test-kernel/utils/text/ExtractDocumentsLegacyFallback.vitest.ts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts`\n- `corepack pnpm exec tsc --noEmit`\n- `corepack pnpm exec eslint src/agent/output/XmlOutputManager.ts src/test-kernel/agent/output/XmlOutputManager.vitest.ts`\n- `git diff --check`\n- `npm run texra-local:build && npm run texra-local:link`\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to workflow output file writes with a regression test; no auth, security, or core runtime behavior changes.
> 
> **Overview**
> **Fixes workflow runs that emit nested document paths** (e.g. `sections/main.tex`) by ensuring parent directories exist before extracted files are written.
> 
> `writeRoundOutput` in `XmlOutputManager` now calls `AbsoluteFS.ensureDir` on the target file’s parent directory (via `path.dirname`) ahead of the existing symlink cleanup and write. Without this, writes under subpaths could fail and the run could finish with no `result.outputs` even when the model returned valid `<document name="...">` XML.
> 
> A Vitest case asserts that `processMultipleLatexDocuments` writes to `/tmp/run/sections/main.tex` when the document name includes a subdirectory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cccd86a7900624993beb1c48213ed66034df0670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->