### PR TITLE
[codex] fix(agent): require canonical agent names

### DIFF
--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { ToolDefinitionSchema } from '@model';
-import { AgentCategory } from '@shared/schemas/agent';
+import { AgentCategory, AgentNameSchema } from '@shared/schemas/agent';
 import { isNonEmptyString } from '@utils/core';
 
 export { AgentCategory };
@@ -101,7 +101,7 @@ export const AgentPromptSchema = z.strictObject({
 export type AgentPrompt = z.infer<typeof AgentPromptSchema>;
 
 export const AgentDefinitionSchema = z.strictObject({
-  name: z.string().trim().min(1),
+  name: AgentNameSchema,
   description: z.string().optional(),
   inherits: z.string().optional(),
   settings: z.record(z.string(), z.unknown()).prefault({}),

--- a/src/agent/index/agentOptionsBuilder.ts
+++ b/src/agent/index/agentOptionsBuilder.ts
@@ -12,19 +12,11 @@ export interface AgentOptionsDataPayload {
   toolUse: AgentOptionData[];
 }
 
-const DETAIL_SEPARATOR = /\s+(?:[\u2013\u2014]|-{2,})\s+/u;
-
-function pickerLabel(name: string): string {
-  const detailStart = name.search(DETAIL_SEPARATOR);
-  if (detailStart === -1) return name;
-  return name.slice(0, detailStart).trim() || name;
-}
-
 function entryToOptionData(entry: AgentEntry): AgentOptionData {
   const key = createKey(entry.source, entry.name);
   return {
     value: key,
-    label: pickerLabel(entry.name),
+    label: entry.name,
     isToolUse: entry.category === AgentCategory.ToolUse,
     isOrchestrator: hasDelegationTool(entry.tools),
     isRemote: entry.source === 'remote',

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -234,7 +234,7 @@ function migrateFilenameAgentNameKeys(entries: readonly AgentEntry[]): void {
     entries.map((entry) => createKey(entry.source, entry.name)),
   );
   const currentNames = new Set(entries.map((entry) => entry.name));
-  const qualified = new Map<string, string>();
+  const qualifiedCandidates = new Map<string, Set<string>>();
   const bareCandidates = new Map<string, Set<string>>();
 
   for (const entry of entries) {
@@ -244,7 +244,9 @@ function migrateFilenameAgentNameKeys(entries: readonly AgentEntry[]): void {
 
     const oldKey = createKey(entry.source, oldName);
     if (!currentKeys.has(oldKey)) {
-      qualified.set(oldKey, createKey(entry.source, entry.name));
+      const targets = qualifiedCandidates.get(oldKey) ?? new Set<string>();
+      targets.add(createKey(entry.source, entry.name));
+      qualifiedCandidates.set(oldKey, targets);
     }
     if (!currentNames.has(oldName)) {
       const targets = bareCandidates.get(oldName) ?? new Set<string>();
@@ -253,13 +255,8 @@ function migrateFilenameAgentNameKeys(entries: readonly AgentEntry[]): void {
     }
   }
 
-  const bare = new Map<string, string>();
-  for (const [oldName, targets] of bareCandidates) {
-    if (targets.size === 1) {
-      const target = targets.values().next().value;
-      if (target) bare.set(oldName, target);
-    }
-  }
+  const qualified = singleTargetMappings(qualifiedCandidates);
+  const bare = singleTargetMappings(bareCandidates);
 
   if (qualified.size === 0 && bare.size === 0) return;
 
@@ -281,6 +278,19 @@ function migrateFilenameAgentNameKeys(entries: readonly AgentEntry[]): void {
     void platform().workspaceState.update(stateKey, unique(migrated));
     logger.info(CHANNEL, `Migrated filename-based agent names in ${stateKey}`);
   }
+}
+
+function singleTargetMappings(
+  candidates: ReadonlyMap<string, ReadonlySet<string>>,
+): Map<string, string> {
+  const mappings = new Map<string, string>();
+  for (const [oldName, targets] of candidates) {
+    if (targets.size === 1) {
+      const target = targets.values().next().value;
+      if (target) mappings.set(oldName, target);
+    }
+  }
+  return mappings;
 }
 
 /**

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -1,5 +1,7 @@
 /** Agent Registry - Flat agent metadata cache with source-priority lookup. */
 
+import * as path from 'node:path';
+
 import { platform } from '@platform/platform';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import * as logger from '@logger/logUtils';
@@ -160,6 +162,8 @@ async function doLoad(options: LoadAgentsOptions = {}): Promise<void> {
     ...remoteEntries,
   ];
 
+  migrateFilenameAgentNameKeys(allEntries);
+
   // Apply category overrides from config
   const toolUseOverrides = new Set(
     platform().workspaceState.get<string[]>(
@@ -218,6 +222,64 @@ function migrateLegacyAgentNameKeys(): void {
 
     void platform().workspaceState.update(stateKey, unique(migrated));
     logger.info(CHANNEL, `Migrated legacy agent names in ${stateKey}`);
+  }
+}
+
+/**
+ * Before canonical YAML names, local agents were keyed by their filename. Keep
+ * persisted visibility selections alive after switching identity to `name:`.
+ */
+function migrateFilenameAgentNameKeys(entries: readonly AgentEntry[]): void {
+  const currentKeys = new Set(
+    entries.map((entry) => createKey(entry.source, entry.name)),
+  );
+  const currentNames = new Set(entries.map((entry) => entry.name));
+  const qualified = new Map<string, string>();
+  const bareCandidates = new Map<string, Set<string>>();
+
+  for (const entry of entries) {
+    if (!entry.path) continue;
+    const oldName = path.basename(entry.path, '.yaml');
+    if (!oldName || oldName === entry.name) continue;
+
+    const oldKey = createKey(entry.source, oldName);
+    if (!currentKeys.has(oldKey)) {
+      qualified.set(oldKey, createKey(entry.source, entry.name));
+    }
+    if (!currentNames.has(oldName)) {
+      const targets = bareCandidates.get(oldName) ?? new Set<string>();
+      targets.add(entry.name);
+      bareCandidates.set(oldName, targets);
+    }
+  }
+
+  const bare = new Map<string, string>();
+  for (const [oldName, targets] of bareCandidates) {
+    if (targets.size === 1) {
+      const target = targets.values().next().value;
+      if (target) bare.set(oldName, target);
+    }
+  }
+
+  if (qualified.size === 0 && bare.size === 0) return;
+
+  for (const stateKey of [
+    WorkspaceStateKey.ENABLED_AGENTS,
+    WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+  ] as const) {
+    const stored = platform().workspaceState.get<string[]>(stateKey, []);
+    if (!stored?.length) continue;
+
+    const migrated = stored.map((key) => {
+      const name = agentName(key);
+      const prefix = key.slice(0, key.length - name.length);
+      if (prefix) return qualified.get(key) ?? key;
+      return bare.get(name) ?? key;
+    });
+    if (migrated.every((key, i) => key === stored[i])) continue;
+
+    void platform().workspaceState.update(stateKey, unique(migrated));
+    logger.info(CHANNEL, `Migrated filename-based agent names in ${stateKey}`);
   }
 }
 

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -48,18 +48,21 @@ export async function scanDirectory(
   if (!dir) return [];
 
   try {
-    const files = await glob('**/*.yaml', {
-      cwd: dir,
-      absolute: true,
-      nodir: true,
-    });
+    const files = (
+      await glob('**/*.yaml', {
+        cwd: dir,
+        absolute: true,
+        nodir: true,
+      })
+    ).toSorted();
     const parsed = (
       await Promise.all(files.map((file) => readYamlDefinition(file)))
     ).filter(filterNotNull);
+    const unique = entriesWithUniqueNames(parsed);
     const definitions = new Map(
-      parsed.map((entry) => [entry.name, entry] as const),
+      unique.map((entry) => [entry.name, entry] as const),
     );
-    const entries = parsed
+    const entries = unique
       .map((entry) => scanYaml(entry, source, definitions))
       .filter(filterNotNull);
 
@@ -69,6 +72,36 @@ export async function scanDirectory(
     logger.error(CHANNEL, `Failed to scan ${dir}: ${toErrorMessage(err)}`);
     return [];
   }
+}
+
+function entriesWithUniqueNames(
+  entries: readonly ParsedAgentYaml[],
+): ParsedAgentYaml[] {
+  const byName = new Map<string, ParsedAgentYaml[]>();
+  for (const entry of entries) {
+    const matches = byName.get(entry.name);
+    if (matches) {
+      matches.push(entry);
+    } else {
+      byName.set(entry.name, [entry]);
+    }
+  }
+
+  const unique: ParsedAgentYaml[] = [];
+  for (const [name, matches] of byName) {
+    const only = matches.at(0);
+    if (matches.length === 1 && only) {
+      unique.push(only);
+      continue;
+    }
+
+    const paths = matches.map((entry) => entry.path).join(', ');
+    logger.warn(
+      CHANNEL,
+      `Duplicate agent name "${name}" in ${paths}; skipping all duplicates.`,
+    );
+  }
+  return unique;
 }
 
 async function readYamlDefinition(

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -1,6 +1,5 @@
 /** Stateless YAML scanning for the agent registry. */
 
-import * as path from 'node:path';
 import { glob } from 'glob';
 import * as yaml from 'yaml';
 
@@ -80,7 +79,7 @@ async function readYamlDefinition(
     const parsed = yaml.parse(content);
     const definition = AgentDefinitionSchema.parse(parsed);
     return {
-      name: path.basename(yamlPath, '.yaml'),
+      name: definition.name,
       path: yamlPath,
       definition,
     };

--- a/src/agent/remote/types.ts
+++ b/src/agent/remote/types.ts
@@ -5,6 +5,7 @@ import {
   AgentSettingSchema,
   AgentPromptSchema,
 } from '@agent/core/definition/AgentDataclass';
+import { AgentNameSchema } from '@shared/schemas/agent';
 
 /**
  * Remote agent list item from DB. Description is cached; YAML is source of truth.
@@ -15,7 +16,7 @@ import {
  */
 export const RemoteAgentListItemSchema = z.object({
   id: z.string(),
-  name: z.string(),
+  name: AgentNameSchema,
   description: z.string().nullish(),
   visibility: z.array(z.string()).nullish(),
   /** Cached tool names from YAML. Available when DB column is populated. */

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -40,13 +40,23 @@ export type AgentSourceType = z.infer<typeof AgentSourceSchema>;
 export const AgentSource = AgentSourceSchema;
 export type AgentSource = AgentSourceType;
 
+const AGENT_NAME_DETAIL_SEPARATOR = /\s+(?:[\u2013\u2014]|-{2,})\s+/u;
+
+export const AgentNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((name) => !AGENT_NAME_DETAIL_SEPARATOR.test(name), {
+    message: 'Agent names must be canonical; put details in description.',
+  });
+
 /**
  * Base schema for agent identity metadata shared across all agent representations.
  * View-specific schemas (RemoteAgentSchema, AgentSelectionItemSchema, etc.)
  * should extend this via `.extend()` rather than redefining these fields.
  */
 export const AgentMetadataBaseSchema = z.object({
-  name: z.string(),
+  name: AgentNameSchema,
   category: AgentCategorySchema,
   description: z.string().optional(),
 });

--- a/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
+++ b/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
@@ -32,25 +32,6 @@ describe('agent option labels', () => {
     expect(option?.label).toBe('Code Reviewer');
   });
 
-  it('removes descriptive dash suffixes from picker labels', () => {
-    const [option] = entriesToOptionData([
-      toolUseAgent('Review \u2014 verify math & consistency'),
-    ]);
-
-    expect(option?.value).toBe(
-      'remote:Review \u2014 verify math & consistency',
-    );
-    expect(option?.label).toBe('Review');
-  });
-
-  it('removes ASCII detail suffixes from picker labels', () => {
-    const [option] = entriesToOptionData([
-      toolUseAgent('Engineer --- software team lead'),
-    ]);
-
-    expect(option?.label).toBe('Engineer');
-  });
-
   it('preserves ordinary hyphenated agent labels', () => {
     const [option] = entriesToOptionData([toolUseAgent('paper-reviewer')]);
 

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -224,6 +224,80 @@ describe('agent registry legacy aliases', () => {
     );
     expect(getVisibleAgents('toolUse').map((entry) => entry.name)).toContain(
       'helper',
+    );
+  });
+
+  it('leaves ambiguous filename-based custom keys unmigrated', async () => {
+    const customDir = await mkdtemp(resolve(tmpdir(), 'texra-custom-agent-'));
+    const firstDir = resolve(customDir, 'first');
+    const secondDir = resolve(customDir, 'second');
+    await mkdir(firstDir);
+    await mkdir(secondDir);
+    await writeFile(
+      resolve(firstDir, 'Readable Helper.yaml'),
+      [
+        'name: helper-one',
+        'description: First custom helper agent',
+        'settings:',
+        '  agentCategory: toolUse',
+        '  tools: []',
+        'prompts:',
+        '  systemPrompt: First custom helper agent.',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(secondDir, 'Readable Helper.yaml'),
+      [
+        'name: helper-two',
+        'description: Second custom helper agent',
+        'settings:',
+        '  agentCategory: toolUse',
+        '  tools: []',
+        'prompts:',
+        '  systemPrompt: Second custom helper agent.',
+        '',
+      ].join('\n'),
+    );
+
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(
+      createFakePlatform(
+        {
+          workspaceState: {
+            [WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS]: [
+              'custom:Readable Helper',
+              'Readable Helper',
+              'review',
+            ],
+          },
+        },
+        { fs: nodeFilesystem },
+      ),
+    );
+    setAgentDirectories({
+      custom: async () => customDir,
+      builtIn: async () =>
+        resolve(REPO_ROOT, 'packages/extension/resources/agents'),
+      builtInToolUse: async () =>
+        resolve(REPO_ROOT, 'packages/extension/resources/tool_use_agents'),
+    });
+
+    await refresh({ includeRemote: false });
+
+    expect(
+      platform().workspaceState.get<string[]>(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      ),
+    ).toEqual(['custom:Readable Helper', 'Readable Helper', 'review']);
+    expect(getAgent('custom:helper-one')?.path).toBe(
+      resolve(firstDir, 'Readable Helper.yaml'),
+    );
+    expect(getAgent('custom:helper-two')?.path).toBe(
+      resolve(secondDir, 'Readable Helper.yaml'),
+    );
+    expect(getVisibleAgents('toolUse').map((entry) => entry.name)).not.toEqual(
+      expect.arrayContaining(['helper-one', 'helper-two']),
     );
   });
 });

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -172,4 +172,58 @@ describe('agent registry legacy aliases', () => {
       'assistant',
     );
   });
+
+  it('migrates persisted filename-based custom agent keys to YAML names', async () => {
+    const customDir = await mkdtemp(resolve(tmpdir(), 'texra-custom-agent-'));
+    await writeFile(
+      resolve(customDir, 'Readable Helper.yaml'),
+      [
+        'name: helper',
+        'description: Custom helper agent',
+        'settings:',
+        '  agentCategory: toolUse',
+        '  tools: []',
+        'prompts:',
+        '  systemPrompt: Custom helper agent.',
+        '',
+      ].join('\n'),
+    );
+
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(
+      createFakePlatform(
+        {
+          workspaceState: {
+            [WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS]: [
+              'custom:Readable Helper',
+              'Readable Helper',
+              'review',
+            ],
+          },
+        },
+        { fs: nodeFilesystem },
+      ),
+    );
+    setAgentDirectories({
+      custom: async () => customDir,
+      builtIn: async () =>
+        resolve(REPO_ROOT, 'packages/extension/resources/agents'),
+      builtInToolUse: async () =>
+        resolve(REPO_ROOT, 'packages/extension/resources/tool_use_agents'),
+    });
+
+    await refresh({ includeRemote: false });
+
+    expect(
+      platform().workspaceState.get<string[]>(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      ),
+    ).toEqual(['custom:helper', 'helper', 'review']);
+    expect(getAgent('custom:helper')?.path).toBe(
+      resolve(customDir, 'Readable Helper.yaml'),
+    );
+    expect(getVisibleAgents('toolUse').map((entry) => entry.name)).toContain(
+      'helper',
+    );
+  });
 });

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -38,21 +38,29 @@ describe('AgentSettingSchema', () => {
 });
 
 describe('AgentDefinitionSchema', () => {
-  it('rejects obsolete displayName metadata', () => {
+  it('rejects unknown top-level metadata', () => {
     const result = AgentDefinitionSchema.safeParse({
       name: 'assistant',
-      displayName: 'Assistant',
+      title: 'Assistant',
     });
 
     expect(result.success).toBe(false);
     if (result.success) {
-      throw new Error('displayName should not be valid agent metadata');
+      throw new Error('unknown metadata should not be valid');
     }
     expect(result.error.issues).toEqual([
       expect.objectContaining({
         code: 'unrecognized_keys',
-        keys: ['displayName'],
+        keys: ['title'],
       }),
     ]);
+  });
+
+  it('rejects names that include descriptive dash details', () => {
+    expect(() =>
+      AgentDefinitionSchema.parse({
+        name: 'Review \u2014 verify math & consistency',
+      }),
+    ).toThrow('Agent names must be canonical');
   });
 });

--- a/src/test-kernel/agent/AgentYamlScanner.vitest.mts
+++ b/src/test-kernel/agent/AgentYamlScanner.vitest.mts
@@ -139,4 +139,45 @@ describe('agent YAML scanner', () => {
 
     expect(entries).toEqual([]);
   });
+
+  it('skips duplicate YAML names instead of returning colliding entries', async () => {
+    const agentDir = await mkdtemp(resolve(tmpdir(), 'texra-agent-scan-'));
+    await writeFile(
+      resolve(agentDir, 'first.yaml'),
+      [
+        'name: shared',
+        'settings:',
+        '  agentCategory: toolUse',
+        'prompts:',
+        '  systemPrompt: first',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(agentDir, 'second.yaml'),
+      [
+        'name: shared',
+        'settings:',
+        '  agentCategory: toolUse',
+        'prompts:',
+        '  systemPrompt: second',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(agentDir, 'unique.yaml'),
+      [
+        'name: unique',
+        'settings:',
+        '  agentCategory: toolUse',
+        'prompts:',
+        '  systemPrompt: unique',
+        '',
+      ].join('\n'),
+    );
+
+    const entries = await scanDirectory(agentDir, 'custom');
+
+    expect(entries.map((entry) => entry.name)).toEqual(['unique']);
+  });
 });

--- a/src/test-kernel/agent/AgentYamlScanner.vitest.mts
+++ b/src/test-kernel/agent/AgentYamlScanner.vitest.mts
@@ -100,4 +100,43 @@ describe('agent YAML scanner', () => {
       entries.find((entry) => entry.name === 'missing-parent')?.rounds,
     ).toBeUndefined();
   });
+
+  it('uses the YAML name as the canonical registry name', async () => {
+    const agentDir = await mkdtemp(resolve(tmpdir(), 'texra-agent-scan-'));
+    await writeFile(
+      resolve(agentDir, 'Readable Helper.yaml'),
+      [
+        'name: helper',
+        'settings:',
+        '  agentCategory: toolUse',
+        'prompts:',
+        '  systemPrompt: help',
+        '',
+      ].join('\n'),
+    );
+
+    const entries = await scanDirectory(agentDir, 'custom');
+
+    expect(entries.map((entry) => entry.name)).toEqual(['helper']);
+  });
+
+  it('skips agent names that include descriptive dash details', async () => {
+    const agentDir = await mkdtemp(resolve(tmpdir(), 'texra-agent-scan-'));
+    await writeFile(
+      resolve(agentDir, 'review.yaml'),
+      [
+        'name: Review \u2014 verify math & consistency',
+        'description: Verifies manuscripts.',
+        'settings:',
+        '  agentCategory: toolUse',
+        'prompts:',
+        '  systemPrompt: review',
+        '',
+      ].join('\n'),
+    );
+
+    const entries = await scanDirectory(agentDir, 'custom');
+
+    expect(entries).toEqual([]);
+  });
 });

--- a/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
@@ -145,6 +145,34 @@ describe('remote agent schema compatibility', () => {
     ]);
   });
 
+  it('drops remote rows with decorative agent names', async () => {
+    installRemoteAgentListClient({
+      data: [
+        {
+          id: 'agent-1',
+          name: 'Review \u2014 verify math & consistency',
+          description: 'Decorated legacy row',
+          visibility: ['public'],
+          tools: [],
+          agent_category: 'toolUse',
+        },
+        {
+          id: 'agent-2',
+          name: 'review',
+          description: 'Canonical row',
+          visibility: ['public'],
+          tools: [],
+          agent_category: 'toolUse',
+        },
+      ],
+      error: null,
+    });
+
+    const agents = await RemoteAgentLoader.listRemoteAgents();
+
+    expect(agents.map((agent) => agent.name)).toEqual(['review']);
+  });
+
   it('does not hide unrelated list-query errors behind legacy fallback', async () => {
     const selectedColumns = installRemoteAgentListClient({
       data: null,

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -46,24 +46,24 @@ describe('CLI AgentListForm row budget', () => {
     expect(hiddenCurrentAgentHint(canonicalAgents, 'review')).toBeUndefined();
   });
 
-  it('does not match display-only labels when canonical names differ', () => {
-    const decoratedAgents = [
+  it('does not match arbitrary labels when canonical names differ', () => {
+    const agentsWithReadableLabel = [
       {
-        value: 'remote:Review \u2014 verify math',
-        label: 'Review',
-      },
-      {
-        value: 'remote:Review \u2014 check style',
-        label: 'Review',
+        value: 'remote:review',
+        label: 'Readable review label',
       },
     ];
 
-    expect(currentVisibleAgent(decoratedAgents, 'Review')).toBeUndefined();
     expect(
-      currentVisibleAgent(decoratedAgents, 'Review \u2014 check style')?.value,
-    ).toBe('remote:Review \u2014 check style');
-    expect(hiddenCurrentAgentHint(decoratedAgents, 'Review')).toBe(
-      'Current: Review (hidden from picker)',
+      currentVisibleAgent(agentsWithReadableLabel, 'Readable review label'),
+    ).toBeUndefined();
+    expect(currentVisibleAgent(agentsWithReadableLabel, 'review')?.value).toBe(
+      'remote:review',
+    );
+    expect(
+      hiddenCurrentAgentHint(agentsWithReadableLabel, 'Readable review label'),
+    ).toBe(
+      'Current: Readable review label (hidden from picker)',
     );
   });
 

--- a/src/test-kernel/cli/AgentListForm.vitest.mts
+++ b/src/test-kernel/cli/AgentListForm.vitest.mts
@@ -62,9 +62,7 @@ describe('CLI AgentListForm row budget', () => {
     );
     expect(
       hiddenCurrentAgentHint(agentsWithReadableLabel, 'Readable review label'),
-    ).toBe(
-      'Current: Readable review label (hidden from picker)',
-    );
+    ).toBe('Current: Readable review label (hidden from picker)');
   });
 
   it('labels the current agent when it is hidden from the picker', () => {


### PR DESCRIPTION
## Summary

Closes #6578.

This removes the display-name-style agent identity path. Agent names are now validated as short canonical IDs, while descriptive text belongs in `description`.

Changes:
- add a shared `AgentNameSchema` and use it for local YAML definitions and remote agent list metadata
- register local agents by the YAML `name` field instead of the YAML filename
- drop the picker-only dash-suffix stripping helper so option labels are the canonical agent name
- add regression coverage for decorated names in local YAML, remote rows, and TUI picker identity matching

## Why

The launcher/TUI could surface long entries like `Review — verify math & consistency`, and the previous fix kept that shape alive by stripping suffixes only at display time. That made agent identity and display text diverge. The registry boundary now rejects that pattern instead.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/AgentSettingSchema.vitest.ts src/test-kernel/agent/AgentYamlScanner.vitest.mts src/test-kernel/agent/AgentOptionsBuilder.vitest.ts src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts src/test-kernel/cli/AgentListForm.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with the existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent identity, registry keys, and persisted workspace state; legacy decorated or duplicate names may disappear from listings until data is fixed.
> 
> **Overview**
> Agent identity is unified on short canonical names: descriptive dash suffixes (e.g. `Review — verify math`) are rejected at validation time instead of stripped only in the UI.
> 
> A shared **`AgentNameSchema`** is applied to local YAML definitions, remote list metadata, and agent metadata. Local agents register under the YAML **`name`** field (not the filename). The YAML scanner drops invalid decorated names and skips all files when the same **`name`** appears more than once. Picker option labels are the canonical **`name`**; the dash-suffix label helper is removed.
> 
> On registry load, persisted enabled-agent keys that still use old filename-based names are migrated to YAML **`name`** when the mapping is unambiguous. Tests cover schema rejection, scanning, remote row filtering, filename migration, and TUI picker matching by canonical name/value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3656b48d9c6127d4fbc0b4fd990ac8f9cff756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->