### PR TITLE
[codex] refactor(progress-view): move follow-up prep into controller

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -624,6 +624,20 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     return new ProgressFollowUpController({
       getAgentCategory: (agent) =>
         getAgent(agent, AgentCategory.ToolUse)?.category,
+      loadModelOptions: async () => {
+        const { modelOptions } = await loadOptions();
+        return modelOptions;
+      },
+      state: {
+        getTaskState: (stream) =>
+          this.provider.state.snapshots.getTaskState(stream),
+        getOutputFiles: (stream) =>
+          this.provider.state.snapshots.getOutputFiles(stream),
+        getCompileFailures: (stream) =>
+          this.provider.state.snapshots.getCompileFailures(stream),
+        getExecutionId: (stream) =>
+          this.provider.state.snapshots.getExecutionId(stream),
+      },
       workspace: {
         locatePath: (candidate) => WorkspaceFS.locatePath(candidate),
         exists: (relativePath) => WorkspaceFS.exists(relativePath),
@@ -818,43 +832,20 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       | MessageFor<typeof PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP>,
     executeImmediately: boolean,
   ): Promise<void> {
-    const taskState = this.provider.state.snapshots.getTaskState(data.stream);
-    const outputFiles = [
-      ...this.provider.state.snapshots.getOutputFiles(data.stream).values(),
-    ].flat();
-    const { modelOptions } = await loadOptions();
-
     await this.applyFollowUpPlan(
-      this.followUpController.planToolUseFollowUp({
+      await this.followUpController.planToolUseFollowUpForStream({
         streamId: data.stream,
-        taskState,
-        outputFiles,
         agent: data.agent,
         model: data.model,
         initialQuestion: data.initialQuestion,
         executeImmediately,
-        modelOptions,
-        executionId: this.provider.state.snapshots.getExecutionId(data.stream),
       }),
     );
   }
 
   private async handleRunCompileFixer(streamId: StreamTabId): Promise<void> {
-    const taskState = this.provider.state.snapshots.getTaskState(streamId);
-    const compileFailures = [
-      ...this.provider.state.snapshots.getCompileFailures(streamId).values(),
-    ].flat();
-    const { modelOptions } = await loadOptions();
-
     await this.applyFollowUpPlan(
-      await this.followUpController.planCompileFixer({
-        streamId,
-        taskState,
-        compileFailures,
-        runOutputs: this.provider.state.snapshots.getOutputFiles(streamId),
-        modelOptions,
-        executionId: this.provider.state.snapshots.getExecutionId(streamId),
-      }),
+      await this.followUpController.planCompileFixerForStream(streamId),
     );
   }
 

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -39,7 +39,16 @@ export interface ProgressFollowUpWorkspace {
 
 export interface ProgressFollowUpControllerDeps {
   getAgentCategory(agent: string): AgentCategory | undefined;
+  loadModelOptions(): Promise<readonly ProgressFollowUpModelOption[]>;
+  state: ProgressFollowUpState;
   workspace: ProgressFollowUpWorkspace;
+}
+
+export interface ProgressFollowUpState {
+  getTaskState(stream: StreamTabId): TaskState | undefined;
+  getOutputFiles(stream: StreamTabId): Map<number, OutputFileInfo[]>;
+  getCompileFailures(stream: StreamTabId): Map<number, CompileFailure[]>;
+  getExecutionId(stream: StreamTabId): string | undefined;
 }
 
 interface CompileFixerTarget {
@@ -82,8 +91,48 @@ export interface CompileFixerInput {
   executionId?: string;
 }
 
+export type StreamToolUseFollowUpInput = Omit<
+  ToolUseFollowUpInput,
+  'taskState' | 'outputFiles' | 'modelOptions' | 'executionId'
+>;
+
 export class ProgressFollowUpController {
   constructor(private readonly deps: ProgressFollowUpControllerDeps) {}
+
+  async planToolUseFollowUpForStream(
+    input: StreamToolUseFollowUpInput,
+  ): Promise<ProgressFollowUpPlan> {
+    const modelOptions = await this.deps.loadModelOptions();
+    const outputFiles = [
+      ...this.deps.state.getOutputFiles(input.streamId).values(),
+    ].flat();
+
+    return this.planToolUseFollowUp({
+      ...input,
+      taskState: this.deps.state.getTaskState(input.streamId),
+      outputFiles,
+      modelOptions,
+      executionId: this.deps.state.getExecutionId(input.streamId),
+    });
+  }
+
+  async planCompileFixerForStream(
+    streamId: StreamTabId,
+  ): Promise<ProgressFollowUpPlan> {
+    const modelOptions = await this.deps.loadModelOptions();
+    const compileFailures = [
+      ...this.deps.state.getCompileFailures(streamId).values(),
+    ].flat();
+
+    return this.planCompileFixer({
+      streamId,
+      taskState: this.deps.state.getTaskState(streamId),
+      compileFailures,
+      runOutputs: this.deps.state.getOutputFiles(streamId),
+      modelOptions,
+      executionId: this.deps.state.getExecutionId(streamId),
+    });
+  }
 
   planToolUseFollowUp(input: ToolUseFollowUpInput): ProgressFollowUpPlan {
     if (!input.taskState || !isWorkflowTaskState(input.taskState)) {

--- a/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
@@ -2,7 +2,10 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - controllers
-import { ProgressFollowUpController } from '@controllers/progressView/ProgressFollowUpController';
+import {
+  ProgressFollowUpController,
+  type ProgressFollowUpState,
+} from '@controllers/progressView/ProgressFollowUpController';
 
 // Local imports - agent
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -71,11 +74,20 @@ function createCompileFailure(): CompileFailure {
   };
 }
 
+const emptyFollowUpState: ProgressFollowUpState = {
+  getTaskState: () => undefined,
+  getOutputFiles: () => new Map(),
+  getCompileFailures: () => new Map(),
+  getExecutionId: () => undefined,
+};
+
 function createController(
   existingFiles: Set<string>,
 ): ProgressFollowUpController {
   return new ProgressFollowUpController({
     getAgentCategory: () => AgentCategory.ToolUse,
+    loadModelOptions: async () => [],
+    state: emptyFollowUpState,
     workspace: {
       locatePath: (candidate) =>
         candidate.startsWith('/external/')

--- a/src/test-kernel/controllers/ProgressFollowUpPlanning.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpPlanning.vitest.ts
@@ -2,10 +2,14 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
-// Standard library imports
+// Local imports - controllers
+import {
+  ProgressFollowUpController,
+  type ProgressFollowUpModelOption,
+  type ProgressFollowUpState,
+} from '@controllers/progressView/ProgressFollowUpController';
 
 // Local imports - agent
-import { ProgressFollowUpController } from '@controllers/progressView/ProgressFollowUpController';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 
@@ -18,8 +22,6 @@ import {
   type OutputFileHarnessOptions,
   createWorkflowTaskState,
 } from '../support/ProgressControllerHarnesses';
-
-// Local imports - controllers
 
 const followUpWorkflowDefaults: Partial<AgentConfig> = {
   inputFiles: ['main.tex'],
@@ -84,12 +86,27 @@ function createCompileFailure(
   };
 }
 
-function createController(
+const emptyFollowUpState: ProgressFollowUpState = {
+  getTaskState: () => undefined,
+  getOutputFiles: () => new Map(),
+  getCompileFailures: () => new Map(),
+  getExecutionId: () => undefined,
+};
+
+function createController({
   existingFiles = new Set(['main.tex']),
-): ProgressFollowUpController {
+  modelOptions = [],
+  state = emptyFollowUpState,
+}: {
+  existingFiles?: Set<string>;
+  modelOptions?: readonly ProgressFollowUpModelOption[];
+  state?: ProgressFollowUpState;
+} = {}): ProgressFollowUpController {
   return new ProgressFollowUpController({
     getAgentCategory: (agent) =>
       agent === 'tool-agent' ? AgentCategory.ToolUse : AgentCategory.Workflow,
+    loadModelOptions: async () => modelOptions,
+    state,
     workspace: {
       locatePath: (candidate) =>
         candidate.startsWith('/external/')
@@ -142,6 +159,41 @@ describe('ProgressFollowUpController', () => {
     );
   });
 
+  it('builds a stream-scoped tool-use plan from snapshot state', async () => {
+    const taskState = createFollowUpWorkflowTaskState();
+    const outputFile = createRunStorageOutputFile();
+    const controller = createController({
+      modelOptions: [{ value: 'gemini31p' }],
+      state: {
+        getTaskState: () => taskState,
+        getOutputFiles: () => new Map([[2, [outputFile]]]),
+        getCompileFailures: () => new Map(),
+        getExecutionId: () => 'exec-123',
+      },
+    });
+
+    const plan = await controller.planToolUseFollowUpForStream({
+      streamId: 'stream-a',
+      agent: 'tool-agent',
+      model: 'gemini31p',
+      initialQuestion: 'Check the final paragraph.',
+      executeImmediately: false,
+    });
+
+    assert.equal(plan.kind, 'restoreState');
+    if (plan.kind !== 'restoreState') return;
+    assert.equal(plan.executeImmediately, false);
+    assert.equal(plan.taskState.agentConfig.agent, 'tool-agent');
+    assert.match(
+      plan.taskState.agentConfig.instruction,
+      /\/executions\/exec-123\/files\/answer\.tex/,
+    );
+    assert.match(
+      plan.taskState.agentConfig.instruction,
+      /User follow-up request: Check the final paragraph\./,
+    );
+  });
+
   it('rejects follow-up setup when the selected model is disabled', () => {
     const plan = createController().planToolUseFollowUp({
       streamId: 'stream-a',
@@ -160,7 +212,9 @@ describe('ProgressFollowUpController', () => {
   });
 
   it('plans latexFixer with generated output sources before input recovery', async () => {
-    const controller = createController(new Set(['source.tex', 'main.tex']));
+    const controller = createController({
+      existingFiles: new Set(['source.tex', 'main.tex']),
+    });
     const output = createRunStorageOutputFile({ source: 'source.tex' });
     const plan = await controller.planCompileFixer({
       streamId: 'stream-a',
@@ -190,7 +244,9 @@ describe('ProgressFollowUpController', () => {
   });
 
   it('uses original workflow inputs as recovery when source metadata is absent', async () => {
-    const controller = createController(new Set(['main.tex', 'chapter.tex']));
+    const controller = createController({
+      existingFiles: new Set(['main.tex', 'chapter.tex']),
+    });
     const plan = await controller.planCompileFixer({
       streamId: 'stream-a',
       taskState: createFollowUpWorkflowTaskState({
@@ -213,7 +269,9 @@ describe('ProgressFollowUpController', () => {
   });
 
   it('warns when compile failures have no editable workspace source', async () => {
-    const plan = await createController(new Set()).planCompileFixer({
+    const plan = await createController({
+      existingFiles: new Set(),
+    }).planCompileFixer({
       streamId: 'stream-a',
       taskState: createFollowUpWorkflowTaskState({
         inputFiles: ['/external/main.tex'],


### PR DESCRIPTION
## Summary
- move stream-scoped follow-up preparation into `ProgressFollowUpController`
- leave `ProgressViewMessageHandler` to route inbound messages and apply returned plans
- add controller coverage for planning from snapshot state

## Why
Issue #6286 calls out that the progress-view handler still gathered task state, output files, compile failures, model options, and execution ids before invoking follow-up planning. This keeps that ownership with the follow-up controller instead of scattering workflow preparation through the webview message bridge.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/controllers/ProgressFollowUpController.vitest.ts src/test-kernel/controllers/ProgressFollowUpPlanning.vitest.ts src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
- `npm run lint` (passes with existing import-order warnings outside this PR)
- `npm run compile:fast`
- `npm test`

Refs #6286

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with added unit coverage; follow-up planning logic is unchanged, only where stream context is assembled.
> 
> **Overview**
> **Stream-scoped follow-up preparation** now lives in `ProgressFollowUpController` instead of `ProgressViewMessageHandler`.
> 
> The handler wires `loadModelOptions` and snapshot accessors (`getTaskState`, output files, compile failures, execution id) into the controller and calls **`planToolUseFollowUpForStream`** / **`planCompileFixerForStream`**, which load model options, read stream state, and delegate to the existing planners. Follow-up and compile-fixer handlers no longer call `loadOptions()` or assemble snapshot data themselves.
> 
> Tests gain the new constructor deps and a case that **`planToolUseFollowUpForStream`** builds the same restore plan from injected snapshot state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 052198c5f21bf9ad2f7083bea2187026ecf184bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->