### PR TITLE
Extract OpenAI prefill logic and add schema path validation

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -44,10 +44,9 @@ import {
   getWebSocketEnabled,
   getUseOpenRouter,
 } from '@utils/config/providerConfig';
-import { flexibleFS } from '@utils/files/flexibleFS';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import { normalizeUsage } from '../support/UsageNormalizer';
-import { prepareExistingOutputContent } from '../utils/fileContentUtils';
+import { initializeOpenAiCompatibleOutputAndPrefill } from '../support/openAiCompatiblePrefill';
 import { tagOpenAISdkError } from './openAISdkError';
 import { withSdkErrorTag } from '../support/sdkErrorTagging';
 import {
@@ -2089,75 +2088,40 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /** Initializes output file and handles prefill content. */
   async initializeOutputAndPrefill(
-    agentConfig: AgentConfig,
+    _agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     messages: ResponseInputItem[],
     workspaceState: AgentWorkspaceState,
     outputLocation: FileLocation,
     prefill: string,
   ): Promise<[boolean, ResponseInputItem[]]> {
-    let endTurn = false;
-
-    if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
-      if (prefill.length === 0) {
-        this.logger.debug(
-          'No prefill provided; skipping pseudo-prefill instruction',
-        );
-        return [endTurn, messages];
-      }
-      const pseudoPrefill = `Organize your response with xml tags. Start your response with:\n${prefill}`;
-      const lastMessage = messages.at(-1);
-      if (lastMessage) {
-        this.appendInputText(lastMessage, pseudoPrefill);
-      } else {
-        const pseudoPrefillMessage: ResponseInputItem.Message = {
-          type: 'message',
-          role: 'user',
-          content: [createInputText(pseudoPrefill)],
-        };
-        messages.push(pseudoPrefillMessage);
-      }
-      this.logger.debug(
-        `Added pseudo prefill message to messages:\n${pseudoPrefill}`,
-      );
-      return [endTurn, messages];
-    }
-
-    // Prepare existing file content (read, clean, extract scratchpad, update state)
-    const { fileContent } = await prepareExistingOutputContent(
-      outputLocation,
-      workspaceState,
-      this.logger,
-    );
-
-    messages.push(this.createAssistantMessage(fileContent));
-
-    if (hasEndTag(agentSetting, fileContent)) {
-      this.logger.debug('End tag detected - skipping continuation');
-      endTurn = true;
-      return [endTurn, messages];
-    }
-
-    this.logger.debug(
-      'Output file exists but no end tag found - continuing from file',
-    );
-    // Only need to handle case where prefill needs to be prepended
-    // (workspace state was already updated above with file content)
-    if (!fileContent.includes(prefill)) {
-      workspaceState.assembly.accumulatedOutput = prefill + fileContent;
-      await flexibleFS.write(
-        outputLocation,
-        workspaceState.assembly.accumulatedOutput,
-      );
-    }
-
-    this.addContinueMessageWithoutPrefill(
+    return initializeOpenAiCompatibleOutputAndPrefill(
+      {
+        logger: this.logger,
+        appendPseudoPrefill: (msgs, pseudoPrefillMsg) => {
+          const lastMessage = msgs.at(-1);
+          if (lastMessage) {
+            this.appendInputText(lastMessage, pseudoPrefillMsg);
+          } else {
+            msgs.push({
+              type: 'message',
+              role: 'user',
+              content: [createInputText(pseudoPrefillMsg)],
+            });
+          }
+        },
+        pushAssistantText: (msgs, text) => {
+          msgs.push(this.createAssistantMessage(text));
+        },
+        addContinue: (msgs, ws, setting) =>
+          this.addContinueMessageWithoutPrefill(msgs, ws, setting),
+      },
+      agentSetting,
       messages,
       workspaceState,
-      agentSetting,
+      outputLocation,
+      prefill,
     );
-
-    return [endTurn, messages];
   }
 
   /** Updates message content for models with prefill support. */

--- a/src/agent/modelHandlers/support/openAiCompatiblePrefill.ts
+++ b/src/agent/modelHandlers/support/openAiCompatiblePrefill.ts
@@ -78,7 +78,7 @@ export async function initializeOpenAiCompatibleOutputAndPrefill<
     return [true, messages];
   }
 
-  adapter.logger.warn(
+  adapter.logger.debug(
     'Output file exists but no end tag found - continuing from file',
   );
   // Only need to handle case where prefill needs to be prepended

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -554,13 +554,21 @@ export type CoreSettings = z.infer<typeof CoreSettingsSchema>;
  */
 type IsRecord<T> = string extends keyof T ? true : false;
 
+/**
+ * `NonNullable` is applied before the `extends object` test so that an optional
+ * group added without a default (`Group | undefined`) still recurses into its
+ * leaves instead of silently collapsing to a single key. The guard therefore
+ * stays sound whether a nested group is declared with `.prefault()` (every group
+ * today) or `.optional()`. Arrays and records resolve to leaves; nested settings
+ * groups recurse.
+ */
 type LeafPaths<T> = {
-  [K in keyof T & string]: T[K] extends readonly unknown[]
+  [K in keyof T & string]: NonNullable<T[K]> extends readonly unknown[]
     ? K
-    : T[K] extends object
-      ? IsRecord<T[K]> extends true
+    : NonNullable<T[K]> extends object
+      ? IsRecord<NonNullable<T[K]>> extends true
         ? K
-        : `${K}.${LeafPaths<T[K]>}`
+        : `${K}.${LeafPaths<NonNullable<T[K]>>}`
       : K;
 }[keyof T & string];
 

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -546,10 +546,38 @@ export const CoreSettingsSchema = z
 export type CoreSettings = z.infer<typeof CoreSettingsSchema>;
 
 /**
+ * Dotted leaf paths of the settings tree, enumerated at the type level.
+ *
+ * Drives the compile-time guards below so {@link CORE_SETTING_PATHS} stays in
+ * lockstep with {@link CoreSettingsShape}: a record/array/primitive field is a
+ * leaf, a nested settings group is recursed into.
+ */
+type IsRecord<T> = string extends keyof T ? true : false;
+
+type LeafPaths<T> = {
+  [K in keyof T & string]: T[K] extends readonly unknown[]
+    ? K
+    : T[K] extends object
+      ? IsRecord<T[K]> extends true
+        ? K
+        : `${K}.${LeafPaths<T[K]>}`
+      : K;
+}[keyof T & string];
+
+/** Errors at build time unless `T` is exactly `never`. */
+type AssertNever<T extends never> = T;
+
+/**
  * Dotted leaf paths for every Core setting.
  *
  * Used by per-host "known TeXRA key" sets to derive `texra.*` prefixed key
  * lists for typo detection without hand-maintaining the list in each host.
+ *
+ * Kept in sync with the schema by the two compile-time guards just below: the
+ * `satisfies` clause rejects a typo'd or renamed path, and `_AssertCorePathsExhaustive`
+ * fails the build if a setting is added to the schema without a matching entry
+ * here. Previously both failure modes were silent (the list compiled fine while
+ * host typo-detection quietly broke).
  */
 export const CORE_SETTING_PATHS = [
   'agentOutputs.autoOpenFinal',
@@ -611,6 +639,11 @@ export const CORE_SETTING_PATHS = [
   'toolUse.requireBashApproval',
   'toolUse.persistence.enabled',
   'toolUse.persistence.ttlHours',
-] as const;
+] as const satisfies readonly LeafPaths<CoreSettings>[];
 
 export type CoreSettingPath = (typeof CORE_SETTING_PATHS)[number];
+
+// Build fails if any schema leaf path is missing from CORE_SETTING_PATHS above.
+type _AssertCorePathsExhaustive = AssertNever<
+  Exclude<LeafPaths<CoreSettings>, CoreSettingPath>
+>;


### PR DESCRIPTION
## Summary

This PR extracts the OpenAI-compatible output initialization and prefill logic into a reusable support module, and adds compile-time validation to ensure `CORE_SETTING_PATHS` stays synchronized with the `CoreSettings` schema.

### Changes

1. **Refactored `initializeOutputAndPrefill` in `ModelHandlerOpenAIResponse`**
   - Extracted the 75-line implementation into a new `initializeOpenAiCompatibleOutputAndPrefill` support function
   - Replaced direct file operations and message manipulation with dependency-injected callbacks (`appendPseudoPrefill`, `pushAssistantText`, `addContinue`)
   - This enables code reuse across OpenAI-compatible providers and improves testability

2. **Added compile-time schema path validation in `CoreSettingsSchema`**
   - Introduced TypeScript type-level helpers (`LeafPaths`, `IsRecord`, `AssertNever`) to enumerate all dotted leaf paths in the settings tree
   - Added `satisfies readonly LeafPaths<CoreSettings>[]` constraint to `CORE_SETTING_PATHS` to catch typos or renamed paths at build time
   - Added `_AssertCorePathsExhaustive` type assertion that fails the build if any schema leaf is missing from the paths list
   - Updated documentation to explain the dual compile-time guards and their purpose

## Issue acceptance gates

N/A (refactoring and internal validation improvement)

## Single source of truth

- **OpenAI prefill logic**: Now owned by `initializeOpenAiCompatibleOutputAndPrefill` in `src/agent/modelHandlers/support/openAiCompatiblePrefill.ts`
- **Core settings paths**: Validated against `CoreSettings` schema via type-level assertions in `src/shared/schemas/coreSettings.ts`

## Duplication and abstraction budget

- **Removed**: 75 lines of duplicated prefill/output initialization logic from `ModelHandlerOpenAIResponse`
- **Added abstraction**: `initializeOpenAiCompatibleOutputAndPrefill` with dependency injection for message operations, enabling reuse across OpenAI-compatible providers without pass-through layers
- **Improved validation**: Eliminated silent failures in host typo-detection by adding build-time guards that ensure `CORE_SETTING_PATHS` stays in lockstep with schema changes

## Host impact

Extension: No functional change; refactored internal logic with same behavior.

Desktop: No functional change; refactored internal logic with same behavior.

CLI: No functional change; refactored internal logic with same behavior.

## Scheduled refactoring

None

## Validation

- Refactoring preserves existing behavior: same prefill logic, same message handling, same file operations
- Build-time type assertions ensure `CORE_SETTING_PATHS` cannot drift from schema without explicit update
- Existing tests for `initializeOutputAndPrefill` continue to pass (behavior unchanged)

https://claude.ai/code/session_01MXTjnJqbnyuVFvjGL449rC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor plus schema-path typing; no auth, data, or API contract changes.
> 
> **Overview**
> **OpenAI Responses prefill** is delegated to `initializeOpenAiCompatibleOutputAndPrefill` in `openAiCompatiblePrefill.ts`. `ModelHandlerOpenAIResponse.initializeOutputAndPrefill` now only wires provider-specific callbacks (pseudo-prefill append, assistant message push, continuation prompt) instead of inlining file checks and message shaping. When resuming from an existing output file without an end tag, that path logs at **debug** instead of **warn**.
> 
> **Core settings** gains type-level `LeafPaths` helpers and two compile-time guards on `CORE_SETTING_PATHS`: `satisfies readonly LeafPaths<CoreSettings>[]` catches invalid or renamed paths, and `_AssertCorePathsExhaustive` fails the build if a new schema leaf is missing from the list—so host typo-detection key sets cannot drift silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f65a4e6f8e0d8dfce314f0ee2660aa9e6d5fe35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->