### PR TITLE
refactor: move tool-result schemas into the shared layer

### DIFF
--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -204,7 +204,7 @@ export class FileManager extends BaseWebviewManager {
         const baseExists = await WorkspaceFS.exists(derivedBaseFile);
         if (baseExists) {
           await this.handleRequestBaseFile({
-            command: 'requestBaseFile',
+            command: MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE,
             preserveBaseFile: true,
           });
           filePathToSelect = derivedBaseFile;

--- a/src/agent/core/execution/AgentWorkspaceState.ts
+++ b/src/agent/core/execution/AgentWorkspaceState.ts
@@ -10,7 +10,7 @@ import {
   type FileLocation,
   type WorkPlanSnapshot,
 } from '@shared/schemas';
-import { FlattenedEditRecordSchema } from '@tools/result';
+import { FlattenedEditRecordSchema } from '@shared/schemas/toolResult';
 import { isObject } from '@utils/core';
 import { pathToLocation } from '@utils/files';
 

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -19,7 +19,7 @@ import { toErrorMessage } from '@common/errors';
 
 // Local imports - logging
 import type { FileLocation } from '@shared/schemas';
-import type { ToolResult } from '@tools/result';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { AbsoluteFS, pathToLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 

--- a/src/agent/core/flows/toolUseRound/toolCallParsing.ts
+++ b/src/agent/core/flows/toolUseRound/toolCallParsing.ts
@@ -10,7 +10,7 @@ import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesForDiagnostics,
   type ValidationErrorDiagnostics,
-} from '@tools/result';
+} from '@shared/schemas/toolResult';
 
 export const DUPLICATE_CALL_ERROR =
   'Duplicate parallel call skipped — same tool name and arguments as an earlier call in this batch. ' +

--- a/src/agent/core/tools/ToolTypes.ts
+++ b/src/agent/core/tools/ToolTypes.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ToolDefinition as ToolDefinitionType } from '@model/ToolDefinition';
-import type { ToolResult as ToolResultType } from '@tools/result';
+import type { ToolResult as ToolResultType } from '@shared/schemas/toolResult';
 
 /**
  * Contract for tool implementations.

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -45,7 +45,7 @@ import { MESSAGE_TYPES } from '@shared/schemas';
 
 // Local imports - tools
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - utils
 import { roundTo } from '@utils/core';

--- a/src/agent/modelHandlers/anthropic/anthropicTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicTools.ts
@@ -8,7 +8,7 @@ import type { AgentTrace } from '@agent/trace';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Type imports - agent and tools
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { extractMimeSubtype } from '@utils/text/stringUtils';
 
 // Local imports - model handlers

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -36,7 +36,7 @@ import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - utils
 import { AbsoluteFS, flexibleFS } from '@utils/files';

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -44,7 +44,7 @@ import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 // Local imports - utils
 import { isNonEmptyString } from '@utils/core';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -9,7 +9,7 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - tools and utils
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - model handlers
 import { ModelHandler } from './ModelHandler';

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -29,7 +29,7 @@ import type { ToolDefinition } from '@model';
 
 // Local imports - tools and utils
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -35,7 +35,7 @@ import { isGpt5ModelName, isGptFamilyModelName } from '@model/modelNames';
 
 // Type imports
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - utils
 import { clamp, delay, filterNotNullish, roundTo } from '@utils/core';

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -19,7 +19,7 @@ import {
   buildErrorLogData,
   getSdkErrorMessage,
 } from '@common/errors/sdkErrorUtils';
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -20,7 +20,7 @@ import {
 
 // Local imports - tools and utils
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { flexibleFS } from '@utils/files';
 import { extractMimeSubtype, joinNonEmpty } from '@utils/text/stringUtils';

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -16,7 +16,7 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 import type { ToolResultPayload } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import type { ToolDefinition } from '@model';
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@tools/result';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import type { ModelConfig, ModelCapabilities } from 'llm-zoo';
 import type { ProviderMessage } from './ProviderMessage';
 import type { ProviderStopReason } from './StopReasonTypes';

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -12,7 +12,7 @@ import {
   FileReferenceSchema,
   EditRecordSchema,
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
-} from '@tools/result';
+} from '@shared/schemas/toolResult';
 
 // Local imports - utils
 import { isNonEmptyString } from '@utils/core';

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -2,10 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - shared schemas
-import {
-  LineChangesSchema,
-  LineCountSchema,
-} from '@shared/schemas/lineChanges';
+import { LineChangesSchema, LineCountSchema } from './lineChanges';
 
 // Type imports
 import type { ZodIssue } from 'zod';

--- a/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseToolResolution.vitest.ts
@@ -4,7 +4,7 @@ import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import type { ToolDefinition } from '@model';
-import type { ToolResult } from '@tools/result';
+import type { ToolResult } from '@shared/schemas/toolResult';
 
 const logger = { warn: () => {} };
 

--- a/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
+++ b/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
@@ -7,7 +7,7 @@ import { describe, it, afterEach } from 'vitest';
 // Local imports - tools
 import * as arxivModule from '@latex/arxivProcessor';
 import { LsTool } from '@tools/ls';
-import type { ToolResult } from '@tools/result';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { ArxivDownloadTool } from '@tools/arxiv/ArxivDownloadTool';
 import { WorkspaceFS } from '@utils/files';
 

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import type { StreamTabId } from '@shared/schemas';
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 import {
   getOpenTurnDraft,
   listOpenThreads,

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -26,7 +26,7 @@ import type { ExecutionId, FileLocation } from '@shared/schemas';
 
 // Local imports - tools
 import { requireRuntimeHost } from '@tools/contextHelpers';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import {
   buildApprovalRejectedResult,

--- a/src/tools/AddCriticismTool.ts
+++ b/src/tools/AddCriticismTool.ts
@@ -9,7 +9,7 @@ import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { type ToolResult, ToolError } from './result';
+import { type ToolResult, ToolError } from '@shared/schemas/toolResult';
 
 const CHANNEL = 'AddCriticismTool';
 logger.initialize(CHANNEL);

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -56,7 +56,7 @@ import {
 import { formatBytes } from '@shared/utils/string';
 
 // Local imports - tools
-import type { ToolResult } from '@tools/result';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import {
   isApprovalBypassedForStream,
   proposalApprovalState,

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -20,7 +20,7 @@ import {
 
 // Local file imports
 import { defineTool } from './core/define';
-import { type ToolResult, ToolError } from './result';
+import { type ToolResult, ToolError } from '@shared/schemas/toolResult';
 
 const CHANNEL = 'DiagnosticsTool';
 logger.initialize(CHANNEL);

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { ToolError, ToolResult } from '@tools/result';
+import { ToolError, ToolResult } from '@shared/schemas/toolResult';
 import {
   recordToolFileRead,
   requireFileReadForEdit,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -63,7 +63,7 @@ import {
   getExecutionStatusInfo,
   resolveExecutionDisplayCategory,
 } from './executionFormatters';
-import { ToolError, type ToolResult } from './result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from './core/define';
 import {
   formatFileView,

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -15,7 +15,7 @@ import {
   currentToolRoot,
   resolveWorkspaceRelativePath,
 } from '@tools/pathResolution';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 // Local imports - utilities
 import {

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 
 // Local imports - tools
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { isOversizedImage, MANY_IMAGE_MAX_DIMENSION } from '@tools/imageUtils';
 import { buildFileAttachment } from '@tools/attachments';
 import { formatFileView, READ_FILE_MAX_LINES } from '@tools/formatting';

--- a/src/tools/ReportReviewIssueTool.ts
+++ b/src/tools/ReportReviewIssueTool.ts
@@ -11,7 +11,7 @@ import * as logger from '@logger/logUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { type ToolResult, ToolError } from './result';
+import { type ToolResult, ToolError } from '@shared/schemas/toolResult';
 
 const CHANNEL = 'ReportReviewIssueTool';
 logger.initialize(CHANNEL);

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -25,7 +25,7 @@ import { splitContentLines } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { ToolResult, ToolError } from './result';
+import { ToolResult, ToolError } from '@shared/schemas/toolResult';
 import { formatFileView, formatLinesWithNumbers } from './formatting';
 import {
   assertWritable,

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 // Internal imports
 import { isTexFile } from '@common/files/fileTypeUtils';
 import replacementEngine from '@replacement/engine';
-import { ToolResult } from '@tools/result';
+import { ToolResult } from '@shared/schemas/toolResult';
 import {
   recordToolFileRead,
   requireFileReadForEdit,

--- a/src/tools/applyPath.ts
+++ b/src/tools/applyPath.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { executeCommand } from '@utils/system/execUtils';
 
 // Local file imports

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -9,7 +9,7 @@ import {
   type BashApprovalAction,
 } from '@shared/schemas/prompts';
 import { requireRuntimeHost } from '@tools/contextHelpers';
-import { type ToolResult } from '@tools/result';
+import { type ToolResult } from '@shared/schemas/toolResult';
 import { getConfig } from '@utils/config/configUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -18,7 +18,7 @@ import {
   LineChangesSchema,
   type LineChanges,
 } from '@shared/schemas/lineChanges';
-import { type ToolResult } from '@tools/result';
+import { type ToolResult } from '@shared/schemas/toolResult';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { countLines } from '@utils/text/stringUtils';

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { toErrorMessage } from '@common/errors';
 import { arxivProcessor } from '@latex/arxivProcessor';
 import { LsTool } from '@tools/ls';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { formatToolOutput } from '@tools/formatting';
 import { defineTool } from '@tools/core/define';
 import { WorkspaceFS } from '@utils/files';

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 // Local imports - latex
 import { toErrorMessage } from '@common/errors';
 import { arxivProcessor } from '@latex/arxivProcessor';
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 import {
   type ArxivPaperMetadata,
   createArxivClient,

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -4,7 +4,7 @@ import {
   resolveAndFormat,
   type WorkspacePathResolution,
 } from '@tools/pathResolution';
-import { ToolError, type ToolFileAttachment } from '@tools/result';
+import { ToolError, type ToolFileAttachment } from '@shared/schemas/toolResult';
 import { wrapApiCall } from '@tools/utils';
 
 // Local imports - core utilities

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -29,7 +29,7 @@ import {
 // Local imports - tools
 import { type StreamTabId, type ExecutionId } from '@shared/schemas';
 import { BASH_TOOL_DEFAULT_TIMEOUT_MS } from '@shared/constants/toolDefaults';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { formatBashDelivery, formatBashError } from '@tools/subagentResults';
 import {
   buildBashApprovalRejectedResult,

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -3,7 +3,7 @@ import { type Work } from '@jamesgopsill/crossref-client';
 import { z } from 'zod';
 
 // Local imports
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -8,7 +8,7 @@ import {
 import { z } from 'zod';
 
 // Local imports
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 import { pluralize } from '@utils/text/stringUtils';

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -40,7 +40,7 @@ import { toErrorMessage } from '@common/errors';
 import type { StreamTabId, ExecutionId, ToolUseLog } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import {
   requestBashApproval,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -44,7 +44,7 @@ import type {
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { CodexSandboxModeSchema } from '@shared/schemas/agentCliSettings';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import {
   requestBashApproval,

--- a/src/tools/contextHelpers.ts
+++ b/src/tools/contextHelpers.ts
@@ -9,7 +9,7 @@
 import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 
 /**
  * Return the active RunContext's runtime host, throwing a ToolError if no

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -9,7 +9,7 @@ import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesForDiagnostics,
   type ToolResult,
-} from '@tools/result';
+} from '@shared/schemas/toolResult';
 
 /**
  * Abstract base class for tool implementations.

--- a/src/tools/fileInteractions.ts
+++ b/src/tools/fileInteractions.ts
@@ -2,7 +2,7 @@
 import { getCurrentToolCallContext } from '@agent/toolUse/ToolFileInteractionContext';
 
 // Local imports - tools
-import { type ToolResult } from '@tools/result';
+import { type ToolResult } from '@shared/schemas/toolResult';
 
 export function recordToolFileRead(path: string): void {
   const context = getCurrentToolCallContext();

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -23,7 +23,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { toErrorMessage } from '@common/errors';
 import type { StreamTabId } from '@shared/schemas';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { executeCommand } from '@utils/system/execUtils';

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { toErrorMessage } from '@common/errors';
-import { ToolError, ToolResult } from '@tools/result';
+import { ToolError, ToolResult } from '@shared/schemas/toolResult';
 import { formatToolOutput } from '@tools/formatting';
 import {
   joinWorkspaceRelativePath,

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { resolveAndFormat, currentToolRoot } from '@tools/pathResolution';
 import { executeCommand } from '@utils/system/execUtils';

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -27,7 +27,7 @@ import {
   type InquiryActionMessage,
   type StreamTabId,
 } from '@shared/schemas';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireRuntimeHost } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 import { formatResultCount } from '@utils/text/stringUtils';

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -16,7 +16,7 @@ import {
   type InquiryThreadStatus,
 } from '@shared/schemas';
 import { normalizeFilePath } from '@shared/utils/path';
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 import { GlobalStorageFS, StorageFS } from '@utils/files';
 import { hexId12 } from '@utils/core/executionId';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -7,7 +7,7 @@ import {
   loadBibliographyEntries,
   summarizeBibliographyEntries,
 } from '@latex/extractBibliography';
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 import { formatToolOutput } from '@tools/formatting';
 import { resolveAndFormat } from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';

--- a/src/tools/latex/ExtractTikzFiguresTool.ts
+++ b/src/tools/latex/ExtractTikzFiguresTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { tikzPictureManager } from '@latex/TikzPictureManager';
-import { type ToolFileAttachment } from '@tools/result';
+import { type ToolFileAttachment } from '@shared/schemas/toolResult';
 import { formatToolOutput } from '@tools/formatting';
 import { defineTool } from '@tools/core/define';
 import { pathToLocation } from '@utils/files';

--- a/src/tools/latex/figureExtractionShared.ts
+++ b/src/tools/latex/figureExtractionShared.ts
@@ -1,4 +1,4 @@
-import { ToolError, type ToolFileAttachment } from '@tools/result';
+import { ToolError, type ToolFileAttachment } from '@shared/schemas/toolResult';
 import { buildFileAttachment } from '@tools/attachments';
 import {
   resolveAndFormat,

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { ToolResult } from '@tools/result';
+import { ToolResult } from '@shared/schemas/toolResult';
 import { isTimeoutErrorCode, isTransientHttpError } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 import { ensureArray } from '@utils/core';

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { toErrorMessage } from '@common/errors';
-import type { ToolResult } from '@tools/result';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import {
   countBySeverity,

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { toErrorMessage } from '@common/errors';
-import { ToolError, ToolResult } from '@tools/result';
+import { ToolError, ToolResult } from '@shared/schemas/toolResult';
 import { formatToolOutput } from '@tools/formatting';
 import {
   joinWorkspaceRelativePath,

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -14,7 +14,7 @@ import { splitContentLines } from '@utils/text/stringUtils';
 
 // Local imports - tool core
 import { defineTool } from '../core/define';
-import { ToolError, type ToolResult } from '../result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import {
   recordToolFileRead,
   requireFileReadForEdit,

--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 
 // Local imports - tools
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 
 // Local imports - core utilities
 import { WorkspaceFS } from '@utils/files';

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -37,7 +37,7 @@ import {
   isGoalEnabled,
   setGoalSessionBashAutoApproval,
 } from '@tools/goal';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -27,7 +27,7 @@ import {
   AGENT_MODE_PRESETS,
   STARTER_AGENT_MODE_PRESET,
 } from '@shared/schemas/agentPresets';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 import { defineTool } from '../core/define';
 

--- a/src/tools/setup/ConfigTools.ts
+++ b/src/tools/setup/ConfigTools.ts
@@ -11,7 +11,7 @@
 
 import { z } from 'zod';
 
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 import { defineTool } from '../core/define';
 import { getSetupPlatform } from './platform';

--- a/src/tools/setup/InstallVscodeExtensionTool.ts
+++ b/src/tools/setup/InstallVscodeExtensionTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { LEAN4_EXTENSION_ID } from '@tools/lean/leanConstants';
 import { delay } from '@utils/core';
 

--- a/src/tools/setup/InvokeCommandTool.ts
+++ b/src/tools/setup/InvokeCommandTool.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 // Local imports
 import { AUTH_COMMANDS } from '@auth/constants';
 import type { CommandId } from '@shared/commands/catalog';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 // Local file imports
 import { defineTool } from '../core/define';

--- a/src/tools/setup/ProbeEnvironmentTool.ts
+++ b/src/tools/setup/ProbeEnvironmentTool.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
 // Local imports
 import { toErrorMessage } from '@common/errors';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { detectPackageManager } from '@utils/system/toolUtils';
 import { extendEnvPath, safeHomedir } from '@utils/system/platformPaths';
 

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports
-import { type ToolResult } from '@tools/result';
+import { type ToolResult } from '@shared/schemas/toolResult';
 import {
   buildBashApprovalRejectedResult,
   requestBashApproval,

--- a/src/tools/setup/SetApiKeyTool.ts
+++ b/src/tools/setup/SetApiKeyTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 // Local file imports
 import { defineTool } from '../core/define';

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports
-import { type ToolResult } from '@tools/result';
+import { type ToolResult } from '@shared/schemas/toolResult';
 
 // Local file imports
 import { defineTool } from '../core/define';

--- a/src/tools/setup/VerifySetupTool.ts
+++ b/src/tools/setup/VerifySetupTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 // Local file imports
 import { defineTool } from '../core/define';

--- a/src/tools/setup/apiKeyHelpers.ts
+++ b/src/tools/setup/apiKeyHelpers.ts
@@ -13,7 +13,7 @@ import {
   type ApiProvider,
 } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 
 import type { SetupPlatform } from './platform';
 

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports - latex utilities
 import { getTeXCount } from '@latex/texcount';
-import { ToolError, type ToolResult } from '@tools/result';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import { ensureArray } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -19,7 +19,7 @@ import {
   countByStatus,
   type TodoItem,
 } from '@shared/schemas';
-import { type ToolResult } from '@tools/result';
+import { type ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 
 const logger = createChannelTrace('TodoWriteTool');

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -10,7 +10,7 @@ import {
   type StreamTabId,
   type UserQuestionAnswers,
 } from '@shared/schemas';
-import type { ToolResult } from '@tools/result';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { requireRuntimeHost } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -5,7 +5,7 @@ import micromatch from 'micromatch';
 import { toErrorMessage } from '@common/errors';
 
 // Local imports - tools
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 
 /**
  * Compile a glob pattern into a matcher that operates on POSIX-style paths.

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 
 // Local imports - core
 import { toErrorMessage } from '@common/errors';
-import { ToolError, ToolResult } from '@tools/result';
+import { ToolError, ToolResult } from '@shared/schemas/toolResult';
 import { isTimeoutErrorCode } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { z } from 'zod';
 
 // Internal imports
-import { ToolResult } from '@tools/result';
+import { ToolResult } from '@shared/schemas/toolResult';
 import { wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { getCurrentToolContexts } from '@agent/toolUse/ToolFileInteractionContext';
 
 // Local imports - tools
-import { ToolResult, ToolError } from '@tools/result';
+import { ToolResult, ToolError } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import {
   buildBashApprovalRejectedResult,

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -25,7 +25,7 @@ import { z } from 'zod';
 // Local imports - core
 import pTimeout from 'p-timeout';
 import { toErrorMessage } from '@common/errors';
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 import { isTimeoutErrorCode } from '@tools/timeouts';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { CROSSREF_CONSTANTS, crossrefClient } from '@tools/citation/constants';

--- a/src/tools/zotero/ZoteroExportTool.ts
+++ b/src/tools/zotero/ZoteroExportTool.ts
@@ -9,7 +9,7 @@
 import { z } from 'zod';
 
 // Local imports - core
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import { pluralize } from '@utils/text/stringUtils';
 

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 
 // Local imports - core
 import { toErrorMessage } from '@common/errors';
-import { ToolError } from '@tools/result';
+import { ToolError } from '@shared/schemas/toolResult';
 import { isTimeoutErrorCode } from '@tools/timeouts';
 import { getConfig } from '@utils/config/configUtils';
 


### PR DESCRIPTION
## Summary

`src/agent/core/README.md` documents that the host-agnostic domain model depends **inward** (`flows → execution → definition`), never up into outer layers. An abstraction-layer audit found that `core` was reaching up into the **tools implementation layer** for pure schema types:

- `core/tools/ToolTypes.ts` — `ITool.call()`'s return type (`ToolResult`) was imported from `@tools/result`, inverting the contract: the domain tool *contract* depended on the tool *implementation* layer.
- `core/execution/AgentWorkspaceState.ts` — `FlattenedEditRecordSchema` (whose own doc-comment says it is "used by AgentWorkspaceState") lived in `@tools/result`.
- `core/flows/toolUseRound/{toolCallParsing,ToolUseDispatchNode}.ts` — same upward import for `ToolResult`.

`src/tools/result.ts` is a **pure Zod-schema module** — its only dependency is `@shared/schemas/lineChanges`. So it belongs in the shared base layer that every layer is allowed to import, not in `tools/`.

## Changes

- Move `src/tools/result.ts` → `src/shared/schemas/toolResult.ts`. No re-export shim is left behind (per the repo's anti-shim convention); all importers are repointed instead.
- Repoint all 77 importers (`src/tools`, `agent/modelHandlers`, `agent/core`, and the three vitest suites) to `@shared/schemas/toolResult`.
- `FlattenedEditRecordSchema` now resolves inward for `AgentWorkspaceState`, eliminating the last `core/execution → tools` schema edge.
- Use `MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE` instead of the bare `'requestBaseFile'` string literal in `FileManager.ts` (the constant was already imported).

No runtime/logic changes — this is a pure relocation plus import-path update.

## Verification

- `npm run typecheck` — exit 0
- `eslint` on the moved/edited files — exit 0
- The three vitest suites that import the schema (`InquiryStorage`, `ToolUseToolResolution`, `ArxivDownloadTool`) — all pass

## Deferred (not in this PR)

The audit also flagged two value-imports that `core/flows` makes from `agent/runtime` and `tools` — `bestConnectionMethod` (ResponseCycleFlow) and the `currentSession()` ambient lookups in `RetryState`/`CommonCycleTypes`. Those require injecting the dependency through the flow's services rather than a file move, so they are left as follow-ups to keep this change a safe, mechanical relocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwXUpjCRwQmrWVXk8d7fz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwXUpjCRwQmrWVXk8d7fz7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical file move and import-path updates only; no runtime or schema behavior changes beyond fixing layer boundaries.
> 
> **Overview**
> Relocates **pure Zod tool-result schemas** (`ToolResult`, `ToolError`, `FlattenedEditRecordSchema`, validation diagnostics, attachments, etc.) from the tools package into **`@shared/schemas/toolResult`**, and repoints **all consumers** (agent core, model handlers, tools, tests) to that path with **no re-export shim**.
> 
> This removes the inverted dependency where **`agent/core`** imported types from **`@tools/result`**—notably `ITool.call()`’s return type and `AgentWorkspaceState`’s `FlattenedEditRecordSchema`—so the domain contract depends on shared schemas instead of the tool implementation layer.
> 
> Also replaces the bare `'requestBaseFile'` string in **`FileManager`** with **`MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b963eda9095a8446ec816a649fdb9d857184e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->