### PR TITLE
[codex] refactor(cli): type login command args

### DIFF
--- a/packages/cli/src/commands/_helpers/defineCliCommand.ts
+++ b/packages/cli/src/commands/_helpers/defineCliCommand.ts
@@ -44,7 +44,7 @@ export interface DefineCliCommandOptions<A extends ArgsDef> {
  * command repeats into one declaration. Behavior is identical to the manual
  * form; only the scaffolding moves here.
  */
-export function defineCliCommand<A extends ArgsDef>(
+export function defineCliCommand<const A extends ArgsDef>(
   options: DefineCliCommandOptions<A>,
 ): CommandDef<A> {
   return defineCommand<A>({

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -44,20 +44,31 @@ import { chatgptAuthCommand } from './chatgptAuth';
 import { authTokenCommand } from './relayTokens';
 import type { CliContext } from '../runtime/cliContext';
 
-type LoginCommandArgs = Record<string, unknown>;
+interface LoginCommandArgs {
+  readonly provider?: string;
+  readonly providerArg?: string;
+  readonly 'no-browser'?: boolean;
+  readonly noBrowser?: boolean;
+  readonly browser?: boolean;
+  readonly device?: boolean;
+  readonly 'select-account'?: boolean;
+  readonly selectAccount?: boolean;
+  readonly 'login-hint'?: string;
+  readonly loginHint?: string;
+}
 
 function readBooleanArg(
   args: LoginCommandArgs,
-  hyphenKey: string,
-  camelKey: string,
+  hyphenKey: keyof LoginCommandArgs,
+  camelKey: keyof LoginCommandArgs,
 ): boolean {
   return args[hyphenKey] === true || args[camelKey] === true;
 }
 
 function readStringArg(
   args: LoginCommandArgs,
-  hyphenKey: string,
-  camelKey: string,
+  hyphenKey: keyof LoginCommandArgs,
+  camelKey: keyof LoginCommandArgs,
 ): string | undefined {
   return optString(args[hyphenKey]) ?? optString(args[camelKey]);
 }


### PR DESCRIPTION
## Summary
- preserve literal command argument inference in `defineCliCommand` with a const generic
- replace the auth login parser's `Record<string, unknown>` arg bag with a private `LoginCommandArgs` shape
- keep existing hyphenated/camel-case compatibility for citty and slash-command callers

## Why
The login parser was accepting an arbitrary map even though only a fixed set of command keys are valid. Preserving the command arg shape in the shared helper lets auth parsing stay typed without assertions or a manual conversion layer.

## Validation
- `corepack pnpm vitest run src/test-kernel/cli/LoginArgs.vitest.mts src/test-kernel/cli/AuthCommand.vitest.mts src/test-kernel/cli/Completion.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `texra-local auth status --output-format json`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time typing only on CLI scaffolding and login arg parsing; auth flow logic is unchanged.
> 
> **Overview**
> **Typing-only refactor** for CLI login argument handling: no intended runtime behavior change.
> 
> `defineCliCommand` now uses a **`const` generic** (`defineCliCommand<const A extends ArgsDef>`) so citty command `args` definitions keep **literal inference** into handlers instead of widening to a generic `ArgsDef`.
> 
> The auth login path replaces **`Record<string, unknown>`** with a private **`LoginCommandArgs`** interface listing the real flags (provider positional/flag, `no-browser` / `noBrowser`, `device`, `select-account` / `selectAccount`, `login-hint` / `loginHint`, plus `browser`). **`readBooleanArg`** and **`readStringArg`** take **`keyof LoginCommandArgs`** so hyphen/camel key pairs stay type-checked while existing citty and slash-command compatibility is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c02f5b964342d80bc34060e94d8961962ca7ec2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->