### PR TITLE
docs: add PRDs for GitHub Copilot model handler (vscode.lm and OAuth routes)

### DIFF
--- a/docs/proposals/copilot-oauth-handler-prd.md
+++ b/docs/proposals/copilot-oauth-handler-prd.md
@@ -114,9 +114,10 @@ Mirrors the Codex proposal almost 1:1; the GitHub flow is actually _simpler_
 
 ### 1. Provider id
 
-A distinct OAuth-credentialed provider. **Do not** add it to
-`API_KEY_PROVIDER_IDS` in `src/model/apiProviders.ts` (that wires an api-key
-field + `<PROVIDER>_API_KEY` env fallback). Model the credential as an OAuth
+A distinct OAuth-credentialed provider. **Do not** add it to `API_PROVIDERS` in
+`src/model/apiProviders.ts` (which aliases `API_KEY_PROVIDER_IDS` from
+`@shared/constants/apiKeyProviders`) — membership there wires an api-key field +
+`<PROVIDER>_API_KEY` env fallback. Model the credential as an OAuth
 token bundle with its own lookup + "Signed in as <login>" status, exactly as the
 Codex proposal specifies for its non-api-key origin.
 

--- a/docs/proposals/copilot-oauth-handler-prd.md
+++ b/docs/proposals/copilot-oauth-handler-prd.md
@@ -52,16 +52,27 @@ Same pre-reserved, inert slot the official route would also use:
 > at a time. If both ship, they need distinct ids (e.g. `copilot` for OAuth vs
 > `copilot-vscode` for the host route), decided at design time.
 
+## Capability comparison against `vscode.lm`
+
+| Capability      | OAuth backend route                                      | `vscode.lm` route                                      |
+| --------------- | -------------------------------------------------------- | ------------------------------------------------------ |
+| Hosts           | Extension, CLI, desktop                                  | VS Code extension host only                            |
+| API shape       | OpenAI Chat Completions-compatible backend               | VS Code Language Model API                             |
+| System guidance | Native OpenAI-style system/developer messages expected   | Folded into user messages; no stable system role       |
+| Image/PDF input | Potentially available later via Copilot vision headers   | Not available in stable `vscode.lm@1.105`              |
+| Usage reporting | Backend may expose OpenAI-style token usage              | No returned usage; only `countTokens()` estimates      |
+| Policy posture  | Reverse-engineered and parked behind maintainer go/no-go | Official API, still rate-limited for agentic workloads |
+
 ## Prior art (verified against source, not blog posts)
 
-|                 | ericc-ch/copilot-api                           | LiteLLM `github_copilot`           | CopilotChat.nvim | Zed                                       |
-| --------------- | ---------------------------------------------- | ---------------------------------- | ---------------- | ----------------------------------------- |
-| OAuth client id | `Iv1.b507a08c87ecfe98`                         | `Iv1.b507a08c87ecfe98` (identical) | (LSP-delegated)  | (LSP-delegated)                           |
-| Device-code URL | `github.com/login/device/code`                 | same                               | via official LSP | via official LSP                          |
-| Token exchange  | `GET api.github.com/copilot_internal/v2/token` | same                               | same             | same                                      |
-| Chat endpoint   | `api.githubcopilot.com/chat/completions`       | same                               | same             | `api.githubcopilot.com/chat/completions`  |
-| Models endpoint | `…/models`                                     | `…/models`                         | `…/models`       | `api.individual.githubcopilot.com/models` |
-| Scope           | `read:user`                                    | `read:user`                        | —                | —                                         |
+|                 | ericc-ch/copilot-api                                   | LiteLLM `github_copilot`           | CopilotChat.nvim | Zed                                               |
+| --------------- | ------------------------------------------------------ | ---------------------------------- | ---------------- | ------------------------------------------------- |
+| OAuth client id | `Iv1.b507a08c87ecfe98`                                 | `Iv1.b507a08c87ecfe98` (identical) | (LSP-delegated)  | (LSP-delegated)                                   |
+| Device-code URL | `https://github.com/login/device/code`                 | same                               | via official LSP | via official LSP                                  |
+| Token exchange  | `GET https://api.github.com/copilot_internal/v2/token` | same                               | same             | same                                              |
+| Chat endpoint   | `https://api.githubcopilot.com/chat/completions`       | same                               | same             | `https://api.githubcopilot.com/chat/completions`  |
+| Models endpoint | `…/models`                                             | `…/models`                         | `…/models`       | `https://api.individual.githubcopilot.com/models` |
+| Scope           | `read:user`                                            | `read:user`                        | —                | —                                                 |
 
 **The two-step token flow:** device flow → GitHub OAuth token (`gho_`/`ghu_`) →
 `GET copilot_internal/v2/token` → short-lived Copilot session token
@@ -75,7 +86,7 @@ Same pre-reserved, inert slot the official route would also use:
 GitHubCopilotChat/<ver>`, `X-GitHub-Api-Version: <date>`, `X-Request-Id`, and
 conditionally `Copilot-Vision-Request: true`.
 
-`api.githubcopilot.com/chat/completions` is OpenAI-compatible: `POST
+`https://api.githubcopilot.com/chat/completions` is OpenAI-compatible: `POST
 /chat/completions`, `GET /models`, SSE streaming, and `tools` / `tool_calls`.
 
 Evidence: ericc-ch `src/lib/api-config.ts` (client id, headers, base),
@@ -125,10 +136,12 @@ Codex proposal specifies for its non-api-key origin.
 
 Port the Codex coordinator shape:
 
-- **Device flow:** `POST github.com/login/device/code` (client id
+- **Device flow:** `POST https://github.com/login/device/code` (client id
   `Iv1.b507a08c87ecfe98`, scope `read:user`) → display user code → poll
-  `github.com/login/oauth/access_token` → GitHub OAuth token.
-- **Copilot token exchange:** `GET api.github.com/copilot_internal/v2/token` →
+  `https://github.com/login/oauth/access_token` with
+  `grant_type=urn:ietf:params:oauth:grant-type:device_code` → GitHub OAuth
+  token.
+- **Copilot token exchange:** `GET https://api.github.com/copilot_internal/v2/token` →
   short-lived Copilot token; refresh within the `refresh_in`/expiry window.
 - **Account type:** detect individual vs business/enterprise to pick the right
   `api.*.githubcopilot.com` host.
@@ -143,8 +156,8 @@ Port the Codex coordinator shape:
 
 `ModelHandlerCopilot` subclassing the OpenAI handler (like `ModelHandlerDeepSeek`):
 
-- `getClient()` → `new OpenAI({ apiKey: copilotToken, baseURL:
-https://api.githubcopilot.com })`; recreate / use a token-getter on refresh.
+- `getClient()` → `new OpenAI({ apiKey: copilotToken, baseURL: 'https://api.githubcopilot.com' })`;
+  recreate / use a token-getter on refresh.
 - Inject the impersonation headers via `defaultHeaders` (or a `fetch` wrapper for
   per-request freshness): `Copilot-Integration-Id: vscode-chat`,
   `Editor-Version`, `Editor-Plugin-Version`, `User-Agent`, `X-GitHub-Api-Version`.

--- a/docs/proposals/copilot-oauth-handler-prd.md
+++ b/docs/proposals/copilot-oauth-handler-prd.md
@@ -1,0 +1,229 @@
+# PRD: GitHub Copilot model handler via OAuth (reverse-engineered API)
+
+**Status:** Proposal — **EXPERIMENTAL / PARKED** (pending an explicit ToS-risk
+decision by the maintainer)
+**Owner:** _unassigned_
+**Tracking branch:** `claude/vscode-copilot-handler-scout-ygc444`
+**Companion proposal:** [`copilot-vscode-lm-handler-prd.md`](./copilot-vscode-lm-handler-prd.md) (the official, VS Code-only route)
+**Closest existing precedent in this repo:** [`chatgpt-subscription-codex-auth.md`](./chatgpt-subscription-codex-auth.md) — structurally near-identical (borrowed client id, unofficial endpoint, OpenAI-shaped backend).
+
+> **⚠️ Parked.** This route is reverse-engineered and runs against GitHub's
+> Copilot Terms / Acceptable Use Policy, with **documented account-suspension
+> risk**. It is written up for completeness and because it is the only route that
+> works across **all three hosts** (extension + CLI + desktop), but it is **not
+> approved for implementation** until the maintainer decides to accept the ToS
+> risk. Do not start building from this PRD without that sign-off.
+
+## Summary
+
+Let a user sign in with their **own GitHub Copilot subscription** via GitHub's
+OAuth **device flow**, then route TeXRA agent requests to the **undocumented
+Copilot chat backend** (`https://api.githubcopilot.com/chat/completions`), which
+is **OpenAI-Chat-Completions-compatible**. Unlike the
+[`vscode.lm` route](./copilot-vscode-lm-handler-prd.md), this works in the CLI and
+desktop shell too, and slots directly into TeXRA's existing OpenAI-compatible
+handler family (the same pattern as DeepSeek/Kimi/MiniMax/GLM).
+
+It rides a **borrowed first-party client id** and editor-impersonation headers,
+so it can break without notice and **must never be presented as a GitHub-
+sanctioned integration** — exactly the framing already used for the Codex
+(ChatGPT-subscription) handler.
+
+## Motivation
+
+- The only way to reach the user's Copilot subscription **outside VS Code** —
+  preserves TeXRA's CLI/desktop parity (which `CLAUDE.md` treats as sacred),
+  which the official `vscode.lm` route cannot.
+- OpenAI-compatible → reuses the existing OpenAI handler machinery; the new work
+  is auth + endpoint + headers + model registry (same delta as Codex).
+- The `ModelProvider.COPILOT` slot is **already stubbed** (see Current state).
+
+## Current state (verified in repo)
+
+Same pre-reserved, inert slot the official route would also use:
+
+| File | Line | State |
+| ---- | ---- | ----- |
+| `src/agent/runtime/ModelFactory.ts` | 122 | `[ModelProvider.COPILOT]: { load: null, compatibilityKey: null }` |
+| `src/shared/constants/providers.ts` | 88 | display name `'Copilot'` |
+| `src/agent/modelHandlers/support/ProxyConfigResolver.ts` | 48 | `null` |
+
+> Note: only **one** of the two Copilot routes can own the `COPILOT` provider id
+> at a time. If both ship, they need distinct ids (e.g. `copilot` for OAuth vs
+> `copilot-vscode` for the host route), decided at design time.
+
+## Prior art (verified against source, not blog posts)
+
+| | ericc-ch/copilot-api | LiteLLM `github_copilot` | CopilotChat.nvim | Zed |
+| --- | --- | --- | --- | --- |
+| OAuth client id | `Iv1.b507a08c87ecfe98` | `Iv1.b507a08c87ecfe98` (identical) | (LSP-delegated) | (LSP-delegated) |
+| Device-code URL | `github.com/login/device/code` | same | via official LSP | via official LSP |
+| Token exchange | `GET api.github.com/copilot_internal/v2/token` | same | same | same |
+| Chat endpoint | `api.githubcopilot.com/chat/completions` | same | same | `api.githubcopilot.com/chat/completions` |
+| Models endpoint | `…/models` | `…/models` | `…/models` | `api.individual.githubcopilot.com/models` |
+| Scope | `read:user` | `read:user` | — | — |
+
+**The two-step token flow:** device flow → GitHub OAuth token (`gho_`/`ghu_`) →
+`GET copilot_internal/v2/token` → short-lived Copilot session token
+(`{ token, expires_at, refresh_in }`, auto-refreshed). Business/Enterprise use
+`api.business.` / `api.enterprise.` hosts and *require* the exchange step.
+
+**Required impersonation headers** (the backend gates on these — missing
+`Editor-Version` → hard `400 missing Editor-Version header for IDE auth`):
+`Authorization: Bearer <copilot_token>`, `Copilot-Integration-Id: vscode-chat`,
+`Editor-Version: vscode/<ver>`, `Editor-Plugin-Version`, `User-Agent:
+GitHubCopilotChat/<ver>`, `X-GitHub-Api-Version: <date>`, `X-Request-Id`, and
+conditionally `Copilot-Vision-Request: true`.
+
+`api.githubcopilot.com/chat/completions` is OpenAI-compatible: `POST
+/chat/completions`, `GET /models`, SSE streaming, and `tools` / `tool_calls`.
+
+Evidence: ericc-ch `src/lib/api-config.ts` (client id, headers, base),
+`src/services/github/get-copilot-token.ts` (exchange),
+`src/services/copilot/create-chat-completions.ts` (stream + tools + `X-Initiator`
+header); LiteLLM `litellm/llms/github_copilot/authenticator.py`; Zed
+`crates/copilot/src/copilot_chat.rs`.
+
+## Risk & policy (the reason this is parked)
+
+- **GitHub Copilot Extension Developer Policy** prohibits, verbatim, "Bypass or
+  circumvent protocols and access controls," "Use unpublished APIs," and "Attempt
+  to reverse engineer … the Platform." This route does all three.
+- **Usage-limits / AUP** enumerate scripted/automated use, proxy use, and
+  excessive activity as restricted; Copilot use is explicitly subject to the AUP.
+- **Real enforcement, quoted from GitHub notices:** abuse-detection warnings
+  ("use of Copilot via scripted interactions … could result in a temporary
+  suspension of your Copilot access") and account-disable notices ("We will not
+  be able to reinstate your Copilot access").
+- **Model parity is not guaranteed:** the public `…/models` set is a plan-gated,
+  server-side allowlist that lags the in-editor catalog (community reports of
+  GPT-5.x/Claude/Gemini missing from the API for some plans while present in
+  Chat).
+- **Header gating is the live breakage vector:** GitHub rejects requests lacking
+  IDE-identifying headers, so the integration must keep impersonating editor
+  versions/integration ids — a moving target.
+
+Framing contrast in the wild: ericc-ch/copilot-api warns explicitly about ban
+risk; aider's docs claim it's allowed. Neither is a GitHub guarantee. Treat as
+**reverse-engineering under tacit tolerance**, like the Codex handler.
+
+## Design (if/when unparked)
+
+Mirrors the Codex proposal almost 1:1; the GitHub flow is actually *simpler*
+(standard device flow, no PKCE/loopback strictly needed).
+
+### 1. Provider id
+
+A distinct OAuth-credentialed provider. **Do not** add it to
+`API_KEY_PROVIDER_IDS` in `src/model/apiProviders.ts` (that wires an api-key
+field + `<PROVIDER>_API_KEY` env fallback). Model the credential as an OAuth
+token bundle with its own lookup + "Signed in as <login>" status, exactly as the
+Codex proposal specifies for its non-api-key origin.
+
+### 2. Auth coordinator (`src/auth/copilot/`)
+
+Port the Codex coordinator shape:
+
+- **Device flow:** `POST github.com/login/device/code` (client id
+  `Iv1.b507a08c87ecfe98`, scope `read:user`) → display user code → poll
+  `github.com/login/oauth/access_token` → GitHub OAuth token.
+- **Copilot token exchange:** `GET api.github.com/copilot_internal/v2/token` →
+  short-lived Copilot token; refresh within the `refresh_in`/expiry window.
+- **Account type:** detect individual vs business/enterprise to pick the right
+  `api.*.githubcopilot.com` host.
+- **Storage:** persist the bundle via `platform().secrets` under a Copilot-
+  specific key **outside** the `apiKey.*` namespace (same isolation rule as
+  `CODEX_SESSION_SECRET_KEY`).
+- Keep **all** magic constants (client id, endpoints, header values, api-version
+  date) in one `copilotConstants.ts` so a GitHub change is a one-file edit, with
+  the same "unofficial / can be revoked" docblock as `codexConstants.ts`.
+
+### 3. Model handler
+
+`ModelHandlerCopilot` subclassing the OpenAI handler (like `ModelHandlerDeepSeek`):
+
+- `getClient()` → `new OpenAI({ apiKey: copilotToken, baseURL:
+  https://api.githubcopilot.com })`; recreate / use a token-getter on refresh.
+- Inject the impersonation headers via `defaultHeaders` (or a `fetch` wrapper for
+  per-request freshness): `Copilot-Integration-Id: vscode-chat`,
+  `Editor-Version`, `Editor-Plugin-Version`, `User-Agent`, `X-GitHub-Api-Version`.
+- Bearer comes from the auth coordinator, **not** `getApiKey()`.
+- Streaming + tool calls reuse the OpenAI handler paths unchanged.
+
+### 4. Model registry & pricing
+
+- v0: hardcode a curated, refreshable set; later add dynamic `GET /models`
+  discovery (the allowlist lags and is plan-dependent).
+- Cost is **subscription-included / premium-request metered**, not $/token —
+  surface as "included in your Copilot plan (rate-limited)"; handle 401/403
+  (model above tier, or abuse-block) with a clear, actionable error.
+
+### 5. Cross-host
+
+Works in extension, CLI, and desktop. Device flow is TTY/headless-friendly
+(matches `texra`'s existing `auth` command pattern from the Codex work).
+
+## ToS / framing (non-negotiable, if unparked)
+
+- **Opt-in only**, off by default, behind an experimental flag, labeled clearly:
+  "use your **own** Copilot subscription, personal use, unofficial, may break,
+  may trigger GitHub abuse detection."
+- Use the user's own signed-in session only — never share/relay tokens.
+- Document the suspension risk in-product before first use (a one-time
+  acknowledgement), mirroring the honesty bar set by the Codex feature.
+- Tokens in the OS keychain via `platform().secrets`; never logged or synced.
+
+## Scope (if unparked)
+
+**In (v0):** device-flow login + two-step token exchange + refresh; OAuth-
+credentialed provider id; OpenAI-handler subclass with impersonation headers;
+curated model registry; Settings + CLI sign-in; experimental flag + risk
+acknowledgement; docs.
+
+**Out (v0):** dynamic `/models` discovery; Business/Enterprise SSO edge cases;
+image/vision (`Copilot-Vision-Request`) until base flow proven; any
+shared/server/multi-account deployment (an explicit AUP violation).
+
+## Open questions
+
+1. **Go/no-go on the ToS risk** — the gating decision; everything below is moot
+   until resolved.
+2. Provider id coexistence with the official route (`copilot` vs
+   `copilot-vscode`).
+3. Whether to borrow `Iv1.b507a08c87ecfe98` (works today, fragile) — isolate it
+   so it can be swapped if GitHub ever ships a sanctioned client id.
+4. How aggressively to throttle client-side to stay under abuse-detection
+   thresholds (TeXRA agent runs are exactly the "strenuous/scripted" pattern
+   GitHub flags).
+5. Representing subscription/premium-request "pricing" in usage/telemetry that
+   assumes $/token (shared with Codex/`vscode.lm` work).
+
+## Rollout (only after go decision)
+
+1. Constants + auth coordinator + token storage (no UI), with unit tests for
+   device flow, token exchange, and refresh.
+2. OpenAI-handler subclass; verify a live streamed `…/chat/completions` call with
+   tools against a real account.
+3. Settings + CLI sign-in behind the experimental flag + one-time risk
+   acknowledgement.
+4. Curated model registry; CHANGELOG under an "Experimental" heading.
+
+## References
+
+- ericc-ch/copilot-api: https://github.com/ericc-ch/copilot-api
+  (`src/lib/api-config.ts`, `src/services/github/get-copilot-token.ts`,
+  `src/services/copilot/create-chat-completions.ts`)
+- LiteLLM provider: https://docs.litellm.ai/docs/providers/github_copilot
+  (`litellm/llms/github_copilot/authenticator.py`)
+- CopilotChat.nvim providers:
+  https://github.com/CopilotC-Nvim/CopilotChat.nvim (`lua/CopilotChat/config/providers.lua`)
+- Zed: `crates/copilot/src/copilot_chat.rs`;
+  https://github.com/zed-industries/zed/issues/22901
+- aider Copilot docs: https://aider.chat/docs/llms/github.html
+- Copilot Extension Developer Policy:
+  https://docs.github.com/en/site-policy/github-terms/github-copilot-extension-developer-policy
+- Copilot usage limits: https://docs.github.com/en/copilot/concepts/usage-limits
+- Enforcement notices (quoted by recipients):
+  https://github.com/orgs/community/discussions/160013 ,
+  https://github.com/orgs/community/discussions/174325
+- In-repo precedent: [`chatgpt-subscription-codex-auth.md`](./chatgpt-subscription-codex-auth.md)

--- a/docs/proposals/copilot-oauth-handler-prd.md
+++ b/docs/proposals/copilot-oauth-handler-prd.md
@@ -42,11 +42,11 @@ sanctioned integration** — exactly the framing already used for the Codex
 
 Same pre-reserved, inert slot the official route would also use:
 
-| File | Line | State |
-| ---- | ---- | ----- |
-| `src/agent/runtime/ModelFactory.ts` | 122 | `[ModelProvider.COPILOT]: { load: null, compatibilityKey: null }` |
-| `src/shared/constants/providers.ts` | 88 | display name `'Copilot'` |
-| `src/agent/modelHandlers/support/ProxyConfigResolver.ts` | 48 | `null` |
+| File                                                     | Line | State                                                             |
+| -------------------------------------------------------- | ---- | ----------------------------------------------------------------- |
+| `src/agent/runtime/ModelFactory.ts`                      | 122  | `[ModelProvider.COPILOT]: { load: null, compatibilityKey: null }` |
+| `src/shared/constants/providers.ts`                      | 88   | display name `'Copilot'`                                          |
+| `src/agent/modelHandlers/support/ProxyConfigResolver.ts` | 48   | `null`                                                            |
 
 > Note: only **one** of the two Copilot routes can own the `COPILOT` provider id
 > at a time. If both ship, they need distinct ids (e.g. `copilot` for OAuth vs
@@ -54,19 +54,19 @@ Same pre-reserved, inert slot the official route would also use:
 
 ## Prior art (verified against source, not blog posts)
 
-| | ericc-ch/copilot-api | LiteLLM `github_copilot` | CopilotChat.nvim | Zed |
-| --- | --- | --- | --- | --- |
-| OAuth client id | `Iv1.b507a08c87ecfe98` | `Iv1.b507a08c87ecfe98` (identical) | (LSP-delegated) | (LSP-delegated) |
-| Device-code URL | `github.com/login/device/code` | same | via official LSP | via official LSP |
-| Token exchange | `GET api.github.com/copilot_internal/v2/token` | same | same | same |
-| Chat endpoint | `api.githubcopilot.com/chat/completions` | same | same | `api.githubcopilot.com/chat/completions` |
-| Models endpoint | `…/models` | `…/models` | `…/models` | `api.individual.githubcopilot.com/models` |
-| Scope | `read:user` | `read:user` | — | — |
+|                 | ericc-ch/copilot-api                           | LiteLLM `github_copilot`           | CopilotChat.nvim | Zed                                       |
+| --------------- | ---------------------------------------------- | ---------------------------------- | ---------------- | ----------------------------------------- |
+| OAuth client id | `Iv1.b507a08c87ecfe98`                         | `Iv1.b507a08c87ecfe98` (identical) | (LSP-delegated)  | (LSP-delegated)                           |
+| Device-code URL | `github.com/login/device/code`                 | same                               | via official LSP | via official LSP                          |
+| Token exchange  | `GET api.github.com/copilot_internal/v2/token` | same                               | same             | same                                      |
+| Chat endpoint   | `api.githubcopilot.com/chat/completions`       | same                               | same             | `api.githubcopilot.com/chat/completions`  |
+| Models endpoint | `…/models`                                     | `…/models`                         | `…/models`       | `api.individual.githubcopilot.com/models` |
+| Scope           | `read:user`                                    | `read:user`                        | —                | —                                         |
 
 **The two-step token flow:** device flow → GitHub OAuth token (`gho_`/`ghu_`) →
 `GET copilot_internal/v2/token` → short-lived Copilot session token
 (`{ token, expires_at, refresh_in }`, auto-refreshed). Business/Enterprise use
-`api.business.` / `api.enterprise.` hosts and *require* the exchange step.
+`api.business.` / `api.enterprise.` hosts and _require_ the exchange step.
 
 **Required impersonation headers** (the backend gates on these — missing
 `Editor-Version` → hard `400 missing Editor-Version header for IDE auth`):
@@ -109,7 +109,7 @@ risk; aider's docs claim it's allowed. Neither is a GitHub guarantee. Treat as
 
 ## Design (if/when unparked)
 
-Mirrors the Codex proposal almost 1:1; the GitHub flow is actually *simpler*
+Mirrors the Codex proposal almost 1:1; the GitHub flow is actually _simpler_
 (standard device flow, no PKCE/loopback strictly needed).
 
 ### 1. Provider id
@@ -143,7 +143,7 @@ Port the Codex coordinator shape:
 `ModelHandlerCopilot` subclassing the OpenAI handler (like `ModelHandlerDeepSeek`):
 
 - `getClient()` → `new OpenAI({ apiKey: copilotToken, baseURL:
-  https://api.githubcopilot.com })`; recreate / use a token-getter on refresh.
+https://api.githubcopilot.com })`; recreate / use a token-getter on refresh.
 - Inject the impersonation headers via `defaultHeaders` (or a `fetch` wrapper for
   per-request freshness): `Copilot-Integration-Id: vscode-chat`,
   `Editor-Version`, `Editor-Plugin-Version`, `User-Agent`, `X-GitHub-Api-Version`.

--- a/docs/proposals/copilot-vscode-lm-handler-prd.md
+++ b/docs/proposals/copilot-vscode-lm-handler-prd.md
@@ -1,0 +1,258 @@
+# PRD: GitHub Copilot model handler via the VS Code Language Model API (`vscode.lm`)
+
+**Status:** Proposal (official path, extension-host only)
+**Owner:** _unassigned_
+**Tracking branch:** `claude/vscode-copilot-handler-scout-ygc444`
+**Companion proposal:** [`copilot-oauth-handler-prd.md`](./copilot-oauth-handler-prd.md) (the cross-host OAuth route — experimental/parked)
+
+## Summary
+
+Let a TeXRA user drive **GitHub Copilot's models** (the ones in their Copilot
+subscription's picker — GPT-4.x, o-series, Claude, Gemini, depending on plan)
+from TeXRA agents, using VS Code's **official** Language Model API
+(`vscode.lm`). The user signs in to Copilot the normal way (the GitHub Copilot
+Chat extension), grants TeXRA per-extension consent once, and TeXRA's agent loop
+calls the selected Copilot model through `vscode.lm.selectChatModels(...)` →
+`model.sendRequest(...)`.
+
+This is the **sanctioned** way to consume Copilot models, but it is
+fundamentally **VS Code-extension-host only**: it cannot work in the `texra` CLI
+or the Electron desktop shell, because the `vscode` module only exists inside the
+extension host. It also has real capability gaps (no system role, no usage/cost
+reporting, no image input in stable, hard abuse-detection rate limits).
+
+## Motivation
+
+- Many academic users already pay for Copilot (often via institutional/education
+  plans) and would rather spend that included quota than top up a separate API
+  key.
+- Copilot's picker exposes a strong multi-vendor set (OpenAI + Claude + Gemini)
+  behind one subscription.
+- It is the **only official** way to reach the user's Copilot subscription — no
+  reverse-engineering, no borrowed client id (contrast the
+  [OAuth route](./copilot-oauth-handler-prd.md)).
+- The provider slot is **already stubbed** in the codebase (see below), so this
+  is largely a matter of filling in a handler plus a new platform port.
+
+## Current state (verified in repo)
+
+`ModelProvider.COPILOT` already exists as an inert, pre-reserved slot:
+
+| File | Line | Current state |
+| ---- | ---- | ------------- |
+| `src/agent/runtime/ModelFactory.ts` | 122 | `[ModelProvider.COPILOT]: { load: null, compatibilityKey: null }` |
+| `src/shared/constants/providers.ts` | 88 | display name `'Copilot'` (in `EXTRA_DISPLAY_NAMES`) |
+| `src/agent/modelHandlers/support/ProxyConfigResolver.ts` | 48 | `[ModelProvider.COPILOT]: null` |
+
+The `PROVIDER_HANDLER_ROUTES` record is `Record<ModelProvider, ...>`, so the
+TypeScript compiler already forces every provider (including `COPILOT`) to have
+an entry — filling it in is the wiring task.
+
+## API surface (verified against `@types/vscode@1.105.0`, the version this repo targets)
+
+`packages/extension/package.json` pins `"vscode": "^1.105.0"`. Read directly from
+the installed `.d.ts`:
+
+**Available (stable):**
+
+- `lm.selectChatModels(selector?)` → `Thenable<LanguageModelChat[]>`; selector on
+  `vendor` / `id` / `family` / `version`. **May return `[]`** — must handle.
+- `lm.onDidChangeChatModels: Event<void>` — re-query when it fires.
+- `LanguageModelChat`: `id`, `name`, `vendor`, `family`, `version`,
+  `maxInputTokens`; `sendRequest(messages, options?, token?)`;
+  `countTokens(text|message)`.
+- Streaming: `response.text` (`AsyncIterable<string>`) and `response.stream`
+  (`LanguageModelTextPart | LanguageModelToolCallPart | unknown`).
+- Tools: `options.tools: LanguageModelChatTool[]` (`name`, `description`,
+  `inputSchema`), `options.toolMode` (`Auto` | `Required`); model emits
+  `LanguageModelToolCallPart` (`callId`, `name`, `input`); reply with a
+  `LanguageModelToolResultPart` keyed by `callId`.
+- `options.justification`, `options.modelOptions` (free-form per-model knobs).
+- Consent: first `sendRequest` shows a per-extension consent dialog;
+  `vscode.env.languageModelAccessInformation.canSendRequest(chat)` checks
+  persisted state (does not prompt).
+- Errors: `LanguageModelError.NoPermissions / Blocked (quota) / NotFound`.
+
+**Hard limitations (confirmed by the 1.105 `.d.ts`):**
+
+- **No system role.** `LanguageModelChatMessageRole` is `User = 1, Assistant = 2`
+  only. System guidance must be folded into a `User` message. TeXRA is
+  system-prompt-heavy, so this is the biggest adapter cost.
+- **No image / data input in stable.**
+  `LanguageModelInputPart = LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelToolCallPart`.
+  There is no data/image content part in 1.105 (the `unknown` in the stream is a
+  documented placeholder for future image parts). TeXRA agents that rely on
+  PDF/image input cannot use those via this route yet.
+- **No usage / cost reporting.** No token-usage field is returned; only
+  `countTokens()` exists. `normalizeUsage`/`computePrice` would be estimates, and
+  cost is "included in subscription," not $/token.
+- **Subscription + Copilot Chat extension required.** `vendor: 'copilot'` models
+  only appear when the user has Copilot and the Copilot Chat extension installed;
+  a consuming extension typically declares
+  `"extensionDependencies": ["github.copilot", "github.copilot-chat"]`.
+- **Aggressive abuse-detection rate limiting** for agentic third-party use (see
+  ToS section).
+
+## The architectural constraint (decisive)
+
+Per `CLAUDE.md`, `src/agent/` and `src/model/` are **VS Code-free zones** — a
+model handler **cannot** `import 'vscode'`, and `vscode.lm` only exists in the
+extension host. So the handler cannot call `vscode.lm.*` directly. This forces a
+**platform port**:
+
+```
+src/platform/                         (interface, vscode-free)
+  CopilotLmPort
+    listModels(): Promise<CopilotModelInfo[]>
+    sendRequest(modelId, messages, tools?, opts, onChunk, signal): Promise<CopilotResult>
+    countTokens(modelId, text): Promise<number>
+    isAvailable(): boolean   // false in CLI/desktop
+
+packages/extension/src/…              (vscode-allowed wiring)
+  VsCodeCopilotLm implements CopilotLmPort  → wraps vscode.lm.*
+
+packages/cli, packages/desktop
+  UnsupportedCopilotLm  → isAvailable() === false; throws a clear error
+
+src/agent/modelHandlers/copilot/modelHandlerCopilot.ts   (vscode-free)
+  extends ModelHandler, delegates to platform().copilotLm (never imports vscode)
+```
+
+This mirrors how every other host capability is reached via `platform()` (config,
+secrets, fs, …).
+
+## Design
+
+Additive; the provider slot already exists.
+
+### 1. Platform port
+
+Add a `CopilotLmPort` to the `Platform` interface (`src/platform/`), wired once
+from `packages/extension/src/extension.ts` (VS Code impl) and from the CLI /
+desktop composition roots (unsupported impl). Keep the port's message/part types
+host-neutral (plain objects), translating to/from `vscode.LanguageModel*` only
+inside the extension implementation.
+
+### 2. Model handler
+
+`ModelHandlerCopilot` in `src/agent/modelHandlers/copilot/`, delegating to
+`platform().copilotLm`. Responsibilities:
+
+- **Message build:** fold the TeXRA system prompt into the first `User` message
+  (no system role); map prior turns to User/Assistant; map tool results to
+  `LanguageModelToolResultPart`.
+- **Streaming:** consume the port's chunk callback; emit TeXRA output/thinking
+  streams as the base `ModelHandler` expects.
+- **Tool calls:** map TeXRA tool contracts → `LanguageModelChatTool`; extract
+  `LanguageModelToolCallPart` → TeXRA's normalized tool-call union; round-trip
+  results.
+- **Usage/cost:** report `cost = 0` / "included (Copilot subscription)"; derive
+  input tokens from `countTokens()`, output tokens estimated. Make the
+  "no real usage data" explicit in telemetry rather than faking precision.
+- **Capabilities:** `supportsToolUse: true`, `supportsImages: false` (stable),
+  `supportsThinking: false`, `supportsCaching: false`, `supportsTokenCounting:
+  true`. No Responses/compaction/web-search.
+
+### 3. Factory wiring
+
+Fill `PROVIDER_HANDLER_ROUTES[ModelProvider.COPILOT]` with a real `load` +
+`compatibilityKey` (add `'ModelHandlerCopilot'` to the
+`ModelHandlerCompatibilityKey` union). Because `vscode.lm` is host-only, also
+guard in `createModelHandler`: if `!platform().copilotLm.isAvailable()`, fail
+with an actionable error ("Copilot models are only available inside VS Code").
+
+### 4. Model registry & availability
+
+- **Dynamic discovery preferred:** populate the picker from
+  `port.listModels()` (which calls `selectChatModels({ vendor: 'copilot' })`),
+  re-querying on `onDidChangeChatModels`. The Copilot catalog is volatile and
+  plan-dependent, so a hardcoded list will go stale.
+- Add a new `ModelAvailabilityKind` (e.g. `copilot-host-only` /
+  `copilot-consent-required`) in the model-selection controller so the Settings →
+  Models tab can show "Available in VS Code with Copilot" and, in CLI/desktop,
+  greys these out with an explanatory tooltip.
+
+### 5. UX & consent
+
+- Consent fires on first `sendRequest`, which **must be a user action** — trigger
+  it from a Settings → Models "Enable Copilot models" button or on first run of
+  an agent the user explicitly started, never on activation.
+- After consent: Copilot models appear in the picker (VS Code only).
+- CLI/desktop: the models are listed-but-disabled with a clear "VS Code only"
+  reason; `texra` documents that Copilot models require the VS Code host.
+
+## Platform / VS Code separation
+
+- `ModelHandlerCopilot`, `src/model/` registry entries, and capability mapping
+  stay `vscode`-free and reach Copilot only through `platform().copilotLm`.
+- All `vscode.lm` calls, `LanguageModelChatMessage` construction, and the
+  consent-triggering command live in `packages/extension/`.
+- `extensionDependencies` on `github.copilot` / `github.copilot-chat` is declared
+  in `packages/extension/package.json`.
+
+## ToS / policy framing (non-negotiable)
+
+- Using `vscode.lm` Copilot models **binds TeXRA to GitHub's Copilot acceptable
+  use policy** (VS Code's own docs state this). Surface that to the user.
+- **Documented enforcement risk even on this official path:** third-party
+  extensions driving Copilot agentically through `vscode.lm` (e.g. Cline) report
+  aggressive token-based rate limiting and lockouts (minutes-to-days) and
+  abuse-detection warnings. The PRD must set expectations: Copilot models are
+  best for light/interactive use, not long autonomous TeXRA runs.
+- This route uses the user's **own** signed-in Copilot session via the official
+  API — no credential sharing, no borrowed client id.
+
+## Scope
+
+**In (v0):** `CopilotLmPort` + VS Code impl + unsupported CLI/desktop impl;
+`ModelHandlerCopilot` (system-prompt folding, streaming, tool calls, estimated
+usage); factory wiring; dynamic model discovery; Settings consent/enable UX;
+availability plumbing; docs.
+
+**Out (v0):** image/PDF input (not in stable `vscode.lm`); accurate $/token
+usage; CLI/desktop support (architecturally impossible via this route — see the
+OAuth proposal for cross-host); caching/Responses/web-search features.
+
+## Alternative / companion idea worth noting
+
+`lm.registerLanguageModelChatProvider(vendor, provider)` is **stable** in 1.105.
+This is the *inverse* direction: TeXRA could **contribute its own models into VS
+Code's Copilot model picker** (the BYOK provider API — `LanguageModelChatProvider`
+with `provideLanguageModelChatInformation` / `provideLanguageModelChatResponse` /
+`provideTokenCount`, and a `capabilities` field that does support `imageInput` and
+`toolCalling`). That is a different product bet (expose TeXRA→VS Code, not
+consume Copilot→TeXRA) and deserves its own proposal if pursued.
+
+## Open questions
+
+1. Provider id naming surfaced to users: keep `Copilot`, or distinguish
+   `Copilot (VS Code)` to signal the host constraint.
+2. New `ModelAvailabilityKind` value(s) vs reusing an existing host-gated kind.
+3. How to represent "subscription-included, rate-limited" cost in usage/telemetry
+   that assumes $/token (shared question with the Codex/OAuth work).
+4. Whether to declare a hard `extensionDependencies` (blocks install without
+   Copilot) or a soft runtime check (degrade gracefully). Soft is friendlier for
+   non-Copilot users.
+5. Helper-model usage: should Copilot models be eligible as the auxiliary/helper
+   model, given the rate limits? Probably no by default.
+
+## Milestones
+
+1. `CopilotLmPort` interface + VS Code implementation + CLI/desktop unsupported
+   stub, with unit tests on the message/tool translation (host-neutral, mockable).
+2. `ModelHandlerCopilot` + factory wiring; smoke-test a real streamed
+   `sendRequest` with tools inside an Extension Development Host.
+3. Dynamic model discovery + availability plumbing in Settings → Models.
+4. Consent/enable UX; CLI/desktop "VS Code only" messaging; CHANGELOG under an
+   appropriate heading.
+
+## References
+
+- VS Code LM API guide: https://code.visualstudio.com/api/extension-guides/ai/language-model
+- VS Code LM tools guide: https://code.visualstudio.com/api/extension-guides/ai/tools
+- BYOK provider API: `vscode.lm.registerLanguageModelChatProvider` (stable, 1.105)
+- Copilot supported models: https://docs.github.com/en/copilot/reference/ai-models/supported-models
+- Third-party rate-limit reports (Cline via `vscode.lm`):
+  https://github.com/orgs/community/discussions/150373
+- Authoritative signatures: `@types/vscode@1.105.0` `index.d.ts`, namespace `lm`
+  (≈ line 20610) and `LanguageModelChat*` types (≈ lines 20003–20605).

--- a/docs/proposals/copilot-vscode-lm-handler-prd.md
+++ b/docs/proposals/copilot-vscode-lm-handler-prd.md
@@ -38,11 +38,11 @@ reporting, no image input in stable, hard abuse-detection rate limits).
 
 `ModelProvider.COPILOT` already exists as an inert, pre-reserved slot:
 
-| File | Line | Current state |
-| ---- | ---- | ------------- |
-| `src/agent/runtime/ModelFactory.ts` | 122 | `[ModelProvider.COPILOT]: { load: null, compatibilityKey: null }` |
-| `src/shared/constants/providers.ts` | 88 | display name `'Copilot'` (in `EXTRA_DISPLAY_NAMES`) |
-| `src/agent/modelHandlers/support/ProxyConfigResolver.ts` | 48 | `[ModelProvider.COPILOT]: null` |
+| File                                                     | Line | Current state                                                     |
+| -------------------------------------------------------- | ---- | ----------------------------------------------------------------- |
+| `src/agent/runtime/ModelFactory.ts`                      | 122  | `[ModelProvider.COPILOT]: { load: null, compatibilityKey: null }` |
+| `src/shared/constants/providers.ts`                      | 88   | display name `'Copilot'` (in `EXTRA_DISPLAY_NAMES`)               |
+| `src/agent/modelHandlers/support/ProxyConfigResolver.ts` | 48   | `[ModelProvider.COPILOT]: null`                                   |
 
 The `PROVIDER_HANDLER_ROUTES` record is `Record<ModelProvider, ...>`, so the
 TypeScript compiler already forces every provider (including `COPILOT`) to have
@@ -151,7 +151,7 @@ inside the extension implementation.
   "no real usage data" explicit in telemetry rather than faking precision.
 - **Capabilities:** `supportsToolUse: true`, `supportsImages: false` (stable),
   `supportsThinking: false`, `supportsCaching: false`, `supportsTokenCounting:
-  true`. No Responses/compaction/web-search.
+true`. No Responses/compaction/web-search.
 
 ### 3. Factory wiring
 
@@ -216,7 +216,7 @@ OAuth proposal for cross-host); caching/Responses/web-search features.
 ## Alternative / companion idea worth noting
 
 `lm.registerLanguageModelChatProvider(vendor, provider)` is **stable** in 1.105.
-This is the *inverse* direction: TeXRA could **contribute its own models into VS
+This is the _inverse_ direction: TeXRA could **contribute its own models into VS
 Code's Copilot model picker** (the BYOK provider API — `LanguageModelChatProvider`
 with `provideLanguageModelChatInformation` / `provideLanguageModelChatResponse` /
 `provideTokenCount`, and a `capabilities` field that does support `imageInput` and

--- a/docs/proposals/copilot-vscode-lm-handler-prd.md
+++ b/docs/proposals/copilot-vscode-lm-handler-prd.md
@@ -93,6 +93,17 @@ the installed `.d.ts`:
 - **Aggressive abuse-detection rate limiting** for agentic third-party use (see
   ToS section).
 
+## Capability comparison against OAuth
+
+| Capability      | `vscode.lm` route                                      | OAuth backend route                                      |
+| --------------- | ------------------------------------------------------ | -------------------------------------------------------- |
+| Hosts           | VS Code extension host only                            | Extension, CLI, desktop                                  |
+| API shape       | VS Code Language Model API                             | OpenAI Chat Completions-compatible backend               |
+| System guidance | Folded into user messages; no stable system role       | Native OpenAI-style system/developer messages expected   |
+| Image/PDF input | Not available in stable `vscode.lm@1.105`              | Potentially available later via Copilot vision headers   |
+| Usage reporting | No returned usage; only `countTokens()` estimates      | Backend may expose OpenAI-style token usage              |
+| Policy posture  | Official API, still rate-limited for agentic workloads | Reverse-engineered and parked behind maintainer go/no-go |
+
 ## The architectural constraint (decisive)
 
 Per `CLAUDE.md`, `src/agent/` and `src/model/` are **VS Code-free zones** — a


### PR DESCRIPTION
Two separate proposals under docs/proposals/:

- copilot-vscode-lm-handler-prd.md: the official VS Code Language Model
  API route. Consumes the user's Copilot subscription via vscode.lm behind
  a new platform port. Extension-host only; documents the no-system-role,
  no-image-input, no-usage-reporting limits verified against
  @types/vscode@1.105.0, plus abuse-detection rate limits.

- copilot-oauth-handler-prd.md: the reverse-engineered OAuth route to
  api.githubcopilot.com. Works across all hosts and mirrors the existing
  Codex handler, but is marked EXPERIMENTAL/PARKED pending a ToS-risk
  decision (documented account-suspension risk).

Both fill the pre-stubbed ModelProvider.COPILOT slot.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NTipcREnr44TRZaNwf1SLg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no product behavior, auth, or API calls change until a future implementation PR.
> 
> **Overview**
> Adds two companion proposals under `docs/proposals/` for filling the stubbed **`ModelProvider.COPILOT`** slot—no runtime code in this PR.
> 
> **`copilot-vscode-lm-handler-prd.md`** describes the **official** path: consume the user’s Copilot subscription via **`vscode.lm`** behind a new **`CopilotLmPort`** on `platform()`, with **`ModelHandlerCopilot`** staying VS Code–free. It documents **extension-host-only** scope, **`@types/vscode@1.105.0`** limits (no system role, no stable image input, estimated usage only), dynamic model discovery, consent UX, and abuse-detection rate limits.
> 
> **`copilot-oauth-handler-prd.md`** describes a **cross-host** (extension, CLI, desktop) route to **`api.githubcopilot.com`** via OAuth device flow and Copilot token exchange, modeled like the Codex handler (OpenAI-compatible subclass, secrets storage, impersonation headers). It is marked **EXPERIMENTAL / PARKED** pending maintainer **ToS / account-suspension** go/no-go, with policy risk and prior art spelled out.
> 
> Both PRDs compare capabilities, note **only one route can own `COPILOT`** if both ship, and outline milestones, scope, and open questions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e1f7843f1622cb5524797c72c12c3b9ed5ca2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->