### PR TITLE
[codex] fix CLI default Physics roster startup

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -19,7 +19,6 @@ import {
   StreamSnapshotStore,
 } from '@transcript';
 import { platform, tryPlatform } from '@platform/platform';
-import { seedRosterFromDefaultTeam } from '@controllers/onboarding/defaultTeamSeeding';
 import { getFirstRunDone } from '@controllers/onboarding/onboardingFunnel';
 import { loadAgents } from '@agent/index';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
@@ -29,6 +28,7 @@ import { type CliToolUseResumeResolution } from '@cli/runtime/sessionResume';
 import { effectiveCliApiMode } from '@cli/runtime/apiAccessMode';
 import { firstRunSetupAgentOverride } from '@cli/onboarding/setupContinuation';
 import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
+import { seedCliRosterFromDefaultTeam } from '@cli/runtime/defaultTeamRoster';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import { initCliPlatform } from '@cli/runtime/initPlatform';
 import {
@@ -272,14 +272,7 @@ export async function runChat(
     pinnedAgent: explicitAgent ?? context.envAgent,
   });
   await loadAgents();
-  await seedRosterFromDefaultTeam({
-    globalState: platform().globalState,
-    workspaceState: platform().workspaceState,
-  }).catch((error: unknown) => {
-    writeTextStderr(
-      `Note: couldn't seed the agent roster from your default team (${toErrorMessage(error)}). Pick agents in Settings or re-run the setup agent.`,
-    );
-  });
+  await seedCliRosterFromDefaultTeam();
   const defaults = await resolveChatDefaults({
     cwd: context.cwd,
     agentOverride: explicitAgent ?? setupAgentOverride,

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -13,6 +13,7 @@ import {
   type CliAgentListOptions,
 } from '../runtime/agents';
 import { CliExitCode } from '../runtime/exitCodes';
+import { seedCliRosterFromDefaultTeam } from '../runtime/defaultTeamRoster';
 import { initLocalCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 
@@ -27,6 +28,9 @@ export async function listAgents(
   options: CliAgentListOptions = {},
 ): Promise<number> {
   await initLocalCliPlatform(context);
+  if (options.includeHidden !== true) {
+    await seedCliRosterFromDefaultTeam();
+  }
   const result = await loadCliAgentList(options);
 
   if (!context.quietLogs) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,9 +1,6 @@
-import { seedRosterFromDefaultTeam } from '@controllers/onboarding/defaultTeamSeeding';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
-import { platform } from '@platform/platform';
 import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { toErrorMessage } from '@common/errors/errorMessage';
 
 import { CLI_BUILTIN_DEFAULT_MODEL } from '../runtime/cliConfig';
 import {
@@ -11,6 +8,7 @@ import {
   implicitDefaultToolUseAgents,
 } from '../runtime/defaultAgents';
 import { CliExitCode } from '../runtime/exitCodes';
+import { seedCliRosterFromDefaultTeam } from '../runtime/defaultTeamRoster';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
 import { effectiveCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
@@ -155,14 +153,7 @@ async function runInit(
   // a seeding failure must not fail `texra init`, but say so on stderr
   // (the extension counterpart logs a warning) so a missing roster is
   // explainable when troubleshooting.
-  await seedRosterFromDefaultTeam({
-    globalState: platform().globalState,
-    workspaceState: platform().workspaceState,
-  }).catch((error: unknown) => {
-    writeTextStderr(
-      `Note: couldn't seed the agent roster from your default team (${toErrorMessage(error)}). Pick agents in Settings or re-run the setup agent.`,
-    );
-  });
+  await seedCliRosterFromDefaultTeam();
 
   if (gitignore) {
     const outcome = await ensureTexraGitignored(context.cwd);

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -1,20 +1,17 @@
 import { defineCommand, showUsage } from 'citty';
 
 import { platform } from '@platform/platform';
-import {
-  DEFAULT_STARTUP_TEAM_ID,
-  seedRosterFromDefaultTeam,
-} from '@controllers/onboarding/defaultTeamSeeding';
+import { DEFAULT_STARTUP_TEAM_ID } from '@controllers/onboarding/defaultTeamSeeding';
 import {
   getDefaultTeamId,
   getFirstRunDone,
 } from '@controllers/onboarding/onboardingFunnel';
 import { getVisibleAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { toErrorMessage } from '@common/errors/errorMessage';
 
 import { firstRunSetupAgentOverride } from '../onboarding/setupContinuation';
 import { CliExitCode } from '../runtime/exitCodes';
+import { seedCliRosterFromDefaultTeam } from '../runtime/defaultTeamRoster';
 import { listCliHistoryEntries } from '../runtime/history';
 import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
@@ -138,14 +135,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
     ? defaultTeamId
     : DEFAULT_STARTUP_TEAM_ID;
   const presetPlanSet = await loadCliMultiAgentPresetPlanSet(presets);
-  await seedRosterFromDefaultTeam({
-    globalState: platform().globalState,
-    workspaceState: platform().workspaceState,
-  }).catch((error: unknown) => {
-    writeTextStderr(
-      `Note: couldn't seed the agent roster from your default team (${toErrorMessage(error)}). Pick agents in Settings or re-run the setup agent.`,
-    );
-  });
+  await seedCliRosterFromDefaultTeam();
   const items = buildCliOrchestrationItems({
     presetPlans: presetPlanSet.plans,
     history,

--- a/packages/cli/src/runtime/defaultTeamRoster.ts
+++ b/packages/cli/src/runtime/defaultTeamRoster.ts
@@ -1,0 +1,21 @@
+import { platform } from '@platform/platform';
+import { seedRosterFromDefaultTeam } from '@controllers/onboarding/defaultTeamSeeding';
+import { loadAgents } from '@agent/index';
+import { toErrorMessage } from '@common/errors/errorMessage';
+
+import { writeTextStderr } from './logSinks';
+
+export async function seedCliRosterFromDefaultTeam(): Promise<boolean> {
+  try {
+    await loadAgents({ includeRemote: false });
+    return await seedRosterFromDefaultTeam({
+      globalState: platform().globalState,
+      workspaceState: platform().workspaceState,
+    });
+  } catch (error: unknown) {
+    writeTextStderr(
+      `Note: couldn't seed the agent roster from your default team (${toErrorMessage(error)}). Pick agents in Settings or re-run the setup agent.`,
+    );
+    return false;
+  }
+}

--- a/src/agent/index/agentOptionsBuilder.ts
+++ b/src/agent/index/agentOptionsBuilder.ts
@@ -7,67 +7,16 @@ import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { byName } from '@utils/core';
 import type { AgentEntry } from './agentEntry';
 
-const DECORATED_AGENT_NAME_SEPARATOR = /\s+(?:—|---|--)\s+/;
-const TITLE_CASE_AGENT_NAME = /^[A-Z][A-Za-z0-9]*(?:\s+[A-Z][A-Za-z0-9]*)*$/;
-
 export interface AgentOptionsDataPayload {
   workflow: AgentOptionData[];
   toolUse: AgentOptionData[];
 }
 
-function canonicalAgentOptionLabel(name: string): string {
-  const trimmed = name.trim();
-  const [head, suffix] = trimmed.split(DECORATED_AGENT_NAME_SEPARATOR, 2);
-  if (suffix === undefined) return trimmed;
-
-  const base = head?.trim() || trimmed;
-  if (!TITLE_CASE_AGENT_NAME.test(base)) return base;
-
-  const words = base.split(/\s+/);
-  return words
-    .map((word, index) =>
-      index === 0 ? word.charAt(0).toLowerCase() + word.slice(1) : word,
-    )
-    .join('');
-}
-
-function optionLabelForEntry(entry: AgentEntry): string {
-  return entry.source === 'remote'
-    ? canonicalAgentOptionLabel(entry.name)
-    : entry.name;
-}
-
-function uniqueAgentOptionLabels(labels: readonly string[]): string[] {
-  const totals = new Map<string, number>();
-  for (const label of labels) {
-    totals.set(label, (totals.get(label) ?? 0) + 1);
-  }
-
-  const reserved = new Set(
-    labels.filter((label) => (totals.get(label) ?? 0) === 1),
-  );
-  const seen = new Map<string, number>();
-  return labels.map((label) => {
-    if ((totals.get(label) ?? 0) < 2) return label;
-    // Do not restore decorated remote names here: duplicate canonical labels
-    // get numbered so a bare id cannot silently bind to one of them.
-    let next = (seen.get(label) ?? 0) + 1;
-    let unique = `${label}${next}`;
-    while (reserved.has(unique)) {
-      next += 1;
-      unique = `${label}${next}`;
-    }
-    seen.set(label, next);
-    reserved.add(unique);
-    return unique;
-  });
-}
-
-function entryToOptionData(entry: AgentEntry, label: string): AgentOptionData {
+function entryToOptionData(entry: AgentEntry): AgentOptionData {
   const key = createKey(entry.source, entry.name);
   return {
     value: key,
-    label,
+    label: entry.name,
     isToolUse: entry.category === AgentCategory.ToolUse,
     isOrchestrator: hasDelegationTool(entry.tools),
     isRemote: entry.source === 'remote',
@@ -79,10 +28,7 @@ function entryToOptionData(entry: AgentEntry, label: string): AgentOptionData {
 export function entriesToOptionData(
   entries: readonly AgentEntry[],
 ): AgentOptionData[] {
-  const labels = uniqueAgentOptionLabels(entries.map(optionLabelForEntry));
-  return entries.map((entry, index) =>
-    entryToOptionData(entry, labels[index] ?? optionLabelForEntry(entry)),
-  );
+  return entries.map(entryToOptionData);
 }
 
 /** Sort entries: preferred agents first (in priority order), then alphabetically. */

--- a/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
+++ b/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
@@ -5,10 +5,14 @@ import { entriesToOptionData } from '@agent/index/agentOptionsBuilder';
 import type { AgentEntry } from '@agent/index/agentEntry';
 
 describe('agent option labels', () => {
-  function remoteToolUseAgent(name: string, description?: string): AgentEntry {
+  function toolUseAgent(
+    name: string,
+    source: AgentEntry['source'] = 'remote',
+    description?: string,
+  ): AgentEntry {
     return {
       name,
-      source: 'remote',
+      source,
       path: '',
       category: AgentCategory.ToolUse,
       description,
@@ -16,66 +20,37 @@ describe('agent option labels', () => {
     };
   }
 
-  it('uses canonical agent ids instead of decorated remote names', () => {
-    const options = entriesToOptionData([
-      remoteToolUseAgent('Review — verify math & consistency'),
-      remoteToolUseAgent('Engineer --- software team lead'),
-      remoteToolUseAgent('Lean Orchestrator — coordinates'),
-    ]);
+  it('uses authored agent names for option labels', () => {
+    const options = entriesToOptionData([toolUseAgent('review')]);
 
-    expect(options.map((option) => option.label)).toEqual([
-      'review',
-      'engineer',
-      'leanOrchestrator',
-    ]);
+    expect(options.map((option) => option.label)).toEqual(['review']);
   });
 
-  it('does not rewrite plain title-case remote names', () => {
-    const [option] = entriesToOptionData([remoteToolUseAgent('Code Reviewer')]);
+  it('keeps title-case names exactly as authored', () => {
+    const [option] = entriesToOptionData([toolUseAgent('Code Reviewer')]);
 
     expect(option?.label).toBe('Code Reviewer');
   });
 
-  it('keeps resolution values stable while canonicalizing labels', () => {
+  it('uses the same authored name for resolution values and labels', () => {
     const [option] = entriesToOptionData([
-      remoteToolUseAgent(
-        'Review — verify math & consistency',
-        'Verifies mathematical correctness.',
-      ),
+      toolUseAgent('review', 'remote', 'Verifies mathematical correctness.'),
     ]);
 
-    expect(option?.value).toBe('remote:Review — verify math & consistency');
+    expect(option?.value).toBe('remote:review');
     expect(option?.label).toBe('review');
     expect(option?.description).toBe('Verifies mathematical correctness.');
   });
 
-  it('keeps duplicate canonical labels unique without showing decorated names', () => {
+  it('does not invent labels to distinguish different authored names', () => {
     const options = entriesToOptionData([
-      remoteToolUseAgent('Review — verify math'),
-      remoteToolUseAgent('Review — verify consistency'),
+      toolUseAgent('review'),
+      toolUseAgent('reviewer'),
     ]);
 
     expect(options.map((option) => option.label)).toEqual([
-      'review1',
-      'review2',
-    ]);
-    expect(options.map((option) => option.value)).toEqual([
-      'remote:Review — verify math',
-      'remote:Review — verify consistency',
-    ]);
-  });
-
-  it('does not collide with existing labels when numbering duplicates', () => {
-    const options = entriesToOptionData([
-      remoteToolUseAgent('Review — verify math'),
-      remoteToolUseAgent('Review — verify consistency'),
-      remoteToolUseAgent('review1'),
-    ]);
-
-    expect(options.map((option) => option.label)).toEqual([
-      'review2',
-      'review3',
-      'review1',
+      'review',
+      'reviewer',
     ]);
   });
 

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -30,25 +30,20 @@ describe('CLI AgentListForm row budget', () => {
     ).toBe('lean');
   });
 
-  it('resolves current agents by canonical labels when values are decorated', () => {
-    const decoratedAgents = [
-      { value: 'remote:Review — verify math & consistency', label: 'review' },
-      {
-        value: 'remote:Lean Orchestrator — coordinates',
-        label: 'leanOrchestrator',
-      },
+  it('resolves current agents by canonical labels and values', () => {
+    const canonicalAgents = [
+      { value: 'remote:review', label: 'review' },
+      { value: 'remote:leanOrchestrator', label: 'leanOrchestrator' },
     ];
 
-    const reviewAgent = currentVisibleAgent(decoratedAgents, 'review');
+    const reviewAgent = currentVisibleAgent(canonicalAgents, 'review');
 
     expect(reviewAgent?.label).toBe('review');
-    expect(reviewAgent?.value).toBe(
-      'remote:Review — verify math & consistency',
-    );
+    expect(reviewAgent?.value).toBe('remote:review');
     expect(
-      currentVisibleAgent(decoratedAgents, 'leanOrchestrator')?.label,
+      currentVisibleAgent(canonicalAgents, 'leanOrchestrator')?.label,
     ).toBe('leanOrchestrator');
-    expect(hiddenCurrentAgentHint(decoratedAgents, 'review')).toBeUndefined();
+    expect(hiddenCurrentAgentHint(canonicalAgents, 'review')).toBeUndefined();
   });
 
   it('labels the current agent when it is hidden from the picker', () => {

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   initLocalCliPlatform: vi.fn(),
   loadAgents: vi.fn(),
   resolveCliAgent: vi.fn(),
+  seedCliRosterFromDefaultTeam: vi.fn(),
   writeTextStderr: vi.fn(),
 }));
 
@@ -23,6 +24,10 @@ vi.mock('@agent/index', () => ({
 
 vi.mock('@cli/runtime/initPlatform', () => ({
   initLocalCliPlatform: mocks.initLocalCliPlatform,
+}));
+
+vi.mock('@cli/runtime/defaultTeamRoster', () => ({
+  seedCliRosterFromDefaultTeam: mocks.seedCliRosterFromDefaultTeam,
 }));
 
 vi.mock('@cli/runtime/logSinks', () => ({
@@ -108,6 +113,7 @@ describe('CLI agents command', () => {
     const exitCode = await listAgents(cliContext());
 
     expect(exitCode).toBe(0);
+    expect(mocks.seedCliRosterFromDefaultTeam).toHaveBeenCalledTimes(1);
     expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
     expect(mocks.emitCliResult).toHaveBeenCalledWith(
       expect.anything(),
@@ -314,6 +320,7 @@ describe('CLI agents command', () => {
     const exitCode = await listAgents(cliContext(), { includeHidden: true });
 
     expect(exitCode).toBe(0);
+    expect(mocks.seedCliRosterFromDefaultTeam).not.toHaveBeenCalled();
     expect(mocks.loadAgents).toHaveBeenCalledWith(undefined);
     expect(mocks.getVisibleAgents).not.toHaveBeenCalled();
     expect(mocks.writeTextStderr).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- seed the CLI workspace roster from the default team before visible `texra agents list` output
- centralize CLI default-team seeding/error handling in one runtime helper used by chat/init/orchestrate/agents
- remove the decorated remote-agent label parser and tests; option labels now use the authored agent name directly

## Evidence
- fresh workspace before this change exposed the full visible catalog from `texra-local agents list --quiet`; after this change it shows the Physicist local roster: `polish`, `correct`, `review`, `research`, `presenter`, `numerics`, `latexFixer`
- `texra-local agents list --quiet --all` still shows the full catalog (44 rows in dogfood)

## Validation
- `corepack pnpm exec vitest run src/test-kernel/agent/AgentOptionsBuilder.vitest.ts src/test-kernel/cli/AgentListForm.vitest.mts src/test-kernel/cli/AgentsCommand.vitest.mts src/test-kernel/cli/InitCommand.vitest.mts src/test-kernel/cli/Orchestration.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with 18 pre-existing import-order warnings outside this change)
- `npm run compile:fast`
- `npm run texra-local:build && npm run texra-local:link`
- clean-workspace dogfood: `texra-local --cwd <tmp> agents list --quiet` => 7 default Physicist rows; `--all` => 44 rows
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir <tmp> orchestrate-launcher compact-orchestrate-launcher`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes workspace roster seeding timing and agent picker display labels; no auth or data-model changes, with failures handled best-effort.
> 
> **Overview**
> Fixes fresh CLI workspaces showing the full visible agent catalog instead of the **default Physicist team roster** by seeding the workspace roster from the user’s default team before commands that rely on visibility.
> 
> Adds **`seedCliRosterFromDefaultTeam`** in `packages/cli/src/runtime/defaultTeamRoster.ts`, which loads local agents, calls `seedRosterFromDefaultTeam`, and prints the same best-effort stderr note on failure. **Chat**, **init**, **orchestrate**, and **`texra agents list`** (default visible list only—not `--all`) now call this helper instead of duplicating inline seeding.
> 
> **Agent dropdown labels** no longer parse or canonicalize decorated remote names (e.g. stripping `—` suffixes or numbering duplicates). `entriesToOptionData` uses each agent’s **authored `entry.name`** for both label and resolution keys, with tests updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06d545c3c05ce440646f1357c7055ab532ec0c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->