### PR TITLE
[codex] fix CLI multi-agent zero-count list noise

### DIFF
--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -138,11 +138,22 @@ function cliMultiAgentPresetAvailabilityParts(
 ): string[] {
   const availability = cliMultiAgentPresetAvailability(plan);
   const parts = [
-    `workflow:${availability.workflow.label}`,
-    `tool-use:${availability.toolUse.label}`,
-  ];
+    formatCliMultiAgentPresetAvailabilityPart(
+      'workflow',
+      availability.workflow,
+    ),
+    formatCliMultiAgentPresetAvailabilityPart('tool-use', availability.toolUse),
+  ].filter((part): part is string => part != null);
   if (availability.status !== 'available') parts.push(availability.status);
   return parts;
+}
+
+function formatCliMultiAgentPresetAvailabilityPart(
+  kind: 'workflow' | 'tool-use',
+  availability: CliMultiAgentPresetAgentAvailability,
+): string | undefined {
+  if (availability.total === 0) return undefined;
+  return `${kind}:${availability.label}`;
 }
 
 export function formatCliMultiAgentPresetList(

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -84,8 +84,9 @@ describe('CLI multi-agent presets', () => {
     const output = formatCliMultiAgentPresetList([plan]);
 
     expect(output).toContain(
-      'built-in\tlean-project\tLean Project\tworkflow:0\ttool-use:2/7\tunavailable',
+      'built-in\tlean-project\tLean Project\ttool-use:2/7\tunavailable',
     );
+    expect(output).not.toContain('workflow:0');
     expect(output).toContain('texra multi-agent inspect <team-id>');
     expect(output).toContain(
       'Researcher Access sign-in may load additional remote team agents',


### PR DESCRIPTION
## Summary
- omit zero-count workflow/tool-use categories from human-readable `texra multi-agent list`
- keep JSON output unchanged so structured callers still see zero totals
- cover the unavailable-team text case with a regression assertion

## Why
The text list was surfacing `workflow:0` for teams whose category is absent, which adds noise and reads like a broken category rather than omitted metadata.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/multiAgentPresets.ts src/test-kernel/cli/MultiAgentPresets.vitest.mts`
- `npm run texra-local:build`
- `npm run compile:fast`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only formatting for CLI list output; structured availability and launch planning logic are untouched.
> 
> **Overview**
> Human-readable **`texra multi-agent list`** output no longer prints **`workflow:0`** or **`tool-use:0`** when a preset has no agents in that category. Availability columns are built through **`formatCliMultiAgentPresetAvailabilityPart`**, which skips categories whose **`total`** is zero.
> 
> **JSON and NDJSON** list output is unchanged: structured records still expose full **`availability.workflow`** / **`toolUse`** totals (including zero). A regression test asserts the lean-project unavailable row shows **`tool-use:2/7`** without **`workflow:0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883c07d8b46f1f152424dc1e329bef951d844d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->