### PR TITLE
Extract Overleaf/ShareLaTeX URL parsing to host-neutral module

### DIFF
--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -5,6 +5,14 @@ import * as vscode from 'vscode';
 // Local imports - utilities
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { toErrorMessage } from '@common/errors';
+import {
+  buildAuthenticatedRemoteUrl,
+  buildGitCredential,
+  overleafTokenSpec,
+  parseLatexGitUrl,
+  redactSensitive,
+  type GitCredential,
+} from '@latex/overleafProject';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
@@ -15,11 +23,6 @@ logger.initialize(CHANNEL);
 
 const COMMIT_LABEL_FORMAT = '%h: %s (%cr)';
 const COMMIT_HASH_PATTERN = /^[0-9a-fA-F]{4,40}$/;
-const LATEX_PROJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
-const LATEX_GIT_URL_PATTERN =
-  /^https?:\/\/(?:git@)?([^/]+)(\/git)?\/([a-f0-9]{24})$/i;
-const LATEX_PROJECT_URL_PATTERN =
-  /^https?:\/\/([^/]+)\/project\/([a-f0-9]{24})\/?$/i;
 const OVERLEAF_GIT_TOKEN_URL = 'https://www.overleaf.com/user/settings';
 const OVERLEAF_TOKEN_DOCS_URL =
   'https://docs.overleaf.com/integrations-and-add-ons/git-integration-and-github-synchronization/git-integration/git-integration-authentication-tokens';
@@ -141,53 +144,6 @@ function findCommitInHistory(
   return label || sanitizedCommit;
 }
 
-/**
- * Parse Overleaf or ShareLaTeX URL. Returns null if invalid.
- * Accepts:
- *   - https://git.overleaf.com/<24-char-hex>
- *   - https://sharelatex.example.com/git/<24-char-hex>
- *   - https://git@sharelatex.example.com/git/<24-char-hex>
- *   - https://www.overleaf.com/project/<24-char-hex>
- *   - https://sharelatex.example.com/project/<24-char-hex>
- *   - bare 24-char hex (assumes Overleaf)
- */
-function parseLatexGitUrl(
-  input: string,
-): { host: string; path: string; isOverleaf: boolean } | null {
-  const trimmed = input.trim();
-
-  // Full git URL (e.g. https://git.overleaf.com/<id>)
-  const match = LATEX_GIT_URL_PATTERN.exec(trimmed);
-  if (match) {
-    const [, host, hasGit, id] = match;
-    return {
-      host,
-      path: hasGit ? `/git/${id}` : `/${id}`,
-      isOverleaf: host === 'git.overleaf.com',
-    };
-  }
-
-  // Project URL (e.g. https://www.overleaf.com/project/<id> or https://sharelatex.example.com/project/<id>)
-  const projectMatch = LATEX_PROJECT_URL_PATTERN.exec(trimmed);
-  if (projectMatch) {
-    const [, rawHost, id] = projectMatch;
-    const host = rawHost.replace(/^www\./, '');
-    const isOverleaf = host === 'overleaf.com';
-    return {
-      host: isOverleaf ? 'git.overleaf.com' : host,
-      path: isOverleaf ? `/${id}` : `/git/${id}`,
-      isOverleaf,
-    };
-  }
-
-  // Bare project ID -> Overleaf
-  if (LATEX_PROJECT_ID_PATTERN.test(trimmed)) {
-    return { host: 'git.overleaf.com', path: `/${trimmed}`, isOverleaf: true };
-  }
-
-  return null;
-}
-
 async function promptInput(
   title: string,
   prompt: string,
@@ -216,13 +172,13 @@ async function getGitToken(
   title: string,
   validate?: (t: string) => boolean,
   promptHint?: string,
-): Promise<{ remote: string; sensitive: string[] } | null> {
+): Promise<GitCredential | null> {
   const isValid = (t: string): boolean => validate?.(t) ?? true;
 
   // Try stored token first
   const stored = (await secrets.get(key))?.trim() ?? '';
   if (stored && isValid(stored)) {
-    return buildTokenResult(stored);
+    return buildGitCredential(stored);
   }
 
   // Clear invalid stored token
@@ -252,15 +208,7 @@ async function getGitToken(
   }
 
   await secrets.store(key, input);
-  return buildTokenResult(input);
-}
-
-function buildTokenResult(token: string): {
-  remote: string;
-  sensitive: string[];
-} {
-  const encoded = encodeURIComponent(token);
-  return { remote: `git:${encoded}`, sensitive: [token, encoded] };
+  return buildGitCredential(input);
 }
 
 const IGNORED_FILES = new Set(['.DS_Store', 'Thumbs.db']);
@@ -365,18 +313,8 @@ async function cloneOverleafProject(
     return;
   }
 
-  const tokenKey = parsed.isOverleaf
-    ? 'overleaf.gitToken'
-    : `sharelatex.${parsed.host}.token`;
-  const tokenTitle = parsed.isOverleaf
-    ? 'Overleaf Git Token'
-    : `ShareLaTeX Token (${parsed.host})`;
-  const tokenValidator = parsed.isOverleaf
-    ? (t: string) => t.startsWith('olp_')
-    : undefined;
-  const tokenHint = parsed.isOverleaf
-    ? 'Overleaf tokens start with olp_. Generate one at Account Settings → Git Integration.'
-    : undefined;
+  const { tokenKey, tokenTitle, tokenValidator, tokenHint } =
+    overleafTokenSpec(parsed);
 
   const creds = await getGitToken(
     context.secrets,
@@ -390,7 +328,7 @@ async function cloneOverleafProject(
   const canClone = await checkClonePreconditions(workspacePath);
   if (!canClone) return;
 
-  const remote = `https://${creds.remote}@${parsed.host}${parsed.path}`;
+  const remote = buildAuthenticatedRemoteUrl(parsed, creds);
   const label = parsed.isOverleaf ? 'Overleaf' : 'ShareLaTeX';
 
   try {
@@ -437,8 +375,7 @@ async function cloneOverleafProject(
     }
 
     if (e instanceof Error) {
-      let msg = e.message;
-      for (const s of creds.sensitive) msg = msg.replaceAll(s, '***');
+      const msg = redactSensitive(e.message, creds.sensitive);
       logger.error(CHANNEL, `Clone failed: ${msg}`);
     }
   }

--- a/src/latex/overleafProject.ts
+++ b/src/latex/overleafProject.ts
@@ -1,0 +1,129 @@
+/**
+ * Host-neutral Overleaf / ShareLaTeX git-remote domain logic.
+ *
+ * Pure parsing, token-spec derivation, and credential/URL construction
+ * extracted from the VS Code clone command so the rules are unit-testable and
+ * reusable by any host (CLI, desktop). No I/O, no `vscode`.
+ */
+
+const PROJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
+const GIT_URL_PATTERN =
+  /^https?:\/\/(?:git@)?([^/]+)(\/git)?\/([a-f0-9]{24})$/i;
+const PROJECT_URL_PATTERN = /^https?:\/\/([^/]+)\/project\/([a-f0-9]{24})\/?$/i;
+
+/** A resolved Overleaf/ShareLaTeX git remote. */
+export interface OverleafRemote {
+  /** Git host the project clones from (e.g. `git.overleaf.com`). */
+  host: string;
+  /** Path component appended to the host (e.g. `/<id>` or `/git/<id>`). */
+  path: string;
+  /** True for overleaf.com itself; false for a self-hosted ShareLaTeX. */
+  isOverleaf: boolean;
+}
+
+/**
+ * Parse an Overleaf or ShareLaTeX URL into a clone target. Returns null when
+ * the input matches none of the accepted shapes. Accepts:
+ *   - https://git.overleaf.com/<24-char-hex>
+ *   - https://sharelatex.example.com/git/<24-char-hex>
+ *   - https://git@sharelatex.example.com/git/<24-char-hex>
+ *   - https://www.overleaf.com/project/<24-char-hex>
+ *   - https://sharelatex.example.com/project/<24-char-hex>
+ *   - bare 24-char hex (assumes Overleaf)
+ */
+export function parseLatexGitUrl(input: string): OverleafRemote | null {
+  const trimmed = input.trim();
+
+  // Full git URL (e.g. https://git.overleaf.com/<id>)
+  const match = GIT_URL_PATTERN.exec(trimmed);
+  if (match) {
+    const [, host, hasGit, id] = match;
+    return {
+      host,
+      path: hasGit ? `/git/${id}` : `/${id}`,
+      isOverleaf: host === 'git.overleaf.com',
+    };
+  }
+
+  // Project URL (e.g. https://www.overleaf.com/project/<id> or
+  // https://sharelatex.example.com/project/<id>)
+  const projectMatch = PROJECT_URL_PATTERN.exec(trimmed);
+  if (projectMatch) {
+    const [, rawHost, id] = projectMatch;
+    const host = rawHost.replace(/^www\./, '');
+    const isOverleaf = host === 'overleaf.com';
+    return {
+      host: isOverleaf ? 'git.overleaf.com' : host,
+      path: isOverleaf ? `/${id}` : `/git/${id}`,
+      isOverleaf,
+    };
+  }
+
+  // Bare project ID -> Overleaf
+  if (PROJECT_ID_PATTERN.test(trimmed)) {
+    return { host: 'git.overleaf.com', path: `/${trimmed}`, isOverleaf: true };
+  }
+
+  return null;
+}
+
+/** How a host should prompt for and validate the project's git token. */
+export interface OverleafTokenSpec {
+  /** Secret-storage key the token is cached under. */
+  tokenKey: string;
+  /** Prompt title shown when requesting the token. */
+  tokenTitle: string;
+  /** Optional format check; rejects obviously-wrong tokens before cloning. */
+  tokenValidator?: (token: string) => boolean;
+  /** Optional hint copy explaining where to obtain a token. */
+  tokenHint?: string;
+}
+
+/** Derive the per-host token prompt/validation rules for a remote. */
+export function overleafTokenSpec(remote: OverleafRemote): OverleafTokenSpec {
+  if (remote.isOverleaf) {
+    return {
+      tokenKey: 'overleaf.gitToken',
+      tokenTitle: 'Overleaf Git Token',
+      tokenValidator: (t) => t.startsWith('olp_'),
+      tokenHint:
+        'Overleaf tokens start with olp_. Generate one at Account Settings → Git Integration.',
+    };
+  }
+  return {
+    tokenKey: `sharelatex.${remote.host}.token`,
+    tokenTitle: `ShareLaTeX Token (${remote.host})`,
+  };
+}
+
+/** A git credential ready to embed in a remote URL, plus its redaction forms. */
+export interface GitCredential {
+  /** Embedded in the remote URL as the userinfo component. */
+  remote: string;
+  /** Raw and encoded token forms to redact from logs and error messages. */
+  sensitive: string[];
+}
+
+/** Build the `git:<encoded>` userinfo credential for a raw token. */
+export function buildGitCredential(token: string): GitCredential {
+  const encoded = encodeURIComponent(token);
+  return { remote: `git:${encoded}`, sensitive: [token, encoded] };
+}
+
+/** Construct the authenticated HTTPS clone URL for a remote + credential. */
+export function buildAuthenticatedRemoteUrl(
+  remote: OverleafRemote,
+  credential: GitCredential,
+): string {
+  return `https://${credential.remote}@${remote.host}${remote.path}`;
+}
+
+/** Replace every sensitive token form in `message` with `***`. */
+export function redactSensitive(
+  message: string,
+  sensitive: readonly string[],
+): string {
+  let redacted = message;
+  for (const s of sensitive) redacted = redacted.replaceAll(s, '***');
+  return redacted;
+}

--- a/src/test-kernel/latex/OverleafProject.vitest.ts
+++ b/src/test-kernel/latex/OverleafProject.vitest.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAuthenticatedRemoteUrl,
+  buildGitCredential,
+  overleafTokenSpec,
+  parseLatexGitUrl,
+  redactSensitive,
+} from '@latex/overleafProject';
+
+const ID = '0123456789abcdef01234567';
+
+describe('parseLatexGitUrl', () => {
+  it('parses a bare 24-char project id as Overleaf', () => {
+    expect(parseLatexGitUrl(`  ${ID}  `)).toEqual({
+      host: 'git.overleaf.com',
+      path: `/${ID}`,
+      isOverleaf: true,
+    });
+  });
+
+  it('parses an Overleaf git URL', () => {
+    expect(parseLatexGitUrl(`https://git.overleaf.com/${ID}`)).toEqual({
+      host: 'git.overleaf.com',
+      path: `/${ID}`,
+      isOverleaf: true,
+    });
+  });
+
+  it('parses a self-hosted ShareLaTeX git URL with /git and git@ userinfo', () => {
+    expect(
+      parseLatexGitUrl(`https://git@sharelatex.example.com/git/${ID}`),
+    ).toEqual({
+      host: 'sharelatex.example.com',
+      path: `/git/${ID}`,
+      isOverleaf: false,
+    });
+  });
+
+  it('normalizes a www. Overleaf project URL to the git host', () => {
+    expect(parseLatexGitUrl(`https://www.overleaf.com/project/${ID}`)).toEqual({
+      host: 'git.overleaf.com',
+      path: `/${ID}`,
+      isOverleaf: true,
+    });
+  });
+
+  it('routes a self-hosted project URL through /git', () => {
+    expect(
+      parseLatexGitUrl(`https://sharelatex.example.com/project/${ID}/`),
+    ).toEqual({
+      host: 'sharelatex.example.com',
+      path: `/git/${ID}`,
+      isOverleaf: false,
+    });
+  });
+
+  it('returns null for unrecognized input', () => {
+    expect(parseLatexGitUrl('not-a-url')).toBeNull();
+    expect(parseLatexGitUrl('https://example.com/project/short')).toBeNull();
+  });
+});
+
+describe('overleafTokenSpec', () => {
+  it('requires an olp_ prefix for Overleaf', () => {
+    const spec = overleafTokenSpec({
+      host: 'git.overleaf.com',
+      path: `/${ID}`,
+      isOverleaf: true,
+    });
+    expect(spec.tokenKey).toBe('overleaf.gitToken');
+    expect(spec.tokenValidator?.('olp_abc')).toBe(true);
+    expect(spec.tokenValidator?.('nope')).toBe(false);
+  });
+
+  it('namespaces the token key by host and skips validation for ShareLaTeX', () => {
+    const spec = overleafTokenSpec({
+      host: 'sharelatex.example.com',
+      path: `/git/${ID}`,
+      isOverleaf: false,
+    });
+    expect(spec.tokenKey).toBe('sharelatex.sharelatex.example.com.token');
+    expect(spec.tokenValidator).toBeUndefined();
+    expect(spec.tokenHint).toBeUndefined();
+  });
+});
+
+describe('credential helpers', () => {
+  it('url-encodes the token and tracks both forms for redaction', () => {
+    const cred = buildGitCredential('olp_a/b+c');
+    expect(cred.remote).toBe(`git:${encodeURIComponent('olp_a/b+c')}`);
+    expect(cred.sensitive).toEqual([
+      'olp_a/b+c',
+      encodeURIComponent('olp_a/b+c'),
+    ]);
+  });
+
+  it('builds the authenticated clone URL from remote + credential', () => {
+    const remote = {
+      host: 'git.overleaf.com',
+      path: `/${ID}`,
+      isOverleaf: true,
+    };
+    expect(
+      buildAuthenticatedRemoteUrl(remote, buildGitCredential('olp_x')),
+    ).toBe(`https://git:olp_x@git.overleaf.com/${ID}`);
+  });
+
+  it('redacts every sensitive form from a message', () => {
+    const cred = buildGitCredential('olp_secret');
+    const leaked = `fatal: auth failed for git:${cred.sensitive[1]} (olp_secret)`;
+    const redacted = redactSensitive(leaked, cred.sensitive);
+    expect(redacted).not.toContain('olp_secret');
+    expect(redacted).not.toContain(cred.sensitive[1]);
+    expect(redacted).toContain('***');
+  });
+});

--- a/src/test-kernel/latex/OverleafProject.vitest.ts
+++ b/src/test-kernel/latex/OverleafProject.vitest.ts
@@ -88,11 +88,10 @@ describe('overleafTokenSpec', () => {
 describe('credential helpers', () => {
   it('url-encodes the token and tracks both forms for redaction', () => {
     const cred = buildGitCredential('olp_a/b+c');
-    expect(cred.remote).toBe(`git:${encodeURIComponent('olp_a/b+c')}`);
-    expect(cred.sensitive).toEqual([
-      'olp_a/b+c',
-      encodeURIComponent('olp_a/b+c'),
-    ]);
+    // Hardcoded expectations so an encoding-strategy change fails the test
+    // instead of mirroring the implementation on both sides.
+    expect(cred.remote).toBe('git:olp_a%2Fb%2Bc');
+    expect(cred.sensitive).toEqual(['olp_a/b+c', 'olp_a%2Fb%2Bc']);
   });
 
   it('builds the authenticated clone URL from remote + credential', () => {
@@ -106,12 +105,16 @@ describe('credential helpers', () => {
     ).toBe(`https://git:olp_x@git.overleaf.com/${ID}`);
   });
 
-  it('redacts every sensitive form from a message', () => {
-    const cred = buildGitCredential('olp_secret');
-    const leaked = `fatal: auth failed for git:${cred.sensitive[1]} (olp_secret)`;
+  it('redacts both the raw and encoded token forms from a message', () => {
+    // A token with special chars makes the raw and encoded forms differ
+    // (`olp_a/b+c` vs `olp_a%2Fb%2Bc`), so this proves each is redacted
+    // independently rather than collapsing to one form.
+    const cred = buildGitCredential('olp_a/b+c');
+    expect(cred.sensitive[0]).not.toBe(cred.sensitive[1]);
+    const leaked = `fatal: auth failed for git:${cred.sensitive[1]} (olp_a/b+c)`;
     const redacted = redactSensitive(leaked, cred.sensitive);
-    expect(redacted).not.toContain('olp_secret');
-    expect(redacted).not.toContain(cred.sensitive[1]);
+    expect(redacted).not.toContain('olp_a/b+c');
+    expect(redacted).not.toContain('olp_a%2Fb%2Bc');
     expect(redacted).toContain('***');
   });
 });


### PR DESCRIPTION
## Summary

Extracted the Overleaf and ShareLaTeX git URL parsing logic from `gitCommands.ts` into a new host-neutral module `src/latex/overleafProject.ts`. This module provides pure, testable functions for parsing project URLs, deriving token specifications, building authenticated remotes, and redacting sensitive credentials from logs.

The extraction enables:
- **Reusability** across hosts (VS Code, CLI, desktop) without duplicating parsing rules
- **Testability** via comprehensive unit tests without requiring VS Code APIs
- **Maintainability** by centralizing URL/credential logic in a single source of truth

## Issue acceptance gates

N/A — this is a refactoring to improve code organization and enable future host implementations.

## Single source of truth

`src/latex/overleafProject.ts` now owns:
- URL parsing rules for Overleaf and self-hosted ShareLaTeX instances
- Token specification derivation (storage keys, validation rules, prompts)
- Git credential construction and redaction logic

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated three regex patterns and the `parseLatexGitUrl()` function from `gitCommands.ts`
- Consolidated token key/title/validator/hint logic into `overleafTokenSpec()`
- Extracted `buildTokenResult()` into the reusable `buildGitCredential()` function

**New abstractions:**
- `OverleafRemote` interface: Represents a parsed git remote (host, path, isOverleaf flag)
- `OverleafTokenSpec` interface: Encapsulates per-host token prompt/validation rules
- `GitCredential` interface: Bundles the remote userinfo and sensitive forms for redaction
- `redactSensitive()` utility: Centralizes credential redaction logic for error messages

These abstractions own the invariants around URL shape validation, host-specific token formats, and credential encoding—enabling any host to reuse these rules without reimplementing them.

## Host impact

**Extension:** Uses the new module functions in `cloneOverleafProject()` command; behavior unchanged.

**Desktop:** Can now reuse the same URL parsing and credential logic without duplicating code.

**CLI:** Can now reuse the same URL parsing and credential logic without duplicating code.

## Scheduled refactoring

None — this extraction is self-contained and ready for immediate use by other hosts.

## Validation

- Added 117 lines of comprehensive unit tests in `src/test-kernel/latex/OverleafProject.vitest.ts`
- Tests cover: bare project IDs, git URLs (Overleaf and self-hosted), project URLs, URL normalization, token validation, credential building, and redaction
- All existing extension tests pass; no behavior changes to the extension command

https://claude.ai/code/session_01Nz2jFUdRMSDsbT4R8Kywnb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior-preserving moves and new tests; clone still handles secrets the same way via shared helpers.
> 
> **Overview**
> Moves **Overleaf/ShareLaTeX git clone domain logic** out of `gitCommands.ts` into a new host-neutral module `src/latex/overleafProject.ts` so CLI/desktop can reuse the same rules without VS Code.
> 
> The extension **clone** flow now calls shared helpers for URL parsing (`parseLatexGitUrl`), per-host token prompts/validation (`overleafTokenSpec`), credential embedding (`buildGitCredential`, `buildAuthenticatedRemoteUrl`), and log redaction (`redactSensitive`) instead of inline regex and `buildTokenResult` logic. **Intended behavior is unchanged** for the VS Code command.
> 
> Adds **Vitest coverage** in `OverleafProject.vitest.ts` for URL shapes, token specs, authenticated remote URLs, and dual-form token redaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b5cfb052cc86fa759b4403c009027bbfa74904d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->