### PR TITLE
Rename ToolUsePrepNode to ToolUseRoundPrepNode and clarify docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,7 +310,8 @@ For good separation of concerns and platform independence, core business logic s
 **Agent execution and tool-use**
 
 - Define agents using `AgentDataclass` and `AgentConfig` (`src/agent/core/`) and compose them via the factories in `src/agent/runtime`.
-- Launch and resume executions via `executeAgent` (`src/agent/runtime/executeAgent.ts`) so session filters, run directories, and resume actions stay synchronized.
+- Launch executions from host code (commands, frontend services, desktop IPC) via `runAgent` (`src/agent/runtime/runAgent.ts`) — it assigns an `executionId`, registers the run in storage, and opens workflow output. Only use the lower-level `executeAgent` when you already own the `executionId` (e.g. subagent dispatch in `DelegationTools.ts` or a resume path). Both functions require an explicit `runtimeHost`.
+- Resume a persisted tool-use session via `resumeToolUseFromSnapshot` (`src/agent/runtime/executeAgent.ts`), not `runAgent`.
 - Add new model handlers under `src/agent/modelHandlers/`, export them through the index, and register capabilities/pricing in `src/model/computeModelOptions.ts`.
 
 **PocketFlow architecture**

--- a/docs/agent-sdk-readiness-audit.md
+++ b/docs/agent-sdk-readiness-audit.md
@@ -1570,7 +1570,7 @@ it adding a wrapper, barrel, or run-entry indirection:
 
 - **`2f062af` "split tool-use cycle flow and agent registry into modules" + `4bb4bbe` (PR #5803,
   `refactor/modularize-monoliths`).** The tool-use cycle flow was decomposed into
-  `core/flows/toolUseCycle/{ToolUsePrepNode,ToolUseProcessNode,ToolUseDispatchNode,cycleShared,toolCallParsing}.ts`
+  `core/flows/toolUseRound/{ToolUseRoundPrepNode,ToolUseProcessNode,ToolUseDispatchNode,roundShared,toolCallParsing}.ts`
   (the §16 backlog had no item here — this is proactive monolith-splitting), and the agent
   registry was split into `index/{agentEntry,agentOptionsBuilder,agentYamlScanner,remoteAgentMeta,agentRegistryConstants}.ts`.
   The latter **largely closes §16 new-finding #1** (the `agentRegistry` UI-altitude mix): the

--- a/docs/design/subagent-output-design.md
+++ b/docs/design/subagent-output-design.md
@@ -404,7 +404,7 @@ The delivery chain:
 
 3. If orchestrator is mid-cycle (model calling / tool executing):
    └→ Text sits in queue
-   └→ On NEXT cycle, ToolUseRoundPrepNode.prep() checks session.hasQueuedFollowUp()
+   └→ On NEXT round, ToolUseRoundPrepNode.prep() checks session.hasQueuedFollowUp()
    └→ Drains queue, calls modelHandler.createUserFollowUpMessages()
    └→ Appended to shared.messages as user message before next model call
 ```
@@ -445,7 +445,7 @@ If the orchestrator's session has ended (WaitNode returned stop, flow exited):
 
 1. `ToolUseFollowUpQueue.enqueue()` still works — it auto-creates the queue
 2. But nobody is listening — the orchestrator's flow has exited
-3. If the user resumes the session, `ToolUsePrepareNode` restores from snapshot and `ToolUseRoundPrepNode` drains the queue on the next cycle
+3. If the user resumes the session, `ToolUsePrepareNode` restores from snapshot and `ToolUseRoundPrepNode` drains the queue on the next round
 
 So results are NOT lost — they persist in the queue until the session resumes or the queue is released. The only true loss case is if `ToolUseFollowUpQueue.release(streamId)` is called before the subagent completes. This happens in `ToolUseSessionLifecycle.dispose()`.
 

--- a/docs/design/subagent-output-design.md
+++ b/docs/design/subagent-output-design.md
@@ -404,7 +404,7 @@ The delivery chain:
 
 3. If orchestrator is mid-cycle (model calling / tool executing):
    └→ Text sits in queue
-   └→ On NEXT cycle, ToolUsePrepNode.prep() checks session.hasQueuedFollowUp()
+   └→ On NEXT cycle, ToolUseRoundPrepNode.prep() checks session.hasQueuedFollowUp()
    └→ Drains queue, calls modelHandler.createUserFollowUpMessages()
    └→ Appended to shared.messages as user message before next model call
 ```
@@ -445,7 +445,7 @@ If the orchestrator's session has ended (WaitNode returned stop, flow exited):
 
 1. `ToolUseFollowUpQueue.enqueue()` still works — it auto-creates the queue
 2. But nobody is listening — the orchestrator's flow has exited
-3. If the user resumes the session, `ToolUsePrepareNode` restores from snapshot and `ToolUsePrepNode` drains the queue on the next cycle
+3. If the user resumes the session, `ToolUsePrepareNode` restores from snapshot and `ToolUseRoundPrepNode` drains the queue on the next cycle
 
 So results are NOT lost — they persist in the queue until the session resumes or the queue is released. The only true loss case is if `ToolUseFollowUpQueue.release(streamId)` is called before the subagent completes. This happens in `ToolUseSessionLifecycle.dispose()`.
 

--- a/src/agent/core/flows/ToolUseRoundFlow.ts
+++ b/src/agent/core/flows/ToolUseRoundFlow.ts
@@ -22,7 +22,7 @@ import { defaultPostCompactionContext } from '@agent/core/flows/CommonCycleTypes
 // Local file imports
 import { FlowTransition } from './FlowTransitions';
 import { ModelInvocationNode } from './ModelInvocationNode';
-import { ToolUsePrepNode } from './toolUseRound/ToolUsePrepNode';
+import { ToolUseRoundPrepNode } from './toolUseRound/ToolUseRoundPrepNode';
 import { ToolUseProcessNode } from './toolUseRound/ToolUseProcessNode';
 import { ToolUseDispatchNode } from './toolUseRound/ToolUseDispatchNode';
 import type { CycleParams, ToolUseRoundServices } from './CycleServices';
@@ -51,7 +51,7 @@ export function createToolUseRoundFlow<C>(): Flow<
   CycleParams,
   ToolUseRoundServices<C>
 > {
-  const prepNode = new ToolUsePrepNode<C>();
+  const prepNode = new ToolUseRoundPrepNode<C>();
   const callNode = new ModelInvocationNode<
     ToolUseRoundShared,
     CycleParams,

--- a/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
@@ -16,26 +16,32 @@ import { FlowTransition } from '../FlowTransitions';
 import type { CycleParams, ToolUseRoundServices } from '../CycleServices';
 import type { ToolUseRoundShared } from './roundShared';
 
-/** Prep result for ToolUsePrepNode - drained queued follow-up plus interrupt flag. */
-interface ToolUsePrepResult {
+/** Prep result for ToolUseRoundPrepNode - drained queued follow-up plus interrupt flag. */
+interface ToolUseRoundPrepResult {
   interrupted: boolean;
   queuedFollowUps: readonly FollowUpQueueBatchItem[] | null;
   synthetic: boolean;
 }
 
 /**
- * Prepares a tool-use round by checking interruptions and injecting queued follow-ups.
+ * Prepares one tool-use **round** (a single LLM invocation) by checking for
+ * interruptions and injecting any queued user follow-ups BEFORE the model call.
+ *
+ * "Round" = one invocation of the model inside `ToolUseRoundFlow`. This is the
+ * inner-loop prep node. Compare `ToolUsePrepareNode` in
+ * `implementations/flows/tooluse/nodes/`, which is the outer session-init node
+ * that runs once per tool-use session (builds initial messages, loads snapshots).
  *
  * If there are queued user messages (typed during previous tool execution),
  * they are injected here BEFORE calling the model. This ensures the model's
  * thinking/response considers the user's feedback.
  */
-export class ToolUsePrepNode<C> extends BaseNode<
+export class ToolUseRoundPrepNode<C> extends BaseNode<
   ToolUseRoundShared,
   CycleParams,
   ToolUseRoundServices<C>
 > {
-  async prep(_shared: ToolUseRoundShared): Promise<ToolUsePrepResult> {
+  async prep(_shared: ToolUseRoundShared): Promise<ToolUseRoundPrepResult> {
     const interrupted = this.services.checkInterruption();
 
     if (!this.services.session?.hasQueuedFollowUp()) {
@@ -57,7 +63,7 @@ export class ToolUsePrepNode<C> extends BaseNode<
 
   async post(
     shared: ToolUseRoundShared,
-    prepRes: ToolUsePrepResult,
+    prepRes: ToolUseRoundPrepResult,
   ): Promise<string | undefined> {
     if (prepRes.interrupted) {
       shared.shouldStop = true;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -13,6 +13,14 @@ type PrepareExecResult =
   | { kind: 'success'; result: PrepareResult }
   | { kind: 'error'; error: Error };
 
+/**
+ * Session-init node: runs **once per tool-use session** to build the initial
+ * message array or restore from a persisted snapshot.
+ *
+ * This is the outer session-level prep. Compare `ToolUseRoundPrepNode` in
+ * `core/flows/toolUseRound/`, which is the inner per-LLM-call prep node that
+ * runs at the start of every model invocation inside `ToolUseRoundFlow`.
+ */
 export class ToolUsePrepareNode<C> extends Node<
   ToolUseRunShared,
   ToolUseFlowParams,


### PR DESCRIPTION
## Summary

Rename `ToolUsePrepNode` to `ToolUseRoundPrepNode` to clarify that it prepares a single LLM invocation round (not the entire tool-use session). Add detailed documentation distinguishing this inner per-round prep node from the outer session-init `ToolUsePrepareNode`. Update AGENTS.md to clarify the distinction between `runAgent` (for launching new executions) and `resumeToolUseFromSnapshot` (for resuming persisted sessions).

## Issue acceptance gates

N/A — internal naming and documentation clarity.

## Single source of truth

The distinction between session-level and round-level preparation is now explicit in class names and docstrings:
- `ToolUsePrepareNode` (outer): runs once per tool-use session, builds initial messages or restores from snapshot
- `ToolUseRoundPrepNode` (inner): runs at the start of each LLM invocation inside `ToolUseRoundFlow`, checks interruptions and injects queued follow-ups

## Duplication and abstraction budget

No duplication removed or added. This is a pure naming and documentation improvement to reduce cognitive load when navigating the two-level prep hierarchy.

## Host impact

Extension: None  
Desktop: None  
CLI: None

## Scheduled refactoring

None

## Validation

- Rename is mechanical: class name, interface name, import statements, and instantiation site updated consistently
- No logic changes; existing tests continue to pass
- Documentation additions clarify the architectural intent without changing behavior

https://claude.ai/code/session_013rVLHysdBDcinnRXciXLKq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename and documentation only; no runtime or API behavior changes.
> 
> **Overview**
> Renames **`ToolUsePrepNode`** to **`ToolUseRoundPrepNode`** (class, prep-result type, file, and `ToolUseRoundFlow` wiring) so the name matches its job: prep for one **round** (single LLM call) inside `ToolUseRoundFlow`, not whole-session setup.
> 
> Adds cross-referencing docstrings on **`ToolUseRoundPrepNode`** and **`ToolUsePrepareNode`** to spell out the two-level hierarchy—**session** prep once per tool-use session vs **round** prep before each model invocation—and updates design/audit docs to use the new names.
> 
> **`AGENTS.md`** now distinguishes **`runAgent`** (new executions from hosts) from **`executeAgent`** / **`resumeToolUseFromSnapshot`** (owned `executionId` or resuming a persisted tool-use session).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02d50a3bcedf65e9e6970f4b90e83235022187f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->