### PR TITLE
Simplify retry error schema using .omit() and destructuring

### DIFF
--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -103,59 +103,33 @@ export const ProviderErrorPartialSchema = z.preprocess(
 );
 export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
 
-/** Minimal error info for retry state tracking */
+/**
+ * Minimal error info for retry state tracking.
+ *
+ * Structurally this is exactly a {@link ProviderError} without `rawErrorBody`
+ * (large, not worth persisting in retry state). Every carried field is already
+ * optional on the base schema, so the two shapes round-trip by narrowing /
+ * widening rather than by re-listing the field set in three places. Deriving
+ * the schema with `.omit()` keeps it from drifting out of sync with
+ * `ProviderErrorObjectSchema` as new error fields are added.
+ */
 export const RetryErrorInfoSchema = z.preprocess(
   normalizeProviderErrorRetryFlag,
-  z.object({
-    message: z.string(),
-    userRetryable: z.boolean(),
-    ...ProviderErrorObjectSchema.pick({
-      statusCode: true,
-      statusText: true,
-      provider: true,
-      isRelayError: true,
-      isCredentialExhausted: true,
-      isUpstreamCreditDepleted: true,
-      requestId: true,
-      streamDiagnostics: true,
-      partialText: true,
-    }).partial().shape,
-  }),
+  ProviderErrorObjectSchema.omit({ rawErrorBody: true }),
 );
 export type RetryErrorInfo = z.infer<typeof RetryErrorInfoSchema>;
 
-/** Convert a full ProviderError into the retry-state record. */
+/** Project a full ProviderError onto the retry-state record by dropping the
+ *  bulky `rawErrorBody`; every other field carries over unchanged. */
 export function toRetryErrorInfo(err: ProviderError): RetryErrorInfo {
-  return {
-    message: err.message,
-    userRetryable: err.userRetryable,
-    statusCode: err.statusCode,
-    statusText: err.statusText,
-    provider: err.provider,
-    isRelayError: err.isRelayError,
-    isCredentialExhausted: err.isCredentialExhausted,
-    isUpstreamCreditDepleted: err.isUpstreamCreditDepleted,
-    requestId: err.requestId,
-    streamDiagnostics: err.streamDiagnostics,
-    partialText: err.partialText,
-  };
+  const { rawErrorBody, ...rest } = err;
+  return rest;
 }
 
-/** Reconstruct a ProviderError from retry-state info. Leaves `isRelayError`
- *  `undefined` when absent so `normalizeProviderError` does not read a
- *  wrong relay verdict from the cached shape. */
+/** Reconstruct a ProviderError from retry-state info. `rawErrorBody` is absent
+ *  and `isRelayError` stays `undefined` when it was absent, so
+ *  `normalizeProviderError` does not read a wrong relay verdict from the cached
+ *  shape. */
 export function toProviderErrorFromRetry(info: RetryErrorInfo): ProviderError {
-  return {
-    message: info.message,
-    userRetryable: info.userRetryable,
-    isRelayError: info.isRelayError,
-    statusCode: info.statusCode,
-    statusText: info.statusText,
-    provider: info.provider,
-    isCredentialExhausted: info.isCredentialExhausted,
-    isUpstreamCreditDepleted: info.isUpstreamCreditDepleted,
-    requestId: info.requestId,
-    streamDiagnostics: info.streamDiagnostics,
-    partialText: info.partialText,
-  };
+  return { ...info };
 }

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -107,11 +107,12 @@ export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
  * Minimal error info for retry state tracking.
  *
  * Structurally this is exactly a {@link ProviderError} without `rawErrorBody`
- * (large, not worth persisting in retry state). Every carried field is already
- * optional on the base schema, so the two shapes round-trip by narrowing /
- * widening rather than by re-listing the field set in three places. Deriving
- * the schema with `.omit()` keeps it from drifting out of sync with
- * `ProviderErrorObjectSchema` as new error fields are added.
+ * (large, not worth persisting in retry state) — that optional field is the
+ * sole difference between the two shapes, so they round-trip by narrowing
+ * (drop `rawErrorBody`) and widening (it stays absent) rather than by
+ * re-listing the field set in three places. Deriving the schema with `.omit()`
+ * keeps it from drifting out of sync with `ProviderErrorObjectSchema` as new
+ * error fields are added.
  */
 export const RetryErrorInfoSchema = z.preprocess(
   normalizeProviderErrorRetryFlag,


### PR DESCRIPTION
## Summary

Refactored the `RetryErrorInfoSchema` and its conversion functions to reduce duplication and improve maintainability. Instead of manually listing fields in three places (schema definition, `toRetryErrorInfo`, and `toProviderErrorFromRetry`), the schema now derives from `ProviderErrorObjectSchema` using `.omit({ rawErrorBody: true })`, and the conversion functions use destructuring to automatically exclude the bulky `rawErrorBody` field.

This change eliminates the risk of the retry error shape drifting out of sync with the base `ProviderError` schema as new error fields are added in the future.

## Issue acceptance gates

N/A — this is a refactoring with no functional change.

## Single source of truth

`ProviderErrorObjectSchema` now owns the complete field set for retry error info; `RetryErrorInfoSchema` derives from it by omitting only `rawErrorBody`.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated manual field listing in `RetryErrorInfoSchema` (was 8 fields spread across `.pick()`)
- Eliminated manual field assignment in `toRetryErrorInfo()` (was 11 fields)
- Eliminated manual field assignment in `toProviderErrorFromRetry()` (was 11 fields)

**Abstraction invariant:**
The `.omit()` pattern ensures that any new optional fields added to `ProviderErrorObjectSchema` automatically become part of `RetryErrorInfoSchema` without requiring updates to three separate locations. The destructuring pattern in the conversion functions keeps the implementation in sync by construction.

## Host impact

Extension: None (internal refactoring)

Desktop: None (internal refactoring)

CLI: None (internal refactoring)

## Scheduled refactoring

None

## Validation

No new tests required. The change is a pure refactoring that preserves the exact same schema shape and conversion behavior. Existing type inference and schema validation tests continue to pass.

https://claude.ai/code/session_01NWsQ7mR9o2aPU9bpGsULyi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal schema/converter refactor with no intended behavior change; retry state consumers still use the same types and call sites.
> 
> **Overview**
> **Retry error persistence** is refactored so `RetryErrorInfoSchema` is derived from `ProviderErrorObjectSchema` with `.omit({ rawErrorBody: true })` instead of a hand-maintained `.pick()` list. `toRetryErrorInfo` drops `rawErrorBody` via destructuring; `toProviderErrorFromRetry` widens with `{ ...info }` instead of field-by-field mapping.
> 
> The persisted retry shape should stay aligned with `ProviderError` as new optional error fields are added, without updating three parallel copies. JSDoc on the schema and converters explains the narrow/widen round-trip and why `rawErrorBody` is excluded from retry state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb04ec68ffca834934c22bf805a3ab503c85120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->