### PR TITLE
[codex] fix: persist workflow copied outputs in history

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,6 +1,7 @@
-import { writeTerminalStatus } from '@agent/storage';
+import { getExecutionStore, writeTerminalStatus } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { toErrorMessage } from '@common/errors/errorMessage';
 import { EXECUTION_STATUS } from '@shared/schemas';
 
 import {
@@ -9,7 +10,7 @@ import {
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
-import { writeErrorStderr } from '../runtime/logSinks';
+import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 import {
   buildHeadlessRunContext,
   resolveCliRunModel,
@@ -133,6 +134,7 @@ export async function runWorkflowAgent(
             },
           )
         ).displayResult;
+        await persistWorkflowResultMeta(executionId, displayResult);
       } catch (error) {
         if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
           writeErrorStderr(error);
@@ -156,6 +158,30 @@ export async function runWorkflowAgent(
       return terminalStatusExitCode(terminalStatus, runContext);
     },
   );
+}
+
+async function persistWorkflowResultMeta(
+  executionId: string,
+  result: CliRunResult,
+): Promise<void> {
+  if (result.category !== AgentCategory.Workflow) return;
+  try {
+    if (result.copiedOutput) {
+      await getExecutionStore(executionId).writeResultMeta({
+        copiedOutput: result.copiedOutput,
+      });
+      return;
+    }
+    if (result.copiedOutputs?.length) {
+      await getExecutionStore(executionId).writeResultMeta({
+        copiedOutputs: result.copiedOutputs,
+      });
+    }
+  } catch (error) {
+    writeTextStderr(
+      `Warning: could not persist workflow result metadata: ${toErrorMessage(error)}`,
+    );
+  }
 }
 
 export const runWorkflowCommand = defineCliCommand({

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -86,13 +86,15 @@ export interface ChildRecord extends ChildRecordData {
   id: ExecutionId;
 }
 
-/** Result metadata for background bash processes. */
+/** Lightweight metadata captured after an execution finishes. */
 const ResultMetaSchema = z.object({
   exitCode: z.int().optional(),
   wallTimeMs: z.number().nonnegative().optional(),
   success: z.boolean().optional(),
   timedOut: z.boolean().optional(),
   command: z.string().optional(),
+  copiedOutput: z.string().optional(),
+  copiedOutputs: z.array(z.string()).optional(),
 });
 export type ResultMeta = z.infer<typeof ResultMetaSchema>;
 

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -11,15 +11,20 @@ import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 const mocks = vi.hoisted(() => {
   return {
     executeCliConfig: vi.fn(),
+    emitCliResult: vi.fn(),
     withExpandedRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
     isAuthenticated: vi.fn(),
     resolveCliLaunchAgent: vi.fn(),
     resolveCliRunModel: vi.fn(),
+    writeResultMeta: vi.fn(),
   };
 });
 
 vi.mock('@agent/storage', () => ({
+  getExecutionStore: vi.fn(() => ({
+    writeResultMeta: mocks.writeResultMeta,
+  })),
   writeTerminalStatus: vi.fn(),
 }));
 
@@ -55,7 +60,7 @@ vi.mock('@cli/runtime/runModel', () => ({
 }));
 
 vi.mock('@cli/commands/_helpers/output', () => ({
-  emitCliResult: vi.fn(),
+  emitCliResult: mocks.emitCliResult,
 }));
 
 vi.mock('@cli/runtime/agents', async (importOriginal) => ({
@@ -75,6 +80,8 @@ vi.mock('@cli/runtime/workflowInputs', () => ({
     );
     return specs.has('-') && specs.size > 1;
   }),
+  isMaterializedStdinWorkflowInputPath: vi.fn(() => false),
+  STDIN_WORKFLOW_INPUT_BASENAME: 'stdin.tex',
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
@@ -346,6 +353,121 @@ describe('CLI workflow run command', () => {
       await expect(
         fs.readFile(path.join(root, 'polished.tex'), 'utf8'),
       ).resolves.toBe('polished');
+      expect(mocks.writeResultMeta).toHaveBeenCalledWith({
+        copiedOutput: path.join(root, 'polished.tex'),
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('persists copied output-dir paths for history details', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-workflow-'));
+    try {
+      const generated = path.join(root, 'run', 'r1', 'paper.tex');
+      await fs.mkdir(path.dirname(generated), { recursive: true });
+      await fs.writeFile(generated, 'polished');
+      mocks.executeCliConfig.mockResolvedValueOnce({
+        ok: true,
+        executionId: 'exec-output-dir',
+        result: {
+          category: AgentCategory.Workflow,
+          executionId: 'exec-output-dir',
+          streamId: 'stream-output-dir',
+          outcome: RUN_OUTCOME.COMPLETED,
+          outputs: [
+            {
+              round: 1,
+              relativePath: 'r1/paper.tex',
+              absolutePath: generated,
+              location: 'runStorage',
+              originalPath: path.join(root, 'paper.tex'),
+              added: null,
+              removed: null,
+            },
+          ],
+          compileFailures: [],
+        },
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      });
+
+      const { runWorkflowAgent } = await import('@cli/commands/workflow');
+
+      const exitCode = await runWorkflowAgent(cliContext({ cwd: root }), {
+        agent: 'polish',
+        inputFiles: ['paper.tex'],
+        contextFiles: [],
+        outputDir: 'out',
+        instruction: '',
+      });
+
+      expect(exitCode).toBe(0);
+      await expect(
+        fs.readFile(path.join(root, 'out', 'paper.tex'), 'utf8'),
+      ).resolves.toBe('polished');
+      expect(mocks.writeResultMeta).toHaveBeenCalledWith({
+        copiedOutputs: [path.join(root, 'out', 'paper.tex')],
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not fail a completed workflow when copied output metadata cannot be persisted', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-workflow-'));
+    try {
+      const generated = path.join(root, 'run', 'r1', 'paper.tex');
+      await fs.mkdir(path.dirname(generated), { recursive: true });
+      await fs.writeFile(generated, 'polished');
+      mocks.executeCliConfig.mockResolvedValueOnce({
+        ok: true,
+        executionId: 'exec-output-meta-fail',
+        result: {
+          category: AgentCategory.Workflow,
+          executionId: 'exec-output-meta-fail',
+          streamId: 'stream-output-meta-fail',
+          outcome: RUN_OUTCOME.COMPLETED,
+          outputs: [
+            {
+              round: 1,
+              relativePath: 'r1/paper.tex',
+              absolutePath: generated,
+              location: 'runStorage',
+              originalPath: path.join(root, 'paper.tex'),
+              added: null,
+              removed: null,
+            },
+          ],
+          compileFailures: [],
+        },
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      });
+      mocks.writeResultMeta.mockRejectedValueOnce(
+        new Error('metadata disk full'),
+      );
+
+      const { runWorkflowAgent } = await import('@cli/commands/workflow');
+
+      const exitCode = await runWorkflowAgent(cliContext({ cwd: root }), {
+        agent: 'polish',
+        inputFiles: ['paper.tex'],
+        contextFiles: [],
+        outputDir: 'out',
+        instruction: '',
+      });
+
+      expect(exitCode).toBe(0);
+      await expect(
+        fs.readFile(path.join(root, 'out', 'paper.tex'), 'utf8'),
+      ).resolves.toBe('polished');
+      expect(mocks.emitCliResult).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          json: expect.objectContaining({
+            copiedOutputs: [path.join(root, 'out', 'paper.tex')],
+          }),
+        }),
+      );
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- persist workflow `--output` / `--output-dir` copy paths into execution result metadata
- widen result metadata from bash-only fields to lightweight execution metadata
- add command-level regression coverage for copied single-output and output-dir workflow runs

Closes #6537.

## Dogfood evidence

Before the fix, a real two-input `texra-local run polish ... --output-dir out --output-format json --no-input` run completed and returned `copiedOutputs`, but `texra-local history show 2632bf9bf4b1 --cwd /tmp/texra-workflow-polish-dogfood --output-format json` returned `resultMeta: null`.

After the fix and local CLI rebuild, a real `correct` workflow run produced execution `2c5a81792a18`; `history show` now returns:

```json
{
  "id": "2c5a81792a18",
  "status": "completed",
  "resultMeta": {
    "copiedOutputs": [
      "/private/tmp/texra-workflow-history-meta/out/src/lemma.tex"
    ]
  }
}
```

The text history view also shows `Result: {"copiedOutputs":[...]}`.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (0 errors, existing warnings only)
- `git diff --check`
- `npm run texra-local:build`
- `npm run compile:fast`
- live `texra-local run correct --cwd /tmp/texra-workflow-history-meta --input src/lemma.tex --output-dir out --model deepseekproT --instruction ... --output-format json --no-input`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive persistence after successful workflow copy; failures are warned and do not change exit codes for completed runs.
> 
> **Overview**
> **Workflow runs with `--output` or `--output-dir` now save where artifacts were copied** into per-execution `result-meta`, so `history show` can surface `copiedOutput` / `copiedOutputs` instead of `resultMeta: null`.
> 
> After `resolveWorkflowOutput`, the workflow command calls `persistWorkflowResultMeta`, which writes those paths through `getExecutionStore(executionId).writeResultMeta`. **Result metadata schema** gains optional `copiedOutput` and `copiedOutputs` (alongside existing bash-style fields). **Persistence failures are non-fatal**: a stderr warning is emitted and the run still completes with the same CLI result.
> 
> Regression tests cover single-file `--output`, `--output-dir`, and the case where metadata write fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ccf49aa031564b3ef60030027058b4650b31b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->