### PR TITLE
[codex] fix agent picker default roster labels

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -268,6 +268,9 @@ function parseList(value: string | undefined): string[] {
 const HARNESS_VISIBLE_TOOL_USE_AGENTS = parseList(
   process.env.HARNESS_VISIBLE_TOOL_USE_AGENTS,
 );
+const HARNESS_VISIBLE_WORKFLOW_AGENTS = parseList(
+  process.env.HARNESS_VISIBLE_WORKFLOW_AGENTS,
+);
 
 if (SHOW_PROJECT_SKILL) {
   seedHarnessProjectSkill();
@@ -285,6 +288,12 @@ if (process.env.HARNESS_VISIBLE_TOOL_USE_AGENTS !== undefined) {
   await platform().workspaceState.update(
     WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
     HARNESS_VISIBLE_TOOL_USE_AGENTS,
+  );
+}
+if (process.env.HARNESS_VISIBLE_WORKFLOW_AGENTS !== undefined) {
+  await platform().workspaceState.update(
+    WorkspaceStateKey.ENABLED_AGENTS,
+    HARNESS_VISIBLE_WORKFLOW_AGENTS,
   );
 }
 await loadAgents({ includeRemote: false });

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -87,17 +87,14 @@ const LONG_EXTERNAL_INQUIRY_ANSWER_FOR_TRUNCATION = Array.from(
 ).join(' ');
 const FULL_WIDTH_AGENT_PROPOSAL_BORDER_80 = `╔${'═'.repeat(78)}╗`;
 const ASYNC_FORM_SETTLE_MS = 12000;
-const VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT = [
+const PHYSICIST_LOCAL_TOOL_USE_AGENTS = [
   'research',
   'review',
-  'creator',
-  'latexDiff',
   'latexFixer',
-  'lean',
   'numerics',
   'presenter',
-  'setup',
 ].join('||');
+const PHYSICIST_WORKFLOW_AGENTS = ['correct', 'polish'].join('||');
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
@@ -645,16 +642,25 @@ const SCENARIOS = [
     name: 'slash-palette-esc-retypes-command',
     env: {
       HARNESS_ENTRIES: '4',
-      HARNESS_VISIBLE_TOOL_USE_AGENTS: VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT,
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: PHYSICIST_LOCAL_TOOL_USE_AGENTS,
+      HARNESS_VISIBLE_WORKFLOW_AGENTS: PHYSICIST_WORKFLOW_AGENTS,
     },
     keys: ['/', `${ESC}/agent\r`],
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
-      'Tool-use and delegating agents',
+      'Tool-use agents',
+      'Workflows',
+      'correct',
+      'polish',
       'texra chat --agent <name>',
     ],
-    unexpect: ['//agent', 'Harness received: //agent', '/agent - error'],
+    unexpect: [
+      '//agent',
+      'Harness received: //agent',
+      '/agent - error',
+      'more workflows',
+    ],
   },
   {
     name: 'slash-palette-csi-escape-ignored',
@@ -694,14 +700,20 @@ const SCENARIOS = [
     name: 'agent-form',
     env: {
       HARNESS_ENTRIES: '4',
-      HARNESS_VISIBLE_TOOL_USE_AGENTS: VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT,
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: PHYSICIST_LOCAL_TOOL_USE_AGENTS,
+      HARNESS_VISIBLE_WORKFLOW_AGENTS: PHYSICIST_WORKFLOW_AGENTS,
     },
     keys: ['/agent', '\r'],
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
-      'Tool-use and delegating agents',
-      'creator',
+      'Tool-use agents',
+      'research',
+      'review',
+      'latexFixer',
+      'Workflows',
+      'correct',
+      'polish',
       'Current: chat (hidden from picker)',
       'texra chat --agent <name>',
       'Esc close',
@@ -710,7 +722,11 @@ const SCENARIOS = [
       'Platform not initialized',
       '/agent - error',
       'texra --agent=<name>',
-      'creator —',
+      'creator',
+      'latexDiff',
+      'lean',
+      'setup',
+      'more workflows',
       'tool-use; built-in',
       'delegating; built-in',
       'orchestrator; built-in',
@@ -721,14 +737,20 @@ const SCENARIOS = [
     cols: 80,
     env: {
       HARNESS_ENTRIES: '4',
-      HARNESS_VISIBLE_TOOL_USE_AGENTS: VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT,
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: PHYSICIST_LOCAL_TOOL_USE_AGENTS,
+      HARNESS_VISIBLE_WORKFLOW_AGENTS: PHYSICIST_WORKFLOW_AGENTS,
     },
     keys: ['/agent', '\r'],
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/agent',
-      'Tool-use and delegating agents',
-      'creator',
+      'Tool-use agents',
+      'research',
+      'review',
+      'latexFixer',
+      'Workflows',
+      'correct',
+      'polish',
       'Current: chat (hidden from picker)',
       'texra chat --agent <name>',
       'Esc close',
@@ -737,7 +759,11 @@ const SCENARIOS = [
       'Platform not initialized',
       '/agent - error',
       'texra --agent=<name>',
-      'creator —',
+      'creator',
+      'latexDiff',
+      'lean',
+      'setup',
+      'more workflows',
       'tool-use; built-in',
       'delegating; built-in',
       'orchestrator; built-in',
@@ -973,7 +999,8 @@ const SCENARIOS = [
     cols: 80,
     env: {
       HARNESS_ENTRIES: '4',
-      HARNESS_VISIBLE_TOOL_USE_AGENTS: VISIBLE_TOOL_USE_AGENTS_WITHOUT_CHAT,
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: PHYSICIST_LOCAL_TOOL_USE_AGENTS,
+      HARNESS_VISIBLE_WORKFLOW_AGENTS: PHYSICIST_WORKFLOW_AGENTS,
     },
     keys: ['/agent', '\r'],
     frame: 'tail',
@@ -981,8 +1008,8 @@ const SCENARIOS = [
     expect: [
       '/agent',
       'Current: chat (hidden from picker)',
-      'Tool-use and delegating agents',
-      '+8 more',
+      'Tool-use agents',
+      '+4 more',
       '↑/↓ navigate',
       'Enter close',
       'Esc close',

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -116,7 +116,7 @@ export function agentSelectWindow({
   }
 
   const remainingRows = availableRows - chromeRows - itemCount;
-  if (workflowCount === 0 || remainingRows < 4) {
+  if (workflowCount === 0 || remainingRows < 3) {
     return {
       maxVisibleItems: itemCount,
       showOverflow: false,
@@ -125,7 +125,8 @@ export function agentSelectWindow({
     };
   }
 
-  const workflowRows = remainingRows - 3;
+  // Workflow heading and run hint are the fixed rows for the secondary list.
+  const workflowRows = remainingRows - 2;
   if (workflowCount <= workflowRows) {
     return {
       maxVisibleItems: itemCount,
@@ -257,7 +258,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
         />
       </Box>
       {visibleWorkflowRows.length > 0 || selectWindow.showWorkflowOverflow ? (
-        <Box marginTop={1} flexDirection="column">
+        <Box flexDirection="column">
           <Text bold>Workflows</Text>
           {visibleWorkflowRows.map((workflow) => (
             <Text key={workflow.value} wrap="truncate-end">

--- a/src/agent/index/agentOptionsBuilder.ts
+++ b/src/agent/index/agentOptionsBuilder.ts
@@ -12,11 +12,15 @@ export interface AgentOptionsDataPayload {
   toolUse: AgentOptionData[];
 }
 
+function optionLabel(name: string): string {
+  return name.split(/\s+(?:---|—)\s+/u)[0]?.trim() || name;
+}
+
 function entryToOptionData(entry: AgentEntry): AgentOptionData {
   const key = createKey(entry.source, entry.name);
   return {
     value: key,
-    label: entry.name,
+    label: optionLabel(entry.name),
     isToolUse: entry.category === AgentCategory.ToolUse,
     isOrchestrator: hasDelegationTool(entry.tools),
     isRemote: entry.source === 'remote',

--- a/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
+++ b/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
@@ -42,6 +42,24 @@ describe('agent option labels', () => {
     expect(option?.description).toBe('Verifies mathematical correctness.');
   });
 
+  it('omits legacy display subtitles from option labels', () => {
+    const options = entriesToOptionData([
+      toolUseAgent(
+        'Review — legacy subtitle',
+        'remote',
+        'Verifies mathematical correctness.',
+      ),
+      toolUseAgent('Engineer --- software team lead'),
+    ]);
+
+    expect(options.map((option) => option.label)).toEqual([
+      'Review',
+      'Engineer',
+    ]);
+    expect(options[0]?.value).toBe('remote:Review — legacy subtitle');
+    expect(options[0]?.description).toBe('Verifies mathematical correctness.');
+  });
+
   it('does not invent labels to distinguish different authored names', () => {
     const options = entriesToOptionData([
       toolUseAgent('review'),

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -38,11 +38,11 @@ describe('AgentSettingSchema', () => {
 });
 
 describe('AgentDefinitionSchema', () => {
-  it('rejects displayName metadata', () => {
+  it('rejects unknown top-level metadata', () => {
     expect(() =>
       AgentDefinitionSchema.parse({
         name: 'assistant',
-        displayName: 'Assistant',
+        label: 'Assistant',
       }),
     ).toThrow();
   });

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -103,6 +103,22 @@ describe('CLI AgentListForm row budget', () => {
     });
   });
 
+  it('shows the full default workflow roster in the normal picker budget', () => {
+    expect(
+      agentSelectWindow({
+        availableRows: 18,
+        extraRows: 1,
+        itemCount: 5,
+        workflowCount: 2,
+      }),
+    ).toEqual({
+      maxVisibleItems: 5,
+      showOverflow: false,
+      maxVisibleWorkflows: 2,
+      showWorkflowOverflow: false,
+    });
+  });
+
   it('shows workflows only when the row budget has room for them', () => {
     expect(
       agentSelectWindow({


### PR DESCRIPTION
## Summary
- tighten the `/agent` picker workflow row budget so the normal TUI frame shows the full default Physicist roster
- let the TUI harness seed workflow visibility as well as tool-use visibility
- keep agent option labels to the canonical agent name, omitting legacy `Name — detail` / `Name --- detail` display subtitles while preserving descriptions as metadata

## Evidence
- before: `/agent` harness frames showed broad agents (`creator`, `latexDiff`, `lean`, `setup`) and hid workflows behind `... more workflows`
- after: standard frames show `research`, `review`, `latexFixer`, `numerics`, `presenter`, plus workflows `correct`, `polish`
- agent-definition parsing rejects unknown top-level metadata; no agent `displayName` field is supported

## Validation
- `corepack pnpm exec vitest run src/test-kernel/agent/AgentOptionsBuilder.vitest.ts src/test-kernel/agent/AgentSettingSchema.vitest.ts src/test-kernel/cli/AgentListForm.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-agent-form-roster-check slash-palette-esc-retypes-command agent-form agent-form-80-cols compact-agent-form`
- `npm run typecheck`
- `npm run lint` (passes with 18 pre-existing import-order warnings outside this change)
- `npm run compile:fast`
- `npm run texra-local:build`
- earlier in the same run: `corepack pnpm --filter @texra-ai/cli validate:run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout, test harness env, and display-only label parsing; no auth or runtime execution path changes.
> 
> **Overview**
> Improves the **`/agent`** TUI picker so the default **Physicist** roster fits in normal frames: **workflow row budgeting** uses one fewer reserved row and drops extra spacing before the Workflows block, so workflows like `correct` and `polish` appear instead of `... more workflows`.
> 
> **Harness and validation** gain **`HARNESS_VISIBLE_WORKFLOW_AGENTS`** (wired to `ENABLED_AGENTS`), mirroring tool-use visibility seeding. TUI scenarios now seed a **Physicist** tool-use list plus workflow agents and assert **Tool-use agents** / **Workflows** sections with canonical names (`research`, `review`, `latexFixer`, etc.) instead of a broad default roster.
> 
> **Agent option labels** in `agentOptionsBuilder` strip legacy **`Name — detail`** / **`Name --- detail`** suffixes for display while keeping full names in option **values** and **descriptions** in metadata. Tests cover label stripping, picker row budgets, and unknown top-level agent definition fields (e.g. `label` rejected like former `displayName`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b70ba6492fe5a92bc65863f22c3c9ab695e739d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->