### PR TITLE
[codex] fix(cli): prevent select hotkeys after escape input

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -148,6 +148,8 @@ const SHOW_LONG_CHILD_OUTPUT = process.env.HARNESS_LONG_CHILD_OUTPUT === '1';
 const SHOW_WIDE_FIRST_CHILD_LINE =
   process.env.HARNESS_WIDE_FIRST_CHILD_LINE === '1';
 const SHOW_ORCHESTRATION = process.env.HARNESS_ORCHESTRATION === '1';
+const SHOW_ORCHESTRATION_STATUS_LINES =
+  process.env.HARNESS_ORCHESTRATION_STATUS_LINES !== '0';
 const SHOW_DELEGATED_ORCHESTRATION_HISTORY =
   process.env.HARNESS_DELEGATED_ORCHESTRATION_HISTORY === '1';
 const SHOW_NO_RUNNABLE_ORCHESTRATION_MODELS =
@@ -424,7 +426,11 @@ if (SHOW_ORCHESTRATION) {
           : []
       }
       apiMode={HARNESS_API_MODE}
-      statusLines={harnessOrchestrationStatusLines()}
+      statusLines={
+        SHOW_ORCHESTRATION_STATUS_LINES
+          ? harnessOrchestrationStatusLines()
+          : undefined
+      }
       allowDefaultModelLaunch={false}
       onResolve={() => undefined}
     />,

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -431,6 +431,25 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'orchestrate-model-pick-esc-back-reselect',
+    env: {
+      HARNESS_ORCHESTRATION: '1',
+      HARNESS_API_MODE: 'personal',
+      HARNESS_ORCHESTRATION_STATUS_LINES: '0',
+    },
+    bootExpect: 'Choose how to start this CLI session.',
+    keys: ['\r', ESC, '\r'],
+    exitKeys: [ESC, ESC],
+    expectExit: true,
+    expect: [
+      'Model · personal API keys',
+      'Model for the first message.',
+      'DeepSeek V4 Flash — api: api key set',
+      'Esc back',
+    ],
+    unexpect: ['Choose how to start this CLI session.', 'Esc exit'],
+  },
+  {
     name: 'orchestrate-no-runnable-models',
     env: {
       HARNESS_ORCHESTRATION: '1',

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -203,21 +203,21 @@ export function selectIndexForHotkeyInput(input: string): number | undefined {
   return first == null ? undefined : selectIndexForHotkey(first);
 }
 
-export function isRawSelectCsiInput(input: string): boolean {
-  return input.startsWith('\u001B[');
+export function isRawSelectNavigationInput(input: string): boolean {
+  return input.startsWith('\u001B[') || input.startsWith('\u001BO');
 }
 
 export function isRawSelectEscChordInput(input: string): boolean {
   return (
     input.startsWith('\u001B') &&
     input.length === 2 &&
-    !isRawSelectCsiInput(input)
+    !isRawSelectNavigationInput(input)
   );
 }
 
 export function rawSelectArrowDirection(input: string): -1 | 1 | undefined {
-  if (input === '\u001B[A') return -1;
-  if (input === '\u001B[B') return 1;
+  if (input === '\u001B[A' || input === '\u001BOA') return -1;
+  if (input === '\u001B[B' || input === '\u001BOB') return 1;
   return undefined;
 }
 
@@ -253,7 +253,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
 
   useInput((input, key) => {
     if (cancelledRef.current) return;
-    const rawCsiInput = isRawSelectCsiInput(input);
+    const rawNavigationInput = isRawSelectNavigationInput(input);
     const rawArrowDirection = rawSelectArrowDirection(input);
     if (key.upArrow || rawArrowDirection === -1) {
       setHighlight((h) =>
@@ -277,10 +277,10 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
     }
     // A fast Esc followed by another key can arrive as an Alt/meta chord or
     // as raw ESC + one printable key. Select forms have no meta shortcuts, so
-    // treat that as cancel-and-drop without swallowing raw CSI navigation.
+    // treat that as cancel-and-drop without swallowing raw terminal navigation.
     if (
       isEscapeInput(input, key) ||
-      (key.meta && !rawCsiInput) ||
+      (key.meta && !rawNavigationInput) ||
       isRawSelectEscChordInput(input)
     ) {
       cancelledRef.current = true;
@@ -293,7 +293,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       return;
     }
     if (!key.ctrl && input.length > 2) {
-      if (rawCsiInput) return;
+      if (rawNavigationInput) return;
       cancelledRef.current = true;
       props.onCancel();
       return;

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -203,6 +203,24 @@ export function selectIndexForHotkeyInput(input: string): number | undefined {
   return first == null ? undefined : selectIndexForHotkey(first);
 }
 
+export function isRawSelectCsiInput(input: string): boolean {
+  return input.startsWith('\u001B[');
+}
+
+export function isRawSelectEscChordInput(input: string): boolean {
+  return (
+    input.startsWith('\u001B') &&
+    input.length === 2 &&
+    !isRawSelectCsiInput(input)
+  );
+}
+
+export function rawSelectArrowDirection(input: string): -1 | 1 | undefined {
+  if (input === '\u001B[A') return -1;
+  if (input === '\u001B[B') return 1;
+  return undefined;
+}
+
 export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   const initial = selectInitialHighlightIndex({
     activeValue: props.activeValue,
@@ -235,16 +253,9 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
 
   useInput((input, key) => {
     if (cancelledRef.current) return;
-    const rawEscChord = input.startsWith('\u001B') && input.length === 2;
-    // A fast Esc followed by another key can arrive as an Alt/meta chord or
-    // as raw ESC + one printable key. Select forms have no meta shortcuts, so
-    // treat that as cancel-and-drop without swallowing raw CSI navigation.
-    if (isEscapeInput(input, key) || key.meta || rawEscChord) {
-      cancelledRef.current = true;
-      props.onCancel();
-      return;
-    }
-    if (key.upArrow) {
+    const rawCsiInput = isRawSelectCsiInput(input);
+    const rawArrowDirection = rawSelectArrowDirection(input);
+    if (key.upArrow || rawArrowDirection === -1) {
       setHighlight((h) =>
         nextSelectHighlightIndex({
           direction: -1,
@@ -254,7 +265,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       );
       return;
     }
-    if (key.downArrow) {
+    if (key.downArrow || rawArrowDirection === 1) {
       setHighlight((h) =>
         nextSelectHighlightIndex({
           direction: 1,
@@ -264,12 +275,25 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       );
       return;
     }
+    // A fast Esc followed by another key can arrive as an Alt/meta chord or
+    // as raw ESC + one printable key. Select forms have no meta shortcuts, so
+    // treat that as cancel-and-drop without swallowing raw CSI navigation.
+    if (
+      isEscapeInput(input, key) ||
+      (key.meta && !rawCsiInput) ||
+      isRawSelectEscChordInput(input)
+    ) {
+      cancelledRef.current = true;
+      props.onCancel();
+      return;
+    }
     if (isPlainReturnInput(input, key)) {
       const choice = props.items[highlight];
       if (choice && !choice.disabled) props.onSelect(choice.value);
       return;
     }
     if (!key.ctrl && input.length > 2) {
+      if (rawCsiInput) return;
       cancelledRef.current = true;
       props.onCancel();
       return;

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -9,7 +9,7 @@
 // `1`-`9` for the first nine rows, then `a`-`z` for rows 10-35.
 
 import { Box, Text, useInput } from 'ink';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { clamp, clampIndex } from '@utils/core';
 
@@ -193,9 +193,12 @@ export function selectIndexForHotkey(input: string): number | undefined {
 
 /**
  * Ink can deliver rapid key presses as one input chunk. Menus should still
- * honor the first shortcut instead of silently dropping the whole chunk.
+ * honor the first shortcut from a tiny burst instead of silently dropping it.
+ * Longer chunks are likely pasted text or a slash command racing a closing
+ * form, so treating their first letter as a row shortcut is surprising.
  */
 export function selectIndexForHotkeyInput(input: string): number | undefined {
+  if (input.length > 2) return undefined;
   const first = input.at(0);
   return first == null ? undefined : selectIndexForHotkey(first);
 }
@@ -207,6 +210,9 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
     items: props.items,
   });
   const [highlight, setHighlight] = useState(initial);
+  // Select cancel handlers close their foreground form, so the component
+  // unmounts after this flips. Future persistent Select users should reset it.
+  const cancelledRef = useRef(false);
 
   useEffect(() => {
     setHighlight((h) => clampIndex(h, props.items.length));
@@ -228,7 +234,13 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   });
 
   useInput((input, key) => {
-    if (isEscapeInput(input, key)) {
+    if (cancelledRef.current) return;
+    const rawEscChord = input.startsWith('\u001B') && input.length === 2;
+    // A fast Esc followed by another key can arrive as an Alt/meta chord or
+    // as raw ESC + one printable key. Select forms have no meta shortcuts, so
+    // treat that as cancel-and-drop without swallowing raw CSI navigation.
+    if (isEscapeInput(input, key) || key.meta || rawEscChord) {
+      cancelledRef.current = true;
       props.onCancel();
       return;
     }
@@ -257,11 +269,15 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       if (choice && !choice.disabled) props.onSelect(choice.value);
       return;
     }
-    // Single-key jumps (1-9, then a-z) for direct selection. Ignore modified
-    // chords: Ctrl+C exits the app (the App's unified handler owns it now that
-    // we render with exitOnCtrlC: false, so Ink no longer mutes it), and
-    // Ctrl/Alt+<letter> were never meant as row hotkeys.
-    if (!key.ctrl && !key.meta) {
+    if (!key.ctrl && input.length > 2) {
+      cancelledRef.current = true;
+      props.onCancel();
+      return;
+    }
+    // Single-key jumps (1-9, then a-z) for direct selection. Ignore Ctrl
+    // chords: Ctrl+C exits the app through App's unified handler, and other
+    // Ctrl+<letter> chords were never meant as row hotkeys.
+    if (!key.ctrl) {
       const idx = selectIndexForHotkeyInput(input);
       if (idx != null && idx < props.items.length) {
         const choice = props.items[idx];

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -150,6 +150,7 @@ export function OrchestrationApp(
         </Text>
         <Box marginTop={1}>
           <Select
+            key="orchestration-model-picker"
             items={modelItems}
             maxVisibleItems={maxVisibleItems}
             showOverflow={modelItems.length > maxVisibleItems}
@@ -181,6 +182,7 @@ export function OrchestrationApp(
       ) : null}
       <Box marginTop={1}>
         <Select
+          key="orchestration-launcher"
           items={items}
           maxVisibleItems={maxVisibleItems}
           showOverflow={items.length > maxVisibleItems}

--- a/src/test-kernel/cli/SelectHotkeys.vitest.mts
+++ b/src/test-kernel/cli/SelectHotkeys.vitest.mts
@@ -38,7 +38,14 @@ describe('Select hotkeys', () => {
   it('uses the first shortcut from buffered terminal input', () => {
     expect(selectIndexForHotkeyInput('21')).toBe(1);
     expect(selectIndexForHotkeyInput('A1')).toBe(9);
+    expect(selectIndexForHotkeyInput('m\r')).toBe(21);
     expect(selectIndexForHotkeyInput('0a')).toBeUndefined();
     expect(selectIndexForHotkeyInput('')).toBeUndefined();
+  });
+
+  it('does not treat command-like buffered text as a row hotkey', () => {
+    expect(selectIndexForHotkeyInput('model')).toBeUndefined();
+    expect(selectIndexForHotkeyInput('/model')).toBeUndefined();
+    expect(selectIndexForHotkeyInput('\u001Bm')).toBeUndefined();
   });
 });

--- a/src/test-kernel/cli/SelectHotkeys.vitest.mts
+++ b/src/test-kernel/cli/SelectHotkeys.vitest.mts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  isRawSelectCsiInput,
+  isRawSelectEscChordInput,
+  rawSelectArrowDirection,
   selectHotkeyForIndex,
   selectIndexForHotkey,
   selectIndexForHotkeyInput,
@@ -47,5 +50,18 @@ describe('Select hotkeys', () => {
     expect(selectIndexForHotkeyInput('model')).toBeUndefined();
     expect(selectIndexForHotkeyInput('/model')).toBeUndefined();
     expect(selectIndexForHotkeyInput('\u001Bm')).toBeUndefined();
+  });
+
+  it('separates raw escape chords from CSI navigation prefixes', () => {
+    expect(isRawSelectEscChordInput('\u001Bm')).toBe(true);
+    expect(isRawSelectEscChordInput('\u001B[')).toBe(false);
+    expect(isRawSelectCsiInput('\u001B[')).toBe(true);
+    expect(isRawSelectCsiInput('\u001B[A')).toBe(true);
+  });
+
+  it('recognizes raw CSI arrow inputs when Ink misses key flags', () => {
+    expect(rawSelectArrowDirection('\u001B[A')).toBe(-1);
+    expect(rawSelectArrowDirection('\u001B[B')).toBe(1);
+    expect(rawSelectArrowDirection('\u001B[6~')).toBeUndefined();
   });
 });

--- a/src/test-kernel/cli/SelectHotkeys.vitest.mts
+++ b/src/test-kernel/cli/SelectHotkeys.vitest.mts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  isRawSelectCsiInput,
   isRawSelectEscChordInput,
+  isRawSelectNavigationInput,
   rawSelectArrowDirection,
   selectHotkeyForIndex,
   selectIndexForHotkey,
@@ -52,16 +52,21 @@ describe('Select hotkeys', () => {
     expect(selectIndexForHotkeyInput('\u001Bm')).toBeUndefined();
   });
 
-  it('separates raw escape chords from CSI navigation prefixes', () => {
+  it('separates raw escape chords from terminal navigation prefixes', () => {
     expect(isRawSelectEscChordInput('\u001Bm')).toBe(true);
     expect(isRawSelectEscChordInput('\u001B[')).toBe(false);
-    expect(isRawSelectCsiInput('\u001B[')).toBe(true);
-    expect(isRawSelectCsiInput('\u001B[A')).toBe(true);
+    expect(isRawSelectEscChordInput('\u001BO')).toBe(false);
+    expect(isRawSelectNavigationInput('\u001B[')).toBe(true);
+    expect(isRawSelectNavigationInput('\u001B[A')).toBe(true);
+    expect(isRawSelectNavigationInput('\u001BO')).toBe(true);
+    expect(isRawSelectNavigationInput('\u001BOA')).toBe(true);
   });
 
-  it('recognizes raw CSI arrow inputs when Ink misses key flags', () => {
+  it('recognizes raw arrow inputs when Ink misses key flags', () => {
     expect(rawSelectArrowDirection('\u001B[A')).toBe(-1);
     expect(rawSelectArrowDirection('\u001B[B')).toBe(1);
+    expect(rawSelectArrowDirection('\u001BOA')).toBe(-1);
+    expect(rawSelectArrowDirection('\u001BOB')).toBe(1);
     expect(rawSelectArrowDirection('\u001B[6~')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- cancel shared CLI select forms when Esc arrives as a meta chord
- stop treating command-like buffered text such as /model or model as row hotkeys
- add focused Select hotkey coverage for command-like buffered chunks

Closes #6560.

## Validation
- corepack pnpm vitest run src/test-kernel/cli/SelectHotkeys.vitest.mts
- node packages/cli/scripts/validate-tui.mjs --snapshot-dir /tmp/texra-tui-select-fix-20260623d agent-form model-form-buffered-hotkey slash-palette-esc-retypes-command slash-palette-csi-escape-ignored model-form-selectable-submit
- npm run texra-local:build
- disposable node-pty repro for fast Esc plus slash input: no unwanted Root agent set message
- git diff --check
- node_modules/.bin/tsc --noEmit -p tsconfig.test-kernel.json
- corepack pnpm --filter @texra-ai/cli typecheck
- npm run lint (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI keyboard handling in Select and orchestration pickers; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **CLI `Select` menus** (model/agent pickers, orchestration launcher) mishandling **fast Esc plus follow-up keys** and **buffered terminal input** that looked like row hotkeys.
> 
> **`Select` input behavior** now treats **Esc, Alt/meta chords, and raw `ESC` + one printable character** as **cancel** (with a guard so duplicate events after cancel are ignored), handles **raw arrow sequences** when Ink does not set arrow flags, and **only maps 1–2 character bursts** to row shortcuts—**longer chunks** like `model`, `/model`, or paste-like input **cancel the form** instead of jumping rows or selecting accidentally.
> 
> **Orchestration TUI** gives each step’s **`Select` a stable `key`** so backing out of the model picker remounts cleanly, and the **TUI harness** can omit orchestration status lines via **`HARNESS_ORCHESTRATION_STATUS_LINES`**. A new **`validate-tui`** scenario covers **Enter → Esc → Enter** on the personal API model pick flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd45c1e120cddea7f25f1dbc0316ce4f3a4c2f5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->