### PR TITLE
fix(cli): show active response follow-up tip

### DIFF
--- a/packages/cli/src/chat/tui/panes/TipRow.tsx
+++ b/packages/cli/src/chat/tui/panes/TipRow.tsx
@@ -29,14 +29,16 @@ export function tipRowText({
   readonly hour: number;
   readonly responseRunning?: boolean;
 }): string {
+  if (responseRunning) {
+    return QUEUE_FOLLOW_UP_TIP;
+  }
+
   const tips = agentSelectionAvailable
     ? [BASE_TIPS[0], BASE_TIPS[1], AGENT_SELECTION_TIP, ...BASE_TIPS.slice(2)]
     : BASE_TIPS;
   const index = ((hour % tips.length) + tips.length) % tips.length;
   const tip = tips[index]!;
-  return !responseRunning && tip === QUEUE_FOLLOW_UP_TIP
-    ? IDLE_QUEUE_FOLLOW_UP_FALLBACK_TIP
-    : tip;
+  return tip === QUEUE_FOLLOW_UP_TIP ? IDLE_QUEUE_FOLLOW_UP_FALLBACK_TIP : tip;
 }
 
 export function TipRow(props: {

--- a/src/test-kernel/cli/TipRow.vitest.mts
+++ b/src/test-kernel/cli/TipRow.vitest.mts
@@ -24,9 +24,9 @@ describe('CLI TipRow', () => {
     );
   });
 
-  it('keeps unrelated tips stable when the response state changes', () => {
+  it('shows queued follow-up guidance for any active response', () => {
     expect(tipRowText({ hour: 9, responseRunning: true })).toBe(
-      'Use /resume to continue a previous session',
+      'Type while a response is running to queue a follow-up',
     );
     expect(tipRowText({ hour: 9, responseRunning: false })).toBe(
       'Use /resume to continue a previous session',


### PR DESCRIPTION
## Summary
- always show queued-follow-up guidance while a CLI response is running
- keep the existing rotating tip behavior for idle chat sessions
- add a TipRow regression test for active-response guidance

Fixes #6521

## Dogfood evidence
- refreshed `texra-local` and confirmed `texra-local --version` = 0.38.9
- `texra-local doctor --output-format json` passed with included access, models, and LaTeX tooling available
- live TTY: launched `texra-local`, selected New chat and the default included relay model, then sent: `Prove that if n^2 is even, then n is even. Keep the proof concise.`
- observed stale `Tip: Use /resume to continue a previous session` while the response was actively streaming; this PR makes the active response tip context-specific

## Validation
- `npm test -- src/test-kernel/cli/TipRow.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-tiprow-20260622 queued-followups transcript`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-dogfood-20260622 slash-goal-help backslash-goal-help plan-approval-goal bash-approval-approve-session subagents subagent-picker task-picker orchestrate-launcher`
- `npm run typecheck`
- `npm run lint` (exits 0 with existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small TUI copy/selection logic change with unit test coverage; no auth, data, or API impact.
> 
> **Overview**
> Fixes the CLI **Tip** row so an active stream always shows *queue a follow-up* guidance instead of whatever hourly tip would have rotated in (e.g. `/resume`).
> 
> `tipRowText` now **short-circuits** when `responseRunning` is true and returns the queued-follow-up string. Idle sessions still rotate tips and substitute Ctrl-R history search when the queue-follow-up slot would appear without an active response.
> 
> Tests assert that any active response hour shows the follow-up tip, not only the slot that previously mapped to that message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5eeebe1d0c67f07aaf01985de4288c62f7f321a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->