### PR TITLE
[codex] remove agent display subtitle aliases

### DIFF
--- a/src/agent/index/agentOptionsBuilder.ts
+++ b/src/agent/index/agentOptionsBuilder.ts
@@ -12,15 +12,11 @@ export interface AgentOptionsDataPayload {
   toolUse: AgentOptionData[];
 }
 
-function optionLabel(name: string): string {
-  return name.split(/\s+(?:---|—)\s+/u)[0]?.trim() || name;
-}
-
 function entryToOptionData(entry: AgentEntry): AgentOptionData {
   const key = createKey(entry.source, entry.name);
   return {
     value: key,
-    label: optionLabel(entry.name),
+    label: entry.name,
     isToolUse: entry.category === AgentCategory.ToolUse,
     isOrchestrator: hasDelegationTool(entry.tools),
     isRemote: entry.source === 'remote',

--- a/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
+++ b/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
@@ -42,24 +42,6 @@ describe('agent option labels', () => {
     expect(option?.description).toBe('Verifies mathematical correctness.');
   });
 
-  it('omits legacy display subtitles from option labels', () => {
-    const options = entriesToOptionData([
-      toolUseAgent(
-        'Review — legacy subtitle',
-        'remote',
-        'Verifies mathematical correctness.',
-      ),
-      toolUseAgent('Engineer --- software team lead'),
-    ]);
-
-    expect(options.map((option) => option.label)).toEqual([
-      'Review',
-      'Engineer',
-    ]);
-    expect(options[0]?.value).toBe('remote:Review — legacy subtitle');
-    expect(options[0]?.description).toBe('Verifies mathematical correctness.');
-  });
-
   it('does not invent labels to distinguish different authored names', () => {
     const options = entriesToOptionData([
       toolUseAgent('review'),


### PR DESCRIPTION
## Summary
- remove agent option label suffix parsing for `---` and em-dash separators
- make launcher option labels use the authored agent name directly
- delete the legacy subtitle compatibility fixture from agent option tests

## Validation
- `corepack pnpm exec vitest run src/test-kernel/agent/AgentOptionsBuilder.vitest.ts`
- `corepack pnpm exec prettier --check src/agent/index/agentOptionsBuilder.ts src/test-kernel/agent/AgentOptionsBuilder.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings outside this change)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label change in agent option building; resolution values and agent keys are unchanged.
> 
> **Overview**
> **Agent launcher dropdown labels** now show the full **authored agent name** instead of a shortened label derived by splitting on `---` or em-dash separators.
> 
> The `optionLabel` helper and its legacy subtitle parsing are removed from `agentOptionsBuilder.ts`; `entryToOptionData` sets `label` to `entry.name` directly. Option `value` keys are unchanged (`source:name`). Tests that asserted stripped labels (e.g. `Review — legacy subtitle` → `Review`) are removed; remaining tests expect labels to match authored names exactly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1609d32152287464deeedb29f3bbfb37738bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->