### PR TITLE
[codex] refactor(progress-view): inject message host

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -63,6 +63,16 @@ type MessageFor<C extends ProgressViewInboundMessage['command']> = Extract<
   { command: C }
 >;
 
+export interface ProgressViewMessageHost {
+  showInfo(message: string): PromiseLike<unknown>;
+  showWarning(
+    message: string,
+    options?: { modal?: boolean },
+    ...items: string[]
+  ): PromiseLike<string | undefined>;
+  showError(message: string): PromiseLike<unknown>;
+}
+
 /**
  * Schema-driven message handler for ProgressView.
  *
@@ -89,6 +99,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   constructor(
     private readonly provider: ProgressViewProvider,
     context: vscode.ExtensionContext,
+    private readonly host: ProgressViewMessageHost,
   ) {
     super('ProgressView', { trackActiveView: true });
 
@@ -202,7 +213,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         },
         bypass: {
           runtimeHost: extensionAgentRuntimeHost,
-          showInfo: (message) => vscode.window.showInformationMessage(message),
+          showInfo: (message) => this.host.showInfo(message),
         },
         file: {
           openFile: async (file, line) =>
@@ -279,7 +290,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         if (view) await this.recordingManager.stop(view);
       },
       [PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]: async (data) => {
-        await vscode.window.showInformationMessage(data.text);
+        await this.host.showInfo(data.text);
       },
       [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: async (data) => {
         const restored =
@@ -541,10 +552,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         },
         readFile: (file) => flexibleFS.read(createExternalLocation(file)),
         showInfo: async (message) => {
-          await vscode.window.showInformationMessage(message);
+          await this.host.showInfo(message);
         },
         showError: async (message) => {
-          await vscode.window.showErrorMessage(message);
+          await this.host.showError(message);
         },
         logError: (message, error) => {
           this.logger.error(this.channel, message, {
@@ -634,7 +645,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
 
   private async handleDeleteAll(): Promise<void> {
-    const confirmation = await vscode.window.showWarningMessage(
+    const confirmation = await this.host.showWarning(
       'Are you sure you want to delete all streams? This action cannot be undone.',
       { modal: true },
       'Delete All',
@@ -657,7 +668,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       data.feedback,
     );
     if (!success) {
-      await vscode.window.showInformationMessage(
+      await this.host.showInfo(
         'No retryable request is available for this stream yet.',
       );
     }
@@ -678,7 +689,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       viaRelay: data.viaRelay,
     });
     if (result.proceeded && !result.retried) {
-      await vscode.window.showInformationMessage(
+      await this.host.showInfo(
         'Switched to your own API key. No pending retry to resume — run the agent again when ready.',
       );
     }
@@ -721,9 +732,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             text: null,
             error: errorMsg,
           });
-          await vscode.window.showErrorMessage(
-            `Error polishing follow-up: ${errorMsg}`,
-          );
+          await this.host.showError(`Error polishing follow-up: ${errorMsg}`);
           this.logger.error(
             this.channel,
             `Error polishing follow-up: ${errorMsg}`,
@@ -747,11 +756,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         return;
       case 'failed':
         this.postToActiveView(result.update);
-        await vscode.window.showErrorMessage(result.userMessage);
+        await this.host.showError(result.userMessage);
         return;
       case 'exception':
         this.postToActiveView(result.update);
-        await vscode.window.showErrorMessage(result.userMessage);
+        await this.host.showError(result.userMessage);
         this.logger.error(this.channel, result.logMessage, {
           data: result.logData,
         });
@@ -860,10 +869,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async applyFollowUpPlan(plan: ProgressFollowUpPlan): Promise<void> {
     switch (plan.kind) {
       case 'warning':
-        await vscode.window.showWarningMessage(plan.message);
+        await this.host.showWarning(plan.message);
         return;
       case 'info':
-        await vscode.window.showInformationMessage(plan.message);
+        await this.host.showInfo(plan.message);
         return;
       case 'restoreState':
         await vscode.commands.executeCommand(

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -45,7 +45,10 @@ import {
   readExternalInquiryThread,
 } from '@tools/inquiry/externalInquiryStorage';
 
-import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
+import {
+  ProgressViewMessageHandler,
+  type ProgressViewMessageHost,
+} from './ProgressViewMessageHandler';
 
 import type { MainViewProvider } from '../MainViewProvider';
 
@@ -237,7 +240,19 @@ export class ProgressViewProvider
         styleKey: 'progressStyleUri',
       },
     );
-    this.messageHandler = new ProgressViewMessageHandler(this, context);
+    const messageHost: ProgressViewMessageHost = {
+      showInfo: (message) => vscode.window.showInformationMessage(message),
+      showWarning: (message, options, ...items) =>
+        options
+          ? vscode.window.showWarningMessage(message, options, ...items)
+          : vscode.window.showWarningMessage(message, ...items),
+      showError: (message) => vscode.window.showErrorMessage(message),
+    };
+    this.messageHandler = new ProgressViewMessageHandler(
+      this,
+      context,
+      messageHost,
+    );
 
     ProgressViewProvider._instance = this;
     setProgressViewBridge(this);

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -2,7 +2,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - progress view
-import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
+import {
+  ProgressViewMessageHandler,
+  type ProgressViewMessageHost,
+} from '@progressView/ProgressViewMessageHandler';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 // Local imports - shared
@@ -28,6 +31,14 @@ function createWebviewView(): vscode.WebviewView {
   return {
     webview: { postMessage: vi.fn() },
   } as unknown as vscode.WebviewView;
+}
+
+function createMessageHost(): ProgressViewMessageHost {
+  return {
+    showInfo: vi.fn(async () => undefined),
+    showWarning: vi.fn(async () => undefined),
+    showError: vi.fn(async () => undefined),
+  };
 }
 
 type ProgressViewProviderFake = ProgressViewProvider & {
@@ -93,7 +104,11 @@ describe('progress-view onboarding refresh wiring', () => {
     const context = createExtensionContext();
     const provider = createProgressViewProvider();
     provider.refreshOnboardingFunnel.mockResolvedValue(undefined);
-    const handler = new ProgressViewMessageHandler(provider, context);
+    const handler = new ProgressViewMessageHandler(
+      provider,
+      context,
+      createMessageHost(),
+    );
 
     await handler.handleMessage(
       {
@@ -130,7 +145,11 @@ describe('progress-view onboarding refresh wiring', () => {
     async (action) => {
       const context = createExtensionContext();
       const provider = createProgressViewProvider();
-      const handler = new ProgressViewMessageHandler(provider, context);
+      const handler = new ProgressViewMessageHandler(
+        provider,
+        context,
+        createMessageHost(),
+      );
 
       await handler.handleMessage(
         {


### PR DESCRIPTION
## Summary

- Add an explicit `ProgressViewMessageHost` port for progress-view info, warning, and error notifications.
- Inject the VS Code-backed implementation from `ProgressViewProvider`.
- Route existing progress message-handler notification paths through the injected host, leaving command execution and progress reporting unchanged.
- Update progress-view onboarding refresh tests to inject a fake message host.

## Why

Issue #6286 calls out `ProgressViewMessageHandler` as a coupling hotspot. This is the smallest concrete slice from that issue: move direct `vscode.window.show*Message` effects behind an explicit host port without broad churn in message decoding or workflow coordination.

Refs #6286.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing import-order warnings outside touched files)
- `npm test`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving dependency injection with no changes to command execution or progress reporting; risk is limited to notification wiring mistakes.
> 
> **Overview**
> Introduces a **`ProgressViewMessageHost`** port (`showInfo`, `showWarning`, `showError`) and requires it in **`ProgressViewMessageHandler`**’s constructor. All user-facing notification paths in the handler that previously called **`vscode.window.show*Message`** now go through the injected host (delete-all confirmation, retry/API-key messages, follow-up polish errors, follow-up plan warnings/info, shared command handlers, and workflow file actions).
> 
> **`ProgressViewProvider`** constructs the production host that delegates to VS Code and passes it when creating the message handler. Onboarding refresh tests construct the handler with a **`createMessageHost()`** fake so they no longer depend on the window API for those effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c80c583076cfc4d3b68c39d909fe918b71f714e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->