### PR TITLE
[codex] fix(cli): explain empty visible agent lists

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -46,7 +46,13 @@ export async function listAgents(
     {
       json: result.agents,
       ndjson: result.agents.map((agent) => ({ kind: 'agent', agent })),
-      text: formatCliAgentList(result.agents),
+      text: formatCliAgentList(result.agents, {
+        category: options.category,
+        showEmptyState:
+          options.includeHidden !== true &&
+          !context.quietLogs &&
+          context.outputFormat === 'text',
+      }),
     },
     { paged: true },
   );

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -178,7 +178,21 @@ export async function loadCliAgentList(
   return { agents, hiddenCount };
 }
 
-export function formatCliAgentList(agents: readonly AgentEntry[]): string {
+export function formatCliAgentList(
+  agents: readonly AgentEntry[],
+  options: {
+    readonly category?: AgentCategory;
+    readonly showEmptyState?: boolean;
+  } = {},
+): string {
+  if (agents.length === 0) {
+    if (options.showEmptyState !== true) return '';
+    const { categoryArg, catalog, qualifier } = cliAgentCatalogHint(
+      options.category,
+    );
+    return `No visible ${qualifier}agents are enabled for this workspace. Use \`texra agents list${categoryArg} --all\` to show the ${catalog}.`;
+  }
+
   return agents
     .map(
       (agent) => `${agent.category}\t${agent.name}\t${agent.description ?? ''}`,
@@ -220,11 +234,22 @@ export function formatCliHiddenAgentsNotice(
   category?: AgentCategory,
 ): string | undefined {
   if (hiddenCount <= 0) return undefined;
-  const categoryArg = category ? ` --category ${category}` : '';
-  const catalog = category
-    ? `${category === AgentCategory.ToolUse ? 'tool-use' : category} catalog`
-    : 'full catalog';
+  const { categoryArg, catalog } = cliAgentCatalogHint(category);
   return `Showing visible agents only; ${hiddenCount} hidden agent${hiddenCount === 1 ? '' : 's'} omitted. Use \`texra agents list${categoryArg} --all\` to show the ${catalog}.`;
+}
+
+function cliAgentCatalogHint(category?: AgentCategory): {
+  readonly categoryArg: string;
+  readonly catalog: string;
+  readonly qualifier: string;
+} {
+  const categoryLabel =
+    category === AgentCategory.ToolUse ? 'tool-use' : category;
+  return {
+    categoryArg: category ? ` --category ${category}` : '',
+    catalog: categoryLabel ? `${categoryLabel} catalog` : 'full catalog',
+    qualifier: categoryLabel ? `${categoryLabel} ` : '',
+  };
 }
 
 function collectCliAgents(

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -161,6 +161,68 @@ describe('CLI agents command', () => {
     );
   });
 
+  it('shows a text empty state when no workflow agents are visible', async () => {
+    const hiddenWorkflowAgent = {
+      name: 'correct',
+      source: 'builtInWorkflow',
+      path: '/tmp/resources/agents/correct.yaml',
+      category: AgentCategory.Workflow,
+      description: 'Corrects LaTeX.',
+    };
+    mocks.getAgentsByCategory.mockImplementation((category: AgentCategory) =>
+      category === AgentCategory.Workflow ? [hiddenWorkflowAgent] : [],
+    );
+    const { listAgents } = await import('@cli/commands/agents');
+
+    const exitCode = await listAgents(cliContext(), {
+      category: AgentCategory.Workflow,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.emitCliResult).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        json: [],
+        ndjson: [],
+        text: 'No visible workflow agents are enabled for this workspace. Use `texra agents list --category workflow --all` to show the workflow catalog.',
+      },
+      { paged: true },
+    );
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'Showing visible agents only; 1 hidden agent omitted. Use `texra agents list --category workflow --all` to show the workflow catalog.',
+    );
+  });
+
+  it('keeps quiet empty agent lists byte-empty for shell completion', async () => {
+    const hiddenWorkflowAgent = {
+      name: 'correct',
+      source: 'builtInWorkflow',
+      path: '/tmp/resources/agents/correct.yaml',
+      category: AgentCategory.Workflow,
+      description: 'Corrects LaTeX.',
+    };
+    mocks.getAgentsByCategory.mockImplementation((category: AgentCategory) =>
+      category === AgentCategory.Workflow ? [hiddenWorkflowAgent] : [],
+    );
+    const { listAgents } = await import('@cli/commands/agents');
+
+    const exitCode = await listAgents(cliContext({ quietLogs: true }), {
+      category: AgentCategory.Workflow,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mocks.emitCliResult).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        json: [],
+        ndjson: [],
+        text: '',
+      },
+      { paged: true },
+    );
+    expect(mocks.writeTextStderr).not.toHaveBeenCalled();
+  });
+
   it('suppresses hidden-agent notices in quiet text mode', async () => {
     const visibleAgent = {
       name: 'polish',


### PR DESCRIPTION
## Summary
- add a human text empty state when `texra agents list` has no visible agents in the selected category
- keep JSON/NDJSON payloads unchanged and keep `--quiet` output byte-empty for shell completion
- cover the empty visible workflow case and quiet completion-safe case in CLI tests

## Dogfood evidence
- `texra-local agents list --category workflow` in the current repo showed no rows, only the hidden-agent stderr notice, because this workspace has no visible workflow agents
- after the patch, normal text output says how to inspect the hidden workflow catalog, while `--quiet` still writes 0 bytes to stdout/stderr

## Validation
- `texra-local doctor --output-format json`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-snapshots.eDQmeF` (140 scenarios passed)
- live workflow: `texra-local run polish ... --model gemini35f` on a Gaussian-normalization LaTeX file; completed 2 rounds with no compile failures
- `corepack pnpm exec vitest run src/test-kernel/cli/AgentsCommand.vitest.mts src/test-kernel/cli/Completion.vitest.mts`
- `npm run texra-local:build`
- `npm run lint` (0 errors, existing import-order warnings)
- `npm run typecheck`
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation and messaging only; no changes to agent loading, auth, or structured output contracts beyond optional text.
> 
> **Overview**
> When **`texra agents list`** returns no visible agents, **text** output now prints a short message that nothing is enabled in the workspace and points users at **`--all`** (with the right **`--category`** when filtered) to see the full catalog. **JSON/NDJSON** payloads stay empty arrays; **`--quiet`** still emits **no stdout/stderr text** so shell completion stays byte-empty.
> 
> Category-specific wording for empty lists and the existing hidden-agent stderr notice is centralized in **`cliAgentCatalogHint`**. Tests cover the workflow empty-visible case and quiet completion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3172713e2eae44c444eba9286625ef4c8e631960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->