### PR TITLE
[codex] fix CLI diagnostic model listing

### DIFF
--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -13,6 +13,7 @@ import {
   resolveCliModelAccessEntry,
   type CliModelListOptions,
 } from '../runtime/modelAccess';
+import { knownCliModelIds } from '../runtime/cliConfig';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
@@ -25,7 +26,10 @@ import type { CliContext } from '../runtime/cliContext';
 
 type ModelAccessList = Awaited<ReturnType<typeof getCliModelAccessList>>;
 
-async function loadModelAccessList(context: CliContext): Promise<
+async function loadModelAccessList(
+  context: CliContext,
+  options: CliModelListOptions = {},
+): Promise<
   | { models: ModelAccessList; apiMode: CliContext['apiMode'] }
   | {
       error: string;
@@ -35,7 +39,11 @@ async function loadModelAccessList(context: CliContext): Promise<
     return await suppressCliFetchStackLogs(async () => {
       await initCliPlatform({ ...context, quietLogs: true });
       const apiMode = effectiveCliApiMode(context);
-      const models = await getCliModelAccessList({ apiMode });
+      const models = await getCliModelAccessList({
+        apiMode,
+        models:
+          options.includeUnavailable === true ? knownCliModelIds() : undefined,
+      });
       return { models, apiMode };
     });
   } catch (error) {
@@ -47,7 +55,7 @@ async function listModels(
   context: CliContext,
   options: CliModelListOptions = {},
 ): Promise<number> {
-  const result = await loadModelAccessList(context);
+  const result = await loadModelAccessList(context, options);
   if ('error' in result) {
     writeTextStderr(result.error);
     return CliExitCode.ModelOrNetworkError;

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -42,6 +42,10 @@ export function isKnownCliModel(model: string): boolean {
   return MODEL_CONFIGS[model] != null;
 }
 
+export function knownCliModelIds(): string[] {
+  return Object.keys(MODEL_CONFIGS);
+}
+
 function normalizeCliModelLookupKey(value: string): string {
   return value
     .trim()

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -62,6 +62,7 @@ const CLI_MODEL_FALLBACK_MODE_BY_SOURCE = {
 
 export interface CliModelAccessListOptions {
   readonly apiMode?: CliApiMode;
+  readonly models?: readonly string[];
 }
 
 export interface CliModelListOptions {
@@ -365,7 +366,7 @@ async function includedAccessRequiresLogin(
 export async function getCliModelAccessList(
   options: CliModelAccessListOptions = {},
 ): Promise<CliModelAccess[]> {
-  const models = await computeModelOptionsData();
+  const models = await computeModelOptionsData(options.models);
   const access = models.map((model) =>
     toCliModelAccess(model, options.apiMode),
   );

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -1060,6 +1060,37 @@ describe('CLI model access resolution', () => {
     ]);
   });
 
+  it('loads explicit model ids for diagnostic lists', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('hiddenFixtureModel', {
+        availability: 'not-included',
+        availabilityLabel: 'Not included',
+        disabled: true,
+        requiresKey: false,
+      }),
+    ]);
+
+    await expect(
+      getCliModelAccessList({
+        apiMode: 'included',
+        models: ['hiddenFixtureModel'],
+      }),
+    ).resolves.toMatchObject([
+      {
+        available: false,
+        status: 'not included',
+        model: {
+          value: 'hiddenFixtureModel',
+          availability: 'not-included',
+          availabilityLabel: 'Not included',
+        },
+      },
+    ]);
+    expect(computeModelOptionsDataMock).toHaveBeenCalledWith([
+      'hiddenFixtureModel',
+    ]);
+  });
+
   it('uses the loaded access list as the availability source of truth', async () => {
     computeModelOptionsDataMock.mockResolvedValueOnce([
       modelOption('sonnet46T', {


### PR DESCRIPTION
## Summary
- make `texra models list --all` load the full known model registry instead of only the visible default list
- keep normal `texra models list` limited to currently runnable visible models
- add focused coverage for explicit diagnostic model access loading

## Root Cause
Dogfooding `texra-local models show glm5.2` showed GLM-5.2 as a known hidden model, but `texra models list --all` still omitted it because the list path only loaded visible models.

## Validation
- `npm run texra-local:build`
- `texra-local models list --api-mode included --all --output-format text --no-color | rg -i "glm|5\.2" -C 2`
- `texra-local models show glm5.2 --api-mode included --output-format text --no-color`
- `texra-local run correct --cwd /private/tmp/texra-cli-workflow-sample --input main.tex --output corrected.tex --model gemini35f --api-mode included --output-format json --no-color --no-input --instruction "Only fix grammar/typos; do not change mathematical meaning."`
- `npm test -- --run src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/RunModel.vitest.mts src/test-kernel/cli/ModelsRecord.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `npm run typecheck`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CLI model listing/diagnostics; default list and run paths are unchanged aside from the new optional `models` parameter on access-list loading.
> 
> **Overview**
> **`texra models list --all`** now loads **every id in `MODEL_CONFIGS`** (via new `knownCliModelIds()`), so hidden or unavailable models such as GLM-5.2 appear with their access status instead of being dropped because only the default visible list was fetched.
> 
> The change threads an optional **`models`** argument through **`getCliModelAccessList`** into **`computeModelOptionsData`**. Default **`models list`** (without `--all`) is unchanged: it still uses the usual visible model set. **`models show`** is also unchanged and does not pass the full registry.
> 
> A unit test asserts that explicit model ids are passed through for diagnostic listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c19563a205fe27dc54a6d59a3228933240f0b16e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->