### PR TITLE
refactor: consolidate duplicate parse methods and use normalizeFilePath

### DIFF
--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -23,6 +23,7 @@ import type {
   WebSearchResultBlock,
   WebFetchToolResultBlock,
 } from '@anthropic-ai/sdk/resources/messages';
+import { safeParseJson } from '@common/parsing/safeParseJson';
 
 /**
  * Minimal stream interface derived from the Anthropic SDK's BetaMessageStream.
@@ -446,35 +447,25 @@ export class AnthropicStreamHandler {
   }
 
   /**
-   * Parses the fetch URL from accumulated input JSON.
+   * Extract a single string field from accumulated server-tool input JSON.
+   * Falls back to regex for partial JSON common during streaming.
    */
-  private parseFetchUrl(input: string | undefined): string {
+  private parseStreamField(input: string | undefined, field: string): string {
     if (!input) return '';
-
-    try {
-      const parsed = JSON.parse(input) as { url?: string };
-      return parsed.url ?? '';
-    } catch {
-      // Partial JSON (common for streaming), try to extract URL with regex
-      const match = input.match(/"url"\s*:\s*"([^"]+)"/);
-      return match?.[1] ?? '';
-    }
+    const parsed = safeParseJson(input);
+    if (parsed.ok) return (parsed.value as Record<string, string>)[field] ?? '';
+    const match = input.match(new RegExp(`"${field}"\\s*:\\s*"([^"]+)"`));
+    return match?.[1] ?? '';
   }
 
-  /**
-   * Parses the search query from accumulated input JSON.
-   */
-  private parseSearchQuery(input: string | undefined): string {
-    if (!input) return '';
+  /** Parses the fetch URL from accumulated input JSON. */
+  private parseFetchUrl(input: string | undefined): string {
+    return this.parseStreamField(input, 'url');
+  }
 
-    try {
-      const parsed = JSON.parse(input) as { query?: string };
-      return parsed.query ?? '';
-    } catch {
-      // Partial JSON (common for streaming), try to extract query with regex
-      const match = input.match(/"query"\s*:\s*"([^"]+)"/);
-      return match?.[1] ?? '';
-    }
+  /** Parses the search query from accumulated input JSON. */
+  private parseSearchQuery(input: string | undefined): string {
+    return this.parseStreamField(input, 'query');
   }
 
   /**

--- a/src/agent/output/lineageMapping.ts
+++ b/src/agent/output/lineageMapping.ts
@@ -8,6 +8,7 @@
 import * as path from 'node:path';
 
 import type { FileLocation } from '@shared/schemas';
+import { normalizeFilePath } from '@shared/utils/path';
 import { createFileMapping, getComparablePath } from '@utils/files';
 
 import type { OutputState } from './outputState';
@@ -43,7 +44,7 @@ function invertMapping(
 
 function buildBaseEntries(baseFiles: FileLocation[]): BaseEntry[] {
   return baseFiles.map((baseLoc) => {
-    const comparablePath = getComparablePath(baseLoc).replaceAll('\\', '/');
+    const comparablePath = normalizeFilePath(getComparablePath(baseLoc));
     const parsedPath = path.posix.parse(comparablePath);
     const relativePathNoExt = path.posix.join(parsedPath.dir, parsedPath.name);
     const baseName = path.posix.basename(comparablePath);
@@ -66,7 +67,7 @@ function findMatchingBaseFile(
   baseEntries: readonly BaseEntry[],
   source: string,
 ): FileLocation | undefined {
-  const normalizedSource = source.replaceAll('\\', '/');
+  const normalizedSource = normalizeFilePath(source);
   const parsedSource = path.posix.parse(normalizedSource);
   const sourcePathNoExt = path.posix.join(parsedSource.dir, parsedSource.name);
   const sourceBaseName = path.posix.basename(normalizedSource);

--- a/src/agent/review/reviewIssues.ts
+++ b/src/agent/review/reviewIssues.ts
@@ -12,6 +12,7 @@
 import { randomUUID } from 'node:crypto';
 
 // Local imports
+import { normalizeFilePath } from '@shared/utils/path';
 import { AGENT_REVIEW_APPROACHES } from '@shared/schemas/coreSettings';
 
 export const REVIEW_SEVERITIES = ['critical', 'warning', 'info'] as const;
@@ -47,7 +48,7 @@ export interface ReviewIssueReport {
 
 /** Strip diff-style `a/`/`b/` prefixes and normalize separators. */
 export function normalizeReviewFilePath(file: string): string {
-  let normalized = file.trim().replaceAll('\\', '/');
+  let normalized = normalizeFilePath(file.trim());
   if (normalized.startsWith('a/') || normalized.startsWith('b/')) {
     normalized = normalized.slice(2);
   }

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -16,6 +16,7 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { KVStore } from '@common/storage/KVStore';
 import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
+import { normalizeFilePath } from '@shared/utils/path';
 import {
   CompileFailureSummarySchema,
   OutputFileSummarySchema,
@@ -268,7 +269,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
 function normalizeWorkspaceFilePaths(paths: readonly string[]): string[] {
   const normalized = new Set<string>();
   for (const rawPath of paths) {
-    const pathValue = rawPath.trim().replaceAll('\\', '/');
+    const pathValue = normalizeFilePath(rawPath.trim());
     if (pathValue) normalized.add(pathValue);
   }
   return [...normalized].sort(byString);

--- a/src/agent/storage/executionWorkspaceFiles.ts
+++ b/src/agent/storage/executionWorkspaceFiles.ts
@@ -4,6 +4,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AbsoluteFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { byStringProp } from '@utils/core/comparators';
+import { normalizeFilePath } from '@shared/utils/path';
 
 export interface ExecutionWorkspaceFile {
   readonly path: string;
@@ -36,7 +37,7 @@ export function resolveExecutionWorkspaceFilePath(
 
   return {
     absolutePath,
-    path: relativePath.replaceAll('\\', '/'),
+    path: normalizeFilePath(relativePath),
   };
 }
 

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { normalizeFilePath } from '@shared/utils/path';
 import {
   WORKFLOW_OUTPUT_BASENAME,
   workflowOutputPath,
@@ -28,7 +29,7 @@ function getSafeDocumentPathParts(source: string): {
   name: string;
   ext: string;
 } {
-  const sourcePath = source.replaceAll('\\', '/');
+  const sourcePath = normalizeFilePath(source);
   const parsed = path.posix.parse(sourcePath);
   const isAbsoluteSource =
     path.posix.isAbsolute(sourcePath) || /^[A-Za-z]:\//.test(sourcePath);

--- a/src/tools/executions/runDirectoryFiles.ts
+++ b/src/tools/executions/runDirectoryFiles.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
+import { normalizeFilePath } from '@shared/utils/path';
 
 export interface RunDirectoryEntry {
   readonly path: string;
@@ -52,7 +53,7 @@ async function walkDirectory(
     // Build raw path for filesystem access (preserves platform separators),
     // then normalize to forward slashes only for display output.
     const entryRaw = relativePath ? path.join(relativePath, name) : name;
-    const entryRelative = entryRaw.replaceAll('\\', '/');
+    const entryRelative = normalizeFilePath(entryRaw);
     const entryFull = path.join(basePath, entryRaw);
     const isDir = isDirectory(type);
 


### PR DESCRIPTION
## Summary

- **`AnthropicStreamHandler`**: Extracted a generic `parseStreamField(input, field)` private helper that consolidates the structurally identical `parseFetchUrl` and `parseSearchQuery` methods. The helper now uses the existing `safeParseJson` utility instead of a bare `try/catch`, removing ~15 lines of boilerplate while keeping the streaming regex fallback.

- **Inline separator normalization → `normalizeFilePath`**: Replaced seven ad-hoc `.replaceAll('\\', '/')` calls across agent and tool files with the already-available `normalizeFilePath` from `@shared/utils/path`. Affected files:
  - `src/agent/review/reviewIssues.ts`
  - `src/agent/output/lineageMapping.ts` (2 sites)
  - `src/agent/utils/outputFileUtils.ts`
  - `src/agent/storage/ExecutionKVStore.ts`
  - `src/agent/storage/executionWorkspaceFiles.ts`
  - `src/tools/executions/runDirectoryFiles.ts`

## Motivation

Both patterns were identified during a codebase consolidation scan. The utility functions (`safeParseJson`, `normalizeFilePath`) already existed and were in use elsewhere — these files simply weren't importing them. Using named utilities over inline one-liners makes intent explicit and ensures future changes to normalization or parsing logic propagate uniformly.

## Test plan

- [x] `npm run compile:fast` — clean build (exit 0)
- [x] `npm test` — 518/519 test files pass; the single failure (`execUtils.vitest.ts` process-group abort timing) is a pre-existing flaky test unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RetuyEbTLbbVZeSBMKJ2b

---
_Generated by [Claude Code](https://claude.ai/code/session_015RetuyEbTLbbVZeSBMKJ2b)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor to existing utilities with no new behavior; touches path normalization in lineage, review, and execution storage but logic is equivalent to prior inline normalization.
> 
> **Overview**
> **Refactors path handling and Anthropic stream parsing** to use shared utilities instead of duplicated inline logic.
> 
> In `AnthropicStreamHandler`, `parseFetchUrl` and `parseSearchQuery` now delegate to a single `parseStreamField` helper that uses `safeParseJson` (with the same regex fallback for partial streaming JSON).
> 
> Across agent output, review, storage, workspace listing, and run-directory traversal, ad-hoc backslash-to-slash normalization is replaced with `normalizeFilePath` from `@shared/utils/path` (behavior unchanged: forward-slash paths for comparison and display).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9816514cac35558f9d817dae140a0af165ef74c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->