### PR TITLE
refactor(modelHandlers): extract shared OpenAI-compatible prefill flow

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -31,7 +31,6 @@ import type { ToolDefinition } from '@model';
 import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString } from '@utils/core';
-import { flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {
   extractMimeSubtype,
@@ -39,7 +38,7 @@ import {
   objectToLogString,
 } from '@utils/text/stringUtils';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
-import { prepareExistingOutputContent } from '../utils/fileContentUtils';
+import { initializeOpenAiCompatibleOutputAndPrefill } from '../support/openAiCompatiblePrefill';
 import { tagOpenAISdkError } from './openAISdkError';
 
 // Local file imports
@@ -1010,73 +1009,32 @@ export class ModelHandlerOpenAI<
     outputLocation: FileLocation,
     prefill: string,
   ): Promise<[boolean, ChatCompletionMessageParam[]]> {
-    let endTurn = false;
-
-    if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
-      if (prefill.length === 0) {
-        this.logger.debug(
-          'No prefill provided; skipping pseudo-prefill instruction',
-        );
-        return [endTurn, messages];
-      }
-      const pseudoPrefillMsg = `Organize your response with xml tags. Start your response with:\n${prefill}`;
-      const lastMessage = messages.at(-1);
-      if (lastMessage && Array.isArray(lastMessage.content)) {
-        lastMessage.content.push({ type: 'text', text: pseudoPrefillMsg });
-      } else if (lastMessage && typeof lastMessage.content === 'string') {
-        lastMessage.content = [
-          { type: 'text', text: lastMessage.content },
-          { type: 'text', text: pseudoPrefillMsg },
-        ];
-      }
-      this.logger.debug(`Added pseudo prefill: "${pseudoPrefillMsg}"`);
-      return [endTurn, messages];
-    }
-
-    // Prepare existing file content (read, clean, extract scratchpad, update state)
-    const { fileContent } = await prepareExistingOutputContent(
-      outputLocation,
-      workspaceState,
-      this.logger,
-    );
-
-    messages.push({
-      role: 'assistant',
-      content: [
-        {
-          type: 'text',
-          text: fileContent,
+    return initializeOpenAiCompatibleOutputAndPrefill(
+      {
+        logger: this.logger,
+        appendPseudoPrefill: (msgs, pseudoPrefillMsg) => {
+          const lastMessage = msgs.at(-1);
+          if (lastMessage && Array.isArray(lastMessage.content)) {
+            lastMessage.content.push({ type: 'text', text: pseudoPrefillMsg });
+          } else if (lastMessage && typeof lastMessage.content === 'string') {
+            lastMessage.content = [
+              { type: 'text', text: lastMessage.content },
+              { type: 'text', text: pseudoPrefillMsg },
+            ];
+          }
         },
-      ],
-    });
-
-    if (hasEndTag(agentSetting, fileContent)) {
-      this.logger.debug(
-        'End tag detected - skipping model call (response already added above)',
-      );
-      endTurn = true;
-      return [endTurn, messages];
-    }
-
-    this.logger.warn(
-      'Output file exists but no end tag found - continuing from file',
-    );
-    // Only need to handle case where prefill needs to be prepended
-    // (workspace state was already updated above with file content)
-    if (!fileContent.includes(prefill)) {
-      workspaceState.assembly.accumulatedOutput = prefill + fileContent;
-      await flexibleFS.write(
-        outputLocation,
-        workspaceState.assembly.accumulatedOutput,
-      );
-    }
-    this.addContinueMessageWithoutPrefill(
+        pushAssistantText: (msgs, text) => {
+          msgs.push({ role: 'assistant', content: [{ type: 'text', text }] });
+        },
+        addContinue: (msgs, ws, setting) =>
+          this.addContinueMessageWithoutPrefill(msgs, ws, setting),
+      },
+      agentSetting,
       messages,
       workspaceState,
-      agentSetting,
+      outputLocation,
+      prefill,
     );
-
-    return [false, messages];
   }
 
   /** Computes cost based on token usage and model pricing. */

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -22,7 +22,6 @@ import {
 import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString } from '@utils/core';
-import { flexibleFS } from '@utils/files';
 import { extractMimeSubtype, joinNonEmpty } from '@utils/text/stringUtils';
 import {
   computeOpenRouterPrice,
@@ -30,7 +29,7 @@ import {
   type OpenRouterPricingConfig,
 } from './openRouterUsage';
 import { tagOpenRouterSdkError } from './openRouterSdkError';
-import { prepareExistingOutputContent } from '../utils/fileContentUtils';
+import { initializeOpenAiCompatibleOutputAndPrefill } from '../support/openAiCompatiblePrefill';
 
 // Local file imports
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
@@ -778,68 +777,38 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     outputLocation: FileLocation,
     prefill: string,
   ): Promise<[boolean, ChatMessages[]]> {
-    if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
-      if (prefill.length === 0) {
-        this.logger.debug(
-          'No prefill provided; skipping pseudo-prefill instruction',
-        );
-        return [false, messages];
-      }
-      const pseudoPrefillMsg = `Organize your response with xml tags. Start your response with:\n${prefill}`;
-      const lastMessage = messages.at(-1);
-      if (lastMessage && Array.isArray(lastMessage.content)) {
-        (lastMessage.content as ChatContentItems[]).push({
-          type: 'text',
-          text: pseudoPrefillMsg,
-        });
-      } else if (lastMessage && typeof lastMessage.content === 'string') {
-        (lastMessage as ChatUserMessage).content = [
-          { type: 'text', text: lastMessage.content },
-          { type: 'text', text: pseudoPrefillMsg },
-        ];
-      }
-      this.logger.debug(`Added pseudo prefill: "${pseudoPrefillMsg}"`);
-      return [false, messages];
-    }
-
-    const { fileContent } = await prepareExistingOutputContent(
-      outputLocation,
-      workspaceState,
-      this.logger,
-    );
-
-    // Push assistant message with file content
-    messages.push({
-      role: 'assistant',
-      content: [{ type: 'text', text: fileContent }],
-    } as ChatMessages);
-
-    // If the file already contains the end tag, the prior run finished — no model call needed
-    if (hasEndTag(agentSetting, fileContent)) {
-      this.logger.debug(
-        'End tag detected - skipping model call (response already added above)',
-      );
-      return [true, messages];
-    }
-
-    this.logger.warn(
-      'Output file exists but no end tag found - continuing from file',
-    );
-
-    if (!fileContent.includes(prefill)) {
-      workspaceState.assembly.accumulatedOutput = prefill + fileContent;
-      await flexibleFS.write(
-        outputLocation,
-        workspaceState.assembly.accumulatedOutput,
-      );
-    }
-    this.addContinueMessageWithoutPrefill(
+    return initializeOpenAiCompatibleOutputAndPrefill(
+      {
+        logger: this.logger,
+        appendPseudoPrefill: (msgs, pseudoPrefillMsg) => {
+          const lastMessage = msgs.at(-1);
+          if (lastMessage && Array.isArray(lastMessage.content)) {
+            (lastMessage.content as ChatContentItems[]).push({
+              type: 'text',
+              text: pseudoPrefillMsg,
+            });
+          } else if (lastMessage && typeof lastMessage.content === 'string') {
+            (lastMessage as ChatUserMessage).content = [
+              { type: 'text', text: lastMessage.content },
+              { type: 'text', text: pseudoPrefillMsg },
+            ];
+          }
+        },
+        pushAssistantText: (msgs, text) => {
+          msgs.push({
+            role: 'assistant',
+            content: [{ type: 'text', text }],
+          } as ChatMessages);
+        },
+        addContinue: (msgs, ws, setting) =>
+          this.addContinueMessageWithoutPrefill(msgs, ws, setting),
+      },
+      agentSetting,
       messages,
       workspaceState,
-      agentSetting,
+      outputLocation,
+      prefill,
     );
-
-    return [false, messages];
   }
 
   updateMessageContentWithPrefill(

--- a/src/agent/modelHandlers/support/openAiCompatiblePrefill.ts
+++ b/src/agent/modelHandlers/support/openAiCompatiblePrefill.ts
@@ -1,0 +1,96 @@
+import type { AgentTrace } from '@agent/trace';
+import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
+import { hasEndTag } from '@agent/core/definition/AgentDataclass';
+import type { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
+import type { FileLocation } from '@shared/schemas';
+import { flexibleFS } from '@utils/files';
+
+import { prepareExistingOutputContent } from '../utils/fileContentUtils';
+import type { ProviderMessage } from '../types/ProviderMessage';
+
+/**
+ * Provider-specific message operations needed by the OpenAI-compatible prefill
+ * flow. Each operation differs only in the concrete provider message shape
+ * (e.g. array-content vs string-content, SDK-specific casts); the control flow,
+ * pseudo-prefill instruction, end-tag handling, and resume write-back below are
+ * identical across the Chat Completions-style handlers, so they live here.
+ */
+export interface OpenAiCompatiblePrefillAdapter<M extends ProviderMessage> {
+  readonly logger: AgentTrace;
+  /** Append the pseudo-prefill instruction to the last (user) message in place. */
+  appendPseudoPrefill(messages: M[], pseudoPrefillMsg: string): void;
+  /** Push an assistant message carrying the given text as array content. */
+  pushAssistantText(messages: M[], text: string): void;
+  /** Append a continuation prompt for models without assistant prefill support. */
+  addContinue(
+    messages: M[],
+    workspaceState: AgentWorkspaceState,
+    agentSetting: AgentSetting,
+  ): void;
+}
+
+/**
+ * Shared `initializeOutputAndPrefill` body for Chat Completions-style handlers
+ * (OpenAI native, OpenRouter native). Sets up the output file and prefills the
+ * conversation, returning `[isComplete, messages]`.
+ *
+ * The three provider message shapes that differ between handlers are injected
+ * via {@link OpenAiCompatiblePrefillAdapter}; everything else (existence check,
+ * the pseudo-prefill instruction text, end-tag short-circuit, and the resume
+ * write-back) is provider-agnostic.
+ */
+export async function initializeOpenAiCompatibleOutputAndPrefill<
+  M extends ProviderMessage,
+>(
+  adapter: OpenAiCompatiblePrefillAdapter<M>,
+  agentSetting: AgentSetting,
+  messages: M[],
+  workspaceState: AgentWorkspaceState,
+  outputLocation: FileLocation,
+  prefill: string,
+): Promise<[boolean, M[]]> {
+  if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
+    if (prefill.length === 0) {
+      adapter.logger.debug(
+        'No prefill provided; skipping pseudo-prefill instruction',
+      );
+      return [false, messages];
+    }
+    const pseudoPrefillMsg = `Organize your response with xml tags. Start your response with:\n${prefill}`;
+    adapter.appendPseudoPrefill(messages, pseudoPrefillMsg);
+    adapter.logger.debug(`Added pseudo prefill: "${pseudoPrefillMsg}"`);
+    return [false, messages];
+  }
+
+  // Prepare existing file content (read, clean, extract scratchpad, update state)
+  const { fileContent } = await prepareExistingOutputContent(
+    outputLocation,
+    workspaceState,
+    adapter.logger,
+  );
+
+  adapter.pushAssistantText(messages, fileContent);
+
+  if (hasEndTag(agentSetting, fileContent)) {
+    adapter.logger.debug(
+      'End tag detected - skipping model call (response already added above)',
+    );
+    return [true, messages];
+  }
+
+  adapter.logger.warn(
+    'Output file exists but no end tag found - continuing from file',
+  );
+  // Only need to handle case where prefill needs to be prepended
+  // (workspace state was already updated above with file content)
+  if (!fileContent.includes(prefill)) {
+    workspaceState.assembly.accumulatedOutput = prefill + fileContent;
+    await flexibleFS.write(
+      outputLocation,
+      workspaceState.assembly.accumulatedOutput,
+    );
+  }
+  adapter.addContinue(messages, workspaceState, agentSetting);
+
+  return [false, messages];
+}


### PR DESCRIPTION
## Summary

A scheduled code-quality scan of the repo flagged the `src/agent/modelHandlers/` provider handlers as the single largest cluster of duplicated logic. On close inspection, the **OpenAI native** and **OpenRouter native** handlers carried a byte-for-byte identical `initializeOutputAndPrefill` implementation — same control flow, the same pseudo-prefill instruction literal (`"Organize your response with xml tags. Start your response with:\n…"`), identical end-tag short-circuit, and the same resume write-back — differing only in the concrete provider message shapes (array- vs string-content casts).

This PR hoists that shared skeleton into a new helper, `support/openAiCompatiblePrefill.ts` → `initializeOpenAiCompatibleOutputAndPrefill`, with the three provider-specific message operations injected via a small adapter:

- `appendPseudoPrefill` — append the pseudo-prefill instruction to the last message
- `pushAssistantText` — push an assistant message carrying text as array content
- `addContinue` — append a continuation prompt for models without assistant prefill

Both handlers now delegate to the helper, so the prefill/resume flow has a **single source of truth**.

## Scope (deliberately conservative)

Only the two genuinely-identical handlers were unified. The **Anthropic** handler (real assistant-prefill support, distinct empty-prefill handling) and the **Google** handler (different SDK shape, no resume write-back, different capitalization) diverge meaningfully and keep their own implementations — folding them in would change behavior, so they were left alone.

## Impact

- ~73 fewer lines of duplicated logic across the two handler files (`+149 / −126`, with the new helper file accounting for the inserts).
- No behavior change — the helper preserves each handler's exact message shapes via the injected adapter.

## Verification

- `npm run typecheck` (root + test-kernel) — clean
- `npx vitest run src/test-kernel/agent/modelHandlers` — **216/216 pass**
- eslint + prettier — clean on all three files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9gnnriupur9yfRi2kVqGx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9gnnriupur9yfRi2kVqGx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication of agent turn-setup logic with provider-specific message mutations preserved via adapters; no auth or API surface changes, and other providers were intentionally left out.
> 
> **Overview**
> Duplicates the same **output/prefill bootstrap** logic that lived in both **OpenAI native** and **OpenRouter native** handlers into a single helper: `support/openAiCompatiblePrefill.ts` → `initializeOpenAiCompatibleOutputAndPrefill`.
> 
> Each handler now passes a small **adapter** for the three message-shape differences (`appendPseudoPrefill`, `pushAssistantText`, `addContinue`); shared steps stay centralized—checking whether the output file exists, injecting the pseudo-prefill XML instruction, loading existing output via `prepareExistingOutputContent`, **end-tag** short-circuit, and resume **write-back** when prefill is missing from file content.
> 
> **Anthropic** and **Google** handlers are unchanged; their prefill flows still differ enough to keep local implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96f499a5093a65d7c2576869272ad5e3b8a5e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->