### PR TITLE
[codex] refactor(progress-view): use shared prompt host

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -32,6 +32,7 @@ import { loadOptions } from '@frontend/agents/optionsLoader';
 import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nativeToolEditApproval';
 import { RecordingManager } from '@frontend/media/RecordingManager';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
+import type { PromptHost } from '@hosts/promptHost';
 import { isApiProvider } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
@@ -63,16 +64,6 @@ type MessageFor<C extends ProgressViewInboundMessage['command']> = Extract<
   { command: C }
 >;
 
-export interface ProgressViewMessageHost {
-  showInfo(message: string): PromiseLike<unknown>;
-  showWarning(
-    message: string,
-    options?: { modal?: boolean },
-    ...items: string[]
-  ): PromiseLike<string | undefined>;
-  showError(message: string): PromiseLike<unknown>;
-}
-
 /**
  * Schema-driven message handler for ProgressView.
  *
@@ -99,7 +90,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   constructor(
     private readonly provider: ProgressViewProvider,
     context: vscode.ExtensionContext,
-    private readonly host: ProgressViewMessageHost,
+    private readonly host: PromptHost,
   ) {
     super('ProgressView', { trackActiveView: true });
 
@@ -213,7 +204,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         },
         bypass: {
           runtimeHost: extensionAgentRuntimeHost,
-          showInfo: (message) => this.host.showInfo(message),
+          showInfo: (message) => this.host.info(message),
         },
         file: {
           openFile: async (file, line) =>
@@ -290,7 +281,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         if (view) await this.recordingManager.stop(view);
       },
       [PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]: async (data) => {
-        await this.host.showInfo(data.text);
+        await this.host.info(data.text);
       },
       [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: async (data) => {
         const restored =
@@ -552,10 +543,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         },
         readFile: (file) => flexibleFS.read(createExternalLocation(file)),
         showInfo: async (message) => {
-          await this.host.showInfo(message);
+          await this.host.info(message);
         },
         showError: async (message) => {
-          await this.host.showError(message);
+          await this.host.error(message);
         },
         logError: (message, error) => {
           this.logger.error(this.channel, message, {
@@ -645,11 +636,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
 
   private async handleDeleteAll(): Promise<void> {
-    const confirmation = await this.host.showWarning(
+    const confirmation = await this.host.warning<'Delete All' | 'Cancel'>(
       'Are you sure you want to delete all streams? This action cannot be undone.',
-      { modal: true },
-      'Delete All',
-      'Cancel',
+      {
+        modal: true,
+        items: ['Delete All', { label: 'Cancel', isCloseAffordance: true }],
+      },
     );
 
     if (confirmation !== 'Delete All') return;
@@ -668,7 +660,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       data.feedback,
     );
     if (!success) {
-      await this.host.showInfo(
+      await this.host.info(
         'No retryable request is available for this stream yet.',
       );
     }
@@ -689,7 +681,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       viaRelay: data.viaRelay,
     });
     if (result.proceeded && !result.retried) {
-      await this.host.showInfo(
+      await this.host.info(
         'Switched to your own API key. No pending retry to resume — run the agent again when ready.',
       );
     }
@@ -732,7 +724,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             text: null,
             error: errorMsg,
           });
-          await this.host.showError(`Error polishing follow-up: ${errorMsg}`);
+          await this.host.error(`Error polishing follow-up: ${errorMsg}`);
           this.logger.error(
             this.channel,
             `Error polishing follow-up: ${errorMsg}`,
@@ -756,11 +748,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         return;
       case 'failed':
         this.postToActiveView(result.update);
-        await this.host.showError(result.userMessage);
+        await this.host.error(result.userMessage);
         return;
       case 'exception':
         this.postToActiveView(result.update);
-        await this.host.showError(result.userMessage);
+        await this.host.error(result.userMessage);
         this.logger.error(this.channel, result.logMessage, {
           data: result.logData,
         });
@@ -869,10 +861,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async applyFollowUpPlan(plan: ProgressFollowUpPlan): Promise<void> {
     switch (plan.kind) {
       case 'warning':
-        await this.host.showWarning(plan.message);
+        await this.host.warning(plan.message);
         return;
       case 'info':
-        await this.host.showInfo(plan.message);
+        await this.host.info(plan.message);
         return;
       case 'restoreState':
         await vscode.commands.executeCommand(

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -14,6 +14,7 @@ import {
   setActiveSidebarView,
 } from '@common/webview';
 import { workspaceSM } from '@common/state';
+import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { createChannelTrace } from '@logger';
 import {
   buildVisibleBasicModelOptionsData,
@@ -45,10 +46,7 @@ import {
   readExternalInquiryThread,
 } from '@tools/inquiry/externalInquiryStorage';
 
-import {
-  ProgressViewMessageHandler,
-  type ProgressViewMessageHost,
-} from './ProgressViewMessageHandler';
+import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 
 import type { MainViewProvider } from '../MainViewProvider';
 
@@ -240,18 +238,10 @@ export class ProgressViewProvider
         styleKey: 'progressStyleUri',
       },
     );
-    const messageHost: ProgressViewMessageHost = {
-      showInfo: (message) => vscode.window.showInformationMessage(message),
-      showWarning: (message, options, ...items) =>
-        options
-          ? vscode.window.showWarningMessage(message, options, ...items)
-          : vscode.window.showWarningMessage(message, ...items),
-      showError: (message) => vscode.window.showErrorMessage(message),
-    };
     this.messageHandler = new ProgressViewMessageHandler(
       this,
       context,
-      messageHost,
+      new VscodePromptHost(),
     );
 
     ProgressViewProvider._instance = this;

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -2,15 +2,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - progress view
-import {
-  ProgressViewMessageHandler,
-  type ProgressViewMessageHost,
-} from '@progressView/ProgressViewMessageHandler';
+import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 // Local imports - shared
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - test support
+import { FakePromptHost } from '../support/FakeHosts';
+
 import type * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => ({
@@ -31,14 +32,6 @@ function createWebviewView(): vscode.WebviewView {
   return {
     webview: { postMessage: vi.fn() },
   } as unknown as vscode.WebviewView;
-}
-
-function createMessageHost(): ProgressViewMessageHost {
-  return {
-    showInfo: vi.fn(async () => undefined),
-    showWarning: vi.fn(async () => undefined),
-    showError: vi.fn(async () => undefined),
-  };
 }
 
 type ProgressViewProviderFake = ProgressViewProvider & {
@@ -107,7 +100,7 @@ describe('progress-view onboarding refresh wiring', () => {
     const handler = new ProgressViewMessageHandler(
       provider,
       context,
-      createMessageHost(),
+      new FakePromptHost(),
     );
 
     await handler.handleMessage(
@@ -148,7 +141,7 @@ describe('progress-view onboarding refresh wiring', () => {
       const handler = new ProgressViewMessageHandler(
         provider,
         context,
-        createMessageHost(),
+        new FakePromptHost(),
       );
 
       await handler.handleMessage(
@@ -165,6 +158,48 @@ describe('progress-view onboarding refresh wiring', () => {
       expect(provider.refreshOnboardingFunnel).not.toHaveBeenCalled();
     },
   );
+
+  it('uses PromptHost warning options before deleting all streams', async () => {
+    const context = createExtensionContext();
+    const provider = createProgressViewProvider();
+    const prompt = new FakePromptHost({
+      promptResponses: ['Cancel', 'Delete All'],
+    });
+    (
+      provider.state.streamLogs as unknown as {
+        keys(): StreamTabId[];
+      }
+    ).keys = vi.fn(() => []);
+
+    const handler = new ProgressViewMessageHandler(provider, context, prompt);
+
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.DELETE_ALL },
+      createWebviewView(),
+    );
+
+    expect(prompt.messages[0]).toMatchObject({
+      kind: 'warning',
+      message:
+        'Are you sure you want to delete all streams? This action cannot be undone.',
+      options: {
+        modal: true,
+        items: ['Delete All', { label: 'Cancel', isCloseAffordance: true }],
+      },
+    });
+    expect(provider.state.clearAll).not.toHaveBeenCalled();
+
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.DELETE_ALL },
+      createWebviewView(),
+    );
+
+    expect(provider.state.clearAll).toHaveBeenCalledOnce();
+    expect(provider.webviewBridge.clearAll).toHaveBeenCalledOnce();
+    expect(provider.syncFullView).toHaveBeenCalledWith({
+      forceRebuild: true,
+    });
+  });
 
   it('delegates onboarding refresh through the main view provider', async () => {
     const refreshOnboardingFunnel = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- replace the duplicate `ProgressViewMessageHost` interface with the existing `PromptHost`
- wire the progress view provider through `VscodePromptHost`
- update tests to use `FakePromptHost` and cover the delete-all confirmation prompt

## Impact
This removes a shallow progress-view-only abstraction and keeps message prompts on the same host boundary already used by settings. The delete-all modal still uses explicit `Delete All` / `Cancel` items through `PromptHost.warning`.

Closes #6533

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run lint` (passes with existing import-order warnings outside this PR)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only prompt abstraction swap with no auth or data-path changes; delete-all behavior is preserved and newly tested.
> 
> **Overview**
> Removes the progress-view-only **`ProgressViewMessageHost`** and routes all user prompts through the shared **`PromptHost`** (`info`, `warning`, `error`), matching settings and other views.
> 
> **`ProgressViewProvider`** now injects **`VscodePromptHost`** instead of an inline `vscode.window` adapter. **`ProgressViewMessageHandler`** call sites are renamed accordingly (e.g. `showInfo` → `info`).
> 
> The **delete all streams** confirmation uses **`PromptHost.warning`** with `{ modal: true, items: ['Delete All', { label: 'Cancel', isCloseAffordance: true }] }` instead of variadic VS Code message arguments.
> 
> Tests switch to **`FakePromptHost`** and add coverage that cancel skips deletion while confirming **Delete All** runs clear/sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e33fdf325fc02f36748035e4fc5e2425533dc8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->