### PR TITLE
docs: add Google Gemini Interactions API migration proposal

### DIFF
--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -54,7 +54,9 @@ us flip the default per-model once the new path is proven.
   function declarations in a single request directly removes a limitation TeXRA
   documents today: the native `googleSearch` tool is currently disabled because
   the `generateContent` API cannot combine `googleSearch` with
-  `functionDeclarations` (see `modelHandlerGoogleGenAI.ts:355`).
+  `functionDeclarations` — the repo comment attributes mixing to the Live API
+  only (`toolConversion.ts:355-357`). The GA announcement says Interactions lifts
+  this on the regular surface (⚠️ verify it actually does before relying on it).
 - **Same SDK.** This rides on the already-installed `@google/genai` dependency —
   no new vendor SDK, consistent with the existing provider boundary.
 
@@ -249,7 +251,9 @@ verify the exact ids and pricing at implementation time.
 
 No new host coupling. `src/agent/modelHandlers/` is a VS Code-free zone and the
 new handler stays there, reaching host services only through `platform()`
-(secrets for the API key via `getApiKey(secrets, 'google')`, config, fs for media
+(secrets for the API key via the base handler's `getApiKey()` —
+`modelHandlerGoogleGenAI.ts:299`,`319` construct `new GoogleGenAI({ apiKey })` —
+config, fs for media
 upload) — identical to the existing Google handler. The settings toggle flows
 through the existing `coreSettings` schema; no new ports needed.
 

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -307,7 +307,9 @@ JSON** — trust the `.d.ts` where they differ.
   `store:false` request to include the initial `user_input` step, all
   model-generated steps exactly as received (including `thought` and
   `function_call`), and the local `function_result` step. This matches v0's
-  local-history plan and is the contract the tests should encode.
+  local-history plan and is the contract the tests should encode. In code shape,
+  this means `input: [initialUserInputStep, ...turn1.steps, functionResultStep]`
+  with no `previous_interaction_id`.
 - **Explicit caching is not yet available in Interactions.** The SDK exposes
   `cached_content`, but the overview lists explicit caching under
   generateContent-only limitations and points Interactions users at implicit
@@ -320,8 +322,9 @@ JSON** — trust the `.d.ts` where they differ.
 
 - **Streamed tool args.** Guide prose: `delta.type === "arguments"` /
   `delta.partial_arguments`. SDK: `ArgumentsDelta` (`:527`) is
-  `{ type:"arguments_delta", arguments?: string }`. Use `"arguments_delta"` and
-  the `arguments` field.
+  `{ type:"arguments_delta", arguments?: string }`. The low line number is
+  anomalous but real in the `@google/genai@2.9.0` tarball; use
+  `"arguments_delta"` and the `arguments` field.
 - **Usage field names.** Guide REST JSON shows `prompt_tokens` /
   `completion_tokens` / `total_tokens`; the SDK `Usage` type (`:13952`) has
   **none** of those — it exposes `total_input_tokens` / `total_output_tokens` /
@@ -405,8 +408,9 @@ error instead of silently falling back to the chat handler.
 
 Add `model.useGoogleInteractionsAPI` to `coreSettings.ts` (the three sites at
 ~81/325/564), mirroring `useOpenAIResponsesAPI`; reuse
-`model.useBackgroundResponses` for `background:true`. Surface in Settings →
-Models; document in `docs/guide/configuration.md`.
+`model.useBackgroundResponses` only for the later `store:true`/background phase
+(v0 ignores it because v0 uses `store:false`). Surface in Settings → Models;
+document in `docs/guide/configuration.md`.
 
 ### 5. Model registry
 
@@ -444,8 +448,9 @@ schema; no new ports.
    compaction working unchanged) vs `store:true` (default) with
    `previous_interaction_id` (payload win, but the server — not TeXRA — then owns
    compaction, and behaviour must be defined when the stored interaction has
-   expired or a run is restored from old history). Official retention is 55 days
-   on paid tier / 1 day on free tier; note `store:false` is incompatible with
+   expired or a run is restored from old history). Official retention is
+   currently 55 days on paid tier / 1 day on free tier (`⚠️` confirm at
+   implementation time); note `store:false` is incompatible with
    `background=true` and with later `previous_interaction_id` use. **Recommend
    `store:false` for v0** to preserve the existing history/compaction contract,
    treating server-side continuation (+ background) as a later optimisation.

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -1,0 +1,360 @@
+# Proposal: Google Gemini via the Interactions API
+
+**Status:** Proposal (research + migration plan; no handler code yet)
+**Owner:** _unassigned_
+**Tracking branch:** `claude/interactions-api-ga-28j8yu`
+**Companion proposal:** [`openai-responses-api.md`](./openai-responses-api.md) — the directly analogous "provider ships a new stateful, server-side-state API" precedent that this design mirrors.
+
+> **Verification note.** The Interactions API reached general availability after
+> this author's training cutoff. The schema below is reconstructed from Google's
+> public announcement, the GA docs index, and the `@google/genai` JS SDK surface
+> as surfaced through web search — Google's `ai.google.dev` doc pages returned
+> HTTP 403 to automated fetches, so **exact field casing and step-type names were
+> not byte-verified against the live reference.** Every place where the precise
+> identifier matters is flagged `⚠️ verify`. Before writing handler code, walk
+> the [Verification checklist](#verification-checklist) against the installed SDK
+> `.d.ts` and the live docs (the way `openai-responses-api.md` and the Copilot
+> PRD were verified against pinned types).
+
+## Summary
+
+Google has made the **Interactions API** (`client.interactions.create(...)`) the
+**primary, recommended interface** for Gemini models *and* agents, GA as of the
+2026 announcement. It is a single stateful endpoint that replaces the
+`generateContent` / chat surface for new work: server-side conversation state
+(continue by referencing a prior interaction id instead of resending history),
+background/async execution, a unified **steps**-based response model, mixing
+built-in tools (Google Search, Maps) with custom functions in one request, tool
+results that can return images, and new media-generation and managed-agent
+capabilities. `generateContent` remains supported, but Google states frontier
+long-running/agentic capabilities will increasingly land **only** on Interactions.
+
+TeXRA today drives Gemini exclusively through the **chat / `generateContent`**
+surface of the same SDK (`@google/genai`). This proposal recommends an
+**additive, feature-flagged** Interactions handler that lives beside the existing
+one — exactly the shape TeXRA already uses for OpenAI's Responses API — rather
+than an in-place rewrite. That keeps the battle-tested `generateContent` path as
+the default/fallback while we gain access to Interactions-only features, and lets
+us flip the default per-model once the new path is proven.
+
+## Motivation
+
+- **Future-proofing.** Google has declared Interactions the default across AI
+  Studio, the Gemini API, and all docs; new frontier agentic/long-running
+  features are expected to be Interactions-only. Staying on `generateContent`
+  means those features become unreachable from TexRA over time.
+- **Server-side state.** Continuing via a prior-interaction id (instead of
+  resending the full `Content[]` history every round) shrinks request payloads
+  and simplifies multi-turn management — the same win TeXRA already realised for
+  OpenAI via `previous_response_id` (see `openai-responses-api.md`).
+- **Background execution.** `background: true` for long-running runs maps
+  naturally onto TeXRA's existing background-response machinery
+  (`texra.model.useBackgroundResponses`, already wired for OpenAI).
+- **Unified tool model.** Mixing built-in tools (Google Search) with custom
+  function declarations in a single request directly removes a limitation TeXRA
+  documents today: the native `googleSearch` tool is currently disabled because
+  the `generateContent` API cannot combine `googleSearch` with
+  `functionDeclarations` (see `modelHandlerGoogleGenAI.ts:355`).
+- **Same SDK.** This rides on the already-installed `@google/genai` dependency —
+  no new vendor SDK, consistent with the existing provider boundary.
+
+## Current state (verified in repo)
+
+TeXRA's Gemini integration is a single, mature handler on the chat surface:
+
+| File | Detail |
+| ---- | ------ |
+| `src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts` (~1366 lines) | `ModelHandlerGoogleGenAI`; calls `client.chats.create()` → `chat.sendMessageStream()` / `chat.sendMessage()`; `client.models.countTokens()`; `client.files.upload()` |
+| `src/agent/modelHandlers/google/googleMessageHelpers.ts` | Strict user/model alternation, `systemInstruction`, parts-based `Content[]` construction |
+| `src/agent/modelHandlers/google/googleUsage.ts` | Token/price/usage normalization from `GenerateContentResponseUsageMetadata` |
+| `src/agent/modelHandlers/google/googleSdkError.ts` | Maps `GoogleApiError` → TeXRA SDK error kinds |
+| `src/agent/modelHandlers/toolConversion.ts:360` | `toGoogleTools()` → `{ functionDeclarations }` |
+| `src/agent/runtime/ModelFactory.ts:73` | `PROVIDER_HANDLER_ROUTES[ModelProvider.GOOGLE]` → loads `ModelHandlerGoogleGenAI`, compatibility key `'ModelHandlerGoogleGenAI'` |
+| `package.json:108`, `packages/extension/package.json:1713` | `@google/genai` `^2.9.0` |
+
+Notable capabilities the new handler must preserve (all currently in
+`modelHandlerGoogleGenAI.ts`):
+
+- **Streaming** with thinking/output separation and end-of-stream usage capture.
+- **Parallel tool calls batched into one model message**, preserving Gemini 3
+  **thought signatures** (`requiresBatchedParallelToolResults = true`, line 346;
+  thought-signature plumbing on `GoogleToolCall`). This is the highest-risk area
+  to reproduce on a new wire format.
+- **Multimodal**: inline base64 (≤20 MB) vs File API upload (>20 MB), Gemini 3
+  media-resolution levels.
+- **Thinking levels** (`LOW`/`MEDIUM`/`HIGH`) via `thinkingConfig`.
+- **Native token counting** (`countTokens`) feeding context-window guards.
+- **Usage/pricing**: input/output/reasoning/cached/tool-use token breakdown and
+  cache rebate.
+
+There are **no** existing references to the Interactions API in the repo.
+
+## The precedent this mirrors: OpenAI Responses API
+
+TeXRA already solved the "provider introduced a newer, stateful, server-side-state
+API alongside the legacy one" problem for OpenAI. The wiring we should copy:
+
+- A **separate handler** `ModelHandlerOpenAIResponse`
+  (`src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts`) coexists with
+  the chat-completions handler.
+- A **compatibility key** `'ModelHandlerOpenAIResponse'` in
+  `ModelHandlerCompatibilityKey` (`ModelFactory.ts:29`) marks the distinct
+  conversation-history format, so history restoration/compaction know which
+  shape a saved run used.
+- A **routing predicate** `shouldUseResponsesAPI(config, useOpenRouter)`
+  (`ModelFactory.ts:175`) decides per-model whether to use the new path, gated by
+  the setting `texra.model.useOpenAIResponsesAPI` (plus per-model `required` and
+  `gpt-oss` forcing).
+- A **settings flag** `model.useOpenAIResponsesAPI` in
+  `src/shared/schemas/coreSettings.ts` (default `true`; lines 81, 325, 564) with
+  a companion `model.useBackgroundResponses`.
+- `createModelHandler()` branches to the Responses handler **before** the
+  default provider route (`ModelFactory.ts:361`).
+
+This proposal reuses that exact pattern for Google.
+
+## API surface (reconstructed — see verification note)
+
+Authoritative source for code will be the **installed `@google/genai` `.d.ts`**;
+the following is the working model.
+
+**Request — `client.interactions.create(params)`** (and a streaming variant):
+
+- `model` *or* `agent` — exactly one. `model` for inference (e.g.
+  `gemini-3.5-flash` ⚠️ verify ids), `agent` for managed agents
+  (`antigravity-preview-*`, `deep-research-*`).
+- `input` — text string, or multimodal/array input (parts: text + inline data +
+  file refs). ⚠️ verify the part object shape vs the chat API's `Part`.
+- `previous_interaction_id` — continue a prior interaction (server-side state).
+  ⚠️ verify exact key (`previousInteractionId` in camelCase SDK vs
+  `previous_interaction_id` in REST).
+- `background: boolean` — async/server-side execution.
+- `stream: boolean` (or a dedicated `createStream`/SSE iterator) ⚠️ verify which.
+- `tools` — array mixing custom functions
+  (`{ type: 'function', name, description, parameters }`) and built-ins
+  (`{ type: 'google_search' }`, `{ type: 'code_execution' }`, Maps). ⚠️ verify
+  exact tool object discriminator and whether function shape is `parameters`
+  (JSON Schema) like the reconstructed form, or nested `functionDeclarations` as
+  in the chat API.
+- `environment` — `'remote'` for managed-agent sandboxes.
+- generation knobs / `system_instruction` / structured-output `response_format`
+  (a polymorphic format that replaced `response_mime_type`) ⚠️ verify, plus
+  `thinking`/reasoning config and `response_modalities` for media generation.
+- service tier: **Flex** (≈50% cost) vs **Priority** (latency). ⚠️ verify key.
+
+**Response — the `Interaction` resource:**
+
+- A chronological **`steps`** array; each step is a typed object —
+  `user_input`, `thought`, `function_call`, function result/`model_output`, text
+  output, etc. ⚠️ verify the exact set and names. This is the schema's headline
+  change ("From Roles to Steps"): every action is its own typed step rather than
+  a role-tagged message with parts.
+- Convenience accessors on the `Interaction` for the common cases (e.g. final
+  text) without walking `steps`. ⚠️ verify accessor names.
+- An interaction `id` (for `previous_interaction_id` continuation), and usage /
+  token metadata. ⚠️ verify usage field names — likely differ from
+  `GenerateContentResponseUsageMetadata` (`promptTokenCount`, `candidatesTokenCount`,
+  `thoughtsTokenCount`, `cachedContentTokenCount`, `toolUsePromptTokenCount`).
+- **Streaming** emits SSE-style events with types such as `step.start` /
+  `step.delta` (text chunks under `delta`) / step completion. ⚠️ verify event
+  and field names.
+- **Retention:** past interactions retrievable, ~55-day retention on paid tier.
+
+**Schema volatility (important).** Search surfaced that the Interactions schema
+churned during beta: the **steps** array replaced an earlier `outputs` shape, and
+a polymorphic `response_format` replaced `response_mime_type`, with the legacy
+shape removed mid-2026. GA means the schema is now stable, but it strongly argues
+for (a) pinning a known-good `@google/genai` version and (b) keeping the legacy
+`generateContent` handler as fallback.
+
+## Mapping: `generateContent`/chat → Interactions
+
+| TeXRA concern | Today (`generateContent`/chat) | Interactions API |
+| ------------- | ------------------------------ | ---------------- |
+| Send a turn | `chat.sendMessage(parts)` | `interactions.create({ model, input })` |
+| Streaming | `chat.sendMessageStream()` → `chunk.candidates[0].content.parts` | stream events → `step.delta` text ⚠️ |
+| Conversation state | resend full `Content[]` each round | `previous_interaction_id` (server-side) ⚠️ |
+| System prompt | `systemInstruction` on chat params | `system_instruction` on create ⚠️ |
+| Custom tools | `{ functionDeclarations: [...] }` | `tools: [{ type:'function', name, description, parameters }]` ⚠️ |
+| Built-in search | **disabled** (can't mix with functions) | `tools: [{ type:'google_search' }, ...functions]` — now mixable |
+| Tool call out | `functionCall` part on candidate | `function_call` step (`name`, args, id) ⚠️ |
+| Tool result in | `functionResponse` part (user msg) | function-result step ⚠️ |
+| **Parallel tool calls** | batched into one model `Content` + thought signatures | must map onto steps **without losing thought signatures** ⚠️ **highest risk** |
+| Thinking | `thinkingConfig` + `thought` parts | reasoning/thinking config + `thought` steps ⚠️ |
+| Multimodal in | inline base64 / File API `uri` parts | inline data / file refs in `input` ⚠️ |
+| Token counting | `client.models.countTokens()` | unchanged `countTokens` (still on `models`)? ⚠️ verify |
+| Usage/pricing | `GenerateContentResponseUsageMetadata` | new usage metadata shape ⚠️ remap `googleUsage.ts` |
+| Background | n/a for Google today | `background: true` (reuse `useBackgroundResponses` machinery) |
+| Caching | `cachedContentTokenCount` rebate | verify cache reporting on the new usage shape ⚠️ |
+
+## Design (additive, feature-flagged)
+
+Mirror the OpenAI Responses precedent end to end.
+
+### 1. New handler
+
+`ModelHandlerGoogleInteractions` in
+`src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts`, extending the
+shared `ModelHandler` base like the existing Google handler. Reuse what is
+provider-shaped rather than wire-shaped:
+
+- **Reuse** `googleSdkError.ts` (same SDK error type), tool **schema conversion**
+  helpers in `toolConversion.ts` (JSON-Schema flattening/`$schema` stripping is
+  wire-agnostic), and the media upload size/threshold logic.
+- **Rewrite** message construction (`googleMessageHelpers.ts` equivalent) for the
+  steps model + `previous_interaction_id`, the streaming loop (step events), tool
+  call extraction/round-trip, and `googleUsage.ts` for the new usage metadata.
+- Keep **thought-signature preservation** for parallel tool calls as a
+  first-class requirement and cover it with a dedicated test (it is the single
+  most likely regression).
+
+### 2. Compatibility key
+
+Add `'ModelHandlerGoogleInteractions'` to the `ModelHandlerCompatibilityKey`
+union (`ModelFactory.ts:29`). Because Interactions stores conversation state
+**server-side** and continues via `previous_interaction_id`, its persisted
+history shape differs from the chat handler's `Content[]` — history
+restoration/compaction must not mix the two. A distinct key is mandatory.
+
+### 3. Routing predicate + factory branch
+
+Add `shouldUseGoogleInteractionsAPI(config, useOpenRouter)` next to
+`shouldUseResponsesAPI` (`ModelFactory.ts`). Gate on a new setting plus a
+per-model `requiresInteractionsAPI`/agent flag (agents like `antigravity-*` /
+`deep-research-*` are Interactions-only and would force it). Branch to the new
+handler in `createModelHandler()` **before** the default Google provider route
+(`PROVIDER_HANDLER_ROUTES[GOOGLE]`), exactly as the Responses branch precedes the
+default OpenAI route. Respect `useOpenRouter` (OpenRouter cannot proxy
+Interactions — fall back to the existing path), the same guard
+`requiresOpenAIResponsesAPI` applies.
+
+### 4. Settings
+
+Add `model.useGoogleInteractionsAPI` to `src/shared/schemas/coreSettings.ts`
+(default, key list, and Zod schema — the three sites at lines ~81/325/564),
+mirroring `useOpenAIResponsesAPI`. Reuse `model.useBackgroundResponses` for the
+`background: true` behaviour, or add a Google-specific companion if semantics
+diverge. Surface the toggle in Settings → Models and document in
+`docs/guide/configuration.md`.
+
+### 5. Model registry
+
+Register the new Gemini model ids / agent ids surfaced at GA (e.g.
+`gemini-3.5-flash`, Antigravity / Deep Research agents) in the model
+configuration source (`llm-zoo` `MODEL_CONFIGS` + `src/model/` capability/pricing
+mapping), marking agent-only entries with the Interactions-required flag. ⚠️
+verify the exact ids and pricing at implementation time.
+
+## Platform / VS Code separation
+
+No new host coupling. `src/agent/modelHandlers/` is a VS Code-free zone and the
+new handler stays there, reaching host services only through `platform()`
+(secrets for the API key via `getApiKey(secrets, 'google')`, config, fs for media
+upload) — identical to the existing Google handler. The settings toggle flows
+through the existing `coreSettings` schema; no new ports needed.
+
+## Risks & open questions
+
+1. **Unverified schema (post-cutoff).** Everything marked ⚠️ must be confirmed
+   against the installed `.d.ts` and live docs before coding. Treat the table
+   above as a hypothesis, not a contract.
+2. **Thought-signature preservation across the steps model.** Gemini 3 parallel
+   tool calling depends on round-tripping thought signatures; the steps schema
+   reorganises how calls/results are represented. This is the most likely place
+   to silently break parallel tool use. Needs an explicit fixture test.
+3. **Schema churn / version pinning.** The beta schema changed materially
+   (`outputs`→`steps`, `response_mime_type`→`response_format`). Pin a known-good
+   `@google/genai` (current dep is `^2.9.0` — confirm it actually exposes
+   `interactions`; the search-surfaced "introduced in 1.33.0" is unverified).
+4. **Server-side state + history/compaction.** TeXRA's history restore and
+   context compaction assume a resend-able local transcript. With
+   `previous_interaction_id` the canonical state lives on Google's servers with a
+   ~55-day retention. Decide whether to (a) keep sending full local history
+   (stateless mode, simplest, loses the payload win) or (b) adopt
+   `previous_interaction_id` and define behaviour when the server-side
+   interaction has expired / when a run is restored from old history. The OpenAI
+   Responses handler already faced this — reuse its resolution.
+5. **OpenRouter interaction.** Interactions is Google-direct only; ensure the
+   `useOpenRouter` path is excluded (as Responses excludes it).
+6. **Usage/pricing remap.** New usage metadata field names → `googleUsage.ts`
+   must be re-derived; cache-token rebate and reasoning-token accounting need
+   re-validation against the new shape.
+7. **Managed agents are a different product surface.** `agent=` + `environment:
+   'remote'` provisions a remote sandbox that browses/executes code. That is a
+   much larger feature than "call a model" and should be **out of scope for v0**
+   (model-mode only); track separately.
+8. **Built-in tools + custom functions mixing** removes the current
+   `googleSearch` limitation — but verify tool-result image return interacts
+   correctly with TeXRA's tool-result attachment plumbing.
+
+## Scope
+
+**In (v0):** research verification; `ModelHandlerGoogleInteractions` in **model
+mode** (text + multimodal in, streaming, custom function calling incl. parallel
+calls with thought signatures, thinking, token counting, usage/pricing);
+compatibility key; routing predicate + factory branch; `useGoogleInteractionsAPI`
+setting + Settings UI + docs; tests (streaming, parallel-tool thought
+signatures, usage mapping, routing); keep `generateContent` handler as default
+fallback.
+
+**Out (v0):** managed agents (`agent=`, `environment:'remote'`); media
+generation (`response_modalities`, Nano Banana / Lyria / TTS); Deep Research
+agent integration; making Interactions the **default** for Gemini (ship behind
+the flag first, flip later); OpenRouter support for Interactions.
+
+## Milestones
+
+1. **Verify** the schema against the installed SDK `.d.ts` + live docs; fill in
+   every ⚠️; confirm `@google/genai` version exposing `interactions` and pin it.
+   Update this proposal's tables to the verified shapes.
+2. `ModelHandlerGoogleInteractions` (model mode) with streaming + custom tools;
+   compatibility key; factory routing behind `useGoogleInteractionsAPI` (default
+   **off**). Unit tests on message/tool/usage translation (host-neutral, mocked
+   SDK), explicitly including parallel-tool thought-signature round-trip.
+3. Multimodal input, thinking levels, token counting, cache/usage parity; mixed
+   built-in `google_search` + functions; settings UI + `configuration.md`.
+4. Real-key smoke test; CHANGELOG entry; decide default flip per-model;
+   register GA Gemini model ids/pricing.
+
+## Verification checklist
+
+Before writing handler code, confirm against the **installed** `@google/genai`
+types and the live docs (resolve every ⚠️ above):
+
+- [ ] `@google/genai` version that exposes `client.interactions` (and pin it).
+- [ ] `interactions.create` param names & casing: `model`/`agent`, `input`,
+      `previous_interaction_id`, `background`, `stream`/`createStream`, `tools`,
+      `system_instruction`, `response_format`, thinking/reasoning config,
+      `response_modalities`, service tier.
+- [ ] `input` part object shape (text / inline data / file ref) — same as chat
+      `Part` or new?
+- [ ] `tools` entry shape: custom `{ type:'function', name, description,
+      parameters }` vs `functionDeclarations`; built-in discriminators
+      (`google_search`, `code_execution`, maps).
+- [ ] `Interaction.steps` exact step types & fields (`function_call` name/args/id;
+      function-result step; `thought`; text/`model_output`); convenience accessors.
+- [ ] **Thought-signature** field on call/result steps for Gemini 3 parallel
+      tool calling, and how to echo it back.
+- [ ] Streaming event types/fields (`step.start`, `step.delta`, completion).
+- [ ] Usage/token metadata field names (input/output/reasoning/cached/tool-use).
+- [ ] `countTokens` availability/shape under the new surface.
+- [ ] `previous_interaction_id` continuation semantics + retention/expiry
+      behaviour for restored runs.
+
+## References
+
+- Interactions API overview: https://ai.google.dev/gemini-api/docs/interactions/interactions-overview
+- API reference: https://ai.google.dev/api/interactions-api
+- Quickstart: https://ai.google.dev/gemini-api/docs/interactions/quickstart
+- Function calling: https://ai.google.dev/gemini-api/docs/interactions/function-calling
+- Streaming: https://ai.google.dev/gemini-api/docs/interactions/streaming
+- Migration (generateContent → Interactions): https://ai.google.dev/gemini-api/docs/interactions
+- Google announcement: https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api/
+- JS SDK: https://github.com/googleapis/js-genai · https://www.npmjs.com/package/@google/genai
+- Community quickstart (Phil Schmid): https://www.philschmid.de/interactions-api-quickstart
+- TeXRA precedent: [`openai-responses-api.md`](./openai-responses-api.md);
+  routing in `src/agent/runtime/ModelFactory.ts:175`; settings in
+  `src/shared/schemas/coreSettings.ts`.
+
+> _All `ai.google.dev` pages returned HTTP 403 to automated fetch during
+> research; the links are for human verification of the ⚠️ items._

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -261,7 +261,7 @@ JSON** — trust the `.d.ts` where they differ.
   open question in risk #2 — both are first-class.)
 - **Convenience accessors exist** on the returned interaction: `output_text`
   (`:7053`), `output_image?: ImageContent` (`:7057`), `output_audio?:
-  AudioContent` (`:7061`). `output_text` joins only the *trailing* `TextContent`
+AudioContent` (`:7061`). `output_text` joins only the _trailing_ `TextContent`
   run, so anything interleaved with thoughts/tools/images still requires walking
   `steps` — which TeXRA does anyway (thinking is separated, tools are handled).
 - **Function-result round-trip:** submit the result as a **new** `create` call
@@ -386,13 +386,13 @@ schema; no new ports.
    a resend-able local transcript. The guide confirms `store` makes both modes
    first-class: `store:false` = stateless drop-in parity (send full `Step[]` each
    round; simplest, keeps compaction working unchanged) vs `store:true` (default)
-   + `previous_interaction_id` (payload win, but the server — not TeXRA — then
-   owns compaction, and behaviour must be defined when the stored interaction has
-   expired or a run is restored from old history). Official retention is 55 days
-   on paid tier / 1 day on free tier; note `store:false` is incompatible with
-   `background=true` and with later `previous_interaction_id` use. **Recommend
-   `store:false` for v0** to preserve the existing history/compaction contract,
-   treating server-side continuation (+ background) as a later optimisation.
+   - `previous_interaction_id` (payload win, but the server — not TeXRA — then
+     owns compaction, and behaviour must be defined when the stored interaction has
+     expired or a run is restored from old history). Official retention is 55 days
+     on paid tier / 1 day on free tier; note `store:false` is incompatible with
+     `background=true` and with later `previous_interaction_id` use. **Recommend
+     `store:false` for v0** to preserve the existing history/compaction contract,
+     treating server-side continuation (+ background) as a later optimisation.
 3. **GA service with active SDK churn.** The official overview marks the API GA,
    and the types ship in the pinned SDK version; `response_mime_type` is already
    deprecated in favour of `response_format`, signalling churn. Pin/snapshot the

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -1,364 +1,328 @@
 # Proposal: Google Gemini via the Interactions API
 
-**Status:** Proposal (research + migration plan; no handler code yet)
+**Status:** Proposal (research verified against the installed SDK; no handler code yet)
 **Owner:** _unassigned_
 **Tracking branch:** `claude/interactions-api-ga-28j8yu`
 **Companion proposal:** [`openai-responses-api.md`](./openai-responses-api.md) — the directly analogous "provider ships a new stateful, server-side-state API" precedent that this design mirrors.
 
-> **Verification note.** The Interactions API reached general availability after
-> this author's training cutoff. The schema below is reconstructed from Google's
-> public announcement, the GA docs index, and the `@google/genai` JS SDK surface
-> as surfaced through web search — Google's `ai.google.dev` doc pages returned
-> HTTP 403 to automated fetches, so **exact field casing and step-type names were
-> not byte-verified against the live reference.** Every place where the precise
-> identifier matters is flagged `⚠️ verify`. Before writing handler code, walk
-> the [Verification checklist](#verification-checklist) against the installed SDK
-> `.d.ts` and the live docs (the way `openai-responses-api.md` and the Copilot
-> PRD were verified against pinned types).
+> **Verification status.** The schema below is **verified against the installed
+> `@google/genai@2.9.0` type definitions** (`node_modules/.../@google/genai/dist/genai.d.ts`)
+> — the exact version already pinned in `package.json:108` and
+> `packages/extension/package.json:1713`. The Interactions surface ships in that
+> version, so **no dependency bump is required to start.** Google's `ai.google.dev`
+> doc pages returned HTTP 403 to automated fetch, so the few facts that live only
+> on the service (GA model/agent ids, $/token pricing, retention window, Flex/
+> Priority cost deltas) remain marked `⚠️ confirm at impl time`. Everything about
+> the **SDK request/response shape is byte-verified** and cited to `genai.d.ts`
+> line numbers.
 
 ## Summary
 
-Google has made the **Interactions API** (`client.interactions.create(...)`) the
-**primary, recommended interface** for Gemini models *and* agents, GA as of the
-2026 announcement. It is a single stateful endpoint that replaces the
-`generateContent` / chat surface for new work: server-side conversation state
-(continue by referencing a prior interaction id instead of resending history),
-background/async execution, a unified **steps**-based response model, mixing
-built-in tools (Google Search, Maps) with custom functions in one request, tool
-results that can return images, and new media-generation and managed-agent
-capabilities. `generateContent` remains supported, but Google states frontier
-long-running/agentic capabilities will increasingly land **only** on Interactions.
+Google has made the **Interactions API** the primary, recommended interface for
+Gemini models *and* agents. In the SDK it is `client.interactions` →
+`GeminiNextGenInteractions` (`genai.d.ts:5677`, `:4598`), with
+`create` / `get` / `delete` / `cancel` methods. It is a single **stateful**
+endpoint that supersedes the chat / `generateContent` surface for new work:
+server-side conversation state (continue via `previous_interaction_id` instead of
+resending history), background/async execution (`background`, `store`,
+`webhook_config`), a unified **steps**-based response (`Interaction.steps:
+Step[]`), mixing built-in tools (Google Search, Maps, code execution, URL
+context, file search, MCP) with custom functions in **one** `tools` array, and
+tool results that can return images.
 
-TeXRA today drives Gemini exclusively through the **chat / `generateContent`**
-surface of the same SDK (`@google/genai`). This proposal recommends an
-**additive, feature-flagged** Interactions handler that lives beside the existing
-one — exactly the shape TeXRA already uses for OpenAI's Responses API — rather
-than an in-place rewrite. That keeps the battle-tested `generateContent` path as
-the default/fallback while we gain access to Interactions-only features, and lets
-us flip the default per-model once the new path is proven.
+TeXRA today drives Gemini exclusively through the chat / `generateContent`
+surface of the **same** SDK (`client.chats.create()` →
+`chat.sendMessageStream()`). This proposal recommends an **additive,
+feature-flagged** Interactions handler beside the existing one — the exact shape
+TeXRA already uses for OpenAI's Responses API — keeping the battle-tested
+`generateContent` path as the default/fallback while we gain Interactions-only
+features, and flipping the default per-model once proven.
 
 ## Motivation
 
 - **Future-proofing.** Google has declared Interactions the default across AI
-  Studio, the Gemini API, and all docs; new frontier agentic/long-running
-  features are expected to be Interactions-only. Staying on `generateContent`
-  means those features become unreachable from TexRA over time.
-- **Server-side state.** Continuing via a prior-interaction id (instead of
-  resending the full `Content[]` history every round) shrinks request payloads
-  and simplifies multi-turn management — the same win TeXRA already realised for
-  OpenAI via `previous_response_id` (see `openai-responses-api.md`).
-- **Background execution.** `background: true` for long-running runs maps
-  naturally onto TeXRA's existing background-response machinery
-  (`texra.model.useBackgroundResponses`, already wired for OpenAI).
-- **Unified tool model.** Mixing built-in tools (Google Search) with custom
-  function declarations in a single request directly removes a limitation TeXRA
-  documents today: the native `googleSearch` tool is currently disabled because
-  the `generateContent` API cannot combine `googleSearch` with
-  `functionDeclarations` — the repo comment attributes mixing to the Live API
-  only (`toolConversion.ts:355-357`). The GA announcement says Interactions lifts
-  this on the regular surface (⚠️ verify it actually does before relying on it).
-- **Same SDK.** This rides on the already-installed `@google/genai` dependency —
-  no new vendor SDK, consistent with the existing provider boundary.
+  Studio, the Gemini API, and docs; frontier agentic/long-running features are
+  expected to be Interactions-only. Staying on `generateContent` strands those.
+- **Server-side state.** `previous_interaction_id` (`genai.d.ts:2411`) continues
+  a conversation without resending the full `Content[]` each round — the same
+  payload win TeXRA already realised for OpenAI via `previous_response_id`.
+- **Background execution.** `background?: boolean` (`:2389`) + `store?`
+  (`:2385`) + `webhook_config?` (`:2416`) map onto TeXRA's existing
+  background-response machinery (`texra.model.useBackgroundResponses`).
+- **Unified tool model.** `tools?: Array<Tool>` where `Tool = FunctionT |
+  CodeExecution | URLContext | ComputerUse | MCPServer | GoogleSearch |
+  FileSearch | GoogleMaps | Retrieval` (`:12272`) — built-in **and** custom
+  functions in one request. This removes the limitation TeXRA documents today:
+  native `googleSearch` is disabled because the `generateContent` API cannot
+  combine `googleSearch` with `functionDeclarations` (`toolConversion.ts:355-357`,
+  attributed there to the Live API). Interactions lifts it on the regular surface.
+- **Tool results with images.** A `function_result` step's `result` can be
+  `string | {} | Array<FunctionResultSubcontent>` where `FunctionResultSubcontent
+  = TextContent | ImageContent` (`:4543`,`:4553`).
+- **Same SDK, same client, no new dependency.** `client.interactions` already
+  exists on the `new GoogleGenAI({ apiKey })` instance TeXRA builds
+  (`modelHandlerGoogleGenAI.ts:304`,`:323`).
 
 ## Current state (verified in repo)
 
-TeXRA's Gemini integration is a single, mature handler on the chat surface:
-
 | File | Detail |
 | ---- | ------ |
-| `src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts` (~1366 lines) | `ModelHandlerGoogleGenAI`; calls `client.chats.create()` → `chat.sendMessageStream()` / `chat.sendMessage()`; `client.models.countTokens()`; `client.files.upload()` |
-| `src/agent/modelHandlers/google/googleMessageHelpers.ts` | Strict user/model alternation, `systemInstruction`, parts-based `Content[]` construction |
-| `src/agent/modelHandlers/google/googleUsage.ts` | Token/price/usage normalization from `GenerateContentResponseUsageMetadata` |
-| `src/agent/modelHandlers/google/googleSdkError.ts` | Maps `GoogleApiError` → TeXRA SDK error kinds |
-| `src/agent/modelHandlers/toolConversion.ts:360` | `toGoogleTools()` → `{ functionDeclarations }` |
-| `src/agent/runtime/ModelFactory.ts:73` | `PROVIDER_HANDLER_ROUTES[ModelProvider.GOOGLE]` → loads `ModelHandlerGoogleGenAI`, compatibility key `'ModelHandlerGoogleGenAI'` |
-| `package.json:108`, `packages/extension/package.json:1713` | `@google/genai` `^2.9.0` |
+| `src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts` (~1366 lines) | `ModelHandlerGoogleGenAI`; `client.chats.create()` (`:496`) → `chat.sendMessageStream()` (`:507`) / `chat.sendMessage()` (`:617`); `client.models.countTokens()` (`:383`); `client.files.upload()` (`:245`); client built `new GoogleGenAI({ apiKey })` (`:304`,`:323`) via base `getApiKey()` (`:299`,`:319`) |
+| `src/agent/modelHandlers/google/googleMessageHelpers.ts` | Strict user/model alternation, `systemInstruction`, parts-based `Content[]` |
+| `src/agent/modelHandlers/google/googleUsage.ts` | Token/price/usage from `GenerateContentResponseUsageMetadata` |
+| `src/agent/modelHandlers/google/googleSdkError.ts` | `GoogleApiError` → TeXRA SDK error kinds (reusable as-is) |
+| `src/agent/modelHandlers/toolConversion.ts:360` | `toGoogleTools()` → `[{ functionDeclarations }]` (chat shape) |
+| `src/agent/runtime/ModelFactory.ts:73` | `PROVIDER_HANDLER_ROUTES[GOOGLE]` → `ModelHandlerGoogleGenAI`, key `'ModelHandlerGoogleGenAI'` |
+| `package.json:108`, `packages/extension/package.json:1713` | `@google/genai` `^2.9.0` (resolved `2.9.0`, exposes `interactions`) |
 
-Notable capabilities the new handler must preserve (all currently in
-`modelHandlerGoogleGenAI.ts`):
-
-- **Streaming** with thinking/output separation and end-of-stream usage capture.
-- **Parallel tool calls batched into one model message**, preserving Gemini 3
-  **thought signatures** (`requiresBatchedParallelToolResults = true`, line 346;
-  thought-signature plumbing on `GoogleToolCall`). This is the highest-risk area
-  to reproduce on a new wire format.
-- **Multimodal**: inline base64 (≤20 MB) vs File API upload (>20 MB), Gemini 3
-  media-resolution levels.
-- **Thinking levels** (`LOW`/`MEDIUM`/`HIGH`) via `thinkingConfig`.
-- **Native token counting** (`countTokens`) feeding context-window guards.
-- **Usage/pricing**: input/output/reasoning/cached/tool-use token breakdown and
-  cache rebate.
+Capabilities the new handler must preserve (all in `modelHandlerGoogleGenAI.ts`):
+streaming with thinking/output separation; **parallel tool calls with Gemini 3
+thought signatures** (`requiresBatchedParallelToolResults`, `:346`); multimodal
+(inline ≤20 MB vs File API >20 MB, media-resolution); thinking levels
+(`thinkingConfig`); native token counting (`:383`); usage/pricing breakdown.
 
 There are **no** existing references to the Interactions API in the repo.
 
 ## The precedent this mirrors: OpenAI Responses API
 
-TeXRA already solved the "provider introduced a newer, stateful, server-side-state
-API alongside the legacy one" problem for OpenAI. The wiring we should copy:
+TeXRA already solved "provider introduced a newer, stateful, server-side-state API
+alongside the legacy one" for OpenAI. Copy this wiring:
 
-- A **separate handler** `ModelHandlerOpenAIResponse`
+- Separate handler `ModelHandlerOpenAIResponse`
   (`src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts`) coexists with
   the chat-completions handler.
-- A **compatibility key** `'ModelHandlerOpenAIResponse'` in
-  `ModelHandlerCompatibilityKey` (`ModelFactory.ts:29`) marks the distinct
-  conversation-history format, so history restoration/compaction know which
-  shape a saved run used.
-- A **routing predicate** `shouldUseResponsesAPI(config, useOpenRouter)`
-  (`ModelFactory.ts:175`) decides per-model whether to use the new path, gated by
-  the setting `texra.model.useOpenAIResponsesAPI` (plus per-model `required` and
-  `gpt-oss` forcing).
-- A **settings flag** `model.useOpenAIResponsesAPI` in
-  `src/shared/schemas/coreSettings.ts` (default `true`; lines 81, 325, 564) with
-  a companion `model.useBackgroundResponses`.
-- `createModelHandler()` branches to the Responses handler **before** the
-  default provider route (`ModelFactory.ts:361`).
+- Compatibility key `'ModelHandlerOpenAIResponse'` in `ModelHandlerCompatibilityKey`
+  (`ModelFactory.ts:29`) marks the distinct conversation-history format so
+  history restore/compaction know which shape a saved run used.
+- Routing predicate `shouldUseResponsesAPI(config, useOpenRouter)`
+  (`ModelFactory.ts:175`) decides per-model, gated by
+  `texra.model.useOpenAIResponsesAPI` (plus per-model `required` / `gpt-oss`).
+- Settings flag `model.useOpenAIResponsesAPI` in `coreSettings.ts`
+  (default `true`; lines 81, 325, 564) with companion `model.useBackgroundResponses`.
+- `createModelHandler()` branches to the Responses handler **before** the default
+  provider route (`ModelFactory.ts:361`).
 
-This proposal reuses that exact pattern for Google.
+## API surface (verified against `@google/genai@2.9.0` `genai.d.ts`)
 
-## API surface (reconstructed — see verification note)
+**Client:** `client.interactions` (`:5677`) → `GeminiNextGenInteractions` (`:4598`):
 
-Authoritative source for code will be the **installed `@google/genai` `.d.ts`**;
-the following is the working model.
+```ts
+create(params: CreateModelInteractionParams… | CreateAgentInteractionParams…)
+  : Promise<GoogleGenAIInteraction>                          // stream:false
+  | Promise<Stream<GoogleGenAIInteractionSSEEvent>>          // stream:true   (:4602-4608)
+get(id, params?)   // (:4609-4611)   delete(id, params?)   // (:4612)   cancel(id, params?)   // (:4615)
+```
 
-**Request — `client.interactions.create(params)`** (and a streaming variant):
+**Request — `CreateModelInteraction` (`:2373`)** — note **snake_case**:
 
-- `model` *or* `agent` — exactly one. `model` for inference (e.g.
-  `gemini-3.5-flash` ⚠️ verify ids), `agent` for managed agents
-  (`antigravity-preview-*`, `deep-research-*`).
-- `input` — text string, or multimodal/array input (parts: text + inline data +
-  file refs). ⚠️ verify the part object shape vs the chat API's `Part`.
-- `previous_interaction_id` — continue a prior interaction (server-side state).
-  ⚠️ verify exact key (`previousInteractionId` in camelCase SDK vs
-  `previous_interaction_id` in REST).
-- `background: boolean` — async/server-side execution.
-- `stream: boolean` (or a dedicated `createStream`/SSE iterator) ⚠️ verify which.
-- `tools` — array mixing custom functions
-  (`{ type: 'function', name, description, parameters }`) and built-ins
-  (`{ type: 'google_search' }`, `{ type: 'code_execution' }`, Maps). ⚠️ verify
-  exact tool object discriminator and whether function shape is `parameters`
-  (JSON Schema) like the reconstructed form, or nested `functionDeclarations` as
-  in the chat API.
-- `environment` — `'remote'` for managed-agent sandboxes.
-- generation knobs / `system_instruction` / structured-output `response_format`
-  (a polymorphic format that replaced `response_mime_type`) ⚠️ verify, plus
-  `thinking`/reasoning config and `response_modalities` for media generation.
-- service tier: **Flex** (≈50% cost) vs **Priority** (latency). ⚠️ verify key.
+| field | type | line |
+| ----- | ---- | ---- |
+| `model` | `Model` (string id) | 2377 |
+| `input` | `InteractionsInput` (required) | 2442 |
+| `stream?` | `boolean` (discriminates streaming vs not) | 2381 |
+| `store?` | `boolean` (persist for later retrieval) | 2385 |
+| `background?` | `boolean` | 2389 |
+| `system_instruction?` | `string` | 2393 |
+| `tools?` | `Array<Tool>` | 2397 |
+| `previous_interaction_id?` | `string` (server-side continuation) | 2411 |
+| `response_format?` | `ResponseFormat \| ResponseFormat[]` (structured output) | 2420 |
+| `response_modalities?` | `Array<ResponseModality>` (TEXT/IMAGE/AUDIO) | 2401 |
+| `generation_config?` | `GenerationConfig` (temp, tokens, thinking, …) | 2428 |
+| `service_tier?` | `ServiceTier` (Flex/Priority) | 2412 |
+| `cached_content?` | `string` (explicit cache handle) | 2438 |
+| `webhook_config?` | `WebhookConfig` | 2416 |
+| `environment?` | `Environment \| string` | 2424 |
+| `response_mime_type?` | `string` — **deprecated**, use `response_format` | 2407 |
 
-**Response — the `Interaction` resource:**
+`CreateAgentInteraction` (`:1987`) swaps `model` for `agent` (`AgentOption`) +
+`agent_config` (`DynamicAgentConfig | DeepResearchAgentConfig`) + `environment`.
 
-- A chronological **`steps`** array; each step is a typed object —
-  `user_input`, `thought`, `function_call`, function result/`model_output`, text
-  output, etc. ⚠️ verify the exact set and names. This is the schema's headline
-  change ("From Roles to Steps"): every action is its own typed step rather than
-  a role-tagged message with parts.
-- Convenience accessors on the `Interaction` for the common cases (e.g. final
-  text) without walking `steps`. ⚠️ verify accessor names.
-- An interaction `id` (for `previous_interaction_id` continuation), and usage /
-  token metadata. ⚠️ verify usage field names — likely differ from
-  `GenerateContentResponseUsageMetadata` (`promptTokenCount`, `candidatesTokenCount`,
-  `thoughtsTokenCount`, `cachedContentTokenCount`, `toolUsePromptTokenCount`).
-- **Streaming** emits SSE-style events with types such as `step.start` /
-  `step.delta` (text chunks under `delta`) / step completion. ⚠️ verify event
-  and field names.
-- **Retention:** past interactions retrievable, ~55-day retention on paid tier.
+**Input — `InteractionsInput` (`:7555`):**
+`string | Array<Step> | Array<Content> | Array<Turn> | Content`, where
+`Content = TextContent | ImageContent | AudioContent | DocumentContent |
+VideoContent` (`:1841`). Multimodal uses **typed content objects**, not the chat
+API's `Part`. Resuming a conversation client-side means passing prior `Step[]`.
 
-**Schema volatility (important).** Search surfaced that the Interactions schema
-churned during beta: the **steps** array replaced an earlier `outputs` shape, and
-a polymorphic `response_format` replaced `response_mime_type`, with the legacy
-shape removed mid-2026. GA means the schema is now stable, but it strongly argues
-for (a) pinning a known-good `@google/genai` version and (b) keeping the legacy
-`generateContent` handler as fallback.
+**Tools — `Tool` (`:12272`):** custom = `FunctionT` (`:4565`)
+`{ type:"function", name?, description?, parameters?: <JSON Schema> }`; built-ins
+= `CodeExecution | URLContext | ComputerUse | MCPServer | GoogleSearch |
+FileSearch | GoogleMaps | Retrieval`. (Contrast chat's `[{ functionDeclarations }]`.)
+
+**Response — `Interaction` (`:6943`)** (the SDK wraps it as `GoogleGenAIInteraction`
+with `steps: Step[]`, `:5683`): `id`, `status: InteractionStatus`, `created`,
+`updated`, `model`/`agent`, `system_instruction`, `tools`, `usage?: Usage`,
+`steps?: Step[]`, `previous_interaction_id`, `environment_id`, `response_format`,
+`generation_config`, `agent_config`.
+
+**Steps — `Step` (`:11664`)** (discriminated by `type`):
+
+| step | shape | line |
+| ---- | ----- | ---- |
+| `UserInputStep` | `{ type:"user_input", content?: Content[] }` | 14035 |
+| `ModelOutputStep` | `{ type:"model_output", content?: Content[] }` | 9235 |
+| `ThoughtStep` | `{ type:"thought", signature?: string, summary?: ThoughtSummaryContent[] }` | 12112 |
+| `FunctionCallStep` | `{ type:"function_call", name: string, arguments: {}, id: string }` | 4403 |
+| `FunctionResultStep` | `{ type:"function_result", name?, is_error?, call_id: string, result: string \| {} \| FunctionResultSubcontent[] }` | 4526 |
+| built-in call/result | `CodeExecution*`, `GoogleSearch*`, `GoogleMaps*`, `FileSearch*`, `URLContext*`, `MCPServerTool*` Step variants | — |
+
+`FunctionResultSubcontent = TextContent | ImageContent` (`:4553`) → tool results
+can include images.
+
+**Streaming — `InteractionSSEEvent` (`:7559`):**
+`InteractionCreatedEvent | InteractionCompletedEvent | InteractionStatusUpdate |
+ErrorEvent | StepStart | StepDelta | StepStop`. Events discriminate on
+**`event_type`** (`"step.start"` `:11699`, `"step.delta"` `:11668`,
+`"step.stop"`). `StepDelta = { event_type:"step.delta", index, delta:
+StepDeltaData, event_id?, metadata? }`; `StepDeltaData` (`:11685`) includes
+`TextDelta`, `ArgumentsDelta` (streamed tool args), `ThoughtSummaryDelta`,
+`ThoughtSignatureDelta`, `FunctionResultDelta`, image/audio/doc deltas, …;
+`StepDeltaMetadata.total_usage?: Usage` (`:11690`) carries running usage.
+
+**Usage — `Usage` (`:13952`)** (snake_case, differs from
+`GenerateContentResponseUsageMetadata`): `total_input_tokens`,
+`total_cached_tokens`, `total_output_tokens`, `total_tool_use_tokens`,
+`total_thought_tokens`, plus `*_by_modality: ModalityTokens[]` and a grand total.
 
 ## Mapping: `generateContent`/chat → Interactions
 
-| TeXRA concern | Today (`generateContent`/chat) | Interactions API |
-| ------------- | ------------------------------ | ---------------- |
+| TeXRA concern | Today (chat/`generateContent`) | Interactions (verified) |
+| ------------- | ------------------------------ | ----------------------- |
 | Send a turn | `chat.sendMessage(parts)` | `interactions.create({ model, input })` |
-| Streaming | `chat.sendMessageStream()` → `chunk.candidates[0].content.parts` | stream events → `step.delta` text ⚠️ |
-| Conversation state | resend full `Content[]` each round | `previous_interaction_id` (server-side) ⚠️ |
-| System prompt | `systemInstruction` on chat params | `system_instruction` on create ⚠️ |
-| Custom tools | `{ functionDeclarations: [...] }` | `tools: [{ type:'function', name, description, parameters }]` ⚠️ |
-| Built-in search | **disabled** (can't mix with functions) | `tools: [{ type:'google_search' }, ...functions]` — now mixable |
-| Tool call out | `functionCall` part on candidate | `function_call` step (`name`, args, id) ⚠️ |
-| Tool result in | `functionResponse` part (user msg) | function-result step ⚠️ |
-| **Parallel tool calls** | batched into one model `Content` + thought signatures | must map onto steps **without losing thought signatures** ⚠️ **highest risk** |
-| Thinking | `thinkingConfig` + `thought` parts | reasoning/thinking config + `thought` steps ⚠️ |
-| Multimodal in | inline base64 / File API `uri` parts | inline data / file refs in `input` ⚠️ |
-| Token counting | `client.models.countTokens()` | unchanged `countTokens` (still on `models`)? ⚠️ verify |
-| Usage/pricing | `GenerateContentResponseUsageMetadata` | new usage metadata shape ⚠️ remap `googleUsage.ts` |
-| Background | n/a for Google today | `background: true` (reuse `useBackgroundResponses` machinery) |
-| Caching | `cachedContentTokenCount` rebate | verify cache reporting on the new usage shape ⚠️ |
+| Streaming | `sendMessageStream()` → `chunk.candidates[0].content.parts` | `Stream<InteractionSSEEvent>`; consume `event_type:"step.delta"` → `delta` (TextDelta etc.) |
+| Conversation state | resend full `Content[]` each round | `previous_interaction_id` (server-side) or pass prior `Step[]` in `input` |
+| System prompt | `systemInstruction` on chat params | `system_instruction` on create |
+| Custom tools | `[{ functionDeclarations:[…] }]` | `tools:[{ type:"function", name, description, parameters }]` |
+| Built-in search | **disabled** (can't mix w/ functions) | `tools:[{ type:"google_search" }, …functions]` — now mixable |
+| Tool call out | `functionCall` part | `FunctionCallStep` `{ name, arguments, id }` (+ streamed `ArgumentsDelta`) |
+| Tool result in | `functionResponse` part (user msg) | a `function_result` step/input `{ call_id, result }`; `result` may include images |
+| **Parallel tools + thought sigs** | batched into one model `Content`, signature on the call part | sigs live on **`ThoughtStep.signature`** + `ThoughtSignatureDelta`, separate from `function_call` steps; server holds them when continuing by id |
+| Thinking | `thinkingConfig` + `thought` parts | `generation_config` thinking + `ThoughtStep`/`ThoughtSummaryDelta` |
+| Multimodal in | inline base64 / File API `uri` parts | typed `Content` (`ImageContent`/`DocumentContent`/…) in `input` |
+| Token counting | `client.models.countTokens()` | unchanged — still on `client.models` |
+| Usage/pricing | `GenerateContentResponseUsageMetadata` | `Usage` (`total_*_tokens`) → remap `googleUsage.ts` |
+| Background | n/a today | `background:true` (+ `store`, `webhook_config`) |
+| Caching | `cachedContentTokenCount` rebate | `cached_content` + `Usage.total_cached_tokens` |
 
 ## Design (additive, feature-flagged)
 
 Mirror the OpenAI Responses precedent end to end.
 
 ### 1. New handler
-
 `ModelHandlerGoogleInteractions` in
-`src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts`, extending the
-shared `ModelHandler` base like the existing Google handler. Reuse what is
-provider-shaped rather than wire-shaped:
-
-- **Reuse** `googleSdkError.ts` (same SDK error type), tool **schema conversion**
-  helpers in `toolConversion.ts` (JSON-Schema flattening/`$schema` stripping is
-  wire-agnostic), and the media upload size/threshold logic.
-- **Rewrite** message construction (`googleMessageHelpers.ts` equivalent) for the
-  steps model + `previous_interaction_id`, the streaming loop (step events), tool
-  call extraction/round-trip, and `googleUsage.ts` for the new usage metadata.
-- Keep **thought-signature preservation** for parallel tool calls as a
-  first-class requirement and cover it with a dedicated test (it is the single
-  most likely regression).
+`src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts`, extending
+`ModelHandler` like the existing Google handler.
+- **Reuse:** `googleSdkError.ts` (same `GoogleApiError`); the JSON-Schema
+  flattening/`$schema`-stripping in `toolConversion.ts` (wire-agnostic) — feed it
+  into `FunctionT.parameters` instead of `functionDeclarations`; the media
+  upload size/threshold logic.
+- **Rewrite:** input construction (typed `Content` + optional prior `Step[]` /
+  `previous_interaction_id`), the streaming loop (SSE `event_type` events, route
+  `TextDelta` → output, `ThoughtSummaryDelta`/`ThoughtSignatureDelta` → thinking,
+  `ArgumentsDelta`/`FunctionCallStep` → tool calls), tool-result steps, and
+  `googleUsage.ts` for the `Usage` shape.
 
 ### 2. Compatibility key
-
-Add `'ModelHandlerGoogleInteractions'` to the `ModelHandlerCompatibilityKey`
-union (`ModelFactory.ts:29`). Because Interactions stores conversation state
-**server-side** and continues via `previous_interaction_id`, its persisted
-history shape differs from the chat handler's `Content[]` — history
-restoration/compaction must not mix the two. A distinct key is mandatory.
+Add `'ModelHandlerGoogleInteractions'` to `ModelHandlerCompatibilityKey`
+(`ModelFactory.ts:29`). Interactions persists state server-side and continues via
+`previous_interaction_id`; its history shape differs from the chat handler's
+`Content[]`, so a distinct key is mandatory for history restore/compaction.
 
 ### 3. Routing predicate + factory branch
-
 Add `shouldUseGoogleInteractionsAPI(config, useOpenRouter)` next to
-`shouldUseResponsesAPI` (`ModelFactory.ts`). Gate on a new setting plus a
-per-model `requiresInteractionsAPI`/agent flag (agents like `antigravity-*` /
-`deep-research-*` are Interactions-only and would force it). Branch to the new
-handler in `createModelHandler()` **before** the default Google provider route
-(`PROVIDER_HANDLER_ROUTES[GOOGLE]`), exactly as the Responses branch precedes the
-default OpenAI route. Respect `useOpenRouter` (OpenRouter cannot proxy
-Interactions — fall back to the existing path), the same guard
-`requiresOpenAIResponsesAPI` applies.
+`shouldUseResponsesAPI`. Gate on a new setting plus per-model
+`requiresInteractionsAPI` (agents like Deep Research are Interactions-only and
+force it). Branch in `createModelHandler()` **before** the default Google route,
+and exclude `useOpenRouter` (OpenRouter can't proxy Interactions).
 
 ### 4. Settings
-
-Add `model.useGoogleInteractionsAPI` to `src/shared/schemas/coreSettings.ts`
-(default, key list, and Zod schema — the three sites at lines ~81/325/564),
-mirroring `useOpenAIResponsesAPI`. Reuse `model.useBackgroundResponses` for the
-`background: true` behaviour, or add a Google-specific companion if semantics
-diverge. Surface the toggle in Settings → Models and document in
-`docs/guide/configuration.md`.
+Add `model.useGoogleInteractionsAPI` to `coreSettings.ts` (the three sites at
+~81/325/564), mirroring `useOpenAIResponsesAPI`; reuse
+`model.useBackgroundResponses` for `background:true`. Surface in Settings →
+Models; document in `docs/guide/configuration.md`.
 
 ### 5. Model registry
-
-Register the new Gemini model ids / agent ids surfaced at GA (e.g.
-`gemini-3.5-flash`, Antigravity / Deep Research agents) in the model
-configuration source (`llm-zoo` `MODEL_CONFIGS` + `src/model/` capability/pricing
-mapping), marking agent-only entries with the Interactions-required flag. ⚠️
-verify the exact ids and pricing at implementation time.
+Register GA Gemini model ids / agent ids (`llm-zoo` `MODEL_CONFIGS` + `src/model/`
+capability/pricing), marking agent-only entries Interactions-required.
+⚠️ confirm exact ids + pricing at impl time.
 
 ## Platform / VS Code separation
 
-No new host coupling. `src/agent/modelHandlers/` is a VS Code-free zone and the
-new handler stays there, reaching host services only through `platform()`
-(secrets for the API key via the base handler's `getApiKey()` —
-`modelHandlerGoogleGenAI.ts:299`,`319` construct `new GoogleGenAI({ apiKey })` —
-config, fs for media
-upload) — identical to the existing Google handler. The settings toggle flows
-through the existing `coreSettings` schema; no new ports needed.
+No new host coupling. The handler stays in the VS Code-free `modelHandlers/`
+zone, reaching host services only through `platform()` (secrets for the API key
+via the base `getApiKey()`, config, fs for media) — identical to the existing
+Google handler. The settings toggle flows through the existing `coreSettings`
+schema; no new ports.
 
 ## Risks & open questions
 
-1. **Unverified schema (post-cutoff).** Everything marked ⚠️ must be confirmed
-   against the installed `.d.ts` and live docs before coding. Treat the table
-   above as a hypothesis, not a contract.
-2. **Thought-signature preservation across the steps model.** Gemini 3 parallel
-   tool calling depends on round-tripping thought signatures; the steps schema
-   reorganises how calls/results are represented. This is the most likely place
-   to silently break parallel tool use. Needs an explicit fixture test.
-3. **Schema churn / version pinning.** The beta schema changed materially
-   (`outputs`→`steps`, `response_mime_type`→`response_format`). Pin a known-good
-   `@google/genai` (current dep is `^2.9.0` — confirm it actually exposes
-   `interactions`; the search-surfaced "introduced in 1.33.0" is unverified).
-4. **Server-side state + history/compaction.** TeXRA's history restore and
-   context compaction assume a resend-able local transcript. With
-   `previous_interaction_id` the canonical state lives on Google's servers with a
-   ~55-day retention. Decide whether to (a) keep sending full local history
-   (stateless mode, simplest, loses the payload win) or (b) adopt
-   `previous_interaction_id` and define behaviour when the server-side
-   interaction has expired / when a run is restored from old history. The OpenAI
-   Responses handler already faced this — reuse its resolution.
-5. **OpenRouter interaction.** Interactions is Google-direct only; ensure the
-   `useOpenRouter` path is excluded (as Responses excludes it).
-6. **Usage/pricing remap.** New usage metadata field names → `googleUsage.ts`
-   must be re-derived; cache-token rebate and reasoning-token accounting need
-   re-validation against the new shape.
-7. **Managed agents are a different product surface.** `agent=` + `environment:
-   'remote'` provisions a remote sandbox that browses/executes code. That is a
-   much larger feature than "call a model" and should be **out of scope for v0**
+1. **Thought-signature model changed (re-scope, not eliminate).** In chat,
+   Gemini 3 signatures ride on the function-call part and TeXRA batches parallel
+   results into one message. In Interactions signatures are their own
+   `ThoughtStep.signature` (+ `ThoughtSignatureDelta`), and when continuing by
+   `previous_interaction_id` the server retains them — likely **simpler**. But if
+   we send history client-side (`input: Step[]`), we must round-trip the
+   `thought` steps verbatim. Needs a fixture test either way; this is still the
+   place most likely to silently break parallel tool use.
+2. **Server-side state vs history/compaction.** TeXRA's restore/compaction assume
+   a resend-able local transcript. Decide per the OpenAI Responses resolution:
+   stateless (send full `Step[]` each round; simplest, loses payload win) vs
+   `previous_interaction_id` (define behaviour when the stored interaction has
+   expired or a run is restored from old history). `store?`/retention interact.
+3. **Preview vs GA stability in 2.9.0.** The types ship in the pinned version;
+   `response_mime_type` is already deprecated in favour of `response_format`,
+   signalling churn. Pin/snapshot the working version and keep `generateContent`
+   as fallback. ⚠️ confirm the endpoint is GA (not preview) for our key.
+4. **Usage/pricing remap.** `Usage.total_*` field names → `googleUsage.ts`
+   re-derivation; re-validate cache-rebate and reasoning-token accounting.
+5. **Managed agents are a different product.** `agent=` + `environment:'remote'`
+   provisions a remote sandbox (browse/exec). **Out of scope for v0**
    (model-mode only); track separately.
-8. **Built-in tools + custom functions mixing** removes the current
-   `googleSearch` limitation — but verify tool-result image return interacts
-   correctly with TeXRA's tool-result attachment plumbing.
+6. **Service ids / pricing / retention** (`⚠️ confirm`): GA model ids
+   (`gemini-3.5-flash`, Deep Research / Antigravity agents), `ServiceTier`
+   Flex/Priority cost deltas, and the retention window are service facts not in
+   the SDK types.
 
 ## Scope
 
-**In (v0):** research verification; `ModelHandlerGoogleInteractions` in **model
-mode** (text + multimodal in, streaming, custom function calling incl. parallel
-calls with thought signatures, thinking, token counting, usage/pricing);
-compatibility key; routing predicate + factory branch; `useGoogleInteractionsAPI`
-setting + Settings UI + docs; tests (streaming, parallel-tool thought
-signatures, usage mapping, routing); keep `generateContent` handler as default
-fallback.
+**In (v0):** `ModelHandlerGoogleInteractions` in **model mode** (text +
+multimodal in, SSE streaming, custom function calling incl. parallel calls +
+thought-signature round-trip, thinking, token counting, `Usage`-based
+pricing); compatibility key; routing predicate + factory branch;
+`useGoogleInteractionsAPI` setting + Settings UI + docs; tests (streaming SSE,
+parallel-tool/thought-signature, usage mapping, routing); keep `generateContent`
+as default fallback.
 
-**Out (v0):** managed agents (`agent=`, `environment:'remote'`); media
-generation (`response_modalities`, Nano Banana / Lyria / TTS); Deep Research
-agent integration; making Interactions the **default** for Gemini (ship behind
-the flag first, flip later); OpenRouter support for Interactions.
+**Out (v0):** managed agents (`agent=`, `environment:'remote'`); media generation
+(`response_modalities`/image/audio out); Deep Research agent; making Interactions
+the **default** for Gemini (ship behind the flag, flip later); OpenRouter support.
 
 ## Milestones
 
-1. **Verify** the schema against the installed SDK `.d.ts` + live docs; fill in
-   every ⚠️; confirm `@google/genai` version exposing `interactions` and pin it.
-   Update this proposal's tables to the verified shapes.
-2. `ModelHandlerGoogleInteractions` (model mode) with streaming + custom tools;
+1. ~~Verify the SDK schema~~ ✅ done (this proposal; `@google/genai@2.9.0`).
+   Remaining: confirm GA model/agent ids + pricing + retention (`⚠️` items).
+2. `ModelHandlerGoogleInteractions` (model mode): SSE streaming + custom tools;
    compatibility key; factory routing behind `useGoogleInteractionsAPI` (default
-   **off**). Unit tests on message/tool/usage translation (host-neutral, mocked
-   SDK), explicitly including parallel-tool thought-signature round-trip.
-3. Multimodal input, thinking levels, token counting, cache/usage parity; mixed
-   built-in `google_search` + functions; settings UI + `configuration.md`.
-4. Real-key smoke test; CHANGELOG entry; decide default flip per-model;
-   register GA Gemini model ids/pricing.
-
-## Verification checklist
-
-Before writing handler code, confirm against the **installed** `@google/genai`
-types and the live docs (resolve every ⚠️ above):
-
-- [ ] `@google/genai` version that exposes `client.interactions` (and pin it).
-- [ ] `interactions.create` param names & casing: `model`/`agent`, `input`,
-      `previous_interaction_id`, `background`, `stream`/`createStream`, `tools`,
-      `system_instruction`, `response_format`, thinking/reasoning config,
-      `response_modalities`, service tier.
-- [ ] `input` part object shape (text / inline data / file ref) — same as chat
-      `Part` or new?
-- [ ] `tools` entry shape: custom `{ type:'function', name, description,
-      parameters }` vs `functionDeclarations`; built-in discriminators
-      (`google_search`, `code_execution`, maps).
-- [ ] `Interaction.steps` exact step types & fields (`function_call` name/args/id;
-      function-result step; `thought`; text/`model_output`); convenience accessors.
-- [ ] **Thought-signature** field on call/result steps for Gemini 3 parallel
-      tool calling, and how to echo it back.
-- [ ] Streaming event types/fields (`step.start`, `step.delta`, completion).
-- [ ] Usage/token metadata field names (input/output/reasoning/cached/tool-use).
-- [ ] `countTokens` availability/shape under the new surface.
-- [ ] `previous_interaction_id` continuation semantics + retention/expiry
-      behaviour for restored runs.
+   **off**). Unit tests on input/tool/usage translation (mocked SDK), explicitly
+   the parallel-tool/thought-signature round-trip.
+3. Multimodal `Content` input, thinking, token counting, cache/usage parity;
+   mixed built-in `google_search` + functions; settings UI + `configuration.md`.
+4. Real-key smoke test; CHANGELOG; decide per-model default flip; register GA ids.
 
 ## References
 
-- Interactions API overview: https://ai.google.dev/gemini-api/docs/interactions/interactions-overview
+- SDK types (authoritative, verified): `@google/genai@2.9.0`
+  `dist/genai.d.ts` — `GeminiNextGenInteractions` (`:4598`), `CreateModelInteraction`
+  (`:2373`), `Interaction` (`:6943`), `Step` (`:11664`), `Usage` (`:13952`),
+  `interactions` namespace (`:7367`).
+- Interactions overview: https://ai.google.dev/gemini-api/docs/interactions/interactions-overview
 - API reference: https://ai.google.dev/api/interactions-api
-- Quickstart: https://ai.google.dev/gemini-api/docs/interactions/quickstart
 - Function calling: https://ai.google.dev/gemini-api/docs/interactions/function-calling
 - Streaming: https://ai.google.dev/gemini-api/docs/interactions/streaming
-- Migration (generateContent → Interactions): https://ai.google.dev/gemini-api/docs/interactions
-- Google announcement: https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api/
-- JS SDK: https://github.com/googleapis/js-genai · https://www.npmjs.com/package/@google/genai
-- Community quickstart (Phil Schmid): https://www.philschmid.de/interactions-api-quickstart
+- Announcement: https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api/
+- JS SDK: https://github.com/googleapis/js-genai
 - TeXRA precedent: [`openai-responses-api.md`](./openai-responses-api.md);
-  routing in `src/agent/runtime/ModelFactory.ts:175`; settings in
-  `src/shared/schemas/coreSettings.ts`.
+  routing `src/agent/runtime/ModelFactory.ts:175`; settings `src/shared/schemas/coreSettings.ts`.
 
-> _All `ai.google.dev` pages returned HTTP 403 to automated fetch during
-> research; the links are for human verification of the ⚠️ items._
+> _`ai.google.dev` pages returned HTTP 403 to automated fetch; the SDK `.d.ts`
+> (verified above) is the source of truth for every shape, with `⚠️` reserved
+> for service-only facts (ids/pricing/retention)._

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -59,13 +59,15 @@ FileSearch | GoogleMaps | Retrieval` (`:12272`) — built-in **and** custom
   functions in one request. This removes the limitation TeXRA documents today:
   native `googleSearch` is disabled because the `generateContent` API cannot
   combine `googleSearch` with `functionDeclarations` (`toolConversion.ts:355-357`,
-  attributed there to the Live API). Interactions lifts it on the regular surface.
+  attributed there to the Live API). Interactions exposes built-ins and custom
+  functions in one `Tool` union; enable mixed requests after model-gated smoke
+  tests rather than assuming every id supports every combination.
 - **Tool results with images.** A `function_result` step's `result` can be
   `string | {} | Array<FunctionResultSubcontent>` where `FunctionResultSubcontent
 = TextContent | ImageContent` (`:4543`,`:4553`).
-- **Same SDK, same client, no new dependency.** `client.interactions` already
-  exists on the `new GoogleGenAI({ apiKey })` instance TeXRA builds
-  (`modelHandlerGoogleGenAI.ts:304`,`:323`).
+- **Same SDK, same dependency.** `client.interactions` already exists on
+  `GoogleGenAI`, so v0 should reuse TeXRA's credential/base URL/retry setup while
+  selecting and smoke-testing the Interactions API version explicitly.
 
 ## Current state (verified in repo)
 
@@ -146,6 +148,9 @@ get(id, params?)   // (:4609-4611)   delete(id, params?)   // (:4612)   cancel(i
 `Content = TextContent | ImageContent | AudioContent | DocumentContent |
 VideoContent` (`:1841`). Multimodal uses **typed content objects**, not the chat
 API's `Part`. Resuming a conversation client-side means passing prior `Step[]`.
+In stateless mode, TeXRA must keep the `user_input` steps it sends because the
+next request must include those local steps in addition to model-generated steps
+returned by `interactions.create`.
 
 **Tools — `Tool` (`:12272`):** custom = `FunctionT` (`:4565`)
 `{ type:"function", name?, description?, parameters?: <JSON Schema> }`; built-ins
@@ -298,6 +303,15 @@ JSON** — trust the `.d.ts` where they differ.
   `error`). Interaction states such as `in_progress` and `requires_action` live
   on `InteractionStatusUpdate.status`, not in `event_type`. `TextDelta` =
   `{ type:"text", text }` (`:11995`).
+- **Stateless function-calling history:** the official guide requires the next
+  `store:false` request to include the initial `user_input` step, all
+  model-generated steps exactly as received (including `thought` and
+  `function_call`), and the local `function_result` step. This matches v0's
+  local-history plan and is the contract the tests should encode.
+- **Explicit caching is not yet available in Interactions.** The SDK exposes
+  `cached_content`, but the overview lists explicit caching under
+  generateContent-only limitations and points Interactions users at implicit
+  caching through `previous_interaction_id`.
 - **Built-in tools are transparent:** `google_search_call` + `google_search_result`
   steps, with **inline** citations as an `annotations` array on the
   `model_output` text content (vs the old separate `groundingMetadata`).
@@ -313,28 +327,31 @@ JSON** — trust the `.d.ts` where they differ.
   **none** of those — it exposes `total_input_tokens` / `total_output_tokens` /
   `total_cached_tokens` / `total_tool_use_tokens` / `total_thought_tokens`
   (+ `*_by_modality`). `googleUsage.ts` must map the SDK names.
-- **REST path** is `v1beta2/interactions` (vs `v1beta/models/…:generateContent`)
-  — informational only; TeXRA calls the SDK, not REST.
+- **REST path / API version** examples currently use `/v1beta/interactions` while
+  the SDK README says default endpoints are beta unless `apiVersion` is set.
+  This is informational for the design because TeXRA calls the SDK, but v0
+  should add a real-key smoke test before hardcoding `apiVersion:'v1'` or reusing
+  any relay endpoint assumptions.
 
 ## Mapping: `generateContent`/chat → Interactions
 
-| TeXRA concern                     | Today (chat/`generateContent`)                               | Interactions (verified)                                                                                                                          |
-| --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Send a turn                       | `chat.sendMessage(parts)`                                    | `interactions.create({ model, input })`                                                                                                          |
-| Streaming                         | `sendMessageStream()` → `chunk.candidates[0].content.parts`  | `Stream<InteractionSSEEvent>`; consume `event_type:"step.delta"` → `delta` (TextDelta etc.)                                                      |
-| Conversation state                | resend full `Content[]` each round                           | v0: pass prior `Step[]` in `input` with `store:false`; later: `previous_interaction_id` when using `store:true`                                  |
-| System prompt                     | `systemInstruction` on chat params                           | `system_instruction` on create                                                                                                                   |
-| Custom tools                      | `[{ functionDeclarations:[…] }]`                             | `tools:[{ type:"function", name, description, parameters }]`                                                                                     |
-| Built-in search                   | **disabled** (can't mix w/ functions)                        | `tools:[{ type:"google_search" }, …functions]` — now mixable                                                                                     |
-| Tool call out                     | `functionCall` part                                          | `FunctionCallStep` `{ name, arguments, id }` (+ streamed `ArgumentsDelta`)                                                                       |
-| Tool result in                    | `functionResponse` part (user msg)                           | a `function_result` step/input `{ call_id, result }`; `result` may include images                                                                |
-| **Parallel tools + thought sigs** | batched into one model `Content`, signature on the call part | sigs live on **`ThoughtStep.signature`** + `ThoughtSignatureDelta`, separate from `function_call` steps; server holds them when continuing by id |
-| Thinking                          | `thinkingConfig` + `thought` parts                           | `generation_config` thinking + `ThoughtStep`/`ThoughtSummaryDelta`                                                                               |
-| Multimodal in                     | inline base64 / File API `uri` parts                         | typed `Content` (`ImageContent`/`DocumentContent`/…) in `input`                                                                                  |
-| Token counting                    | `client.models.countTokens()`                                | unchanged — still on `client.models`                                                                                                             |
-| Usage/pricing                     | `GenerateContentResponseUsageMetadata`                       | `Usage` (`total_*_tokens`) → remap `googleUsage.ts`                                                                                              |
-| Background                        | n/a today                                                    | `background:true` (+ `store`, `webhook_config`)                                                                                                  |
-| Caching                           | `cachedContentTokenCount` rebate                             | `cached_content` + `Usage.total_cached_tokens`                                                                                                   |
+| TeXRA concern                     | Today (chat/`generateContent`)                               | Interactions (verified)                                                                                                                                       |
+| --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Send a turn                       | `chat.sendMessage(parts)`                                    | `interactions.create({ model, input })`                                                                                                                       |
+| Streaming                         | `sendMessageStream()` → `chunk.candidates[0].content.parts`  | `Stream<InteractionSSEEvent>`; consume `event_type:"step.delta"` → `delta` (TextDelta etc.)                                                                   |
+| Conversation state                | resend full `Content[]` each round                           | v0: pass prior `Step[]` in `input` with `store:false`; later: `previous_interaction_id` when using `store:true`                                               |
+| System prompt                     | `systemInstruction` on chat params                           | `system_instruction` on create                                                                                                                                |
+| Custom tools                      | `[{ functionDeclarations:[…] }]`                             | `tools:[{ type:"function", name, description, parameters }]`                                                                                                  |
+| Built-in search                   | **disabled** (can't mix w/ functions)                        | same `tools` array type as custom functions; enable mixed requests after model-gated smoke tests                                                              |
+| Tool call out                     | `functionCall` part                                          | `FunctionCallStep` `{ name, arguments, id }` (+ streamed `ArgumentsDelta`)                                                                                    |
+| Tool result in                    | `functionResponse` part (user msg)                           | a `function_result` step/input `{ call_id, result }`; `result` may include images                                                                             |
+| **Parallel tools + thought sigs** | batched into one model `Content`, signature on the call part | custom function steps have no signature fields in 2.9.0; preserve `ThoughtStep.signature`/`ThoughtSignatureDelta` and any signed built-in tool steps verbatim |
+| Thinking                          | `thinkingConfig` + `thought` parts                           | `generation_config` thinking + `ThoughtStep`/`ThoughtSummaryDelta`                                                                                            |
+| Multimodal in                     | inline base64 / File API `uri` parts                         | typed `Content` (`ImageContent`/`DocumentContent`/…) in `input`                                                                                               |
+| Token counting                    | `client.models.countTokens()`                                | unchanged — still on `client.models`                                                                                                                          |
+| Usage/pricing                     | `GenerateContentResponseUsageMetadata`                       | `Usage` (`total_*_tokens`) → remap `googleUsage.ts`                                                                                                           |
+| Background                        | n/a today                                                    | `background:true` (+ `store`, `webhook_config`)                                                                                                               |
+| Caching                           | explicit cache rebate via `cachedContentTokenCount`          | v0: no explicit cache parity; later `store:true` can use implicit caching via `previous_interaction_id`; explicit caching is documented as unavailable        |
 
 For v0, `store:false` means the handler cannot rely on `previous_interaction_id`;
 conversation state must come from local `Step[]` resending. Send request-level
@@ -358,7 +375,9 @@ Mirror the OpenAI Responses precedent end to end.
 - **Reuse:** `googleSdkError.ts` (same `GoogleApiError`); the JSON-Schema
   flattening/`$schema`-stripping in `toolConversion.ts` (wire-agnostic) — feed it
   into `FunctionT.parameters` instead of `functionDeclarations`; the media
-  upload size/threshold logic.
+  upload size/threshold logic; the credential/base URL/retry setup from
+  `getClient`, with an explicit Interactions API-version smoke test before
+  choosing an `apiVersion` override.
 - **Rewrite:** input construction (typed `Content` + optional prior `Step[]` /
   `previous_interaction_id`), the streaming loop (SSE `event_type` events, route
   `TextDelta` → output, `ThoughtSummaryDelta`/`ThoughtSignatureDelta` → thinking,
@@ -376,9 +395,11 @@ Add `'ModelHandlerGoogleInteractions'` to `ModelHandlerCompatibilityKey`
 
 Add `shouldUseGoogleInteractionsAPI(config, useOpenRouter)` next to
 `shouldUseResponsesAPI`. Gate on a new setting plus per-model
-`requiresInteractionsAPI` (agents like Deep Research are Interactions-only and
-force it). Branch in `createModelHandler()` **before** the default Google route,
-and exclude `useOpenRouter` (OpenRouter can't proxy Interactions).
+`requiresInteractionsAPI` for model ids that cannot use `generateContent`.
+Branch in `createModelHandler()` **before** the default Google route, and exclude
+`useOpenRouter` (OpenRouter can't proxy Interactions). If an Interactions-only
+model is selected while `useOpenRouter` is active, surface a clear availability
+error instead of silently falling back to the chat handler.
 
 ### 4. Settings
 
@@ -389,11 +410,12 @@ Models; document in `docs/guide/configuration.md`.
 
 ### 5. Model registry
 
-Register the Interactions-supported model and agent ids (`llm-zoo`
-`MODEL_CONFIGS` + `src/model/` capability/pricing), marking agent-only entries
-Interactions-required. The official overview currently includes Gemini
-3.1/3/2.5 model ids, Lyria preview model ids, and Deep Research / Antigravity
-preview agent ids; confirm the exact set to expose and pricing at impl time.
+Register only model-mode Interactions-supported ids in v0 (`llm-zoo`
+`MODEL_CONFIGS` + `src/model/` capability/pricing). The official overview
+currently includes Gemini 3.1/3/2.5 model ids, Lyria preview model ids, and Deep
+Research / Antigravity preview agent ids; keep agent-only ids documented but do
+not expose them until an agent-mode branch exists. Confirm the exact model set
+and pricing at impl time.
 
 ## Platform / VS Code separation
 
@@ -405,20 +427,23 @@ schema; no new ports.
 
 ## Risks & open questions
 
-1. **Thought-signature model changed (re-scope, not eliminate).** In chat,
-   Gemini 3 signatures ride on the function-call part and TeXRA batches parallel
-   results into one message. In Interactions signatures are their own
-   `ThoughtStep.signature` (+ `ThoughtSignatureDelta`), and when continuing by
-   `previous_interaction_id` the server retains them — likely **simpler**. But if
-   we send history client-side (`input: Step[]`), we must round-trip the
-   `thought` steps verbatim. Needs a fixture test either way; this is still the
-   place most likely to silently break parallel tool use.
+1. **Thought/signature model changed (re-scope, not eliminate).** In chat,
+   Gemini 3 signatures ride on generated parts and TeXRA batches parallel
+   results into one message. In Interactions, custom `FunctionCallStep` and
+   `FunctionResultStep` have no `signature` field in `@google/genai@2.9.0`;
+   thought signatures are `ThoughtStep.signature` (+ `ThoughtSignatureDelta`).
+   Several built-in tool call/result step types also expose `signature`, so
+   stateless mode must round-trip all prior `Step[]` entries verbatim rather
+   than reconstructing only a thought/function subset. Needs a fixture test
+   either way; this is still the place most likely to silently break parallel
+   tool use.
 2. **Server-side state vs history/compaction.** TeXRA's restore/compaction assume
    a resend-able local transcript. The guide confirms `store` makes both modes
-   first-class: `store:false` = stateless drop-in parity (send full `Step[]` each
-   round; simplest, keeps compaction working unchanged) vs `store:true` (default)
-   with `previous_interaction_id` (payload win, but the server — not TeXRA — then
-   owns compaction, and behaviour must be defined when the stored interaction has
+   first-class: `store:false` = stateless drop-in parity (send local
+   `user_input` steps plus returned model steps each round; simplest, keeps
+   compaction working unchanged) vs `store:true` (default) with
+   `previous_interaction_id` (payload win, but the server — not TeXRA — then owns
+   compaction, and behaviour must be defined when the stored interaction has
    expired or a run is restored from old history). Official retention is 55 days
    on paid tier / 1 day on free tier; note `store:false` is incompatible with
    `background=true` and with later `previous_interaction_id` use. **Recommend
@@ -430,11 +455,18 @@ schema; no new ports.
    working version, verify key/model access in a real-key smoke test, and keep
    `generateContent` as fallback.
 4. **Usage/pricing remap.** `Usage.total_*` field names → `googleUsage.ts`
-   re-derivation; re-validate cache-rebate and reasoning-token accounting.
-5. **Managed agents are a different product.** `agent=` + `environment:'remote'`
+   re-derivation; re-validate implicit-cache and reasoning-token accounting. Do
+   not claim explicit `cached_content` parity until Google marks explicit caching
+   available for Interactions despite the field existing in SDK types.
+5. **API version and relay compatibility.** The existing Google handler does not
+   set `apiVersion`; the SDK defaults to beta endpoints, and official REST
+   examples currently use `/v1beta/interactions`. Before enabling included relay
+   keys or hardcoding `apiVersion:'v1'`, smoke-test personal-key and relay-key
+   calls for endpoint support, snake_case request fields, and error mapping.
+6. **Managed agents are a different product.** `agent=` + `environment:'remote'`
    provisions a remote sandbox (browse/exec). **Out of scope for v0**
    (model-mode only); track separately.
-6. **Service ids / pricing** (`⚠️ confirm`): supported model and agent ids are
+7. **Service ids / pricing** (`⚠️ confirm`): supported model and agent ids are
    listed in the official overview, but TeXRA still needs an implementation-time
    decision about which ids to register plus current $/token pricing and
    `ServiceTier` Flex/Priority cost deltas.
@@ -443,15 +475,16 @@ schema; no new ports.
 
 **In (v0):** `ModelHandlerGoogleInteractions` in **model mode** (text +
 multimodal in, SSE streaming, custom function calling incl. parallel calls +
-thought-signature round-trip, thinking, token counting, `Usage`-based
+verbatim `Step[]` signature round-trip, thinking, token counting, `Usage`-based
 pricing); compatibility key; routing predicate + factory branch;
 `useGoogleInteractionsAPI` setting + Settings UI + docs; tests (streaming SSE,
 parallel-tool/thought-signature, usage mapping, routing); keep `generateContent`
 as default fallback.
 
 **Out (v0):** managed agents (`agent=`, `environment:'remote'`); media generation
-(`response_modalities`/image/audio out); Deep Research agent; making Interactions
-the **default** for Gemini (ship behind the flag, flip later); OpenRouter support.
+(`response_modalities`/image/audio out); explicit `cached_content` parity; Deep
+Research agent; making Interactions the **default** for Gemini (ship behind the
+flag, flip later); OpenRouter support.
 
 ## Milestones
 
@@ -461,10 +494,12 @@ the **default** for Gemini (ship behind the flag, flip later); OpenRouter suppor
 2. `ModelHandlerGoogleInteractions` (model mode): SSE streaming + custom tools;
    compatibility key; factory routing behind `useGoogleInteractionsAPI` (default
    **off**). Unit tests on input/tool/usage translation (mocked SDK), explicitly
-   the parallel-tool/thought-signature round-trip.
-3. Multimodal `Content` input, thinking, token counting, cache/usage parity;
-   mixed built-in `google_search` + functions; settings UI + `configuration.md`.
-4. Real-key smoke test; CHANGELOG; decide per-model default flip; register GA ids.
+   the parallel-tool/verbatim-steps signature round-trip.
+3. Multimodal `Content` input, thinking, token counting, implicit-cache usage
+   accounting; settings UI + `configuration.md`.
+4. Mixed built-in `google_search` + functions after model-gated smoke tests
+   confirm support for the selected model ids.
+5. Real-key smoke test; CHANGELOG; decide per-model default flip; register GA ids.
 
 ## References
 

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -322,7 +322,7 @@ JSON** — trust the `.d.ts` where they differ.
 | --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Send a turn                       | `chat.sendMessage(parts)`                                    | `interactions.create({ model, input })`                                                                                                          |
 | Streaming                         | `sendMessageStream()` → `chunk.candidates[0].content.parts`  | `Stream<InteractionSSEEvent>`; consume `event_type:"step.delta"` → `delta` (TextDelta etc.)                                                      |
-| Conversation state                | resend full `Content[]` each round                           | `previous_interaction_id` (server-side) or pass prior `Step[]` in `input`                                                                        |
+| Conversation state                | resend full `Content[]` each round                           | v0: pass prior `Step[]` in `input` with `store:false`; later: `previous_interaction_id` when using `store:true`                                  |
 | System prompt                     | `systemInstruction` on chat params                           | `system_instruction` on create                                                                                                                   |
 | Custom tools                      | `[{ functionDeclarations:[…] }]`                             | `tools:[{ type:"function", name, description, parameters }]`                                                                                     |
 | Built-in search                   | **disabled** (can't mix w/ functions)                        | `tools:[{ type:"google_search" }, …functions]` — now mixable                                                                                     |
@@ -336,11 +336,14 @@ JSON** — trust the `.d.ts` where they differ.
 | Background                        | n/a today                                                    | `background:true` (+ `store`, `webhook_config`)                                                                                                  |
 | Caching                           | `cachedContentTokenCount` rebate                             | `cached_content` + `Usage.total_cached_tokens`                                                                                                   |
 
-For v0, send `system_instruction` on every `interactions.create` request rather
-than assuming it persists across future `previous_interaction_id` continuations.
-This mirrors the OpenAI Responses implementation, which re-sends instructions
-with each request; a later `store:true` phase can loosen this only after a
-real-key fixture proves continuation semantics.
+For v0, `store:false` means the handler cannot rely on `previous_interaction_id`;
+conversation state must come from local `Step[]` resending. Send request-level
+fields (`system_instruction`, `tools`, `generation_config`, `response_format`)
+on every `interactions.create` request rather than assuming they persist across
+future `previous_interaction_id` continuations. This mirrors the OpenAI
+Responses implementation, which re-sends instructions with each request; a later
+`store:true` phase can loosen this only after a real-key fixture proves
+continuation semantics.
 
 ## Design (additive, feature-flagged)
 

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -183,6 +183,68 @@ StepDeltaData, event_id?, metadata? }`; `StepDeltaData` (`:11685`) includes
 `total_cached_tokens`, `total_output_tokens`, `total_tool_use_tokens`,
 `total_thought_tokens`, plus `*_by_modality: ModalityTokens[]` and a grand total.
 
+## Surface area
+
+### SDK surface (`@google/genai@2.9.0`)
+
+The same `GoogleGenAI` client TeXRA already constructs exposes three lazily-built
+"next-gen" getters (`genai.d.ts:5677-5679`) beside the existing
+`models`/`chats`/`files`/`caches`/`live`/`batches`/… :
+
+- `client.interactions` → `GeminiNextGenInteractions` — `create` (model/agent ×
+  streaming), `get`, `delete`, `cancel`. **This is all v0 needs.**
+- `client.agents` → `GeminiNextGenAgents` — `create`/`list`/`get`/`delete`
+  managed agents (out of scope v0).
+- `client.webhooks` → `GeminiNextGenWebhooks` — register/rotate/ping webhooks for
+  `background` completion callbacks (out of scope v0; relevant if we later wire
+  background runs to push instead of poll via `get`).
+
+The `interactions` namespace (`:7367-7550`) is broad — beyond the v0 surface it
+carries built-in tool steps + deltas for code execution, Google Search, Google
+Maps, file search, URL context, MCP servers; `Environment`/`Network` egress
+config; `ComputerUse`; `DeepResearchAgentConfig`/`DynamicAgentConfig`;
+`Visualization`. v0 touches only: `CreateModelInteraction`, `InteractionsInput`,
+`Content`, `FunctionT`/`GoogleSearch` tools, `Step` (`function_call` /
+`function_result` / `thought` / `model_output` / `user_input`),
+`InteractionSSEEvent` + deltas, and `Usage`. The rest is upside for later phases,
+not work for v0.
+
+### TeXRA implementation surface
+
+The change is **contained and additive** — the existing Google handler is
+referenced from a small, known set:
+
+- **Code:** `ModelFactory.ts` (the one wiring point); `googleUsage.ts` and
+  `utils/fileContentUtils.ts` (shared helpers, **reusable** — the latter already
+  consolidates Anthropic/OpenAI/Google patterns); `modelHandlers/README.md`.
+- **Tests (6):** `ModelFactoryRouting`, `ModelHandlerGoogle`,
+  `ModelHandlerGoogleGenAI`, `GoogleGenAIStreamingText`, `GoogleCachePricing`,
+  `EmptyPrefill` — plus `SdkErrorUtils` for the (reused) error tagging. New
+  Interactions tests sit alongside these.
+
+A new handler must satisfy the `ModelHandler` contract — **19 abstract methods**
+(`ModelHandler.ts`) plus the hooks the Google handler overrides
+(`supportsTokenCounting`, `requiresBatchedParallelToolResults`,
+`estimateTokenCount`). They split cleanly:
+
+- **Reusable / thin port (≈ copy):** `getClient` (same client + `getApiKey()`),
+  `computePrice`/`normalizeUsage` (point at remapped `googleUsage.ts`),
+  `processThinkingBlock`, `shouldContinue`, `estimateTokenCount`
+  (`client.models.countTokens` unchanged), media size/threshold logic.
+- **Wire-format rewrites (the real work):** `initializeMessages` /
+  `createRoundMessages` / `createMediaContent` / `addMediaToUserMessage` /
+  `prependTextToUserMessage` (typed `Content` + `Step[]` input vs chat parts);
+  `extractResponse` / `extractToolUse` (walk `steps` vs candidate parts);
+  `createToolUseFollowUpMessages` + the batched parallel variant (emit
+  `function_result` steps keyed by `call_id`, round-trip `thought` steps);
+  `createUserFollowUpMessages` / `createAssistantMessage` /
+  `updateMessageContentWith[out]Prefill` (steps-shaped); the streaming loop (SSE
+  `event_type` events vs chunk parts).
+
+So the surface is ~one new ~800-1000 line handler file mirroring the chat one,
+one routing predicate, one settings field (×3 sites), and a handful of tests —
+no cross-cutting refactor, no new platform port, no dependency bump.
+
 ## Mapping: `generateContent`/chat → Interactions
 
 | TeXRA concern | Today (chat/`generateContent`) | Interactions (verified) |

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -223,28 +223,38 @@ referenced from a small, known set:
   `EmptyPrefill` — plus `SdkErrorUtils` for the (reused) error tagging. New
   Interactions tests sit alongside these.
 
-A new handler must satisfy the `ModelHandler` contract — **19 abstract methods**
-(`ModelHandler.ts`) plus the hooks the Google handler overrides
-(`supportsTokenCounting`, `requiresBatchedParallelToolResults`,
+A new handler must satisfy the `ModelHandler` contract — **all 19 abstract
+methods** (`ModelHandler.ts`) plus the protected/override hooks the Google handler
+defines (`createResponseImpl`, `sdkErrorTagger`, `extractAssistantText`,
+`createMediaMessage`, `supportsTokenCounting`, `requiresBatchedParallelToolResults`,
 `estimateTokenCount`). They split cleanly:
 
 - **Reusable / thin port (≈ copy):** `getClient` (same client + `getApiKey()`),
-  `computePrice`/`normalizeUsage` (point at remapped `googleUsage.ts`),
+  `computePrice` / `normalizeUsage` (point at remapped `googleUsage.ts`),
   `processThinkingBlock`, `shouldContinue`, `estimateTokenCount`
-  (`client.models.countTokens` unchanged), media size/threshold logic.
-- **Wire-format rewrites (the real work):** `initializeMessages` /
-  `createRoundMessages` / `createMediaContent` / `addMediaToUserMessage` /
-  `prependTextToUserMessage` (typed `Content` + `Step[]` input vs chat parts);
-  `extractResponse` / `extractToolUse` (walk `steps` vs candidate parts);
-  `createToolUseFollowUpMessages` + the batched parallel variant (emit
-  `function_result` steps keyed by `call_id`, round-trip `thought` steps);
-  `createUserFollowUpMessages` / `createAssistantMessage` /
-  `updateMessageContentWith[out]Prefill` (steps-shaped); the streaming loop (SSE
-  `event_type` events vs chunk parts).
+  (`client.models.countTokens` unchanged), the `sdkErrorTagger` override (reuse
+  `googleSdkError.ts`), media size/threshold logic, and the
+  `supportsTokenCounting` / `requiresBatchedParallelToolResults` capability hooks.
+- **Core rewrite (the real work):** `createResponseImpl` (`:405`) — today builds
+  `chats.create()` → `sendMessageStream()` / `sendMessage()`; becomes
+  `interactions.create({ …, stream })` driving the SSE `event_type` lifecycle
+  (`step.start`/`step.delta`/`step.stop` → output vs `arguments_delta` vs
+  thought). **Single biggest piece.**
+- **Wire-format rewrites:** message build — `initializeMessages` /
+  `createRoundMessages` / `createUserFollowUpMessages` / `createAssistantMessage`
+  / `prependTextToUserMessage` / `addMediaToUserMessage` / `createMediaContent` /
+  `createMediaMessage` (typed `Content` + `Step[]` input vs chat parts); prefill —
+  `initializeOutputAndPrefill` (uses `fileContentUtils`) /
+  `addContinueMessageWithoutPrefill` / `updateMessageContentWith[out]Prefill`
+  (re-expressed for steps); extraction — `extractResponse` /
+  `extractAssistantText` / `extractToolUse` (walk `steps` vs candidate parts);
+  tool round-trip — `createToolUseFollowUpMessages` + the batched parallel variant
+  (emit `function_result` steps keyed by `call_id`, round-trip `thought` steps).
 
-So the surface is ~one new ~800-1000 line handler file mirroring the chat one,
-one routing predicate, one settings field (×3 sites), and a handful of tests —
-no cross-cutting refactor, no new platform port, no dependency bump.
+That accounts for all 19 abstract methods plus the 7 overrides. So the surface is
+~one new ~800-1000 line handler file mirroring the chat one, one routing
+predicate, one settings field (×3 sites), and a handful of tests — no
+cross-cutting refactor, no new platform port, no dependency bump.
 
 ## Official migration guide × SDK types (reconciliation)
 

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -245,6 +245,55 @@ So the surface is ~one new ~800-1000 line handler file mirroring the chat one,
 one routing predicate, one settings field (×3 sites), and a handful of tests —
 no cross-cutting refactor, no new platform port, no dependency bump.
 
+## Official migration guide × SDK types (reconciliation)
+
+Google's `generateContent`→Interactions migration guide was cross-checked against
+the installed `@google/genai@2.9.0` `.d.ts`. Most of it matches; the mismatches
+matter because **TeXRA's TypeScript sees the SDK types, not the guide's prose/REST
+JSON** — trust the `.d.ts` where they differ.
+
+**Confirmed by both:**
+
+- **State on by default.** `store` defaults `true` (server-side history); set
+  `store:false` for stateless behaviour. So TeXRA has two clean options:
+  `store:false` for drop-in parity with today's stateless resend, or
+  `store:true` + `previous_interaction_id` for the payload win. (Resolves the
+  open question in risk #2 — both are first-class.)
+- **Convenience accessors exist** on the returned interaction: `output_text`
+  (`:7053`), `output_image?: ImageContent` (`:7057`), `output_audio?:
+  AudioContent` (`:7061`). `output_text` joins only the *trailing* `TextContent`
+  run, so anything interleaved with thoughts/tools/images still requires walking
+  `steps` — which TeXRA does anyway (thinking is separated, tools are handled).
+- **Function-result round-trip:** submit the result as a **new** `create` call
+  with `previous_interaction_id` and `input` = a `function_result`
+  `{ type:"function_result", call_id: <call.id>, name, result:[{type:"text",text}] }`.
+  The pending interaction reports `status:"requires_action"` and the
+  `function_call` step sits `status:"waiting"`. `InteractionStatus` (`:7620`) =
+  `in_progress|requires_action|completed|failed|cancelled|incomplete|budget_exceeded`.
+- **Structured output** is a top-level `response_format` array of
+  `{ type:"text", mime_type:"application/json", schema }` (`response_mime_type` is
+  deprecated). **Streaming** discriminates events on `event_type`
+  (`interaction.created` / `interaction.in_progress` / `step.start` /
+  `step.delta` / `step.stop` / `interaction.requires_action` /
+  `interaction.completed`). `TextDelta` = `{ type:"text", text }` (`:11995`).
+- **Built-in tools are transparent:** `google_search_call` + `google_search_result`
+  steps, with **inline** citations as an `annotations` array on the
+  `model_output` text content (vs the old separate `groundingMetadata`).
+
+**Discrepancies — follow the SDK, not the guide:**
+
+- **Streamed tool args.** Guide prose: `delta.type === "arguments"` /
+  `delta.partial_arguments`. SDK: `ArgumentsDelta` (`:527`) is
+  `{ type:"arguments_delta", arguments?: string }`. Use `"arguments_delta"` and
+  the `arguments` field.
+- **Usage field names.** Guide REST JSON shows `prompt_tokens` /
+  `completion_tokens` / `total_tokens`; the SDK `Usage` type (`:13952`) has
+  **none** of those — it exposes `total_input_tokens` / `total_output_tokens` /
+  `total_cached_tokens` / `total_tool_use_tokens` / `total_thought_tokens`
+  (+ `*_by_modality`). `googleUsage.ts` must map the SDK names.
+- **REST path** is `v1beta2/interactions` (vs `v1beta/models/…:generateContent`)
+  — informational only; TeXRA calls the SDK, not REST.
+
 ## Mapping: `generateContent`/chat → Interactions
 
 | TeXRA concern                     | Today (chat/`generateContent`)                               | Interactions (verified)                                                                                                                          |
@@ -334,12 +383,16 @@ schema; no new ports.
    `thought` steps verbatim. Needs a fixture test either way; this is still the
    place most likely to silently break parallel tool use.
 2. **Server-side state vs history/compaction.** TeXRA's restore/compaction assume
-   a resend-able local transcript. Decide per the OpenAI Responses resolution:
-   stateless (send full `Step[]` each round; simplest, loses payload win) vs
-   `previous_interaction_id` (define behaviour when the stored interaction has
+   a resend-able local transcript. The guide confirms `store` makes both modes
+   first-class: `store:false` = stateless drop-in parity (send full `Step[]` each
+   round; simplest, keeps compaction working unchanged) vs `store:true` (default)
+   + `previous_interaction_id` (payload win, but the server — not TeXRA — then
+   owns compaction, and behaviour must be defined when the stored interaction has
    expired or a run is restored from old history). Official retention is 55 days
-   on paid tier and 1 day on free tier; `store=false` opts out but is
-   incompatible with `background=true` and later `previous_interaction_id` use.
+   on paid tier / 1 day on free tier; note `store:false` is incompatible with
+   `background=true` and with later `previous_interaction_id` use. **Recommend
+   `store:false` for v0** to preserve the existing history/compaction contract,
+   treating server-side continuation (+ background) as a later optimisation.
 3. **GA service with active SDK churn.** The official overview marks the API GA,
    and the types ship in the pinned SDK version; `response_mime_type` is already
    deprecated in favour of `response_format`, signalling churn. Pin/snapshot the

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -7,14 +7,15 @@
 
 > **Verification status.** The schema below is **verified against the installed
 > `@google/genai@2.9.0` type definitions** (`node_modules/.../@google/genai/dist/genai.d.ts`)
-> — the exact version already pinned in `package.json:108` and
-> `packages/extension/package.json:1713`. The Interactions surface ships in that
-> version, so **no dependency bump is required to start.** Google's official
+> — the version currently resolved in `pnpm-lock.yaml`. The package manifests
+> already depend on `@google/genai` at `^2.9.0` (`package.json:108` and
+> `packages/extension/package.json:1713`), so **no dependency bump is required to
+> start.** Google's official
 > Interactions overview was reachable on 2026-06-22 and confirms GA status,
 > recommended use for new projects, supported model/agent IDs, and storage
-> retention. Pricing and Flex/Priority cost deltas remain `⚠️ confirm at impl
-time`. Everything about the **SDK request/response shape is byte-verified**
-> and cited to `genai.d.ts` line numbers.
+> retention. Pricing and Flex/Priority cost deltas still need implementation-time
+> confirmation. Everything about the **SDK request/response shape is
+> byte-verified** and cited to `genai.d.ts` line numbers.
 
 ## Summary
 
@@ -260,10 +261,11 @@ JSON** — trust the `.d.ts` where they differ.
   `store:true` + `previous_interaction_id` for the payload win. (Resolves the
   open question in risk #2 — both are first-class.)
 - **Convenience accessors exist** on the returned interaction: `output_text`
-  (`:7053`), `output_image?: ImageContent` (`:7057`), `output_audio?:
-AudioContent` (`:7061`). `output_text` joins only the _trailing_ `TextContent`
-  run, so anything interleaved with thoughts/tools/images still requires walking
-  `steps` — which TeXRA does anyway (thinking is separated, tools are handled).
+  (`:7053`), `output_image?: ImageContent` (`:7057`), and
+  `output_audio?: AudioContent` (`:7061`). `output_text` joins only the
+  _trailing_ `TextContent` run, so anything interleaved with
+  thoughts/tools/images still requires walking `steps` — which TeXRA does anyway
+  (thinking is separated, tools are handled).
 - **Function-result round-trip:** submit the result as a **new** `create` call
   with `previous_interaction_id` and `input` = a `function_result`
   `{ type:"function_result", call_id: <call.id>, name, result:[{type:"text",text}] }`.
@@ -386,13 +388,13 @@ schema; no new ports.
    a resend-able local transcript. The guide confirms `store` makes both modes
    first-class: `store:false` = stateless drop-in parity (send full `Step[]` each
    round; simplest, keeps compaction working unchanged) vs `store:true` (default)
-   - `previous_interaction_id` (payload win, but the server — not TeXRA — then
-     owns compaction, and behaviour must be defined when the stored interaction has
-     expired or a run is restored from old history). Official retention is 55 days
-     on paid tier / 1 day on free tier; note `store:false` is incompatible with
-     `background=true` and with later `previous_interaction_id` use. **Recommend
-     `store:false` for v0** to preserve the existing history/compaction contract,
-     treating server-side continuation (+ background) as a later optimisation.
+   with `previous_interaction_id` (payload win, but the server — not TeXRA — then
+   owns compaction, and behaviour must be defined when the stored interaction has
+   expired or a run is restored from old history). Official retention is 55 days
+   on paid tier / 1 day on free tier; note `store:false` is incompatible with
+   `background=true` and with later `previous_interaction_id` use. **Recommend
+   `store:false` for v0** to preserve the existing history/compaction contract,
+   treating server-side continuation (+ background) as a later optimisation.
 3. **GA service with active SDK churn.** The official overview marks the API GA,
    and the types ship in the pinned SDK version; `response_mime_type` is already
    deprecated in favour of `response_format`, signalling churn. Pin/snapshot the

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -19,7 +19,7 @@
 ## Summary
 
 Google has made the **Interactions API** the primary, recommended interface for
-Gemini models *and* agents. In the SDK it is `client.interactions` →
+Gemini models _and_ agents. In the SDK it is `client.interactions` →
 `GeminiNextGenInteractions` (`genai.d.ts:5677`, `:4598`), with
 `create` / `get` / `delete` / `cancel` methods. It is a single **stateful**
 endpoint that supersedes the chat / `generateContent` surface for new work:
@@ -50,30 +50,30 @@ features, and flipping the default per-model once proven.
   (`:2385`) + `webhook_config?` (`:2416`) map onto TeXRA's existing
   background-response machinery (`texra.model.useBackgroundResponses`).
 - **Unified tool model.** `tools?: Array<Tool>` where `Tool = FunctionT |
-  CodeExecution | URLContext | ComputerUse | MCPServer | GoogleSearch |
-  FileSearch | GoogleMaps | Retrieval` (`:12272`) — built-in **and** custom
+CodeExecution | URLContext | ComputerUse | MCPServer | GoogleSearch |
+FileSearch | GoogleMaps | Retrieval` (`:12272`) — built-in **and** custom
   functions in one request. This removes the limitation TeXRA documents today:
   native `googleSearch` is disabled because the `generateContent` API cannot
   combine `googleSearch` with `functionDeclarations` (`toolConversion.ts:355-357`,
   attributed there to the Live API). Interactions lifts it on the regular surface.
 - **Tool results with images.** A `function_result` step's `result` can be
   `string | {} | Array<FunctionResultSubcontent>` where `FunctionResultSubcontent
-  = TextContent | ImageContent` (`:4543`,`:4553`).
+= TextContent | ImageContent` (`:4543`,`:4553`).
 - **Same SDK, same client, no new dependency.** `client.interactions` already
   exists on the `new GoogleGenAI({ apiKey })` instance TeXRA builds
   (`modelHandlerGoogleGenAI.ts:304`,`:323`).
 
 ## Current state (verified in repo)
 
-| File | Detail |
-| ---- | ------ |
+| File                                                                      | Detail                                                                                                                                                                                                                                                                                                         |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts` (~1366 lines) | `ModelHandlerGoogleGenAI`; `client.chats.create()` (`:496`) → `chat.sendMessageStream()` (`:507`) / `chat.sendMessage()` (`:617`); `client.models.countTokens()` (`:383`); `client.files.upload()` (`:245`); client built `new GoogleGenAI({ apiKey })` (`:304`,`:323`) via base `getApiKey()` (`:299`,`:319`) |
-| `src/agent/modelHandlers/google/googleMessageHelpers.ts` | Strict user/model alternation, `systemInstruction`, parts-based `Content[]` |
-| `src/agent/modelHandlers/google/googleUsage.ts` | Token/price/usage from `GenerateContentResponseUsageMetadata` |
-| `src/agent/modelHandlers/google/googleSdkError.ts` | `GoogleApiError` → TeXRA SDK error kinds (reusable as-is) |
-| `src/agent/modelHandlers/toolConversion.ts:360` | `toGoogleTools()` → `[{ functionDeclarations }]` (chat shape) |
-| `src/agent/runtime/ModelFactory.ts:73` | `PROVIDER_HANDLER_ROUTES[GOOGLE]` → `ModelHandlerGoogleGenAI`, key `'ModelHandlerGoogleGenAI'` |
-| `package.json:108`, `packages/extension/package.json:1713` | `@google/genai` `^2.9.0` (resolved `2.9.0`, exposes `interactions`) |
+| `src/agent/modelHandlers/google/googleMessageHelpers.ts`                  | Strict user/model alternation, `systemInstruction`, parts-based `Content[]`                                                                                                                                                                                                                                    |
+| `src/agent/modelHandlers/google/googleUsage.ts`                           | Token/price/usage from `GenerateContentResponseUsageMetadata`                                                                                                                                                                                                                                                  |
+| `src/agent/modelHandlers/google/googleSdkError.ts`                        | `GoogleApiError` → TeXRA SDK error kinds (reusable as-is)                                                                                                                                                                                                                                                      |
+| `src/agent/modelHandlers/toolConversion.ts:360`                           | `toGoogleTools()` → `[{ functionDeclarations }]` (chat shape)                                                                                                                                                                                                                                                  |
+| `src/agent/runtime/ModelFactory.ts:73`                                    | `PROVIDER_HANDLER_ROUTES[GOOGLE]` → `ModelHandlerGoogleGenAI`, key `'ModelHandlerGoogleGenAI'`                                                                                                                                                                                                                 |
+| `package.json:108`, `packages/extension/package.json:1713`                | `@google/genai` `^2.9.0` (resolved `2.9.0`, exposes `interactions`)                                                                                                                                                                                                                                            |
 
 Capabilities the new handler must preserve (all in `modelHandlerGoogleGenAI.ts`):
 streaming with thinking/output separation; **parallel tool calls with Gemini 3
@@ -115,24 +115,24 @@ get(id, params?)   // (:4609-4611)   delete(id, params?)   // (:4612)   cancel(i
 
 **Request — `CreateModelInteraction` (`:2373`)** — note **snake_case**:
 
-| field | type | line |
-| ----- | ---- | ---- |
-| `model` | `Model` (string id) | 2377 |
-| `input` | `InteractionsInput` (required) | 2442 |
-| `stream?` | `boolean` (discriminates streaming vs not) | 2381 |
-| `store?` | `boolean` (persist for later retrieval) | 2385 |
-| `background?` | `boolean` | 2389 |
-| `system_instruction?` | `string` | 2393 |
-| `tools?` | `Array<Tool>` | 2397 |
-| `previous_interaction_id?` | `string` (server-side continuation) | 2411 |
-| `response_format?` | `ResponseFormat \| ResponseFormat[]` (structured output) | 2420 |
-| `response_modalities?` | `Array<ResponseModality>` (TEXT/IMAGE/AUDIO) | 2401 |
-| `generation_config?` | `GenerationConfig` (temp, tokens, thinking, …) | 2428 |
-| `service_tier?` | `ServiceTier` (Flex/Priority) | 2412 |
-| `cached_content?` | `string` (explicit cache handle) | 2438 |
-| `webhook_config?` | `WebhookConfig` | 2416 |
-| `environment?` | `Environment \| string` | 2424 |
-| `response_mime_type?` | `string` — **deprecated**, use `response_format` | 2407 |
+| field                      | type                                                     | line |
+| -------------------------- | -------------------------------------------------------- | ---- |
+| `model`                    | `Model` (string id)                                      | 2377 |
+| `input`                    | `InteractionsInput` (required)                           | 2442 |
+| `stream?`                  | `boolean` (discriminates streaming vs not)               | 2381 |
+| `store?`                   | `boolean` (persist for later retrieval)                  | 2385 |
+| `background?`              | `boolean`                                                | 2389 |
+| `system_instruction?`      | `string`                                                 | 2393 |
+| `tools?`                   | `Array<Tool>`                                            | 2397 |
+| `previous_interaction_id?` | `string` (server-side continuation)                      | 2411 |
+| `response_format?`         | `ResponseFormat \| ResponseFormat[]` (structured output) | 2420 |
+| `response_modalities?`     | `Array<ResponseModality>` (TEXT/IMAGE/AUDIO)             | 2401 |
+| `generation_config?`       | `GenerationConfig` (temp, tokens, thinking, …)           | 2428 |
+| `service_tier?`            | `ServiceTier` (Flex/Priority)                            | 2412 |
+| `cached_content?`          | `string` (explicit cache handle)                         | 2438 |
+| `webhook_config?`          | `WebhookConfig`                                          | 2416 |
+| `environment?`             | `Environment \| string`                                  | 2424 |
+| `response_mime_type?`      | `string` — **deprecated**, use `response_format`         | 2407 |
 
 `CreateAgentInteraction` (`:1987`) swaps `model` for `agent` (`AgentOption`) +
 `agent_config` (`DynamicAgentConfig | DeepResearchAgentConfig`) + `environment`.
@@ -156,14 +156,14 @@ with `steps: Step[]`, `:5683`): `id`, `status: InteractionStatus`, `created`,
 
 **Steps — `Step` (`:11664`)** (discriminated by `type`):
 
-| step | shape | line |
-| ---- | ----- | ---- |
-| `UserInputStep` | `{ type:"user_input", content?: Content[] }` | 14035 |
-| `ModelOutputStep` | `{ type:"model_output", content?: Content[] }` | 9235 |
-| `ThoughtStep` | `{ type:"thought", signature?: string, summary?: ThoughtSummaryContent[] }` | 12112 |
-| `FunctionCallStep` | `{ type:"function_call", name: string, arguments: {}, id: string }` | 4403 |
-| `FunctionResultStep` | `{ type:"function_result", name?, is_error?, call_id: string, result: string \| {} \| FunctionResultSubcontent[] }` | 4526 |
-| built-in call/result | `CodeExecution*`, `GoogleSearch*`, `GoogleMaps*`, `FileSearch*`, `URLContext*`, `MCPServerTool*` Step variants | — |
+| step                 | shape                                                                                                               | line  |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- | ----- |
+| `UserInputStep`      | `{ type:"user_input", content?: Content[] }`                                                                        | 14035 |
+| `ModelOutputStep`    | `{ type:"model_output", content?: Content[] }`                                                                      | 9235  |
+| `ThoughtStep`        | `{ type:"thought", signature?: string, summary?: ThoughtSummaryContent[] }`                                         | 12112 |
+| `FunctionCallStep`   | `{ type:"function_call", name: string, arguments: {}, id: string }`                                                 | 4403  |
+| `FunctionResultStep` | `{ type:"function_result", name?, is_error?, call_id: string, result: string \| {} \| FunctionResultSubcontent[] }` | 4526  |
+| built-in call/result | `CodeExecution*`, `GoogleSearch*`, `GoogleMaps*`, `FileSearch*`, `URLContext*`, `MCPServerTool*` Step variants      | —     |
 
 `FunctionResultSubcontent = TextContent | ImageContent` (`:4553`) → tool results
 can include images.
@@ -247,32 +247,34 @@ no cross-cutting refactor, no new platform port, no dependency bump.
 
 ## Mapping: `generateContent`/chat → Interactions
 
-| TeXRA concern | Today (chat/`generateContent`) | Interactions (verified) |
-| ------------- | ------------------------------ | ----------------------- |
-| Send a turn | `chat.sendMessage(parts)` | `interactions.create({ model, input })` |
-| Streaming | `sendMessageStream()` → `chunk.candidates[0].content.parts` | `Stream<InteractionSSEEvent>`; consume `event_type:"step.delta"` → `delta` (TextDelta etc.) |
-| Conversation state | resend full `Content[]` each round | `previous_interaction_id` (server-side) or pass prior `Step[]` in `input` |
-| System prompt | `systemInstruction` on chat params | `system_instruction` on create |
-| Custom tools | `[{ functionDeclarations:[…] }]` | `tools:[{ type:"function", name, description, parameters }]` |
-| Built-in search | **disabled** (can't mix w/ functions) | `tools:[{ type:"google_search" }, …functions]` — now mixable |
-| Tool call out | `functionCall` part | `FunctionCallStep` `{ name, arguments, id }` (+ streamed `ArgumentsDelta`) |
-| Tool result in | `functionResponse` part (user msg) | a `function_result` step/input `{ call_id, result }`; `result` may include images |
+| TeXRA concern                     | Today (chat/`generateContent`)                               | Interactions (verified)                                                                                                                          |
+| --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Send a turn                       | `chat.sendMessage(parts)`                                    | `interactions.create({ model, input })`                                                                                                          |
+| Streaming                         | `sendMessageStream()` → `chunk.candidates[0].content.parts`  | `Stream<InteractionSSEEvent>`; consume `event_type:"step.delta"` → `delta` (TextDelta etc.)                                                      |
+| Conversation state                | resend full `Content[]` each round                           | `previous_interaction_id` (server-side) or pass prior `Step[]` in `input`                                                                        |
+| System prompt                     | `systemInstruction` on chat params                           | `system_instruction` on create                                                                                                                   |
+| Custom tools                      | `[{ functionDeclarations:[…] }]`                             | `tools:[{ type:"function", name, description, parameters }]`                                                                                     |
+| Built-in search                   | **disabled** (can't mix w/ functions)                        | `tools:[{ type:"google_search" }, …functions]` — now mixable                                                                                     |
+| Tool call out                     | `functionCall` part                                          | `FunctionCallStep` `{ name, arguments, id }` (+ streamed `ArgumentsDelta`)                                                                       |
+| Tool result in                    | `functionResponse` part (user msg)                           | a `function_result` step/input `{ call_id, result }`; `result` may include images                                                                |
 | **Parallel tools + thought sigs** | batched into one model `Content`, signature on the call part | sigs live on **`ThoughtStep.signature`** + `ThoughtSignatureDelta`, separate from `function_call` steps; server holds them when continuing by id |
-| Thinking | `thinkingConfig` + `thought` parts | `generation_config` thinking + `ThoughtStep`/`ThoughtSummaryDelta` |
-| Multimodal in | inline base64 / File API `uri` parts | typed `Content` (`ImageContent`/`DocumentContent`/…) in `input` |
-| Token counting | `client.models.countTokens()` | unchanged — still on `client.models` |
-| Usage/pricing | `GenerateContentResponseUsageMetadata` | `Usage` (`total_*_tokens`) → remap `googleUsage.ts` |
-| Background | n/a today | `background:true` (+ `store`, `webhook_config`) |
-| Caching | `cachedContentTokenCount` rebate | `cached_content` + `Usage.total_cached_tokens` |
+| Thinking                          | `thinkingConfig` + `thought` parts                           | `generation_config` thinking + `ThoughtStep`/`ThoughtSummaryDelta`                                                                               |
+| Multimodal in                     | inline base64 / File API `uri` parts                         | typed `Content` (`ImageContent`/`DocumentContent`/…) in `input`                                                                                  |
+| Token counting                    | `client.models.countTokens()`                                | unchanged — still on `client.models`                                                                                                             |
+| Usage/pricing                     | `GenerateContentResponseUsageMetadata`                       | `Usage` (`total_*_tokens`) → remap `googleUsage.ts`                                                                                              |
+| Background                        | n/a today                                                    | `background:true` (+ `store`, `webhook_config`)                                                                                                  |
+| Caching                           | `cachedContentTokenCount` rebate                             | `cached_content` + `Usage.total_cached_tokens`                                                                                                   |
 
 ## Design (additive, feature-flagged)
 
 Mirror the OpenAI Responses precedent end to end.
 
 ### 1. New handler
+
 `ModelHandlerGoogleInteractions` in
 `src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts`, extending
 `ModelHandler` like the existing Google handler.
+
 - **Reuse:** `googleSdkError.ts` (same `GoogleApiError`); the JSON-Schema
   flattening/`$schema`-stripping in `toolConversion.ts` (wire-agnostic) — feed it
   into `FunctionT.parameters` instead of `functionDeclarations`; the media
@@ -284,12 +286,14 @@ Mirror the OpenAI Responses precedent end to end.
   `googleUsage.ts` for the `Usage` shape.
 
 ### 2. Compatibility key
+
 Add `'ModelHandlerGoogleInteractions'` to `ModelHandlerCompatibilityKey`
 (`ModelFactory.ts:29`). Interactions persists state server-side and continues via
 `previous_interaction_id`; its history shape differs from the chat handler's
 `Content[]`, so a distinct key is mandatory for history restore/compaction.
 
 ### 3. Routing predicate + factory branch
+
 Add `shouldUseGoogleInteractionsAPI(config, useOpenRouter)` next to
 `shouldUseResponsesAPI`. Gate on a new setting plus per-model
 `requiresInteractionsAPI` (agents like Deep Research are Interactions-only and
@@ -297,12 +301,14 @@ force it). Branch in `createModelHandler()` **before** the default Google route,
 and exclude `useOpenRouter` (OpenRouter can't proxy Interactions).
 
 ### 4. Settings
+
 Add `model.useGoogleInteractionsAPI` to `coreSettings.ts` (the three sites at
 ~81/325/564), mirroring `useOpenAIResponsesAPI`; reuse
 `model.useBackgroundResponses` for `background:true`. Surface in Settings →
 Models; document in `docs/guide/configuration.md`.
 
 ### 5. Model registry
+
 Register GA Gemini model ids / agent ids (`llm-zoo` `MODEL_CONFIGS` + `src/model/`
 capability/pricing), marking agent-only entries Interactions-required.
 ⚠️ confirm exact ids + pricing at impl time.

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -46,7 +46,10 @@ features, and flipping the default per-model once proven.
   expected to be Interactions-only. Staying on `generateContent` strands those.
 - **Server-side state.** `previous_interaction_id` (`genai.d.ts:2411`) continues
   a conversation without resending the full `Content[]` each round — the same
-  payload win TeXRA already realised for OpenAI via `previous_response_id`.
+  payload win TeXRA already realised for OpenAI via `previous_response_id`. The
+  v0 plan deliberately starts with `store:false` to preserve TeXRA's current
+  history/compaction contract, then enables server-side continuation after
+  expiry/restore behaviour is specified and tested.
 - **Background execution.** `background?: boolean` (`:2389`) + `store?`
   (`:2385`) + `webhook_config?` (`:2416`) map onto TeXRA's existing
   background-response machinery (`texra.model.useBackgroundResponses`).
@@ -172,12 +175,17 @@ can include images.
 **Streaming — `InteractionSSEEvent` (`:7559`):**
 `InteractionCreatedEvent | InteractionCompletedEvent | InteractionStatusUpdate |
 ErrorEvent | StepStart | StepDelta | StepStop`. Events discriminate on
-**`event_type`** (`"step.start"` `:11699`, `"step.delta"` `:11668`,
-`"step.stop"`). `StepDelta = { event_type:"step.delta", index, delta:
-StepDeltaData, event_id?, metadata? }`; `StepDeltaData` (`:11685`) includes
-`TextDelta`, `ArgumentsDelta` (streamed tool args), `ThoughtSummaryDelta`,
-`ThoughtSignatureDelta`, `FunctionResultDelta`, image/audio/doc deltas, …;
-`StepDeltaMetadata.total_usage?: Usage` (`:11690`) carries running usage.
+**`event_type`**: interaction lifecycle events (`"interaction.created"`
+`:7100`, `"interaction.completed"` `:7078`, `"interaction.status_update"`
+`:7625`, `"error"` `:3556`) and step events (`"step.start"` `:11699`,
+`"step.delta"` `:11668`, `"step.stop"` `:11719`). Status changes such as
+`"in_progress"` and `"requires_action"` are the `status` field on
+`InteractionStatusUpdate`, not distinct `event_type` values. `StepDelta = {
+event_type:"step.delta", index, delta: StepDeltaData, event_id?, metadata? }`;
+`StepDeltaData` (`:11685`) includes `TextDelta`, `ArgumentsDelta` (streamed tool
+args), `ThoughtSummaryDelta`, `ThoughtSignatureDelta`, `FunctionResultDelta`,
+image/audio/doc deltas, …; `StepDeltaMetadata.total_usage?: Usage` (`:11690`)
+carries running usage.
 
 **Usage — `Usage` (`:13952`)** (snake_case, differs from
 `GenerateContentResponseUsageMetadata`): `total_input_tokens`,
@@ -285,9 +293,11 @@ JSON** — trust the `.d.ts` where they differ.
 - **Structured output** is a top-level `response_format` array of
   `{ type:"text", mime_type:"application/json", schema }` (`response_mime_type` is
   deprecated). **Streaming** discriminates events on `event_type`
-  (`interaction.created` / `interaction.in_progress` / `step.start` /
-  `step.delta` / `step.stop` / `interaction.requires_action` /
-  `interaction.completed`). `TextDelta` = `{ type:"text", text }` (`:11995`).
+  (`interaction.created` / `interaction.completed` /
+  `interaction.status_update` / `step.start` / `step.delta` / `step.stop` /
+  `error`). Interaction states such as `in_progress` and `requires_action` live
+  on `InteractionStatusUpdate.status`, not in `event_type`. `TextDelta` =
+  `{ type:"text", text }` (`:11995`).
 - **Built-in tools are transparent:** `google_search_call` + `google_search_result`
   steps, with **inline** citations as an `annotations` array on the
   `model_output` text content (vs the old separate `groundingMetadata`).
@@ -325,6 +335,12 @@ JSON** — trust the `.d.ts` where they differ.
 | Usage/pricing                     | `GenerateContentResponseUsageMetadata`                       | `Usage` (`total_*_tokens`) → remap `googleUsage.ts`                                                                                              |
 | Background                        | n/a today                                                    | `background:true` (+ `store`, `webhook_config`)                                                                                                  |
 | Caching                           | `cachedContentTokenCount` rebate                             | `cached_content` + `Usage.total_cached_tokens`                                                                                                   |
+
+For v0, send `system_instruction` on every `interactions.create` request rather
+than assuming it persists across future `previous_interaction_id` continuations.
+This mirrors the OpenAI Responses implementation, which re-sends instructions
+with each request; a later `store:true` phase can loosen this only after a
+real-key fixture proves continuation semantics.
 
 ## Design (additive, feature-flagged)
 

--- a/docs/proposals/google-interactions-api.md
+++ b/docs/proposals/google-interactions-api.md
@@ -9,12 +9,12 @@
 > `@google/genai@2.9.0` type definitions** (`node_modules/.../@google/genai/dist/genai.d.ts`)
 > — the exact version already pinned in `package.json:108` and
 > `packages/extension/package.json:1713`. The Interactions surface ships in that
-> version, so **no dependency bump is required to start.** Google's `ai.google.dev`
-> doc pages returned HTTP 403 to automated fetch, so the few facts that live only
-> on the service (GA model/agent ids, $/token pricing, retention window, Flex/
-> Priority cost deltas) remain marked `⚠️ confirm at impl time`. Everything about
-> the **SDK request/response shape is byte-verified** and cited to `genai.d.ts`
-> line numbers.
+> version, so **no dependency bump is required to start.** Google's official
+> Interactions overview was reachable on 2026-06-22 and confirms GA status,
+> recommended use for new projects, supported model/agent IDs, and storage
+> retention. Pricing and Flex/Priority cost deltas remain `⚠️ confirm at impl
+time`. Everything about the **SDK request/response shape is byte-verified**
+> and cited to `genai.d.ts` line numbers.
 
 ## Summary
 
@@ -309,9 +309,11 @@ Models; document in `docs/guide/configuration.md`.
 
 ### 5. Model registry
 
-Register GA Gemini model ids / agent ids (`llm-zoo` `MODEL_CONFIGS` + `src/model/`
-capability/pricing), marking agent-only entries Interactions-required.
-⚠️ confirm exact ids + pricing at impl time.
+Register the Interactions-supported model and agent ids (`llm-zoo`
+`MODEL_CONFIGS` + `src/model/` capability/pricing), marking agent-only entries
+Interactions-required. The official overview currently includes Gemini
+3.1/3/2.5 model ids, Lyria preview model ids, and Deep Research / Antigravity
+preview agent ids; confirm the exact set to expose and pricing at impl time.
 
 ## Platform / VS Code separation
 
@@ -335,20 +337,23 @@ schema; no new ports.
    a resend-able local transcript. Decide per the OpenAI Responses resolution:
    stateless (send full `Step[]` each round; simplest, loses payload win) vs
    `previous_interaction_id` (define behaviour when the stored interaction has
-   expired or a run is restored from old history). `store?`/retention interact.
-3. **Preview vs GA stability in 2.9.0.** The types ship in the pinned version;
-   `response_mime_type` is already deprecated in favour of `response_format`,
-   signalling churn. Pin/snapshot the working version and keep `generateContent`
-   as fallback. ⚠️ confirm the endpoint is GA (not preview) for our key.
+   expired or a run is restored from old history). Official retention is 55 days
+   on paid tier and 1 day on free tier; `store=false` opts out but is
+   incompatible with `background=true` and later `previous_interaction_id` use.
+3. **GA service with active SDK churn.** The official overview marks the API GA,
+   and the types ship in the pinned SDK version; `response_mime_type` is already
+   deprecated in favour of `response_format`, signalling churn. Pin/snapshot the
+   working version, verify key/model access in a real-key smoke test, and keep
+   `generateContent` as fallback.
 4. **Usage/pricing remap.** `Usage.total_*` field names → `googleUsage.ts`
    re-derivation; re-validate cache-rebate and reasoning-token accounting.
 5. **Managed agents are a different product.** `agent=` + `environment:'remote'`
    provisions a remote sandbox (browse/exec). **Out of scope for v0**
    (model-mode only); track separately.
-6. **Service ids / pricing / retention** (`⚠️ confirm`): GA model ids
-   (`gemini-3.5-flash`, Deep Research / Antigravity agents), `ServiceTier`
-   Flex/Priority cost deltas, and the retention window are service facts not in
-   the SDK types.
+6. **Service ids / pricing** (`⚠️ confirm`): supported model and agent ids are
+   listed in the official overview, but TeXRA still needs an implementation-time
+   decision about which ids to register plus current $/token pricing and
+   `ServiceTier` Flex/Priority cost deltas.
 
 ## Scope
 
@@ -367,7 +372,8 @@ the **default** for Gemini (ship behind the flag, flip later); OpenRouter suppor
 ## Milestones
 
 1. ~~Verify the SDK schema~~ ✅ done (this proposal; `@google/genai@2.9.0`).
-   Remaining: confirm GA model/agent ids + pricing + retention (`⚠️` items).
+   Remaining: choose/register the supported model/agent ids and confirm pricing
+   (`⚠️` items).
 2. `ModelHandlerGoogleInteractions` (model mode): SSE streaming + custom tools;
    compatibility key; factory routing behind `useGoogleInteractionsAPI` (default
    **off**). Unit tests on input/tool/usage translation (mocked SDK), explicitly
@@ -391,6 +397,7 @@ the **default** for Gemini (ship behind the flag, flip later); OpenRouter suppor
 - TeXRA precedent: [`openai-responses-api.md`](./openai-responses-api.md);
   routing `src/agent/runtime/ModelFactory.ts:175`; settings `src/shared/schemas/coreSettings.ts`.
 
-> _`ai.google.dev` pages returned HTTP 403 to automated fetch; the SDK `.d.ts`
-> (verified above) is the source of truth for every shape, with `⚠️` reserved
-> for service-only facts (ids/pricing/retention)._
+> _The SDK `.d.ts` (verified above) is the source of truth for request/response
+> shapes. The official overview is the source for GA status, recommended use,
+> supported ids, and retention; `⚠️` is reserved for implementation-time pricing
+> and model-registration decisions._


### PR DESCRIPTION
Add a research-grounded proposal for adopting Google's GA Interactions API (`client.interactions.create`) for Gemini in TeXRA.

The proposal now:

- Maps the current `generateContent`/chat-based Google handler onto the steps-based Interactions schema.
- Recommends an additive, feature-flagged handler mirroring the existing OpenAI Responses API pattern.
- Verifies SDK request/response shape against installed `@google/genai@2.9.0` types.
- Reconciles the official migration guide with SDK types and flags the real implementation risks: thought-signature round-tripping, server-side state vs history/compaction, SDK churn, usage remapping, and pricing/model-registration decisions.

Follow-up pushed after review:

- Clarified `^2.9.0` manifest range vs lockfile-resolved `2.9.0`.
- Removed stale 403 caveats now that the official Interactions overview is reachable.
- Corrected service-fact caveats for GA status, supported IDs, and retention.
- Fixed Markdown wrapping around `output_audio` and `store:true` / `previous_interaction_id`.

Validation:

- `corepack pnpm exec prettier --check docs/proposals/google-interactions-api.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no application code, settings, or routing behavior is modified.
> 
> **Overview**
> Adds **`docs/proposals/google-interactions-api.md`**, a design doc for adopting Google’s GA **Interactions API** (`client.interactions`) for Gemini without changing runtime code yet.
> 
> The proposal maps today’s **`generateContent`/chat** Google handler onto the **steps-based** Interactions schema (verified against `@google/genai@2.9.0`), and recommends an **additive, feature-flagged** `ModelHandlerGoogleInteractions` wired like the existing **OpenAI Responses** pattern (`ModelFactory` routing, compatibility key, `useGoogleInteractionsAPI` setting). **v0** is scoped to **`store:false`** local `Step[]` history, SSE streaming, tools/thinking/multimodal, and **`generateContent` as default fallback**; agents, background/webhooks, and OpenRouter are explicitly out of scope.
> 
> It also documents **migration-guide vs SDK** differences (e.g. `arguments_delta`, `Usage` field names), a **chat→Interactions** concern matrix, implementation surface (~new handler + tests), milestones, and **risks** (thought-signature round-trip, server-side state vs compaction, usage remap, API version/relay smoke tests, pricing/model registration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a99238038a090f84266d3bee5ddf62823c4e5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->