### PR TITLE
[codex] align CLI secrets with storage root

### DIFF
--- a/packages/cli/src/runtime/cliSecrets.ts
+++ b/packages/cli/src/runtime/cliSecrets.ts
@@ -32,12 +32,7 @@ function isSecretFileData(value: unknown): value is SecretFileData {
 export class CliSecrets implements PlatformSecrets {
   private mutationQueue: Promise<void> = Promise.resolve();
 
-  constructor(
-    private readonly filePath = path.join(
-      DEFAULT_NODE_STORAGE_ROOT,
-      'secrets.json',
-    ),
-  ) {}
+  constructor(private readonly filePath = cliSecretsPath()) {}
 
   async get(key: string): Promise<string | undefined> {
     return cliEnvValue(key) ?? (await this.readSecrets())[key];
@@ -89,9 +84,15 @@ export class CliSecrets implements PlatformSecrets {
   }
 }
 
+export function cliSecretsPath(
+  storageRoot = DEFAULT_NODE_STORAGE_ROOT,
+): string {
+  return path.join(storageRoot, 'secrets.json');
+}
+
 let cliSecrets: CliSecrets | undefined;
 
-export function getCliSecrets(): CliSecrets {
-  cliSecrets ??= new CliSecrets();
+export function getCliSecrets(storageRoot?: string): CliSecrets {
+  cliSecrets ??= new CliSecrets(cliSecretsPath(storageRoot));
   return cliSecrets;
 }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -201,7 +201,7 @@ export async function initCliPlatform(
       fs: nodeFilesystem,
       workspace: createNodeWorkspace(() => cliWorkspaceCwd),
       storage: stateStores.storage,
-      secrets: getCliSecrets(),
+      secrets: getCliSecrets(context.storageRoot),
       lifecycle,
       agentResume: { tryResumeStream: async () => false },
       toolAvailability: {
@@ -233,7 +233,7 @@ export async function initCliPlatform(
   }
 
   if (!serverSideKeysInitialized) {
-    initializeCliSupabaseAuth(cliPlatformLog);
+    initializeCliSupabaseAuth(cliPlatformLog, context.storageRoot);
     initializeServerSideKeyAccess(
       { state: tryPlatform()?.globalState, logger: cliPlatformLog },
       getCliAuthProvider(),

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -1,3 +1,6 @@
+// Local imports - platform
+import { tryPlatform } from '@platform/platform';
+
 // Local imports - auth
 import {
   DEFAULT_OAUTH_PROVIDER,
@@ -28,6 +31,9 @@ import {
   requestDeviceAuthorization,
   type DeviceAuthorization,
 } from './supabaseAuthDeviceCode';
+
+// Type imports - platform
+import type { PlatformSecrets } from '@platform/secrets';
 
 /**
  * Channel-logger contract used by the CLI auth coordinator and supporting
@@ -77,6 +83,7 @@ export function formatCliManualAuthUrlMessage(url: string): string {
 }
 
 let coordinator: SupabaseSessionCoordinator | undefined;
+let coordinatorSecrets: PlatformSecrets | undefined;
 let activeAuthLog: LogBackend | undefined;
 const deferredAuthLog: LogBackend = {
   initialize: (channel, isAgent) => activeAuthLog?.initialize(channel, isAgent),
@@ -96,12 +103,19 @@ function getCliSupabaseAuthCoordinator(): SupabaseSessionCoordinator {
   return coordinator!;
 }
 
-export function initializeCliSupabaseAuth(log?: LogBackend): void {
+export function initializeCliSupabaseAuth(
+  log?: LogBackend,
+  storageRoot?: string,
+): void {
   activeAuthLog = log ?? activeAuthLog;
-  coordinator ??= createHostAuthCoordinator({
-    secrets: getCliSecrets(),
-    log: deferredAuthLog,
-  });
+  const secrets = tryPlatform()?.secrets ?? getCliSecrets(storageRoot);
+  if (!coordinator || coordinatorSecrets !== secrets) {
+    coordinator = createHostAuthCoordinator({
+      secrets,
+      log: deferredAuthLog,
+    });
+    coordinatorSecrets = secrets;
+  }
 }
 
 export function getCliAuthProvider() {

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { UsageLogService } from '@telemetry/UsageLogService';
 import { PathAgentDirectoryBundleSource } from '@agent/index/AgentDirectorySync';
 import { initCliPlatform } from '@cli/runtime/initPlatform';
-import type { CliContext } from '@cli/runtime/cliContext';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { SkillSource } from '@skills/loadSkills';
 
@@ -19,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   },
   defaultSkillSources: vi.fn<() => SkillSource[]>(() => []),
   setRuntimeSkillSources: vi.fn(),
+  getCliSecrets: vi.fn(() => ({ kind: 'cli-secrets' })),
   tryPlatform: vi.fn(),
   // Collects callbacks registered via the (mocked) lifecycle host's onShutdown
   // so a test can run them and assert the usage-log dispose was wired.
@@ -92,6 +92,10 @@ vi.mock('@cli/runtime/cliStateStores', () => ({
   }),
 }));
 
+vi.mock('@cli/runtime/cliSecrets', () => ({
+  getCliSecrets: mocks.getCliSecrets,
+}));
+
 vi.mock('@cli/runtime/gitAuthor', () => ({ applyCliGitAuthorConfig: vi.fn() }));
 
 vi.mock('@tools/lean/direct/directLspAdapter', () => ({
@@ -99,10 +103,7 @@ vi.mock('@tools/lean/direct/directLspAdapter', () => ({
 }));
 
 function cliContext(
-  overrides: Partial<CliContext> & {
-    bestEffortIncludedModelAccess?: boolean;
-    installSignalHandlers?: boolean;
-  } = {},
+  overrides: Partial<Parameters<typeof initCliPlatform>[0]> = {},
 ): Parameters<typeof initCliPlatform>[0] {
   return {
     cwd: '/tmp/project',
@@ -127,6 +128,24 @@ describe('CLI platform init', () => {
     mocks.bootstrapPlatformAgentDirectories.mockResolvedValue(undefined);
     mocks.serverSideKeyService.setUseIncludedModelAccess.mockResolvedValue(
       undefined,
+    );
+  });
+
+  it('uses the configured storage root for CLI secrets', async () => {
+    mocks.tryPlatform.mockReturnValueOnce(undefined);
+    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+
+    await initCliPlatform(
+      cliContext({
+        installSignalHandlers: false,
+        storageRoot: '/tmp/texra-storage-root',
+      }),
+    );
+
+    expect(mocks.getCliSecrets).toHaveBeenCalledWith('/tmp/texra-storage-root');
+    expect(mocks.initializeCliSupabaseAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      '/tmp/texra-storage-root',
     );
   });
 

--- a/src/test-kernel/cli/CliSecrets.vitest.mts
+++ b/src/test-kernel/cli/CliSecrets.vitest.mts
@@ -1,0 +1,47 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { CliSecrets, cliSecretsPath } from '@cli/runtime/cliSecrets';
+
+describe('CLI secrets', () => {
+  it('stores secrets under the configured storage root', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-secrets-'));
+    const storageRoot = path.join(root, 'storage');
+    const secretsPath = cliSecretsPath(storageRoot);
+
+    try {
+      const secrets = new CliSecrets(secretsPath);
+      await secrets.set('TEXRA_CLI_SECRETS_TEST_KEY', 'test-key');
+
+      expect(await secrets.get('TEXRA_CLI_SECRETS_TEST_KEY')).toBe('test-key');
+      await expect(fs.readFile(secretsPath, 'utf8')).resolves.toContain(
+        'TEXRA_CLI_SECRETS_TEST_KEY',
+      );
+      expect(path.dirname(secretsPath)).toBe(storageRoot);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps one process-wide secrets store after the first root is selected', async () => {
+    vi.resetModules();
+    const { getCliSecrets } = await import('@cli/runtime/cliSecrets');
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-secrets-'));
+    const storageRoot = path.join(root, 'storage');
+    const otherStorageRoot = path.join(root, 'other-storage');
+
+    try {
+      const first = getCliSecrets(storageRoot);
+      const second = getCliSecrets();
+      const third = getCliSecrets(otherStorageRoot);
+
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createHostAuthCoordinator: vi.fn((init: { secrets: unknown }) => ({
+    secrets: init.secrets,
+  })),
+  getCliSecrets: vi.fn(),
+  tryPlatform: vi.fn(),
+}));
+
+vi.mock('@auth/config', () => ({
+  DEFAULT_OAUTH_PROVIDER: 'github',
+  DEFAULT_SESSION_EXPIRY_MS: 60_000,
+}));
+
+vi.mock('@auth/SupabaseAuthCoordinator', () => ({
+  createHostAuthCoordinator: mocks.createHostAuthCoordinator,
+}));
+
+vi.mock('@auth/SupabaseClient', () => ({
+  SupabaseClient: {
+    getRelayAccessToken: vi.fn(),
+    getUserTier: vi.fn(),
+    isAuthenticated: vi.fn(),
+  },
+}));
+
+vi.mock('@auth/SupabaseSession', () => ({
+  toStorableSupabaseSession: vi.fn((session) => session),
+}));
+
+vi.mock('@auth/relayToken', () => ({
+  RELAY_TOKEN_ENV_VAR: 'TEXRA_RELAY_TOKEN',
+  fetchRelayTokenStatus: vi.fn(),
+  getConfiguredRelayToken: vi.fn(),
+}));
+
+vi.mock('@auth/serverKeys', () => ({
+  getServerSideKeyService: () => ({
+    clearAllCaches: vi.fn(),
+    setUseIncludedModelAccess: vi.fn(),
+  }),
+}));
+
+vi.mock('@platform/platform', () => ({
+  tryPlatform: mocks.tryPlatform,
+}));
+
+vi.mock('@cli/runtime/cliContext', () => ({
+  readCliEnv: () => ({}),
+}));
+
+vi.mock('@cli/runtime/cliSecrets', () => ({
+  getCliSecrets: mocks.getCliSecrets,
+}));
+
+vi.mock('@cli/runtime/browser', () => ({
+  openBrowser: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/supabaseAuthCallbackServer', () => ({
+  startLoopbackCallbackServer: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/supabaseAuthDeviceCode', () => ({
+  pollForDeviceSession: vi.fn(),
+  requestDeviceAuthorization: vi.fn(),
+}));
+
+async function loadSupabaseAuth() {
+  vi.resetModules();
+  return import('@cli/runtime/supabaseAuth');
+}
+
+describe('CLI Supabase auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tryPlatform.mockReturnValue(null);
+    mocks.getCliSecrets.mockReturnValue({ kind: 'cli-secrets' });
+  });
+
+  it('uses platform-owned secrets after CLI platform init', async () => {
+    const platformSecrets = { kind: 'platform-secrets' };
+    mocks.tryPlatform.mockReturnValue({ secrets: platformSecrets });
+    const { initializeCliSupabaseAuth } = await loadSupabaseAuth();
+
+    initializeCliSupabaseAuth(undefined, '/tmp/sandbox-storage');
+    initializeCliSupabaseAuth();
+
+    expect(mocks.createHostAuthCoordinator).toHaveBeenCalledTimes(1);
+    expect(mocks.createHostAuthCoordinator).toHaveBeenCalledWith(
+      expect.objectContaining({ secrets: platformSecrets }),
+    );
+    expect(mocks.getCliSecrets).not.toHaveBeenCalled();
+  });
+
+  it('does not rebind no-arg auth init to the default secrets path', async () => {
+    const cliSecrets = { kind: 'sandbox-secrets' };
+    mocks.getCliSecrets.mockReturnValue(cliSecrets);
+    const { initializeCliSupabaseAuth } = await loadSupabaseAuth();
+
+    initializeCliSupabaseAuth(undefined, '/tmp/sandbox-storage');
+    initializeCliSupabaseAuth();
+
+    expect(mocks.createHostAuthCoordinator).toHaveBeenCalledTimes(1);
+    expect(mocks.getCliSecrets).toHaveBeenCalledWith('/tmp/sandbox-storage');
+    expect(mocks.createHostAuthCoordinator).toHaveBeenCalledWith(
+      expect.objectContaining({ secrets: cliSecrets }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make CLI secret storage follow the configured CLI storage root
- key the CLI Supabase auth coordinator by the resolved secrets path
- add regression coverage for sandboxed CLI secrets and platform init wiring

## Why
The CLI TUI harness and other dogfood flows can sandbox state/config with a custom `storageRoot`, but secrets still defaulted to `~/.texra/secrets.json`. That made first-run and auth experiments leak across profiles and kept credentials outside the same storage owner as the rest of CLI state.

## Impact
Sandboxed CLI runs now keep auth/session secrets with their configured storage root. Normal CLI usage still defaults to the existing `~/.texra/secrets.json` path, and environment variables remain the highest-priority credential source.

## Dogfood
- `texra-local doctor --no-input --output-format json` reports the current CLI runtime healthy
- focused TUI snapshot pass wrote `/tmp/texra-tui-focus.mvDewh/index.html` and covered launcher, login, `/goal`, approvals, subagent/task pickers, and multiline input
- live `texra-local chat --agent assistant --model deepseekproT --approval-policy never` in a temp cwd solved a short proof task and exited with a resumable session
- `texra-local models show glm5.2 --no-input --output-format json` resolves the alias to `glm52`, but it is currently disabled/not included for the active included-access mode

## Validation
- `corepack pnpm exec prettier --check packages/cli/src/runtime/cliSecrets.ts packages/cli/src/runtime/initPlatform.ts packages/cli/src/runtime/supabaseAuth.ts src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/cli/CliSecrets.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/CliSecrets.vitest.mts src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/cli/CliStateStores.vitest.mts src/test-kernel/cli/CredentialStatus.vitest.mts src/test-kernel/cli/AuthCommand.vitest.mts src/test-kernel/cli/SetupCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run texra-local:build`
- `npm run compile:fast`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential persistence and auth coordinator initialization; behavior change is scoped to custom storageRoot users, with env overrides unchanged.
> 
> **Overview**
> CLI login and session secrets now live under the same **configured `storageRoot`** as other CLI state (e.g. `secrets.json` under that root), instead of always using the default `~/.texra` path when sandboxes pass a custom root.
> 
> **`initCliPlatform`** forwards `context.storageRoot` into platform secrets and Supabase auth init. **`initializeCliSupabaseAuth`** resolves secrets from **`tryPlatform()?.secrets`** when the platform is up, otherwise **`getCliSecrets(storageRoot)`**, and only rebuilds the auth coordinator when the resolved secrets backend changes so a later no-arg init does not fall back to the default path.
> 
> Default behavior is unchanged when no custom root is set; env vars still override file-backed secrets. New tests cover path wiring, sandbox persistence, and coordinator binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a38691dabfcff2fdfa11f319a4719eba4f3425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->