### PR TITLE
fix(cli): simplify agent picker rows

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -669,7 +669,7 @@ const SCENARIOS = [
     expect: [
       '/agent',
       'Tool-use and delegating agents',
-      'Creator — delegating',
+      'Creator',
       'Current: chat (hidden from picker)',
       'texra chat --agent=<name>',
       'Esc close',
@@ -678,6 +678,7 @@ const SCENARIOS = [
       'Platform not initialized',
       '/agent - error',
       'texra --agent=<name>',
+      'Creator —',
       'tool-use; built-in',
       'delegating; built-in',
       'orchestrator; built-in',
@@ -695,7 +696,7 @@ const SCENARIOS = [
     expect: [
       '/agent',
       'Tool-use and delegating agents',
-      'Creator — delegating',
+      'Creator',
       'Current: chat (hidden from picker)',
       'texra chat --agent=<name>',
       'Esc close',
@@ -704,6 +705,7 @@ const SCENARIOS = [
       'Platform not initialized',
       '/agent - error',
       'texra --agent=<name>',
+      'Creator —',
       'tool-use; built-in',
       'delegating; built-in',
       'orchestrator; built-in',

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -34,17 +34,6 @@ interface AgentGroups {
 type AgentIdentity = Pick<AgentOptionData, 'label' | 'value'>;
 type AgentDelegationFlag = Pick<AgentOptionData, 'isOrchestrator'>;
 
-export function agentDescription(agent: AgentOptionData): string {
-  return [
-    isDelegatingAgent(agent) ? 'delegating' : undefined,
-    agent.isRemote ? 'remote' : undefined,
-    agent.isCustom ? 'custom' : undefined,
-    agent.description,
-  ]
-    .filter((part) => part != null && part.length > 0)
-    .join('; ');
-}
-
 function isDelegatingAgent(agent: AgentDelegationFlag): boolean {
   return agent.isOrchestrator === true;
 }
@@ -185,7 +174,6 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   const items = agents.toolUse.map((agent) => ({
     value: agent.value,
     label: formatAgentOptionLabel(agent.label),
-    description: agentDescription(agent),
   }));
   // The current agent may be stored as a canonical key (`source:name`) or a
   // bare name; rows are keyed by canonical value, so match Select in that same
@@ -199,7 +187,6 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   const workflowRows = agents.workflow.map((agent) => ({
     value: agent.value,
     name: formatAgentOptionLabel(agent.label),
-    description: agentDescription(agent),
   }));
   const selectWindow = agentSelectWindow({
     availableRows: props.availableRows,
@@ -277,9 +264,6 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
             <Text key={workflow.value} wrap="truncate-end">
               {'  '}
               {workflow.name}
-              {workflow.description ? (
-                <Text dimColor>{` — ${workflow.description}`}</Text>
-              ) : null}
             </Text>
           ))}
           {selectWindow.showWorkflowOverflow ? (

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  agentDescription,
   agentPickerPrimarySectionTitle,
   agentSelectWindow,
   currentVisibleAgent,
@@ -71,43 +70,6 @@ describe('CLI AgentListForm row budget', () => {
         { isOrchestrator: true },
       ]),
     ).toBe('Tool-use and delegating agents');
-  });
-
-  it('omits default role/source noise from agent descriptions', () => {
-    expect(
-      agentDescription({
-        value: 'builtInToolUse:research',
-        label: 'Research',
-        isToolUse: true,
-        description: 'derivations and numerics',
-      }),
-    ).toBe('derivations and numerics');
-    expect(
-      agentDescription({
-        value: 'builtInWorkflow:correct',
-        label: 'correct',
-        description: 'revise the manuscript',
-      }),
-    ).toBe('revise the manuscript');
-  });
-
-  it('keeps only distinguishing agent metadata in descriptions', () => {
-    expect(
-      agentDescription({
-        value: 'remote:orchestrator',
-        label: 'orchestrator',
-        isRemote: true,
-        isOrchestrator: true,
-        description: 'plan and delegate tasks',
-      }),
-    ).toBe('delegating; remote; plan and delegate tasks');
-    expect(
-      agentDescription({
-        value: 'custom:reviewer',
-        label: 'reviewer',
-        isCustom: true,
-      }),
-    ).toBe('custom');
   });
 
   it('windows long agent lists inside the available foreground rows', () => {


### PR DESCRIPTION
## Summary
- remove the CLI-only agent row description formatter from `/agent` picker rows
- keep agent picker rows focused on names, with descriptions left to detail-oriented catalog surfaces
- update PTY harness expectations so `Creator — delegating` cannot regress back into the picker

Closes #6524

## Validation
- `texra-local doctor --output-format json`
- live `texra-local chat` TTY smoke: `/goal`, `/login`, Esc close, Ctrl-C idle exit
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-full-20260622` (139 scenarios) before the cleanup
- `npm test -- src/test-kernel/cli/AgentListForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-agent-picker-pr-20260622 agent-form agent-form-80-cols compact-agent-form slash-palette`
- `npm run typecheck`
- `npm run lint` (0 errors; existing 18 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to the agent picker UI and test expectations; no auth, data, or session logic touched.
> 
> **Overview**
> The `/agent` TUI picker no longer shows per-row metadata (delegating, remote, custom, or catalog descriptions). Tool-use agents render as **names only** in the main `Select` list, and workflow rows drop the dim ` — description` suffix.
> 
> The exported `agentDescription` helper is removed from `AgentListForm.tsx`. PTY harness scenarios `agent-form` and `agent-form-80-cols` now expect plain `Creator` and forbid strings like `Creator —` and `tool-use; built-in`. Unit tests that covered `agentDescription` formatting are deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c847dcdebabf592ec487f5a4e4aff87cede8e469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->