### PR TITLE
Extract async list form loading/error UI into shared helper

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -2,7 +2,6 @@
 // first message, tool-use agents can be chosen as the root chat agent.
 
 import { Box, Text } from 'ink';
-import { Spinner } from '@inkjs/ui';
 
 import { computeAgentOptionsData } from '@agent/index';
 import type { AgentOptionData } from '@shared/schemas';
@@ -10,7 +9,11 @@ import { agentName } from '@shared/schemas/agent';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
-import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
+import {
+  CompactFormKeyHints,
+  FormFrame,
+  renderAsyncListFormTransient,
+} from './_shared/FormFrame';
 import {
   computeSelectWindowSize,
   isCompactFormRows,
@@ -151,21 +154,13 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     onClose: props.onClose,
   });
 
-  if (loading) {
-    return (
-      <FormFrame color="cyan" title="/agent">
-        <Spinner label="Loading agent registry..." />
-      </FormFrame>
-    );
-  }
-
-  if (error) {
-    return (
-      <FormFrame color="red" title="/agent - error">
-        <Text>{error}</Text>
-      </FormFrame>
-    );
-  }
+  const transient = renderAsyncListFormTransient({
+    loading,
+    error,
+    title: '/agent',
+    loadingLabel: 'Loading agent registry...',
+  });
+  if (transient) return transient;
 
   const agents: AgentGroups = data ?? { toolUse: [], workflow: [] };
   const primarySectionTitle = agentPickerPrimarySectionTitle(agents.toolUse);

--- a/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
@@ -2,7 +2,6 @@
 // memory is selected.
 
 import { Box, Text } from 'ink';
-import { Spinner } from '@inkjs/ui';
 
 import {
   CLI_MEMORY_LIST_LIMIT,
@@ -13,7 +12,7 @@ import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
-import { FormFrame } from './_shared/FormFrame';
+import { FormFrame, renderAsyncListFormTransient } from './_shared/FormFrame';
 import {
   computeSelectWindowSize,
   type SelectWindowSize,
@@ -40,21 +39,13 @@ export function MemoryListForm(props: MemoryListFormProps): React.JSX.Element {
     isEmpty: (entries) => entries.length === 0,
   });
 
-  if (loading) {
-    return (
-      <FormFrame color="cyan" title="/memory">
-        <Spinner label="Loading memories..." />
-      </FormFrame>
-    );
-  }
-
-  if (error) {
-    return (
-      <FormFrame color="red" title="/memory - error">
-        <Text>{error}</Text>
-      </FormFrame>
-    );
-  }
+  const transient = renderAsyncListFormTransient({
+    loading,
+    error,
+    title: '/memory',
+    loadingLabel: 'Loading memories...',
+  });
+  if (transient) return transient;
 
   const items = data ?? [];
   if (items.length === 0) {

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -4,7 +4,6 @@
 // switch the live conversation to a compatible model for future turns.
 
 import { Box, Text, useInput } from 'ink';
-import { Spinner } from '@inkjs/ui';
 import { useEffect, useRef } from 'react';
 
 import {
@@ -18,7 +17,11 @@ import {
 import { formatCliApiMode, type CliApiMode } from '@cli/runtime/apiAccessMode';
 import { Select, selectIndexForHotkeyInput } from '../ui/Select';
 import { KeyHints } from '../ui/KeyHints';
-import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
+import {
+  CompactFormKeyHints,
+  FormFrame,
+  renderAsyncListFormTransient,
+} from './_shared/FormFrame';
 import {
   computeSelectWindowSize,
   isCompactFormRows,
@@ -138,20 +141,13 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     props.selectable,
   ]);
 
-  if (loading) {
-    return (
-      <FormFrame color="cyan" title="/model">
-        <Spinner label="Loading model registry..." />
-      </FormFrame>
-    );
-  }
-  if (error) {
-    return (
-      <FormFrame color="red" title="/model - error">
-        <Text>{error}</Text>
-      </FormFrame>
-    );
-  }
+  const transient = renderAsyncListFormTransient({
+    loading,
+    error,
+    title: '/model',
+    loadingLabel: 'Loading model registry...',
+  });
+  if (transient) return transient;
 
   if (isCompactFormRows(props.availableRows) && items.length > 0) {
     return (

--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -2,7 +2,6 @@
 // current chat TUI.
 
 import { Box, Text } from 'ink';
-import { Spinner } from '@inkjs/ui';
 
 import {
   listCliHistoryEntries,
@@ -14,7 +13,7 @@ import type { ExecutionId } from '@shared/schemas';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
-import { FormFrame } from './_shared/FormFrame';
+import { FormFrame, renderAsyncListFormTransient } from './_shared/FormFrame';
 import {
   computeSelectWindowSize,
   type SelectWindowSize,
@@ -48,21 +47,13 @@ export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
     },
   );
 
-  if (loading) {
-    return (
-      <FormFrame color="cyan" title="/resume">
-        <Spinner label="Loading execution history..." />
-      </FormFrame>
-    );
-  }
-
-  if (error) {
-    return (
-      <FormFrame color="red" title="/resume - error">
-        <Text>{error}</Text>
-      </FormFrame>
-    );
-  }
+  const transient = renderAsyncListFormTransient({
+    loading,
+    error,
+    title: '/resume',
+    loadingLabel: 'Loading execution history...',
+  });
+  if (transient) return transient;
 
   const entries = data ?? [];
   if (entries.length === 0) {

--- a/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
@@ -3,7 +3,6 @@
 // shared runtime formatter instead of duplicating skill wiring in the UI layer.
 
 import { Box, Text } from 'ink';
-import { Spinner } from '@inkjs/ui';
 
 import { formatRuntimeSkillActivation } from '@skills/runtimeSkills';
 import { readCliRuntimeSkills, skillListRecord } from '@cli/runtime/skills';
@@ -11,7 +10,11 @@ import { escapeText } from '@shared/utils/xmlEscape';
 
 import { KeyHints } from '../ui/KeyHints';
 import { Select, type SelectItem } from '../ui/Select';
-import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
+import {
+  CompactFormKeyHints,
+  FormFrame,
+  renderAsyncListFormTransient,
+} from './_shared/FormFrame';
 import {
   computeSelectWindowSize,
   isCompactFormRows,
@@ -100,21 +103,14 @@ export function SkillsListForm(props: SkillsListFormProps): React.JSX.Element {
     },
   );
 
-  if (loading) {
-    return (
-      <FormFrame color="cyan" title="/skills" showCloseHint={false}>
-        <Spinner label="Loading skills..." />
-      </FormFrame>
-    );
-  }
-
-  if (error) {
-    return (
-      <FormFrame color="red" title="/skills - error" showCloseHint={false}>
-        <Text>{error}</Text>
-      </FormFrame>
-    );
-  }
+  const transient = renderAsyncListFormTransient({
+    loading,
+    error,
+    title: '/skills',
+    loadingLabel: 'Loading skills...',
+    showCloseHint: false,
+  });
+  if (transient) return transient;
 
   const skills = data?.skills ?? [];
   const issueSummary = skillImportIssueSummary(data?.errors.length ?? 0);

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -2,7 +2,6 @@
 // and toggles integrations that are marked toggleable in EXTERNAL_TOOL_DEFS.
 
 import { Box, Text } from 'ink';
-import { Spinner } from '@inkjs/ui';
 
 import {
   readCliToolStatuses,
@@ -12,7 +11,11 @@ import {
 import { toolStatusLabel } from '@shared/tools/toolStatusLabels';
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
-import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
+import {
+  CompactFormKeyHints,
+  FormFrame,
+  renderAsyncListFormTransient,
+} from './_shared/FormFrame';
 import {
   computeSelectWindowSize,
   isCompactFormRows,
@@ -70,21 +73,14 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
     onClose: props.onClose,
   });
 
-  if (loading) {
-    return (
-      <FormFrame color="cyan" title="/tools" showCloseHint={false}>
-        <Spinner label="Checking tool integrations..." />
-      </FormFrame>
-    );
-  }
-
-  if (error) {
-    return (
-      <FormFrame color="red" title="/tools - error" showCloseHint={false}>
-        <Text>{error}</Text>
-      </FormFrame>
-    );
-  }
+  const transient = renderAsyncListFormTransient({
+    loading,
+    error,
+    title: '/tools',
+    loadingLabel: 'Checking tool integrations...',
+    showCloseHint: false,
+  });
+  if (transient) return transient;
 
   const tools = data ?? [];
   const selectWindow = toolsSelectWindow({

--- a/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
@@ -3,6 +3,7 @@
 // bordered column with a colored title and an `Esc close` footer.
 
 import { Box, Text, useWindowSize } from 'ink';
+import { Spinner } from '@inkjs/ui';
 
 import { KeyHints, type KeyHint } from '@cli/chat/tui/ui/KeyHints';
 import { clamp } from '@utils/core';
@@ -53,6 +54,46 @@ export function FormFrame(props: FormFrameProps): React.JSX.Element {
       )}
     </Box>
   );
+}
+
+/**
+ * The loading / error transient frame every async list form rendered before its
+ * data resolved: a cyan `<Spinner>` frame while loading, then a red `{error}`
+ * frame on failure. Returns `null` once data is ready so callers fall through to
+ * their real layout: `const t = renderAsyncListFormTransient(...); if (t) return t;`.
+ * `showCloseHint` is forwarded to `FormFrame` so each form keeps its existing
+ * footer behaviour (forms with their own footer pass `false`).
+ */
+export function renderAsyncListFormTransient(props: {
+  readonly loading: boolean;
+  readonly error: string | undefined;
+  readonly title: string;
+  readonly loadingLabel: string;
+  readonly showCloseHint?: boolean;
+}): React.JSX.Element | null {
+  if (props.loading) {
+    return (
+      <FormFrame
+        color="cyan"
+        title={props.title}
+        showCloseHint={props.showCloseHint}
+      >
+        <Spinner label={props.loadingLabel} />
+      </FormFrame>
+    );
+  }
+  if (props.error !== undefined) {
+    return (
+      <FormFrame
+        color="red"
+        title={`${props.title} - error`}
+        showCloseHint={props.showCloseHint}
+      >
+        <Text>{props.error}</Text>
+      </FormFrame>
+    );
+  }
+  return null;
 }
 
 export function CompactFormKeyHints(props: {


### PR DESCRIPTION
## Summary

Refactors repeated loading and error state UI patterns across six async list forms (`SkillsListForm`, `ToolsListForm`, `AgentListForm`, `ModelListForm`, `MemoryListForm`, `ResumeListForm`) into a single reusable helper function `renderAsyncListFormTransient()` in `FormFrame.tsx`.

Each form previously duplicated the same pattern: render a cyan spinner frame while loading, then a red error frame on failure, then return `null` to fall through to the real layout. This change consolidates that logic into one place with configurable title, loading label, and optional close hint behavior.

## Issue acceptance gates

N/A — This is a refactoring to reduce duplication and improve maintainability.

## Single source of truth

The `renderAsyncListFormTransient()` function in `packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx` now owns the loading/error transient UI pattern for async list forms.

## Duplication and abstraction budget

**Duplication removed:** ~70 lines of nearly identical loading/error handling code across 6 form components.

**Abstraction added:** `renderAsyncListFormTransient()` encapsulates the invariant that async list forms show:
- A cyan spinner frame with a custom loading label while `loading === true`
- A red error frame with the error message if `error` is defined
- `null` once data is ready, allowing callers to render their real layout

The function accepts `showCloseHint` as an optional parameter to preserve each form's existing footer behavior (forms with their own footer pass `false`).

## Host impact

**CLI:** Simplified async list form implementations with no behavioral change. The transient UI pattern is now centralized and easier to maintain.

## Scheduled refactoring

None.

## Validation

- All six forms (`SkillsListForm`, `ToolsListForm`, `AgentListForm`, `ModelListForm`, `MemoryListForm`, `ResumeListForm`) have been updated to use the new helper with identical behavior.
- Removed redundant `Spinner` imports from all six form files (now only imported in `FormFrame.tsx`).
- No functional changes to the UI or state handling—purely a refactoring of duplicate code into a shared utility.

https://claude.ai/code/session_01FbzadmERRjhFnGf7AA2xHv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation refactor only; loading/error rendering is centralized with the same frames, labels, and close-hint options as before.
> 
> **Overview**
> **Deduplicates** the repeated loading and error branches across six chat TUI slash-command list forms (`/agent`, `/memory`, `/model`, `/resume`, `/skills`, `/tools`) by routing them through a new shared helper **`renderAsyncListFormTransient`** in `FormFrame.tsx`.
> 
> Each form now uses the same early-return pattern: cyan `FormFrame` + spinner while loading, red `FormFrame` with the error text on failure, then `null` so the existing list/empty layouts run unchanged. Per-form **titles** and **loading labels** stay configurable; **`showCloseHint`** is forwarded so forms that already hide the default Esc footer (e.g. `/skills`, `/tools`) keep that behavior.
> 
> **`Spinner`** is imported only from `FormFrame` instead of in every form file. No change to data loading, selection, or empty-state handling beyond consolidating the transient UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 691c1b73d3134390980bb2b8e1e840c7c5a9c454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->