### PR TITLE
feat(relay): Max tier full model access + higher concurrency caps

### DIFF
--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -7,10 +7,10 @@
  * RESEARCHER ACCESS PROGRAM:
  * All server-side API key access is provided as a convenience for researchers.
  *
- * TIER HIERARCHY (cumulative access):
- * - free: Included non-premium models (up to $3/M input)
- * - Max: Free-tier models plus any future Max-only additions
- * - Ultra: All models above $3/M input
+ * TIER HIERARCHY (model access):
+ * - free: input <= $1.5/M AND output <= $9/M
+ * - Max: every model
+ * - Ultra: every model
  */
 
 import { LRUCache } from 'lru-cache';

--- a/src/auth/tier/index.ts
+++ b/src/auth/tier/index.ts
@@ -11,10 +11,10 @@
  * All server-side API key access is provided as a convenience for researchers.
  * Users can always choose between server-side keys or their own API keys.
  *
- * TIER HIERARCHY (cumulative access):
- * - free: Included non-premium models (up to $3/M input)
- * - Max: Free-tier models plus any future Max-only additions
- * - Ultra: All models above $3/M input
+ * TIER HIERARCHY (model access):
+ * - free: input <= $1.5/M AND output <= $9/M
+ * - Max: every model
+ * - Ultra: every model
  */
 
 import { SUPABASE_CUSTOM_DOMAIN } from '../sharedConfig';

--- a/src/auth/tier/types.ts
+++ b/src/auth/tier/types.ts
@@ -5,10 +5,10 @@
  * All server-side API key access is provided as a convenience for researchers.
  * Users can always choose between server-side keys or their own API keys.
  *
- * TIER HIERARCHY (cumulative access):
- * - free: Included non-premium models (up to $3/M input)
- * - Max: Free-tier models plus any future Max-only additions
- * - Ultra: All models above $3/M input
+ * TIER HIERARCHY (model access):
+ * - free: input <= $1.5/M AND output <= $9/M
+ * - Max: every model
+ * - Ultra: every model
  *
  * ACCESS EXPIRATION:
  * - All researcher access has an expiration date to prevent abuse

--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -1,0 +1,37 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { describe, it } from 'vitest';
+
+// Local imports - Supabase relay
+import {
+  FREE_TIER,
+  MAX_TIER,
+  TIER_CONFIG,
+  ULTRA_TIER,
+  isModelAllowedForTier,
+} from '../../../supabase/functions/relay/models';
+
+describe('relay tier model access', () => {
+  it('gives Max and Ultra full model access', () => {
+    assert.equal(TIER_CONFIG.tiers.Max?.models, '*');
+    assert.equal(TIER_CONFIG.tiers.Ultra?.models, '*');
+
+    assert.equal(isModelAllowedForTier(MAX_TIER, 'unknown-model'), true);
+    assert.equal(isModelAllowedForTier(MAX_TIER, null), true);
+    assert.equal(isModelAllowedForTier(ULTRA_TIER, 'unknown-model'), true);
+    assert.equal(isModelAllowedForTier(ULTRA_TIER, null), true);
+  });
+
+  it('keeps free tier restricted to known price-bounded models', () => {
+    assert.equal(isModelAllowedForTier(FREE_TIER, 'gemini-3.5-flash'), true);
+    assert.equal(
+      isModelAllowedForTier(FREE_TIER, 'google/gemini-3.5-flash'),
+      true,
+    );
+    assert.equal(isModelAllowedForTier(FREE_TIER, 'gpt-5-2025-08-07'), false);
+    assert.equal(isModelAllowedForTier(FREE_TIER, 'unknown-model'), false);
+    assert.equal(isModelAllowedForTier(FREE_TIER, null), false);
+  });
+});

--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -14,12 +14,12 @@ import {
 } from '../../../supabase/functions/relay/models';
 
 describe('relay tier model access', () => {
-  it('gives Max and Ultra full model access', () => {
+  it('gives Max full explicit-model access and Ultra passthrough', () => {
     assert.equal(TIER_CONFIG.tiers.Max?.models, '*');
     assert.equal(TIER_CONFIG.tiers.Ultra?.models, '*');
 
     assert.equal(isModelAllowedForTier(MAX_TIER, 'unknown-model'), true);
-    assert.equal(isModelAllowedForTier(MAX_TIER, null), true);
+    assert.equal(isModelAllowedForTier(MAX_TIER, null), false);
     assert.equal(isModelAllowedForTier(ULTRA_TIER, 'unknown-model'), true);
     assert.equal(isModelAllowedForTier(ULTRA_TIER, null), true);
   });

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -36,6 +36,7 @@
  * which the relay enforces below (immediate, even for a still-valid token).
  * ============================================================================
  *
+ * TIER HIERARCHY (model access):
  * - free: input <= $1.5/M AND output <= $9/M
  * - Max: every model
  * - Ultra: every model
@@ -621,7 +622,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     }
   }
 
-  // 6. Validate model for non-Ultra tiers
+  // 6. Apply tier constraints for non-Ultra tiers.
   // Skip model validation for endpoints that don't require a model (e.g., file uploads)
   // - OpenAI: /v1/files
   // - Anthropic: /v1/files (same as OpenAI)

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -36,10 +36,9 @@
  * which the relay enforces below (immediate, even for a still-valid token).
  * ============================================================================
  *
- * TIER HIERARCHY (cumulative access):
- * - Max: Free-tier models plus any future Max-only additions
  * - free: input <= $1.5/M AND output <= $9/M
- * - Ultra: everything else
+ * - Max: every model
+ * - Ultra: every model
  *
  * Authentication: JWT tokens are extracted from SDK auth headers:
  * - OpenAI: Authorization: Bearer {jwt}

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -262,18 +262,22 @@ function resolveAllModelsByApiName(modelName: string): RelayModel[] {
  * Check if a model is allowed for a given tier.
  * Free tier: models within the free price ceiling (input <= $1.5/M AND
  * output <= $9/M).
- * Max/Ultra tier: all models.
+ * Max tier: any explicit model name.
+ * Ultra tier: all model names and model-less provider endpoints.
  *
  * When multiple llm-zoo entries share the same API model name, a `some()`
  * check is used: access is granted if at least one interpretation falls
- * within the user's tier. Unknown model names are denied for the free tier.
+ * within the user's tier. Unknown model names are denied for the free tier and
+ * allowed for Max, where the relay only needs to distinguish explicit model
+ * requests from model-less provider endpoints.
  */
 export function isModelAllowedForTier(
   tier: string,
   modelName: string | null,
 ): boolean {
-  if (tier === ULTRA_TIER || tier === MAX_TIER) return true;
+  if (tier === ULTRA_TIER) return true;
   if (!modelName) return false;
+  if (tier === MAX_TIER) return true;
 
   const models = resolveAllModelsByApiName(modelName);
   if (models.length === 0) return false;

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -7,8 +7,8 @@
  * flagship (gemini-3.x-pro at $2/$12, gpt-5 at $1.25/$10) can no longer leak into
  * free on input price alone. See MAX_FREE_INPUT_PRICE / MAX_FREE_OUTPUT_PRICE.
  * - free: input <= $1.5/M AND output <= $9/M
- * - Max: free-tier models plus any future Max-only additions
- * - Ultra: everything else
+ * - Max: every model (not bounded by the free-tier price ceiling)
+ * - Ultra: every model
  */
 
 import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
@@ -123,12 +123,8 @@ const RELAY_MODELS: RelayModel[] = Object.values(MODEL_CONFIGS)
 // =============================================================================
 
 const FREE_TIER_MODELS = RELAY_MODELS.filter((m) => m.minTier === 'free');
-const MAX_TIER_MODELS = RELAY_MODELS.filter(
-  (m) => m.minTier === 'free' || m.minTier === 'Max',
-);
 
 const FREE_TIER_SHORT_NAMES = FREE_TIER_MODELS.map((m) => m.shortName);
-const MAX_TIER_SHORT_NAMES = MAX_TIER_MODELS.map((m) => m.shortName);
 
 // All supported providers
 const ALL_PROVIDERS = [
@@ -151,7 +147,7 @@ export const TIER_CONFIG: TierModelConfig = {
   providers: [...ALL_PROVIDERS],
   tiers: {
     free: { models: FREE_TIER_SHORT_NAMES },
-    Max: { models: MAX_TIER_SHORT_NAMES },
+    Max: { models: '*' },
     Ultra: { models: '*' },
   },
 };
@@ -174,8 +170,8 @@ export const TIER_SPENDING_LIMITS: TierSpendingLimits = {
  */
 export const TIER_REQUEST_LIMITS: TierRequestLimits = {
   free: { ratePerMinute: 20, concurrent: 2 },
-  Max: { ratePerMinute: 60, concurrent: 4 },
-  Ultra: { ratePerMinute: 120, concurrent: 8 },
+  Max: { ratePerMinute: 60, concurrent: 8 },
+  Ultra: { ratePerMinute: 120, concurrent: 16 },
 };
 
 // =============================================================================
@@ -264,28 +260,23 @@ function resolveAllModelsByApiName(modelName: string): RelayModel[] {
 
 /**
  * Check if a model is allowed for a given tier.
- * Free/Max tier: models within the free price ceiling (input <= $1.5/M AND
- * output <= $9/M); Max currently has identical access.
- * Ultra tier: all models.
+ * Free tier: models within the free price ceiling (input <= $1.5/M AND
+ * output <= $9/M).
+ * Max/Ultra tier: all models.
  *
  * When multiple llm-zoo entries share the same API model name, a `some()`
  * check is used: access is granted if at least one interpretation falls
- * within the user's tier. Unknown model names are denied for non-Ultra tiers.
+ * within the user's tier. Unknown model names are denied for the free tier.
  */
 export function isModelAllowedForTier(
   tier: string,
   modelName: string | null,
 ): boolean {
-  if (tier === ULTRA_TIER) return true;
+  if (tier === ULTRA_TIER || tier === MAX_TIER) return true;
   if (!modelName) return false;
 
   const models = resolveAllModelsByApiName(modelName);
   if (models.length === 0) return false;
 
-  if (tier === MAX_TIER) {
-    return models.some(
-      (m) => m.minTier === FREE_TIER || m.minTier === MAX_TIER,
-    );
-  }
   return models.some((m) => m.minTier === FREE_TIER);
 }


### PR DESCRIPTION
## Summary

Two relay tier changes, both in `supabase/functions/relay/models.ts`:

1. **Max tier gets all models.** Max was effectively identical to free — capped at the free-tier price ceiling (`input <= $1.5/M AND output <= $9/M`) — because `getTierFromPrice` only ever returns `'free'` or `'Ultra'`, so `MAX_TIER_MODELS` (free + Max) equaled the free set. Max now gets unbounded model access (`'*'`, same as Ultra), no longer bounded by the free price cut.

2. **Higher per-user concurrency caps.** Max `4 → 8`, Ultra `8 → 16`. The concurrency value is passed to the `relay_request_gate` Postgres RPC as a parameter, so no migration is needed.

## Details

- `TIER_CONFIG.tiers.Max` → `{ models: '*' }`
- `isModelAllowedForTier` → Max short-circuits to `true` alongside Ultra; the free-price `some()` check now applies to the free tier only
- Removed the now-dead `MAX_TIER_MODELS` / `MAX_TIER_SHORT_NAMES` derivations
- `TIER_REQUEST_LIMITS` → Max/Ultra `concurrent` bumped; rate limits unchanged
- Header + function doc comments updated

## Unchanged (deliberately)

- **Billing**: Max keeps its own `$50/mo` spending limit (vs Ultra `$300`) — this PR is about *access* and *concurrency*, not cost.
- **Rate limits**: Max `60/min`, Ultra `120/min` left as-is.
- **Client side**: no change needed — `TierService.isModelAvailable` already treats `models === '*'` as full access and reads tier config from the `/tier-config` endpoint.

## Deploy note

This is an edge function. It must be deployed with `--no-verify-jwt` (per `docs/supabase/RELAY_SETUP.md`), otherwise the platform gateway re-enables JWT verification and rejects Google (`x-goog-api-key`) / Anthropic (`x-api-key`) requests with `401` at the gateway. Already deployed to production with the correct flag.

## Test

- No DB migration; the gate RPC reads concurrency from its parameter.
- `npm test` covers relay tier logic (`src/test-kernel/supabase/`). Deno type-check not run locally (Deno not installed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands which upstream models Max users can hit under the same $50/mo cap and doubles concurrent relay load for Max/Ultra, affecting cost and abuse surface on the edge relay.
> 
> **Overview**
> **Max tier relay access** is no longer tied to the free-tier price ceiling. `/tier-config` now exposes `Max: { models: '*' }` (same wildcard as Ultra), and `isModelAllowedForTier` treats Max like full access for any explicit model name while still rejecting model-less requests (Ultra still allows those). The old `MAX_TIER_*` model list derivations are removed.
> 
> **Fairness gates** raise Max concurrent relay slots **4 → 8** and Ultra **8 → 16**; per-minute rate limits are unchanged. Monthly spend caps ($50 Max / $300 Ultra) are untouched.
> 
> Docs in the auth tier modules and relay entrypoint are aligned with the new hierarchy. **Vitest** in `RelayModelAccess.vitest.ts` locks in Max/Ultra `*` config, Max unknown-model allow, and free-tier price bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 202b5f1b6a86ba9c2993ad7adf85b23b458548be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->