### PR TITLE
fix(cli): preserve agent category in hidden notice

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -30,7 +30,10 @@ export async function listAgents(
   const result = await loadCliAgentList(options);
 
   if (context.outputFormat === 'text' && !context.quietLogs) {
-    const hiddenNotice = formatCliHiddenAgentsNotice(result.hiddenCount);
+    const hiddenNotice = formatCliHiddenAgentsNotice(
+      result.hiddenCount,
+      options.category,
+    );
     if (hiddenNotice) writeTextStderr(hiddenNotice);
   }
 

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -217,9 +217,14 @@ export function formatCliAgentDetails(entry: AgentEntry): string {
 
 export function formatCliHiddenAgentsNotice(
   hiddenCount: number,
+  category?: AgentCategory,
 ): string | undefined {
   if (hiddenCount <= 0) return undefined;
-  return `Showing visible agents only; ${hiddenCount} hidden agent${hiddenCount === 1 ? '' : 's'} omitted. Use \`texra agents list --all\` to show the full catalog.`;
+  const categoryArg = category ? ` --category ${category}` : '';
+  const catalog = category
+    ? `${category === AgentCategory.ToolUse ? 'tool-use' : category} catalog`
+    : 'full catalog';
+  return `Showing visible agents only; ${hiddenCount} hidden agent${hiddenCount === 1 ? '' : 's'} omitted. Use \`texra agents list${categoryArg} --all\` to show the ${catalog}.`;
 }
 
 function collectCliAgents(

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -210,7 +210,51 @@ describe('CLI agents command', () => {
       { paged: true },
     );
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      'Showing visible agents only; 1 hidden agent omitted. Use `texra agents list --all` to show the full catalog.',
+      'Showing visible agents only; 1 hidden agent omitted. Use `texra agents list --category toolUse --all` to show the tool-use catalog.',
+    );
+  });
+
+  it('keeps the workflow category in the hidden-agent notice', async () => {
+    const visibleWorkflowAgent = {
+      name: 'polish',
+      source: 'builtInWorkflow',
+      path: '/tmp/resources/agents/polish.yaml',
+      category: AgentCategory.Workflow,
+      description: 'Polishes prose.',
+    };
+    const hiddenWorkflowAgent = {
+      name: 'correct',
+      source: 'builtInWorkflow',
+      path: '/tmp/resources/agents/correct.yaml',
+      category: AgentCategory.Workflow,
+      description: 'Corrects LaTeX.',
+    };
+    mocks.getVisibleAgents.mockImplementation((category: AgentCategory) =>
+      category === AgentCategory.Workflow ? [visibleWorkflowAgent] : [],
+    );
+    mocks.getAgentsByCategory.mockImplementation((category: AgentCategory) =>
+      category === AgentCategory.Workflow
+        ? [visibleWorkflowAgent, hiddenWorkflowAgent]
+        : [],
+    );
+    const { listAgents } = await import('@cli/commands/agents');
+
+    const exitCode = await listAgents(cliContext(), {
+      category: AgentCategory.Workflow,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.emitCliResult).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        json: [visibleWorkflowAgent],
+        ndjson: [{ kind: 'agent', agent: visibleWorkflowAgent }],
+        text: 'workflow\tpolish\tPolishes prose.',
+      },
+      { paged: true },
+    );
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'Showing visible agents only; 1 hidden agent omitted. Use `texra agents list --category workflow --all` to show the workflow catalog.',
     );
   });
 


### PR DESCRIPTION
## Summary
- preserve the active `agents list --category` filter in hidden-agent notices
- describe the filtered catalog instead of sending users to the full mixed catalog
- add regression coverage for category-filtered hidden-agent notices

Closes #6526

## Validation
- `npm test -- src/test-kernel/cli/AgentsCommand.vitest.mts`
- `npm run texra-local:build && npm run texra-local:link`
- `texra-local agents list --category workflow`
- `texra-local agents list --category toolUse`
- `npm run typecheck`
- `npm run lint` (passes with 18 existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only stderr copy and argument threading; no agent loading or visibility logic changes.
> 
> **Overview**
> When `texra agents list` runs with `--category` and some agents are hidden, the stderr notice now suggests **`texra agents list --category <filter> --all`** instead of dropping the filter and pointing at the mixed full catalog.
> 
> **`formatCliHiddenAgentsNotice`** takes the active category and labels the target as the **workflow**, **tool-use**, or **full** catalog accordingly. **`listAgents`** passes through `options.category`. Tests cover **toolUse** and **workflow** filtered notices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682ad9067a016a70f899d2824d712f1cf396b489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->