### PR TITLE
[codex] fix(cli): show model recovery hints

### DIFF
--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -102,7 +102,7 @@ async function showModel(context: CliContext, id: string): Promise<number> {
   emitCliResult(context, {
     json: cliModelRecord(entry.model),
     ndjson: { kind: 'model', model: cliModelRecord(entry.model) },
-    text: formatCliModelDetails(entry),
+    text: formatCliModelDetails(entry, result.apiMode),
   });
   return CliExitCode.Success;
 }

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -428,7 +428,56 @@ export function formatNoListableModelsMessage(
   ].join('\n');
 }
 
-export function formatCliModelDetails(entry: CliModelAccess): string {
+function formatCliModelRecovery(
+  entry: CliModelAccess,
+  apiMode: CliApiMode | undefined,
+): string | undefined {
+  if (entry.available) return undefined;
+
+  const {
+    includedModeAction,
+    loginAction,
+    personalModeAction,
+    configureKeyAction,
+  } = cliModelRecoveryActions();
+
+  const availability = entry.model.availability;
+
+  switch (availability) {
+    case 'included-login-required':
+      return apiMode === 'personal'
+        ? `${startSentence(loginAction)} for included relay access, then ${includedModeAction}.`
+        : `${startSentence(loginAction)} for included relay access, or ${personalModeAction} after configuring a provider API key.`;
+    case 'relay-quota-exhausted':
+      return apiMode === 'personal'
+        ? 'Retry later.'
+        : `Retry later, or ${personalModeAction} after configuring a provider API key.`;
+    case 'missing-key':
+      return apiMode === 'personal'
+        ? `${startSentence(configureKeyAction)} for personal mode, or ${loginAction} and ${includedModeAction} if this model is included.`
+        : `${startSentence(configureKeyAction)}, then ${personalModeAction}.`;
+    case 'provider-key':
+    case 'openrouter-key':
+      return apiMode === 'included'
+        ? `${startSentence(personalModeAction)}.`
+        : undefined;
+    case 'included-access':
+      return apiMode === 'personal'
+        ? `${startSentence(includedModeAction)}.`
+        : undefined;
+    case 'not-included':
+      return apiMode === 'personal'
+        ? `${startSentence(configureKeyAction)} for personal mode.`
+        : `${startSentence(configureKeyAction)}, then ${personalModeAction}.`;
+    default:
+      return undefined;
+  }
+}
+
+export function formatCliModelDetails(
+  entry: CliModelAccess,
+  apiMode?: CliApiMode,
+): string {
   const { model, status } = entry;
   const lines: string[] = [];
   lines.push(`id: ${model.value}`);
@@ -437,6 +486,8 @@ export function formatCliModelDetails(entry: CliModelAccess): string {
   lines.push(`status: ${status}`);
   if (model.availabilityLabel)
     lines.push(`availability: ${model.availabilityLabel}`);
+  const recovery = formatCliModelRecovery(entry, apiMode);
+  if (recovery) lines.push(`recovery: ${recovery}`);
   if (model.context) lines.push(`context: ${model.context}`);
   if (model.cost) lines.push(`cost: ${model.cost}`);
   if (model.hint) {

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   emptyModelListMessageForCliMode,
   findCliModelAccessEntry,
+  formatCliModelDetails,
   formatCliNoAvailableModelsRecovery,
   formatCliNoRunnableModelsLaunchBlock,
   formatCliNoRunnableModelsMessage,
@@ -791,6 +792,163 @@ describe('CLI model access resolution', () => {
     ).rejects.toThrow(
       'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Run `texra login` for included relay access.',
     );
+  });
+
+  it('shows a recovery hint for not-included models in model details', () => {
+    const text = formatCliModelDetails(
+      model('glm52', {
+        available: false,
+        status: 'not included',
+        model: modelOption('glm52', {
+          label: 'GLM-5.2',
+          availability: 'not-included',
+          availabilityLabel: 'Not included',
+          disabled: true,
+        }),
+      }),
+      'included',
+    );
+
+    expect(text).toContain('status: not included');
+    expect(text).toContain(
+      'recovery: Add a provider API key with `texra setup`, then retry with `--api-mode personal`.',
+    );
+  });
+
+  it('does not suggest included mode for not-included models in personal mode', () => {
+    const text = formatCliModelDetails(
+      model('glm52', {
+        available: false,
+        status: 'not included',
+        model: modelOption('glm52', {
+          label: 'GLM-5.2',
+          availability: 'not-included',
+          availabilityLabel: 'Not included',
+          disabled: true,
+        }),
+      }),
+      'personal',
+    );
+
+    expect(text).toContain(
+      'recovery: Add a provider API key with `texra setup` for personal mode.',
+    );
+    expect(text).not.toContain('`--api-mode included`');
+  });
+
+  it('shows a recovery hint for missing provider-key models in model details', () => {
+    const text = formatCliModelDetails(
+      model('glm52', {
+        available: false,
+        status: 'missing api key',
+        model: modelOption('glm52', {
+          label: 'GLM-5.2',
+          availability: 'missing-key',
+          availabilityLabel: 'Missing API key',
+          disabled: true,
+          requiresKey: true,
+        }),
+      }),
+      'personal',
+    );
+
+    expect(text).toContain('status: missing api key');
+    expect(text).toContain(
+      'recovery: Add a provider API key with `texra setup` for personal mode, or run `texra login` and retry with `--api-mode included` if this model is included.',
+    );
+  });
+
+  it('tells included-mode users to switch modes after adding a missing key', () => {
+    const text = formatCliModelDetails(
+      model('glm52', {
+        available: false,
+        status: 'missing api key',
+        model: modelOption('glm52', {
+          label: 'GLM-5.2',
+          availability: 'missing-key',
+          availabilityLabel: 'Missing API key',
+          disabled: true,
+          requiresKey: true,
+        }),
+      }),
+      'included',
+    );
+
+    expect(text).toContain(
+      'recovery: Add a provider API key with `texra setup`, then retry with `--api-mode personal`.',
+    );
+  });
+
+  it('does not ask users to configure a key that is already present', () => {
+    const text = formatCliModelDetails(
+      model('deepseekT', {
+        available: false,
+        status: 'api key set',
+        model: modelOption('deepseekT', {
+          availability: 'provider-key',
+          availabilityLabel: 'API key set',
+        }),
+      }),
+      'included',
+    );
+
+    expect(text).toContain('recovery: Retry with `--api-mode personal`.');
+    expect(text).not.toContain('configuring a provider API key');
+  });
+
+  it('shows the included-mode recovery hint for included models in personal mode', () => {
+    const text = formatCliModelDetails(
+      model('sonnet46T', {
+        available: false,
+        status: 'relay: included',
+        model: modelOption('sonnet46T', {
+          availability: 'included-access',
+          availabilityLabel: 'Included access',
+        }),
+      }),
+      'personal',
+    );
+
+    expect(text).toContain('recovery: Retry with `--api-mode included`.');
+    expect(text).not.toContain('texra login');
+  });
+
+  it('does not repeat personal-mode advice when showing login-required models', () => {
+    const text = formatCliModelDetails(
+      model('sonnet46T', {
+        available: false,
+        status: 'login required',
+        model: modelOption('sonnet46T', {
+          availability: 'included-login-required',
+          availabilityLabel: 'Login required',
+          disabled: true,
+        }),
+      }),
+      'personal',
+    );
+
+    expect(text).toContain(
+      'recovery: Run `texra login` for included relay access, then retry with `--api-mode included`.',
+    );
+    expect(text).not.toContain('retry with `--api-mode personal`');
+  });
+
+  it('does not repeat personal-mode advice for quota-exhausted models', () => {
+    const text = formatCliModelDetails(
+      model('sonnet46T', {
+        available: false,
+        status: 'relay quota exhausted',
+        model: modelOption('sonnet46T', {
+          availability: 'relay-quota-exhausted',
+          availabilityLabel: 'Relay quota exhausted',
+          disabled: true,
+        }),
+      }),
+      'personal',
+    );
+
+    expect(text).toContain('recovery: Retry later.');
+    expect(text).not.toContain('use `--api-mode personal`');
   });
 
   it('marks explicitly included-mode models as login-required when signed out', async () => {


### PR DESCRIPTION
## Summary
- Add a text-only recovery line to `texra models show` when the selected model is not runnable in the active API mode.
- Reuse the resolved model access state; JSON and NDJSON output stay unchanged for scripts.
- Dogfood case: `texra-local models show glm5.2` resolves to `glm52`, but the model is not included and needs personal mode plus a GLM provider key.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ModelsRecord.vitest.mts src/test-kernel/cli/RunModel.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run texra-local:build`
- `texra-local models show glm5.2 --api-mode included`
- `texra-local models show glm5.2 --api-mode personal`
- `texra-local models show glm5.2 --api-mode included --output-format json`
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation and help text only; no changes to model resolution, credentials, or structured output contracts.
> 
> **Overview**
> **`texra models show`** now adds a **`recovery:`** line in **text** output when the model is not runnable in the active API mode, so users get next steps (login, `texra setup`, or `--api-mode` switches) without guessing.
> 
> Recovery copy is driven by **`formatCliModelRecovery`**, which maps each model **availability** kind and the current **`included` / `personal`** mode to the same action phrases used elsewhere (`cliModelRecoveryActions`). **`models show`** passes the resolved **`apiMode`** into **`formatCliModelDetails`**. **JSON** and **NDJSON** shapes are unchanged.
> 
> Vitest cases in **`ModelAccess.vitest.mts`** lock in wording for not-included, missing-key, provider-key, included-access, login-required, and quota-exhausted scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8214e5e0c6db15ac580d5e199fbe2e89954842a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->