### PR TITLE
refactor(ui): replace command-URI placeholder in TaskGroupList with wa-button event dispatch

### DIFF
--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -23,6 +23,7 @@ import {
   truncateSummaryToWidth,
 } from '../render/terminalText';
 
+// Terminal-safe Unicode glyph — Font Awesome is not available in Ink TUI.
 const STATUS_DOT = '●';
 const OUTPUT_CORNER = '⎿';
 const MAX_HEADER_PREVIEW = 80;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -74,6 +74,7 @@ import { persistOpenTurnDraft } from '@tools/inquiry/externalInquiryStorage';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import { getConfig } from '@utils/config/configUtils';
 
+import { buildDesktopOnboardingSetStateMessage } from '../desktopOnboardingMessages.js';
 import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
 import {
   createDesktopToolEditApprovalController,
@@ -602,9 +603,13 @@ export class DesktopProgressBridge {
     });
     return {
       ...sharedHandlers,
-      // Getting-started actions from the progress empty-state. On desktop
-      // these VS Code commands are unavailable; surface a brief notice.
+      // Getting-started actions from the progress empty-state. openWalkthrough
+      // has a desktop equivalent; the remaining four actions are VS Code-only.
       [PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION]: async (data) => {
+        if (data.action === 'openWalkthrough') {
+          this.postToRenderer(buildDesktopOnboardingSetStateMessage(true));
+          return;
+        }
         const labels: Record<typeof data.action, string> = {
           runSetup: 'Run setup assistant',
           createSampleProject: 'Create sample project',

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -602,6 +602,20 @@ export class DesktopProgressBridge {
     });
     return {
       ...sharedHandlers,
+      // Getting-started actions from the progress empty-state. On desktop
+      // these VS Code commands are unavailable; surface a brief notice.
+      [PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION]: async (data) => {
+        const labels: Record<typeof data.action, string> = {
+          runSetup: 'Run setup assistant',
+          createSampleProject: 'Create sample project',
+          cloneOverleaf: 'Import from Overleaf',
+          downloadArxiv: 'Import from arXiv',
+          openWalkthrough: 'Open walkthrough',
+        };
+        await this.options.showInfoMessage?.(
+          `"${labels[data.action]}" requires the VS Code extension.`,
+        );
+      },
       // External inquiry rides outside the shared registry (as in the
       // extension's ProgressViewMessageHandler): draft persists the open
       // turn, submit/drop settle the durable thread.

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -255,6 +255,13 @@ function dispatchMainViewInboundOnShell(
     case MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS:
       actions.sendRecentCommits();
       return true;
+    case MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION:
+      // openWalkthrough has a desktop equivalent; the remaining actions
+      // require VS Code and are silently consumed on desktop.
+      if (message.action === 'openWalkthrough') {
+        actions.showFirstRunWalkthrough?.();
+      }
+      return true;
     default:
       return false;
   }

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -62,6 +62,7 @@ export interface DesktopShellActionFactoryOptions {
     commits: string[];
     isGitRepo: boolean;
   }>;
+  showInfoMessage?: (message: string) => Promise<void> | void;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -83,6 +84,7 @@ export interface DesktopShellActions extends DesktopCommandActions {
    * best-effort `isGitRepo` flag derived from `isWorkspaceGitRepo`.
    */
   sendRecentCommits(): void;
+  showInfoMessage?(message: string): void;
 }
 
 const SWITCH_VIEW_ROUTES = {
@@ -204,6 +206,13 @@ export function createDesktopShellActions(
     showFirstRunWalkthrough: () => {
       renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(true));
     },
+    showInfoMessage: options.showInfoMessage
+      ? (message) => {
+          void Promise.resolve(options.showInfoMessage!(message)).catch(
+            reportAsyncError,
+          );
+        }
+      : undefined,
   };
 }
 
@@ -256,10 +265,19 @@ function dispatchMainViewInboundOnShell(
       actions.sendRecentCommits();
       return true;
     case MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION:
-      // openWalkthrough has a desktop equivalent; the remaining actions
-      // require VS Code and are silently consumed on desktop.
       if (message.action === 'openWalkthrough') {
         actions.showFirstRunWalkthrough?.();
+      } else {
+        const labels: Record<typeof message.action, string> = {
+          runSetup: 'Run setup assistant',
+          createSampleProject: 'Create sample project',
+          cloneOverleaf: 'Import from Overleaf',
+          downloadArxiv: 'Import from arXiv',
+          openWalkthrough: 'Open walkthrough',
+        };
+        actions.showInfoMessage?.(
+          `"${labels[message.action]}" requires the VS Code extension.`,
+        );
       }
       return true;
     default:

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -629,6 +629,9 @@ function createWindow(options: {
       openWorkspaceFolder,
       signIn: () => desktopAuth.signIn(),
       getRecentCommits: () => gitHost.getRecentCommits(),
+      showInfoMessage: async (message) => {
+        await dialog.showMessageBox(window, { type: 'info', message });
+      },
       onAsyncError: reportAsyncError,
     },
   );

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -821,8 +821,12 @@ function wireConversation(): void {
   conversationView.addEventListener('compile-fixer-run', () =>
     runCompileFixer(ctx()),
   );
-  conversationView.addEventListener('getting-started-action', ((e: CustomEvent) =>
-    handleGettingStartedAction(e.detail.action as GettingStartedAction)) as EventListener);
+  conversationView.addEventListener('getting-started-action', ((
+    e: CustomEvent,
+  ) =>
+    handleGettingStartedAction(
+      e.detail.action as GettingStartedAction,
+    )) as EventListener);
   conversationView.addEventListener('followup-request-options', () =>
     handleFollowupRequestOptions(ctx()),
   );

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -19,6 +19,7 @@ import {
   handleFollowUpClear,
   handleFollowUpPolish,
   handleFollowUpSend,
+  handleGettingStartedAction,
   handlePermissionAction,
   handleStreamDelete,
   handleStreamSwitch,
@@ -47,7 +48,7 @@ import { COMMON_COMMANDS } from '@shared/ipc';
 import '@settingsView/frontend';
 import '@webview/frontend';
 import { postMessage } from '@shared/hostBridge';
-import type { StreamTabId } from '@shared/schemas';
+import type { GettingStartedAction, StreamTabId } from '@shared/schemas';
 import { Signal } from '@shared/signals';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import {
@@ -820,6 +821,8 @@ function wireConversation(): void {
   conversationView.addEventListener('compile-fixer-run', () =>
     runCompileFixer(ctx()),
   );
+  conversationView.addEventListener('getting-started-action', ((e: CustomEvent) =>
+    handleGettingStartedAction(e.detail.action as GettingStartedAction)) as EventListener);
   conversationView.addEventListener('followup-request-options', () =>
     handleFollowupRequestOptions(ctx()),
   );

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -389,7 +389,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           default: {
             const exhaustive: never = data.action;
             throw new Error(
-              `Unhandled getting-started action: ${String(exhaustive)}`,
+              `Unhandled getting-started action: ${exhaustive}`,
             );
           }
         }

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -388,9 +388,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             break;
           default: {
             const exhaustive: never = data.action;
-            throw new Error(
-              `Unhandled getting-started action: ${exhaustive}`,
-            );
+            throw new Error(`Unhandled getting-started action: ${exhaustive}`);
           }
         }
       },

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -348,6 +348,30 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.processToolUseFollowup(data, true),
       [PROGRESS_VIEW_COMMANDS.RUN_COMPILE_FIXER]: (data) =>
         this.handleRunCompileFixer(data.stream),
+
+      [PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION]: async (data) => {
+        switch (data.action) {
+          case 'runSetup':
+            await safeExecuteCommand('texra.runSetupAssistant', [], this.viewName);
+            break;
+          case 'createSampleProject':
+            await safeExecuteCommand('texra.createSampleProject', [], this.viewName);
+            break;
+          case 'cloneOverleaf':
+            await safeExecuteCommand('texra.cloneOverleafProject', [], this.viewName);
+            break;
+          case 'downloadArxiv':
+            await safeExecuteCommand('texra.downloadArXivSource', [], this.viewName);
+            break;
+          case 'openWalkthrough':
+            await safeExecuteCommand('texra.openGettingStarted', [], this.viewName);
+            break;
+          default: {
+            const exhaustive: never = data.action;
+            throw new Error(`Unhandled getting-started action: ${String(exhaustive)}`);
+          }
+        }
+      },
     };
   }
 

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -352,23 +352,45 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION]: async (data) => {
         switch (data.action) {
           case 'runSetup':
-            await safeExecuteCommand('texra.runSetupAssistant', [], this.viewName);
+            await safeExecuteCommand(
+              'texra.runSetupAssistant',
+              [],
+              this.viewName,
+            );
             break;
           case 'createSampleProject':
-            await safeExecuteCommand('texra.createSampleProject', [], this.viewName);
+            await safeExecuteCommand(
+              'texra.createSampleProject',
+              [],
+              this.viewName,
+            );
             break;
           case 'cloneOverleaf':
-            await safeExecuteCommand('texra.cloneOverleafProject', [], this.viewName);
+            await safeExecuteCommand(
+              'texra.cloneOverleafProject',
+              [],
+              this.viewName,
+            );
             break;
           case 'downloadArxiv':
-            await safeExecuteCommand('texra.downloadArXivSource', [], this.viewName);
+            await safeExecuteCommand(
+              'texra.downloadArXivSource',
+              [],
+              this.viewName,
+            );
             break;
           case 'openWalkthrough':
-            await safeExecuteCommand('texra.openGettingStarted', [], this.viewName);
+            await safeExecuteCommand(
+              'texra.openGettingStarted',
+              [],
+              this.viewName,
+            );
             break;
           default: {
             const exhaustive: never = data.action;
-            throw new Error(`Unhandled getting-started action: ${String(exhaustive)}`);
+            throw new Error(
+              `Unhandled getting-started action: ${String(exhaustive)}`,
+            );
           }
         }
       },

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -488,8 +488,9 @@ export class ProgressApp extends ProgressAppBase {
   private onCompileFixerRun = (): void =>
     runCompileFixer(this.getEventHandlerContext());
 
-  private onGettingStartedAction = (e: CustomEvent<GettingStartedActionDetail>): void =>
-    handleGettingStartedAction(e.detail.action);
+  private onGettingStartedAction = (
+    e: CustomEvent<GettingStartedActionDetail>,
+  ): void => handleGettingStartedAction(e.detail.action);
 
   private onFollowupRequestOptions = (): void =>
     handleFollowupRequestOptions(this.getEventHandlerContext());

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -21,6 +21,7 @@ import { PersistedState } from '@shared/state';
 // Local imports - shared schemas
 import {
   AgentCategoryFilterSchema,
+  type GettingStartedActionDetail,
   type ProgressViewOutboundMessage,
   type StreamTabId,
 } from '@shared/schemas';
@@ -70,6 +71,7 @@ import {
   handleFollowUpClear,
   handleFollowUpPolish,
   handleFollowUpSend,
+  handleGettingStartedAction,
   handlePermissionAction,
   handleStreamDelete,
   handleStreamSwitch,
@@ -246,6 +248,7 @@ export class ProgressApp extends ProgressAppBase {
                     @permission-action=${this.onPermissionAction}
                     @file-action=${this.onFileAction}
                     @compile-fixer-run=${this.onCompileFixerRun}
+                    @getting-started-action=${this.onGettingStartedAction}
                     @followup-request-options=${this.onFollowupRequestOptions}
                     @followup-setup=${this.onFollowupSetup}
                     @followup-run=${this.onFollowupRun}
@@ -484,6 +487,9 @@ export class ProgressApp extends ProgressAppBase {
 
   private onCompileFixerRun = (): void =>
     runCompileFixer(this.getEventHandlerContext());
+
+  private onGettingStartedAction = (e: CustomEvent<GettingStartedActionDetail>): void =>
+    handleGettingStartedAction(e.detail.action);
 
   private onFollowupRequestOptions = (): void =>
     handleFollowupRequestOptions(this.getEventHandlerContext());

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -6,13 +6,14 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { guard } from 'lit/directives/guard.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 // Local imports - shared schemas
 import { STREAM_STATUS } from '@shared/schemas';
+import type { GettingStartedAction } from '@shared/schemas';
 
 // Local imports - shared utilities
 // Side-effect imports - register WA icon and spinner components
+import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 
@@ -20,7 +21,7 @@ import { designTokens } from '@shared/styles';
 import type { LogMessageData, TaskGroup } from '@shared/schemas';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { scrollToBottom } from '@shared/utils/dom';
-import { getGettingStartedHtml } from '@shared/utils/uiConstants';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { formatDuration } from '@utils/core';
 
 // Local imports - progress view constants
@@ -43,10 +44,7 @@ import { getTimeFormatter } from '../formatters/timestampUtils';
 // Local imports - sibling helpers
 import { MessageIndex, type GroupTree } from './messageIndex';
 import { TerminalBuffer, processTerminalText } from './terminalBuffer';
-
-const PLACEHOLDER_HTML = getGettingStartedHtml(
-  'No runs yet—use TeXRA commands to start. Try ',
-);
+import { ProgressEvents } from '../events';
 
 const DEFAULT_TIMELINE_ITEM_WINDOW = 120;
 const TIMELINE_ITEM_WINDOW_STEP = 120;
@@ -544,6 +542,10 @@ export class TaskGroupList extends LitElement {
     return html`<div class="terminal-container">${[committed, tail]}</div>`;
   }
 
+  private handleGettingStartedAction(action: GettingStartedAction): void {
+    this.dispatchEvent(ProgressEvents.gettingStartedAction({ action }));
+  }
+
   override render(): TemplateResult {
     // Show placeholder only when there are no streams in the current filter
     if (!this.hasStreams) {
@@ -553,7 +555,36 @@ export class TaskGroupList extends LitElement {
           class="log-container"
           @scroll=${this.handleScroll}
         >
-          <div class="log-placeholder">${unsafeHTML(PLACEHOLDER_HTML)}</div>
+          <div class="log-placeholder">
+            No runs yet—use TeXRA commands to start.
+            <div class="log-placeholder-actions">
+              <wa-button
+                appearance="outlined"
+                size="small"
+                @click=${() => this.handleGettingStartedAction('runSetup')}
+              >${waIcon('rocket', { slot: 'start' })} Run setup</wa-button>
+              <wa-button
+                appearance="outlined"
+                size="small"
+                @click=${() => this.handleGettingStartedAction('createSampleProject')}
+              >${waIcon('file-circle-plus', { slot: 'start' })} Sample project</wa-button>
+              <wa-button
+                appearance="outlined"
+                size="small"
+                @click=${() => this.handleGettingStartedAction('cloneOverleaf')}
+              >${waIcon('cloud-arrow-down', { slot: 'start' })} Import Overleaf</wa-button>
+              <wa-button
+                appearance="outlined"
+                size="small"
+                @click=${() => this.handleGettingStartedAction('downloadArxiv')}
+              >${waIcon('download', { slot: 'start' })} Import arXiv</wa-button>
+              <wa-button
+                appearance="outlined"
+                size="small"
+                @click=${() => this.handleGettingStartedAction('openWalkthrough')}
+              >${waIcon('book', { slot: 'start' })} Walkthrough</wa-button>
+            </div>
+          </div>
         </div>
       `;
     }

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -562,27 +562,37 @@ export class TaskGroupList extends LitElement {
                 appearance="outlined"
                 size="small"
                 @click=${() => this.handleGettingStartedAction('runSetup')}
-              >${waIcon('rocket', { slot: 'start' })} Run setup</wa-button>
+                >${waIcon('rocket', { slot: 'start' })} Run setup</wa-button
+              >
               <wa-button
                 appearance="outlined"
                 size="small"
-                @click=${() => this.handleGettingStartedAction('createSampleProject')}
-              >${waIcon('file-circle-plus', { slot: 'start' })} Sample project</wa-button>
+                @click=${() =>
+                  this.handleGettingStartedAction('createSampleProject')}
+                >${waIcon('file-circle-plus', { slot: 'start' })} Sample
+                project</wa-button
+              >
               <wa-button
                 appearance="outlined"
                 size="small"
                 @click=${() => this.handleGettingStartedAction('cloneOverleaf')}
-              >${waIcon('cloud-arrow-down', { slot: 'start' })} Import Overleaf</wa-button>
+                >${waIcon('cloud-arrow-down', { slot: 'start' })} Import
+                Overleaf</wa-button
+              >
               <wa-button
                 appearance="outlined"
                 size="small"
                 @click=${() => this.handleGettingStartedAction('downloadArxiv')}
-              >${waIcon('download', { slot: 'start' })} Import arXiv</wa-button>
+                >${waIcon('download', { slot: 'start' })} Import
+                arXiv</wa-button
+              >
               <wa-button
                 appearance="outlined"
                 size="small"
-                @click=${() => this.handleGettingStartedAction('openWalkthrough')}
-              >${waIcon('book', { slot: 'start' })} Walkthrough</wa-button>
+                @click=${() =>
+                  this.handleGettingStartedAction('openWalkthrough')}
+                >${waIcon('book', { slot: 'start' })} Walkthrough</wa-button
+              >
             </div>
           </div>
         </div>

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -29,6 +29,7 @@ import type {
   StreamEventDetail,
   ToolbarCommandDetail,
 } from './events';
+import type { GettingStartedAction } from '@shared/schemas';
 import type {
   FrontendEventHandlerContext,
   MessageHandlerContext,
@@ -88,6 +89,10 @@ export function handleFilterChange(
 
 export function handleDeleteAll(): void {
   postMessage(PROGRESS_VIEW_COMMANDS.DELETE_ALL, {});
+}
+
+export function handleGettingStartedAction(action: GettingStartedAction): void {
+  postMessage(PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION, { action });
 }
 
 export function handleToolbarCommand(

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -3,8 +3,11 @@
  * Both dispatch and handler sides use these types.
  */
 
-import type { StringValueDetail } from '@shared/schemas';
-import type { UserQuestionAnswers } from '@shared/schemas';
+import type {
+  GettingStartedActionDetail,
+  StringValueDetail,
+  UserQuestionAnswers,
+} from '@shared/schemas';
 import { createEvent } from '@shared/utils/events';
 import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
 
@@ -124,4 +127,7 @@ export const ProgressEvents = {
 
   followupFocusComplete: () =>
     createEvent('followup-focus-complete', undefined),
+
+  gettingStartedAction: (detail: GettingStartedActionDetail) =>
+    createEvent('getting-started-action', detail),
 } as const;

--- a/packages/extension/src/progressView/frontend/styles/logStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logStyles.ts
@@ -62,14 +62,12 @@ export const layoutStyles = css`
     padding: var(--wa-space-s) var(--wa-space-xs);
   }
 
-  .log-placeholder a {
-    color: var(--color-text-link);
-    cursor: pointer;
-    text-decoration: none;
-  }
-
-  .log-placeholder a:hover {
-    text-decoration: underline;
+  .log-placeholder-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--wa-space-3xs);
+    margin-top: var(--wa-space-xs);
   }
 `;
 

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -315,6 +315,46 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.applyConfigUpdate(
           this.interactionController.getDismissConfigUpdate(m),
         ),
+      [MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION]: async (m) => {
+        switch (m.action) {
+          case 'runSetup':
+            await safeExecuteCommand(
+              'texra.runSetupAssistant',
+              [],
+              this.viewName,
+            );
+            await this.onboarding?.refreshOnboardingFunnel();
+            break;
+          case 'createSampleProject':
+            await safeExecuteCommand(
+              'texra.createSampleProject',
+              [],
+              this.viewName,
+            );
+            break;
+          case 'cloneOverleaf':
+            await safeExecuteCommand(
+              'texra.cloneOverleafProject',
+              [],
+              this.viewName,
+            );
+            break;
+          case 'downloadArxiv':
+            await safeExecuteCommand(
+              'texra.downloadArXivSource',
+              [],
+              this.viewName,
+            );
+            break;
+          case 'openWalkthrough':
+            await safeExecuteCommand(
+              'texra.openGettingStarted',
+              [],
+              this.viewName,
+            );
+            break;
+        }
+      },
       [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP]: async () => {
         // Persist the user-scoped declined flag (same flag the CLI picker
         // writes), then re-derive so the card disappears and the normal

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -353,6 +353,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
               this.viewName,
             );
             break;
+          default: {
+            const exhaustive: never = m.action;
+            throw new Error(`Unhandled getting started action: ${exhaustive}`);
+          }
         }
       },
       [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP]: async () => {

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -41,6 +41,7 @@ import {
   type EditedFileChangeDetail,
   type FileActionDetail,
   type FocusInstructionDetail,
+  type GettingStartedActionDetail,
   type InstallGuideDetail,
   type InstructionChangeDetail,
   type LatexDiffsActionDetail,
@@ -1480,6 +1481,14 @@ export class MainApp extends MainAppBase {
     this.gettingStartedDismissed.set(true);
   }
 
+  private handleComponentGettingStartedAction(
+    e: CustomEvent<GettingStartedActionDetail>,
+  ): void {
+    postMessage(MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION, {
+      action: e.detail.action,
+    });
+  }
+
   private handleComponentDismissSessionHint(): void {
     postMessage(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER);
     this.sessionHintDismissed.set(true);
@@ -1833,6 +1842,7 @@ export class MainApp extends MainAppBase {
             @dismiss-login=${this.handleComponentDismissLogin}
             @dismiss-getting-started=${this
               .handleComponentDismissGettingStarted}
+            @getting-started-action=${this.handleComponentGettingStartedAction}
           ></banner-group>
 
           <wa-divider></wa-divider>

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -12,7 +12,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
-import { COMMAND_LINKS } from '@shared/utils/uiConstants';
+import type { GettingStartedAction } from '@shared/schemas';
 
 import { applyBannerVisibility, bannerStyles } from '../styles/bannerStyles';
 import { MainViewEvents } from '../events';
@@ -90,6 +90,10 @@ export class GettingStartedBanner extends LitElement {
     this.dispatchEvent(MainViewEvents.dismissGettingStarted());
   }
 
+  private handleAction(action: GettingStartedAction): void {
+    this.dispatchEvent(MainViewEvents.gettingStartedAction({ action }));
+  }
+
   override render(): TemplateResult {
     return html`
       <div class="banner-frame">
@@ -113,14 +117,14 @@ export class GettingStartedBanner extends LitElement {
                   variant="brand"
                   appearance="filled"
                   size="small"
-                  href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}
+                  @click=${() => this.handleAction('runSetup')}
                 >
                   ${waIcon('rocket', { slot: 'start' })} Run setup assistant
                 </wa-button>
                 <wa-button
                   appearance="outlined"
                   size="small"
-                  href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
+                  @click=${() => this.handleAction('createSampleProject')}
                 >
                   ${waIcon('file-circle-plus', { slot: 'start' })} Sample
                   project
@@ -128,7 +132,7 @@ export class GettingStartedBanner extends LitElement {
                 <wa-button
                   appearance="outlined"
                   size="small"
-                  href=${COMMAND_LINKS.CLONE_OVERLEAF}
+                  @click=${() => this.handleAction('cloneOverleaf')}
                 >
                   ${waIcon('cloud-arrow-down', { slot: 'start' })} Import
                   Overleaf
@@ -136,14 +140,14 @@ export class GettingStartedBanner extends LitElement {
                 <wa-button
                   appearance="outlined"
                   size="small"
-                  href=${COMMAND_LINKS.DOWNLOAD_ARXIV}
+                  @click=${() => this.handleAction('downloadArxiv')}
                 >
                   ${waIcon('download', { slot: 'start' })} Import arXiv
                 </wa-button>
                 <wa-button
                   appearance="outlined"
                   size="small"
-                  href=${COMMAND_LINKS.GETTING_STARTED}
+                  @click=${() => this.handleAction('openWalkthrough')}
                 >
                   ${waIcon('book', { slot: 'start' })} Walkthrough
                 </wa-button>

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -25,10 +25,6 @@ export class GettingStartedBanner extends LitElement {
     commonViewStyles,
     bannerStyles,
     css`
-      wa-callout.getting-started-banner a {
-        text-decoration: none;
-      }
-
       .getting-started-row {
         display: flex;
         align-items: flex-start;
@@ -64,35 +60,6 @@ export class GettingStartedBanner extends LitElement {
         display: flex;
         flex-wrap: wrap;
         gap: var(--wa-space-3xs);
-      }
-
-      .action-link {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: var(--wa-space-3xs);
-        min-height: 24px;
-        max-width: 100%;
-        padding: 2px var(--wa-space-xs);
-        border: 1px solid var(--vscode-button-border, transparent);
-        border-radius: var(--wa-border-radius-s, 4px);
-        background: var(--vscode-button-secondaryBackground);
-        color: var(--vscode-button-secondaryForeground);
-        line-height: var(--line-height-normal);
-        white-space: nowrap;
-      }
-
-      .action-link:hover {
-        background: var(--vscode-button-secondaryHoverBackground);
-      }
-
-      .action-link--primary {
-        background: var(--vscode-button-background);
-        color: var(--vscode-button-foreground);
-      }
-
-      .action-link--primary:hover {
-        background: var(--vscode-button-hoverBackground);
       }
 
       .dismiss-button {
@@ -131,27 +98,41 @@ export class GettingStartedBanner extends LitElement {
                 </span>
               </div>
               <div class="getting-started-actions">
-                <a
-                  class="action-link action-link--primary"
+                <wa-button
+                  appearance="filled"
+                  size="small"
                   href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}
                 >
-                  ${waIcon('rocket')} Run setup
-                </a>
-                <a
-                  class="action-link"
+                  ${waIcon('rocket', { slot: 'start' })} Run setup
+                </wa-button>
+                <wa-button
+                  appearance="outlined"
+                  size="small"
                   href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
                 >
-                  ${waIcon('file-circle-plus')} Sample project
-                </a>
-                <a class="action-link" href=${COMMAND_LINKS.CLONE_OVERLEAF}>
-                  ${waIcon('cloud-arrow-down')} Overleaf
-                </a>
-                <a class="action-link" href=${COMMAND_LINKS.DOWNLOAD_ARXIV}>
-                  ${waIcon('download')} arXiv
-                </a>
-                <a class="action-link" href=${COMMAND_LINKS.GETTING_STARTED}>
-                  ${waIcon('book')} Walkthrough
-                </a>
+                  ${waIcon('file-circle-plus', { slot: 'start' })} Sample project
+                </wa-button>
+                <wa-button
+                  appearance="outlined"
+                  size="small"
+                  href=${COMMAND_LINKS.CLONE_OVERLEAF}
+                >
+                  ${waIcon('cloud-arrow-down', { slot: 'start' })} Overleaf
+                </wa-button>
+                <wa-button
+                  appearance="outlined"
+                  size="small"
+                  href=${COMMAND_LINKS.DOWNLOAD_ARXIV}
+                >
+                  ${waIcon('download', { slot: 'start' })} arXiv
+                </wa-button>
+                <wa-button
+                  appearance="outlined"
+                  size="small"
+                  href=${COMMAND_LINKS.GETTING_STARTED}
+                >
+                  ${waIcon('book', { slot: 'start' })} Walkthrough
+                </wa-button>
               </div>
             </div>
             <wa-button

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -56,10 +56,20 @@ export class GettingStartedBanner extends LitElement {
         color: var(--vscode-descriptionForeground);
       }
 
+      .getting-started-copy {
+        margin: 0;
+        color: var(--vscode-descriptionForeground);
+        line-height: var(--line-height-normal, 1.4);
+      }
+
       .getting-started-actions {
         display: flex;
         flex-wrap: wrap;
         gap: var(--wa-space-3xs);
+      }
+
+      .getting-started-actions wa-button::part(base) {
+        min-height: 26px;
       }
 
       .dismiss-button {
@@ -92,18 +102,20 @@ export class GettingStartedBanner extends LitElement {
             <div class="getting-started-body">
               <div class="getting-started-title">
                 <strong>No LaTeX files yet</strong>
-                <span>
-                  Run setup to connect TeXRA, check this workspace, or import a
-                  source.
-                </span>
+                <span>Start from a sample or import an existing paper.</span>
               </div>
+              <p class="getting-started-copy">
+                Then run setup to connect TeXRA, check LaTeX, and choose a
+                starter agent team.
+              </p>
               <div class="getting-started-actions">
                 <wa-button
+                  variant="brand"
                   appearance="filled"
                   size="small"
                   href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}
                 >
-                  ${waIcon('rocket', { slot: 'start' })} Run setup
+                  ${waIcon('rocket', { slot: 'start' })} Run setup assistant
                 </wa-button>
                 <wa-button
                   appearance="outlined"
@@ -118,14 +130,15 @@ export class GettingStartedBanner extends LitElement {
                   size="small"
                   href=${COMMAND_LINKS.CLONE_OVERLEAF}
                 >
-                  ${waIcon('cloud-arrow-down', { slot: 'start' })} Overleaf
+                  ${waIcon('cloud-arrow-down', { slot: 'start' })} Import
+                  Overleaf
                 </wa-button>
                 <wa-button
                   appearance="outlined"
                   size="small"
                   href=${COMMAND_LINKS.DOWNLOAD_ARXIV}
                 >
-                  ${waIcon('download', { slot: 'start' })} arXiv
+                  ${waIcon('download', { slot: 'start' })} Import arXiv
                 </wa-button>
                 <wa-button
                   appearance="outlined"

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -110,7 +110,8 @@ export class GettingStartedBanner extends LitElement {
                   size="small"
                   href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
                 >
-                  ${waIcon('file-circle-plus', { slot: 'start' })} Sample project
+                  ${waIcon('file-circle-plus', { slot: 'start' })} Sample
+                  project
                 </wa-button>
                 <wa-button
                   appearance="outlined"

--- a/packages/extension/src/webview/frontend/events.ts
+++ b/packages/extension/src/webview/frontend/events.ts
@@ -15,6 +15,7 @@ import type {
   EditedFileChangeDetail,
   FileActionDetail,
   FocusInstructionDetail,
+  GettingStartedActionDetail,
   InstallGuideDetail,
   InstructionChangeDetail,
   LatexDiffsActionDetail,
@@ -103,6 +104,9 @@ export const MainViewEvents = {
 
   dismissGettingStarted: () =>
     createEvent('dismiss-getting-started', undefined),
+
+  gettingStartedAction: (detail: GettingStartedActionDetail) =>
+    createEvent('getting-started-action', detail),
 
   dismissSessionHint: () => createEvent('dismiss-session-hint', undefined),
 

--- a/src/shared/ipc/mainViewCommands.ts
+++ b/src/shared/ipc/mainViewCommands.ts
@@ -63,6 +63,7 @@ export const MAIN_VIEW_COMMANDS = {
   HIDE_DEPENDENCY_BANNER: 'hideDependencyBanner',
   SHOW_GETTING_STARTED_BANNER: 'showGettingStartedBanner',
   HIDE_GETTING_STARTED_BANNER: 'hideGettingStartedBanner',
+  GETTING_STARTED_ACTION: 'gettingStartedAction',
   SHOW_LOGIN_BANNER: 'showLoginBanner',
   HIDE_LOGIN_BANNER: 'hideLoginBanner',
   SIGN_IN_FROM_BANNER: 'signInFromBanner',

--- a/src/shared/ipc/progressViewCommands.ts
+++ b/src/shared/ipc/progressViewCommands.ts
@@ -81,7 +81,7 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   OPEN_PROFILE: 'openProfile',
 
-  GETTING_STARTED_ACTION: 'gettingStartedAction',
+  GETTING_STARTED_ACTION: 'progressGettingStartedAction',
 
   POP_OUT: 'popOut',
   POP_BACK: 'popBack',

--- a/src/shared/ipc/progressViewCommands.ts
+++ b/src/shared/ipc/progressViewCommands.ts
@@ -81,6 +81,8 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   OPEN_PROFILE: 'openProfile',
 
+  GETTING_STARTED_ACTION: 'gettingStartedAction',
+
   POP_OUT: 'popOut',
   POP_BACK: 'popBack',
   SET_PLACEMENT: 'setPlacement',

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -24,7 +24,7 @@ import {
   ExtendedDocumentFileTypeSchema,
   MultipleDocumentFileTypeSchema,
 } from '../fileTypes';
-import { SessionTypeSchema } from './state';
+import { GettingStartedActionSchema, SessionTypeSchema } from './state';
 
 const CommonMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.WEBVIEW_READY),
@@ -199,6 +199,10 @@ const BannerMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER),
   commandOnly(MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER),
   commandOnly(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER),
+  z.object({
+    command: z.literal(MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION),
+    action: GettingStartedActionSchema,
+  }),
   z.object({
     command: z.literal(MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER),
     missingTools: z.array(z.string()).optional(),

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -272,6 +272,22 @@ export const BannerActionDetailSchema = z.object({
 });
 export type BannerActionDetail = z.infer<typeof BannerActionDetailSchema>;
 
+export const GettingStartedActionSchema = z.enum([
+  'runSetup',
+  'createSampleProject',
+  'cloneOverleaf',
+  'downloadArxiv',
+  'openWalkthrough',
+]);
+export type GettingStartedAction = z.infer<typeof GettingStartedActionSchema>;
+
+export const GettingStartedActionDetailSchema = z.object({
+  action: GettingStartedActionSchema,
+});
+export type GettingStartedActionDetail = z.infer<
+  typeof GettingStartedActionDetailSchema
+>;
+
 export const InstallGuideDetailSchema = z.object({
   tool: z.string(),
 });

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -27,6 +27,7 @@ import {
   UserQuestionAnswersSchema,
 } from '../prompts';
 import { AgentCategoryFilterSchema } from './data';
+import { GettingStartedActionSchema } from '../mainView/state';
 
 const TrimmedStringSchema = z
   .string()
@@ -344,6 +345,11 @@ const OpenLabelMessageSchema = z.object({
   label: z.string().min(1),
 });
 
+const GettingStartedActionMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION),
+  action: GettingStartedActionSchema,
+});
+
 export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
   'command',
   [
@@ -397,6 +403,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     GetFollowupOptionsMessageSchema,
     SetupFollowupMessageSchema,
     RunFollowupMessageSchema,
+    GettingStartedActionMessageSchema,
   ],
 );
 

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -1,4 +1,3 @@
-
 export const PERMISSION_KIND = {
   TOOL_EDIT: 'toolEdit',
   BASH: 'bash',
@@ -21,4 +20,3 @@ export const FEEDBACK_ELIGIBLE_KINDS = new Set<PermissionKind>([
   PERMISSION_KIND.EXTERNAL_INQUIRY,
   PERMISSION_KIND.USER_QUESTION,
 ]);
-

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -1,11 +1,3 @@
-/** VS Code command URIs for use in anchor href attributes. */
-export const COMMAND_LINKS = {
-  RUN_SETUP_ASSISTANT: 'command:texra.runSetupAssistant',
-  GETTING_STARTED: 'command:texra.openGettingStarted',
-  CREATE_SAMPLE_PROJECT: 'command:texra.createSampleProject',
-  CLONE_OVERLEAF: 'command:texra.cloneOverleafProject',
-  DOWNLOAD_ARXIV: 'command:texra.downloadArXivSource',
-} as const;
 
 export const PERMISSION_KIND = {
   TOOL_EDIT: 'toolEdit',
@@ -30,14 +22,3 @@ export const FEEDBACK_ELIGIBLE_KINDS = new Set<PermissionKind>([
   PERMISSION_KIND.USER_QUESTION,
 ]);
 
-/** Generates the getting started banner HTML with command links. */
-export function getGettingStartedHtml(prefix = ''): string {
-  return (
-    prefix +
-    `<a href="${COMMAND_LINKS.RUN_SETUP_ASSISTANT}">run the setup assistant agent</a>, ` +
-    `<a href="${COMMAND_LINKS.GETTING_STARTED}">open the getting started walkthrough</a>, ` +
-    `<a href="${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}">create a sample project</a>, ` +
-    `<a href="${COMMAND_LINKS.CLONE_OVERLEAF}">clone an Overleaf project</a>, or ` +
-    `<a href="${COMMAND_LINKS.DOWNLOAD_ARXIV}">download an arXiv source</a>.`
-  );
-}

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -92,10 +92,10 @@ describe('extension onboarding experience', () => {
     expect(normalizedSource).toContain('Sample project');
     expect(normalizedSource).toContain('Import Overleaf');
     expect(source).toContain('Import arXiv');
-    expect(source).toContain('COMMAND_LINKS.RUN_SETUP_ASSISTANT');
+    expect(source).toContain('MainViewEvents.gettingStartedAction');
     expect(source).toContain('variant="brand"');
     expect(source).toContain('appearance="filled"');
-    expect(source).toContain('COMMAND_LINKS.GETTING_STARTED');
+    expect(source).not.toContain('COMMAND_LINKS');
     expect(source).not.toContain('Empty project');
     expect(source).not.toContain('action-link');
   });

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -83,13 +83,21 @@ describe('extension onboarding experience', () => {
 
   it('keeps empty-project onboarding action oriented', () => {
     const source = readWebviewComponent('GettingStartedBanner');
+    const normalizedSource = source.replaceAll(/\s+/g, ' ');
 
     expect(source).toContain('No LaTeX files yet');
-    expect(source).toContain('Run setup to connect TeXRA');
+    expect(normalizedSource).toContain('Start from a sample');
+    expect(normalizedSource).toContain('run setup to connect TeXRA');
+    expect(source).toContain('Run setup assistant');
+    expect(normalizedSource).toContain('Sample project');
+    expect(normalizedSource).toContain('Import Overleaf');
+    expect(source).toContain('Import arXiv');
     expect(source).toContain('COMMAND_LINKS.RUN_SETUP_ASSISTANT');
+    expect(source).toContain('variant="brand"');
     expect(source).toContain('appearance="filled"');
     expect(source).toContain('COMMAND_LINKS.GETTING_STARTED');
     expect(source).not.toContain('Empty project');
+    expect(source).not.toContain('action-link');
   });
 
   it('keeps the no-workspace welcome view project-first', () => {

--- a/src/test-kernel/webview/OnboardingExperience.vitest.mts
+++ b/src/test-kernel/webview/OnboardingExperience.vitest.mts
@@ -87,7 +87,7 @@ describe('extension onboarding experience', () => {
     expect(source).toContain('No LaTeX files yet');
     expect(source).toContain('Run setup to connect TeXRA');
     expect(source).toContain('COMMAND_LINKS.RUN_SETUP_ASSISTANT');
-    expect(source).toContain('action-link--primary');
+    expect(source).toContain('appearance="filled"');
     expect(source).toContain('COMMAND_LINKS.GETTING_STARTED');
     expect(source).not.toContain('Empty project');
   });


### PR DESCRIPTION
## Summary

Follow-up to #6492 ("also apply to desktop" — LionSR).

The progress view's empty-state placeholder in `TaskGroupList` used `getGettingStartedHtml()` to generate `<a href="command:...">` links rendered via `unsafeHTML()`. This approach has two problems:
- VS Code command URIs don't work in the Electron desktop renderer (no URI interception)
- `unsafeHTML` bypasses Lit's template safety and couples a shared component to VS Code semantics

This PR applies the same `<wa-button @click>` + typed event dispatch pattern used in `GettingStartedBanner` (#6492) to the progress view's `TaskGroupList` empty state.

## Changes

- **`TaskGroupList.ts`**: Replace `unsafeHTML(PLACEHOLDER_HTML)` with five `<wa-button @click>` elements dispatching `ProgressEvents.gettingStartedAction({ action })` (bubbles + composed through shadow DOM)
- **`events.ts`**: Add `gettingStartedAction` event creator to `ProgressEvents`
- **`eventHandlers.ts`**: Add `handleGettingStartedAction(action)` → `postMessage(GETTING_STARTED_ACTION, { action })`
- **`ProgressApp.ts`**: Add `@getting-started-action` listener on `<stream-conversation>` → `onGettingStartedAction` handler
- **`ProgressViewMessageHandler.ts`**: Add exhaustive switch handler mapping all five actions to `safeExecuteCommand` calls
- **`desktop/main.ts`**: Add `getting-started-action` listener in `wireConversation()` using the shared handler
- **`progressViewCommands.ts`**: Add `GETTING_STARTED_ACTION` IPC command
- **`progressView/inbound.ts`**: Add `GettingStartedActionMessageSchema` and register in discriminated union
- **`logStyles.ts`**: Replace dead `.log-placeholder a` rules with `.log-placeholder-actions` flex layout
- **`uiConstants.ts`**: Remove now-dead `COMMAND_LINKS` and `getGettingStartedHtml()` — both callers are gone

## Test plan

- [ ] Open the progress view with no streams — verify five action buttons render in place of the old text links
- [ ] Click each button — verify the correct VS Code command fires (`texra.runSetupAssistant`, `texra.createSampleProject`, `texra.cloneOverleafProject`, `texra.downloadArXivSource`, `texra.openGettingStarted`)
- [ ] Repeat in the Electron desktop — verify buttons render and fire (no command URI needed)
- [ ] `npm test` passes (pre-existing `execUtils` flaky test excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBSFqMT9aQ1853QyoSmDxd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBSFqMT9aQ1853QyoSmDxd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and IPC wiring only; behavior mirrors prior command links with clearer desktop fallbacks and no auth or execution-path changes.
> 
> **Overview**
> **Getting-started onboarding** no longer uses `command:` URI links or `unsafeHTML`. Empty states in the progress view (`TaskGroupList`) and main view (`GettingStartedBanner`) now use **Web Awesome buttons** that dispatch a shared **`getting-started-action`** event, which posts typed **`GETTING_STARTED_ACTION`** IPC to the host.
> 
> On **VS Code**, progress and main handlers map five actions (`runSetup`, sample project, Overleaf/arXiv import, walkthrough) to existing `texra.*` commands; setup also refreshes the onboarding funnel on the main view.
> 
> On **desktop**, **walkthrough** opens first-run onboarding; the other four actions show an info dialog that they need the extension. The same routing exists for main-view IPC (`desktopShellIpc`) and progress empty-state (`desktopAgentExecution`), wired through optional **`showInfoMessage`** (Electron message box).
> 
> Shared **`GettingStartedAction`** schema and inbound message types were added; **`COMMAND_LINKS`** / **`getGettingStartedHtml`** were removed. Styles switch from placeholder anchor rules to a flex **`.log-placeholder-actions`** layout. Onboarding component tests were updated for the new banner markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9fda5cd86a21509b2622a501d655ef4c396b034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->