### PR TITLE
[codex] fix(cli): report rejected interactive flags precisely

### DIFF
--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -191,36 +191,37 @@ export const GLOBAL_BOOL_FLAGS = new Set<string>(
   }),
 );
 
-const HEADLESS_ONLY_GLOBAL_FLAG_SPELLINGS =
-  HEADLESS_ONLY_GLOBAL_ARG_NAMES.flatMap((name) =>
-    flagSpellings(name, GLOBAL_ARGS[name]),
-  );
-const HEADLESS_ONLY_GLOBAL_FLAG_LABELS = formatCommaList(
-  HEADLESS_ONLY_GLOBAL_FLAG_SPELLINGS.filter((flag) => flag.startsWith('--')),
-);
-const HEADLESS_ONLY_GLOBAL_FLAGS = new Set<string>(
-  HEADLESS_ONLY_GLOBAL_FLAG_SPELLINGS,
-);
-
 export function optString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
-function isHeadlessOnlyFlag(arg: string): boolean {
-  if (HEADLESS_ONLY_GLOBAL_FLAGS.has(arg)) return true;
-  return HEADLESS_ONLY_GLOBAL_FLAG_SPELLINGS.some(
-    (flag) => flag.startsWith('--') && arg.startsWith(`${flag}=`),
-  );
+function headlessOnlyFlagLabel(arg: string): string | undefined {
+  for (const name of HEADLESS_ONLY_GLOBAL_ARG_NAMES) {
+    for (const spelling of flagSpellings(name, GLOBAL_ARGS[name])) {
+      if (arg === spelling) return `--${name}`;
+      if (spelling.startsWith('--') && arg.startsWith(`${spelling}=`)) {
+        return spelling;
+      }
+    }
+  }
+  return undefined;
 }
 
 export function rejectHeadlessOnlyFlags(
   rawArgs: readonly string[],
   commandName: string,
 ): void {
-  if (!rawArgs.some(isHeadlessOnlyFlag)) return;
+  const labels = [
+    ...new Set(
+      rawArgs
+        .map(headlessOnlyFlagLabel)
+        .filter((label): label is string => label !== undefined),
+    ),
+  ];
+  if (labels.length === 0) return;
 
   throw new CliUsageError(
-    `texra ${commandName} is interactive and does not support ${HEADLESS_ONLY_GLOBAL_FLAG_LABELS}. For scripting, use \`texra run\` or a concrete non-interactive subcommand.`,
+    `texra ${commandName} is interactive and does not support ${formatCommaList(labels)}. For scripting, use \`texra run\` or a concrete non-interactive subcommand.`,
   );
 }
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -447,19 +447,32 @@ describe('CLI root argument routing', () => {
 
   it('rejects headless-only flags on interactive command bodies', () => {
     expect(() => rejectHeadlessOnlyFlags(['--print'], 'chat')).toThrow(
-      'texra chat is interactive',
+      'texra chat is interactive and does not support --print.',
+    );
+    expect(() => rejectHeadlessOnlyFlags(['-p'], 'chat')).toThrow(
+      'texra chat is interactive and does not support --print.',
     );
     expect(() =>
       rejectHeadlessOnlyFlags(['--output-format=json'], 'orchestrate'),
-    ).toThrow('texra orchestrate is interactive');
+    ).toThrow(
+      'texra orchestrate is interactive and does not support --output-format.',
+    );
     expect(() => rejectHeadlessOnlyFlags(['--no-input'], 'chat')).toThrow(
-      'texra chat is interactive',
+      'texra chat is interactive and does not support --no-input.',
     );
     expect(() => rejectHeadlessOnlyFlags(['--no-input=true'], 'chat')).toThrow(
-      'texra chat is interactive',
+      'texra chat is interactive and does not support --no-input.',
     );
     expect(() => rejectHeadlessOnlyFlags(['--print=true'], 'chat')).toThrow(
-      'texra chat is interactive',
+      'texra chat is interactive and does not support --print.',
+    );
+    expect(() =>
+      rejectHeadlessOnlyFlags(
+        ['--print', '--output-format', 'json', '--no-input'],
+        'chat',
+      ),
+    ).toThrow(
+      'texra chat is interactive and does not support --print, --output-format, and --no-input.',
     );
     expect(() =>
       rejectHeadlessOnlyFlags(['--approval-policy', 'ask'], 'chat'),
@@ -1265,14 +1278,22 @@ describe('runCli usage output stream routing', () => {
   it('preserves the interactive-command error for headless-only flags', async () => {
     const result = await runCli(['chat', '--print']);
     expect(result.exitCode).toBe(2);
-    expect(stderr).toContain('texra chat is interactive');
+    expect(stderr).toContain(
+      'texra chat is interactive and does not support --print.',
+    );
+    expect(stderr).not.toContain('--output-format');
+    expect(stderr).not.toContain('--no-input');
     expect(stderr).not.toContain('Unknown option');
     expect(stdout).toBe('');
 
     stderr = '';
     const resumeResult = await runCli(['resume', 'abc123', '--print']);
     expect(resumeResult.exitCode).toBe(2);
-    expect(stderr).toContain('texra resume is interactive');
+    expect(stderr).toContain(
+      'texra resume is interactive and does not support --print.',
+    );
+    expect(stderr).not.toContain('--output-format');
+    expect(stderr).not.toContain('--no-input');
     expect(stderr).not.toContain('Unknown option');
     expect(stdout).toBe('');
 
@@ -1284,21 +1305,33 @@ describe('runCli usage output stream routing', () => {
       'abc123',
     ]);
     expect(resumeShortcutResult.exitCode).toBe(2);
-    expect(stderr).toContain('texra resume is interactive');
+    expect(stderr).toContain(
+      'texra resume is interactive and does not support --output-format.',
+    );
+    expect(stderr).not.toContain('--print');
+    expect(stderr).not.toContain('--no-input');
     expect(stderr).not.toContain('Unknown option');
     expect(stdout).toBe('');
 
     stderr = '';
     const setupResult = await runCli(['setup', '--no-input']);
     expect(setupResult.exitCode).toBe(2);
-    expect(stderr).toContain('texra setup is interactive');
+    expect(stderr).toContain(
+      'texra setup is interactive and does not support --no-input.',
+    );
+    expect(stderr).not.toContain('--print');
+    expect(stderr).not.toContain('--output-format');
     expect(stderr).not.toContain('Unknown option');
     expect(stdout).toBe('');
 
     stderr = '';
     const inlineSetupResult = await runCli(['setup', '--no-input=true']);
     expect(inlineSetupResult.exitCode).toBe(2);
-    expect(stderr).toContain('texra setup is interactive');
+    expect(stderr).toContain(
+      'texra setup is interactive and does not support --no-input.',
+    );
+    expect(stderr).not.toContain('--print');
+    expect(stderr).not.toContain('--output-format');
     expect(stderr).not.toContain('Unknown option');
     expect(stdout).toBe('');
   });


### PR DESCRIPTION
## Summary

- Report only the headless-only flags actually passed to interactive commands such as `chat`, `orchestrate`, `setup`, and `resume`.
- Keep the shared `rejectHeadlessOnlyFlags()` validation path, but derive the displayed flag list from `rawArgs` instead of a static all-flags label.
- Add coverage for single-flag, inline-value, and multi-flag rejection messages.

Closes #6548.

## Why

While dogfooding a real `texra-local run correct` workflow and then checking the completed workflow's history/resume surface, `texra-local resume ... --no-input` correctly rejected the headless-only flag but told the user that `--print`, `--output-format`, and `--no-input` were unsupported. That was technically true for the command but noisy and misleading for the actual invocation.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check packages/cli/src/commands/_helpers/globalArgs.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npm run texra-local:build`
- Dogfood after rebuild:
  - `texra-local resume 9697a70e268d --cwd /tmp/texra-workflow-dogfood-20260623 --no-input`
  - `texra-local resume 9697a70e268d --cwd /tmp/texra-workflow-dogfood-20260623 --output-format json`
  - `texra-local chat --print --no-input`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to CLI usage-error messaging and matching tests; no behavior change to flag acceptance or command execution.
> 
> **Overview**
> When interactive commands (`chat`, `resume`, `setup`, `orchestrate`, etc.) receive headless-only globals like `--print`, `--output-format`, or `--no-input`, the usage error now names **only the flags present on the invocation**, not the full set of unsupported headless flags.
> 
> `rejectHeadlessOnlyFlags()` in `globalArgs.ts` replaces the static “all headless flags” label with per-argument detection via `headlessOnlyFlagLabel()` (long names, aliases like `-p`, and `flag=value` forms), deduplicated and formatted with the existing comma list helper. Tests in `CliRootArgs.vitest.mts` assert precise messages for single, inline, and multi-flag cases and that integration `runCli` paths do not mention unrelated flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aad50f63277046b0cd9508ec37fed1fb488ac0f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->