### PR TITLE
[codex] fix: preserve workflow lineage for same basenames

### DIFF
--- a/src/agent/output/lineageMapping.ts
+++ b/src/agent/output/lineageMapping.ts
@@ -15,6 +15,8 @@ import type { RoundFileEntry, RoundFileMapping } from './types';
 
 interface BaseEntry {
   readonly loc: FileLocation;
+  readonly relativePath: string;
+  readonly relativePathNoExt: string;
   readonly baseName: string;
   readonly baseNameNoExt: string;
 }
@@ -41,42 +43,47 @@ function invertMapping(
 
 function buildBaseEntries(baseFiles: FileLocation[]): BaseEntry[] {
   return baseFiles.map((baseLoc) => {
-    const baseName = path.basename(
-      baseLoc.kind !== 'external' ? baseLoc.relativePath : baseLoc.absolutePath,
-    );
+    const comparablePath = getComparablePath(baseLoc).replaceAll('\\', '/');
+    const parsedPath = path.posix.parse(comparablePath);
+    const relativePathNoExt = path.posix.join(parsedPath.dir, parsedPath.name);
+    const baseName = path.posix.basename(comparablePath);
     return {
       loc: baseLoc,
+      relativePath: comparablePath,
+      relativePathNoExt,
       baseName,
-      baseNameNoExt: path.parse(baseName).name,
+      baseNameNoExt: path.posix.parse(baseName).name,
     };
   });
 }
 
 /**
- * Find base file matching source name using prioritized heuristics:
- * 1. Exact match
- * 2. Names without extensions
- * 3. Base name matches source
- * 4. Source matches base name
+ * Find the base file matching a model-reported source path.
+ * Match full relative paths first, then fall back to basename-only matching for
+ * legacy outputs that report just a filename.
  */
 function findMatchingBaseFile(
   baseEntries: readonly BaseEntry[],
   source: string,
 ): FileLocation | undefined {
-  const sourceNoExt = path.parse(source).name;
+  const normalizedSource = source.replaceAll('\\', '/');
+  const parsedSource = path.posix.parse(normalizedSource);
+  const sourcePathNoExt = path.posix.join(parsedSource.dir, parsedSource.name);
+  const sourceBaseName = path.posix.basename(normalizedSource);
+  const sourceBaseNameNoExt = path.posix.parse(sourceBaseName).name;
 
-  const matchers: Array<(b: string, bNoExt: string) => boolean> = [
-    (b) => b === source,
-    (_b, bNoExt) => bNoExt === sourceNoExt,
-    (_b, bNoExt) => bNoExt === source,
-    (b) => b === sourceNoExt,
+  const matchers: Array<(entry: BaseEntry) => boolean> = [
+    (entry) => entry.relativePath === normalizedSource,
+    (entry) => entry.relativePathNoExt === sourcePathNoExt,
+    (entry) => entry.baseName === normalizedSource,
+    (entry) => entry.baseNameNoExt === sourceBaseNameNoExt,
+    (entry) => entry.baseNameNoExt === normalizedSource,
+    (entry) => entry.baseName === sourceBaseNameNoExt,
   ];
 
   for (const match of matchers) {
-    for (const { loc, baseName, baseNameNoExt } of baseEntries) {
-      if (match(baseName, baseNameNoExt)) {
-        return loc;
-      }
+    for (const entry of baseEntries) {
+      if (match(entry)) return entry.loc;
     }
   }
 
@@ -118,10 +125,11 @@ export function traceFileLineage(
   const mapping = new Map<string, RoundFileEntry>();
   for (const entry of currentOutputs) {
     const key = getComparablePath(entry.location);
+    const origin = findMatchingBaseFile(baseEntries, entry.source);
     mapping.set(key, {
-      base: baseToOutput.get(key),
+      base: origin ?? baseToOutput.get(key),
       prev: prevToOutput.get(key),
-      origin: findMatchingBaseFile(baseEntries, entry.source),
+      origin,
     });
   }
 

--- a/src/test-kernel/agent/output/LineageMapping.vitest.ts
+++ b/src/test-kernel/agent/output/LineageMapping.vitest.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { traceFileLineage } from '@agent/output/lineageMapping';
+import { OutputXmlSummarySchema, type ExecutionId } from '@shared/schemas';
+import { createRunStorageLocation, getComparablePath } from '@utils/files';
+
+describe('workflow output lineage mapping', () => {
+  const executionId: ExecutionId = 'abc123';
+
+  function runStorageFile(relativePath: string) {
+    return createRunStorageLocation(
+      `/run/${relativePath}`,
+      relativePath,
+      executionId,
+    );
+  }
+
+  it('matches extracted documents by relative path before basename fallbacks', () => {
+    const chapter1 = runStorageFile('inputs/chapter1/lemma.tex');
+    const chapter2 = runStorageFile('inputs/chapter2/lemma.tex');
+    const chapter1Output = runStorageFile('r0/inputs/chapter1/lemma.tex');
+    const chapter2Output = runStorageFile('r0/inputs/chapter2/lemma.tex');
+
+    const mapping = traceFileLineage(
+      {
+        rounds: new Map([
+          [
+            0,
+            {
+              round: 0,
+              rawOutput: null,
+              outputs: [
+                {
+                  source: 'inputs/chapter1/lemma.tex',
+                  round: 0,
+                  location: chapter1Output,
+                  lineage: null,
+                  diff: null,
+                },
+                {
+                  source: 'inputs/chapter2/lemma.tex',
+                  round: 0,
+                  location: chapter2Output,
+                  lineage: null,
+                  diff: null,
+                },
+              ],
+              compileFailures: [],
+              xmlSummary: OutputXmlSummarySchema.parse({}),
+            },
+          ],
+        ]),
+        openedOutputs: new Set(),
+        storageKey: null,
+        runPreparation: null,
+      },
+      [chapter1, chapter2],
+      0,
+    );
+
+    expect(mapping.get(getComparablePath(chapter1Output))?.origin).toBe(
+      chapter1,
+    );
+    expect(mapping.get(getComparablePath(chapter2Output))?.origin).toBe(
+      chapter2,
+    );
+    expect(mapping.get(getComparablePath(chapter1Output))?.base).toBe(chapter1);
+    expect(mapping.get(getComparablePath(chapter2Output))?.base).toBe(chapter2);
+  });
+});


### PR DESCRIPTION
## Summary
- fix workflow lineage matching so exact relative document names win before basename fallbacks
- use exact lineage as the output diff base when present, avoiding same-basename collapse
- add a regression test for multi-input workflow outputs named `lemma.tex` in different directories

Closes #6535.

## Dogfood Evidence
Before the fix, `texra-local run correct` with `inputs/chapter1/lemma.tex` and `inputs/chapter2/lemma.tex` failed with `Workflow completed without expected output: inputs/chapter2/lemma.tex; copied 1 of 2 expected outputs`.

After the fix, the same command completed and copied both outputs under `out/inputs/chapter1/lemma.tex` and `out/inputs/chapter2/lemma.tex`; the JSON result also reported distinct `originalPath` values for both outputs.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/output/LineageMapping.vitest.ts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts`
- `npm run texra-local:build`
- live `texra-local run correct` multi-input dogfood with same basenames
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core output lineage and diff-base selection for multi-input workflows; wrong matching could still mis-attribute files, but scope is limited to path-matching heuristics with a targeted regression test.
> 
> **Overview**
> **Fixes workflow output lineage** when multiple inputs share the same filename in different directories (e.g. two `lemma.tex` paths). Previously, basename-only matching could collapse them so only one expected output was resolved.
> 
> `findMatchingBaseFile` now normalizes paths with **posix-style relative paths** and tries **full relative path** (and path-without-extension) matches before legacy basename fallbacks. `buildBaseEntries` precomputes those fields for each base file.
> 
> In `traceFileLineage`, the **`base` used for diffs** prefers the matched **origin** (`origin ?? baseToOutput.get(key)`), so same-basename inputs keep distinct bases instead of sharing a substring/`contains` mapping.
> 
> Adds a **regression test** in `LineageMapping.vitest.ts` for two chapter outputs both named `lemma.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c0bee22c5345df6cd6c3a4d59e42265c1a2af01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->