### PR TITLE
[codex] Clarify extension onboarding entry points

### DIFF
--- a/packages/extension/src/frontend/ui/welcomeView.ts
+++ b/packages/extension/src/frontend/ui/welcomeView.ts
@@ -113,9 +113,9 @@ function renderWelcomeHtml(): string {
   </p>
   <p>${ONBOARDING_NARRATIVE}</p>
   <ol>
-    <li>Open a single-folder workspace containing your LaTeX project.</li>
-    <li>Choose ${ONBOARDING_CHOICE_CHATGPT.label}, ${ONBOARDING_CHOICE_SIGN_IN.label}, or a provider API key.</li>
-    <li>Let the setup assistant check the project and launch the first run.</li>
+    <li>Open a single-folder workspace containing your LaTeX project, or start with the sample project.</li>
+    <li>The main view will show the credential picker: ${ONBOARDING_CHOICE_CHATGPT.label}, ${ONBOARDING_CHOICE_SIGN_IN.label}, or a provider API key.</li>
+    <li>Run setup once to check LaTeX, apply the right team, and launch the first review.</li>
   </ol>
   <div class="actions">
     <a class="button" href="${openFolder}">Open Folder</a>

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -124,8 +124,11 @@ export class GettingStartedBanner extends LitElement {
           <div class="getting-started-row">
             <div class="getting-started-body">
               <div class="getting-started-title">
-                <strong>Empty project</strong>
-                <span>Start with setup or bring in a LaTeX source.</span>
+                <strong>No LaTeX files yet</strong>
+                <span>
+                  Run setup to connect TeXRA, check this workspace, or import a
+                  source.
+                </span>
               </div>
               <div class="getting-started-actions">
                 <a

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -84,10 +84,28 @@ describe('extension onboarding experience', () => {
   it('keeps empty-project onboarding action oriented', () => {
     const source = readWebviewComponent('GettingStartedBanner');
 
-    expect(source).toContain('Empty project');
+    expect(source).toContain('No LaTeX files yet');
+    expect(source).toContain('Run setup to connect TeXRA');
     expect(source).toContain('COMMAND_LINKS.RUN_SETUP_ASSISTANT');
     expect(source).toContain('action-link--primary');
     expect(source).toContain('COMMAND_LINKS.GETTING_STARTED');
-    expect(source).not.toContain('Empty folder');
+    expect(source).not.toContain('Empty project');
+  });
+
+  it('keeps the no-workspace welcome view project-first', () => {
+    const source = readRepoFile(
+      'packages/extension/src/frontend/ui/welcomeView.ts',
+    );
+    const openWorkspace = source.indexOf(
+      'Open a single-folder workspace containing your LaTeX project',
+    );
+    const credentialPicker = source.indexOf(
+      'The main view will show the credential picker',
+    );
+
+    expect(openWorkspace).toBeGreaterThanOrEqual(0);
+    expect(credentialPicker).toBeGreaterThanOrEqual(0);
+    expect(openWorkspace).toBeLessThan(credentialPicker);
+    expect(source).toContain('Run setup once to check LaTeX');
   });
 });


### PR DESCRIPTION
Closes #6486.

## Summary
- Make the no-workspace welcome view project-first, then point users to the main-view credential picker after a folder is open.
- Update the empty-project banner to explain that setup connects TeXRA, checks the workspace, and can help import a source.
- Extend the onboarding experience test to lock the project-first no-workspace path.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/webview/OnboardingExperience.vitest.mts`
- `corepack pnpm exec prettier --check packages/extension/src/frontend/ui/welcomeView.ts packages/extension/src/webview/frontend/components/GettingStartedBanner.ts src/test-kernel/webview/OnboardingExperience.vitest.mts`
- `npm run lint` (passes; unrelated existing import-order warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing onboarding strings and source-level regression tests only; no auth, setup logic, or activation flow changes.
> 
> **Overview**
> **Onboarding copy** is updated so users see a clearer sequence: open a project first, then credentials in the main view, then one-time setup.
> 
> The **no-workspace welcome** (`welcomeView.ts`) reorders and rewrites the numbered steps: open a single-folder LaTeX workspace (or the sample project) comes first; step 2 explains the **main-view credential picker** (ChatGPT, sign-in, or API key); step 3 describes **run setup once** (LaTeX check, team, first review).
> 
> The **empty-project banner** (`GettingStartedBanner`) retitles **"Empty project"** to **"No LaTeX files yet"** and expands the subtitle so setup is framed as connecting TeXRA, checking the workspace, and helping import a source. Primary actions are unchanged.
> 
> **Tests** in `OnboardingExperience.vitest.mts` assert the new banner strings and add a case that the welcome view stays **project-first** (workspace step before credential-picker copy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c5636fb898908ffe0cad10be987db66cde2777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->