### PR TITLE
refactor(ui): replace custom action-link buttons with wa-button in GettingStartedBanner

### DIFF
--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -23,6 +23,7 @@ import {
   truncateSummaryToWidth,
 } from '../render/terminalText';
 
+// Terminal-safe Unicode glyph — Font Awesome is not available in Ink TUI.
 const STATUS_DOT = '●';
 const OUTPUT_CORNER = '⎿';
 const MAX_HEADER_PREVIEW = 80;

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -315,6 +315,46 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.applyConfigUpdate(
           this.interactionController.getDismissConfigUpdate(m),
         ),
+      [MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION]: async (m) => {
+        switch (m.action) {
+          case 'runSetup':
+            await safeExecuteCommand(
+              'texra.runSetupAssistant',
+              [],
+              this.viewName,
+            );
+            await this.onboarding?.refreshOnboardingFunnel();
+            break;
+          case 'createSampleProject':
+            await safeExecuteCommand(
+              'texra.createSampleProject',
+              [],
+              this.viewName,
+            );
+            break;
+          case 'cloneOverleaf':
+            await safeExecuteCommand(
+              'texra.cloneOverleafProject',
+              [],
+              this.viewName,
+            );
+            break;
+          case 'downloadArxiv':
+            await safeExecuteCommand(
+              'texra.downloadArXivSource',
+              [],
+              this.viewName,
+            );
+            break;
+          case 'openWalkthrough':
+            await safeExecuteCommand(
+              'texra.openGettingStarted',
+              [],
+              this.viewName,
+            );
+            break;
+        }
+      },
       [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP]: async () => {
         // Persist the user-scoped declined flag (same flag the CLI picker
         // writes), then re-derive so the card disappears and the normal

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -353,6 +353,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
               this.viewName,
             );
             break;
+          default: {
+            const exhaustive: never = m.action;
+            throw new Error(`Unhandled getting started action: ${exhaustive}`);
+          }
         }
       },
       [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP]: async () => {

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -41,6 +41,7 @@ import {
   type EditedFileChangeDetail,
   type FileActionDetail,
   type FocusInstructionDetail,
+  type GettingStartedActionDetail,
   type InstallGuideDetail,
   type InstructionChangeDetail,
   type LatexDiffsActionDetail,
@@ -1480,6 +1481,14 @@ export class MainApp extends MainAppBase {
     this.gettingStartedDismissed.set(true);
   }
 
+  private handleComponentGettingStartedAction(
+    e: CustomEvent<GettingStartedActionDetail>,
+  ): void {
+    postMessage(MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION, {
+      action: e.detail.action,
+    });
+  }
+
   private handleComponentDismissSessionHint(): void {
     postMessage(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER);
     this.sessionHintDismissed.set(true);
@@ -1833,6 +1842,7 @@ export class MainApp extends MainAppBase {
             @dismiss-login=${this.handleComponentDismissLogin}
             @dismiss-getting-started=${this
               .handleComponentDismissGettingStarted}
+            @getting-started-action=${this.handleComponentGettingStartedAction}
           ></banner-group>
 
           <wa-divider></wa-divider>

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -12,7 +12,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
-import { COMMAND_LINKS } from '@shared/utils/uiConstants';
+import type { GettingStartedAction } from '@shared/schemas';
 
 import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
@@ -90,6 +90,10 @@ export class GettingStartedBanner extends LitElement {
     this.dispatchEvent(MainViewEvents.dismissGettingStarted());
   }
 
+  private handleAction(action: GettingStartedAction): void {
+    this.dispatchEvent(MainViewEvents.gettingStartedAction({ action }));
+  }
+
   override render(): TemplateResult {
     return html`
       <div class="banner-frame">
@@ -113,14 +117,14 @@ export class GettingStartedBanner extends LitElement {
                   variant="brand"
                   appearance="filled"
                   size="small"
-                  href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}
+                  @click=${() => this.handleAction('runSetup')}
                 >
                   ${waIcon('rocket', { slot: 'start' })} Run setup assistant
                 </wa-button>
                 <wa-button
                   appearance="outlined"
                   size="small"
-                  href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
+                  @click=${() => this.handleAction('createSampleProject')}
                 >
                   ${waIcon('file-circle-plus', { slot: 'start' })} Sample
                   project
@@ -128,7 +132,7 @@ export class GettingStartedBanner extends LitElement {
                 <wa-button
                   appearance="outlined"
                   size="small"
-                  href=${COMMAND_LINKS.CLONE_OVERLEAF}
+                  @click=${() => this.handleAction('cloneOverleaf')}
                 >
                   ${waIcon('cloud-arrow-down', { slot: 'start' })} Import
                   Overleaf
@@ -136,14 +140,14 @@ export class GettingStartedBanner extends LitElement {
                 <wa-button
                   appearance="outlined"
                   size="small"
-                  href=${COMMAND_LINKS.DOWNLOAD_ARXIV}
+                  @click=${() => this.handleAction('downloadArxiv')}
                 >
                   ${waIcon('download', { slot: 'start' })} Import arXiv
                 </wa-button>
                 <wa-button
                   appearance="outlined"
                   size="small"
-                  href=${COMMAND_LINKS.GETTING_STARTED}
+                  @click=${() => this.handleAction('openWalkthrough')}
                 >
                   ${waIcon('book', { slot: 'start' })} Walkthrough
                 </wa-button>

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -25,10 +25,6 @@ export class GettingStartedBanner extends LitElement {
     commonViewStyles,
     bannerStyles,
     css`
-      wa-callout.getting-started-banner a {
-        text-decoration: none;
-      }
-
       .getting-started-row {
         display: flex;
         align-items: flex-start;
@@ -64,35 +60,6 @@ export class GettingStartedBanner extends LitElement {
         display: flex;
         flex-wrap: wrap;
         gap: var(--wa-space-3xs);
-      }
-
-      .action-link {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: var(--wa-space-3xs);
-        min-height: 24px;
-        max-width: 100%;
-        padding: 2px var(--wa-space-xs);
-        border: 1px solid var(--vscode-button-border, transparent);
-        border-radius: var(--wa-border-radius-s, 4px);
-        background: var(--vscode-button-secondaryBackground);
-        color: var(--vscode-button-secondaryForeground);
-        line-height: var(--line-height-normal);
-        white-space: nowrap;
-      }
-
-      .action-link:hover {
-        background: var(--vscode-button-secondaryHoverBackground);
-      }
-
-      .action-link--primary {
-        background: var(--vscode-button-background);
-        color: var(--vscode-button-foreground);
-      }
-
-      .action-link--primary:hover {
-        background: var(--vscode-button-hoverBackground);
       }
 
       .dismiss-button {
@@ -131,27 +98,41 @@ export class GettingStartedBanner extends LitElement {
                 </span>
               </div>
               <div class="getting-started-actions">
-                <a
-                  class="action-link action-link--primary"
+                <wa-button
+                  appearance="filled"
+                  size="small"
                   href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}
                 >
-                  ${waIcon('rocket')} Run setup
-                </a>
-                <a
-                  class="action-link"
+                  ${waIcon('rocket', { slot: 'start' })} Run setup
+                </wa-button>
+                <wa-button
+                  appearance="outlined"
+                  size="small"
                   href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
                 >
-                  ${waIcon('file-circle-plus')} Sample project
-                </a>
-                <a class="action-link" href=${COMMAND_LINKS.CLONE_OVERLEAF}>
-                  ${waIcon('cloud-arrow-down')} Overleaf
-                </a>
-                <a class="action-link" href=${COMMAND_LINKS.DOWNLOAD_ARXIV}>
-                  ${waIcon('download')} arXiv
-                </a>
-                <a class="action-link" href=${COMMAND_LINKS.GETTING_STARTED}>
-                  ${waIcon('book')} Walkthrough
-                </a>
+                  ${waIcon('file-circle-plus', { slot: 'start' })} Sample project
+                </wa-button>
+                <wa-button
+                  appearance="outlined"
+                  size="small"
+                  href=${COMMAND_LINKS.CLONE_OVERLEAF}
+                >
+                  ${waIcon('cloud-arrow-down', { slot: 'start' })} Overleaf
+                </wa-button>
+                <wa-button
+                  appearance="outlined"
+                  size="small"
+                  href=${COMMAND_LINKS.DOWNLOAD_ARXIV}
+                >
+                  ${waIcon('download', { slot: 'start' })} arXiv
+                </wa-button>
+                <wa-button
+                  appearance="outlined"
+                  size="small"
+                  href=${COMMAND_LINKS.GETTING_STARTED}
+                >
+                  ${waIcon('book', { slot: 'start' })} Walkthrough
+                </wa-button>
               </div>
             </div>
             <wa-button

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -56,10 +56,20 @@ export class GettingStartedBanner extends LitElement {
         color: var(--vscode-descriptionForeground);
       }
 
+      .getting-started-copy {
+        margin: 0;
+        color: var(--vscode-descriptionForeground);
+        line-height: var(--line-height-normal, 1.4);
+      }
+
       .getting-started-actions {
         display: flex;
         flex-wrap: wrap;
         gap: var(--wa-space-3xs);
+      }
+
+      .getting-started-actions wa-button::part(base) {
+        min-height: 26px;
       }
 
       .dismiss-button {
@@ -92,18 +102,20 @@ export class GettingStartedBanner extends LitElement {
             <div class="getting-started-body">
               <div class="getting-started-title">
                 <strong>No LaTeX files yet</strong>
-                <span>
-                  Run setup to connect TeXRA, check this workspace, or import a
-                  source.
-                </span>
+                <span>Start from a sample or import an existing paper.</span>
               </div>
+              <p class="getting-started-copy">
+                Then run setup to connect TeXRA, check LaTeX, and choose a
+                starter agent team.
+              </p>
               <div class="getting-started-actions">
                 <wa-button
+                  variant="brand"
                   appearance="filled"
                   size="small"
                   href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}
                 >
-                  ${waIcon('rocket', { slot: 'start' })} Run setup
+                  ${waIcon('rocket', { slot: 'start' })} Run setup assistant
                 </wa-button>
                 <wa-button
                   appearance="outlined"
@@ -118,14 +130,15 @@ export class GettingStartedBanner extends LitElement {
                   size="small"
                   href=${COMMAND_LINKS.CLONE_OVERLEAF}
                 >
-                  ${waIcon('cloud-arrow-down', { slot: 'start' })} Overleaf
+                  ${waIcon('cloud-arrow-down', { slot: 'start' })} Import
+                  Overleaf
                 </wa-button>
                 <wa-button
                   appearance="outlined"
                   size="small"
                   href=${COMMAND_LINKS.DOWNLOAD_ARXIV}
                 >
-                  ${waIcon('download', { slot: 'start' })} arXiv
+                  ${waIcon('download', { slot: 'start' })} Import arXiv
                 </wa-button>
                 <wa-button
                   appearance="outlined"

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -110,7 +110,8 @@ export class GettingStartedBanner extends LitElement {
                   size="small"
                   href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
                 >
-                  ${waIcon('file-circle-plus', { slot: 'start' })} Sample project
+                  ${waIcon('file-circle-plus', { slot: 'start' })} Sample
+                  project
                 </wa-button>
                 <wa-button
                   appearance="outlined"

--- a/packages/extension/src/webview/frontend/events.ts
+++ b/packages/extension/src/webview/frontend/events.ts
@@ -15,6 +15,7 @@ import type {
   EditedFileChangeDetail,
   FileActionDetail,
   FocusInstructionDetail,
+  GettingStartedActionDetail,
   InstallGuideDetail,
   InstructionChangeDetail,
   LatexDiffsActionDetail,
@@ -103,6 +104,9 @@ export const MainViewEvents = {
 
   dismissGettingStarted: () =>
     createEvent('dismiss-getting-started', undefined),
+
+  gettingStartedAction: (detail: GettingStartedActionDetail) =>
+    createEvent('getting-started-action', detail),
 
   dismissSessionHint: () => createEvent('dismiss-session-hint', undefined),
 

--- a/src/shared/ipc/mainViewCommands.ts
+++ b/src/shared/ipc/mainViewCommands.ts
@@ -63,6 +63,7 @@ export const MAIN_VIEW_COMMANDS = {
   HIDE_DEPENDENCY_BANNER: 'hideDependencyBanner',
   SHOW_GETTING_STARTED_BANNER: 'showGettingStartedBanner',
   HIDE_GETTING_STARTED_BANNER: 'hideGettingStartedBanner',
+  GETTING_STARTED_ACTION: 'gettingStartedAction',
   SHOW_LOGIN_BANNER: 'showLoginBanner',
   HIDE_LOGIN_BANNER: 'hideLoginBanner',
   SIGN_IN_FROM_BANNER: 'signInFromBanner',

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -24,7 +24,7 @@ import {
   ExtendedDocumentFileTypeSchema,
   MultipleDocumentFileTypeSchema,
 } from '../fileTypes';
-import { SessionTypeSchema } from './state';
+import { GettingStartedActionSchema, SessionTypeSchema } from './state';
 
 const CommonMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.WEBVIEW_READY),
@@ -199,6 +199,10 @@ const BannerMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER),
   commandOnly(MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER),
   commandOnly(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER),
+  z.object({
+    command: z.literal(MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION),
+    action: GettingStartedActionSchema,
+  }),
   z.object({
     command: z.literal(MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER),
     missingTools: z.array(z.string()).optional(),

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -272,6 +272,22 @@ export const BannerActionDetailSchema = z.object({
 });
 export type BannerActionDetail = z.infer<typeof BannerActionDetailSchema>;
 
+export const GettingStartedActionSchema = z.enum([
+  'runSetup',
+  'createSampleProject',
+  'cloneOverleaf',
+  'downloadArxiv',
+  'openWalkthrough',
+]);
+export type GettingStartedAction = z.infer<typeof GettingStartedActionSchema>;
+
+export const GettingStartedActionDetailSchema = z.object({
+  action: GettingStartedActionSchema,
+});
+export type GettingStartedActionDetail = z.infer<
+  typeof GettingStartedActionDetailSchema
+>;
+
 export const InstallGuideDetailSchema = z.object({
   tool: z.string(),
 });

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -92,10 +92,10 @@ describe('extension onboarding experience', () => {
     expect(normalizedSource).toContain('Sample project');
     expect(normalizedSource).toContain('Import Overleaf');
     expect(source).toContain('Import arXiv');
-    expect(source).toContain('COMMAND_LINKS.RUN_SETUP_ASSISTANT');
+    expect(source).toContain('MainViewEvents.gettingStartedAction');
     expect(source).toContain('variant="brand"');
     expect(source).toContain('appearance="filled"');
-    expect(source).toContain('COMMAND_LINKS.GETTING_STARTED');
+    expect(source).not.toContain('COMMAND_LINKS');
     expect(source).not.toContain('Empty project');
     expect(source).not.toContain('action-link');
   });

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -83,13 +83,21 @@ describe('extension onboarding experience', () => {
 
   it('keeps empty-project onboarding action oriented', () => {
     const source = readWebviewComponent('GettingStartedBanner');
+    const normalizedSource = source.replaceAll(/\s+/g, ' ');
 
     expect(source).toContain('No LaTeX files yet');
-    expect(source).toContain('Run setup to connect TeXRA');
+    expect(normalizedSource).toContain('Start from a sample');
+    expect(normalizedSource).toContain('run setup to connect TeXRA');
+    expect(source).toContain('Run setup assistant');
+    expect(normalizedSource).toContain('Sample project');
+    expect(normalizedSource).toContain('Import Overleaf');
+    expect(source).toContain('Import arXiv');
     expect(source).toContain('COMMAND_LINKS.RUN_SETUP_ASSISTANT');
+    expect(source).toContain('variant="brand"');
     expect(source).toContain('appearance="filled"');
     expect(source).toContain('COMMAND_LINKS.GETTING_STARTED');
     expect(source).not.toContain('Empty project');
+    expect(source).not.toContain('action-link');
   });
 
   it('keeps the no-workspace welcome view project-first', () => {

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -87,7 +87,7 @@ describe('extension onboarding experience', () => {
     expect(source).toContain('No LaTeX files yet');
     expect(source).toContain('Run setup to connect TeXRA');
     expect(source).toContain('COMMAND_LINKS.RUN_SETUP_ASSISTANT');
-    expect(source).toContain('action-link--primary');
+    expect(source).toContain('appearance="filled"');
     expect(source).toContain('COMMAND_LINKS.GETTING_STARTED');
     expect(source).not.toContain('Empty project');
   });


### PR DESCRIPTION
## Summary

- **`GettingStartedBanner.ts`**: The five action anchors (`Run setup`, `Sample project`, `Overleaf`, `arXiv`, `Walkthrough`) were styled with a hand-rolled `.action-link` / `.action-link--primary` CSS class pair. These duplicated button styling already provided by `<wa-button>` used everywhere else in the webview layer. All five `<a>` elements are replaced with `<wa-button href appearance="filled|outlined" size="small">` and the 30-line custom CSS block is deleted.
- **`toolRenderers.tsx`**: Added a one-line comment on `STATUS_DOT` explaining that terminal-safe Unicode glyphs are used because Font Awesome is not available in Ink TUI — preventing future contributors from "standardising" it away.

## What was not changed

- `welcomeView.ts` — the audit initially flagged this for hardcoded colors, but on inspection every color already uses `--vscode-*` design tokens. Spacing pixel values (`16px`, `8px`, etc.) cannot use `--wa-space-*` tokens because that view does not load Web Awesome. No change needed.

## Test plan

- [ ] Open a folder-less VS Code workspace with the extension installed; confirm the Getting Started banner renders with correct filled/outlined button appearances
- [ ] Click each banner action button and confirm the corresponding command fires (Run setup, Sample project, Overleaf, Overleaf clone, arXiv download, Walkthrough)
- [ ] Dismiss button still works
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBSFqMT9aQ1853QyoSmDxd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBSFqMT9aQ1853QyoSmDxd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to onboarding UI and reuse existing safeExecuteCommand flows; no auth or data-model changes.
> 
> **Overview**
> The empty-workspace **Getting Started** banner no longer uses `COMMAND_LINKS` anchors and custom `.action-link` styling. Its five actions are **`wa-button`** controls that emit a typed **`getting-started-action`** event, which **`MainApp`** forwards as **`GETTING_STARTED_ACTION`** to the extension host.
> 
> The host maps each action to the existing **`texra.*`** commands (setup assistant, sample project, Overleaf clone, arXiv download, walkthrough); **run setup** also refreshes the onboarding funnel. Shared **Zod** schemas and inbound message validation define the allowed action enum end-to-end.
> 
> Copy on the banner is tightened (sample/import first, then setup). **`OnboardingExperience`** tests assert the new buttons, IPC event, and absence of **`COMMAND_LINKS`**. The CLI TUI adds a one-line comment on **`STATUS_DOT`** explaining terminal-safe glyphs vs Font Awesome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10fcdfe6895059ab6c70f7dba5f6b1be8b8fed12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->