### PR TITLE
refactor: replace nested Math.min/max clamps with clamp()

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -194,6 +194,8 @@ export function allocateMiddleRows({
       : 0;
   const foregroundRows = availableRows - transcriptRows;
   return {
+    // The early returns above and transcript reservation keep this at least 1,
+    // so the lower clamp bound cannot inflate an empty foreground.
     foregroundRows:
       foregroundMaxRows === undefined
         ? foregroundRows

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -22,6 +22,7 @@ import {
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
+import { clamp } from '@utils/core';
 
 import { assertNever } from './assertNever';
 import { SLASH_PALETTE_ROWS } from './commands/SlashPalette';
@@ -196,7 +197,7 @@ export function allocateMiddleRows({
     foregroundRows:
       foregroundMaxRows === undefined
         ? foregroundRows
-        : Math.min(foregroundRows, Math.max(1, foregroundMaxRows)),
+        : clamp(foregroundMaxRows, 1, foregroundRows),
     transcriptRows,
   };
 }
@@ -662,7 +663,7 @@ export function App(props: AppProps): React.JSX.Element {
     ? queuedFollowUpPanelRowCount(queuedFollowUpMessages)
     : 0;
   const queuedFollowUpPanelRows = queuedFollowUpPanelWanted
-    ? Math.min(requestedQueuedFollowUpPanelRows, Math.max(0, rows - footerRows))
+    ? clamp(rows - footerRows, 0, requestedQueuedFollowUpPanelRows)
     : 0;
   const queuedFollowUpPanelVisible = queuedFollowUpPanelRows > 0;
   const tipRowVisible =

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -699,7 +699,8 @@ export function computePickerListLayout({
     const end = start + visibleCount;
     const markerRows =
       rowBudget >= 3 ? (start > 0 ? 1 : 0) + (end < itemCount ? 1 : 0) : 0;
-    visibleCount = clamp(rowBudget - markerRows, 1, itemCount);
+    visibleCount =
+      itemCount === 0 ? 0 : clamp(rowBudget - markerRows, 1, itemCount);
   }
   const start = windowStart(visibleCount);
   const end = start + visibleCount;

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -691,7 +691,7 @@ export function computePickerListLayout({
   const rowBudget = Math.max(1, rows - fixedRows);
   const windowStart = (count: number): number => {
     const lastStart = Math.max(0, itemCount - count);
-    return Math.min(lastStart, Math.max(0, highlight - Math.floor(count / 2)));
+    return clamp(highlight - Math.floor(count / 2), 0, lastStart);
   };
   let visibleCount = Math.min(itemCount, rowBudget);
   for (let i = 0; i < 2; i += 1) {
@@ -699,7 +699,7 @@ export function computePickerListLayout({
     const end = start + visibleCount;
     const markerRows =
       rowBudget >= 3 ? (start > 0 ? 1 : 0) + (end < itemCount ? 1 : 0) : 0;
-    visibleCount = Math.min(itemCount, Math.max(1, rowBudget - markerRows));
+    visibleCount = clamp(rowBudget - markerRows, 1, itemCount);
   }
   const start = windowStart(visibleCount);
   const end = start + visibleCount;

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -21,6 +21,7 @@ import {
 } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import {
+  clamp,
   filterNotNullish,
   formatCompactDuration,
   formatCompactTokenCount,
@@ -240,7 +241,7 @@ export function queuedFollowUpsSummary(
   const previewLength =
     maxColumns === undefined
       ? QUEUED_FOLLOW_UP_PREVIEW_LENGTH
-      : Math.min(QUEUED_FOLLOW_UP_PREVIEW_LENGTH, Math.max(0, maxColumns));
+      : clamp(maxColumns, 0, QUEUED_FOLLOW_UP_PREVIEW_LENGTH);
   if (previewLength < STATUS_BAR_MIN_RIGHT_PREVIEW) return undefined;
   if (messages.length > 1) {
     return queuedFollowUpsListSummary(messages, previewLength);

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -7,7 +7,7 @@
 import { Box, Text } from 'ink';
 import { structuredPatch, type StructuredPatchHunk } from 'diff';
 
-import { filterNotNullish, isObject } from '@utils/core';
+import { clamp, filterNotNullish, isObject } from '@utils/core';
 
 import { wrapAnsiToWidth } from './ansiWrap';
 import { maxScrollableRowOffset, scrollBoundedRows } from './scrollBounds';
@@ -227,7 +227,7 @@ function compactBoundedDiffDisplayLines(
   const visibleBudget = Math.max(1, maxDisplayLines);
   const visibleCount = visibleBudget === 1 ? 1 : visibleBudget - 1;
   const anchor = representativeDiffLineIndex(lines);
-  const start = Math.max(0, Math.min(anchor, lines.length - visibleCount));
+  const start = clamp(anchor, 0, lines.length - visibleCount);
   const visibleLines = lines.slice(start, start + visibleCount);
   if (visibleBudget === 1) return visibleLines;
 

--- a/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
+++ b/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
@@ -1,3 +1,4 @@
+import { clamp } from '@utils/core';
 import { summarizeEmbeddedSubagentFollowups } from '@shared/subagentFollowup';
 
 const KNOWN_HTML_TAG_RE =
@@ -14,7 +15,7 @@ function quoteHtmlBlock(body: string): string {
 
 function headingMarker(level: string): string {
   const parsed = Number.parseInt(level, 10);
-  const depth = Number.isFinite(parsed) ? Math.min(6, Math.max(1, parsed)) : 3;
+  const depth = Number.isFinite(parsed) ? clamp(parsed, 1, 6) : 3;
   return '#'.repeat(depth);
 }
 

--- a/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
+++ b/packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts
@@ -1,5 +1,5 @@
-import { clamp } from '@utils/core';
 import { summarizeEmbeddedSubagentFollowups } from '@shared/subagentFollowup';
+import { clamp } from '@utils/core';
 
 const KNOWN_HTML_TAG_RE =
   /<\/?(?:blockquote|strong|b|em|i|code|p|div|br|h[1-6])\b/i;

--- a/src/shared/constants/delegationPolicy.ts
+++ b/src/shared/constants/delegationPolicy.ts
@@ -14,6 +14,8 @@
  *   (orchestrator → sub-orchestrator → leaf agent), and so on.
  */
 
+import { clamp } from '@utils/core';
+
 /** Supported range for the max-depth setting and its default. */
 export const NESTED_DELEGATION_DEPTH_RANGE = {
   min: 1,
@@ -33,9 +35,10 @@ export function clampNestedDelegationDepth(value: unknown): number {
     typeof value === 'number' && Number.isFinite(value)
       ? value
       : NESTED_DELEGATION_DEPTH_RANGE.default;
-  return Math.min(
+  return clamp(
+    Math.round(n),
+    NESTED_DELEGATION_DEPTH_RANGE.min,
     NESTED_DELEGATION_DEPTH_RANGE.max,
-    Math.max(NESTED_DELEGATION_DEPTH_RANGE.min, Math.round(n)),
   );
 }
 

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -1518,4 +1518,20 @@ describe('CLI child execution controls', () => {
       visibleCount: 3,
     });
   });
+
+  it('keeps empty picker windows empty', () => {
+    expect(
+      computePickerListLayout({
+        availableRows: 10,
+        highlight: 0,
+        itemCount: 0,
+        scopeLineCount: 1,
+      }),
+    ).toMatchObject({
+      hiddenAfter: 0,
+      hiddenBefore: 0,
+      start: 0,
+      visibleCount: 0,
+    });
+  });
 });

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -10,18 +10,15 @@ import which from 'which';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
+import { unique } from '@utils/core';
 import { AbsoluteFS } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
-import { unique } from '@utils/core';
 
 /** Whether the current platform is Windows (cached at module load). */
 export const IS_WINDOWS = process.platform === 'win32';
 
 /** Whether the current platform is macOS (cached at module load). */
 export const IS_MACOS = process.platform === 'darwin';
-
-/** Whether the current platform is Linux (cached at module load). */
-export const IS_LINUX = process.platform === 'linux';
 
 // Common LaTeX tool names used across the system
 const TEX_TOOLS = ['latexdiff', 'latexindent', 'latexmk'] as const;

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -20,6 +20,9 @@ export const IS_WINDOWS = process.platform === 'win32';
 /** Whether the current platform is macOS (cached at module load). */
 export const IS_MACOS = process.platform === 'darwin';
 
+/** Whether the current platform is Linux (cached at module load). */
+export const IS_LINUX = process.platform === 'linux';
+
 // Common LaTeX tool names used across the system
 const TEX_TOOLS = ['latexdiff', 'latexindent', 'latexmk'] as const;
 

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -10,9 +10,9 @@ import which from 'which';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
-import { unique } from '@utils/core';
 import { AbsoluteFS } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
+import { unique } from '@utils/core';
 
 /** Whether the current platform is Windows (cached at module load). */
 export const IS_WINDOWS = process.platform === 'win32';


### PR DESCRIPTION
## Summary

- Replace inline `Math.min` / `Math.max` bounding expressions with the shared `clamp()` helper where the bounds are valid for that helper.
- Preserve the empty child-control picker behavior (`visibleCount: 0`) and cover it with a regression test.
- Remove the speculative `IS_LINUX` export from the net diff; `platformPaths.ts` is no longer changed by this PR.

## Test plan

- `corepack pnpm vitest run src/test-kernel/cli/ChildControls.vitest.mts`
- `node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm prettier --check packages/cli/src/chat/tui/modals/ChildControlPicker.tsx packages/cli/src/chat/tui/render/htmlMarkdownNormalize.ts src/test-kernel/cli/ChildControls.vitest.mts src/utils/system/platformPaths.ts`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with one guarded layout edge case; delegation clamping semantics are unchanged aside from using the same helper.
> 
> **Overview**
> Replaces inline `Math.min` / `Math.max` bounding with the shared **`clamp()`** helper from `@utils/core` across CLI TUI layout/render code and **`clampNestedDelegationDepth`** in delegation policy.
> 
> Touches row/column budgeting in **`App`** (foreground and queued follow-up panels), **`ChildControlPicker`** list windowing, **`StatusBar`** queued-follow-up preview width, **`DiffView`** compact diff anchoring, and **`htmlMarkdownNormalize`** heading depth. Behavior is intended to stay the same except the child-control picker: when **`itemCount === 0`**, **`visibleCount`** stays **0** instead of being forced to at least one row—covered by a new test in **`ChildControls.vitest.mts`**. A short comment in **`allocateMiddleRows`** documents why the foreground lower bound cannot inflate an empty layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bc7009af44c5642fc3f134492b616368a4419bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->