### PR TITLE
[codex] fix(cli): persist workflow result metadata

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,4 +1,8 @@
-import { getExecutionStore, writeTerminalStatus } from '@agent/storage';
+import {
+  getExecutionStore,
+  writeTerminalStatus,
+  type ResultMeta,
+} from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { toErrorMessage } from '@common/errors/errorMessage';
@@ -166,17 +170,17 @@ async function persistWorkflowResultMeta(
 ): Promise<void> {
   if (result.category !== AgentCategory.Workflow) return;
   try {
+    const resultMeta: ResultMeta = {
+      outputs: [...result.outputs],
+      compileFailures: [...result.compileFailures],
+    };
     if (result.copiedOutput) {
-      await getExecutionStore(executionId).writeResultMeta({
-        copiedOutput: result.copiedOutput,
-      });
-      return;
+      resultMeta.copiedOutput = result.copiedOutput;
     }
     if (result.copiedOutputs?.length) {
-      await getExecutionStore(executionId).writeResultMeta({
-        copiedOutputs: result.copiedOutputs,
-      });
+      resultMeta.copiedOutputs = [...result.copiedOutputs];
     }
+    await getExecutionStore(executionId).writeResultMeta(resultMeta);
   } catch (error) {
     writeTextStderr(
       `Warning: could not persist workflow result metadata: ${toErrorMessage(error)}`,

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -1,5 +1,4 @@
 import { getExecutionStore } from '@agent/storage';
-import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import { runAgent } from '@agent/runtime/runAgent';
 
 import { projectRunOutcome } from '@common/constants/streamStatus';
@@ -105,5 +104,3 @@ export async function readCliTerminalStatus(
     .catch(() => undefined);
   return cliTerminalStatus(result, meta?.terminalStatus);
 }
-
-export type { OutputFileSummary };

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -4,10 +4,10 @@ import * as path from 'node:path';
 import type { AgentEntry } from '@agent/index';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+import type { OutputFileSummary } from '@shared/schemas/output';
 import { getRunDir } from '@utils/files';
 
 import { CliUsageError, type CliContext } from './cliContext';

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -9,53 +9,10 @@ import {
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
-
-/**
- * Flattened projection of {@link OutputFileInfo} for use in {@link AgentFlowResult}.
- *
- * The internal `OutputFileInfo` carries rich `FileLocationSchema` objects, full
- * `FileLineageSchema` chains, and complete `DiffStats`. This summary strips those
- * down to plain strings and scalars so the result can be cleanly serialized and
- * consumed by orchestrators or storage without dragging in location internals.
- *
- * Conversion: see `toOutputSummaries()` in `executeAgent.ts`.
- */
-export const OutputFileSummarySchema = z.object({
-  round: z.int().nonnegative(),
-  relativePath: z.string(),
-  absolutePath: z.string(),
-  /** The `kind` discriminant of the source `FileLocation`. */
-  location: z.enum(['workspace', 'runStorage', 'external']),
-  /**
-   * Absolute path of the lineage base file (diffBase takes precedence over
-   * original when both are present), or null if no lineage was recorded.
-   */
-  originalPath: z.string().nullable(),
-  added: z.int().nonnegative().nullable(),
-  removed: z.int().nonnegative().nullable(),
-});
-
-export type OutputFileSummary = z.infer<typeof OutputFileSummarySchema>;
-
-/**
- * Flattened projection of {@link CompileFailure} for use in {@link AgentFlowResult}.
- *
- * `CompileFailure` stores `FileLocationSchema` objects for `output` and `log`.
- * This summary extracts plain paths: `outputPath` is workspace-relative for
- * non-external files (absolute for external), `logPath` is always relative,
- * and `logAbsolutePath` is always absolute for direct opening.
- *
- * Conversion: see `toCompileFailureSummaries()` in `executeAgent.ts`.
- */
-export const CompileFailureSummarySchema = z.object({
-  round: z.int().nonnegative(),
-  displayName: z.string(),
-  outputPath: z.string(),
-  logPath: z.string(),
-  logAbsolutePath: z.string(),
-});
-
-export type CompileFailureSummary = z.infer<typeof CompileFailureSummarySchema>;
+import {
+  CompileFailureSummarySchema,
+  OutputFileSummarySchema,
+} from '@shared/schemas/output';
 
 const AgentFlowMetaSchema = z.object({
   executionId: ExecutionIdSchema,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -30,6 +30,10 @@ import {
   type RoundOutput,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
+import type {
+  CompileFailureSummary,
+  OutputFileSummary,
+} from '@shared/schemas/output';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 
 import {
@@ -42,12 +46,7 @@ import { currentSession, type SessionHandle } from './SessionHandle';
 import { createInterruptCallbacks } from './InterruptManager';
 import { generateSessionDescription } from './sessionDescription';
 import { getProgressViewBridge } from './ProgressViewBridge';
-import {
-  AgentFlowError,
-  type AgentFlowResult,
-  type CompileFailureSummary,
-  type OutputFileSummary,
-} from './AgentFlowResult';
+import { AgentFlowError, type AgentFlowResult } from './AgentFlowResult';
 import type { AgentRunHandle } from './executionRegistry';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -16,6 +16,10 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { KVStore } from '@common/storage/KVStore';
 import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
+import {
+  CompileFailureSummarySchema,
+  OutputFileSummarySchema,
+} from '@shared/schemas/output';
 import { byString, filterNotNull } from '@utils/core';
 import { TASK_RUNS_DIR } from '@utils/files';
 
@@ -95,6 +99,8 @@ const ResultMetaSchema = z.object({
   command: z.string().optional(),
   copiedOutput: z.string().optional(),
   copiedOutputs: z.array(z.string()).optional(),
+  outputs: z.array(OutputFileSummarySchema).optional(),
+  compileFailures: z.array(CompileFailureSummarySchema).optional(),
 });
 export type ResultMeta = z.infer<typeof ResultMetaSchema>;
 

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -61,8 +61,23 @@ export const OutputFileInfoSchema = OutputFileSchema.extend({
 
 export const OutputFileInfoListSchema = OutputFileInfoSchema.array();
 
+/**
+ * Flattened projection of {@link OutputFileInfo} for agent results and
+ * execution metadata. It keeps persisted workflow summaries independent from
+ * the richer file-location internals used while a run is active.
+ */
+export const OutputFileSummarySchema = z.object({
+  round: z.int().nonnegative(),
+  relativePath: z.string(),
+  absolutePath: z.string(),
+  location: z.enum(['workspace', 'runStorage', 'external']),
+  originalPath: z.string().nullable(),
+  added: z.int().nonnegative().nullable(),
+  removed: z.int().nonnegative().nullable(),
+});
+
 export const CompileFailureSchema = z.strictObject({
-  round: z.number(),
+  round: z.int().nonnegative(),
   displayName: z.string(),
   output: FileLocationSchema,
   log: FileLocationSchema,
@@ -72,7 +87,21 @@ export const CompileFailureSchema = z.strictObject({
 export type OutputFile = z.infer<typeof OutputFileSchema>;
 export type FileLineage = z.infer<typeof FileLineageSchema>;
 export type OutputFileInfo = z.infer<typeof OutputFileInfoSchema>;
+export type OutputFileSummary = z.infer<typeof OutputFileSummarySchema>;
 export type CompileFailure = z.infer<typeof CompileFailureSchema>;
+
+/**
+ * Flattened projection of {@link CompileFailure} for agent results and
+ * execution metadata.
+ */
+export const CompileFailureSummarySchema = z.object({
+  round: z.int().nonnegative(),
+  displayName: z.string(),
+  outputPath: z.string(),
+  logPath: z.string(),
+  logAbsolutePath: z.string(),
+});
+export type CompileFailureSummary = z.infer<typeof CompileFailureSummarySchema>;
 
 export const CompileResultSchema = z.discriminatedUnion('status', [
   z.strictObject({

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -301,6 +301,42 @@ describe('CLI history runtime', () => {
     expect(text).not.toContain('CLI output:  /tmp/texra-output/polished.tex ');
   });
 
+  it('surfaces workflow result metadata in history details', async () => {
+    const outputSummary = {
+      round: 1,
+      relativePath: 'r1/paper.tex',
+      absolutePath: '/tmp/run/r1/paper.tex',
+      location: 'runStorage' as const,
+      originalPath: '/tmp/paper.tex',
+      added: 8,
+      removed: 0,
+    };
+    const compileFailure = {
+      round: 1,
+      displayName: 'paper.tex',
+      outputPath: 'r1/paper.tex',
+      logPath: 'compile/r1_paper.tex.log',
+      logAbsolutePath: '/tmp/run/compile/r1_paper.tex.log',
+    };
+    mocks.readResultMeta.mockResolvedValue({
+      copiedOutput: '/tmp/annotated.tex',
+      outputs: [outputSummary],
+      compileFailures: [compileFailure],
+    });
+
+    const details = await readCliHistoryDetails('a1' as ExecutionId);
+    const text = formatCliHistoryDetailsText(details!);
+
+    expect(details?.resultMeta).toEqual({
+      copiedOutput: '/tmp/annotated.tex',
+      outputs: [outputSummary],
+      compileFailures: [compileFailure],
+    });
+    expect(text).toContain('"copiedOutput":"/tmp/annotated.tex"');
+    expect(text).toContain('"compileFailures"');
+    expect(text).toContain('compile/r1_paper.tex.log');
+  });
+
   it('shows a bounded final assistant preview when no report is stored', async () => {
     mocks.readConversation.mockResolvedValue([
       { role: 'user', content: 'Review the proof.' },

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -307,6 +307,22 @@ describe('CLI workflow run command', () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-workflow-'));
     try {
       const generated = path.join(root, 'run', 'r1', 'paper.tex');
+      const outputSummary = {
+        round: 1,
+        relativePath: 'r1/paper.tex',
+        absolutePath: generated,
+        location: 'runStorage',
+        originalPath: path.join(root, 'paper.tex'),
+        added: null,
+        removed: null,
+      };
+      const compileFailure = {
+        round: 1,
+        displayName: 'paper.tex',
+        outputPath: 'r1/paper.tex',
+        logPath: 'compile/r1_paper.tex.log',
+        logAbsolutePath: path.join(root, 'run', 'compile', 'r1_paper.tex.log'),
+      };
       await fs.mkdir(path.dirname(generated), { recursive: true });
       await fs.writeFile(generated, 'polished');
       mocks.executeCliConfig.mockResolvedValueOnce({
@@ -317,18 +333,8 @@ describe('CLI workflow run command', () => {
           executionId: 'exec-output',
           streamId: 'stream-output',
           outcome: RUN_OUTCOME.COMPLETED,
-          outputs: [
-            {
-              round: 1,
-              relativePath: 'r1/paper.tex',
-              absolutePath: generated,
-              location: 'runStorage',
-              originalPath: path.join(root, 'paper.tex'),
-              added: null,
-              removed: null,
-            },
-          ],
-          compileFailures: [],
+          outputs: [outputSummary],
+          compileFailures: [compileFailure],
         },
         terminalStatus: EXECUTION_STATUS.COMPLETED,
       });
@@ -355,6 +361,8 @@ describe('CLI workflow run command', () => {
       ).resolves.toBe('polished');
       expect(mocks.writeResultMeta).toHaveBeenCalledWith({
         copiedOutput: path.join(root, 'polished.tex'),
+        outputs: [outputSummary],
+        compileFailures: [compileFailure],
       });
     } finally {
       await fs.rm(root, { recursive: true, force: true });
@@ -365,6 +373,15 @@ describe('CLI workflow run command', () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-workflow-'));
     try {
       const generated = path.join(root, 'run', 'r1', 'paper.tex');
+      const outputSummary = {
+        round: 1,
+        relativePath: 'r1/paper.tex',
+        absolutePath: generated,
+        location: 'runStorage',
+        originalPath: path.join(root, 'paper.tex'),
+        added: null,
+        removed: null,
+      };
       await fs.mkdir(path.dirname(generated), { recursive: true });
       await fs.writeFile(generated, 'polished');
       mocks.executeCliConfig.mockResolvedValueOnce({
@@ -375,17 +392,7 @@ describe('CLI workflow run command', () => {
           executionId: 'exec-output-dir',
           streamId: 'stream-output-dir',
           outcome: RUN_OUTCOME.COMPLETED,
-          outputs: [
-            {
-              round: 1,
-              relativePath: 'r1/paper.tex',
-              absolutePath: generated,
-              location: 'runStorage',
-              originalPath: path.join(root, 'paper.tex'),
-              added: null,
-              removed: null,
-            },
-          ],
+          outputs: [outputSummary],
           compileFailures: [],
         },
         terminalStatus: EXECUTION_STATUS.COMPLETED,
@@ -407,6 +414,8 @@ describe('CLI workflow run command', () => {
       ).resolves.toBe('polished');
       expect(mocks.writeResultMeta).toHaveBeenCalledWith({
         copiedOutputs: [path.join(root, 'out', 'paper.tex')],
+        outputs: [outputSummary],
+        compileFailures: [],
       });
     } finally {
       await fs.rm(root, { recursive: true, force: true });

--- a/src/tools/subagentDiffs.ts
+++ b/src/tools/subagentDiffs.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 
 import { diff_match_patch } from 'diff-match-patch';
 
-import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
 import type { ExecutionId } from '@shared/schemas';
+import type { OutputFileSummary } from '@shared/schemas/output';
 import { AbsoluteFS } from '@utils/files';
 import { getRunDir, ensureRunDir } from '@utils/files/taskRunStorage';
 import { countLines } from '@utils/text/stringUtils';

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -8,10 +8,7 @@
  * (just before injection into model context via FollowUpQueue).
  */
 
-import type {
-  AgentFlowResult,
-  OutputFileSummary,
-} from '@agent/runtime/AgentFlowResult';
+import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import { normalizeProviderError, toErrorMessage } from '@common/errors';
 import type {
@@ -20,6 +17,7 @@ import type {
   TodoItem,
   WorkPlanSnapshot,
 } from '@shared/schemas';
+import type { OutputFileSummary } from '@shared/schemas/output';
 import type { ExecResult } from '@shared/schemas/opResults';
 import { countByStatus, STATUS_DISPLAY } from '@shared/schemas/todoDisplay';
 import { planSummaryLine } from '@shared/schemas/workPlan';


### PR DESCRIPTION
## Summary

- move workflow output and compile-failure summary schemas into the shared output schema module
- persist workflow `outputs` and `compileFailures` alongside copied output paths in execution result metadata
- update summary-type consumers to import directly from the shared schema module
- cover both the workflow write path and `history show` read path

Fixes #6553.

## Why

Dogfooding `texra-local run criticize` produced direct run JSON with generated outputs and compile-failure log paths, but `texra-local history show` only retained `copiedOutput`. That made the durable history record hide the important diagnostic data for a copied output that failed to compile.

The root cause was a lossy projection in `persistWorkflowResultMeta`: it wrote only `copiedOutput` or `copiedOutputs`, even though the CLI already had the richer workflow result object in hand.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/History.vitest.mts src/test-kernel/tools/SubagentResults.vitest.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `git diff --check`
- `npm run lint` (passes with the existing 18 import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive persistence and schema relocation with tests; no auth or execution-path behavior changes beyond richer metadata writes.
> 
> **Overview**
> **Workflow runs now store full result summaries in execution history**, not only where copied artifacts landed. `persistWorkflowResultMeta` writes `outputs` and `compileFailures` on every workflow completion, and still adds `copiedOutput` / `copiedOutputs` when `--output` or `--output-dir` is used—so `history show` can surface generated paths and compile log locations after a failed LaTeX build.
> 
> **Shared schema consolidation:** `OutputFileSummary` and `CompileFailureSummary` move from `AgentFlowResult` into `@shared/schemas/output`, and `ResultMeta` validates the new optional fields. Runtime, CLI, storage, and subagent tooling import the shared types instead of re-exporting from the agent flow module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1803388a7ee3404007e145a6c9ce8dd53c4e90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->