### PR TITLE
fix(agent): attach structured ProviderError to flow-failure rethrows

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -309,9 +309,7 @@ export abstract class RetryableInvocationNode<
 
   protected getFallbackResult(
     error: Error,
-  ):
-    | { kind: 'cancelled' }
-    | ({ kind: 'failed' } & RetryErrorInfo) {
+  ): { kind: 'cancelled' } | ({ kind: 'failed' } & RetryErrorInfo) {
     if (this._userCancelled || isUserAbort(error)) {
       return { kind: 'cancelled' };
     }

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -15,7 +15,11 @@ import {
   toErrorMessage,
 } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
-import { STREAM_STATUS, type RetryErrorInfo } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  toRetryErrorInfo,
+  type RetryErrorInfo,
+} from '@shared/schemas';
 import { getConfig } from '@utils/config/configUtils';
 
 const BACKGROUND_MODE_MIN_RETRIES = 3;
@@ -43,7 +47,7 @@ interface ManualRetryPromptResult {
 /** success: model response | failed: retries exhausted | cancelled: user cancelled | skipped: shouldStop was true */
 export type InvocationResult<TSuccess> =
   | ({ kind: 'success' } & TSuccess)
-  | { kind: 'failed'; message: string; userRetryable?: boolean }
+  | ({ kind: 'failed' } & RetryErrorInfo)
   | { kind: 'cancelled' }
   | { kind: 'skipped' };
 
@@ -307,7 +311,7 @@ export abstract class RetryableInvocationNode<
     error: Error,
   ):
     | { kind: 'cancelled' }
-    | { kind: 'failed'; message: string; userRetryable?: boolean } {
+    | ({ kind: 'failed' } & RetryErrorInfo) {
     if (this._userCancelled || isUserAbort(error)) {
       return { kind: 'cancelled' };
     }
@@ -322,8 +326,7 @@ export abstract class RetryableInvocationNode<
     }
     return {
       kind: 'failed',
-      message: formatted.message,
-      userRetryable: formatted.userRetryable,
+      ...toRetryErrorInfo(formatted),
     };
   }
 }
@@ -358,9 +361,10 @@ export function handleInvocationResult<T extends { response: unknown }>(
   }
 
   if (result.kind === 'failed') {
+    const { kind: _, ...errorInfo } = result;
     retryState.lastError = {
-      message: result.message,
-      userRetryable: result.userRetryable ?? false,
+      ...errorInfo,
+      userRetryable: errorInfo.userRetryable ?? false,
     };
     state.shouldStop = true;
     state.endTurn = false;

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -360,10 +360,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
 
   if (result.kind === 'failed') {
     const { kind: _, ...errorInfo } = result;
-    retryState.lastError = {
-      ...errorInfo,
-      userRetryable: errorInfo.userRetryable ?? false,
-    };
+    retryState.lastError = errorInfo;
     state.shouldStop = true;
     state.endTurn = false;
     return null;

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -11,7 +11,8 @@ import type {
   ConversationRoundStateSnapshot,
 } from '@agent/core/execution/AgentState';
 import { ensureError, normalizeProviderError } from '@common/errors';
-import type { AgentFileLocation } from '@shared/schemas';
+import type { AgentFileLocation, RetryErrorInfo } from '@shared/schemas';
+import { toRetryErrorInfo } from '@shared/schemas';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
 import type {
@@ -30,7 +31,12 @@ interface CyclePrepInput {
 type CycleOutcome =
   | { outcome: 'completed'; endTurn: boolean }
   | { outcome: 'cancelled' }
-  | { outcome: 'failed'; error: Error; userRetryable?: boolean };
+  | {
+      outcome: 'failed';
+      error: Error;
+      userRetryable: boolean;
+      lastError?: RetryErrorInfo;
+    };
 
 export class ResponseCycleNode<C = unknown> extends Node<
   ReflectionFlowShared,
@@ -112,6 +118,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
           outcome: 'failed',
           error: new Error(cycleShared.lastError.message),
           userRetryable: cycleShared.lastError.userRetryable,
+          lastError: cycleShared.lastError,
         };
       }
       if (cycleShared.shouldStop && !cycleShared.endTurn) {
@@ -126,6 +133,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
         outcome: 'failed',
         error: ensureError(error),
         userRetryable: formatted.userRetryable,
+        lastError: toRetryErrorInfo(formatted),
       };
     }
   }
@@ -135,7 +143,12 @@ export class ResponseCycleNode<C = unknown> extends Node<
     error: Error,
   ): Promise<CycleOutcome> {
     const formatted = normalizeProviderError(error);
-    return { outcome: 'failed', error, userRetryable: formatted.userRetryable };
+    return {
+      outcome: 'failed',
+      error,
+      userRetryable: formatted.userRetryable,
+      lastError: toRetryErrorInfo(formatted),
+    };
   }
 
   async post(
@@ -149,9 +162,9 @@ export class ResponseCycleNode<C = unknown> extends Node<
 
     if (execRes.outcome === 'failed') {
       logger.error(`Response cycle failed: ${execRes.error.message}`);
-      shared.lastError = {
+      shared.lastError = execRes.lastError ?? {
         message: execRes.error.message,
-        userRetryable: execRes.userRetryable ?? false,
+        userRetryable: execRes.userRetryable,
       };
       shared.continueRounds = false;
       shared.endTurn = false;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -23,10 +23,7 @@ import {
   WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_RAW_OUTPUT_EXT,
 } from '@agent/output/workflowOutputLayout';
-import {
-  attachProviderError,
-  markErrorLogged,
-} from '@common/errors/sdkErrorUtils';
+import { attachProviderError } from '@common/errors/sdkErrorUtils';
 import { LatexMediaManager } from '@latex/LatexMediaManager';
 import {
   RUN_OUTCOME,
@@ -317,7 +314,6 @@ export async function runReflectionFlow<C = unknown>(
       // sniffing the message string.
       const err = new Error(shared.lastError.message);
       attachProviderError(err, toProviderErrorFromRetry(shared.lastError));
-      markErrorLogged(err);
       throw err;
     } else {
       outcome = flowOutcome;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -316,10 +316,7 @@ export async function runReflectionFlow<C = unknown>(
       // formatters can surface statusCode, provider, etc. without
       // sniffing the message string.
       const err = new Error(shared.lastError.message);
-      attachProviderError(
-        err,
-        toProviderErrorFromRetry(shared.lastError),
-      );
+      attachProviderError(err, toProviderErrorFromRetry(shared.lastError));
       markErrorLogged(err);
       throw err;
     } else {

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -23,9 +23,14 @@ import {
   WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_RAW_OUTPUT_EXT,
 } from '@agent/output/workflowOutputLayout';
+import {
+  attachProviderError,
+  markErrorLogged,
+} from '@common/errors/sdkErrorUtils';
 import { LatexMediaManager } from '@latex/LatexMediaManager';
 import {
   RUN_OUTCOME,
+  toProviderErrorFromRetry,
   type AgentFileLocation,
   type EndGroupStatus,
   type RoundOutput,
@@ -307,7 +312,16 @@ export async function runReflectionFlow<C = unknown>(
       outcome = RUN_OUTCOME.FAILED;
       // Re-throw so runFlowWithLifecycle logs the error and shows
       // the user notification. State was already projected per-step.
-      throw new Error(shared.lastError.message);
+      // Attach the full structured provider error so downstream error
+      // formatters can surface statusCode, provider, etc. without
+      // sniffing the message string.
+      const err = new Error(shared.lastError.message);
+      attachProviderError(
+        err,
+        toProviderErrorFromRetry(shared.lastError),
+      );
+      markErrorLogged(err);
+      throw err;
     } else {
       outcome = flowOutcome;
     }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -7,7 +7,8 @@ import {
 } from '@agent/core/flows/ToolUseRoundFlow';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { normalizeProviderError, toErrorMessage } from '@common/errors';
-import { MESSAGE_TYPES } from '@shared/schemas';
+import { MESSAGE_TYPES, toRetryErrorInfo } from '@shared/schemas';
+import type { RetryErrorInfo } from '@shared/schemas';
 
 import {
   type ToolUseRunShared,
@@ -20,7 +21,12 @@ type ToolUseCycleOutcome =
   | { outcome: 'completed'; messages: ProviderMessage[] }
   | { outcome: 'skipped' }
   | { outcome: 'cancelled' }
-  | { outcome: 'failed'; message: string; userRetryable?: boolean };
+  | {
+      outcome: 'failed';
+      message: string;
+      userRetryable: boolean;
+      lastError?: RetryErrorInfo;
+    };
 
 export class ToolUseCycleNode<C> extends Node<
   ToolUseRunShared,
@@ -117,6 +123,7 @@ export class ToolUseCycleNode<C> extends Node<
           outcome: 'failed',
           message: roundShared.lastError.message,
           userRetryable: roundShared.lastError.userRetryable,
+          lastError: roundShared.lastError,
         };
       }
       if (roundShared.shouldStop && !roundShared.endTurn) {
@@ -140,6 +147,7 @@ export class ToolUseCycleNode<C> extends Node<
       outcome: 'failed',
       message: error.message,
       userRetryable: formatted.userRetryable,
+      lastError: toRetryErrorInfo(formatted),
     };
   }
 
@@ -184,9 +192,9 @@ export class ToolUseCycleNode<C> extends Node<
       case 'skipped':
         break;
       case 'failed':
-        shared.lastError = {
+        shared.lastError = execRes.lastError ?? {
           message: execRes.message,
-          userRetryable: execRes.userRetryable ?? false,
+          userRetryable: execRes.userRetryable,
         };
         // Surface the failure in the transcript. Without this the WaitNode
         // resets lastError when the user sends a follow-up (see

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -20,10 +20,7 @@ import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import type { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { evaluateCurrentDelegationGate } from '@agent/runtime/delegationPolicy';
 import { deriveRunOutcome } from '@common/constants/streamStatus';
-import {
-  attachProviderError,
-  markErrorLogged,
-} from '@common/errors/sdkErrorUtils';
+import { attachProviderError } from '@common/errors/sdkErrorUtils';
 import {
   RUN_OUTCOME,
   toProviderErrorFromRetry,
@@ -377,7 +374,6 @@ export async function runToolUseFlow<C = unknown>(
         totalCostUsd,
       });
       attachProviderError(err, toProviderErrorFromRetry(shared.lastError));
-      markErrorLogged(err);
       throw err;
     }
   } finally {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -376,10 +376,7 @@ export async function runToolUseFlow<C = unknown>(
         touchedFiles,
         totalCostUsd,
       });
-      attachProviderError(
-        err,
-        toProviderErrorFromRetry(shared.lastError),
-      );
+      attachProviderError(err, toProviderErrorFromRetry(shared.lastError));
       markErrorLogged(err);
       throw err;
     }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -20,7 +20,15 @@ import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import type { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { evaluateCurrentDelegationGate } from '@agent/runtime/delegationPolicy';
 import { deriveRunOutcome } from '@common/constants/streamStatus';
-import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
+import {
+  attachProviderError,
+  markErrorLogged,
+} from '@common/errors/sdkErrorUtils';
+import {
+  RUN_OUTCOME,
+  toProviderErrorFromRetry,
+  type RunOutcome,
+} from '@shared/schemas';
 import type { SubagentProgressUpdate } from '@shared/schemas';
 
 import { getDefaultToolRegistry } from '@tools/registry';
@@ -359,12 +367,21 @@ export async function runToolUseFlow<C = unknown>(
     if (shared.lastError) {
       // Re-throw so runFlowWithLifecycle logs the error and shows
       // the user notification, while preserving terminal run accounting.
-      throw new ToolUseFlowError(shared.lastError.message, {
+      // Attach the full structured provider error so downstream error
+      // formatters can surface statusCode, provider, etc. without
+      // sniffing the message string.
+      const err = new ToolUseFlowError(shared.lastError.message, {
         outcome,
         lastResponse,
         touchedFiles,
         totalCostUsd,
       });
+      attachProviderError(
+        err,
+        toProviderErrorFromRetry(shared.lastError),
+      );
+      markErrorLogged(err);
+      throw err;
     }
   } finally {
     activePersistedFlow = undefined;

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -13,7 +13,6 @@ import {
   getSdkErrorMessage,
   type AgentErrorKind,
 } from '@common/errors';
-import { isErrorLogged } from '@common/errors/sdkErrorUtils';
 import { projectRunOutcome } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
@@ -238,9 +237,7 @@ export async function runFlowWithLifecycle(
     // Root-agent failures are surfaced in the stream log. Subagent failures
     // are delivered to the orchestrator below, so avoid adding a second
     // wrapper error that makes a child failure look like the parent failed.
-    // Skip when the flow already emitted an ERROR trace event for the same
-    // failure — prevents duplicate ERROR rows in the transcript.
-    if (kind !== 'abort' && !options?.isSubagent && !isErrorLogged(err)) {
+    if (kind !== 'abort' && !options?.isSubagent) {
       logSdkError(ctx.logger, errorMsg, err, {
         operation: `execute ${agentIdentifier}`,
       });

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -13,6 +13,7 @@ import {
   getSdkErrorMessage,
   type AgentErrorKind,
 } from '@common/errors';
+import { isErrorLogged } from '@common/errors/sdkErrorUtils';
 import { projectRunOutcome } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
@@ -237,7 +238,9 @@ export async function runFlowWithLifecycle(
     // Root-agent failures are surfaced in the stream log. Subagent failures
     // are delivered to the orchestrator below, so avoid adding a second
     // wrapper error that makes a child failure look like the parent failed.
-    if (kind !== 'abort' && !options?.isSubagent) {
+    // Skip when the flow already emitted an ERROR trace event for the same
+    // failure — prevents duplicate ERROR rows in the transcript.
+    if (kind !== 'abort' && !options?.isSubagent && !isErrorLogged(err)) {
       logSdkError(ctx.logger, errorMsg, err, {
         operation: `execute ${agentIdentifier}`,
       });

--- a/src/common/errors/sdkError/errorMetadata.ts
+++ b/src/common/errors/sdkError/errorMetadata.ts
@@ -66,3 +66,20 @@ export const detectPartialText = partialTextMetadata.detect;
 
 export const providerErrorMetadata =
   createErrorMetadata<ProviderError>('providerError');
+
+/** Cache a structured ProviderError on any object so downstream error
+ *  formatters can recover it without sniffing the message string. */
+export const attachProviderError = providerErrorMetadata.attach;
+export const detectProviderError = providerErrorMetadata.detect;
+
+const loggedErrorMetadata = createErrorMetadata<true>('errorLogged');
+
+/** Mark an error as already logged so duplicate trace rows are skipped. */
+export function markErrorLogged(err: unknown): void {
+  loggedErrorMetadata.attach(err, true);
+}
+
+/** Check whether an error has already been logged to the trace. */
+export function isErrorLogged(err: unknown): boolean {
+  return loggedErrorMetadata.detect(err) === true;
+}

--- a/src/common/errors/sdkError/errorMetadata.ts
+++ b/src/common/errors/sdkError/errorMetadata.ts
@@ -70,4 +70,3 @@ export const providerErrorMetadata =
 /** Cache a structured ProviderError on any object so downstream error
  *  formatters can recover it without sniffing the message string. */
 export const attachProviderError = providerErrorMetadata.attach;
-export const detectProviderError = providerErrorMetadata.detect;

--- a/src/common/errors/sdkError/errorMetadata.ts
+++ b/src/common/errors/sdkError/errorMetadata.ts
@@ -71,15 +71,3 @@ export const providerErrorMetadata =
  *  formatters can recover it without sniffing the message string. */
 export const attachProviderError = providerErrorMetadata.attach;
 export const detectProviderError = providerErrorMetadata.detect;
-
-const loggedErrorMetadata = createErrorMetadata<true>('errorLogged');
-
-/** Mark an error as already logged so duplicate trace rows are skipped. */
-export function markErrorLogged(err: unknown): void {
-  loggedErrorMetadata.attach(err, true);
-}
-
-/** Check whether an error has already been logged to the trace. */
-export function isErrorLogged(err: unknown): boolean {
-  return loggedErrorMetadata.detect(err) === true;
-}

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -223,14 +223,29 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   };
 }
 
+function detectCachedProviderError(err: unknown): ProviderError | undefined {
+  for (
+    let current: unknown = err;
+    current != null && typeof current === 'object';
+    current = (current as { cause?: unknown }).cause
+  ) {
+    const cached = providerErrorMetadata.detect(current);
+    if (cached) return cached;
+  }
+  return undefined;
+}
+
 /**
  * Normalize an upstream or SDK error once and attach the structured result to
  * the thrown value. Retry code should consume this helper so provider-boundary
  * code can own classification while downstream layers only read the shape.
  */
 export function normalizeProviderError(err: unknown): ProviderError {
-  const cached = providerErrorMetadata.detect(err);
-  if (cached) return cached;
+  const cached = detectCachedProviderError(err);
+  if (cached) {
+    providerErrorMetadata.attach(err, cached);
+    return cached;
+  }
 
   const formatted = formatProviderHttpError(err);
   providerErrorMetadata.attach(err, formatted);
@@ -238,7 +253,7 @@ export function normalizeProviderError(err: unknown): ProviderError {
 }
 
 export function getSdkErrorMessage(err: unknown): string {
-  return formatProviderHttpError(err).message;
+  return normalizeProviderError(err).message;
 }
 
 /** Builds consistent error data for logging with MESSAGE_TYPES.ERROR. */
@@ -246,7 +261,7 @@ export function buildErrorLogData(
   err: unknown,
   context?: ErrorContext,
 ): ErrorLogData {
-  const formatted = formatProviderHttpError(err);
+  const formatted = normalizeProviderError(err);
   const rawMessage = toErrorMessage(err);
 
   return {

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -236,20 +236,28 @@ function detectCachedProviderError(err: unknown): ProviderError | undefined {
 }
 
 /**
- * Normalize an upstream or SDK error once and attach the structured result to
- * the thrown value. Retry code should consume this helper so provider-boundary
- * code can own classification while downstream layers only read the shape.
+ * Normalize an upstream or SDK error. If a structured `ProviderError` was
+ * explicitly attached at a provider/flow boundary (possibly on a deeper
+ * `cause`), recover it; otherwise format the error fresh. Retry code consumes
+ * this helper so provider-boundary code owns classification while downstream
+ * layers only read the shape.
  */
 export function normalizeProviderError(err: unknown): ProviderError {
   const cached = detectCachedProviderError(err);
   if (cached) {
+    // Migrate an explicitly-attached ProviderError from a deeper cause onto the
+    // wrapper so later reads skip the chain walk.
     providerErrorMetadata.attach(err, cached);
     return cached;
   }
 
-  const formatted = formatProviderHttpError(err);
-  providerErrorMetadata.attach(err, formatted);
-  return formatted;
+  // Compute fresh but DO NOT cache the result: a caller may format an error for
+  // logging before later metadata (streamDiagnostics / partialText) is attached
+  // to it, and a deliberately status-stripped wrapper (e.g. background-polling
+  // 404) must not inherit a status cached by an incidental normalize on its
+  // cause. Only explicit `attachProviderError` at provider/flow boundaries seeds
+  // the cache the lookup above recovers.
+  return formatProviderHttpError(err);
 }
 
 export function getSdkErrorMessage(err: unknown): string {

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -17,8 +17,6 @@ export {
   attachStreamDiagnostics,
   attachPartialText,
   attachProviderError,
-  markErrorLogged,
-  isErrorLogged,
 } from './sdkError/errorMetadata';
 
 export { detectStatusCode } from './sdkError/errorInspection';

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -16,6 +16,9 @@ export {
   attachSdkErrorMetadata,
   attachStreamDiagnostics,
   attachPartialText,
+  attachProviderError,
+  markErrorLogged,
+  isErrorLogged,
 } from './sdkError/errorMetadata';
 
 export { detectStatusCode } from './sdkError/errorInspection';

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -139,13 +139,14 @@ export function toRetryErrorInfo(err: ProviderError): RetryErrorInfo {
   };
 }
 
-/** Reconstruct a ProviderError from retry-state info. Defaults `isRelayError`
- *  to `false` when absent (it was optional in earlier persisted records). */
+/** Reconstruct a ProviderError from retry-state info. Leaves `isRelayError`
+ *  `undefined` when absent so `normalizeProviderError` does not read a
+ *  wrong relay verdict from the cached shape. */
 export function toProviderErrorFromRetry(info: RetryErrorInfo): ProviderError {
   return {
     message: info.message,
     userRetryable: info.userRetryable,
-    isRelayError: info.isRelayError ?? false,
+    isRelayError: info.isRelayError as boolean,
     statusCode: info.statusCode,
     statusText: info.statusText,
     provider: info.provider,

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -104,9 +104,55 @@ export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
 /** Minimal error info for retry state tracking */
 export const RetryErrorInfoSchema = z.preprocess(
   normalizeProviderErrorRetryFlag,
-  ProviderErrorObjectSchema.pick({
-    message: true,
-    userRetryable: true,
+  z.object({
+    message: z.string(),
+    userRetryable: z.boolean(),
+    ...ProviderErrorObjectSchema.pick({
+      statusCode: true,
+      statusText: true,
+      provider: true,
+      isRelayError: true,
+      isCredentialExhausted: true,
+      isUpstreamCreditDepleted: true,
+      requestId: true,
+      streamDiagnostics: true,
+      partialText: true,
+    }).partial().shape,
   }),
 );
 export type RetryErrorInfo = z.infer<typeof RetryErrorInfoSchema>;
+
+/** Convert a full ProviderError into the retry-state record. */
+export function toRetryErrorInfo(err: ProviderError): RetryErrorInfo {
+  return {
+    message: err.message,
+    userRetryable: err.userRetryable,
+    statusCode: err.statusCode,
+    statusText: err.statusText,
+    provider: err.provider,
+    isRelayError: err.isRelayError,
+    isCredentialExhausted: err.isCredentialExhausted,
+    isUpstreamCreditDepleted: err.isUpstreamCreditDepleted,
+    requestId: err.requestId,
+    streamDiagnostics: err.streamDiagnostics,
+    partialText: err.partialText,
+  };
+}
+
+/** Reconstruct a ProviderError from retry-state info. Defaults `isRelayError`
+ *  to `false` when absent (it was optional in earlier persisted records). */
+export function toProviderErrorFromRetry(info: RetryErrorInfo): ProviderError {
+  return {
+    message: info.message,
+    userRetryable: info.userRetryable,
+    isRelayError: info.isRelayError ?? false,
+    statusCode: info.statusCode,
+    statusText: info.statusText,
+    provider: info.provider,
+    isCredentialExhausted: info.isCredentialExhausted,
+    isUpstreamCreditDepleted: info.isUpstreamCreditDepleted,
+    requestId: info.requestId,
+    streamDiagnostics: info.streamDiagnostics,
+    partialText: info.partialText,
+  };
+}

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -50,7 +50,9 @@ const ProviderErrorObjectSchema = z.object({
    *  true (because they need user action — a key swap or new API key —
    *  before any retry makes sense). */
   userRetryable: z.boolean(),
-  isRelayError: z.boolean(),
+  /** True when the error is known to come from the relay. Omitted when the
+   *  retry-state path cannot determine the relay verdict. */
+  isRelayError: z.boolean().optional(),
   /** True when the credential (relay monthly limit OR upstream provider
    *  account) has been exhausted. Auto-retry is skipped for these errors
    *  and the retry panel offers a "Use your own API key" button. */
@@ -146,7 +148,7 @@ export function toProviderErrorFromRetry(info: RetryErrorInfo): ProviderError {
   return {
     message: info.message,
     userRetryable: info.userRetryable,
-    isRelayError: info.isRelayError as boolean,
+    isRelayError: info.isRelayError,
     statusCode: info.statusCode,
     statusText: info.statusText,
     provider: info.provider,

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -11,7 +11,10 @@ import {
 } from '@agent/modelHandlers/openai/openAIResponseErrors';
 
 // Local imports - common errors
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  normalizeProviderError,
+} from '@common/errors/sdkErrorUtils';
 
 describe('OpenAI Responses error normalization', () => {
   it('normalizes provider errors at the OpenAI Responses boundary', () => {
@@ -77,6 +80,11 @@ describe('OpenAI Responses error normalization', () => {
     expect(providerError.requestId).toBe('req_poll');
     expect(providerError.userRetryable).toBe(true);
     expect(providerError.message).toContain('resp_123');
+
+    const normalized = normalizeProviderError(wrapped);
+    expect(normalized.statusCode).toBeUndefined();
+    expect(normalized.requestId).toBe('req_poll');
+    expect(normalized.userRetryable).toBe(true);
   });
 
   it('keeps terminal background statuses retryable without HTTP metadata', () => {

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -23,6 +23,7 @@ import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
 
 // Local imports - common errors
 import {
+  attachProviderError,
   attachSdkErrorMetadata,
   formatProviderHttpError,
   isUserAbort,
@@ -34,7 +35,10 @@ import {
 import {
   ErrorLogDataSchema,
   RetryErrorInfoSchema,
+  toProviderErrorFromRetry,
+  toRetryErrorInfo,
 } from '@shared/schemas/errors';
+import type { ProviderError, RetryErrorInfo } from '@shared/schemas/errors';
 
 class APIError extends Error {}
 
@@ -500,5 +504,178 @@ describe('provider error schemas', () => {
     expect(errorLog.userRetryable).toBe(false);
     expect('retryable' in errorLog).toBe(false);
     expect(retryInfo.userRetryable).toBe(true);
+  });
+});
+
+describe('toRetryErrorInfo / toProviderErrorFromRetry round-trip', () => {
+  const fullProviderError: ProviderError = {
+    message: 'HTTP 429 Too Many Requests – rate limited',
+    userRetryable: true,
+    isRelayError: true,
+    statusCode: 429,
+    statusText: 'Too Many Requests',
+    provider: 'anthropic',
+    isCredentialExhausted: true,
+    isUpstreamCreditDepleted: undefined,
+    requestId: 'req_abc123',
+    streamDiagnostics: {
+      thinkingChars: 100,
+      textChars: 200,
+      toolInputChars: 0,
+      blockTypesSeen: ['text', 'thinking'],
+      eventsProcessed: 15,
+      lastEventType: 'content_block_stop',
+      elapsedSecs: 2.5,
+      secsSinceLastEvent: 0.1,
+      finalized: false,
+      messageStartReceived: true,
+      messageStopReceived: false,
+      stopReason: null,
+      anthropicMessageId: 'msg_01ABC',
+    },
+    partialText: 'Here is the analysis of the',
+  };
+
+  it('preserves statusCode, provider, and relay flags through the round-trip', () => {
+    const info = toRetryErrorInfo(fullProviderError);
+    const reconstructed = toProviderErrorFromRetry(info);
+
+    expect(reconstructed.statusCode).toBe(429);
+    expect(reconstructed.provider).toBe('anthropic');
+    expect(reconstructed.isRelayError).toBe(true);
+    expect(reconstructed.isCredentialExhausted).toBe(true);
+    expect(reconstructed.requestId).toBe('req_abc123');
+    expect(reconstructed.userRetryable).toBe(true);
+  });
+
+  it('preserves stream diagnostics and partial text through the round-trip', () => {
+    const info = toRetryErrorInfo(fullProviderError);
+    const reconstructed = toProviderErrorFromRetry(info);
+
+    expect(reconstructed.streamDiagnostics?.eventsProcessed).toBe(15);
+    expect(reconstructed.streamDiagnostics?.anthropicMessageId).toBe('msg_01ABC');
+    expect(reconstructed.partialText).toBe('Here is the analysis of the');
+  });
+
+  it('leaves isRelayError undefined when absent from RetryErrorInfo', () => {
+    const minimalInfo: RetryErrorInfo = {
+      message: 'Connection timed out',
+      userRetryable: true,
+      statusCode: undefined,
+      provider: 'openai',
+    };
+
+    const reconstructed = toProviderErrorFromRetry(minimalInfo);
+
+    // isRelayError was not in the RetryErrorInfo — it should stay
+    // undefined so normalizeProviderError won't cache a wrong verdict.
+    expect(reconstructed.isRelayError).toBeUndefined();
+    expect(reconstructed.provider).toBe('openai');
+    expect(reconstructed.userRetryable).toBe(true);
+    expect(reconstructed.statusCode).toBeUndefined();
+  });
+
+  it('omits rawErrorBody from the RetryErrorInfo record', () => {
+    const info = toRetryErrorInfo(fullProviderError);
+
+    // rawErrorBody is intentionally excluded from RetryErrorInfo (large,
+    // not worth persisting). Verify the schema doesn't carry it.
+    expect('rawErrorBody' in info).toBe(false);
+  });
+
+  it('reconstructs a usable ProviderError from minimal retry info', () => {
+    // Simulates the common failure path: a model error surfaced through
+    // the retry state, written to shared.lastError, then reconstructed
+    // at the flow rethrow via toProviderErrorFromRetry.
+    const minimalInfo: RetryErrorInfo = {
+      message: 'HTTP 500 Internal Server Error – upstream failure',
+      userRetryable: true,
+      statusCode: 500,
+      provider: 'anthropic',
+    };
+
+    const reconstructed = toProviderErrorFromRetry(minimalInfo);
+
+    // Downstream error formatters need at least these two fields to
+    // produce a useful error surface.
+    expect(reconstructed.statusCode).toBe(500);
+    expect(reconstructed.provider).toBe('anthropic');
+    expect(reconstructed.message).toBe(
+      'HTTP 500 Internal Server Error – upstream failure',
+    );
+    expect(reconstructed.userRetryable).toBe(true);
+  });
+
+  it('carries statusCode and provider from a tool-use model failure shape', () => {
+    // Simulate the shape that ToolUseCycleNode.post writes to
+    // shared.lastError after this PR: the full RetryErrorInfo from the
+    // round-level shared state, including statusCode and provider.
+    const toolUseFailureInfo: RetryErrorInfo = {
+      message: 'HTTP 429 Too Many Requests – rate limited',
+      userRetryable: true,
+      statusCode: 429,
+      statusText: 'Too Many Requests',
+      provider: 'openai',
+      isRelayError: false,
+      isCredentialExhausted: undefined,
+      requestId: 'req_tooluse_123',
+    };
+
+    const reconstructed = toProviderErrorFromRetry(toolUseFailureInfo);
+
+    expect(reconstructed.statusCode).toBe(429);
+    expect(reconstructed.provider).toBe('openai');
+    expect(reconstructed.requestId).toBe('req_tooluse_123');
+    expect(reconstructed.isRelayError).toBe(false);
+    expect(reconstructed.userRetryable).toBe(true);
+  });
+
+  it('carries statusCode and provider from a reflection model failure shape', () => {
+    // Simulate the shape that ResponseCycleNode.post writes to
+    // shared.lastError after this PR: the full RetryErrorInfo from the
+    // cycle-level shared state, including statusCode and provider.
+    const reflectionFailureInfo: RetryErrorInfo = {
+      message: 'HTTP 503 Service Unavailable – server overloaded',
+      userRetryable: true,
+      statusCode: 503,
+      statusText: 'Service Unavailable',
+      provider: 'anthropic',
+      isRelayError: false,
+    };
+
+    const reconstructed = toProviderErrorFromRetry(reflectionFailureInfo);
+
+    expect(reconstructed.statusCode).toBe(503);
+    expect(reconstructed.provider).toBe('anthropic');
+    expect(reconstructed.statusText).toBe('Service Unavailable');
+    expect(reconstructed.userRetryable).toBe(true);
+  });
+});
+
+describe('attachProviderError end-to-end', () => {
+  it('surfaces a cached ProviderError with statusCode and provider via normalizeProviderError', () => {
+    // Simulates what happens at the flow rethrow: toProviderErrorFromRetry
+    // reconstructs a shape, attachProviderError caches it, then
+    // normalizeProviderError recovers it downstream.
+    const retryInfo: RetryErrorInfo = {
+      message: 'HTTP 429 Too Many Requests – rate limited',
+      userRetryable: true,
+      statusCode: 429,
+      provider: 'anthropic',
+      isRelayError: true,
+    };
+
+    const reconstructed = toProviderErrorFromRetry(retryInfo);
+    const err = new Error(retryInfo.message);
+    attachProviderError(err, reconstructed);
+
+    const recovered = normalizeProviderError(err);
+
+    expect(recovered.statusCode).toBe(429);
+    expect(recovered.provider).toBe('anthropic');
+    expect(recovered.isRelayError).toBe(true);
+    expect(recovered.userRetryable).toBe(true);
+    // Verify the cache hit — second call returns the same object.
+    expect(normalizeProviderError(err)).toBe(recovered);
   });
 });

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -25,7 +25,9 @@ import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
 import {
   attachProviderError,
   attachSdkErrorMetadata,
+  buildErrorLogData,
   formatProviderHttpError,
+  getSdkErrorMessage,
   isUserAbort,
   normalizeProviderError,
   sdkErrorKindFromStatusCode,
@@ -553,7 +555,9 @@ describe('toRetryErrorInfo / toProviderErrorFromRetry round-trip', () => {
     const reconstructed = toProviderErrorFromRetry(info);
 
     expect(reconstructed.streamDiagnostics?.eventsProcessed).toBe(15);
-    expect(reconstructed.streamDiagnostics?.anthropicMessageId).toBe('msg_01ABC');
+    expect(reconstructed.streamDiagnostics?.anthropicMessageId).toBe(
+      'msg_01ABC',
+    );
     expect(reconstructed.partialText).toBe('Here is the analysis of the');
   });
 
@@ -677,5 +681,33 @@ describe('attachProviderError end-to-end', () => {
     expect(recovered.userRetryable).toBe(true);
     // Verify the cache hit — second call returns the same object.
     expect(normalizeProviderError(err)).toBe(recovered);
+  });
+
+  it('recovers cached ProviderError data through wrapper causes', () => {
+    const retryInfo: RetryErrorInfo = {
+      message: 'HTTP 503 Service Unavailable – server overloaded',
+      userRetryable: true,
+      statusCode: 503,
+      provider: 'anthropic',
+      requestId: 'req_wrapped_503',
+    };
+
+    const reconstructed = toProviderErrorFromRetry(retryInfo);
+    const cause = new Error(retryInfo.message);
+    attachProviderError(cause, reconstructed);
+    const wrapper = new Error('Tool-use flow failed', { cause });
+
+    expect(getSdkErrorMessage(wrapper)).toBe(retryInfo.message);
+
+    const logData = buildErrorLogData(wrapper, {
+      operation: 'execute orchestrator',
+    });
+
+    expect(logData.statusCode).toBe(503);
+    expect(logData.provider).toBe('anthropic');
+    expect(logData.requestId).toBe('req_wrapped_503');
+    expect(logData.rawMessage).toBe('Tool-use flow failed');
+    expect(logData.operation).toBe('execute orchestrator');
+    expect(normalizeProviderError(wrapper)).toBe(reconstructed);
   });
 });

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -25,6 +25,7 @@ import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
 import {
   attachProviderError,
   attachSdkErrorMetadata,
+  attachStreamDiagnostics,
   buildErrorLogData,
   formatProviderHttpError,
   getSdkErrorMessage,
@@ -473,21 +474,44 @@ describe('formatProviderHttpError', () => {
     expect(sdkErrorKindFromStatusCode(undefined)).toBe('api_error');
   });
 
-  it('caches normalized provider errors for downstream retry handling', () => {
-    const error = new Error('provider quota');
+  it('does not cache a fresh normalization, so metadata attached afterward is still surfaced', () => {
+    const error = new Error('stream failed');
     attachSdkErrorMetadata(error, {
       provider: 'fixture',
-      kind: 'rate_limit',
-      statusCode: 429,
+      kind: 'api_error',
+      statusCode: 500,
     });
 
-    const first = normalizeProviderError(error);
-    const second = normalizeProviderError(error);
+    // Mirrors the Anthropic stream path: an early debug-log call formats the
+    // error before stream diagnostics are attached to it.
+    const before = normalizeProviderError(error);
+    expect(before.provider).toBe('fixture');
+    expect(before.statusCode).toBe(500);
+    expect(before.streamDiagnostics).toBeUndefined();
 
-    expect(second).toBe(first);
-    expect(second.provider).toBe('fixture');
-    expect(second.statusCode).toBe(429);
-    expect(second.userRetryable).toBe(true);
+    const diagnostics = {
+      thinkingChars: 0,
+      textChars: 12,
+      toolInputChars: 0,
+      blockTypesSeen: ['text'],
+      eventsProcessed: 7,
+      lastEventType: 'content_block_delta',
+      elapsedSecs: 1.2,
+      secsSinceLastEvent: 0.3,
+      finalized: false,
+      messageStartReceived: true,
+      messageStopReceived: false,
+      stopReason: null,
+      anthropicMessageId: null,
+    };
+    attachStreamDiagnostics(error, diagnostics);
+
+    // A fresh normalize must reflect the newly-attached diagnostics — i.e. the
+    // earlier call must NOT have cached a diagnostics-less ProviderError on the
+    // error (which would otherwise be returned here and lose the diagnostics).
+    const after = normalizeProviderError(error);
+    expect(after.streamDiagnostics).toEqual(diagnostics);
+    expect(after.statusCode).toBe(500);
   });
 });
 


### PR DESCRIPTION
## Summary

Preserves structured provider-error metadata across flow-failure rethrows, so downstream logging/formatting recovers more than just `message` + `userRetryable`.

- Widen `RetryErrorInfoSchema` (`src/shared/schemas/errors.ts`) to carry optional structured `ProviderError` fields; add `toRetryErrorInfo` / `toProviderErrorFromRetry`.
- Widen `InvocationResult['failed']` / fallback handling in `src/agent/core/flows/RetryState.ts`, and propagate the full `RetryErrorInfo` through the cycle nodes (`ResponseCycleNode`, `ToolUseCycleNode`) into `shared.lastError`.
- Attach the structured shape at the rethrows in `runReflectionFlow.ts` and `runToolUseFlow.ts` via `attachProviderError` (`src/common/errors/`); recover it downstream by walking the `cause` chain in `normalizeProviderError`, which `getSdkErrorMessage` / `buildErrorLogData` now consume.
- `normalizeProviderError` no longer caches incidental formatting — it only migrates an *explicitly-attached* `ProviderError`. This avoids a stale-cache bug that lost late-attached `streamDiagnostics` / `partialText` (Anthropic streams) and kept status-stripped wrappers (OpenAI background polling) correctly user-retryable.

Schema changes are backward-compatible (new fields optional; `isRelayError` left `undefined` when unknown rather than forced to `false`).

> Note: an earlier draft also proposed a `markErrorLogged` / `isErrorLogged` dedup guard in `AgentRunLifecycle.ts`; that was deliberately dropped because the reflection flow emits no structured ERROR event, so the guard would have suppressed the only ERROR row for those failures.

Closes #6010.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (error-pipeline + flow suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> [!NOTE]
> **Medium Risk**
> Touches shared error normalization and persisted retry-state shape; behavior changes how failures are logged and surfaced, but new schema fields are optional and tests lock in the caching and rethrow paths.
>
> **Overview**
> **Structured provider errors now survive agent run failures end-to-end.** `RetryErrorInfo` is widened (optional `statusCode`, `provider`, relay/credential flags, `requestId`, stream diagnostics, partial text) with `toRetryErrorInfo` / `toProviderErrorFromRetry`; retry `failed` results and cycle nodes propagate that shape into `shared.lastError`.
>
> **Reflection and tool-use flows** rethrow with `attachProviderError(toProviderErrorFromRetry(shared.lastError))` so lifecycle logging sees the same fields the retry layer already classified.
>
> **`normalizeProviderError`** only reuses errors explicitly attached at boundaries (including walking `cause`); incidental formatting no longer caches on the thrown value, so late `streamDiagnostics` / `partialText` and status-stripped wrappers (e.g. OpenAI background polling) stay correct. `isRelayError` on retry records is optional when unknown.
>
> Tests cover round-trips, wrapped causes, and the no-stale-cache stream path.