### PR TITLE
Centralize terminal UI glyphs in shared module

### DIFF
--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -14,6 +14,7 @@ import {
 
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
+import { POINTER } from '../ui/glyphs';
 
 export interface SlashPaletteProps {
   /** The current input value (excluding the leading `/`, after the slash). */
@@ -204,7 +205,7 @@ export function SlashPalette(
           <Box key={cmd.name} flexDirection="row">
             <Box flexShrink={0} width={commandLabelWidth}>
               <Text color={i === highlight ? 'cyan' : undefined}>
-                {i === highlight ? '›' : ' '} /{cmd.name}
+                {i === highlight ? POINTER : ' '} /{cmd.name}
               </Text>
             </Box>
             <Box flexShrink={1}>

--- a/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
@@ -13,6 +13,7 @@ import {
 
 import { BaseTextInput } from '../input/BaseTextInput';
 import { KeyHints } from '../ui/KeyHints';
+import { POINTER } from '../ui/glyphs';
 
 export interface ApiKeyEntryFormProps {
   readonly provider: ApiProvider;
@@ -53,7 +54,7 @@ export function ApiKeyEntryForm(
       <Text dimColor>Provider: {label}</Text>
       {keyUrl ? <Text dimColor>Get a key: {keyUrl}</Text> : null}
       <Box marginTop={1}>
-        <Text>{'› '}</Text>
+        <Text>{`${POINTER} `}</Text>
         <BaseTextInput
           value={key}
           masked

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -372,7 +372,7 @@ function renderItem(
     <Box key={item.executionId} minWidth={0}>
       <Box flexShrink={0}>
         <Text color={highlighted ? 'cyan' : undefined}>
-          {highlighted ? '›' : ' '} {index + 1}.{' '}
+          {highlighted ? POINTER : ' '} {index + 1}.{' '}
         </Text>
       </Box>
       <Box flexShrink={0} maxWidth={SELECT_LABEL_MAX_COLS}>

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -25,6 +25,7 @@ import { useLiveNowMs } from '../state/useLiveNowMs';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { textDisplayWidth } from '../render/terminalText';
 import { KEY_HINT_SEPARATOR, KeyHints, type KeyHint } from '../ui/KeyHints';
+import { POINTER } from '../ui/glyphs';
 import { SELECT_LABEL_MAX_COLS } from '../ui/Select';
 import type { StreamSlice } from '../state/cliState';
 
@@ -343,7 +344,7 @@ function renderItem(
         <Box minWidth={0}>
           <Box flexShrink={0}>
             <Text color={highlighted ? 'cyan' : undefined}>
-              {highlighted ? '›' : ' '} {index + 1}.{' '}
+              {highlighted ? POINTER : ' '} {index + 1}.{' '}
             </Text>
           </Box>
           <Box flexShrink={0} maxWidth={SELECT_LABEL_MAX_COLS}>

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -25,6 +25,7 @@ import {
   visibleSelectRange,
 } from '../ui/Select';
 import { KeyHints, type KeyHint } from '../ui/KeyHints';
+import { POINTER, TICK } from '../ui/glyphs';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface UserQuestionProps {
@@ -411,8 +412,8 @@ function MultiSelectQuestion(
           <Box key={option.label} minWidth={0}>
             <Box flexShrink={0}>
               <Text color={focused ? 'cyan' : undefined}>
-                {focused ? '›' : ' '} {checked ? '✓' : ' '} {optionIndex + 1}
-                .{' '}
+                {focused ? POINTER : ' '} {checked ? TICK : ' '}{' '}
+                {optionIndex + 1}.{' '}
               </Text>
             </Box>
             <Box flexShrink={0} maxWidth={24}>

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -14,6 +14,7 @@ import { ReverseSearch } from '../input/ReverseSearch';
 import { isCtrlInput } from '../input/inputKeys';
 import { openRegisteredCliSlashForm } from '../commands/slashForms';
 import { SlashPalette } from '../commands/SlashPalette';
+import { POINTER } from '../ui/glyphs';
 import {
   matchSlashCommands,
   parseSlashInput,
@@ -348,7 +349,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         aria-role="textbox"
       >
         <Text aria-hidden color="cyan">
-          {prompt ?? '›'}{' '}
+          {prompt ?? POINTER}{' '}
         </Text>
         {disabled && props.disabledMessage ? (
           <Text dimColor>{props.disabledMessage}</Text>

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -1,4 +1,5 @@
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
+import { STATUS_DOT } from '../ui/glyphs';
 
 export function childStatusColor(status: string | undefined): string {
   if (!status) return 'green';
@@ -16,4 +17,4 @@ export function childStatusColor(status: string | undefined): string {
 // non-alt-screen repaint can leave stale glyphs behind on those reprints. Status
 // is conveyed by `childStatusColor`, and liveness by the `running · Ns` text, so
 // the animation bought churn without information.
-export const CHILD_STATUS_MARKER = '● ';
+export const CHILD_STATUS_MARKER = `${STATUS_DOT} `;

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -22,9 +22,8 @@ import {
   textDisplayWidth,
   truncateSummaryToWidth,
 } from '../render/terminalText';
+import { STATUS_DOT } from '../ui/glyphs';
 
-// Terminal-safe Unicode glyph — Font Awesome is not available in Ink TUI.
-const STATUS_DOT = '●';
 const OUTPUT_CORNER = '⎿';
 const MAX_HEADER_PREVIEW = 80;
 const MAX_ERROR_PREVIEW = 240;

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -1,7 +1,7 @@
 // Numbered select primitive for slash forms + future palettes.
 //
-// Renders each item with a `›` pointer on the focused row (Ink figures.pointer
-// equivalent in plain ASCII) and a `✓` on the currently-active value per
+// Renders each item with the shared POINTER glyph on the focused row and the
+// TICK glyph on the currently-active value (see ./glyphs) per
 // docs/prds/cli-tui-ink/10-architecture.md § Intuitiveness conventions.
 //
 // `↑/↓` walks the rows, Enter calls `onSelect`, Esc calls `onCancel`. Items
@@ -12,6 +12,7 @@ import { Box, Text, useInput } from 'ink';
 import { useEffect, useRef, useState } from 'react';
 
 import { clamp, clampIndex } from '@utils/core';
+import { POINTER, TICK } from './glyphs';
 
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 
@@ -321,8 +322,8 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
         const i = visibleRange.start + offset;
         const focused = i === highlight;
         const active = item.value === props.activeValue;
-        const pointer = focused ? '›' : ' ';
-        const tick = active ? '✓' : ' ';
+        const pointer = focused ? POINTER : ' ';
+        const tick = active ? TICK : ' ';
         const hotkey = selectHotkeyForIndex(i);
         const shortcut = hotkey ? `${hotkey}.` : '  ';
         const showInlineOverflow = focused && inlineOverflowText;

--- a/packages/cli/src/chat/tui/ui/glyphs.ts
+++ b/packages/cli/src/chat/tui/ui/glyphs.ts
@@ -1,0 +1,18 @@
+// Terminal-safe Unicode glyphs shared across the Ink TUI. Font Awesome (the
+// webview/desktop icon set) is not available in a terminal, so the TUI renders
+// these single-column glyphs directly. They are intentionally plain, stable
+// codepoints — NOT the `figures` package, whose `pointer`/`tick` resolve to
+// `❯`/`✔` and would change the established look — picked per
+// docs/prds/cli-tui-ink/10-architecture.md § Intuitiveness conventions.
+//
+// Centralized here so every list/select/prompt uses the same marker instead of
+// re-declaring the literal in each component.
+
+/** Focused-row marker for selects, palettes, pickers, and prompts. */
+export const POINTER = '›';
+
+/** Active/checked marker for selectable values. */
+export const TICK = '✓';
+
+/** Steady status dot for tool rows and subagent rows (never animated). */
+export const STATUS_DOT = '●';

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
@@ -162,7 +162,21 @@ export const latexTabStyles: CSSResult = css`
     margin-top: var(--wa-space-2xs);
   }
 
-  /* .section-header chrome lives in commonViewStyles. */
+  /* .section-header chrome lives in commonViewStyles; this view spaces the
+     subsequent sections from the cards above them. */
+  .section-header.spaced {
+    margin-top: var(--wa-space-s);
+  }
+
+  /* Number / enum controls inside a setting card sit below the description. */
+  .setting-number-input {
+    margin-top: var(--wa-space-2xs);
+    width: 140px;
+  }
+
+  .setting-enum-select {
+    margin-top: var(--wa-space-2xs);
+  }
 
   .setting-info {
     flex: 1;

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -459,7 +459,7 @@ export class LaTeXTab extends LitElement {
         ${this.desktopHost
           ? nothing
           : html`
-              <div class="section-header" style="margin-top:var(--wa-space-s)">
+              <div class="section-header spaced">
                 ${waIcon('settings-gear')} Recommended Settings
               </div>
 
@@ -481,7 +481,7 @@ export class LaTeXTab extends LitElement {
 
   private renderInlineCriticismSetting(): TemplateResult {
     return html`
-      <div class="section-header" style="margin-top:var(--wa-space-s)">
+      <div class="section-header spaced">
         ${waIcon('comment-discussion')} Inline Criticism
       </div>
       <div class="setting-card">
@@ -524,7 +524,7 @@ export class LaTeXTab extends LitElement {
   private renderCompileDiffSettings(): TemplateResult {
     const cv = this.configValues;
     return html`
-      <div class="section-header" style="margin-top:var(--wa-space-s)">
+      <div class="section-header spaced">
         ${waIcon('zap')} Compile &amp; Diff
       </div>
       <div class="latex-description">
@@ -724,7 +724,7 @@ export class LaTeXTab extends LitElement {
                   : Math.max(opts.min, integer);
               this.dispatchSetConfigValue(opts.field, clamped);
             }}
-            style="margin-top:var(--wa-space-2xs);width:140px;"
+            class="setting-number-input"
           ></wa-input>
         </div>
         ${isCustom
@@ -758,7 +758,7 @@ export class LaTeXTab extends LitElement {
               const v = (e.target as WaSelect).value as LatexConfigValueFor<F>;
               this.dispatchSetConfigValue(opts.field, v);
             }}
-            style="margin-top:var(--wa-space-2xs);"
+            class="setting-enum-select"
           >
             ${opts.options.map(
               (o) => html`


### PR DESCRIPTION
## Summary

Extracted terminal UI glyphs (`›`, `✓`, `●`) into a centralized `glyphs.ts` module to establish a single source of truth for these symbols across the CLI TUI. This eliminates literal glyph duplication across multiple components and ensures consistent styling per the architecture conventions documented in `docs/prds/cli-tui-ink/10-architecture.md`.

## Issue acceptance gates

N/A — this is a refactoring to improve maintainability and consistency.

## Single source of truth

`packages/cli/src/chat/tui/ui/glyphs.ts` now owns the terminal-safe Unicode glyphs used throughout the CLI TUI:
- `POINTER` (`›`) — focused-row marker for selects, palettes, pickers, and prompts
- `TICK` (`✓`) — active/checked marker for selectable values
- `STATUS_DOT` (`●`) — steady status dot for tool and subagent rows

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated hardcoded `'›'` literals from 5 components (Select, UserQuestion, SlashPalette, ApiKeyEntryForm, ChildControlPicker, InputBar)
- Eliminated hardcoded `'✓'` literals from 2 components (Select, UserQuestion)
- Consolidated `STATUS_DOT` definition from `toolRenderers.tsx` into the shared module and updated `SubagentListDisplay.ts` to import it

**Abstraction invariant:**
The `glyphs.ts` module owns the contract that these symbols are intentionally plain, stable Unicode codepoints (not the `figures` package) to maintain the established TUI look per architecture conventions.

## Host impact

**Extension:** Minor CSS refactoring in LaTeX settings tab — moved inline margin styles to CSS classes (`.spaced`, `.setting-number-input`, `.setting-enum-select`) for better maintainability. No functional change.

**Desktop:** None.

**CLI:** All glyph references now import from the centralized module instead of using literals. Behavior is identical; this improves consistency and maintainability.

## Scheduled refactoring

None.

## Validation

- No new tests required; this is a pure refactoring with no behavioral changes.
- Existing CLI TUI tests continue to pass (glyph rendering behavior unchanged).
- Extension CSS changes are purely stylistic (margin consolidation).

https://claude.ai/code/session_01VvKzB8bLQ3cSgC9b3HaFgN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only glyph imports and cosmetic CSS; no auth, data, or behavior changes.
> 
> **Overview**
> Adds **`packages/cli/src/chat/tui/ui/glyphs.ts`** as the single source for terminal markers (`POINTER`, `TICK`, `STATUS_DOT`) and wires CLI TUI lists, palettes, prompts, tool rows, and subagent status to import them instead of inline `'›'`, `'✓'`, and `'●'`. Comments document why these stay plain Unicode rather than the `figures` package.
> 
> In the extension **LaTeX** settings tab, replaces inline `style` margins on section headers and number/enum controls with CSS classes (`.section-header.spaced`, `.setting-number-input`, `.setting-enum-select`) in `LaTeXTab.styles.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c19628a8b43e977bddd4323647e64753b5f406c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->