### PR TITLE
[codex] refactor(model-handlers): share reasoning batching default

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
@@ -40,14 +40,6 @@ export class ModelHandlerDeepSeek extends ReasoningModelHandlerOpenAI<DeepSeekTo
   }
 
   /**
-   * DeepSeek emits reasoning_content alongside parallel tool calls, which must be
-   * preserved by batching the results into a single follow-up message.
-   */
-  override get requiresBatchedParallelToolResults(): boolean {
-    return true;
-  }
-
-  /**
    * DeepSeek accepts a reasoning-level override whenever it supports reasoning,
    * even though it doesn't expose a granular configurable-effort capability.
    */

--- a/src/agent/modelHandlers/openai/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerGLM.ts
@@ -19,6 +19,14 @@ import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
  */
 export class ModelHandlerGLM extends ReasoningModelHandlerOpenAI {
   /**
+   * GLM keeps reasoning continuity without batching parallel tool results into
+   * one follow-up message.
+   */
+  override get requiresBatchedParallelToolResults(): boolean {
+    return false;
+  }
+
+  /**
    * GLM effort-capable models accept only high/max on the OpenAI-compatible
    * surface. Keep lower user selections valid by mapping them to high.
    */

--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -40,14 +40,6 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
     return 'moonshot';
   }
 
-  /**
-   * Kimi emits reasoning_content alongside parallel tool calls, which must be
-   * preserved by batching the results into a single follow-up message.
-   */
-  override get requiresBatchedParallelToolResults(): boolean {
-    return true;
-  }
-
   // Kimi K2.5 supports vision with standard OpenAI-style image_url format;
   // only stringify content for non-vision variants so image parts survive.
   protected override readonly convertContentToStringUnlessVision = true;

--- a/src/agent/modelHandlers/openai/modelHandlerMiniMax.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerMiniMax.ts
@@ -37,14 +37,6 @@ function extractTextFromReasoningDetails(details: unknown): string | undefined {
  */
 export class ModelHandlerMiniMax extends ReasoningModelHandlerOpenAI {
   /**
-   * MiniMax emits reasoning alongside parallel tool calls, which must be
-   * preserved by batching the results into a single follow-up message.
-   */
-  override get requiresBatchedParallelToolResults(): boolean {
-    return true;
-  }
-
-  /**
    * Adds `reasoning_split: true` for thinking models so MiniMax returns
    * reasoning separately instead of embedding `<think>` tags in content.
    */

--- a/src/agent/modelHandlers/openai/reasoningModelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/reasoningModelHandlerOpenAI.ts
@@ -16,12 +16,15 @@ import type { DeepSeekToolCall, OpenAIToolCall } from '../types/IModelHandler';
  *   content on separate channels, so the aggregator is always on.
  * - `shouldIncludeReasoningInToolCalls()` — when the model reasons, its
  *   reasoning must be replayed into tool-use follow-up messages.
+ * - `requiresBatchedParallelToolResults` — most providers with separate
+ *   reasoning channels need one batched follow-up message to preserve that
+ *   reasoning across parallel tool calls.
  *
  * Overrides that vary between these providers stay on the concrete handlers:
- * `requiresBatchedParallelToolResults` (GLM does not batch), the
- * content-stringification flags (DeepSeek stringifies unconditionally while
- * Kimi/GLM/MiniMax preserve vision parts), the `thinking`/`reasoning_split`
- * parameter shape, and each provider's reasoning-field extraction.
+ * the GLM batching exception, content-stringification flags (DeepSeek
+ * stringifies unconditionally while Kimi/GLM/MiniMax preserve vision parts),
+ * the `thinking`/`reasoning_split` parameter shape, and each provider's
+ * reasoning-field extraction.
  *
  * Providers that merely tolerate reasoning tokens without a separate channel
  * (xAI, DashScope) intentionally keep extending {@link ModelHandlerOpenAI}.
@@ -30,6 +33,10 @@ export class ReasoningModelHandlerOpenAI<
   TCall extends OpenAIToolCall | DeepSeekToolCall = OpenAIToolCall,
 > extends ModelHandlerOpenAI<TCall> {
   protected override useReasoningStreamAggregator = true;
+
+  override get requiresBatchedParallelToolResults(): boolean {
+    return true;
+  }
 
   protected override shouldIncludeReasoningInToolCalls(): boolean {
     return this.capabilities.supportsReasoning;

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -16,6 +16,7 @@ import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/google/modelHandle
 import { ModelHandlerDeepSeek } from '@agent/modelHandlers/openai/modelHandlerDeepSeek';
 import { ModelHandlerKimi } from '@agent/modelHandlers/openai/modelHandlerKimi';
 import { ModelHandlerMiniMax } from '@agent/modelHandlers/openai/modelHandlerMiniMax';
+import { ModelHandlerGLM } from '@agent/modelHandlers/openai/modelHandlerGLM';
 import {
   activeModelHandlerCompatibilityKey,
   createModelHandler,
@@ -348,9 +349,9 @@ describe('OpenRouter-proxied provider capabilities', () => {
 });
 
 describe('direct handler capability overrides', () => {
-  // Formal coverage of the per-handler `requiresBatchedParallelToolResults`
-  // overrides that replaced the inline isGoogle/isDeepSeek/isKimi/isMiniMax gate.
-  it('flags batching on the four reasoning-carrying providers and not on plain OpenAI', () => {
+  // Formal coverage of `requiresBatchedParallelToolResults` behavior that
+  // replaced the inline isGoogle/isDeepSeek/isKimi/isMiniMax gate.
+  it('flags batching on reasoning-carrying providers except GLM', () => {
     expect(
       new ModelHandlerGoogleGenAI(modelConfig(ModelProvider.GOOGLE))
         .requiresBatchedParallelToolResults,
@@ -367,6 +368,10 @@ describe('direct handler capability overrides', () => {
       new ModelHandlerMiniMax(modelConfig(ModelProvider.MINIMAX))
         .requiresBatchedParallelToolResults,
     ).toBe(true);
+    expect(
+      new ModelHandlerGLM(modelConfig(ModelProvider.GLM))
+        .requiresBatchedParallelToolResults,
+    ).toBe(false);
     expect(
       new ModelHandlerOpenAI(modelConfig(ModelProvider.OPENAI))
         .requiresBatchedParallelToolResults,


### PR DESCRIPTION
## Summary

- Move the shared `requiresBatchedParallelToolResults = true` behavior for OpenAI-compatible reasoning handlers into `ReasoningModelHandlerOpenAI`.
- Remove identical DeepSeek, Kimi, and MiniMax overrides.
- Make GLM's non-batching behavior explicit and cover it in the direct handler routing test.

This addresses the first checklist item in #5837 without coupling unrelated model-handler surfaces.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor that preserves prior behavior via inheritance plus an explicit GLM exception; only affects how parallel tool follow-ups are formatted for reasoning models.
> 
> **Overview**
> **Moves the shared `requiresBatchedParallelToolResults = true` default into `ReasoningModelHandlerOpenAI`**, so DeepSeek, Kimi, and MiniMax no longer duplicate the same getter.
> 
> **GLM now explicitly overrides batching to `false`**, documenting that it preserves reasoning continuity without merging parallel tool results into one follow-up message.
> 
> Routing tests are updated to assert batching for Google/DeepSeek/Kimi/MiniMax and **no batching for GLM** and plain OpenAI handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbbd835fa3e39558e2a39afacf34594c4dbcb41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->