### PR TITLE
[codex] Align walkthrough credential onboarding

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1112,7 +1112,7 @@
           {
             "id": "texra.gettingStarted.signIn",
             "title": "Choose how TeXRA should sign in",
-            "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Sign in with ChatGPT](command:texra.auth.chatgpt.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
+            "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Sign in with ChatGPT](command:texra.auth.chatgpt.signIn)\n\n**Sign in with Researcher Access** — Free for academics; no API key needed. Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
             "media": {
               "image": "resources/walkthroughs/media/api-key-setup.png",
               "altText": "Screenshot of the model credential configuration view"

--- a/packages/extension/resources/walkthroughs/getting-started.md
+++ b/packages/extension/resources/walkthroughs/getting-started.md
@@ -8,8 +8,8 @@ The shortest path is: choose a credential, run setup once, then let the orchestr
 
 A credential is the one step no agent can do for you. Three ways in:
 
-- **Sign in — free for academics** -- Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.
-- **Use ChatGPT subscription** -- ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan from the Models tab.
+- **Use ChatGPT subscription** -- ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.
+- **Sign in with Researcher Access** -- Free for academics; no API key needed. Signing in also unlocks remote agents, including the orchestrator.
 - **Use your own provider API key** -- Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions (Claude Pro, ChatGPT for non-Codex models, etc.) do not include API access; you need a key from the provider's developer platform.
 
 You can also pick **Skip for now** and come back later, but nothing below runs without a credential.

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -1552,7 +1552,7 @@
                 "onCommand:texra.auth.chatgpt.signIn",
                 "onCommand:texra.setApiKey"
               ],
-              "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Sign in — free for academics** — Researcher Access: no API key needed (recommended). Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Sign in with ChatGPT](command:texra.auth.chatgpt.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
+              "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Sign in with ChatGPT](command:texra.auth.chatgpt.signIn)\n\n**Sign in with Researcher Access** — Free for academics; no API key needed. Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
               "id": "texra.gettingStarted.signIn",
               "media": {
                 "altText": "Screenshot of the model credential configuration view",

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -14,6 +14,10 @@ function readWebviewComponent(name: string): string {
   );
 }
 
+function readRepoFile(path: string): string {
+  return readFileSync(repoPath(path), 'utf8');
+}
+
 describe('extension onboarding experience', () => {
   it('shows the State 0 path from credential to first review', () => {
     const source = readWebviewComponent('OnboardingWelcomeCard');
@@ -39,6 +43,24 @@ describe('extension onboarding experience', () => {
     );
     expect(chatGptButton).toContain('variant="brand"');
     expect(chatGptButton).toContain('appearance="filled"');
+  });
+
+  it('keeps walkthrough credential copy aligned with ChatGPT-first onboarding', () => {
+    for (const source of [
+      readRepoFile('packages/extension/package.json'),
+      readRepoFile(
+        'packages/extension/resources/walkthroughs/getting-started.md',
+      ),
+    ]) {
+      const chatGptStart = source.indexOf('**Use ChatGPT subscription**');
+      const researcherStart = source.indexOf(
+        '**Sign in with Researcher Access**',
+      );
+
+      expect(chatGptStart).toBeGreaterThanOrEqual(0);
+      expect(researcherStart).toBeGreaterThanOrEqual(0);
+      expect(chatGptStart).toBeLessThan(researcherStart);
+    }
   });
 
   it('keeps empty-project onboarding action oriented', () => {


### PR DESCRIPTION
## Summary

- Put ChatGPT subscription first in the VS Code Getting Started walkthrough credential step.
- Align the markdown walkthrough with the live onboarding welcome card and setup picker.
- Add an onboarding regression test that checks walkthrough copy keeps ChatGPT before Researcher Access.
- Update the extension package invariant snapshot for the manifest copy change.

## Why

The live onboarding flow already treats ChatGPT subscription as the primary credential path, but the packaged walkthrough still recommended Researcher Access first. That made the extension onboarding inconsistent across first-run surfaces.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/webview/OnboardingExperience.vitest.mts`
- `npm run check:extension-package-invariants`
- `corepack pnpm exec prettier --check packages/extension/package.json packages/extension/resources/walkthroughs/getting-started.md src/test-kernel/webview/OnboardingExperience.vitest.mts scripts/extension-package-invariants.snapshot.json`
- `npm run lint` (passes with 4 existing import-order warnings outside this change)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and manifest copy only; no auth routing or credential logic changes.
> 
> **Overview**
> **Credential onboarding copy** now lists **ChatGPT subscription** first and **Researcher Access** second in the VS Code Getting Started walkthrough step (`package.json`) and in `getting-started.md`, matching the live welcome card. Researcher Access no longer carries the old “recommended” framing; command links are reordered so ChatGPT sign-in appears before TeXRA sign-in.
> 
> The **extension package invariants snapshot** is updated so CI keeps the walkthrough manifest in sync.
> 
> A **regression test** in `OnboardingExperience.vitest.mts` asserts that `**Use ChatGPT subscription**` appears before `**Sign in with Researcher Access**` in both packaged walkthrough sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc2429f2bc7b13755aeb1d3cc6c46d2ca6e3624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->