### PR TITLE
[codex] refactor CLI workflow output results

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -124,20 +124,18 @@ export async function runWorkflowAgent(
       const { executionId, result, terminalStatus } = execution;
       let displayResult: CliRunResult;
       try {
-        displayResult = (
-          await resolveWorkflowOutput(
-            init.output,
-            init.outputDir,
-            result,
-            runContext,
-            {
-              expectedOutputFiles: init.outputDir
-                ? expectedOutputFilesForOutputDir(agent, inputFiles)
-                : undefined,
-              terminalStatus,
-            },
-          )
-        ).displayResult;
+        displayResult = await resolveWorkflowOutput(
+          init.output,
+          init.outputDir,
+          result,
+          runContext,
+          {
+            expectedOutputFiles: init.outputDir
+              ? expectedOutputFilesForOutputDir(agent, inputFiles)
+              : undefined,
+            terminalStatus,
+          },
+        );
         await persistWorkflowResultMeta(executionId, displayResult);
       } catch (error) {
         if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -203,10 +203,7 @@ export async function resolveWorkflowOutput(
   result: ExecuteAgentResult,
   context: CliContext,
   options: WorkflowOutputResolutionOptions,
-): Promise<{
-  copiedOutput: string | undefined;
-  displayResult: CliRunResult;
-}> {
+): Promise<CliRunResult> {
   const { terminalStatus } = options;
   if (
     result.category === AgentCategory.Workflow &&
@@ -214,12 +211,9 @@ export async function resolveWorkflowOutput(
     (outputFile || outputDir)
   ) {
     if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-      return {
-        copiedOutput: undefined,
-        displayResult: createCliRunResult(result, terminalStatus, {
-          workingDirectory: context.cwd,
-        }),
-      };
+      return createCliRunResult(result, terminalStatus, {
+        workingDirectory: context.cwd,
+      });
     }
     if (outputDir) {
       throw new Error(
@@ -270,33 +264,26 @@ export async function resolveWorkflowOutput(
       );
     }
 
-    const displayResult = createCliRunResult(result, terminalStatus, {
+    return createCliRunResult(result, terminalStatus, {
       workingDirectory: context.cwd,
       runDirectory,
       copiedOutputs,
     });
-    return { copiedOutput: undefined, displayResult };
   }
 
   if (!outputFile || result.category !== AgentCategory.Workflow) {
-    return {
-      copiedOutput: undefined,
-      displayResult: createCliRunResult(result, terminalStatus, {
-        workingDirectory: context.cwd,
-        runDirectory,
-      }),
-    };
+    return createCliRunResult(result, terminalStatus, {
+      workingDirectory: context.cwd,
+      runDirectory,
+    });
   }
 
   const finalOutput = latestWorkflowOutput(result.outputs);
   if (!finalOutput) {
-    return {
-      copiedOutput: undefined,
-      displayResult: createCliRunResult(result, terminalStatus, {
-        workingDirectory: context.cwd,
-        runDirectory,
-      }),
-    };
+    return createCliRunResult(result, terminalStatus, {
+      workingDirectory: context.cwd,
+      runDirectory,
+    });
   }
 
   const targetPath = joinCwdRelative(outputFile, context.cwd);
@@ -305,12 +292,11 @@ export async function resolveWorkflowOutput(
     await fs.copyFile(finalOutput.absolutePath, targetPath);
   }
 
-  const displayResult = createCliRunResult(result, terminalStatus, {
+  return createCliRunResult(result, terminalStatus, {
     workingDirectory: context.cwd,
     runDirectory,
     copiedOutput: targetPath,
   });
-  return { copiedOutput: targetPath, displayResult };
 }
 
 export function formatWorkflowTextResult(result: CliWorkflowRunResult): string {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -980,27 +980,25 @@ describe('CLI root argument routing', () => {
   });
 
   it('keeps stopped workflows with missing requested outputs interrupted', async () => {
-    await expect(
-      resolveWorkflowOutput(
-        'corrected.tex',
-        undefined,
-        {
-          outcome: RUN_OUTCOME.CANCELLED,
-          category: AgentCategory.Workflow,
-          executionId: 'stopped-without-output',
-          streamId: 'stopped-stream-without-output',
-          outputs: [],
-          compileFailures: [],
-        },
-        cliContext(),
-        { terminalStatus: EXECUTION_STATUS.INTERRUPTED },
-      ),
-    ).resolves.toMatchObject({
-      copiedOutput: undefined,
-      displayResult: {
-        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+    const result = await resolveWorkflowOutput(
+      'corrected.tex',
+      undefined,
+      {
+        outcome: RUN_OUTCOME.CANCELLED,
+        category: AgentCategory.Workflow,
+        executionId: 'stopped-without-output',
+        streamId: 'stopped-stream-without-output',
+        outputs: [],
+        compileFailures: [],
       },
+      cliContext(),
+      { terminalStatus: EXECUTION_STATUS.INTERRUPTED },
+    );
+
+    expect(result).toMatchObject({
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
     });
+    expect(Object.hasOwn(result, 'copiedOutput')).toBe(false);
   });
 
   it('formats model list network failures without raw stack traces', () => {

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -105,7 +105,7 @@ describe('CLI workflow output resolution', () => {
     await writeFile(runA2, 'A2');
     await writeFile(runB, 'B');
 
-    const { displayResult } = await resolveWorkflowOutput(
+    const displayResult = await resolveWorkflowOutput(
       undefined,
       'out',
       workflowResult([
@@ -148,7 +148,7 @@ describe('CLI workflow output resolution', () => {
 
     expect(expectedOutputFiles).toEqual(['stdin.tex']);
 
-    const { displayResult } = await resolveWorkflowOutput(
+    const displayResult = await resolveWorkflowOutput(
       undefined,
       'out',
       workflowResult([
@@ -188,7 +188,7 @@ describe('CLI workflow output resolution', () => {
     await writeFile(runMain, 'main');
     await writeFile(runSeries, 'series');
 
-    const { displayResult } = await resolveWorkflowOutput(
+    const displayResult = await resolveWorkflowOutput(
       undefined,
       'out',
       workflowResult([
@@ -241,7 +241,7 @@ describe('CLI workflow output resolution', () => {
     await writeFile(runRoot, 'root');
     await writeFile(runNested, 'nested');
 
-    const { displayResult } = await resolveWorkflowOutput(
+    const displayResult = await resolveWorkflowOutput(
       undefined,
       'out',
       workflowResult([
@@ -400,7 +400,7 @@ describe('CLI workflow output resolution', () => {
     await writeFile(runA1, 'A1');
     await writeFile(runA2, 'A2');
 
-    const { displayResult } = await resolveWorkflowOutput(
+    const displayResult = await resolveWorkflowOutput(
       'out/a.tex',
       undefined,
       workflowResult([


### PR DESCRIPTION
## Summary
- make `resolveWorkflowOutput()` return the final `CliRunResult` directly instead of wrapping it in `{ copiedOutput, displayResult }`
- keep copied output paths owned by the run result itself (`copiedOutput` / `copiedOutputs`), which was already the only value callers consumed
- update workflow-output tests to assert the simplified result shape

## Why
While dogfooding the workflow-mode CLI path, the headless workflow output resolver had two representations for the same data: a top-level `copiedOutput` wrapper value and the same copied-output metadata inside `displayResult`. The wrapper was unused by production callers and added an extra conditional shape to reason about.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run typecheck`
- `npm run lint` (passes with 18 pre-existing import-order warnings outside this change)
- `npm run compile:fast`
- `npm run texra-local:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CLI refactor with no behavior change beyond API shape; callers and tests only.
> 
> **Overview**
> **`resolveWorkflowOutput()`** now returns a **`CliRunResult`** directly instead of `{ copiedOutput, displayResult }`, removing a duplicate top-level `copiedOutput` that production code never used.
> 
> The workflow **`run`** command assigns that value straight through for persistence and CLI emission. Copied paths stay on the result via **`copiedOutput`** / **`copiedOutputs`** inside **`createCliRunResult`**. Tests were updated to match the flatter shape, including asserting interrupted runs with no outputs do not own a **`copiedOutput`** property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4587167bd231defad1f2d6dc48229a0db7700c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->