### PR TITLE
[codex] refactor(model-handlers): inline compaction trigger checks

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -133,17 +133,6 @@ export class ModelHandlerOpenAI<
   // ── Compaction internals ──────────────────────────────────────────────
 
   /**
-   * Check if the conversation should be compacted based on token usage.
-   * Compaction is only triggered when:
-   * - In tool-use mode (only mode with multi-turn message accumulation)
-   * - Manual request via requestCompaction(), OR
-   * - Last known input tokens exceed the configured threshold
-   */
-  private shouldCompact(): boolean {
-    return this.shouldCompactByInputTokens(this.lastKnownInputTokens);
-  }
-
-  /**
    * Compact the conversation using client-side summarization via system-prompt-swap.
    * Sends conversation messages as-is to the model with a summarization system prompt,
    * then replaces all messages with the summary.
@@ -556,7 +545,7 @@ export class ModelHandlerOpenAI<
     let updatedMessages: ChatCompletionMessageParam[] | undefined;
     let messagesToUse = rawMessages;
 
-    if (this.shouldCompact()) {
+    if (this.shouldCompactByInputTokens(this.lastKnownInputTokens)) {
       const isManual = this.compactionRequested;
       // Clear manual flag immediately when attempted — matches Anthropic and
       // OpenAI Responses handlers. Prevents infinite retry on graceful failure.

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -156,7 +156,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     let updatedMessages: ChatMessages[] | undefined;
     let messagesToUse = rawMessages;
 
-    if (this.shouldCompact()) {
+    if (this.shouldCompactByInputTokens(this.lastKnownInputTokens)) {
       this.compactionRequested = false;
       const { compactedMessages, didCompact } = await this.compactConversation(
         client,
@@ -282,10 +282,6 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   // ---------------------------------------------------------------------------
   // Compaction
   // ---------------------------------------------------------------------------
-
-  private shouldCompact(): boolean {
-    return this.shouldCompactByInputTokens(this.lastKnownInputTokens);
-  }
 
   private async compactConversation(
     client: OpenRouter,


### PR DESCRIPTION
## Summary
- Remove the duplicate private `shouldCompact()` pass-through wrappers from OpenAI chat completions and OpenRouter native handlers.
- Call the existing base helper `shouldCompactByInputTokens(this.lastKnownInputTokens)` directly at each compaction site.
- Leave provider-specific `compactConversation()` request construction in place; the shared provider-agnostic scaffold already lives in `ModelHandler.runClientCompaction()`.

Refs #5837.

## Validation
- `corepack pnpm vitest run src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with no intended behavior change; compaction still uses the same base threshold and manual-request rules.
> 
> **Overview**
> Removes redundant private `shouldCompact()` wrappers in the **OpenAI chat completions** and **OpenRouter native** handlers and calls the shared base helper `shouldCompactByInputTokens(this.lastKnownInputTokens)` directly in each handler’s Phase 0 compaction gate.
> 
> Provider-specific `compactConversation()` logic is unchanged; only the indirection layer is dropped so compaction triggering matches the pattern already documented on `ModelHandler`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e85a4c71b859bf3985174ed8685628341303d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->