### PR TITLE
fix: replace currentSession() ambient lookups with injected dependencies

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -12,8 +12,12 @@ import type {
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import type { AgentRunStateSnapshot } from '@agent/core/execution/AgentState';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type {
+  RetryRequestOptions,
+  RetryResult,
+} from '@agent/runtime/RetryRequestCoordinator';
 import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import type { ActiveChildInfo, ExecutionId, StreamTabId } from '@shared/schemas';
 
 /** Callback invoked when a round/cycle completes for usage tracking. */
 export type RoundFinalizedCallback = (
@@ -50,6 +54,16 @@ export interface AgentCore<C = unknown> {
   approvalPromptsUnavailable?: boolean;
   /** Tools unavailable because the current host/runtime cannot support them. */
   runtimeUnavailableTools?: readonly string[];
+  /** Get active subagent and process children for a parent stream. */
+  getActiveChildren: (parentStreamId: StreamTabId) => {
+    subagents: ActiveChildInfo[];
+    processes: ActiveChildInfo[];
+  };
+  /** Wait for user decision on a retry prompt (resolve-side bridge to run coordinators). */
+  waitForRetry: (
+    streamId: StreamTabId,
+    options: RetryRequestOptions,
+  ) => Promise<RetryResult>;
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {

--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -17,7 +17,11 @@ import type {
   RetryResult,
 } from '@agent/runtime/RetryRequestCoordinator';
 import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
-import type { ActiveChildInfo, ExecutionId, StreamTabId } from '@shared/schemas';
+import type {
+  ActiveChildInfo,
+  ExecutionId,
+  StreamTabId,
+} from '@shared/schemas';
 
 /** Callback invoked when a round/cycle completes for usage tracking. */
 export type RoundFinalizedCallback = (

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -12,7 +12,6 @@ import {
 } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
-import { currentSession } from '@agent/runtime/SessionHandle';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {
   maybeSaveDebugObject,
@@ -127,8 +126,9 @@ export async function saveCycleDebug(
 export function defaultPostCompactionContext(
   services: CycleServices,
 ): string | null {
-  const { subagents, processes } =
-    currentSession().executions.getActiveChildren(services.streamId);
+  const { subagents, processes } = services.getActiveChildren(
+    services.streamId,
+  );
   return formatPostCompactionContext(
     subagents,
     processes,

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -5,8 +5,10 @@ import { StatusCodes } from 'http-status-codes';
 import { Node, type NonIterableObject } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { type RetryResult } from '@agent/runtime/RetryRequestCoordinator';
-import { currentSession } from '@agent/runtime/SessionHandle';
+import {
+  type RetryResult,
+  type RetryRequestOptions,
+} from '@agent/runtime/RetryRequestCoordinator';
 import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
@@ -54,6 +56,10 @@ interface RetryableNodeServices {
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
   refreshClient?: () => Promise<void>;
+  waitForRetry: (
+    streamId: string,
+    options: RetryRequestOptions,
+  ) => Promise<RetryResult>;
 }
 
 /**
@@ -276,13 +282,12 @@ export abstract class RetryableInvocationNode<
     streamStatus.set(streamId, STREAM_STATUS.WAITING, {
       runtimeHost,
     });
-    const result: RetryResult =
-      await currentSession().coordinators.waitForRetry(streamId, {
-        operation: operationName,
-        errorMessage: formatted.message,
-        logger,
-        errorDetails: formatted,
-      });
+    const result: RetryResult = await this.services.waitForRetry(streamId, {
+      operation: operationName,
+      errorMessage: formatted.message,
+      logger,
+      errorDetails: formatted,
+    });
 
     if (result.action === 'retry') {
       logger.debug('Manual retry triggered');

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -375,6 +375,10 @@ async function assembleAgentLaunchContext(
     },
     session,
     disposeTrace: runTrace.dispose,
+    getActiveChildren: (parentStreamId) =>
+      session.executions.getActiveChildren(parentStreamId),
+    waitForRetry: (streamId, options) =>
+      session.coordinators.waitForRetry(streamId, options),
   };
 }
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -137,6 +137,8 @@ function createLifecycleContext({
       proposal: new AgentProposalCoordinator(explicit.host),
       retry: new RetryRequestCoordinatorImpl(explicit.host),
     },
+    getActiveChildren: () => ({ subagents: [], processes: [] }),
+    waitForRetry: vi.fn(),
   };
 }
 

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { noopTrace, type AgentTrace } from '@agent/trace';
 import type { NonIterableObject } from '@agent/node';
 import { RetryableInvocationNode } from '@agent/core/flows/RetryState';
+import type { RetryResult } from '@agent/runtime/RetryRequestCoordinator';
 import {
   StreamStatusRegistry,
   StreamStatusService,
@@ -15,22 +16,16 @@ import {
 } from '@agent/runtime/AgentRuntimeHost';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
-const coordinatorMocks = vi.hoisted(() => ({
-  waitForRetry: vi.fn(),
-}));
-
-vi.mock('@agent/runtime/runCoordinators', () => ({
-  runCoordinatorBridge: {
-    waitForRetry: coordinatorMocks.waitForRetry,
-  },
-}));
-
 interface TestRetryServices {
   streamId: StreamTabId;
   runtimeHost: AgentRuntimeHost;
   streamStatus: StreamStatusRegistry;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
+  waitForRetry: (
+    streamId: string,
+    options: { operation: string; errorMessage?: string; logger: AgentTrace },
+  ) => Promise<RetryResult>;
 }
 
 class ExposedRetryNode extends RetryableInvocationNode<
@@ -63,15 +58,17 @@ describe('RetryState', () => {
   it('updates the injected stream status owner during manual retry', async () => {
     const streamId = 'retry-state-owner' as StreamTabId;
     const streamStatus = new StreamStatusRegistry();
+    const waitForRetry = vi.fn<() => Promise<RetryResult>>();
     const node = new ExposedRetryNode().setServices({
       streamId,
       runtimeHost: noopAgentRuntimeHost,
       streamStatus,
       logger: noopTrace,
       setAbortController: vi.fn(),
+      waitForRetry,
     });
 
-    coordinatorMocks.waitForRetry.mockResolvedValueOnce({ action: 'retry' });
+    waitForRetry.mockResolvedValueOnce({ action: 'retry' });
 
     try {
       streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
@@ -83,7 +80,7 @@ describe('RetryState', () => {
 
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
       expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
-      expect(coordinatorMocks.waitForRetry).toHaveBeenCalledWith(
+      expect(waitForRetry).toHaveBeenCalledWith(
         streamId,
         expect.objectContaining({
           operation: 'Tool-use call',
@@ -92,7 +89,6 @@ describe('RetryState', () => {
     } finally {
       streamStatus.clear(streamId, { emit: false });
       StreamStatusService.clear(streamId, { emit: false });
-      coordinatorMocks.waitForRetry.mockReset();
     }
   });
 
@@ -101,15 +97,17 @@ describe('RetryState', () => {
     async (action) => {
       const streamId = `retry-state-${action}` as StreamTabId;
       const streamStatus = new StreamStatusRegistry();
+      const waitForRetry = vi.fn<() => Promise<RetryResult>>();
       const node = new ExposedRetryNode().setServices({
         streamId,
         runtimeHost: noopAgentRuntimeHost,
         streamStatus,
         logger: noopTrace,
         setAbortController: vi.fn(),
+        waitForRetry,
       });
 
-      coordinatorMocks.waitForRetry.mockResolvedValueOnce({ action });
+      waitForRetry.mockResolvedValueOnce({ action });
 
       try {
         streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
@@ -119,7 +117,6 @@ describe('RetryState', () => {
         expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
       } finally {
         streamStatus.clear(streamId, { emit: false });
-        coordinatorMocks.waitForRetry.mockReset();
       }
     },
   );

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -58,7 +58,7 @@ describe('RetryState', () => {
   it('updates the injected stream status owner during manual retry', async () => {
     const streamId = 'retry-state-owner' as StreamTabId;
     const streamStatus = new StreamStatusRegistry();
-    const waitForRetry = vi.fn<() => Promise<RetryResult>>();
+    const waitForRetry = vi.fn<TestRetryServices['waitForRetry']>();
     const node = new ExposedRetryNode().setServices({
       streamId,
       runtimeHost: noopAgentRuntimeHost,
@@ -97,7 +97,7 @@ describe('RetryState', () => {
     async (action) => {
       const streamId = `retry-state-${action}` as StreamTabId;
       const streamStatus = new StreamStatusRegistry();
-      const waitForRetry = vi.fn<() => Promise<RetryResult>>();
+      const waitForRetry = vi.fn<TestRetryServices['waitForRetry']>();
       const node = new ExposedRetryNode().setServices({
         streamId,
         runtimeHost: noopAgentRuntimeHost,

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -121,6 +121,8 @@ function createLifecycleContext(
       retry: new RetryRequestCoordinatorImpl(explicit.host),
     },
     session,
+    getActiveChildren: () => ({ subagents: [], processes: [] }),
+    waitForRetry: vi.fn(),
   };
 }
 

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -106,6 +106,8 @@ function createCtx(overrides?: { logger?: TraceEmitter }): {
       proposal: new AgentProposalCoordinator(explicit.host),
       retry: new RetryRequestCoordinatorImpl(explicit.host),
     },
+    getActiveChildren: () => ({ subagents: [], processes: [] }),
+    waitForRetry: vi.fn(),
   };
   return { ctx, streamStatus };
 }

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -209,6 +209,8 @@ describe('BashTool', () => {
       executionId: 'test-execution-id',
       run,
       workspace: workspaceState,
+      getActiveChildren: () => ({ subagents: [], processes: [] }),
+      waitForRetry: vi.fn(),
     };
 
     const messages: ProviderMessage[] = [];
@@ -335,6 +337,8 @@ describe('BashTool', () => {
       executionId: 'test-execution-id',
       run,
       workspace: workspaceState,
+      getActiveChildren: () => ({ subagents: [], processes: [] }),
+      waitForRetry: vi.fn(),
     };
 
     const call = {


### PR DESCRIPTION
Closes #6498.

Remove the value-import of `currentSession` from `@agent/runtime/SessionHandle` in `CommonCycleTypes.ts` and `RetryState.ts`, which violated the inward-dependency rule documented in `src/agent/core/README.md`.

Add `getActiveChildren` and `waitForRetry` as injected dependencies on the `AgentCore` interface in `BaseFlowServices.ts`, following the existing `runtimeHost`/`streamStatus` injection pattern. Wire the real values from the run's session at the `AgentLaunchContext` construction site, preserving per-run isolation.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches manual retry and post-compaction context, which are user-visible run behaviors, but wiring is explicit at launch and tests were updated to match injection.
> 
> **Overview**
> **Agent core** no longer calls `currentSession()` for post-compaction child context or manual retry prompts. Those paths now use **`getActiveChildren`** and **`waitForRetry`** on `AgentCore`, wired at **`AgentLaunchContext`** from the run’s `SessionHandle` so behavior stays per-run isolated.
> 
> **`RetryableInvocationNode`** takes `waitForRetry` via services instead of a global coordinator bridge; **`RetryState.vitest`** drops the `runCoordinators` mock and injects `vi.fn()` like other lifecycle/tool tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519227395107800c5c6a3ed3b4c550b04ebe4279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->