### PR TITLE
Replace Promise.all with pMap for controlled concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,6 @@
     "monaco-editor": "^0.55.1",
     "mutative": "^1.3.0",
     "nanoid": "^5.1.15",
-    "node-pandoc": "^0.3.0",
     "openai": "^6.44.0",
     "p-defer": "^4.0.1",
     "p-map": "^7.0.4",

--- a/packages/desktop/tsconfig.paths.json
+++ b/packages/desktop/tsconfig.paths.json
@@ -39,7 +39,6 @@
       "@auth/*": ["src/auth/*"],
       "@platform": ["src/platform"],
       "@platform/*": ["src/platform/*"],
-      "node-pandoc": ["src/types/node-pandoc.d.ts"],
       "turndown-plugin-gfm": ["src/types/turndown-plugin-gfm.d.ts"],
       "vscode-jsonrpc/node": ["node_modules/vscode-jsonrpc/lib/node/main"],
       "@openrouter/sdk": ["node_modules/@openrouter/sdk/esm/index.d.ts"],

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1748,7 +1748,6 @@
     "minimatch": "^10.2.5",
     "mutative": "^1.3.0",
     "nanoid": "^5.1.15",
-    "node-pandoc": "^0.3.0",
     "openai": "^6.44.0",
     "p-map": "^7.0.4",
     "pdf2pic": "^3.2.0",

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -45,7 +45,6 @@
       "@auth/*": ["../../src/auth/*"],
       "@platform": ["../../src/platform"],
       "@platform/*": ["../../src/platform/*"],
-      "node-pandoc": ["../../src/types/node-pandoc.d.ts"],
       "turndown-plugin-gfm": ["../../src/types/turndown-plugin-gfm.d.ts"],
       "@openrouter/sdk": ["../../node_modules/@openrouter/sdk/esm/index.d.ts"],
       "@openrouter/sdk/models": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,9 +176,6 @@ importers:
       nanoid:
         specifier: ^5.1.15
         version: 5.1.15
-      node-pandoc:
-        specifier: ^0.3.0
-        version: 0.3.0
       openai:
         specifier: ^6.44.0
         version: 6.44.0(ws@8.21.0)(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,9 +634,6 @@ importers:
       nanoid:
         specifier: ^5.1.15
         version: 5.1.15
-      node-pandoc:
-        specifier: ^0.3.0
-        version: 0.3.0
       openai:
         specifier: ^6.44.0
         version: 6.44.0(ws@8.21.0)(zod@4.4.3)
@@ -4839,9 +4836,6 @@ packages:
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
-
-  node-pandoc@0.3.0:
-    resolution: {integrity: sha512-e+kANHQQFBlN7J8wEFf7sNc1sSCLltyPtPqNA/IEapiNsA1LjZ9mtV/B0lU6b2cAdvn7rrAVNBONw+Fo1YsY+A==}
 
   node-pty@1.1.0:
     resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
@@ -10602,8 +10596,6 @@ snapshots:
       html-entities: 2.6.0
 
   node-int64@0.4.0: {}
-
-  node-pandoc@0.3.0: {}
 
   node-pty@1.1.0:
     dependencies:

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -1,6 +1,7 @@
 /** Stateless YAML scanning for the agent registry. */
 
 import { glob } from 'glob';
+import pMap from 'p-map';
 import * as yaml from 'yaml';
 
 import {
@@ -56,7 +57,7 @@ export async function scanDirectory(
       })
     ).toSorted();
     const parsed = (
-      await Promise.all(files.map((file) => readYamlDefinition(file)))
+      await pMap(files, (file) => readYamlDefinition(file), { concurrency: 8 })
     ).filter(filterNotNull);
     const unique = entriesWithUniqueNames(parsed);
     const definitions = new Map(

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -84,20 +84,22 @@ export class LatexMediaManager {
       return;
     }
 
-    const tasks = [...absolutePaths].map(async (absolutePath) => {
-      try {
-        await this.fileService!.mirrorWorkspaceFile(
-          pathToLocation(absolutePath),
-        );
-      } catch (error) {
-        const message = toErrorMessage(error);
-        this.logger.debug(
-          `Unable to mirror figure dependency ${absolutePath}: ${message}`,
-        );
-      }
-    });
-
-    await Promise.all(tasks);
+    await pMap(
+      [...absolutePaths],
+      async (absolutePath) => {
+        try {
+          await this.fileService!.mirrorWorkspaceFile(
+            pathToLocation(absolutePath),
+          );
+        } catch (error) {
+          const message = toErrorMessage(error);
+          this.logger.debug(
+            `Unable to mirror figure dependency ${absolutePath}: ${message}`,
+          );
+        }
+      },
+      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
+    );
   }
 
   /**
@@ -191,8 +193,9 @@ export class LatexMediaManager {
     // path first so a mirrored symlink inside run storage points back to
     // the original workspace tree — otherwise project-local .cls/.sty/.bst/
     // latexmkrc files that live beside the real source are invisible.
-    await Promise.all(
-      texFiles.map(async (file) => {
+    await pMap(
+      texFiles,
+      async (file) => {
         let siblingDir = path.dirname(file.absolutePath);
         try {
           siblingDir = path.dirname(
@@ -204,7 +207,8 @@ export class LatexMediaManager {
           );
         }
         await this.mirrorProjectSiblings(siblingDir);
-      }),
+      },
+      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
     );
 
     while (worklist.length > 0) {
@@ -215,8 +219,9 @@ export class LatexMediaManager {
       const deps = await this.collectDependencies(file);
       if (deps.length === 0) continue;
 
-      await Promise.all(
-        deps.map(async (absolutePath) => {
+      await pMap(
+        deps,
+        async (absolutePath) => {
           const depLocation = pathToLocation(absolutePath);
           const isTex = hasExtension(absolutePath, '.tex');
           try {
@@ -231,7 +236,8 @@ export class LatexMediaManager {
               `Unable to mirror LaTeX dependency ${absolutePath}: ${toErrorMessage(error)}`,
             );
           }
-        }),
+        },
+        { concurrency: LATEX_CONCURRENCY, stopOnError: false },
       );
       this.logger.debug(
         `Mirrored ${deps.length} LaTeX dependencies from ${file.absolutePath}`,
@@ -323,8 +329,9 @@ export class LatexMediaManager {
 
     if (candidates.length === 0) return;
 
-    await Promise.all(
-      candidates.map(async (absolutePath) => {
+    await pMap(
+      candidates,
+      async (absolutePath) => {
         try {
           const stats = await platform().fs.stat(absolutePath);
           if (!isFile(stats.type)) return;
@@ -336,7 +343,8 @@ export class LatexMediaManager {
             `Unable to mirror project sibling ${absolutePath}: ${toErrorMessage(error)}`,
           );
         }
-      }),
+      },
+      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
     );
   }
 
@@ -412,11 +420,10 @@ export class LatexMediaManager {
         pathToLocation(path.normalize(path.join(baseDir, relativePath))),
       );
 
-      const existenceChecks = await Promise.all(
-        fileLocations.map(async (loc) => ({
-          loc,
-          exists: await flexibleFS.exists(loc),
-        })),
+      const existenceChecks = await pMap(
+        fileLocations,
+        async (loc) => ({ loc, exists: await flexibleFS.exists(loc) }),
+        { concurrency: LATEX_CONCURRENCY, stopOnError: false },
       );
 
       for (const { loc, exists } of existenceChecks) {
@@ -500,11 +507,10 @@ export class LatexMediaManager {
       return;
     }
 
-    const existingFilesInfo = await Promise.all(
-      files.map(async (file) => ({
-        file,
-        exists: await flexibleFS.exists(file),
-      })),
+    const existingFilesInfo = await pMap(
+      files,
+      async (file) => ({ file, exists: await flexibleFS.exists(file) }),
+      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
     );
     const existingFiles = existingFilesInfo
       .filter((f) => f.exists)

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -10,6 +10,9 @@
 // Standard library imports
 import * as path from 'node:path';
 
+// Third-party imports
+import pMap from 'p-map';
+
 // Local imports
 import { platform } from '@platform/platform';
 import type { FileLocation } from '@shared/schemas';
@@ -80,10 +83,12 @@ export async function extractLatexFileDependencies(
   const bibCandidates = collectBibliographyPaths(latexDir, uncommented);
 
   const [texResolved, bibResolved] = await Promise.all([
-    Promise.all(texInputPaths.map((raw) => resolveTexInputPath(raw, latexDir))),
-    Promise.all(
-      bibCandidates.map((absolute) => existingExternalPath(absolute)),
-    ),
+    pMap(texInputPaths, (raw) => resolveTexInputPath(raw, latexDir), {
+      concurrency: 8,
+    }),
+    pMap(bibCandidates, (absolute) => existingExternalPath(absolute), {
+      concurrency: 8,
+    }),
   ]);
 
   const results = new Set<string>();

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -85,9 +85,11 @@ export async function extractLatexFileDependencies(
   const [texResolved, bibResolved] = await Promise.all([
     pMap(texInputPaths, (raw) => resolveTexInputPath(raw, latexDir), {
       concurrency: 8,
+      stopOnError: false,
     }),
     pMap(bibCandidates, (absolute) => existingExternalPath(absolute), {
       concurrency: 8,
+      stopOnError: false,
     }),
   ]);
 

--- a/src/types/node-pandoc.d.ts
+++ b/src/types/node-pandoc.d.ts
@@ -1,1 +1,0 @@
-declare module 'node-pandoc';

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -14,6 +14,7 @@ import { toErrorMessage } from '@common/errors';
 // Local imports - utils
 import * as logger from '@logger/logUtils';
 import { checkToolInstalled } from '@utils/system/toolUtils';
+import { extendEnvPath } from '@utils/system/platformPaths';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Format Detection (inlined from xmlFormatDetection.ts - only used here)
@@ -177,6 +178,7 @@ async function convertWithPandoc(text: string): Promise<string | null> {
     const { stdout } = await execa('pandoc', ['-f', format, '-t', 'markdown'], {
       input: text,
       stripFinalNewline: false,
+      env: { ...process.env, PATH: extendEnvPath() },
     });
     return normalizePandocReferences(stdout);
   } catch (err) {

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -176,6 +176,7 @@ async function convertWithPandoc(text: string): Promise<string | null> {
   try {
     const { stdout } = await execa('pandoc', ['-f', format, '-t', 'markdown'], {
       input: text,
+      stripFinalNewline: false,
     });
     return normalizePandocReferences(stdout);
   } catch (err) {

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -6,7 +6,7 @@
 // Third-party imports
 import TurndownService from 'turndown';
 import { gfm } from 'turndown-plugin-gfm';
-import nodePandoc from 'node-pandoc';
+import { execa } from 'execa';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
@@ -174,21 +174,10 @@ async function convertWithPandoc(text: string): Promise<string | null> {
   }
 
   try {
-    const result = await new Promise<string>((resolve, reject) => {
-      nodePandoc(
-        text,
-        ['-f', format, '-t', 'markdown'],
-        (err: Error | null, res: string) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(res);
-          }
-        },
-      );
+    const { stdout } = await execa('pandoc', ['-f', format, '-t', 'markdown'], {
+      input: text,
     });
-    // Normalize Pandoc reference syntax to canonical LaTeX format
-    return normalizePandocReferences(result);
+    return normalizePandocReferences(stdout);
   } catch (err) {
     logger.error(CHANNEL, `Pandoc conversion failed: ${toErrorMessage(err)}`);
     return null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,7 +48,6 @@
       "@auth/*": ["src/auth/*"],
       "@platform": ["src/platform"],
       "@platform/*": ["src/platform/*"],
-      "node-pandoc": ["src/types/node-pandoc.d.ts"],
       "turndown-plugin-gfm": ["src/types/turndown-plugin-gfm.d.ts"],
       "@openrouter/sdk": ["node_modules/@openrouter/sdk/esm/index.d.ts"],
       "@openrouter/sdk/models": [


### PR DESCRIPTION
## Summary

Replace `Promise.all()` calls with `pMap()` from the `p-map` library to implement controlled concurrency limits across file I/O and dependency processing operations. This prevents resource exhaustion when processing large numbers of files or dependencies by limiting concurrent operations to a configurable level.

Additionally, replace the `node-pandoc` callback-based wrapper with direct `execa` calls for cleaner async/await Pandoc invocation.

## Issue acceptance gates

N/A

## Single source of truth

The `LATEX_CONCURRENCY` constant in `LatexMediaManager` now owns the concurrency limit for all LaTeX file mirroring and dependency processing operations. The `extractLatexFileDependencies` module and `agentYamlScanner` use a hardcoded concurrency of 8 for their respective file resolution and YAML parsing tasks.

## Duplication and abstraction budget

Removed callback-based promise wrapping in `convertWithPandoc()` by switching to `execa`, which provides native async/await support. This eliminates boilerplate and improves readability.

Replaced 6 separate `Promise.all()` + `.map()` patterns in `LatexMediaManager` with `pMap()` calls, applying consistent concurrency control (`{ concurrency: LATEX_CONCURRENCY, stopOnError: false }`) across all file I/O operations.

## Host impact

**Extension:** File mirroring and LaTeX dependency processing will now respect concurrency limits, reducing memory and file descriptor pressure during large document builds.

**Desktop:** Same as extension.

**CLI:** Same as extension.

## Scheduled refactoring

None

## Validation

- Existing unit tests pass (no test changes required; behavior is functionally equivalent)
- Concurrency limits are applied consistently via `pMap` options
- Error handling preserved: `stopOnError: false` maintains the original behavior of continuing on individual failures

https://claude.ai/code/session_01QfXUUW4bp6h2wGnzhaJHEc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how many LaTeX mirrors/compiles and dependency lookups run at once and how Pandoc is invoked; behavior should match but large projects may see different timing or resource use if PATH/pandoc resolution differs from the old wrapper.
> 
> **Overview**
> Limits parallel file work by swapping unbounded **`Promise.all`** batches for **`pMap`** with explicit concurrency caps, mainly in LaTeX mirroring/compilation (`LATEX_CONCURRENCY = 4`) and in agent YAML scanning / TeX–bib dependency resolution (concurrency **8**, **`stopOnError: false`** so one failure does not abort the rest).
> 
> Drops the **`node-pandoc`** dependency and its TS path shim; **`convertWithPandoc`** now runs the **`pandoc`** CLI through **`execa`** (stdin input, **`extendEnvPath()`** on **`PATH`**) while keeping the same availability check and reference normalization.
> 
> Lockfiles and **`tsconfig`** path entries are updated to match the removed package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b325ba03e25979aafcb68a2341ed639c6bdc0db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->