### PR TITLE
fix(cli): reject --device + --no-browser in chat login path

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -12,6 +12,8 @@ import {
 import { type CliContext } from '@cli/runtime/cliContext';
 import {
   githubSelectAccountWarning,
+  hasLoginTransportConflict,
+  LOGIN_TRANSPORT_CONFLICT_MESSAGE,
   parseChatLoginSlashArgs,
   type CliLoginSlashArgs,
   type CliTexraLoginSlashArgs,
@@ -107,6 +109,13 @@ export async function loginFromChat(
   const args = parseChatLoginSlashArgs(input);
   if (!args) {
     appendLocalAssistantTranscript(CHAT_LOGIN_USAGE);
+    return;
+  }
+
+  // Match the CLI `login` guard: reject `--device` + `--no-browser` from the
+  // user's parsed flags before the ChatGPT path can auto-resolve `device`.
+  if (hasLoginTransportConflict(args)) {
+    appendLocalAssistantTranscript(LOGIN_TRANSPORT_CONFLICT_MESSAGE);
     return;
   }
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -6,7 +6,9 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
 import {
   githubSelectAccountWarning,
+  hasLoginTransportConflict,
   isCliLoginProvider,
+  LOGIN_TRANSPORT_CONFLICT_MESSAGE,
   resolveLoginProvider,
   unsupportedLoginProviderMessage,
   type CliLoginInit,
@@ -86,6 +88,14 @@ export function loginInitFromArgs(args: LoginCommandArgs): CliLoginInit {
     selectAccount: readBooleanArg(args, 'select-account', 'selectAccount'),
     loginHint: readStringArg(args, 'login-hint', 'loginHint'),
   };
+}
+
+export function assertLoginTransportExclusive(
+  init: Pick<CliLoginInit, 'device' | 'noBrowser'>,
+): void {
+  if (hasLoginTransportConflict(init)) {
+    throw new CliUsageError(LOGIN_TRANSPORT_CONFLICT_MESSAGE);
+  }
 }
 
 export function shouldPromptForLoginProvider(
@@ -226,15 +236,7 @@ export const loginCommand = withUsageSections(
     },
     run: (context, ctx) => {
       const init = loginInitFromArgs(ctx.args);
-      // `--device` and `--no-browser` are distinct sign-in transports, not
-      // refinements of each other (device-code shows no loopback URL), and the
-      // device branch silently wins when both are set. Reject the combination
-      // so the choice is explicit instead of quietly ignored.
-      if (init.device && init.noBrowser) {
-        throw new CliUsageError(
-          'Use either --device or --no-browser, not both: --device signs in with a one-time code (no loopback URL), while --no-browser prints the loopback sign-in URL.',
-        );
-      }
+      assertLoginTransportExclusive(init);
       return runLoginCommand(context, init);
     },
   }),

--- a/packages/cli/src/runtime/loginOptions.ts
+++ b/packages/cli/src/runtime/loginOptions.ts
@@ -57,6 +57,20 @@ export function isCliLoginProvider(
   return isOAuthProvider(provider);
 }
 
+// `--device` and `--no-browser` are distinct sign-in transports, not
+// refinements of each other (device-code shows no loopback URL), and the
+// device branch silently wins when both are set. Both the CLI command and the
+// chat `/login` path reject the combination so the choice is explicit instead
+// of quietly ignored.
+export const LOGIN_TRANSPORT_CONFLICT_MESSAGE =
+  'Use either --device or --no-browser, not both: --device signs in with a one-time code (no loopback URL), while --no-browser prints the loopback sign-in URL.';
+
+export function hasLoginTransportConflict(
+  args: Pick<CliLoginInit, 'device' | 'noBrowser'>,
+): boolean {
+  return args.device && args.noBrowser;
+}
+
 export function githubSelectAccountWarning(
   init: Pick<CliLoginInit, 'provider' | 'selectAccount' | 'loginHint'>,
 ): string | undefined {

--- a/src/test-kernel/cli/LoginArgs.vitest.mts
+++ b/src/test-kernel/cli/LoginArgs.vitest.mts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  assertLoginTransportExclusive,
   loginInitFromArgs,
   shouldPromptForLoginProvider,
 } from '@cli/commands/auth';
+import { CliUsageError } from '@cli/runtime/cliContext';
 import {
   githubSelectAccountWarning,
+  hasLoginTransportConflict,
+  LOGIN_TRANSPORT_CONFLICT_MESSAGE,
   parseChatLoginSlashArgs,
   resolveLoginProvider,
   unsupportedLoginProviderMessage,
@@ -147,6 +151,36 @@ describe('CLI login arguments (texra login)', () => {
       device: true,
       noBrowser: false,
     });
+  });
+
+  it('treats --device and --no-browser as a transport conflict only when both are set', () => {
+    expect(hasLoginTransportConflict({ device: true, noBrowser: true })).toBe(
+      true,
+    );
+    expect(hasLoginTransportConflict({ device: true, noBrowser: false })).toBe(
+      false,
+    );
+    expect(hasLoginTransportConflict({ device: false, noBrowser: true })).toBe(
+      false,
+    );
+    expect(hasLoginTransportConflict({ device: false, noBrowser: false })).toBe(
+      false,
+    );
+  });
+
+  it('rejects --device + --no-browser from the CLI login command', () => {
+    expect(() =>
+      assertLoginTransportExclusive({ device: true, noBrowser: true }),
+    ).toThrow(CliUsageError);
+    expect(() =>
+      assertLoginTransportExclusive({ device: true, noBrowser: true }),
+    ).toThrow(LOGIN_TRANSPORT_CONFLICT_MESSAGE);
+    expect(() =>
+      assertLoginTransportExclusive({ device: true, noBrowser: false }),
+    ).not.toThrow();
+    expect(() =>
+      assertLoginTransportExclusive({ device: false, noBrowser: true }),
+    ).not.toThrow();
   });
 
   it('rejects invalid in-chat login slash command options', () => {


### PR DESCRIPTION
## Summary

Closes #6583 (follow-up from #6582).

PR #6582 added a `--device` + `--no-browser` mutual-exclusion guard to the CLI `login` command, but the chat `/login` path still silently let `--device` win when both flags were passed. This wires the same rule into the chat surface and removes the duplicated guard logic.

## Changes

- **`runtime/loginOptions.ts`** — new single source of truth for the rule: `LOGIN_TRANSPORT_CONFLICT_MESSAGE` constant and `hasLoginTransportConflict()` predicate, used by both surfaces.
- **`commands/auth.ts`** — the inline check (with a duplicated message string) is replaced by an extracted, exported `assertLoginTransportExclusive()` called from `run`.
- **`chat/tui/commands/handlers/loginCommands.ts`** — `loginFromChat` now rejects the combination from the user's *parsed* flags, before the ChatGPT path auto-resolves `device` (so an auto-set `device` + user `--no-browser` is not a false positive).

## Tests

- `hasLoginTransportConflict` flagged only when both flags are set.
- `assertLoginTransportExclusive` throws `CliUsageError` with the shared message (the CLI guard was previously uncovered, per #6582 review feedback).

## Verification

- `npx vitest run src/test-kernel/cli/LoginArgs.vitest.mts` — 14 passed
- `npm run typecheck` — clean
- `eslint` on the four changed files — clean

https://claude.ai/code/session_01LWZ68B1fnWJovfgo9wa7Hk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI/auth UX guard with no changes to OAuth flows beyond rejecting an invalid flag combination.
> 
> **Overview**
> Centralizes the **mutual exclusion** between `--device` and `--no-browser` in `loginOptions.ts` via `hasLoginTransportConflict()` and a shared `LOGIN_TRANSPORT_CONFLICT_MESSAGE`, so CLI and chat surfaces stay aligned.
> 
> The **`texra login`** command now calls exported `assertLoginTransportExclusive()` instead of an inline check. **`/login` in chat** applies the same rule on the user’s parsed flags **before** ChatGPT can auto-enable device code, avoiding silent “device wins” behavior and false positives when only one flag was user-supplied.
> 
> Tests cover the predicate and CLI assertion (including the shared error message).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce57a7e874bf0ea8f35905aa8ea1794427c89d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->