### PR TITLE
[codex] refactor(agent): keep picker options name-only

### DIFF
--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -13,7 +13,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { keyed } from 'lit/directives/keyed.js';
 
 // Local imports - shared schemas and types
-import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
+import type { ModelOptionData } from '@shared/schemas';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
@@ -113,14 +113,6 @@ export class InstructionPanel extends LitElement {
   private fileDrop = new FileDropController(this, (paths) =>
     postDroppedFiles(paths),
   );
-
-  /** Get the tooltip for an agent dropdown based on the selected agent's description. */
-  private getAgentTooltip(
-    options: AgentOptionData[],
-    selectedValue: string,
-  ): string {
-    return options.find((o) => o.value === selectedValue)?.description ?? '';
-  }
 
   /** Get the tooltip for the model dropdown based on the selected model's hint. */
   private getModelTooltip(
@@ -426,8 +418,6 @@ export class InstructionPanel extends LitElement {
                     class="agent-select"
                     data-session-type=${agent.sessionType}
                     aria-label=${agent.ariaLabel}
-                    title=${this.getAgentTooltip(agent.options, agent.value) ||
-                    nothing}
                     placement="top"
                     placeholder="Agent…"
                     .value=${agent.value}

--- a/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
@@ -18,19 +18,16 @@ const SAMPLE_OPTIONS: FollowupOptionsState = {
     {
       value: 'tooluse-research',
       label: 'tooluse-research',
-      description: 'Interactive research over the workflow outputs',
       isToolUse: true,
     },
     {
       value: 'tooluse-revise',
       label: 'tooluse-revise',
-      description: 'Iteratively revise the revised files',
       isToolUse: true,
     },
     {
       value: 'tooluse-explain',
       label: 'tooluse-explain',
-      description: 'Walk through what changed and why',
       isToolUse: true,
     },
   ],

--- a/src/agent/index/agentOptionsBuilder.ts
+++ b/src/agent/index/agentOptionsBuilder.ts
@@ -21,7 +21,6 @@ function entryToOptionData(entry: AgentEntry): AgentOptionData {
     isOrchestrator: hasDelegationTool(entry.tools),
     isRemote: entry.source === 'remote',
     isCustom: entry.source === 'custom',
-    description: entry.description,
   };
 }
 

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -84,7 +84,6 @@ export const AgentOptionDataSchema = PickerOptionBaseSchema.extend({
   isOrchestrator: z.boolean().optional(),
   isRemote: z.boolean().optional(),
   isCustom: z.boolean().optional(),
-  description: z.string().optional(),
 });
 export type AgentOptionData = z.infer<typeof AgentOptionDataSchema>;
 

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -28,7 +28,6 @@ function buildAgentTooltip(opt: AgentOptionData): string {
     );
   if (opt.isRemote) hints.push(properties.remote.hint);
   if (opt.isCustom) hints.push(properties.custom.hint);
-  if (opt.description) hints.push(opt.description);
   if (opt.isToolUse) hints.push('Can execute tools and code');
 
   return hints.join('\n');
@@ -46,7 +45,6 @@ function renderAgentOption(opt: AgentOptionData): TemplateResult {
       data-tool-use=${opt.isToolUse ? 'true' : nothing}
       data-remote=${opt.isRemote ? 'true' : nothing}
       data-custom=${opt.isCustom ? 'true' : nothing}
-      data-description=${opt.description || nothing}
     >
       ${isOrch
         ? html`<span class="agent-icon">${waIcon('bullseye')} </span>`

--- a/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
+++ b/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
@@ -32,14 +32,14 @@ describe('agent option labels', () => {
     expect(option?.label).toBe('Code Reviewer');
   });
 
-  it('uses the same authored name for resolution values and labels', () => {
+  it('does not carry descriptions into picker options', () => {
     const [option] = entriesToOptionData([
       toolUseAgent('review', 'remote', 'Verifies mathematical correctness.'),
     ]);
 
     expect(option?.value).toBe('remote:review');
     expect(option?.label).toBe('review');
-    expect(option?.description).toBe('Verifies mathematical correctness.');
+    expect(option).not.toHaveProperty('description');
   });
 
   it('does not invent labels to distinguish different authored names', () => {


### PR DESCRIPTION
## Summary
- remove agent descriptions from launcher/picker option data
- stop writing agent descriptions into Web Awesome option metadata or selected-agent titles
- keep agent option labels strictly tied to authored agent names

## Why
The launcher should not synthesize display labels like `Review — verify math & consistency`. Descriptions are still available in catalog/settings metadata, but picker rows now have a lean name-only contract.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/agent/AgentOptionsBuilder.vitest.ts src/test-kernel/cli/AgentListForm.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UI/schema contract change with no auth or execution-path impact; main effect is less descriptive hover text in agent dropdowns.
> 
> **Overview**
> Agent launcher and follow-up pickers now use a **name-only** option contract: **`description` is removed from `AgentOptionData`** (Zod schema, IPC payloads, and `entriesToOptionData`).
> 
> **`renderAgentOptions`** tooltips are built only from flags (orchestrator, remote, custom, tool-use)—not catalog descriptions—and **`data-description`** / the instruction panel’s selected-agent **`title`** tooltip are gone. Labels stay the authored agent **`name`**; descriptions remain elsewhere (catalog/settings), not in picker rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16cb18bb4a4077205199b8f84d9437c589cae44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->