### PR TITLE
[codex] refactor(model-handlers): share pricing config fields

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -23,6 +23,7 @@ import type {
 } from '@agent/core/execution/AgentState';
 import type { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
+import type { StandardPricingConfig } from '@agent/utils/priceUtils';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { K_SLICE } from '@agent/core/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -174,6 +175,15 @@ export abstract class ModelHandler<
 
   public getAgentCategory(): AgentCategory | undefined {
     return this.agentCategory;
+  }
+
+  /** Common pricing fields used by providers with standard cache-read rebates. */
+  protected standardPricingConfig(): StandardPricingConfig {
+    return {
+      inputPrice: this.config.inputPrice,
+      outputPrice: this.config.outputPrice,
+      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
+    };
   }
 
   /**

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -1128,10 +1128,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /** Pricing/caching inputs for the extracted usage helpers. */
   private pricingConfig(): AnthropicPricingConfig {
     return {
-      inputPrice: this.config.inputPrice,
-      outputPrice: this.config.outputPrice,
+      ...this.standardPricingConfig(),
       supportsPromptCaching: this.capabilities.supportsPromptCaching,
-      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
     };
   }
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -49,11 +49,7 @@ import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
-import {
-  computeGooglePrice,
-  normalizeGoogleUsage,
-  type GooglePricingConfig,
-} from './googleUsage';
+import { computeGooglePrice, normalizeGoogleUsage } from './googleUsage';
 import { prepareExistingOutputContent } from '../utils/fileContentUtils';
 import { tagGoogleSdkError } from './googleSdkError';
 import {
@@ -831,16 +827,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   computePrice(
     responseUsage: GenerateContentResponseUsageMetadata | null,
   ): number {
-    return computeGooglePrice(responseUsage, this.pricingConfig());
-  }
-
-  /** Pricing inputs for the extracted usage helpers. */
-  private pricingConfig(): GooglePricingConfig {
-    return {
-      inputPrice: this.config.inputPrice,
-      outputPrice: this.config.outputPrice,
-      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
-    };
+    return computeGooglePrice(responseUsage, this.standardPricingConfig());
   }
 
   /** Normalizes Google GenAI usage data into a unified format. */
@@ -848,7 +835,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     rawUsage: GenerateContentResponseUsageMetadata | null,
     responseTimeMs: number,
   ): NormalizedUsage {
-    return normalizeGoogleUsage(rawUsage, responseTimeMs, this.pricingConfig());
+    return normalizeGoogleUsage(
+      rawUsage,
+      responseTimeMs,
+      this.standardPricingConfig(),
+    );
   }
 
   addContinueMessageWithPrefill(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -42,11 +42,7 @@ import { initializeOpenAiCompatibleOutputAndPrefill } from '../support/openAiCom
 import { tagOpenAISdkError } from './openAISdkError';
 
 // Local file imports
-import {
-  computeOpenAIPrice,
-  normalizeOpenAIUsage,
-  type OpenAIPricingConfig,
-} from './openAIUsage';
+import { computeOpenAIPrice, normalizeOpenAIUsage } from './openAIUsage';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
 import { normalizeOpenAIMessageContent } from './openAIMessageUtils';
 import {
@@ -1039,16 +1035,7 @@ export class ModelHandlerOpenAI<
 
   /** Computes cost based on token usage and model pricing. */
   computePrice(responseUsage: ExtendedCompletionUsage | null): number {
-    return computeOpenAIPrice(responseUsage, this.pricingConfig());
-  }
-
-  /** Pricing/caching inputs for the extracted usage helpers. */
-  private pricingConfig(): OpenAIPricingConfig {
-    return {
-      inputPrice: this.config.inputPrice,
-      outputPrice: this.config.outputPrice,
-      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
-    };
+    return computeOpenAIPrice(responseUsage, this.standardPricingConfig());
   }
 
   /**
@@ -1069,7 +1056,7 @@ export class ModelHandlerOpenAI<
       rawUsage,
       responseTimeMs,
       this.usageProvider,
-      this.pricingConfig(),
+      this.standardPricingConfig(),
     );
   }
 

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -26,7 +26,6 @@ import { extractMimeSubtype, joinNonEmpty } from '@utils/text/stringUtils';
 import {
   computeOpenRouterPrice,
   normalizeOpenRouterUsage,
-  type OpenRouterPricingConfig,
 } from './openRouterUsage';
 import { tagOpenRouterSdkError } from './openRouterSdkError';
 import { initializeOpenAiCompatibleOutputAndPrefill } from '../support/openAiCompatiblePrefill';
@@ -572,16 +571,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   // ---------------------------------------------------------------------------
 
   computePrice(responseUsage: ChatUsage | null): number {
-    return computeOpenRouterPrice(responseUsage, this.pricingConfig());
-  }
-
-  /** Pricing/caching inputs for the extracted usage helpers. */
-  private pricingConfig(): OpenRouterPricingConfig {
-    return {
-      inputPrice: this.config.inputPrice,
-      outputPrice: this.config.outputPrice,
-      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
-    };
+    return computeOpenRouterPrice(responseUsage, this.standardPricingConfig());
   }
 
   normalizeUsage(
@@ -592,7 +582,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       rawUsage,
       responseTimeMs,
       this.usageProvider,
-      this.pricingConfig(),
+      this.standardPricingConfig(),
     );
   }
 


### PR DESCRIPTION
## Summary

- Add `ModelHandler.standardPricingConfig()` for the shared input/output/cache-discount fields used by standard provider pricing helpers.
- Remove duplicated private pricing-config builders from OpenAI, Google, and OpenRouter handlers.
- Keep Anthropic's provider-specific config method, but build its common fields from the shared helper and add only `supportsPromptCaching`.

This addresses the second checklist item in #5837 without changing provider pricing formulas or adding a new service layer.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/modelHandlers/AnthropicCachePricing.vitest.ts src/test-kernel/agent/modelHandlers/GoogleCachePricing.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only deduplication of pricing config assembly; billing math stays in existing usage helpers with no behavioral change intended.
> 
> **Overview**
> Centralizes the repeated **input/output price + cache discount** wiring used for usage pricing.
> 
> Adds **`ModelHandler.standardPricingConfig()`** on the base handler so OpenAI, Google, and OpenRouter handlers pass the same object into their existing `*Usage` helpers instead of each defining a private `pricingConfig()` with identical fields.
> 
> **Anthropic** still has a provider-specific `pricingConfig()` that spreads the shared helper and only adds **`supportsPromptCaching`**.
> 
> No change to provider pricing formulas or usage normalization logic—call sites now share one builder for the common fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0785ed8945341e4509da3f90d2fb61c18972479b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->