### PR TITLE
refactor: simplify data structure designs across shared schemas and agent core

### DIFF
--- a/src/agent/core/execution/AgentState.ts
+++ b/src/agent/core/execution/AgentState.ts
@@ -35,12 +35,11 @@ export type AgentRunStateSnapshot = z.output<
  */
 export function recordCycleMetrics(
   run: AgentRunStateSnapshot,
-  cycleIndex: number,
   responseTimeMs: number,
   normalizedUsage: NormalizedUsage | null,
 ): void {
   if (normalizedUsage) {
-    recordNormalizedUsage(run.usageAccumulator, cycleIndex, normalizedUsage);
+    recordNormalizedUsage(run.usageAccumulator, normalizedUsage);
   }
   run.totalResponseTimeMs += responseTimeMs;
 }
@@ -50,10 +49,5 @@ export function recordRound(
   run: AgentRunStateSnapshot,
   roundState: ConversationRoundStateSnapshot,
 ): void {
-  recordCycleMetrics(
-    run,
-    roundState.roundIndex,
-    roundState.responseTimeMs,
-    roundState.normalizedUsage,
-  );
+  recordCycleMetrics(run, roundState.responseTimeMs, roundState.normalizedUsage);
 }

--- a/src/agent/core/execution/AgentState.ts
+++ b/src/agent/core/execution/AgentState.ts
@@ -49,5 +49,9 @@ export function recordRound(
   run: AgentRunStateSnapshot,
   roundState: ConversationRoundStateSnapshot,
 ): void {
-  recordCycleMetrics(run, roundState.responseTimeMs, roundState.normalizedUsage);
+  recordCycleMetrics(
+    run,
+    roundState.responseTimeMs,
+    roundState.normalizedUsage,
+  );
 }

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -178,7 +178,6 @@ export class ToolUseProcessNode<C> extends BaseNode<
 
     recordCycleMetrics(
       run,
-      shared.roundIndex,
       shared.roundResponseTimeMs,
       shared.roundNormalizedUsage ?? null,
     );

--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -30,22 +30,44 @@ const RunUsageTotalsSchema = z.object({
 });
 export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
 
-/** Schema for normalized usage snapshot. Internal only. */
-const NormalizedUsageSnapshotSchema = z.object({
-  round: z.int().nonnegative(),
-  usage: NormalizedUsageSchema,
-});
-
 /**
  * Schema for RunUsageAccumulator JSON serialization.
- * Uses .prefault() for input normalization before validation; the per-field
- * `.prefault(0)` declarations on `RunUsageTotalsSchema` expand `{}` into a
- * fully-defaulted totals object.
+ * Uses .prefault() for input normalization before validation.
+ *
+ * `latestUsage` replaces the old unbounded `normalizedSnapshots` array —
+ * only the most-recent round's usage is needed at runtime. The preprocess
+ * migrates legacy persisted data (with `normalizedSnapshots`) by extracting
+ * the last element, so existing sessions resume without data loss.
  */
-export const RunUsageAccumulatorJSONSchema = z.object({
-  totals: RunUsageTotalsSchema.prefault({}),
-  normalizedSnapshots: z.array(NormalizedUsageSnapshotSchema).prefault([]),
-});
+export const RunUsageAccumulatorJSONSchema = z.preprocess(
+  (raw) => {
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      !Array.isArray(raw) &&
+      !('latestUsage' in raw) &&
+      'normalizedSnapshots' in raw &&
+      Array.isArray((raw as Record<string, unknown>).normalizedSnapshots)
+    ) {
+      const snapshots = (raw as Record<string, unknown>)
+        .normalizedSnapshots as unknown[];
+      const last = snapshots.at(-1);
+      const usage =
+        last &&
+        typeof last === 'object' &&
+        !Array.isArray(last) &&
+        'usage' in (last as Record<string, unknown>)
+          ? (last as Record<string, unknown>).usage
+          : null;
+      return { ...(raw as Record<string, unknown>), latestUsage: usage ?? null };
+    }
+    return raw;
+  },
+  z.object({
+    totals: RunUsageTotalsSchema.prefault({}),
+    latestUsage: NormalizedUsageSchema.nullable().prefault(null),
+  }),
+);
 
 /**
  * Output type for RunUsageAccumulator serialization.
@@ -62,7 +84,6 @@ export type RunUsageAccumulatorJSON = z.output<
 /** Record a normalized usage entry. Mutates acc in place. */
 export function recordNormalizedUsage(
   acc: RunUsageAccumulatorJSON,
-  round: number,
   usage: NormalizedUsage,
 ): void {
   if (acc.totals.firstInputTokens === 0) {
@@ -79,5 +100,5 @@ export function recordNormalizedUsage(
   acc.totals.totalToolUsePromptTokens += usage.toolUsePromptTokens ?? 0;
   acc.totals.totalServerToolRequests += usage.serverToolRequests ?? 0;
 
-  acc.normalizedSnapshots.push({ round, usage });
+  acc.latestUsage = usage;
 }

--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -59,7 +59,10 @@ export const RunUsageAccumulatorJSONSchema = z.preprocess(
         'usage' in (last as Record<string, unknown>)
           ? (last as Record<string, unknown>).usage
           : null;
-      return { ...(raw as Record<string, unknown>), latestUsage: usage ?? null };
+      return {
+        ...(raw as Record<string, unknown>),
+        latestUsage: usage ?? null,
+      };
     }
     return raw;
   },

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -130,7 +130,7 @@ export class OutputFileProcessor {
     await tryOperation(
       async () => {
         const rawContent = await flexibleFS.read(rawOutput);
-        const tagContents: Record<string, string | string[]> = {};
+        const tagContents: Record<string, string[]> = {};
         const documents: string[] = [];
         const documentTag = this.ctx.agentSetting.documentTag;
 
@@ -139,12 +139,9 @@ export class OutputFileProcessor {
           documentTag,
         );
         if (documentEntries.length > 0) {
-          const trimmedDocuments = documentEntries.map((e) => e.content.trim());
-          if (trimmedDocuments.length === 1) {
-            tagContents[documentTag] = trimmedDocuments[0];
-          } else {
-            tagContents[documentTag] = trimmedDocuments;
-          }
+          tagContents[documentTag] = documentEntries.map((e) =>
+            e.content.trim(),
+          );
 
           for (const entry of documentEntries) {
             const nameAttr = entry.name ? ` name="${entry.name}"` : '';
@@ -158,7 +155,7 @@ export class OutputFileProcessor {
             documentTag,
           ).trim();
           if (singleDocument) {
-            tagContents[documentTag] = singleDocument;
+            tagContents[documentTag] = [singleDocument];
             documents.push(
               `<${documentTag}>${singleDocument}</${documentTag}>`,
             );
@@ -170,7 +167,7 @@ export class OutputFileProcessor {
           'scratchpad',
         ).trim();
         if (scratchpadContent) {
-          tagContents.scratchpad = scratchpadContent;
+          tagContents.scratchpad = [scratchpadContent];
         }
 
         data.xmlSummary = {

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -111,8 +111,7 @@ export class UsageMonitor {
     try {
       const totals = stateGlobal.usageAccumulator.totals;
       this.lastSeenTotals = totals;
-      const latestUsage =
-        stateGlobal.usageAccumulator.normalizedSnapshots.at(-1)?.usage;
+      const latestUsage = stateGlobal.usageAccumulator.latestUsage;
 
       // Per-round usage - sent to both UI (for accumulation) and backend analytics
       const roundInputTokens = latestUsage?.inputTokens ?? 0;

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -90,13 +90,27 @@ export type CompileResult = z.infer<typeof CompileResultSchema>;
 
 export const OutputXmlSummarySchema = z.strictObject({
   tagContents: z
-    .record(z.string(), z.union([z.string(), z.array(z.string())]))
+    .record(
+      z.string(),
+      z
+        .union([z.array(z.string()), z.string().transform((s) => [s])])
+        .catch([]),
+    )
     .prefault(() => ({})),
   documents: z.array(z.string()).prefault(() => []),
   singleOutputFile: z.string().nullable().prefault(null),
   sourceLocation: FileLocationSchema.nullable().prefault(null),
 });
 export type OutputXmlSummary = z.infer<typeof OutputXmlSummarySchema>;
+
+/**
+ * Schema factory for round-indexed records: `{ "1": T[], "2": T[], … }`.
+ * Used by both the live stream state and the persisted snapshot so the
+ * shape is defined once and shared.
+ */
+export function roundIndexedRecord<T extends z.ZodType>(valueSchema: T) {
+  return z.record(z.string(), z.array(valueSchema)).prefault({});
+}
 
 export const RoundOutputSchema = z.strictObject({
   round: z.number(),

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -30,7 +30,7 @@ import {
 import { PlanSchema } from '../plan';
 import { TodoItemSchema } from '../todo';
 import { ContextStateDataSchema } from '../contextManagement';
-import { TokenUsageStatsSchema } from '../usage';
+import { RunUsageMapSchema, TokenUsageStatsSchema } from '../usage';
 import { AgentCategoryFilterSchema, ProgressViewPlacementSchema } from './data';
 
 export const UpdateStreamsMessageSchema = z.object({
@@ -276,7 +276,7 @@ export const SyncStreamContentMessageSchema = z.object({
     .optional(),
   // Per-run usage map — used by both workflow and tool-use so resume
   // correctly accumulates. Frontend derives sessionUsage as the sum.
-  runUsage: z.record(z.string(), TokenUsageStatsSchema).optional(),
+  runUsage: RunUsageMapSchema.optional(),
   contextState: ContextStateDataSchema.optional(),
   todos: z.array(TodoItemSchema),
   plan: PlanSchema.nullable(),

--- a/src/shared/schemas/streamSnapshot.ts
+++ b/src/shared/schemas/streamSnapshot.ts
@@ -25,13 +25,17 @@
 import { z } from 'zod';
 
 import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
-import { OutputFileInfoSchema, CompileFailureSchema } from './output';
+import {
+  OutputFileInfoSchema,
+  CompileFailureSchema,
+  roundIndexedRecord,
+} from './output';
 import { StreamStatusSchema } from './stream';
 import {
   ActiveChildInfoSchema,
   ConversationProgressSchema,
 } from './streamState';
-import { TokenUsageStatsSchema } from './usage';
+import { RunUsageMapSchema } from './usage';
 import { WorkPlanSnapshotShape } from './workPlan';
 
 /**
@@ -46,16 +50,10 @@ export const STREAM_SNAPSHOT_SCHEMA_VERSION = 1 as const;
 // Round / run keyed records (match the on-disk JSON: string keys → arrays)
 // ============================================================================
 
-const OutputFilesByRoundSchema = z
-  .record(z.string(), z.array(OutputFileInfoSchema))
-  .prefault({});
-const MissingOutputsByRoundSchema = z
-  .record(z.string(), z.array(z.string()))
-  .prefault({});
-const CompileFailuresByRoundSchema = z
-  .record(z.string(), z.array(CompileFailureSchema))
-  .prefault({});
-const RunUsageSchema = z.record(z.string(), TokenUsageStatsSchema).prefault({});
+const OutputFilesByRoundSchema = roundIndexedRecord(OutputFileInfoSchema);
+const MissingOutputsByRoundSchema = roundIndexedRecord(z.string());
+const CompileFailuresByRoundSchema = roundIndexedRecord(CompileFailureSchema);
+const RunUsageSchema = RunUsageMapSchema.prefault({});
 
 // ============================================================================
 // Persisted workPlan.json — the one NEW durable file

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -2,13 +2,17 @@ import { z } from 'zod';
 
 import { GoalStatusSchema } from './goal';
 import { AgentCategory, AgentCategorySchema } from './agent';
-import { CompileFailureSchema, OutputFileInfoSchema } from './output';
+import {
+  CompileFailureSchema,
+  OutputFileInfoSchema,
+  roundIndexedRecord,
+} from './output';
 import { STREAM_STATUS, StreamStatusSchema } from './stream';
 import { TaskGroupSchema } from './taskGroup';
 import { PlanSchema } from './plan';
 import { TodoItemSchema } from './todo';
 import { ContextStateDataSchema } from './contextManagement';
-import { TokenUsageStatsSchema } from './usage';
+import { RunUsageMapSchema, TokenUsageStatsSchema } from './usage';
 
 // Active Child Info (shared shape for subagent and process badges)
 
@@ -90,12 +94,6 @@ export const ToolUseUIStateSchema = z.object({
 
 export type ToolUseUIState = z.infer<typeof ToolUseUIStateSchema>;
 
-// Shared helper for run-keyed records
-
-function RunScopedRecord<T extends z.ZodType>(valueSchema: T) {
-  return z.record(z.string(), valueSchema).prefault({});
-}
-
 // Tool-Use Stream State
 
 export const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
@@ -110,7 +108,7 @@ export const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   goalStatus: GoalStatusSchema.optional(),
   goalObjective: z.string().optional(),
   // Per-run usage for accumulation; sessionUsage is derived as their sum.
-  runUsage: RunScopedRecord(TokenUsageStatsSchema),
+  runUsage: RunUsageMapSchema.prefault({}),
   sessionUsage: TokenUsageStatsSchema.nullable().prefault(null),
   // Frontend-owned (nested under ui)
   ui: ToolUseUIStateSchema.prefault({}),
@@ -121,20 +119,16 @@ export type ToolUseStreamState = z.infer<typeof ToolUseStreamStateSchema>;
 // Workflow Stream State
 // One run per tab — all run-scoped data is flat, not keyed by runId.
 
-function RoundIndexedRecord<T extends z.ZodType>(valueSchema: T) {
-  return z.record(z.string(), z.array(valueSchema)).prefault({});
-}
-
 export const WorkflowStreamStateSchema = BaseStreamStateSchema.extend({
   kind: z.literal(AgentCategory.Workflow),
   // Frontend-owned fields updated by targeted progress-view messages.
   // Per-run usage mirrors tool-use so resume correctly accumulates across
   // the original and resumed runs; sessionUsage is derived as their sum.
-  runUsage: RunScopedRecord(TokenUsageStatsSchema),
+  runUsage: RunUsageMapSchema.prefault({}),
   sessionUsage: TokenUsageStatsSchema.nullable().prefault(null),
-  files: RoundIndexedRecord(OutputFileInfoSchema),
-  missingOutputs: RoundIndexedRecord(z.string()),
-  compileFailures: RoundIndexedRecord(CompileFailureSchema),
+  files: roundIndexedRecord(OutputFileInfoSchema),
+  missingOutputs: roundIndexedRecord(z.string()),
+  compileFailures: roundIndexedRecord(CompileFailureSchema),
 });
 
 export type WorkflowStreamState = z.infer<typeof WorkflowStreamStateSchema>;

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -45,6 +45,11 @@ export function sumUsageStats(
   return total;
 }
 
+/** Run-keyed usage map: `{ runId: TokenUsageStats }`. Single source of truth used by
+ * stream state, snapshot, and IPC message schemas so all four sites stay in sync. */
+export const RunUsageMapSchema = z.record(z.string(), TokenUsageStatsSchema);
+export type RunUsageMap = z.infer<typeof RunUsageMapSchema>;
+
 /**
  * Extended token usage with per-round deltas. Note: percentageCached is
  * calculated from accumulated session totals for overall caching effectiveness.

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { RunUsageAccumulatorJSONSchema } from '@agent/core/usage/RunUsageAccumulator';
+import { OutputXmlSummarySchema } from '@shared/schemas';
+
+// Minimal NormalizedUsage fixture: all required fields, no optionals.
+const usageFixture = {
+  inputTokens: 100,
+  outputTokens: 20,
+  cost: 0.01,
+  responseTimeMs: 500,
+  provider: 'anthropic',
+} as const;
+
+describe('RunUsageAccumulatorJSONSchema — legacy normalizedSnapshots migration', () => {
+  it('extracts latestUsage from a single-element normalizedSnapshots array', () => {
+    const result = RunUsageAccumulatorJSONSchema.parse({
+      normalizedSnapshots: [{ round: 0, usage: usageFixture }],
+    });
+
+    expect(result.latestUsage).toMatchObject(usageFixture);
+  });
+
+  it('takes the last element when normalizedSnapshots has multiple entries', () => {
+    const older = { ...usageFixture, inputTokens: 50 };
+    const latest = { ...usageFixture, inputTokens: 200 };
+    const result = RunUsageAccumulatorJSONSchema.parse({
+      normalizedSnapshots: [
+        { round: 0, usage: older },
+        { round: 1, usage: latest },
+      ],
+    });
+
+    expect(result.latestUsage?.inputTokens).toBe(200);
+  });
+
+  it('sets latestUsage to null for an empty normalizedSnapshots array', () => {
+    const result = RunUsageAccumulatorJSONSchema.parse({
+      normalizedSnapshots: [],
+    });
+
+    expect(result.latestUsage).toBeNull();
+  });
+
+  it('is idempotent: already-migrated data passes through unchanged', () => {
+    const result = RunUsageAccumulatorJSONSchema.parse({
+      latestUsage: usageFixture,
+    });
+
+    expect(result.latestUsage).toMatchObject(usageFixture);
+  });
+
+  it('parses empty object to zero totals and null latestUsage', () => {
+    const result = RunUsageAccumulatorJSONSchema.parse({});
+
+    expect(result.latestUsage).toBeNull();
+    expect(result.totals.totalInputTokens).toBe(0);
+  });
+});
+
+describe('OutputXmlSummarySchema — tagContents legacy string coercion', () => {
+  it('coerces a bare string value to a single-element array', () => {
+    const result = OutputXmlSummarySchema.parse({
+      tagContents: { title: 'My Paper' },
+    });
+
+    expect(result.tagContents['title']).toEqual(['My Paper']);
+  });
+
+  it('passes an existing string[] through unchanged', () => {
+    const result = OutputXmlSummarySchema.parse({
+      tagContents: { authors: ['Alice', 'Bob'] },
+    });
+
+    expect(result.tagContents['authors']).toEqual(['Alice', 'Bob']);
+  });
+
+  it('degrades a malformed value to [] via .catch', () => {
+    const result = OutputXmlSummarySchema.parse({
+      tagContents: { broken: 42 },
+    });
+
+    expect(result.tagContents['broken']).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Four mechanical refactors identified in a data-structure complexity review, each self-contained and verified against the full test suite (3550 passing, 1 pre-existing flaky).

### `tagContents`: uniform `string[]` (was `string | string[]`)

`OutputXmlSummarySchema.tagContents` held `Record<string, string | string[]>`, forcing every reader to narrow the value type before use. The write site in `OutputFileProcessor` already made the single-vs-multiple decision explicitly — moving that decision into the schema's union transform (`z.string().transform(s => [s])`) means the field always outputs `string[]`. Legacy persisted data containing bare strings is migrated at parse time with no data loss.

### `roundIndexedRecord`: shared factory (was duplicated in two modules)

The `RoundIndexedRecord` helper in `streamState.ts` (private) and the inline `z.record(...).prefault({})` blocks in `streamSnapshot.ts` both produced `Record<string, T[]>` schemas with identical semantics but no shared definition. A rename between `files` and `outputFilesByRound` could silently diverge the two. Extracted as an exported `roundIndexedRecord<T>()` factory in `output.ts`; both modules now import it.

### `RunUsageMapSchema`: single source of truth (was declared 4×)

`Record<string, TokenUsageStats>` appeared independently in `ToolUseStreamState`, `WorkflowStreamState`, `StreamSnapshot`, and `SyncStreamContentMessage`. All four sites now import `RunUsageMapSchema` from `usage.ts`.

### `normalizedSnapshots` → `latestUsage`: bounded field (was unbounded array)

`RunUsageAccumulatorJSON` carried a `NormalizedUsage[]` array that grew with every model invocation. The sole consumer (`UsageMonitor`) read only `.at(-1)?.usage`. Replaced with `latestUsage: NormalizedUsage | null`; a `z.preprocess` migration extracts the last entry from legacy persisted data so existing sessions resume without data loss. The now-unused `round` / `cycleIndex` parameters were removed from `recordNormalizedUsage` and `recordCycleMetrics`.

## Test plan

- [x] `npm run typecheck` — clean (0 errors)
- [x] `npm test` — 3550 passed, 3 skipped; 1 pre-existing flaky (`execUtils` process-group abort test, confirmed failing on `main` too)
- [x] Backward compat for persisted `tagContents` strings and `normalizedSnapshots` arrays verified via schema migration paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKbEqpiroQqRDSP4fExxvg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKbEqpiroQqRDSP4fExxvg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are schema/refactor-only with explicit preprocess migrations and new tests; session resume depends on those migrations behaving correctly, but no security or billing logic was rewritten.
> 
> **Overview**
> Mechanical schema and accumulator refactors so shared shapes are defined once and runtime state stays bounded, with **parse-time migrations** for persisted session data.
> 
> **`OutputXmlSummary.tagContents`** is always `string[]` now. `OutputFileProcessor` always writes arrays; `OutputXmlSummarySchema` coerces legacy bare strings via `transform` and `.catch` for bad values.
> 
> **`roundIndexedRecord`** in `output.ts` replaces duplicate `Record<string, T[]>` helpers in `streamState.ts` and `streamSnapshot.ts` for workflow files, missing outputs, and compile failures.
> 
> **`RunUsageMapSchema`** in `usage.ts` is the single definition for run-keyed `TokenUsageStats` on tool-use/workflow stream state, stream snapshots, and `SyncStreamContentMessage`.
> 
> **`RunUsageAccumulator`** drops the growing `normalizedSnapshots` list in favor of **`latestUsage`** (what `UsageMonitor` actually read). `z.preprocess` maps old persisted arrays to the last snapshot; **`recordNormalizedUsage`** / **`recordCycleMetrics`** no longer take round/cycle indices. New tests cover both migration paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9fd4f8e67b37714866af4d543226c57d5936f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->