### PR TITLE
[codex] Show credential onboarding first

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -734,12 +734,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const welcomeKey = 'texra.welcomeShown';
   if (!context.globalState.get<boolean>(welcomeKey)) {
-    // Land first-run users on the Multi-Agent tab so they see the
-    // team card grid (icons, descriptions, agent pills) as their first
-    // interaction, then open the walkthrough alongside for the rest of
-    // the onboarding tips.
+    // Land first-run users on the main welcome card so the credential choice
+    // (ChatGPT subscription first) is the first real action, then open the
+    // walkthrough alongside for the rest of the onboarding tips.
     void vscode.commands
-      .executeCommand('texra.showMultiAgent')
+      .executeCommand('texra.showMainView')
       .then(() => vscode.commands.executeCommand('texra.openGettingStarted'))
       .then(() => context.globalState.update(welcomeKey, true));
   }

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -63,6 +63,24 @@ describe('extension onboarding experience', () => {
     }
   });
 
+  it('lands first-run extension users on the credential welcome card', () => {
+    const source = readRepoFile('packages/extension/src/extension.ts');
+    const firstRunBlock = source.slice(source.indexOf('const welcomeKey'));
+    const showMainView = firstRunBlock.indexOf(
+      "executeCommand('texra.showMainView')",
+    );
+    const openWalkthrough = firstRunBlock.indexOf(
+      "executeCommand('texra.openGettingStarted')",
+    );
+
+    expect(showMainView).toBeGreaterThanOrEqual(0);
+    expect(openWalkthrough).toBeGreaterThanOrEqual(0);
+    expect(showMainView).toBeLessThan(openWalkthrough);
+    expect(firstRunBlock).not.toContain(
+      "executeCommand('texra.showMultiAgent')",
+    );
+  });
+
   it('keeps empty-project onboarding action oriented', () => {
     const source = readWebviewComponent('GettingStartedBanner');
 


### PR DESCRIPTION
## Summary

- Land first-run extension users on the main TeXRA view instead of the Multi-Agent tab.
- Keep the getting-started walkthrough opening after the main view so the credential welcome card is the first actionable surface.
- Add a static onboarding regression test for the first-run activation command sequence.

Fixes #6483.

## Validation

- `corepack pnpm exec prettier --check packages/extension/src/extension.ts src/test-kernel/webview/OnboardingExperience.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/webview/OnboardingExperience.vitest.mts`
- `npm run lint` (passes with existing import-order warnings)
- `npm run typecheck`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding-only navigation change with no auth, data, or core runtime impact; covered by a source-level regression test.
> 
> **Overview**
> **First-run activation** now opens the main TeXRA launcher (`texra.showMainView`) instead of the Multi-Agent tab, so the credential welcome card (ChatGPT subscription first) is the first actionable surface. The getting-started walkthrough still opens immediately after, unchanged in order.
> 
> A static regression test in `OnboardingExperience.vitest.mts` asserts that sequence and that `texra.showMultiAgent` is no longer used in the first-run block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b6ed55c7b101a394b69c30a1b6d5d77e066b34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->