### PR TITLE
[codex] fix(agent): simplify picker labels

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -62,9 +62,7 @@ export function currentVisibleAgent(
     return (
       agent.value === current ||
       valueName === current ||
-      valueName === currentName ||
-      agent.label === current ||
-      agent.label === currentName
+      valueName === currentName
     );
   });
 }

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -21,19 +21,20 @@ import {
   computeModelOptionsData,
 } from '@model/computeModelOptions';
 import { ApprovalRequestHandler } from '@progressView/managers/ApprovalRequestHandler';
-import type {
-  AgentProposalPermission,
-  BashPermission,
-  ExternalInquiryPermission,
-  PlanApprovalPermission,
-  ProgressViewOutboundMessage,
-  ProgressViewPlacement,
-  RetryPermission,
-  StreamTabId,
-  ToolEditPermission,
-  UserQuestionPermission,
+import {
+  AgentCategory,
+  type AgentProposalPermission,
+  type BashPermission,
+  type ExternalInquiryPermission,
+  type PlanApprovalPermission,
+  type ProgressViewOutboundMessage,
+  type ProgressViewPlacement,
+  type RetryPermission,
+  type StreamTabId,
+  type ToolEditPermission,
+  type UserQuestionPermission,
 } from '@shared/schemas';
-import { AgentCategory } from '@shared/schemas';
+import { agentName } from '@shared/schemas/agent';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
@@ -323,8 +324,8 @@ export class ProgressViewProvider
     const loadAgentOptions = async () => {
       const all = await computeAgentOptionsData();
       const raw = isWorkflow ? all.workflow : all.toolUse;
-      // proposal.agent is a plain name (not source/name), so use label as value.
-      return raw.map((opt) => ({ ...opt, value: opt.label }));
+      // proposal.agent is a plain name, so keep identity separate from label.
+      return raw.map((opt) => ({ ...opt, value: agentName(opt.value) }));
     };
     const [modelOptions, agentOptions] = await Promise.all([
       computeModelOptionsData().catch(() =>

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -623,9 +623,7 @@ export class MainApp extends MainAppBase {
     // Match by name: handles source changes, plain-name defaults, and remote
     // rows whose value still carries legacy decorated storage names.
     const name = agentName(currentValue);
-    const byName = options.find(
-      (opt) => agentName(opt.value) === name || opt.label === name,
-    );
+    const byName = options.find((opt) => agentName(opt.value) === name);
     if (byName) return byName.value;
     for (const preferred of preferredFallback) {
       const match = options.find((opt) => agentName(opt.value) === preferred);

--- a/src/agent/index/agentOptionsBuilder.ts
+++ b/src/agent/index/agentOptionsBuilder.ts
@@ -12,11 +12,19 @@ export interface AgentOptionsDataPayload {
   toolUse: AgentOptionData[];
 }
 
+const DETAIL_SEPARATOR = /\s+(?:[\u2013\u2014]|-{2,})\s+/u;
+
+function pickerLabel(name: string): string {
+  const detailStart = name.search(DETAIL_SEPARATOR);
+  if (detailStart === -1) return name;
+  return name.slice(0, detailStart).trim() || name;
+}
+
 function entryToOptionData(entry: AgentEntry): AgentOptionData {
   const key = createKey(entry.source, entry.name);
   return {
     value: key,
-    label: entry.name,
+    label: pickerLabel(entry.name),
     isToolUse: entry.category === AgentCategory.ToolUse,
     isOrchestrator: hasDelegationTool(entry.tools),
     isRemote: entry.source === 'remote',

--- a/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
+++ b/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
@@ -32,6 +32,31 @@ describe('agent option labels', () => {
     expect(option?.label).toBe('Code Reviewer');
   });
 
+  it('removes descriptive dash suffixes from picker labels', () => {
+    const [option] = entriesToOptionData([
+      toolUseAgent('Review \u2014 verify math & consistency'),
+    ]);
+
+    expect(option?.value).toBe(
+      'remote:Review \u2014 verify math & consistency',
+    );
+    expect(option?.label).toBe('Review');
+  });
+
+  it('removes ASCII detail suffixes from picker labels', () => {
+    const [option] = entriesToOptionData([
+      toolUseAgent('Engineer --- software team lead'),
+    ]);
+
+    expect(option?.label).toBe('Engineer');
+  });
+
+  it('preserves ordinary hyphenated agent labels', () => {
+    const [option] = entriesToOptionData([toolUseAgent('paper-reviewer')]);
+
+    expect(option?.label).toBe('paper-reviewer');
+  });
+
   it('does not carry descriptions into picker options', () => {
     const [option] = entriesToOptionData([
       toolUseAgent('review', 'remote', 'Verifies mathematical correctness.'),

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -38,12 +38,21 @@ describe('AgentSettingSchema', () => {
 });
 
 describe('AgentDefinitionSchema', () => {
-  it('rejects unknown top-level metadata', () => {
-    expect(() =>
-      AgentDefinitionSchema.parse({
-        name: 'assistant',
-        label: 'Assistant',
+  it('rejects obsolete displayName metadata', () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: 'assistant',
+      displayName: 'Assistant',
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error('displayName should not be valid agent metadata');
+    }
+    expect(result.error.issues).toEqual([
+      expect.objectContaining({
+        code: 'unrecognized_keys',
+        keys: ['displayName'],
       }),
-    ).toThrow();
+    ]);
   });
 });

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -30,7 +30,7 @@ describe('CLI AgentListForm row budget', () => {
     ).toBe('lean');
   });
 
-  it('resolves current agents by canonical labels and values', () => {
+  it('resolves current agents by canonical names and values', () => {
     const canonicalAgents = [
       { value: 'remote:review', label: 'review' },
       { value: 'remote:leanOrchestrator', label: 'leanOrchestrator' },
@@ -44,6 +44,27 @@ describe('CLI AgentListForm row budget', () => {
       currentVisibleAgent(canonicalAgents, 'leanOrchestrator')?.label,
     ).toBe('leanOrchestrator');
     expect(hiddenCurrentAgentHint(canonicalAgents, 'review')).toBeUndefined();
+  });
+
+  it('does not match display-only labels when canonical names differ', () => {
+    const decoratedAgents = [
+      {
+        value: 'remote:Review \u2014 verify math',
+        label: 'Review',
+      },
+      {
+        value: 'remote:Review \u2014 check style',
+        label: 'Review',
+      },
+    ];
+
+    expect(currentVisibleAgent(decoratedAgents, 'Review')).toBeUndefined();
+    expect(
+      currentVisibleAgent(decoratedAgents, 'Review \u2014 check style')?.value,
+    ).toBe('remote:Review \u2014 check style');
+    expect(hiddenCurrentAgentHint(decoratedAgents, 'Review')).toBe(
+      'Current: Review (hidden from picker)',
+    );
   });
 
   it('labels the current agent when it is hidden from the picker', () => {

--- a/src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts
@@ -34,4 +34,19 @@ describe('ProgressViewProvider pending permissions', () => {
       'this.userQuestionHandler.hasPendingForStream(streamId)',
     );
   });
+
+  it('keeps proposal agent dropdown identity separate from display labels', () => {
+    const source = readProgressViewProvider();
+    const methodStart = source.indexOf('sendProposalModelOptions');
+    const methodEnd = source.indexOf(
+      'public static getInstance',
+      methodStart,
+    );
+    expect(methodStart).toBeGreaterThanOrEqual(0);
+    expect(methodEnd).toBeGreaterThan(methodStart);
+    const method = source.slice(methodStart, methodEnd);
+
+    expect(method).toContain('value: agentName(opt.value)');
+    expect(method).not.toContain('value: opt.label');
+  });
 });

--- a/src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts
@@ -38,10 +38,7 @@ describe('ProgressViewProvider pending permissions', () => {
   it('keeps proposal agent dropdown identity separate from display labels', () => {
     const source = readProgressViewProvider();
     const methodStart = source.indexOf('sendProposalModelOptions');
-    const methodEnd = source.indexOf(
-      'public static getInstance',
-      methodStart,
-    );
+    const methodEnd = source.indexOf('public static getInstance', methodStart);
     expect(methodStart).toBeGreaterThanOrEqual(0);
     expect(methodEnd).toBeGreaterThan(methodStart);
     const method = source.slice(methodStart, methodEnd);


### PR DESCRIPTION
## Summary
- reject obsolete top-level agent displayName metadata in the schema test
- keep launcher/proposal picker labels to the canonical name before dash-style detail suffixes
- preserve full agent values for lookup/storage and keep proposal approval identity on the full plain agent name
- remove label-based matching so simplified display labels cannot affect current-agent resolution

## Validation
- corepack pnpm vitest run src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts src/test-kernel/cli/AgentListForm.vitest.mts src/test-kernel/agent/AgentOptionsBuilder.vitest.ts src/test-kernel/agent/AgentSettingSchema.vitest.ts
- npm run typecheck
- npm run lint (passes with existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI labeling and selection-matching only; stored agent keys and execution identity are preserved, with targeted tests covering edge cases.
> 
> **Overview**
> **Agent picker labels** are derived from the authored name by keeping only the part before em/en dash or `---` detail suffixes (e.g. `Review — verify math` → label `Review`), while **option values** still use full `source:name` keys. Ordinary single hyphens (e.g. `paper-reviewer`) are unchanged.
> 
> **Resolution** across CLI `/agent`, main view agent dropdowns, and progress-view proposal agent options now keys off **canonical agent names** (`agentName` on values), not picker **labels**. That avoids ambiguous matches when several agents share the same shortened label, and proposal dropdown values use plain names again instead of labels.
> 
> **Schema test** now asserts obsolete top-level `displayName` on agent definitions is rejected as an unrecognized key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b052059fe3105b4495b34121459f2e8140c9201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->