### PR TITLE
fix: surface OpenRouter mismatch before credential prompt in setup

### DIFF
--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -313,17 +313,23 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
       return 'already-running';
     }
 
-    const proceed = await ensureCredentialOrPrompt();
-    if (!proceed) {
+    // Check routing configuration before credentials: a ChatGPT-
+    // subscription user whose "Use OpenRouter" flag is on without an OR
+    // key would otherwise fall into the credential prompt first because
+    // isCodexSubscriptionActive returns false under OpenRouter routing
+    // (shouldUseCodexSubscription short-circuits when useOpenRouter is
+    // true — see codexRouting.ts:28).
+    if (!(await ensureRoutingConfigured())) {
       void vscode.window.showInformationMessage(
-        'Setup assistant cancelled. Run `TeXRA: Run Setup Assistant` again once you have signed in, enabled ChatGPT subscription, or set an API key.',
+        'Setup assistant cancelled. Resolve the "Use OpenRouter" configuration (add an OpenRouter key or disable the setting in Dashboard → Models), then run `TeXRA: Run Setup Assistant` again.',
       );
       return 'not-started';
     }
 
-    if (!(await ensureRoutingConfigured())) {
+    const proceed = await ensureCredentialOrPrompt();
+    if (!proceed) {
       void vscode.window.showInformationMessage(
-        'Setup assistant cancelled. Resolve the "Use OpenRouter" configuration (add an OpenRouter key or disable the setting in Dashboard → Models), then run `TeXRA: Run Setup Assistant` again.',
+        'Setup assistant cancelled. Run `TeXRA: Run Setup Assistant` again once you have signed in, enabled ChatGPT subscription, or set an API key.',
       );
       return 'not-started';
     }

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -316,9 +316,8 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
     // Check routing configuration before credentials: a ChatGPT-
     // subscription user whose "Use OpenRouter" flag is on without an OR
     // key would otherwise fall into the credential prompt first because
-    // isCodexSubscriptionActive returns false under OpenRouter routing
-    // (shouldUseCodexSubscription short-circuits when useOpenRouter is
-    // true — see codexRouting.ts:28).
+    // isCodexSubscriptionActive returns false because
+    // shouldUseCodexSubscription short-circuits when useOpenRouter is true.
     if (!(await ensureRoutingConfigured())) {
       void vscode.window.showInformationMessage(
         'Setup assistant cancelled. Resolve the "Use OpenRouter" configuration (add an OpenRouter key or disable the setting in Dashboard → Models), then run `TeXRA: Run Setup Assistant` again.',

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * warning instead of a confusing "no credential" picker.
  */
 
-const agentHandles = vi.fn<() => { agentName: { agentName: string } }[]>();
+const agentHandles = vi.fn<() => { agentName: string }[]>();
 
 const mocks = vi.hoisted(() => ({
   getUseOpenRouter: vi.fn<() => boolean>(),
@@ -16,7 +16,9 @@ const mocks = vi.hoisted(() => ({
   showWarningMessage: vi.fn<() => Promise<string | undefined>>(),
   showQuickPick: vi.fn<() => Promise<unknown>>(),
   showInformationMessage: vi.fn<() => Promise<unknown>>(),
+  showErrorMessage: vi.fn<() => Promise<unknown>>(),
   executeCommand: vi.fn<() => Promise<unknown>>(),
+  logError: vi.fn(),
 }));
 
 vi.mock('@utils/config/providerConfig', () => ({
@@ -50,6 +52,9 @@ vi.mock('@auth/serverKeys', () => ({
 }));
 
 vi.mock('@common/state', () => ({
+  GlobalStateKey: {
+    USE_OPENROUTER: 'useOpenRouter',
+  },
   globalSM: {
     get: () => undefined,
     update: () => Promise.resolve(),
@@ -73,7 +78,7 @@ vi.mock('vscode', () => ({
     showWarningMessage: mocks.showWarningMessage,
     showQuickPick: mocks.showQuickPick,
     showInformationMessage: mocks.showInformationMessage,
-    showErrorMessage: async () => undefined,
+    showErrorMessage: mocks.showErrorMessage,
     createOutputChannel: () => ({
       appendLine: () => {},
       append: () => {},
@@ -114,7 +119,7 @@ vi.mock('@frontend/agentRuntime/extensionAgentRuntimeHost', () => ({
 
 vi.mock('@logger/logUtils', () => ({
   initialize: () => {},
-  error: () => {},
+  error: mocks.logError,
   warn: () => {},
   info: () => {},
 }));
@@ -143,13 +148,16 @@ describe('setup assistant routing check ordering', () => {
     mocks.showWarningMessage.mockReset();
     mocks.showQuickPick.mockReset();
     mocks.showInformationMessage.mockReset();
+    mocks.showErrorMessage.mockReset();
     mocks.executeCommand.mockReset();
+    mocks.logError.mockReset();
     // Default: no OpenRouter, no keys — safe baseline.
     mocks.getUseOpenRouter.mockReturnValue(false);
     mocks.hasUsableApiKey.mockResolvedValue(false);
     mocks.showWarningMessage.mockResolvedValue(undefined);
     mocks.showQuickPick.mockResolvedValue(undefined);
     mocks.showInformationMessage.mockResolvedValue(undefined);
+    mocks.showErrorMessage.mockResolvedValue(undefined);
     mocks.executeCommand.mockResolvedValue(undefined);
   });
 
@@ -202,6 +210,7 @@ describe('setup assistant routing check ordering', () => {
 
     expect(mocks.showWarningMessage).not.toHaveBeenCalled();
     expect(mocks.showQuickPick).not.toHaveBeenCalled();
-    expect(['launched', 'not-started']).toContain(result);
+    expect(mocks.showErrorMessage).not.toHaveBeenCalled();
+    expect(result).toBe('launched');
   });
 });

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -132,9 +132,8 @@ await import('@auth/serverKeys');
 await import('@common/state');
 
 // Module under test — imported after all mock factories are materialized.
-const { launchSetupAssistant } = await import(
-  '@commands/setup/setupAssistantCommand'
-);
+const { launchSetupAssistant } =
+  await import('@commands/setup/setupAssistantCommand');
 
 describe('setup assistant routing check ordering', () => {
   beforeEach(() => {

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -1,0 +1,208 @@
+// Third-party imports
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Verify that the setup assistant surfaces the OpenRouter-without-key
+ * routing mismatch BEFORE the credential prompt, so a ChatGPT-subscription
+ * user who has "Use OpenRouter" enabled (and no OR key) sees the routing
+ * warning instead of a confusing "no credential" picker.
+ */
+
+const agentHandles = vi.fn<() => { agentName: { agentName: string } }[]>();
+
+const mocks = vi.hoisted(() => ({
+  getUseOpenRouter: vi.fn<() => boolean>(),
+  hasUsableApiKey: vi.fn<(provider: string) => Promise<boolean>>(),
+  showWarningMessage: vi.fn<() => Promise<string | undefined>>(),
+  showQuickPick: vi.fn<() => Promise<unknown>>(),
+  showInformationMessage: vi.fn<() => Promise<unknown>>(),
+  executeCommand: vi.fn<() => Promise<unknown>>(),
+}));
+
+vi.mock('@utils/config/providerConfig', () => ({
+  getUseOpenRouter: mocks.getUseOpenRouter,
+}));
+
+vi.mock('@frontend/secretManager', () => ({
+  SecretManager: {
+    hasUsableApiKey: mocks.hasUsableApiKey,
+    API_PROVIDERS: ['openRouter', 'openai', 'anthropic', 'google'] as string[],
+    getApiKeySecretName: (provider: string) => `apiKey.${provider}`,
+  },
+}));
+
+vi.mock('@agent/runtime/executionRegistry', () => ({
+  executionRegistry: {
+    getAgentHandles: () => agentHandles(),
+  },
+}));
+
+vi.mock('@auth/codex', () => ({
+  isCodexSubscriptionActive: () => Promise.resolve(false),
+}));
+
+vi.mock('@auth/serverKeys', () => ({
+  getServerSideKeyService: () => ({
+    canUseServerSideKeys: () => Promise.resolve(false),
+    canUseServerSideKeysForModel: () => Promise.resolve(false),
+    canUseModelSync: () => false,
+  }),
+}));
+
+vi.mock('@common/state', () => ({
+  globalSM: {
+    get: () => undefined,
+    update: () => Promise.resolve(),
+  },
+}));
+
+vi.mock('vscode', () => ({
+  Uri: {
+    file: (p: string) => ({ fsPath: p, toString: () => p, path: p }),
+    parse: (s: string) => ({ fsPath: s, toString: () => s, path: s }),
+  },
+  EventEmitter: class {
+    event = () => ({ dispose: () => {} });
+    fire() {}
+    dispose() {}
+  },
+  Disposable: {
+    from: (..._: unknown[]) => ({ dispose: () => {} }),
+  },
+  window: {
+    showWarningMessage: mocks.showWarningMessage,
+    showQuickPick: mocks.showQuickPick,
+    showInformationMessage: mocks.showInformationMessage,
+    showErrorMessage: async () => undefined,
+    createOutputChannel: () => ({
+      appendLine: () => {},
+      append: () => {},
+      show: () => {},
+      dispose: () => {},
+    }),
+  },
+  commands: {
+    executeCommand: mocks.executeCommand,
+  },
+  workspace: {
+    getConfiguration: () => ({
+      get: () => undefined,
+    }),
+    onDidChangeConfiguration: () => ({ dispose: () => {} }),
+  },
+  ProgressLocation: { Notification: 15, Window: 10 },
+  ThemeColor: class {},
+  StatusBarAlignment: { Left: 1, Right: 2 },
+  FileType: { Unknown: 0, File: 1, Directory: 2, SymbolicLink: 64 },
+}));
+
+vi.mock('@agent/index', () => ({
+  loadAgents: () => Promise.resolve(),
+}));
+
+vi.mock('@agent/storage', () => ({
+  registerExecution: () => Promise.resolve(),
+}));
+
+vi.mock('@agent/runtime/executeAgent', () => ({
+  executeAgent: () => Promise.resolve(),
+}));
+
+vi.mock('@frontend/agentRuntime/extensionAgentRuntimeHost', () => ({
+  extensionAgentRuntimeHost: {},
+}));
+
+vi.mock('@logger/logUtils', () => ({
+  initialize: () => {},
+  error: () => {},
+  warn: () => {},
+  info: () => {},
+}));
+
+// Force materialization of hoisted mocks into vitest's module graph
+// before the module under test imports them. Without this, dynamic
+// imports inside setupAssistantCommand may resolve the real modules
+// (or the alias-resolved stubs) before the mock factories execute.
+await import('vscode');
+await import('@utils/config/providerConfig');
+await import('@frontend/secretManager');
+await import('@agent/runtime/executionRegistry');
+await import('@auth/codex');
+await import('@auth/serverKeys');
+await import('@common/state');
+
+// Module under test — imported after all mock factories are materialized.
+const { launchSetupAssistant } = await import(
+  '@commands/setup/setupAssistantCommand'
+);
+
+describe('setup assistant routing check ordering', () => {
+  beforeEach(() => {
+    agentHandles.mockReturnValue([]);
+    mocks.getUseOpenRouter.mockReset();
+    mocks.hasUsableApiKey.mockReset();
+    mocks.showWarningMessage.mockReset();
+    mocks.showQuickPick.mockReset();
+    mocks.showInformationMessage.mockReset();
+    mocks.executeCommand.mockReset();
+    // Default: no OpenRouter, no keys — safe baseline.
+    mocks.getUseOpenRouter.mockReturnValue(false);
+    mocks.hasUsableApiKey.mockResolvedValue(false);
+    mocks.showWarningMessage.mockResolvedValue(undefined);
+    mocks.showQuickPick.mockResolvedValue(undefined);
+    mocks.showInformationMessage.mockResolvedValue(undefined);
+    mocks.executeCommand.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows routing warning before credential prompt when OpenRouter is on without a key', async () => {
+    // Override baseline: enable OpenRouter routing.
+    mocks.getUseOpenRouter.mockReturnValue(true);
+
+    const result = await launchSetupAssistant();
+
+    // Routing warning must be shown; credential prompt must not.
+    expect(result).toBe('not-started');
+    expect(mocks.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Use OpenRouter'),
+      expect.objectContaining({ modal: true }),
+      expect.any(String),
+      expect.any(String),
+    );
+    expect(mocks.showQuickPick).not.toHaveBeenCalled();
+  });
+
+  it('proceeds to credential check when routing is correctly configured', async () => {
+    // Baseline is already correct: OR off, no keys → credential prompt.
+
+    const result = await launchSetupAssistant();
+
+    // Credential prompt shown (routing check passed first silently).
+    expect(result).toBe('not-started');
+    expect(mocks.showWarningMessage).not.toHaveBeenCalled();
+    expect(mocks.showQuickPick).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        placeHolder: expect.stringContaining('credential'),
+      }),
+    );
+  });
+
+  it('passes routing check when OR is on with a key, then reaches credential check', async () => {
+    // OpenRouter on with a valid key → routing OK. The OR key itself
+    // counts as a usable credential, so both preflight checks pass.
+    mocks.getUseOpenRouter.mockReturnValue(true);
+    mocks.hasUsableApiKey.mockImplementation(
+      async (provider: string) => provider === 'openRouter',
+    );
+
+    const result = await launchSetupAssistant();
+
+    expect(mocks.showWarningMessage).not.toHaveBeenCalled();
+    expect(mocks.showQuickPick).not.toHaveBeenCalled();
+    expect(['launched', 'not-started']).toContain(result);
+  });
+});


### PR DESCRIPTION
Moved `ensureRoutingConfigured()` before `ensureCredentialOrPrompt()` in `launchSetupAssistant()` so ChatGPT-subscription users with "Use OpenRouter" enabled (and no OR key) see the routing-mismatch warning instead of a misleading "no credential" prompt.

Root cause: `isCodexSubscriptionActive()` returns false under OpenRouter routing via `shouldUseCodexSubscription()` in `codexRouting.ts:28`, so `hasAnyUsableSetupCredential()` reports no credential despite a valid signed-in subscription.

Closes #6461

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX/preflight reorder in setup launch only; behavior is covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> **Reorders setup assistant preflight** so `ensureRoutingConfigured()` runs before `ensureCredentialOrPrompt()` in `launchSetupAssistant()`, and aligns the cancel messages with that sequence.
> 
> When **Use OpenRouter** is on but no OpenRouter key is set, users now get the routing misconfiguration modal first instead of a misleading “no credential” quick pick. That matters for signed-in ChatGPT subscription users: with OpenRouter routing enabled, Codex subscription is not treated as active, so the old order looked like missing credentials.
> 
> Adds **`SetupAssistantRouting.vitest.ts`** to lock in the ordering (routing warning vs credential picker vs successful launch when an OR key exists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d3a011cb92568186567ec50688b7ce9aaea221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->