### PR TITLE
fix(docs): revert walkthrough altText to match screenshot

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1115,7 +1115,7 @@
             "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Sign in with ChatGPT](command:texra.auth.chatgpt.signIn)\n\n**Sign in with Researcher Access** — Free for academics; no API key needed. Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
             "media": {
               "image": "resources/walkthroughs/media/api-key-setup.png",
-              "altText": "Screenshot of the model credential configuration view"
+              "altText": "Screenshot of the API key configuration view"
             },
             "completionEvents": [
               "onCommand:texra.auth.signIn",

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -1555,7 +1555,7 @@
               "description": "A credential is the one step no agent can do for you. Three ways in:\n\n**Use ChatGPT subscription** — ChatGPT Plus/Pro/Team can route Codex models through your ChatGPT plan.\n\n[Sign in with ChatGPT](command:texra.auth.chatgpt.signIn)\n\n**Sign in with Researcher Access** — Free for academics; no API key needed. Signing in also unlocks remote agents, including the orchestrator.\n\n[Sign In](command:texra.auth.signIn)\n\n**Use your own provider API key** — Anthropic, OpenAI, Google, and more. Except for Codex through ChatGPT subscription, chat subscriptions do not include API access.\n\n[Set API key](command:texra.setApiKey)",
               "id": "texra.gettingStarted.signIn",
               "media": {
-                "altText": "Screenshot of the model credential configuration view",
+                "altText": "Screenshot of the API key configuration view",
                 "image": "resources/walkthroughs/media/api-key-setup.png"
               },
               "title": "Choose how TeXRA should sign in"


### PR DESCRIPTION
Revert the altText in the gettingStarted.signIn walkthrough step from "Screenshot of the model credential configuration view" back to "Screenshot of the API key configuration view". The alt text was changed in PR #6453 but the screenshot was not regenerated, causing a mismatch that affects screen-reader users.

The screenshot still needs to be regenerated by a human to include the ChatGPT subscription section — that requires Electron + Playwright and is not feasible in CI.

Closes #6459

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only manifest and snapshot changes with no runtime or security impact.
> 
> **Overview**
> Reverts the **getting started sign-in** walkthrough image `altText` from “model credential configuration view” back to **“API key configuration view”** in `package.json` and the extension package invariants snapshot.
> 
> The walkthrough copy still describes ChatGPT subscription, Researcher Access, and API keys, but the `api-key-setup.png` asset was never re-captured after the alt text change in PR #6453. Aligning alt text with the current screenshot restores accurate screen-reader descriptions until the image is regenerated manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ba709e573d31ce9df48977fd0a871e352c30de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->