### PR TITLE
Extract agent execution flows into dedicated functions

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -51,10 +51,7 @@ import { createInterruptCallbacks } from './InterruptManager';
 import { generateSessionDescription } from './sessionDescription';
 import { getProgressViewBridge } from './ProgressViewBridge';
 import { AgentFlowError, type AgentFlowResult } from './AgentFlowResult';
-import type {
-  AgentExecutionHandle,
-  AgentRunHandle,
-} from './executionRegistry';
+import type { AgentExecutionHandle, AgentRunHandle } from './executionRegistry';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const CHANNEL = 'executeAgent';

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -17,7 +17,11 @@ import {
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import type { RoundFinalizedCallback } from '@agent/core/flows/BaseFlowServices';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import {
+  AgentCategory,
+  type AgentToolUseSetting,
+  type AgentWorkflowSetting,
+} from '@agent/core/definition/AgentDataclass';
 import { computeDelegationDepthFromStorage } from '@agent/runtime/delegationPolicy';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { AgentError, getSdkErrorMessage } from '@common/errors';
@@ -47,7 +51,10 @@ import { createInterruptCallbacks } from './InterruptManager';
 import { generateSessionDescription } from './sessionDescription';
 import { getProgressViewBridge } from './ProgressViewBridge';
 import { AgentFlowError, type AgentFlowResult } from './AgentFlowResult';
-import type { AgentRunHandle } from './executionRegistry';
+import type {
+  AgentExecutionHandle,
+  AgentRunHandle,
+} from './executionRegistry';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const CHANNEL = 'executeAgent';
@@ -198,6 +205,7 @@ function createUsageRecordingCallback(
 async function runToolUseAgent(
   ctx: AgentLaunchContext,
   handle: AgentExecutionHandle,
+  setting: AgentToolUseSetting,
   options: Pick<
     ExecuteAgentOptions,
     'isSubagent' | 'onBeforeWaiting' | 'onFollowUpConsumed' | 'onProgress'
@@ -212,7 +220,7 @@ async function runToolUseAgent(
         ...ctx,
         ...createInterruptCallbacks(),
         onRoundFinalized,
-        setting: ctx.setting,
+        setting,
         isSubagent: options.isSubagent,
         onBeforeWaiting: options.onBeforeWaiting,
         onProgress: (update) => {
@@ -235,6 +243,9 @@ async function runToolUseAgent(
           options.onFollowUpConsumed?.();
         },
         onModelChanged: (modelHandler) => {
+          // The tool-use flow already wrote services.config.model
+          // (=== ctx.config.model, same object), so the live model is updated
+          // before this fires; only the usage side-effect is left to do here.
           ctx.usageMonitor.setModelInfo({
             capabilities: modelHandler.capabilities,
             config: modelHandler.config,
@@ -277,6 +288,7 @@ async function runToolUseAgent(
  */
 async function runReflectionAgent(
   ctx: AgentLaunchContext,
+  setting: AgentWorkflowSetting,
   options: Pick<ExecuteAgentOptions, 'onProgress'>,
 ): Promise<AgentFlowResult> {
   const { streamId } = ctx;
@@ -291,7 +303,7 @@ async function runReflectionAgent(
     ...ctx,
     ...createInterruptCallbacks(),
     onRoundFinalized,
-    setting: ctx.setting,
+    setting,
     parentStage: ctx.parentStage,
     onRoundCompleted,
   });
@@ -437,9 +449,9 @@ export async function executeAgent(
         logger.info(`Executing ${config.agent} with model ${config.model}`);
 
         if (setting.agentCategory === AgentCategory.ToolUse) {
-          return runToolUseAgent(ctx, handle, options);
+          return runToolUseAgent(ctx, handle, setting, options);
         }
-        return runReflectionAgent(ctx, options);
+        return runReflectionAgent(ctx, setting, options);
       },
       {
         isSubagent,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -187,6 +187,122 @@ function createUsageRecordingCallback(
   };
 }
 
+/**
+ * Run the tool-use flow for a single agent execution.
+ *
+ * Owns all tool-use-specific wiring: progress counters, follow-up queuing,
+ * model-change side effects, and error wrapping into `AgentFlowError`.
+ * The caller (`executeAgent`) owns lifecycle and stream-status; this function
+ * owns only what is specific to the ToolUse category.
+ */
+async function runToolUseAgent(
+  ctx: AgentLaunchContext,
+  handle: AgentExecutionHandle,
+  options: Pick<
+    ExecuteAgentOptions,
+    'isSubagent' | 'onBeforeWaiting' | 'onFollowUpConsumed' | 'onProgress'
+  >,
+): Promise<AgentFlowResult> {
+  const { streamId } = ctx;
+  let toolUseTurns = 0;
+  const onRoundFinalized = createUsageRecordingCallback(ctx);
+  try {
+    const result = await runToolUseFlow(
+      {
+        ...ctx,
+        ...createInterruptCallbacks(),
+        onRoundFinalized,
+        setting: ctx.setting,
+        isSubagent: options.isSubagent,
+        onBeforeWaiting: options.onBeforeWaiting,
+        onProgress: (update) => {
+          if (update.kind === 'overview') {
+            toolUseTurns++;
+            ctx.runtimeHost.emit('updateConversationProgress', {
+              streamId,
+              progress: {
+                conversationTurns: toolUseTurns,
+                toolCallCount: update.toolCallCount,
+              },
+            });
+          }
+          options.onProgress?.(update);
+        },
+        onFollowUpConsumed: () => {
+          ctx.runtimeHost.emit('updateQueuedFollowUps', {
+            streamId: ctx.streamId,
+          });
+          options.onFollowUpConsumed?.();
+        },
+        onModelChanged: (modelHandler) => {
+          ctx.usageMonitor.setModelInfo({
+            capabilities: modelHandler.capabilities,
+            config: modelHandler.config,
+          });
+        },
+      },
+      undefined,
+      (flowContext) => {
+        handle.attachToolUseFlow(flowContext);
+        return () => handle.detachToolUseFlow(flowContext);
+      },
+    );
+    return buildToolUseFlowResult(
+      result,
+      ctx.executionId,
+      streamId,
+      ctx.attachedMemoryMisses,
+    );
+  } catch (err) {
+    const failedResult = getToolUseFlowErrorResult(err);
+    if (!failedResult) throw err;
+    throw new AgentFlowError(
+      getSdkErrorMessage(err),
+      buildToolUseFlowResult(
+        failedResult,
+        ctx.executionId,
+        streamId,
+        ctx.attachedMemoryMisses,
+      ),
+      { cause: err },
+    );
+  }
+}
+
+/**
+ * Run the reflection (workflow) flow for a single agent execution.
+ *
+ * Owns all workflow-specific wiring: per-round progress callbacks and usage
+ * recording. The caller (`executeAgent`) owns lifecycle and stream-status.
+ */
+async function runReflectionAgent(
+  ctx: AgentLaunchContext,
+  options: Pick<ExecuteAgentOptions, 'onProgress'>,
+): Promise<AgentFlowResult> {
+  const { streamId } = ctx;
+  const onRoundCompleted = createRoundProgressCallback(
+    ctx.executionId,
+    streamId,
+    ctx.runtimeHost,
+    options.onProgress,
+  );
+  const onRoundFinalized = createUsageRecordingCallback(ctx);
+  const result = await runReflectionFlow({
+    ...ctx,
+    ...createInterruptCallbacks(),
+    onRoundFinalized,
+    setting: ctx.setting,
+    parentStage: ctx.parentStage,
+    onRoundCompleted,
+  });
+  return buildWorkflowFlowResult(
+    result,
+    ctx.executionId,
+    streamId,
+    ctx.attachedMemoryMisses,
+  );
+}
+
 /** Toast payload shown when the progress view cannot be opened. */
 type FallbackNotification = NonNullable<
   ProgressEventPayloads['requestEnsureProgressView']['fallbackNotification']
@@ -319,99 +435,11 @@ export async function executeAgent(
         });
 
         logger.info(`Executing ${config.agent} with model ${config.model}`);
-        const interrupts = createInterruptCallbacks();
 
         if (setting.agentCategory === AgentCategory.ToolUse) {
-          let toolUseTurns = 0;
-          const onRoundFinalized = createUsageRecordingCallback(ctx);
-          try {
-            const result = await runToolUseFlow(
-              {
-                ...ctx,
-                ...interrupts,
-                onRoundFinalized,
-                setting,
-                isSubagent,
-                onBeforeWaiting: options.onBeforeWaiting,
-                onProgress: (update) => {
-                  if (update.kind === 'overview') {
-                    toolUseTurns++;
-                    ctx.runtimeHost.emit('updateConversationProgress', {
-                      streamId,
-                      progress: {
-                        conversationTurns: toolUseTurns,
-                        toolCallCount: update.toolCallCount,
-                      },
-                    });
-                  }
-                  options.onProgress?.(update);
-                },
-                onFollowUpConsumed: () => {
-                  ctx.runtimeHost.emit('updateQueuedFollowUps', {
-                    streamId: ctx.streamId,
-                  });
-                  options.onFollowUpConsumed?.();
-                },
-                onModelChanged: (modelHandler) => {
-                  // The tool-use flow already wrote services.config.model
-                  // (=== ctx.config.model, same object), so the live model is
-                  // updated before this fires; only the usage side-effect is
-                  // left to do here.
-                  ctx.usageMonitor.setModelInfo({
-                    capabilities: modelHandler.capabilities,
-                    config: modelHandler.config,
-                  });
-                },
-              },
-              undefined,
-              (flowContext) => {
-                handle.attachToolUseFlow(flowContext);
-                return () => handle.detachToolUseFlow(flowContext);
-              },
-            );
-            return buildToolUseFlowResult(
-              result,
-              ctx.executionId,
-              streamId,
-              ctx.attachedMemoryMisses,
-            );
-          } catch (err) {
-            const failedResult = getToolUseFlowErrorResult(err);
-            if (!failedResult) throw err;
-            throw new AgentFlowError(
-              getSdkErrorMessage(err),
-              buildToolUseFlowResult(
-                failedResult,
-                ctx.executionId,
-                streamId,
-                ctx.attachedMemoryMisses,
-              ),
-              { cause: err },
-            );
-          }
+          return runToolUseAgent(ctx, handle, options);
         }
-
-        const onRoundCompleted = createRoundProgressCallback(
-          ctx.executionId,
-          streamId,
-          ctx.runtimeHost,
-          options.onProgress,
-        );
-        const onRoundFinalized = createUsageRecordingCallback(ctx);
-        const result = await runReflectionFlow({
-          ...ctx,
-          ...interrupts,
-          onRoundFinalized,
-          setting,
-          parentStage: ctx.parentStage,
-          onRoundCompleted,
-        });
-        return buildWorkflowFlowResult(
-          result,
-          ctx.executionId,
-          streamId,
-          ctx.attachedMemoryMisses,
-        );
+        return runReflectionAgent(ctx, options);
       },
       {
         isSubagent,


### PR DESCRIPTION
## Summary

Refactor `executeAgent` to extract tool-use and reflection agent execution logic into two dedicated functions: `runToolUseAgent` and `runReflectionAgent`. This improves code organization and readability by separating agent-category-specific concerns from the main execution orchestrator.

## Issue acceptance gates

N/A — internal refactoring with no behavioral changes.

## Single source of truth

The `executeAgent` function remains the single orchestrator for agent lifecycle and stream-status management. The new `runToolUseAgent` and `runReflectionAgent` functions own only the category-specific wiring (progress callbacks, usage recording, error handling) for their respective flows.

## Duplication and abstraction budget

Removed ~90 lines of nested logic from `executeAgent` by extracting:
- **`runToolUseAgent`**: Owns tool-use-specific wiring including progress counters, follow-up queuing, model-change side effects, and error wrapping into `AgentFlowError`.
- **`runReflectionAgent`**: Owns reflection (workflow)-specific wiring including per-round progress callbacks and usage recording.

Both functions accept a minimal set of options (via `Pick<ExecuteAgentOptions, ...>`) to avoid pass-through layers, and both return `AgentFlowResult` for consistent handling by the caller.

## Host impact

Extension: No user-facing changes.

Desktop: No user-facing changes.

CLI: No user-facing changes.

## Scheduled refactoring

None.

## Validation

This is a pure refactoring with no behavioral changes. The extracted functions preserve all existing logic, error handling, and callback wiring. Existing test coverage for `executeAgent` continues to apply.

https://claude.ai/code/session_01Fom1VGzXiN2rgQaMngbu5p

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical move of existing logic within executeAgent; resume and other entry points are unchanged aside from the new call sites.
> 
> **Overview**
> **`executeAgent`** no longer inlines category-specific flow wiring; it delegates to **`runToolUseAgent`** or **`runReflectionAgent`** based on `AgentCategory`.
> 
> **`runToolUseAgent`** centralizes the former tool-use block: `runToolUseFlow`, conversation progress / follow-up / model-change callbacks, flow attach/detach via **`AgentExecutionHandle`**, and **`AgentFlowError`** wrapping from partial failures. **`runReflectionAgent`** holds the reflection path: round progress, usage recording, and **`buildWorkflowFlowResult`**.
> 
> Imports add **`AgentToolUseSetting`**, **`AgentWorkflowSetting`**, and **`AgentExecutionHandle`**. Lifecycle, UI setup, and **`runFlowWithLifecycle`** stay in **`executeAgent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a27cbc97f73e70fe892f8c61643f775be58f3f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->