### PR TITLE
[codex] fix(cli): show hidden agent hints for json lists

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -29,7 +29,7 @@ export async function listAgents(
   await initLocalCliPlatform(context);
   const result = await loadCliAgentList(options);
 
-  if (context.outputFormat === 'text' && !context.quietLogs) {
+  if (!context.quietLogs) {
     const hiddenNotice = formatCliHiddenAgentsNotice(
       result.hiddenCount,
       options.category,

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -82,7 +82,7 @@ describe('CLI agents command', () => {
     expect(parseCliAgentCategoryFilter('unknown')).toBeUndefined();
   });
 
-  it('lists visible agents by default and reports hidden agents in text mode', async () => {
+  it('lists visible agents by default and reports hidden agents', async () => {
     const visibleAgent = {
       name: 'lean',
       source: 'builtInToolUse',
@@ -120,6 +120,38 @@ describe('CLI agents command', () => {
     );
     expect(mocks.writeTextStderr).toHaveBeenCalledWith(
       'Showing visible agents only; 1 hidden agent omitted. Use `texra agents list --all` to show the full catalog.',
+    );
+  });
+
+  it('reports hidden agents in json mode without changing stdout payload', async () => {
+    const hiddenWorkflowAgent = {
+      name: 'correct',
+      source: 'builtInWorkflow',
+      path: '/tmp/resources/agents/correct.yaml',
+      category: AgentCategory.Workflow,
+      description: 'Corrects LaTeX.',
+    };
+    mocks.getAgentsByCategory.mockImplementation((category: AgentCategory) =>
+      category === AgentCategory.Workflow ? [hiddenWorkflowAgent] : [],
+    );
+    const { listAgents } = await import('@cli/commands/agents');
+
+    const exitCode = await listAgents(cliContext({ outputFormat: 'json' }), {
+      category: AgentCategory.Workflow,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.emitCliResult).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        json: [],
+        ndjson: [],
+        text: '',
+      },
+      { paged: true },
+    );
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'Showing visible agents only; 1 hidden agent omitted. Use `texra agents list --category workflow --all` to show the workflow catalog.',
     );
   });
 


### PR DESCRIPTION
## Summary

- Emit the existing hidden-agent catalog notice for every non-quiet `texra agents list` output mode, not just text mode.
- Keep machine-readable stdout unchanged: JSON still returns the agent array and NDJSON still returns agent records.
- Add coverage for JSON output with an empty visible list and hidden workflow catalog.

Closes #6551.

## Why

While dogfooding the CLI, `texra-local agents list --category workflow` explained that visible workflow agents were hidden and suggested `--all`, but `texra-local agents list --category workflow --output-format json` returned only `[]` with no hint. That made the workflow catalog look empty even though the text command already knew how to explain the situation.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/AgentsCommand.vitest.mts`
- `corepack pnpm vitest run src/test-kernel/shared/SelectTemplates.vitest.ts src/test-kernel/cli/AgentListForm.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm exec prettier --check packages/cli/src/commands/agents.ts src/test-kernel/cli/AgentsCommand.vitest.mts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npm run texra-local:build`
- Dogfood:
  - `texra-local agents list --category workflow --output-format json` keeps stdout parseable and prints the hidden-catalog hint on stderr.
  - `texra-local agents list --category workflow --output-format json --quiet` keeps stderr empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI UX change: stderr messaging only, with no change to list payloads or agent resolution logic.
> 
> **Overview**
> **`texra agents list`** now writes the existing hidden-catalog notice to **stderr** whenever logs are not quiet, regardless of `--output-format` (text, JSON, or NDJSON).
> 
> Stdout stays machine-parseable: JSON still returns the visible agent array (e.g. `[]` when none are visible) and NDJSON still streams agent records. **`--quiet`** continues to suppress the stderr hint.
> 
> Tests were updated to drop the text-only assumption and to cover JSON mode with an empty visible workflow list plus a hidden agent, asserting stderr guidance without changing the emitted JSON payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5bd9ff86060376a111eb413badde1b2452ff0b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->