### PR TITLE
[codex] fix: keep CLI agent picker copy within frame

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -620,7 +620,7 @@ const SCENARIOS = [
     expect: [
       '/agent',
       'Tool-use and delegating agents',
-      'texra chat --agent=<name>',
+      'texra chat --agent <name>',
     ],
     unexpect: ['//agent', 'Harness received: //agent', '/agent - error'],
   },
@@ -671,7 +671,7 @@ const SCENARIOS = [
       'Tool-use and delegating agents',
       'Creator',
       'Current: chat (hidden from picker)',
-      'texra chat --agent=<name>',
+      'texra chat --agent <name>',
       'Esc close',
     ],
     unexpect: [
@@ -698,7 +698,7 @@ const SCENARIOS = [
       'Tool-use and delegating agents',
       'Creator',
       'Current: chat (hidden from picker)',
-      'texra chat --agent=<name>',
+      'texra chat --agent <name>',
       'Esc close',
     ],
     unexpect: [

--- a/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
@@ -50,7 +50,7 @@ export function applyInitialCliAgentSelection(
 ): void {
   if (!chatTuiCanStartRootRun(context.session)) {
     appendLocalAssistantTranscript(
-      'Agent changes are only available before the first message. Start a new chat with texra chat --agent=<name> to choose a different root agent.',
+      'Agent changes are only available before the first message. Use texra chat --agent <name> to choose a root agent in a new chat.',
     );
     return;
   }

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -238,8 +238,8 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     <FormFrame color="cyan" title="/agent" showCloseHint={false}>
       <Text dimColor wrap="truncate-end">
         {props.selectable
-          ? 'Choose the root agent for the first message.'
-          : 'Available agents. Start a new chat with texra chat --agent=<name> to choose the root agent.'}
+          ? 'Choose the root agent for this chat.'
+          : 'Viewing agents. Use texra chat --agent <name> to switch in a new chat.'}
       </Text>
       {currentAgentHint ? (
         <Text dimColor wrap="truncate-end">


### PR DESCRIPTION
## Summary
- shorten the non-selectable `/agent` picker description so it fits inside the TUI frame
- update validate-tui expectations for the revised command text

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/AgentListForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-dogfood-agent-form slash-palette-esc-retypes-command agent-form agent-form-80-cols compact-agent-form`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes to TUI strings and test expectations; no behavior or CLI parsing changes in this diff.
> 
> **Overview**
> Shortens **/agent** picker helper text so it fits inside the TUI frame and reads more clearly in both selectable and read-only modes.
> 
> User-facing hints now use **`texra chat --agent <name>`** (space instead of `=`) in `AgentListForm`, the “agent change blocked after first message” transcript message, and the **`validate-tui`** scenarios that snapshot the agent form and slash-palette flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc974ac08e3b40a7f1d42a43b1d61853f69e2223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->