### PR TITLE
[codex] fix(extension): seed default team before launcher

### DIFF
--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -359,13 +359,11 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
       instruction: SETUP_INSTRUCTION,
     });
 
-    // Activation fires `loadAgents()` fire-and-forget, so a user
-    // invoking the setup assistant from the first walkthrough step (or
-    // immediately after install, especially with remote-agent fetches
-    // in flight) can race the agent registry and hit "Could not find
-    // agent: setup". `loadAgents()` is idempotent: it returns the
-    // in-flight promise if loading is still running, or resolves
-    // immediately if already initialized, or kicks off a fresh load.
+    // Activation initializes the registry, but this command can also be
+    // invoked directly in tests or unusual startup paths. `loadAgents()` is
+    // idempotent: it returns the in-flight promise if loading is still
+    // running, resolves immediately if already initialized, or kicks off a
+    // fresh load.
     await loadAgents();
 
     const launch = async () => {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -304,27 +304,36 @@ export async function activate(context: vscode.ExtensionContext) {
     (async () => {
       await copyDefaultAgents(context);
       await registerAgentDirectoryRoots(context);
-      loadAgents()
-        .then(() =>
-          // Seed a never-configured workspace's roster from the user-level
-          // default team, falling back to the built-in Physicist team. Needs
-          // the registry, hence sequenced after the agent scan.
-          seedRosterFromDefaultTeam({
+      try {
+        await loadAgents({ includeRemote: false });
+        // Seed a never-configured workspace's roster from the user-level
+        // default team, falling back to the built-in Physicist team. Needs
+        // the local registry, hence sequenced after the bundled-agent scan
+        // and before activation completes so the first launcher render is
+        // already scoped without waiting on remote agent fetches.
+        try {
+          await seedRosterFromDefaultTeam({
             globalState: context.globalState,
             workspaceState: workspaceSM,
-          }).catch((err) => {
-            logger.warn(
-              'extension',
-              `Default-team roster seeding failed: ${toErrorMessage(err)}`,
-            );
-          }),
-        )
-        .catch((err) => {
-          logger.error(
+          });
+        } catch (err) {
+          logger.warn(
             'extension',
-            `Failed to initialize agent index: ${toErrorMessage(err)}`,
+            `Default-team roster seeding failed: ${toErrorMessage(err)}`,
+          );
+        }
+        void loadAgents().catch((err) => {
+          logger.warn(
+            'extension',
+            `Remote agent refresh failed: ${toErrorMessage(err)}`,
           );
         });
+      } catch (err) {
+        logger.error(
+          'extension',
+          `Failed to initialize agent index: ${toErrorMessage(err)}`,
+        );
+      }
     })(),
     (async () => {
       try {

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -113,14 +113,16 @@ export async function loadAgents(
     return;
   }
 
+  const previousInitialized = initialized;
+  const previousCacheIncludesRemote = cacheIncludesRemote;
   initPromise = doLoad({ includeRemote })
     .then(() => {
       initialized = true;
       cacheIncludesRemote = includeRemote;
     })
     .catch((error: unknown) => {
-      initialized = false;
-      cacheIncludesRemote = false;
+      initialized = previousInitialized;
+      cacheIncludesRemote = previousCacheIncludesRemote;
       throw error;
     })
     .finally(() => {
@@ -132,7 +134,6 @@ export async function loadAgents(
 
 async function doLoad(options: LoadAgentsOptions = {}): Promise<void> {
   const startTime = Date.now();
-  cache.clear();
 
   // Migrate legacy builtIn:* → builtInWorkflow:* in persisted state
   migrateLegacySourceKeys();
@@ -172,12 +173,18 @@ async function doLoad(options: LoadAgentsOptions = {}): Promise<void> {
     ),
   );
 
+  const nextCache = new Map<string, AgentEntry>();
   for (const entry of allEntries) {
     if (toolUseOverrides.has(entry.name)) {
       entry.category = AgentCategory.ToolUse;
       entry.rounds = undefined;
     }
     const key = `${entry.source}:${entry.name}`;
+    nextCache.set(key, entry);
+  }
+
+  cache.clear();
+  for (const [key, entry] of nextCache) {
     cache.set(key, entry);
   }
 

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -40,14 +40,15 @@ export type AgentSourceType = z.infer<typeof AgentSourceSchema>;
 export const AgentSource = AgentSourceSchema;
 export type AgentSource = AgentSourceType;
 
-const AGENT_NAME_DETAIL_SEPARATOR = /\s+(?:[\u2013\u2014]|-{2,})\s+/u;
+const AGENT_NAME_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9_-]*$/u;
 
 export const AgentNameSchema = z
   .string()
   .trim()
   .min(1)
-  .refine((name) => !AGENT_NAME_DETAIL_SEPARATOR.test(name), {
-    message: 'Agent names must be canonical; put details in description.',
+  .refine((name) => AGENT_NAME_IDENTIFIER.test(name), {
+    message:
+      'Agent names must be identifiers: letters, numbers, underscores, or hyphens.',
   });
 
 /**

--- a/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
+++ b/src/test-kernel/agent/AgentOptionsBuilder.vitest.ts
@@ -26,10 +26,10 @@ describe('agent option labels', () => {
     expect(options.map((option) => option.label)).toEqual(['review']);
   });
 
-  it('keeps title-case names exactly as authored', () => {
-    const [option] = entriesToOptionData([toolUseAgent('Code Reviewer')]);
+  it('keeps camelCase names exactly as authored', () => {
+    const [option] = entriesToOptionData([toolUseAgent('codeReviewer')]);
 
-    expect(option?.label).toBe('Code Reviewer');
+    expect(option?.label).toBe('codeReviewer');
   });
 
   it('preserves ordinary hyphenated agent labels', () => {
@@ -60,18 +60,18 @@ describe('agent option labels', () => {
     ]);
   });
 
-  it('leaves custom agent labels exactly as authored', () => {
+  it('leaves custom agent identifiers exactly as authored', () => {
     const [option] = entriesToOptionData([
       {
-        name: 'My Paper Helper',
+        name: 'myPaperHelper',
         source: 'custom',
-        path: '/agents/My Paper Helper.yaml',
+        path: '/agents/myPaperHelper.yaml',
         category: AgentCategory.ToolUse,
         tools: [],
       },
     ]);
 
-    expect(option?.value).toBe('custom:My Paper Helper');
-    expect(option?.label).toBe('My Paper Helper');
+    expect(option?.value).toBe('custom:myPaperHelper');
+    expect(option?.label).toBe('myPaperHelper');
   });
 });

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -17,6 +17,8 @@ import {
   getAgent,
   getVisibleAgent,
   getVisibleAgents,
+  isAgentRegistryReady,
+  loadAgents,
   refresh,
 } from '@agent/index/agentRegistry';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -83,6 +85,62 @@ describe('agent registry legacy aliases', () => {
     const workflow = getAgent('builtInWorkflow:polish', AgentCategory.ToolUse);
     expect(workflow?.name).toBe('polish');
     expect(workflow?.category).toBe(AgentCategory.Workflow);
+  });
+
+  it('keeps the current cache visible while a refresh is pending', async () => {
+    expect(getAgent('assistant')?.name).toBe('assistant');
+
+    let releaseBuiltInToolUseDir: (() => void) | undefined;
+    const waitForBuiltInToolUseDir = new Promise<void>((resolveWait) => {
+      releaseBuiltInToolUseDir = resolveWait;
+    });
+    setAgentDirectories({
+      custom: async () => '',
+      builtIn: async () =>
+        resolve(REPO_ROOT, 'packages/extension/resources/agents'),
+      builtInToolUse: async () => {
+        await waitForBuiltInToolUseDir;
+        return resolve(
+          REPO_ROOT,
+          'packages/extension/resources/tool_use_agents',
+        );
+      },
+    });
+
+    const pendingRefresh = refresh({ includeRemote: false });
+    await new Promise((resolveNextTick) => setTimeout(resolveNextTick, 0));
+
+    expect(getAgent('assistant')?.name).toBe('assistant');
+
+    releaseBuiltInToolUseDir?.();
+    await pendingRefresh;
+  });
+
+  it('keeps the registry marked ready when a later refresh fails', async () => {
+    expect(isAgentRegistryReady()).toBe(true);
+    expect(getAgent('assistant')?.name).toBe('assistant');
+
+    setAgentDirectories({
+      custom: async () => '',
+      builtIn: async () =>
+        resolve(REPO_ROOT, 'packages/extension/resources/agents'),
+      builtInToolUse: async () => {
+        throw new Error('refresh failed');
+      },
+    });
+
+    await expect(loadAgents()).rejects.toThrow('refresh failed');
+
+    expect(isAgentRegistryReady()).toBe(true);
+    expect(getAgent('assistant')?.name).toBe('assistant');
+
+    setAgentDirectories({
+      custom: async () => '',
+      builtIn: async () =>
+        resolve(REPO_ROOT, 'packages/extension/resources/agents'),
+      builtInToolUse: async () =>
+        resolve(REPO_ROOT, 'packages/extension/resources/tool_use_agents'),
+    });
   });
 
   it('migrates persisted legacy keys at load time', () => {

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -56,11 +56,11 @@ describe('AgentDefinitionSchema', () => {
     ]);
   });
 
-  it('rejects names that include descriptive dash details', () => {
+  it('rejects names that are not identifiers', () => {
     expect(() =>
       AgentDefinitionSchema.parse({
-        name: 'Review \u2014 verify math & consistency',
+        name: 'review team',
       }),
-    ).toThrow('Agent names must be canonical');
+    ).toThrow('Agent names must be identifiers');
   });
 });

--- a/src/test-kernel/agent/AgentYamlScanner.vitest.mts
+++ b/src/test-kernel/agent/AgentYamlScanner.vitest.mts
@@ -120,12 +120,12 @@ describe('agent YAML scanner', () => {
     expect(entries.map((entry) => entry.name)).toEqual(['helper']);
   });
 
-  it('skips agent names that include descriptive dash details', async () => {
+  it('skips agent names that are not identifiers', async () => {
     const agentDir = await mkdtemp(resolve(tmpdir(), 'texra-agent-scan-'));
     await writeFile(
       resolve(agentDir, 'review.yaml'),
       [
-        'name: Review \u2014 verify math & consistency',
+        'name: review team',
         'description: Verifies manuscripts.',
         'settings:',
         '  agentCategory: toolUse',

--- a/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
@@ -145,13 +145,13 @@ describe('remote agent schema compatibility', () => {
     ]);
   });
 
-  it('drops remote rows with decorative agent names', async () => {
+  it('drops remote rows with non-identifier agent names', async () => {
     installRemoteAgentListClient({
       data: [
         {
           id: 'agent-1',
-          name: 'Review \u2014 verify math & consistency',
-          description: 'Decorated legacy row',
+          name: 'review team',
+          description: 'Legacy row',
           visibility: ['public'],
           tools: [],
           agent_category: 'toolUse',


### PR DESCRIPTION
Closes #6580.

## Summary
- load the local bundled agent registry during activation before the first launcher render
- seed never-configured workspaces from the default Physicist team before activation completes
- refresh remote agents afterward in the background so startup does not wait on network fetches
- keep registry reloads visible during async refresh by building the next cache before swapping it in
- preserve the previous registry readiness flags if a later refresh fails after a valid cache is already serving
- make agent names identifier-only so picker labels cannot become display-name strings like `Review — ...`
- keep default-team seeding failures non-fatal and update the setup assistant comment

## Validation
- corepack pnpm vitest run src/test-kernel/agent/AgentRegistryAlias.vitest.mts src/test-kernel/agent/AgentSettingSchema.vitest.ts src/test-kernel/agent/AgentYamlScanner.vitest.mts src/test-kernel/agent/AgentOptionsBuilder.vitest.ts src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts
- npm run typecheck
- npm run lint (passes with 18 existing import-order warnings)
- npm run compile:fast
- npm run validate:tui -- --snapshot-dir /tmp/texra-tui-snapshots-physics-ready-flag agent-form compact-agent-form
- corepack pnpm exec prettier --check src/shared/schemas/agent.ts src/agent/index/agentRegistry.ts src/test-kernel/agent/AgentOptionsBuilder.vitest.ts src/test-kernel/agent/AgentRegistryAlias.vitest.mts src/test-kernel/agent/AgentSettingSchema.vitest.ts src/test-kernel/agent/AgentYamlScanner.vitest.mts src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches extension activation ordering and agent registry concurrency, which affect first-launcher UX and all agent lookups; identifier-only names may reject legacy decorated names in YAML and remote data.
> 
> **Overview**
> Fixes startup ordering so the **first launcher render** does not wait on remote fetches or miss roster seeding (#6580).
> 
> **Extension activation** now **awaits** `loadAgents({ includeRemote: false })`, runs **`seedRosterFromDefaultTeam`** while the local registry is ready, then kicks off a full **`loadAgents()`** in the background (remote failures log as warnings only). Default-team seed errors stay non-fatal.
> 
> **Agent registry** reloads build a **`nextCache`** and swap it in so lookups stay valid during async refresh; failed reloads **restore** prior `initialized` / remote-cache flags instead of wiping readiness.
> 
> **Agent naming** validation switches from rejecting decorative dash titles to requiring **identifier-only** names (`letters`, `numbers`, `_`, `-`), with matching test updates for YAML scan, remote rows, and picker labels.
> 
> Setup assistant comment text is adjusted; it still **`await loadAgents()`** before launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56532ed690f09be7b59e0793622fd4556ef0d200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->