### PR TITLE
Inject ProgressEventBus into ProgressEventHandler

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -364,7 +364,7 @@ export class DesktopProgressBridge {
     });
     this.state = this.backend.state;
     this.streamLogs = this.state.streamLogs;
-    const backendSubscription = this.backend.setupEventListeners();
+    const backendSubscription = this.backend.setupEventListeners(bus);
     // Compose the extracted progress-event bridge for ghost-stream hydration,
     // stream-snapshot persistence, restored-display sending, and progress-event
     // → rail-update translation.  See #6329.

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -14,6 +14,7 @@ import {
   setActiveSidebarView,
 } from '@common/webview';
 import { workspaceSM } from '@common/state';
+import { bus } from '@eventBus/ProgressEventBus';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { createChannelTrace } from '@logger';
 import {
@@ -263,7 +264,7 @@ export class ProgressViewProvider
 
   public async initialize(): Promise<void> {
     await this.backend.load();
-    this._disposables.push(this.backend.setupEventListeners());
+    this._disposables.push(this.backend.setupEventListeners(bus));
     this.logger.debug('ProgressViewProvider initialized');
   }
 

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -1,10 +1,8 @@
 // Standard library imports
 import * as path from 'node:path';
 
-// Third-party imports
-import fsExtra from 'fs-extra';
-
 // Local imports
+import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
@@ -62,7 +60,7 @@ export class PathAgentDirectoryBundleSource implements AgentDirectoryBundleSourc
     directoryName: BundledAgentDirectoryName,
     destinationPath: string,
   ): Promise<void> {
-    await fsExtra.copy(
+    await platform().fs.copy(
       path.join(this.resourcesBasePath, directoryName),
       destinationPath,
       { overwrite: true },

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -1,5 +1,6 @@
 // Local imports - shared progress backend
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { ProgressEventBusLike } from '@eventBus/ProgressEventBus';
 import type { ProgressViewOutboundMessage } from '@shared/schemas';
 import {
   WebviewBridge,
@@ -98,8 +99,8 @@ export class ProgressBackend {
     await this.state.load();
   }
 
-  setupEventListeners(): ProgressEventSubscription {
-    return this.eventHandler.setupEventListeners();
+  setupEventListeners(bus: ProgressEventBusLike): ProgressEventSubscription {
+    return this.eventHandler.setupEventListeners(bus);
   }
 
   dispose(): void {

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -3,8 +3,10 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { isInFlightStatus } from '@common/constants/streamStatus';
-import { bus } from '@eventBus/ProgressEventBus';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type {
+  ProgressEventBusLike,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import {
   STREAM_STATUS,
@@ -90,7 +92,7 @@ export class ProgressEventHandler {
     }
   }
 
-  setupEventListeners(): ProgressEventSubscription {
+  setupEventListeners(bus: ProgressEventBusLike): ProgressEventSubscription {
     const controller = new AbortController();
     const { signal } = controller;
 

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -157,7 +157,7 @@ describe('ProgressBackend', () => {
       hasTarget: () => true,
       configureUi: () => createUiConfig(),
     });
-    const subscription = backend.setupEventListeners();
+    const subscription = backend.setupEventListeners(bus);
 
     try {
       bus.emit('setActiveStream', {


### PR DESCRIPTION
## Summary

Make `ProgressEventHandler.setupEventListeners()` accept the event bus as a dependency injection parameter instead of importing it directly. This decouples the handler from the global bus instance and enables better testability and flexibility in event bus configuration.

Additionally, replace the direct `fsExtra` import in `AgentDirectorySync.ts` with the platform abstraction layer to maintain consistency with the codebase's dependency injection patterns.

## Issue acceptance gates

N/A

## Single source of truth

The `ProgressEventBus` is now injected at the call site (`ProgressViewProvider` and `DesktopProgressBridge`) rather than being a hard dependency within `ProgressEventHandler`. This allows callers to control which bus instance is used.

## Duplication and abstraction budget

- Removed direct import of `bus` from `ProgressEventHandler.ts`; added `ProgressEventBusLike` type import for the parameter
- Replaced `fsExtra` direct import with `platform().fs` in `AgentDirectorySync.ts` to use the platform abstraction consistently
- No new abstractions added; existing `ProgressEventBusLike` type is reused

## Host impact

**Extension:** `ProgressViewProvider.initialize()` now passes `bus` to `setupEventListeners()`

**Desktop:** `DesktopProgressBridge` constructor now passes `bus` to `setupEventListeners()`

**CLI:** No impact

## Scheduled refactoring

None

## Validation

- Existing test in `src/test-kernel/progressView/ProgressBackend.vitest.ts` updated to pass `bus` parameter
- Changes are straightforward dependency injection refactoring with no behavioral changes
- Type safety maintained through `ProgressEventBusLike` interface

https://claude.ai/code/session_015ALYJtqZgd4Hqdtyf5PMoQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-injection refactor with no intended behavior change; bundled agent copy should be equivalent through the platform FS API.
> 
> **Overview**
> **Progress event wiring** no longer hard-codes the global bus inside `ProgressEventHandler`. `setupEventListeners` now takes a `ProgressEventBusLike` argument, threaded through `ProgressBackend` so **extension** (`ProgressViewProvider`) and **desktop** (`DesktopProgressBridge`) pass the shared `bus` when subscribing.
> 
> **Bundled agent sync** copies directories via `platform().fs.copy` instead of a direct `fs-extra` import, matching the platform filesystem abstraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e97b511f33a9b4dd12b38bd2aab968ef4c04ed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->