### PR TITLE
refactor(mimeUtils): use path.extname() instead of manual lastIndexOf

### DIFF
--- a/src/utils/files/mimeUtils.ts
+++ b/src/utils/files/mimeUtils.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import * as path from 'node:path';
+
 // Third-party imports
 import mime from 'mime-types';
 
@@ -9,23 +12,28 @@ const AUDIO_MIME_TYPE_OVERRIDES: Readonly<Record<string, string>> = {
   '.opus': 'audio/opus',
 };
 
+/**
+ * Accepts a full path, a dotfile name (`.opus`), or a bare extension (`opus`).
+ * Returns the lowercase extension with a leading dot, or `''` for
+ * extensionless paths that have a directory separator.
+ */
 function getExtension(pathOrExtension: string): string {
-  const hasPathSeparator = /[\\/]/.test(pathOrExtension);
-  const fileName = pathOrExtension.split(/[\\/]/).at(-1) ?? pathOrExtension;
+  const normalized = pathOrExtension.replaceAll('\\', '/');
+  const hasPathSeparator = normalized.includes('/');
+  const fileName = normalized.split('/').at(-1) ?? normalized;
+
+  // Dotfile with no further dot (e.g. `.opus`) — treat the whole name as the extension.
   if (fileName.startsWith('.') && !fileName.slice(1).includes('.')) {
     return fileName.toLowerCase();
   }
 
-  const dotIndex = fileName.lastIndexOf('.');
-  if (dotIndex >= 0) {
-    return fileName.slice(dotIndex).toLowerCase();
-  }
+  const ext = path.extname(fileName);
+  if (ext) return ext.toLowerCase();
 
-  if (hasPathSeparator) {
-    return '';
-  }
+  // Bare extension string like `opus` (no separator, no dot) → `.opus`.
+  if (!hasPathSeparator) return `.${fileName.toLowerCase()}`;
 
-  return `.${fileName.toLowerCase()}`;
+  return '';
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace manual `lastIndexOf('.')` + regex-split (`/[\\/]/`) in `mimeUtils.ts::getExtension` with `node:path.extname()` and a simple `replaceAll('\\', '/')` normalize step
- Eliminate the regex `/[\\/]/` test for path-separator detection in favour of `normalized.includes('/')`
- Add a JSDoc comment to `getExtension` describing the three accepted input forms

## Why

A codebase-wide scan surfaced this as the one place where extension extraction was done manually instead of via the already-available `path.extname()`. The rest of the codebase (e.g. `pathCore.ts::getExtensionLowercase`) consistently delegates to `path.extname()`; this brings `mimeUtils` in line.

The refactor preserves all three input forms the function intentionally handles:
| Input | Result |
|---|---|
| Full path `/tmp/clip.opus` | `.opus` |
| Dotfile `.mulaw` | `.mulaw` |
| Bare extension `opus` | `.opus` |
| Extensionless path `/tmp/opus` | `''` |

## Test plan

- [x] All 3 existing `mimeUtils.vitest.ts` tests pass (file paths, bare extensions, extensionless paths)
- [x] Full test suite: 504 files / 3550 tests pass; the single pre-existing failure (`execUtils > aborts shell command process groups`) is an environment issue unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjA51jqLtSHysM5eNZ7zwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjA51jqLtSHysM5eNZ7zwJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, behavior-preserving refactor in MIME helper code with no auth or data-path changes; risk is limited to edge cases in extension parsing.
> 
> **Overview**
> Refactors **`getExtension`** in `mimeUtils.ts` to align with the rest of the codebase: it now normalizes backslashes, uses **`node:path.extname()`** for extension parsing, and **`includes('/')`** instead of a regex for path detection. A **JSDoc** documents the supported input shapes (full path, dotfile, bare extension).
> 
> **`getMimeType`** and the audio override map are unchanged; existing tests still cover paths, bare extensions, and extensionless paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee4ed1fedd6c7ef2acdfec3fa4abbb4250c3349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->