### PR TITLE
Refactor DiffManager to use typed message parameters

### DIFF
--- a/packages/extension/src/webview/managers/DiffManager.ts
+++ b/packages/extension/src/webview/managers/DiffManager.ts
@@ -1,93 +1,51 @@
 import * as vscode from 'vscode';
 
 import { fetchRecentCommits } from '@frontend/git/recentCommits';
-import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import { mainViewMessages } from '@shared/schemas';
+import type {
+  LatexdiffMessage,
+  LatexdiffvcMessage,
+  LatexdiffvcOperationMessage,
+  RequestRecentCommitsMessage,
+} from '@shared/schemas';
 
 import { BaseWebviewManager } from './BaseWebviewManager';
 
-const CHANNEL = 'DiffManager';
-logger.initialize(CHANNEL);
-
 export class DiffManager extends BaseWebviewManager {
-  protected readonly channel = CHANNEL;
+  protected readonly channel = 'DiffManager';
 
-  handleLatexdiff(message: unknown): void {
-    const data = this.parseMessage(
-      mainViewMessages.LatexdiffMessageSchema,
-      message,
-      'latexdiff',
-    );
-    if (!data) return;
+  handleLatexdiff(message: LatexdiffMessage): void {
     void vscode.commands.executeCommand(
-      `texra.${data.command}`,
-      data.inputFile,
-      data.baseFile,
-      data.editedFile,
+      `texra.${message.command}`,
+      message.inputFile,
+      message.baseFile,
+      message.editedFile,
     );
   }
 
-  handleLatexdiffvc(message: unknown): void {
-    const data = this.parseMessage(
-      mainViewMessages.LatexdiffvcMessageSchema,
-      message,
-      'latexdiffvc',
-    );
-    if (!data) return;
+  handleLatexdiffvc(message: LatexdiffvcMessage): void {
     void vscode.commands.executeCommand(
-      `texra.${data.command}`,
-      data.inputFile,
-      data.baseFile,
-      data.commitHash,
+      `texra.${message.command}`,
+      message.inputFile,
+      message.baseFile,
+      message.commitHash,
     );
   }
 
-  handleLatexdiffvcOperation(message: unknown): void {
-    const data = this.parseMessage(
-      mainViewMessages.LatexdiffvcOperationMessageSchema,
-      message,
-      'latexdiffvc operation',
-    );
-    if (!data) return;
+  handleLatexdiffvcOperation(message: LatexdiffvcOperationMessage): void {
     void vscode.commands.executeCommand(
-      `texra.${data.command}`,
-      data.inputFile,
-      data.baseFile,
-      data.commitHash,
-      data.clean,
+      `texra.${message.command}`,
+      message.inputFile,
+      message.baseFile,
+      message.commitHash,
+      message.clean,
     );
   }
 
-  /** Parse message with schema, logging warning on failure */
-  private parseMessage<T>(
-    schema: {
-      safeParse: (
-        data: unknown,
-      ) => { success: true; data: T } | { success: false; error: unknown };
-    },
-    message: unknown,
-    context: string,
-  ): T | null {
-    const result = schema.safeParse(message);
-    if (!result.success) {
-      logger.warn(CHANNEL, `Invalid ${context} message`, {
-        data: result.error,
-      });
-      return null;
-    }
-    return result.data;
-  }
-
-  async handleRequestRecentCommits(message: unknown): Promise<void> {
-    const data = this.parseMessage(
-      mainViewMessages.RequestRecentCommitsMessageSchema,
-      message,
-      'request recent commits',
-    );
-    if (!data) return;
-
-    await this.postRecentCommits(data.notifyWhenEmpty ?? undefined);
+  async handleRequestRecentCommits(
+    message: RequestRecentCommitsMessage,
+  ): Promise<void> {
+    await this.postRecentCommits(message.notifyWhenEmpty ?? undefined);
   }
 
   async handleRefreshCommits(): Promise<void> {

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -214,8 +214,9 @@ const BannerMessages = [
 ] as const;
 
 // ============================================================
-// Git diff message schemas (shared by the inbound union and the
-// extension's DiffManager, which parses each individually).
+// Git diff message schemas. Part of the inbound union, so
+// dispatchMainViewInbound validates and narrows them at the
+// dispatch boundary before DiffManager's typed handlers run.
 // ============================================================
 
 export const RequestRecentCommitsMessageSchema = z.object({


### PR DESCRIPTION
## Summary

Refactored `DiffManager` to accept strongly-typed message parameters instead of `unknown` types with runtime schema validation. Message validation is now performed at the call site (in the base class or message router), allowing handlers to work directly with validated types.

This change removes:
- Runtime schema parsing logic from individual handlers
- Logger initialization and channel management from the manager
- Redundant `parseMessage` helper method

## Issue acceptance gates

N/A — This is a refactoring to improve type safety and reduce duplication.

## Single source of truth

Message validation responsibility moves from `DiffManager` handlers to the message routing layer (caller), which is the appropriate boundary for IPC message validation.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated the `parseMessage` helper method that was duplicating schema validation logic
- Removed logger initialization boilerplate (`CHANNEL` constant, `logger.initialize()`)
- Simplified handler signatures by removing redundant null-checks after validation

**Abstraction improvement:**
- Handlers now declare their expected message types explicitly via TypeScript parameters
- Type safety is enforced at compile time rather than relying on runtime validation within handlers
- Cleaner separation of concerns: validation happens at the boundary, handlers focus on command execution

## Host impact

**Extension:** Message handlers in `DiffManager` now receive pre-validated typed messages. No behavioral change; validation still occurs but at the call site.

**Desktop:** N/A

**CLI:** N/A

## Scheduled refactoring

None — This pattern should be applied to other webview managers for consistency.

## Validation

- Type checking: All handler signatures now match their message types from `@shared/schemas`
- No runtime behavior change: validation logic is preserved, just relocated to the caller
- Existing tests should pass without modification (handlers still execute the same commands)

https://claude.ai/code/session_01FukxKKG4owUo5TtRvsNv6A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: command execution paths are unchanged; invalid messages should still be rejected at dispatch before handlers run.
> 
> **Overview**
> **`DiffManager`** no longer validates IPC payloads itself: latexdiff / latexdiff-vc handlers accept **`LatexdiffMessage`**, **`LatexdiffvcMessage`**, **`LatexdiffvcOperationMessage`**, and **`RequestRecentCommitsMessage`** and forward fields straight to `texra.*` commands. The private **`parseMessage`** helper, per-handler **`safeParse`** / null guards, and dedicated logger setup were removed.
> 
> Inbound schema comments in **`inbound.ts`** now state that git-diff messages are validated and narrowed at the **`dispatchMainViewInbound`** boundary (as wired from **`MainViewMessageHandler`**) before these handlers run—same behavior, validation moved upstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192c2e9c8640d4099753fdc45ccea3ed5d4fd9e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->