### PR TITLE
feat(desktop): derive real onboarding funnel state instead of hardcoding 'done'

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -99,6 +99,14 @@ export interface DesktopAgentExecutionOptions {
    */
   streamSnapshotStore?: DesktopStreamSnapshotStore;
   progressSnapshotStore?: StreamSnapshotStore;
+  /**
+   * Fired once a run in this window's session reaches a completed terminal
+   * result. Used to recompute the onboarding funnel after a user's first run
+   * (the lifecycle has already persisted `firstRunDone` by the time the
+   * terminal `result` event reaches `session.onResult`), so the renderer leaves
+   * the setup card without waiting for a restart.
+   */
+  onRunCompleted?: () => void;
 }
 
 export interface DesktopAgentExecution {
@@ -128,6 +136,8 @@ export interface DesktopProgressBridgeOptions {
   showErrorMessage?: (message: string) => Promise<void> | void;
   streamSnapshotStore?: DesktopStreamSnapshotStore;
   progressSnapshotStore?: StreamSnapshotStore;
+  /** See DesktopAgentExecutionOptions.onRunCompleted. */
+  onRunCompleted?: () => void;
 }
 
 class MemoryProgressStorage implements MementoStorage {
@@ -377,11 +387,23 @@ export class DesktopProgressBridge {
     const unsubscribeShowError = bus.on('requestShowError', ({ message }) => {
       void this.options.showErrorMessage?.(message);
     });
+    // Onboarding funnel (PRD: agent-native onboarding): a completed run ends
+    // State 1. `AgentRunLifecycle` persists `firstRunDone` BEFORE it emits the
+    // terminal `result` event, so by the time this listener fires the funnel
+    // derivation will read the up-to-date flag. The setup agent's own run does
+    // not flip `firstRunDone` (the lifecycle skips it), but recomputing here is
+    // still safe — the derivation is idempotent.
+    const unsubscribeResult = this.session.onResult((event) => {
+      if (event.outcome === 'completed') {
+        this.options.onRunCompleted?.();
+      }
+    });
     this.unsubscribe = () => {
       backendSubscription.dispose();
       unsubscribeGoal();
       unsubscribeEnsureProgress();
       unsubscribeShowError();
+      unsubscribeResult();
     };
     this.runtimeHost = {
       emit: (event, payload) => this.handleProgressEvent(event, payload),
@@ -1317,6 +1339,7 @@ export function createDesktopAgentExecution(
     showErrorMessage: options.showErrorMessage,
     streamSnapshotStore: options.streamSnapshotStore,
     progressSnapshotStore: options.progressSnapshotStore,
+    onRunCompleted: options.onRunCompleted,
   });
 
   return {

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -2,6 +2,7 @@ import { platform } from '@platform/platform';
 import {
   planOnboardingFunnelTransition,
   readOnboardingFlags,
+  setFirstRunDone,
   setOnboardingDeclined,
   type OnboardingFunnelState,
 } from '@controllers/onboarding/onboardingFunnel';
@@ -26,6 +27,12 @@ export interface DesktopOnboardingIpcOptions {
    * and the secrets read can involve disk/network I/O.
    */
   hasCredential?: () => boolean | Promise<boolean>;
+  /** Post SET_SELECTED_AGENT to the renderer when entering State 1. */
+  selectSetupAgent?: () => Promise<void>;
+  /** Auto-start the setup conversation on the State 0→1 transition. */
+  kickoffSetup?: () => Promise<void>;
+  /** Run ChatGPT sign-in flow from the welcome card. */
+  signInWithChatGpt?: () => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -40,6 +47,7 @@ export function createDesktopOnboardingIpc(
 ): DesktopOnboardingIpc {
   const state = options.state ?? platform().globalState;
   let previousFunnelState: OnboardingFunnelState | undefined;
+  let setupKickoffStarted = false;
 
   function postCurrentState(): void {
     const dismissed = state.get<boolean>(
@@ -68,6 +76,17 @@ export function createDesktopOnboardingIpc(
     if (transition.clearDeclined) {
       await setOnboardingDeclined(state, false);
     }
+    if (transition.selectSetupAgent) {
+      await options.selectSetupAgent?.();
+    }
+    if (transition.kickoffSetup && !setupKickoffStarted) {
+      setupKickoffStarted = true;
+      try {
+        await options.kickoffSetup?.();
+      } catch {
+        setupKickoffStarted = false;
+      }
+    }
   }
 
   async function dismiss(): Promise<void> {
@@ -80,11 +99,28 @@ export function createDesktopOnboardingIpc(
     await refreshOnboardingFunnel();
   }
 
+  async function skipSetup(): Promise<void> {
+    await setFirstRunDone(state, true);
+    await refreshOnboardingFunnel();
+  }
+
+  async function runSetup(): Promise<void> {
+    await options.selectSetupAgent?.();
+    await options.kickoffSetup?.();
+    await refreshOnboardingFunnel();
+  }
+
+  async function signInWithChatGpt(): Promise<void> {
+    await options.signInWithChatGpt?.();
+    await refreshOnboardingFunnel();
+  }
+
   return {
     ...createCommandHandler(
       {
-        // Desktop does not run State 0/1 yet, so every main-view mount must
-        // clear MainApp's first-paint `pending` guard with a concrete state.
+        // Every main-view mount must clear MainApp's first-paint `pending`
+        // guard with a concrete state (State 0 welcome card, State 1 setup,
+        // or State 2 done).
         [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: {
           when: (message) => message.view === 'main',
           run: () => refreshOnboardingFunnel(),
@@ -97,6 +133,10 @@ export function createDesktopOnboardingIpc(
         // persisting the declined flag, recompute the funnel; the derivation
         // produces 'done' when no credential is present.
         [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP]: () => skipMainOnboarding(),
+        [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP_SETUP]: () => skipSetup(),
+        [MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP]: () => runSetup(),
+        [MAIN_VIEW_COMMANDS.ONBOARDING_SIGN_IN_CHATGPT]: () =>
+          signInWithChatGpt(),
       },
       { onAsyncError: options.onAsyncError },
     ),

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -107,14 +107,30 @@ export function createDesktopOnboardingIpc(
     if (transition.selectSetupAgent) {
       await options.selectSetupAgent?.();
     }
-    if (transition.kickoffSetup && !setupKickoffStarted) {
-      setupKickoffStarted = true;
-      try {
-        await options.kickoffSetup?.();
-      } catch {
-        setupKickoffStarted = false;
-      }
+    // The funnel state was already pushed above so the renderer can paint the
+    // setup card immediately; the kickoff runs fire-and-forget (see
+    // startSetupKickoff) so a later refresh isn't blocked behind it.
+    if (transition.kickoffSetup) {
+      startSetupKickoff();
     }
+  }
+
+  // Single guarded entry point for launching setup. Both the auto-kickoff on the
+  // needs-credential→setup transition and the explicit "Run Setup" card action
+  // route through here, so a setup run can't be started twice concurrently —
+  // the host's `handleExecute`/`runAgent` has no in-flight dedup of its own.
+  function startSetupKickoff(): void {
+    if (setupKickoffStarted) return;
+    setupKickoffStarted = true;
+    // Fire-and-forget: the host kickoff runs the setup conversation to
+    // completion, which must NOT block the serialized funnel-refresh chain —
+    // otherwise a later "skip setup" / sign-out / credential-removal refresh
+    // would queue behind the entire setup run, leaving the card stuck on 'setup'.
+    void Promise.resolve(options.kickoffSetup?.()).catch(() => {
+      // Reset the guard so a later credential change can re-trigger setup; the
+      // kickoff handler already surfaced the error to the user.
+      setupKickoffStarted = false;
+    });
   }
 
   function refreshOnboardingFunnel(): Promise<void> {
@@ -152,7 +168,9 @@ export function createDesktopOnboardingIpc(
 
   async function runSetup(): Promise<void> {
     await options.selectSetupAgent?.();
-    await options.kickoffSetup?.();
+    // Route through the shared guard so a manual "Run Setup" click after an
+    // auto-kickoff (or a double-click) can't launch a second concurrent run.
+    startSetupKickoff();
     await refreshOnboardingFunnel();
   }
 

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -1,5 +1,10 @@
 import { platform } from '@platform/platform';
-import { setOnboardingDeclined } from '@controllers/onboarding/onboardingFunnel';
+import {
+  planOnboardingFunnelTransition,
+  readOnboardingFlags,
+  setOnboardingDeclined,
+  type OnboardingFunnelState,
+} from '@controllers/onboarding/onboardingFunnel';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
 import {
   buildDesktopOnboardingSetStateMessage,
@@ -15,14 +20,26 @@ import type { StateStore } from '@platform/interfaces/state';
 
 export interface DesktopOnboardingIpcOptions {
   state?: StateStore;
+  /**
+   * Host-provided check for a usable credential (relay sign-in + server-side
+   * keys, or any provider API key). Async because both the relay auth check
+   * and the secrets read can involve disk/network I/O.
+   */
+  hasCredential?: () => boolean | Promise<boolean>;
   onAsyncError?: (error: unknown) => void;
+}
+
+export interface DesktopOnboardingIpc extends DesktopMessageHandler {
+  /** Recompute the funnel from credentials + flags and push it to the webview. */
+  refreshOnboardingFunnel(): Promise<void>;
 }
 
 export function createDesktopOnboardingIpc(
   renderer: DesktopRenderer,
   options: DesktopOnboardingIpcOptions = {},
-): DesktopMessageHandler {
+): DesktopOnboardingIpc {
   const state = options.state ?? platform().globalState;
+  let previousFunnelState: OnboardingFunnelState | undefined;
 
   function postCurrentState(): void {
     const dismissed = state.get<boolean>(
@@ -32,11 +49,25 @@ export function createDesktopOnboardingIpc(
     renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(!dismissed));
   }
 
-  function postMainViewFunnelState(): void {
+  async function refreshOnboardingFunnel(): Promise<void> {
+    const hasCredential = options.hasCredential
+      ? await Promise.resolve(options.hasCredential()).catch(() => false)
+      : false;
+    const flags = readOnboardingFlags(state);
+    const transition = planOnboardingFunnelTransition(previousFunnelState, {
+      hasCredential,
+      ...flags,
+    });
+    previousFunnelState = transition.state;
+
     renderer.postToRenderer({
       command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
-      state: 'done',
+      state: transition.state,
     });
+
+    if (transition.clearDeclined) {
+      await setOnboardingDeclined(state, false);
+    }
   }
 
   async function dismiss(): Promise<void> {
@@ -46,25 +77,29 @@ export function createDesktopOnboardingIpc(
 
   async function skipMainOnboarding(): Promise<void> {
     await setOnboardingDeclined(state, true);
-    postMainViewFunnelState();
+    await refreshOnboardingFunnel();
   }
 
-  return createCommandHandler(
-    {
-      // Desktop does not run State 0/1 yet, so every main-view mount must
-      // clear MainApp's first-paint `pending` guard with a concrete state.
-      [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: {
-        when: (message) => message.view === 'main',
-        run: () => postMainViewFunnelState(),
-        claim: false,
+  return {
+    ...createCommandHandler(
+      {
+        // Desktop does not run State 0/1 yet, so every main-view mount must
+        // clear MainApp's first-paint `pending` guard with a concrete state.
+        [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: {
+          when: (message) => message.view === 'main',
+          run: () => refreshOnboardingFunnel(),
+          claim: false,
+        },
+        [DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE]: () => postCurrentState(),
+        [DESKTOP_ONBOARDING_COMMANDS.DISMISS]: () => dismiss(),
+        // Welcome-card skip (PRD: agent-native onboarding). Host-neutral
+        // declined flag — the same one the CLI picker persists. After
+        // persisting the declined flag, recompute the funnel; the derivation
+        // produces 'done' when no credential is present.
+        [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP]: () => skipMainOnboarding(),
       },
-      [DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE]: () => postCurrentState(),
-      [DESKTOP_ONBOARDING_COMMANDS.DISMISS]: () => dismiss(),
-      // Welcome-card skip (PRD: agent-native onboarding). Host-neutral
-      // declined flag — the same one the CLI picker persists. Keep the
-      // renderer on desktop's current `done` funnel state afterward.
-      [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP]: () => skipMainOnboarding(),
-    },
-    { onAsyncError: options.onAsyncError },
-  );
+      { onAsyncError: options.onAsyncError },
+    ),
+    refreshOnboardingFunnel,
+  };
 }

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -126,11 +126,18 @@ export function createDesktopOnboardingIpc(
     // completion, which must NOT block the serialized funnel-refresh chain —
     // otherwise a later "skip setup" / sign-out / credential-removal refresh
     // would queue behind the entire setup run, leaving the card stuck on 'setup'.
-    void Promise.resolve(options.kickoffSetup?.()).catch(() => {
-      // Reset the guard so a later credential change can re-trigger setup; the
-      // kickoff handler already surfaced the error to the user.
-      setupKickoffStarted = false;
-    });
+    void Promise.resolve(options.kickoffSetup?.())
+      .catch(() => {
+        // Swallow — the kickoff handler already surfaced the error to the user.
+      })
+      .finally(() => {
+        // Clear the guard once the run settles (success or failure), not only on
+        // error: while it's in flight the guard blocks a concurrent second run,
+        // but afterwards a manual "Run Setup" click or a later credential cycle
+        // must be able to launch setup again (otherwise the guard would stay
+        // stuck for the window's lifetime after the first kickoff).
+        setupKickoffStarted = false;
+      });
   }
 
   function refreshOnboardingFunnel(): Promise<void> {

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -27,12 +27,25 @@ export interface DesktopOnboardingIpcOptions {
    * and the secrets read can involve disk/network I/O.
    */
   hasCredential?: () => boolean | Promise<boolean>;
+  /**
+   * Resolves once the host's one-shot first-run backfill has settled. The first
+   * funnel derivation waits for it so a returning veteran isn't transiently
+   * pushed into State 1 (firing `selectSetupAgent`) before the backfill marks
+   * them `done`. Optional: when absent, refreshes derive immediately.
+   */
+  readyGate?: Promise<void>;
   /** Post SET_SELECTED_AGENT to the renderer when entering State 1. */
   selectSetupAgent?: () => Promise<void>;
   /** Auto-start the setup conversation on the State 0→1 transition. */
   kickoffSetup?: () => Promise<void>;
   /** Run ChatGPT sign-in flow from the welcome card. */
   signInWithChatGpt?: () => Promise<void>;
+  /**
+   * Open the getting-started walkthrough from the State 0 welcome card. The
+   * desktop shell can't host the VS Code walkthrough, so the host wires this to
+   * the closest analog: opening the desktop getting-started docs externally.
+   */
+  openGettingStarted?: () => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -48,6 +61,16 @@ export function createDesktopOnboardingIpc(
   const state = options.state ?? platform().globalState;
   let previousFunnelState: OnboardingFunnelState | undefined;
   let setupKickoffStarted = false;
+  // Serialize refreshes so concurrent callers (WEBVIEW_READY, post-backfill,
+  // auth refresh, api-key hooks, run completion) never interleave. The funnel
+  // derivation has an internal `await` (the credential probe) and mutates the
+  // shared `previousFunnelState`; without serialization the last caller to
+  // finish could push a `SET_ONBOARDING_FUNNEL` derived from a stale previous
+  // state. A latch coalesces overlapping requests: while one refresh is in
+  // flight, a single re-run is queued and run once the current one settles, so
+  // callers always observe a consistent terminal state.
+  let refreshChain: Promise<void> = Promise.resolve();
+  let rerunRequested = false;
 
   function postCurrentState(): void {
     const dismissed = state.get<boolean>(
@@ -57,7 +80,12 @@ export function createDesktopOnboardingIpc(
     renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(!dismissed));
   }
 
-  async function refreshOnboardingFunnel(): Promise<void> {
+  async function runOnboardingFunnelRefresh(): Promise<void> {
+    // Wait for the host's first-run backfill to settle before the first
+    // derivation; resolves instantly on every subsequent refresh.
+    if (options.readyGate) {
+      await options.readyGate.catch(() => undefined);
+    }
     const hasCredential = options.hasCredential
       ? await Promise.resolve(options.hasCredential()).catch(() => false)
       : false;
@@ -89,6 +117,24 @@ export function createDesktopOnboardingIpc(
     }
   }
 
+  function refreshOnboardingFunnel(): Promise<void> {
+    // If a refresh is already running, mark that another full pass is needed
+    // and return the chain tail — every caller resolves only once the queued
+    // pass has settled, so they all observe the same terminal funnel state.
+    rerunRequested = true;
+    refreshChain = refreshChain
+      .catch(() => undefined)
+      .then(async () => {
+        // Collapse multiple overlapping requests that arrived while a pass was
+        // running into a single re-run.
+        while (rerunRequested) {
+          rerunRequested = false;
+          await runOnboardingFunnelRefresh();
+        }
+      });
+    return refreshChain;
+  }
+
   async function dismiss(): Promise<void> {
     await state.update(DESKTOP_ONBOARDING_DISMISSED_STATE_KEY, true);
     renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(false));
@@ -115,6 +161,10 @@ export function createDesktopOnboardingIpc(
     await refreshOnboardingFunnel();
   }
 
+  async function openGettingStarted(): Promise<void> {
+    await options.openGettingStarted?.();
+  }
+
   return {
     ...createCommandHandler(
       {
@@ -137,6 +187,11 @@ export function createDesktopOnboardingIpc(
         [MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP]: () => runSetup(),
         [MAIN_VIEW_COMMANDS.ONBOARDING_SIGN_IN_CHATGPT]: () =>
           signInWithChatGpt(),
+        // State 0 walkthrough button. The desktop shell can't host the VS Code
+        // getting-started walkthrough, so this opens the desktop docs externally
+        // (the host wires `openGettingStarted`).
+        [MAIN_VIEW_COMMANDS.ONBOARDING_OPEN_GETTING_STARTED]: () =>
+          openGettingStarted(),
       },
       { onAsyncError: options.onAsyncError },
     ),

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -709,6 +709,10 @@ export function createDesktopSettingsIpc(
       postModelSelectionData(),
       postMainModelOptionsData(),
     ]);
+    // ChatGPT sign-in/out is a credential change too: refresh the onboarding
+    // funnel so a user who signs in from Settings leaves `needs-credential`
+    // without needing a reload.
+    await options.onApiKeyChanged?.();
   }
 
   async function signInChatGpt(): Promise<void> {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -166,10 +166,13 @@ export interface DesktopSettingsIpcOptions {
   }) => Promise<void>;
   onError?: (error: unknown) => void;
   modelListRefresh?: PromiseLike<void>;
+  /** Called after a provider API key is saved or removed. */
+  onApiKeyChanged?: () => Promise<void>;
 }
 
 export interface DesktopSettingsIpc extends DesktopMessageHandler {
   refreshAuthDependentData(): Promise<void>;
+  signInChatGpt(): Promise<void>;
 }
 
 export function createDesktopSettingsIpc(
@@ -601,6 +604,7 @@ export function createDesktopSettingsIpc(
     await postProfileData();
     await postModelSelectionData();
     await postMainModelOptionsData();
+    await options.onApiKeyChanged?.();
   }
 
   async function setProviderKey(
@@ -1165,6 +1169,7 @@ export function createDesktopSettingsIpc(
 
   return {
     refreshAuthDependentData,
+    signInChatGpt,
 
     handleMessage(message: DesktopCommandMessage) {
       // WEBVIEW_READY is a broadcast: act on it but return false so sibling

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -172,7 +172,7 @@ export interface DesktopSettingsIpcOptions {
 
 export interface DesktopSettingsIpc extends DesktopMessageHandler {
   refreshAuthDependentData(): Promise<void>;
-  signInChatGpt(): Promise<void>;
+  signInChatGpt(options?: { enableSubscription?: boolean }): Promise<void>;
 }
 
 export function createDesktopSettingsIpc(
@@ -700,6 +700,11 @@ export function createDesktopSettingsIpc(
     }
     invalidateModelOptionsCache();
     await Promise.all([postProfileData(), postModelSelectionData()]);
+    // Switching included ↔ personal access mode changes the credential
+    // predicate (`getUseIncludedModelAccess()`), so refresh the onboarding
+    // funnel — otherwise a user enabling included access stays on
+    // `needs-credential` until a reload.
+    await options.onApiKeyChanged?.();
   }
 
   async function refreshAfterChatGptAuthChange(): Promise<void> {
@@ -715,7 +720,9 @@ export function createDesktopSettingsIpc(
     await options.onApiKeyChanged?.();
   }
 
-  async function signInChatGpt(): Promise<void> {
+  async function signInChatGpt(signInOptions?: {
+    enableSubscription?: boolean;
+  }): Promise<void> {
     try {
       if (!options.openExternalUrl) {
         await options.showErrorMessage?.(
@@ -727,6 +734,15 @@ export function createDesktopSettingsIpc(
         coordinator: codexCoordinator(),
         openBrowser: options.openExternalUrl,
       });
+      // The onboarding welcome card's "Sign in with ChatGPT" implies the user
+      // wants subscription routing, so enable the preference after a successful
+      // login (mirrors the extension's `codexSubscriptionSignIn`). Without this
+      // `isCodexSubscriptionActive` stays false (the preference defaults off)
+      // and the funnel bounces the user straight back to `needs-credential`.
+      // The Settings sign-in command leaves the preference to its own toggle.
+      if (signInOptions?.enableSubscription) {
+        await setPreferCodexSubscription(true);
+      }
       await options.showInfoMessage?.(
         `Signed in with ChatGPT as ${session.email ?? session.accountId ?? 'your account'}.`,
       );

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -687,9 +687,8 @@ function createWindow(options: {
       // onboarding IPC keeps this one-shot; on a resolution failure it throws so
       // that guard resets and a later credential change can retry.
       kickoffSetup: async () => {
-        const { buildDesktopSetupExecuteMessage } = await import(
-          '@controllers/onboarding/setupLaunch'
-        );
+        const { buildDesktopSetupExecuteMessage } =
+          await import('@controllers/onboarding/setupLaunch');
         const message = await buildDesktopSetupExecuteMessage();
         if (!message) {
           await showErrorMessage(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -68,6 +68,7 @@ import {
   type DesktopAuthCallbackState,
   type DesktopAuthCoordinator,
 } from './desktopSupabaseAuth.js';
+import { DESKTOP_DOCS_URL } from '../desktopCommandSurface.js';
 import { reportFatalStartupError } from './fatalStartupError.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeDesktopCrashReporting } from './desktopCrashReporting.js';
@@ -265,6 +266,12 @@ function createWindow(options: {
   initializeCrashReporting: () => Promise<void>;
   streamSnapshotStore?: DesktopStreamSnapshotStore;
   progressSnapshotStore: StreamSnapshotStore;
+  /**
+   * Captured in `initializeElectronPlatform` BEFORE the bundled-agent sync
+   * writes LAST_KNOWN_VERSION, so the onboarding backfill can tell a returning
+   * veteran from a fresh install. See ElectronPlatformInitResult.hasPriorInstall.
+   */
+  hasPriorInstall: boolean;
 }): void {
   const window = new BrowserWindow({
     width: 960,
@@ -304,6 +311,25 @@ function createWindow(options: {
   const onboardingIpcRef: {
     current?: DesktopOnboardingIpc;
   } = {};
+  // Single source of truth for "does the user have a usable credential" on
+  // desktop: active ChatGPT (Codex) subscription, relay sign-in with Included
+  // Access to server-side keys, or a non-blank provider API key. Shared by the
+  // onboarding-funnel derivation and the first-run backfill (formerly two
+  // near-verbatim copies — Codex review).
+  const probeCredential = async (): Promise<boolean> => {
+    if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) return true;
+    const isRelaySignedIn = await SupabaseClient.isAuthenticated();
+    if (isRelaySignedIn) {
+      const serverKeyService = getServerSideKeyService();
+      if (
+        serverKeyService.getUseIncludedModelAccess() &&
+        (await serverKeyService.canUseServerSideKeys())
+      ) {
+        return true;
+      }
+    }
+    return hasAnyProviderApiKey(platform().secrets);
+  };
   const showErrorMessage = async (message: string) => {
     await dialog.showMessageBox(window, { message, type: 'error' });
   };
@@ -470,6 +496,13 @@ function createWindow(options: {
     showErrorMessage,
     streamSnapshotStore: options.streamSnapshotStore,
     progressSnapshotStore: options.progressSnapshotStore,
+    // Recompute the onboarding funnel after a run completes so a user's first
+    // successful run leaves the setup card without waiting for a restart
+    // (the run lifecycle has already persisted firstRunDone). Mirrors the
+    // extension's post-run refresh hooks in MainViewMessageHandler.
+    onRunCompleted: () => {
+      void onboardingIpcRef.current?.refreshOnboardingFunnel();
+    },
   };
   let agentExecution: DesktopAgentExecution | undefined;
   let agentExecutionLoad: Promise<DesktopAgentExecution> | undefined;
@@ -624,23 +657,20 @@ function createWindow(options: {
     ensureProgress: async () => (await getAgentExecution()).progress,
     onAsyncError: reportAsyncError,
   });
+  // Opened once the one-shot backfill below has settled. The onboarding IPC
+  // awaits this before its first funnel derivation so a returning veteran
+  // (credential present, `firstRunDone` not yet written) can't have WEBVIEW_READY
+  // transiently derive State 1 — firing `selectSetupAgent` and clobbering the
+  // launcher's agent selection — before the backfill marks them `done`.
+  let openOnboardingReadyGate: () => void = () => {};
+  const onboardingReadyGate = new Promise<void>((resolve) => {
+    openOnboardingReadyGate = resolve;
+  });
   const onboardingIpc = createDesktopOnboardingIpc(
     { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
     {
-      hasCredential: async () => {
-        if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
-          return true;
-        }
-        const isRelaySignedIn = await SupabaseClient.isAuthenticated();
-        if (isRelaySignedIn) {
-          const serverKeyService = getServerSideKeyService();
-          if (serverKeyService.getUseIncludedModelAccess()) {
-            const canUseServer = await serverKeyService.canUseServerSideKeys();
-            if (canUseServer) return true;
-          }
-        }
-        return hasAnyProviderApiKey(platform().secrets);
-      },
+      hasCredential: probeCredential,
+      readyGate: onboardingReadyGate,
       selectSetupAgent: async () => {
         const entry = getAgent('setup', AgentCategory.ToolUse);
         ipcRef.current?.postToRenderer({
@@ -649,14 +679,45 @@ function createWindow(options: {
           sessionType: 'toolUse' as const,
         });
       },
-      // Auto-kickoff is declared as a callback so the planner's output is not
-      // silently discarded (see MainViewProvider.refreshOnboardingFunnel for
-      // the extension-side equivalent). Desktop wires it as a no-op for now;
-      // a future PR can replace it with `handleExecute` once the setup launch
-      // path is host-neutral.
-      kickoffSetup: async () => {},
+      // Auto-start the setup conversation, mirroring the extension's
+      // `launchSetupAssistant` → `handleExecute` path: resolve a model the
+      // user's credentials can call, build the setup execute message, and run
+      // it through the same desktop execute path the renderer's Execute button
+      // uses. The per-session `setupKickoffStarted` dedup guard inside the
+      // onboarding IPC keeps this one-shot; on a resolution failure it throws so
+      // that guard resets and a later credential change can retry.
+      kickoffSetup: async () => {
+        const { buildDesktopSetupExecuteMessage } = await import(
+          '@controllers/onboarding/setupLaunch'
+        );
+        const message = await buildDesktopSetupExecuteMessage();
+        if (!message) {
+          await showErrorMessage(
+            'No model is available for your current credentials. Sign in with ChatGPT, add a provider API key, or check your Researcher Access tier, then try setup again.',
+          );
+          // Throw so the onboarding IPC clears its kickoff guard and a later
+          // credential change can re-trigger the auto-start.
+          throw new Error('Setup launch: no runnable model resolved.');
+        }
+        // Idempotent: returns the in-flight/initialized registry so a kickoff
+        // racing the startup `loadAgents()` cannot hit "Could not find agent:
+        // setup" (mirrors `setupAssistantCommand.launchSetupAssistant`).
+        const { loadAgents } = await import('@agent/index');
+        await loadAgents();
+        await (await getAgentExecution()).handleExecute(message);
+      },
       signInWithChatGpt: async () => {
-        await settingsIpc.signInChatGpt();
+        // Welcome-card sign-in enables ChatGPT subscription routing so the
+        // funnel recognises the new credential instead of bouncing back to
+        // `needs-credential`.
+        await settingsIpc.signInChatGpt({ enableSubscription: true });
+      },
+      // The desktop shell can't host the VS Code getting-started walkthrough, so
+      // the State 0 walkthrough button opens the desktop docs externally — the
+      // closest desktop analog, reusing the same docs URL the Help menu's
+      // "Desktop Documentation" item opens.
+      openGettingStarted: async () => {
+        await previewHost.openExternal(DESKTOP_DOCS_URL);
       },
       onAsyncError: reportAsyncError,
     },
@@ -668,6 +729,7 @@ function createWindow(options: {
   // (`runOnboarding.tsx:154`) backfill, which desktop formerly skipped by
   // hardcoding `'done'`.
   void (async () => {
+    let didBackfill = false;
     try {
       const globalState = platform().globalState;
       // Gate the whole probe + backfill on the flag being unwritten, so the
@@ -680,24 +742,13 @@ function createWindow(options: {
       ) {
         return;
       }
-      const hasCredential = await (async () => {
-        if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) return true;
-        const isRelaySignedIn = await SupabaseClient.isAuthenticated();
-        if (isRelaySignedIn) {
-          const serverKeyService = getServerSideKeyService();
-          if (
-            serverKeyService.getUseIncludedModelAccess() &&
-            (await serverKeyService.canUseServerSideKeys())
-          ) {
-            return true;
-          }
-        }
-        return hasAnyProviderApiKey(platform().secrets);
-      })().catch(() => false);
-      const hasPriorInstall =
-        globalState.get<string | undefined>(
-          GlobalStateKey.LAST_KNOWN_VERSION,
-        ) !== undefined;
+      const hasCredential = await probeCredential().catch(() => false);
+      // `options.hasPriorInstall` was read in `initializeElectronPlatform`
+      // BEFORE the bundled-agent sync wrote LAST_KNOWN_VERSION during this same
+      // session. Reading the key here instead would always be defined (the sync
+      // already ran and is awaited before createWindow), wrongly classifying a
+      // fresh credentialed user as a veteran → 'done', so State 1 never shows.
+      const hasPriorInstall = options.hasPriorInstall;
       // Inline `listExecutions` import so the agent storage module tree-shakes
       // from the desktop main bundle unless we actually reach the backfill
       // path on the first launch.
@@ -710,12 +761,20 @@ function createWindow(options: {
         hasPriorInstall,
         hasRunHistory,
       });
-      // The backfill can finish after the webview has already mounted and
-      // pushed an initial funnel state, so re-derive once it lands to avoid
-      // stranding an upgraded user on the welcome/setup card for the session.
-      await onboardingIpcRef.current?.refreshOnboardingFunnel();
+      didBackfill = true;
     } catch {
       // Swallow — backfill failure must not block window creation.
+    } finally {
+      // Open the gate whether we backfilled or early-returned, so the
+      // onboarding IPC's first refresh can proceed. Opening it here (before the
+      // post-backfill refresh below) also avoids a self-deadlock, since that
+      // refresh awaits this same gate.
+      openOnboardingReadyGate();
+    }
+    // Only when we actually wrote the flag does the renderer need a re-derive:
+    // the webview may have mounted mid-backfill, so push the settled state.
+    if (didBackfill) {
+      await onboardingIpcRef.current?.refreshOnboardingFunnel().catch(() => {});
     }
   })();
   // Real desktop git host — closes audit item A from
@@ -881,6 +940,7 @@ if (protocolLifecycle.shouldContinue) {
           initializeCrashReporting,
           streamSnapshotStore,
           progressSnapshotStore: platformInit.progressSnapshotStore,
+          hasPriorInstall: platformInit.hasPriorInstall,
         });
       reopenMainWindow();
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -728,7 +728,6 @@ function createWindow(options: {
   // (`runOnboarding.tsx:154`) backfill, which desktop formerly skipped by
   // hardcoding `'done'`.
   void (async () => {
-    let didBackfill = false;
     try {
       const globalState = platform().globalState;
       // Gate the whole probe + backfill on the flag being unwritten, so the
@@ -760,20 +759,17 @@ function createWindow(options: {
         hasPriorInstall,
         hasRunHistory,
       });
-      didBackfill = true;
     } catch {
       // Swallow — backfill failure must not block window creation.
     } finally {
-      // Open the gate whether we backfilled or early-returned, so the
-      // onboarding IPC's first refresh can proceed. Opening it here (before the
-      // post-backfill refresh below) also avoids a self-deadlock, since that
-      // refresh awaits this same gate.
+      // Open the gate (whether we backfilled or early-returned) so the
+      // onboarding IPC's gated first refresh — driven by WEBVIEW_READY — derives
+      // the settled post-backfill state. That gated refresh covers both mount
+      // orders (webview before or after backfill), so no separate post-backfill
+      // refresh is issued here: a premature one could run before the renderer is
+      // listening and consume the one-time selectSetupAgent transition, leaving
+      // the launcher on the default agent while the setup card is shown.
       openOnboardingReadyGate();
-    }
-    // Only when we actually wrote the flag does the renderer need a re-derive:
-    // the webview may have mounted mid-backfill, so push the settled state.
-    if (didBackfill) {
-      await onboardingIpcRef.current?.refreshOnboardingFunnel().catch(() => {});
     }
   })();
   // Real desktop git host — closes audit item A from

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -13,13 +13,21 @@ import {
 } from 'electron';
 
 import { platform } from '@platform/platform';
-import { hasAnyProviderApiKey } from '@controllers/onboarding/onboardingFunnel';
+import {
+  backfillFirstRunDone,
+  hasAnyProviderApiKey,
+} from '@controllers/onboarding/onboardingFunnel';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
+import { getAgent, createKey } from '@agent/index/agentRegistry';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
+import { isCodexSubscriptionActive } from '@auth/codex';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { TerminalRunResult } from '@hosts/terminalHost';
+import { CHATGPT_SETUP_MODEL } from '@model/setupModelDefaults';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
+import { AgentCategory } from '@shared/schemas/agent';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { setDesktopAgentResumeHandler } from './desktopAgentResume.js';
 import {
@@ -605,6 +613,8 @@ function createWindow(options: {
     runInstallCommand: async (command) => {
       await runSetupCommand(command);
     },
+    onApiKeyChanged: () =>
+      onboardingIpcRef.current?.refreshOnboardingFunnel(),
     onError: reportAsyncError,
   });
   settingsIpcRef.current = settingsIpc;
@@ -617,6 +627,9 @@ function createWindow(options: {
     { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
     {
       hasCredential: async () => {
+        if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
+          return true;
+        }
         const isRelaySignedIn = await SupabaseClient.isAuthenticated();
         if (isRelaySignedIn) {
           const serverKeyService = getServerSideKeyService();
@@ -627,10 +640,70 @@ function createWindow(options: {
         }
         return hasAnyProviderApiKey(platform().secrets);
       },
+      selectSetupAgent: async () => {
+        const entry = getAgent('setup', AgentCategory.ToolUse);
+        ipcRef.current?.postToRenderer({
+          command: MAIN_VIEW_COMMANDS.SET_SELECTED_AGENT,
+          agentId: entry ? createKey(entry.source, entry.name) : 'setup',
+          sessionType: 'toolUse' as const,
+        });
+      },
+      // Auto-kickoff is declared as a callback so the planner's output is not
+      // silently discarded (see MainViewProvider.refreshOnboardingFunnel for
+      // the extension-side equivalent). Desktop wires it as a no-op for now;
+      // a future PR can replace it with `handleExecute` once the setup launch
+      // path is host-neutral.
+      kickoffSetup: async () => {},
+      signInWithChatGpt: async () => {
+        await settingsIpc.signInChatGpt();
+      },
       onAsyncError: reportAsyncError,
     },
   );
   onboardingIpcRef.current = onboardingIpc;
+  // One-shot migration: existing desktop users with a credential or run
+  // history never see the welcome card (State 0) or setup auto-start (State
+  // 1). Mirrors the extension (`extension.ts:282`) and CLI
+  // (`runOnboarding.tsx:154`) backfill, which desktop formerly skipped by
+  // hardcoding `'done'`. The async backfill races the in-page webview mount,
+  // which is fine: the WB_READY handler reads the same global-state flags.
+  void (async () => {
+    try {
+      const hasCredential = await (async () => {
+        if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) return true;
+        const isRelaySignedIn = await SupabaseClient.isAuthenticated();
+        if (isRelaySignedIn) {
+          const serverKeyService = getServerSideKeyService();
+          if (
+            serverKeyService.getUseIncludedModelAccess() &&
+            (await serverKeyService.canUseServerSideKeys())
+          ) {
+            return true;
+          }
+        }
+        return hasAnyProviderApiKey(platform().secrets);
+      })().catch(() => false);
+      const globalState = platform().globalState;
+      const hasPriorInstall =
+        globalState.get<string | undefined>(
+          GlobalStateKey.LAST_KNOWN_VERSION,
+        ) !== undefined;
+      // Inline `listExecutions` + `clearStoreCache` import so the agent
+      // storage module tree-shakes from the desktop main bundle unless we
+      // actually reach the backfill path on the first launch.
+      const { listExecutions } = await import('@agent/storage');
+      const hasRunHistory = await listExecutions()
+        .then((entries) => entries.length > 0)
+        .catch(() => false);
+      await backfillFirstRunDone(globalState, {
+        hasCredential,
+        hasPriorInstall,
+        hasRunHistory,
+      });
+    } catch {
+      // Swallow — backfill failure must not block window creation.
+    }
+  })();
   // Real desktop git host — closes audit item A from
   // `docs/dev/standalone-trajectory-audit.md` (trajectory #16). Spawns
   // `git log` under the active workspace to populate the launcher banner's

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -13,6 +13,7 @@ import {
 } from 'electron';
 
 import { platform } from '@platform/platform';
+import { hasAnyProviderApiKey } from '@controllers/onboarding/onboardingFunnel';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -36,7 +37,10 @@ import {
 } from './desktopAppLog.js';
 import { installDesktopMenu } from './desktopMenu.js';
 import { installDesktopNavigationPolicy } from './desktopNavigationPolicy.js';
-import { createDesktopOnboardingIpc } from './desktopOnboardingIpc.js';
+import {
+  createDesktopOnboardingIpc,
+  type DesktopOnboardingIpc,
+} from './desktopOnboardingIpc.js';
 import { refreshDesktopModelListStateIfNeeded } from './desktopModelListRefresh.js';
 import { promptInRenderer } from './desktopPrompt.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
@@ -289,6 +293,9 @@ function createWindow(options: {
   const settingsIpcRef: {
     current?: ReturnType<typeof createDesktopSettingsIpc>;
   } = {};
+  const onboardingIpcRef: {
+    current?: DesktopOnboardingIpc;
+  } = {};
   const showErrorMessage = async (message: string) => {
     await dialog.showMessageBox(window, { message, type: 'error' });
   };
@@ -356,6 +363,7 @@ function createWindow(options: {
         : MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER,
     });
     await settingsIpcRef.current?.refreshAuthDependentData();
+    await onboardingIpcRef.current?.refreshOnboardingFunnel();
   };
   const desktopAuth = createDesktopSupabaseAuth({
     router: protocolLifecycle.router,
@@ -607,8 +615,22 @@ function createWindow(options: {
   });
   const onboardingIpc = createDesktopOnboardingIpc(
     { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
-    { onAsyncError: reportAsyncError },
+    {
+      hasCredential: async () => {
+        const isRelaySignedIn = await SupabaseClient.isAuthenticated();
+        if (isRelaySignedIn) {
+          const serverKeyService = getServerSideKeyService();
+          if (serverKeyService.getUseIncludedModelAccess()) {
+            const canUseServer = await serverKeyService.canUseServerSideKeys();
+            if (canUseServer) return true;
+          }
+        }
+        return hasAnyProviderApiKey(platform().secrets);
+      },
+      onAsyncError: reportAsyncError,
+    },
   );
+  onboardingIpcRef.current = onboardingIpc;
   // Real desktop git host — closes audit item A from
   // `docs/dev/standalone-trajectory-audit.md` (trajectory #16). Spawns
   // `git log` under the active workspace to populate the launcher banner's

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -613,8 +613,9 @@ function createWindow(options: {
     runInstallCommand: async (command) => {
       await runSetupCommand(command);
     },
-    onApiKeyChanged: () =>
-      onboardingIpcRef.current?.refreshOnboardingFunnel(),
+    onApiKeyChanged: async () => {
+      await onboardingIpcRef.current?.refreshOnboardingFunnel();
+    },
     onError: reportAsyncError,
   });
   settingsIpcRef.current = settingsIpc;
@@ -665,10 +666,20 @@ function createWindow(options: {
   // history never see the welcome card (State 0) or setup auto-start (State
   // 1). Mirrors the extension (`extension.ts:282`) and CLI
   // (`runOnboarding.tsx:154`) backfill, which desktop formerly skipped by
-  // hardcoding `'done'`. The async backfill races the in-page webview mount,
-  // which is fine: the WB_READY handler reads the same global-state flags.
+  // hardcoding `'done'`.
   void (async () => {
     try {
+      const globalState = platform().globalState;
+      // Gate the whole probe + backfill on the flag being unwritten, so the
+      // credential/relay/`listExecutions` I/O only runs once (first launch
+      // after upgrade) rather than on every window creation.
+      if (
+        globalState.get<boolean | undefined>(
+          GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
+        ) !== undefined
+      ) {
+        return;
+      }
       const hasCredential = await (async () => {
         if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) return true;
         const isRelaySignedIn = await SupabaseClient.isAuthenticated();
@@ -683,14 +694,13 @@ function createWindow(options: {
         }
         return hasAnyProviderApiKey(platform().secrets);
       })().catch(() => false);
-      const globalState = platform().globalState;
       const hasPriorInstall =
         globalState.get<string | undefined>(
           GlobalStateKey.LAST_KNOWN_VERSION,
         ) !== undefined;
-      // Inline `listExecutions` + `clearStoreCache` import so the agent
-      // storage module tree-shakes from the desktop main bundle unless we
-      // actually reach the backfill path on the first launch.
+      // Inline `listExecutions` import so the agent storage module tree-shakes
+      // from the desktop main bundle unless we actually reach the backfill
+      // path on the first launch.
       const { listExecutions } = await import('@agent/storage');
       const hasRunHistory = await listExecutions()
         .then((entries) => entries.length > 0)
@@ -700,6 +710,10 @@ function createWindow(options: {
         hasPriorInstall,
         hasRunHistory,
       });
+      // The backfill can finish after the webview has already mounted and
+      // pushed an initial funnel state, so re-derive once it lands to avoid
+      // stranding an upgraded user on the welcome/setup card for the session.
+      await onboardingIpcRef.current?.refreshOnboardingFunnel();
     } catch {
       // Swallow — backfill failure must not block window creation.
     }

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -158,8 +158,9 @@ export async function initializeElectronPlatform(
   // Reading it afterwards would always be defined, so a fresh install with a
   // credential would be misread as a returning veteran. See ElectronPlatformInitResult.
   const hasPriorInstall =
-    globalStateStore.get<string | undefined>(GlobalStateKey.LAST_KNOWN_VERSION) !==
-    undefined;
+    globalStateStore.get<string | undefined>(
+      GlobalStateKey.LAST_KNOWN_VERSION,
+    ) !== undefined;
 
   const resourcesPath = resolveResourcesPath(mainDirname);
   initializeGoalPrompts(join(resourcesPath, 'goal', 'goal.yaml'));

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -18,6 +18,7 @@ import { initializeGoalPrompts } from '@agent/goal';
 import { toErrorMessage } from '@common/errors';
 import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
 import { configKeyVariants } from '@shared/config/configKeys';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 
 import { bootstrapElectronAgentDirectories } from './agentDirectories.js';
@@ -37,6 +38,17 @@ export interface ElectronPlatformInitResult {
   workspacePath: string | undefined;
   lifecycle: LifecycleHost;
   progressSnapshotStore: StreamSnapshotStore;
+  /**
+   * Whether TeXRA had run on this machine before this session, captured from
+   * `LAST_KNOWN_VERSION` BEFORE the bundled-agent directory sync writes that
+   * key during this same init. Threaded out so the onboarding backfill can
+   * tell a returning user (veteran) from a fresh install — reading the key
+   * after init would always see the just-written version and misclassify a
+   * brand-new credentialed user as a veteran (→ State 2 'done', so the setup
+   * card never shows). Mirrors the extension's read-before-write ordering
+   * (`extension.ts` LAST_KNOWN_VERSION comment).
+   */
+  hasPriorInstall: boolean;
 }
 
 const WORKSPACE_CONFIG_MIGRATED_KEY =
@@ -140,6 +152,15 @@ export async function initializeElectronPlatform(
     toolAvailability: NO_TOOL_AVAILABILITY_HOST,
   });
   registerAgentFeatures();
+
+  // Capture the prior-install signal BEFORE bootstrapElectronAgentDirectories
+  // (below) writes LAST_KNOWN_VERSION via the bundled-agent directory sync.
+  // Reading it afterwards would always be defined, so a fresh install with a
+  // credential would be misread as a returning veteran. See ElectronPlatformInitResult.
+  const hasPriorInstall =
+    globalStateStore.get<string | undefined>(GlobalStateKey.LAST_KNOWN_VERSION) !==
+    undefined;
+
   const resourcesPath = resolveResourcesPath(mainDirname);
   initializeGoalPrompts(join(resourcesPath, 'goal', 'goal.yaml'));
 
@@ -155,5 +176,10 @@ export async function initializeElectronPlatform(
 
   await bootstrapElectronAgentDirectories(resourcesPath, app.getVersion());
 
-  return { workspacePath, lifecycle, progressSnapshotStore: snapshotStore };
+  return {
+    workspacePath,
+    lifecycle,
+    progressSnapshotStore: snapshotStore,
+    hasPriorInstall,
+  };
 }

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -1,0 +1,94 @@
+/**
+ * Host-neutral setup-assistant launch helpers (PRD: agent-native onboarding).
+ *
+ * The VS Code host owns a richer launch path (`setupAssistantCommand.ts`) with
+ * interactive credential/routing prompts. Hosts without a quick-pick UI (the
+ * Electron desktop shell) need a smaller, prompt-free path: resolve a model the
+ * user's current credentials can actually call and build the execute request the
+ * shared agent-run path consumes. This module keeps that resolution truth in one
+ * agnostic place so desktop does not re-derive setup routing.
+ */
+
+import { platform } from '@platform/platform';
+import { isCodexSubscriptionActive } from '@auth/codex';
+import { getServerSideKeyService } from '@auth/serverKeys';
+import { lookupApiKey, API_PROVIDERS } from '@model/apiProviders';
+import {
+  CHATGPT_SETUP_MODEL,
+  SETUP_MODEL_BY_PROVIDER,
+} from '@model/setupModelDefaults';
+import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
+import { SETUP_AGENT_NAME } from '@shared/constants/agents';
+import { isNonEmptyString } from '@utils/core';
+import { getUseOpenRouter } from '@utils/config/providerConfig';
+
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionMessageController';
+
+/** Instruction handed to the setup agent on auto-kickoff (mirrors the extension). */
+export const SETUP_INSTRUCTION =
+  'Please help me finish installing TeXRA. Probe my environment, install anything missing, and get me a working credential.';
+
+/**
+ * Pick a model the setup agent can actually call given the user's current
+ * credentials and the global `useOpenRouter` routing flag. Returns `null` when
+ * no credential resolves to a runnable model (the caller refuses launch rather
+ * than starting a run that fails at runtime). Mirrors the extension's
+ * `resolveLaunchModel`, minus the OpenRouter-flag flip (desktop has no
+ * interactive routing prompt, so it only uses OpenRouter when the flag is
+ * already on or an OpenRouter key is the only credential).
+ */
+export async function resolveDesktopSetupModel(): Promise<string | null> {
+  // Global OR routing re-routes every call through OpenRouter regardless of
+  // provider, so a direct/server pick would be misrouted — short-circuit to the
+  // OR-routed default.
+  if (getUseOpenRouter()) {
+    return SETUP_MODEL_BY_PROVIDER.openRouter;
+  }
+
+  if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
+    return CHATGPT_SETUP_MODEL;
+  }
+
+  const serverKeys = getServerSideKeyService();
+  if (await serverKeys.canUseServerSideKeysForModel(DEFAULT_AGENT_MODEL)) {
+    return DEFAULT_AGENT_MODEL;
+  }
+  if (await serverKeys.canUseServerSideKeys()) {
+    for (const [provider, model] of Object.entries(SETUP_MODEL_BY_PROVIDER)) {
+      if (provider === 'openRouter') continue;
+      if (serverKeys.canUseModelSync(model)) return model;
+    }
+  }
+
+  const secrets = platform().secrets;
+  for (const provider of API_PROVIDERS) {
+    if (provider === 'openRouter') continue;
+    const model = SETUP_MODEL_BY_PROVIDER[provider];
+    if (!model) continue;
+    if (isNonEmptyString(await lookupApiKey(secrets, provider))) {
+      return model;
+    }
+  }
+
+  if (isNonEmptyString(await lookupApiKey(secrets, 'openRouter'))) {
+    return SETUP_MODEL_BY_PROVIDER.openRouter;
+  }
+
+  return null;
+}
+
+/**
+ * Build the execute message that auto-starts the setup conversation, or `null`
+ * when no credential resolves to a runnable model. The message rides the same
+ * `handleExecute` path the renderer's execute button uses.
+ */
+export async function buildDesktopSetupExecuteMessage(): Promise<MainViewExecuteMessage | null> {
+  const model = await resolveDesktopSetupModel();
+  if (!model) return null;
+  return {
+    agent: SETUP_AGENT_NAME,
+    model,
+    instruction: SETUP_INSTRUCTION,
+    isToolUseAgent: true,
+  };
+}

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -33,16 +33,24 @@ export const SETUP_INSTRUCTION =
  * credentials and the global `useOpenRouter` routing flag. Returns `null` when
  * no credential resolves to a runnable model (the caller refuses launch rather
  * than starting a run that fails at runtime). Mirrors the extension's
- * `resolveLaunchModel`, minus the OpenRouter-flag flip (desktop has no
- * interactive routing prompt, so it only uses OpenRouter when the flag is
- * already on or an OpenRouter key is the only credential).
+ * `resolveLaunchModel`, minus the interactive OpenRouter-flag flip: desktop has
+ * no routing prompt, so OpenRouter is chosen only when the flag is already on
+ * AND an OpenRouter key exists. A bare OpenRouter key with the flag off yields
+ * `null` rather than an unrouted (and doomed) run.
  */
 export async function resolveDesktopSetupModel(): Promise<string | null> {
+  const secrets = platform().secrets;
+
   // Global OR routing re-routes every call through OpenRouter regardless of
   // provider, so a direct/server pick would be misrouted — short-circuit to the
-  // OR-routed default.
+  // OR-routed default. But only when an OpenRouter key is actually configured:
+  // otherwise the run would fail at inference time, so refuse launch (the caller
+  // surfaces "no runnable model"). Mirrors the extension's `ensureRoutingConfigured`.
   if (getUseOpenRouter()) {
-    return SETUP_MODEL_BY_PROVIDER.openRouter;
+    if (isNonEmptyString(await lookupApiKey(secrets, 'openRouter'))) {
+      return SETUP_MODEL_BY_PROVIDER.openRouter;
+    }
+    return null;
   }
 
   if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
@@ -60,7 +68,6 @@ export async function resolveDesktopSetupModel(): Promise<string | null> {
     }
   }
 
-  const secrets = platform().secrets;
   for (const provider of API_PROVIDERS) {
     if (provider === 'openRouter') continue;
     const model = SETUP_MODEL_BY_PROVIDER[provider];
@@ -70,10 +77,12 @@ export async function resolveDesktopSetupModel(): Promise<string | null> {
     }
   }
 
-  if (isNonEmptyString(await lookupApiKey(secrets, 'openRouter'))) {
-    return SETUP_MODEL_BY_PROVIDER.openRouter;
-  }
-
+  // OpenRouter is only a valid pick when `useOpenRouter` routing is on (handled
+  // at the top). A bare OpenRouter key with the flag off can't be used: the
+  // desktop launch passes only a model string to `handleExecute` and never flips
+  // the routing flag, so an OR model would run unrouted and fail at inference.
+  // Refuse instead (the caller surfaces "no runnable model"); the user enables
+  // OpenRouter routing or adds a directly-usable key.
   return null;
 }
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -73,7 +73,9 @@ type RunExecutionRequest = (
     // This window's SessionHandle. The onboarding run-completion test drives a
     // terminal `result` event through it via `attachRunTrace`.
     session: {
-      attachRunTrace(trace: { subscribe(fn: (event: unknown) => void): unknown }): () => void;
+      attachRunTrace(trace: {
+        subscribe(fn: (event: unknown) => void): unknown;
+      }): () => void;
     };
   },
 ) => Promise<void>;

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -70,6 +70,11 @@ type RunExecutionRequest = (
       outcome: RunOutcome;
       outputs: Array<{ absolutePath: string }>;
     }): Promise<void>;
+    // This window's SessionHandle. The onboarding run-completion test drives a
+    // terminal `result` event through it via `attachRunTrace`.
+    session: {
+      attachRunTrace(trace: { subscribe(fn: (event: unknown) => void): unknown }): () => void;
+    };
   },
 ) => Promise<void>;
 
@@ -88,6 +93,7 @@ interface DesktopAgentExecutionModule {
       openBuildDisplay?(location: { absolutePath: string }): Promise<void>;
     };
     showErrorMessage?: (message: string) => Promise<void> | void;
+    onRunCompleted?: () => void;
   }): DesktopExecution;
 }
 
@@ -266,6 +272,7 @@ async function createExecution(options: {
   showErrorMessage?: (message: string) => Promise<void> | void;
   prepareMainViewExecutionRequest: (message: unknown) => unknown;
   runAgent?: RunExecutionRequest;
+  onRunCompleted?: () => void;
 }): Promise<DesktopExecution> {
   vi.resetModules();
   vi.doMock('@agent/runtime/ProgressViewBridge', () => ({
@@ -320,6 +327,7 @@ async function createExecution(options: {
     postToRenderer: options.postToRenderer ?? vi.fn(),
     opener: options.opener,
     showErrorMessage: options.showErrorMessage,
+    onRunCompleted: options.onRunCompleted,
   });
 }
 
@@ -1300,6 +1308,101 @@ describe('DesktopProgressBridge', () => {
     try {
       await execution.handleExecute({ command: 'execute' });
       expect(opener.openPath).toHaveBeenCalledWith('/tmp/result.pdf');
+    } finally {
+      execution.dispose();
+    }
+  });
+
+  // Minimal AgentTrace stand-in: the desktop bridge bridges a run's trace into
+  // the window session's onResult channel via `session.attachRunTrace`, which
+  // only needs `subscribe`. `emit` fans an event out to subscribers, matching
+  // how the real lifecycle publishes the terminal `result` event.
+  function makeFakeTrace(): {
+    subscribe(fn: (event: unknown) => void): () => void;
+    emit(event: unknown): void;
+  } {
+    const subscribers = new Set<(event: unknown) => void>();
+    return {
+      subscribe(fn) {
+        subscribers.add(fn);
+        return () => subscribers.delete(fn);
+      },
+      emit(event) {
+        for (const fn of subscribers) fn(event);
+      },
+    };
+  }
+
+  it('fires onRunCompleted when a run reaches a completed terminal result', async () => {
+    const onRunCompleted = vi.fn();
+    // The mock run bridges a trace into the window session's onResult channel
+    // (mirroring AgentLaunchContext.attachRunTrace) and emits a completed
+    // result — exactly what the lifecycle does after persisting firstRunDone.
+    const runAgent = vi.fn(async (_request, options) => {
+      const trace = makeFakeTrace();
+      options.session.attachRunTrace(trace);
+      trace.emit({
+        type: 'result',
+        outcome: RUN_OUTCOME.COMPLETED,
+        executionId: 'exec-1',
+        streamId: 'stream-1',
+        agentName: 'proofreader',
+        category: 'workflow',
+        isSubagent: false,
+      });
+    });
+    const execution = await createExecution({
+      runAgent,
+      onRunCompleted,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    try {
+      await execution.handleExecute({ command: 'execute' });
+      expect(onRunCompleted).toHaveBeenCalledOnce();
+    } finally {
+      execution.dispose();
+    }
+  });
+
+  it('does not fire onRunCompleted on a failed terminal result', async () => {
+    const onRunCompleted = vi.fn();
+    const runAgent = vi.fn(async (_request, options) => {
+      const trace = makeFakeTrace();
+      options.session.attachRunTrace(trace);
+      trace.emit({
+        type: 'result',
+        outcome: RUN_OUTCOME.FAILED,
+        executionId: 'exec-2',
+        streamId: 'stream-2',
+        agentName: 'proofreader',
+        category: 'workflow',
+        isSubagent: false,
+      });
+    });
+    const execution = await createExecution({
+      runAgent,
+      onRunCompleted,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    try {
+      await execution.handleExecute({ command: 'execute' });
+      expect(onRunCompleted).not.toHaveBeenCalled();
     } finally {
       execution.dispose();
     }

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -71,12 +71,14 @@ interface DesktopOnboardingIpcModule {
         get<T>(key: string, defaultValue?: T): T;
         update(key: string, value: unknown): PromiseLike<void>;
       };
+      hasCredential?: () => boolean | Promise<boolean>;
       onAsyncError?: (error: unknown) => void;
     },
   ): {
     handleMessage(
       message: { command: string } & Record<string, unknown>,
     ): boolean;
+    refreshOnboardingFunnel(): Promise<void>;
   };
 }
 
@@ -427,9 +429,10 @@ describe('desktop IPC adapters', () => {
         view: 'main',
       }),
     ).toBe(false);
+    // Fresh install with no credential → State 0 (welcome card).
     expect(postToRenderer).toHaveBeenLastCalledWith({
       command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
-      state: 'done',
+      state: 'needs-credential',
     });
     postToRenderer.mockClear();
 

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -485,6 +485,180 @@ describe('desktop IPC adapters', () => {
     });
   });
 
+  it('derives State 1 (setup) when hasCredential is true on fresh install', async () => {
+    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
+    const values = new Map<string, unknown>();
+    const update = vi.fn(async (key: string, value: unknown) => {
+      values.set(key, value);
+    });
+    const state = {
+      get<T>(key: string, defaultValue?: T): T {
+        return (values.has(key) ? values.get(key) : defaultValue) as T;
+      },
+      update,
+    };
+    const postToRenderer = vi.fn();
+    const selectSetupAgent = vi.fn(async () => {});
+    const onboarding = createDesktopOnboardingIpc(
+      { postToRenderer },
+      {
+        state,
+        hasCredential: () => true,
+        selectSetupAgent,
+      },
+    );
+
+    expect(
+      onboarding.handleMessage({
+        command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'main',
+      }),
+    ).toBe(false);
+    await Promise.resolve();
+    // Credential present, firstRunDone not set → State 1 (setup card).
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
+      state: 'setup',
+    });
+    // selectSetupAgent callback fires on State 1 entry.
+    expect(selectSetupAgent).toHaveBeenCalled();
+  });
+
+  it('derives State 2 (done) for backfilled veterans with firstRunDone set', async () => {
+    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
+    const values = new Map<string, unknown>();
+    values.set(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE, true);
+    const update = vi.fn(async (key: string, value: unknown) => {
+      values.set(key, value);
+    });
+    const state = {
+      get<T>(key: string, defaultValue?: T): T {
+        return (values.has(key) ? values.get(key) : defaultValue) as T;
+      },
+      update,
+    };
+    const postToRenderer = vi.fn();
+    const onboarding = createDesktopOnboardingIpc(
+      { postToRenderer },
+      {
+        state,
+        hasCredential: () => true,
+      },
+    );
+
+    expect(
+      onboarding.handleMessage({
+        command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'main',
+      }),
+    ).toBe(false);
+    await Promise.resolve();
+    // Backfilled veteran → State 2 (done), no onboarding UI shown.
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
+      state: 'done',
+    });
+  });
+
+  it('handles ONBOARDING_SKIP_SETUP by setting firstRunDone and pushing done', async () => {
+    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
+    const values = new Map<string, unknown>();
+    const update = vi.fn(async (key: string, value: unknown) => {
+      values.set(key, value);
+    });
+    const state = {
+      get<T>(key: string, defaultValue?: T): T {
+        return (values.has(key) ? values.get(key) : defaultValue) as T;
+      },
+      update,
+    };
+    const postToRenderer = vi.fn();
+    const onboarding = createDesktopOnboardingIpc(
+      { postToRenderer },
+      {
+        state,
+        hasCredential: () => true,
+      },
+    );
+
+    // Enter State 1 first.
+    onboarding.handleMessage({
+      command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
+      view: 'main',
+    });
+    await Promise.resolve();
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
+      state: 'setup',
+    });
+    postToRenderer.mockClear();
+    update.mockClear();
+
+    // Skip setup → firstRunDone=true, funnel → 'done'.
+    expect(
+      onboarding.handleMessage({
+        command: MAIN_VIEW_COMMANDS.ONBOARDING_SKIP_SETUP,
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(update).toHaveBeenCalledWith(
+      GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
+      true,
+    );
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
+      state: 'done',
+    });
+  });
+
+  it('calls onboarding run-setup / sign-in-chatgpt callbacks', async () => {
+    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
+    const values = new Map<string, unknown>();
+    const update = vi.fn(async (key: string, value: unknown) => {
+      values.set(key, value);
+    });
+    const state = {
+      get<T>(key: string, defaultValue?: T): T {
+        return (values.has(key) ? values.get(key) : defaultValue) as T;
+      },
+      update,
+    };
+    const postToRenderer = vi.fn();
+    const runSetupCalled = vi.fn(async () => {});
+    const signInCalled = vi.fn(async () => {});
+    const onboarding = createDesktopOnboardingIpc(
+      { postToRenderer },
+      {
+        state,
+        hasCredential: () => true,
+        selectSetupAgent: runSetupCalled, // reused for run_setup path
+        kickoffSetup: runSetupCalled,
+        signInWithChatGpt: signInCalled,
+      },
+    );
+
+    // ONBOARDING_RUN_SETUP calls selectSetupAgent + kickoffSetup + refresh.
+    expect(
+      onboarding.handleMessage({
+        command: MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP,
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(runSetupCalled).toHaveBeenCalledTimes(2); // selectSetupAgent + kickoffSetup
+
+    // ONBOARDING_SIGN_IN_CHATGPT calls signInCallback + refresh.
+    expect(
+      onboarding.handleMessage({
+        command: MAIN_VIEW_COMMANDS.ONBOARDING_SIGN_IN_CHATGPT,
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(signInCalled).toHaveBeenCalled();
+  });
+
   it('serves desktop log snapshots and copy/export actions', async () => {
     const { createDesktopLogIpc } = await loadDesktopLogIpc();
     const postToRenderer = vi.fn();

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -100,12 +100,17 @@ interface DesktopViewStateIpcModule {
   };
 }
 
-// The WEBVIEW_READY handler triggers refreshOnboardingFunnel as a
-// fire-and-forget task. When `hasCredential` is supplied it adds an extra
-// awaited `Promise.resolve(...).catch(...)` hop before the funnel state is
-// posted, so a single microtask flush isn't enough — drain a few.
+// The WEBVIEW_READY / run-setup handlers trigger refreshOnboardingFunnel as a
+// fire-and-forget task whose chain (readyGate → credential probe →
+// selectSetupAgent → guarded kickoffSetup → re-derive) is several awaits deep.
+// Drain via macrotask boundaries rather than counting microtask hops: each
+// setTimeout(0) lets the entire pending microtask queue — and any
+// setTimeout(0)-scheduled credential probe — settle, so this stays correct if
+// the chain depth changes.
 async function flushAsync(): Promise<void> {
-  for (let i = 0; i < 5; i++) await Promise.resolve();
+  for (let i = 0; i < 3; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
 }
 
 async function loadDesktopShellIpc(): Promise<DesktopShellIpcModule> {
@@ -654,15 +659,18 @@ describe('desktop IPC adapters', () => {
       },
     );
 
-    // ONBOARDING_RUN_SETUP calls selectSetupAgent + kickoffSetup + refresh.
+    // ONBOARDING_RUN_SETUP: runSetup selects the setup agent (1) and kicks off
+    // the conversation through the guarded path (1), then the follow-up refresh
+    // re-enters State 1 and selects the setup agent again (1). The shared mock
+    // therefore lands at 3 once the chain fully drains; the guard keeps kickoff
+    // to exactly one call.
     expect(
       onboarding.handleMessage({
         command: MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP,
       }),
     ).toBe(true);
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(runSetupCalled).toHaveBeenCalledTimes(2); // selectSetupAgent + kickoffSetup
+    await flushAsync();
+    expect(runSetupCalled).toHaveBeenCalledTimes(3);
 
     // ONBOARDING_SIGN_IN_CHATGPT calls signInCallback + refresh.
     expect(
@@ -670,8 +678,7 @@ describe('desktop IPC adapters', () => {
         command: MAIN_VIEW_COMMANDS.ONBOARDING_SIGN_IN_CHATGPT,
       }),
     ).toBe(true);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
     expect(signInCalled).toHaveBeenCalled();
   });
 

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -72,9 +72,11 @@ interface DesktopOnboardingIpcModule {
         update(key: string, value: unknown): PromiseLike<void>;
       };
       hasCredential?: () => boolean | Promise<boolean>;
+      readyGate?: Promise<void>;
       selectSetupAgent?: () => Promise<void>;
       kickoffSetup?: () => Promise<void>;
       signInWithChatGpt?: () => Promise<void>;
+      openGettingStarted?: () => Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
   ): {
@@ -440,6 +442,9 @@ describe('desktop IPC adapters', () => {
         view: 'main',
       }),
     ).toBe(false);
+    // The refresh is serialized through a promise chain (concurrency guard), so
+    // drain microtasks before asserting the pushed state.
+    await flushAsync();
     // Fresh install with no credential → State 0 (welcome card).
     expect(postToRenderer).toHaveBeenLastCalledWith({
       command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
@@ -484,8 +489,9 @@ describe('desktop IPC adapters', () => {
     expect(
       onboarding.handleMessage({ command: MAIN_VIEW_COMMANDS.ONBOARDING_SKIP }),
     ).toBe(true);
-    await Promise.resolve();
-    await Promise.resolve();
+    // The skip persists the declined flag then refreshes through the serialized
+    // chain, so drain microtasks before asserting.
+    await flushAsync();
     expect(update).toHaveBeenLastCalledWith(
       GlobalStateKey.ONBOARDING_DECLINED,
       true,
@@ -667,6 +673,192 @@ describe('desktop IPC adapters', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(signInCalled).toHaveBeenCalled();
+  });
+
+  it('runs the real kickoff path on ONBOARDING_RUN_SETUP and refreshes after', async () => {
+    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
+    const values = new Map<string, unknown>();
+    const update = vi.fn(async (key: string, value: unknown) => {
+      values.set(key, value);
+    });
+    const state = {
+      get<T>(key: string, defaultValue?: T): T {
+        return (values.has(key) ? values.get(key) : defaultValue) as T;
+      },
+      update,
+    };
+    const postToRenderer = vi.fn();
+    const callOrder: string[] = [];
+    const selectSetupAgent = vi.fn(async () => {
+      callOrder.push('select');
+    });
+    const kickoffSetup = vi.fn(async () => {
+      callOrder.push('kickoff');
+    });
+    const onboarding = createDesktopOnboardingIpc(
+      { postToRenderer },
+      {
+        state,
+        hasCredential: () => true,
+        selectSetupAgent,
+        kickoffSetup,
+      },
+    );
+
+    expect(
+      onboarding.handleMessage({
+        command: MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP,
+      }),
+    ).toBe(true);
+    await flushAsync();
+
+    // Real run-setup path: `runSetup` selects the setup agent and kicks off the
+    // conversation, then recomputes the funnel. The follow-up refresh enters
+    // State 1 (credential present) so it also selects the setup agent — hence
+    // `select` fires twice, framing `kickoff`. The terminal state is 'setup'.
+    expect(kickoffSetup).toHaveBeenCalledOnce();
+    expect(selectSetupAgent).toHaveBeenCalledTimes(2);
+    expect(callOrder).toEqual(['select', 'kickoff', 'select']);
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
+      state: 'setup',
+    });
+  });
+
+  it('opens the getting-started docs on ONBOARDING_OPEN_GETTING_STARTED', async () => {
+    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
+    const values = new Map<string, unknown>();
+    const state = {
+      get<T>(key: string, defaultValue?: T): T {
+        return (values.has(key) ? values.get(key) : defaultValue) as T;
+      },
+      update: vi.fn(async (key: string, value: unknown) => {
+        values.set(key, value);
+      }),
+    };
+    const postToRenderer = vi.fn();
+    const openGettingStarted = vi.fn(async () => {});
+    const onboarding = createDesktopOnboardingIpc(
+      { postToRenderer },
+      { state, openGettingStarted },
+    );
+
+    expect(
+      onboarding.handleMessage({
+        command: MAIN_VIEW_COMMANDS.ONBOARDING_OPEN_GETTING_STARTED,
+      }),
+    ).toBe(true);
+    await flushAsync();
+    expect(openGettingStarted).toHaveBeenCalledOnce();
+    // Opening the walkthrough does not push a funnel state (no derivation
+    // change), so no SET_ONBOARDING_FUNNEL is sent for this command.
+    expect(postToRenderer).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
+      }),
+    );
+  });
+
+  it('serializes overlapping funnel refreshes to one consistent terminal state', async () => {
+    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
+    const values = new Map<string, unknown>();
+    const state = {
+      get<T>(key: string, defaultValue?: T): T {
+        return (values.has(key) ? values.get(key) : defaultValue) as T;
+      },
+      update: vi.fn(async (key: string, value: unknown) => {
+        values.set(key, value);
+      }),
+    };
+    const postToRenderer = vi.fn();
+    // A credential probe that resolves on the next macrotask, so two refreshes
+    // started back-to-back genuinely overlap in flight. `selectSetupAgent`
+    // would only fire when `previous !== 'setup'`; if the two refreshes
+    // interleaved and both computed against `previous === undefined`, it would
+    // be called twice. Serialized, the second refresh sees `previous === 'setup'`
+    // and does not re-select.
+    let credentialPresent = false;
+    const hasCredential = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          setTimeout(() => resolve(credentialPresent), 0);
+        }),
+    );
+    const selectSetupAgent = vi.fn(async () => {});
+    const onboarding = createDesktopOnboardingIpc(
+      { postToRenderer },
+      { state, hasCredential, selectSetupAgent },
+    );
+
+    // First refresh: no credential yet → needs-credential. Second refresh: a
+    // credential lands → setup. Fire them overlapping (no await between).
+    const first = onboarding.refreshOnboardingFunnel();
+    credentialPresent = true;
+    const second = onboarding.refreshOnboardingFunnel();
+    await Promise.all([first, second]);
+    await flushAsync();
+
+    const funnelStates = postToRenderer.mock.calls
+      .map(([message]) => message as { command: string; state?: string })
+      .filter(
+        (message) =>
+          message.command === MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
+      )
+      .map((message) => message.state);
+
+    // The terminal state is consistent (setup), and the State 0→1 transition
+    // selected the setup agent exactly once — proof the refreshes did not
+    // interleave and clobber `previousFunnelState`.
+    expect(funnelStates.at(-1)).toBe('setup');
+    expect(selectSetupAgent).toHaveBeenCalledOnce();
+  });
+
+  it('defers the first funnel derivation until the readyGate resolves', async () => {
+    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
+    const values = new Map<string, unknown>();
+    const state = {
+      get<T>(key: string, defaultValue?: T): T {
+        return (values.has(key) ? values.get(key) : defaultValue) as T;
+      },
+      update: vi.fn(async (key: string, value: unknown) => {
+        values.set(key, value);
+      }),
+    };
+    const postToRenderer = vi.fn();
+    let openGate: () => void = () => {};
+    const readyGate = new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
+    // A returning veteran: credential present but firstRunDone not yet written.
+    // Before the backfill settles this derives 'setup'; the gate must hold the
+    // first derivation so the renderer never sees the transient State 1.
+    const selectSetupAgent = vi.fn(async () => {});
+    const onboarding = createDesktopOnboardingIpc(
+      { postToRenderer },
+      { state, readyGate, hasCredential: () => true, selectSetupAgent },
+    );
+
+    expect(
+      onboarding.handleMessage({
+        command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'main',
+      }),
+    ).toBe(false);
+    await flushAsync();
+    // Gate still closed → no funnel pushed, no setup-agent selection yet.
+    expect(postToRenderer).not.toHaveBeenCalled();
+    expect(selectSetupAgent).not.toHaveBeenCalled();
+
+    // Backfill marks the veteran done, then opens the gate.
+    values.set(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE, true);
+    openGate();
+    await flushAsync();
+
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
+      state: 'done',
+    });
+    expect(selectSetupAgent).not.toHaveBeenCalled();
   });
 
   it('serves desktop log snapshots and copy/export actions', async () => {

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -72,6 +72,9 @@ interface DesktopOnboardingIpcModule {
         update(key: string, value: unknown): PromiseLike<void>;
       };
       hasCredential?: () => boolean | Promise<boolean>;
+      selectSetupAgent?: () => Promise<void>;
+      kickoffSetup?: () => Promise<void>;
+      signInWithChatGpt?: () => Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
   ): {
@@ -93,6 +96,14 @@ interface DesktopViewStateIpcModule {
     handleMessage(message: { command: string }): boolean;
     dispose(): void;
   };
+}
+
+// The WEBVIEW_READY handler triggers refreshOnboardingFunnel as a
+// fire-and-forget task. When `hasCredential` is supplied it adds an extra
+// awaited `Promise.resolve(...).catch(...)` hop before the funnel state is
+// posted, so a single microtask flush isn't enough — drain a few.
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
 }
 
 async function loadDesktopShellIpc(): Promise<DesktopShellIpcModule> {
@@ -514,7 +525,7 @@ describe('desktop IPC adapters', () => {
         view: 'main',
       }),
     ).toBe(false);
-    await Promise.resolve();
+    await flushAsync();
     // Credential present, firstRunDone not set → State 1 (setup card).
     expect(postToRenderer).toHaveBeenLastCalledWith({
       command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
@@ -552,7 +563,7 @@ describe('desktop IPC adapters', () => {
         view: 'main',
       }),
     ).toBe(false);
-    await Promise.resolve();
+    await flushAsync();
     // Backfilled veteran → State 2 (done), no onboarding UI shown.
     expect(postToRenderer).toHaveBeenLastCalledWith({
       command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
@@ -586,7 +597,7 @@ describe('desktop IPC adapters', () => {
       command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
       view: 'main',
     });
-    await Promise.resolve();
+    await flushAsync();
     expect(postToRenderer).toHaveBeenLastCalledWith({
       command: MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL,
       state: 'setup',
@@ -600,8 +611,7 @@ describe('desktop IPC adapters', () => {
         command: MAIN_VIEW_COMMANDS.ONBOARDING_SKIP_SETUP,
       }),
     ).toBe(true);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
     expect(update).toHaveBeenCalledWith(
       GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
       true,


### PR DESCRIPTION
## Summary

The desktop main process hardcoded the onboarding funnel state to `'done'`, permanently hiding the State 0/1 welcome card. This derives the real state like the extension does.

- `packages/desktop/src/main/desktopOnboardingIpc.ts`: replace the hardcoded `'done'` push with `refreshOnboardingFunnel()` deriving state via `planOnboardingFunnelTransition` + `readOnboardingFlags` (`src/controllers/onboarding/onboardingFunnel.ts`), mirroring `MainViewProvider.refreshOnboardingFunnel`.
- Add a `hasCredential` callback to `DesktopOnboardingIpcOptions`, wired in `packages/desktop/src/main/index.ts` (relay sign-in OR any provider API key).
- Refresh on `WEBVIEW_READY` and on credential changes.
- `DesktopIpcAdapters.vitest.mts`: a fresh no-credential install now expects `'needs-credential'` instead of `'done'`.

Closes #5840.

## Test plan
- [ ] `npm run typecheck`
- [ ] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbqDpJ9JY8vWw55PrZ83Pk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-run UX, credential detection, and auto-launched setup runs across auth/settings/desktop IPC; race handling is explicit but behavior is user-visible on every launch.
> 
> **Overview**
> Replaces the desktop main process always pushing onboarding funnel **`done`** with the shared **`planOnboardingFunnelTransition`** / **`readOnboardingFlags`** flow, so the main view can show **needs-credential**, **setup**, or **done** like the VS Code host.
> 
> **`desktopOnboardingIpc`** recomputes and pushes **`SET_ONBOARDING_FUNNEL`** on **`WEBVIEW_READY`**, wires welcome/setup actions (skip, run setup, ChatGPT sign-in, getting-started docs), serializes overlapping refreshes, and guards setup auto-kickoff so it cannot run twice. **`index.ts`** supplies **`hasCredential`** (Codex subscription, relay + included keys, or any provider key), a **`readyGate`** until one-shot **`backfillFirstRunDone`** finishes, setup agent selection + **`buildDesktopSetupExecuteMessage`** kickoff, and refreshes after auth/API-key changes and when a run completes (**`onRunCompleted`** on the agent execution bridge).
> 
> Adds **`setupLaunch.ts`** for prompt-free setup model resolution and execute message building. **`hasPriorInstall`** is captured before **`LAST_KNOWN_VERSION`** is written so upgrade backfill does not misclassify fresh installs. Welcome-card ChatGPT sign-in can enable subscription routing via **`signInChatGpt({ enableSubscription: true })`**. Tests updated for derived states, run-completion hook, and IPC behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3362f407a6749e9505e3c57848ddbec37086df26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->