### PR TITLE
[codex] fix canonical agent picker labels

### DIFF
--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -620,9 +620,8 @@ export class MainApp extends MainAppBase {
     if (options.some((opt) => opt.value === currentValue)) {
       return currentValue;
     }
-    // Match by name: handles source changes and plain-name defaults. Option
-    // values are "source:name" keys; labels may be display names, so match
-    // the value-derived name as well as the label.
+    // Match by name: handles source changes, plain-name defaults, and remote
+    // rows whose value still carries legacy decorated storage names.
     const name = agentName(currentValue);
     const byName = options.find(
       (opt) => agentName(opt.value) === name || opt.label === name,

--- a/src/agent/index/agentOptionsBuilder.ts
+++ b/src/agent/index/agentOptionsBuilder.ts
@@ -7,23 +7,82 @@ import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { byName } from '@utils/core';
 import type { AgentEntry } from './agentEntry';
 
+const DECORATED_AGENT_NAME_SEPARATOR = /\s+(?:—|---|--)\s+/;
+const TITLE_CASE_AGENT_NAME = /^[A-Z][A-Za-z0-9]*(?:\s+[A-Z][A-Za-z0-9]*)*$/;
+
 export interface AgentOptionsDataPayload {
   workflow: AgentOptionData[];
   toolUse: AgentOptionData[];
 }
 
-/** Convert AgentEntry to typed option data. */
-export function entryToOptionData(entry: AgentEntry): AgentOptionData {
+function canonicalAgentOptionLabel(name: string): string {
+  const trimmed = name.trim();
+  const [head, suffix] = trimmed.split(DECORATED_AGENT_NAME_SEPARATOR, 2);
+  if (suffix === undefined) return trimmed;
+
+  const base = head?.trim() || trimmed;
+  if (!TITLE_CASE_AGENT_NAME.test(base)) return base;
+
+  const words = base.split(/\s+/);
+  return words
+    .map((word, index) =>
+      index === 0 ? word.charAt(0).toLowerCase() + word.slice(1) : word,
+    )
+    .join('');
+}
+
+function optionLabelForEntry(entry: AgentEntry): string {
+  return entry.source === 'remote'
+    ? canonicalAgentOptionLabel(entry.name)
+    : entry.name;
+}
+
+function uniqueAgentOptionLabels(labels: readonly string[]): string[] {
+  const totals = new Map<string, number>();
+  for (const label of labels) {
+    totals.set(label, (totals.get(label) ?? 0) + 1);
+  }
+
+  const reserved = new Set(
+    labels.filter((label) => (totals.get(label) ?? 0) === 1),
+  );
+  const seen = new Map<string, number>();
+  return labels.map((label) => {
+    if ((totals.get(label) ?? 0) < 2) return label;
+    // Do not restore decorated remote names here: duplicate canonical labels
+    // get numbered so a bare id cannot silently bind to one of them.
+    let next = (seen.get(label) ?? 0) + 1;
+    let unique = `${label}${next}`;
+    while (reserved.has(unique)) {
+      next += 1;
+      unique = `${label}${next}`;
+    }
+    seen.set(label, next);
+    reserved.add(unique);
+    return unique;
+  });
+}
+
+function entryToOptionData(entry: AgentEntry, label: string): AgentOptionData {
   const key = createKey(entry.source, entry.name);
   return {
     value: key,
-    label: entry.name,
+    label,
     isToolUse: entry.category === AgentCategory.ToolUse,
     isOrchestrator: hasDelegationTool(entry.tools),
     isRemote: entry.source === 'remote',
     isCustom: entry.source === 'custom',
     description: entry.description,
   };
+}
+
+export function entriesToOptionData(
+  entries: readonly AgentEntry[],
+): AgentOptionData[] {
+  const labels = uniqueAgentOptionLabels(entries.map(optionLabelForEntry));
+  return entries.map((entry, index) =>
+    entryToOptionData(entry, labels[index] ?? optionLabelForEntry(entry)),
+  );
 }
 
 /** Sort entries: preferred agents first (in priority order), then alphabetically. */

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -21,7 +21,7 @@ import {
 import { scanDirectory } from './agentYamlScanner';
 import { loadRemoteAgents, persistRemoteAgentMeta } from './remoteAgentMeta';
 import {
-  entryToOptionData,
+  entriesToOptionData,
   sortAgentEntries,
   type AgentOptionsDataPayload,
 } from './agentOptionsBuilder';
@@ -477,12 +477,11 @@ export async function computeAgentOptionsData(): Promise<AgentOptionsDataPayload
   }
 
   return {
-    workflow: sortAgentEntries(getVisibleAgents('workflow'), [
-      DEFAULT_WORKFLOW_AGENT,
-    ]).map(entryToOptionData),
-    toolUse: sortAgentEntries(
-      getVisibleAgents('toolUse'),
-      PREFERRED_TOOL_USE_AGENTS,
-    ).map(entryToOptionData),
+    workflow: entriesToOptionData(
+      sortAgentEntries(getVisibleAgents('workflow'), [DEFAULT_WORKFLOW_AGENT]),
+    ),
+    toolUse: entriesToOptionData(
+      sortAgentEntries(getVisibleAgents('toolUse'), PREFERRED_TOOL_USE_AGENTS),
+    ),
   };
 }

--- a/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
+++ b/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { entriesToOptionData } from '@agent/index/agentOptionsBuilder';
+import type { AgentEntry } from '@agent/index/agentEntry';
+
+describe('agent option labels', () => {
+  function remoteToolUseAgent(name: string, description?: string): AgentEntry {
+    return {
+      name,
+      source: 'remote',
+      path: '',
+      category: AgentCategory.ToolUse,
+      description,
+      tools: [],
+    };
+  }
+
+  it('uses canonical agent ids instead of decorated remote names', () => {
+    const options = entriesToOptionData([
+      remoteToolUseAgent('Review — verify math & consistency'),
+      remoteToolUseAgent('Engineer --- software team lead'),
+      remoteToolUseAgent('Lean Orchestrator — coordinates'),
+    ]);
+
+    expect(options.map((option) => option.label)).toEqual([
+      'review',
+      'engineer',
+      'leanOrchestrator',
+    ]);
+  });
+
+  it('does not rewrite plain title-case remote names', () => {
+    const [option] = entriesToOptionData([remoteToolUseAgent('Code Reviewer')]);
+
+    expect(option?.label).toBe('Code Reviewer');
+  });
+
+  it('keeps resolution values stable while canonicalizing labels', () => {
+    const [option] = entriesToOptionData([
+      remoteToolUseAgent(
+        'Review — verify math & consistency',
+        'Verifies mathematical correctness.',
+      ),
+    ]);
+
+    expect(option?.value).toBe('remote:Review — verify math & consistency');
+    expect(option?.label).toBe('review');
+    expect(option?.description).toBe('Verifies mathematical correctness.');
+  });
+
+  it('keeps duplicate canonical labels unique without showing decorated names', () => {
+    const options = entriesToOptionData([
+      remoteToolUseAgent('Review — verify math'),
+      remoteToolUseAgent('Review — verify consistency'),
+    ]);
+
+    expect(options.map((option) => option.label)).toEqual([
+      'review1',
+      'review2',
+    ]);
+    expect(options.map((option) => option.value)).toEqual([
+      'remote:Review — verify math',
+      'remote:Review — verify consistency',
+    ]);
+  });
+
+  it('does not collide with existing labels when numbering duplicates', () => {
+    const options = entriesToOptionData([
+      remoteToolUseAgent('Review — verify math'),
+      remoteToolUseAgent('Review — verify consistency'),
+      remoteToolUseAgent('review1'),
+    ]);
+
+    expect(options.map((option) => option.label)).toEqual([
+      'review2',
+      'review3',
+      'review1',
+    ]);
+  });
+
+  it('leaves custom agent labels exactly as authored', () => {
+    const [option] = entriesToOptionData([
+      {
+        name: 'My Paper Helper',
+        source: 'custom',
+        path: '/agents/My Paper Helper.yaml',
+        category: AgentCategory.ToolUse,
+        tools: [],
+      },
+    ]);
+
+    expect(option?.value).toBe('custom:My Paper Helper');
+    expect(option?.label).toBe('My Paper Helper');
+  });
+});

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -30,20 +30,25 @@ describe('CLI AgentListForm row budget', () => {
     ).toBe('lean');
   });
 
-  it('resolves current agents by value name when rows use display labels', () => {
-    const displayAgents = [
-      { value: 'builtInToolUse:setup', label: 'Setup assistant' },
-      { value: 'remote:orchestrator', label: 'Orchestrator' },
+  it('resolves current agents by canonical labels when values are decorated', () => {
+    const decoratedAgents = [
+      { value: 'remote:Review — verify math & consistency', label: 'review' },
+      {
+        value: 'remote:Lean Orchestrator — coordinates',
+        label: 'leanOrchestrator',
+      },
     ];
 
-    const setupAgent = currentVisibleAgent(displayAgents, 'setup');
+    const reviewAgent = currentVisibleAgent(decoratedAgents, 'review');
 
-    expect(setupAgent?.label).toBe('Setup assistant');
-    expect(setupAgent?.value).toBe('builtInToolUse:setup');
+    expect(reviewAgent?.label).toBe('review');
+    expect(reviewAgent?.value).toBe(
+      'remote:Review — verify math & consistency',
+    );
     expect(
-      currentVisibleAgent(displayAgents, 'remote:orchestrator')?.label,
-    ).toBe('Orchestrator');
-    expect(hiddenCurrentAgentHint(displayAgents, 'setup')).toBeUndefined();
+      currentVisibleAgent(decoratedAgents, 'leanOrchestrator')?.label,
+    ).toBe('leanOrchestrator');
+    expect(hiddenCurrentAgentHint(decoratedAgents, 'review')).toBeUndefined();
   });
 
   it('labels the current agent when it is hidden from the picker', () => {


### PR DESCRIPTION
## Summary
- canonicalize agent option labels before rendering picker rows
- strip decorated remote names such as `Review — verify math & consistency` down to canonical ids like `review`
- keep source-qualified option values unchanged so agent resolution still uses the original registry identity

## Why
The extension launcher could surface agent rows as display-name-style strings when upstream metadata included descriptive names. That made the agent list noisy and let descriptions leak into the primary selection label.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/agent/AgentOptionsBuilder.vitest.ts src/test-kernel/cli/AgentListForm.vitest.mts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label changes with stable option values and new unit coverage; no auth or execution-path changes.
> 
> **Overview**
> **Remote agent rows** in workflow/tool-use pickers now show **canonical ids** (e.g. `review`, `leanOrchestrator`) instead of long decorated names like `Review — verify math & consistency`, while **option values** stay `source:originalRegistryName` so resolution is unchanged.
> 
> `agentOptionsBuilder` gains **`entriesToOptionData`**: for **remote** entries it strips text after em/en dashes, camelCases title-case heads, and **suffixes duplicates** (`review1`, `review2`) without re-showing decorated names; **custom** labels are unchanged. `computeAgentOptionsData` routes sorted visible agents through this helper instead of one-off `entryToOptionData` mapping.
> 
> **Selection matching** is documented/aligned for persisted plain names and legacy decorated **values** via label/name fallback (`MainApp.validateAgentSelection`, CLI `currentVisibleAgent` tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e0af425d422041a6591a99cf886cfa66033afbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->