### PR TITLE
docs: 0.38.10 changelog + version-bump CI fix

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,6 +11,11 @@ permissions:
 jobs:
   bump-version:
     runs-on: ubuntu-latest
+    # Releases are cut in pairs off the same commit: `vX.Y.Z` for the extension
+    # and `cli-vX.Y.Z` for the CLI (plus legacy `vX.Y.Z-frontend` tags). Bump
+    # only once, off the canonical extension tag — otherwise the `cli-` tag fires
+    # a second, redundant run and races the first on the same PR branch.
+    if: ${{ startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.38.10] - 2026-06-23
+
 ### Shared (all surfaces)
+
+#### Features
+
+- **Experimental: use your own ChatGPT subscription for Codex models** — sign in with your ChatGPT Plus/Pro/Team account and route Codex models through your subscription instead of a separate API key. In the CLI, sign in with `texra auth chatgpt login` and toggle it with `/subscription on|off` (alias `/sub`); in the VS Code extension, sign in from Settings → Models. Turn it on with the "chatgptCodex.preferSubscription" setting. The login opens your browser or, on a headless shell, shows a one-time device code; check or end the session with `texra auth chatgpt status` and `logout`. Off by default and clearly marked experimental and personal-use: it relies on an unofficial OpenAI endpoint that can change or stop working without notice, and it only ever uses your own signed-in session.
+- **Workflow round counts** — workflow progress now reports how many rounds are planned, so you can see how far a multi-round run has to go.
 
 #### Improvements
 
 - **More reliable Lean theorem search** — Loogle queries now retry automatically when the server times out, drops the connection, or returns a transient server error, so a brief hiccup no longer surfaces as a failed search; genuine bad requests still fail fast.
+- **Proofreading preserves math style** — the Correct agent now keeps your existing math formatting intact while fixing the surrounding prose.
+
+#### Bug Fixes
+
+- **Cleaner history previews** — provider "thinking" / reasoning text no longer leaks into the previews shown when browsing past conversations.
+- **OpenRouter setup mismatch** — when a configured model isn't available on OpenRouter, setup now surfaces the mismatch before prompting for credentials instead of after.
 
 ### CLI
 
@@ -16,9 +29,41 @@ All notable changes to this project will be documented in this file.
 
 - **Smoother terminal redraws** — the chat TUI now repaints atomically (synchronized output) when you resize the window or switch between the main transcript and a focused sub-agent, so resizing and view switches no longer flicker or leave stray fragments on terminals that support it.
 
+#### Bug Fixes
+
+- **Discoverable hidden models and agents** — hidden CLI models, launchable agents, and JSON agent listings now surface their entries (with hints) instead of appearing empty, and shell completion offers the right agents and `--model` values for zsh.
+- **Tidier agent and child pickers** — the agent picker and child-stream picker now keep their labels, rows, and copy within the frame instead of overflowing in narrow terminals.
+- **Multi-agent launcher polish** — clearer launcher hint, completions scoped to the launch category, zero-count categories omitted, and a more stable multi-agent run validator.
+- **Correct workflow output handling** — workflows write nested output paths and directories correctly, use stable filenames for stdin input, persist copied outputs in history, and preserve file lineage when inputs share a basename.
+- **Better history defaults** — `texra history` with no subcommand now lists your history, and history details show the team identity and the workflow's output files; runs hidden because they belong to another working directory now explain why instead of silently vanishing.
+- **Friendlier errors and hints** — unknown commands are rejected before help is shown, model names are normalized, model-recovery hints appear when a model is unavailable, rejected interactive flags are reported precisely, and the personal-API status label is clearer.
+- **Smaller transcript and approval fixes** — the inquiry tool's raw syntax is hidden in the transcript, edit-approval hunk counts are pluralized correctly, quiet-agent visibility notices are suppressed, and the active-response follow-up tip is shown.
+- **Correct status and credentials** — the `/status` view shows the right working directory, CLI credentials are stored under your configured storage root (so a custom storage location keeps its own sign-in), and an invalid workflow input is reported clearly instead of surfacing as an unrelated model error.
+- **`agents inspect` alias** — `texra agents inspect` is now accepted as an alias.
+- **Local software-engineer team** — the built-in software-engineer team now completes correctly when run locally.
+
+### Desktop
+
 #### Features
 
-- **Experimental: use your own ChatGPT subscription for Codex models** — sign in with your ChatGPT Plus/Pro/Team account from the terminal with `texra auth chatgpt login`, then turn on "chatgptCodex.preferSubscription" in your CLI config to route Codex models through your subscription instead of a separate API key. The command opens your browser or, on a headless shell, shows a one-time device code; check or end the session with `texra auth chatgpt status` and `logout`. Off by default and clearly marked experimental and personal-use: it relies on an unofficial OpenAI endpoint that can change or stop working without notice, and it only ever uses your own signed-in session.
+- **Real onboarding state** — the desktop app now derives its onboarding funnel state from your actual credentials and setup instead of always reporting "done".
+
+#### Bug Fixes
+
+- **More secure, more reliable sign-in** — desktop OAuth callbacks are bound to a per-attempt nonce and the auth-bridge deep link is locked to the TeXRA publisher, and sign-in is relayed through an https bridge so Linux/Firefox can complete the flow.
+- **No stale display after close** — a disposed desktop window no longer briefly shows restored content.
+
+### Extension (VS Code)
+
+#### Features
+
+- **Sign in with ChatGPT in Settings → Models** — the extension adds a ChatGPT-subscription sign-in control alongside the GitHub-token status, with a matching sign-in/sign-out round-trip.
+- **Improved onboarding actions** — clearer first-run onboarding with more direct setup actions.
+
+#### Bug Fixes
+
+- **Clearer onboarding flow** — credential onboarding is shown first, entry points are clarified, the walkthrough is aligned with credential setup, ChatGPT onboarding is prioritized, and onboarding refreshes after a setup action.
+- **Stable task rows** — stopped task rows stay in place instead of jumping.
 
 ## [0.38.9] - 2026-06-18
 

--- a/scripts/bump-workspace-version.mjs
+++ b/scripts/bump-workspace-version.mjs
@@ -11,7 +11,10 @@ const MANIFEST_PATHS = [
   'packages/extension/package.json',
 ];
 
-const VERSION_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/;
+// Accept the canonical extension tag (`v0.38.9`), the CLI tag (`cli-v0.38.9`),
+// and a bare version (`0.38.9`). Release tags are cut in pairs off the same
+// commit, so either tag resolves to the same next version.
+const VERSION_PATTERN = /^(?:cli-)?v?(\d+)\.(\d+)\.(\d+)$/;
 
 // Release trains use patch values 0 through 10; after .10, development moves
 // to the next minor train.

--- a/scripts/bump-workspace-version.mjs
+++ b/scripts/bump-workspace-version.mjs
@@ -14,7 +14,7 @@ const MANIFEST_PATHS = [
 // Accept the canonical extension tag (`v0.38.9`), the CLI tag (`cli-v0.38.9`),
 // and a bare version (`0.38.9`). Release tags are cut in pairs off the same
 // commit, so either tag resolves to the same next version.
-const VERSION_PATTERN = /^(?:cli-)?v?(\d+)\.(\d+)\.(\d+)$/;
+const VERSION_PATTERN = /^(?:cli-v|v)?(\d+)\.(\d+)\.(\d+)$/;
 
 // Release trains use patch values 0 through 10; after .10, development moves
 // to the next minor train.
@@ -29,6 +29,7 @@ function printUsage() {
       '',
       'Examples:',
       '  node scripts/bump-workspace-version.mjs --from v0.37.10',
+      '  node scripts/bump-workspace-version.mjs --from cli-v0.37.10',
       '  node scripts/bump-workspace-version.mjs --version 0.38.0 --check',
     ].join('\n'),
   );
@@ -78,7 +79,9 @@ function parseArgs(argv) {
 function parseVersion(rawVersion, label) {
   const match = VERSION_PATTERN.exec(rawVersion);
   if (match == null) {
-    fail(`${label} must be MAJOR.MINOR.PATCH, with an optional leading v.`);
+    fail(
+      `${label} must be MAJOR.MINOR.PATCH, with an optional leading v or cli-v prefix.`,
+    );
   }
 
   const [, major, minor, patch] = match;

--- a/src/test-kernel/scripts/BumpWorkspaceVersion.vitest.ts
+++ b/src/test-kernel/scripts/BumpWorkspaceVersion.vitest.ts
@@ -1,0 +1,71 @@
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const scriptPath = path.join(repoRoot, 'scripts/bump-workspace-version.mjs');
+const manifestPaths = [
+  'package.json',
+  'packages/core/package.json',
+  'packages/cli/package.json',
+  'packages/desktop/package.json',
+  'packages/extension/package.json',
+];
+
+async function writeWorkspaceManifests(root: string, version: string) {
+  await Promise.all(
+    manifestPaths.map(async (manifestPath) => {
+      const absolutePath = path.join(root, manifestPath);
+      await mkdir(path.dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, `${JSON.stringify({ version })}\n`);
+    }),
+  );
+}
+
+function runVersionBump(args: readonly string[], cwd = repoRoot) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+}
+
+describe('bump-workspace-version script', () => {
+  it('accepts CLI release tags when computing the next workspace version', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'texra-version-bump-'));
+    try {
+      await writeWorkspaceManifests(root, '0.38.10');
+
+      const result = runVersionBump(['--from', 'cli-v0.38.9', '--check'], root);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('0.38.10\n');
+      expect(result.stderr).toBe('');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('documents the accepted release tag prefixes in parse errors', () => {
+    const result = runVersionBump(['--from', 'v0.8.5-frontend', '--check']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Release tag must be MAJOR.MINOR.PATCH, with an optional leading v or cli-v prefix.',
+    );
+    expect(result.stderr).toContain(
+      'node scripts/bump-workspace-version.mjs --from cli-v0.37.10',
+    );
+  });
+
+  it('rejects CLI-prefixed release tags without the tag v', () => {
+    const result = runVersionBump(['--from', 'cli-0.38.9', '--check']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Release tag must be MAJOR.MINOR.PATCH, with an optional leading v or cli-v prefix.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Prepare the **0.38.10** release notes and fix the version-bump workflow that left a failing run on every CLI release.

### Changelog (`docs:` commit)
- 0.38.9 actually shipped to the VS Code Marketplace, Open VSX, and npm (2026-06-18/19) but was never tagged on GitHub. The `v0.38.9` / `cli-v0.38.9` releases have now been backfilled, which triggered the auto-bump to 0.38.10 (#6555, merged).
- This adds the `[0.38.10] - 2026-06-23` changelog section, curating the user-facing changes since 0.38.9 and grouping them Shared / CLI / Desktop / Extension. Internal refactors/test/style changes are excluded; clustered intermediate fixes are collapsed per the changelog guidelines.

### CI fix (`ci:` commit)
- Releases are cut in pairs off the same commit (`vX.Y.Z` for the extension, `cli-vX.Y.Z` for the CLI). The version-bump job fired for **both** tags, but `bump-workspace-version.mjs`'s tag regex rejected the `cli-` prefix — so every CLI release produced a red, redundant workflow run (and risked racing the real bump on the same PR branch).
- **Workflow:** gate the job to the canonical `vX.Y.Z` tag (skip `cli-*` and legacy `*-frontend`) so the bump runs exactly once per release.
- **Script:** also accept an optional `cli-` prefix so a manual `--from cli-vX.Y.Z` resolves to the same next version instead of erroring.

### Verification
- `node scripts/bump-workspace-version.mjs --from cli-v0.38.9` → `0.38.10` (previously errored); `--from v0.38.10` → `0.39.0` (train rollover); `--from v0.8.5-frontend` still rejected.
- Workflow `if` truth table: `v0.38.9`/`v0.38.10` → run; `cli-v0.38.9`/`*-frontend` → skip.

https://claude.ai/code/session_01KQ2uGiJimmSZ8mqfFsroN3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and release-automation changes only; workflow gating reduces CI race risk without touching runtime product code.
> 
> **Overview**
> Adds the **[0.38.10] - 2026-06-23** changelog section, grouping user-facing changes since 0.38.9 across Shared, CLI, Desktop, and Extension (ChatGPT subscription routing, workflow round counts, CLI TUI/history/workflow fixes, desktop auth/onboarding, extension onboarding and task UI).
> 
> Fixes **duplicate failing version-bump runs** when both extension (`vX.Y.Z`) and CLI (`cli-vX.Y.Z`) releases publish from the same commit: the workflow now runs **only** on canonical `v` tags without a hyphen (skipping `cli-*` and legacy `*-frontend`). **`bump-workspace-version.mjs`** also accepts an optional **`cli-v`** prefix on `--from` for manual bumps, with new vitest coverage for CLI tags and invalid tag shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da375226468625141715ed9e44fb79b589317ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->