### PR TITLE
Replace axios with ky HTTP client and add retry logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "@xterm/xterm": "^6.0.0",
     "arxiv-client": "^0.0.9",
     "async-mutex": "^0.5.0",
-    "axios": "^1.18.0",
     "bibtex": "^0.9.0",
     "deepmerge": "^4.3.1",
     "delay": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       async-mutex:
         specifier: ^0.5.0
         version: 0.5.0
-      axios:
-        specifier: ^1.18.0
-        version: 1.18.0
       bibtex:
         specifier: ^0.9.0
         version: 0.9.0

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -1,8 +1,9 @@
 import * as path from 'node:path';
+import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
+import type { ReadableStream as NodeWebReadableStream } from 'node:stream/web';
 import { createGunzip } from 'node:zlib';
 
-import axios from 'axios';
 import { StatusCodes } from 'http-status-codes';
 import * as arxivIdentifiers from 'identifiers-arxiv';
 import pRetry, { AbortError } from 'p-retry';
@@ -173,11 +174,8 @@ class ArxivSourceProcessor {
     let destPath = destBasePath;
     let shouldCleanup = true;
     try {
-      const response = await axios.get(url, {
-        responseType: 'stream',
-        validateStatus: () => true,
-        timeout,
-      });
+      // AbortSignal.timeout covers both connection establishment and body streaming.
+      const response = await fetch(url, { signal: AbortSignal.timeout(timeout) });
 
       if (response.status === StatusCodes.NOT_FOUND) {
         throw new AbortError('Source not available for this arXiv ID');
@@ -192,7 +190,7 @@ class ArxivSourceProcessor {
       }
 
       // Extract filename from Content-Disposition header if available
-      const disposition = response.headers['content-disposition'];
+      const disposition = response.headers.get('content-disposition');
       if (disposition) {
         const match = /filename="?([^";]+)"?/i.exec(disposition);
         if (match) {
@@ -203,15 +201,18 @@ class ArxivSourceProcessor {
           );
         }
       } else {
-        const rawContentType = response.headers['content-type'];
-        const contentType =
-          typeof rawContentType === 'string' ? rawContentType : '';
+        const contentType = response.headers.get('content-type') ?? '';
         const extension = this.getExtensionFromContentType(contentType);
         destPath = destBasePath + extension;
       }
 
+      if (!response.body) {
+        throw new Error('Response has no body');
+      }
+
       await pipeline(
-        response.data as NodeJS.ReadableStream,
+        // response.body is a web ReadableStream; Readable.fromWeb bridges to Node streams.
+        Readable.fromWeb(response.body as NodeWebReadableStream),
         AbsoluteFS.createWriteStream(destPath),
       );
       shouldCleanup = false;

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -175,7 +175,9 @@ class ArxivSourceProcessor {
     let shouldCleanup = true;
     try {
       // AbortSignal.timeout covers both connection establishment and body streaming.
-      const response = await fetch(url, { signal: AbortSignal.timeout(timeout) });
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(timeout),
+      });
 
       if (response.status === StatusCodes.NOT_FOUND) {
         throw new AbortError('Source not available for this arXiv ID');

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -27,6 +27,11 @@ export interface ExtractOptions {
   channel?: string;
 }
 
+// AbortSignal.timeout() covers the entire request including body streaming,
+// unlike the old axios timeout which only covered header receipt. Use a
+// generous deadline so large tarballs (10s+ on a slow link) can complete.
+const DOWNLOAD_TIMEOUT_MS = 120_000; // 2 min
+
 export type ArxivDownloadDestination = 'root' | 'references';
 
 export interface DownloadSourceOptions {
@@ -369,6 +374,7 @@ class ArxivSourceProcessor {
     const downloadedPath = await this.downloadFile(
       downloadUrl,
       downloadBasePath,
+      DOWNLOAD_TIMEOUT_MS,
     );
 
     // Detect PDF-only submissions (no LaTeX source available)

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -1,51 +1,47 @@
 // Third-party imports
-import { AxiosError, AxiosHeaders } from 'axios';
+import { HTTPError, TimeoutError } from 'ky';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - tools
 import { isTransientHttpError } from '@tools/timeouts';
 
-function axiosErrorWithStatus(status: number): AxiosError {
-  const error = new AxiosError('http error', 'ERR_BAD_RESPONSE');
-  error.response = {
-    status,
-    statusText: '',
-    data: undefined,
-    headers: {},
-    config: { headers: new AxiosHeaders() },
-  };
-  return error;
+function kyErrorWithStatus(status: number): HTTPError {
+  return new HTTPError(
+    new Response(null, { status }),
+    new Request('https://example.com'),
+    {} as never,
+  );
 }
 
 describe('isTransientHttpError', () => {
-  it('treats request timeouts as transient', () => {
+  it('treats ky TimeoutError as transient', () => {
     expect(
-      isTransientHttpError(new AxiosError('timeout', 'ECONNABORTED')),
+      isTransientHttpError(new TimeoutError(new Request('https://example.com'))),
     ).toBe(true);
-    expect(isTransientHttpError(new AxiosError('timeout', 'ETIMEDOUT'))).toBe(
-      true,
-    );
   });
 
-  it('treats network failures with no response as transient', () => {
-    // No `.response` set — the request never completed.
-    expect(isTransientHttpError(new AxiosError('reset', 'ECONNRESET'))).toBe(
-      true,
-    );
+  it('treats AbortSignal.timeout() errors as transient', () => {
+    const err = Object.assign(new Error('Timeout'), { name: 'TimeoutError' });
+    expect(isTransientHttpError(err)).toBe(true);
+  });
+
+  it('treats network failures (no response) as transient', () => {
+    // fetch throws TypeError for connection reset, DNS failure, socket hang-up
+    expect(isTransientHttpError(new TypeError('Failed to fetch'))).toBe(true);
   });
 
   it('treats rate limits and 5xx server errors as transient', () => {
-    expect(isTransientHttpError(axiosErrorWithStatus(429))).toBe(true);
-    expect(isTransientHttpError(axiosErrorWithStatus(500))).toBe(true);
-    expect(isTransientHttpError(axiosErrorWithStatus(503))).toBe(true);
+    expect(isTransientHttpError(kyErrorWithStatus(429))).toBe(true);
+    expect(isTransientHttpError(kyErrorWithStatus(500))).toBe(true);
+    expect(isTransientHttpError(kyErrorWithStatus(503))).toBe(true);
   });
 
   it('treats 4xx responses as permanent', () => {
-    expect(isTransientHttpError(axiosErrorWithStatus(400))).toBe(false);
-    expect(isTransientHttpError(axiosErrorWithStatus(404))).toBe(false);
+    expect(isTransientHttpError(kyErrorWithStatus(400))).toBe(false);
+    expect(isTransientHttpError(kyErrorWithStatus(404))).toBe(false);
   });
 
-  it('treats non-axios errors as permanent', () => {
+  it('treats non-http errors as permanent', () => {
     expect(isTransientHttpError(new Error('boom'))).toBe(false);
     expect(isTransientHttpError('nope')).toBe(false);
     expect(isTransientHttpError(undefined)).toBe(false);

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -16,7 +16,9 @@ function kyErrorWithStatus(status: number): HTTPError {
 describe('isTransientHttpError', () => {
   it('treats ky TimeoutError as transient', () => {
     expect(
-      isTransientHttpError(new TimeoutError(new Request('https://example.com'))),
+      isTransientHttpError(
+        new TimeoutError(new Request('https://example.com')),
+      ),
     ).toBe(true);
   });
 

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -28,7 +28,9 @@ describe('isTransientHttpError', () => {
   });
 
   it('treats AbortError with TimeoutError cause as transient (undici wrapping)', () => {
-    const cause = Object.assign(new Error('signal timed out'), { name: 'TimeoutError' });
+    const cause = Object.assign(new Error('signal timed out'), {
+      name: 'TimeoutError',
+    });
     const err = Object.assign(new Error('The operation was aborted'), {
       name: 'AbortError',
       cause,

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -27,6 +27,15 @@ describe('isTransientHttpError', () => {
     expect(isTransientHttpError(err)).toBe(true);
   });
 
+  it('treats AbortError with TimeoutError cause as transient (undici wrapping)', () => {
+    const cause = Object.assign(new Error('signal timed out'), { name: 'TimeoutError' });
+    const err = Object.assign(new Error('The operation was aborted'), {
+      name: 'AbortError',
+      cause,
+    });
+    expect(isTransientHttpError(err)).toBe(true);
+  });
+
   it('treats network failures (no response) as transient', () => {
     // fetch throws TypeError for connection reset, DNS failure, socket hang-up
     expect(isTransientHttpError(new TypeError('Failed to fetch'))).toBe(true);

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -4,14 +4,14 @@
  * Uses the Loogle API at https://loogle.lean-lang.org/
  */
 
-import axios from 'axios';
+import ky from 'ky';
 import pRetry, { AbortError } from 'p-retry';
 import { z } from 'zod';
 
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { ToolResult } from '@shared/schemas/toolResult';
-import { isTimeoutErrorCode, isTransientHttpError } from '@tools/timeouts';
+import { isTimeoutError, isTransientHttpError } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 import { ensureArray } from '@utils/core';
 
@@ -138,23 +138,26 @@ Useful for finding the right lemma when you know roughly what type it should hav
   private async fetchLoogle(query: string): Promise<LoogleResponse> {
     return pRetry(
       async () => {
-        const response = await axios
-          .get<unknown>(LOOGLE_API_URL, {
-            params: { q: query },
-            headers: {
-              'User-Agent': 'TeXRA-VSCode-Extension',
-            },
-            timeout: LOOGLE_TIMEOUT_MS,
-          })
-          .catch((error: unknown) => {
-            if (isTransientHttpError(error)) throw error;
-            throw new AbortError(
-              error instanceof Error ? error : new Error(String(error)),
-            );
-          });
+        let raw: unknown;
+        try {
+          raw = await ky
+            .get(LOOGLE_API_URL, {
+              searchParams: { q: query },
+              headers: { 'User-Agent': 'TeXRA-VSCode-Extension' },
+              timeout: false,
+              signal: AbortSignal.timeout(LOOGLE_TIMEOUT_MS),
+              retry: 0,
+            })
+            .json<unknown>();
+        } catch (error: unknown) {
+          if (isTransientHttpError(error)) throw error;
+          throw new AbortError(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
         // Validate the body at the boundary. A malformed shape is not transient,
         // so abort retries and let executeSingle surface it as a tool error.
-        const parsed = LoogleResponseSchema.safeParse(response.data);
+        const parsed = LoogleResponseSchema.safeParse(raw);
         if (!parsed.success) {
           throw new AbortError(
             new Error(
@@ -230,7 +233,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
         },
       };
     } catch (error) {
-      if (axios.isAxiosError(error) && isTimeoutErrorCode(error.code)) {
+      if (isTimeoutError(error)) {
         return {
           query,
           result: {

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -133,7 +133,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
   /**
    * Fetch one Loogle query, retrying transient failures (timeouts, 5xx,
    * 429 rate limits, dropped connections) with jittered backoff. Non-429
-   * 4xx responses and non-axios errors abort immediately.
+   * 4xx responses and non-network errors abort immediately.
    */
   private async fetchLoogle(query: string): Promise<LoogleResponse> {
     return pRetry(

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -11,14 +11,23 @@ import { HTTPError, TimeoutError } from 'ky';
 /**
  * Whether an error is a request timeout.
  *
- * Covers two sources:
+ * Covers three sources:
  * - ky's own `TimeoutError` (thrown when the `timeout:` option fires)
  * - `DOMException`/`Error` with `name === 'TimeoutError'` (thrown when
- *   `AbortSignal.timeout()` fires before the response or body arrives)
+ *   `AbortSignal.timeout()` fires in Node.js 20+ / undici v6+)
+ * - `AbortError` whose `cause` is a `TimeoutError` — the shape some undici
+ *   versions produce when `AbortSignal.timeout()` fires mid-request
  */
 export function isTimeoutError(error: unknown): boolean {
   if (error instanceof TimeoutError) return true;
   if (error instanceof Error && error.name === 'TimeoutError') return true;
+  if (
+    error instanceof Error &&
+    error.name === 'AbortError' &&
+    isTimeoutError(error.cause)
+  ) {
+    return true;
+  }
   return false;
 }
 
@@ -38,8 +47,9 @@ export function isTransientHttpError(error: unknown): boolean {
     return error.response.status === 429 || error.response.status >= 500;
   }
   // Network-level TypeError from the underlying fetch — connection reset, DNS
-  // hiccup, socket hang-up. TypeErrors from ky/fetch calls are always network
-  // failures; programmer TypeErrors don't surface here.
+  // hiccup, socket hang-up. Only safe because callers must wrap only the
+  // ky/fetch call itself in the try block; programmer TypeErrors must not be
+  // caught by the same handler.
   if (error instanceof TypeError) return true;
   return false;
 }

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -1,39 +1,45 @@
 /**
- * Shared timeout helpers for tool implementations.
+ * Shared timeout and HTTP-error helpers for tool implementations.
  *
  * Each tool defines its own timeout constant locally. This module only
- * provides the helpers that enforce a consistent error format across tools.
+ * provides the predicates that enforce a consistent error-classification
+ * policy across tools (built around the `ky` HTTP client).
  */
 
-import axios from 'axios';
+import { HTTPError, TimeoutError } from 'ky';
 
 /**
- * Check whether an axios error code indicates a timeout.
+ * Whether an error is a request timeout.
  *
- * axios uses ECONNABORTED by default and ETIMEDOUT when
- * `clarifyTimeoutError` is enabled or via the fetch adapter.
+ * Covers two sources:
+ * - ky's own `TimeoutError` (thrown when the `timeout:` option fires)
+ * - `DOMException`/`Error` with `name === 'TimeoutError'` (thrown when
+ *   `AbortSignal.timeout()` fires before the response or body arrives)
  */
-export function isTimeoutErrorCode(code: string | undefined): boolean {
-  return code === 'ECONNABORTED' || code === 'ETIMEDOUT';
+export function isTimeoutError(error: unknown): boolean {
+  if (error instanceof TimeoutError) return true;
+  if (error instanceof Error && error.name === 'TimeoutError') return true;
+  return false;
 }
 
 /**
- * Whether an error from an axios request is worth retrying.
+ * Whether an HTTP request error is transient (worth retrying).
  *
- * Transient = a retry could plausibly succeed: request timeouts, network-level
- * failures (no response received — DNS hiccup, connection reset), 429 rate
- * limits, and 5xx server errors. Permanent = the same request will keep
- * failing: other 4xx statuses (bad request, not found, auth), and non-axios /
- * application errors.
+ * Transient = timeout, network-level failure (no response received), 429
+ * rate limit, or 5xx server error.
+ * Permanent = other 4xx responses and non-network errors.
  *
- * Only safe to use for idempotent requests (GET / read-only RPC); retrying a
- * non-idempotent write risks duplicate side effects.
+ * Only safe to use for idempotent requests (GET / read-only RPC); retrying
+ * a non-idempotent write risks duplicate side effects.
  */
 export function isTransientHttpError(error: unknown): boolean {
-  if (!axios.isAxiosError(error)) return false;
-  if (isTimeoutErrorCode(error.code)) return true;
-  // No response means the request never completed (connection reset, DNS,
-  // socket hang up) — generally worth one more attempt for an external API.
-  if (!error.response) return true;
-  return error.response.status === 429 || error.response.status >= 500;
+  if (isTimeoutError(error)) return true;
+  if (error instanceof HTTPError) {
+    return error.response.status === 429 || error.response.status >= 500;
+  }
+  // Network-level TypeError from the underlying fetch — connection reset, DNS
+  // hiccup, socket hang-up. TypeErrors from ky/fetch calls are always network
+  // failures; programmer TypeErrors don't surface here.
+  if (error instanceof TypeError) return true;
+  return false;
 }

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -2,18 +2,20 @@
 import { isIP } from 'node:net';
 
 // Third-party imports
-import axios from 'axios';
-import { StatusCodes } from 'http-status-codes';
+import ky, { HTTPError } from 'ky';
+import pRetry, { AbortError } from 'p-retry';
 import TurndownService from 'turndown';
 import { z } from 'zod';
 
 // Local imports - core
 import { toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
-import { isTimeoutErrorCode } from '@tools/timeouts';
+import { isTimeoutError, isTransientHttpError } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 
 const WEB_FETCH_TIMEOUT_MS = 30_000; // 30 s
+const WEB_FETCH_RETRIES = 2;
+const MAX_CONTENT_BYTES = 10 * 1024 * 1024; // 10 MB
 
 const WebFetchInputSchema = z.strictObject({
   url: z
@@ -80,46 +82,59 @@ export class WebFetchTool extends defineTool({
       );
     }
 
-    let response;
+    let rawBody: string;
+    let contentType: string;
+
     try {
-      response = await axios.get(url, {
-        responseType: 'text',
-        timeout: WEB_FETCH_TIMEOUT_MS,
-        maxRedirects: 5,
-        maxContentLength: 10 * 1024 * 1024,
-        maxBodyLength: 10 * 1024 * 1024,
-        validateStatus: (status) =>
-          status >= StatusCodes.OK && status < StatusCodes.BAD_REQUEST,
-      });
+      ({ rawBody, contentType } = await pRetry(
+        async (): Promise<{ rawBody: string; contentType: string }> => {
+          let response: Response;
+          try {
+            // AbortSignal.timeout covers both connection and body read;
+            // ky's own timeout only clears once headers arrive.
+            response = await ky.get(url, {
+              timeout: false,
+              signal: AbortSignal.timeout(WEB_FETCH_TIMEOUT_MS),
+              retry: 0,
+            });
+          } catch (error: unknown) {
+            if (isTransientHttpError(error)) throw error;
+            throw new AbortError(
+              error instanceof Error ? error : new Error(String(error)),
+            );
+          }
+
+          const lengthHeader = response.headers.get('content-length');
+          if (lengthHeader && Number(lengthHeader) > MAX_CONTENT_BYTES) {
+            throw new AbortError(
+              `Response too large (${lengthHeader} bytes); maximum is ${MAX_CONTENT_BYTES / (1024 * 1024)} MB.`,
+            );
+          }
+
+          const ct = response.headers.get('content-type') ?? '';
+          const text = await response.text();
+          return { rawBody: text, contentType: ct };
+        },
+        { retries: WEB_FETCH_RETRIES, minTimeout: 500, randomize: true },
+      ));
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        if (isTimeoutErrorCode(error.code)) {
-          throw new ToolError(
-            `Request to ${url} timed out after ${WEB_FETCH_TIMEOUT_MS / 1000}s. ` +
-              `The remote server did not respond in time. Retry the request, or try a different URL.`,
-          );
-        }
-
-        if (error.response) {
-          throw new ToolError(
-            `HTTP ${error.response.status}: Failed to fetch ${url}`,
-          );
-        }
-
-        if (error.request) {
-          throw new ToolError(
-            `Network error fetching ${url}: ${error.message}`,
-          );
-        }
+      if (isTimeoutError(error)) {
+        throw new ToolError(
+          `Request to ${url} timed out after ${WEB_FETCH_TIMEOUT_MS / 1000}s. ` +
+            `The remote server did not respond in time. Retry the request, or try a different URL.`,
+        );
       }
-
+      if (error instanceof HTTPError) {
+        throw new ToolError(
+          `HTTP ${error.response.status}: Failed to fetch ${url}`,
+        );
+      }
+      if (error instanceof TypeError) {
+        throw new ToolError(`Network error fetching ${url}: ${error.message}`);
+      }
       throw new ToolError(`Failed to fetch ${url}: ${toErrorMessage(error)}`);
     }
 
-    const rawBody = response.data;
-    const contentType = String(
-      response.headers?.['content-type'] ?? '',
-    ).toLowerCase();
     const isMarkupContent =
       contentType.includes('html') ||
       contentType.includes('xml') ||

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -21,6 +21,7 @@ const MAX_CONTENT_BYTES = 10 * 1024 * 1024; // 10 MB
  * Read a response body into a string, aborting with AbortError if accumulated
  * bytes exceed `maxBytes`. Enforces the cap on received data rather than
  * trusting the Content-Length header (chunked responses omit it entirely).
+ * Respects the charset from the Content-Type header (falls back to UTF-8).
  */
 async function readBodyWithLimit(
   response: Response,
@@ -30,7 +31,14 @@ async function readBodyWithLimit(
   if (!reader) {
     return '';
   }
-  const decoder = new TextDecoder();
+  const ct = response.headers.get('content-type') ?? '';
+  const charsetMatch = /charset=([^\s;]+)/i.exec(ct);
+  let decoder: TextDecoder;
+  try {
+    decoder = new TextDecoder(charsetMatch?.[1] ?? 'utf-8');
+  } catch {
+    decoder = new TextDecoder();
+  }
   const parts: string[] = [];
   let total = 0;
   try {

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -17,6 +17,41 @@ const WEB_FETCH_TIMEOUT_MS = 30_000; // 30 s
 const WEB_FETCH_RETRIES = 2;
 const MAX_CONTENT_BYTES = 10 * 1024 * 1024; // 10 MB
 
+/**
+ * Read a response body into a string, aborting with AbortError if accumulated
+ * bytes exceed `maxBytes`. Enforces the cap on received data rather than
+ * trusting the Content-Length header (chunked responses omit it entirely).
+ */
+async function readBodyWithLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return '';
+  }
+  const decoder = new TextDecoder();
+  const parts: string[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        throw new AbortError(
+          `Response too large (exceeds ${maxBytes / (1024 * 1024)} MB maximum).`,
+        );
+      }
+      parts.push(decoder.decode(value, { stream: true }));
+    }
+    parts.push(decoder.decode());
+  } finally {
+    reader.releaseLock();
+  }
+  return parts.join('');
+}
+
 const WebFetchInputSchema = z.strictObject({
   url: z
     .url('Provide a valid absolute URL to fetch.')
@@ -112,7 +147,7 @@ export class WebFetchTool extends defineTool({
           }
 
           const ct = response.headers.get('content-type') ?? '';
-          const text = await response.text();
+          const text = await readBodyWithLimit(response, MAX_CONTENT_BYTES);
           return { rawBody: text, contentType: ct };
         },
         { retries: WEB_FETCH_RETRIES, minTimeout: 500, randomize: true },
@@ -135,10 +170,11 @@ export class WebFetchTool extends defineTool({
       throw new ToolError(`Failed to fetch ${url}: ${toErrorMessage(error)}`);
     }
 
+    const ctLower = contentType.toLowerCase();
     const isMarkupContent =
-      contentType.includes('html') ||
-      contentType.includes('xml') ||
-      contentType.includes('xhtml') ||
+      ctLower.includes('html') ||
+      ctLower.includes('xml') ||
+      ctLower.includes('xhtml') ||
       (!contentType && rawBody.trim().startsWith('<'));
 
     let markdown: string;

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -33,9 +33,10 @@ async function readBodyWithLimit(
   }
   const ct = response.headers.get('content-type') ?? '';
   const charsetMatch = /charset=([^\s;]+)/i.exec(ct);
+  const charset = charsetMatch?.[1]?.replace(/^["']|["']$/gu, '');
   let decoder: TextDecoder;
   try {
-    decoder = new TextDecoder(charsetMatch?.[1] ?? 'utf-8');
+    decoder = new TextDecoder(charset || 'utf-8');
   } catch {
     decoder = new TextDecoder();
   }

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -1,11 +1,16 @@
 // Third-party imports
-import axios from 'axios';
+import ky from 'ky';
+import pRetry, { AbortError } from 'p-retry';
 import { z } from 'zod';
 
 // Internal imports
-import { ToolResult } from '@shared/schemas/toolResult';
-import { wrapApiCall } from '@tools/utils';
+import { toErrorMessage } from '@common/errors';
+import { ToolError, ToolResult } from '@shared/schemas/toolResult';
+import { isTransientHttpError } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
+
+const DDG_TIMEOUT_MS = 15_000; // 15 s
+const DDG_RETRIES = 2;
 
 const WebSearchInputSchema = z.strictObject({
   query: z
@@ -49,14 +54,37 @@ export class WebSearchTool extends defineTool({
   protected async execute(input: WebSearchInput): Promise<ToolResult> {
     const { query, max_results } = input;
 
-    const response = await wrapApiCall(
-      () =>
-        axios.get<DuckDuckGoResponse>('https://api.duckduckgo.com/', {
-          params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
-        }),
-      'Web search failed',
-    );
-    const data = response.data;
+    let data: DuckDuckGoResponse;
+    try {
+      data = await pRetry(
+        async () => {
+          let response: Response;
+          try {
+            response = await ky.get('https://api.duckduckgo.com/', {
+              searchParams: {
+                q: query,
+                format: 'json',
+                no_redirect: 1,
+                no_html: 1,
+              },
+              timeout: false,
+              signal: AbortSignal.timeout(DDG_TIMEOUT_MS),
+              retry: 0,
+            });
+          } catch (error: unknown) {
+            if (isTransientHttpError(error)) throw error;
+            throw new AbortError(
+              error instanceof Error ? error : new Error(String(error)),
+            );
+          }
+          return response.json() as Promise<DuckDuckGoResponse>;
+        },
+        { retries: DDG_RETRIES, minTimeout: 500, randomize: true },
+      );
+    } catch (error) {
+      throw new ToolError(`Web search failed: ${toErrorMessage(error)}`);
+    }
+
     const results: string[] = [];
 
     // Extract abstract/summary if available (direct answers)

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -1,12 +1,12 @@
 // Third-party imports
-import ky from 'ky';
+import ky, { HTTPError } from 'ky';
 import pRetry, { AbortError } from 'p-retry';
 import { z } from 'zod';
 
 // Internal imports
 import { toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
-import { isTransientHttpError } from '@tools/timeouts';
+import { isTimeoutError, isTransientHttpError } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 
 const DDG_TIMEOUT_MS = 15_000; // 15 s
@@ -81,6 +81,19 @@ export class WebSearchTool extends defineTool({
         { retries: DDG_RETRIES, minTimeout: 500, randomize: true },
       );
     } catch (error) {
+      if (isTimeoutError(error)) {
+        throw new ToolError(
+          `Web search timed out after ${DDG_TIMEOUT_MS / 1000}s. Retry the request.`,
+        );
+      }
+      if (error instanceof HTTPError) {
+        throw new ToolError(
+          `Web search failed: HTTP ${error.response.status} from DuckDuckGo.`,
+        );
+      }
+      if (error instanceof TypeError) {
+        throw new ToolError(`Web search failed: network error — ${error.message}`);
+      }
       throw new ToolError(`Web search failed: ${toErrorMessage(error)}`);
     }
 

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -70,7 +70,7 @@ export class WebSearchTool extends defineTool({
               signal: AbortSignal.timeout(DDG_TIMEOUT_MS),
               retry: 0,
             });
-            return response.json() as Promise<DuckDuckGoResponse>;
+            return (await response.json()) as DuckDuckGoResponse;
           } catch (error: unknown) {
             if (isTransientHttpError(error)) throw error;
             throw new AbortError(

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -92,7 +92,9 @@ export class WebSearchTool extends defineTool({
         );
       }
       if (error instanceof TypeError) {
-        throw new ToolError(`Web search failed: network error — ${error.message}`);
+        throw new ToolError(
+          `Web search failed: network error — ${error.message}`,
+        );
       }
       throw new ToolError(`Web search failed: ${toErrorMessage(error)}`);
     }

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -58,9 +58,8 @@ export class WebSearchTool extends defineTool({
     try {
       data = await pRetry(
         async () => {
-          let response: Response;
           try {
-            response = await ky.get('https://api.duckduckgo.com/', {
+            const response = await ky.get('https://api.duckduckgo.com/', {
               searchParams: {
                 q: query,
                 format: 'json',
@@ -71,13 +70,13 @@ export class WebSearchTool extends defineTool({
               signal: AbortSignal.timeout(DDG_TIMEOUT_MS),
               retry: 0,
             });
+            return response.json() as Promise<DuckDuckGoResponse>;
           } catch (error: unknown) {
             if (isTransientHttpError(error)) throw error;
             throw new AbortError(
               error instanceof Error ? error : new Error(String(error)),
             );
           }
-          return response.json() as Promise<DuckDuckGoResponse>;
         },
         { retries: DDG_RETRIES, minTimeout: 500, randomize: true },
       );

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -17,7 +17,7 @@
  */
 
 // Third-party imports
-import axios, { AxiosError } from 'axios';
+import ky from 'ky';
 import { type Work } from '@jamesgopsill/crossref-client';
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
@@ -26,7 +26,7 @@ import { z } from 'zod';
 import pTimeout from 'p-timeout';
 import { toErrorMessage } from '@common/errors';
 import { ToolError } from '@shared/schemas/toolResult';
-import { isTimeoutErrorCode } from '@tools/timeouts';
+import { isTimeoutError } from '@tools/timeouts';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { CROSSREF_CONSTANTS, crossrefClient } from '@tools/citation/constants';
 import { defineTool } from '@tools/core/define';
@@ -120,8 +120,10 @@ interface ConnectorResult {
  */
 async function checkZoteroRunning(port: number): Promise<void> {
   try {
-    await axios.get(`http://127.0.0.1:${port}/connector/ping`, {
-      timeout: ZOTERO_PING_TIMEOUT_MS,
+    await ky.get(`http://127.0.0.1:${port}/connector/ping`, {
+      timeout: false,
+      signal: AbortSignal.timeout(ZOTERO_PING_TIMEOUT_MS),
+      retry: 0,
     });
   } catch {
     throw new ToolError(
@@ -139,27 +141,17 @@ async function callZoteroConnector(
   body: object,
   port: number,
 ): Promise<ConnectorResult> {
+  let response: Response;
   try {
-    const response = await axios.post(
-      `http://127.0.0.1:${port}/connector/${endpoint}`,
-      body,
-      {
-        timeout: ZOTERO_CONNECTOR_TIMEOUT_MS,
-        headers: { 'Content-Type': 'application/json' },
-      },
-    );
-    if (
-      response.status === StatusCodes.OK ||
-      response.status === StatusCodes.CREATED
-    ) {
-      return { status: 'success' };
-    }
-    return {
-      status: 'error',
-      message: `Unexpected response status: ${response.status}`,
-    };
-  } catch (error) {
-    if (error instanceof AxiosError && isTimeoutErrorCode(error.code)) {
+    response = await ky.post(`http://127.0.0.1:${port}/connector/${endpoint}`, {
+      json: body,
+      timeout: false,
+      signal: AbortSignal.timeout(ZOTERO_CONNECTOR_TIMEOUT_MS),
+      retry: 0,
+      throwHttpErrors: false,
+    });
+  } catch (error: unknown) {
+    if (isTimeoutError(error)) {
       return {
         status: 'error',
         message:
@@ -167,12 +159,25 @@ async function callZoteroConnector(
           `Retry the request. If it persists, ask the user to check that Zotero is responsive.`,
       };
     }
-    const message =
-      error instanceof AxiosError && error.response?.data?.error
-        ? String(error.response.data.error)
-        : toErrorMessage(error);
-    return { status: 'error', message };
+    return { status: 'error', message: toErrorMessage(error) };
   }
+
+  if (
+    response.status === StatusCodes.OK ||
+    response.status === StatusCodes.CREATED
+  ) {
+    return { status: 'success' };
+  }
+
+  // Try to extract a machine-readable error message from the response body.
+  let errorMessage = `Unexpected response status: ${response.status}`;
+  try {
+    const data = (await response.json()) as { error?: string };
+    if (data?.error) errorMessage = String(data.error);
+  } catch {
+    // Body is not JSON or is empty; use the generic status message.
+  }
+  return { status: 'error', message: errorMessage };
 }
 
 /**

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -240,8 +240,9 @@ export async function callBetterBibTeX<T>(
           'Ask the user to install it from https://retorque.re/zotero-better-bibtex/',
       );
     }
-    // TypeError from fetch: network-level failure — for a localhost endpoint
-    // this almost always means Zotero is not running.
+    // TypeError from fetch (ECONNREFUSED → TypeError in native fetch): for a
+    // localhost endpoint this is always a connection failure. This try block
+    // wraps only the ky.post call, so no programmer TypeError can reach here.
     if (error instanceof TypeError) {
       throw new ToolError(
         `Zotero is not reachable on port ${port}. ` +

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -231,7 +231,10 @@ export async function callBetterBibTeX<T>(
           `Retry the request. If it persists, ask the user to check that Zotero is responsive.`,
       );
     }
-    if (error instanceof HTTPError && error.response.status === StatusCodes.NOT_FOUND) {
+    if (
+      error instanceof HTTPError &&
+      error.response.status === StatusCodes.NOT_FOUND
+    ) {
       throw new ToolError(
         'Better BibTeX plugin is not installed in Zotero. ' +
           'Ask the user to install it from https://retorque.re/zotero-better-bibtex/',

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -8,14 +8,14 @@
  */
 
 // Third-party imports
-import axios from 'axios';
+import ky, { HTTPError } from 'ky';
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
 // Local imports - core
 import { toErrorMessage } from '@common/errors';
 import { ToolError } from '@shared/schemas/toolResult';
-import { isTimeoutErrorCode } from '@tools/timeouts';
+import { isTimeoutError } from '@tools/timeouts';
 import { getConfig } from '@utils/config/configUtils';
 
 const ZOTERO_BBT_TIMEOUT_MS = 10_000; // 10 s
@@ -214,37 +214,41 @@ export async function callBetterBibTeX<T>(
 ): Promise<T> {
   const url = `http://127.0.0.1:${port}/better-bibtex/json-rpc`;
 
-  const response = await axios
-    .post<unknown>(
-      url,
-      { jsonrpc: '2.0', method, params, id: 1 },
-      { timeout, headers: { 'Content-Type': 'application/json' } },
-    )
-    .catch((error: unknown) => {
-      if (axios.isAxiosError(error)) {
-        if (isTimeoutErrorCode(error.code)) {
-          throw new ToolError(
-            `Zotero API request timed out after ${timeout / 1000}s. ` +
-              `Retry the request. If it persists, ask the user to check that Zotero is responsive.`,
-          );
-        }
-        if (error.code === 'ECONNREFUSED') {
-          throw new ToolError(
-            `Zotero is not reachable on port ${port}. ` +
-              `Ask the user to start Zotero or verify the port (setting: texra.bib.zoteroPort).`,
-          );
-        }
-        if (error.response?.status === StatusCodes.NOT_FOUND) {
-          throw new ToolError(
-            'Better BibTeX plugin is not installed in Zotero. ' +
-              'Ask the user to install it from https://retorque.re/zotero-better-bibtex/',
-          );
-        }
-      }
-      throw new ToolError(`Better BibTeX API error: ${toErrorMessage(error)}`);
-    });
+  let raw: unknown;
+  try {
+    raw = await ky
+      .post(url, {
+        json: { jsonrpc: '2.0', method, params, id: 1 },
+        timeout: false,
+        signal: AbortSignal.timeout(timeout),
+        retry: 0,
+      })
+      .json<unknown>();
+  } catch (error: unknown) {
+    if (isTimeoutError(error)) {
+      throw new ToolError(
+        `Zotero API request timed out after ${timeout / 1000}s. ` +
+          `Retry the request. If it persists, ask the user to check that Zotero is responsive.`,
+      );
+    }
+    if (error instanceof HTTPError && error.response.status === StatusCodes.NOT_FOUND) {
+      throw new ToolError(
+        'Better BibTeX plugin is not installed in Zotero. ' +
+          'Ask the user to install it from https://retorque.re/zotero-better-bibtex/',
+      );
+    }
+    // TypeError from fetch: network-level failure — for a localhost endpoint
+    // this almost always means Zotero is not running.
+    if (error instanceof TypeError) {
+      throw new ToolError(
+        `Zotero is not reachable on port ${port}. ` +
+          `Ask the user to start Zotero or verify the port (setting: texra.bib.zoteroPort).`,
+      );
+    }
+    throw new ToolError(`Better BibTeX API error: ${toErrorMessage(error)}`);
+  }
 
-  const parsed = jsonRpcResponseSchema(resultSchema).safeParse(response.data);
+  const parsed = jsonRpcResponseSchema(resultSchema).safeParse(raw);
   if (!parsed.success) {
     throw new ToolError(
       `Better BibTeX returned an unexpected response for ${method}: ${parsed.error.message}`,


### PR DESCRIPTION
## Summary

Migrate all HTTP requests from axios to the ky HTTP client library, which provides better timeout handling and native fetch integration. Add automatic retry logic with exponential backoff for transient failures (timeouts, network errors, 5xx responses, rate limits) across web-facing tools.

**Key improvements:**
- **Better timeout semantics:** Use `AbortSignal.timeout()` which covers both connection establishment and body streaming, replacing axios's timeout which only fires after headers arrive
- **Automatic retries:** Web fetch, web search, and Loogle tools now retry transient failures up to 2 times with randomized backoff
- **Cleaner error handling:** Replace axios error code checks with type-based predicates (`HTTPError`, `TimeoutError`, `TypeError`)
- **Reduced dependencies:** Remove axios from package.json

## Issue acceptance gates

N/A (refactoring/infrastructure improvement)

## Single source of truth

Error classification logic is now centralized in `src/tools/timeouts.ts`:
- `isTimeoutError()` - detects both ky `TimeoutError` and `AbortSignal.timeout()` errors
- `isTransientHttpError()` - classifies errors as retryable (timeouts, network failures, 429, 5xx) vs permanent (4xx, application errors)

This ensures consistent retry behavior across all tools using ky.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated per-tool timeout/error handling boilerplate by centralizing predicates in `timeouts.ts`
- Replaced axios-specific error checks (`axios.isAxiosError()`, `error.code === 'ECONNABORTED'`) with generic type checks

**New abstraction:**
- `isTransientHttpError()` predicate encodes the retry policy (what errors are worth retrying) in one place, used by `pRetry` across multiple tools

## Host impact

Extension: Tools (web fetch, web search, Loogle, Zotero) now have automatic retry logic and better timeout handling. No user-facing behavior change; requests are more resilient to transient failures.

Desktop: Same as extension (shared tool implementations).

CLI: Same as extension.

## Scheduled refactoring

None. The migration is complete across all HTTP-using tools.

## Validation

- Updated unit tests in `src/test-kernel/tools/TransientHttpError.vitest.ts` to test ky error types instead of axios
- Existing tool tests continue to pass (no test changes needed for retry logic—it's transparent to callers)
- Manual verification: Web fetch, web search, and Loogle tools now retry on transient errors; permanent errors (4xx, malformed responses) fail immediately

https://claude.ai/code/session_01KmAsLUFGkoyW8SvN91EzEt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many shared tool HTTP paths (web, Loogle, Zotero, arXiv); behavior should be more resilient but timeout/retry and error-mapping changes could alter edge-case failures compared to axios.
> 
> **Overview**
> **Removes `axios`** and routes outbound HTTP through **`ky`** / native **`fetch`**, with shared classification in `timeouts.ts` (`isTimeoutError`, `isTransientHttpError`).
> 
> **Timeouts** now use **`AbortSignal.timeout()`** (connection + body) instead of axios header-only timeouts. arXiv source downloads use **`fetch`** + stream piping, with a **2-minute** deadline for large tarballs.
> 
> **Retries** (`pRetry`, up to 2, jittered) are added or aligned for **web fetch**, **web search**, and **Loogle** on transient failures; permanent **4xx** and malformed responses abort immediately.
> 
> **Web fetch** gains **streaming body reads** with a **10 MB** cap enforced while reading (not only via `Content-Length`), plus clearer timeout/network/HTTP errors.
> 
> **Zotero** connector and Better BibTeX calls use **`ky`** with `throwHttpErrors: false` where needed; connector errors can be parsed from JSON bodies. Tests in `TransientHttpError.vitest.ts` were updated for **ky** / **fetch** error shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daba7e0df62728ace3fd24aa3a07b80a384a3379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->