### PR TITLE
style(imports): add grouping comments to four large files

### DIFF
--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -5,9 +5,12 @@
  * Handles agent enable/disable, create/customize/delete, YAML editing,
  * custom agent directories, and agent teams.
  */
+
+// Standard library and third-party imports
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
+// Local imports
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
@@ -31,6 +34,7 @@ import type { SettingsAgentVisibilityController } from '@controllers/settingsVie
 import type { SettingsAgentDirectoryController } from '@controllers/settingsView/SettingsAgentDirectoryController';
 import type { SettingsAgentCatalogController } from '@controllers/settingsView/SettingsAgentCatalogController';
 
+// Local imports - handler context
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
 
 /**

--- a/src/agent/core/execution/AgentWorkspaceState.ts
+++ b/src/agent/core/execution/AgentWorkspaceState.ts
@@ -1,5 +1,7 @@
+// Third-party imports
 import { z } from 'zod';
 
+// Local imports
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import {
   FileLocationSchema,

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -1,5 +1,7 @@
+// Standard library imports
 import * as path from 'node:path';
 
+// Local imports
 import { platform } from '@platform/platform';
 import { getExecutionStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';
@@ -43,6 +45,7 @@ import {
 } from '@utils/files';
 import { PromptBuilder } from '@utils/prompt';
 
+// Local imports - flow nodes and state
 import { TeXCountNode } from './nodes/TeXCountNode';
 import { MediaExtractionNode } from './nodes/MediaExtractionNode';
 import { PrepareContextNode } from './nodes/PrepareContextNode';

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -1,5 +1,7 @@
+// Third-party imports
 import { MODEL_CONFIGS } from 'llm-zoo';
 
+// Local imports - agent
 import { getExecutionStore } from '@agent/storage';
 import {
   activeModelHandlerCompatibilityKey,
@@ -23,6 +25,7 @@ import { deriveRunOutcome } from '@common/constants/streamStatus';
 import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
 import type { SubagentProgressUpdate } from '@shared/schemas';
 
+// Local imports - tools and flow
 import { getDefaultToolRegistry } from '@tools/registry';
 import { TaskRunFileService } from '@utils/files';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';


### PR DESCRIPTION
## Summary

Adds `// Third-party imports` / `// Local imports - <category>` grouping comments at existing blank-line boundaries in four large files, per the convention in AGENTS.md:55 (example: `src/agent/index/AgentDirectorySync.ts`). No imports were reordered — comment headers only.

Files:
- `packages/extension/src/settingsView/handlers/agentHandlers.ts`
- `src/agent/core/execution/AgentWorkspaceState.ts`
- `src/agent/implementations/flows/reflection/runReflectionFlow.ts`
- `src/agent/implementations/flows/tooluse/runToolUseFlow.ts`

Closes #6058.

## Test plan
- [ ] `npm run lint`
- [ ] `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbqDpJ9JY8vWw55PrZ83Pk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits with no logic, API, or import-order changes.
> 
> **Overview**
> Adds **import-section comment headers** only in four large modules, matching the **AGENTS.md** convention (e.g. `AgentDirectorySync.ts`). Labels include `// Standard library and third-party imports`, `// Third-party imports`, `// Local imports`, and scoped variants like `// Local imports - handler context` or `// Local imports - flow nodes and state`.
> 
> **No imports were reordered** and **no runtime behavior changes**—this is documentation/structure for reviewers navigating long import blocks in settings agent handlers, workspace state, reflection flow, and tool-use flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed05ec6a24a503517715298d8c7ea65616d32ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->