### PR TITLE
[codex] refactor(cli): narrow workflow run results

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -35,10 +35,7 @@ import {
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
 import { executeCliConfig } from '../runtime/runExecution';
-import {
-  terminalStatusExitCode,
-  type CliRunResult,
-} from '../runtime/terminalStatus';
+import { terminalStatusExitCode } from '../runtime/terminalStatus';
 import {
   hasMixedStdinWorkflowInputSpecs,
   withExpandedRunInputs,
@@ -46,6 +43,7 @@ import {
 import {
   assertOutputDirAvailable,
   assertOutputFileAvailable,
+  type CliWorkflowRunResult,
   expectedOutputFilesForOutputDir,
   formatWorkflowTextResult,
   resolveWorkflowOutput,
@@ -118,13 +116,15 @@ export async function runWorkflowAgent(
         enforceCategory: true,
         registerExecution: true,
         markErrorOnThrow: true,
+        expectedCategory: AgentCategory.Workflow,
+        categoryMismatchMessage: `Agent "${init.agent}" resolved to a non workflow run.`,
       });
       if (!execution.ok) return execution.exitCode;
 
       const { executionId, result, terminalStatus } = execution;
-      let displayResult: CliRunResult;
+      let workflowResult: CliWorkflowRunResult;
       try {
-        displayResult = await resolveWorkflowOutput(
+        workflowResult = await resolveWorkflowOutput(
           init.output,
           init.outputDir,
           result,
@@ -136,7 +136,7 @@ export async function runWorkflowAgent(
             terminalStatus,
           },
         );
-        await persistWorkflowResultMeta(executionId, displayResult);
+        await persistWorkflowResultMeta(executionId, workflowResult);
       } catch (error) {
         if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
           writeErrorStderr(error);
@@ -149,12 +149,9 @@ export async function runWorkflowAgent(
       }
 
       emitCliResult(runContext, {
-        json: displayResult,
-        ndjson: { kind: 'result', result: displayResult },
-        text:
-          displayResult.category === AgentCategory.Workflow
-            ? formatWorkflowTextResult(displayResult)
-            : terminalStatus,
+        json: workflowResult,
+        ndjson: { kind: 'result', result: workflowResult },
+        text: formatWorkflowTextResult(workflowResult),
       });
 
       return terminalStatusExitCode(terminalStatus, runContext);
@@ -164,9 +161,8 @@ export async function runWorkflowAgent(
 
 async function persistWorkflowResultMeta(
   executionId: string,
-  result: CliRunResult,
+  result: CliWorkflowRunResult,
 ): Promise<void> {
-  if (result.category !== AgentCategory.Workflow) return;
   try {
     const resultMeta: ResultMeta = {
       outputs: [...result.outputs],

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -83,6 +83,10 @@ export type CliWorkflowRunResult = Extract<
   CliRunResult,
   { category: 'workflow' }
 >;
+type WorkflowAgentResult = Extract<
+  ExecuteAgentResult,
+  { category: 'workflow' }
+>;
 
 export interface WorkflowOutputResolutionOptions {
   readonly expectedOutputFiles?: readonly string[];
@@ -200,16 +204,12 @@ function latestWorkflowOutput(
 export async function resolveWorkflowOutput(
   outputFile: string | undefined,
   outputDir: string | undefined,
-  result: ExecuteAgentResult,
+  result: WorkflowAgentResult,
   context: CliContext,
   options: WorkflowOutputResolutionOptions,
-): Promise<CliRunResult> {
+): Promise<CliWorkflowRunResult> {
   const { terminalStatus } = options;
-  if (
-    result.category === AgentCategory.Workflow &&
-    result.outputs.length === 0 &&
-    (outputFile || outputDir)
-  ) {
+  if (result.outputs.length === 0 && (outputFile || outputDir)) {
     if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
       return createCliRunResult(result, terminalStatus, {
         workingDirectory: context.cwd,
@@ -227,11 +227,8 @@ export async function resolveWorkflowOutput(
     }
   }
 
-  const runDirectory =
-    result.category === AgentCategory.Workflow
-      ? (options.runDirectory ?? getRunDir(result.executionId))
-      : undefined;
-  if (outputDir && result.category === AgentCategory.Workflow) {
+  const runDirectory = options.runDirectory ?? getRunDir(result.executionId);
+  if (outputDir) {
     const targetRoot = joinCwdRelative(outputDir, context.cwd);
     const expectedOutputFiles = options.expectedOutputFiles ?? [];
     const outputsByRelativePath = new Map<string, OutputFileSummary>();
@@ -271,7 +268,7 @@ export async function resolveWorkflowOutput(
     });
   }
 
-  if (!outputFile || result.category !== AgentCategory.Workflow) {
+  if (!outputFile) {
     return createCliRunResult(result, terminalStatus, {
       workingDirectory: context.cwd,
       runDirectory,

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -303,6 +303,24 @@ describe('CLI workflow run command', () => {
     }
   });
 
+  it('enforces workflow results at the shared execution boundary', async () => {
+    const { runWorkflowAgent } = await import('@cli/commands/workflow');
+
+    const exitCode = await runWorkflowAgent(cliContext(), {
+      agent: 'polish',
+      inputFiles: ['paper.tex'],
+      contextFiles: [],
+      instruction: '',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.executeCliConfig.mock.calls[0]?.[2]).toMatchObject({
+      enforceCategory: true,
+      expectedCategory: AgentCategory.Workflow,
+      categoryMismatchMessage: 'Agent "polish" resolved to a non workflow run.',
+    });
+  });
+
   it('keeps the single-output copy target separate from workflow output names', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-workflow-'));
     try {


### PR DESCRIPTION
## Summary
- make `texra run` pass `expectedCategory: workflow` into the shared CLI execution helper
- narrow workflow output resolution to workflow results only
- remove now-dead non-workflow fallback branches from workflow result formatting and metadata persistence

## Why
`texra run` already builds a workflow config and sets `enforceCategory`, but it did not pass the expected category to the shared execution helper. That left downstream workflow-output code accepting broad run results and carrying defensive category branches that should be owned at the execution boundary.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with stronger typing and boundary checks; behavior for valid workflow runs should be unchanged, with mismatches failing earlier at execution.
> 
> **Overview**
> **`texra run`** now passes **`expectedCategory: workflow`** (with a custom mismatch message) into **`executeCliConfig`**, so category enforcement lives in the shared execution helper instead of scattered checks downstream.
> 
> Workflow output handling is typed as **`CliWorkflowRunResult`** / **`WorkflowAgentResult`** only: **`resolveWorkflowOutput`** no longer branches on agent category, **`persistWorkflowResultMeta`** always persists workflow metadata, and CLI text output always goes through **`formatWorkflowTextResult`** (no non-workflow fallback). A test asserts the execution options include the new category guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f2a4939f600028d14a6dc9050944c6d23fe5d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->