### PR TITLE
[codex] refactor(cli): keep init agent choices name-only

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,7 +30,6 @@ import type { CliContext } from '../runtime/cliContext';
 
 interface InitAgentOption {
   readonly name: string;
-  readonly description?: string;
 }
 
 export function defaultInitAgentOptions(
@@ -38,7 +37,6 @@ export function defaultInitAgentOptions(
 ): InitAgentOption[] {
   return implicitDefaultToolUseAgents(agents).map((agent) => ({
     name: agent.name,
-    description: agent.description,
   }));
 }
 

--- a/packages/cli/src/init/runInitWizard.tsx
+++ b/packages/cli/src/init/runInitWizard.tsx
@@ -22,7 +22,6 @@ import type { CliModelAccess } from '../runtime/modelAccess';
 
 export interface InitWizardAgentOption {
   readonly name: string;
-  readonly description?: string;
 }
 
 export interface InitWizardOptions {
@@ -197,7 +196,6 @@ function WizardApp(props: WizardAppProps): React.JSX.Element {
           items={props.options.agents.map((agent) => ({
             value: agent.name,
             label: agent.name,
-            description: agent.description,
           }))}
           onSelect={(agent) => commit({ agent })}
           onCancel={cancel}

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -39,16 +39,14 @@ describe('CLI init command', () => {
   });
 
   it('does not offer simplifier as a default init agent option', () => {
-    const options = defaultInitAgentOptions([
+    const registryAgents: Array<{ name: string; description: string }> = [
       { name: 'chat', description: 'General chat' },
       { name: 'simplifier', description: 'Code simplification' },
       { name: 'review', description: 'Code review' },
-    ]);
+    ];
+    const options = defaultInitAgentOptions(registryAgents);
 
-    expect(options).toEqual([
-      { name: 'chat', description: 'General chat' },
-      { name: 'review', description: 'Code review' },
-    ]);
+    expect(options).toEqual([{ name: 'chat' }, { name: 'review' }]);
   });
 
   it('disables init model rows unavailable in the active API mode', () => {


### PR DESCRIPTION
## Summary
- keep `texra init` agent choices as canonical names only
- remove agent descriptions from the init wizard select rows so selectable agent identities cannot render as `Name — description`
- update the init command test to lock the name-only option shape

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/InitCommand.vitest.mts src/test-kernel/agent/AgentOptionsBuilder.vitest.ts src/test-kernel/cli/AgentListForm.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow init-wizard presentation and type-shape change with no auth, data, or config semantics altered.
> 
> **Overview**
> **`texra init` agent picker now uses canonical agent names only** — optional `description` is removed from `InitAgentOption` / `InitWizardAgentOption`, and `defaultInitAgentOptions` maps registry agents to `{ name }` without carrying descriptions forward.
> 
> The init wizard’s default-agent `Select` rows no longer pass `description`, so choices render as the agent name instead of `Name — description`. Model, approval, output, and gitignore steps are unchanged.
> 
> Tests assert the name-only option shape from `defaultInitAgentOptions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e1b673129a12747546ffe720e080882ebe9bffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->