### PR TITLE
fix(progress): refresh onboarding after setup action

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -357,6 +357,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
               [],
               this.viewName,
             );
+            await this.provider.refreshOnboardingFunnel();
             break;
           case 'createSampleProject':
             await safeExecuteCommand(

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -273,6 +273,10 @@ export class ProgressViewProvider
     this._mainViewProvider = mvp;
   }
 
+  public async refreshOnboardingFunnel(): Promise<void> {
+    await this._mainViewProvider?.refreshOnboardingFunnel();
+  }
+
   public getContentProvider(): BundledViewContentProvider {
     return this.contentProvider;
   }

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - progress view
 import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 // Local imports - shared
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
@@ -29,7 +30,11 @@ function createWebviewView(): vscode.WebviewView {
   } as unknown as vscode.WebviewView;
 }
 
-function createProgressViewProvider(): unknown {
+type ProgressViewProviderFake = ProgressViewProvider & {
+  refreshOnboardingFunnel: ReturnType<typeof vi.fn>;
+};
+
+function createProgressViewProvider(): ProgressViewProviderFake {
   const snapshots = {
     getTaskState: vi.fn(),
     getExecutionId: vi.fn(),
@@ -61,7 +66,24 @@ function createProgressViewProvider(): unknown {
     refreshOnboardingFunnel: vi.fn(),
     setActiveStream: vi.fn(),
     syncFullView: vi.fn(),
-  };
+  } as unknown as ProgressViewProviderFake;
+}
+
+function createProviderShell(
+  mainViewProvider?: Pick<ProgressViewProvider, 'refreshOnboardingFunnel'>,
+): ProgressViewProvider {
+  const provider = Object.create(
+    ProgressViewProvider.prototype,
+  ) as ProgressViewProvider;
+  (
+    provider as unknown as {
+      _mainViewProvider?: Pick<
+        ProgressViewProvider,
+        'refreshOnboardingFunnel'
+      >;
+    }
+  )._mainViewProvider = mainViewProvider;
+  return provider;
 }
 
 describe('progress-view onboarding refresh wiring', () => {
@@ -70,15 +92,13 @@ describe('progress-view onboarding refresh wiring', () => {
     mocks.safeExecuteCommand.mockResolvedValue(undefined);
   });
 
-  it('refreshes the onboarding funnel after progress setup actions', () => {
+  it('refreshes the onboarding funnel after progress setup actions', async () => {
     const context = createExtensionContext();
-    const provider = createProgressViewProvider() as {
-      refreshOnboardingFunnel: ReturnType<typeof vi.fn>;
-    };
+    const provider = createProgressViewProvider();
     provider.refreshOnboardingFunnel.mockResolvedValue(undefined);
-    const handler = new ProgressViewMessageHandler(provider as never, context);
+    const handler = new ProgressViewMessageHandler(provider, context);
 
-    void handler.handleMessage(
+    await handler.handleMessage(
       {
         command: PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION,
         action: 'runSetup',
@@ -93,6 +113,55 @@ describe('progress-view onboarding refresh wiring', () => {
         'ProgressView',
       );
       expect(provider.refreshOnboardingFunnel).toHaveBeenCalledOnce();
+      const setupCallOrder =
+        mocks.safeExecuteCommand.mock.invocationCallOrder[0];
+      const refreshCallOrder =
+        provider.refreshOnboardingFunnel.mock.invocationCallOrder[0];
+      expect(setupCallOrder).toBeDefined();
+      expect(refreshCallOrder).toBeDefined();
+      expect(setupCallOrder!).toBeLessThan(refreshCallOrder!);
     });
+  });
+
+  it.each([
+    'createSampleProject',
+    'cloneOverleaf',
+    'downloadArxiv',
+    'openWalkthrough',
+  ] as const)(
+    'does not refresh the onboarding funnel for %s',
+    async (action) => {
+      const context = createExtensionContext();
+      const provider = createProgressViewProvider();
+      const handler = new ProgressViewMessageHandler(provider, context);
+
+      await handler.handleMessage(
+        {
+          command: PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION,
+          action,
+        },
+        createWebviewView(),
+      );
+
+      await vi.waitFor(() => {
+        expect(mocks.safeExecuteCommand).toHaveBeenCalledOnce();
+      });
+      expect(provider.refreshOnboardingFunnel).not.toHaveBeenCalled();
+    },
+  );
+
+  it('delegates onboarding refresh through the main view provider', async () => {
+    const refreshOnboardingFunnel = vi.fn().mockResolvedValue(undefined);
+    const provider = createProviderShell({ refreshOnboardingFunnel });
+
+    await provider.refreshOnboardingFunnel();
+
+    expect(refreshOnboardingFunnel).toHaveBeenCalledOnce();
+  });
+
+  it('ignores onboarding refresh when no main view provider is wired', async () => {
+    const provider = createProviderShell();
+
+    await expect(provider.refreshOnboardingFunnel()).resolves.toBeUndefined();
   });
 });

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -76,10 +76,7 @@ describe('progress-view onboarding refresh wiring', () => {
       refreshOnboardingFunnel: ReturnType<typeof vi.fn>;
     };
     provider.refreshOnboardingFunnel.mockResolvedValue(undefined);
-    const handler = new ProgressViewMessageHandler(
-      provider as never,
-      context,
-    );
+    const handler = new ProgressViewMessageHandler(provider as never, context);
 
     void handler.handleMessage(
       {

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -77,10 +77,7 @@ function createProviderShell(
   ) as ProgressViewProvider;
   (
     provider as unknown as {
-      _mainViewProvider?: Pick<
-        ProgressViewProvider,
-        'refreshOnboardingFunnel'
-      >;
+      _mainViewProvider?: Pick<ProgressViewProvider, 'refreshOnboardingFunnel'>;
     }
   )._mainViewProvider = mainViewProvider;
   return provider;

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -1,0 +1,101 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - progress view
+import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
+
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type { StreamTabId } from '@shared/schemas';
+import type * as vscode from 'vscode';
+
+const mocks = vi.hoisted(() => ({
+  safeExecuteCommand: vi.fn(),
+}));
+
+vi.mock('@frontend/system/commandUtils', () => ({
+  safeExecuteCommand: mocks.safeExecuteCommand,
+}));
+
+function createExtensionContext(): vscode.ExtensionContext {
+  return {
+    subscriptions: [],
+  } as unknown as vscode.ExtensionContext;
+}
+
+function createWebviewView(): vscode.WebviewView {
+  return {
+    webview: { postMessage: vi.fn() },
+  } as unknown as vscode.WebviewView;
+}
+
+function createProgressViewProvider(): unknown {
+  const snapshots = {
+    getTaskState: vi.fn(),
+    getExecutionId: vi.fn(),
+    getOutputFiles: vi.fn(() => new Map()),
+    getKnownFilePaths: vi.fn(() => new Set()),
+    getCompileFailures: vi.fn(() => new Map()),
+  };
+  return {
+    state: {
+      activeStream: '',
+      agentCategoryFilter: 'all',
+      streamLogs: new Map<StreamTabId, unknown>(),
+      snapshots,
+      pickValidActiveStream: vi.fn(() => ''),
+      clearStream: vi.fn(),
+      clearAll: vi.fn(),
+    },
+    webviewUpdater: {
+      updateGoalActive: vi.fn(),
+    },
+    webviewBridge: {
+      clearStream: vi.fn(),
+      clearAll: vi.fn(),
+    },
+    getPendingAgentProposal: vi.fn(),
+    markWebviewReady: vi.fn(),
+    popOutToEditor: vi.fn(),
+    popBackToSidebar: vi.fn(),
+    refreshOnboardingFunnel: vi.fn(),
+    setActiveStream: vi.fn(),
+    syncFullView: vi.fn(),
+  };
+}
+
+describe('progress-view onboarding refresh wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.safeExecuteCommand.mockResolvedValue(undefined);
+  });
+
+  it('refreshes the onboarding funnel after progress setup actions', () => {
+    const context = createExtensionContext();
+    const provider = createProgressViewProvider() as {
+      refreshOnboardingFunnel: ReturnType<typeof vi.fn>;
+    };
+    provider.refreshOnboardingFunnel.mockResolvedValue(undefined);
+    const handler = new ProgressViewMessageHandler(
+      provider as never,
+      context,
+    );
+
+    void handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION,
+        action: 'runSetup',
+      },
+      createWebviewView(),
+    );
+
+    return vi.waitFor(() => {
+      expect(mocks.safeExecuteCommand).toHaveBeenCalledWith(
+        'texra.runSetupAssistant',
+        [],
+        'ProgressView',
+      );
+      expect(provider.refreshOnboardingFunnel).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a progress-view provider method for refreshing the onboarding funnel
- call it after the progress empty-state `runSetup` action completes
- delegate the refresh to the existing main-view provider when it is wired
- add regression coverage for the progress handler behavior

Closes #6518

## Validation
- `npm test -- src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with 18 existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UI wiring after an existing setup command; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes stale onboarding when users launch setup from the **progress view** empty state instead of the main launcher.
> 
> **`ProgressViewProvider`** gains **`refreshOnboardingFunnel()`**, which forwards to the wired **`MainViewProvider`** (no-op if unset). **`ProgressViewMessageHandler`** awaits **`texra.runSetupAssistant`**, then calls that refresh **only** for the **`runSetup`** getting-started action—not for sample project, Overleaf clone, arXiv download, or walkthrough.
> 
> New **`ProgressViewOnboardingRefresh.vitest.mts`** covers call order (setup before refresh), the other actions skipping refresh, delegation, and the unwired main-view case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cebd99dd5cb58ea3d51bc4373492e29a3349d20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->